### PR TITLE
Fix 0004896 and 0006114 (ped vehicles aren't jackable)

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPedManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientPedManager.cpp
@@ -57,11 +57,11 @@ void CClientPedManager::DoPulse ( bool bDoStandardPulses )
 }
 
 
-CClientPed* CClientPedManager::Get ( ElementID ID, bool bCheckPlayers )
+CClientPed* CClientPedManager::Get ( ElementID ID, bool bIncludePlayers )
 {
     // Grab the element with the given id. Check its type.
     CClientEntity* pEntity = CElementIDs::GetElement ( ID );
-    if ( pEntity && ( pEntity->GetType () == CCLIENTPED || ( bCheckPlayers && pEntity->GetType () == CCLIENTPLAYER ) ) )
+    if ( pEntity && ( pEntity->GetType () == CCLIENTPED || ( bIncludePlayers && pEntity->GetType () == CCLIENTPLAYER ) ) )
     {
         return static_cast < CClientPed* > ( pEntity );
     }

--- a/Client/mods/deathmatch/logic/CClientPedManager.h
+++ b/Client/mods/deathmatch/logic/CClientPedManager.h
@@ -10,8 +10,7 @@
 *
 *****************************************************************************/
 
-#ifndef __CClientPedManager_H
-#define __CClientPedManager_H
+#pragma once
 
 #include <list>
 
@@ -29,7 +28,7 @@ public:
     void                            DeleteAll                       ( void );
 
     void                            DoPulse                         ( bool bDoStandardPulses );
-    CClientPed*                     Get                             ( ElementID ID, bool bCheckPlayers = false );    
+    CClientPed*                     Get                             ( ElementID ID, bool bIncludePlayers = false );    
     CClientPed*                     Get                             ( CPlayerPed* pPlayer, bool bValidatePointer, bool bCheckPlayers );
     CClientPed*                     GetSafe                         ( CEntity * pEntity, bool bCheckPlayers );
 
@@ -63,4 +62,3 @@ protected:
     bool                            m_bRemoveFromList;
 };
 
-#endif

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -1870,18 +1870,17 @@ void CPacketHandler::Packet_Vehicle_InOut ( NetBitStreamInterface& bitStream )
                         // Read out the player that's going into the vehicle
                         ElementID PlayerInside = INVALID_ELEMENT_ID;
                         bitStream.Read ( PlayerInside );
