### PR TITLE
Fix server crash on server-window resize

### DIFF
--- a/Server/core/CServerImpl.h
+++ b/Server/core/CServerImpl.h
@@ -14,10 +14,9 @@
 *
 *****************************************************************************/
 
-class CServerImpl;
+#pragma once
 
-#ifndef __CSERVERIMPL_H
-#define __CSERVERIMPL_H
+class CServerImpl;
 
 #include "MTAPlatform.h"
 #include <string>
@@ -99,21 +98,18 @@ private:
     bool                m_bRequestedQuit;
     bool                m_bRequestedReset;
 
-    wchar_t             m_szInputBuffer[255];
+    wchar_t             m_szInputBuffer [ 255 ];
     unsigned int        m_uiInputCount;
     
-    char                m_szTag[80];
+    char                m_szTag [ 80 ];
 
     double              m_dLastTimeMs;
     double              m_dPrevOverrun;
 
 #ifdef WIN32
-    HANDLE              m_hConsole;
-    HANDLE              m_hConsoleInput;
-    CHAR_INFO           m_ScrnBuffer[256];
-
-    CThreadCommandQueue*    m_pThreadCommandQueue;
+    HANDLE                      m_hConsole;
+    HANDLE                      m_hConsoleInput;
+    std::vector < CHAR_INFO >   m_vecScreenBuffer;
+    CThreadCommandQueue *       m_pThreadCommandQueue;
 #endif
 };
-
-#endif

--- a/Server/core/CThreadCommandQueue.cpp
+++ b/Server/core/CThreadCommandQueue.cpp
@@ -20,22 +20,20 @@
 void CThreadCommandQueue::Add ( const char* szCommand )
 {
     // Add command to queue thread-safe
-    m_Mutex.lock ( );
+    std::lock_guard < std::mutex > lock ( m_Mutex );
     m_Commands.push ( szCommand );
-    m_Mutex.unlock ( );
 }
-
 
 void CThreadCommandQueue::Process ( bool& bRequestedQuit, CModManagerImpl* pModManager )
 {
     // Lock the critical section
-    m_Mutex.lock ( );
+    std::lock_guard < std::mutex > lock ( m_Mutex );
 
     // Got commands to process?
     while ( !m_Commands.empty ( ) )
     {
         // Grab the string
-        auto str = m_Commands.front ( );
+        const auto& str = m_Commands.front ( );
 
         // Check for the most important command: quit and exit.
         if ( str == "quit" || str == "exit" )
@@ -46,9 +44,6 @@ void CThreadCommandQueue::Process ( bool& bRequestedQuit, CModManagerImpl* pModM
         // Remove it from the queue
         m_Commands.pop ( );
     }
-
-    // Unlock the critical section
-    m_Mutex.unlock ( );
 }
 
 #endif

--- a/Server/core/CThreadCommandQueue.h
+++ b/Server/core/CThreadCommandQueue.h
@@ -10,12 +10,12 @@
 *
 *****************************************************************************/
 
-#ifndef __CTHREADCOMMANDQUEUE_H
-#define __CTHREADCOMMANDQUEUE_H
+#pragma once
 
 #ifdef WIN32
 
-#include <list>
+#include <mutex>
+#include <queue>
 #include <string>
 
 class CThreadCommandQueue
@@ -25,10 +25,8 @@ public:
     void                Process         ( bool& bRequestedQuit, class CModManagerImpl* pModManager );
 
 private:
-    std::list < std::string >       m_Commands;
-    CCriticalSection                m_Critical;
+    std::queue < std::string >  m_Commands;
+    std::mutex                  m_Mutex;
 };
-
-#endif
 
 #endif


### PR DESCRIPTION
This pull request patches the server implementation to use a vector instead of a fixed-width array, because the method `ShowInfoTag` used to write beyond the array boundaries if you resize the server window corrupting the memory of the command queue and further.

I may not have enough experience when it's about C++, performance and vectors. Please tell me your thoughts about the code below (as review or comment).
