### PR TITLE
Keep text selection in client console

### DIFF
--- a/Client/core/CConsole.cpp
+++ b/Client/core/CConsole.cpp
@@ -529,6 +529,11 @@ void CConsole::FlushPendingAdd ( void )
         float fScroll = m_pHistory->GetVerticalScrollPosition ();
         float fMaxScroll = m_pHistory->GetScrollbarDocumentSize () - m_pHistory->GetScrollbarPageSize ();
 
+        // Grab selection
+        uint uiSelectionStart = m_pHistory->GetSelectionStart ();
+        uint uiSelectionEnd = m_pHistory->GetSelectionEnd ();
+        uint uiSelectionLength = m_pHistory->GetSelectionLength ();
+
         // Make new buffer
         SString strBuffer = m_pHistory->GetText ();
         strBuffer += m_strPendingAdd;
@@ -547,5 +552,9 @@ void CConsole::FlushPendingAdd ( void )
         // If not at the end, keep the scrollbar position
         if ( fScroll < fMaxScroll )
             m_pHistory->SetVerticalScrollPosition ( fScroll );
+
+        // Keep text selection if any
+        if ( uiSelectionLength > 0 )
+            m_pHistory->SetSelection ( uiSelectionStart, uiSelectionEnd );
     }
 }

--- a/Client/gui/CGUIMemo_Impl.cpp
+++ b/Client/gui/CGUIMemo_Impl.cpp
@@ -147,6 +147,30 @@ float CGUIMemo_Impl::GetScrollbarPageSize ( void )
 }
 
 
+void CGUIMemo_Impl::SetSelection ( unsigned int uiStart, unsigned int uiEnd )
+{
+    reinterpret_cast < CEGUI::MultiLineEditbox* > ( m_pWindow ) -> setSelection ( uiStart, uiEnd );
+}
+
+
+unsigned int CGUIMemo_Impl::GetSelectionStart ( void )
+{
+    return static_cast < unsigned int > ( reinterpret_cast < CEGUI::MultiLineEditbox* > ( m_pWindow ) -> getSelectionStartIndex () );
+}
+
+
+unsigned int CGUIMemo_Impl::GetSelectionEnd ( void )
+{
+    return static_cast < unsigned int > ( reinterpret_cast < CEGUI::MultiLineEditbox* > ( m_pWindow ) -> getSelectionEndIndex () );
+}
+
+
+unsigned int CGUIMemo_Impl::GetSelectionLength ( void )
+{
+    return static_cast < unsigned int > ( reinterpret_cast < CEGUI::MultiLineEditbox* > ( m_pWindow ) -> getSelectionLength () );
+}
+
+
 bool CGUIMemo_Impl::ActivateOnTab ( void )
 {
     // Only select this as active if its visible and writable

--- a/Client/gui/CGUIMemo_Impl.h
+++ b/Client/gui/CGUIMemo_Impl.h
@@ -21,35 +21,40 @@
 class CGUIMemo_Impl : public CGUIMemo, public CGUIElement_Impl, public CGUITabListItem
 {
 public:
-                CGUIMemo_Impl           ( class CGUI_Impl* pGUI, CGUIElement* pParent = NULL, const char* szText = "" );
-                ~CGUIMemo_Impl          ( void );
+                        CGUIMemo_Impl               ( class CGUI_Impl* pGUI, CGUIElement* pParent = NULL, const char* szText = "" );
+                        ~CGUIMemo_Impl              ( void );
 
-    void        SetReadOnly             ( bool bReadOnly );
-    bool        IsReadOnly              ( void );
+    void                SetReadOnly                 ( bool bReadOnly );
+    bool                IsReadOnly                  ( void );
 
-    size_t      GetCaretIndex           ( void );
-    void        SetCaretIndex           ( size_t Index );
+    size_t              GetCaretIndex               ( void );
+    void                SetCaretIndex               ( size_t Index );
 
-    float       GetVerticalScrollPosition   ( void );
-    void        SetVerticalScrollPosition   ( float fPosition );
-    float       GetScrollbarDocumentSize    ( void );
-    float       GetScrollbarPageSize        ( void );
+    float               GetVerticalScrollPosition   ( void );
+    void                SetVerticalScrollPosition   ( float fPosition );
+    float               GetScrollbarDocumentSize    ( void );
+    float               GetScrollbarPageSize        ( void );
 
-    void        EnsureCaratIsVisible    ( void );
+    void                SetSelection                ( unsigned int uiStart, unsigned int uiEnd );
+    unsigned int        GetSelectionStart           ( void );
+    unsigned int        GetSelectionEnd             ( void );
+    unsigned int        GetSelectionLength          ( void );
 
-    bool        ActivateOnTab           ( void );
+    void                EnsureCaratIsVisible        ( void );
 
-    void        SetTextChangedHandler   ( const GUI_CALLBACK & Callback );
+    bool                ActivateOnTab               ( void );
 
-    eCGUIType   GetType                 ( void ) { return CGUI_MEMO; };
+    void                SetTextChangedHandler       ( const GUI_CALLBACK & Callback );
+
+    eCGUIType           GetType                     ( void ) { return CGUI_MEMO; };
 
     #include "CGUIElement_Inc.h"
 
 private:
-    bool        Event_TextChanged       ( const CEGUI::EventArgs& e );
-    bool        Event_OnKeyDown         ( const CEGUI::EventArgs& e );
+    bool                Event_TextChanged       ( const CEGUI::EventArgs& e );
+    bool                Event_OnKeyDown         ( const CEGUI::EventArgs& e );
 
-    GUI_CALLBACK    m_TextChanged;
+    GUI_CALLBACK        m_TextChanged;
 };
 
 #endif

--- a/Client/sdk/gui/CGUIMemo.h
+++ b/Client/sdk/gui/CGUIMemo.h
@@ -31,6 +31,11 @@ public:
     virtual float           GetScrollbarDocumentSize    ( void ) = 0;
     virtual float           GetScrollbarPageSize        ( void ) = 0;
 
+    virtual void            SetSelection            ( unsigned int uiStart, unsigned int uiEnd ) = 0;
+    virtual unsigned int    GetSelectionStart       ( void ) = 0;
+    virtual unsigned int    GetSelectionEnd         ( void ) = 0;
+    virtual unsigned int    GetSelectionLength      ( void ) = 0;
+
     virtual void            EnsureCaratIsVisible    ( void ) = 0;
 
     virtual void            SetTextChangedHandler   ( const GUI_CALLBACK & Callback ) = 0;


### PR DESCRIPTION
Currently the client console looses text selection whenever any new message arrives. This behaviour is very annoying on live server. When there are a lot of players writing on chat it is almost impossible to copy some parts of output from the window. These changes solve the problem.