### PR TITLE
Add possibility to adjust vehicles LOD distance

### DIFF
--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -309,6 +309,7 @@ void CClientVariables::LoadDefaults ( void )
     DEFAULT ( "grass",                      1 );                            // Enable grass
     DEFAULT ( "heat_haze",                  1 );                            // Enable heat haze
     DEFAULT ( "tyre_smoke_enabled",         1 );                            // Enable tyre smoke
+    DEFAULT ( "high_detail_vehicles",       0 );                            // Disable rendering high detail vehicles all the time
     DEFAULT ( "fast_clothes_loading",       1 );                            // 0-off 1-auto 2-on
     DEFAULT ( "allow_screen_upload",        1 );                            // 0-off 1-on
     DEFAULT ( "max_clientscript_log_kb",    5000 );                         // Max size in KB (0-No limit)

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -616,6 +616,7 @@ void CCore::ApplyGameSettings ( void )
     CVARS_GET ( "heat_haze",        bval ); m_pMultiplayer->SetHeatHazeEnabled ( bval );
     CVARS_GET ( "fast_clothes_loading", iVal ); m_pMultiplayer->SetFastClothesLoading ( (CMultiplayer::EFastClothesLoading)iVal );
     CVARS_GET ( "tyre_smoke_enabled", bval ); m_pMultiplayer->SetTyreSmokeEnabled ( bval );
+    m_pGame->GetSettings ()->ResetVehiclesLODDistance ( );
     pController->SetVerticalAimSensitivityRawValue( CVARS_GET_VALUE < float > ( "vertical_aim_sensitivity" ) );
 }
 

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -783,6 +783,10 @@ void CSettings::CreateGUI ( void )
     m_pCheckBoxTyreSmokeParticles->SetPosition ( CVector2D ( vecTemp.fX, vecTemp.fY + 90.0f ) );
     m_pCheckBoxTyreSmokeParticles->AutoSize ( NULL, 20.0f );
 
+    m_pCheckBoxHighDetailVehicles = reinterpret_cast < CGUICheckBox* > ( pManager->CreateCheckBox ( pTabVideo, _("Render vehicles always in high detail"), true ) );
+    m_pCheckBoxHighDetailVehicles->SetPosition ( CVector2D ( vecTemp.fX, vecTemp.fY + 110.0f ) );
+    m_pCheckBoxHighDetailVehicles->AutoSize ( NULL, 20.0f );
+
     float fPosY =  vecTemp.fY;
     m_pCheckBoxMinimize = reinterpret_cast < CGUICheckBox* > ( pManager->CreateCheckBox ( pTabVideo, _("Full Screen Minimize"), true ) );
     m_pCheckBoxMinimize->SetPosition ( CVector2D ( vecTemp.fX + 245.0f, fPosY + 30.0f ) );
@@ -1776,6 +1780,11 @@ void CSettings::UpdateVideoTab ( void )
     bool bTyreSmokeEnabled;
     CVARS_GET ( "tyre_smoke_enabled", bTyreSmokeEnabled );
     m_pCheckBoxTyreSmokeParticles->SetSelected ( bTyreSmokeEnabled );
+
+    // High detail vehicles
+    bool bHighDetailVehicles;
+    CVARS_GET ( "high_detail_vehicles", bHighDetailVehicles );
+    m_pCheckBoxHighDetailVehicles->SetSelected ( bHighDetailVehicles );
 
     PopulateResolutionComboBox();
     
@@ -3049,6 +3058,10 @@ void CSettings::SaveData ( void )
     bool bTyreSmokeEnabled = m_pCheckBoxTyreSmokeParticles->GetSelected ();
     CVARS_SET ( "tyre_smoke_enabled", bTyreSmokeEnabled );
     g_pCore->GetMultiplayer ()->SetTyreSmokeEnabled ( bTyreSmokeEnabled );
+
+    // High detail vehicles (just set cvar, real change occur on next connect)
+    bool bHighDetailVehicles = m_pCheckBoxHighDetailVehicles->GetSelected ();
+    CVARS_SET ( "high_detail_vehicles", bHighDetailVehicles );
 
     // Fast clothes loading
     if ( CGUIListItem* pSelected = m_pFastClothesCombo->GetSelectedItem () )

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -2020,6 +2020,7 @@ bool CSettings::OnVideoDefaultClick ( CGUIElement* pElement )
     CVARS_SET ( "grass", true );
     CVARS_SET ( "heat_haze", true );
     CVARS_SET ( "tyre_smoke_enabled", true );
