### PR TITLE
0009849: add some missing Vehicle class methods

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -138,6 +138,11 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
 {
     lua_newclass(luaVM);
 
+    lua_classfunction(luaVM, "getModelFromName", "getVehicleModelFromName");
+    lua_classfunction(luaVM, "getNameFromModel", "getVehicleNameFromModel");
+    lua_classfunction(luaVM, "getOriginalHandling", "getOriginalHandling");
+    lua_classfunction(luaVM, "getUpgradeSlotName", "getVehicleUpgradeSlotName");
+
     lua_classfunction(luaVM, "create", "createVehicle");
     lua_classfunction(luaVM, "blow", "blowVehicle");
     lua_classfunction(luaVM, "fix", "fixVehicle");


### PR DESCRIPTION
**Mantis Bug Tracker issue:**
[9894](https://bugs.multitheftauto.com/view.php?id=9849)

**Summary:**
- Although advertised on Wiki, client-side `Vehicle.getModelFromName`, `Vehicle.getNameFromModel`, `Vehicle.getOriginalHandling`, `Vehicle.getUpgradeSlotName` are missing (can be found server-side, however);
- Pretty small and simple fix, easy to test.