### PR TITLE
Element freezing changes

### DIFF
--- a/MTA10/game_sa/CPhysicalSA.cpp
+++ b/MTA10/game_sa/CPhysicalSA.cpp
@@ -370,3 +370,22 @@ void CPhysicalSA::SetLighting ( float fLighting )
     CPhysicalSAInterface * pInterface = (CPhysicalSAInterface *)this->GetInterface();
     pInterface->m_fLighting = fLighting;
 }
+
+void CPhysicalSA::SetMovementDisabled ( bool bDisabled )
+{
+    CPhysicalSAInterface * pInterface = (CPhysicalSAInterface *) this->GetInterface();
+    // Ignore non gravity entities
+    if ( pInterface->bApplyGravity )
+    {
+        // Make entity (not) movable
+        pInterface->bDisableMovement = bDisabled;
+        // Make entity (not) rotatable
+        pInterface->bDisableFriction = bDisabled;
+    }
+    else
+    {
+        // Reset move speed manually only for non gravity entities 
+        SetMoveSpeed ( &CVector() );
+    }
+    SetTurnSpeed ( &CVector() );
+}

--- a/MTA10/game_sa/CPhysicalSA.h
+++ b/MTA10/game_sa/CPhysicalSA.h
@@ -153,6 +153,8 @@ public:
     float       GetLighting                 ( void );
     void        SetLighting                 ( float fLighting );
 
