### PR TITLE
Fix client/server ped dead-state inconsistency

### DIFF
--- a/Server/mods/deathmatch/logic/CPed.cpp
+++ b/Server/mods/deathmatch/logic/CPed.cpp
@@ -55,7 +55,7 @@ CPed::CPed ( CPedManager* pPedManager, CElement* pParent, CXMLNode* pNode, unsig
     memset ( &m_Weapons[0], 0, sizeof ( m_Weapons ) );
     m_ucAlpha = 255;
     m_pContactElement = NULL;
-    m_bIsDead = true;
+    m_bIsDead = false;
     m_bSpawned = false;
     m_fRotation = 0.0f;
     m_pTargetedEntity = NULL;


### PR DESCRIPTION
## Description
Fixes #487

This tiny pull request fixes the inconsistency between client and server code to match the current 'dead' state of a ped.

**Issue:** [#9496: Client 'isPedDead' returns 'false' when not yet spawned](https://bugs.mtasa.com/view.php?id=9496)
**Client:** [mods/deathmatch/logic/CClientPed.cpp](https://github.com/multitheftauto/mtasa-blue/blob/master/Client/mods/deathmatch/logic/CClientPed.cpp#L140)

### Notes
Your player ped is spawned and not dead after the initial connect, but the server code doesn't represent this state pre-PR. [(see here)](https://github.com/multitheftauto/mtasa-blue/blob/master/Server/mods/deathmatch/logic/CGame.cpp#L3945)