### PR TITLE
Remove error for missing registry key

### DIFF
--- a/Client/loader/CInstallManager.cpp
+++ b/Client/loader/CInstallManager.cpp
@@ -588,11 +588,13 @@ SString CInstallManager::_ProcessLayoutChecks ( void )
         RemoveDirectory ( ExtractPath ( strTestFilePath ) );
     }
 
-    /* Check reg key exists
+#if MTASA_VERSION_TYPE != VERSION_TYPE_CUSTOM
+    // Check reg key exists
     {
         if ( GetRegistryValue ( "", "Last Install Location" ).empty () )
             ShowLayoutError ( "[Registry key not present]" );   // Can't find reg key
-    } */
+    }
+#endif
 
     // Check reg key writable
     {

--- a/Client/loader/CInstallManager.cpp
+++ b/Client/loader/CInstallManager.cpp
@@ -588,11 +588,11 @@ SString CInstallManager::_ProcessLayoutChecks ( void )
         RemoveDirectory ( ExtractPath ( strTestFilePath ) );
     }
 
-    // Check reg key exists
+    /* Check reg key exists
     {
         if ( GetRegistryValue ( "", "Last Install Location" ).empty () )
             ShowLayoutError ( "[Registry key not present]" );   // Can't find reg key
-    }
+    } */
 
     // Check reg key writable
     {


### PR DESCRIPTION
This pull request removes the error for the missing registry key **"Last Install Location"** if you run the build from the **Bin** directory. Another hurdle for developers, which want to run their build of MTA.

Please correct me in this matter, if there is any reason for MTA to stop working when the registry key is missing. I didn't have any issues when I ran MTA with this patch.
