### PR TITLE
Clamp rain level in setRainLevel

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.World.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.World.cpp
@@ -1416,14 +1416,17 @@ int CLuaFunctionDefs::GetRainLevel ( lua_State* luaVM )
 int CLuaFunctionDefs::SetRainLevel ( lua_State* luaVM )
 {
 //  bool setRainLevel ( float amount )
-    float fAmount;
+    float fRainLevel;
 
     CScriptArgReader argStream ( luaVM );
-    argStream.ReadNumber ( fAmount );
+    argStream.ReadNumber ( fRainLevel );
 
     if ( !argStream.HasErrors () )
     {
-        g_pGame->GetWeather ()->SetAmountOfRain ( fAmount );
+        // Clamp amount of rain to avoid game freezing/crash
+        fRainLevel = Clamp( 0.0f, fRainLevel, 10.0f );
+
+        g_pGame->GetWeather ()->SetAmountOfRain ( fRainLevel );
 
         lua_pushboolean ( luaVM, true );
         return 1;

--- a/Server/mods/deathmatch/logic/luadefs/CLuaWorldDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaWorldDefs.cpp
@@ -849,6 +849,9 @@ int CLuaWorldDefs::setRainLevel ( lua_State* luaVM )
 
     if ( !argStream.HasErrors ( ) )
     {
+        // Clamp amount of rain to avoid game freezing/crash
+        fRainLevel = Clamp( 0.0f, fRainLevel, 10.0f );
+
         if ( CStaticFunctionDefinitions::SetRainLevel ( fRainLevel ) )
         {
             lua_pushboolean ( luaVM, true );


### PR DESCRIPTION
## Description
This PR clamps the rain level value between 0.0 and 10.0. Negative values are broken and usually show no signs of rain, they neither let the rain go upwards and it makes no sense to set it lower than 0.0 anyway. The upper limit **10.0** is a personal choice, because anything above causes game lag and doesn't look like rain anymore (looks like TV noise).

**Issue:** [9622: [Crash] setRainLevel(-9999999999) crash client](https://bugs.mtasa.com/view.php?id=9622)