### PR TITLE
Make getAlivePlayers() exclude unspawned players

### DIFF
--- a/MTA10_Server/mods/deathmatch/logic/CGame.cpp
+++ b/MTA10_Server/mods/deathmatch/logic/CGame.cpp
@@ -3866,9 +3866,6 @@ void CGame::PlayerCompleteConnect ( CPlayer* pPlayer, bool bSuccess, const char*
 
         // Send him the join details
         pPlayer->Send ( CPlayerConnectCompletePacket () );
-
-        // The player is spawned when he's connected, just the Camera is not faded in/not targetting
-        pPlayer->SetSpawned ( true );
     }
     else
     {

--- a/MTA10_Server/mods/deathmatch/logic/luadefs/CLuaHandlingDefs.cpp
+++ b/MTA10_Server/mods/deathmatch/logic/luadefs/CLuaHandlingDefs.cpp
@@ -16,13 +16,13 @@
 void CLuaHandlingDefs::LoadFunctions ( void )
 {
     // Set
-    CLuaCFunctions::AddFunction ( "setVehicleHandling", CLuaHandlingDefs::SetVehicleHandling );
-    CLuaCFunctions::AddFunction ( "setModelHandling", CLuaHandlingDefs::SetModelHandling );
+    CLuaCFunctions::AddFunction ( "setVehicleHandling", SetVehicleHandling );
+    CLuaCFunctions::AddFunction ( "setModelHandling", SetModelHandling );
 
     // Get
-    CLuaCFunctions::AddFunction ( "getVehicleHandling", CLuaHandlingDefs::GetVehicleHandling );
-    CLuaCFunctions::AddFunction ( "getModelHandling", CLuaHandlingDefs::GetModelHandling );
-    CLuaCFunctions::AddFunction ( "getOriginalHandling", CLuaHandlingDefs::GetOriginalHandling );
+    CLuaCFunctions::AddFunction ( "getVehicleHandling", GetVehicleHandling );
+    CLuaCFunctions::AddFunction ( "getModelHandling", GetModelHandling );
+    CLuaCFunctions::AddFunction ( "getOriginalHandling", GetOriginalHandling );
 }
 
 int CLuaHandlingDefs::SetVehicleHandling ( lua_State* luaVM )

--- a/MTA10_Server/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
+++ b/MTA10_Server/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
@@ -500,27 +500,21 @@ int CLuaPlayerDefs::GetPlayerWantedLevel ( lua_State* luaVM )
 
 int CLuaPlayerDefs::GetAlivePlayers ( lua_State* luaVM )
 {
-    CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine ( luaVM );
-    if ( pLuaMain )
-    {
-        // Create a new table
-        lua_newtable ( luaVM );
+    // Create a new table
+    lua_newtable ( luaVM );
 
-        // Add all alive players
-        unsigned int uiIndex = 0;
-        list < CPlayer* > ::const_iterator iter = m_pPlayerManager->IterBegin ();
-        for ( ; iter != m_pPlayerManager->IterEnd (); ++iter )
+    // Add all alive players
+    unsigned int uiIndex = 0;
+    list < CPlayer* > ::const_iterator iter = m_pPlayerManager->IterBegin ();
+    for ( ; iter != m_pPlayerManager->IterEnd (); ++iter )
+    {
+        if ( ( *iter )->IsSpawned () && !( *iter )->IsBeingDeleted () )
         {
-            if ( ( *iter )->IsSpawned () && !( *iter )->IsBeingDeleted () )
-            {
-                lua_pushnumber ( luaVM, ++uiIndex );
-                lua_pushelement ( luaVM, *iter );
-                lua_settable ( luaVM, -3 );
-            }
+            lua_pushnumber ( luaVM, ++uiIndex );
+            lua_pushelement ( luaVM, *iter );
+            lua_settable ( luaVM, -3 );
         }
-        return 1;
     }
-    lua_pushboolean ( luaVM, false );
     return 1;
 }
 


### PR DESCRIPTION
This would fix https://bugs.mtasa.com/view.php?id=5705

At the moment the game thinks that a player is spawned when they have
joined, even if spawnPlayer was not called.

This commit could introduce BC issues and needs to be tested thoroughly.
