### PR TITLE
Added guiGetCursorType function

### DIFF
--- a/Client/gui/CGUI_Impl.cpp
+++ b/Client/gui/CGUI_Impl.cpp
@@ -543,6 +543,34 @@ float CGUI_Impl::GetCurrentServerCursorAlpha ( void )
 }
 
 
+eCursorType CGUI_Impl::GetCursorType ( void )
+{
+    auto image = CEGUI::MouseCursor::getSingleton ( ).getImage ( );
+
+    if ( image == nullptr )
+        return CURSORTYPE_NONE;
+
+    auto imageName = image->getName ( );
+
+    if ( !imageName.compare ( "MouseArrow" ) )
+        return CURSORTYPE_DEFAULT;
+    else if ( !imageName.compare ( "NSSizingCursorImage" ) )
+        return CURSORTYPE_SIZING_NS;
+    else if ( !imageName.compare ( "EWSizingCursorImage" ) )
+        return CURSORTYPE_SIZING_EW;
+    else if ( !imageName.compare ( "NWSESizingCursorImage" ) )
+        return CURSORTYPE_SIZING_NWSE;
+    else if ( !imageName.compare ( "NESWSizingCursorImage" ) )
+        return CURSORTYPE_SIZING_NESW;
+    else if ( !imageName.compare ( "MouseEsWeCursor" ) )
+        return CURSORTYPE_SIZING_ESWE;
+    else if ( !imageName.compare ( "MouseMoveCursor" ) )
+        return CURSORTYPE_MOVE;
+    else
+        return CURSORTYPE_DEFAULT;
+}
+
+
 void CGUI_Impl::AddChild ( CGUIElement_Impl* pChild )
 {
     m_pTop->addChildWindow ( pChild->GetWindow () );

--- a/Client/gui/CGUI_Impl.h
+++ b/Client/gui/CGUI_Impl.h
@@ -147,6 +147,7 @@ public:
     bool                            IsCursorEnabled             ( void );
     void                            SetCursorAlpha              ( float fAlpha, bool bOnlyCurrentServer = false );
     float                           GetCurrentServerCursorAlpha ( void );
+    eCursorType                     GetCursorType               ( void );
 
     void                            AddChild                    ( CGUIElement_Impl* pChild );
     CEGUI::FontManager*             GetFontManager              ( void );

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -4748,6 +4748,13 @@ eInputMode CStaticFunctionDefinitions::GUIGetInputMode ( void )
     return m_pGUI->GetGUIInputMode();
 }
 
