### PR TITLE
Add setElementCollidableWithType

### DIFF
--- a/Client/mods/deathmatch/logic/CClientEntity.cpp
+++ b/Client/mods/deathmatch/logic/CClientEntity.cpp
@@ -173,6 +173,12 @@ CClientEntity::~CClientEntity ( void )
     SAFE_RELEASE( m_pChildrenListSnapshot );
     g_pCore->GetGraphics ()->GetRenderItemManager ()->RemoveClientEntityRefs ( this );
     g_pCore->UpdateDummyProgress();
+
+    // Remove from m_DisabledCollisions
+    CClientPlayer::m_DisabledCollisions.remove ( this );
+    CClientPed::m_DisabledCollisions.remove ( this );
+    CClientObject::m_DisabledCollisions.remove ( this );
+    CClientVehicle::m_DisabledCollisions.remove ( this );
 }
 
 
@@ -1648,6 +1654,7 @@ void CClientEntity::SetCollidableWith ( CClientEntity * pEntity, bool bCanCollid
     }
     // Set in the other entity as well
     pEntity->SetCollidableWith ( this, bCanCollide );
+    g_pCore->GetConsole ()->Printf ( "Collision toggle: ", bCanCollide );
 }
 
 

--- a/Client/mods/deathmatch/logic/CClientEntity.cpp
+++ b/Client/mods/deathmatch/logic/CClientEntity.cpp
@@ -1455,6 +1455,41 @@ void CClientEntity::RemoveEntityFromRoot ( unsigned int uiTypeHash, CClientEntit
         CClientEntity::RemoveEntityFromRoot ( (*iter)->GetTypeHash (), *iter );
 }
 
+
+CFastList < CClientEntity* > CClientEntity::GetEntitiesFromRoot ( unsigned int uiTypeHash, bool bStreamedIn )
+{
+    CFastList < CClientEntity* > entities;
+
+    t_mapEntitiesFromRoot::iterator find = ms_mapEntitiesFromRoot.find ( uiTypeHash );
+    if ( find != ms_mapEntitiesFromRoot.end () )
+    {
+        CFromRootListType& listEntities = find->second;
+        CClientEntity* pEntity;
+        unsigned int uiIndex = 0;
+
+        for ( CFromRootListType::reverse_iterator i = listEntities.rbegin ();
+            i != listEntities.rend ();
+            ++i )
+        {
+            pEntity = *i;
+
+            // Only streamed in elements?
+            if ( !bStreamedIn || !pEntity->IsStreamingCompatibleClass () ||
+                reinterpret_cast < CClientStreamElement* > ( pEntity )->IsStreamedIn () )
+            {
+                if ( !pEntity->IsBeingDeleted () )
+                {
+                    // Add it to the table
+                    entities.push_back ( pEntity );
+                }
+            }
+        }
+    }
+
+    return entities;
+}
+
+
 void CClientEntity::GetEntitiesFromRoot ( unsigned int uiTypeHash, lua_State* luaVM, bool bStreamedIn )
 {
 #if CHECK_ENTITIES_FROM_ROOT

--- a/Client/mods/deathmatch/logic/CClientEntity.cpp
+++ b/Client/mods/deathmatch/logic/CClientEntity.cpp
@@ -175,10 +175,19 @@ CClientEntity::~CClientEntity ( void )
     g_pCore->UpdateDummyProgress();
 
     // Remove from m_DisabledCollisions
-    CClientPlayer::m_DisabledCollisions.remove ( this );
-    CClientPed::m_DisabledCollisions.remove ( this );
-    CClientObject::m_DisabledCollisions.remove ( this );
-    CClientVehicle::m_DisabledCollisions.remove ( this );
+    switch ( this->GetType () )
+    {
+        case CCLIENTPLAYER:
+        case CCLIENTPED:
+        case CCLIENTOBJECT:
+        case CCLIENTVEHICLE:
+            CClientPlayer::m_DisabledCollisions.remove ( this );
+            CClientPed::m_DisabledCollisions.remove ( this );
+            CClientObject::m_DisabledCollisions.remove ( this );
+            CClientVehicle::m_DisabledCollisions.remove ( this );
+            break;
+        default: break;
+    }
 }
 
 
@@ -1654,7 +1663,6 @@ void CClientEntity::SetCollidableWith ( CClientEntity * pEntity, bool bCanCollid
     }
     // Set in the other entity as well
     pEntity->SetCollidableWith ( this, bCanCollide );
-    g_pCore->GetConsole ()->Printf ( "Collision toggle: ", bCanCollide );
 }
 
 

--- a/Client/mods/deathmatch/logic/CClientEntity.cpp
+++ b/Client/mods/deathmatch/logic/CClientEntity.cpp
@@ -175,19 +175,10 @@ CClientEntity::~CClientEntity ( void )
     g_pCore->UpdateDummyProgress();
 
     // Remove from m_DisabledCollisions
