### PR TITLE
0008565: Radio in some interiors doesn't play by default

### DIFF
--- a/MTA10/mods/deathmatch/logic/CClientGame.cpp
+++ b/MTA10/mods/deathmatch/logic/CClientGame.cpp
@@ -285,6 +285,7 @@ CClientGame::CClientGame ( bool bLocalPlay )
     g_pMultiplayer->SetGameEntityRenderHandler( CClientGame::StaticGameEntityRenderHandler );
     g_pMultiplayer->SetFxSystemDestructionHandler ( CClientGame::StaticFxSystemDestructionHandler );
     g_pMultiplayer->SetDrivebyAnimationHandler( CClientGame::StaticDrivebyAnimationHandler );
+    g_pMultiplayer->SetAudioZoneRadioSwitchHandler ( CClientGame::StaticAudioZoneRadioSwitchHandler );
     g_pGame->SetPreWeaponFireHandler ( CClientGame::PreWeaponFire );
     g_pGame->SetPostWeaponFireHandler ( CClientGame::PostWeaponFire );
     g_pGame->SetTaskSimpleBeHitHandler ( CClientGame::StaticTaskSimpleBeHitHandler );
@@ -3811,6 +3812,11 @@ AnimationId CClientGame::StaticDrivebyAnimationHandler(AnimationId animGroup, As
     return g_pClientGame->DrivebyAnimationHandler(animGroup, animId);
 }
 
+void CClientGame::StaticAudioZoneRadioSwitchHandler ( DWORD dwStationID )
+{
+    g_pClientGame->AudioZoneRadioSwitchHandler ( dwStationID );
+}
+
 void CClientGame::DrawRadarAreasHandler ( void )
 {
     m_pRadarAreaManager->DoPulse ();
@@ -6620,6 +6626,11 @@ AnimationId CClientGame::DrivebyAnimationHandler(AnimationId animId, AssocGroupI
         return 231;
 
     return animId;
+}
+
+void CClientGame::AudioZoneRadioSwitchHandler ( DWORD dwStationID )
+{
+    m_pPlayerManager->GetLocalPlayer ()->SetCurrentRadioChannel ( dwStationID );
 }
 
 

--- a/MTA10/mods/deathmatch/logic/CClientGame.h
+++ b/MTA10/mods/deathmatch/logic/CClientGame.h
@@ -525,6 +525,7 @@ private:
     static void                         StaticTaskSimpleBeHitHandler    ( CPedSAInterface* pPedAttacker, ePedPieceTypes hitBodyPart, int hitBodySide, int weaponId );
     static void                         StaticFxSystemDestructionHandler ( void * pFxSAInterface );
     static AnimationId                  StaticDrivebyAnimationHandler   ( AnimationId animGroup, AssocGroupId animId );
+    static void                         StaticAudioZoneRadioSwitchHandler   ( DWORD dwStationID );
 
     bool                                DamageHandler                   ( CPed* pDamagePed, CEventDamage * pEvent );
     void                                DeathHandler                    ( CPed* pKilledPed, unsigned char ucDeathReason, unsigned char ucBodyPart );
@@ -554,6 +555,7 @@ private:
     void                                WorldSoundHandler               ( uint uiGroup, uint uiIndex );
     void                                TaskSimpleBeHitHandler          ( CPedSAInterface* pPedAttacker, ePedPieceTypes hitBodyPart, int hitBodySide, int weaponId );
     AnimationId                         DrivebyAnimationHandler         ( AnimationId animGroup, AssocGroupId animId );
+    void                                AudioZoneRadioSwitchHandler     ( DWORD dwStationID );
 
     static bool                         StaticProcessMessage            ( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );
     bool                                ProcessMessage                  ( HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam );

--- a/MTA10/multiplayer_sa/CMultiplayerSA.cpp
+++ b/MTA10/multiplayer_sa/CMultiplayerSA.cpp
@@ -292,6 +292,9 @@ DWORD RETURN_CTaskSimplyGangDriveBy__ProcessPed = 0x62D5AC;
 DWORD RETURN_CAERadioTrackManager__ChooseMusicTrackIndex             = 0x4EA2A0;
 DWORD RETURN_CAERadioTrackManager__ChooseMusicTrackIndex_Regenerate  = 0x04EA286;
 
+#define HOOKPOS_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StartRadio    0x4D7198
+#define HOOKPOS_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StopRadio     0x4D71E7
+
 CPed* pContextSwitchedPed = 0;
 CVector vecCenterOfWorld;
 FLOAT fFalseHeading;
@@ -361,6 +364,7 @@ ObjectDamageHandler* m_pObjectDamageHandler = NULL;
 ObjectBreakHandler* m_pObjectBreakHandler = NULL;
 FxSystemDestructionHandler* m_pFxSystemDestructionHandler = NULL;
 DrivebyAnimationHandler* m_pDrivebyAnimationHandler = NULL;
+AudioZoneRadioSwitchHandler* m_pAudioZoneRadioSwitchHandler = NULL;
 
 CEntitySAInterface * dwSavedPlayerPointer = 0;
 CEntitySAInterface * activeEntityForStreaming = 0; // the entity that the streaming system considers active
@@ -505,6 +509,9 @@ void HOOK_FxManager_c__DestroyFxSystem ();
 void HOOK_CTaskSimpleGangDriveBy__ProcessPed();
 
 void HOOK_CAERadioTrackManager__ChooseMusicTrackIndex ( );
+
+void HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StartRadio ( );
+void HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StopRadio ( );
 
 CMultiplayerSA::CMultiplayerSA()
 {
@@ -718,6 +725,9 @@ void CMultiplayerSA::InitHooks()
         // CAERadioTrackManager::ChooseMusicTrackIndex hook for fixing a crash with the steam audio files
         HookInstall(HOOKPOS_CAERadioTrackManager__ChooseMusicTrackIndex, (DWORD) HOOK_CAERadioTrackManager__ChooseMusicTrackIndex, 10);
     }
+    
+    HookInstall ( HOOKPOS_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StartRadio, (DWORD) HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StartRadio, 5 );
+    HookInstall ( HOOKPOS_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StopRadio, (DWORD) HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StopRadio, 5 );
 
     // Disable GTA setting g_bGotFocus to false when we minimize
     MemSet ( (void *)ADDR_GotFocus, 0x90, pGameInterface->GetGameVersion () == VERSION_EU_10 ? 6 : 10 );
@@ -2224,6 +2234,11 @@ void CMultiplayerSA::SetFxSystemDestructionHandler ( FxSystemDestructionHandler 
 void CMultiplayerSA::SetDrivebyAnimationHandler(DrivebyAnimationHandler * pHandler)
 {
     m_pDrivebyAnimationHandler = pHandler;
+}
+
+void CMultiplayerSA::SetAudioZoneRadioSwitchHandler ( AudioZoneRadioSwitchHandler * pHandler )
+{
+    m_pAudioZoneRadioSwitchHandler = pHandler;
 }
 
 // What we do here is check if the idle handler has been set
@@ -6866,5 +6881,51 @@ void _declspec(naked) HOOK_CAERadioTrackManager__ChooseMusicTrackIndex ( )
         mov ecx, dwNumberOfTracks
         // jump back to normal processing
         jmp RETURN_CAERadioTrackManager__ChooseMusicTrackIndex
+    }
+}
+
+DWORD dwLastRequestedStation = -1;
+void CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume ( DWORD dwStationID )
+{
+    // Avoid event spam.
+    if ( dwLastRequestedStation != dwStationID )
+    {
+        if ( m_pAudioZoneRadioSwitchHandler  )
+        {
+            m_pAudioZoneRadioSwitchHandler ( dwStationID );
+        }
+    }
+    dwLastRequestedStation = dwStationID;
+}
+
+void _declspec(naked) HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StartRadio ( )
+{
+    _asm
+    {
+        push    [esi+3]
+        call    CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume
+        add     esp, 4
+        pop     edi
+        pop     esi
+        pop     ebp
+        pop     ebx
+        add     esp, 36
+        retn
+    }
+}
+
+void _declspec(naked) HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StopRadio ( )
+{
+    _asm
+    {
+        push    0
+        call    CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume
+        add     esp, 4
+        pop     edi
+        pop     esi
+        pop     ebp
+        pop     ebx
+        add     esp, 36
+        retn
     }
 }

