### PR TITLE
0005204: Fix Weather blending at server

### DIFF
--- a/Server/mods/deathmatch/logic/CBlendedWeather.cpp
+++ b/Server/mods/deathmatch/logic/CBlendedWeather.cpp
@@ -25,6 +25,11 @@ CBlendedWeather::CBlendedWeather(CClock* pClock)
     m_pClock = pClock;
 }
 
+void CBlendedWeather::DoPulse(void)
+{
+    Update();
+}
+
 void CBlendedWeather::SetWeather(unsigned char ucWeather)
 {
     // Set the primary and secondary weather instantly and stop any blending we might've been doing
@@ -36,9 +41,6 @@ void CBlendedWeather::SetWeather(unsigned char ucWeather)
 
 void CBlendedWeather::SetWeatherBlended(unsigned char ucWeather, unsigned char ucHour)
 {
-    // TODO: Should write it to not require this
-    Update();
-
     // Store the weather we blend to for the timing
     m_ucPrimaryBlendedWeather = m_ucSecondaryWeather;
     m_ucSecondaryBlendedWeather = ucWeather;
@@ -54,9 +56,6 @@ void CBlendedWeather::SetWeatherBlended(unsigned char ucWeather, unsigned char u
 
 unsigned char CBlendedWeather::GetWeather(void)
 {
-    // TODO: Should write it to not require this
-    Update();
-
     // If we're blending the weather, return the weather we started blending from
     if (m_ucBlendStopHour != 0xFF)
     {

--- a/Server/mods/deathmatch/logic/CBlendedWeather.h
+++ b/Server/mods/deathmatch/logic/CBlendedWeather.h
@@ -18,6 +18,8 @@ class CBlendedWeather
 public:
     CBlendedWeather(CClock* pClock);
 
+    void DoPulse(void);
+
     void SetWeather(unsigned char ucWeather);
     void SetWeatherBlended(unsigned char ucWeather, unsigned char ucHour);
 

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -469,6 +469,8 @@ void CGame::DoPulse(void)
 
     CLOCK_CALL1(m_pAsyncTaskScheduler->CollectResults());
 
+    CLOCK_CALL1(m_pMapManager->GetWeather()->DoPulse(););
+
     PrintLogOutputFromNetModule();
     m_pScriptDebugging->UpdateLogOutput();
 


### PR DESCRIPTION
Bugtracker:
https://bugs.mtasa.com/view.php?id=5204

The current weather-system at serverside is not so good.
It saves the end-hour of a weather-blending and asks, if the current hour is the end-hour. So to make the serversided blending work, the server has to compare the hours at every hour atleast once.

Currently the comparation of the hours for the weather-blending happens only on "SetSeatherBlended" and "GetWeather". So to not get a bug, we would have to call one of them at the end-hour of the blending (after how many days doesn't matter).

So my "workaround" would be to add a "DoPulse" to check it every interval. This solution fixes the bug without changing much.