### PR TITLE
Add getResourceOrganizationalPath server function

### DIFF
--- a/Server/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
@@ -55,6 +55,7 @@ void CLuaResourceDefs::LoadFunctions ( void )
     CLuaCFunctions::AddFunction ( "getResourceDynamicElementRoot", getResourceDynamicElementRoot );
     CLuaCFunctions::AddFunction ( "getResourceMapRootElement", getResourceMapRootElement );
     CLuaCFunctions::AddFunction ( "getResourceExportedFunctions", getResourceExportedFunctions );
+    CLuaCFunctions::AddFunction ( "getResourceOrganizationalPath", getResourceOrganizationalPath);
 
     // Set stuff
     CLuaCFunctions::AddFunction ( "setResourceInfo", setResourceInfo );
@@ -106,6 +107,7 @@ void CLuaResourceDefs::AddClass ( lua_State* luaVM )
     lua_classfunction ( luaVM, "getDynamicElementRoot", "getResourceDynamicElementRoot" );
     lua_classfunction ( luaVM, "getRootElement", "getResourceRootElement" );
     lua_classfunction ( luaVM, "getExportedFunctions", "getResourceExportedFunctions" );
+    lua_classfunction ( luaVM, "getOrganizationalPath", "getResourceOrganizationalPath");
     lua_classfunction ( luaVM, "getLastStartTime", "getResourceLastStartTime" );
     lua_classfunction ( luaVM, "getLoadTime", "getResourceLoadTime" );
     lua_classfunction ( luaVM, "getInfo", "getResourceInfo" );
@@ -117,6 +119,7 @@ void CLuaResourceDefs::AddClass ( lua_State* luaVM )
 
     lua_classvariable ( luaVM, "dynamicElementRoot", NULL, "getResourceDynamicElementRoot" );
     lua_classvariable ( luaVM, "exportedFunctions", NULL, "getResourceExportedFunctions" );
+    lua_classvariable ( luaVM, "organizationalPath", nullptr, "getResourceOrganizationalPath" );
     lua_classvariable ( luaVM, "lastStartTime", NULL, "getResourceLastStartTime" );
     lua_classvariable ( luaVM, "aclRequests", NULL, "getResourceACLRequests" );
     lua_classvariable ( luaVM, "loadTime", NULL, "getResourceLoadTime" );
@@ -1061,6 +1064,41 @@ int CLuaResourceDefs::getResourceExportedFunctions ( lua_State* luaVM )
     lua_pushboolean ( luaVM, false );
     return 1;
 }
+
+
+int CLuaResourceDefs::getResourceOrganizationalPath ( lua_State* luaVM )
+{
+    // string getResourceOrganizationalPath ( resource theResource )
+    // Returns a string representing the resource organizational path, false if invalid resource was provided. 
+
+    CResource* pResource;
+
+    CScriptArgReader argStream ( luaVM );
+    argStream.ReadUserData ( pResource );
+    
+    if ( !argStream.HasErrors() )
+    {
+        SString strOrganizationalPath = m_pResourceManager->GetResourceOrganizationalPath ( pResource );
+        
+        if ( !strOrganizationalPath.empty() )
+        {
+            // Normalize path separator, it is always slash on resources side
+            ReplaceOccurrencesInString ( strOrganizationalPath, "\\", "/" );
+
+            // The leading separator won't be needed
+            strOrganizationalPath = strOrganizationalPath.TrimStart ( "/" );
+        }
+        
+        lua_pushstring ( luaVM, strOrganizationalPath );
+        return 1;
+    }
+    else
+        m_pScriptDebugging->LogCustom ( luaVM, argStream.GetFullErrorMessage() );
+     
+    lua_pushboolean ( luaVM, false );
+    return 1;
+}
+
 
 int CLuaResourceDefs::call ( lua_State* luaVM )
 {

--- a/Server/mods/deathmatch/logic/luadefs/CLuaResourceDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaResourceDefs.h
@@ -57,6 +57,7 @@ public:
     LUA_DECLARE ( getResourceDynamicElementRoot );
     LUA_DECLARE ( getResourceMapRootElement );
     LUA_DECLARE ( getResourceExportedFunctions );
+    LUA_DECLARE ( getResourceOrganizationalPath );
 
     // Set stuff
     LUA_DECLARE ( setResourceInfo );


### PR DESCRIPTION
## Background
Organizational paths are a great way to keep resources structure nice and clean on the filesystem side. I am personally missing this ability on the Lua side. I think it would be great if developers were able to e.g. create maps listing divided to categories based on their organizational directories. 

Every resource has this information internally (and it is currently only settable via `copyResource` and `createResource` functions IIRC) so it is just a matter of making a public getter. Server-side only obviously.

## Implementation
I've used `CResourceManager::GetResourceOrganizationalPath` to obtain the organizational path of resource (relative, real filesystem path so the separator is OS-dependent) and then `ReplaceOccurrencesInString` from Utils to ensure that slash (`/`) is used as a path separator (because it is in every other MTA-Lua function which touches the filesystem in some way and I've also seen that `CResourceManager::ParseResourcePathInput` performs the normalization in the same way).
Finally, leading slash is trimmed out because it's just not needed here.

### Syntax
`getResourceOrganizationalPath(resource)`

### OOP syntax
```
resource.organizationalPath
resource:getOrganizationalPath()
```

### Return values
- String representing the resource organizational path (empty string when resource is in the root directory)
- Boolean (`false`) if invalid resource was provided as an argument

### Examples / tests
Using standard resources
```
assert("[gamemodes]/[assault]/[maps]" == Resource.getFromName("as-cliff").organizationalPath)
assert(""                             == Resource.getFromName("editor_dump").organizationalPath)
assert("[editor]"                     == Resource.getFromName("editor"):getOrganizationalPath())
assert("[web]"                        == getResourceOrganizationalPath(getResourceFromName("resourcemanager")))
assert(false                          == getResourceOrganizationalPath("rubbish"))
```


PS There is a typo spreaded across the project regarding the path separator macro name. It should be PATH_SEP**A**RATOR instead of PATH_SEP**E**RATOR. I've been faster than intellisense when I was experimenting and was wondering why the code doesn't want to compile 😕 