### PR TITLE
0009418: setElementFrozen directly after resource start not working

### DIFF
--- a/Client/game_sa/CPhysicalSA.cpp
+++ b/Client/game_sa/CPhysicalSA.cpp
@@ -366,7 +366,7 @@ void CPhysicalSA::SetFrozen ( bool bFrozen )
 {
     CPhysicalSAInterface * pInterface = (CPhysicalSAInterface *)this->GetInterface();
     // Set movement ability
-    pInterface->bDisableMovement = bFrozen;
+    pInterface->bDontApplySpeed = bFrozen;
     // Set rotation movement ability
     pInterface->bDisableFriction = bFrozen;
 }

--- a/Client/game_sa/CPhysicalSA.h
+++ b/Client/game_sa/CPhysicalSA.h
@@ -50,7 +50,7 @@ public:
     uint32 bBroken : 1;
     uint32 b0x800 : 1; // ref @ 0x6F5CF0
     uint32 b0x1000 : 1;//
-    uint32 b0x2000 : 1;//
+    uint32 bDontApplySpeed : 1;//
     uint32 b0x4000 : 1;//
     uint32 b0x8000 : 1;//
 

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -2911,9 +2911,9 @@ void CPacketHandler::Packet_EntityAdd ( NetBitStreamInterface& bitStream )
                         }
                         pObject->SetScale ( vecScale );
 
-                        bool bStatic;
-                        if ( bitStream.ReadBit ( bStatic ) )
-                            pObject->SetStatic ( bStatic );
+                        bool bFrozen;
+                        if ( bitStream.ReadBit ( bFrozen ) )
+                            pObject->SetFrozen ( bFrozen );
 
                         SObjectHealthSync health;
                         if ( bitStream.Read ( &health ) )

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -3842,7 +3842,7 @@ bool CStaticFunctionDefinitions::SetObjectStatic ( CClientEntity& Entity, bool b
     if ( IS_OBJECT ( &Entity ) )
     {
         CDeathmatchObject& Object = static_cast < CDeathmatchObject& > ( Entity );
-        Object.SetStatic ( bStatic );
+        Object.SetFrozen ( bStatic );
         return true;
     }
 

--- a/Server/mods/deathmatch/logic/CObject.cpp
+++ b/Server/mods/deathmatch/logic/CObject.cpp
@@ -33,7 +33,7 @@ CObject::CObject ( CElement* pParent, CXMLNode* pNode, CObjectManager* pObjectMa
     m_fHealth = 1000.0f;
     m_bSyncable = true;
     m_pSyncer = NULL;
-    m_bIsStatic = false;
+    m_bIsFrozen = false;
 
     m_bCollisionsEnabled = true;
 
@@ -171,7 +171,7 @@ bool CObject::ReadSpecialData ( void )
 
     bool bFrozen;
     if ( GetCustomDataBool ( "frozen", bFrozen, true ) )
-        m_bIsStatic = bFrozen;
+        m_bIsFrozen = bFrozen;
 
     // Success
     return true;

--- a/Server/mods/deathmatch/logic/CObject.h
+++ b/Server/mods/deathmatch/logic/CObject.h
@@ -62,8 +62,8 @@ public:
     inline bool                 GetCollisionEnabled     ( void )                        { return m_bCollisionsEnabled; }
     inline void                 SetCollisionEnabled     ( bool bCollisionEnabled )      { m_bCollisionsEnabled = bCollisionEnabled; }
 
-    inline bool                 IsStatic                ( void )                        { return m_bIsStatic; }
-    inline void                 SetStatic               ( bool bStatic )                { m_bIsStatic = bStatic; }
+    inline bool                 IsFrozen                ( void )                        { return m_bIsFrozen; }
+    inline void                 SetFrozen               ( bool bFrozen )                { m_bIsFrozen = bFrozen; }
 
     inline float                GetHealth               ( void )                        { return m_fHealth; }
     inline void                 SetHealth               ( float fHealth )               { m_fHealth = fHealth; }
@@ -84,7 +84,7 @@ private:
     unsigned char               m_ucAlpha;
     unsigned short              m_usModel;
     CVector                     m_vecScale;
-    bool                        m_bIsStatic;
+    bool                        m_bIsFrozen;
     float                       m_fHealth;
     bool                        m_bBreakable;
     bool                        m_bSyncable;

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -924,7 +924,7 @@ bool CStaticFunctionDefinitions::IsElementFrozen ( CElement* pElement, bool &bFr
         case CElement::OBJECT:
         {
             CObject* pObject = static_cast < CObject* > ( pElement );
-            bFrozen = pObject->IsStatic ();
+            bFrozen = pObject->IsFrozen ();
             break;
         }
         default: return false;
@@ -1938,7 +1938,7 @@ bool CStaticFunctionDefinitions::SetElementFrozen ( CElement* pElement, bool bFr
         case CElement::OBJECT:
         {
             CObject * pObject = static_cast < CObject* > ( pElement );
-            pObject->SetStatic ( bFrozen );
+            pObject->SetFrozen ( bFrozen );
             break;
         }
         default: return false;

--- a/Server/mods/deathmatch/logic/packets/CEntityAddPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CEntityAddPacket.cpp
@@ -275,9 +275,9 @@ bool CEntityAddPacket::Write ( NetBitStreamInterface& BitStream ) const
                         BitStream.Write( vecScale.fX );
                     }
 
-                    // Static
-                    bool bStatic = pObject->IsStatic ();
-                    BitStream.WriteBit ( bStatic );
+                    // Frozen
+                    bool bFrozen = pObject->IsFrozen ();
+                    BitStream.WriteBit ( bFrozen );
 
                     // Health
                     SObjectHealthSync health;


### PR DESCRIPTION
Also fixes strange issue with collisions between local player ped and frozen object (I used flag from https://github.com/jte/GTASA/blob/master/Engine/Physics/CPhysical.h#L101).
