### PR TITLE
0009894: fix falling under the map up to -5000 for vehicles

### DIFF
--- a/Client/game_sa/CWorldSA.cpp
+++ b/Client/game_sa/CWorldSA.cpp
@@ -55,7 +55,7 @@ void _declspec(naked) HOOK_FallenPeds()
 
 void _declspec(naked) HOOK_FallenCars()
 {
-    if (pGame && !pGame->IsUnderWorldWarpEnabled())
+    if (pGame && pGame->IsUnderWorldWarpEnabled())
     {
         _asm
         {


### PR DESCRIPTION
**Mantis Bug Tracker issue:**
[9894](https://bugs.multitheftauto.com/view.php?id=9894)

**Summary:**
- pGame->IsUnderWorldWarpEnabled() check is inverted in HOOK_FallenCars while in HOOK_FallenPeds it's done right;
- Pretty small and simple fix, easy to test.
- Caused in #208 