### PR TITLE
Remove wrong info at pickupHit

### DIFF
--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -1470,7 +1470,7 @@ void CGame::AddBuiltInEvents ( void )
     // Object events
 
     // Pickup events
-    m_Events.AddEvent ( "onPickupHit", "player, matchingDimension", NULL, false );
+    m_Events.AddEvent ( "onPickupHit", "player", NULL, false );
     m_Events.AddEvent ( "onPickupUse", "player", NULL, false );
     m_Events.AddEvent ( "onPickupSpawn", "", NULL, false );
 
@@ -1488,7 +1488,7 @@ void CGame::AddBuiltInEvents ( void )
     m_Events.AddEvent ( "onPlayerWeaponSwitch", "previous, current", NULL, false );
     m_Events.AddEvent ( "onPlayerMarkerHit", "marker, matchingDimension", NULL, false );
     m_Events.AddEvent ( "onPlayerMarkerLeave", "marker, matchingDimension", NULL, false );
-    m_Events.AddEvent ( "onPlayerPickupHit", "pickup, matchingDimension", NULL, false );
+    m_Events.AddEvent ( "onPlayerPickupHit", "pickup", NULL, false );
     m_Events.AddEvent ( "onPlayerPickupUse", "pickup", NULL, false );
     m_Events.AddEvent ( "onPlayerClick", "button, state, element, posX, posY, posZ", NULL, false );
     m_Events.AddEvent ( "onPlayerContact", "previous, current", NULL, false );


### PR DESCRIPTION
onPickupHit and onPlayerPickupHit both don't have any a "matchingDimension" argument, they can only get triggered when the player and the pickup are both in the same dimension.
Also had to change it in the wiki (see history):
https://wiki.multitheftauto.com/wiki/OnPlayerPickupHit

Sry for the other two closed pull requests, seems like I always used the wrong branch.