+    CVARS_SET ( "high_detail_vehicles", false );
 
     // change
     bool bIsVideoModeChanged = GetVideoModeManager ()->SetVideoMode ( 0, false, false, FULLSCREEN_STANDARD );

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -177,6 +177,7 @@ protected:
 	CGUICheckBox*       m_pCheckBoxGrass;
 	CGUICheckBox*       m_pCheckBoxHeatHaze;
     CGUICheckBox*       m_pCheckBoxTyreSmokeParticles;
+    CGUICheckBox*       m_pCheckBoxHighDetailVehicles;
     CGUILabel*          m_pFieldOfViewLabel;
     CGUIScrollBar*      m_pFieldOfView;
     CGUILabel*          m_pFieldOfViewValueLabel;

--- a/Client/core/Graphics/CRenderItemManager.cpp
+++ b/Client/core/Graphics/CRenderItemManager.cpp
@@ -783,6 +783,7 @@ void CRenderItemManager::GetDxStatus ( SDxStatus& outStatus )
     outStatus.settings.aspectRatio = gameSettings->GetAspectRatio ();
     outStatus.settings.bHUDMatchAspectRatio = true;
     outStatus.settings.fFieldOfView = 70;
+    outStatus.settings.bHighDetailVehicles = false;
 
     CVARS_GET ( "streaming_memory",     outStatus.settings.iStreamingMemory );
     CVARS_GET ( "display_windowed",     outStatus.settings.bWindowed );
@@ -793,6 +794,7 @@ void CRenderItemManager::GetDxStatus ( SDxStatus& outStatus )
     CVARS_GET ( "anisotropic",          outStatus.settings.iAnisotropicFiltering );
     CVARS_GET ( "hud_match_aspect_ratio", outStatus.settings.bHUDMatchAspectRatio );
     CVARS_GET ( "fov",                  outStatus.settings.fFieldOfView );
