### PR TITLE
Fix client's fileGetPath() FormatException

### DIFF
--- a/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
@@ -617,7 +617,7 @@ int CLuaFileDefs::fileWrite ( lua_State* luaVM )
         long lBytesWritten = 0; // Total bytes written
         
         // While we're not out of string arguments
-        // (we will always have one string because we validated it above)
+        // (we will always have at least one string because we validated it above)
         while ( argStream.NextIsString () )
         {
             // Grab argument and length
@@ -737,7 +737,11 @@ int CLuaFileDefs::fileGetPath ( lua_State* luaVM )
             // we need to prepend :resourceName to the path
             if ( pThisResource != pFileResource )
             {
+#ifdef MTA_CLIENT
+                strFilePath = SString ( ":%s/%s", pFileResource->GetName (), *strFilePath );
+#else
                 strFilePath = SString ( ":%s/%s", *pFileResource->GetName (), *strFilePath );
+#endif
             }
 
             lua_pushlstring ( luaVM, strFilePath, strFilePath.length () );


### PR DESCRIPTION
FormatException is returned when getting path of files residing in another
resource. This happens because `CResource::GetName` is of different type on
client and server side (`const char*` vs `const SString&`).

Possibly it would be better to even out these methods but it also requires
adjustments and verification in other parts of project.

**Lua tests:**
https://github.com/4O4/mtasa-lua-tests/tree/master/%5Btests%5D/test-file-get-path