### PR TITLE
0009694: Added size column in the server list

### DIFF
--- a/Client/core/Serverbrowser/CServerBrowser.h
+++ b/Client/core/Serverbrowser/CServerBrowser.h
@@ -188,6 +188,7 @@ protected:
     // Server list columns
     CGUIHandle          m_hVersion [ SERVER_BROWSER_TYPE_COUNT ];
     CGUIHandle          m_hLocked [ SERVER_BROWSER_TYPE_COUNT ];
+    CGUIHandle          m_hResSize [ SERVER_BROWSER_TYPE_COUNT ];
     CGUIHandle          m_hName [ SERVER_BROWSER_TYPE_COUNT ];
     CGUIHandle          m_hPing [ SERVER_BROWSER_TYPE_COUNT ];
     CGUIHandle          m_hPlayers [ SERVER_BROWSER_TYPE_COUNT ];

--- a/Client/core/Serverbrowser/CServerList.cpp
+++ b/Client/core/Serverbrowser/CServerList.cpp
@@ -635,12 +635,12 @@ bool CServerListItem::ParseQuery ( const char * szBuffer, unsigned int nLength )
 
     // Get player nicks
     vecPlayers.clear ();
-    while ( i < nLength )
+    while ( i < nLength - 4 )
     {
         std::string strPlayer;
         try
         {
-            if ( ReadString ( strPlayer, szBuffer, i, nLength ) )
+            if ( ReadString ( strPlayer, szBuffer, i, nLength - 4 ) )
             {
                 // Remove color code, unless that results in an empty string
                 SString strResult = RemoveColorCodes ( strPlayer.c_str () );
@@ -655,6 +655,10 @@ bool CServerListItem::ParseQuery ( const char * szBuffer, unsigned int nLength )
             // yeah that's what I thought.
             return false;
         }
+    }
+    if (i + 4 == nLength)
+    {
+        fResSize = *(float*)&szBuffer[i];
     }
 
     bScanned = true;

--- a/Client/core/Serverbrowser/CServerList.h
+++ b/Client/core/Serverbrowser/CServerList.h
@@ -139,6 +139,7 @@ public:
         nPlayers = 0;
         nMaxPlayers = 0;
         nPing = 9999;
+        fResSize = 0;
         uiCacheNoReplyCount = 0;
         m_ElapsedTime.SetMaxIncrement ( 500 );
         m_ElapsedTime.Reset ();
@@ -191,6 +192,7 @@ public:
     unsigned short      nPlayers;      // Current players
     unsigned short      nMaxPlayers;   // Maximum players
     unsigned short      nPing;         // Ping time
+    float               fResSize;      // Resources size
     bool                bPassworded;    // Password protected
     bool                bSerials;       // Serial verification on
     bool                bScanned;

--- a/Server/mods/deathmatch/logic/ASE.cpp
+++ b/Server/mods/deathmatch/logic/ASE.cpp
@@ -477,7 +477,7 @@ std::string ASE::QueryLight ( void )
     CPlayer* pPlayer = NULL;
 
     // Keep the packet under 1350 bytes to try to avoid fragmentation 
-    int iBytesLeft = 1340 - (int)reply.tellp ();
+    int iBytesLeft = 1336 - (int)reply.tellp ();
     int iPlayersLeft = iJoinedPlayers;
 
     list < CPlayer* > ::const_iterator pIter = m_pPlayerManager->IterBegin ();
@@ -500,6 +500,9 @@ std::string ASE::QueryLight ( void )
             reply << strPlayerName.c_str ();
         }
     }
+
+    float fResSize = g_pGame->GetResourceManager()->GetTotalResourcesSize() / ( float ) 1024;
+    reply.write(reinterpret_cast < const char* > ( &fResSize ), sizeof ( float ) );
 
     return reply.str();
 }

