### PR TITLE
Add 'manuallyChanged' parameter to onPlayerChangeNick

### DIFF
--- a/MTA10_Server/mods/deathmatch/logic/CConsoleCommands.cpp
+++ b/MTA10_Server/mods/deathmatch/logic/CConsoleCommands.cpp
@@ -753,6 +753,7 @@ bool CConsoleCommands::Nick ( CConsole* pConsole, const char* szArguments, CClie
                                 CLuaArguments Arguments;
                                 Arguments.PushString ( pClient->GetNick () );
                                 Arguments.PushString ( szNewNick );
+                                Arguments.PushBoolean ( true ); // manually changed
                                 if ( pPlayer->CallEvent ( "onPlayerChangeNick", Arguments ) )
                                 {
                                     // Tell the console

--- a/MTA10_Server/mods/deathmatch/logic/CGame.cpp
+++ b/MTA10_Server/mods/deathmatch/logic/CGame.cpp
@@ -1474,7 +1474,7 @@ void CGame::AddBuiltInEvents ( void )
     m_Events.AddEvent ( "onPlayerBan", "ban", NULL, false );
     m_Events.AddEvent ( "onPlayerLogin", "guest_account, account, auto-login", NULL, false );
     m_Events.AddEvent ( "onPlayerLogout", "account, guest_account", NULL, false );
-    m_Events.AddEvent ( "onPlayerChangeNick", "oldnick, newnick", NULL, false );
+    m_Events.AddEvent ( "onPlayerChangeNick", "oldnick, newnick, manuallyChanged", NULL, false );
     m_Events.AddEvent ( "onPlayerPrivateMessage", "text, player", NULL, false );
     m_Events.AddEvent ( "onPlayerStealthKill", "target", NULL, false );
     m_Events.AddEvent ( "onPlayerMute", "", NULL, false );

--- a/MTA10_Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/MTA10_Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -2048,6 +2048,7 @@ bool CStaticFunctionDefinitions::SetPlayerName ( CElement* pElement, const char*
                             CLuaArguments Arguments;
                             Arguments.PushString ( szNick );
                             Arguments.PushString ( szName );
+                            Arguments.PushBoolean ( false ); // manually changed
                             pPlayer->CallEvent ( "onPlayerChangeNick", Arguments );
 
                             // Tell the console


### PR DESCRIPTION
This PR adds a new parameter to the onPlayerChangeNick event, it tells whether the player changed his nickname manually (i.e. with the **nick** command) or it was set "automatically" with the **setPlayerName** function, It's useful to tell if the event can be cancelled or not, To show messages only when the player tries to change his nickname manually etc.