+    CVARS_GET ( "high_detail_vehicles", outStatus.settings.bHighDetailVehicles );
 
     if ( outStatus.settings.iFXQuality == 0 )
     {

--- a/Client/game_sa/CSettingsSA.cpp
+++ b/Client/game_sa/CSettingsSA.cpp
@@ -35,6 +35,8 @@ void HOOK_GetFxQuality ();
 DWORD RETURN_StoreShadowForVehicle =        0x70BDA9;
 void HOOK_StoreShadowForVehicle ();
 
+float ms_fVehicleLODDistance, ms_fTrainPlaneLODDistance;
+
 CSettingsSA::CSettingsSA ( void )
 {
     m_pInterface = (CSettingsSAInterface *)CLASS_CMenuManager;
@@ -47,6 +49,9 @@ CSettingsSA::CSettingsSA ( void )
     m_iDesktopWidth = 0;
     m_iDesktopHeight = 0;
     MemPut < BYTE > ( 0x6FF420, 0xC3 );     // Truncate CalculateAspectRatio
+
+    MemPut ( 0x732926, &ms_fVehicleLODDistance );
+    MemPut ( 0x732940, &ms_fTrainPlaneLODDistance );
 
     // Set "radar map and radar" as default radar mode
     SetRadarMode ( RADAR_MODE_ALL );
@@ -532,6 +537,41 @@ void CSettingsSA::SetFieldOfViewVehicleMax ( float fAngle )
     ms_fFOVCarMax = fAngle;
     MemPut < void* > ( 0x0524BB4, &ms_fFOVCarMax );
     MemPut < float > ( 0x0524BC5, ms_fFOVCarMax );
+}
+
+
+////////////////////////////////////////////////
+//
+// Vehicles LOD draw distance
+//
+////////////////////////////////////////////////
+void CSettingsSA::SetVehiclesLODDistance ( float fVehiclesLODDistance, float fTrainsPlanesLODDistance )
+{
+    ms_fVehicleLODDistance = fVehiclesLODDistance;
+    ms_fTrainPlaneLODDistance = fTrainsPlanesLODDistance;
+}
+
+void CSettingsSA::ResetVehiclesLODDistance ( void )
+{
+    bool bHighDetailVehicles;
+    g_pCore->GetCVars()->Get ( "high_detail_vehicles", bHighDetailVehicles );
+
+    if ( bHighDetailVehicles )
+    {
+        ms_fVehicleLODDistance = MAX_VEHICLE_LOD_DISTANCE;
+        ms_fTrainPlaneLODDistance = MAX_VEHICLE_LOD_DISTANCE;
+    }
+    else
+    {
+        ms_fVehicleLODDistance = DEFAULT_VEHICLE_LOD_DISTANCE;
+        ms_fTrainPlaneLODDistance = DEFAULT_VEHICLE_LOD_DISTANCE * TRAIN_LOD_DISTANCE_MULTIPLIER;
+    }
+}
+
+void CSettingsSA::GetVehiclesLODDistance ( float& fVehiclesLODDistance, float& fTrainsPlanesLODDistance )
+{
+    fVehiclesLODDistance = ms_fVehicleLODDistance;
+    fTrainsPlanesLODDistance = ms_fTrainPlaneLODDistance;
 }
 
 

--- a/Client/game_sa/CSettingsSA.h
+++ b/Client/game_sa/CSettingsSA.h
@@ -36,6 +36,11 @@
 
 #define FUNC_SetAntiAliasing    0x7F8A90
 
+#define DEFAULT_VEHICLE_LOD_DISTANCE    ( 70.0f )
+// Default train distance is 150, so make it relative to default vehicle distance
+#define TRAIN_LOD_DISTANCE_MULTIPLIER   ( 2.14f )
+#define MAX_VEHICLE_LOD_DISTANCE        ( 500.0f )
+
 struct CSettingsSAInterface // see code around 0x57CE9A for where these are
 {
     BYTE pad1[4];
@@ -152,6 +157,10 @@ public:
     float                   GetFieldOfViewPlayer        ( void );
     float                   GetFieldOfViewVehicle       ( void );
     float                   GetFieldOfViewVehicleMax    ( void );
+
+    void                    SetVehiclesLODDistance      ( float fVehiclesLODDistance, float fTrainsPlanesLODDistance );
+    void                    ResetVehiclesLODDistance    ( void );
+    void                    GetVehiclesLODDistance      ( float& fVehiclesLODDistance, float& fTrainsPlanesLODDistance );
 
     void                    Save                        ( void );
 

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -5497,6 +5497,9 @@ void CClientGame::ResetMapInfo ( void )
     // Fog distance
     g_pMultiplayer->RestoreFogDistance ( );
 
+    // Vehicles LOD distance
+    g_pGame->GetSettings()->ResetVehiclesLODDistance ( );
+
     // Sun color
     g_pMultiplayer->ResetSunColor ( );
 

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.World.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.World.cpp
@@ -1543,6 +1543,49 @@ int CLuaFunctionDefs::ResetNearClipDistance ( lua_State* luaVM )
     return 1;
 }
 
+int CLuaFunctionDefs::GetVehiclesLODDistance ( lua_State* luaVM )
+{
+//  float float getVehiclesLODDistance ( )
+    float fVehiclesDistance, fTrainsPlanesDistance;
+
+    g_pGame->GetSettings()->GetVehiclesLODDistance ( fVehiclesDistance, fTrainsPlanesDistance );
+    lua_pushnumber ( luaVM, fVehiclesDistance );
+    lua_pushnumber ( luaVM, fTrainsPlanesDistance );
+    return 2;
+}
+
+int CLuaFunctionDefs::SetVehiclesLODDistance ( lua_State* luaVM )
+{
+//  bool setVehiclesLODDistance ( float vehiclesDistance, float trainsAndPlanesDistance = vehiclesDistance * 2.14 )
+    float fVehiclesDistance, fTrainsPlanesDistance;
+
+    CScriptArgReader argStream ( luaVM );
+    argStream.ReadNumber ( fVehiclesDistance );
+    fVehiclesDistance = Clamp ( 0.0f, fVehiclesDistance, 500.0f );
+
+    // Default train distance is 2.14 times bigger than normal vehicles
+    argStream.ReadNumber ( fTrainsPlanesDistance, Clamp ( 0.0f, fVehiclesDistance * 2.14f, 500.0f ) );
+
+    if ( !argStream.HasErrors () )
+    {
+        g_pGame->GetSettings()->SetVehiclesLODDistance ( fVehiclesDistance, fTrainsPlanesDistance );
+        lua_pushboolean ( luaVM, true );
+        return 1;
+    }
+    else
+        m_pScriptDebugging->LogCustom ( luaVM, argStream.GetFullErrorMessage() );
+
+    lua_pushboolean ( luaVM, false );
+    return 1;
+}
+
+int CLuaFunctionDefs::ResetVehiclesLODDistance ( lua_State* luaVM )
+{
+    g_pGame->GetSettings()->ResetVehiclesLODDistance ();
+    lua_pushboolean ( luaVM, true );
+    return 1;
+}
+
 int CLuaFunctionDefs::GetFogDistance ( lua_State* luaVM )
 {
     lua_pushnumber ( luaVM, g_pMultiplayer->GetFogDistance());

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.h
@@ -162,6 +162,9 @@ public:
     LUA_DECLARE ( GetNearClipDistance );
     LUA_DECLARE ( SetNearClipDistance );
     LUA_DECLARE ( ResetNearClipDistance );
+    LUA_DECLARE ( GetVehiclesLODDistance );
+    LUA_DECLARE ( SetVehiclesLODDistance );
+    LUA_DECLARE ( ResetVehiclesLODDistance );
     LUA_DECLARE ( GetFogDistance );
     LUA_DECLARE ( SetFogDistance );
     LUA_DECLARE ( ResetFogDistance );

--- a/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -299,6 +299,7 @@ void CLuaManager::LoadCFunctions ( void )
     CLuaCFunctions::AddFunction ( "getInteriorFurnitureEnabled", CLuaFunctionDefs::GetInteriorFurnitureEnabled );
     CLuaCFunctions::AddFunction ( "getFarClipDistance", CLuaFunctionDefs::GetFarClipDistance );
     CLuaCFunctions::AddFunction ( "getNearClipDistance", CLuaFunctionDefs::GetNearClipDistance );
+    CLuaCFunctions::AddFunction ( "getVehiclesLODDistance", CLuaFunctionDefs::GetVehiclesLODDistance );
     CLuaCFunctions::AddFunction ( "getFogDistance", CLuaFunctionDefs::GetFogDistance );
     CLuaCFunctions::AddFunction ( "getSunColor", CLuaFunctionDefs::GetSunColor );
     CLuaCFunctions::AddFunction ( "getSunSize", CLuaFunctionDefs::GetSunSize );
@@ -343,6 +344,8 @@ void CLuaManager::LoadCFunctions ( void )
     CLuaCFunctions::AddFunction ( "resetFarClipDistance", CLuaFunctionDefs::ResetFarClipDistance );
     CLuaCFunctions::AddFunction ( "setNearClipDistance", CLuaFunctionDefs::SetNearClipDistance );
     CLuaCFunctions::AddFunction ( "resetNearClipDistance", CLuaFunctionDefs::ResetNearClipDistance );
+    CLuaCFunctions::AddFunction ( "setVehiclesLODDistance", CLuaFunctionDefs::SetVehiclesLODDistance );
+    CLuaCFunctions::AddFunction ( "resetVehiclesLODDistance", CLuaFunctionDefs::ResetVehiclesLODDistance );
     CLuaCFunctions::AddFunction ( "setFogDistance", CLuaFunctionDefs::SetFogDistance );
     CLuaCFunctions::AddFunction ( "resetFogDistance", CLuaFunctionDefs::ResetFogDistance );
     CLuaCFunctions::AddFunction ( "setSunColor", CLuaFunctionDefs::SetSunColor );

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -1212,6 +1212,9 @@ int CLuaDrawingDefs::DxGetStatus ( lua_State* luaVM )
         lua_pushnumber ( luaVM, dxStatus.settings.fFieldOfView );
         lua_settable ( luaVM, -3 );
 
+        lua_pushstring ( luaVM, "SettingHighDetailVehicles" );
+        lua_pushboolean ( luaVM, dxStatus.settings.bHighDetailVehicles );
+        lua_settable ( luaVM, -3 );
         return 1;
     }
     else

--- a/Client/sdk/core/CRenderItemManagerInterface.h
+++ b/Client/sdk/core/CRenderItemManagerInterface.h
@@ -124,6 +124,7 @@ struct SDxStatus
         eAspectRatio    aspectRatio;
         bool            bHUDMatchAspectRatio;
         float           fFieldOfView;
+        bool            bHighDetailVehicles;
     } settings;
 };
 