--- a/Server/mods/deathmatch/logic/CResource.cpp
+++ b/Server/mods/deathmatch/logic/CResource.cpp
@@ -599,6 +599,7 @@ void CResource::SetInfoValue ( const char * szKey, const char * szValue, bool bS
 bool CResource::GenerateChecksums ( void )
 {
     bool bOk = true;
+    uint64 uiResourceSize = 0;
 
     list < CResourceFile* > ::iterator iterf = m_resourceFiles.begin ();
     for ( ; iterf != m_resourceFiles.end (); iterf++ )
@@ -657,6 +658,7 @@ bool CResource::GenerateChecksums ( void )
                         if ( pResourceFile->IsNoClientCache () )
                             FileDelete ( pResourceFile->GetCachedPathFilename ( true ) );
                     }
+                    uiResourceSize += uiFileSize;
                 }
                 break;
 
@@ -672,6 +674,7 @@ bool CResource::GenerateChecksums ( void )
     {
         m_metaChecksum = CChecksum::GenerateChecksumFromFile ( strPath );
     }
+    m_uiResourceSize = uiResourceSize;
 
     return bOk;
 }

--- a/Server/mods/deathmatch/logic/CResource.h
+++ b/Server/mods/deathmatch/logic/CResource.h
@@ -205,6 +205,7 @@ private:
     bool                    m_bSyncMapElementDataDefined;
 
     CChecksum               m_metaChecksum;     // Checksum of meta.xml last time this was loaded, generated in GenerateChecksums()
+    uint64                  m_uiResourceSize;
 
     unsigned short          m_usNetID; // resource ID    
     uint                    m_uiScriptID;
@@ -292,6 +293,7 @@ public:
     bool                    StopAllResourceItems ( void );    
 
     bool                    GenerateChecksums ( void );
+    uint64                  GetResourceSize ( void ) { return m_uiResourceSize; }
     const CChecksum&        GetLastMetaChecksum ( void ) { return m_metaChecksum; }
     bool                    HasResourceChanged ( void );
     void                    ApplyUpgradeModifications ( void );

--- a/Server/mods/deathmatch/logic/CResourceManager.cpp
+++ b/Server/mods/deathmatch/logic/CResourceManager.cpp
@@ -725,6 +725,21 @@ bool CResourceManager::StopAllResources ( void )
     return true;
 }
 
+uint64 CResourceManager::GetTotalResourcesSize(void)
+{
+    uint64 uiTotalSize = 0;
+    list < CResource* > ::const_iterator iter = m_resources.begin();
+    for (; iter != m_resources.end(); iter++)
+    {
+        CResource* pResource = *iter;
+        if (pResource->IsActive())
+        {
+            uiTotalSize += pResource->GetResourceSize();
+        }
+    }
+    return uiTotalSize;
+}
+
 
 void CResourceManager::QueueResource ( CResource* pResource, eResourceQueue eQueueType, const sResourceStartFlags* Flags, list < CResource* > * dependents )
 {

--- a/Server/mods/deathmatch/logic/CResourceManager.h
+++ b/Server/mods/deathmatch/logic/CResourceManager.h
@@ -88,6 +88,7 @@ public:
     bool                        StartResource                   ( CResource* pResource, list < CResource* > * dependents = NULL, bool bStartedManually = false, bool bStartIncludedResources = true, bool bConfigs = true, bool bMaps = true, bool bScripts = true, bool bHTML = true, bool bClientConfigs = true, bool bClientScripts = true, bool bClientFiles = true );
     bool                        Reload                          ( CResource* pResource );
     bool                        StopAllResources                ( void );
+    uint64                      GetTotalResourcesSize           ( void );
 
     void                        QueueResource                   ( CResource* pResource, eResourceQueue eQueueType, const sResourceStartFlags* Flags, list < CResource* > * dependents = NULL );
     void                        ProcessQueue                    ( void );


### PR DESCRIPTION
This is an a little bit ugly realization of [#9694](https://bugs.mtasa.com/view.php?id=9694): adds a new column to the server list that displays the total size of all currently loaded resources on the server.
TODO: sorting in this column
Screenshot:
![screenshot](https://user-images.githubusercontent.com/30495180/28720113-0789803c-73ce-11e7-8094-7a8b21583b3c.png)