### PR TITLE
Better handling of text pasting in GUI textboxes

### DIFF
--- a/Client/gui/CGUI_Impl.cpp
+++ b/Client/gui/CGUI_Impl.cpp
@@ -864,12 +864,18 @@ bool CGUI_Impl::Event_KeyDown ( const CEGUI::EventArgs& Args )
                                 CloseClipboard();
                                 return true;
                             }
-                            strEditText = WndEdit->getText ();
+
+                            strEditText = WndEdit->getText();
                             iSelectionStart = WndEdit->getSelectionStartIndex ();
                             iSelectionLength = WndEdit->getSelectionLength();
                             iMaxLength = WndEdit->getMaxTextLength();
                             iCaratIndex = WndEdit->getCaratIndex();
                             bReplaceNewLines = false;
+
+                            // Plus one character, because there is always an extra '\n' in
+                            // MultiLineEditbox's text data and it causes MaxLength limit to 
+                            // be exceeded during pasting the text
+                            iMaxLength += 1;
                         }
 
                         std::wstring strClipboardText = ClipboardBuffer;
@@ -901,7 +907,7 @@ bool CGUI_Impl::Event_KeyDown ( const CEGUI::EventArgs& Args )
 
                         // Put the editbox's data into a string and insert the data if it has not reached it's maximum text length
                         std::wstring tmp = MbUTF8ToUTF16(strEditText.c_str());
-                        if ( ( strClipboardText.length () + tmp.length () ) < iMaxLength )
+                        if ( ( strClipboardText.length () + tmp.length () ) <= iMaxLength )
                         {
                             // Are there characters selected?
                             size_t sizeCaratIndex = 0;

--- a/Client/gui/CGUI_Impl.cpp
+++ b/Client/gui/CGUI_Impl.cpp
@@ -907,7 +907,7 @@ bool CGUI_Impl::Event_KeyDown ( const CEGUI::EventArgs& Args )
 
                         // Put the editbox's data into a string and insert the data if it has not reached it's maximum text length
                         std::wstring tmp = MbUTF8ToUTF16(strEditText.c_str());
-                        if ( ( strClipboardText.length () + tmp.length () ) <= iMaxLength )
+                        if ( ( strClipboardText.length () + tmp.length () - iSelectionLength ) <= iMaxLength )
                         {
                             // Are there characters selected?
                             size_t sizeCaratIndex = 0;


### PR DESCRIPTION
Fixed two problems with pasting the text to GUI textboxes. It affects internal stuff like client console (which was the main reason of investigating this) and also Memos and Edits created by resources.

#### 1. Fix problem with pasting text when its length is matching GUI element's MaxLength

If Editbox or MultiLineEditbox have MaxTextLength set to e.g. 100 characters
then it is impossible to paste any text containing exactly 100 characters
into it.

The best moment to observe this is when user fills the control with text
until it's full, then cuts all of it and tries to paste it again.

Lua test script is available at:
https://github.com/4O4/mtasa-lua-tests/tree/master/%5Btests%5D/test-gui-limited-textbox-paste

#### 2. Exclude selection when checking MaxLength limit during text paste

The selected text is replaced after pasting so it should always be ignored.