### PR TITLE
Avoid using va_pass in functions exposed to modules

### DIFF
--- a/Client/mods/deathmatch/logic/CScriptDebugging.h
+++ b/Client/mods/deathmatch/logic/CScriptDebugging.h
@@ -42,6 +42,7 @@ public:
 
     void LogCustom(lua_State* luaVM, unsigned char ucRed, unsigned char ucGreen, unsigned char ucBlue, const char* szFormat, ...);
     void LogInformation(lua_State* luaVM, const char* szFormat, ...);
+    void LogInformationv(lua_State* luaVM, const char* szFormat, va_list marker);
     void LogWarning(lua_State* luaVM, const char* szFormat, ...);
     void LogError(lua_State* luaVM, const char* szFormat, ...);
     void LogBadPointer(lua_State* luaVM, const char* szArgumentType, unsigned int uiArgument);

--- a/Server/mods/deathmatch/logic/CLogger.cpp
+++ b/Server/mods/deathmatch/logic/CLogger.cpp
@@ -35,6 +35,16 @@ void CLogger::LogPrintf(const char* szFormat, ...)
     HandleLogPrint(true, "", szBuffer, true, true, false);
 }
 
+void CLogger::LogPrintfv(const char* szFormat, va_list marker)
+{
+    // Compose the formatted message
+    char    szBuffer[MAX_STRING_LENGTH];
+    VSNPRINTF(szBuffer, MAX_STRING_LENGTH, szFormat, marker);
+
+    // Timestamp and send to the console and logfile
+    HandleLogPrint(true, "", szBuffer, true, true, false);
+}
+
 void CLogger::LogPrint(const char* szText)
 {
     // Timestamp and send to the console and logfile
@@ -50,6 +60,16 @@ void CLogger::LogPrintf(eLogLevel logLevel, const char* szFormat, ...)
     va_start(marker, szFormat);
     VSNPRINTF(szBuffer, MAX_STRING_LENGTH, szFormat, marker);
     va_end(marker);
+
+    // Timestamp and send to the console and logfile
+    HandleLogPrint(true, "", szBuffer, true, true, false, logLevel);
+}
+
+void CLogger::LogPrintfv(eLogLevel logLevel, const char* szFormat, va_list marker)
+{
+    // Compose the formatted message
+    char    szBuffer[MAX_STRING_LENGTH];
+    VSNPRINTF(szBuffer, MAX_STRING_LENGTH, szFormat, marker);
 
     // Timestamp and send to the console and logfile
     HandleLogPrint(true, "", szBuffer, true, true, false, logLevel);
@@ -116,6 +136,36 @@ void CLogger::AuthPrintf(const char* szFormat, ...)
     va_start(marker, szFormat);
     VSNPRINTF(szBuffer, MAX_STRING_LENGTH, szFormat, marker);
     va_end(marker);
+
+    // Timestamp and send to the console, logfile and authfile
+    HandleLogPrint(true, "", szBuffer, true, true, true);
+}
+
+void CLogger::ErrorPrintfv(const char* szFormat, va_list marker)
+{
+    // Compose the formatted message
+    char    szBuffer[MAX_STRING_LENGTH];
+    VSNPRINTF(szBuffer, MAX_STRING_LENGTH, szFormat, marker);
+
+    // Timestamp and send to the console and logfile
+    HandleLogPrint(true, "ERROR: ", szBuffer, true, true, false);
+}
+void CLogger::DebugPrintfv(const char* szFormat, va_list marker)
+{
+#ifdef MTA_DEBUG
+    // Compose the formatted message
+    char    szBuffer[MAX_STRING_LENGTH];
+    VSNPRINTF(szBuffer, MAX_STRING_LENGTH, szFormat, marker);
+
+    // Timestamp and send to the console and logfile
+    HandleLogPrint(true, "DEBUG: ", szBuffer, true, true, false);
+#endif
+}
+void CLogger::AuthPrintfv(const char* szFormat, va_list marker)
+{
+    // Compose the formatted message
+    char    szBuffer[MAX_STRING_LENGTH];
+    VSNPRINTF(szBuffer, MAX_STRING_LENGTH, szFormat, marker);
 
     // Timestamp and send to the console, logfile and authfile
     HandleLogPrint(true, "", szBuffer, true, true, true);

--- a/Server/mods/deathmatch/logic/CLogger.h
+++ b/Server/mods/deathmatch/logic/CLogger.h
@@ -24,9 +24,11 @@ class CLogger
 {
 public:
     static void LogPrintf(const char* szFormat, ...);
+    static void LogPrintfv(const char* szFormat, va_list marker);
     static void LogPrint(const char* szText);
 
     static void LogPrintf(eLogLevel logLevel, const char* szFormat, ...);
+    static void LogPrintfv(eLogLevel logLevel, const char* szFormat, va_list marker);
     static void LogPrint(eLogLevel logLevel, const char* szText);
 
     static void LogPrintfNoStamp(const char* szFormat, ...);
@@ -35,6 +37,10 @@ public:
     static void ErrorPrintf(const char* szFormat, ...);
     static void DebugPrintf(const char* szFormat, ...);
     static void AuthPrintf(const char* szFormat, ...);
+    
+    static void ErrorPrintfv(const char* szFormat, va_list marker);
+    static void DebugPrintfv(const char* szFormat, va_list marker);
+    static void AuthPrintfv(const char* szFormat, va_list marker);
 
     static bool SetLogFile(const char* szLogFile);
     static bool SetAuthFile(const char* szAuthFile);

--- a/Server/mods/deathmatch/logic/CScriptDebugging.h
+++ b/Server/mods/deathmatch/logic/CScriptDebugging.h
@@ -43,6 +43,7 @@ public:
 
     void LogCustom(lua_State* luaVM, unsigned char ucRed, unsigned char ucGreen, unsigned char ucBlue, const char* szFormat, ...);
     void LogInformation(lua_State* luaVM, const char* szFormat, ...);
+    void LogInformationv(lua_State* luaVM, const char* szFormat, va_list marker);
     void LogWarning(lua_State* luaVM, const char* szFormat, ...);
     void LogError(lua_State* luaVM, const char* szFormat, ...);
     void LogBadPointer(lua_State* luaVM, const char* szArgumentType, unsigned int uiArgument);

--- a/Server/mods/deathmatch/logic/lua/CLuaModule.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaModule.cpp
@@ -250,7 +250,7 @@ void CLuaModule::ErrorPrintf(const char* szFormat, ...)
 {
     va_list args;
     va_start(args, szFormat);
-    CLogger::ErrorPrintf(szFormat, va_pass(args));
+    CLogger::ErrorPrintfv(szFormat, args);
     va_end(args);
 }
 
@@ -258,7 +258,7 @@ void CLuaModule::DebugPrintf(lua_State* luaVM, const char* szFormat, ...)
 {
     va_list args;
     va_start(args, szFormat);
-    m_pScriptDebugging->LogInformation(luaVM, szFormat, va_pass(args));
+    m_pScriptDebugging->LogInformationv(luaVM, szFormat, args);
     va_end(args);
 }
 
@@ -266,7 +266,7 @@ void CLuaModule::Printf(const char* szFormat, ...)
 {
     va_list args;
     va_start(args, szFormat);
-    CLogger::LogPrintf(szFormat, va_pass(args));
+    CLogger::LogPrintfv(szFormat, args);
     va_end(args);
 }
 

--- a/Shared/mods/deathmatch/logic/CScriptDebugging.cpp
+++ b/Shared/mods/deathmatch/logic/CScriptDebugging.cpp
@@ -73,6 +73,18 @@ void CScriptDebugging::LogInformation(lua_State* luaVM, const char* szFormat, ..
     LogString("INFO: ", GetLuaDebugInfo(luaVM), szBuffer, 3);
 }
 
+void CScriptDebugging::LogInformationv(lua_State* luaVM, const char* szFormat, va_list marker)
+{
+    assert(szFormat);
+
+    // Compose the formatted message
+    char    szBuffer[MAX_STRING_LENGTH];
+    VSNPRINTF(szBuffer, MAX_STRING_LENGTH, szFormat, marker);
+
+    // Log it
+    LogString("INFO: ", GetLuaDebugInfo(luaVM), szBuffer, 3);
+}
+
 void CScriptDebugging::LogWarning(lua_State* luaVM, const char* szFormat, ...)
 {
     assert(szFormat);


### PR DESCRIPTION
Using a compiler other than VS may generate unexpected output.

Following example is taken from a module compiled with MinGW.
![Example output](https://s8.postimg.cc/vldh0eqj9/out.png)