### PR TITLE
0009376: Deleted tabpanel tab crashes MTA if you change the selected tab

### DIFF
--- a/Client/core/Serverbrowser/CServerBrowser.cpp
+++ b/Client/core/Serverbrowser/CServerBrowser.cpp
@@ -289,6 +289,10 @@ CServerBrowser::CServerBrowser ( void )
 
 CServerBrowser::~CServerBrowser ( void )
 {
+    // Save options now and disable selection handler
+    SaveOptions ( );
+    m_pPanel->SetSelectionHandler ( nullptr );
+
     // Delete the Tabs
     DeleteTab ( ServerBrowserTypes::INTERNET );
     DeleteTab ( ServerBrowserTypes::LAN );

--- a/Client/gui/CGUITab_Impl.cpp
+++ b/Client/gui/CGUITab_Impl.cpp
@@ -51,7 +51,11 @@ CGUITab_Impl::CGUITab_Impl ( CGUI_Impl* pGUI, CGUIElement_Impl* pParent, const c
 
 CGUITab_Impl::~CGUITab_Impl ( void )
 {
-    DestroyElement ();
+    CGUIElement_Impl* pParent = static_cast < CGUIElement_Impl* > (m_pParent);
+    CEGUI::TabControl* pControl = reinterpret_cast < CEGUI::TabControl* > ( ( ( CGUITabPanel_Impl* ) pParent )->m_pWindow );
+    pControl->removeTab ( this->GetWindow ( )->getName ( ) );
+
+    DestroyElement();
 }
 
 


### PR DESCRIPTION
If you destroy a tab element with `destroyElement` then the corresponding tab panel won't be notified about the deleted tab in his hierarchy and it will keep showing the deleted tab. If you then click on any other tab in that specific tab panel, MTA will crash as a result.

This pull request explicitly removes the tab from the tabcontrol when `CGUITab_Impl` is being deleted to prevent that crash.

The serverbrowser saves it's options when the client changes the tab in the serverbrowser's tab panel. If you delete the currently selected tab in a tab panel, and that happens when you quit MTA and the serverbrowser deletes itself; the CEGUI library will pick the first tab in the tab panel, triggering the selection handler. You can't check for a `nullptr` in SaveOptions, because the handler is being triggered synchronously when the tab is being deleted.

**Note:** I tested this patch, but I can't test every part of the codebase.
