### PR TITLE
Improve task reset in warpPedIntoVehicle

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -1374,6 +1374,26 @@ void CClientPed::WarpIntoVehicle ( CClientVehicle* pVehicle, unsigned int uiSeat
     SetSunbathing ( false );
     KillAnimation ();
 
+    if ( m_pPlayerPed )
+    {
+        // Fall tasks
+        KillTask ( TASK_PRIORITY_EVENT_RESPONSE_TEMP );
+        // Swim tasks
+        KillTask ( TASK_PRIORITY_EVENT_RESPONSE_NONTEMP );
+        // Jump & vehicle enter/exit & custom animation tasks
+        KillTask ( TASK_PRIORITY_PRIMARY );
+
+        KillTaskSecondary ( TASK_SECONDARY_ATTACK );
+
+        // check we aren't in the fall and get up task
+        CTask * pTaskPhysicalResponse = m_pTaskManager->GetTask ( TASK_PRIORITY_PHYSICAL_RESPONSE );
+        // check our physical response task
+        if ( pTaskPhysicalResponse && strcmp ( pTaskPhysicalResponse->GetTaskName ( ), "TASK_COMPLEX_FALL_AND_GET_UP" ) == 0 )
+        {
+            m_pTaskManager->RemoveTask ( TASK_PRIORITY_PHYSICAL_RESPONSE );
+        }
+    }
+
     // Eventually remove us from a previous vehicle
     RemoveFromVehicle ();
     //m_uiOccupyingSeat = uiSeat;
@@ -4057,17 +4077,6 @@ void CClientPed::InternalWarpIntoVehicle ( CVehicle* pGameVehicle )
 {
     if ( m_pPlayerPed )
     {
-        // Reset whatever task
-        m_pTaskManager->RemoveTask ( TASK_PRIORITY_PRIMARY );
-
-        // check we aren't in the fall and get up task
-        CTask * pTaskPhysicalResponse = m_pTaskManager->GetTask ( TASK_PRIORITY_PHYSICAL_RESPONSE );
-        // check our physical response task
-        if ( pTaskPhysicalResponse && strcmp ( pTaskPhysicalResponse->GetTaskName ( ), "TASK_COMPLEX_FALL_AND_GET_UP" ) == 0 )
-        {
-            m_pTaskManager->RemoveTask ( TASK_PRIORITY_PHYSICAL_RESPONSE );
-        }
-
         // Create a task to warp the player in and execute it
         CTaskSimpleCarSetPedInAsDriver* pInTask = g_pGame->GetTasks ()->CreateTaskSimpleCarSetPedInAsDriver ( pGameVehicle );
         if ( pInTask )


### PR DESCRIPTION
Fixes:
- [#9381 (warpPedIntoVehicle during freefall preserves falling animation)](https://bugs.multitheftauto.com/view.php?id=9381)
- some tasks aren't cleared at all if ped is warped to passenger seat (reported by Dutchman101 [here](https://bugs.multitheftauto.com/view.php?id=8617#c22647))
- water jump animation remains after warp
- IK aiming remains after warp