-    switch ( this->GetType () )
-    {
-        case CCLIENTPLAYER:
-        case CCLIENTPED:
-        case CCLIENTOBJECT:
-        case CCLIENTVEHICLE:
-            CClientPlayer::m_DisabledCollisions.remove ( this );
-            CClientPed::m_DisabledCollisions.remove ( this );
-            CClientObject::m_DisabledCollisions.remove ( this );
-            CClientVehicle::m_DisabledCollisions.remove ( this );
-            break;
-        default: break;
-    }
+    CClientPlayer::m_DisabledCollisions.remove ( this );
+    CClientPed::m_DisabledCollisions.remove ( this );
+    CClientObject::m_DisabledCollisions.remove ( this );
+    CClientVehicle::m_DisabledCollisions.remove ( this );
 }
 
 

--- a/Client/mods/deathmatch/logic/CClientEntity.h
+++ b/Client/mods/deathmatch/logic/CClientEntity.h
@@ -373,11 +373,13 @@ protected:
 public:
     // Optimization for getElementsByType starting at root
     static void                     StartupEntitiesFromRoot ( );
+    static CFastList < CClientEntity* > GetEntitiesFromRoot ( unsigned int uiTypeHash, bool bStreamedIn );
 private:
     static bool                     IsFromRoot              ( CClientEntity* pEntity );
     static void                     AddEntityFromRoot       ( unsigned int uiTypeHash, CClientEntity* pEntity, bool bDebugCheck = true );
     static void                     RemoveEntityFromRoot    ( unsigned int uiTypeHash, CClientEntity* pEntity );
     static void                     GetEntitiesFromRoot     ( unsigned int uiTypeHash, lua_State* luaVM, bool bStreamedIn );
+    
 
 #if CHECK_ENTITIES_FROM_ROOT
     static void                     _CheckEntitiesFromRoot      ( unsigned int uiTypeHash );

--- a/Client/mods/deathmatch/logic/CClientEntity.h
+++ b/Client/mods/deathmatch/logic/CClientEntity.h
@@ -379,7 +379,6 @@ private:
     static void                     AddEntityFromRoot       ( unsigned int uiTypeHash, CClientEntity* pEntity, bool bDebugCheck = true );
     static void                     RemoveEntityFromRoot    ( unsigned int uiTypeHash, CClientEntity* pEntity );
     static void                     GetEntitiesFromRoot     ( unsigned int uiTypeHash, lua_State* luaVM, bool bStreamedIn );
-    
 
 #if CHECK_ENTITIES_FROM_ROOT
     static void                     _CheckEntitiesFromRoot      ( unsigned int uiTypeHash );

--- a/Client/mods/deathmatch/logic/CClientObject.cpp
+++ b/Client/mods/deathmatch/logic/CClientObject.cpp
@@ -21,6 +21,10 @@
 #define M_PI 3.14159265358979323846
 #endif
 
+using std::list;
+
+list < CClientEntity* > CClientObject::m_DisabledCollisions;
+
 CClientObject::CClientObject ( CClientManager* pManager, ElementID ID, unsigned short usModel, bool bLowLod )
     : ClassInit ( this )
     , CClientStreamElement ( bLowLod ? pManager->GetObjectLodStreamer () : pManager->GetObjectStreamer (), ID )
@@ -54,6 +58,16 @@ CClientObject::CClientObject ( CClientManager* pManager, ElementID ID, unsigned 
 
     if ( m_bIsLowLod )
         m_pManager->OnLowLODElementCreated ();
+
+    // Check DisableCollisions //
+    if ( !m_DisabledCollisions.empty () )
+    {
+        std::list < CClientEntity * > ::iterator iter = m_DisabledCollisions.begin ();
+        for ( ; iter != m_DisabledCollisions.end (); iter++ )
+        {
+            SetCollidableWith ( *iter, false );
+        }
+    }
 }
 
 

--- a/Client/mods/deathmatch/logic/CClientObject.cpp
+++ b/Client/mods/deathmatch/logic/CClientObject.cpp
@@ -60,13 +60,9 @@ CClientObject::CClientObject ( CClientManager* pManager, ElementID ID, unsigned 
         m_pManager->OnLowLODElementCreated ();
 
     // Check DisableCollisions //
-    if ( !m_DisabledCollisions.empty () )
+    for ( CClientEntity * entity : m_DisabledCollisions )
     {
-        std::list < CClientEntity * > ::iterator iter = m_DisabledCollisions.begin ();
-        for ( ; iter != m_DisabledCollisions.end (); iter++ )
-        {
-            SetCollidableWith ( *iter, false );
-        }
+        SetCollidableWith ( entity, false );
     }
 }
 

--- a/Client/mods/deathmatch/logic/CClientObject.cpp
+++ b/Client/mods/deathmatch/logic/CClientObject.cpp
@@ -21,9 +21,7 @@
 #define M_PI 3.14159265358979323846
 #endif
 
