### PR TITLE
[mtaserver.conf] Raise default maxfps to 50

### DIFF
--- a/Server/mods/deathmatch/mtaserver.conf
+++ b/Server/mods/deathmatch/mtaserver.conf
@@ -189,7 +189,7 @@
 
     <!-- Specifies the frame rate limit that will be applied to connecting clients.
          Available range: 25 to 100. Default: 36. -->
-    <fpslimit>36</fpslimit>
+    <fpslimit>50</fpslimit>
 
     <!-- This parameter specifies whether or not to enable player voice chat in-game
          Values: 0 - disabled , 1 - enabled -->


### PR DESCRIPTION
I suggest we change fpslimit to 50 by default, as this is the highest fps avoiding all GTA bugs that might be objections.
- The slower swimming bug isn't present on 50fps, on 60 it is.
- The strafing bug isn't present on 50fps.
- The skimmer water take-off bug isn't really present at 50fps (it will just increase its runway to takeoff a bit, but succeed. Acceptable for the benefits of 50fps)

So, 50fps is a breaking point at which we won't get high-fps related GTA bugs. But 50fps feels lot less laggier than default 36, and fact is many servers stick to default value so it will increase overall quality of gameplay within MTA.

Any thoughts? It may be a trivial PR, but the dialogue on whether to do this or not isn't.

Side note: 60fps feels lots smoother than 50 (a huge leap), but would introduce the first bugs: total inability to take off with the Skimmer and a bit slower swimming (although not a gameplay impeding slowdown). But if that's off-prioritized by the gain from 50 to 60fps, I'd be open to suggestions to instead raise to 60 also.