### PR TITLE
0009742: add support for Vec2s on createColPolygon client-side and allow passing in more Vec2s server-side

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
@@ -255,6 +255,15 @@ int CLuaColShapeDefs::CreateColPolygon(lua_State* luaVM)
     CScriptArgReader argStream(luaVM);
     argStream.ReadVector2D(vecPosition);
 
+    // Get the points
+    std::vector<CVector2D> vecPointList;
+    for (uint i = 0; i < 3 || argStream.NextIsVector2D(); i++)
+    {
+        CVector2D vecPoint;
+        argStream.ReadVector2D(vecPoint);
+        vecPointList.push_back(vecPoint);
+    }
+
     if (!argStream.HasErrors())
     {
         CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
@@ -267,11 +276,10 @@ int CLuaColShapeDefs::CreateColPolygon(lua_State* luaVM)
                 CClientColPolygon* pShape = CStaticFunctionDefinitions::CreateColPolygon(*pResource, vecPosition);
                 if (pShape)
                 {
-                    // Get the points
-                    while (argStream.NextCouldBeNumber() && argStream.NextCouldBeNumber(1))
+                    // Add the points
+                    for (uint i = 0; i < vecPointList.size(); i++)
                     {
-                        argStream.ReadVector2D(vecPosition);
-                        pShape->AddPoint(vecPosition);
+                        pShape->AddPoint(vecPointList[i]);
                     }
 
                     CElementGroup* pGroup = pResource->GetElementGroup();

--- a/Server/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
@@ -249,7 +249,7 @@ int CLuaColShapeDefs::CreateColPolygon(lua_State* luaVM)
     std::vector<CVector2D> vecPointList;
 
     CScriptArgReader argStream(luaVM);
-    for (uint i = 0; i < 4 || argStream.NextCouldBeNumber(); i++)
+    for (uint i = 0; i < 4 || argStream.NextIsVector2D(); i++)
     {
         CVector2D vecPoint;
         argStream.ReadVector2D(vecPoint);


### PR DESCRIPTION
**Mantis Bug Tracker issue:**
[9742](https://bugs.mtasa.com/view.php?id=9742)

**Co-contributors:**
@4O4 ([PR](https://github.com/multitheftauto/mtasa-blue/pull/163))

I was fixing someone's Lua script and that's how I encountered this bug. I searched for the issue on Mantis Bug Tracker and then I found a link to [@4O4's old PR](https://github.com/multitheftauto/mtasa-blue/pull/163) which I reviewed. My patch is slightly different. I read the comments @qaisjp had written. I did not directly copy any code from his PR, but I do want to give him credits obviously for delivering a patch before me.

**Function:**
[createColPolygon](https://wiki.multitheftauto.com/wiki/CreateColPolygon)

**Summary:**
- Passing in Vec2s client-side was not working;
- Passing in Vec2s server-side was limited to 4;
- Neither of which threw errors if not all 3 required points were given (due to it reading argStream wrong);
- Pretty small and simple fix, easy to test.

**Testing:**
While I could provide my own tests, I found that [@4O4's tests](https://github.com/4O4/mtasa-lua-tests/tree/master/%5Btests%5D/test-colshape-polygon) do the same thing. All tests passed and making complicated polygon colshapes is working.