+    void        SetMovementDisabled         ( bool bDisabled );
+
     /*
     VOID        SetMassMultiplier(FLOAT fMassMultiplier);
     FLOAT       GetMassMultiplier();

--- a/MTA10/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/MTA10/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1119,21 +1119,18 @@ bool CStaticFunctionDefinitions::SetElementVelocity ( CClientEntity& Entity, con
         case CCLIENTPLAYER:
         {
             CClientPed& Ped = static_cast < CClientPed& > ( Entity );
-            Ped.SetMoveSpeed ( vecVelocity );
-            break;
+            return Ped.SetMoveSpeed ( vecVelocity );
         }
         case CCLIENTVEHICLE:
         {
             CClientVehicle& Vehicle = static_cast < CClientVehicle& > ( Entity );
-            Vehicle.SetMoveSpeed ( vecVelocity );
-            break;
+            return Vehicle.SetMoveSpeed ( vecVelocity );
         }
         case CCLIENTOBJECT:
         case CCLIENTWEAPON:
         {
             CClientObject& Object = static_cast < CClientObject& > ( Entity );
-            Object.SetMoveSpeed ( vecVelocity );
-            break;
+            return Object.SetMoveSpeed ( vecVelocity );
         }
         case CCLIENTPROJECTILE:
         {

--- a/MTA10/mods/shared_logic/CClientObject.cpp
+++ b/MTA10/mods/shared_logic/CClientObject.cpp
@@ -342,7 +342,10 @@ void CClientObject::Render ( void )
 void CClientObject::SetStatic ( bool bStatic )
 {
     m_bIsStatic = bStatic;
-    m_pObject->SetMovementDisabled ( bStatic );
+    if ( m_pObject )
+    {
+        m_pObject->SetMovementDisabled ( bStatic );
+    }
     m_vecMoveSpeed = CVector();
 }
 

--- a/MTA10/mods/shared_logic/CClientObject.cpp
+++ b/MTA10/mods/shared_logic/CClientObject.cpp
@@ -342,7 +342,8 @@ void CClientObject::Render ( void )
 void CClientObject::SetStatic ( bool bStatic )
 {
     m_bIsStatic = bStatic;
-    StreamOutForABit ( );
+    m_pObject->SetMovementDisabled ( bStatic );
+    m_vecMoveSpeed = CVector();
 }
 
 
@@ -502,10 +503,8 @@ void CClientObject::Create ( void )
                 // Add XRef
                 g_pClientGame->GetGameEntityXRefManager ()->AddEntityXRef ( this, m_pObject );
 
-                // If set to true,this has the effect of forcing the object to be static at all times
-                m_pObject->SetStaticWaitingForCollision ( m_bIsStatic );
-
                 // Apply our data to the object
+                m_pObject->SetMovementDisabled ( m_bIsStatic );
                 m_pObject->Teleport ( m_vecPosition.fX, m_vecPosition.fY, m_vecPosition.fZ );
                 m_pObject->SetOrientation ( m_vecRotation.fX, m_vecRotation.fY, m_vecRotation.fZ );
                 #ifndef MTA_BUILDINGS
@@ -644,13 +643,18 @@ void CClientObject::GetMoveSpeed ( CVector& vecMoveSpeed ) const
 }
 
 
-void CClientObject::SetMoveSpeed ( const CVector& vecMoveSpeed )
+bool CClientObject::SetMoveSpeed ( const CVector& vecMoveSpeed )
 {
-    if ( m_pObject )
+    if ( !m_bIsStatic )
     {
-        m_pObject->SetMoveSpeed ( const_cast < CVector* > ( &vecMoveSpeed ) );
+        if ( m_pObject )
+        {
+            m_pObject->SetMoveSpeed ( const_cast < CVector* > ( &vecMoveSpeed ) );
+        }
+        m_vecMoveSpeed = vecMoveSpeed;
+        return true;
     }
-    m_vecMoveSpeed = vecMoveSpeed;
+    return false;
 }
 
 

--- a/MTA10/mods/shared_logic/CClientObject.h
+++ b/MTA10/mods/shared_logic/CClientObject.h
@@ -54,7 +54,7 @@ public:
     virtual void                    SetRotationRadians      ( const CVector& vecRotation );
 
     void                            GetMoveSpeed            ( CVector& vecMoveSpeed ) const;
-    void                            SetMoveSpeed            ( const CVector& vecMoveSpeed );
+    bool                            SetMoveSpeed            ( const CVector& vecMoveSpeed );
 
     void                            GetOrientation          ( CVector& vecPosition, CVector& vecRotationRadians );
     virtual void                    SetOrientation          ( const CVector& vecPosition, const CVector& vecRotationRadians );

--- a/MTA10/mods/shared_logic/CClientPed.cpp
+++ b/MTA10/mods/shared_logic/CClientPed.cpp
@@ -790,13 +790,18 @@ void CClientPed::GetMoveSpeed ( CVector& vecMoveSpeed ) const
 }
 
 
-void CClientPed::SetMoveSpeed ( const CVector& vecMoveSpeed )
+bool CClientPed::SetMoveSpeed ( const CVector& vecMoveSpeed )
 {
-    if ( m_pPlayerPed )
+    if ( !m_bFrozen )
     {
-        m_pPlayerPed->SetMoveSpeed ( const_cast < CVector* > ( &vecMoveSpeed ) );
+        if ( m_pPlayerPed )
+        {
+            m_pPlayerPed->SetMoveSpeed ( const_cast < CVector* > ( &vecMoveSpeed ) );
+        }
+        m_vecMoveSpeed = vecMoveSpeed;
+        return true;
     }
-    m_vecMoveSpeed = vecMoveSpeed;
+    return false;
 }
 
 
@@ -813,13 +818,18 @@ void CClientPed::GetTurnSpeed ( CVector& vecTurnSpeed ) const
 }
 
 
-void CClientPed::SetTurnSpeed ( const CVector& vecTurnSpeed )
+bool CClientPed::SetTurnSpeed ( const CVector& vecTurnSpeed )
 {
-    if ( m_pPlayerPed )
+    if ( !m_bFrozen )
     {
-        m_pPlayerPed->SetTurnSpeed ( const_cast < CVector* > ( &vecTurnSpeed ) );
+        if ( m_pPlayerPed )
+        {
+            m_pPlayerPed->SetTurnSpeed ( const_cast < CVector* > ( &vecTurnSpeed ) );
+        }
+        m_vecTurnSpeed = vecTurnSpeed;
+        return true;
     }
-    m_vecTurnSpeed = vecTurnSpeed;
+    return false;
 }
 
 

--- a/MTA10/mods/shared_logic/CClientPed.h
+++ b/MTA10/mods/shared_logic/CClientPed.h
@@ -186,10 +186,10 @@ public:
     void                        SetCameraRotation           ( float fRotation );
 
     void                        GetMoveSpeed                ( CVector& vecMoveSpeed ) const;
-    void                        SetMoveSpeed                ( const CVector& vecMoveSpeed );
+    bool                        SetMoveSpeed                ( const CVector& vecMoveSpeed );
 
     void                        GetTurnSpeed                ( CVector& vecTurnSpeed ) const;
-    void                        SetTurnSpeed                ( const CVector& vecTurnSpeed );
+    bool                        SetTurnSpeed                ( const CVector& vecTurnSpeed );
 
     void                        GetControllerState          ( CControllerState& ControllerState );
     void                        GetLastControllerState      ( CControllerState& ControllerState );

--- a/MTA10/mods/shared_logic/CClientVehicle.cpp
+++ b/MTA10/mods/shared_logic/CClientVehicle.cpp
@@ -557,7 +557,7 @@ void CClientVehicle::GetMoveSpeedMeters ( CVector& vecMoveSpeed ) const
 }
 
 
-void CClientVehicle::SetMoveSpeed ( const CVector& vecMoveSpeed )
+bool CClientVehicle::SetMoveSpeed ( const CVector& vecMoveSpeed )
 {
     if ( !m_bIsFrozen )
     {
@@ -569,7 +569,9 @@ void CClientVehicle::SetMoveSpeed ( const CVector& vecMoveSpeed )
 
         if ( IsFrozenWaitingForGroundToLoad() )
             m_vecWaitingForGroundSavedMoveSpeed = vecMoveSpeed;
+        return true;
     }
+    return false;
 }
 
 
@@ -590,7 +592,7 @@ void CClientVehicle::GetTurnSpeed ( CVector& vecTurnSpeed ) const
 }
 
 
-void CClientVehicle::SetTurnSpeed ( const CVector& vecTurnSpeed )
+bool CClientVehicle::SetTurnSpeed ( const CVector& vecTurnSpeed )
 {
     if ( !m_bIsFrozen )
     {
@@ -602,7 +604,9 @@ void CClientVehicle::SetTurnSpeed ( const CVector& vecTurnSpeed )
 
         if ( IsFrozenWaitingForGroundToLoad() )
             m_vecWaitingForGroundSavedTurnSpeed = vecTurnSpeed;
+        return true;
     }
+    return false;
 }
 
 

--- a/MTA10/mods/shared_logic/CClientVehicle.h
+++ b/MTA10/mods/shared_logic/CClientVehicle.h
@@ -176,9 +176,9 @@ public:
 
     void                        GetMoveSpeed            ( CVector& vecMoveSpeed ) const;
     void                        GetMoveSpeedMeters      ( CVector& vecMoveSpeed ) const;
-    void                        SetMoveSpeed            ( const CVector& vecMoveSpeed );
+    bool                        SetMoveSpeed            ( const CVector& vecMoveSpeed );
     void                        GetTurnSpeed            ( CVector& vecTurnSpeed ) const;
-    void                        SetTurnSpeed            ( const CVector& vecTurnSpeed );
+    bool                        SetTurnSpeed            ( const CVector& vecTurnSpeed );
 
     bool                        IsVisible               ( void );
     void                        SetVisible              ( bool bVisible );

--- a/MTA10/sdk/game/CPhysical.h
+++ b/MTA10/sdk/game/CPhysical.h
@@ -51,6 +51,8 @@ public:
     virtual float       GetLighting                 ( void ) = 0;
     virtual void        SetLighting                 ( float fLighting ) = 0;
 
+    virtual void        SetMovementDisabled         ( bool bDisabled ) = 0;
+
 /*  virtual VOID        SetMass(FLOAT fMass)=0;
     virtual FLOAT       GetMass()=0;
     virtual VOID        SetTurnMass(FLOAT fTurnMass)=0;


### PR DESCRIPTION
Do not recreate object when changing frozen state - fixes frozen related
crashes described in #8765 and looks better (object don't "blink").
Made clientside setElementVelocity & setVehicleTurnVelocity return false if element
is frozen (it does nothing already, so would be good to inform user there is no effect).
