### PR TITLE
0009760: Add Team:getPlayers to clientside

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaTeamDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaTeamDefs.cpp
@@ -33,6 +33,7 @@ void CLuaTeamDefs::AddClass ( lua_State* luaVM )
     lua_classfunction ( luaVM, "getFriendlyFire", "getTeamFriendlyFire" );
     lua_classfunction ( luaVM, "getName", "getTeamName" );
     lua_classfunction ( luaVM, "getColor", "getTeamColor" );
+    lua_classfunction ( luaVM, "getPlayers", "getPlayersInTeam" );
 
     lua_classvariable ( luaVM, "playerCount", NULL, "countPlayersInTeam" );
     lua_classvariable ( luaVM, "friendlyFire", NULL, "getTeamFriendlyFire" );


### PR DESCRIPTION
Add Team.getPlayers to clientside, it's missing.

Bugtracker:
https://bugs.mtasa.com/view.php?id=9760

Had a similar pull request some weeks ago, but it's not the same:
https://github.com/multitheftauto/mtasa-blue/pull/168

Tested
