### PR TITLE
0004166: Engine Sounds of other Helicopters and planes missing...

### DIFF
--- a/Client/game_sa/CAEAudioHardwareSA.cpp
+++ b/Client/game_sa/CAEAudioHardwareSA.cpp
@@ -1,0 +1,50 @@
+/*****************************************************************************
+*
+*  PROJECT:     Multi Theft Auto v1.0
+*  LICENSE:     See LICENSE in the top level directory
+*  FILE:        game_sa/CAEAudioHardwareSA.cpp
+*  PURPOSE:     Audio hardware
+*
+*  Multi Theft Auto is available from http://www.multitheftauto.com/
+*
+*****************************************************************************/
+
+#include "StdInc.h"
+
+CAEAudioHardwareSA::CAEAudioHardwareSA ( CAEAudioHardwareSAInterface * pInterface )
+{
+    m_pInterface = pInterface;
+}
+
+bool CAEAudioHardwareSA::IsSoundBankLoaded ( short wSoundBankID, short wSoundBankSlotID )
+{
+    DWORD dwSoundBankID = wSoundBankID;
+    DWORD dwSoundBankSlotID = wSoundBankSlotID;
+    DWORD dwThis = ( DWORD ) m_pInterface;
+    DWORD dwFunc = FUNC_CAEAudioHardware__IsSoundBankLoaded;
+    bool bReturn = false;
+    _asm
+    {
+        push    dwSoundBankSlotID
+        push    dwSoundBankID
+        mov     ecx, dwThis
+        call    dwFunc
+        mov     bReturn, al
+    }
+    return bReturn;
+}
+
+void CAEAudioHardwareSA::LoadSoundBank ( short wSoundBankID, short wSoundBankSlotID )
+{
+    DWORD dwSoundBankID = wSoundBankID;
+    DWORD dwSoundBankSlotID = wSoundBankSlotID;
+    DWORD dwThis = ( DWORD ) m_pInterface;
+    DWORD dwFunc = FUNC_CAEAudioHardware__LoadSoundBank;
+    _asm
+    {
+        push    dwSoundBankSlotID
+        push    dwSoundBankID
+        mov     ecx, dwThis
+        call    dwFunc
+    }
+}

--- a/Client/game_sa/CAEAudioHardwareSA.h
+++ b/Client/game_sa/CAEAudioHardwareSA.h
@@ -1,0 +1,39 @@
+/*****************************************************************************
+*
+*  PROJECT:     Multi Theft Auto v1.0
+*  LICENSE:     See LICENSE in the top level directory
+*  FILE:        game_sa/CAEAudioHardwareSA.h
+*  PURPOSE:     Audio hardware header
+*
+*  Multi Theft Auto is available from http://www.multitheftauto.com/
+*
+*****************************************************************************/
+
+#ifndef __CAEAUDIOHARDWARESA
+#define __CAEAUDIOHARDWARESA
+
+#include "Common.h"
+#include <game/CAEAudioHardware.h>
+
+#define FUNC_CAEAudioHardware__IsSoundBankLoaded                            0x4D88C0
+#define FUNC_CAEAudioHardware__LoadSoundBank                                0x4D88A0
+
+#define CLASS_CAEAudioHardware                                              0xB5F8B8
+
+class CAEAudioHardwareSAInterface
+{
+
+};
+
+class CAEAudioHardwareSA : public CAEAudioHardware
+{
+public:
+                                        CAEAudioHardwareSA                  ( CAEAudioHardwareSAInterface * pInterface );
+    bool                                IsSoundBankLoaded                   ( short wSoundBankID, short wSoundBankSlotID );
+    void                                LoadSoundBank                       ( short wSoundBankID, short wSoundBankSlotID );
+
+private:
+    CAEAudioHardwareSAInterface *       m_pInterface;
+};
+
+#endif

--- a/Client/game_sa/CAEAudioHardwareSA.h
+++ b/Client/game_sa/CAEAudioHardwareSA.h
@@ -9,8 +9,7 @@
 *
 *****************************************************************************/
 
-#ifndef __CAEAUDIOHARDWARESA
-#define __CAEAUDIOHARDWARESA
+#pragma once
 
 #include "Common.h"
 #include <game/CAEAudioHardware.h>
@@ -35,5 +34,3 @@ public:
 private:
     CAEAudioHardwareSAInterface *       m_pInterface;
 };
-
-#endif

--- a/Client/game_sa/CAEVehicleAudioEntitySA.cpp
+++ b/Client/game_sa/CAEVehicleAudioEntitySA.cpp
@@ -1,0 +1,41 @@
+/*****************************************************************************
+*
+*  PROJECT:     Multi Theft Auto v1.0
+*  LICENSE:     See LICENSE in the top level directory
+*  FILE:        game_sa/CAEVehicleAudioEntitySA.cpp
+*  PURPOSE:     Vehicle audio entity
+*
+*  Multi Theft Auto is available from http://www.multitheftauto.com/
+*
+*****************************************************************************/
+
+#include "StdInc.h"
+
+CAEVehicleAudioEntitySA::CAEVehicleAudioEntitySA ( CAEVehicleAudioEntitySAInterface * pInterface )
+{
+    m_pInterface = pInterface;
+}
+
+// Based on CAEVehicleAudioEntity::JustGotInVehicleAsDriver
+// Loads accelerate sound bank for planes and helis.
+void CAEVehicleAudioEntitySA::LoadDriverSounds ( void )
+{
+    CAEVehicleAudioEntitySAInterface * pVehicleAudioEntity = m_pInterface;
+    char soundType = pVehicleAudioEntity->m_nSettings.m_nVehicleSoundType;
+
+    // If it's heli or plane sound type
+    if ( soundType == 4 || soundType == 5 )
+    {
+        // If there is accelerate sound bank defined
+        if ( pVehicleAudioEntity->m_wEngineAccelerateSoundBankId != -1 )
+        {
+            CAEAudioHardware * pAEAudioHardware = pGame->GetAEAudioHardware ();
+            // If this bank is not already loaded
+            if ( !pAEAudioHardware->IsSoundBankLoaded ( pVehicleAudioEntity->m_wEngineAccelerateSoundBankId, BANKSLOT_ENGINE_RESIDENT ) )
+            {
+                // Load it
+                pAEAudioHardware->LoadSoundBank ( pVehicleAudioEntity->m_wEngineAccelerateSoundBankId, BANKSLOT_ENGINE_RESIDENT );
+            }
+        }
+    }
+}

