### PR TITLE
Implemented Travis-CI Builds and Fixed x64 Linux builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - utils/premake5_x64 gmake
   - cd Build
 
-script: make -j 3 CXX=g++-5 CC=gcc-5 config=release_x64
+script: make -j 3 CXX=g++-5 CC=gcc-5 config=debug_x64
  
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: cpp
 dist: trusty
+sudo: required
 compiler: 
   - gcc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ before_script:
   - utils/premake5_x64 gmake
   - cd Build
 
-script: make CXX=foo CC=bar config=release_x64
+script: make CXX=g++-5 CC=gcc-5 config=release_x64
  
 notifications:
   irc:
     channels:
-      - "irc.gtanet.com#mta"
+      - "irc.gtanet.com#mta.dev"
     on_success: change
     on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - gcc-5
-    - g++-5
-    env: COMPILER=g++-5
+    - gcc-4.9
+    - g++-4.9
+    env: COMPILER=g++-4.9
     
 before_script:
   - utils/premake5_x64 gmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ before_script:
   - utils/premake5_x64 gmake
   - cd Build
 
-script: make CXX=$COMPILER config=release_x64
+script: echo breakpad.make
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
-language: ruby
-rvm:
- - 2.2
- - jruby
- - rbx-2
+language: cpp
+compiler: 
+  - gcc
+
+before_script:
+  - utils/premake5_x64 gmake
+  - cd Build
+
+script: make config=release_x64

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ before_script:
   - utils/premake5_x64 gmake
   - cd Build
 
-script: make config=release_x64
+script: make CXX=$COMPILER config=release_x64

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: cpp
-dist: trusty
-sudo: required
 compiler: 
   - gcc
 
@@ -11,6 +9,7 @@ addons:
     packages:
     - gcc-5
     - g++-5
+    env: COMPILER=g++-5
     
 before_script:
   - utils/premake5_x64 gmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ before_script:
   - utils/premake5_x64 gmake
   - cd Build
 
-script: make CXX=g++-5 CC=g++-5 release_x64
+script: make CXX=g++-5 CC=g++-5 config=release_x64
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,5 @@ notifications:
   irc:
     channels:
       - "irc.gtanet.com#mta.dev"
-    on_success: never
-    on_failure: never
+    on_success: change
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: cpp
-sudo: required
-dist: trusty
 compiler: 
   - gcc
 
@@ -14,7 +12,7 @@ addons:
     env: COMPILER=g++-5
     
 before_script:
-  - utils/premake5_x64 gmake
+  - utils/premake5_x86 gmake
   - cd Build
 
 script: make -j 3 CXX=g++-5 CC=gcc-5 config=release_x64

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
     env: COMPILER=g++-5
     
 before_script:
-  - wget https://github.com/sbx320/premake5-travis/blob/master/premake5?raw=true
+  - wget https://github.com/sbx320/premake5-travis/blob/master/premake5?raw=true -O ./premake5
   - chmod +x ./premake5
   - ./premake5 gmake
   - cd Build

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,14 @@ sudo: required
 compiler: 
   - gcc
 
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - gcc-5
+    - g++-5
+    
 before_script:
   - utils/premake5_x64 gmake
   - cd Build

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - utils/premake5_x64 gmake
   - cd Build
 
-script: make -j 3 CXX=g++-5 CC=gcc-5 config=debug_x64
+script: make -j 3 CXX=g++-5 CC=gcc-5 config=release_x64
  
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ before_script:
   - utils/premake5_x64 gmake
   - cd Build
 
-script: echo breakpad.make
+script: cat breakpad.make
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ before_script:
   - utils/premake5_x64 gmake
   - cd Build
 
-script: make CXX=g++-5 CC=g++-5 config=release_x64
+script: make CXX=g++-5 CC=gcc-5 config=release_x64
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - utils/premake5_x64 gmake
   - cd Build
 
-script: make CXX=g++-5 CC=gcc-5 config=release_x64
+script: make -j 3 CXX=g++-5 CC=gcc-5 config=release_x64
  
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ addons:
     env: COMPILER=g++-5
     
 before_script:
-  - wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha9/premake-5.0.0-alpha9-linux.tar.gz
-  - tar xzf premake-5.0.0-alpha9-linux.tar.gz
+  - wget https://github.com/sbx320/premake5-travis/blob/master/premake5?raw=true
+  - chmod +x ./premake5
   - ./premake5 gmake
   - cd Build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,27 @@
-language: cpp
-compiler: 
-  - gcc
+sudo: false
+language: csharp
+mono:
+    - alpha
 
