### PR TITLE
0009897: fix getVehicleModelExhaustFumesPosition & setVehicleModelExhaustFumesPosition client crash

### DIFF
--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -923,14 +923,22 @@ CVector CModelInfoSA::GetVehicleExhaustFumesPosition()
     if (!IsVehicle())
         return CVector();
 
+    // Request model load right now if not loaded yet (#9897)
+    if (!IsLoaded())
+        Request(BLOCKING, "GetVehicleExhaustFumesPosition");
+
     auto pVehicleModel = reinterpret_cast<CVehicleModelInfoSAInterface*>(m_pInterface);
     return pVehicleModel->pVisualInfo->exhaustPosition;
 }
 
-void CModelInfoSA::SetVehicleExhaustFumesPosition(const CVector& position)
+void CModelInfoSA::SetVehicleExhaustFumesPosition(const CVector& vecPosition)
 {
     if (!IsVehicle())
         return;
+
+    // Request model load right now if not loaded yet (#9897)
+    if (!IsLoaded())
+        Request(BLOCKING, "SetVehicleExhaustFumesPosition");
 
     // Store default position in map
     auto pVehicleModel = reinterpret_cast<CVehicleModelInfoSAInterface*>(m_pInterface);
@@ -941,7 +949,7 @@ void CModelInfoSA::SetVehicleExhaustFumesPosition(const CVector& position)
     }
 
     // Set fumes position
-    pVehicleModel->pVisualInfo->exhaustPosition = position;
+    pVehicleModel->pVisualInfo->exhaustPosition = vecPosition;
 }
 
 void CModelInfoSA::ResetAllVehicleExhaustFumes()

--- a/Client/game_sa/CModelInfoSA.h
+++ b/Client/game_sa/CModelInfoSA.h
@@ -334,7 +334,7 @@ public:
     void*        GetVehicleSuspensionData(void);
     void*        SetVehicleSuspensionData(void* pSuspensionLines);
     CVector      GetVehicleExhaustFumesPosition() override;
-    void         SetVehicleExhaustFumesPosition(const CVector& position) override;
+    void         SetVehicleExhaustFumesPosition(const CVector& vecPosition) override;
     static void  ResetAllVehicleExhaustFumes();
 
     // ONLY use for peds


### PR DESCRIPTION
**Mantis Bug Tracker issue:**
[9897](https://bugs.multitheftauto.com/view.php?id=9897)

**Summary:**
- If you execute `getVehicleModelExhaustFumesPosition` or `setVehicleModelExhaustFumesPosition` any earlier than once you've got the vehicle model loaded, it crashes the client;
- Pretty small and simple fix, easy to test.