### PR TITLE
Support for objects and weapons in ped damage events

### DIFF
--- a/MTA10/game_sa/CEventDamageSA.cpp
+++ b/MTA10/game_sa/CEventDamageSA.cpp
@@ -79,6 +79,9 @@ CEntity * CEventDamageSA::GetInflictingEntity ( void )
             case ENTITY_TYPE_VEHICLE:
                 pReturn = pPools->GetVehicle ( (DWORD *)pInterface );
                 break;
+            case ENTITY_TYPE_OBJECT:
+                pReturn = pPools->GetObject ( (DWORD *)pInterface );
+                break;
             default: break;
         }
     }


### PR DESCRIPTION
Now onClientPlayerDamage & onClientPedDamage & onPlayerDamage returns correct attacker instead of false/nil.

Test for objects:

```
crun addEventHandler("onClientPlayerDamage", localPlayer, function(attacker) outputChatBox("Attacker: " .. tostring(attacker)) end)
crun obj = Object(1222, localPlayer.position + Vector3(0, 0, 10))
crun obj.velocity = Vector3(0, 0, 0.001)
```

Fixes #8082.