--- a/Client/game_sa/CAEVehicleAudioEntitySA.h
+++ b/Client/game_sa/CAEVehicleAudioEntitySA.h
@@ -1,0 +1,259 @@
+/*****************************************************************************
+*
+*  PROJECT:     Multi Theft Auto v1.0
+*  LICENSE:     See LICENSE in the top level directory
+*  FILE:        game_sa/CAEVehicleAudioEntitySA.h
+*  PURPOSE:     Vehicle audio entity header
+*
+*  Multi Theft Auto is available from http://www.multitheftauto.com/
+*
+*****************************************************************************/
+
+#ifndef __CAEVEHICLEAUDIOENTITYSA
+#define __CAEVEHICLEAUDIOENTITYSA
+
+#include "Common.h"
+#include "CAudioEngineSA.h"
+#include <game/CAEVehicleAudioEntity.h>
+
+#define FUNC_CAEVehicleAudioEntity__RequestBankSlot                                    0x4F4D10
+#define FUNC_CAEVehicleAudioEntity__StoppedUsingBankSlot                               0x4F4DF0
+#define FUNC_CAEVehicleAudioEntity__DoesBankSlotContainThisBank                        0x4F4E30
+#define FUNC_CAEVehicleAudioEntity__DemandBankSlot                                     0x4F4E60
+#define FUNC_CAEVehicleAudioEntity__StaticService                                      0x4F4EC0
+#define FUNC_CAEVehicleAudioEntity__StaticGetPlayerVehicleAudioSettingsForRadio        0x4F4ED0
+#define FUNC_CAEVehicleAudioEntity__EnableHelicoptors                                  0x4F4EE0
+#define FUNC_CAEVehicleAudioEntity__DisableHelicoptors                                 0x4F4EF0
+#define FUNC_CAEVehicleAudioEntity__GetVehicleTypeForAudio                             0x4F4F00
+#define FUNC_CAEVehicleAudioEntity__IsAccInhibited                                     0x4F4F70
+#define FUNC_CAEVehicleAudioEntity__IsAccInhibitedBackwards                            0x4F4FC0
+#define FUNC_CAEVehicleAudioEntity__IsAccInhibitedForLowSpeed                          0x4F4FF0
+#define FUNC_CAEVehicleAudioEntity__IsAccInhibitedForTime                              0x4F5020
+#define FUNC_CAEVehicleAudioEntity__InhibitAccForTime                                  0x4F5030
+#define FUNC_CAEVehicleAudioEntity__IsCrzInhibitedForTime                              0x4F5050
+#define FUNC_CAEVehicleAudioEntity__InhibitCrzForTime                                  0x4F5060
+#define FUNC_CAEVehicleAudioEntity__GetAccelAndBrake                                   0x4F5080
+#define FUNC_CAEVehicleAudioEntity__GetVolumeForDummyIdle                              0x4F51F0
+#define FUNC_CAEVehicleAudioEntity__GetFrequencyForDummyIdle                           0x4F5310
+#define FUNC_CAEVehicleAudioEntity__GetVolumeForDummyRev                               0x4F53D0
+#define FUNC_CAEVehicleAudioEntity__GetFrequencyForDummyRev                            0x4F54F0
+#define FUNC_CAEVehicleAudioEntity__CancelVehicleEngineSound                           0x4F55C0
+#define FUNC_CAEVehicleAudioEntity__UpdateVehicleEngineSound                           0x4F56D0
+#define FUNC_CAEVehicleAudioEntity__JustGotInVehicleAsDriver                           0x4F5700
+#define FUNC_CAEVehicleAudioEntity__TurnOnRadioForVehicle                              0x4F5B20
+#define FUNC_CAEVehicleAudioEntity__TurnOffRadioForVehicle                             0x4F5B60
+#define FUNC_CAEVehicleAudioEntity__PlayerAboutToExitVehicleAsDriver                   0x4F5BA0
+#define FUNC_CAEVehicleAudioEntity__DisableHelicoptor                                  0x4F5BF0
+#define FUNC_CAEVehicleAudioEntity__EnableHelicoptor                                   0x4F5C00
+#define FUNC_CAEVehicleAudioEntity__GetVehicleAudioSettings                            0x4F5C10
+#define FUNC_CAEVehicleAudioEntity__CopHeli                                            0x4F5C40
+#define FUNC_CAEVehicleAudioEntity__GetFreqForIdle                                     0x4F5C60
+#define FUNC_CAEVehicleAudioEntity__GetVolForPlayerEngineSound                         0x4F5D00
+#define FUNC_CAEVehicleAudioEntity__JustFinishedAccelerationLoop                       0x4F5E50
+#define FUNC_CAEVehicleAudioEntity__UpdateGasPedalAudio                                0x4F5EB0
+#define FUNC_CAEVehicleAudioEntity__GetVehicleDriveWheelSkidValue                      0x4F5F30
+#define FUNC_CAEVehicleAudioEntity__GetVehicleNonDriveWheelSkidValue                   0x4F6000
+#define FUNC_CAEVehicleAudioEntity__GetBaseVolumeForBicycleTyre                        0x4F60B0
+#define FUNC_CAEVehicleAudioEntity__GetFlyingMetalVolume                               0x4F6150
+#define FUNC_CAEVehicleAudioEntity__GetHornState                                       0x4F61E0
+#define FUNC_CAEVehicleAudioEntity__GetSirenState                                      0x4F62A0
+#define FUNC_CAEVehicleAudioEntity__StopGenericEngineSound                             0x4F6320
+#define FUNC_CAEVehicleAudioEntity__CAEVehicleAudioEntity                              0x4F63E0
+#define FUNC_CAEVehicleAudioEntity__AddAudioEvent                                      0x4F6420
+#define FUNC_CAEVehicleAudioEntity__AddAudioEvent_1                                    0x4F7580 // (renamed)
+#define FUNC_CAEVehicleAudioEntity__Initialise                                         0x4F7670
+#define FUNC_CAEVehicleAudioEntity__RequestNewPlayerCarEngineSound                     0x4F7A50
+#define FUNC_CAEVehicleAudioEntity__StartVehicleEngineSound                            0x4F7F20
+#define FUNC_CAEVehicleAudioEntity__GetFreqForPlayerEngineSound                        0x4F8070
+#define FUNC_CAEVehicleAudioEntity__PlaySkidSound                                      0x4F8360
+#define FUNC_CAEVehicleAudioEntity__PlayRoadNoiseSound                                 0x4F84D0
+#define FUNC_CAEVehicleAudioEntity__PlayFlatTyreSound                                  0x4F8650
+#define FUNC_CAEVehicleAudioEntity__PlayReverseSound                                   0x4F87D0
+#define FUNC_CAEVehicleAudioEntity__ProcessVehicleFlatTyre                             0x4F8940
+#define FUNC_CAEVehicleAudioEntity__ProcessVehicleRoadNoise                            0x4F8B00
+#define FUNC_CAEVehicleAudioEntity__ProcessReverseGear                                 0x4F8DF0
+#define FUNC_CAEVehicleAudioEntity__ProcessVehicleSkidding                             0x4F8F10
+#define FUNC_CAEVehicleAudioEntity__ProcessRainOnVehicle                               0x4F92C0
+#define FUNC_CAEVehicleAudioEntity__PlayAircraftSound                                  0x4F93C0
+#define FUNC_CAEVehicleAudioEntity__GetAircraftNearPosition                            0x4F96A0
+#define FUNC_CAEVehicleAudioEntity__PlayBicycleSound                                   0x4F9710
+#define FUNC_CAEVehicleAudioEntity__PlayHornOrSiren                                    0x4F99D0
+#define FUNC_CAEVehicleAudioEntity__UpdateBoatSound                                    0x4F9E90
+#define FUNC_CAEVehicleAudioEntity__ProcessBoatMovingOverWater                         0x4FA0C0
+#define FUNC_CAEVehicleAudioEntity__UpdateTrainSound                                   0x4FA1C0
+#define FUNC_CAEVehicleAudioEntity__ProcessTrainTrackSound                             0x4FA3F0
+#define FUNC_CAEVehicleAudioEntity__PlayTrainBrakeSound                                0x4FA630
+#define FUNC_CAEVehicleAudioEntity__ProcessDummyRCPlane                                0x4FA7C0
+#define FUNC_CAEVehicleAudioEntity__ProcessDummyRCHeli                                 0x4FAA80
+#define FUNC_CAEVehicleAudioEntity__UpdateGenericVehicleSound                          0x4FAD40
+#define FUNC_CAEVehicleAudioEntity__ProcessEngineDamage                                0x4FAE20
+#define FUNC_CAEVehicleAudioEntity__ProcessNitro                                       0x4FB070
+#define FUNC_CAEVehicleAudioEntity__ProcessMovingParts                                 0x4FB260
+#define FUNC_CAEVehicleAudioEntity__UpdateParameters                                   0x4FB6C0
+#define FUNC_CAEVehicleAudioEntity__Terminate                                          0x4FB8C0
+#define FUNC_CAEVehicleAudioEntity__ProcessPlayerVehicleEngine                         0x4FBB10
+#define FUNC_CAEVehicleAudioEntity__ProcessDummyStateTransition                        0x4FCA10
+#define FUNC_CAEVehicleAudioEntity__JustGotOutOfVehicleAsDriver                        0x4FCF40
+#define FUNC_CAEVehicleAudioEntity__JustWreckedVehicle                                 0x4FD0B0
+#define FUNC_CAEVehicleAudioEntity__ProcessPlayerProp                                  0x4FD290
+#define FUNC_CAEVehicleAudioEntity__ProcessDummyProp                                   0x4FD8F0
+#define FUNC_CAEVehicleAudioEntity__ProcessAIProp                                      0x4FDFD0
+#define FUNC_CAEVehicleAudioEntity__ProcessPlayerHeli                                  0x4FE420
+#define FUNC_CAEVehicleAudioEntity__ProcessDummyHeli                                   0x4FE940
+#define FUNC_CAEVehicleAudioEntity__ProcessAIHeli                                      0x4FEE20
+#define FUNC_CAEVehicleAudioEntity__ProcessPlayerSeaPlane                              0x4FF320
+#define FUNC_CAEVehicleAudioEntity__ProcessDummySeaPlane                               0x4FF7C0
+#define FUNC_CAEVehicleAudioEntity__ProcessGenericJet                                  0x4FF900
+#define FUNC_CAEVehicleAudioEntity__ProcessDummyBicycle                                0x4FFDC0
+#define FUNC_CAEVehicleAudioEntity__ProcessPlayerBicycle                               0x500040
+#define FUNC_CAEVehicleAudioEntity__ProcessVehicleSirenAlarmHorn                       0x5002C0
+#define FUNC_CAEVehicleAudioEntity__ProcessBoatEngine                                  0x5003A0
+#define FUNC_CAEVehicleAudioEntity__ProcessDummyTrainEngine                            0x500710
+#define FUNC_CAEVehicleAudioEntity__ProcessPlayerTrainBrakes                           0x500AB0
+#define FUNC_CAEVehicleAudioEntity__ProcessPlayerCombine                               0x500CE0
+#define FUNC_CAEVehicleAudioEntity__ProcessDummyRCCar                                  0x500DC0
+#define FUNC_CAEVehicleAudioEntity__ProcessDummyHovercraft                             0x500F50
+#define FUNC_CAEVehicleAudioEntity__ProcessDummyGolfCart                               0x501270
+#define FUNC_CAEVehicleAudioEntity__ProcessDummyVehicleEngine                          0x501480
+#define FUNC_CAEVehicleAudioEntity__ProcessPlayerJet                                   0x501650
+#define FUNC_CAEVehicleAudioEntity__ProcessDummyJet                                    0x501960
+#define FUNC_CAEVehicleAudioEntity__ProcessSpecialVehicle                              0x501AB0
+#define FUNC_CAEVehicleAudioEntity__ProcessAircraft                                    0x501C50
+#define FUNC_CAEVehicleAudioEntity__ProcessVehicle                                     0x501E10
+#define FUNC_CAEVehicleAudioEntity__Service                                            0x502280
+
+struct tVehicleAudioSettings
+{
+    char    m_nVehicleSoundType;
+    char    unk1;
+    short   m_wEngineOnSoundBankId;
+    short   m_wEngineOffSoundBankId;
+    char    m_nStereo;
+    char    unk2;
+    int     unk3;
+    int     unk4;
+    char    m_bHornTon;
+    char    unk5[3];
+    float   m_fHornHigh;
+    char    m_nDoorSound;
+    char    unk6;
+    char    m_nRadioNum;
+    char    m_nRadioType;
+    char    unk7;
+    char    unk8[3];
+    float   m_fHornVolumeDelta;
+};
+static_assert(sizeof(tVehicleAudioSettings) == 0x24, "Invalid size for tVehicleAudioSettings");
+
+struct tVehicleSound
+{
+    int m_dwIndex;
+    CAESound * m_pSound;
+};
+
+class CAETwinLoopSoundEntity : CAEAudioEntity
+{
+    short   m_wBankSlotId;
+    short   m_wSoundType[2];
+    char    pad1[2];
+    CAEAudioEntity * m_pBaseAudio;
+    short   unk1;
+    short   unk2;
+    short   unk3;
+    short   m_wPlayTimeMin;
+    short   m_wPlayTimeMax;
+    char    pad2[2];
+    unsigned int m_dwTimeToSwapSounds;
+    bool    m_bPlayingFirstSound;
+    char    pad3;
+    short   m_wStartingPlayPercentage[2];
+    short   unk4;
+    CAESound * m_apSounds[2];
+};
+static_assert(sizeof(CAETwinLoopSoundEntity) == 0xA8, "Invalid size for CAETwinLoopSoundEntity");
+
+class CAEVehicleAudioEntitySAInterface : public CAEAudioEntity
+{
+public:
+    short   unk1;                                               // +124
+    char    unk2[2];                                            // +126
+    tVehicleAudioSettings m_nSettings;                          // +128
+    bool    m_bEnabled;                                         // +164
+    bool    m_bPlayerDriver;                                    // +165
+    bool    m_bPlayerPassenger;                                 // +166
+    bool    m_bVehicleRadioPaused;                              // +167
+    bool    m_bSoundsStopped;                                   // +168
+    char    m_nEngineState;                                     // +169
+    char    unk3;                                               // +170
+    char    unk4;                                               // +171
+    int     unk5;                                               // +172
+    bool    m_bInhibitAccForLowSpeed;                           // +176
+    char    unk6;                                               // +177
+    short   m_wRainDropCounter;                                 // +178
+    short   unk7;                                               // +180
+    char    pad1[2];                                            // +182
+    int     unk8;                                               // +184
+    char    unk9;                                               // +188
+    bool    m_bDisableHeliEngineSounds;                         // +189
+    char    unk10;                                              // +190
+    bool    m_bSirenOrAlarmPlaying;                             // +191
+    bool    m_bHornPlaying;                                     // +192
+    char    pad2[3];                                            // +193
+    float   m_fSirenVolume;                                     // +196
+    bool    m_bModelWithSiren;                                  // +200
+    char    pad3[3];                                            // +201
+    unsigned int m_dwBoatHitWaveLastPlayedTime;                 // +204
+    unsigned int m_dwTimeToInhibitAcc;                          // +208
+    unsigned int m_dwTimeToInhibitCrz;                          // +212
+    float   m_fGeneralVehicleSoundVolume;                       // +216
+    short   m_wEngineDecelerateSoundBankId;                     // +220
+    short   m_wEngineAccelerateSoundBankId;                     // +222
+    short   m_wEngineBankSlotId;                                // +224
+    short   unk11;                                              // +226
+    tVehicleSound m_aEngineSounds[12];                          // +228
+    int     unk12;                                              // +324
+    short   unk13;                                              // +328
+    short   unk14;                                              // +330
+    short   unk15;                                              // +332
+    short   unk16;                                              // +334
+    int     unk17; // some time in ms (@0x4F5638)               // +336
+    short   unk18;                                              // +340
+    short   m_wSkidSoundType;                                   // +342
+    CAESound * unk19;                                           // +344
+    short   m_wRoadNoiseSoundType;                              // +348
+    char    pad4[2];                                            // +350
+    CAESound * m_pRoadNoiseSound;                               // +352
+    short   m_wFlatTyreSoundType;                               // +356
+    char    pad5[2];                                            // +358
+    CAESound * m_pFlatTyreSound;                                // +360
+    short   m_wReverseGearSoundType;                            // +364
+    char    pad6[2];                                            // +366
+    CAESound * m_pReverseGearSound;                             // +368
+    char    pad7[4];                                            // +372
+    CAESound * m_pHornTonSound;                                 // +376
+    CAESound * m_pSirenSound;                                   // +380
+    CAESound * m_pPoliceSirenSound;                             // +384
+    CAETwinLoopSoundEntity m_nTwinLoopSoundEntity;              // +388
+    float   unk20;                                              // +556
+    float   unk21;                                              // +560
+    float   unk22;                                              // +564
+    float   unk23;                                              // +568
+    float   unk24;                                              // +572
+    int     unk25;                                              // +576
+    bool    m_bNitroSoundPresent;                               // +580
+    char    unk26;                                              // +581
+    float   unk27;                                              // +582
+};
+static_assert(sizeof(CAEVehicleAudioEntitySAInterface) == 0x24C, "Invalid size for CAEVehicleAudioEntitySAInterface");
+
+class CAEVehicleAudioEntitySA : public CAEVehicleAudioEntity
+{
+public:
+                                        CAEVehicleAudioEntitySA                 ( CAEVehicleAudioEntitySAInterface * pInterface );
+    void                                LoadDriverSounds                        ( void );
+
+private:
+    CAEVehicleAudioEntitySAInterface *  m_pInterface;
+};
+
+#endif