-script: make config=release_x64
+solution: SteamKit2/SteamKit2.sln
+
+install:
+    - nuget restore SteamKit2/SteamKit2.sln
+    - nuget restore Samples/Samples.sln
+    - nuget install xunit.runner.console -Version 2.0.0 -o SteamKit2/packages
+
+script:
+    - xbuild /p:NoWarn=1584 SteamKit2/SteamKit2.sln /target:SteamKit2 /target:Tests
+    - xbuild Samples/Samples.sln
+    - mono SteamKit2/packages/xunit.runner.console.2.0.0/tools/xunit.console.exe SteamKit2/Tests/bin/Debug/Tests.dll
+
+notifications:
+    irc:
+        channels:
+            - "irc.gamesurge.net#opensteamworks"
+        on_success: never
+        on_failure: always
+
+cache:
+    directories:
+        - "~/.local/share/NuGet/Cache"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ before_script:
   - utils/premake5_x64 gmake
   - cd Build
 
-script: make CXX=g++-5 CC=g++-5 config=release_x86
+script: make CXX=g++-5 CC=g++-5 config=release_x64
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ before_script:
   - utils/premake5_x64 gmake
   - cd Build
 
-script: make CXX=g++-5 CC=g++-5 config=release_x64
+script: make CXX=g++-5 CC=g++-5 config=release_x86
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - utils/premake5_x64 gmake
   - cd Build
 
-script: make CXX=g++-5 CC=gcc-5 config=release_x64
+script: make CXX=foo CC=bar config=release_x64
  
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: cpp
+compiler: 
+  - gcc
+
+before_script:
+  - utils/premake5_x64 gmake
+  - cd Build
+
+script: make config=release_x64

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: cpp
+sudo: required
+dist: trusty
 compiler: 
   - gcc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ addons:
     env: COMPILER=g++-5
     
 before_script:
-  - utils/premake5_x86 gmake
+  - wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha9/premake-5.0.0-alpha9-linux.tar.gz
+  - tar xzf premake-5.0.0-alpha9-linux.tar.gz
+  - ./premake gmake
   - cd Build
 
 script: make -j 3 CXX=g++-5 CC=gcc-5 config=release_x64
@@ -21,5 +23,5 @@ notifications:
   irc:
     channels:
       - "irc.gtanet.com#mta.dev"
-    on_success: change
-    on_failure: always
+    on_success: never
+    on_failure: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,5 @@
-sudo: false
-language: csharp
-mono:
-    - alpha
-
-solution: SteamKit2/SteamKit2.sln
-
-install:
-    - nuget restore SteamKit2/SteamKit2.sln
-    - nuget restore Samples/Samples.sln
-    - nuget install xunit.runner.console -Version 2.0.0 -o SteamKit2/packages
-
-script:
-    - xbuild /p:NoWarn=1584 SteamKit2/SteamKit2.sln /target:SteamKit2 /target:Tests
-    - xbuild Samples/Samples.sln
-    - mono SteamKit2/packages/xunit.runner.console.2.0.0/tools/xunit.console.exe SteamKit2/Tests/bin/Debug/Tests.dll
-
-notifications:
-    irc:
-        channels:
-            - "irc.gamesurge.net#opensteamworks"
-        on_success: never
-        on_failure: always
-
-cache:
-    directories:
-        - "~/.local/share/NuGet/Cache"
+language: ruby
+rvm:
+ - 2.2
+ - jruby
+ - rbx-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+dist: trusty
 compiler: 
   - gcc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - gcc-4.9
-    - g++-4.9
-    env: COMPILER=g++-4.9
+    - gcc-5
+    - g++-5
+    env: COMPILER=g++-5
     
 before_script:
   - utils/premake5_x64 gmake
   - cd Build
 
-script: cat breakpad.make
+script: make CXX=g++-5 CC=g++-5 release_x64
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,9 @@ before_script:
 
 script: make CXX=g++-5 CC=gcc-5 config=release_x64
  
+notifications:
+  irc:
+    channels:
+      - "irc.gtanet.com#mta"
+    on_success: change
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 before_script:
   - wget https://github.com/premake/premake-core/releases/download/v5.0.0-alpha9/premake-5.0.0-alpha9-linux.tar.gz
   - tar xzf premake-5.0.0-alpha9-linux.tar.gz
-  - ./premake gmake
+  - ./premake5 gmake
   - cd Build
 
 script: make -j 3 CXX=g++-5 CC=gcc-5 config=release_x64

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,4 @@ language: cpp
 compiler: 
   - gcc
 
