### PR TITLE
Applying change of type of latent events percentage

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Event.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Event.cpp
@@ -357,7 +357,7 @@ int CLuaFunctionDefs::GetLatentEventStatus ( lua_State* luaVM )
             lua_settable    ( luaVM, -3 );
 
             lua_pushstring  ( luaVM, "percentComplete" );
-            lua_pushinteger ( luaVM, sendStatus.iPercentComplete );
+            lua_pushnumber  ( luaVM, sendStatus.dPercentComplete );
             lua_settable    ( luaVM, -3 );
             return 1;
         }

--- a/Server/mods/deathmatch/logic/lua/CLuaFunctionDefs.Event.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaFunctionDefs.Event.cpp
@@ -380,7 +380,7 @@ int CLuaFunctionDefs::GetLatentEventStatus ( lua_State* luaVM )
             lua_settable ( luaVM, -3 );
 
             lua_pushstring ( luaVM, "percentComplete" );
-            lua_pushinteger ( luaVM, sendStatus.iPercentComplete );
+            lua_pushnumber  ( luaVM, sendStatus.dPercentComplete );
             lua_settable ( luaVM, -3 );
             return 1;
         }

--- a/Shared/mods/deathmatch/logic/CLatentSendQueue.cpp
+++ b/Shared/mods/deathmatch/logic/CLatentSendQueue.cpp
@@ -230,7 +230,7 @@ bool CLatentSendQueue::GetSendStatus ( SSendHandle handle, SSendStatus* pOutSend
             pOutSendStatus->iStartTimeMsOffset = iTimeMsBefore - iter->iEstSendDurationMsUsed;
             pOutSendStatus->iEndTimeMsOffset = iTimeMsBefore + iter->iEstSendDurationMsRemaining;
             pOutSendStatus->iTotalSize = iter->bufferRef->GetSize ();
-            pOutSendStatus->iPercentComplete = iter->uiReadPosition * 100 / std::max ( 1, pOutSendStatus->iTotalSize );
+            pOutSendStatus->dPercentComplete = iter->uiReadPosition * 100 / std::max ( 1, pOutSendStatus->iTotalSize );
             return true;
         }
         iTimeMsBefore += iter->iEstSendDurationMsRemaining;

--- a/Shared/mods/deathmatch/logic/CLatentSendQueue.cpp
+++ b/Shared/mods/deathmatch/logic/CLatentSendQueue.cpp
@@ -230,7 +230,7 @@ bool CLatentSendQueue::GetSendStatus ( SSendHandle handle, SSendStatus* pOutSend
             pOutSendStatus->iStartTimeMsOffset = iTimeMsBefore - iter->iEstSendDurationMsUsed;
             pOutSendStatus->iEndTimeMsOffset = iTimeMsBefore + iter->iEstSendDurationMsRemaining;
             pOutSendStatus->iTotalSize = iter->bufferRef->GetSize ();
-            pOutSendStatus->dPercentComplete = iter->uiReadPosition * 100 / std::max ( 1, pOutSendStatus->iTotalSize );
+            pOutSendStatus->dPercentComplete = iter->uiReadPosition * 100.0 / std::max ( 1, pOutSendStatus->iTotalSize );
             return true;
         }
         iTimeMsBefore += iter->iEstSendDurationMsRemaining;

--- a/Shared/mods/deathmatch/logic/CLatentTransferManager.h
+++ b/Shared/mods/deathmatch/logic/CLatentTransferManager.h
@@ -99,7 +99,7 @@ struct SSendStatus
     int     iStartTimeMsOffset;     // Est. start time (Negative if already started)
     int     iEndTimeMsOffset;       // Est. end time 
     int     iTotalSize;
-    int     iPercentComplete;       // How much done
+    double  dPercentComplete;       // How much done
 };
 
 


### PR DESCRIPTION
This patch changes the type of percentage received from getLatentEventStatus

Sometimes you need more precision than simply the integer value of that (specially for drawing information) so my idea was simply to change the type.

Do you guys consider this a good suggestion?