### PR TITLE
New server side event: onPlayerTeamChange

### DIFF
--- a/MTA10_Server/mods/deathmatch/logic/CElementDeleter.cpp
+++ b/MTA10_Server/mods/deathmatch/logic/CElementDeleter.cpp
@@ -22,18 +22,27 @@ void CElementDeleter::Delete ( class CElement* pElement, bool bUnlink, bool bUpd
     {
         if ( !IsBeingDeleted ( pElement ) )
         {
+            // Flag it as being deleted
+            pElement->SetIsBeingDeleted ( true );
+
+            // We have to call RemoveAllPlayers here so it's not too late for it
+            // to trigger onPlayerTeamChange with a valid element as previous team
+            if ( pElement->GetType ( ) == CElement::TEAM )
+            {
+                ( ( CTeam* ) pElement )->RemoveAllPlayers ( );
+            }
+
             // Before we do anything, fire the on-destroy event
             CLuaArguments Arguments;
             pElement->CallEvent ( "onElementDestroy", Arguments );
 
             // Add it to our list
-            if ( !pElement->IsBeingDeleted () )
+            if ( !IsBeingDeleted ( pElement ) )
             {
                 m_List.push_back ( pElement );
             }
 
-            // Flag it as being deleted and unlink it from the tree/managers
-            pElement->SetIsBeingDeleted ( true );
+            // unlink it from the tree/managers
             pElement->ClearChildren ();
             pElement->SetParentObject ( NULL, bUpdatePerPlayerEntities );
 

--- a/MTA10_Server/mods/deathmatch/logic/CGame.cpp
+++ b/MTA10_Server/mods/deathmatch/logic/CGame.cpp
@@ -1475,7 +1475,8 @@ void CGame::AddBuiltInEvents ( void )
     m_Events.AddEvent ( "onPlayerCommand", "command", NULL, false );
     m_Events.AddEvent ( "onPlayerModInfo", "type, ids, names", NULL, false );
     m_Events.AddEvent ( "onPlayerNetworkStatus", "type, ticks", NULL, false );
-    m_Events.AddEvent ( "onPlayerScreenShot", "resource, status, file_data, timestamp, tag", NULL, false );
+    m_Events.AddEvent ( "onPlayerScreenShot", "resource, status, file_data, timestamp, tag", NULL, false);
+    m_Events.AddEvent ( "onPlayerTeamChange", "previous, current", NULL, false);
 
     // Ped events
     m_Events.AddEvent ( "onPedWasted", "ammo, killer, weapon, bodypart", NULL, false );

--- a/MTA10_Server/mods/deathmatch/logic/CPlayer.cpp
+++ b/MTA10_Server/mods/deathmatch/logic/CPlayer.cpp
@@ -490,12 +490,22 @@ void CPlayer::SetTeam ( CTeam* pTeam, bool bChangeTeam )
 {
     if ( pTeam == m_pTeam ) return;
 
+    // Setting parameters for the onPlayerTeamChange event
+    CLuaArguments Arguments;
+    Arguments.PushElement( m_pTeam );
+    Arguments.PushElement( pTeam );
+
+    // Trigger onPlayerTeamChange and cancel the execution if canceled (but you can't cancel it if it's because of the player's team being deleted)
+    if ( !CallEvent ( "onPlayerTeamChange", Arguments ) && m_pTeam && !m_pTeam->IsBeingDeleted ( ) )
+        return;
+
     if ( m_pTeam && bChangeTeam )
         m_pTeam->RemovePlayer ( this, false );
 
+    if ( pTeam && bChangeTeam )
+        pTeam->AddPlayer ( this, false );
+
     m_pTeam = pTeam;
-    if ( m_pTeam && bChangeTeam )
-        m_pTeam->AddPlayer ( this, false );
 }
 
 

--- a/MTA10_Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/MTA10_Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -9134,7 +9134,7 @@ bool CStaticFunctionDefinitions::SetPlayerTeam ( CPlayer* pPlayer, CTeam* pTeam 
     assert ( pPlayer );
 
     // If its a different team
-    if ( pTeam != pPlayer->GetTeam () )
+    if ( pTeam != pPlayer->GetTeam ( ) )
     {
         // Change his team
         pPlayer->SetTeam ( pTeam, true );

--- a/MTA10_Server/mods/deathmatch/logic/CTeam.cpp
+++ b/MTA10_Server/mods/deathmatch/logic/CTeam.cpp
@@ -30,7 +30,7 @@ CTeam::CTeam ( CTeamManager* pTeamManager, CElement* pParent, CXMLNode* pNode, c
 
 CTeam::~CTeam ( void )
 {
-    RemoveAllPlayers ();
+    //RemoveAllPlayers (); // Already called in CElementDeleter::Delete
     Unlink ();
 }
 


### PR DESCRIPTION
This is my first pull-request and I added the onPlayerTeamChange server side event using the player as source and the handler arguments oldTeam, newTeam.

Btw, if the previous team was null, I'm still sending that value as is. So I don't know if it's an ok way to do.

Just got the idea because of a Scripting thread I replied with an homemade onPlayerTeamChange with a setTimer to check the players team because the guy needed that event.

source: The player who changed team
oldTeam: The previous player's team if any, nil otherwise
newTeam: The new player's team
