### PR TITLE
0009178: Fix bindKey & unbindKey on commands

### DIFF
--- a/Client/core/CKeyBinds.cpp
+++ b/Client/core/CKeyBinds.cpp
@@ -787,11 +787,12 @@ bool CKeyBinds::SetCommandActive(const char* szKey, const char* szCommand, bool 
                         {
                             if (!szArguments || (pBind->szArguments && strcmp(pBind->szArguments, szArguments) == 0))
                             {
+                                bool oldval = pBind->bActive;
                                 pBind->bActive = bActive;
                                 if (szArguments)
                                     return true;
                                 else
-                                    ret = true;
+                                    ret = ret || oldval != bActive;
                             }
                         }
                     }

--- a/Client/core/CKeyBinds.cpp
+++ b/Client/core/CKeyBinds.cpp
@@ -771,6 +771,7 @@ bool CKeyBinds::SetCommandActive(const char* szKey, const char* szCommand, bool 
     NullEmptyStrings(szKey, szCommand, szArguments);
 
     list<CKeyBind*>::const_iterator iter = m_pList->begin();
+    bool ret = false;
     for (; iter != m_pList->end(); iter++)
     {
         if ((*iter)->GetType() == KEY_BIND_COMMAND)
@@ -787,7 +788,10 @@ bool CKeyBinds::SetCommandActive(const char* szKey, const char* szCommand, bool 
                             if (!szArguments || (pBind->szArguments && strcmp(pBind->szArguments, szArguments) == 0))
                             {
                                 pBind->bActive = bActive;
-                                return true;
+                                if (strcmp(pBind->szCommand, "chatbox") != 0)
+                                    return true;
+                                else
+                                    ret = true;
                             }
                         }
                     }
@@ -795,7 +799,7 @@ bool CKeyBinds::SetCommandActive(const char* szKey, const char* szCommand, bool 
             }
         }
     }
-    return false;
+    return ret;
 }
 
 void CKeyBinds::SetAllCommandsActive(const char* szResource, bool bActive, const char* szCommand, bool bState, const char* szArguments, bool checkHitState)