--- a/Client/game_sa/CAEVehicleAudioEntitySA.h
+++ b/Client/game_sa/CAEVehicleAudioEntitySA.h
@@ -9,8 +9,7 @@
 *
 *****************************************************************************/
 
-#ifndef __CAEVEHICLEAUDIOENTITYSA
-#define __CAEVEHICLEAUDIOENTITYSA
+#pragma once
 
 #include "Common.h"
 #include "CAudioEngineSA.h"
@@ -255,5 +254,3 @@ public:
 private:
     CAEVehicleAudioEntitySAInterface *  m_pInterface;
 };
-
-#endif

--- a/Client/game_sa/CAudioEngineSA.h
+++ b/Client/game_sa/CAudioEngineSA.h
@@ -55,38 +55,67 @@ class CAEAudioEntity
 public:
     CAEAudioEntityVTBL * vtbl;
     CEntitySAInterface * pEntity;
+    char m_tempSound[0x74]; // CAESound
 };
+static_assert(sizeof(CAEAudioEntity) == 0x7C, "Invalid size for CAEAudioEntity");
 
 class CAESound
 {
 public:
-    ushort  usGroup;    //+0
-    ushort  usIndex;    //+2
-    CAEAudioEntity*         pAudioEntity;   //+4
-    CEntitySAInterface*     pGameEntity;    //+8    Either a player or NULL
-    int     a;          //+c  = 3
-    float   b;          //+10 = -1.f
-    float   c;          //+14 = -50.f
-    float   fVolume;    //+18 = 1.f
-    float   fPitch;     //+1c = 1.f
-    uint    d;          //+20
-    CVector vec1;       //+24 = Position of player?
-    CVector vec2;       //+30 = Position of player?
-    int     e;          //+3c = 1,621         set from framecounter, no set pos if non zero
-    int     f;          //+40 = 300           time in milliseconds
-    int     g;          //+44 = 300           set from framecounter
-    float   h;          //+48 = 2997.3567f    start something?
-    float   j;          //+4c = 2997.3567f    current something?
-    float   k;          //+50 = 1.0f
-    ushort  l;          //+54 = 31488
-    ushort  m;          //+56 = 1005
-    int     n;          //+58 = 1
-    int     o;          //+5C = 0
-    float   p;          //+60 = -100.f
-    float   q;          //+64 = 1.f
-    ushort  r;          //+68 = 0         (1 on stop)
-    ushort  s;          //+6a = 114       
+    ushort  usGroup;                        // +0
+    ushort  usIndex;                        // +2
+    CAEAudioEntity*         pAudioEntity;   // +4
+    CEntitySAInterface*     pGameEntity;    // +8    Either a player or NULL
+    unsigned int m_dwEvent;                 // +12
+    float   m_fMaxVolume;                   // +16
+    float   m_fVolume;                      // +20
+    float   m_fSoundDistance;               // +24
+    float   m_fSpeed;                       // +28
+    float   unk1;                           // +32
+    CVector m_vCurrPosn;                    // +36
+    CVector m_vPrevPosn;                    // +48
+    int     m_dwLastFrameUpdate;            // +60
+    int     m_dwCurrTimeUpdate;             // +64
+    int     m_dwPrevTimeUpdate;             // +68
+    float   m_fCurrCamDist;                 // +72
+    float   m_fPrevCamDist;                 // +76
+    float   m_fTimeScale;                   // +80
+    char    unk2;                           // +84 = 31488
+    char    unk3;                           // +85 = 1005
+    union
+    {
+        unsigned short m_wEnvironmentFlags;
+        struct
+        {
+            unsigned short m_bFrontEnd : 1;
+            unsigned short m_bUncancellable : 1;
+            unsigned short m_bRequestUpdates : 1;
+            unsigned short m_bPlayPhysically : 1;
+            unsigned short m_bUnpausable : 1;
+            unsigned short m_bStartPercentage : 1;
+            unsigned short m_bMusicMastered : 1;
+            unsigned short m_bLifespanTiedToPhysicalEntity : 1;
+            unsigned short m_bUndackable : 1;
+            unsigned short m_bUncompressable : 1;
+            unsigned short m_bRolledOff : 1;
+            unsigned short m_bSmoothDucking : 1;
+            unsigned short m_bForcedFront : 1;
+        };
+    };
+    unsigned short m_wIsUsed;               // +88
+    short   unk4;                           // +90 = 1005
+    short   m_wCurrentPlayPosition;         // +92
+    short   unk5;                           // +94 = 0
+    float   m_fFinalVolume;                 // +96
+    float   m_fFrequency;                   // +100
+    short   m_wPlayingState;                // +104
+    char    unk6[2];                        // +106
+    float   m_fSoundHeadRoom;               // +108
+    short   unk7;                           // +112
+    short   unk8;                           // +114
+
 };
