### PR TITLE
Add player element for onClientChatMessage

### DIFF
--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -1311,11 +1311,8 @@ void CPacketHandler::Packet_ChatEcho ( NetBitStreamInterface& bitStream )
                 StripControlCodes ( szMessage, ' ' );
 
                 // Determine the event source entity
-                CClientEntity * pEntity = g_pClientGame->GetRootEntity();
-
-                if ( pClient ) {
-                    pEntity = pClient;
-                }
+                CClientEntity * pRootEntity = g_pClientGame->GetRootEntity();
+                CClientEntity * pEntity = pClient ? pClient : pRootEntity;
 
                 // Call an event
                 CLuaArguments Arguments;
@@ -1323,7 +1320,7 @@ void CPacketHandler::Packet_ChatEcho ( NetBitStreamInterface& bitStream )
                 Arguments.PushNumber ( ucRed );
                 Arguments.PushNumber ( ucGreen );
                 Arguments.PushNumber ( ucBlue );
-                bool bCancelled = !pEntity->CallEvent ( "onClientChatMessage", Arguments, false );
+                bool bCancelled = !pEntity->CallEvent ( "onClientChatMessage", Arguments, pEntity != pRootEntity );
                 if ( !bCancelled )
                 {
                     // Echo it

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -1268,6 +1268,7 @@ void CPacketHandler::Packet_ChatEcho ( NetBitStreamInterface& bitStream )
     // unsigned char    (1)     - green
     // unsigned char    (1)     - blue
     // unsigned char    (1)     - color-coded
+    // ElementID        (2)     - client (if typed by a player)
     // unsigned char    (x)     - message
 
     // Read out the color
@@ -1275,14 +1276,28 @@ void CPacketHandler::Packet_ChatEcho ( NetBitStreamInterface& bitStream )
     unsigned char ucGreen;
     unsigned char ucBlue;
     bool ucColorCoded;
+
+    CClientEntity * pClient = nullptr;
+
     if ( bitStream.Read ( ucRed ) &&
          bitStream.Read ( ucGreen ) &&
          bitStream.Read ( ucBlue ) &&
          bitStream.ReadBit ( ucColorCoded ) )
     {
-        // Valid length?
+        // Read the client's ID
+        int iNumberOfBytesUsed;
 
-        int iNumberOfBytesUsed = bitStream.GetNumberOfBytesUsed () - 4;
+        if ( bitStream.Version() >= 0x06B ) {
+            ElementID ClientID;
+            bitStream.Read( ClientID );
+            pClient = ( ClientID != INVALID_ELEMENT_ID ) ? CElementIDs::GetElement( ClientID ) : nullptr;
+            iNumberOfBytesUsed = bitStream.GetNumberOfBytesUsed() - 6;
+        }
+        else {
+            iNumberOfBytesUsed = bitStream.GetNumberOfBytesUsed() - 4;
+        }
+
+        // Valid length?
         if ( iNumberOfBytesUsed >= MIN_CHATECHO_LENGTH  )
         {
             // Read the message into a buffer
@@ -1295,13 +1310,20 @@ void CPacketHandler::Packet_ChatEcho ( NetBitStreamInterface& bitStream )
                 // Strip it for bad characters
                 StripControlCodes ( szMessage, ' ' );
 
+                // Determine the event source entity
+                CClientEntity * pEntity = g_pClientGame->GetRootEntity();
+
+                if ( pClient ) {
+                    pEntity = pClient;
+                }
+
                 // Call an event
                 CLuaArguments Arguments;
                 Arguments.PushString ( szMessage );
                 Arguments.PushNumber ( ucRed );
                 Arguments.PushNumber ( ucGreen );
                 Arguments.PushNumber ( ucBlue );
-                bool bCancelled = !g_pClientGame->GetRootEntity()->CallEvent ( "onClientChatMessage", Arguments, false );
+                bool bCancelled = !pEntity->CallEvent ( "onClientChatMessage", Arguments, false );
                 if ( !bCancelled )
                 {
                     // Echo it

--- a/Client/version.h
+++ b/Client/version.h
@@ -77,7 +77,7 @@
 #define _NETCODE_VERSION_BRANCH_ID      0x4         // Use 0x1 - 0xF to indicate an incompatible branch is being used (0x0 is reserved, 0x4 is trunk)
 #define _CLIENT_NET_MODULE_VERSION      0x0A7       // (0x000 - 0xfff) Lvl9 wizards only
 #define _NETCODE_VERSION                0x1DA       // (0x000 - 0xfff) Increment when net messages change (pre-release)
-#define MTA_DM_BITSTREAM_VERSION        0x06A       // (0x000 - 0xfff) Increment when net messages change (post-release). (Changing will also require additional backward compatibility code).
+#define MTA_DM_BITSTREAM_VERSION        0x06B       // (0x000 - 0xfff) Increment when net messages change (post-release). (Changing will also require additional backward compatibility code).
 
 // To avoid user confusion, make sure the ASE version matches only if communication is possible
 #if defined(MTA_DM_CONNECT_TO_PUBLIC)

--- a/Server/mods/deathmatch/logic/CConsoleCommands.cpp
+++ b/Server/mods/deathmatch/logic/CConsoleCommands.cpp
@@ -361,13 +361,15 @@ bool CConsoleCommands::Say ( CConsole* pConsole, const char* szInArguments, CCli
                                 }
 
                                 // Broadcast the message to all clients
-                                pConsole->GetPlayerManager ()->BroadcastOnlyJoined ( CChatEchoPacket ( strEcho, ucR, ucG, ucB, true ) );
+                                auto ChatEchoPacket = CChatEchoPacket ( strEcho, ucR, ucG, ucB, true );
+                                ChatEchoPacket.SetSourceElement( pPlayer );
+                                pConsole->GetPlayerManager ()->BroadcastOnlyJoined ( ChatEchoPacket );
 
                                 // Call onChatMessage if players chat message was delivered
                                 CLuaArguments Arguments2;
                                 Arguments2.PushString ( szArguments );
                                 Arguments2.PushElement ( pPlayer );
-                                static_cast < CPlayer* > ( pClient )->CallEvent ( "onChatMessage", Arguments2 );
+                                pPlayer->CallEvent ( "onChatMessage", Arguments2 );
                             }
 
                             break;

--- a/Server/mods/deathmatch/logic/packets/CChatEchoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CChatEchoPacket.cpp
@@ -20,6 +20,11 @@ bool CChatEchoPacket::Write ( NetBitStreamInterface& BitStream ) const
     BitStream.Write ( m_ucBlue );
     BitStream.WriteBit ( m_bColorCoded );
 
+    // Write the client's ID
+    if ( BitStream.Version() >= 0x06B ) {
+        BitStream.Write ( GetSourceElement() ? GetSourceElement()->GetID() : NULL );
+    }
+
     // Too short?
     size_t sizeMessage = m_strMessage.length();
     if ( sizeMessage >= MIN_CHATECHO_LENGTH )

--- a/Server/mods/deathmatch/logic/packets/CChatEchoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CChatEchoPacket.cpp
@@ -22,7 +22,7 @@ bool CChatEchoPacket::Write ( NetBitStreamInterface& BitStream ) const
 
     // Write the client's ID
     if ( BitStream.Version() >= 0x06B ) {
-        BitStream.Write ( GetSourceElement() ? GetSourceElement()->GetID() : NULL );
+        BitStream.Write ( GetSourceElement() ? GetSourceElement()->GetID() : INVALID_ELEMENT_ID );
     }
 
     // Too short?

--- a/Server/version.h
+++ b/Server/version.h
@@ -81,7 +81,7 @@
 #define _NETCODE_VERSION_BRANCH_ID      0x4         // Use 0x1 - 0xF to indicate an incompatible branch is being used (0x0 is reserved, 0x4 is trunk)
 #define _SERVER_NET_MODULE_VERSION      0x0A7       // (0x000 - 0xfff) Lvl9 wizards only
 #define _NETCODE_VERSION                0x1DA       // (0x000 - 0xfff) Increment when net messages change (pre-release)
-#define MTA_DM_BITSTREAM_VERSION        0x06A       // (0x000 - 0xfff) Increment when net messages change (post-release). (Changing will also require additional backward compatibility code).
+#define MTA_DM_BITSTREAM_VERSION        0x06B       // (0x000 - 0xfff) Increment when net messages change (post-release). (Changing will also require additional backward compatibility code).
 
 // To avoid user confusion, make sure the ASE version matches only if communication is possible
 #if defined(MTA_DM_CONNECT_FROM_PUBLIC)


### PR DESCRIPTION
# Description
This pull request changes the BitStream for the ChatEcho packet to include the responsible client for the **onClientChatMessage** event.

**Note:** You have to use **/stop freeroam** with the default resources if you are going to test this functionality, because the freeroam resource cancels the **onPlayerChat** event, which results in MTA not triggering the clientside event at all.

**Issue:** [#6117: Event Request: onClientPlayerChat](https://bugs.mtasa.com/view.php?id=6117)