### PR TITLE
Display seconds in disconnect message box if viable

### DIFF
--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -581,13 +581,17 @@ void CPacketHandler::Packet_ServerDisconnected ( NetBitStreamInterface& bitStrea
             int iHours = static_cast < int > ( Duration / 3600 );
             Duration = Duration % 3600;
             int iMins = static_cast < int > ( Duration / 60 );
+            Duration = Duration % 60;
+            int iSeconds = static_cast < int > ( Duration );
 
             if ( iDays )
-                strReason += SString(_tn( "%d day", "%d days", iDays ),iDays) += iHours ? " " : "";
+                strReason += SString( _tn( "%d day", "%d days", iDays ), iDays ) += (iHours || iMins) ? " " : "";
             if ( iHours )
-                strReason += SString(_tn( "%d hour", "%d hours", iHours ),iHours)  += iMins ? " " : "";
+                strReason += SString( _tn( "%d hour", "%d hours", iHours ), iHours )  += iMins ? " " : "";
             if ( iMins )
-                strReason += SString(_tn( "%d minute", "%d minutes", iMins ),iMins);
+                strReason += SString( _tn( "%d minute", "%d minutes", iMins ), iMins ) += iSeconds?  " " : "";
+            if ( !iDays && !iHours && iSeconds )
+                strReason += SString( _tn( "%d second", "%d seconds", iSeconds ), iSeconds );
         }
 
         // Display the error


### PR DESCRIPTION
Shows the seconds of the remaining time duration if there are zero days and zero hours left.