### PR TITLE
0009159: Self created water becomes invisible in higher z-offsets

### DIFF
--- a/MTA10/multiplayer_sa/CMultiplayerSA.cpp
+++ b/MTA10/multiplayer_sa/CMultiplayerSA.cpp
@@ -545,6 +545,7 @@ CMultiplayerSA::CMultiplayerSA()
 
     m_bHeatHazeEnabled = true;
     m_bHeatHazeCustomized = false;
+    m_fMaddDoggPoolLevel = 1082.73f;
 }
 
 void CMultiplayerSA::InitHooks()
@@ -1440,6 +1441,18 @@ void CMultiplayerSA::InitHooks()
 
     // Increase intensity of vehicle tail light corona
     MemPut < BYTE > ( 0x6E1A22, 0xF0 );
+
+    // Do not change visibility flag for water areas above level 950 (fix for #9159)
+    // do it only for Madd Dogg's mansion pool instead
+    MemPut ( 0x6E5869, &m_fMaddDoggPoolLevel );
+    MemPut ( 0x6E58BD, &m_fMaddDoggPoolLevel );
+    MemPut ( 0x6E594B, &m_fMaddDoggPoolLevel );
+    MemPut ( 0x6E5995, &m_fMaddDoggPoolLevel );
+
+    MemCpy ( (void*) 0x6E5871, "\x40\x74", 2 );
+    MemCpy ( (void*) 0x6E58C5, "\x40\x74", 2 );
+    MemCpy ( (void*) 0x6E5951, "\x40\x74", 2 );
+    MemCpy ( (void*) 0x6E599D, "\x40\x74", 2 );
 
 
     InitHooks_CrashFixHacks ();

--- a/MTA10/multiplayer_sa/CMultiplayerSA.h
+++ b/MTA10/multiplayer_sa/CMultiplayerSA.h
@@ -281,6 +281,7 @@ private:
     bool                        m_bHeatHazeEnabled;
     bool                        m_bHeatHazeCustomized;
     float                       m_fNearClipDistance;
+    float                       m_fMaddDoggPoolLevel;
 
 /*  VOID                        SetPlayerShotVectors(CPlayerPed* player, Vector3D * vecTarget, Vector3D * vecStart);
     VOID                        SetPlayerCameraVectors(CPlayerPed* player, Vector3D * vecSource, Vector3D * vecFront);


### PR DESCRIPTION
This is a little tricky but... original way is tricky. Originally this function change visibility flag for all water above 950 level. This visibility flag mean the water is visible only in interior 5 (you can check this by changing the last line number in water.dat to 2). I changed these checks so now it is
`== 1082.73`
instead of
`> 950`
This new float is the exactly Madd Dogg's mansion pool level so this won't break anything and allow creating new water areas in the sky.

To be more precise, I changed 

```
fcomp   ds:flt_MaddDoggPoolLevel
fnstsw  ax
test    ah, 41h
jnz     ...
```

to

```
(...)
test    ah, 40h
jz      ...
```

x4

Review/discussion/whateva please.