-                        CClientPlayer* pInsidePlayer = g_pClientGame->m_pPlayerManager->Get ( PlayerInside );
+                        CClientPed* pInsidePlayer = g_pClientGame->m_pPedManager->Get ( PlayerInside, true );
                         if ( pInsidePlayer )
                         {
                             // And the one dumping out on the outside
                             ElementID PlayerOutside = INVALID_ELEMENT_ID;
                             bitStream.Read ( PlayerOutside );
-                            CClientPlayer* pOutsidePlayer = g_pClientGame->m_pPlayerManager->Get ( PlayerOutside );
+                            CClientPed* pOutsidePlayer = g_pClientGame->m_pPedManager->Get ( PlayerOutside, true );
                             if ( pOutsidePlayer )
                             {
                                 // If local player, we are now allowed to enter it again
-                                if ( pInsidePlayer->IsLocalPlayer () ||
-                                        pOutsidePlayer->IsLocalPlayer () )
+                                if ( pInsidePlayer->IsLocalPlayer () || pOutsidePlayer->IsLocalPlayer () )
                                 {
                                     g_pClientGame->ResetVehicleInOut ();
                                 }

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -2780,15 +2780,14 @@ void CGame::Packet_Vehicle_InOut ( CVehicleInOutPacket& Packet )
                                                 }
                                                 else
                                                 {
-                                                    // TODO: support jacking peds (not simple!)
                                                     // Is the jacked person a player and stationary in the car (ie not getting in or out)
-                                                    if ( IS_PLAYER ( pOccupant ) && pOccupant->GetVehicleAction () == CPlayer::VEHICLEACTION_NONE )
+                                                    if ( pOccupant->GetVehicleAction () == CPed::VEHICLEACTION_NONE )
                                                     {
                                                         // He's now jacking the car and the occupant is getting jacked
-                                                        pPlayer->SetVehicleAction ( CPlayer::VEHICLEACTION_JACKING );
+                                                        pPlayer->SetVehicleAction ( CPed::VEHICLEACTION_JACKING );
                                                         pPlayer->SetJackingVehicle ( pVehicle );
                                                         pVehicle->SetJackingPlayer ( pPlayer );
-                                                        pOccupant->SetVehicleAction ( CPlayer::VEHICLEACTION_JACKED );
+                                                        pOccupant->SetVehicleAction ( CPed::VEHICLEACTION_JACKED );
 
                                                         // Call the entering vehicle event
                                                         CLuaArguments EnterArguments;
@@ -2799,7 +2798,7 @@ void CGame::Packet_Vehicle_InOut ( CVehicleInOutPacket& Packet )
                                                         if ( pVehicle->CallEvent ( "onVehicleStartEnter", EnterArguments ) )
                                                         {
                                                             // HACK?: check the player's vehicle-action is still the same (not warped in?)
-                                                            if ( pPlayer->GetVehicleAction () == CPlayer::VEHICLEACTION_JACKING )
+                                                            if ( pPlayer->GetVehicleAction () == CPed::VEHICLEACTION_JACKING )
                                                             {
                                                                 // Call the exiting vehicle event
                                                                 CLuaArguments ExitArguments;
@@ -2809,7 +2808,7 @@ void CGame::Packet_Vehicle_InOut ( CVehicleInOutPacket& Packet )
                                                                 if ( pVehicle->CallEvent ( "onVehicleStartExit", ExitArguments ) )
                                                                 {
                                                                     // HACK?: check the player's vehicle-action is still the same (not warped out?)
-                                                                    if ( pOccupant->GetVehicleAction () == CPlayer::VEHICLEACTION_JACKED )
+                                                                    if ( pOccupant->GetVehicleAction () == CPed::VEHICLEACTION_JACKED )
                                                                     {
                                                                         /* Jax: we don't need to worry about a syncer if we already have and will have a driver
                                                                         // Force the player as the syncer of the vehicle to which they are entering
@@ -2837,7 +2836,7 @@ void CGame::Packet_Vehicle_InOut ( CVehicleInOutPacket& Packet )
                                                         failReason = FAIL_JACKED_ACTION;
                                                 }
                                             }
-                                            else
+                                            else // We're not going for driver
                                             {
                                                 CPed* pCurrentOccupant = pVehicle->GetOccupant ( ucSeat );
                                                 if ( pCurrentOccupant || ucSeat > pVehicle->GetMaxPassengers () )


### PR DESCRIPTION
<details><summary>Dev note: refer to below snippet before merging:</summary>
<pre>
&lt;Cazomino05&gt; I heard qaisjp was working on Custom Train Tracks again
&lt;Cazomino05&gt; it isn't impossible to merge it though it requires some work still looking at what has changed since I last worked on it
&lt;Cazomino05&gt; from memory: issues relating to deleting tracks when a train is on it when they are streamed in, issues relating to having nodes too close together (iirc one of the fields is an unsigned short which was dumb), tracks can't be close together even if they have differing track ID's because trains will always warp to the nearest track or worse lock up the game
&lt;Cazomino05&gt; the API needed extensive work because it was impossible to get it working in a form that I was satisfied with (I really hated having sets/gets for node positions)
&lt;Cazomino05&gt; CTrain::DoPulse inside the game code was fairly dumb it just tried to find the x,y,z position of the nearest track point ignoring the stored track ID
&lt;Cazomino05&gt; there is a logic bug inside the code for CTrain::??? where it finds the position based on track where if nodes are too close together it cannot complete the while loop and return because it constantly starts again
&lt;Cazomino05&gt; changing that to only look at the current track ID would have several benefits: 1) performance increase 2) no logic bug 3) working custom train tracks 4) trains would never skip tracks when they are streamed in
&lt;Cazomino05&gt; FindClosestRailTrackNode 
&lt;Cazomino05&gt; actually it was GetTrainNodeNearPoint I believe
&lt;Cazomino05&gt; oh yeah and tracks were not using elements too that was annoying
&lt;Cazomino05&gt; and I was having some problems figuring out what should happen when a track is deleted because we only have 255 IDs to use internally
&lt;Cazomino05&gt; "distance += (nextPosition - position).Length(); // TODO: Check if this must be 2D. Yes, it must! Maybe not"
&lt;Cazomino05&gt; it should be 2D
&lt;Cazomino05&gt; from memory trains don't really slow down on hills
&lt;Cazomino05&gt; could be an option really
&lt;Cazomino05&gt; when you test the API make sure you test with large, negative and zero values
&lt;Cazomino05&gt; also near zero values because it deals heavily with integers and rounding will occur
&lt;Cazomino05&gt; oh and the cool stuff - rotation of trains isn't impossible either
&lt;Cazomino05&gt; so they can rotate across the other 2 axis 
&lt;Cazomino05&gt; I could see that being useful
&lt;Cazomino05&gt; at the moment they are just filled with zeros when the position is calculated
&lt;Cazomino05&gt; https://github.com/multitheftauto/mtasa-blue/pull/58
&lt;Cazomino05&gt; be careful with this and changes like this, unless something has changed drastically in vehicle entry it is a multi packet process
&lt;Cazomino05&gt; the comment is referring to the fact that usually you have a query response system in place for jacking
&lt;Cazomino05&gt; you tell the player being jacked that you are jacking them, they respond with an ack, you respond with an entry etc it's a big dance of packets
&lt;Cazomino05&gt; consequences: onVehicleStartExit is now called for peds on the server and malformed vehicle entry packets (very bad)
&lt;Cazomino05&gt; if you look around the code that's where it is calling onVehicleStartEnter consider what'd happen if the ped drove off?
&lt;Cazomino05&gt; or due to lag the vehicle crashed into a wall and stopped briefly long enough to enter
&lt;Cazomino05&gt; network troubles caused by vehicle entry are very common because it is one of the few places it updates the context id used in every packet as an ignore flag
&lt;Cazomino05&gt; gotta be really careful
<pre>
</details>
