### PR TITLE
0009433: Fix missing compatible vehicle-upgrades at clientside

### DIFF
--- a/Client/mods/deathmatch/logic/CVehicleUpgrades.cpp
+++ b/Client/mods/deathmatch/logic/CVehicleUpgrades.cpp
@@ -79,6 +79,13 @@ bool CVehicleUpgrades::IsUpgradeCompatible(unsigned short usUpgrade)
     if (us == VEHICLEUPGRADE_NITRO_5X || us == VEHICLEUPGRADE_NITRO_2X || us == VEHICLEUPGRADE_NITRO_10X || us == VEHICLEUPGRADE_HYDRAULICS)
         return true;
 
+    if (us == 1000 || us == 1001 || us == 1002 || us == 1003 || us == 1014 || /* spoiler */
+        us == 1015 || us == 1016 || us == 1023 || us == 1049 || us == 1050 || us == 1058 || us == 1060 || us == 1138 || us == 1139 || us == 1146 ||
+        us == 1147 || us == 1158 || us == 1162 || us == 1163 || us == 116)
+    {
+        return true;
+    }
+
     bool bReturn = false;
     switch (usModel)
     {


### PR DESCRIPTION
Bugtracker:
https://bugs.mtasa.com/view.php?id=9433

There were upgrades missing in IsUpgradeCompatible in clientside code. So the "not compatible" upgrades weren't added at clientside on new sync.

Source:
https://github.com/multitheftauto/mtasa-blue/blob/c39e2cbf9ef355e8720d98c7de7cda93fc25d735/Server/mods/deathmatch/logic/CVehicleUpgrades.cpp#L87