### PR TITLE
0007818: Remove "explode" for BlowVehicle, fix bug

### DIFF
--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -5228,10 +5228,10 @@ bool CStaticFunctionDefinitions::FixVehicle(CElement* pElement)
     return false;
 }
 
-bool CStaticFunctionDefinitions::BlowVehicle(CElement* pElement, bool bExplode)
+bool CStaticFunctionDefinitions::BlowVehicle(CElement* pElement)
 {
     assert(pElement);
-    RUN_CHILDREN(BlowVehicle(*iter, bExplode))
+    RUN_CHILDREN(BlowVehicle(*iter))
 
     if (IS_VEHICLE(pElement))
     {
@@ -5247,8 +5247,7 @@ bool CStaticFunctionDefinitions::BlowVehicle(CElement* pElement, bool bExplode)
             pVehicle->CallEvent("onVehicleExplode", Arguments);
         }
         pVehicle->SetHealth(0.0f);
-        if (!bExplode)
-            pVehicle->SetIsBlown(true);
+        pVehicle->SetIsBlown(true);
 
         // Update our engine State
         pVehicle->SetEngineOn(false);

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -282,7 +282,7 @@ public:
 
     // Vehicle set functions
     static bool FixVehicle(CElement* pElement);
-    static bool BlowVehicle(CElement* pElement, bool bExplode);
+    static bool BlowVehicle(CElement* pElement);
     static bool SetVehicleColor(CElement* pElement, const CVehicleColor& color);
     static bool SetVehicleLandingGearDown(CElement* pElement, bool bLandingGearDown);
     static bool SetVehicleLocked(CElement* pElement, bool bLocked);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -1741,15 +1741,13 @@ int CLuaVehicleDefs::FixVehicle(lua_State* luaVM)
 int CLuaVehicleDefs::BlowVehicle(lua_State* luaVM)
 {
     CElement* pElement;
-    bool      bExplode;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pElement);
-    argStream.ReadBool(bExplode, true);
 
     if (!argStream.HasErrors())
     {
-        if (CStaticFunctionDefinitions::BlowVehicle(pElement, bExplode))
+        if (CStaticFunctionDefinitions::BlowVehicle(pElement))
         {
             lua_pushboolean(luaVM, true);
             return 1;


### PR DESCRIPTION
Bugtracker:
https://bugs.mtasa.com/view.php?id=7817

The "explode" argument does nothing but bug the system, cause it only prevents using "SetIsBlown", which is kinda important.

The bug in the bugtracker occured because "SetIsBlown" wasn't used and the server didn't know, that the vehicle was already blown. So if a player synced the vehicle getting blown, the server checked "GetIsBlown()" and got false, so it triggered onVehicleExplode again.