### PR TITLE
Fix OOP method-function for getProperty of custom weapons

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaWeaponDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaWeaponDefs.cpp
@@ -53,7 +53,7 @@ void CLuaWeaponDefs::AddClass ( lua_State* luaVM )
     lua_classfunction ( luaVM, "setAmmo", "setWeaponAmmo" );
     lua_classfunction ( luaVM, "setClipAmmo", "setWeaponClipAmmo" );
 
-    lua_classfunction ( luaVM, "getProperty", "setWeaponProperty" );
+    lua_classfunction ( luaVM, "getProperty", "getWeaponProperty" );
     lua_classfunction ( luaVM, "getOwner", "getWeaponOwner" );
     lua_classfunction ( luaVM, "getTarget", "getWeaponTarget" );
     lua_classfunction ( luaVM, "getFiringRate", "getWeaponFiringRate" );


### PR DESCRIPTION
This pull request fixes the issue with `getProperty` method of custom weapons pointing to the `setWeaponProperty` function instead of `getWeaponProperty`.
