### PR TITLE
0009178: Fix bindKey & unbindKey on commands (2)

### DIFF
--- a/Client/core/CKeyBinds.cpp
+++ b/Client/core/CKeyBinds.cpp
@@ -766,7 +766,7 @@ bool CKeyBinds::CommandExists(const char* szKey, const char* szCommand, bool bCh
 }
 
 bool CKeyBinds::SetCommandActive(const char* szKey, const char* szCommand, bool bState, const char* szArguments, const char* szResource, bool bActive,
-                                 bool checkHitState)
+                                 bool checkHitState, bool bCanWithOriginalKeyInstead)
 {
     NullEmptyStrings(szKey, szCommand, szArguments);
 
@@ -775,9 +775,11 @@ bool CKeyBinds::SetCommandActive(const char* szKey, const char* szCommand, bool 
     {
         if ((*iter)->GetType() == KEY_BIND_COMMAND)
         {
-            if (!szKey || (stricmp((*iter)->boundKey->szKey, szKey) == 0))
+            CCommandBind* pBind = static_cast<CCommandBind*>(*iter);
+            if (!szKey 
+                || (stricmp(pBind->boundKey->szKey, szKey) == 0)
+                || (bCanWithOriginalKeyInstead && pBind->bIsReplacingScriptKey && stricmp(pBind->strOriginalScriptKey, szKey) == 0))
             {
-                CCommandBind* pBind = static_cast<CCommandBind*>(*iter);
                 if (pBind->szResource && (strcmp(pBind->szResource, szResource) == 0))
                 {
                     if (!szCommand || (strcmp(pBind->szCommand, szCommand) == 0))
@@ -798,7 +800,7 @@ bool CKeyBinds::SetCommandActive(const char* szKey, const char* szCommand, bool 
     return false;
 }
 
-void CKeyBinds::SetAllCommandsActive(const char* szResource, bool bActive, const char* szCommand, bool bState, const char* szArguments, bool checkHitState)
+void CKeyBinds::SetAllCommandsActive(const char* szResource, bool bActive, const char* szCommand, bool bState, const char* szArguments, bool checkHitState, const char* szOnlyWithDefaultKey)
 {
     NullEmptyStrings(szCommand, szArguments);
 
@@ -816,7 +818,12 @@ void CKeyBinds::SetAllCommandsActive(const char* szResource, bool bActive, const
                     {
                         if (!szArguments || (pBind->szArguments && strcmp(pBind->szArguments, szArguments) == 0))
                         {
-                            pBind->bActive = bActive;
+                            if (!szOnlyWithDefaultKey 
+                                || (pBind->bIsReplacingScriptKey && stricmp(pBind->strOriginalScriptKey, szOnlyWithDefaultKey) == 0)
+                                || stricmp(pBind->boundKey->szKey, szOnlyWithDefaultKey) == 0)
+                            {
+                                pBind->bActive = bActive;
+                            }
                         }
                     }
                 }

--- a/Client/core/CKeyBinds.cpp
+++ b/Client/core/CKeyBinds.cpp
@@ -766,7 +766,7 @@ bool CKeyBinds::CommandExists(const char* szKey, const char* szCommand, bool bCh
 }
 
 bool CKeyBinds::SetCommandActive(const char* szKey, const char* szCommand, bool bState, const char* szArguments, const char* szResource, bool bActive,
-                                 bool checkHitState, bool bCanWithOriginalKeyInstead)
+                                 bool checkHitState, bool bConsiderDefaultKey)
 {
     NullEmptyStrings(szKey, szCommand, szArguments);
 
@@ -778,7 +778,7 @@ bool CKeyBinds::SetCommandActive(const char* szKey, const char* szCommand, bool 
             CCommandBind* pBind = static_cast<CCommandBind*>(*iter);
             if (!szKey 
                 || (stricmp(pBind->boundKey->szKey, szKey) == 0)
-                || (bCanWithOriginalKeyInstead && pBind->bIsReplacingScriptKey && stricmp(pBind->strOriginalScriptKey, szKey) == 0))
+                || (bConsiderDefaultKey && pBind->bIsReplacingScriptKey && stricmp(pBind->strOriginalScriptKey, szKey) == 0))
             {
                 if (pBind->szResource && (strcmp(pBind->szResource, szResource) == 0))
                 {

--- a/Client/core/CKeyBinds.cpp
+++ b/Client/core/CKeyBinds.cpp
@@ -278,7 +278,7 @@ CKeyBinds::CKeyBinds(CCore* pCore)
     m_pList = new list<CKeyBind*>;
     m_bMouseWheel = false;
     m_bInVehicle = false;
-    m_pChatBoxBind = NULL;
+    m_pChatBoxBind = nullptr;
     m_bProcessingKeyStroke = false;
     m_KeyStrokeHandler = NULL;
     m_CharacterKeyHandler = NULL;
@@ -363,7 +363,7 @@ bool CKeyBinds::ProcessKeyStroke(const SBindableKey* pKey, bool bState)
 
     // Search through binds
     bool                            bFound = false;
-    CKeyBind*                       pBind = NULL;
+    CKeyBind*                       pBind = nullptr;
     list<CCommandBind*>             processedList;
     list<CKeyBind*>                 cloneList = *m_pList;
     list<CKeyBind*>::const_iterator iter = cloneList.begin();
@@ -553,7 +553,7 @@ bool CKeyBinds::Call(CKeyBind* pKeyBind)
             {
                 CCommandBind* pBind = static_cast<CCommandBind*>(pKeyBind);
                 if (pBind->bActive)
-                    m_pCore->GetCommands()->Execute(pBind->szCommand, pBind->szArguments, false, pBind->szResource != NULL);
+                    m_pCore->GetCommands()->Execute(pBind->szCommand, pBind->szArguments, false, pBind->szResource != nullptr);
                 break;
             }
             case KEY_BIND_FUNCTION:
@@ -583,7 +583,7 @@ bool CKeyBinds::AddCommand(const char* szKey, const char* szCommand, const char*
 {
     NullEmptyStrings(szCommand, szArguments, szResource);
 
-    if (szKey == NULL || szCommand == NULL)
+    if (szKey == nullptr || szCommand == nullptr)
         return false;
 
     const SBindableKey* boundKey = GetBindableFromKey(szKey);
@@ -593,7 +593,7 @@ bool CKeyBinds::AddCommand(const char* szKey, const char* szCommand, const char*
         if (szResource && bScriptCreated)
         {
             // Check if there is a waiting replacement
-            CCommandBind* pUserAddedBind = FindCommandMatch(NULL, szCommand, szArguments, szResource, szKey, true, bState, true, false);
+            CCommandBind* pUserAddedBind = FindCommandMatch(nullptr, szCommand, szArguments, szResource, szKey, true, bState, true, false);
             if (pUserAddedBind)
             {
                 // Upgrade
@@ -638,7 +638,7 @@ bool CKeyBinds::AddCommand(const SBindableKey* pKey, const char* szCommand, cons
 {
     NullEmptyStrings(szCommand, szArguments);
 
-    if (pKey == NULL || szCommand == NULL)
+    if (pKey == nullptr || szCommand == nullptr)
         return false;
 
     CCommandBind* bind = new CCommandBind;
@@ -651,7 +651,7 @@ bool CKeyBinds::AddCommand(const SBindableKey* pKey, const char* szCommand, cons
         strcpy(bind->szArguments, szArguments);
     }
     else
-        bind->szArguments = NULL;
+        bind->szArguments = nullptr;
 
     bind->bHitState = bState;
     bind->bState = false;
@@ -662,7 +662,7 @@ bool CKeyBinds::AddCommand(const SBindableKey* pKey, const char* szCommand, cons
 
 bool CKeyBinds::RemoveCommand(const char* szKey, const char* szCommand, bool bCheckState, bool bState)
 {
-    if (szKey == NULL || szCommand == NULL)
+    if (szKey == nullptr || szCommand == nullptr)
         return false;
 
     bool                      bFound = false;
@@ -704,7 +704,7 @@ bool CKeyBinds::RemoveCommand(const char* szKey, const char* szCommand, bool bCh
 
 bool CKeyBinds::RemoveAllCommands(const char* szKey, bool bCheckState, bool bState)
 {
-    if (szKey == NULL)
+    if (szKey == nullptr)
         return false;
 
     bool                      bFound = false;
@@ -751,12 +751,12 @@ bool CKeyBinds::RemoveAllCommands(void)
 bool CKeyBinds::CommandExists(const char* szKey, const char* szCommand, bool bCheckState, bool bState, const char* szArguments, const char* szResource,
                               bool bCheckScriptCreated, bool bScriptCreated)
 {
-    const char* szOriginalScriptKey = NULL;
+    const char* szOriginalScriptKey = nullptr;
     if (bCheckScriptCreated && bScriptCreated)
     {
         // If looking for script created command, check original key instead of current key
         szOriginalScriptKey = szKey;
-        szKey = NULL;
+        szKey = nullptr;
     }
 
     if (FindCommandMatch(szKey, szCommand, szArguments, szResource, szOriginalScriptKey, bCheckState, bState, bCheckScriptCreated, bScriptCreated))
@@ -848,10 +848,10 @@ CCommandBind* CKeyBinds::GetBindFromCommand(const char* szCommand, const char* s
 
             if ((bMatchCase && strcmp(szBindCommand, szCommand) == 0) || (!bMatchCase && stricmp(szBindCommand, szCommand) == 0))
             {
-                if (szArguments == NULL || (szBindArguments && (bMatchCase && strcmp(szBindArguments, szArguments) == 0) ||
+                if (szArguments == nullptr || (szBindArguments && (bMatchCase && strcmp(szBindArguments, szArguments) == 0) ||
                                             (!bMatchCase && stricmp(szBindArguments, szArguments) == 0)))
                 {
-                    if ((szKey == NULL) || (stricmp(pBind->boundKey->szKey, szKey) == 0))
+                    if ((szKey == nullptr) || (stricmp(pBind->boundKey->szKey, szKey) == 0))
                     {
                         if ((!bCheckHitState) || (bState == pBind->bHitState))
                         {
@@ -863,7 +863,7 @@ CCommandBind* CKeyBinds::GetBindFromCommand(const char* szCommand, const char* s
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 CCommandBind* CKeyBinds::FindCommandMatch(const char* szKey, const char* szCommand, const char* szArguments, const char* szResource,
@@ -901,7 +901,7 @@ CCommandBind* CKeyBinds::FindCommandMatch(const char* szKey, const char* szComma
             }
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 //
@@ -909,7 +909,7 @@ CCommandBind* CKeyBinds::FindCommandMatch(const char* szKey, const char* szComma
 //
 CCommandBind* CKeyBinds::FindMatchingUpBind(CCommandBind* pBind)
 {
-    return FindCommandMatch(pBind->boundKey->szKey, pBind->szCommand, NULL, pBind->szResource, pBind->strOriginalScriptKey, true, false, true,
+    return FindCommandMatch(pBind->boundKey->szKey, pBind->szCommand, nullptr, pBind->szResource, pBind->strOriginalScriptKey, true, false, true,
                             pBind->bScriptCreated);
 }
 
@@ -1016,7 +1016,7 @@ bool CKeyBinds::GetBoundCommands(const char* szCommand, list<CCommandBind*>& com
 
 bool CKeyBinds::AddGTAControl(const char* szKey, const char* szControl)
 {
-    if (szKey == NULL || szControl == NULL)
+    if (szKey == nullptr || szControl == nullptr)
         return false;
 
     const SBindableKey*  boundKey = GetBindableFromKey(szKey);
@@ -1056,7 +1056,7 @@ bool CKeyBinds::AddGTAControl(const SBindableKey* pKey, SBindableGTAControl* pCo
 
 bool CKeyBinds::RemoveGTAControl(const char* szKey, const char* szControl)
 {
-    if (szKey == NULL || szControl == NULL)
+    if (szKey == nullptr || szControl == nullptr)
         return false;
 
     list<CKeyBind*>::iterator iter = m_pList->begin();
@@ -1083,7 +1083,7 @@ bool CKeyBinds::RemoveGTAControl(const char* szKey, const char* szControl)
 
 bool CKeyBinds::RemoveAllGTAControls(const char* szKey)
 {
-    if (szKey == NULL)
+    if (szKey == nullptr)
         return false;
 
     bool                      bFound = false;
@@ -1417,7 +1417,7 @@ bool CKeyBinds::GetBoundControls(SBindableGTAControl* pControl, list<CGTAControl
 
 bool CKeyBinds::AddFunction(const char* szKey, KeyFunctionBindHandler Handler, bool bState, bool bIgnoreGUI)
 {
-    if (szKey == NULL)
+    if (szKey == nullptr)
         return false;
 
     const SBindableKey* boundKey = GetBindableFromKey(szKey);
@@ -1581,7 +1581,7 @@ bool CKeyBinds::FunctionExists(const SBindableKey* pKey, KeyFunctionBindHandler 
 
 bool CKeyBinds::AddControlFunction(const char* szControl, ControlFunctionBindHandler Handler, bool bState)
 {
-    if (szControl == NULL || Handler == NULL)
+    if (szControl == nullptr || Handler == NULL)
         return false;
 
     SBindableGTAControl* boundControl = GetBindableFromControl(szControl);
@@ -1589,7 +1589,7 @@ bool CKeyBinds::AddControlFunction(const char* szControl, ControlFunctionBindHan
     if (boundControl)
     {
         CControlFunctionBind* pBind = new CControlFunctionBind;
-        pBind->boundKey = NULL;
+        pBind->boundKey = nullptr;
         pBind->control = boundControl;
         pBind->Handler = Handler;
         pBind->bHitState = bState;
@@ -1611,7 +1611,7 @@ bool CKeyBinds::AddControlFunction(SBindableGTAControl* pControl, ControlFunctio
     if (pControl)
     {
         CControlFunctionBind* pBind = new CControlFunctionBind;
-        pBind->boundKey = NULL;
+        pBind->boundKey = nullptr;
         pBind->control = pControl;
         pBind->Handler = Handler;
         pBind->bHitState = bState;
@@ -1772,7 +1772,7 @@ const SBindableKey* CKeyBinds::GetBindableFromKey(const char* szKey)
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 SBindableGTAControl* CKeyBinds::GetBindableFromAction(eControllerAction action)
@@ -1786,7 +1786,7 @@ SBindableGTAControl* CKeyBinds::GetBindableFromAction(eControllerAction action)
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 bool CKeyBinds::IsKey(const char* szKey)
@@ -1808,11 +1808,11 @@ const SBindableKey* CKeyBinds::GetBindableFromMessage(UINT uMsg, WPARAM wParam, 
     if (uMsg != WM_KEYDOWN && uMsg != WM_KEYUP && uMsg != WM_SYSKEYDOWN && uMsg != WM_SYSKEYUP && uMsg != WM_LBUTTONDOWN && uMsg != WM_LBUTTONUP &&
         uMsg != WM_RBUTTONDOWN && uMsg != WM_RBUTTONUP && uMsg != WM_MBUTTONDOWN && uMsg != WM_MBUTTONUP && uMsg != WM_XBUTTONDOWN && uMsg != WM_XBUTTONUP &&
         uMsg != WM_MOUSEWHEEL)
-        return NULL;
+        return nullptr;
 
     // Prevents a simulated lctrl with Alt Gr keys
     if (IsFakeCtrl_L(uMsg, wParam, lParam))
-        return NULL;
+        return nullptr;
 
     bool bFirstHit = (lParam & 0x40000000) ? false : true;
     if (uMsg == WM_MBUTTONDOWN || uMsg == WM_MBUTTONUP || uMsg == WM_XBUTTONDOWN || uMsg == WM_XBUTTONUP || uMsg == WM_MOUSEWHEEL)
@@ -1881,7 +1881,7 @@ const SBindableKey* CKeyBinds::GetBindableFromMessage(UINT uMsg, WPARAM wParam, 
                     {
                         // Grab the correct key
                         if (!bindable->ucNumpadRelative)
-                            return NULL;
+                            return nullptr;
 
                         // m_pCore->GetConsole ()->Printf ( "returned: %s", g_bkKeys [ bindable->ucNumpadRelative ].szKey );
                         return &g_bkKeys[bindable->ucNumpadRelative];
@@ -1892,7 +1892,7 @@ const SBindableKey* CKeyBinds::GetBindableFromMessage(UINT uMsg, WPARAM wParam, 
             }
         }
     }
-    return NULL;
+    return nullptr;
 }
 
 SBindableGTAControl* CKeyBinds::GetBindableFromControl(const char* szControl)
@@ -1906,7 +1906,7 @@ SBindableGTAControl* CKeyBinds::GetBindableFromControl(const char* szControl)
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 const SBindableKey* CKeyBinds::GetBindableFromGTARelative(int iGTAKey)
@@ -1920,7 +1920,7 @@ const SBindableKey* CKeyBinds::GetBindableFromGTARelative(int iGTAKey)
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 bool CKeyBinds::IsControl(const char* szControl)
@@ -2024,7 +2024,7 @@ void CKeyBinds::DoPreFramePulse(void)
     if (m_pChatBoxBind)
     {
         Call(m_pChatBoxBind);
-        m_pChatBoxBind = NULL;
+        m_pChatBoxBind = nullptr;
     }
 
     // HACK: shift keys
@@ -2212,7 +2212,7 @@ bool CKeyBinds::LoadFromXML(CXMLNode* pMainNode)
     bool bLoadDefaults = false;
     if (pMainNode)
     {
-        CXMLNode*    pNode = NULL;
+        CXMLNode*    pNode = nullptr;
         unsigned int uiCount = pMainNode->GetSubNodeCount();
 
         if (uiCount == 0)
@@ -2222,7 +2222,7 @@ bool CKeyBinds::LoadFromXML(CXMLNode* pMainNode)
         {
             pNode = pMainNode->GetSubNode(i);
 
-            if (pNode == NULL)
+            if (pNode == nullptr)
                 continue;
 
             std::string strValue;
@@ -2321,19 +2321,19 @@ bool CKeyBinds::LoadFromXML(CXMLNode* pMainNode)
 
 bool CKeyBinds::SaveToXML(CXMLNode* pMainNode)
 {
-    CXMLAttribute* pA = NULL;
+    CXMLAttribute* pA = nullptr;
     if (pMainNode)
     {
         // Clear our current bind nodes
         pMainNode->DeleteAllSubNodes();
 
         // Iterate the key binds adding them to the XML tree
-        CXMLNode*                       pNode = NULL;
+        CXMLNode*                       pNode = nullptr;
         CXMLAttributes*                 pAttributes;
         list<CKeyBind*>::const_iterator iter = m_pList->begin();
         for (; iter != m_pList->end(); iter++)
         {
-            if ((*iter)->boundKey == NULL)
+            if ((*iter)->boundKey == nullptr)
                 continue;
 
             // Create the new 'bind' node
@@ -2436,7 +2436,7 @@ void CKeyBinds::LoadDefaultCommands(bool bForce)
     for (int i = 0; *g_dcbDefaultCommands[i].szKey != NULL; i++)
     {
         SDefaultCommandBind* temp = &g_dcbDefaultCommands[i];
-        if (bForce || !CommandExists(NULL, temp->szCommand, true, temp->bState, temp->szArguments))
+        if (bForce || !CommandExists(nullptr, temp->szCommand, true, temp->bState, temp->szArguments))
             AddCommand(temp->szKey, temp->szCommand, temp->szArguments, temp->bState);
     }
 }
@@ -2496,7 +2496,7 @@ void CKeyBinds::BindCommand(const char* szCmdLine)
     CConsoleInterface* pConsole = m_pCore->GetConsole();
 
     char* szError = "* Syntax: bind <defaults/key> [<up/down>] <command> [<arguments>]";
-    if (szCmdLine == NULL)
+    if (szCmdLine == nullptr)
     {
         pConsole->Print(szError);
         return;
@@ -2508,7 +2508,7 @@ void CKeyBinds::BindCommand(const char* szCmdLine)
 
     // Split it up into bind key, command and arguments
     char* szKey = strtok(szTemp, " ");
-    char* szCommand = strtok(NULL, " ");
+    char* szCommand = strtok(nullptr, " ");
 
     if (szKey)
     {
@@ -2537,12 +2537,12 @@ void CKeyBinds::BindCommand(const char* szCmdLine)
                 if (strcmp(szCommand, "up") == 0 || strcmp(szCommand, "down") == 0)
                 {
                     bState = (strcmp(szCommand, "down") == 0);
-                    szCommand = strtok(NULL, " ");
+                    szCommand = strtok(nullptr, " ");
                 }
 
                 if (szCommand)
                 {
-                    char*   szArguments = strtok(NULL, "\0");
+                    char*   szArguments = strtok(nullptr, "\0");
                     SString strKeyState("%s", bState ? "down" : "up");
                     SString strCommandAndArguments("%s%s%s", szCommand, szArguments ? " " : "", szArguments ? szArguments : "");
 
@@ -2574,7 +2574,7 @@ void CKeyBinds::UnbindCommand(const char* szCmdLine)
     CConsoleInterface* pConsole = m_pCore->GetConsole();
 
     char* szError = "* Syntax: unbind <all/key> [<up/down> <command>]";
-    if (szCmdLine == NULL)
+    if (szCmdLine == nullptr)
     {
         pConsole->Print(szError);
         return;
@@ -2586,7 +2586,7 @@ void CKeyBinds::UnbindCommand(const char* szCmdLine)
 
     // Split it up into bind key and command
     char* szKey = strtok(szTemp, " ");
-    char* szCommand = strtok(NULL, " ");
+    char* szCommand = strtok(nullptr, " ");
 
     if (szKey)
     {
@@ -2611,7 +2611,7 @@ void CKeyBinds::UnbindCommand(const char* szCmdLine)
                 if (strcmp(szCommand, "up") == 0 || strcmp(szCommand, "down") == 0)
                 {
                     bState = (strcmp(szCommand, "down") == 0);
-                    szCommand = strtok(NULL, " ");
+                    szCommand = strtok(nullptr, " ");
                 }
 
                 if (szCommand)
@@ -2647,8 +2647,8 @@ void CKeyBinds::PrintBindsCommand(const char* szCmdLine)
     CConsoleInterface* pConsole = m_pCore->GetConsole();
 
     // Get the key
-    char* szTemp = NULL;
-    char* szKey = NULL;
+    char* szTemp = nullptr;
+    char* szKey = nullptr;
 
     if (szCmdLine)
     {

--- a/Client/core/CKeyBinds.cpp
+++ b/Client/core/CKeyBinds.cpp
@@ -278,7 +278,7 @@ CKeyBinds::CKeyBinds(CCore* pCore)
     m_pList = new list<CKeyBind*>;
     m_bMouseWheel = false;
     m_bInVehicle = false;
-    m_pChatBoxBind = nullptr;
+    m_pChatBoxBind = NULL;
     m_bProcessingKeyStroke = false;
     m_KeyStrokeHandler = NULL;
     m_CharacterKeyHandler = NULL;
@@ -363,7 +363,7 @@ bool CKeyBinds::ProcessKeyStroke(const SBindableKey* pKey, bool bState)
 
     // Search through binds
     bool                            bFound = false;
-    CKeyBind*                       pBind = nullptr;
+    CKeyBind*                       pBind = NULL;
     list<CCommandBind*>             processedList;
     list<CKeyBind*>                 cloneList = *m_pList;
     list<CKeyBind*>::const_iterator iter = cloneList.begin();
@@ -553,7 +553,7 @@ bool CKeyBinds::Call(CKeyBind* pKeyBind)
             {
                 CCommandBind* pBind = static_cast<CCommandBind*>(pKeyBind);
                 if (pBind->bActive)
-                    m_pCore->GetCommands()->Execute(pBind->szCommand, pBind->szArguments, false, pBind->szResource != nullptr);
+                    m_pCore->GetCommands()->Execute(pBind->szCommand, pBind->szArguments, false, pBind->szResource != NULL);
                 break;
             }
             case KEY_BIND_FUNCTION:
@@ -583,7 +583,7 @@ bool CKeyBinds::AddCommand(const char* szKey, const char* szCommand, const char*
 {
     NullEmptyStrings(szCommand, szArguments, szResource);
 
-    if (szKey == nullptr || szCommand == nullptr)
+    if (szKey == NULL || szCommand == NULL)
         return false;
 
     const SBindableKey* boundKey = GetBindableFromKey(szKey);
@@ -593,7 +593,7 @@ bool CKeyBinds::AddCommand(const char* szKey, const char* szCommand, const char*
         if (szResource && bScriptCreated)
         {
             // Check if there is a waiting replacement
-            CCommandBind* pUserAddedBind = FindCommandMatch(nullptr, szCommand, szArguments, szResource, szKey, true, bState, true, false);
+            CCommandBind* pUserAddedBind = FindCommandMatch(NULL, szCommand, szArguments, szResource, szKey, true, bState, true, false);
             if (pUserAddedBind)
             {
                 // Upgrade
@@ -638,7 +638,7 @@ bool CKeyBinds::AddCommand(const SBindableKey* pKey, const char* szCommand, cons
 {
     NullEmptyStrings(szCommand, szArguments);
 
-    if (pKey == nullptr || szCommand == nullptr)
+    if (pKey == NULL || szCommand == NULL)
         return false;
 
     CCommandBind* bind = new CCommandBind;
@@ -651,7 +651,7 @@ bool CKeyBinds::AddCommand(const SBindableKey* pKey, const char* szCommand, cons
         strcpy(bind->szArguments, szArguments);
     }
     else
-        bind->szArguments = nullptr;
+        bind->szArguments = NULL;
 
     bind->bHitState = bState;
     bind->bState = false;
@@ -662,7 +662,7 @@ bool CKeyBinds::AddCommand(const SBindableKey* pKey, const char* szCommand, cons
 
 bool CKeyBinds::RemoveCommand(const char* szKey, const char* szCommand, bool bCheckState, bool bState)
 {
-    if (szKey == nullptr || szCommand == nullptr)
+    if (szKey == NULL || szCommand == NULL)
         return false;
 
     bool                      bFound = false;
@@ -704,7 +704,7 @@ bool CKeyBinds::RemoveCommand(const char* szKey, const char* szCommand, bool bCh
 
 bool CKeyBinds::RemoveAllCommands(const char* szKey, bool bCheckState, bool bState)
 {
-    if (szKey == nullptr)
+    if (szKey == NULL)
         return false;
 
     bool                      bFound = false;
@@ -751,12 +751,12 @@ bool CKeyBinds::RemoveAllCommands(void)
 bool CKeyBinds::CommandExists(const char* szKey, const char* szCommand, bool bCheckState, bool bState, const char* szArguments, const char* szResource,
                               bool bCheckScriptCreated, bool bScriptCreated)
 {
-    const char* szOriginalScriptKey = nullptr;
+    const char* szOriginalScriptKey = NULL;
     if (bCheckScriptCreated && bScriptCreated)
     {
         // If looking for script created command, check original key instead of current key
         szOriginalScriptKey = szKey;
-        szKey = nullptr;
+        szKey = NULL;
     }
 
     if (FindCommandMatch(szKey, szCommand, szArguments, szResource, szOriginalScriptKey, bCheckState, bState, bCheckScriptCreated, bScriptCreated))
@@ -848,10 +848,10 @@ CCommandBind* CKeyBinds::GetBindFromCommand(const char* szCommand, const char* s
 
             if ((bMatchCase && strcmp(szBindCommand, szCommand) == 0) || (!bMatchCase && stricmp(szBindCommand, szCommand) == 0))
             {
-                if (szArguments == nullptr || (szBindArguments && (bMatchCase && strcmp(szBindArguments, szArguments) == 0) ||
+                if (szArguments == NULL || (szBindArguments && (bMatchCase && strcmp(szBindArguments, szArguments) == 0) ||
                                             (!bMatchCase && stricmp(szBindArguments, szArguments) == 0)))
                 {
-                    if ((szKey == nullptr) || (stricmp(pBind->boundKey->szKey, szKey) == 0))
+                    if ((szKey == NULL) || (stricmp(pBind->boundKey->szKey, szKey) == 0))
                     {
                         if ((!bCheckHitState) || (bState == pBind->bHitState))
                         {
@@ -863,7 +863,7 @@ CCommandBind* CKeyBinds::GetBindFromCommand(const char* szCommand, const char* s
         }
     }
 
-    return nullptr;
+    return NULL;
 }
 
 CCommandBind* CKeyBinds::FindCommandMatch(const char* szKey, const char* szCommand, const char* szArguments, const char* szResource,
@@ -901,7 +901,7 @@ CCommandBind* CKeyBinds::FindCommandMatch(const char* szKey, const char* szComma
             }
         }
     }
-    return nullptr;
+    return NULL;
 }
 
 //
@@ -909,7 +909,7 @@ CCommandBind* CKeyBinds::FindCommandMatch(const char* szKey, const char* szComma
 //
 CCommandBind* CKeyBinds::FindMatchingUpBind(CCommandBind* pBind)
 {
-    return FindCommandMatch(pBind->boundKey->szKey, pBind->szCommand, nullptr, pBind->szResource, pBind->strOriginalScriptKey, true, false, true,
+    return FindCommandMatch(pBind->boundKey->szKey, pBind->szCommand, NULL, pBind->szResource, pBind->strOriginalScriptKey, true, false, true,
                             pBind->bScriptCreated);
 }
 
@@ -1016,7 +1016,7 @@ bool CKeyBinds::GetBoundCommands(const char* szCommand, list<CCommandBind*>& com
 
 bool CKeyBinds::AddGTAControl(const char* szKey, const char* szControl)
 {
-    if (szKey == nullptr || szControl == nullptr)
+    if (szKey == NULL || szControl == NULL)
         return false;
 
     const SBindableKey*  boundKey = GetBindableFromKey(szKey);
@@ -1056,7 +1056,7 @@ bool CKeyBinds::AddGTAControl(const SBindableKey* pKey, SBindableGTAControl* pCo
 
 bool CKeyBinds::RemoveGTAControl(const char* szKey, const char* szControl)
 {
-    if (szKey == nullptr || szControl == nullptr)
+    if (szKey == NULL || szControl == NULL)
         return false;
 
     list<CKeyBind*>::iterator iter = m_pList->begin();
@@ -1083,7 +1083,7 @@ bool CKeyBinds::RemoveGTAControl(const char* szKey, const char* szControl)
 
 bool CKeyBinds::RemoveAllGTAControls(const char* szKey)
 {
-    if (szKey == nullptr)
+    if (szKey == NULL)
         return false;
 
     bool                      bFound = false;
@@ -1417,7 +1417,7 @@ bool CKeyBinds::GetBoundControls(SBindableGTAControl* pControl, list<CGTAControl
 
 bool CKeyBinds::AddFunction(const char* szKey, KeyFunctionBindHandler Handler, bool bState, bool bIgnoreGUI)
 {
-    if (szKey == nullptr)
+    if (szKey == NULL)
         return false;
 
     const SBindableKey* boundKey = GetBindableFromKey(szKey);
@@ -1581,7 +1581,7 @@ bool CKeyBinds::FunctionExists(const SBindableKey* pKey, KeyFunctionBindHandler 
 
 bool CKeyBinds::AddControlFunction(const char* szControl, ControlFunctionBindHandler Handler, bool bState)
 {
-    if (szControl == nullptr || Handler == NULL)
+    if (szControl == NULL || Handler == NULL)
         return false;
 
     SBindableGTAControl* boundControl = GetBindableFromControl(szControl);
@@ -1589,7 +1589,7 @@ bool CKeyBinds::AddControlFunction(const char* szControl, ControlFunctionBindHan
     if (boundControl)
     {
         CControlFunctionBind* pBind = new CControlFunctionBind;
-        pBind->boundKey = nullptr;
+        pBind->boundKey = NULL;
         pBind->control = boundControl;
         pBind->Handler = Handler;
         pBind->bHitState = bState;
@@ -1611,7 +1611,7 @@ bool CKeyBinds::AddControlFunction(SBindableGTAControl* pControl, ControlFunctio
     if (pControl)
     {
         CControlFunctionBind* pBind = new CControlFunctionBind;
-        pBind->boundKey = nullptr;
+        pBind->boundKey = NULL;
         pBind->control = pControl;
         pBind->Handler = Handler;
         pBind->bHitState = bState;
@@ -1772,7 +1772,7 @@ const SBindableKey* CKeyBinds::GetBindableFromKey(const char* szKey)
         }
     }
 
-    return nullptr;
+    return NULL;
 }
 
 SBindableGTAControl* CKeyBinds::GetBindableFromAction(eControllerAction action)
@@ -1786,7 +1786,7 @@ SBindableGTAControl* CKeyBinds::GetBindableFromAction(eControllerAction action)
         }
     }
 
-    return nullptr;
+    return NULL;
 }
 
 bool CKeyBinds::IsKey(const char* szKey)
@@ -1808,11 +1808,11 @@ const SBindableKey* CKeyBinds::GetBindableFromMessage(UINT uMsg, WPARAM wParam, 
     if (uMsg != WM_KEYDOWN && uMsg != WM_KEYUP && uMsg != WM_SYSKEYDOWN && uMsg != WM_SYSKEYUP && uMsg != WM_LBUTTONDOWN && uMsg != WM_LBUTTONUP &&
         uMsg != WM_RBUTTONDOWN && uMsg != WM_RBUTTONUP && uMsg != WM_MBUTTONDOWN && uMsg != WM_MBUTTONUP && uMsg != WM_XBUTTONDOWN && uMsg != WM_XBUTTONUP &&
         uMsg != WM_MOUSEWHEEL)
-        return nullptr;
+        return NULL;
 
     // Prevents a simulated lctrl with Alt Gr keys
     if (IsFakeCtrl_L(uMsg, wParam, lParam))
-        return nullptr;
+        return NULL;
 
     bool bFirstHit = (lParam & 0x40000000) ? false : true;
     if (uMsg == WM_MBUTTONDOWN || uMsg == WM_MBUTTONUP || uMsg == WM_XBUTTONDOWN || uMsg == WM_XBUTTONUP || uMsg == WM_MOUSEWHEEL)
@@ -1881,7 +1881,7 @@ const SBindableKey* CKeyBinds::GetBindableFromMessage(UINT uMsg, WPARAM wParam, 
                     {
                         // Grab the correct key
                         if (!bindable->ucNumpadRelative)
-                            return nullptr;
+                            return NULL;
 
                         // m_pCore->GetConsole ()->Printf ( "returned: %s", g_bkKeys [ bindable->ucNumpadRelative ].szKey );
                         return &g_bkKeys[bindable->ucNumpadRelative];
@@ -1892,7 +1892,7 @@ const SBindableKey* CKeyBinds::GetBindableFromMessage(UINT uMsg, WPARAM wParam, 
             }
         }
     }
-    return nullptr;
+    return NULL;
 }
 
 SBindableGTAControl* CKeyBinds::GetBindableFromControl(const char* szControl)
@@ -1906,7 +1906,7 @@ SBindableGTAControl* CKeyBinds::GetBindableFromControl(const char* szControl)
         }
     }
 
-    return nullptr;
+    return NULL;
 }
 
 const SBindableKey* CKeyBinds::GetBindableFromGTARelative(int iGTAKey)
@@ -1920,7 +1920,7 @@ const SBindableKey* CKeyBinds::GetBindableFromGTARelative(int iGTAKey)
         }
     }
 
-    return nullptr;
+    return NULL;
 }
 
 bool CKeyBinds::IsControl(const char* szControl)
@@ -2024,7 +2024,7 @@ void CKeyBinds::DoPreFramePulse(void)
     if (m_pChatBoxBind)
     {
         Call(m_pChatBoxBind);
-        m_pChatBoxBind = nullptr;
+        m_pChatBoxBind = NULL;
     }
 
     // HACK: shift keys
@@ -2212,7 +2212,7 @@ bool CKeyBinds::LoadFromXML(CXMLNode* pMainNode)
     bool bLoadDefaults = false;
     if (pMainNode)
     {
-        CXMLNode*    pNode = nullptr;
+        CXMLNode*    pNode = NULL;
         unsigned int uiCount = pMainNode->GetSubNodeCount();
 
         if (uiCount == 0)
@@ -2222,7 +2222,7 @@ bool CKeyBinds::LoadFromXML(CXMLNode* pMainNode)
         {
             pNode = pMainNode->GetSubNode(i);
 
-            if (pNode == nullptr)
+            if (pNode == NULL)
                 continue;
 
             std::string strValue;
@@ -2321,19 +2321,19 @@ bool CKeyBinds::LoadFromXML(CXMLNode* pMainNode)
 
 bool CKeyBinds::SaveToXML(CXMLNode* pMainNode)
 {
-    CXMLAttribute* pA = nullptr;
+    CXMLAttribute* pA = NULL;
     if (pMainNode)
     {
         // Clear our current bind nodes
         pMainNode->DeleteAllSubNodes();
 
         // Iterate the key binds adding them to the XML tree
-        CXMLNode*                       pNode = nullptr;
+        CXMLNode*                       pNode = NULL;
         CXMLAttributes*                 pAttributes;
         list<CKeyBind*>::const_iterator iter = m_pList->begin();
         for (; iter != m_pList->end(); iter++)
         {
-            if ((*iter)->boundKey == nullptr)
+            if ((*iter)->boundKey == NULL)
                 continue;
 
             // Create the new 'bind' node
@@ -2436,7 +2436,7 @@ void CKeyBinds::LoadDefaultCommands(bool bForce)
     for (int i = 0; *g_dcbDefaultCommands[i].szKey != NULL; i++)
     {
         SDefaultCommandBind* temp = &g_dcbDefaultCommands[i];
-        if (bForce || !CommandExists(nullptr, temp->szCommand, true, temp->bState, temp->szArguments))
+        if (bForce || !CommandExists(NULL, temp->szCommand, true, temp->bState, temp->szArguments))
             AddCommand(temp->szKey, temp->szCommand, temp->szArguments, temp->bState);
     }
 }
@@ -2496,7 +2496,7 @@ void CKeyBinds::BindCommand(const char* szCmdLine)
     CConsoleInterface* pConsole = m_pCore->GetConsole();
 
     char* szError = "* Syntax: bind <defaults/key> [<up/down>] <command> [<arguments>]";
-    if (szCmdLine == nullptr)
+    if (szCmdLine == NULL)
     {
         pConsole->Print(szError);
         return;
@@ -2508,7 +2508,7 @@ void CKeyBinds::BindCommand(const char* szCmdLine)
 
     // Split it up into bind key, command and arguments
     char* szKey = strtok(szTemp, " ");
-    char* szCommand = strtok(nullptr, " ");
+    char* szCommand = strtok(NULL, " ");
 
     if (szKey)
     {
@@ -2537,12 +2537,12 @@ void CKeyBinds::BindCommand(const char* szCmdLine)
                 if (strcmp(szCommand, "up") == 0 || strcmp(szCommand, "down") == 0)
                 {
                     bState = (strcmp(szCommand, "down") == 0);
-                    szCommand = strtok(nullptr, " ");
+                    szCommand = strtok(NULL, " ");
                 }
 
                 if (szCommand)
                 {
-                    char*   szArguments = strtok(nullptr, "\0");
+                    char*   szArguments = strtok(NULL, "\0");
                     SString strKeyState("%s", bState ? "down" : "up");
                     SString strCommandAndArguments("%s%s%s", szCommand, szArguments ? " " : "", szArguments ? szArguments : "");
 
@@ -2574,7 +2574,7 @@ void CKeyBinds::UnbindCommand(const char* szCmdLine)
     CConsoleInterface* pConsole = m_pCore->GetConsole();
 
     char* szError = "* Syntax: unbind <all/key> [<up/down> <command>]";
-    if (szCmdLine == nullptr)
+    if (szCmdLine == NULL)
     {
         pConsole->Print(szError);
         return;
@@ -2586,7 +2586,7 @@ void CKeyBinds::UnbindCommand(const char* szCmdLine)
 
     // Split it up into bind key and command
     char* szKey = strtok(szTemp, " ");
-    char* szCommand = strtok(nullptr, " ");
+    char* szCommand = strtok(NULL, " ");
 
     if (szKey)
     {
@@ -2611,7 +2611,7 @@ void CKeyBinds::UnbindCommand(const char* szCmdLine)
                 if (strcmp(szCommand, "up") == 0 || strcmp(szCommand, "down") == 0)
                 {
                     bState = (strcmp(szCommand, "down") == 0);
-                    szCommand = strtok(nullptr, " ");
+                    szCommand = strtok(NULL, " ");
                 }
 
                 if (szCommand)
@@ -2647,8 +2647,8 @@ void CKeyBinds::PrintBindsCommand(const char* szCmdLine)
     CConsoleInterface* pConsole = m_pCore->GetConsole();
 
     // Get the key
-    char* szTemp = nullptr;
-    char* szKey = nullptr;
+    char* szTemp = NULL;
+    char* szKey = NULL;
 
     if (szCmdLine)
     {

--- a/Client/core/CKeyBinds.h
+++ b/Client/core/CKeyBinds.h
@@ -63,7 +63,7 @@ public:
     bool CommandExists(const char* szKey, const char* szCommand, bool bCheckState = false, bool bState = true, const char* szArguments = NULL,
                        const char* szResource = NULL, bool bCheckScriptCreated = false, bool bScriptCreated = false);
     bool SetCommandActive(const char* szKey, const char* szCommand, bool bState, const char* szArguments, const char* szResource, bool bActive,
-                          bool checkHitState, bool bCanWithOriginalKeyInstead = false);
+                          bool checkHitState, bool bConsiderDefaultKey = false);
     void SetAllCommandsActive(const char* szResource, bool bActive, const char* szCommand = NULL, bool bState = true, const char* szArguments = NULL,
                               bool checkHitState = false, const char* szOnlyWithDefaultKey = NULL);
     CCommandBind* GetBindFromCommand(const char* szCommand, const char* szArguments = NULL, bool bMatchCase = true, const char* szKey = NULL,

--- a/Client/core/CKeyBinds.h
+++ b/Client/core/CKeyBinds.h
@@ -54,20 +54,20 @@ public:
     std::list<CKeyBind*>::const_iterator IterEnd(void) { return m_pList->end(); }
 
     // Command-bind funcs
-    bool AddCommand(const char* szKey, const char* szCommand, const char* szArguments, bool bState, const char* szResource = nullptr, bool bScriptCreated = false,
-                    const char* szOriginalScriptKey = nullptr);
-    bool AddCommand(const SBindableKey* pKey, const char* szCommand, const char* szArguments = nullptr, bool bState = true);
+    bool AddCommand(const char* szKey, const char* szCommand, const char* szArguments, bool bState, const char* szResource = NULL, bool bScriptCreated = false,
+                    const char* szOriginalScriptKey = NULL);
+    bool AddCommand(const SBindableKey* pKey, const char* szCommand, const char* szArguments = NULL, bool bState = true);
     bool RemoveCommand(const char* szKey, const char* szCommand, bool bCheckState = false, bool bState = true);
     bool RemoveAllCommands(const char* szKey, bool bCheckState = false, bool bState = true);
     bool RemoveAllCommands(void);
-    bool CommandExists(const char* szKey, const char* szCommand, bool bCheckState = false, bool bState = true, const char* szArguments = nullptr,
-                       const char* szResource = nullptr, bool bCheckScriptCreated = false, bool bScriptCreated = false);
+    bool CommandExists(const char* szKey, const char* szCommand, bool bCheckState = false, bool bState = true, const char* szArguments = NULL,
+                       const char* szResource = NULL, bool bCheckScriptCreated = false, bool bScriptCreated = false);
     bool SetCommandActive(const char* szKey, const char* szCommand, bool bState, const char* szArguments, const char* szResource, bool bActive,
                           bool checkHitState, bool bConsiderDefaultKey = false);
-    void SetAllCommandsActive(const char* szResource, bool bActive, const char* szCommand = nullptr, bool bState = true, const char* szArguments = nullptr,
-                              bool checkHitState = false, const char* szOnlyWithDefaultKey = nullptr);
-    CCommandBind* GetBindFromCommand(const char* szCommand, const char* szArguments = nullptr, bool bMatchCase = true, const char* szKey = nullptr,
-                                     bool bCheckHitState = false, bool bState = false);
+    void SetAllCommandsActive(const char* szResource, bool bActive, const char* szCommand = NULL, bool bState = true, const char* szArguments = NULL,
+                              bool checkHitState = false, const char* szOnlyWithDefaultKey = NULL);
+    CCommandBind* GetBindFromCommand(const char* szCommand, const char* szArguments = NULL, bool bMatchCase = true, const char* szKey = NULL,
+                                     bool bCheckHitState = false, bool bState = NULL);
     bool          GetBoundCommands(const char* szCommand, std::list<CCommandBind*>& commandsList);
     void          UserChangeCommandBoundKey(CCommandBind* pBind, const SBindableKey* pNewBoundKey);
     void          UserRemoveCommandBoundKey(CCommandBind* pBind);

--- a/Client/core/CKeyBinds.h
+++ b/Client/core/CKeyBinds.h
@@ -65,7 +65,7 @@ public:
     bool SetCommandActive(const char* szKey, const char* szCommand, bool bState, const char* szArguments, const char* szResource, bool bActive,
                           bool checkHitState, bool bConsiderDefaultKey = false);
     void SetAllCommandsActive(const char* szResource, bool bActive, const char* szCommand = NULL, bool bState = true, const char* szArguments = NULL,
-                              bool checkHitState = false, const char* szOnlyWithDefaultKey = NULL);
+                              bool checkHitState = false, const char* szOnlyWithDefaultKey = nullptr);
     CCommandBind* GetBindFromCommand(const char* szCommand, const char* szArguments = NULL, bool bMatchCase = true, const char* szKey = NULL,
                                      bool bCheckHitState = false, bool bState = NULL);
     bool          GetBoundCommands(const char* szCommand, std::list<CCommandBind*>& commandsList);

--- a/Client/core/CKeyBinds.h
+++ b/Client/core/CKeyBinds.h
@@ -63,9 +63,9 @@ public:
     bool CommandExists(const char* szKey, const char* szCommand, bool bCheckState = false, bool bState = true, const char* szArguments = NULL,
                        const char* szResource = NULL, bool bCheckScriptCreated = false, bool bScriptCreated = false);
     bool SetCommandActive(const char* szKey, const char* szCommand, bool bState, const char* szArguments, const char* szResource, bool bActive,
-                          bool checkHitState);
+                          bool checkHitState, bool bCanWithOriginalKeyInstead = false);
     void SetAllCommandsActive(const char* szResource, bool bActive, const char* szCommand = NULL, bool bState = true, const char* szArguments = NULL,
-                              bool checkHitState = false);
+                              bool checkHitState = false, const char* szOnlyWithDefaultKey = NULL);
     CCommandBind* GetBindFromCommand(const char* szCommand, const char* szArguments = NULL, bool bMatchCase = true, const char* szKey = NULL,
                                      bool bCheckHitState = false, bool bState = NULL);
     bool          GetBoundCommands(const char* szCommand, std::list<CCommandBind*>& commandsList);

--- a/Client/core/CKeyBinds.h
+++ b/Client/core/CKeyBinds.h
@@ -54,20 +54,20 @@ public:
     std::list<CKeyBind*>::const_iterator IterEnd(void) { return m_pList->end(); }
 
     // Command-bind funcs
-    bool AddCommand(const char* szKey, const char* szCommand, const char* szArguments, bool bState, const char* szResource = NULL, bool bScriptCreated = false,
-                    const char* szOriginalScriptKey = NULL);
-    bool AddCommand(const SBindableKey* pKey, const char* szCommand, const char* szArguments = NULL, bool bState = true);
+    bool AddCommand(const char* szKey, const char* szCommand, const char* szArguments, bool bState, const char* szResource = nullptr, bool bScriptCreated = false,
+                    const char* szOriginalScriptKey = nullptr);
+    bool AddCommand(const SBindableKey* pKey, const char* szCommand, const char* szArguments = nullptr, bool bState = true);
     bool RemoveCommand(const char* szKey, const char* szCommand, bool bCheckState = false, bool bState = true);
     bool RemoveAllCommands(const char* szKey, bool bCheckState = false, bool bState = true);
     bool RemoveAllCommands(void);
-    bool CommandExists(const char* szKey, const char* szCommand, bool bCheckState = false, bool bState = true, const char* szArguments = NULL,
-                       const char* szResource = NULL, bool bCheckScriptCreated = false, bool bScriptCreated = false);
+    bool CommandExists(const char* szKey, const char* szCommand, bool bCheckState = false, bool bState = true, const char* szArguments = nullptr,
+                       const char* szResource = nullptr, bool bCheckScriptCreated = false, bool bScriptCreated = false);
     bool SetCommandActive(const char* szKey, const char* szCommand, bool bState, const char* szArguments, const char* szResource, bool bActive,
                           bool checkHitState, bool bConsiderDefaultKey = false);
-    void SetAllCommandsActive(const char* szResource, bool bActive, const char* szCommand = NULL, bool bState = true, const char* szArguments = NULL,
-                              bool checkHitState = false, const char* szOnlyWithDefaultKey = NULL);
-    CCommandBind* GetBindFromCommand(const char* szCommand, const char* szArguments = NULL, bool bMatchCase = true, const char* szKey = NULL,
-                                     bool bCheckHitState = false, bool bState = NULL);
+    void SetAllCommandsActive(const char* szResource, bool bActive, const char* szCommand = nullptr, bool bState = true, const char* szArguments = nullptr,
+                              bool checkHitState = false, const char* szOnlyWithDefaultKey = nullptr);
+    CCommandBind* GetBindFromCommand(const char* szCommand, const char* szArguments = nullptr, bool bMatchCase = true, const char* szKey = nullptr,
+                                     bool bCheckHitState = false, bool bState = false);
     bool          GetBoundCommands(const char* szCommand, std::list<CCommandBind*>& commandsList);
     void          UserChangeCommandBoundKey(CCommandBind* pBind, const SBindableKey* pNewBoundKey);
     void          UserRemoveCommandBoundKey(CCommandBind* pBind);

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -6511,16 +6511,16 @@ bool CStaticFunctionDefinitions::UnbindKey(const char* szKey, const char* szHitS
             }
         }
         if ((!stricmp(szHitState, "down") || !stricmp(szHitState, "both")) &&
-            pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, nullptr, szResource, false, true, true))
+            pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, NULL, szResource, false, true, true))
         {
-            pKeyBinds->SetAllCommandsActive(szResource, false, szCommandName, bHitState, nullptr, true, szKey);
+            pKeyBinds->SetAllCommandsActive(szResource, false, szCommandName, bHitState, NULL, true, szKey);
             bSuccess = true;
         }
         bHitState = false;
         if ((!stricmp(szHitState, "up") || !stricmp(szHitState, "both")) &&
-            pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, nullptr, szResource, false, true, true))
+            pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, NULL, szResource, false, true, true))
         {
-            pKeyBinds->SetAllCommandsActive(szResource, false, szCommandName, bHitState, nullptr, true, szKey);
+            pKeyBinds->SetAllCommandsActive(szResource, false, szCommandName, bHitState, NULL, true, szKey);
             bSuccess = true;
         }
     }

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -6421,7 +6421,7 @@ bool CStaticFunctionDefinitions::BindKey(const char* szKey, const char* szHitSta
     {
         bool bHitState = true;
         // Activate all keys for this command
-        pKeyBinds->SetAllCommandsActive(szResource, true, szCommandName, bHitState, szArguments, true);
+        pKeyBinds->SetAllCommandsActive(szResource, true, szCommandName, bHitState, szArguments, true, szKey);
         // Check if its binded already (dont rebind)
         if (pKeyBinds->CommandExists(szKey, szCommandName, true, bHitState, szArguments, szResource, true, true))
             return true;
@@ -6434,7 +6434,7 @@ bool CStaticFunctionDefinitions::BindKey(const char* szKey, const char* szHitSta
         }
 
         bHitState = false;
-        pKeyBinds->SetAllCommandsActive(szResource, true, szCommandName, bHitState, szArguments, true);
+        pKeyBinds->SetAllCommandsActive(szResource, true, szCommandName, bHitState, szArguments, true, szKey);
         if (pKeyBinds->CommandExists(szKey, szCommandName, true, bHitState, szArguments, szResource, true, true))
             return true;
 
@@ -6511,16 +6511,16 @@ bool CStaticFunctionDefinitions::UnbindKey(const char* szKey, const char* szHitS
             }
         }
         if ((!stricmp(szHitState, "down") || !stricmp(szHitState, "both")) &&
-            pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, NULL, szResource, false, true))
+            pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, NULL, szResource, false, true, true))
         {
-            pKeyBinds->SetAllCommandsActive(szResource, false, szCommandName, bHitState, NULL, true);
+            pKeyBinds->SetAllCommandsActive(szResource, false, szCommandName, bHitState, NULL, true, szKey);
             bSuccess = true;
         }
         bHitState = false;
         if ((!stricmp(szHitState, "up") || !stricmp(szHitState, "both")) &&
-            pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, NULL, szResource, false, true))
+            pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, NULL, szResource, false, true, true))
         {
-            pKeyBinds->SetAllCommandsActive(szResource, false, szCommandName, bHitState, NULL, true);
+            pKeyBinds->SetAllCommandsActive(szResource, false, szCommandName, bHitState, NULL, true, szKey);
             bSuccess = true;
         }
     }

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -6511,16 +6511,16 @@ bool CStaticFunctionDefinitions::UnbindKey(const char* szKey, const char* szHitS
             }
         }
         if ((!stricmp(szHitState, "down") || !stricmp(szHitState, "both")) &&
-            pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, NULL, szResource, false, true, true))
+            pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, nullptr, szResource, false, true, true))
         {
-            pKeyBinds->SetAllCommandsActive(szResource, false, szCommandName, bHitState, NULL, true, szKey);
+            pKeyBinds->SetAllCommandsActive(szResource, false, szCommandName, bHitState, nullptr, true, szKey);
             bSuccess = true;
         }
         bHitState = false;
         if ((!stricmp(szHitState, "up") || !stricmp(szHitState, "both")) &&
-            pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, NULL, szResource, false, true, true))
+            pKeyBinds->SetCommandActive(szKey, szCommandName, bHitState, nullptr, szResource, false, true, true))
         {
-            pKeyBinds->SetAllCommandsActive(szResource, false, szCommandName, bHitState, NULL, true, szKey);
+            pKeyBinds->SetAllCommandsActive(szResource, false, szCommandName, bHitState, nullptr, true, szKey);
             bSuccess = true;
         }
     }

--- a/Client/sdk/core/CKeyBindsInterface.h
+++ b/Client/sdk/core/CKeyBindsInterface.h
@@ -158,17 +158,17 @@ public:
     virtual std::list<CKeyBind*>::const_iterator IterEnd(void) = 0;
 
     // Command-bind funcs
-    virtual bool AddCommand(const char* szKey, const char* szCommand, const char* szArguments, bool bState, const char* szResource = NULL,
-                            bool bScriptCreated = false, const char* szOriginalScriptKey = NULL) = 0;
-    virtual bool AddCommand(const SBindableKey* pKey, const char* szCommand, const char* szArguments = NULL, bool bState = true) = 0;
-    virtual bool CommandExists(const char* szKey, const char* szCommand, bool bCheckState = false, bool bState = true, const char* szArguments = NULL,
-                               const char* szResource = NULL, bool bCheckScriptCreated = false, bool bScriptCreated = false) = 0;
+    virtual bool AddCommand(const char* szKey, const char* szCommand, const char* szArguments, bool bState, const char* szResource = nullptr,
+                            bool bScriptCreated = false, const char* szOriginalScriptKey = nullptr) = 0;
+    virtual bool AddCommand(const SBindableKey* pKey, const char* szCommand, const char* szArguments = nullptr, bool bState = true) = 0;
+    virtual bool CommandExists(const char* szKey, const char* szCommand, bool bCheckState = false, bool bState = true, const char* szArguments = nullptr,
+                               const char* szResource = nullptr, bool bCheckScriptCreated = false, bool bScriptCreated = false) = 0;
     virtual bool SetCommandActive(const char* szKey, const char* szCommand, bool bState, const char* szArguments, const char* szResource, bool bActive,
                                   bool checkHitState, bool bConsiderDefaultKey = false) = 0;
-    virtual void SetAllCommandsActive(const char* szResource, bool bActive, const char* szCommand = NULL, bool bState = true, const char* szArguments = NULL,
-                                      bool checkHitState = false, const char* szOnlyWithDefaultKey = NULL) = 0;
-    virtual CCommandBind* GetBindFromCommand(const char* szCommand, const char* szArguments = NULL, bool bMatchCase = true, const char* szKey = NULL,
-                                             bool bCheckHitState = false, bool bState = NULL) = 0;
+    virtual void SetAllCommandsActive(const char* szResource, bool bActive, const char* szCommand = nullptr, bool bState = true, const char* szArguments = nullptr,
+                                      bool checkHitState = false, const char* szOnlyWithDefaultKey = nullptr) = 0;
+    virtual CCommandBind* GetBindFromCommand(const char* szCommand, const char* szArguments = nullptr, bool bMatchCase = true, const char* szKey = nullptr,
+                                             bool bCheckHitState = false, bool bState = false) = 0;
     virtual bool          GetBoundCommands(const char* szCommand, std::list<CCommandBind*>& commandsList) = 0;
     virtual void          UserChangeCommandBoundKey(CCommandBind* pBind, const SBindableKey* pNewBoundKey) = 0;
     virtual void          UserRemoveCommandBoundKey(CCommandBind* pBind) = 0;

--- a/Client/sdk/core/CKeyBindsInterface.h
+++ b/Client/sdk/core/CKeyBindsInterface.h
@@ -158,17 +158,17 @@ public:
     virtual std::list<CKeyBind*>::const_iterator IterEnd(void) = 0;
 
     // Command-bind funcs
-    virtual bool AddCommand(const char* szKey, const char* szCommand, const char* szArguments, bool bState, const char* szResource = nullptr,
-                            bool bScriptCreated = false, const char* szOriginalScriptKey = nullptr) = 0;
-    virtual bool AddCommand(const SBindableKey* pKey, const char* szCommand, const char* szArguments = nullptr, bool bState = true) = 0;
-    virtual bool CommandExists(const char* szKey, const char* szCommand, bool bCheckState = false, bool bState = true, const char* szArguments = nullptr,
-                               const char* szResource = nullptr, bool bCheckScriptCreated = false, bool bScriptCreated = false) = 0;
+    virtual bool AddCommand(const char* szKey, const char* szCommand, const char* szArguments, bool bState, const char* szResource = NULL,
+                            bool bScriptCreated = false, const char* szOriginalScriptKey = NULL) = 0;
+    virtual bool AddCommand(const SBindableKey* pKey, const char* szCommand, const char* szArguments = NULL, bool bState = true) = 0;
+    virtual bool CommandExists(const char* szKey, const char* szCommand, bool bCheckState = false, bool bState = true, const char* szArguments = NULL,
+                               const char* szResource = NULL, bool bCheckScriptCreated = false, bool bScriptCreated = false) = 0;
     virtual bool SetCommandActive(const char* szKey, const char* szCommand, bool bState, const char* szArguments, const char* szResource, bool bActive,
                                   bool checkHitState, bool bConsiderDefaultKey = false) = 0;
-    virtual void SetAllCommandsActive(const char* szResource, bool bActive, const char* szCommand = nullptr, bool bState = true, const char* szArguments = nullptr,
-                                      bool checkHitState = false, const char* szOnlyWithDefaultKey = nullptr) = 0;
-    virtual CCommandBind* GetBindFromCommand(const char* szCommand, const char* szArguments = nullptr, bool bMatchCase = true, const char* szKey = nullptr,
-                                             bool bCheckHitState = false, bool bState = false) = 0;
+    virtual void SetAllCommandsActive(const char* szResource, bool bActive, const char* szCommand = NULL, bool bState = true, const char* szArguments = NULL,
+                                      bool checkHitState = false, const char* szOnlyWithDefaultKey = NULL) = 0;
+    virtual CCommandBind* GetBindFromCommand(const char* szCommand, const char* szArguments = NULL, bool bMatchCase = true, const char* szKey = NULL,
+                                             bool bCheckHitState = false, bool bState = NULL) = 0;
     virtual bool          GetBoundCommands(const char* szCommand, std::list<CCommandBind*>& commandsList) = 0;
     virtual void          UserChangeCommandBoundKey(CCommandBind* pBind, const SBindableKey* pNewBoundKey) = 0;
     virtual void          UserRemoveCommandBoundKey(CCommandBind* pBind) = 0;

--- a/Client/sdk/core/CKeyBindsInterface.h
+++ b/Client/sdk/core/CKeyBindsInterface.h
@@ -164,9 +164,9 @@ public:
     virtual bool CommandExists(const char* szKey, const char* szCommand, bool bCheckState = false, bool bState = true, const char* szArguments = NULL,
                                const char* szResource = NULL, bool bCheckScriptCreated = false, bool bScriptCreated = false) = 0;
     virtual bool SetCommandActive(const char* szKey, const char* szCommand, bool bState, const char* szArguments, const char* szResource, bool bActive,
-                                  bool checkHitState) = 0;
+                                  bool checkHitState, bool bCanWithOriginalKeyInstead = false) = 0;
     virtual void SetAllCommandsActive(const char* szResource, bool bActive, const char* szCommand = NULL, bool bState = true, const char* szArguments = NULL,
-                                      bool checkHitState = false) = 0;
+                                      bool checkHitState = false, const char* szOnlyWithDefaultKey = NULL) = 0;
     virtual CCommandBind* GetBindFromCommand(const char* szCommand, const char* szArguments = NULL, bool bMatchCase = true, const char* szKey = NULL,
                                              bool bCheckHitState = false, bool bState = NULL) = 0;
     virtual bool          GetBoundCommands(const char* szCommand, std::list<CCommandBind*>& commandsList) = 0;

--- a/Client/sdk/core/CKeyBindsInterface.h
+++ b/Client/sdk/core/CKeyBindsInterface.h
@@ -164,7 +164,7 @@ public:
     virtual bool CommandExists(const char* szKey, const char* szCommand, bool bCheckState = false, bool bState = true, const char* szArguments = NULL,
                                const char* szResource = NULL, bool bCheckScriptCreated = false, bool bScriptCreated = false) = 0;
     virtual bool SetCommandActive(const char* szKey, const char* szCommand, bool bState, const char* szArguments, const char* szResource, bool bActive,
-                                  bool checkHitState, bool bCanWithOriginalKeyInstead = false) = 0;
+                                  bool checkHitState, bool bConsiderDefaultKey = false) = 0;
     virtual void SetAllCommandsActive(const char* szResource, bool bActive, const char* szCommand = NULL, bool bState = true, const char* szArguments = NULL,
                                       bool checkHitState = false, const char* szOnlyWithDefaultKey = NULL) = 0;
     virtual CCommandBind* GetBindFromCommand(const char* szCommand, const char* szArguments = NULL, bool bMatchCase = true, const char* szKey = NULL,


### PR DESCRIPTION
Bugtracker:
https://bugs.mtasa.com/view.php?id=9178

Sorry for the last PR and the bug it produced, didn't know about being able to change the key of a bind by yourself.

This PR should fix all the bugs - and the changes are much better than the last time (cause now I can understand why SetAllCommandsActive was used).