### PR TITLE
Fix invalid time conversion causing assertion failure.

### DIFF
--- a/MTA10/core/CVersionUpdater.Util.hpp
+++ b/MTA10/core/CVersionUpdater.Util.hpp
@@ -316,7 +316,7 @@ namespace
         SString ToString ( void ) const
         {
             time_t t = ToSeconds ();
-            tm* tmp = gmtime ( &t );
+            tm* tmp = localtime ( &t );
             assert ( tmp );
 
             char outstr[200] = { 0 };


### PR DESCRIPTION
Bug: mktime works on local time and gmtime on UTC time. You cant mix them up.
History: I had assertion failure when running MTA in Wine because gmtime was returning NULL. t was equal to -1. Problem was caused by mktime being to able to convert "1970-01-01 00:00:00" from version_lastchecktime to time_t. Im in GMT+1 and mktime returns -1 for me for dates < "1970-01-01 01:00:00". Don't blame Wine for anything because on Windows mktime returns -1 too. There is one thing I dont understand. MTA didnt crash for me on Windows even if I set version_lastchecktime to some invalid dates before 1970. Maybe assert function is working differently there.
