### PR TITLE
Add sound throttling from ID 0008814

### DIFF
--- a/MTA10/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/MTA10/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -7282,17 +7282,17 @@ CClientEffect* CStaticFunctionDefinitions::CreateEffect(CResource& Resource, con
 }
 
 
-CClientSound* CStaticFunctionDefinitions::PlaySound ( CResource* pResource, const SString& strSound, bool bIsURL, bool bLoop )
+CClientSound* CStaticFunctionDefinitions::PlaySound ( CResource* pResource, const SString& strSound, bool bIsURL, bool bLoop, bool bThrottle )
 {
-    CClientSound* pSound = m_pSoundManager->PlaySound2D ( strSound, bIsURL, bLoop );
+    CClientSound* pSound = m_pSoundManager->PlaySound2D ( strSound, bIsURL, bLoop, bThrottle );
     if ( pSound ) pSound->SetParent ( pResource->GetResourceDynamicEntity() );
     return pSound;
 }
 
 
-CClientSound* CStaticFunctionDefinitions::PlaySound3D ( CResource* pResource, const SString& strSound, bool bIsURL, const CVector& vecPosition, bool bLoop )
+CClientSound* CStaticFunctionDefinitions::PlaySound3D ( CResource* pResource, const SString& strSound, bool bIsURL, const CVector& vecPosition, bool bLoop, bool bThrottle )
 {
-    CClientSound* pSound = m_pSoundManager->PlaySound3D ( strSound, bIsURL, vecPosition, bLoop );
+    CClientSound* pSound = m_pSoundManager->PlaySound3D ( strSound, bIsURL, vecPosition, bLoop, bThrottle );
     if ( pSound ) pSound->SetParent ( pResource->GetResourceDynamicEntity() );
     return pSound;
 }

--- a/MTA10/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/MTA10/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -632,8 +632,8 @@ public:
     static CClientEffect*               CreateEffect                        ( CResource& Resource, const SString& strFxName, const CVector& vecPosition );
 
     // Sound funcs
-    static CClientSound*                PlaySound                           ( CResource* pResource, const SString& strSound, bool bIsURL, bool bLoop );
-    static CClientSound*                PlaySound3D                         ( CResource* pResource, const SString& strSound, bool bIsURL, const CVector& vecPosition, bool bLoop );
+    static CClientSound*                PlaySound                           ( CResource* pResource, const SString& strSound, bool bIsURL, bool bLoop, bool bThrottle );
+    static CClientSound*                PlaySound3D                         ( CResource* pResource, const SString& strSound, bool bIsURL, const CVector& vecPosition, bool bLoop, bool bThrottle );
     static bool                         StopSound                           ( CClientSound& Sound );
     static bool                         SetSoundPosition                    ( CClientSound& Sound, double dPosition );
     static bool                         GetSoundPosition                    ( CClientSound& Sound, double& dPosition );

--- a/MTA10/mods/shared_logic/CBassAudio.cpp
+++ b/MTA10/mods/shared_logic/CBassAudio.cpp
@@ -68,10 +68,11 @@ namespace
 }
 
 
-CBassAudio::CBassAudio ( bool bStream, const SString& strPath, bool bLoop, bool b3D )
+CBassAudio::CBassAudio ( bool bStream, const SString& strPath, bool bLoop, bool bThrottle, bool b3D )
     : m_bStream ( bStream )
     , m_strPath ( strPath )
     , m_bLoop ( bLoop )
