### PR TITLE
Add getCommandHandlers function

### DIFF
--- a/Server/mods/deathmatch/logic/CRegisteredCommands.cpp
+++ b/Server/mods/deathmatch/logic/CRegisteredCommands.cpp
@@ -271,6 +271,60 @@ void CRegisteredCommands::CallCommandHandler ( CLuaMain* pLuaMain, const CLuaFun
 }
 
 
+void CRegisteredCommands::GetCommands ( lua_State* luaVM )
+{
+    unsigned int uiIndex = 0;
+    m_bIteratingList = true;
+    list < SCommand* > ::iterator iter = m_Commands.begin ();
+
+    // Create the main table
+    lua_newtable( luaVM );
+
+    for ( ; iter != m_Commands.end (); iter++ )
+    {
+        // Create a subtable ({'command', resource})
+        lua_pushinteger ( luaVM, ++uiIndex );
+        lua_createtable ( luaVM, 0, 2 );
+        {
+            lua_pushstring ( luaVM, (*iter)->strKey );
+            lua_rawseti ( luaVM, -2, 1 );
+
+            lua_pushresource ( luaVM, (*iter)->pLuaMain->GetResource() );
+            lua_rawseti ( luaVM, -2, 2 );
+        }
+        lua_settable ( luaVM, -3 );
+    }
+
+    m_bIteratingList = false;
+}
+
+
+void CRegisteredCommands::GetCommands ( lua_State* luaVM, CLuaMain* pTargetLuaMain )
+{
+    unsigned int uiIndex = 0;
+    m_bIteratingList = true;
+    list < SCommand* > ::iterator iter = m_Commands.begin ();
+
+    // Create the table
+    lua_newtable( luaVM );
+
+    for ( ; iter != m_Commands.end (); iter++ )
+    {
+        // Matching VMs?
+        if ( (*iter)->pLuaMain == pTargetLuaMain )
+        {
+            lua_pushinteger ( luaVM, ++uiIndex );
+            lua_pushstring ( luaVM, (*iter)->strKey );
+            lua_settable ( luaVM, -3 );
+        }
+    }
+
+    //lua_settable ( luaVM, -3 );
+
+    m_bIteratingList = false;
+}
+
+
 void CRegisteredCommands::TakeOutTheTrash ( void )
 {
     list < SCommand* > ::iterator iter = m_TrashCan.begin ();

--- a/Server/mods/deathmatch/logic/CRegisteredCommands.h
+++ b/Server/mods/deathmatch/logic/CRegisteredCommands.h
@@ -45,6 +45,9 @@ public:
 
     bool                                CommandExists                   ( const char* szKey, class CLuaMain* pLuaMain = NULL );
 
+    void                                GetCommands                     ( lua_State* luaVM );
+    void                                GetCommands                     ( lua_State* luaVM, CLuaMain* pTargetLuaMain );
+
     bool                                ProcessCommand                  ( const char* szKey, const char* szArguments, class CClient* pClient );
 
 private:

--- a/Server/mods/deathmatch/logic/lua/CLuaFunctionDefs.Server.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaFunctionDefs.Server.cpp
@@ -318,6 +318,49 @@ int CLuaFunctionDefs::ExecuteCommandHandler ( lua_State* luaVM )
     return 1;
 }
 
+
+int CLuaFunctionDefs::GetCommandHandlers ( lua_State* luaVM )
+{
+    // table getCommandHandlers ( [ resource sourceResource ] );
+    CResource* pResource;
+    bool bSpecificResource = false;
+
+    CScriptArgReader argStream ( luaVM );
+    if ( !argStream.NextIsNone() )
+    {
+        argStream.ReadUserData ( pResource );
+        bSpecificResource = true;
+    }
+
+    if ( !argStream.HasErrors() )
+    {
+        if ( bSpecificResource )
+        {
+            // Grab resource virtual machine
+            CLuaMain* pLuaMain = pResource->GetVirtualMachine ();
+
+            if ( pLuaMain )
+            {
+                m_pRegisteredCommands->GetCommands( luaVM, pLuaMain );
+
+                return 1;
+            }
+        }
+        else
+        {
+            m_pRegisteredCommands->GetCommands( luaVM );
+
+            return 1;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom ( luaVM, argStream.GetFullErrorMessage () );
+
+    lua_pushboolean ( luaVM, false );
+    return 1;
+}
+
+
 int CLuaFunctionDefs::OutputServerLog ( lua_State* luaVM )
 {
     SString strMessage;

--- a/Server/mods/deathmatch/logic/lua/CLuaFunctionDefs.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaFunctionDefs.h
@@ -106,6 +106,7 @@ public:
     LUA_DECLARE ( AddCommandHandler );
     LUA_DECLARE ( RemoveCommandHandler );
     LUA_DECLARE ( ExecuteCommandHandler );
+    LUA_DECLARE ( GetCommandHandlers );
 
     // Standard server functions
     LUA_DECLARE ( GetMaxPlayers );

--- a/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -233,6 +233,7 @@ void CLuaManager::LoadCFunctions ( void )
     CLuaCFunctions::AddFunction ( "addCommandHandler", CLuaFunctionDefs::AddCommandHandler );
     CLuaCFunctions::AddFunction ( "removeCommandHandler", CLuaFunctionDefs::RemoveCommandHandler );
     CLuaCFunctions::AddFunction ( "executeCommandHandler", CLuaFunctionDefs::ExecuteCommandHandler );
+    CLuaCFunctions::AddFunction ( "getCommandHandlers", CLuaFunctionDefs::GetCommandHandlers );
 
     // Server standard funcs
     CLuaCFunctions::AddFunction ( "getMaxPlayers", CLuaFunctionDefs::GetMaxPlayers );


### PR DESCRIPTION
This PR adds a new function which returns all the registered command handlers of a given resource (or of all resources)

``` lua
table getCommandHandlers ( [ resource sourceResource ] )
```

Returns a table containing all the commands of the given resource or a table with subtables containing the command and the sourceResource ({ "command", resource }).

it's server side only because of the possibility to get the commands of all resources, can't this cause security issues or something? 