-using std::list;
-
-list < CClientEntity* > CClientObject::m_DisabledCollisions;
+std::list < CClientEntity* > CClientObject::m_DisabledCollisions;
 
 CClientObject::CClientObject ( CClientManager* pManager, ElementID ID, unsigned short usModel, bool bLowLod )
     : ClassInit ( this )

--- a/Client/mods/deathmatch/logic/CClientObject.h
+++ b/Client/mods/deathmatch/logic/CClientObject.h
@@ -153,6 +153,7 @@ protected:
 public:
     CObject*                            m_pObject;
     SLastSyncedObjectData               m_LastSyncedData;
+    static std::list < CClientEntity * >   m_DisabledCollisions;
 };
 
 #endif

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -16,11 +16,10 @@
 
 #include "StdInc.h"
 
-using std::list;
 using std::vector;
 
 extern CClientGame* g_pClientGame;
-list < CClientEntity* > CClientPed::m_DisabledCollisions;
+std::list < CClientEntity* > CClientPed::m_DisabledCollisions;
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -17,9 +17,10 @@
 #include "StdInc.h"
 
 using std::vector;
+using std::list;
 
 extern CClientGame* g_pClientGame;
-std::list < CClientEntity* > CClientPed::m_DisabledCollisions;
+list < CClientEntity* > CClientPed::m_DisabledCollisions;
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -245,13 +245,9 @@ void CClientPed::Init ( CClientManager* pManager, unsigned long ulModelID, bool 
     }
 
     // Check DisableCollisions //
-    if ( !m_DisabledCollisions.empty () )
+    for ( CClientEntity * entity : m_DisabledCollisions )
     {
-        list < CClientEntity * > ::iterator iter = m_DisabledCollisions.begin ();
-        for ( ; iter != m_DisabledCollisions.end (); iter++ )
-        {
-            SetCollidableWith ( *iter, false );
-        }
+        SetCollidableWith ( entity, false );
     }
 }
 

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -20,6 +20,7 @@ using std::list;
 using std::vector;
 
 extern CClientGame* g_pClientGame;
+list < CClientEntity* > CClientPed::m_DisabledCollisions;
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
@@ -241,6 +242,16 @@ void CClientPed::Init ( CClientManager* pManager, unsigned long ulModelID, bool 
         SetStat ( MAX_HEALTH, 569.0f );     // Default max_health stat
 
         SetArmor ( 0.0f );
+    }
+
+    // Check DisableCollisions //
+    if ( !m_DisabledCollisions.empty () )
+    {
+        list < CClientEntity * > ::iterator iter = m_DisabledCollisions.begin ();
+        for ( ; iter != m_DisabledCollisions.end (); iter++ )
+        {
+            SetCollidableWith ( *iter, false );
+        }
     }
 }
 

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -646,6 +646,8 @@ public:
 
     CVector                     m_vecPrevTargetPosition;
     uint                        m_uiForceLocalCounter;
+
+    static std::list < CClientEntity * >   m_DisabledCollisions;
 };
 
 #endif

