### PR TITLE
Remove max password length limit for server accounts

### DIFF
--- a/Server/mods/deathmatch/Config.h
+++ b/Server/mods/deathmatch/Config.h
@@ -47,9 +47,8 @@ public:
 
 #define MAX_TEAM_NAME_LENGTH 255
 
-// Min and max number of characters in passwords
+// Min number of characters in passwords
 #define MIN_PASSWORD_LENGTH 1
-#define MAX_PASSWORD_LENGTH 30
 
 // Min and max number of characters in chat messages
 #define MIN_CHAT_LENGTH 1

--- a/Server/mods/deathmatch/logic/CAccountManager.cpp
+++ b/Server/mods/deathmatch/logic/CAccountManager.cpp
@@ -942,7 +942,7 @@ bool CAccountManager::IsValidAccountName( const SString& strName )
 //
 bool CAccountManager::IsValidPassword( const SString& strPassword )
 {
-    if ( strPassword.length() < MIN_PASSWORD_LENGTH || strPassword.length() > MAX_PASSWORD_LENGTH )
+    if ( strPassword.length() < MIN_PASSWORD_LENGTH )
         return false;
     return true;
 }


### PR DESCRIPTION
There is currently no reason for its existence. Limiting maximum password length in any system is generally a bad practice and a potential security weakness. This should really be changed. 