### PR TITLE
0009616: `XMLLoadFile` print error if something wrong with xml

### DIFF
--- a/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
@@ -138,6 +138,7 @@ int CLuaXMLDefs::xmlLoadFile ( lua_State* luaVM )
 
     // Grab our resource
     CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine ( luaVM );
+    SString strError = "";
     if ( pLuaMain )
     {
         SString strFileInput;
@@ -184,6 +185,7 @@ int CLuaXMLDefs::xmlLoadFile ( lua_State* luaVM )
                             }
                         }
 
+                        xmlFile->GetLastError ( strError );
                         // Destroy it if we failed
                         pLuaMain->DestroyXML ( xmlFile );
                     }
@@ -196,7 +198,8 @@ int CLuaXMLDefs::xmlLoadFile ( lua_State* luaVM )
     }
 
     lua_pushboolean ( luaVM, false );
-    return 1;
+    lua_pushstring ( luaVM, strError );
+    return 2;
 }
 
 int CLuaXMLDefs::xmlCopyFile ( lua_State* luaVM )

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
@@ -186,6 +186,7 @@ int CLuaXMLDefs::xmlLoadFile ( lua_State* luaVM )
                         }
 
                         xmlFile->GetLastError ( strError );
+                        argStream.SetCustomError(strError, SString("Unable to read XML file %s", strFileInput.c_str()));
                         // Destroy it if we failed
                         pLuaMain->DestroyXML ( xmlFile );
                     }
@@ -198,8 +199,7 @@ int CLuaXMLDefs::xmlLoadFile ( lua_State* luaVM )
     }
 
     lua_pushboolean ( luaVM, false );
-    lua_pushstring ( luaVM, strError );
-    return 2;
+    return 1;
 }
 
 int CLuaXMLDefs::xmlCopyFile ( lua_State* luaVM )

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
@@ -184,7 +184,8 @@ int CLuaXMLDefs::xmlLoadFile ( lua_State* luaVM )
                             }
                         }
 
-                        if ( FileExists ( strPath ) ) {
+                        if ( FileExists ( strPath ) )
+                        {
                             SString strError;
                             xmlFile->GetLastError ( strError );
                             if ( !strError.empty( ) )

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
@@ -186,7 +186,10 @@ int CLuaXMLDefs::xmlLoadFile ( lua_State* luaVM )
                         }
 
                         xmlFile->GetLastError ( strError );
-                        argStream.SetCustomError(strError, SString("Unable to read XML file %s", strFileInput.c_str()));
+                        const int exists = strstr ( strError, "Failed to open file" ) != NULL;
+                        if( exists==0 )
+                            argStream.SetCustomError ( strError, SString("Unable to read XML file %", strFileInput.c_str() ) );
+
                         // Destroy it if we failed
                         pLuaMain->DestroyXML ( xmlFile );
                     }

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
@@ -188,7 +188,7 @@ int CLuaXMLDefs::xmlLoadFile ( lua_State* luaVM )
                         xmlFile->GetLastError ( strError );
                         const int exists = strstr ( strError, "Failed to open file" ) != NULL;
                         if( exists==0 )
-                            argStream.SetCustomError ( strError, SString("Unable to read XML file %", strFileInput.c_str() ) );
+                            argStream.SetCustomError ( strError, SString("Unable to read XML file %s", strFileInput.c_str() ) );
 
                         // Destroy it if we failed
                         pLuaMain->DestroyXML ( xmlFile );

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
@@ -138,7 +138,6 @@ int CLuaXMLDefs::xmlLoadFile ( lua_State* luaVM )
 
     // Grab our resource
     CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine ( luaVM );
-    SString strError = "";
     if ( pLuaMain )
     {
         SString strFileInput;
@@ -185,11 +184,12 @@ int CLuaXMLDefs::xmlLoadFile ( lua_State* luaVM )
                             }
                         }
 
-                        xmlFile->GetLastError ( strError );
-                        const int exists = strstr ( strError, "Failed to open file" ) != NULL;
-                        if( exists==0 )
-                            argStream.SetCustomError ( strError, SString("Unable to read XML file %s", strFileInput.c_str() ) );
-
+                        if ( FileExists ( strPath ) ) {
+                            SString strError;
+                            xmlFile->GetLastError ( strError );
+                            if ( !strError.empty( ) )
+                                argStream.SetCustomError ( strError, SString("Unable to read XML file %s", strFileInput.c_str( ) ) );
+                        }
                         // Destroy it if we failed
                         pLuaMain->DestroyXML ( xmlFile );
                     }


### PR DESCRIPTION
Added exclude for `Failed to open file`
Same example script will not shown any error if file not exist
[xmlErrorTest.zip](https://github.com/multitheftauto/mtasa-blue/files/1516948/xmlErrorTest.zip)
![0ungdkzorfifvisi0wfywg](https://user-images.githubusercontent.com/22455534/33420105-a38fd454-d5ad-11e7-9552-c6183d99aeae.png)