### PR TITLE
Use proper camera mode for vehicle targets

### DIFF
--- a/Client/mods/deathmatch/logic/CClientCamera.cpp
+++ b/Client/mods/deathmatch/logic/CClientCamera.cpp
@@ -82,17 +82,17 @@ void CClientCamera::DoPulse ( void )
                     {
                         if ( !pVehicle )
                         {
-                            SetFocus ( m_pFocusedPlayer, MODE_BEHINDCAR );
+                            SetFocus ( m_pFocusedPlayer, MODE_CAM_ON_A_STRING );
                         }
                     }
                     else if ( pVehicle )
                     {
-                        SetFocus ( m_pFocusedPlayer, MODE_BEHINDCAR );
+                        SetFocus ( m_pFocusedPlayer, MODE_CAM_ON_A_STRING );
                     }
                 }
                 else
                 {
-                    SetFocus ( m_pFocusedPlayer, MODE_BEHINDCAR );
+                    SetFocus ( m_pFocusedPlayer, MODE_CAM_ON_A_STRING );
                 }
             }
 
@@ -357,8 +357,7 @@ void CClientCamera::SetFocus ( CClientEntity* pEntity, eCamMode eMode, bool bSmo
             }
 
             // Hacky, used to follow peds
-            //if ( eMode == MODE_CAM_ON_A_STRING && eType == CCLIENTPLAYERMODEL )
-            if ( eMode == MODE_BEHINDCAR && ( eType == CCLIENTPED || eType == CCLIENTPLAYER ) )
+            if ( eMode == MODE_CAM_ON_A_STRING && ( eType == CCLIENTPED || eType == CCLIENTPLAYER ) )
                 eMode = MODE_FOLLOWPED;
 
             // Do it
@@ -503,7 +502,7 @@ void CClientCamera::RestoreEntity ( CClientEntity* pEntity )
     {
         if ( m_pFocusedEntity && m_pFocusedEntity == pEntity )
         {
-            SetFocus ( pEntity, MODE_BEHINDCAR );
+            SetFocus ( pEntity, MODE_CAM_ON_A_STRING );
             m_bInvalidated = false;
         }
     }

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -4630,7 +4630,7 @@ bool CStaticFunctionDefinitions::SetCameraTarget ( CClientEntity * pEntity )
                 // TODO: stream in the player here (needs to be done through the streamer)
 
                 // Put the focus on that player
-                m_pCamera->SetFocus ( pPlayer, MODE_BEHINDCAR, false );
+                m_pCamera->SetFocus ( pPlayer, MODE_CAM_ON_A_STRING, false );
             }
             break;
         }

--- a/Client/mods/deathmatch/logic/rpc/CCameraRPCs.cpp
+++ b/Client/mods/deathmatch/logic/rpc/CCameraRPCs.cpp
@@ -86,7 +86,7 @@ void CCameraRPCs::SetCameraTarget ( NetBitStreamInterface& bitStream )
                     else
                     {
                         // Put the focus on that player
-                        m_pCamera->SetFocus ( pPlayer, MODE_BEHINDCAR, false );
+                        m_pCamera->SetFocus ( pPlayer, MODE_CAM_ON_A_STRING, false );
                     }
                     break;
                 }


### PR DESCRIPTION
Fixes [#5306](https://bugs.mtasa.com/view.php?id=5306) and [#7594](https://bugs.mtasa.com/view.php?id=7594).

Normally car camera uses mode `MODE_CAM_ON_A_STRING`, not `MODE_BEHINDCAR`.