### PR TITLE
add dxDrawTriangle

### DIFF
--- a/Client/core/Graphics/CGraphics.cpp
+++ b/Client/core/Graphics/CGraphics.cpp
@@ -766,19 +766,23 @@ void CGraphics::DrawTriangleQueued ( CVector2D vecPos1,
                                      unsigned long ulColorVert3,
                                      bool bPostGUI )
 {
-    //if (g_pCore->IsWindowMinimized ())
-    //    return;
+    // Prevent queuing when minimized
+    if (g_pCore->IsWindowMinimized ())
+    {
+        m_pTriangleBatcherPreGUI->ClearQueue ();
+        m_pTriangleBatcherPostGUI->ClearQueue ();
+        return;
+    }
 
     vecPos1.fY = m_pAspectRatioConverter->ConvertPositionForAspectRatio ( vecPos1.fY );
     vecPos2.fY = m_pAspectRatioConverter->ConvertPositionForAspectRatio ( vecPos2.fY );
     vecPos3.fY = m_pAspectRatioConverter->ConvertPositionForAspectRatio ( vecPos3.fY );
 
     // Add it to the queue
-    if (bPostGUI)
+    if (bPostGUI && !CCore::GetSingleton ().IsMenuVisible ())
         m_pTriangleBatcherPostGUI->AddTriangle ( vecPos1, vecPos2, vecPos3, ulColorVert1, ulColorVert2, ulColorVert3 );
     else
         m_pTriangleBatcherPreGUI->AddTriangle ( vecPos1, vecPos2, vecPos3, ulColorVert1, ulColorVert2, ulColorVert3 );
-
 }
 
 void CGraphics::DrawLineQueued ( float fX1, float fY1,
@@ -1692,6 +1696,8 @@ void CGraphics::OnChangingRenderTarget ( uint uiNewViewportSizeX, uint uiNewView
     DrawPreGUIQueue ();
     // Inform tile batcher
     m_pTileBatcher->OnChangingRenderTarget ( uiNewViewportSizeX, uiNewViewportSizeY );
+    m_pTriangleBatcherPreGUI->OnChangingRenderTarget ( uiNewViewportSizeX, uiNewViewportSizeY );
+    m_pTriangleBatcherPostGUI->OnChangingRenderTarget ( uiNewViewportSizeX, uiNewViewportSizeY );
 }
 
 

--- a/Client/core/Graphics/CGraphics.h
+++ b/Client/core/Graphics/CGraphics.h
@@ -30,6 +30,7 @@ class CGraphics;
 
 class CTileBatcher;
 class CLine3DBatcher;
+class CTriangleBatcher;
 class CMaterialLine3DBatcher;
 class CAspectRatioConverter;
 struct IDirect3DDevice9;
@@ -124,6 +125,14 @@ public:
     void                SetCursorPosition       ( int iX, int iY, DWORD Flags );
 
     // Queued up drawing funcs
+    void                DrawTriangleQueued      ( CVector2D vecPos1,
+                                                  CVector2D vecPos2,
+                                                  CVector2D vecPos3,
+                                                  unsigned long ulColorVert1,
+                                                  unsigned long ulColorVert2,
+                                                  unsigned long ulColorVert3,
+                                                  bool bPostGUI );
+
     void                DrawLineQueued          ( float fX1, float fY1,
                                                   float fX2, float fY2,
                                                   float fWidth,
@@ -241,6 +250,8 @@ private:
     CTileBatcher*               m_pTileBatcher;
     CLine3DBatcher*             m_pLine3DBatcherPreGUI;
     CLine3DBatcher*             m_pLine3DBatcherPostGUI;
+    CTriangleBatcher*           m_pTriangleBatcherPreGUI;
+    CTriangleBatcher*           m_pTriangleBatcherPostGUI;
     CMaterialLine3DBatcher*     m_pMaterialLine3DBatcher;
     CAspectRatioConverter*      m_pAspectRatioConverter;
 

--- a/Client/core/Graphics/CTriangleBatcher.cpp
+++ b/Client/core/Graphics/CTriangleBatcher.cpp
@@ -178,7 +178,7 @@ void CTriangleBatcher::Flush ( void )
 //
 // CTriangleBatcher::ClearQueue
 //
-// Clears all triangles for current queue
+// Clears all triangles in current queue
 //
 ////////////////////////////////////////////////////////////////
 void CTriangleBatcher::ClearQueue ()

--- a/Client/core/Graphics/CTriangleBatcher.cpp
+++ b/Client/core/Graphics/CTriangleBatcher.cpp
@@ -1,0 +1,135 @@
+/*****************************************************************************
+*
+*  PROJECT:     Multi Theft Auto v1.0
+*               (Shared logic for modifications)
+*  LICENSE:     See LICENSE in the top level directory
+*  FILE:        CTriangleBatcher.cpp
+*  PURPOSE:
+*  DEVELOPERS:  forkerer, based on CLine3DBatcher by vidiot
+*
+*
+*****************************************************************************/
+
+#include <StdInc.h>
+#include "CTriangleBatcher.h"
+
+////////////////////////////////////////////////////////////////
+//
+// CTriangleBatcher::CTriangleBatcher
+//
+//
+//
+////////////////////////////////////////////////////////////////
+CTriangleBatcher::CTriangleBatcher ( bool m_bZTest )
+{
+    m_bZTest = m_bZTest;
+}
+
+
+////////////////////////////////////////////////////////////////
+//
+// CTriangleBatcher::~CTriangleBatcher
+//
+//
+//
+////////////////////////////////////////////////////////////////
+CTriangleBatcher::~CTriangleBatcher ( void )
+{
+}
+
+
+////////////////////////////////////////////////////////////////
+//
+// CTriangleBatcher::OnDeviceCreate
+//
+//
+//
+////////////////////////////////////////////////////////////////
+void CTriangleBatcher::OnDeviceCreate ( IDirect3DDevice9* pDevice, float fViewportSizeX, float fViewportSizeY )
+{
+    m_pDevice = pDevice;
+}
+
+
+////////////////////////////////////////////////////////////////
+//
+// CTriangleBatcher::Flush
+//
+// Send all buffered vertices to D3D
+//
+////////////////////////////////////////////////////////////////
+void CTriangleBatcher::Flush ( void )
+{
+    if (m_triangleList.empty ())
+        return;
+    
+    // Save render states
+    IDirect3DStateBlock9* pSavedStateBlock = NULL;
+    m_pDevice->CreateStateBlock ( D3DSBT_ALL, &pSavedStateBlock );
+
+    // Set vertex stream
+    uint PrimitiveCount = m_triangleList.size()/3;
+    const void* pVertexStreamZeroData = &m_triangleList[0];
+    uint VertexStreamZeroStride = sizeof ( TriangleVertice );
+    m_pDevice->SetFVF ( D3DFVF_XYZRHW | D3DFVF_DIFFUSE );
+    
+    // Set states
+    m_pDevice->SetRenderState ( D3DRS_ZENABLE, m_bZTest ? D3DZB_TRUE : D3DZB_FALSE );
+    m_pDevice->SetRenderState ( D3DRS_ZFUNC, D3DCMP_LESSEQUAL );
+    m_pDevice->SetRenderState ( D3DRS_ZWRITEENABLE, FALSE );
+    m_pDevice->SetRenderState ( D3DRS_CULLMODE, D3DCULL_NONE );
+    m_pDevice->SetRenderState ( D3DRS_SHADEMODE, D3DSHADE_GOURAUD );
+    m_pDevice->SetRenderState ( D3DRS_ALPHABLENDENABLE, TRUE );
+    m_pDevice->SetRenderState ( D3DRS_SRCBLEND, D3DBLEND_SRCALPHA );
+    m_pDevice->SetRenderState ( D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA );
+    m_pDevice->SetRenderState ( D3DRS_ALPHATESTENABLE, TRUE );
+    m_pDevice->SetRenderState ( D3DRS_ALPHAREF, 0x01 );
+    m_pDevice->SetRenderState ( D3DRS_ALPHAFUNC, D3DCMP_GREATEREQUAL );
+    m_pDevice->SetRenderState ( D3DRS_LIGHTING, FALSE );
+    m_pDevice->SetTextureStageState ( 0, D3DTSS_COLOROP, D3DTOP_SELECTARG2 );
+    m_pDevice->SetTextureStageState ( 0, D3DTSS_COLORARG2, D3DTA_DIFFUSE );
+    m_pDevice->SetTextureStageState ( 0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG2 );
+    m_pDevice->SetTextureStageState ( 0, D3DTSS_ALPHAARG2, D3DTA_DIFFUSE );
+    m_pDevice->SetTextureStageState ( 1, D3DTSS_COLOROP, D3DTOP_DISABLE );
+    m_pDevice->SetTextureStageState ( 1, D3DTSS_ALPHAOP, D3DTOP_DISABLE );
+
+    // Draw
+    m_pDevice->SetTexture ( 0, NULL );
+    m_pDevice->DrawPrimitiveUP ( D3DPT_TRIANGLELIST, PrimitiveCount, pVertexStreamZeroData, VertexStreamZeroStride );
+
+    // Clean up
+    size_t prevSize = m_triangleList.size ();
+    m_triangleList.clear ();
+    m_triangleList.reserve ( prevSize );
+
+    // Restore render states
+    if (pSavedStateBlock)
+    {
+        pSavedStateBlock->Apply ();
+        SAFE_RELEASE ( pSavedStateBlock );
+    }
+}
+
+
+////////////////////////////////////////////////////////////////
+//
+// CTriangleBatcher::AddTriangle
+//
+// Add a new triangle to the list
+//
+////////////////////////////////////////////////////////////////
+void CTriangleBatcher::AddTriangle ( CVector2D vecPos1,
+                                     CVector2D vecPos2,
+                                     CVector2D vecPos3,
+                                     unsigned long ulColorVert1,
+                                     unsigned long ulColorVert2,
+                                     unsigned long ulColorVert3 )
+{
+    TriangleVertice vert1 = { vecPos1.fX,vecPos1.fY, 0, 1, ulColorVert1 };
+    TriangleVertice vert2 = { vecPos2.fX,vecPos2.fY, 0, 1, ulColorVert2 };
+    TriangleVertice vert3 = { vecPos3.fX,vecPos3.fY, 0, 1, ulColorVert3 };
+
+    m_triangleList.push_back ( vert1 );
+    m_triangleList.push_back ( vert2 );
+    m_triangleList.push_back ( vert3 );
+}

--- a/Client/core/Graphics/CTriangleBatcher.cpp
+++ b/Client/core/Graphics/CTriangleBatcher.cpp
@@ -163,9 +163,7 @@ void CTriangleBatcher::Flush ( void )
     m_pDevice->DrawPrimitiveUP ( D3DPT_TRIANGLELIST, PrimitiveCount, pVertexStreamZeroData, VertexStreamZeroStride );
 
     // Clean up
-    size_t prevSize = m_triangleList.size ();
-    m_triangleList.clear ();
-    m_triangleList.reserve ( prevSize );
+    ClearQueue ();
 
     // Restore render states
     if (pSavedStateBlock)

--- a/Client/core/Graphics/CTriangleBatcher.cpp
+++ b/Client/core/Graphics/CTriangleBatcher.cpp
@@ -5,7 +5,7 @@
 *  LICENSE:     See LICENSE in the top level directory
 *  FILE:        CTriangleBatcher.cpp
 *  PURPOSE:
-*  DEVELOPERS:  forkerer, based on CLine3DBatcher by vidiot
+*  DEVELOPERS:  forkerer, based on CLine3DBatcher and CTileBatcher by vidiot
 *
 *
 *****************************************************************************/
@@ -48,6 +48,63 @@ CTriangleBatcher::~CTriangleBatcher ( void )
 void CTriangleBatcher::OnDeviceCreate ( IDirect3DDevice9* pDevice, float fViewportSizeX, float fViewportSizeY )
 {
     m_pDevice = pDevice;
+
+    // Cache matrices
+    UpdateMatrices ( fViewportSizeX, fViewportSizeY );
+}
+
+////////////////////////////////////////////////////////////////
+//
+// CTriangleBatcher::OnRenderTargetChange
+//
+//
+//
+////////////////////////////////////////////////////////////////
+void CTriangleBatcher::OnChangingRenderTarget ( uint uiNewViewportSizeX, uint uiNewViewportSizeY )
+{
+    // Flush dx draws
+    Flush ();
+
+    // Make new projection transform
+    UpdateMatrices ( uiNewViewportSizeX, uiNewViewportSizeY );
+}
+
+
+////////////////////////////////////////////////////////////////
+//
+// CTriangleBatcher::UpdateMatrices
+//
+//
+//
+////////////////////////////////////////////////////////////////
+void CTriangleBatcher::UpdateMatrices ( float fViewportSizeX, float fViewportSizeY )
+{
+    m_fViewportSizeX = fViewportSizeX;
+    m_fViewportSizeY = fViewportSizeY;
+
+    D3DXMatrixIdentity ( &m_MatView );
+    D3DXMatrixIdentity ( &m_MatProjection );
+
+    // Make projection 3D friendly, so shaders can alter the z coord for fancy effects
+    float fFarPlane = 10000;
+    float fNearPlane = 100;
+    float Q = fFarPlane / (fFarPlane - fNearPlane);
+    float fAdjustZFactor = 1000.f;
+    float rcpSizeX = 2.0f / m_fViewportSizeX;
+    float rcpSizeY = -2.0f / m_fViewportSizeY;
+    rcpSizeX *= fAdjustZFactor;
+    rcpSizeY *= fAdjustZFactor;
+
+    m_MatProjection.m[0][0] = rcpSizeX;
+    m_MatProjection.m[1][1] = rcpSizeY;
+    m_MatProjection.m[2][2] = Q;
+    m_MatProjection.m[2][3] = 1;
+    m_MatProjection.m[3][0] = (-m_fViewportSizeX / 2.0f - 0.5f) * rcpSizeX;
+    m_MatProjection.m[3][1] = (-m_fViewportSizeY / 2.0f - 0.5f) * rcpSizeY;
+    m_MatProjection.m[3][2] = -Q * fNearPlane;
+    m_MatProjection.m[3][3] = 0;
+
+    m_MatView.m[3][2] = fAdjustZFactor;
 }
 
 
@@ -67,11 +124,19 @@ void CTriangleBatcher::Flush ( void )
     IDirect3DStateBlock9* pSavedStateBlock = NULL;
     m_pDevice->CreateStateBlock ( D3DSBT_ALL, &pSavedStateBlock );
 
+    // Set transformations
+    D3DXMATRIX matWorld;
+    D3DXMatrixIdentity ( &matWorld );
+
+    m_pDevice->SetTransform ( D3DTS_WORLD, &matWorld );
+    m_pDevice->SetTransform ( D3DTS_VIEW, &m_MatView );
+    m_pDevice->SetTransform ( D3DTS_PROJECTION, &m_MatProjection );
+
     // Set vertex stream
     uint PrimitiveCount = m_triangleList.size()/3;
     const void* pVertexStreamZeroData = &m_triangleList[0];
     uint VertexStreamZeroStride = sizeof ( TriangleVertice );
-    m_pDevice->SetFVF ( D3DFVF_XYZRHW | D3DFVF_DIFFUSE );
+    m_pDevice->SetFVF ( D3DFVF_XYZ | D3DFVF_DIFFUSE );
     
     // Set states
     m_pDevice->SetRenderState ( D3DRS_ZENABLE, m_bZTest ? D3DZB_TRUE : D3DZB_FALSE );
@@ -113,6 +178,22 @@ void CTriangleBatcher::Flush ( void )
 
 ////////////////////////////////////////////////////////////////
 //
+// CTriangleBatcher::ClearQueue
+//
+// Clears all triangles for current queue
+//
+////////////////////////////////////////////////////////////////
+void CTriangleBatcher::ClearQueue ()
+{
+    // Clean up
+    size_t prevSize = m_triangleList.size ();
+    m_triangleList.clear ();
+    m_triangleList.reserve ( prevSize );
+}
+
+
+////////////////////////////////////////////////////////////////
+//
 // CTriangleBatcher::AddTriangle
 //
 // Add a new triangle to the list
@@ -125,9 +206,9 @@ void CTriangleBatcher::AddTriangle ( CVector2D vecPos1,
                                      unsigned long ulColorVert2,
                                      unsigned long ulColorVert3 )
 {
-    TriangleVertice vert1 = { vecPos1.fX,vecPos1.fY, 0, 1, ulColorVert1 };
-    TriangleVertice vert2 = { vecPos2.fX,vecPos2.fY, 0, 1, ulColorVert2 };
-    TriangleVertice vert3 = { vecPos3.fX,vecPos3.fY, 0, 1, ulColorVert3 };
+    TriangleVertice vert1 = { vecPos1.fX,vecPos1.fY, 0, ulColorVert1 };
+    TriangleVertice vert2 = { vecPos2.fX,vecPos2.fY, 0, ulColorVert2 };
+    TriangleVertice vert3 = { vecPos3.fX,vecPos3.fY, 0, ulColorVert3 };
 
     m_triangleList.push_back ( vert1 );
     m_triangleList.push_back ( vert2 );

--- a/Client/core/Graphics/CTriangleBatcher.h
+++ b/Client/core/Graphics/CTriangleBatcher.h
@@ -1,0 +1,43 @@
+/*****************************************************************************
+*
+*  PROJECT:     Multi Theft Auto v1.0
+*  LICENSE:     See LICENSE in the top level directory
+*  FILE:        CTriangleBatcher.h
+*  PURPOSE:
+*  DEVELOPERS:  forkerer, based on CLine3DBatcher by vidiot
+*
+*
+*****************************************************************************/
+
+// Vertex type used by the triangle batcher
+struct TriangleVertice
+{
+    float   x, y, z, w;
+    SColor  color;
+};
+
+
+//
+// Batches triangle drawing
+// 
+class CTriangleBatcher
+{
+public:
+    ZERO_ON_NEW
+                CTriangleBatcher    ( bool m_bZTest );
+                ~CTriangleBatcher   ( void );
+
+        void    OnDeviceCreate      ( IDirect3DDevice9* pDevice, float fViewportSizeX, float fViewportSizeY );
+        void    Flush               ( void );
+        void    AddTriangle         ( CVector2D vecPos1,
+                                      CVector2D vecPos2,
+                                      CVector2D vecPos3,
+                                      unsigned long ulColorVert1,
+                                      unsigned long ulColorVert2,
+                                      unsigned long ulColorVert3 );
+
+protected:
+    bool                            m_bZTest;
+    IDirect3DDevice9*               m_pDevice;
+    std::vector < TriangleVertice > m_triangleList;
+};

--- a/Client/core/Graphics/CTriangleBatcher.h
+++ b/Client/core/Graphics/CTriangleBatcher.h
@@ -4,7 +4,7 @@
 *  LICENSE:     See LICENSE in the top level directory
 *  FILE:        CTriangleBatcher.h
 *  PURPOSE:
-*  DEVELOPERS:  forkerer, based on CLine3DBatcher by vidiot
+*  DEVELOPERS:  forkerer, based on CLine3DBatcher and CTileBatcher by vidiot
 *
 *
 *****************************************************************************/
@@ -12,7 +12,7 @@
 // Vertex type used by the triangle batcher
 struct TriangleVertice
 {
-    float   x, y, z, w;
+    float   x, y, z;
     SColor  color;
 };
 
@@ -24,20 +24,27 @@ class CTriangleBatcher
 {
 public:
     ZERO_ON_NEW
-                CTriangleBatcher    ( bool m_bZTest );
-                ~CTriangleBatcher   ( void );
+                CTriangleBatcher        ( bool m_bZTest );
+                ~CTriangleBatcher       ( void );
 
-        void    OnDeviceCreate      ( IDirect3DDevice9* pDevice, float fViewportSizeX, float fViewportSizeY );
-        void    Flush               ( void );
-        void    AddTriangle         ( CVector2D vecPos1,
-                                      CVector2D vecPos2,
-                                      CVector2D vecPos3,
-                                      unsigned long ulColorVert1,
-                                      unsigned long ulColorVert2,
-                                      unsigned long ulColorVert3 );
+        void    OnDeviceCreate          ( IDirect3DDevice9* pDevice, float fViewportSizeX, float fViewportSizeY );
+        void    OnChangingRenderTarget  ( uint uiNewViewportSizeX, uint uiNewViewportSizeY );
+        void    UpdateMatrices          ( float fViewportSizeX, float fViewportSizeY );
+        void    Flush                   ( void );
+        void    ClearQueue              ( void );
+        void    AddTriangle             ( CVector2D vecPos1,
+                                          CVector2D vecPos2,
+                                          CVector2D vecPos3,
+                                          unsigned long ulColorVert1,
+                                          unsigned long ulColorVert2,
+                                          unsigned long ulColorVert3 );
 
 protected:
     bool                            m_bZTest;
     IDirect3DDevice9*               m_pDevice;
     std::vector < TriangleVertice > m_triangleList;
+    float                       m_fViewportSizeX;
+    float                       m_fViewportSizeY;
+    D3DXMATRIX                  m_MatView;
+    D3DXMATRIX                  m_MatProjection;
 };

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -15,6 +15,7 @@ extern bool g_bAllowAspectRatioAdjustment;
 
 void CLuaDrawingDefs::LoadFunctions ( void )
 {
+    CLuaCFunctions::AddFunction ( "dxDrawTriangle", DxDrawTriangle );
     CLuaCFunctions::AddFunction ( "dxDrawLine", DxDrawLine );
     CLuaCFunctions::AddFunction ( "dxDrawMaterialLine3D", DxDrawMaterialLine3D );
     CLuaCFunctions::AddFunction ( "dxDrawMaterialSectionLine3D", DxDrawMaterialSectionLine3D );
@@ -134,6 +135,34 @@ void CLuaDrawingDefs::AddDxRenderTargetClass ( lua_State* luaVM )
     lua_classfunction ( luaVM, "setAsTarget", "dxSetRenderTarget" );
 
     lua_registerclass ( luaVM, "DxRenderTarget", "DxTexture" );
+}
+
+int CLuaDrawingDefs::DxDrawTriangle ( lua_State* luaVM )
+{
+    //  bool dxDrawLine ( int startX, int startY, int endX, int endY, int color, [float width=1, bool postGUI=false] )
+    CVector2D vecPos1; CVector2D vecPos2; CVector2D vecPos3; SColor ulColorVert1; SColor ulColorVert2; SColor ulColorVert3; bool bPostGUI;
+
+    CScriptArgReader argStream ( luaVM );
+    argStream.ReadVector2D ( vecPos1 );
+    argStream.ReadVector2D ( vecPos2 );
+    argStream.ReadVector2D ( vecPos3 );
+    argStream.ReadColor ( ulColorVert1, 0xFFFFFFFF );
+    argStream.ReadColor ( ulColorVert2, ulColorVert1 );
+    argStream.ReadColor ( ulColorVert3, ulColorVert1 );
+    argStream.ReadBool ( bPostGUI, false );
+
+    if (!argStream.HasErrors ())
+    {
+        g_pCore->GetGraphics ()->DrawTriangleQueued ( vecPos1, vecPos2, vecPos3, ulColorVert1, ulColorVert2, ulColorVert3, bPostGUI );
+        lua_pushboolean ( luaVM, true );
+        return 1;
+    }
+    else
+        m_pScriptDebugging->LogCustom ( luaVM, argStream.GetFullErrorMessage () );
+
+    // Failed
+    lua_pushboolean ( luaVM, false );
+    return 1;
 }
 
 int CLuaDrawingDefs::DxDrawLine ( lua_State* luaVM )

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -139,7 +139,7 @@ void CLuaDrawingDefs::AddDxRenderTargetClass ( lua_State* luaVM )
 
 int CLuaDrawingDefs::DxDrawTriangle ( lua_State* luaVM )
 {
-    //  bool dxDrawLine ( int startX, int startY, int endX, int endY, int color, [float width=1, bool postGUI=false] )
+    //  bool dxDrawTriangle ( vec2 posVert1, vec2 posVert2, vec2 posVert3, [int colorVert1, int colorVert2, int colorVert3, bool postGUI=false] )
     CVector2D vecPos1; CVector2D vecPos2; CVector2D vecPos3; SColor ulColorVert1; SColor ulColorVert2; SColor ulColorVert3; bool bPostGUI;
 
     CScriptArgReader argStream ( luaVM );

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.h
@@ -18,6 +18,7 @@ public:
     static void LoadFunctions ( void );
     static void AddClass ( lua_State* luaVM );
 
+    LUA_DECLARE ( DxDrawTriangle );
     LUA_DECLARE ( DxDrawLine );
     LUA_DECLARE ( DxDrawLine3D );
     LUA_DECLARE ( DxDrawMaterialLine3D );

--- a/Client/sdk/core/CGraphicsInterface.h
+++ b/Client/sdk/core/CGraphicsInterface.h
@@ -105,6 +105,14 @@ public:
     virtual void                    DrawTexture         ( CTextureItem* texture, float fX, float fY, float fScaleX = 1.0f, float fScaleY = 1.0f, float fRotation = 0.0f, float fCenterX = 0.0f, float fCenterY = 0.0f, DWORD dwColor = 0xFFFFFFFF, float fU = 0, float fV = 0, float fSizeU = 1, float fSizeV = 1, bool bRelativeUV = true ) = 0;
 
     // Queued up drawing
+    virtual void                    DrawTriangleQueued  ( CVector2D vecPos1,
+                                                          CVector2D vecPos2,
+                                                          CVector2D vecPos3,
+                                                          unsigned long ulColorVert1,
+                                                          unsigned long ulColorVert2,
+                                                          unsigned long ulColorVert3,
+                                                          bool bPostGUI ) = 0;
+
     virtual void                    DrawLineQueued      ( float fX1, float fY1,
                                                           float fX2, float fY2,
                                                           float fWidth,


### PR DESCRIPTION
Since there is currently no easy way to draw triangles in MTA, and they are most basic shape that can be used to draw any other shape, i decided to add dxDrawTriangle function.

This branch contains 2 new files, CTriangleBatcher.cpp and CTriangleBatcher.h, used system is similiar to (and based on) ones used currently in dxDrawLine3D or dxDrawImage, all triangles can be drawn either PreGUI or PostGUI.
There are no problems with drawing on RenderTargets.
The function looks like this:
`bool dxDrawTriangle( vec2 posVert1, vec2 posVert2, vec2 posVert3, [int colorVert1, int colorVert2, int colorVert3, bool postGUI=false] )`
If only first color is specified, all vertices will share that color, otherwise the color is interpolated between vertices.
Example image:
[solid color triangle, gradient, and triangle using alpha](https://imgur.com/a/mTpXY)