### PR TITLE
[editor] Set default FPS limit to 100

### DIFF
--- a/Server/mods/deathmatch/editor.conf
+++ b/Server/mods/deathmatch/editor.conf
@@ -184,8 +184,8 @@
     <htmldebuglevel>0</htmldebuglevel>
 
     <!-- Specifies the frame rate limit that will be applied to connecting clients.
-         Available range: 25 to 100. Default: 36. -->
-    <fpslimit>36</fpslimit>
+         Available range: 25 to 100. Default: 100. -->
+    <fpslimit>100</fpslimit>
     
     <!-- Specifies whether or not players should automatically be logged in based on their IP adresses -->
     <autologin>0</autologin>


### PR DESCRIPTION
Set default FPS limit to 100, because there is no point in limiting fps to 36, however it may scare and annoy players who are new to map editor.