+static_assert(sizeof(CAESound) == 0x74, "Invalid size for CAESound");
 
 class CAudioEngineSA : public CAudioEngine
 {

--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -66,6 +66,7 @@ CGameSA::CGameSA()
 
     DEBUG_TRACE("CGameSA::CGameSA()");
     this->m_pAudioEngine            = new CAudioEngineSA((CAudioEngineSAInterface*)CLASS_CAudioEngine);
+    this->m_pAEAudioHardware        = new CAEAudioHardwareSA((CAEAudioHardwareSAInterface*)CLASS_CAEAudioHardware);
     this->m_pAudioContainer         = new CAudioContainerSA();
     this->m_pWorld                  = new CWorldSA();
     this->m_pPools                  = new CPoolsSA();
@@ -240,6 +241,7 @@ CGameSA::~CGameSA ( void )
     delete reinterpret_cast < CPoolsSA* > ( m_pPools );
     delete reinterpret_cast < CWorldSA* > ( m_pWorld );
     delete reinterpret_cast < CAudioEngineSA* > ( m_pAudioEngine );
+    delete reinterpret_cast < CAEAudioHardwareSA* > ( m_pAEAudioHardware );
     delete reinterpret_cast < CAudioContainerSA* > ( m_pAudioContainer );
     delete reinterpret_cast < CPointLightsSA * > ( m_pPointLights );
 }