-before_script:
-  - utils/premake5_x64 gmake
-  - cd Build
-
 script: make config=release_x64

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ before_script:
   - cd Build
 
 script: make CXX=$COMPILER config=release_x64
+ 

--- a/Server/mods/deathmatch/premake5.lua
+++ b/Server/mods/deathmatch/premake5.lua
@@ -63,4 +63,7 @@ project "Deathmatch"
 		includedirs { "../../../vendor/pthreads/include" }
 		buildoptions { "-Zm130" }
 		links { "ws2_32" }
+		
+	filter "system:not windows"
+		buildoptions { "-Wno-narrowing" } -- We should fix the warnings at some point
 	

--- a/premake5.lua
+++ b/premake5.lua
@@ -33,10 +33,13 @@ workspace "MTASA"
 	filter "configurations:Debug"
 		defines { "MTA_DEBUG" }
 		targetsuffix "_d"
-		
+	
+	-- Skip Optimization in CI Builds for build speed
+	if os.getenv("CONTINUOUS_INTEGRATION") ~= "true" then
 	filter "configurations:Release or configurations:Nightly"
 		flags { "Optimize" }
-		
+	end
+	
 	filter {"system:windows", "configurations:Nightly", "kind:not StaticLib"}
 		os.mkdir("Build/Symbols")
 		linkoptions "/PDB:\"Symbols\\$(ProjectName).pdb\""

--- a/vendor/google-breakpad/premake5.lua
+++ b/vendor/google-breakpad/premake5.lua
@@ -4,7 +4,7 @@ project "breakpad"
 	targetname "breakpad"
 	
 	includedirs { "src", "src/third_party/glog/src" }
-	
+	buildoptions { "-fpermissive" }
 	vpaths { 
 		["Headers/*"] = "src/**.h",
 		["Sources/*"] = {"src/**.cc", "src/**.c"},

--- a/vendor/google-breakpad/premake5.lua
+++ b/vendor/google-breakpad/premake5.lua
@@ -4,7 +4,6 @@ project "breakpad"
 	targetname "breakpad"
 	
 	includedirs { "src", "src/third_party/glog/src" }
-	buildoptions { "-fpermissive" }
 	vpaths { 
 		["Headers/*"] = "src/**.h",
 		["Sources/*"] = {"src/**.cc", "src/**.c"},

--- a/vendor/google-breakpad/src/third_party/glog/src/config.h
+++ b/vendor/google-breakpad/src/third_party/glog/src/config.h
@@ -138,16 +138,14 @@
 #define PACKAGE_VERSION "0.3.1"
 
 /* How to access the PC from a struct ucontext */
-/* The size of `void *', as computed by sizeof. */
 #if defined(__x86_64__)
-#define PC_FROM_UCONTEXT uc_mcontext.gregs[REG_EIP]
-#define SIZEOF_VOID_P 8
+#define PC_FROM_UCONTEXT uc_mcontext.gregs[REG_RIP]
 #else
 #define PC_FROM_UCONTEXT uc_mcontext.gregs[REG_EIP]
-#define SIZEOF_VOID_P 4
 #endif
 
-
+/* The size of `void *', as computed by sizeof. */
+#define SIZEOF_VOID_P (sizeof(void*)
 
 /* Define to 1 if you have the ANSI C header files. */
 /* #undef STDC_HEADERS */

--- a/vendor/google-breakpad/src/third_party/glog/src/config.h
+++ b/vendor/google-breakpad/src/third_party/glog/src/config.h
@@ -138,14 +138,16 @@
 #define PACKAGE_VERSION "0.3.1"
 
 /* How to access the PC from a struct ucontext */
-#define PC_FROM_UCONTEXT uc_mcontext.gregs[REG_EIP]
-
-/* Define to necessary symbol if this constant uses a non-standard name on
-   your system. */
-/* #undef PTHREAD_CREATE_JOINABLE */
-
 /* The size of `void *', as computed by sizeof. */
+#if defined(__x86_64__)
+#define PC_FROM_UCONTEXT uc_mcontext.gregs[REG_EIP]
+#define SIZEOF_VOID_P 8
+#else
+#define PC_FROM_UCONTEXT uc_mcontext.gregs[REG_EIP]
 #define SIZEOF_VOID_P 4
+#endif
+
+
 
 /* Define to 1 if you have the ANSI C header files. */
 /* #undef STDC_HEADERS */


### PR DESCRIPTION
- Adds Travis-CI
- Fixes Linux libdisasm trying to use REG_EIP and sizeof(void*) == 4 in x64 mode
- Also disables a warning narrowing conversions which is an error from g++5 onwards
