### PR TITLE
Remove wrong info at pickupHit

### DIFF
--- a/Server/mods/deathmatch/logic/CAccountManager.cpp
+++ b/Server/mods/deathmatch/logic/CAccountManager.cpp
@@ -881,7 +881,7 @@ void CAccountManager::GetAccountsByIP( const SString& strIP, std::vector<CAccoun
 
 void CAccountManager::GetAccountByID ( const unsigned& ID, CAccount* outAccount ) {
     CRegistryResult result;
-    m_pDatabaseManager->QueryWithResultf( m_hDbConnection, &result, "SELECT name FROM accounts WHERE id = ?", SQLITE_TEXT, to_string ( ID ) );
+    m_pDatabaseManager->QueryWithResultf( m_hDbConnection, &result, "SELECT name FROM accounts WHERE id = ?", SQLITE_TEXT, to_string ( ID ).c_str() );
 
     for ( CRegistryResultIterator iter = result->begin(); iter != result->end(); ++iter ) {
         const CRegistryResultRow& row = *iter;

--- a/Server/mods/deathmatch/logic/CAccountManager.cpp
+++ b/Server/mods/deathmatch/logic/CAccountManager.cpp
@@ -879,18 +879,6 @@ void CAccountManager::GetAccountsByIP( const SString& strIP, std::vector<CAccoun
     }
 }
 
-void CAccountManager::GetAccountByID ( const unsigned& ID, CAccount* outAccount ) {
-    CRegistryResult result;
-    m_pDatabaseManager->QueryWithResultf( m_hDbConnection, &result, "SELECT name FROM accounts WHERE id = ?", SQLITE_TEXT, to_string ( ID ).c_str() );
-
-    for ( CRegistryResultIterator iter = result->begin(); iter != result->end(); ++iter ) {
-        const CRegistryResultRow& row = *iter;
-
-        outAccount = Get( (const char*) row[0].pVal );
-        break;
-    }
-}
-
 void CAccountManager::GetAccountsByData ( const SString& dataName, const SString& value, std::vector<CAccount*>& outAccounts ) {
     CRegistryResult result;
     m_pDatabaseManager->QueryWithResultf( m_hDbConnection, &result, "SELECT acc.name FROM accounts acc, userdata dat WHERE dat.key = ? AND dat.value = ? AND dat.userid = acc.id", SQLITE_TEXT, dataName.c_str(), value.c_str() );

--- a/Server/mods/deathmatch/logic/CAccountManager.cpp
+++ b/Server/mods/deathmatch/logic/CAccountManager.cpp
@@ -874,7 +874,7 @@ void CAccountManager::GetAccountsByIP( const SString& strIP, std::vector<CAccoun
     for ( CRegistryResultIterator iter = result->begin(); iter != result->end(); ++iter ) {
         const CRegistryResultRow& row = *iter;
 
-        CAccount* pAccount = Get( (const char*) row[1].pVal );
+        CAccount* pAccount = Get( (const char*) row[0].pVal );
         outAccounts.push_back( pAccount );
     }
 }
@@ -886,8 +886,20 @@ void CAccountManager::GetAccountByID ( const unsigned& ID, CAccount* outAccount 
     for ( CRegistryResultIterator iter = result->begin(); iter != result->end(); ++iter ) {
         const CRegistryResultRow& row = *iter;
 
-        outAccount = Get( (const char*) row[1].pVal );
+        outAccount = Get( (const char*) row[0].pVal );
         break;
+    }
+}
+
+void CAccountManager::GetAccountsByData ( const SString& dataName, const SString& value, std::vector<CAccount*>& outAccounts ) {
+    CRegistryResult result;
+    m_pDatabaseManager->QueryWithResultf( m_hDbConnection, &result, "SELECT acc.name FROM accounts acc, userdata dat WHERE dat.key = ? AND dat.value = ? AND dat.userid = acc.id", SQLITE_TEXT, dataName.c_str(), value.c_str() );
+
+    for ( CRegistryResultIterator iter = result->begin(); iter != result->end(); ++iter ) {
+        const CRegistryResultRow& row = *iter;
+
+        CAccount* pAccount = Get( (const char*) row[0].pVal );
+        outAccounts.push_back( pAccount );
     }
 }
 

--- a/Server/mods/deathmatch/logic/CAccountManager.cpp
+++ b/Server/mods/deathmatch/logic/CAccountManager.cpp
@@ -867,11 +867,13 @@ void CAccountManager::GetAccountsBySerial ( const SString& strSerial, std::vecto
     }
 }
 
-void CAccountManager::GetAccountsByIP( const SString& strIP, std::vector<CAccount*>& outAccounts ) {
+void CAccountManager::GetAccountsByIP( const SString& strIP, std::vector<CAccount*>& outAccounts ) 
+{
     CRegistryResult result;
     m_pDatabaseManager->QueryWithResultf( m_hDbConnection, &result, "SELECT name FROM accounts WHERE added_ip = ?", SQLITE_TEXT, strIP.c_str() );
 
-    for ( CRegistryResultIterator iter = result->begin(); iter != result->end(); ++iter ) {
+    for ( CRegistryResultIterator iter = result->begin(); iter != result->end(); ++iter ) 
+    {
         const CRegistryResultRow& row = *iter;
 
         CAccount* pAccount = Get( (const char*) row[0].pVal );
@@ -879,11 +881,13 @@ void CAccountManager::GetAccountsByIP( const SString& strIP, std::vector<CAccoun
     }
 }
 
-void CAccountManager::GetAccountsByData ( const SString& dataName, const SString& value, std::vector<CAccount*>& outAccounts ) {
+void CAccountManager::GetAccountsByData ( const SString& dataName, const SString& value, std::vector<CAccount*>& outAccounts ) 
+{
     CRegistryResult result;
     m_pDatabaseManager->QueryWithResultf( m_hDbConnection, &result, "SELECT acc.name FROM accounts acc, userdata dat WHERE dat.key = ? AND dat.value = ? AND dat.userid = acc.id", SQLITE_TEXT, dataName.c_str(), SQLITE_TEXT, value.c_str() );
 
-    for ( CRegistryResultIterator iter = result->begin(); iter != result->end(); ++iter ) {
+    for ( CRegistryResultIterator iter = result->begin(); iter != result->end(); ++iter ) 
+    {
         const CRegistryResultRow& row = *iter;
 
         CAccount* pAccount = Get( (const char*) row[0].pVal );

--- a/Server/mods/deathmatch/logic/CAccountManager.cpp
+++ b/Server/mods/deathmatch/logic/CAccountManager.cpp
@@ -879,6 +879,18 @@ void CAccountManager::GetAccountsByIP( const SString& strIP, std::vector<CAccoun
     }
 }
 
+void CAccountManager::GetAccountByID ( const unsigned& ID, CAccount* outAccount ) {
+    CRegistryResult result;
+    m_pDatabaseManager->QueryWithResultf( m_hDbConnection, &result, "SELECT name FROM accounts WHERE id = ?", SQLITE_TEXT, to_string ( ID ) );
+
+    for ( CRegistryResultIterator iter = result->begin(); iter != result->end(); ++iter ) {
+        const CRegistryResultRow& row = *iter;
+
+        outAccount = Get( (const char*) row[1].pVal );
+        break;
+    }
+}
+
 CAccount* CAccountManager::AddGuestAccount( const SString& strName )
 {
     CAccount* pAccount = new CAccount ( this, EAccountType::Guest, strName );

--- a/Server/mods/deathmatch/logic/CAccountManager.cpp
+++ b/Server/mods/deathmatch/logic/CAccountManager.cpp
@@ -881,7 +881,7 @@ void CAccountManager::GetAccountsByIP( const SString& strIP, std::vector<CAccoun
 
 void CAccountManager::GetAccountsByData ( const SString& dataName, const SString& value, std::vector<CAccount*>& outAccounts ) {
     CRegistryResult result;
-    m_pDatabaseManager->QueryWithResultf( m_hDbConnection, &result, "SELECT acc.name FROM accounts acc, userdata dat WHERE dat.key = ? AND dat.value = ? AND dat.userid = acc.id", SQLITE_TEXT, dataName.c_str(), value.c_str() );
+    m_pDatabaseManager->QueryWithResultf( m_hDbConnection, &result, "SELECT acc.name FROM accounts acc, userdata dat WHERE dat.key = ? AND dat.value = ? AND dat.userid = acc.id", SQLITE_TEXT, dataName.c_str(), SQLITE_TEXT, value.c_str() );
 
     for ( CRegistryResultIterator iter = result->begin(); iter != result->end(); ++iter ) {
         const CRegistryResultRow& row = *iter;

--- a/Server/mods/deathmatch/logic/CAccountManager.cpp
+++ b/Server/mods/deathmatch/logic/CAccountManager.cpp
@@ -867,6 +867,18 @@ void CAccountManager::GetAccountsBySerial ( const SString& strSerial, std::vecto
     }
 }
 
+void CAccountManager::GetAccountsByIP( const SString& strIP, std::vector<CAccount*>& outAccounts ) {
+    CRegistryResult result;
+    m_pDatabaseManager->QueryWithResultf( m_hDbConnection, &result, "SELECT name FROM accounts WHERE added_ip = ?", SQLITE_TEXT, strIP.c_str() );
+
+    for ( CRegistryResultIterator iter = result->begin(); iter != result->end(); ++iter ) {
+        const CRegistryResultRow& row = *iter;
+
+        CAccount* pAccount = Get( (const char*) row[1].pVal );
+        outAccounts.push_back( pAccount );
+    }
+}
+
 CAccount* CAccountManager::AddGuestAccount( const SString& strName )
 {
     CAccount* pAccount = new CAccount ( this, EAccountType::Guest, strName );

--- a/Server/mods/deathmatch/logic/CAccountManager.cpp
+++ b/Server/mods/deathmatch/logic/CAccountManager.cpp
@@ -874,7 +874,7 @@ void CAccountManager::GetAccountsByIP( const SString& strIP, std::vector<CAccoun
     for ( CRegistryResultIterator iter = result->begin(); iter != result->end(); ++iter ) {
         const CRegistryResultRow& row = *iter;
 
-        CAccount* pAccount = Get( (const char*) row[1].pVal );
+        CAccount* pAccount = Get( (const char*) row[0].pVal );
         outAccounts.push_back( pAccount );
     }
 }
@@ -886,7 +886,7 @@ void CAccountManager::GetAccountByID ( const unsigned& ID, CAccount* outAccount 
     for ( CRegistryResultIterator iter = result->begin(); iter != result->end(); ++iter ) {
         const CRegistryResultRow& row = *iter;
 
-        outAccount = Get( (const char*) row[1].pVal );
+        outAccount = Get( (const char*) row[0].pVal );
         break;
     }
 }

--- a/Server/mods/deathmatch/logic/CAccountManager.h
+++ b/Server/mods/deathmatch/logic/CAccountManager.h
@@ -147,6 +147,7 @@ public:
     bool                        GetAllAccountData           ( CAccount* pAccount, lua_State* pLua );
 
     void                        GetAccountsBySerial         ( const SString& strSerial, std::vector<CAccount*>& outAccounts );
+    void                        GetAccountsByIP             ( const SString& strIP, std::vector<CAccount*>& outAccounts );
 
     CAccount*                   AddGuestAccount             ( const SString& strName );
     CAccount*                   AddConsoleAccount           ( const SString& strName );

--- a/Server/mods/deathmatch/logic/CAccountManager.h
+++ b/Server/mods/deathmatch/logic/CAccountManager.h
@@ -149,6 +149,7 @@ public:
     void                        GetAccountsBySerial         ( const SString& strSerial, std::vector<CAccount*>& outAccounts );
     void                        GetAccountsByIP             ( const SString& strIP, std::vector<CAccount*>& outAccounts );
     void                        GetAccountByID              ( const unsigned& ID, CAccount* outAccount );
+    void                        GetAccountsByData           ( const SString& dataName, const SString& value, std::vector<CAccount*>& outAccounts );
 
     CAccount*                   AddGuestAccount             ( const SString& strName );
     CAccount*                   AddConsoleAccount           ( const SString& strName );

--- a/Server/mods/deathmatch/logic/CAccountManager.h
+++ b/Server/mods/deathmatch/logic/CAccountManager.h
@@ -148,7 +148,6 @@ public:
 
     void                        GetAccountsBySerial         ( const SString& strSerial, std::vector<CAccount*>& outAccounts );
     void                        GetAccountsByIP             ( const SString& strIP, std::vector<CAccount*>& outAccounts );
-    void                        GetAccountByID              ( const unsigned& ID, CAccount* outAccount );
     void                        GetAccountsByData           ( const SString& dataName, const SString& value, std::vector<CAccount*>& outAccounts );
 
     CAccount*                   AddGuestAccount             ( const SString& strName );

--- a/Server/mods/deathmatch/logic/CAccountManager.h
+++ b/Server/mods/deathmatch/logic/CAccountManager.h
@@ -148,6 +148,7 @@ public:
 
     void                        GetAccountsBySerial         ( const SString& strSerial, std::vector<CAccount*>& outAccounts );
     void                        GetAccountsByIP             ( const SString& strIP, std::vector<CAccount*>& outAccounts );
+    void                        GetAccountByID              ( const unsigned& ID, CAccount* outAccount );
 
     CAccount*                   AddGuestAccount             ( const SString& strName );
     CAccount*                   AddConsoleAccount           ( const SString& strName );

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -1470,7 +1470,7 @@ void CGame::AddBuiltInEvents ( void )
     // Object events
 
     // Pickup events
-    m_Events.AddEvent ( "onPickupHit", "player, matchingDimension", NULL, false );
+    m_Events.AddEvent ( "onPickupHit", "player", NULL, false );
     m_Events.AddEvent ( "onPickupUse", "player", NULL, false );
     m_Events.AddEvent ( "onPickupSpawn", "", NULL, false );
 
@@ -1488,7 +1488,7 @@ void CGame::AddBuiltInEvents ( void )
     m_Events.AddEvent ( "onPlayerWeaponSwitch", "previous, current", NULL, false );
     m_Events.AddEvent ( "onPlayerMarkerHit", "marker, matchingDimension", NULL, false );
     m_Events.AddEvent ( "onPlayerMarkerLeave", "marker, matchingDimension", NULL, false );
-    m_Events.AddEvent ( "onPlayerPickupHit", "pickup, matchingDimension", NULL, false );
+    m_Events.AddEvent ( "onPlayerPickupHit", "pickup", NULL, false );
     m_Events.AddEvent ( "onPlayerPickupUse", "pickup", NULL, false );
     m_Events.AddEvent ( "onPlayerClick", "button, state, element, posX, posY, posZ", NULL, false );
     m_Events.AddEvent ( "onPlayerContact", "previous, current", NULL, false );

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -11332,6 +11332,34 @@ bool CStaticFunctionDefinitions::RemoveAccount ( CAccount* pAccount )
 }
 
 
+bool CStaticFunctionDefinitions::SetAccountName ( CAccount* pAccount, SString strNewName, bool bAllowCaseVariations, SString& strOutError )
+{
+    assert ( pAccount );
+    assert ( !strNewName.empty() );
+
+    if ( pAccount->IsRegistered () ) {
+            // Check for case variations if not allowed
+        if ( !bAllowCaseVariations ) {
+            SString strCaseVariation = m_pAccountManager->GetActiveCaseVariation( strNewName );
+            if ( !strCaseVariation.empty() ) {
+                strOutError = SString( "Already an account using a case variation of that name ('%s')", *strCaseVariation );
+                return NULL;
+            }
+        }
+
+        if ( m_pAccountManager->Get( strNewName ) != NULL ) {
+            strOutError = "Account already exists";
+        } else if ( !CAccountManager::IsValidNewAccountName( strNewName ) ) {
+            strOutError = "Name invalid";
+        } else {
+            pAccount->SetName ( strNewName );
+            return true;
+        }
+    }
+    return false;
+}
+
+
 bool CStaticFunctionDefinitions::SetAccountPassword ( CAccount* pAccount, SString strPassword, CAccountPassword::EAccountPasswordType ePasswordType )
 {
     assert ( pAccount );

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -11195,6 +11195,12 @@ bool CStaticFunctionDefinitions::GetAllAccountData ( lua_State* pLua, CAccount* 
     return true;
 }
 
+bool CStaticFunctionDefinitions::GetAccountsByData ( const SString& dataName, const SString& value, std::vector<CAccount*>& outAccounts )
+{
+    m_pAccountManager->GetAccountsByData ( dataName, value, outAccounts );
+    return true;
+}
+
 
 bool CStaticFunctionDefinitions::GetAccountSerial ( CAccount* pAccount, SString& strSerial )
 {

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -11343,7 +11343,7 @@ bool CStaticFunctionDefinitions::SetAccountName ( CAccount* pAccount, SString st
             SString strCaseVariation = m_pAccountManager->GetActiveCaseVariation( strNewName );
             if ( !strCaseVariation.empty() ) {
                 strOutError = SString( "Already an account using a case variation of that name ('%s')", *strCaseVariation );
-                return NULL;
+                return false;
             }
         }
 

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -11324,21 +11324,29 @@ bool CStaticFunctionDefinitions::SetAccountName ( CAccount* pAccount, SString st
     assert ( pAccount );
     assert ( !strNewName.empty() );
 
-    if ( pAccount->IsRegistered () ) {
+    if ( pAccount->IsRegistered () ) 
+    {
             // Check for case variations if not allowed
-        if ( !bAllowCaseVariations ) {
+        if ( !bAllowCaseVariations ) 
+        {
             SString strCaseVariation = m_pAccountManager->GetActiveCaseVariation( strNewName );
-            if ( !strCaseVariation.empty() ) {
+            if ( !strCaseVariation.empty() ) 
+            {
                 strOutError = SString( "Already an account using a case variation of that name ('%s')", *strCaseVariation );
                 return false;
             }
         }
 
-        if ( m_pAccountManager->Get( strNewName ) != NULL ) {
+        if ( m_pAccountManager->Get( strNewName ) != NULL ) 
+        {
             strOutError = "Account already exists";
-        } else if ( !CAccountManager::IsValidNewAccountName( strNewName ) ) {
+        } 
+        else if ( !CAccountManager::IsValidNewAccountName( strNewName ) ) 
+        {
             strOutError = "Name invalid";
-        } else {
+        } 
+        else 
+        {
             pAccount->SetName ( strNewName );
             return true;
         }

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -11213,6 +11213,21 @@ bool CStaticFunctionDefinitions::GetAccountsBySerial ( const SString& strSerial,
 }
 
 
+bool CStaticFunctionDefinitions::GetAccountIP( CAccount* pAccount, SString& strIP ) {
+    bool bRegistered = pAccount->IsRegistered();
+    if ( bRegistered )
+        strIP = pAccount->GetIP();
+
+    return bRegistered;
+}
+
+
+bool CStaticFunctionDefinitions::GetAccountsByIP( const SString& strIP, std::vector<CAccount*>& outAccounts ) {
+    m_pAccountManager->GetAccountsByIP( strIP, outAccounts );
+    return true;
+}
+
+
 CAccount* CStaticFunctionDefinitions::AddAccount ( const SString& strName, const SString& strPassword, bool bAllowCaseVariations, SString& strOutError )
 {
     // Check for case variations if not allowed

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -11219,7 +11219,8 @@ bool CStaticFunctionDefinitions::GetAccountsBySerial ( const SString& strSerial,
 }
 
 
-bool CStaticFunctionDefinitions::GetAccountIP( CAccount* pAccount, SString& strIP ) {
+bool CStaticFunctionDefinitions::GetAccountIP( CAccount* pAccount, SString& strIP ) 
+{
     bool bRegistered = pAccount->IsRegistered();
     if ( bRegistered )
         strIP = pAccount->GetIP();
@@ -11228,7 +11229,8 @@ bool CStaticFunctionDefinitions::GetAccountIP( CAccount* pAccount, SString& strI
 }
 
 
-bool CStaticFunctionDefinitions::GetAccountsByIP( const SString& strIP, std::vector<CAccount*>& outAccounts ) {
+bool CStaticFunctionDefinitions::GetAccountsByIP( const SString& strIP, std::vector<CAccount*>& outAccounts ) 
+{
     m_pAccountManager->GetAccountsByIP( strIP, outAccounts );
     return true;
 }

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -11228,6 +11228,21 @@ bool CStaticFunctionDefinitions::GetAccountsByIP( const SString& strIP, std::vec
 }
 
 
+bool CStaticFunctionDefinitions::GetAccountID( CAccount* pAccount, unsigned& ID ) {
+    bool bRegistered = pAccount->IsRegistered();
+    if ( bRegistered )
+        ID = pAccount->GetID();
+
+    return bRegistered;
+}
+
+
+bool CStaticFunctionDefinitions::GetAccountByID( const unsigned& ID, CAccount* outAccount ) {
+    m_pAccountManager->GetAccountByID( ID, outAccount );
+    return true;
+}
+
+
 CAccount* CStaticFunctionDefinitions::AddAccount ( const SString& strName, const SString& strPassword, bool bAllowCaseVariations, SString& strOutError )
 {
     // Check for case variations if not allowed

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -11234,21 +11234,6 @@ bool CStaticFunctionDefinitions::GetAccountsByIP( const SString& strIP, std::vec
 }
 
 
-bool CStaticFunctionDefinitions::GetAccountID( CAccount* pAccount, unsigned& ID ) {
-    bool bRegistered = pAccount->IsRegistered();
-    if ( bRegistered )
-        ID = pAccount->GetID();
-
-    return bRegistered;
-}
-
-
-bool CStaticFunctionDefinitions::GetAccountByID( const unsigned& ID, CAccount* outAccount ) {
-    m_pAccountManager->GetAccountByID( ID, outAccount );
-    return true;
-}
-
-
 CAccount* CStaticFunctionDefinitions::AddAccount ( const SString& strName, const SString& strPassword, bool bAllowCaseVariations, SString& strOutError )
 {
     // Check for case variations if not allowed

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -641,6 +641,8 @@ public:
     static bool                 GetAccountsBySerial                 ( const SString& strSerial, std::vector<CAccount*>& outAccounts );
     static bool                 GetAccountIP                        ( CAccount* pAccount, SString& strIP );
     static bool                 GetAccountsByIP                     ( const SString& strIP, std::vector<CAccount*>& outAccount );
+    static bool                 GetAccountID                        ( CAccount* pAccount, unsigned& ID );
+    static bool                 GetAccountByID                      ( const unsigned& ID, CAccount* outAccount );
 
     // Account set funcs
     static CAccount*            AddAccount                          ( const SString& strName, const SString& strPassword, bool bAllowCaseVariations, SString& strOutError );

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -648,6 +648,7 @@ public:
     // Account set funcs
     static CAccount*            AddAccount                          ( const SString& strName, const SString& strPassword, bool bAllowCaseVariations, SString& strOutError );
     static bool                 RemoveAccount                       ( CAccount* pAccount );
+    static bool                 SetAccountName                      ( CAccount* pAccount, SString strNewName, bool bAllowCaseVariations, SString& strOutError );
     static bool                 SetAccountPassword                  ( CAccount* pAccount, SString szPassword, CAccountPassword::EAccountPasswordType ePasswordType );
     static bool                 SetAccountData                      ( CAccount* pAccount, const char* szKey, CLuaArgument * pArgument );
     static bool                 CopyAccountData                     ( CAccount* pAccount, CAccount* pFromAccount );

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -637,10 +637,11 @@ public:
     static bool                 IsGuestAccount                      ( CAccount* pAccount, bool& bGuest );
     static std::shared_ptr<CLuaArgument> GetAccountData             ( CAccount* pAccount, const char* szKey );
     static bool                 GetAllAccountData                   ( lua_State* pLua, CAccount* pAccount );
+    static bool                 GetAccountsByData                   ( const SString& dataName, const SString& value, std::vector<CAccount*>& outAccounts );
     static bool                 GetAccountSerial                    ( CAccount* pAccount, SString& strSerial );
     static bool                 GetAccountsBySerial                 ( const SString& strSerial, std::vector<CAccount*>& outAccounts );
     static bool                 GetAccountIP                        ( CAccount* pAccount, SString& strIP );
-    static bool                 GetAccountsByIP                     ( const SString& strIP, std::vector<CAccount*>& outAccount );
+    static bool                 GetAccountsByIP                     ( const SString& strIP, std::vector<CAccount*>& outAccounts );
     static bool                 GetAccountID                        ( CAccount* pAccount, unsigned& ID );
     static bool                 GetAccountByID                      ( const unsigned& ID, CAccount* outAccount );
 

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -642,8 +642,6 @@ public:
     static bool                 GetAccountsBySerial                 ( const SString& strSerial, std::vector<CAccount*>& outAccounts );
     static bool                 GetAccountIP                        ( CAccount* pAccount, SString& strIP );
     static bool                 GetAccountsByIP                     ( const SString& strIP, std::vector<CAccount*>& outAccounts );
-    static bool                 GetAccountID                        ( CAccount* pAccount, unsigned& ID );
-    static bool                 GetAccountByID                      ( const unsigned& ID, CAccount* outAccount );
 
     // Account set funcs
     static CAccount*            AddAccount                          ( const SString& strName, const SString& strPassword, bool bAllowCaseVariations, SString& strOutError );

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -639,6 +639,8 @@ public:
     static bool                 GetAllAccountData                   ( lua_State* pLua, CAccount* pAccount );
     static bool                 GetAccountSerial                    ( CAccount* pAccount, SString& strSerial );
     static bool                 GetAccountsBySerial                 ( const SString& strSerial, std::vector<CAccount*>& outAccounts );
+    static bool                 GetAccountIP                        ( CAccount* pAccount, SString& strIP );
+    static bool                 GetAccountsByIP                     ( const SString& strIP, std::vector<CAccount*>& outAccount );
 
     // Account set funcs
     static CAccount*            AddAccount                          ( const SString& strName, const SString& strPassword, bool bAllowCaseVariations, SString& strOutError );

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
@@ -432,7 +432,8 @@ int CLuaAccountDefs::RemoveAccount ( lua_State* luaVM )
 }
 
 
-int CLuaAccountDefs::SetAccountName ( lua_State* luaVM ) {
+int CLuaAccountDefs::SetAccountName ( lua_State* luaVM ) 
+{
     // bool setAccountPassword ( account theAccount, string name[, bool allowCaseVariations = false ] )
     CAccount* pAccount; 
     SString strNewName;
@@ -444,12 +445,15 @@ int CLuaAccountDefs::SetAccountName ( lua_State* luaVM ) {
     argStream.ReadBool ( bAllowCaseVariations, false );
 
     SString strError;
-    if ( !argStream.HasErrors() ) {
-        if ( CStaticFunctionDefinitions::SetAccountName ( pAccount, strNewName, bAllowCaseVariations, strError ) ) {
+    if ( !argStream.HasErrors() ) 
+    {
+        if ( CStaticFunctionDefinitions::SetAccountName ( pAccount, strNewName, bAllowCaseVariations, strError ) ) 
+        {
             lua_pushboolean ( luaVM, true );
             return 1;
         }
-    } else 
+    } 
+    else 
          m_pScriptDebugging->LogCustom ( luaVM, argStream.GetFullErrorMessage () );
     lua_pushboolean ( luaVM, false );
     return 1;

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
@@ -25,6 +25,7 @@ void CLuaAccountDefs::LoadFunctions ()
     CLuaCFunctions::AddFunction ( "getAllAccountData", GetAllAccountData );
     CLuaCFunctions::AddFunction ( "getAccount", GetAccount );
     CLuaCFunctions::AddFunction ( "getAccounts", GetAccounts );
+    CLuaCFunctions::AddFunction ( "getAccountsByData", GetAccountsByData );
     CLuaCFunctions::AddFunction ( "getAccountSerial", GetAccountSerial );
     CLuaCFunctions::AddFunction ( "getAccountsBySerial", GetAccountsBySerial );
     CLuaCFunctions::AddFunction ( "getAccountIP", GetAccountIP );
@@ -45,6 +46,7 @@ void CLuaAccountDefs::AddClass ( lua_State* luaVM )
     lua_newclass ( luaVM );
 
     lua_classfunction ( luaVM, "getAll", "getAccounts" );
+    lua_classfunction ( luaVM, "getAllByData", "getAccountsByData" );
     lua_classfunction ( luaVM, "getAllBySerial", "getAccountsBySerial" );
     lua_classfunction ( luaVM, "getAllByIP", "getAccountsByIP" );
     lua_classfunction ( luaVM, "getFromPlayer", "getPlayerAccount" );

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
@@ -30,8 +30,6 @@ void CLuaAccountDefs::LoadFunctions ()
     CLuaCFunctions::AddFunction ( "getAccountsBySerial", GetAccountsBySerial );
     CLuaCFunctions::AddFunction ( "getAccountIP", GetAccountIP );
     CLuaCFunctions::AddFunction ( "getAccountsByIP", GetAccountsByIP );
-    CLuaCFunctions::AddFunction ( "getAccountID", GetAccountID );
-    CLuaCFunctions::AddFunction ( "getAccountByID", GetAccountByID );
 
     // Account set functions
     CLuaCFunctions::AddFunction ( "addAccount", AddAccount );
@@ -64,7 +62,6 @@ void CLuaAccountDefs::AddClass ( lua_State* luaVM )
 
     lua_classfunction ( luaVM, "getSerial", "getAccountSerial" );
     lua_classfunction ( luaVM, "getIP", "getAccountIP" );
-    lua_classfunction ( luaVM, "getID", "getAccountID" );
     lua_classfunction ( luaVM, "getData", "getAccountData" );
     lua_classfunction ( luaVM, "getAllData", "getAllAccountData" );
     lua_classfunction ( luaVM, "getName", "getAccountName" );
@@ -74,7 +71,6 @@ void CLuaAccountDefs::AddClass ( lua_State* luaVM )
     lua_classvariable ( luaVM, "serial", NULL, "getAccountSerial" );
     lua_classvariable ( luaVM, "name", "setAccountName", "getAccountName" );
     lua_classvariable ( luaVM, "ip", NULL, "getAccountIP" );
-    lua_classvariable ( luaVM, "id", NULL, "getAccountID" );
     lua_classvariable ( luaVM, "player", NULL, "getAccountPlayer" );
     lua_classvariable ( luaVM, "guest", NULL, "isGuestAccount" );
     lua_classvariable ( luaVM, "password", "setAccountPassword", NULL );
@@ -360,48 +356,6 @@ int CLuaAccountDefs::GetAccountsByIP( lua_State* luaVM ) {
             lua_settable( luaVM, -3 );
         }
         return 1;
-    } else
-        m_pScriptDebugging->LogCustom( luaVM, argStream.GetFullErrorMessage() );
-
-    lua_pushboolean( luaVM, false );
-    return 1;
-}
-
-int CLuaAccountDefs::GetAccountID( lua_State* luaVM ) {
-    //  string getAccountSerial ( account theAccount )
-    CAccount* pAccount;
-
-    CScriptArgReader argStream( luaVM );
-    argStream.ReadUserData( pAccount );
-
-    if ( !argStream.HasErrors() ) {
-        unsigned ID;
-        if ( CStaticFunctionDefinitions::GetAccountID( pAccount, ID ) ) {
-            lua_pushnumber( luaVM, ID );
-            return 1;
-        }
-    } else
-        m_pScriptDebugging->LogCustom( luaVM, argStream.GetFullErrorMessage() );
-
-    lua_pushboolean( luaVM, false );
-    return 1;
-}
-
-int CLuaAccountDefs::GetAccountByID( lua_State* luaVM ) {
-    //  table getAccountsByIP ( string ip )
-    unsigned ID;
-
-    CScriptArgReader argStream( luaVM );
-    argStream.ReadNumber( ID );
-
-    if ( !argStream.HasErrors() ) {
-        lua_newtable( luaVM );
-        CAccount* account;
-
-        if ( CStaticFunctionDefinitions::GetAccountByID( ID, account ) ) {
-            lua_pushnumber ( luaVM, ID );
-            return 1;
-        }
     } else
         m_pScriptDebugging->LogCustom( luaVM, argStream.GetFullErrorMessage() );
 

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
@@ -29,6 +29,8 @@ void CLuaAccountDefs::LoadFunctions ()
     CLuaCFunctions::AddFunction ( "getAccountsBySerial", GetAccountsBySerial );
     CLuaCFunctions::AddFunction ( "getAccountIP", GetAccountIP );
     CLuaCFunctions::AddFunction ( "getAccountsByIP", GetAccountsByIP );
+    CLuaCFunctions::AddFunction ( "getAccountID", GetAccountID );
+    CLuaCFunctions::AddFunction ( "getAccountByID", GetAccountByID );
 
     // Account set functions
     CLuaCFunctions::AddFunction ( "addAccount", AddAccount );
@@ -58,6 +60,7 @@ void CLuaAccountDefs::AddClass ( lua_State* luaVM )
 
     lua_classfunction ( luaVM, "getSerial", "getAccountSerial" );
     lua_classfunction ( luaVM, "getIP", "getAccountIP" );
+    lua_classfunction ( luaVM, "getID", "getAccountID" );
     lua_classfunction ( luaVM, "getData", "getAccountData" );
     lua_classfunction ( luaVM, "getAllData", "getAllAccountData" );
     lua_classfunction ( luaVM, "getName", "getAccountName" );
@@ -67,6 +70,7 @@ void CLuaAccountDefs::AddClass ( lua_State* luaVM )
     lua_classvariable ( luaVM, "serial", NULL, "getAccountSerial" );
     lua_classvariable ( luaVM, "name", NULL, "getAccountName" );
     lua_classvariable ( luaVM, "ip", NULL, "getAccountIP" );
+    lua_classvariable ( luaVM, "id", NULL, "getAccountID" );
     lua_classvariable ( luaVM, "player", NULL, "getAccountPlayer" );
     lua_classvariable ( luaVM, "guest", NULL, "isGuestAccount" );
     lua_classvariable ( luaVM, "password", "setAccountPassword", NULL );
@@ -325,6 +329,48 @@ int CLuaAccountDefs::GetAccountsByIP( lua_State* luaVM ) {
             lua_settable( luaVM, -3 );
         }
         return 1;
+    } else
+        m_pScriptDebugging->LogCustom( luaVM, argStream.GetFullErrorMessage() );
+
+    lua_pushboolean( luaVM, false );
+    return 1;
+}
+
+int CLuaAccountDefs::GetAccountID( lua_State* luaVM ) {
+    //  string getAccountSerial ( account theAccount )
+    CAccount* pAccount;
+
+    CScriptArgReader argStream( luaVM );
+    argStream.ReadUserData( pAccount );
+
+    if ( !argStream.HasErrors() ) {
+        unsigned ID;
+        if ( CStaticFunctionDefinitions::GetAccountID( pAccount, ID ) ) {
+            lua_pushnumber( luaVM, ID );
+            return 1;
+        }
+    } else
+        m_pScriptDebugging->LogCustom( luaVM, argStream.GetFullErrorMessage() );
+
+    lua_pushboolean( luaVM, false );
+    return 1;
+}
+
+int CLuaAccountDefs::GetAccountByID( lua_State* luaVM ) {
+    //  table getAccountsByIP ( string ip )
+    unsigned ID;
+
+    CScriptArgReader argStream( luaVM );
+    argStream.ReadNumber( ID );
+
+    if ( !argStream.HasErrors() ) {
+        lua_newtable( luaVM );
+        CAccount* account;
+
+        if ( CStaticFunctionDefinitions::GetAccountByID( ID, account ) ) {
+            lua_pushnumber ( luaVM, ID );
+            return 1;
+        }
     } else
         m_pScriptDebugging->LogCustom( luaVM, argStream.GetFullErrorMessage() );
 

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
@@ -238,7 +238,8 @@ int CLuaAccountDefs::GetAccounts ( lua_State* luaVM )
     return 1;
 }
 
-int CLuaAccountDefs::GetAccountsByData( lua_State* luaVM ) {
+int CLuaAccountDefs::GetAccountsByData( lua_State* luaVM ) 
+{
     //  table GetAccountsByData ( string dataName, string value )
     SString dataName;
     SString value;
@@ -247,18 +248,21 @@ int CLuaAccountDefs::GetAccountsByData( lua_State* luaVM ) {
     argStream.ReadString( dataName );
     argStream.ReadString ( value );
 
-    if ( !argStream.HasErrors() ) {
+    if ( !argStream.HasErrors() ) 
+    {
         lua_newtable( luaVM );
         std::vector<CAccount*> accounts;
 
         CStaticFunctionDefinitions::GetAccountsByData( dataName, value, accounts );
-        for ( unsigned int i = 0; i < accounts.size(); ++i ) {
+        for ( unsigned int i = 0; i < accounts.size(); ++i ) 
+        {
             lua_pushnumber( luaVM, i + 1 );
             lua_pushaccount( luaVM, accounts[i] );
             lua_settable( luaVM, -3 );
         }
         return 1;
-    } else
+    } 
+    else
         m_pScriptDebugging->LogCustom( luaVM, argStream.GetFullErrorMessage() );
 
     lua_pushboolean( luaVM, false );
@@ -325,38 +329,45 @@ int CLuaAccountDefs::GetAccountIP( lua_State* luaVM ) {
     CScriptArgReader argStream( luaVM );
     argStream.ReadUserData( pAccount );
 
-    if ( !argStream.HasErrors() ) {
+    if ( !argStream.HasErrors() ) 
+    {
         SString strIP;
-        if ( CStaticFunctionDefinitions::GetAccountIP( pAccount, strIP ) ) {
+        if ( CStaticFunctionDefinitions::GetAccountIP( pAccount, strIP ) ) 
+        {
             lua_pushstring( luaVM, strIP );
             return 1;
         }
-    } else
+    } 
+    else
         m_pScriptDebugging->LogCustom( luaVM, argStream.GetFullErrorMessage() );
 
     lua_pushboolean( luaVM, false );
     return 1;
 }
 
-int CLuaAccountDefs::GetAccountsByIP( lua_State* luaVM ) {
+int CLuaAccountDefs::GetAccountsByIP( lua_State* luaVM ) 
+{
     //  table getAccountsByIP ( string ip )
     SString strIP;
 
     CScriptArgReader argStream( luaVM );
     argStream.ReadString( strIP );
 
-    if ( !argStream.HasErrors() ) {
+    if ( !argStream.HasErrors() ) 
+    {
         lua_newtable( luaVM );
         std::vector<CAccount*> accounts;
 
         CStaticFunctionDefinitions::GetAccountsByIP( strIP, accounts );
-        for ( unsigned int i = 0; i < accounts.size(); ++i ) {
+        for ( unsigned int i = 0; i < accounts.size(); ++i ) 
+        {
             lua_pushnumber( luaVM, i + 1 );
             lua_pushaccount( luaVM, accounts[i] );
             lua_settable( luaVM, -3 );
         }
         return 1;
-    } else
+    } 
+    else
         m_pScriptDebugging->LogCustom( luaVM, argStream.GetFullErrorMessage() );
 
     lua_pushboolean( luaVM, false );

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
@@ -27,6 +27,8 @@ void CLuaAccountDefs::LoadFunctions ()
     CLuaCFunctions::AddFunction ( "getAccounts", GetAccounts );
     CLuaCFunctions::AddFunction ( "getAccountSerial", GetAccountSerial );
     CLuaCFunctions::AddFunction ( "getAccountsBySerial", GetAccountsBySerial );
+    CLuaCFunctions::AddFunction ( "getAccountIP", GetAccountIP );
+    CLuaCFunctions::AddFunction ( "getAccountsByIP", GetAccountsByIP );
 
     // Account set functions
     CLuaCFunctions::AddFunction ( "addAccount", AddAccount );
@@ -42,6 +44,7 @@ void CLuaAccountDefs::AddClass ( lua_State* luaVM )
 
     lua_classfunction ( luaVM, "getAll", "getAccounts" );
     lua_classfunction ( luaVM, "getAllBySerial", "getAccountsBySerial" );
+    lua_classfunction ( luaVM, "getAllByIP", "getAccountsByIP" );
     lua_classfunction ( luaVM, "getFromPlayer", "getPlayerAccount" );
     lua_classfunction ( luaVM, "logPlayerOut", "logOut" );
 
@@ -54,6 +57,7 @@ void CLuaAccountDefs::AddClass ( lua_State* luaVM )
     lua_classfunction ( luaVM, "setPassword", "setAccountPassword" );
 
     lua_classfunction ( luaVM, "getSerial", "getAccountSerial" );
+    lua_classfunction ( luaVM, "getIP", "getAccountIP" );
     lua_classfunction ( luaVM, "getData", "getAccountData" );
     lua_classfunction ( luaVM, "getAllData", "getAllAccountData" );
     lua_classfunction ( luaVM, "getName", "getAccountName" );
@@ -62,6 +66,7 @@ void CLuaAccountDefs::AddClass ( lua_State* luaVM )
 
     lua_classvariable ( luaVM, "serial", NULL, "getAccountSerial" );
     lua_classvariable ( luaVM, "name", NULL, "getAccountName" );
+    lua_classvariable ( luaVM, "ip", NULL, "getAccountIP" );
     lua_classvariable ( luaVM, "player", NULL, "getAccountPlayer" );
     lua_classvariable ( luaVM, "guest", NULL, "isGuestAccount" );
     lua_classvariable ( luaVM, "password", "setAccountPassword", NULL );
@@ -279,6 +284,51 @@ int CLuaAccountDefs::GetAccountsBySerial ( lua_State* luaVM )
         m_pScriptDebugging->LogCustom ( luaVM, argStream.GetFullErrorMessage () );
 
     lua_pushboolean ( luaVM, false );
+    return 1;
+}
+
+int CLuaAccountDefs::GetAccountIP( lua_State* luaVM ) {
+    //  string getAccountSerial ( account theAccount )
+    CAccount* pAccount;
+
+    CScriptArgReader argStream( luaVM );
+    argStream.ReadUserData( pAccount );
+
+    if ( !argStream.HasErrors() ) {
+        SString strIP;
+        if ( CStaticFunctionDefinitions::GetAccountIP( pAccount, strIP ) ) {
+            lua_pushstring( luaVM, strIP );
+            return 1;
+        }
+    } else
+        m_pScriptDebugging->LogCustom( luaVM, argStream.GetFullErrorMessage() );
+
+    lua_pushboolean( luaVM, false );
+    return 1;
+}
+
+int CLuaAccountDefs::GetAccountsByIP( lua_State* luaVM ) {
+    //  table getAccountsByIP ( string ip )
+    SString strIP;
+
+    CScriptArgReader argStream( luaVM );
+    argStream.ReadString( strIP );
+
+    if ( !argStream.HasErrors() ) {
+        lua_newtable( luaVM );
+        std::vector<CAccount*> accounts;
+
+        CStaticFunctionDefinitions::GetAccountsByIP( strIP, accounts );
+        for ( unsigned int i = 0; i < accounts.size(); ++i ) {
+            lua_pushnumber( luaVM, i + 1 );
+            lua_pushaccount( luaVM, accounts[i] );
+            lua_settable( luaVM, -3 );
+        }
+        return 1;
+    } else
+        m_pScriptDebugging->LogCustom( luaVM, argStream.GetFullErrorMessage() );
+
+    lua_pushboolean( luaVM, false );
     return 1;
 }
 

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
@@ -38,6 +38,7 @@ void CLuaAccountDefs::LoadFunctions ()
     CLuaCFunctions::AddFunction ( "removeAccount", RemoveAccount );
     CLuaCFunctions::AddFunction ( "setAccountPassword", SetAccountPassword );
     CLuaCFunctions::AddFunction ( "setAccountData", SetAccountData );
+    CLuaCFunctions::AddFunction ( "setAccountName", SetAccountName );
     CLuaCFunctions::AddFunction ( "copyAccountData", CopyAccountData );
 }
 
@@ -59,6 +60,7 @@ void CLuaAccountDefs::AddClass ( lua_State* luaVM )
 
     lua_classfunction ( luaVM, "setData", "setAccountData" );
     lua_classfunction ( luaVM, "setPassword", "setAccountPassword" );
+    lua_classfunction ( luaVM, "setName", "setAccountName" );
 
     lua_classfunction ( luaVM, "getSerial", "getAccountSerial" );
     lua_classfunction ( luaVM, "getIP", "getAccountIP" );
@@ -70,7 +72,7 @@ void CLuaAccountDefs::AddClass ( lua_State* luaVM )
     lua_classfunction ( luaVM, "isGuest", "isGuestAccount" );
 
     lua_classvariable ( luaVM, "serial", NULL, "getAccountSerial" );
-    lua_classvariable ( luaVM, "name", NULL, "getAccountName" );
+    lua_classvariable ( luaVM, "name", "setAccountName", "getAccountName" );
     lua_classvariable ( luaVM, "ip", NULL, "getAccountIP" );
     lua_classvariable ( luaVM, "id", NULL, "getAccountID" );
     lua_classvariable ( luaVM, "player", NULL, "getAccountPlayer" );
@@ -460,6 +462,30 @@ int CLuaAccountDefs::RemoveAccount ( lua_State* luaVM )
     if ( argStream.HasErrors () )
         m_pScriptDebugging->LogCustom ( luaVM, argStream.GetFullErrorMessage () );
 
+    lua_pushboolean ( luaVM, false );
+    return 1;
+}
+
+
+int CLuaAccountDefs::SetAccountName ( lua_State* luaVM ) {
+    // bool setAccountPassword ( account theAccount, string name[, bool allowCaseVariations = false ] )
+    CAccount* pAccount; 
+    SString strNewName;
+    bool bAllowCaseVariations;
+
+    CScriptArgReader argStream ( luaVM );
+    argStream.ReadUserData ( pAccount );
+    argStream.ReadString ( strNewName );
+    argStream.ReadBool ( bAllowCaseVariations, false );
+
+    SString strError;
+    if ( !argStream.HasErrors() ) {
+        if ( CStaticFunctionDefinitions::SetAccountName ( pAccount, strNewName, bAllowCaseVariations, strError ) ) {
+            lua_pushboolean ( luaVM, true );
+            return 1;
+        }
+    } else 
+         m_pScriptDebugging->LogCustom ( luaVM, argStream.GetFullErrorMessage () );
     lua_pushboolean ( luaVM, false );
     return 1;
 }

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
@@ -238,6 +238,33 @@ int CLuaAccountDefs::GetAccounts ( lua_State* luaVM )
     return 1;
 }
 
+int CLuaAccountDefs::GetAccountsByData( lua_State* luaVM ) {
+    //  table GetAccountsByData ( string dataName, string value )
+    SString dataName;
+    SString value;
+
+    CScriptArgReader argStream( luaVM );
+    argStream.ReadString( dataName );
+    argStream.ReadString ( value );
+
+    if ( !argStream.HasErrors() ) {
+        lua_newtable( luaVM );
+        std::vector<CAccount*> accounts;
+
+        CStaticFunctionDefinitions::GetAccountsByData( dataName, value, accounts );
+        for ( unsigned int i = 0; i < accounts.size(); ++i ) {
+            lua_pushnumber( luaVM, i + 1 );
+            lua_pushaccount( luaVM, accounts[i] );
+            lua_settable( luaVM, -3 );
+        }
+        return 1;
+    } else
+        m_pScriptDebugging->LogCustom( luaVM, argStream.GetFullErrorMessage() );
+
+    lua_pushboolean( luaVM, false );
+    return 1;
+}
+
 int CLuaAccountDefs::GetAccountSerial ( lua_State* luaVM )
 {
     //  string getAccountSerial ( account theAccount )

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.h
@@ -35,8 +35,6 @@ public:
     LUA_DECLARE ( GetAccountsBySerial );
     LUA_DECLARE ( GetAccountIP );
     LUA_DECLARE ( GetAccountsByIP );
-    LUA_DECLARE ( GetAccountID );
-    LUA_DECLARE ( GetAccountByID );
 
     // Account set funcs
     LUA_DECLARE ( AddAccount );

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.h
@@ -34,6 +34,8 @@ public:
     LUA_DECLARE ( GetAccountsBySerial );
     LUA_DECLARE ( GetAccountIP );
     LUA_DECLARE ( GetAccountsByIP );
+    LUA_DECLARE ( GetAccountID );
+    LUA_DECLARE ( GetAccountByID );
 
     // Account set funcs
     LUA_DECLARE ( AddAccount );

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.h
@@ -41,6 +41,7 @@ public:
     // Account set funcs
     LUA_DECLARE ( AddAccount );
     LUA_DECLARE ( RemoveAccount );
+    LUA_DECLARE ( SetAccountName );
     LUA_DECLARE ( SetAccountPassword );
     LUA_DECLARE ( SetAccountData );
     LUA_DECLARE ( CopyAccountData );

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.h
@@ -32,6 +32,8 @@ public:
     LUA_DECLARE ( GetAllAccountData );
     LUA_DECLARE ( GetAccountSerial );
     LUA_DECLARE ( GetAccountsBySerial );
+    LUA_DECLARE ( GetAccountIP );
+    LUA_DECLARE ( GetAccountsByIP );
 
     // Account set funcs
     LUA_DECLARE ( AddAccount );

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.h
@@ -30,6 +30,7 @@ public:
     LUA_DECLARE ( IsGuestAccount );
     LUA_DECLARE ( GetAccountData );
     LUA_DECLARE ( GetAllAccountData );
+    LUA_DECLARE ( GetAccountsByData );
     LUA_DECLARE ( GetAccountSerial );
     LUA_DECLARE ( GetAccountsBySerial );
     LUA_DECLARE ( GetAccountIP );


### PR DESCRIPTION
onPickupHit and onPlayerPickupHit both don't have any a "matchingDimension" argument, they can only get triggered when the player and the pickup are both in the same dimension.
Also had to change it in the wiki (see history):
https://wiki.multitheftauto.com/wiki/OnPlayerPickupHit