--- a/Client/core/CKeyBinds.cpp
+++ b/Client/core/CKeyBinds.cpp
@@ -785,7 +785,7 @@ bool CKeyBinds::SetCommandActive(const char* szKey, const char* szCommand, bool 
                     {
                         if (!checkHitState || (pBind->bHitState == bState))
                         {
-                            if (!szArguments || (pBind->szArguments && strcmp(pBind->szArguments, szArguments) == 0))
+                            if (!szArguments && (!bActive || !pBind->szArguments) || szArguments && (pBind->szArguments && strcmp(pBind->szArguments, szArguments) == 0))
                             {
                                 bool oldval = pBind->bActive;
                                 pBind->bActive = bActive;

--- a/Client/core/CKeyBinds.cpp
+++ b/Client/core/CKeyBinds.cpp
@@ -788,7 +788,7 @@ bool CKeyBinds::SetCommandActive(const char* szKey, const char* szCommand, bool 
                             if (!szArguments || (pBind->szArguments && strcmp(pBind->szArguments, szArguments) == 0))
                             {
                                 pBind->bActive = bActive;
-                                if (strcmp(pBind->szCommand, "chatbox") != 0)
+                                if (szArguments)
                                     return true;
                                 else
                                     ret = true;

--- a/Client/core/CKeyBinds.cpp
+++ b/Client/core/CKeyBinds.cpp
@@ -770,8 +770,8 @@ bool CKeyBinds::SetCommandActive(const char* szKey, const char* szCommand, bool 
 {
     NullEmptyStrings(szKey, szCommand, szArguments);
 
+    bool bReturn = false;
     list<CKeyBind*>::const_iterator iter = m_pList->begin();
-    bool ret = false;
     for (; iter != m_pList->end(); iter++)
     {
         if ((*iter)->GetType() == KEY_BIND_COMMAND)
@@ -785,14 +785,17 @@ bool CKeyBinds::SetCommandActive(const char* szKey, const char* szCommand, bool 
                     {
                         if (!checkHitState || (pBind->bHitState == bState))
                         {
-                            if (!szArguments && (!bActive || !pBind->szArguments) || szArguments && (pBind->szArguments && strcmp(pBind->szArguments, szArguments) == 0))
+                            if ((!szArguments && (!bActive || !pBind->szArguments)) 
+                                || (szArguments && pBind->szArguments && strcmp(pBind->szArguments, szArguments) == 0))
                             {
-                                bool oldval = pBind->bActive;
+                                bool bOldActive = pBind->bActive;
                                 pBind->bActive = bActive;
                                 if (szArguments)
+                                {
                                     return true;
+                                }
                                 else
-                                    ret = ret || oldval != bActive;
+                                    bReturn = (bReturn || bOldActive != bActive);
                             }
                         }
                     }
@@ -800,7 +803,7 @@ bool CKeyBinds::SetCommandActive(const char* szKey, const char* szCommand, bool 
             }
         }
     }
-    return ret;
+    return bReturn;
 }
 
 void CKeyBinds::SetAllCommandsActive(const char* szResource, bool bActive, const char* szCommand, bool bState, const char* szArguments, bool checkHitState)

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -6420,8 +6420,7 @@ bool CStaticFunctionDefinitions::BindKey(const char* szKey, const char* szHitSta
     if (bKey)
     {
         bool bHitState = true;
-        // Activate all keys for this command
-        pKeyBinds->SetAllCommandsActive(szResource, true, szCommandName, bHitState, szArguments, true);
+        pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, szArguments, szResource, true, true);
         // Check if its binded already (dont rebind)
         if (pKeyBinds->CommandExists(szKey, szCommandName, true, bHitState, szArguments, szResource, true, true))
             return true;
@@ -6434,7 +6433,7 @@ bool CStaticFunctionDefinitions::BindKey(const char* szKey, const char* szHitSta
         }
 
         bHitState = false;
-        pKeyBinds->SetAllCommandsActive(szResource, true, szCommandName, bHitState, szArguments, true);
+        pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, szArguments, szResource, true, true);
         if (pKeyBinds->CommandExists(szKey, szCommandName, true, bHitState, szArguments, szResource, true, true))
             return true;
 

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -6408,6 +6408,24 @@ bool CStaticFunctionDefinitions::BindKey(const char* szKey, const char* szHitSta
     return bSuccess;
 }
 
+static inline void BindKeyAtHitState(CKeyBindsInterface* pKeyBinds, const char* szKey, const char* szCommandName, const char* szArguments, const char* szResource, const bool bHitState, bool& bSuccess)
+{    
+    // Check if its binded already (dont rebind)
+    if (!pKeyBinds->CommandExists(szKey, szCommandName, true, bHitState, szArguments, szResource, true, true))
+    {
+        if (pKeyBinds->AddCommand(szKey, szCommandName, szArguments, bHitState, szResource, true))
+        {
+            pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, szArguments, szResource, true, true);
+            bSuccess = true;
+        }
+    }
+    else 
+    {
+        pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, szArguments, szResource, true, true);
+        bSuccess = true;
+    }
+}
+
 bool CStaticFunctionDefinitions::BindKey(const char* szKey, const char* szHitState, const char* szCommandName, const char* szArguments, const char* szResource)
 {
     assert(szKey);
@@ -6419,29 +6437,13 @@ bool CStaticFunctionDefinitions::BindKey(const char* szKey, const char* szHitSta
     bool                bKey = pKeyBinds->IsKey(szKey);
     if (bKey)
     {
-        bool bHitState = true;
-        pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, szArguments, szResource, true, true);
-        // Check if its binded already (dont rebind)
-        if (pKeyBinds->CommandExists(szKey, szCommandName, true, bHitState, szArguments, szResource, true, true))
-            return true;
-
-        if ((!stricmp(szHitState, "down") || !stricmp(szHitState, "both")) &&
-            pKeyBinds->AddCommand(szKey, szCommandName, szArguments, bHitState, szResource, true))
+        if (!stricmp(szHitState, "down") || !stricmp(szHitState, "both")) 
         {
-            pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, szArguments, szResource, true, true);
-            bSuccess = true;
+            BindKeyAtHitState(pKeyBinds, szKey, szCommandName, szArguments, szResource, true, bSuccess);
         }
-
-        bHitState = false;
-        pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, szArguments, szResource, true, true);
-        if (pKeyBinds->CommandExists(szKey, szCommandName, true, bHitState, szArguments, szResource, true, true))
-            return true;
-
-        if ((!stricmp(szHitState, "up") || !stricmp(szHitState, "both")) &&
-            pKeyBinds->AddCommand(szKey, szCommandName, szArguments, bHitState, szResource, true))
+        if (!stricmp(szHitState, "up") || !stricmp(szHitState, "both"))
         {
-            pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, szArguments, szResource, true, true);
-            bSuccess = true;
+            BindKeyAtHitState(pKeyBinds, szKey, szCommandName, szArguments, szResource, false, bSuccess);
         }
     }
     return bSuccess;
@@ -6497,29 +6499,14 @@ bool CStaticFunctionDefinitions::UnbindKey(const char* szKey, const char* szHitS
     bool                bKey = pKeyBinds->IsKey(szKey);
     if (bKey)
     {
-        bool bCheckHitState = false, bHitState = true;
-        if (szHitState)
-        {
-            if (stricmp(szHitState, "down") == 0)
-            {
-                bCheckHitState = true, bHitState = true;
-            }
-            else if (stricmp(szHitState, "up") == 0)
-            {
-                bCheckHitState = true, bHitState = false;
-            }
-        }
         if ((!stricmp(szHitState, "down") || !stricmp(szHitState, "both")) &&
-            pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, NULL, szResource, false, true))
+            pKeyBinds->SetCommandActive(szKey, szCommandName, true, NULL, szResource, false, true))
         {
-            pKeyBinds->SetAllCommandsActive(szResource, false, szCommandName, bHitState, NULL, true);
             bSuccess = true;
         }
-        bHitState = false;
         if ((!stricmp(szHitState, "up") || !stricmp(szHitState, "both")) &&
-            pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, NULL, szResource, false, true))
+            pKeyBinds->SetCommandActive(szKey, szCommandName, false, NULL, szResource, false, true))
         {
-            pKeyBinds->SetAllCommandsActive(szResource, false, szCommandName, bHitState, NULL, true);
             bSuccess = true;
         }
     }


### PR DESCRIPTION
Bugtracker: 
https://bugs.mtasa.com/view.php?id=9178

bindKey and unbindKey were really strange for commands, so I rewrote them a bit. 
Now it should work perfectly (tested it as much as I could, no problems for me).

Still wonder why "SetAllCommandsActive" was used there.

You can ignore the first commit (f1c3e50), wasn't the solution.