### PR TITLE
Add option to enable io os and package libs and few functions

### DIFF
--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -937,6 +937,15 @@ bool CGame::Start ( int iArgumentCount, char* szArguments [] )
             CLogger::LogPrintf("WARNING: <owner_email_address> not set\n");
         }
     }
+    
+    if (m_pMainConfig->IsAdvancedModeEnabled())
+    {
+        CLogger::LogPrint("Advanced mode: Enabled!\n");
+    }
+    else
+    {
+        CLogger::LogPrint("Advanced mode: Disabled!\n");
+    }
 
     // Done
     // If you're ever going to change this message, update the "server ready" determination

--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -96,6 +96,7 @@ CMainConfig::CMainConfig ( CConsole* pConsole, CLuaManager* pLuaMain ): CXMLConf
     m_iBackupInterval = 3;
     m_iBackupAmount = 5;
     m_bSyncMapElementData = true;
+    m_bAdvancedMode = false;
 }
 
 
@@ -541,6 +542,13 @@ bool CMainConfig::Load ( void )
     {
         GetInteger ( m_pRootNode, "lightsync_rate", g_TickRateSettings.iLightSync );
         g_TickRateSettings.iLightSync = Clamp ( 200, g_TickRateSettings.iLightSync, 4000 );
+    }
+    // Advanced mode, unlock io, os and package and disable InitSecurity();
+    iTemp = m_bAdvancedMode;
+    iResult = GetInteger(m_pRootNode, "advanced_mode", iTemp, 0, 1);
+    if (iResult == IS_SUCCESS)
+    {
+        m_bAdvancedMode = iTemp ? true : false;
     }
 
     ApplyNetOptions ();

--- a/Server/mods/deathmatch/logic/CMainConfig.h
+++ b/Server/mods/deathmatch/logic/CMainConfig.h
@@ -133,6 +133,7 @@ public:
     const std::vector< SString >&   GetOwnerEmailAddressList        ( void ) const                      { return m_OwnerEmailAddressList; }
     bool                            IsDatabaseCredentialsProtectionEnabled ( void ) const               { return m_bDatabaseCredentialsProtectionEnabled != 0; }
     bool                            IsFakeLagCommandEnabled         ( void ) const                      { return m_bFakeLagCommandEnabled != 0; }
+    bool                            IsAdvancedModeEnabled           ( void ) const                      { return m_bAdvancedMode != 0; }
 
     SString                         GetSetting                      ( const SString& configSetting );
     bool                            GetSetting                      ( const SString& configSetting, SString& strValue );

--- a/Server/mods/deathmatch/logic/CMainConfig.h
+++ b/Server/mods/deathmatch/logic/CMainConfig.h
@@ -230,6 +230,7 @@ private:
     int                             m_bFilterDuplicateLogLinesEnabled;
     int                             m_bDatabaseCredentialsProtectionEnabled;
     int                             m_bFakeLagCommandEnabled;
+    bool                            m_bAdvancedMode;
 };
 
 #endif

--- a/Server/mods/deathmatch/logic/lua/CLuaFunctionDefs.Server.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaFunctionDefs.Server.cpp
@@ -697,6 +697,12 @@ int CLuaFunctionDefs::GetServerHttpPort ( lua_State* luaVM )
     return 1;
 }
 
+int CLuaFunctionDefs::GetAdvancedMode(lua_State* luaVM)
+{
+    lua_pushboolean(luaVM, g_pGame->GetConfig()->IsAdvancedModeEnabled() == 1 ? true : false );
+    return 1;
+}
+
 
 int CLuaFunctionDefs::GetServerIP ( lua_State* luaVM )
 {

--- a/Server/mods/deathmatch/logic/lua/CLuaFunctionDefs.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaFunctionDefs.h
@@ -122,7 +122,7 @@ public:
     LUA_DECLARE ( SetServerPassword );
     LUA_DECLARE ( GetServerConfigSetting );
     LUA_DECLARE ( SetServerConfigSetting );
-
+    LUA_DECLARE ( GetAdvancedMode );
     LUA_DECLARE ( shutdown );
 
     // Util functions to make scripting easier for the end user

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -191,8 +191,25 @@ void CLuaMain::InitVM ( void )
     luaopen_debug ( m_luaVM );
     luaopen_utf8 ( m_luaVM );
 
-    // Initialize security restrictions. Very important to prevent lua trojans and viruses!
-    InitSecurity ();
+    // Enable package,io and os lib. Hosting providers can disable this.
+    if (g_pGame->GetConfig()->IsAdvancedModeEnabled()) {
+        lua_pushcfunction(m_luaVM, luaopen_package);
+        lua_pushstring(m_luaVM, "package");
+        lua_call(m_luaVM, 1, 0);
+
+        lua_pushcfunction(m_luaVM, luaopen_io);
+        lua_pushstring(m_luaVM, "io");
+        lua_call(m_luaVM, 1, 0);
+
+        lua_pushcfunction(m_luaVM, luaopen_os);
+        lua_pushstring(m_luaVM, "os");
+        lua_call(m_luaVM, 1, 0);
+    }
+    else
+    {
+        // Initialize security restrictions. Very important to prevent lua trojans and viruses!
+        InitSecurity();
+    }
 
     // Registering C functions
     CLuaCFunctions::RegisterFunctionsWithVM ( m_luaVM );

--- a/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -248,6 +248,7 @@ void CLuaManager::LoadCFunctions ( void )
     CLuaCFunctions::AddFunction ( "setServerPassword", CLuaFunctionDefs::SetServerPassword );
     CLuaCFunctions::AddFunction ( "getServerConfigSetting", CLuaFunctionDefs::GetServerConfigSetting );
     CLuaCFunctions::AddFunction ( "setServerConfigSetting", CLuaFunctionDefs::SetServerConfigSetting, true );
+    CLuaCFunctions::AddFunction ( "isAdvancedModeEnabled", CLuaFunctionDefs::GetAdvancedMode );
 
     CLuaCFunctions::AddFunction ( "shutdown", CLuaFunctionDefs::shutdown, true );
 


### PR DESCRIPTION
This is my first pull request, i lern :)

This pull request add another tag to mta mtaserver.conf named "advanced_mode" which unlock io, os and package libs and function dofile loadfile require loadlib getfenv and newproxy
and function to check if advanced mode is enabled:
bool isAdvancedModeEnabled( )  -- true if enabled, false otherwise

By default this is disabled so, nothing change in current scripts.
Hosting providers can disallow to enable this mode simply by block tag "advanced_mode"
if tag has value equal 1 then advanced mode is enabled.
When server started print information about state of this mode.

Simple check:

if(isAdvancedModeEnabled())then -- did <advanced_mode>1</advanced_mode> ?
	print("Enabled!",os,io,package) -- table exists
else
	print("Disabled!",os,io,package)  -- nil
end