--- a/MTA10/multiplayer_sa/CMultiplayerSA.h
+++ b/MTA10/multiplayer_sa/CMultiplayerSA.h
@@ -128,6 +128,7 @@ public:
     void                        SetGameEntityRenderHandler  ( GameEntityRenderHandler * pHandler );
     void                        SetFxSystemDestructionHandler ( FxSystemDestructionHandler * pHandler );
     void                        SetDrivebyAnimationHandler  (DrivebyAnimationHandler * pHandler);
+    void                        SetAudioZoneRadioSwitchHandler ( AudioZoneRadioSwitchHandler * pHandler );
 
     void                        AllowMouseMovement          ( bool bAllow );
     void                        DoSoundHacksOnLostFocus     ( bool bLostFocus );

--- a/MTA10/sdk/multiplayer/CMultiplayer.h
+++ b/MTA10/sdk/multiplayer/CMultiplayer.h
@@ -81,6 +81,7 @@ typedef void ( GameModelRemoveHandler ) ( ushort usModelId );
 typedef void ( GameEntityRenderHandler ) ( CEntitySAInterface* pEntity );
 typedef void ( FxSystemDestructionHandler ) ( void* pFxSA );
 typedef AnimationId(DrivebyAnimationHandler) (AnimationId animGroup, AssocGroupId animId);
+typedef void ( AudioZoneRadioSwitchHandler ) ( DWORD dwStationID );
 
 /**
  * This class contains information used for shot syncing, one exists per player.
@@ -194,6 +195,7 @@ public:
     virtual void                        SetGameEntityRenderHandler      ( GameEntityRenderHandler * pHandler ) = 0;
     virtual void                        SetFxSystemDestructionHandler   ( FxSystemDestructionHandler * pHandler ) = 0;
     virtual void                        SetDrivebyAnimationHandler      (DrivebyAnimationHandler * pHandler) = 0;
+    virtual void                        SetAudioZoneRadioSwitchHandler  ( AudioZoneRadioSwitchHandler * pHandler ) = 0;
 
     virtual void                        AllowMouseMovement          ( bool bAllow ) = 0;
     virtual void                        DoSoundHacksOnLostFocus     ( bool bLostFocus ) = 0;


### PR DESCRIPTION
Radio zones doesn't work because StartRadio & StopRadio is disabled by MTA. I do hook in audio zones update function and now it's handled by MTA functions so onClientPlayerRadioSwitch event is called and also can be canceled. setInteriorSoundsEnabled works as before.

The only minor problem is this affect vehicle radio too, so for example if you leave zone it changes radio to 0. I don't know how to avoid this as this is shared.
