### PR TITLE
Fixed 'stream_title' meta tag when the playback is started

### DIFF
--- a/Client/mods/deathmatch/logic/CBassAudio.cpp
+++ b/Client/mods/deathmatch/logic/CBassAudio.cpp
@@ -424,6 +424,19 @@ void CBassAudio::CompleteStreamConnect(HSTREAM pSound)
                 }
             }
         }
+
+        const char* szMeta = BASS_ChannelGetTags(pSound, BASS_TAG_META);
+        if (szMeta)
+        {
+            SString strMeta = szMeta;
+            if (!strMeta.empty())
+            {
+                m_pVars->criticalSection.Lock();
+                m_pVars->onClientSoundChangedMetaQueue.push_back(strMeta);
+                m_pVars->criticalSection.Unlock();
+            }
+        }
+
         // set sync for stream titles
         m_hSyncMeta = BASS_ChannelSetSync(pSound, BASS_SYNC_META, 0, &MetaSync, m_uiCallbackId);            // Shoutcast
         // g_pCore->GetConsole()->Printf ( "BASS ERROR %d in BASS_SYNC_META", BASS_ErrorGetCode() );


### PR DESCRIPTION
After bass.dll update 'onClientSoundChangedMeta' event won't be triggered when the stream begins to play.
