### PR TITLE
`xmlLoadFile` print error

### DIFF
--- a/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
@@ -138,6 +138,7 @@ int CLuaXMLDefs::xmlLoadFile ( lua_State* luaVM )
 
     // Grab our resource
     CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine ( luaVM );
+    SString strError = "";
     if ( pLuaMain )
     {
         SString strFileInput;
@@ -184,6 +185,7 @@ int CLuaXMLDefs::xmlLoadFile ( lua_State* luaVM )
                             }
                         }
 
+                        xmlFile->GetLastError ( strError );
                         // Destroy it if we failed
                         pLuaMain->DestroyXML ( xmlFile );
                     }
@@ -196,7 +198,8 @@ int CLuaXMLDefs::xmlLoadFile ( lua_State* luaVM )
     }
 
     lua_pushboolean ( luaVM, false );
-    return 1;
+    lua_pushstring ( luaVM, strError );
+    return 2;
 }
 
 int CLuaXMLDefs::xmlCopyFile ( lua_State* luaVM )

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
@@ -186,6 +186,7 @@ int CLuaXMLDefs::xmlLoadFile ( lua_State* luaVM )
                         }
 
                         xmlFile->GetLastError ( strError );
+                        argStream.SetCustomError(strError, SString("Unable to read XML file %s", strFileInput.c_str()));
                         // Destroy it if we failed
                         pLuaMain->DestroyXML ( xmlFile );
                     }
@@ -198,8 +199,7 @@ int CLuaXMLDefs::xmlLoadFile ( lua_State* luaVM )
     }
 
     lua_pushboolean ( luaVM, false );
-    lua_pushstring ( luaVM, strError );
-    return 2;
+    return 1;
 }
 
 int CLuaXMLDefs::xmlCopyFile ( lua_State* luaVM )


### PR DESCRIPTION
xmlLoadFile print error in console when somethink wrong with xml
Now you dont know what's wrong with your file, now you know!

example script lua
```lua
a=xmlLoadFile("wrong.xml")
iprint(a)
```
wrong.xml
```xml
<xml>
  asdf
  <b> </b>

  <a> </b>
</xml>
```
![e5vrmfwbsukven-zyxksoq](https://user-images.githubusercontent.com/22455534/33238416-a9a1359a-d28d-11e7-9650-ca34b1146220.png)
