### PR TITLE
0009381: Fix warpPedIntoVehicle during freefall preserves falling ani…

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -4059,14 +4059,7 @@ void CClientPed::InternalWarpIntoVehicle ( CVehicle* pGameVehicle )
     {
         // Reset whatever task
         m_pTaskManager->RemoveTask ( TASK_PRIORITY_PRIMARY );
-
-        // check we aren't in the fall and get up task
-        CTask * pTaskPhysicalResponse = m_pTaskManager->GetTask ( TASK_PRIORITY_PHYSICAL_RESPONSE );
-        // check our physical response task
-        if ( pTaskPhysicalResponse && strcmp ( pTaskPhysicalResponse->GetTaskName ( ), "TASK_COMPLEX_FALL_AND_GET_UP" ) == 0 )
-        {
-            m_pTaskManager->RemoveTask ( TASK_PRIORITY_PHYSICAL_RESPONSE );
-        }
+        m_pTaskManager->RemoveTask ( TASK_PRIORITY_EVENT_RESPONSE_TEMP );
 
         // Create a task to warp the player in and execute it
         CTaskSimpleCarSetPedInAsDriver* pInTask = g_pGame->GetTasks ()->CreateTaskSimpleCarSetPedInAsDriver ( pGameVehicle );


### PR DESCRIPTION
I think this `TASK_COMPLEX_FALL_AND_GET_UP` task is used only in script. Normal fall appears to occur only on slot 1.
