### PR TITLE
Fix input horizontal scroll during history navigation in client console

### DIFF
--- a/Client/core/CConsole.h
+++ b/Client/core/CConsole.h
@@ -65,6 +65,8 @@ protected:
     bool                Edit_OnTextAccepted             ( CGUIElement* pElement );
     bool                History_OnTextChanged           ( CGUIElement* pElement );
     void                FlushPendingAdd                 ( void );
+    void                GracefullySetEditboxText        ( const char * szText );
+    bool                GracefullyMoveEditboxCaret      ( CGUIElement* pElement );
 
 private:
     void                CreateElements                  ( CGUIElement* pParent = NULL );

--- a/Client/gui/CGUIEdit_Impl.cpp
+++ b/Client/gui/CGUIEdit_Impl.cpp
@@ -35,6 +35,8 @@ CGUIEdit_Impl::CGUIEdit_Impl ( CGUI_Impl* pGUI, CGUIElement* pParent, const char
     // Register our event
     m_pWindow->subscribeEvent ( CEGUI::Editbox::EventKeyDown, CEGUI::Event::Subscriber ( &CGUIEdit_Impl::Event_OnKeyDown, this ) );
     m_pWindow->subscribeEvent ( CEGUI::Editbox::EventTextChanged, CEGUI::Event::Subscriber ( &CGUIEdit_Impl::Event_OnTextChanged, this ) );
+    m_pWindow->subscribeEvent ( CEGUI::Editbox::EventRenderingEnded, CEGUI::Event::Subscriber ( &CGUIEdit_Impl::Event_OnRenderingEnded, this ) );
+    m_pWindow->subscribeEvent ( CEGUI::Editbox::EventRenderingStarted, CEGUI::Event::Subscriber ( &CGUIEdit_Impl::Event_OnRenderingStarted, this ) );
     AddEvents ();
 
     // If a parent is specified, add it to it's children list, if not, add it as a child to the pManager
@@ -165,6 +167,18 @@ void CGUIEdit_Impl::SetTextChangedHandler ( GUI_CALLBACK Callback )
 }
 
 
+void CGUIEdit_Impl::SetRenderingEndedHandler ( GUI_CALLBACK Callback )
+{
+    m_OnRenderingEnded = Callback;
+}
+
+
+void CGUIEdit_Impl::SetRenderingStartedHandler ( GUI_CALLBACK Callback )
+{
+    m_OnRenderingStarted = Callback;
+}
+
+
 bool CGUIEdit_Impl::ActivateOnTab ( void )
 {
     // Only select this as active if its visible and writable
@@ -182,6 +196,22 @@ bool CGUIEdit_Impl::Event_OnTextChanged ( const CEGUI::EventArgs& e )
 {
     if ( m_OnTextChanged )
         m_OnTextChanged ( reinterpret_cast < CGUIElement* > ( this ) );
+    return true;
+}
+
+
+bool CGUIEdit_Impl::Event_OnRenderingEnded ( const CEGUI::EventArgs& e )
+{
+    if ( m_OnRenderingEnded )
+        m_OnRenderingEnded ( reinterpret_cast < CGUIElement* > ( this ) );
+    return true;
+}
+
+
+bool CGUIEdit_Impl::Event_OnRenderingStarted ( const CEGUI::EventArgs& e )
+{
+    if ( m_OnRenderingStarted )
+        m_OnRenderingStarted ( reinterpret_cast < CGUIElement* > ( this ) );
     return true;
 }
 

--- a/Client/gui/CGUIEdit_Impl.h
+++ b/Client/gui/CGUIEdit_Impl.h
@@ -42,21 +42,27 @@ public:
     void                SetCaretAtEnd           ( void );
     unsigned int        GetCaretIndex           ( void );
 
-    void                SetTextAcceptedHandler  ( GUI_CALLBACK Callback );
-    void                SetTextChangedHandler   ( GUI_CALLBACK Callback );
+    void                SetTextAcceptedHandler      ( GUI_CALLBACK Callback );
+    void                SetTextChangedHandler       ( GUI_CALLBACK Callback );
+    void                SetRenderingEndedHandler    ( GUI_CALLBACK Callback );
+    void                SetRenderingStartedHandler  ( GUI_CALLBACK Callback );
 
-    bool                ActivateOnTab           ( void );
+    bool                ActivateOnTab               ( void );
 
-    eCGUIType           GetType                 ( void ) { return CGUI_EDIT; };
+    eCGUIType           GetType                     ( void ) { return CGUI_EDIT; };
 
     #include "CGUIElement_Inc.h"
 
 protected:
-    bool                Event_OnTextChanged     ( const CEGUI::EventArgs& e );
-    bool                Event_OnKeyDown         ( const CEGUI::EventArgs& e );
+    bool                Event_OnTextChanged         ( const CEGUI::EventArgs& e );
+    bool                Event_OnKeyDown             ( const CEGUI::EventArgs& e );
+    bool                Event_OnRenderingEnded      ( const CEGUI::EventArgs& e );
+    bool                Event_OnRenderingStarted    ( const CEGUI::EventArgs& e );
 
     GUI_CALLBACK        m_OnTextAccepted;
     GUI_CALLBACK        m_OnTextChanged;
+    GUI_CALLBACK        m_OnRenderingEnded;
+    GUI_CALLBACK        m_OnRenderingStarted;
 };
 
 #endif

--- a/Client/sdk/gui/CGUIEdit.h
+++ b/Client/sdk/gui/CGUIEdit.h
@@ -38,8 +38,10 @@ public:
     virtual void                SetCaretAtEnd           ( void ) = 0;
     virtual unsigned int        GetCaretIndex           ( void ) = 0;
 
-    virtual void                SetTextAcceptedHandler  ( GUI_CALLBACK Callback ) = 0;
-    virtual void                SetTextChangedHandler   ( GUI_CALLBACK Callback ) = 0;
+    virtual void                SetTextAcceptedHandler      ( GUI_CALLBACK Callback ) = 0;
+    virtual void                SetTextChangedHandler       ( GUI_CALLBACK Callback ) = 0;
+    virtual void                SetRenderingEndedHandler    ( GUI_CALLBACK Callback ) = 0;
+    virtual void                SetRenderingStartedHandler  ( GUI_CALLBACK Callback ) = 0;
 };
 
 #endif


### PR DESCRIPTION
This problem occurs on command history navigation (up / down) and
autocompletion (tab). When some command lines are longer than input
width, the editbox gets semi-permanently scrolled horizontally to
the end. When user keeps navigating through shorter commands he only
sees part of them (beginning is invisible) or doesn't see anything at
all, but the whole text is still there. This is bad.

Current solution, which is to simply set caret position to input start
and then immediately to the end doesn't do the job, because visual state
hasn't changed and Editbox is not being re-rendered.

The solution is to delay movement of caret to input end until the next
rendering phase.

Side effect: minimal caret flickering on the start of input text, which is a small price for such an improvement.

---

As you have probably seen, I've recently made 3 other pull requests which improve UX of client console ( #98 #101 #100 ) . I hope they will all get merged eventually (one of them already is! 🙌), because I personally love using text consoles of any kind and these small bugs are effectively stopping me from doing productive things while using the MTA's one. 

I know that you guys have more important stuff to do, so despite my lack of C++ experience, I decided to try to fix something by myself instead of filling reports in tracker. I have to say it is a great way of learning and such things aren't as hard as I thought they are. I will surely bring more contributions when I have some spare time.

Make client console great again!