### PR TITLE
0008523: Fix empty string in getVehicleNameFromModel (instead of false)

### DIFF
--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -2470,7 +2470,7 @@ bool CStaticFunctionDefinitions::GetVehicleUpgradeSlotName(unsigned short usUpgr
 bool CStaticFunctionDefinitions::GetVehicleNameFromModel(unsigned short usModel, SString& strOutName)
 {
     strOutName = CVehicleNames::GetVehicleName(usModel);
-    return true;
+    return !strOutName.empty();
 }
 
 bool CStaticFunctionDefinitions::GetHelicopterRotorSpeed(CClientVehicle& Vehicle, float& fSpeed)

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -4903,7 +4903,7 @@ bool CStaticFunctionDefinitions::GetVehicleName(CVehicle* pVehicle, SString& str
 bool CStaticFunctionDefinitions::GetVehicleNameFromModel(unsigned short usModel, SString& strOutName)
 {
     strOutName = CVehicleNames::GetVehicleName(usModel);
-    return true;
+    return !strOutName.empty();
 }
 
 CPed* CStaticFunctionDefinitions::GetVehicleOccupant(CVehicle* pVehicle, unsigned int uiSeat)


### PR DESCRIPTION
Bugtracker:
https://bugs.mtasa.com/view.php?id=8523

Currently getVehicleNameFromModel returns an empty string when the model is invalid.
Instead it should return "false".

Is a confirmed bug in bugtracker ...
And the change is really small and was really fast - so you can reject the PR if you want.