--- a/Client/sdk/game/CSettings.h
+++ b/Client/sdk/game/CSettings.h
@@ -155,6 +155,10 @@ public:
     virtual float           GetFieldOfViewVehicle   ( void ) = 0;
     virtual float           GetFieldOfViewVehicleMax( void ) = 0;
 
+    virtual void            SetVehiclesLODDistance  ( float fVehiclesLODDistance, float fTrainsPlanesLODDistance ) = 0;
+    virtual void            ResetVehiclesLODDistance  ( void ) = 0;
+    virtual void            GetVehiclesLODDistance  ( float& fVehiclesLODDistance, float& fTrainsPlanesLODDistance ) = 0;
+
     virtual void            Save                    ( void ) = 0;
 };
 


### PR DESCRIPTION
Basically #9386.

Adds new checkbox in video settings: http://imgur.com/2iq0nsL (disabled by default)
Enabled means max value which is set to 500 for both normal vehicles and trains/planes, disabled means GTA default (70 and 150).

And functions:
```
float float getVehiclesLODDistance ( )
bool setVehiclesLODDistance ( float vehiclesDistance, float trainsAndPlanesDistance = vehiclesDistance * 2.14 )
bool resetVehiclesLODDistance ( )
```

Disabled: http://imgur.com/3cNKNTO
Enabled: http://imgur.com/OvsduOw

setVehiclesLODDistance(0): http://imgur.com/f2xn9IZ