### PR TITLE
0008696: Fix cloned elements not getting removed on resource stop

### DIFF
--- a/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -297,7 +297,8 @@ int CLuaElementDefs::cloneElement ( lua_State* luaVM )
                 if ( pNewElement )
                 {
                     CElementGroup * pGroup = pResource->GetElementGroup ();
-                    if ( pGroup ) {
+                    if ( pGroup ) 
+                    {
                         pGroup->Add ( pNewElement );
                     }
                     lua_pushelement ( luaVM, pNewElement );

--- a/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -296,6 +296,10 @@ int CLuaElementDefs::cloneElement ( lua_State* luaVM )
 
                 if ( pNewElement )
                 {
+                    CElementGroup * pGroup = pResource->GetElementGroup ();
+                    if ( pGroup ) {
+                        pGroup->Add ( pNewElement );
+                    }
                     lua_pushelement ( luaVM, pNewElement );
                     return 1;
                 }


### PR DESCRIPTION
Cloned elements should now get removed on resource-stop.

Bugtracker: https://bugs.mtasa.com/view.php?id=8696
Tested: Only with #getElementsByType("object")