--- a/Client/game_sa/CGameSA.h
+++ b/Client/game_sa/CGameSA.h
@@ -135,6 +135,7 @@ public:
     inline CTheCarGenerators        * GetTheCarGenerators()     { DEBUG_TRACE("CTheCarGenerators  * GetTheCarGenerators()");return m_pTheCarGenerators; };
     inline CAERadioTrackManager     * GetAERadioTrackManager()  { DEBUG_TRACE("CAERadioTrackManager * GetAERadioTrackManager()");return m_pCAERadioTrackManager; };
     inline CAudioEngine             * GetAudioEngine()          { DEBUG_TRACE("CAudio     * GetAudioEngine()");return m_pAudioEngine; };
+    inline CAEAudioHardware         * GetAEAudioHardware()      { DEBUG_TRACE("CAEAudioHardware     * GetAEAudioHardware()");return m_pAEAudioHardware; };
     inline CAudioEngine             * GetAudio()                { DEBUG_TRACE("CAudio     * GetAudioEngine()");return m_pAudioEngine; };
     inline CAudioContainer          * GetAudioContainer()       { DEBUG_TRACE("CAudio     * GetAudioContainer()");return m_pAudioContainer; };
     inline CMenuManager             * GetMenuManager()          { DEBUG_TRACE("CMenuManager         * GetMenuManager()");return m_pMenuManager; };
