### PR TITLE
Add compact argument for toJSON from ID 0008848

### DIFF
--- a/MTA10/mods/shared_logic/lua/CLuaArguments.cpp
+++ b/MTA10/mods/shared_logic/lua/CLuaArguments.cpp
@@ -529,12 +529,12 @@ bool CLuaArguments::WriteToBitStream ( NetBitStreamInterface& bitStream, CFastHa
 }
 
 
-bool CLuaArguments::WriteToJSONString ( std::string& strJSON, bool bSerialize )
+bool CLuaArguments::WriteToJSONString ( std::string& strJSON, bool bSerialize, bool bCompact )
 {
     json_object * my_array = WriteToJSONArray ( bSerialize );
     if ( my_array )
     {
-        strJSON = json_object_get_string ( my_array );
+        strJSON = json_object_to_json_string_ext ( my_array, bCompact ? JSON_C_TO_STRING_PLAIN : JSON_C_TO_STRING_SPACED );
         json_object_put ( my_array ); // dereference - causes a crash, is actually commented out in the example too
         return true;
     }

--- a/MTA10/mods/shared_logic/lua/CLuaArguments.h
+++ b/MTA10/mods/shared_logic/lua/CLuaArguments.h
@@ -75,7 +75,7 @@ public:
     bool                                                WriteToBitStream    ( NetBitStreamInterface& bitStream, CFastHashMap < CLuaArguments*, unsigned long > * pKnownTables = NULL ) const;
     void                                                ValidateTableKeys   ( void );
     bool                                                ReadFromJSONString  ( const char* szJSON );
-    bool                                                WriteToJSONString   ( std::string& strJSON, bool bSerialize = false );
+    bool                                                WriteToJSONString   ( std::string& strJSON, bool bSerialize = false, bool bCompact = false );
     json_object *                                       WriteTableToJSONObject ( bool bSerialize = false, CFastHashMap < CLuaArguments*, unsigned long > * pKnownTables = NULL );
     json_object *                                       WriteToJSONArray    ( bool bSerialize );
     bool                                                ReadFromJSONObject  ( json_object * object, std::vector < CLuaArguments* > * pKnownTables = NULL );

--- a/MTA10/mods/shared_logic/lua/CLuaFunctionDefs.Commands.cpp
+++ b/MTA10/mods/shared_logic/lua/CLuaFunctionDefs.Commands.cpp
@@ -121,13 +121,16 @@ int CLuaFunctionDefs::toJSON ( lua_State* luaVM )
 
     if ( !argStream.NextIsNil ( ) )
     {
+        bool bCompact = false;
         // Read the argument
         CLuaArguments JSON;
         JSON.ReadArgument ( luaVM, 1 );
+        argStream.Skip ( 1 );
+        argStream.ReadBool ( bCompact, false );
 
         // Convert it to a JSON string
         std::string strJSON;
-        if ( JSON.WriteToJSONString ( strJSON ) )
+        if ( JSON.WriteToJSONString ( strJSON, false, bCompact ) )
         {
             // Return the JSON string
             lua_pushstring ( luaVM, strJSON.c_str () );

--- a/MTA10/mods/shared_logic/lua/CLuaFunctionDefs.Commands.cpp
+++ b/MTA10/mods/shared_logic/lua/CLuaFunctionDefs.Commands.cpp
@@ -119,7 +119,7 @@ int CLuaFunctionDefs::toJSON ( lua_State* luaVM )
     // Got a string argument?
     CScriptArgReader argStream ( luaVM );
 
-    if ( !argStream.NextIsNil ( ) )
+    if ( !argStream.NextIsNil () )
     {
         bool bCompact = false;
         // Read the argument
@@ -128,14 +128,19 @@ int CLuaFunctionDefs::toJSON ( lua_State* luaVM )
         argStream.Skip ( 1 );
         argStream.ReadBool ( bCompact, false );
 
-        // Convert it to a JSON string
-        std::string strJSON;
-        if ( JSON.WriteToJSONString ( strJSON, false, bCompact ) )
+        if ( !argStream.HasErrors () )
         {
-            // Return the JSON string
-            lua_pushstring ( luaVM, strJSON.c_str () );
-            return 1;
+            // Convert it to a JSON string
+            std::string strJSON;
+            if ( JSON.WriteToJSONString ( strJSON, false, bCompact ) )
+            {
+                // Return the JSON string
+                lua_pushstring ( luaVM, strJSON.c_str () );
+                return 1;
+            }
         }
+        else
+            m_pScriptDebugging->LogCustom ( luaVM, argStream.GetFullErrorMessage () );
     }
     else
         m_pScriptDebugging->LogBadType ( luaVM );

--- a/MTA10_Server/mods/deathmatch/logic/lua/CLuaArguments.cpp
+++ b/MTA10_Server/mods/deathmatch/logic/lua/CLuaArguments.cpp
@@ -589,12 +589,12 @@ bool CLuaArguments::WriteToBitStream ( NetBitStreamInterface& bitStream, CFastHa
 }
 
 
-bool CLuaArguments::WriteToJSONString ( std::string& strJSON, bool bSerialize )
+bool CLuaArguments::WriteToJSONString ( std::string& strJSON, bool bSerialize, bool bCompact )
 {
     json_object * my_array = WriteToJSONArray ( bSerialize );
     if ( my_array )
     {
-        strJSON = json_object_get_string ( my_array );
+        strJSON = json_object_to_json_string_ext ( my_array, bCompact ? JSON_C_TO_STRING_PLAIN : JSON_C_TO_STRING_SPACED );
         json_object_put ( my_array ); // dereference - causes a crash, is actually commented out in the example too
         return true;
     }

--- a/MTA10_Server/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/MTA10_Server/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -93,7 +93,7 @@ public:
     bool                                                ReadFromBitStream   ( NetBitStreamInterface& bitStream, std::vector < CLuaArguments* > * pKnownTables = NULL );
     bool                                                ReadFromJSONString  ( const char* szJSON );
     bool                                                WriteToBitStream    ( NetBitStreamInterface& bitStream, CFastHashMap < CLuaArguments*, unsigned long > * pKnownTables = NULL ) const;
-    bool                                                WriteToJSONString   ( std::string& strJSON, bool bSerialize = false );
+    bool                                                WriteToJSONString   ( std::string& strJSON, bool bSerialize = false, bool bCompact = false );
     json_object *                                       WriteTableToJSONObject ( bool bSerialize = false, CFastHashMap < CLuaArguments*, unsigned long > * pKnownTables = NULL );
     json_object *                                       WriteToJSONArray    ( bool bSerialize );
     bool                                                ReadFromJSONObject  ( json_object * object, std::vector < CLuaArguments* > * pKnownTables = NULL );

--- a/MTA10_Server/mods/deathmatch/logic/lua/CLuaFunctionDefs.Utility.cpp
+++ b/MTA10_Server/mods/deathmatch/logic/lua/CLuaFunctionDefs.Utility.cpp
@@ -374,6 +374,7 @@ int CLuaFunctionDefs::toJSON ( lua_State* luaVM )
 {
     // Got a string argument?
     CScriptArgReader argStream ( luaVM );
+
     if ( !argStream.NextIsNil () )
     {
         bool bCompact = false;
@@ -383,15 +384,22 @@ int CLuaFunctionDefs::toJSON ( lua_State* luaVM )
         argStream.Skip ( 1 );
         argStream.ReadBool ( bCompact, false );
 
-        // Convert it to a JSON string
-        std::string strJSON;
-        if ( JSON.WriteToJSONString ( strJSON, false, bCompact ) )
+        if ( !argStream.HasErrors () )
         {
-            // Return the JSON string
-            lua_pushstring ( luaVM, strJSON.c_str () );
-            return 1;
+            // Convert it to a JSON string
+            std::string strJSON;
+            if ( JSON.WriteToJSONString ( strJSON, false, bCompact ) )
+            {
+                // Return the JSON string
+                lua_pushstring ( luaVM, strJSON.c_str () );
+                return 1;
+            }
         }
+        else
+            m_pScriptDebugging->LogCustom ( luaVM, argStream.GetFullErrorMessage () );
     }
+    else
+        m_pScriptDebugging->LogBadType ( luaVM );
 
     // Failed
     lua_pushnil ( luaVM );

--- a/MTA10_Server/mods/deathmatch/logic/lua/CLuaFunctionDefs.Utility.cpp
+++ b/MTA10_Server/mods/deathmatch/logic/lua/CLuaFunctionDefs.Utility.cpp
@@ -376,13 +376,16 @@ int CLuaFunctionDefs::toJSON ( lua_State* luaVM )
     CScriptArgReader argStream ( luaVM );
     if ( !argStream.NextIsNil () )
     {
+        bool bCompact = false;
         // Read the argument
         CLuaArguments JSON;
         JSON.ReadArgument ( luaVM, 1 );
+        argStream.Skip ( 1 );
+        argStream.ReadBool ( bCompact, false );
 
         // Convert it to a JSON string
         std::string strJSON;
-        if ( JSON.WriteToJSONString ( strJSON ) )
+        if ( JSON.WriteToJSONString ( strJSON, false, bCompact ) )
         {
             // Return the JSON string
             lua_pushstring ( luaVM, strJSON.c_str () );


### PR DESCRIPTION
Edits the following function server-/client-side:
string toJSON ( var value[, bool compact = false] )

compact : A boolean representing whether the json string will be output without white spaces. To remove white spaces, use true. White spaces will be inserted per default.

Screenshot:
http://1drv.ms/1Is2IGF
