### PR TITLE
Add support for command aliases in addCommandHandler

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Commands.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Commands.cpp
@@ -21,21 +21,23 @@
 
 int CLuaFunctionDefs::AddCommandHandler ( lua_State* luaVM )
 {
-//  bool addCommandHandler ( string commandName, function handlerFunction, [bool caseSensitive = true] )
+//  bool addCommandHandler ( string/table commandName, function handlerFunction, [bool caseSensitive = true] )
     SString strKey;
-    std::vector < CPlayer* > vecKey;
+    std::vector < SString > vecKey;
+    bool bType;
     CLuaFunctionRef iLuaFunction; bool bCaseSensitive;
     
     CScriptArgReader argStream ( luaVM );
-    if (argStream.NextIsTable())
+    if ( argStream.NextIsTable() )
     {
-        std::vector < CPlayer* > sendList;
+        argStream.ReadStringTable( vecKey );
+        bType = false;
     }
     else
     {
-
+        argStream.ReadString( strKey );
+        bType = true;
     }
-    argStream.ReadString ( strKey );
     argStream.ReadFunction ( iLuaFunction );
     argStream.ReadBool ( bCaseSensitive, true );
     argStream.ReadFunctionComplete ();
@@ -46,10 +48,28 @@ int CLuaFunctionDefs::AddCommandHandler ( lua_State* luaVM )
         CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine ( luaVM );
         if ( pLuaMain )
         {
-            // Add them to our list over command handlers
-            if ( m_pRegisteredCommands->AddCommand ( pLuaMain, strKey, iLuaFunction, bCaseSensitive ) )
+            if ( bType )
             {
-                lua_pushboolean ( luaVM, true );
+                // Add them to our list over command handlers
+                if ( strKey == "" || m_pRegisteredCommands->AddCommand(pLuaMain, strKey, iLuaFunction, bCaseSensitive) )
+                {
+                    lua_pushboolean( luaVM, true );
+                    return 1;
+                }
+            }
+            else
+            {
+                // Add them to our list over command handlers from table {"command1","command2",...}
+                bool bCommandError = false;
+                for (uint i = 0; i < vecKey.size(); i++)
+                {
+                    if ( vecKey[i] == "" || !m_pRegisteredCommands->AddCommand(pLuaMain, vecKey[i], iLuaFunction, bCaseSensitive) )
+                    {
+                        bCommandError = true;
+                        break;
+                    }
+                }
+                lua_pushboolean( luaVM, !bCommandError );
                 return 1;
             }
         }

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Commands.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Commands.cpp
@@ -22,9 +22,19 @@
 int CLuaFunctionDefs::AddCommandHandler ( lua_State* luaVM )
 {
 //  bool addCommandHandler ( string commandName, function handlerFunction, [bool caseSensitive = true] )
-    SString strKey; CLuaFunctionRef iLuaFunction; bool bCaseSensitive;
-
+    SString strKey;
+    std::vector < CPlayer* > vecKey;
+    CLuaFunctionRef iLuaFunction; bool bCaseSensitive;
+    
     CScriptArgReader argStream ( luaVM );
+    if (argStream.NextIsTable())
+    {
+        std::vector < CPlayer* > sendList;
+    }
+    else
+    {
+
+    }
     argStream.ReadString ( strKey );
     argStream.ReadFunction ( iLuaFunction );
     argStream.ReadBool ( bCaseSensitive, true );


### PR DESCRIPTION
Added option to pass at first argument table with commands. ( client and server side )
example working resource:

client
```lua
addCommandHandler({"test1","test2","test3"},function(command)
  outputChatBox("client table command:"..command)
end)
addCommandHandler("test0",function(command)
  outputChatBox("client normal command:"..command)
end)

-- output
--[[
client normal command:test0
client table command:test1
client table command:test2
client table command:test3
]]
```

server
```lua
addCommandHandler({"stest1","stest2","stest3"},function(plr,command)
  outputChatBox("server table command:"..command)
end)
addCommandHandler("stest0",function(plr,command)
  outputChatBox("server normal command:"..command)
end)

-- output
--[[
server normal command:stest0
server table command:stest1
server table command:stest2
server table command:stest3
]]
```