@@ -296,6 +297,7 @@ private:
     CTheCarGenerators           * m_pTheCarGenerators;
     CAERadioTrackManager        * m_pCAERadioTrackManager;
     CAudioEngine                * m_pAudioEngine;
+    CAEAudioHardware            * m_pAEAudioHardware;
     CAudioContainer             * m_pAudioContainer;
     CMenuManager                * m_pMenuManager;
     CText                       * m_pText;

--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -265,6 +265,8 @@ void CVehicleSA::Init ( void )
 
     // only applicable for CAutomobile based vehicles (i.e. not bikes, trains or boats, but includes planes, helis etc)
     this->m_pDamageManager = new CDamageManagerSA( m_pInterface, (CDamageManagerSAInterface *)((DWORD)this->GetInterface() + 1440));
+    
+    this->m_pVehicleAudioEntity = new CAEVehicleAudioEntitySA ( &GetVehicleInterface()->m_VehicleAudioEntity );
 
     // Replace the handling interface with our own to prevent handlig.cfg cheats and allow custom handling stuff.
     // We don't use SA's array because we want one handling per vehicle type and also allow custom handlings
@@ -342,6 +344,12 @@ CVehicleSA::~CVehicleSA()
             {
                 delete m_pDamageManager;
                 m_pDamageManager = NULL;
+            }
+
+            if ( m_pVehicleAudioEntity )
+            {
+                delete m_pVehicleAudioEntity;
+                m_pVehicleAudioEntity = NULL;
             }
 
             if ( m_pSuspensionLines )

--- a/Client/game_sa/CVehicleSA.h
+++ b/Client/game_sa/CVehicleSA.h
@@ -29,6 +29,7 @@ class CVehicleSA;
 #include "CDamageManagerSA.h"
 #include "CDoorSA.h"
 #include "CColPointSA.h"
