### PR TITLE
Set max input length in client console

### DIFF
--- a/Client/core/CConsole.cpp
+++ b/Client/core/CConsole.cpp
@@ -18,8 +18,10 @@
 using SharedUtil::CalcMTASAPath;
 using std::string;
 
-#define CONSOLE_HISTORY_LENGTH 128
-#define CONSOLE_SIZE 4096
+#define CONSOLE_HISTORY_LENGTH      128
+#define CONSOLE_SIZE                4096
+
+#define MAX_CONSOLE_COMMAND_LENGTH  255
 
 #define NATIVE_RES_X    1152.0f
 #define NATIVE_RES_Y    864.0f
@@ -49,6 +51,7 @@ CConsole::CConsole ( CGUI* pManager, CGUIElement* pParent )
     m_pWindow->SetSizedHandler ( GUI_CALLBACK ( &CConsole::OnWindowSize, this ) );
 
     m_pInput->SetTextAcceptedHandler ( GUI_CALLBACK ( &CConsole::Edit_OnTextAccepted, this ) );
+    m_pInput->SetMaxLength ( MAX_CONSOLE_COMMAND_LENGTH );
 
     m_pHistory->SetTextChangedHandler ( GUI_CALLBACK ( &CConsole::History_OnTextChanged, this ) );
 


### PR DESCRIPTION
Client console doesn't have any input length limit and it causes bad user
experience when inputting more than 255 characters. Command string is being
silently truncated by Deathmatch module (which has fixed limit of max command
length on both client and server side). If something has a limited length
then user should know about it in advance.

Such situations can happen mostly when using 'runcode' for fast prototyping.
Code is unexpectedly being cut and at best it will just fail to execute
due to syntax error. At worst, syntax will be valid and some code won't be
executed without user knowing about it.

New macro holding max console command length is added because we don't have such information in Core. I realize it might not be a perfect solution so I'm open to discussion with you guys and willing to improve this.