--- a/Client/mods/deathmatch/logic/CClientPlayer.cpp
+++ b/Client/mods/deathmatch/logic/CClientPlayer.cpp
@@ -95,7 +95,7 @@ CClientPlayer::CClientPlayer ( CClientManager* pManager, ElementID ID, bool bIsL
     // Check DisableCollisions //
     if ( !m_DisabledCollisions.empty () )
     {
-        std::list < CClientEntity * > ::iterator iter = m_DisabledCollisions.begin ();
+        list < CClientEntity * > ::iterator iter = m_DisabledCollisions.begin ();
         for ( ; iter != m_DisabledCollisions.end (); iter++ )
         {
             SetCollidableWith ( *iter, false );

--- a/Client/mods/deathmatch/logic/CClientPlayer.cpp
+++ b/Client/mods/deathmatch/logic/CClientPlayer.cpp
@@ -16,9 +16,13 @@
 *****************************************************************************/
 
 #include <StdInc.h>
+
+using std::list;
+
 int g_iDamageEventLimit = -1;
 extern float g_fApplyDamageLastAmount;
 extern CClientPed* g_pApplyDamageLastDamagedPed;
+list < CClientEntity* > CClientPlayer::m_DisabledCollisions;
 
 CClientPlayer::CClientPlayer ( CClientManager* pManager, ElementID ID, bool bIsLocalPlayer ) : ClassInit ( this ), CClientPed ( pManager, 0, ID, bIsLocalPlayer )
 {
@@ -87,6 +91,16 @@ CClientPlayer::CClientPlayer ( CClientManager* pManager, ElementID ID, bool bIsL
 
     // Add us to the player list
     m_pManager->GetPlayerManager ()->AddToList ( this );
+
+    // Check DisableCollisions //
+    if ( !m_DisabledCollisions.empty () )
+    {
+        std::list < CClientEntity * > ::iterator iter = m_DisabledCollisions.begin ();
+        for ( ; iter != m_DisabledCollisions.end (); iter++ )
+        {
+            SetCollidableWith ( *iter, false );
+        }
+    }
 
 #ifdef MTA_DEBUG
     m_bShowingWepdata = false;

--- a/Client/mods/deathmatch/logic/CClientPlayer.cpp
+++ b/Client/mods/deathmatch/logic/CClientPlayer.cpp
@@ -17,12 +17,10 @@
 
 #include <StdInc.h>
 
-using std::list;
-
 int g_iDamageEventLimit = -1;
 extern float g_fApplyDamageLastAmount;
 extern CClientPed* g_pApplyDamageLastDamagedPed;
-list < CClientEntity* > CClientPlayer::m_DisabledCollisions;
+std::list < CClientEntity* > CClientPlayer::m_DisabledCollisions;
 
 CClientPlayer::CClientPlayer ( CClientManager* pManager, ElementID ID, bool bIsLocalPlayer ) : ClassInit ( this ), CClientPed ( pManager, 0, ID, bIsLocalPlayer )
 {

--- a/Client/mods/deathmatch/logic/CClientPlayer.cpp
+++ b/Client/mods/deathmatch/logic/CClientPlayer.cpp
@@ -93,13 +93,9 @@ CClientPlayer::CClientPlayer ( CClientManager* pManager, ElementID ID, bool bIsL
     m_pManager->GetPlayerManager ()->AddToList ( this );
 
     // Check DisableCollisions //
-    if ( !m_DisabledCollisions.empty () )
+    for ( CClientEntity * entity : m_DisabledCollisions )
     {
-        list < CClientEntity * > ::iterator iter = m_DisabledCollisions.begin ();
-        for ( ; iter != m_DisabledCollisions.end (); iter++ )
-        {
-            SetCollidableWith ( *iter, false );
-        }
+        SetCollidableWith ( entity, false );
     }
 
 #ifdef MTA_DEBUG

--- a/Client/mods/deathmatch/logic/CClientPlayer.h
+++ b/Client/mods/deathmatch/logic/CClientPlayer.h
@@ -120,6 +120,7 @@ public:
     CVector                         m_vecPrevBulletSyncStart;
     CVector                         m_vecPrevBulletSyncEnd;
     uchar                           m_ucPrevBulletSyncOrderCounter;
+    static std::list < CClientEntity * >   m_DisabledCollisions;
 private:
     bool                            m_bIsLocalPlayer;
     SString                         m_strNick;

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -21,9 +21,11 @@
 
 #include "StdInc.h"
 
+using std::list;
+
 extern CClientGame* g_pClientGame;
 std::set < const CClientEntity* > ms_AttachedVehiclesToIgnore;
-std::list < CClientEntity* > CClientVehicle::m_DisabledCollisions;
+list < CClientEntity* > CClientVehicle::m_DisabledCollisions;
 
 // To hide the ugly "pointer truncation from DWORD* to unsigned long warning
 #pragma warning(disable:4311)

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -182,13 +182,9 @@ CClientVehicle::CClientVehicle ( CClientManager* pManager, ElementID ID, unsigne
     m_bJustStreamedIn = false;
 
     // Check DisableCollisions //
-    if ( !m_DisabledCollisions.empty () )
+    for ( CClientEntity * entity : m_DisabledCollisions )
     {
-        list < CClientEntity * > ::iterator iter = m_DisabledCollisions.begin ();
-        for ( ; iter != m_DisabledCollisions.end (); iter++ )
-        {
-            SetCollidableWith ( *iter, false );
-        }
+        SetCollidableWith ( entity, false );
     }
 }
 

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -25,6 +25,7 @@ using std::list;
 
 extern CClientGame* g_pClientGame;
 std::set < const CClientEntity* > ms_AttachedVehiclesToIgnore;
+std::list < CClientEntity* > CClientVehicle::m_DisabledCollisions;
 
 // To hide the ugly "pointer truncation from DWORD* to unsigned long warning
 #pragma warning(disable:4311)
@@ -179,6 +180,16 @@ CClientVehicle::CClientVehicle ( CClientManager* pManager, ElementID ID, unsigne
 
     // We've not yet been streamed in 
     m_bJustStreamedIn = false;
+
+    // Check DisableCollisions //
+    if ( !m_DisabledCollisions.empty () )
+    {
+        list < CClientEntity * > ::iterator iter = m_DisabledCollisions.begin ();
+        for ( ; iter != m_DisabledCollisions.end (); iter++ )
+        {
+            SetCollidableWith ( *iter, false );
+        }
+    }
 }
 
 

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -21,8 +21,6 @@
 
 #include "StdInc.h"
 
-using std::list;
-
 extern CClientGame* g_pClientGame;
 std::set < const CClientEntity* > ms_AttachedVehiclesToIgnore;
 std::list < CClientEntity* > CClientVehicle::m_DisabledCollisions;

--- a/Client/mods/deathmatch/logic/CClientVehicle.h
+++ b/Client/mods/deathmatch/logic/CClientVehicle.h
@@ -686,6 +686,7 @@ public:
     SSirenInfo                  m_tSirenBeaconInfo;
     std::map<SString, SVehicleComponentData>  m_ComponentData;
     bool                        m_bAsyncLoadingDisabled;
+    static std::list < CClientEntity * >   m_DisabledCollisions;
 
 };
 

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -3603,6 +3603,47 @@ bool CStaticFunctionDefinitions::SetElementCollidableWith ( CClientEntity & Enti
 }
 
 
+bool CStaticFunctionDefinitions::SetElementCollidableWith ( CClientEntity & Entity, const char* szTypeName, bool bCanCollide, bool bOnlyCreated )
+{
+    switch ( Entity.GetType () )
+    {
+        case CCLIENTPLAYER:
+        case CCLIENTPED:
+        case CCLIENTOBJECT:
+        case CCLIENTVEHICLE:
+        {
+            switch ( CClientEntity::GetTypeID ( szTypeName ) )
+            {
+                case CCLIENTPLAYER:
+                case CCLIENTPED:
+                case CCLIENTOBJECT:
+                case CCLIENTVEHICLE:
+                {
+                    CFastList < CClientEntity* > entities = CClientEntity::GetEntitiesFromRoot ( HashString ( szTypeName ), false );
+
+                    CChildListType::const_iterator iter = entities.begin ();
+                    for ( ; iter != entities.end (); iter++ )
+                    {
+                        CClientEntity* pEntity = *iter;
+                        Entity.SetCollidableWith ( pEntity, bCanCollide );
+                    }
+
+                    if ( !bOnlyCreated ) 
+                    {
+
+                    }
+
+                    return true;
+                }
+                default: break;
+            }
+        }
+    }
+
+    return false;
+}
+
+
 bool CStaticFunctionDefinitions::SetElementFrozen ( CClientEntity& Entity, bool bFrozen )
 {
     switch ( Entity.GetType () )

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -3611,66 +3611,65 @@ bool CStaticFunctionDefinitions::SetElementCollidableWithType ( CClientEntity & 
         case CCLIENTPED:
         case CCLIENTOBJECT:
         case CCLIENTVEHICLE:
+            break;
+        default: return;
+    }
+
+    unsigned int uiType = CClientEntity::GetTypeID ( szTypeName );
+
+    switch ( uiType )
+    {
+        case CCLIENTPLAYER:
+        case CCLIENTPED:
+        case CCLIENTOBJECT:
+        case CCLIENTVEHICLE:
+            break;
+        default: return;
+    }
+
+    // Change CollidableWith for all elements of this type on the server
+    CFastList < CClientEntity* > entities = CClientEntity::GetEntitiesFromRoot ( HashString ( szTypeName ), false );
+
+    CChildListType::const_iterator iter = entities.begin ();
+    for ( ; iter != entities.end (); iter++ )
+    {
+        CClientEntity* pEntity = *iter;
+        Entity.SetCollidableWith ( pEntity, bCanCollide );
+    }
+
+    // Save it so new created elements also have to consider CollidableWith
+    if ( !bOnlyWithCreated ) 
+    {
+        switch ( uiType )
         {
-            unsigned int uiType = CClientEntity::GetTypeID ( szTypeName );
-
-            switch ( uiType )
-            {
-                case CCLIENTPLAYER:
-                case CCLIENTPED:
-                case CCLIENTOBJECT:
-                case CCLIENTVEHICLE:
-                {
-                    // Change CollidableWith for all elements of this type on the server
-                    CFastList < CClientEntity* > entities = CClientEntity::GetEntitiesFromRoot ( HashString ( szTypeName ), false );
-
-                    CChildListType::const_iterator iter = entities.begin ();
-                    for ( ; iter != entities.end (); iter++ )
-                    {
-                        CClientEntity* pEntity = *iter;
-                        Entity.SetCollidableWith ( pEntity, bCanCollide );
-                    }
-
-                    // Save it so new created elements also have to consider CollidableWith
-                    if ( !bOnlyWithCreated ) 
-                    {
-                        switch ( uiType )
-                        {
-                            case CCLIENTPLAYER:
-                                if ( bCanCollide )
-                                    CClientPlayer::m_DisabledCollisions.remove ( &Entity );
-                                else
-                                    CClientPlayer::m_DisabledCollisions.push_back ( &Entity );
-                                break;
-                            case CCLIENTPED:
-                                if ( bCanCollide )
-                                    CClientPed::m_DisabledCollisions.remove ( &Entity );
-                                else 
-                                    CClientPed::m_DisabledCollisions.push_back ( &Entity );
-                                break;
-                            case CCLIENTOBJECT:
-                                if ( bCanCollide )
-                                    CClientObject::m_DisabledCollisions.remove ( &Entity );
-                                else
-                                    CClientObject::m_DisabledCollisions.push_back ( &Entity );
-                                break;
-                            case CCLIENTVEHICLE:
-                                if ( bCanCollide )
-                                    CClientVehicle::m_DisabledCollisions.remove ( &Entity );
-                                else
-                                    CClientVehicle::m_DisabledCollisions.push_back ( &Entity );
-                                break;
-                        }
-                    }
-
-                    return true;
-                }
-                default: break;
-            }
+            case CCLIENTPLAYER:
+                if ( bCanCollide )
+                    CClientPlayer::m_DisabledCollisions.remove ( &Entity );
+                else
+                    CClientPlayer::m_DisabledCollisions.push_back ( &Entity );
+                break;
+            case CCLIENTPED:
+                if ( bCanCollide )
+                    CClientPed::m_DisabledCollisions.remove ( &Entity );
+                else 
+                    CClientPed::m_DisabledCollisions.push_back ( &Entity );
+                break;
+            case CCLIENTOBJECT:
+                if ( bCanCollide )
+                    CClientObject::m_DisabledCollisions.remove ( &Entity );
+                else
+                    CClientObject::m_DisabledCollisions.push_back ( &Entity );
+                break;
+            case CCLIENTVEHICLE:
+                if ( bCanCollide )
+                    CClientVehicle::m_DisabledCollisions.remove ( &Entity );
+                else
+                    CClientVehicle::m_DisabledCollisions.push_back ( &Entity );
+                break;
         }
     }
 
-    return false;
+    return true;
 }
 
 

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -3612,7 +3612,7 @@ bool CStaticFunctionDefinitions::SetElementCollidableWithType ( CClientEntity & 
         case CCLIENTOBJECT:
         case CCLIENTVEHICLE:
             break;
-        default: return;
+        default: return false;
     }
 
     unsigned int uiType = CClientEntity::GetTypeID ( szTypeName );
@@ -3624,7 +3624,7 @@ bool CStaticFunctionDefinitions::SetElementCollidableWithType ( CClientEntity & 
         case CCLIENTOBJECT:
         case CCLIENTVEHICLE:
             break;
-        default: return;
+        default: return false;
     }
 
     // Change CollidableWith for all elements of this type on the server

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -108,7 +108,7 @@ public:
     static bool                         SetElementModel                     ( CClientEntity& Entity, unsigned short usModel );
     static bool                         SetElementCollisionsEnabled         ( CClientEntity& Entity, bool bEnabled );
     static bool                         SetElementCollidableWith            ( CClientEntity& Entity, CClientEntity& ThisEntity, bool bCanCollide );
-    static bool                         SetElementCollidableWith            ( CClientEntity& Entity, const char* szTypeName, bool bCanCollide, bool bOnlyCreated );
+    static bool                         SetElementCollidableWithType        ( CClientEntity& Entity, const char* szTypeName, bool bCanCollide, bool bOnlyWithCreated );
     static bool                         SetElementFrozen                    ( CClientEntity& Entity, bool bFrozen );
     static bool                         SetLowLodElement                    ( CClientEntity& Entity, CClientEntity* pLowLodEntity );
     static bool                         SetElementCallPropagationEnabled    ( CClientEntity& Entity, bool bEnabled );

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -108,6 +108,7 @@ public:
     static bool                         SetElementModel                     ( CClientEntity& Entity, unsigned short usModel );
     static bool                         SetElementCollisionsEnabled         ( CClientEntity& Entity, bool bEnabled );
     static bool                         SetElementCollidableWith            ( CClientEntity& Entity, CClientEntity& ThisEntity, bool bCanCollide );
+    static bool                         SetElementCollidableWith            ( CClientEntity& Entity, const char* szTypeName, bool bCanCollide, bool bOnlyCreated );
     static bool                         SetElementFrozen                    ( CClientEntity& Entity, bool bFrozen );
     static bool                         SetLowLodElement                    ( CClientEntity& Entity, CClientEntity* pLowLodEntity );
     static bool                         SetElementCallPropagationEnabled    ( CClientEntity& Entity, bool bEnabled );

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -2183,7 +2183,7 @@ int CLuaElementDefs::SetElementCollidableWith ( lua_State* luaVM )
 
 
 int CLuaElementDefs::SetElementCollidableWithType ( lua_State* luaVM ) {
-    // bool SetElementCollidableWithType ( element theElement, string withType, bool enabled[, bool onlyWithCreated = false] )  
+    // bool setElementCollidableWithType ( element theElement, string withType, bool enabled[, bool onlyWithCreated = false] )  
     CClientEntity* pEntity = NULL;
     SString strType;
     bool bCanCollide = true;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -2156,24 +2156,49 @@ int CLuaElementDefs::SetElementCollisionsEnabled ( lua_State* luaVM )
 int CLuaElementDefs::SetElementCollidableWith ( lua_State* luaVM )
 {
     CClientEntity* pEntity = NULL;
-    CClientEntity* pWithEntity = NULL;
     bool bCanCollide = true;
     CScriptArgReader argStream ( luaVM );
     argStream.ReadUserData ( pEntity );
-    argStream.ReadUserData ( pWithEntity );
-    argStream.ReadBool ( bCanCollide );
-
-    // Verify the arguments
-    if ( !argStream.HasErrors () )
+    // bool setElementCollidableWith ( element theElement, element withElement, bool enabled ) 
+    if ( argStream.NextIsUserData() ) 
     {
-        if ( CStaticFunctionDefinitions::SetElementCollidableWith ( *pEntity, *pWithEntity, bCanCollide ) )
+        CClientEntity* pWithEntity = NULL;
+        argStream.ReadUserData ( pWithEntity );
+        argStream.ReadBool ( bCanCollide );
+
+        // Verify the arguments
+        if ( !argStream.HasErrors () )
         {
-            lua_pushboolean ( luaVM, true );
-            return 1;
+            if ( CStaticFunctionDefinitions::SetElementCollidableWith ( *pEntity, *pWithEntity, bCanCollide ) )
+            {
+                lua_pushboolean ( luaVM, true );
+                return 1;
+            }
         }
+        else
+            m_pScriptDebugging->LogCustom ( luaVM, argStream.GetFullErrorMessage () );
     }
-    else
-        m_pScriptDebugging->LogCustom ( luaVM, argStream.GetFullErrorMessage () );
+    // bool setElementCollidableWith ( element theElement, string withType, bool enabled )  
+    else     
+    {
+        SString strType; 
+        bool bOnlyCreated;
+        argStream.ReadString ( strType );
+        argStream.ReadBool ( bCanCollide );
+        argStream.ReadBool ( bOnlyCreated, false );
+
+        // Verify the arguments
+        if ( !argStream.HasErrors () )
+        {
+            if ( CStaticFunctionDefinitions::SetElementCollidableWith ( *pEntity, strType.c_str (), bCanCollide, bOnlyCreated ) )
+            {
+                lua_pushboolean ( luaVM, true );
+                return 1;
+            }
+        }
+        else
+            m_pScriptDebugging->LogCustom ( luaVM, argStream.GetFullErrorMessage () );
+    }
 
     lua_pushboolean ( luaVM, false );
     return 1;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -2184,7 +2184,7 @@ int CLuaElementDefs::SetElementCollidableWith ( lua_State* luaVM )
 
 int CLuaElementDefs::SetElementCollidableWithType ( lua_State* luaVM ) {
     // bool setElementCollidableWithType ( element theElement, string withType, bool enabled[, bool onlyWithCreated = false] )  
-    CClientEntity* pEntity = NULL;
+    CClientEntity* pEntity = nullptr;
     SString strType;
     bool bCanCollide = true;
     bool bOnlyWithCreated = false;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -85,6 +85,7 @@ void CLuaElementDefs::LoadFunctions ( void )
     CLuaCFunctions::AddFunction ( "setElementStreamable", SetElementStreamable );
     CLuaCFunctions::AddFunction ( "setElementCollisionsEnabled", SetElementCollisionsEnabled );
     CLuaCFunctions::AddFunction ( "setElementCollidableWith", SetElementCollidableWith );
+    CLuaCFunctions::AddFunction ( "setElementCollidableWithType", SetElementCollidableWithType );
     CLuaCFunctions::AddFunction ( "setElementDoubleSided", SetElementDoubleSided );
     CLuaCFunctions::AddFunction ( "setElementFrozen", SetElementFrozen );
     CLuaCFunctions::AddFunction ( "setLowLODElement", SetLowLodElement );
@@ -167,6 +168,7 @@ void CLuaElementDefs::AddClass ( lua_State* luaVM )
     lua_classfunction ( luaVM, "setModel", "setElementModel" );
     lua_classfunction ( luaVM, "setCollisionsEnabled", "setElementCollisionsEnabled" );
     lua_classfunction ( luaVM, "setCollidableWith", "setElementCollidableWith" );
+    lua_classfunction ( luaVM, "setCollidableWithType", "setElementCollidableWithType" );
     lua_classfunction ( luaVM, "setFrozen", "setElementFrozen" );
     lua_classfunction ( luaVM, "setLowLOD", "setLowLODElement" );
     lua_classfunction ( luaVM, "setCallPropagationEnabled", "setElementCallPropagationEnabled" );
@@ -2156,54 +2158,56 @@ int CLuaElementDefs::SetElementCollisionsEnabled ( lua_State* luaVM )
 int CLuaElementDefs::SetElementCollidableWith ( lua_State* luaVM )
 {
     CClientEntity* pEntity = NULL;
+    CClientEntity* pWithEntity = NULL;
     bool bCanCollide = true;
     CScriptArgReader argStream ( luaVM );
     argStream.ReadUserData ( pEntity );
-    // bool setElementCollidableWith ( element theElement, element withElement, bool enabled ) 
-    if ( argStream.NextIsUserData() ) 
-    {
-        CClientEntity* pWithEntity = NULL;
-        argStream.ReadUserData ( pWithEntity );
-        argStream.ReadBool ( bCanCollide );
+    argStream.ReadUserData ( pWithEntity );
+    argStream.ReadBool ( bCanCollide );
 
-        // Verify the arguments
-        if ( !argStream.HasErrors () )
-        {
-            if ( CStaticFunctionDefinitions::SetElementCollidableWith ( *pEntity, *pWithEntity, bCanCollide ) )
-            {
-                lua_pushboolean ( luaVM, true );
-                return 1;
-            }
-        }
-        else
-            m_pScriptDebugging->LogCustom ( luaVM, argStream.GetFullErrorMessage () );
-    }
-    // bool setElementCollidableWith ( element theElement, string withType, bool enabled )  
-    else     
+    // Verify the arguments
+    if ( !argStream.HasErrors () )
     {
-        SString strType; 
-        bool bOnlyCreated;
-        argStream.ReadString ( strType );
-        argStream.ReadBool ( bCanCollide );
-        argStream.ReadBool ( bOnlyCreated, false );
-
-        // Verify the arguments
-        if ( !argStream.HasErrors () )
+        if ( CStaticFunctionDefinitions::SetElementCollidableWith ( *pEntity, *pWithEntity, bCanCollide ) )
         {
-            if ( CStaticFunctionDefinitions::SetElementCollidableWith ( *pEntity, strType.c_str (), bCanCollide, bOnlyCreated ) )
-            {
-                lua_pushboolean ( luaVM, true );
-                return 1;
-            }
+            lua_pushboolean ( luaVM, true );
+            return 1;
         }
-        else
-            m_pScriptDebugging->LogCustom ( luaVM, argStream.GetFullErrorMessage () );
     }
+    else
+        m_pScriptDebugging->LogCustom ( luaVM, argStream.GetFullErrorMessage () );
 
     lua_pushboolean ( luaVM, false );
     return 1;
 }
 
+
+int CLuaElementDefs::SetElementCollidableWithType ( lua_State* luaVM ) {
+    // bool SetElementCollidableWithType ( element theElement, string withType, bool enabled, bool onlyWithCreated = false )  
+    CClientEntity* pEntity = NULL;
+    SString strType;
+    bool bCanCollide = true;
+    bool bOnlyWithCreated = false;
+    CScriptArgReader argStream ( luaVM );
+    argStream.ReadUserData ( pEntity );
+    argStream.ReadString ( strType );
+    argStream.ReadBool ( bCanCollide );
+    argStream.ReadBool ( bOnlyWithCreated, false );
+
+    // Verify the arguments
+    if ( !argStream.HasErrors () )
+    {
+        if ( CStaticFunctionDefinitions::SetElementCollidableWithType ( *pEntity, strType.c_str (), bCanCollide, bOnlyWithCreated ) )
+        {
+            lua_pushboolean ( luaVM, true );
+            return 1;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom ( luaVM, argStream.GetFullErrorMessage () );
+    lua_pushboolean ( luaVM, false );
+    return 1;
+}
 
 int CLuaElementDefs::SetElementDoubleSided ( lua_State* luaVM )
 {

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -2183,7 +2183,7 @@ int CLuaElementDefs::SetElementCollidableWith ( lua_State* luaVM )
 
 
 int CLuaElementDefs::SetElementCollidableWithType ( lua_State* luaVM ) {
-    // bool SetElementCollidableWithType ( element theElement, string withType, bool enabled, bool onlyWithCreated = false )  
+    // bool SetElementCollidableWithType ( element theElement, string withType, bool enabled[, bool onlyWithCreated = false] )  
     CClientEntity* pEntity = NULL;
     SString strType;
     bool bCanCollide = true;
@@ -2194,7 +2194,6 @@ int CLuaElementDefs::SetElementCollidableWithType ( lua_State* luaVM ) {
     argStream.ReadBool ( bCanCollide );
     argStream.ReadBool ( bOnlyWithCreated, false );
 
-    // Verify the arguments
     if ( !argStream.HasErrors () )
     {
         if ( CStaticFunctionDefinitions::SetElementCollidableWithType ( *pEntity, strType.c_str (), bCanCollide, bOnlyWithCreated ) )

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
@@ -88,6 +88,7 @@ public:
     LUA_DECLARE ( SetElementStreamable );
     LUA_DECLARE ( SetElementModel );
     LUA_DECLARE ( SetElementCollidableWith );
+    LUA_DECLARE ( SetElementCollidableWithType );
     LUA_DECLARE ( SetElementDoubleSided );
     LUA_DECLARE ( SetElementFrozen );
     LUA_DECLARE ( SetLowLodElement );


### PR DESCRIPTION
With this function you can disable the collision of a element with all the elements of a type and also new created ones.
I had struggles to create this kind of script in my newbie-times and also experienced many other new scripters having problems. So why not create a simple function which does, what you want?

Syntax:
bool setElementCollidableWithType ( element theElement, string withType, bool enabled[, bool onlyWithCreated = false ])

Use "onlyWithCreated" if you don't want to consider new created elements (like it is right now in setElementCollidableWith).

Oh and the first commits could be strange.
Wanted to overload the setElementCollidableWith function, then decided to create a new function.