+    , m_bThrottle ( bThrottle )
     , m_b3D ( b3D )
 {
     m_fVolume = 1.0f;
@@ -85,7 +86,7 @@ CBassAudio::CBassAudio ( bool bStream, const SString& strPath, bool bLoop, bool 
 }
 
 
-CBassAudio::CBassAudio ( void* pBuffer, unsigned int uiBufferLength, bool bLoop, bool b3D ) : m_bStream ( false ), m_pBuffer ( pBuffer ), m_uiBufferLength ( uiBufferLength ), m_bLoop ( bLoop ), m_b3D ( b3D )
+CBassAudio::CBassAudio ( void* pBuffer, unsigned int uiBufferLength, bool bLoop, bool b3D ) : m_bStream ( false ), m_pBuffer ( pBuffer ), m_uiBufferLength ( uiBufferLength ), m_bLoop ( bLoop ), m_bThrottle( false), m_b3D ( b3D )
 {
     m_fVolume = 1.0f;
     m_fDefaultFrequency = 44100.0f;
@@ -149,6 +150,9 @@ bool CBassAudio::BeginLoadingMedia ( void )
 #endif
     if ( m_bLoop )
         lFlags |= BASS_SAMPLE_LOOP;
+
+    if ( m_bThrottle )
+        lFlags |= BASS_STREAM_RESTRATE;
 
     if ( m_bStream )
     {

--- a/MTA10/mods/shared_logic/CBassAudio.h
+++ b/MTA10/mods/shared_logic/CBassAudio.h
@@ -48,7 +48,7 @@ class CBassAudio
 {
 public:
     ZERO_ON_NEW
-                            CBassAudio              ( bool bStream, const SString& strPath, bool bLoop, bool b3D );
+                            CBassAudio              ( bool bStream, const SString& strPath, bool bLoop, bool bThrottle, bool b3D );
                             CBassAudio              ( void* pBuffer, unsigned int uiBufferLength, bool bLoop, bool b3D );
                             ~CBassAudio             ( void );
     void                    Destroy                 ( void );
@@ -107,6 +107,7 @@ private:
     const SString           m_strPath;
     const bool              m_b3D;
     const bool              m_bLoop;
+    const bool              m_bThrottle;
     void*                   m_pBuffer;
     unsigned int            m_uiBufferLength;
 

--- a/MTA10/mods/shared_logic/CClientSound.cpp
+++ b/MTA10/mods/shared_logic/CClientSound.cpp
@@ -113,7 +113,7 @@ bool CClientSound::Create ( void )
 
     // Initial state
     if ( !m_pBuffer )
-        m_pAudio = new CBassAudio ( m_bStream, m_strPath, m_bLoop, m_b3D );
+        m_pAudio = new CBassAudio ( m_bStream, m_strPath, m_bLoop, m_bThrottle, m_b3D );
     else
         m_pAudio = new CBassAudio ( m_pBuffer, m_uiBufferLength, m_bLoop, m_b3D );
         
@@ -286,7 +286,7 @@ bool CClientSound::Play3D ( void* pMemory, unsigned int uiLength, bool bLoop )
 }
 
 
-void CClientSound::PlayStream ( const SString& strURL, bool bLoop, bool b3D )
+void CClientSound::PlayStream ( const SString& strURL, bool bLoop, bool bThrottle, bool b3D )
 {
     assert ( m_strPath.empty () );
 
@@ -294,6 +294,7 @@ void CClientSound::PlayStream ( const SString& strURL, bool bLoop, bool b3D )
     m_b3D = b3D;
     m_strPath = strURL;
     m_bLoop = bLoop;
+    m_bThrottle = bThrottle;
 
     // Instant distance-stream in if not 3D
     if ( !m_b3D )

--- a/MTA10/mods/shared_logic/CClientSound.h
+++ b/MTA10/mods/shared_logic/CClientSound.h
@@ -38,7 +38,7 @@ public:
     bool                    Play                    ( void* pMemory, unsigned int uiLength, bool bLoop );
     bool                    Play3D                  ( const SString& strPath, bool bLoop );
     bool                    Play3D                  ( void* pMemory, unsigned int uiLength, bool bLoop );
-    void                    PlayStream              ( const SString& strURL, bool bLoop, bool b3D = false );
+    void                    PlayStream              ( const SString& strURL, bool bLoop, bool bThrottle, bool b3D = false );
 
     void                    SetPaused               ( bool bPaused  );
     bool                    IsPaused                ( void );
@@ -111,6 +111,7 @@ private:
     bool        m_b3D;
     SString     m_strPath;
     bool        m_bLoop;
+    bool        m_bThrottle;
     void*       m_pBuffer;
     unsigned int m_uiBufferLength;
 

--- a/MTA10/mods/shared_logic/CClientSoundManager.cpp
+++ b/MTA10/mods/shared_logic/CClientSoundManager.cpp
@@ -127,12 +127,12 @@ void CClientSoundManager::SetDimension ( unsigned short usDimension )
     m_usDimension = usDimension;
 }
 
-CClientSound* CClientSoundManager::PlaySound2D ( const SString& strSound, bool bIsURL, bool bLoop )
+CClientSound* CClientSoundManager::PlaySound2D ( const SString& strSound, bool bIsURL, bool bLoop, bool bThrottle )
 {
     CClientSound* pSound = new CClientSound ( m_pClientManager, INVALID_ELEMENT_ID );
     if ( bIsURL )
     {
-        pSound->PlayStream ( strSound, bLoop );
+        pSound->PlayStream ( strSound, bLoop, bThrottle );
         return pSound;
     }
     else
@@ -154,13 +154,13 @@ CClientSound* CClientSoundManager::PlaySound2D ( void* pMemory, unsigned int uiL
     return NULL;
 }
 
-CClientSound* CClientSoundManager::PlaySound3D ( const SString& strSound, bool bIsURL, const CVector& vecPosition, bool bLoop )
+CClientSound* CClientSoundManager::PlaySound3D ( const SString& strSound, bool bIsURL, const CVector& vecPosition, bool bLoop, bool bThrottle )
 {
     CClientSound* pSound = new CClientSound ( m_pClientManager, INVALID_ELEMENT_ID );
 
     if ( bIsURL )
     {
-        pSound->PlayStream ( strSound, bLoop, true );
+        pSound->PlayStream ( strSound, bLoop, bThrottle, true );
         pSound->SetPosition ( vecPosition );
         return pSound;
     }

--- a/MTA10/mods/shared_logic/CClientSoundManager.h
+++ b/MTA10/mods/shared_logic/CClientSoundManager.h
@@ -31,9 +31,9 @@ public:
 
     void                    SetDimension                ( unsigned short usDimension );
 
-    CClientSound*           PlaySound2D                 ( const SString& strSound, bool bIsURL, bool bLoop );
+    CClientSound*           PlaySound2D                 ( const SString& strSound, bool bIsURL, bool bLoop, bool bThrottle );
     CClientSound*           PlaySound2D                 ( void* pMemory, unsigned int uiLength, bool bLoop );
-    CClientSound*           PlaySound3D                 ( const SString& strSound, bool bIsURL, const CVector& vecPosition, bool bLoop );
+    CClientSound*           PlaySound3D                 ( const SString& strSound, bool bIsURL, const CVector& vecPosition, bool bLoop, bool bThrottle );
     CClientSound*           PlaySound3D                 ( void* pMemory, unsigned int uiLength, const CVector& vecPosition, bool bLoop );
 
     CClientSound*           PlayGTASFX                  ( eAudioLookupIndex containerIndex, int iBankIndex, int iAudioIndex, bool bLoop = false );

--- a/MTA10/mods/shared_logic/lua/CLuaFunctionDefs.Audio.cpp
+++ b/MTA10/mods/shared_logic/lua/CLuaFunctionDefs.Audio.cpp
@@ -23,9 +23,11 @@ int CLuaFunctionDefs::PlaySound ( lua_State* luaVM )
 {
     SString strSound = "";
     bool bLoop = false;
+    bool bThrottle = true;
     CScriptArgReader argStream ( luaVM );
     argStream.ReadString ( strSound );
     argStream.ReadBool ( bLoop, false );
+    argStream.ReadBool ( bThrottle, true );
 
     if ( !argStream.HasErrors() )
     {
@@ -46,7 +48,7 @@ int CLuaFunctionDefs::PlaySound ( lua_State* luaVM )
                 // Fixes #6507 - Caz
                 if ( pResource )
                 {
-                    CClientSound* pSound = CStaticFunctionDefinitions::PlaySound ( pResource, strSound, bIsURL, bLoop );
+                    CClientSound* pSound = CStaticFunctionDefinitions::PlaySound ( pResource, strSound, bIsURL, bLoop, bThrottle );
                     if ( pSound )
                     {
                         // call onClientSoundStarted
@@ -74,10 +76,12 @@ int CLuaFunctionDefs::PlaySound3D ( lua_State* luaVM )
     SString strSound = "";
     CVector vecPosition;
     bool bLoop = false;
+    bool bThrottle = false;
     CScriptArgReader argStream ( luaVM );
     argStream.ReadString ( strSound );
     argStream.ReadVector3D ( vecPosition );
     argStream.ReadBool ( bLoop, false );
+    argStream.ReadBool ( bThrottle, true );
 
     if ( !argStream.HasErrors() )
     {
@@ -98,7 +102,7 @@ int CLuaFunctionDefs::PlaySound3D ( lua_State* luaVM )
                 // Fixes #6507 - Caz
                 if ( pResource )
                 {
-                    CClientSound* pSound = CStaticFunctionDefinitions::PlaySound3D ( pResource, strSound, bIsURL, vecPosition, bLoop );
+                    CClientSound* pSound = CStaticFunctionDefinitions::PlaySound3D ( pResource, strSound, bIsURL, vecPosition, bLoop, bThrottle );
                     if ( pSound )
                     {
                         // call onClientSoundStarted


### PR DESCRIPTION
Edits the following functions:
playSound ( string soundPath, [ bool looped = false, [ bool throttled = true ] ] )
playSound3D ( string soundPath, float x, float y, float z, [ bool looped = false, [ bool throttled = true ] ] )
throttled: A boolean representing whether the sound will be throttled. To throttle the sound, use true. Sounds will be throttled per default and only for URLs.

Throttled graph:
http://1drv.ms/1zUymd8

Not Throttled graph:
http://1drv.ms/1PA6aha