+#include "CAEVehicleAudioEntitySA.h"
 
 #define SIZEOF_CHELI                            2584
 
@@ -322,17 +323,6 @@ struct CTrainFlags
     unsigned char unknown7 : 8;
 };
 
-
-// TODO: Size?
-class CAEVehicleAudioEntity
-{
-    BYTE pad1[154];
-public:
-    BYTE bCurrentRadioStation;
-private:
-    BYTE pad2;
-};
-
 class CAutoPilot
 {
     BYTE pad[56];
@@ -346,9 +336,7 @@ class CAutoPilot
 class CVehicleSAInterface : public CPhysicalSAInterface
 {
 public:
-    CAEVehicleAudioEntity m_VehicleAudioEntity; // 312
-
-    int padaudio[108];
+    CAEVehicleAudioEntitySAInterface m_VehicleAudioEntity; // 312
 
     tHandlingDataSA* pHandlingData;                             // +900
     tFlyingHandlingDataSA* pFlyingHandlingData;                 // +904
@@ -515,6 +503,7 @@ class CVehicleSA : public virtual CVehicle, public virtual CPhysicalSA
     friend class CPoolsSA;
 private:
     CDamageManagerSA*           m_pDamageManager;
+    CAEVehicleAudioEntitySA*    m_pVehicleAudioEntity;
     CHandlingEntrySA*           m_pHandlingData;
     void*                       m_pSuspensionLines;
     bool                        m_bIsDerailable;
@@ -787,6 +776,8 @@ public:
     bool                        SetWindowOpenFlagState          ( unsigned char ucWindow, bool bState );
 
     void                        UpdateLandingGearPosition       ( );
+
+    CAEVehicleAudioEntitySA *   GetVehicleAudioEntity           ( void )  { return m_pVehicleAudioEntity; };
 
 private:
     void                        RecalculateSuspensionLines          ( void );

--- a/Client/game_sa/StdInc.h
+++ b/Client/game_sa/StdInc.h
@@ -59,6 +59,8 @@
 #include "CPedSA.h"
 #include "CPedSoundSA.h"
 #include "CAudioEngineSA.h"
+#include "CAEAudioHardwareSA.h"
+#include "CAEVehicleAudioEntitySA.h"
 #include "CAudioContainerSA.h"
 #include "CPlayerInfoSA.h"
 #include "CPopulationSA.h"

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -4158,10 +4158,14 @@ void CClientPed::InternalWarpIntoVehicle ( CVehicle* pGameVehicle )
             pInTask->Destroy ();
         }        
 
-        // If we're a remote player, make sure we can't fall off
+        // If we're a remote player
         if ( !m_bIsLocalPlayer )
         {
+            // Make sure we can't fall off
             SetCanBeKnockedOffBike ( false );
+
+            // Load driver sounds (GTA does it when local player enter vehicle)
+            pGameVehicle->GetVehicleAudioEntity ()->LoadDriverSounds ();
         }
 
         // Jax: make sure our camera is fixed on the new vehicle

--- a/Client/sdk/game/CAEAudioHardware.h
+++ b/Client/sdk/game/CAEAudioHardware.h
@@ -9,8 +9,7 @@
 *
 *****************************************************************************/
 
-#ifndef __CGAME_CAEAUDIOHARDWARE
-#define __CGAME_CAEAUDIOHARDWARE
+#pragma once
 
 enum eBankSlot : short
 {
@@ -67,5 +66,3 @@ public:
     virtual bool                        IsSoundBankLoaded                   ( short wSoundBankID, short wSoundBankSlotID ) = 0;
     virtual void                        LoadSoundBank                       ( short wSoundBankID, short wSoundBankSlotID ) = 0;
 };
-
-#endif

--- a/Client/sdk/game/CAEAudioHardware.h
+++ b/Client/sdk/game/CAEAudioHardware.h
@@ -1,0 +1,71 @@
+/*****************************************************************************
+*
+*  PROJECT:		Multi Theft Auto v1.0
+*  LICENSE:		See LICENSE in the top level directory
+*  FILE:		sdk/game/CAEAudioHardware.h
+*  PURPOSE:		Game audio hardware interface
+*
+*  Multi Theft Auto is available from http://www.multitheftauto.com/
+*
+*****************************************************************************/
+
+#ifndef __CGAME_CAEAUDIOHARDWARE
+#define __CGAME_CAEAUDIOHARDWARE
+
+enum eBankSlot : short
+{
+    BANKSLOT_FRONTEND_GAME = 0,
+    BANKSLOT_FRONTEND_MENU = 1,
+    BANKSLOT_COLLISIONS = 2,
+    BANKSLOT_BULLET_SOUNDS = 3,
+    BANKSLOT_EXPLOSIONS = 4,
+    BANKSLOT_WEAPONS = 5,
+    BANKSLOT_WEATHER_RAIN = 6,
+    BANKSLOT_STREAM_ENGINE_1 = 7,
+    BANKSLOT_STREAM_ENGINE_2 = 8,
+    BANKSLOT_STREAM_ENGINE_3 = 9,
+    BANKSLOT_STREAM_ENGINE_4 = 10,
+    BANKSLOT_STREAM_ENGINE_5 = 11,
+    BANKSLOT_STREAM_ENGINE_6 = 12,
+    BANKSLOT_STREAM_ENGINE_7 = 13,
+    BANKSLOT_STREAM_ENGINE_8 = 14,
+    BANKSLOT_STREAM_ENGINE_9 = 15,
+    BANKSLOT_STREAM_ENGINE_10 = 16,
+    BANKSLOT_HORNS = 17,
+    BANKSLOT_HELICOPTER = 18,
+    BANKSLOT_VEHICLE_EXTRAS = 19,
+    BANKSLOT_SPEECH_0 = 20,
+    BANKSLOT_SPEECH_1 = 21,
+    BANKSLOT_SPEECH_2 = 22,
+    BANKSLOT_SPEECH_3 = 23,
+    BANKSLOT_SPEECH_4 = 24,
+    BANKSLOT_PLAYER_SPEECH = 25,
+    BANKSLOT_SCRIPT_SPEECH_0 = 26,
+    BANKSLOT_SCRIPT_SPEECH_1 = 27,
+    BANKSLOT_SCRIPT_SPEECH_2 = 28,
+    BANKSLOT_SCRIPT_SPEECH_3 = 29,
+    BANKSLOT_AMBIENT_RESIDENT = 30,
+    BANKSLOT_DOORS = 31,
+    BANKSLOT_WATER = 32,
+    BANKSLOT_33 = 33,
+    BANKSLOT_34 = 34,
+    BANKSLOT_35 = 35,
+    BANKSLOT_36 = 36,
+    BANKSLOT_37 = 37,
+    BANKSLOT_38 = 38,
+    BANKSLOT_39 = 39,
+    BANKSLOT_ENGINE_RESIDENT = 40,
+    BANKSLOT_FEET_RESIDENT = 41,
+    BANKSLOT_BULLET_TRAIL = 42,
+    BANKSLOT_43 = 43,
+    BANKSLOT_44 = 44
+};
+
+class CAEAudioHardware
+{
+public:
+    virtual bool                        IsSoundBankLoaded                   ( short wSoundBankID, short wSoundBankSlotID ) = 0;
+    virtual void                        LoadSoundBank                       ( short wSoundBankID, short wSoundBankSlotID ) = 0;
+};
+
+#endif

--- a/Client/sdk/game/CAEVehicleAudioEntity.h
+++ b/Client/sdk/game/CAEVehicleAudioEntity.h
@@ -9,13 +9,10 @@
 *
 *****************************************************************************/
 
-#ifndef __CGAME_CAEVEHICLEAUDIOENTITY
-#define __CGAME_CAEVEHICLEAUDIOENTITY
+#pragma once
 
 class CAEVehicleAudioEntity
 {
 public:
     virtual void                        LoadDriverSounds                        ( void ) = 0;
 };
-
-#endif

--- a/Client/sdk/game/CAEVehicleAudioEntity.h
+++ b/Client/sdk/game/CAEVehicleAudioEntity.h
@@ -1,0 +1,21 @@
+/*****************************************************************************
+*
+*  PROJECT:		Multi Theft Auto v1.0
+*  LICENSE:		See LICENSE in the top level directory
+*  FILE:		sdk/game/CAEVehicleAudioEntity.h
+*  PURPOSE:		Vehicle audio interface
+*
+*  Multi Theft Auto is available from http://www.multitheftauto.com/
+*
+*****************************************************************************/
+
+#ifndef __CGAME_CAEVEHICLEAUDIOENTITY
+#define __CGAME_CAEVEHICLEAUDIOENTITY
+
+class CAEVehicleAudioEntity
+{
+public:
+    virtual void                        LoadDriverSounds                        ( void ) = 0;
+};
+
+#endif

--- a/Client/sdk/game/CGame.h
+++ b/Client/sdk/game/CGame.h
@@ -25,6 +25,8 @@ typedef void ( InRenderer ) ( void );
 #include "CAnimBlock.h"
 #include "CAnimManager.h"
 #include "CAudioEngine.h"
+#include "CAEAudioHardware.h"
+#include "CAEVehicleAudioEntity.h"
 #include "CAudioContainer.h"
 #include "CCam.h"
 #include "CCamera.h"
@@ -136,6 +138,7 @@ public:
     virtual CPad                * GetPad()=0;
     virtual CAERadioTrackManager* GetAERadioTrackManager()=0;
     virtual CAudioEngine        * GetAudioEngine()=0;
+    virtual CAEAudioHardware    * GetAEAudioHardware()=0;
     virtual CAudioEngine        * GetAudio()=0;
     virtual CAudioContainer     * GetAudioContainer()=0;
     virtual CMenuManager        * GetMenuManager()=0;

--- a/Client/sdk/game/CVehicle.h
+++ b/Client/sdk/game/CVehicle.h
@@ -19,6 +19,7 @@
 #include "CHandlingManager.h"
 #include "CDoor.h"
 #include "CWeaponInfo.h"
+#include "CAEVehicleAudioEntity.h"
 
 #include <CVector.h>
 
@@ -314,6 +315,7 @@ public:
     virtual void                 UpdateLandingGearPosition              ( void ) = 0;
     virtual bool                 SetPlateText                           ( const SString& strText ) = 0;
     virtual bool                 SetWindowOpenFlagState                 ( unsigned char ucWindow, bool bState ) = 0;
+    virtual CAEVehicleAudioEntity * GetVehicleAudioEntity               ( void ) = 0;
 };
 
 #endif


### PR DESCRIPTION
It loads acceleration sound bank slot when remote ped enters vehicle. Similar to way the GTA does it for player (at `CAEVehicleAudioEntity::JustGotInVehicleAsDriver` / `0x4F5700`). This is limited only for planes and helis as we need.

I updated related structs & addresses. Credits to DK22Pac/plugin-sdk:
* https://github.com/DK22Pac/plugin-sdk/blob/26afb9cb0eb1f09bbb9ff82f680c85800b0b9bb8/plugin_sa/game_sa/CAEVehicleAudioEntity.h
* http://gtaforums.com/topic/194199-documenting-gta-sa-memory-addresses/?p=1064394505