### PR TITLE
Fix CClientPed::WarpIntoVehicle being called twice for local player

### DIFF
--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -1630,13 +1630,6 @@ void CPacketHandler::Packet_Vehicle_InOut ( NetBitStreamInterface& bitStream )
 
                     case CClientGame::VEHICLE_NOTIFY_IN_RETURN:
                     {
-                        // Is he not getting in the vehicle yet?
-                        //if ( !pPlayer->IsGettingIntoVehicle () )
-                        {
-                            // Warp him in
-                            pPlayer->WarpIntoVehicle ( pVehicle, ucSeat );
-                        }
-
                         // Reset vehicle in out state
                         pPlayer->SetVehicleInOutState ( VEHICLE_INOUT_NONE );
 
@@ -1645,6 +1638,11 @@ void CPacketHandler::Packet_Vehicle_InOut ( NetBitStreamInterface& bitStream )
                         {
                             g_pClientGame->m_bNoNewVehicleTask = false;
                             g_pClientGame->m_NoNewVehicleTaskReasonID = INVALID_ELEMENT_ID;
+                        }
+                        else
+                        {
+                            // Warp him in. Don't do that for local player as he is already warped.
+                            pPlayer->WarpIntoVehicle ( pVehicle, ucSeat );
                         }
 
                         // Call the onClientPlayerEnterVehicle event


### PR DESCRIPTION
First call seems to be here:
https://github.com/multitheftauto/mtasa-blue/blob/97ab9f71dd85d45b368d33ec366335bfb15b698f/Client/mods/deathmatch/logic/CClientGame.cpp#L1671