+
+eCursorType CStaticFunctionDefinitions::GUIGetCursorType ( void )
+{
+    return m_pGUI->GetCursorType ( );
+}
+
+
 CClientGUIElement* CStaticFunctionDefinitions::GUICreateWindow ( CLuaMain& LuaMain, float fX, float fY, float fWidth, float fHeight, const char* szCaption, bool bRelative )
 {
     CGUIElement *pElement = m_pGUI->CreateWnd ( NULL, szCaption );

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -388,6 +388,7 @@ public:
     static bool                         GUIGetInputEnabled                  ( void );
     static eInputMode                   GUIGetInputMode                     ( void );
     static void                         GUISetInputMode                     ( eInputMode inputMode );
+    static eCursorType                  GUIGetCursorType                    ( void );
 
     static CClientGUIElement*           GUICreateWindow                     ( CLuaMain& LuaMain, float fX, float fY, float fWidth, float fHeight, const char* szCaption, bool bRelative );
     static CClientGUIElement*           GUICreateLabel                      ( CLuaMain& LuaMain, float fX, float fY, float fWidth, float fHeight, const char* szCaption, bool bRelative, CClientGUIElement* pParent );

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
@@ -478,6 +478,21 @@ IMPLEMENT_ENUM_BEGIN ( eJSONPrettyType )
     ADD_ENUM ( JSONPRETTY_TABS, "tabs" )
 IMPLEMENT_ENUM_END ( "json-pretty-type" )
 
+IMPLEMENT_ENUM_BEGIN ( eCursorType )
+    ADD_ENUM ( CURSORTYPE_NONE,         "none" )            // cursor has no image
+    ADD_ENUM ( CURSORTYPE_DEFAULT,      "arrow" )           // default cursor
+    ADD_ENUM ( CURSORTYPE_SIZING_NS,    "sizing_ns" )       // N-S (up-down) sizing cursor
+    ADD_ENUM ( CURSORTYPE_SIZING_EW,    "sizing_ew" )       // E-W (left-right) sizing cursor
+    ADD_ENUM ( CURSORTYPE_SIZING_NWSE,  "sizing_nwse" )     // NW-SE diagonal sizing cursor
+    ADD_ENUM ( CURSORTYPE_SIZING_NESW,  "sizing_nesw" )     // NE-SW diagonal sizing cursor
+    ADD_ENUM ( CURSORTYPE_SIZING_ESWE,  "sizing_eswe" )     // ES-WE horizontal sizing cursor
+    ADD_ENUM ( CURSORTYPE_MOVE,         "move" )            // move cursor
+    ADD_ENUM ( CURSORTYPE_DRAG,         "container_drag" )  // drag container cursor (note: not in use)
+    ADD_ENUM ( CURSORTYPE_SEG_MOVING,   "segment_moving" )  // segment moving cursor (note: not in use)
+    ADD_ENUM ( CURSORTYPE_SEG_SIZING,   "segment_sizing" )  // segment sizing cursor (note: not in use)
+IMPLEMENT_ENUM_END ( "cursor-type" )
+
+
 //
 // Get best guess at name of userdata type
 //

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
@@ -9,8 +9,11 @@
 *
 *****************************************************************************/
 
+#pragma once
+
 // Forward declare enum reflection stuff
-#include <gui/CGUI.h>
+#include <gui/CGUIEnumDefs.h>
+
 enum eLuaType { };
 DECLARE_ENUM( eLuaType );
 DECLARE_ENUM( CGUIVerticalAlign );
@@ -43,6 +46,7 @@ DECLARE_ENUM( eRadioStreamIndex );
 DECLARE_ENUM( EComponentBase::EComponentBaseType );
 DECLARE_ENUM( eWebBrowserMouseButton );
 DECLARE_ENUM( eTrayIconType )
+DECLARE_ENUM( eCursorType )
 
 enum eDXHorizontalAlign
 {

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -112,6 +112,7 @@ void CLuaGUIDefs::LoadFunctions ( void )
     CLuaCFunctions::AddFunction ( "guiGetSize", GUIGetSize );
     CLuaCFunctions::AddFunction ( "guiGetPosition", GUIGetPosition );
     CLuaCFunctions::AddFunction ( "guiGetVisible", GUIGetVisible );
+    CLuaCFunctions::AddFunction ( "guiGetCursorType", GUIGetCursorType );
 
     CLuaCFunctions::AddFunction ( "guiCheckBoxGetSelected", GUICheckBoxGetSelected );
     CLuaCFunctions::AddFunction ( "guiRadioButtonGetSelected", GUIRadioButtonGetSelected );
@@ -190,6 +191,7 @@ void CLuaGUIDefs::AddGuiElementClass ( lua_State* luaVM )
     lua_classfunction ( luaVM, "isTransferBoxActive", "isTransferBoxActive" );
     lua_classfunction ( luaVM, "isInputEnabled", "guiGetInputEnabled" );
     lua_classfunction ( luaVM, "getInputMode", "guiGetInputMode" );
+    lua_classfunction ( luaVM, "getCursorType", "guiGetCursorType" );
 
     lua_classfunction ( luaVM, "getScreenSize", "guiGetScreenSize" );
     lua_classfunction ( luaVM, "getProperties", "guiGetProperties" );
@@ -222,6 +224,7 @@ void CLuaGUIDefs::AddGuiElementClass ( lua_State* luaVM )
     lua_classvariable ( luaVM, "inputEnabled", "guiSetInputEnabled", "guiGetInputEnabled" );
     lua_classvariable ( luaVM, "inputMode", "guiGetInputMode", "guiSetInputMode" );
     lua_classvariable ( luaVM, "cursorAlpha", "setCursorAlpha", "getCursorAlpha" );
+    lua_classvariable ( luaVM, "cursorType", NULL, "guiGetCursorType" );
     lua_classvariable ( luaVM, "font", "guiSetFont", "guiGetFont" );
     lua_classvariable ( luaVM, "visible", "guiSetVisible", "guiGetVisible" );
     lua_classvariable ( luaVM, "properties", NULL, "guiGetProperties" );
@@ -3702,5 +3705,14 @@ int CLuaGUIDefs::GUICreateFont ( lua_State* luaVM )
 
     // error: bad arguments
     lua_pushboolean ( luaVM, false );
+    return 1;
+}
+
+
+int CLuaGUIDefs::GUIGetCursorType ( lua_State* luaVM )
+{
+//  string guiGetCursorType ( )
+    auto eType = CStaticFunctionDefinitions::GUIGetCursorType ( );
+    lua_pushstring (luaVM, EnumToString ( eType ) );
     return 1;
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
@@ -141,6 +141,7 @@ public:
     LUA_DECLARE ( GUIComboBoxSetSelected );
     LUA_DECLARE ( GUIComboBoxGetItemText );
     LUA_DECLARE ( GUIComboBoxSetItemText );
+    LUA_DECLARE ( GUIGetCursorType );
 
 private:
     static void AddGuiElementClass ( lua_State* luaVM );

--- a/Client/sdk/gui/CGUI.h
+++ b/Client/sdk/gui/CGUI.h
@@ -9,13 +9,12 @@
 *
 *****************************************************************************/
 
+#pragma once
+
 class CGUI;
 
-#ifndef __CGUI_H
-#define __CGUI_H
-
+#include "CGUIEnumDefs.h"
 #include "CGUIElement.h"
-
 #include "CGUIButton.h"
 #include "CGUICallback.h"
 #include "CGUICheckBox.h"
@@ -45,35 +44,6 @@ class CGUI;
 #define CGUI_ICON_MESSAGEBOX_ERROR      "cgui\\images\\error.png"
 #define CGUI_ICON_SERVER_PASSWORD       "cgui\\images\\locked.png"
 #define CGUI_GetMaxTextExtent(...) GetMaxTextExtent(__VA_ARGS__, SString())
-
-// Message box types
-enum CMessageBoxFlag
-{
-    MB_BUTTON_NONE = 0,
-    MB_BUTTON_OK = 1,
-    MB_BUTTON_CANCEL = 2,
-    MB_BUTTON_YES = 4,
-    MB_BUTTON_NO = 8,
-    MB_ICON_INFO = 16,
-    MB_ICON_QUESTION = 32,
-    MB_ICON_WARNING = 64,
-    MB_ICON_ERROR = 128,
-};
-
-// Input handler switcher
-enum eInputChannel
-{ 
-    INPUT_CORE = 0,
-    INPUT_MOD = 1,
-    INPUT_CHANNEL_COUNT = 2,
-};
-
-enum eInputMode
-{
-    INPUTMODE_ALLOW_BINDS = 0,
-    INPUTMODE_NO_BINDS = 1,
-    INPUTMODE_NO_BINDS_ON_EDIT = 2,
-};
 
 #define CHECK_CHANNEL(channel) assert ( channel >= 0 && channel < INPUT_CHANNEL_COUNT )
 
@@ -158,6 +128,7 @@ public:
     virtual bool                IsCursorEnabled         ( void ) = 0;
     virtual void                SetCursorAlpha          ( float fAlpha, bool bOnlyCurrentServer = false ) = 0;
     virtual float               GetCurrentServerCursorAlpha ( void ) = 0;
+    virtual eCursorType         GetCursorType           ( void ) = 0;
 
     virtual CVector2D           GetResolution           ( void ) = 0;
     virtual void                SetResolution           ( float fWidth, float fHeight ) = 0;
@@ -202,5 +173,3 @@ public:
     virtual CGUIWindow*         LoadLayout                  ( CGUIElement* pParent, const SString& strFilename ) = 0;
     virtual bool                LoadImageset                ( const SString& strFilename ) = 0;
 };
-
-#endif

--- a/Client/sdk/gui/CGUIEnumDefs.h
+++ b/Client/sdk/gui/CGUIEnumDefs.h
@@ -1,0 +1,59 @@
+/*****************************************************************************
+*
+*  PROJECT:     Multi Theft Auto v1.0
+*  LICENSE:     See LICENSE in the top level directory
+*  FILE:        sdk/gui/CGUIEnumDefs.h
+*  PURPOSE:     Graphical User Interface module interface
+*
+*  Multi Theft Auto is available from http://www.multitheftauto.com/
+*
+*****************************************************************************/
+
+#pragma once
+
+// Message box types
+enum CMessageBoxFlag
+{
+    MB_BUTTON_NONE = 0,
+    MB_BUTTON_OK = 1,
+    MB_BUTTON_CANCEL = 2,
+    MB_BUTTON_YES = 4,
+    MB_BUTTON_NO = 8,
+    MB_ICON_INFO = 16,
+    MB_ICON_QUESTION = 32,
+    MB_ICON_WARNING = 64,
+    MB_ICON_ERROR = 128,
+};
+
+
+// Input handler switcher
+enum eInputChannel
+{ 
+    INPUT_CORE,
+    INPUT_MOD,
+    INPUT_CHANNEL_COUNT,
+};
+
+
+enum eInputMode
+{
+    INPUTMODE_ALLOW_BINDS,
+    INPUTMODE_NO_BINDS,
+    INPUTMODE_NO_BINDS_ON_EDIT,
+};
+
+
+enum eCursorType
+{
+    CURSORTYPE_NONE,
+    CURSORTYPE_DEFAULT,
+    CURSORTYPE_SIZING_NS,
+    CURSORTYPE_SIZING_EW,
+    CURSORTYPE_SIZING_NWSE,
+    CURSORTYPE_SIZING_NESW,
+    CURSORTYPE_SIZING_ESWE,
+    CURSORTYPE_MOVE,
+    CURSORTYPE_DRAG,
+    CURSORTYPE_SEG_MOVING,
+    CURSORTYPE_SEG_SIZING
+};


### PR DESCRIPTION
Issue: [[Request] getCursorType](https://bugs.multitheftauto.com/view.php?id=9378)

This pull request adds, as said in the title, the `guiGetCursorType` (`GuiElement.getCursorType`, `<gui-element>.cursorType`) to the GUI functions. You can identify the cursor type by the returned string and the table below:

``` cpp
ADD_ENUM ( CURSORTYPE_NONE,         "none" )            // cursor has no image
ADD_ENUM ( CURSORTYPE_DEFAULT,      "arrow" )           // default cursor
ADD_ENUM ( CURSORTYPE_SIZING_NS,    "sizing_ns" )       // N-S (up-down) sizing cursor
ADD_ENUM ( CURSORTYPE_SIZING_EW,    "sizing_ew" )       // E-W (left-right) sizing cursor
ADD_ENUM ( CURSORTYPE_SIZING_NWSE,  "sizing_nwse" )     // NW-SE diagonal sizing cursor
ADD_ENUM ( CURSORTYPE_SIZING_NESW,  "sizing_nesw" )     // NE-SW diagonal sizing cursor
ADD_ENUM ( CURSORTYPE_SIZING_ESWE,  "sizing_eswe" )     // ES-WE horizontal sizing cursor
ADD_ENUM ( CURSORTYPE_MOVE,         "move" )            // move cursor
ADD_ENUM ( CURSORTYPE_DRAG,         "container_drag" )  // drag container cursor (note: not in use)
ADD_ENUM ( CURSORTYPE_SEG_MOVING,   "segment_moving" )  // segment moving cursor (note: not in use)
ADD_ENUM ( CURSORTYPE_SEG_SIZING,   "segment_sizing" )  // segment sizing cursor (note: not in use)
```
