### PR TITLE
Fix vectors, required and optional parameters handling in ColShape.Polygon APIs (client and server)

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
@@ -219,9 +219,22 @@ int CLuaColShapeDefs::CreateColRectangle ( lua_State* luaVM )
 
 int CLuaColShapeDefs::CreateColPolygon ( lua_State* luaVM )
 {
+    //  colshape createColPolygon ( float fX, float fY, float fX1, float fY1, float fX2, float fY2, float fX3, float fY3, ... )
+
     CVector2D vecPosition;
+    std::vector < CVector2D > vecPointList;
     CScriptArgReader argStream ( luaVM );
+
+    // Get position
     argStream.ReadVector2D ( vecPosition );
+
+    // Get first 3 required points
+    for ( uint i = 0; i < 3; i++ )
+    {
+        CVector2D vecPoint;
+        argStream.ReadVector2D ( vecPoint );
+        vecPointList.push_back ( vecPoint );
+    }
 
     if ( !argStream.HasErrors () )
     {
@@ -235,11 +248,18 @@ int CLuaColShapeDefs::CreateColPolygon ( lua_State* luaVM )
                 CClientColPolygon* pShape = CStaticFunctionDefinitions::CreateColPolygon ( *pResource, vecPosition );
                 if ( pShape )
                 {
-                    // Get the points
-                    while ( argStream.NextCouldBeNumber () && argStream.NextCouldBeNumber ( 1 ) )
+                    // Get additional points
+                    while ( argStream.NextIsVector2D () )
                     {
-                        argStream.ReadVector2D ( vecPosition );
-                        pShape->AddPoint ( vecPosition );
+                        CVector2D vecPoint;
+                        argStream.ReadVector2D ( vecPoint );
+                        vecPointList.push_back ( vecPoint );
+                    }
+
+                    // Add all points
+                    for( uint i = 0 ; i < vecPointList.size() ; i++ )
+                    {
+                        pShape->AddPoint( vecPointList[i] );
                     }
 
                     CElementGroup * pGroup = pResource->GetElementGroup ();

--- a/Server/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
@@ -215,10 +215,12 @@ int CLuaColShapeDefs::CreateColRectangle ( lua_State* luaVM )
 int CLuaColShapeDefs::CreateColPolygon ( lua_State* luaVM )
 {
     //  colshape createColPolygon ( float fX, float fY, float fX1, float fY1, float fX2, float fY2, float fX3, float fY3, ... )
+
     std::vector < CVector2D > vecPointList;
 
+    // Get position and first 3 required points
     CScriptArgReader argStream ( luaVM );
-    for ( uint i = 0; i < 4 || argStream.NextCouldBeNumber (); i++ )
+    for ( uint i = 0; i < 4; i++ )
     {
         CVector2D vecPoint;
         argStream.ReadVector2D ( vecPoint );
@@ -233,6 +235,14 @@ int CLuaColShapeDefs::CreateColPolygon ( lua_State* luaVM )
             CResource* pResource = pLuaMain->GetResource ();
             if ( pResource )
             {
+                // Get additional points
+                while ( argStream.NextIsVector2D () )
+                {
+                    CVector2D vecPoint;
+                    argStream.ReadVector2D ( vecPoint );
+                    vecPointList.push_back ( vecPoint );
+                }
+
                 CColPolygon* pShape = CStaticFunctionDefinitions::CreateColPolygon ( pResource, vecPointList );
                 if ( pShape )
                 {


### PR DESCRIPTION
This pull request fixes the initial problem described in https://bugs.mtasa.com/view.php?id=9742 and also some additional problems on client side:
- makes position and first 3 points to be required parameters (just like the wiki says and just like the server side API works)
- adds support for Vectors as params in addition to plain numbers

Full test suite is available at:
https://github.com/4O4/mtasa-lua-tests/tree/master/%5Btests%5D/test-colshape-polygon
Obviously it fails miserably without this patch 😄 