### PR TITLE
0009896: add a master volume level setting

### DIFF
--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -252,6 +252,7 @@ void CClientVariables::ValidateValues(void)
     ClampValue("chat_position_vertical", Chat::Position::Vertical::TOP, Chat::Position::Vertical::BOTTOM);
     ClampValue("chat_text_alignment", Chat::Text::Align::LEFT, Chat::Text::Align::RIGHT);
     ClampValue("text_scale", 0.8f, 3.0f);
+    ClampValue("mastervolume", 0.0f, 1.0f);
     ClampValue("mtavolume", 0.0f, 1.0f);
     ClampValue("voicevolume", 0.0f, 1.0f);
     ClampValue("mapalpha", 0, 255);
@@ -309,6 +310,7 @@ void CClientVariables::LoadDefaults(void)
     DEFAULT("fly_with_mouse", false);                                                 // flying with mouse controls
     DEFAULT("steer_with_mouse", false);                                               // steering with mouse controls
     DEFAULT("classic_controls", false);                                               // classic/standard controls
+    DEFAULT("mastervolume", 1.0f);                                                    // master volume
     DEFAULT("mtavolume", 1.0f);                                                       // custom sound's volume
     DEFAULT("voicevolume", 1.0f);                                                     // voice chat output volume
     DEFAULT("mapalpha", 155);                                                         // map alpha
@@ -334,6 +336,7 @@ void CClientVariables::LoadDefaults(void)
     DEFAULT("multimon_fullscreen_minimize", 1);                                       // 0-off 1-on
     DEFAULT("vertical_aim_sensitivity", 0.0015f);                                     // 0.0015f is GTA default setting
     DEFAULT("process_priority", 0);                                                   // 0-normal 1-above normal 2-high
+    DEFAULT("mute_master_when_minimized", 0);                                         // 0-off 1-on
     DEFAULT("mute_sfx_when_minimized", 0);                                            // 0-off 1-on
     DEFAULT("mute_radio_when_minimized", 0);                                          // 0-off 1-on
     DEFAULT("mute_mta_when_minimized", 0);                                            // 0-off 1-on

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -184,8 +184,8 @@ CCore::~CCore(void)
     // Destroy tray icon
     delete m_pTrayIcon;
 
-    // This will save GTA volume using the GTA volume level fader value set in settings
-    // and will not be "attenuated" by the master volume level setting.
+    // This will set the GTA volume to the GTA volume value in the settings,
+    // and is not affected by the master volume setting.
     m_pLocalGUI->GetMainMenu()->GetSettingsWindow()->ResetGTAVolume();
 
     // Delete the mod manager

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -184,7 +184,8 @@ CCore::~CCore(void)
     // Destroy tray icon
     delete m_pTrayIcon;
 
-    // Reset GTA volume levels by ignoring master level
+    // This will save GTA volume using the GTA volume level fader value set in settings
+    // and will not be "attenuated" by the master volume level setting.
     m_pLocalGUI->GetMainMenu()->GetSettingsWindow()->ResetGTAVolume();
 
     // Delete the mod manager

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -184,6 +184,9 @@ CCore::~CCore(void)
     // Destroy tray icon
     delete m_pTrayIcon;
 
+    // Reset GTA volume levels by ignoring master level
+    m_pLocalGUI->GetMainMenu()->GetSettingsWindow()->ResetGTAVolume();
+
     // Delete the mod manager
     delete m_pModManager;
     SAFE_DELETE(m_pMessageBox);

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -1762,7 +1762,8 @@ bool CSettings::OnVideoDefaultClick(CGUIElement* pElement)
 
 void CSettings::ResetGTAVolume()
 {
-    // This will reset and save GTA volume to given GTA volume levels and skip master volume level
+    // This will save GTA volume using the GTA volume level fader value set in settings
+    // and will not be "attenuated" by the master volume level setting.
     CGameSettings* gameSettings = CCore::GetSingleton().GetGame()->GetSettings();
     gameSettings->SetRadioVolume(m_fRadioVolume * 64.0f);
     gameSettings->SetSFXVolume(m_fSFXVolume * 64.0f);

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -551,7 +551,7 @@ void CSettings::CreateGUI(void)
     m_pCheckBoxUserAutoscan->GetPosition(vecTemp, false);
 
     vecTemp.fX = fIndentX + 260;
-    m_pAudioMuteLabel = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabAudio, _("Mute settings")));
+    m_pAudioMuteLabel = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabAudio, _("Mute options")));
     m_pAudioMuteLabel->SetPosition(CVector2D(vecTemp.fX, 13.0f));
     m_pAudioMuteLabel->GetPosition(vecTemp, false);
     m_pAudioMuteLabel->AutoSize(NULL, 5.0f);

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -1376,11 +1376,12 @@ void CSettings::UpdateAudioTab()
 
     CGameSettings* gameSettings = CCore::GetSingleton().GetGame()->GetSettings();
 
-    m_pAudioMasterVolume->SetScrollPosition(fMasterVolume);
     m_pAudioRadioVolume->SetScrollPosition(m_fRadioVolume);
     m_pAudioSFXVolume->SetScrollPosition(m_fSFXVolume);
     m_pAudioMTAVolume->SetScrollPosition(fMTAVolume);
     m_pAudioVoiceVolume->SetScrollPosition(fVoiceVolume);
+    // Lastly, set our master volume scroll position
+    m_pAudioMasterVolume->SetScrollPosition(fMasterVolume);
 
     m_pCheckBoxAudioEqualizer->SetSelected(gameSettings->IsRadioEqualizerEnabled());
     m_pCheckBoxAudioAutotune->SetSelected(gameSettings->IsRadioAutotuneEnabled());

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -1187,6 +1187,11 @@ void CSettings::CreateGUI(void)
     m_pAudioSFXVolume->SetOnScrollHandler(GUI_CALLBACK(&CSettings::OnSFXVolumeChanged, this));
     m_pAudioMTAVolume->SetOnScrollHandler(GUI_CALLBACK(&CSettings::OnMTAVolumeChanged, this));
     m_pAudioVoiceVolume->SetOnScrollHandler(GUI_CALLBACK(&CSettings::OnVoiceVolumeChanged, this));
+    m_pCheckBoxMuteMaster->SetClickHandler(GUI_CALLBACK(&CSettings::OnMasterMuteMinimizedChanged, this));
+    m_pCheckBoxMuteRadio->SetClickHandler(GUI_CALLBACK(&CSettings::OnRadioMuteMinimizedChanged, this));
+    m_pCheckBoxMuteSFX->SetClickHandler(GUI_CALLBACK(&CSettings::OnSFXMuteMinimizedChanged, this));
+    m_pCheckBoxMuteMTA->SetClickHandler(GUI_CALLBACK(&CSettings::OnMTAMuteMinimizedChanged, this));
+    m_pCheckBoxMuteVoice->SetClickHandler(GUI_CALLBACK(&CSettings::OnVoiceMuteMinimizedChanged, this));
     m_pFieldOfView->SetOnScrollHandler(GUI_CALLBACK(&CSettings::OnFieldOfViewChanged, this));
     m_pDrawDistance->SetOnScrollHandler(GUI_CALLBACK(&CSettings::OnDrawDistanceChanged, this));
     m_pBrightness->SetOnScrollHandler(GUI_CALLBACK(&CSettings::OnBrightnessChanged, this));
@@ -1382,15 +1387,21 @@ void CSettings::UpdateAudioTab()
     m_pCheckBoxUserAutoscan->SetSelected(gameSettings->IsUsertrackAutoScan());
 
     CVARS_GET("mute_master_when_minimized", m_bMuteMaster);
-    CVARS_GET("mute_sfx_when_minimized", m_bMuteSFX);
     CVARS_GET("mute_radio_when_minimized", m_bMuteRadio);
+    CVARS_GET("mute_sfx_when_minimized", m_bMuteSFX);
     CVARS_GET("mute_mta_when_minimized", m_bMuteMTA);
     CVARS_GET("mute_voice_when_minimized", m_bMuteVoice);
+
     m_pCheckBoxMuteMaster->SetSelected(m_bMuteMaster);
-    m_pCheckBoxMuteSFX->SetSelected(m_bMuteSFX);
     m_pCheckBoxMuteRadio->SetSelected(m_bMuteRadio);
+    m_pCheckBoxMuteSFX->SetSelected(m_bMuteSFX);
     m_pCheckBoxMuteMTA->SetSelected(m_bMuteMTA);
     m_pCheckBoxMuteVoice->SetSelected(m_bMuteVoice);
+
+    m_pCheckBoxMuteRadio->SetEnabled(!m_bMuteMaster);
+    m_pCheckBoxMuteSFX->SetEnabled(!m_bMuteMaster);
+    m_pCheckBoxMuteMTA->SetEnabled(!m_bMuteMaster);
+    m_pCheckBoxMuteVoice->SetEnabled(!m_bMuteMaster);
 
     m_pComboUsertrackMode->SetSelectedItemByIndex(gameSettings->GetUsertrackMode());
 }
@@ -2843,6 +2854,17 @@ bool CSettings::OnCancelButtonClick(CGUIElement* pElement)
     CVARS_SET("mute_mta_when_minimized", m_bOldMuteMTA);
     CVARS_SET("mute_voice_when_minimized", m_bOldMuteVoice);
 
+    m_pCheckBoxMuteMaster->SetSelected(m_bOldMuteMaster);
+    m_pCheckBoxMuteRadio->SetSelected(m_bOldMuteRadio);
+    m_pCheckBoxMuteSFX->SetSelected(m_bOldMuteSFX);
+    m_pCheckBoxMuteMTA->SetSelected(m_bOldMuteMTA);
+    m_pCheckBoxMuteVoice->SetSelected(m_bOldMuteVoice);
+
+    m_pCheckBoxMuteRadio->SetEnabled(!m_bOldMuteMaster);
+    m_pCheckBoxMuteSFX->SetEnabled(!m_bOldMuteMaster);
+    m_pCheckBoxMuteMTA->SetEnabled(!m_bOldMuteMaster);
+    m_pCheckBoxMuteVoice->SetEnabled(!m_bOldMuteMaster);
+
     return true;
 }
 
@@ -2895,15 +2917,21 @@ void CSettings::LoadData(void)
     m_pCheckBoxUserAutoscan->SetSelected(gameSettings->IsUsertrackAutoScan());
 
     CVARS_GET("mute_master_when_minimized", m_bOldMuteMaster);
-    CVARS_GET("mute_sfx_when_minimized", m_bOldMuteSFX);
     CVARS_GET("mute_radio_when_minimized", m_bOldMuteRadio);
+    CVARS_GET("mute_sfx_when_minimized", m_bOldMuteSFX);
     CVARS_GET("mute_mta_when_minimized", m_bOldMuteMTA);
     CVARS_GET("mute_voice_when_minimized", m_bOldMuteVoice);
+
     m_pCheckBoxMuteMaster->SetSelected(m_bOldMuteMaster);
-    m_pCheckBoxMuteSFX->SetSelected(m_bOldMuteSFX);
     m_pCheckBoxMuteRadio->SetSelected(m_bOldMuteRadio);
+    m_pCheckBoxMuteSFX->SetSelected(m_bOldMuteSFX);
     m_pCheckBoxMuteMTA->SetSelected(m_bOldMuteMTA);
     m_pCheckBoxMuteVoice->SetSelected(m_bOldMuteVoice);
+
+    m_pCheckBoxMuteRadio->SetEnabled(!m_bOldMuteMaster);
+    m_pCheckBoxMuteSFX->SetEnabled(!m_bOldMuteMaster);
+    m_pCheckBoxMuteMTA->SetEnabled(!m_bOldMuteMaster);
+    m_pCheckBoxMuteVoice->SetEnabled(!m_bOldMuteMaster);
 
     unsigned int uiUsertrackMode = gameSettings->GetUsertrackMode();
     if (uiUsertrackMode == 0)
@@ -3298,17 +3326,6 @@ void CSettings::SaveData(void)
     gameSettings->SetRadioEqualizerEnabled(m_pCheckBoxAudioEqualizer->GetSelected());
     gameSettings->SetRadioAutotuneEnabled(m_pCheckBoxAudioAutotune->GetSelected());
     gameSettings->SetUsertrackAutoScan(m_pCheckBoxUserAutoscan->GetSelected());
-
-    m_bMuteMaster = m_pCheckBoxMuteMaster->GetSelected();
-    m_bMuteSFX = m_pCheckBoxMuteSFX->GetSelected();
-    m_bMuteRadio = m_pCheckBoxMuteRadio->GetSelected();
-    m_bMuteMTA = m_pCheckBoxMuteMTA->GetSelected();
-    m_bMuteVoice = m_pCheckBoxMuteVoice->GetSelected();
-    CVARS_SET("mute_master_when_minimized", m_bMuteMaster);
-    CVARS_SET("mute_sfx_when_minimized", m_bMuteSFX);
-    CVARS_SET("mute_radio_when_minimized", m_bMuteRadio);
-    CVARS_SET("mute_mta_when_minimized", m_bMuteMTA);
-    CVARS_SET("mute_voice_when_minimized", m_bMuteVoice);
 
     if (CGUIListItem* pSelected = m_pComboUsertrackMode->GetSelectedItem())
     {
@@ -4069,6 +4086,41 @@ bool CSettings::OnMTAVolumeChanged(CGUIElement* pElement)
 
     CVARS_SET("mtavolume", m_pAudioMTAVolume->GetScrollPosition());
 
+    return true;
+}
+
+bool CSettings::OnMasterMuteMinimizedChanged(CGUIElement* pElement)
+{
+    bool bSelected = m_pCheckBoxMuteMaster->GetSelected();
+    m_pCheckBoxMuteRadio->SetEnabled(!bSelected);
+    m_pCheckBoxMuteSFX->SetEnabled(!bSelected);
+    m_pCheckBoxMuteMTA->SetEnabled(!bSelected);
+    m_pCheckBoxMuteVoice->SetEnabled(!bSelected);
+    CVARS_SET("mute_master_when_minimized", bSelected);
+    return true;
+}
+
+bool CSettings::OnRadioMuteMinimizedChanged(CGUIElement* pElement)
+{
+    CVARS_SET("mute_radio_when_minimized", m_pCheckBoxMuteRadio->GetSelected());
+    return true;
+}
+
+bool CSettings::OnSFXMuteMinimizedChanged(CGUIElement* pElement)
+{
+    CVARS_SET("mute_sfx_when_minimized", m_pCheckBoxMuteSFX->GetSelected());
+    return true;
+}
+
+bool CSettings::OnMTAMuteMinimizedChanged(CGUIElement* pElement)
+{
+    CVARS_SET("mute_mta_when_minimized", m_pCheckBoxMuteMTA->GetSelected());
+    return true;
+}
+
+bool CSettings::OnVoiceMuteMinimizedChanged(CGUIElement* pElement)
+{
+    CVARS_SET("mute_voice_when_minimized", m_pCheckBoxMuteVoice->GetSelected());
     return true;
 }
 

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -1762,8 +1762,8 @@ bool CSettings::OnVideoDefaultClick(CGUIElement* pElement)
 
 void CSettings::ResetGTAVolume()
 {
-    // This will save GTA volume using the GTA volume level fader value set in settings
-    // and will not be "attenuated" by the master volume level setting.
+    // This will set the GTA volume to the GTA volume value in the settings,
+    // and is not affected by the master volume setting.
     CGameSettings* gameSettings = CCore::GetSingleton().GetGame()->GetSettings();
     gameSettings->SetRadioVolume(m_fRadioVolume * 64.0f);
     gameSettings->SetSFXVolume(m_fSFXVolume * 64.0f);

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -26,6 +26,10 @@ extern SBindableKey        g_bkKeys[];
 
 CSettings::CSettings(void)
 {
+    CGameSettings* gameSettings = CCore::GetSingleton().GetGame()->GetSettings();
+    m_fRadioVolume = (float)gameSettings->GetRadioVolume() / 64.0f;
+    m_fSFXVolume = (float)gameSettings->GetSFXVolume() / 64.0f;
+
     m_iMaxAnisotropic = g_pDeviceState->AdapterState.MaxAnisotropicSetting;
     m_pWindow = NULL;
     m_bBrowserListsChanged = false;
@@ -398,12 +402,12 @@ void CSettings::CreateGUI(void)
     m_pMapAlphaValueLabel = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabMultiplayer, "0%"));
     m_pMapAlphaValueLabel->SetPosition(CVector2D(vecTemp.fX + vecSize.fX + 5.0f, vecTemp.fY));
     m_pMapAlphaValueLabel->GetPosition(vecTemp, false);
-    m_pMapAlphaValueLabel->AutoSize("100% ");
+    m_pMapAlphaValueLabel->AutoSize("100%");
 
     /**
      *  Audio tab
      **/
-    fIndentX = pManager->CGUI_GetMaxTextExtent("default-normal", _("Radio volume:"), _("SFX volume:"), _("MTA volume:"), _("Voice volume:"), _("Play mode:"));
+    fIndentX = pManager->CGUI_GetMaxTextExtent("default-normal", _("Master volume:"), _("Radio volume:"), _("SFX volume:"), _("MTA volume:"), _("Voice volume:"), _("Play mode:"));
 
     m_pAudioGeneralLabel = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabAudio, _("General")));
     m_pAudioGeneralLabel->SetPosition(CVector2D(11, 13));
@@ -411,6 +415,25 @@ void CSettings::CreateGUI(void)
     m_pAudioGeneralLabel->AutoSize(NULL, 5.0f);
     m_pAudioGeneralLabel->SetFont("default-bold-small");
 
+    m_pLabelMasterVolume = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabAudio, _("Master volume:")));
+    m_pLabelMasterVolume->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 29.0f), false);
+    m_pLabelMasterVolume->GetPosition(vecTemp, false);
+    m_pLabelMasterVolume->AutoSize();
+
+    m_pAudioMasterVolume = reinterpret_cast<CGUIScrollBar*>(pManager->CreateScrollBar(true, pTabAudio));
+    m_pAudioMasterVolume->SetPosition(CVector2D(vecTemp.fX + fIndentX + 5.0f, vecTemp.fY));
+    m_pAudioMasterVolume->GetPosition(vecTemp, false);
+    m_pAudioMasterVolume->SetSize(CVector2D(160.0f, 20.0f));
+    m_pAudioMasterVolume->GetSize(vecSize, false);
+    m_pAudioMasterVolume->SetProperty("StepSize", "0.01");
+
+    m_pLabelMasterVolumeValue = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabAudio, "0%"));
+    m_pLabelMasterVolumeValue->SetPosition(CVector2D(vecTemp.fX + vecSize.fX + 5.0f, vecTemp.fY));
+    m_pLabelMasterVolumeValue->GetPosition(vecTemp, false);
+    m_pLabelMasterVolumeValue->AutoSize("100%");
+    m_pLabelMasterVolumeValue->GetSize(vecSize, false);
+
+    vecTemp.fX = 11;
     m_pLabelRadioVolume = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabAudio, _("Radio volume:")));
     m_pLabelRadioVolume->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 29.0f), false);
     m_pLabelRadioVolume->GetPosition(vecTemp, false);
@@ -487,35 +510,19 @@ void CSettings::CreateGUI(void)
     m_pLabelVoiceVolumeValue->GetSize(vecSize, false);
 
     vecTemp.fX = 11;
-
-    m_pCheckBoxMuteRadio = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabAudio, _("Mute Radio sounds when minimized"), true));
-    m_pCheckBoxMuteRadio->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 32.0f));
-    m_pCheckBoxMuteRadio->GetPosition(vecTemp, false);
-    m_pCheckBoxMuteRadio->AutoSize(NULL, 20.0f);
-
-    m_pCheckBoxMuteSFX = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabAudio, _("Mute SFX sounds when minimized"), true));
-    m_pCheckBoxMuteSFX->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 16.0f));
-    m_pCheckBoxMuteSFX->GetPosition(vecTemp, false);
-    m_pCheckBoxMuteSFX->AutoSize(NULL, 20.0f);
-
-    m_pCheckBoxMuteMTA = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabAudio, _("Mute MTA sounds when minimized"), true));
-    m_pCheckBoxMuteMTA->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 16.0f));
-    m_pCheckBoxMuteMTA->GetPosition(vecTemp, false);
-    m_pCheckBoxMuteMTA->AutoSize(NULL, 20.0f);
-
-    m_pCheckBoxMuteVoice = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabAudio, _("Mute Voice sounds when minimized"), true));
-    m_pCheckBoxMuteVoice->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 16.0f));
-    m_pCheckBoxMuteVoice->GetPosition(vecTemp, false);
-    m_pCheckBoxMuteVoice->AutoSize(NULL, 20.0f);
-
-    vecTemp.fX = 11;
+    m_pAudioRadioLabel = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabAudio, _("Radio options")));
+    m_pAudioRadioLabel->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 30.0f), false);
+    m_pAudioRadioLabel->GetPosition(vecTemp, false);
+    m_pAudioRadioLabel->AutoSize(NULL, 10.0f);
+    m_pAudioRadioLabel->SetFont("default-bold-small");
 
     m_pCheckBoxAudioEqualizer = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabAudio, _("Radio Equalizer"), true));
-    m_pCheckBoxAudioEqualizer->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 30.0f));
+    m_pCheckBoxAudioEqualizer->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 29.0f));
     m_pCheckBoxAudioEqualizer->AutoSize(NULL, 20.0f);
+    m_pCheckBoxAudioEqualizer->GetPosition(vecTemp);
 
     m_pCheckBoxAudioAutotune = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabAudio, _("Radio Auto-tune"), true));
-    m_pCheckBoxAudioAutotune->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 50.0f));
+    m_pCheckBoxAudioAutotune->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 20.0f));
     m_pCheckBoxAudioAutotune->AutoSize(NULL, 20.0f);
     m_pCheckBoxAudioAutotune->GetPosition(vecTemp);
 
@@ -542,6 +549,38 @@ void CSettings::CreateGUI(void)
     m_pCheckBoxUserAutoscan->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 32.0f));
     m_pCheckBoxUserAutoscan->AutoSize(NULL, 20.0f);
     m_pCheckBoxUserAutoscan->GetPosition(vecTemp, false);
+
+    vecTemp.fX = fIndentX + 260;
+    m_pAudioMuteLabel = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabAudio, _("Mute settings")));
+    m_pAudioMuteLabel->SetPosition(CVector2D(vecTemp.fX, 13.0f));
+    m_pAudioMuteLabel->GetPosition(vecTemp, false);
+    m_pAudioMuteLabel->AutoSize(NULL, 5.0f);
+    m_pAudioMuteLabel->SetFont("default-bold-small");
+
+    m_pCheckBoxMuteMaster = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabAudio, _("Mute All sounds when minimized"), true));
+    m_pCheckBoxMuteMaster->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 29.0f));
+    m_pCheckBoxMuteMaster->GetPosition(vecTemp, false);
+    m_pCheckBoxMuteMaster->AutoSize(NULL, 20.0f);
+
+    m_pCheckBoxMuteRadio = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabAudio, _("Mute Radio sounds when minimized"), true));
+    m_pCheckBoxMuteRadio->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 20.0f));
+    m_pCheckBoxMuteRadio->GetPosition(vecTemp, false);
+    m_pCheckBoxMuteRadio->AutoSize(NULL, 20.0f);
+
+    m_pCheckBoxMuteSFX = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabAudio, _("Mute SFX sounds when minimized"), true));
+    m_pCheckBoxMuteSFX->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 20.0f));
+    m_pCheckBoxMuteSFX->GetPosition(vecTemp, false);
+    m_pCheckBoxMuteSFX->AutoSize(NULL, 20.0f);
+
+    m_pCheckBoxMuteMTA = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabAudio, _("Mute MTA sounds when minimized"), true));
+    m_pCheckBoxMuteMTA->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 20.0f));
+    m_pCheckBoxMuteMTA->GetPosition(vecTemp, false);
+    m_pCheckBoxMuteMTA->AutoSize(NULL, 20.0f);
+
+    m_pCheckBoxMuteVoice = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabAudio, _("Mute Voice sounds when minimized"), true));
+    m_pCheckBoxMuteVoice->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 20.0f));
+    m_pCheckBoxMuteVoice->GetPosition(vecTemp, false);
+    m_pCheckBoxMuteVoice->AutoSize(NULL, 20.0f);
 
     m_pTabs->GetSize(vecTemp);
     m_pAudioDefButton = reinterpret_cast<CGUIButton*>(pManager->CreateButton(pTabAudio, _("Load defaults")));
@@ -634,7 +673,7 @@ void CSettings::CreateGUI(void)
 
     m_pDrawDistanceValueLabel = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabVideo, "0%"));
     m_pDrawDistanceValueLabel->SetPosition(CVector2D(vecTemp.fX + vecSize.fX + 5.0f, vecTemp.fY));
-    m_pDrawDistanceValueLabel->AutoSize("100% ");
+    m_pDrawDistanceValueLabel->AutoSize("100%");
 
     vecTemp.fX = 11;
 
@@ -652,7 +691,7 @@ void CSettings::CreateGUI(void)
 
     m_pBrightnessValueLabel = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabVideo, "0%"));
     m_pBrightnessValueLabel->SetPosition(CVector2D(vecTemp.fX + vecSize.fX + 5.0f, vecTemp.fY));
-    m_pBrightnessValueLabel->AutoSize("100% ");
+    m_pBrightnessValueLabel->AutoSize("100%");
 
     vecTemp.fX = 11;
 
@@ -1143,6 +1182,7 @@ void CSettings::CreateGUI(void)
     m_pInterfaceLanguageSelector->SetSelectionHandler(GUI_CALLBACK(&CSettings::OnLanguageChanged, this));
     m_pInterfaceSkinSelector->SetSelectionHandler(GUI_CALLBACK(&CSettings::OnSkinChanged, this));
     m_pMapAlpha->SetOnScrollHandler(GUI_CALLBACK(&CSettings::OnMapAlphaChanged, this));
+    m_pAudioMasterVolume->SetOnScrollHandler(GUI_CALLBACK(&CSettings::OnMasterVolumeChanged, this));
     m_pAudioRadioVolume->SetOnScrollHandler(GUI_CALLBACK(&CSettings::OnRadioVolumeChanged, this));
     m_pAudioSFXVolume->SetOnScrollHandler(GUI_CALLBACK(&CSettings::OnSFXVolumeChanged, this));
     m_pAudioMTAVolume->SetOnScrollHandler(GUI_CALLBACK(&CSettings::OnMTAVolumeChanged, this));
@@ -1323,24 +1363,30 @@ void CSettings::Update(void)
 
 void CSettings::UpdateAudioTab()
 {
+    float fMasterVolume = 0, fMTAVolume = 0, fVoiceVolume = 0;
+
+    CVARS_GET("mastervolume", fMasterVolume);
+    CVARS_GET("mtavolume", fMTAVolume);
+    CVARS_GET("voicevolume", fVoiceVolume);
+
     CGameSettings* gameSettings = CCore::GetSingleton().GetGame()->GetSettings();
 
-    float fMTAVolume = 0, fRadioVolume = (float)(gameSettings->GetRadioVolume()) / 64.0f, fSFXVolume = (float)(gameSettings->GetSFXVolume()) / 64.0f;
-
-    CVARS_GET("mtavolume", fMTAVolume);
-
+    m_pAudioRadioVolume->SetScrollPosition(m_fRadioVolume);
+    m_pAudioSFXVolume->SetScrollPosition(m_fSFXVolume);
     m_pAudioMTAVolume->SetScrollPosition(fMTAVolume);
-    m_pAudioRadioVolume->SetScrollPosition(fRadioVolume);
-    m_pAudioSFXVolume->SetScrollPosition(fSFXVolume);
+    m_pAudioVoiceVolume->SetScrollPosition(fVoiceVolume);
+    m_pAudioMasterVolume->SetScrollPosition(fMasterVolume);
 
     m_pCheckBoxAudioEqualizer->SetSelected(gameSettings->IsRadioEqualizerEnabled());
     m_pCheckBoxAudioAutotune->SetSelected(gameSettings->IsRadioAutotuneEnabled());
     m_pCheckBoxUserAutoscan->SetSelected(gameSettings->IsUsertrackAutoScan());
 
+    CVARS_GET("mute_master_when_minimized", m_bMuteMaster);
     CVARS_GET("mute_sfx_when_minimized", m_bMuteSFX);
     CVARS_GET("mute_radio_when_minimized", m_bMuteRadio);
     CVARS_GET("mute_mta_when_minimized", m_bMuteMTA);
     CVARS_GET("mute_voice_when_minimized", m_bMuteVoice);
+    m_pCheckBoxMuteMaster->SetSelected(m_bMuteMaster);
     m_pCheckBoxMuteSFX->SetSelected(m_bMuteSFX);
     m_pCheckBoxMuteRadio->SetSelected(m_bMuteRadio);
     m_pCheckBoxMuteMTA->SetSelected(m_bMuteMTA);
@@ -1702,27 +1748,58 @@ bool CSettings::OnVideoDefaultClick(CGUIElement* pElement)
     return true;
 }
 
+void CSettings::ResetGTAVolume()
+{
+    // This will reset and save GTA volume to given GTA volume levels and skip master volume level
+    CGameSettings* gameSettings = CCore::GetSingleton().GetGame()->GetSettings();
+    gameSettings->SetRadioVolume(m_fRadioVolume * 64.0f);
+    gameSettings->SetSFXVolume(m_fSFXVolume * 64.0f);
+    gameSettings->Save();
+}
+
+void CSettings::SetRadioVolume(float fVolume)
+{
+    fVolume = std::max(0.0f, std::min(fVolume, 1.0f));
+
+    m_fRadioVolume = fVolume;
+
+    CCore::GetSingleton().GetGame()->GetSettings()->SetRadioVolume(m_fRadioVolume * CVARS_GET_VALUE<float>("mastervolume") * 64.0f);
+}
+
+void CSettings::SetSFXVolume(float fVolume)
+{
+    fVolume = std::max(0.0f, std::min(fVolume, 1.0f));
+
+    m_fSFXVolume = fVolume;
+
+    CCore::GetSingleton().GetGame()->GetSettings()->SetSFXVolume(m_fSFXVolume * CVARS_GET_VALUE<float>("mastervolume") * 64.0f);
+}
+
 //
 // Called when the user clicks on the audio 'Load Defaults' button.
 //
 bool CSettings::OnAudioDefaultClick(CGUIElement* pElement)
 {
-    CGameSettings* gameSettings = CCore::GetSingleton().GetGame()->GetSettings();
-    gameSettings->SetRadioVolume(100);
-    gameSettings->SetSFXVolume(100);
-    CVARS_SET("mtavolume", 100);
+    CVARS_SET("mastervolume", 1.0f);
+    SetRadioVolume(1.0f);
+    SetSFXVolume(1.0f);
+    CVARS_SET("mtavolume", 1.0f);
+    CVARS_SET("voicevolume", 1.0f);
 
-    gameSettings->SetRadioAutotuneEnabled(true);
-    gameSettings->SetRadioEqualizerEnabled(true);
-
-    gameSettings->SetUsertrackAutoScan(false);
-
+    CVARS_SET("mute_master_when_minimized", false);
     CVARS_SET("mute_sfx_when_minimized", false);
     CVARS_SET("mute_radio_when_minimized", false);
     CVARS_SET("mute_mta_when_minimized", false);
     CVARS_SET("mute_voice_when_minimized", false);
 
+    CGameSettings* gameSettings = CCore::GetSingleton().GetGame()->GetSettings();
+
+    gameSettings->SetRadioAutotuneEnabled(true);
+    gameSettings->SetRadioEqualizerEnabled(true);
+
+    gameSettings->SetUsertrackAutoScan(false);
     gameSettings->SetUsertrackMode(0);
+
     // Update the GUI
     UpdateAudioTab();
 
@@ -2752,12 +2829,19 @@ bool CSettings::OnCancelButtonClick(CGUIElement* pElement)
     m_pWindow->SetVisible(false);
     pMainMenu->m_bIsInSubWindow = false;
 
-    // restore old audio settings
-    CGameSettings* gameSettings = CCore::GetSingleton().GetGame()->GetSettings();
-    gameSettings->SetRadioVolume(m_ucOldRadioVolume);
-    gameSettings->SetSFXVolume(m_ucOldSFXVolume);
+    // restore old audio volume settings
+    CVARS_SET("mastervolume", m_fOldMasterVolume);
+    SetRadioVolume(m_fOldRadioVolume);
+    SetSFXVolume(m_fOldSFXVolume);
     CVARS_SET("mtavolume", m_fOldMTAVolume);
     CVARS_SET("voicevolume", m_fOldVoiceVolume);
+
+    // restore old audio mute settings
+    CVARS_SET("mute_master_when_minimized", m_bOldMuteMaster);
+    CVARS_SET("mute_radio_when_minimized", m_bOldMuteRadio);
+    CVARS_SET("mute_sfx_when_minimized", m_bOldMuteSFX);
+    CVARS_SET("mute_mta_when_minimized", m_bOldMuteMTA);
+    CVARS_SET("mute_voice_when_minimized", m_bOldMuteVoice);
 
     return true;
 }
@@ -2806,23 +2890,20 @@ void CSettings::LoadData(void)
     m_pVerticalAimSensitivity->SetScrollPosition(pController->GetVerticalAimSensitivity());
 
     // Audio
-    m_ucOldRadioVolume = gameSettings->GetRadioVolume();
-    m_pAudioRadioVolume->SetScrollPosition((float)m_ucOldRadioVolume / 64.0f);
-    m_ucOldSFXVolume = gameSettings->GetSFXVolume();
-    m_pAudioSFXVolume->SetScrollPosition((float)m_ucOldSFXVolume / 64.0f);
-
     m_pCheckBoxAudioEqualizer->SetSelected(gameSettings->IsRadioEqualizerEnabled());
     m_pCheckBoxAudioAutotune->SetSelected(gameSettings->IsRadioAutotuneEnabled());
     m_pCheckBoxUserAutoscan->SetSelected(gameSettings->IsUsertrackAutoScan());
 
-    CVARS_GET("mute_sfx_when_minimized", m_bMuteSFX);
-    CVARS_GET("mute_radio_when_minimized", m_bMuteRadio);
-    CVARS_GET("mute_mta_when_minimized", m_bMuteMTA);
-    CVARS_GET("mute_voice_when_minimized", m_bMuteVoice);
-    m_pCheckBoxMuteSFX->SetSelected(m_bMuteSFX);
-    m_pCheckBoxMuteRadio->SetSelected(m_bMuteRadio);
-    m_pCheckBoxMuteMTA->SetSelected(m_bMuteMTA);
-    m_pCheckBoxMuteVoice->SetSelected(m_bMuteVoice);
+    CVARS_GET("mute_master_when_minimized", m_bOldMuteMaster);
+    CVARS_GET("mute_sfx_when_minimized", m_bOldMuteSFX);
+    CVARS_GET("mute_radio_when_minimized", m_bOldMuteRadio);
+    CVARS_GET("mute_mta_when_minimized", m_bOldMuteMTA);
+    CVARS_GET("mute_voice_when_minimized", m_bOldMuteVoice);
+    m_pCheckBoxMuteMaster->SetSelected(m_bOldMuteMaster);
+    m_pCheckBoxMuteSFX->SetSelected(m_bOldMuteSFX);
+    m_pCheckBoxMuteRadio->SetSelected(m_bOldMuteRadio);
+    m_pCheckBoxMuteMTA->SetSelected(m_bOldMuteMTA);
+    m_pCheckBoxMuteVoice->SetSelected(m_bOldMuteVoice);
 
     unsigned int uiUsertrackMode = gameSettings->GetUsertrackMode();
     if (uiUsertrackMode == 0)
@@ -2832,10 +2913,17 @@ void CSettings::LoadData(void)
     else if (uiUsertrackMode == 2)
         m_pComboUsertrackMode->SetText(_("Sequential"));
 
+    CVARS_GET("mastervolume", m_fOldMasterVolume);
     CVARS_GET("mtavolume", m_fOldMTAVolume);
     CVARS_GET("voicevolume", m_fOldVoiceVolume);
+    m_fOldMasterVolume = max(0.0f, min(1.0f, m_fOldMasterVolume));
+    m_fOldRadioVolume = max(0.0f, min(1.0f, m_fRadioVolume));
+    m_fOldSFXVolume = max(0.0f, min(1.0f, m_fSFXVolume));
     m_fOldMTAVolume = max(0.0f, min(1.0f, m_fOldMTAVolume));
     m_fOldVoiceVolume = max(0.0f, min(1.0f, m_fOldVoiceVolume));
+    m_pAudioMasterVolume->SetScrollPosition(m_fOldMasterVolume);
+    m_pAudioRadioVolume->SetScrollPosition(m_fOldRadioVolume);
+    m_pAudioSFXVolume->SetScrollPosition(m_fOldSFXVolume);
     m_pAudioMTAVolume->SetScrollPosition(m_fOldMTAVolume);
     m_pAudioVoiceVolume->SetScrollPosition(m_fOldVoiceVolume);
 
@@ -3211,10 +3299,12 @@ void CSettings::SaveData(void)
     gameSettings->SetRadioAutotuneEnabled(m_pCheckBoxAudioAutotune->GetSelected());
     gameSettings->SetUsertrackAutoScan(m_pCheckBoxUserAutoscan->GetSelected());
 
+    m_bMuteMaster = m_pCheckBoxMuteMaster->GetSelected();
     m_bMuteSFX = m_pCheckBoxMuteSFX->GetSelected();
     m_bMuteRadio = m_pCheckBoxMuteRadio->GetSelected();
     m_bMuteMTA = m_pCheckBoxMuteMTA->GetSelected();
     m_bMuteVoice = m_pCheckBoxMuteVoice->GetSelected();
+    CVARS_SET("mute_master_when_minimized", m_bMuteMaster);
     CVARS_SET("mute_sfx_when_minimized", m_bMuteSFX);
     CVARS_SET("mute_radio_when_minimized", m_bMuteRadio);
     CVARS_SET("mute_mta_when_minimized", m_bMuteMTA);
@@ -3937,24 +4027,37 @@ bool CSettings::OnMapAlphaChanged(CGUIElement* pElement)
     return true;
 }
 
+bool CSettings::OnMasterVolumeChanged(CGUIElement* pElement)
+{
+    int iVolume = m_pAudioMasterVolume->GetScrollPosition() * 100.0f;
+    m_pLabelMasterVolumeValue->SetText(SString("%i%%", iVolume).c_str());
+    
+    CVARS_SET("mastervolume", m_pAudioMasterVolume->GetScrollPosition());
+
+    OnRadioVolumeChanged(nullptr);
+    OnSFXVolumeChanged(nullptr);
+    OnMTAVolumeChanged(nullptr);
+    OnVoiceVolumeChanged(nullptr);
+
+    return true;
+}
+
 bool CSettings::OnRadioVolumeChanged(CGUIElement* pElement)
 {
-    unsigned char ucVolume = m_pAudioRadioVolume->GetScrollPosition() * 100.0f;
-    m_pLabelRadioVolumeValue->SetText(SString("%i%%", ucVolume).c_str());
+    int iVolume = m_pAudioRadioVolume->GetScrollPosition() * 100.0f;
+    m_pLabelRadioVolumeValue->SetText(SString("%i%%", iVolume).c_str());
 
-    CGameSettings* gameSettings = CCore::GetSingleton().GetGame()->GetSettings();
-    gameSettings->SetRadioVolume(m_pAudioRadioVolume->GetScrollPosition() * 64);
+    SetRadioVolume(m_pAudioRadioVolume->GetScrollPosition());
 
     return true;
 }
 
 bool CSettings::OnSFXVolumeChanged(CGUIElement* pElement)
 {
-    unsigned char ucVolume = m_pAudioSFXVolume->GetScrollPosition() * 100.0f;
-    m_pLabelSFXVolumeValue->SetText(SString("%i%%", ucVolume).c_str());
+    int iVolume = m_pAudioSFXVolume->GetScrollPosition() * 100.0f;
+    m_pLabelSFXVolumeValue->SetText(SString("%i%%", iVolume).c_str());
 
-    CGameSettings* gameSettings = CCore::GetSingleton().GetGame()->GetSettings();
-    gameSettings->SetSFXVolume(m_pAudioSFXVolume->GetScrollPosition() * 64);
+    SetSFXVolume(m_pAudioSFXVolume->GetScrollPosition());
 
     return true;
 }

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -1376,11 +1376,11 @@ void CSettings::UpdateAudioTab()
 
     CGameSettings* gameSettings = CCore::GetSingleton().GetGame()->GetSettings();
 
+    m_pAudioMasterVolume->SetScrollPosition(fMasterVolume);
     m_pAudioRadioVolume->SetScrollPosition(m_fRadioVolume);
     m_pAudioSFXVolume->SetScrollPosition(m_fSFXVolume);
     m_pAudioMTAVolume->SetScrollPosition(fMTAVolume);
     m_pAudioVoiceVolume->SetScrollPosition(fVoiceVolume);
-    m_pAudioMasterVolume->SetScrollPosition(fMasterVolume);
 
     m_pCheckBoxAudioEqualizer->SetSelected(gameSettings->IsRadioEqualizerEnabled());
     m_pCheckBoxAudioAutotune->SetSelected(gameSettings->IsRadioAutotuneEnabled());

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -212,20 +212,26 @@ protected:
     CGUILabel*     m_pCachePathLabel;
     CGUILabel*     m_pCachePathValue;
     CGUIButton*    m_pCachePathShowButton;
+    CGUILabel*     m_pLabelMasterVolume;
     CGUILabel*     m_pLabelRadioVolume;
     CGUILabel*     m_pLabelSFXVolume;
     CGUILabel*     m_pLabelMTAVolume;
     CGUILabel*     m_pLabelVoiceVolume;
+    CGUILabel*     m_pLabelMasterVolumeValue;
     CGUILabel*     m_pLabelRadioVolumeValue;
     CGUILabel*     m_pLabelSFXVolumeValue;
     CGUILabel*     m_pLabelMTAVolumeValue;
     CGUILabel*     m_pLabelVoiceVolumeValue;
+    CGUIScrollBar* m_pAudioMasterVolume;
     CGUIScrollBar* m_pAudioRadioVolume;
     CGUIScrollBar* m_pAudioSFXVolume;
     CGUIScrollBar* m_pAudioMTAVolume;
     CGUIScrollBar* m_pAudioVoiceVolume;
+    CGUILabel*     m_pAudioRadioLabel;
     CGUICheckBox*  m_pCheckBoxAudioEqualizer;
     CGUICheckBox*  m_pCheckBoxAudioAutotune;
+    CGUILabel*     m_pAudioMuteLabel;
+    CGUICheckBox*  m_pCheckBoxMuteMaster;
     CGUICheckBox*  m_pCheckBoxMuteSFX;
     CGUICheckBox*  m_pCheckBoxMuteRadio;
     CGUICheckBox*  m_pCheckBoxMuteMTA;
@@ -336,6 +342,7 @@ protected:
     bool OnBrightnessChanged(CGUIElement* pElement);
     bool OnAnisotropicChanged(CGUIElement* pElement);
     bool OnMapAlphaChanged(CGUIElement* pElement);
+    bool OnMasterVolumeChanged(CGUIElement* pElement);
     bool OnRadioVolumeChanged(CGUIElement* pElement);
     bool OnSFXVolumeChanged(CGUIElement* pElement);
     bool OnMTAVolumeChanged(CGUIElement* pElement);
@@ -392,16 +399,36 @@ private:
     int    GetMilliseconds(CGUIEdit* pEdit);
     void   SetMilliseconds(CGUIEdit* pEdit, int milliseconds);
 
+    void ResetGTAVolume();
+    void SetRadioVolume(float fVolume);
+    void SetSFXVolume(float fVolume);
+
     unsigned int m_uiCaptureKey;
     bool         m_bCaptureKey;
     bool         m_bCaptureAxis;
 
     bool m_bIsModLoaded;
 
-    unsigned char m_ucOldRadioVolume;
-    unsigned char m_ucOldSFXVolume;
-    float         m_fOldMTAVolume;
-    float         m_fOldVoiceVolume;
+    float m_fRadioVolume;
+    float m_fSFXVolume;
+
+    float m_fOldMasterVolume;
+    float m_fOldRadioVolume;
+    float m_fOldSFXVolume;
+    float m_fOldMTAVolume;
+    float m_fOldVoiceVolume;
+
+    bool m_bOldMuteMaster;
+    bool m_bOldMuteSFX;
+    bool m_bOldMuteRadio;
+    bool m_bOldMuteMTA;
+    bool m_bOldMuteVoice;
+
+    bool m_bMuteMaster;
+    bool m_bMuteSFX;
+    bool m_bMuteRadio;
+    bool m_bMuteMTA;
+    bool m_bMuteVoice;
 
     CGUIListItem* m_pSelectedBind;
 
@@ -409,11 +436,6 @@ private:
     bool  m_bShownVolumetricShadowsWarning;
     bool  m_bShownAllowScreenUploadMessage;
     int   m_iMaxAnisotropic;
-
-    bool m_bMuteSFX;
-    bool m_bMuteRadio;
-    bool m_bMuteMTA;
-    bool m_bMuteVoice;
 
     std::list<SKeyBindSection*> m_pKeyBindSections;
 };

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -347,6 +347,11 @@ protected:
     bool OnSFXVolumeChanged(CGUIElement* pElement);
     bool OnMTAVolumeChanged(CGUIElement* pElement);
     bool OnVoiceVolumeChanged(CGUIElement* pElement);
+    bool OnMasterMuteMinimizedChanged(CGUIElement* pElement);
+    bool OnRadioMuteMinimizedChanged(CGUIElement* pElement);
+    bool OnSFXMuteMinimizedChanged(CGUIElement* pElement);
+    bool OnMTAMuteMinimizedChanged(CGUIElement* pElement);
+    bool OnVoiceMuteMinimizedChanged(CGUIElement* pElement);
     bool OnChatRedChanged(CGUIElement* pElement);
     bool OnChatGreenChanged(CGUIElement* pElement);
     bool OnChatBlueChanged(CGUIElement* pElement);

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -3910,14 +3910,16 @@ void CClientGame::IdleHandler(void)
             CLuaArguments Arguments;
             m_pRootEntity->CallEvent("onClientMinimize", Arguments, false);
 
+            bool bMuteAny = g_pCore->GetCVars()->GetValue<bool>("mute_master_when_minimized");
+
             // Apply mute on minimize options
-            if (g_pCore->GetCVars()->GetValue<bool>("mute_sfx_when_minimized"))
+            if (bMuteAny || g_pCore->GetCVars()->GetValue<bool>("mute_sfx_when_minimized"))
                 g_pGame->GetAudio()->SetEffectsMasterVolume(0);
 
-            if (g_pCore->GetCVars()->GetValue<bool>("mute_radio_when_minimized"))
+            if (bMuteAny || g_pCore->GetCVars()->GetValue<bool>("mute_radio_when_minimized"))
                 g_pGame->GetAudio()->SetMusicMasterVolume(0);
 
-            if (g_pCore->GetCVars()->GetValue<bool>("mute_mta_when_minimized"))
+            if (bMuteAny || g_pCore->GetCVars()->GetValue<bool>("mute_mta_when_minimized"))
                 m_pManager->GetSoundManager()->SetMinimizeMuted(true);
         }
     }

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -3913,11 +3913,11 @@ void CClientGame::IdleHandler(void)
             bool bMuteAll = g_pCore->GetCVars()->GetValue<bool>("mute_master_when_minimized");
 
             // Apply mute on minimize options
-            if (bMuteAll || g_pCore->GetCVars()->GetValue<bool>("mute_sfx_when_minimized"))
-                g_pGame->GetAudio()->SetEffectsMasterVolume(0);
-
             if (bMuteAll || g_pCore->GetCVars()->GetValue<bool>("mute_radio_when_minimized"))
                 g_pGame->GetAudio()->SetMusicMasterVolume(0);
+
+            if (bMuteAll || g_pCore->GetCVars()->GetValue<bool>("mute_sfx_when_minimized"))
+                g_pGame->GetAudio()->SetEffectsMasterVolume(0);
 
             if (bMuteAll || g_pCore->GetCVars()->GetValue<bool>("mute_mta_when_minimized"))
                 m_pManager->GetSoundManager()->SetMinimizeMuted(true);

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -3910,16 +3910,16 @@ void CClientGame::IdleHandler(void)
             CLuaArguments Arguments;
             m_pRootEntity->CallEvent("onClientMinimize", Arguments, false);
 
-            bool bMuteAny = g_pCore->GetCVars()->GetValue<bool>("mute_master_when_minimized");
+            bool bMuteAll = g_pCore->GetCVars()->GetValue<bool>("mute_master_when_minimized");
 
             // Apply mute on minimize options
-            if (bMuteAny || g_pCore->GetCVars()->GetValue<bool>("mute_sfx_when_minimized"))
+            if (bMuteAll || g_pCore->GetCVars()->GetValue<bool>("mute_sfx_when_minimized"))
                 g_pGame->GetAudio()->SetEffectsMasterVolume(0);
 
-            if (bMuteAny || g_pCore->GetCVars()->GetValue<bool>("mute_radio_when_minimized"))
+            if (bMuteAll || g_pCore->GetCVars()->GetValue<bool>("mute_radio_when_minimized"))
                 g_pGame->GetAudio()->SetMusicMasterVolume(0);
 
-            if (bMuteAny || g_pCore->GetCVars()->GetValue<bool>("mute_mta_when_minimized"))
+            if (bMuteAll || g_pCore->GetCVars()->GetValue<bool>("mute_mta_when_minimized"))
                 m_pManager->GetSoundManager()->SetMinimizeMuted(true);
         }
     }

--- a/Client/mods/deathmatch/logic/CClientPlayerVoice.cpp
+++ b/Client/mods/deathmatch/logic/CClientPlayerVoice.cpp
@@ -35,7 +35,7 @@ CClientPlayerVoice::CClientPlayerVoice(CClientPlayer* pPlayer, CVoiceRecorder* p
     // Get initial voice volume
     m_fVolume = 1.0f;
     g_pCore->GetCVars()->Get("voicevolume", m_fVolumeScale);
-    m_fVolumeScale *= g_pCore->GetCVars()->GetValue<float>("mastervolume");
+    m_fVolumeScale *= g_pCore->GetCVars()->GetValue<float>("mastervolume", 1.0f);
 
     m_fVolume = m_fVolume * m_fVolumeScale;
 
@@ -115,7 +115,7 @@ void CClientPlayerVoice::DoPulse(void)
     m_CS.Lock();
     float fPreviousVolume = 0.0f;
     g_pCore->GetCVars()->Get("voicevolume", fPreviousVolume);
-    fPreviousVolume *= g_pCore->GetCVars()->GetValue<float>("mastervolume");
+    fPreviousVolume *= g_pCore->GetCVars()->GetValue<float>("mastervolume", 1.0f);
     m_CS.Unlock();
 
     if (fPreviousVolume != m_fVolumeScale && m_pPlayer->IsLocalPlayer() == false)

--- a/Client/mods/deathmatch/logic/CClientPlayerVoice.cpp
+++ b/Client/mods/deathmatch/logic/CClientPlayerVoice.cpp
@@ -35,6 +35,7 @@ CClientPlayerVoice::CClientPlayerVoice(CClientPlayer* pPlayer, CVoiceRecorder* p
     // Get initial voice volume
     m_fVolume = 1.0f;
     g_pCore->GetCVars()->Get("voicevolume", m_fVolumeScale);
+    m_fVolumeScale *= g_pCore->GetCVars()->GetValue<float>("mastervolume");
 
     m_fVolume = m_fVolume * m_fVolumeScale;
 
@@ -114,6 +115,7 @@ void CClientPlayerVoice::DoPulse(void)
     m_CS.Lock();
     float fPreviousVolume = 0.0f;
     g_pCore->GetCVars()->Get("voicevolume", fPreviousVolume);
+    fPreviousVolume *= g_pCore->GetCVars()->GetValue<float>("mastervolume");
     m_CS.Unlock();
 
     if (fPreviousVolume != m_fVolumeScale && m_pPlayer->IsLocalPlayer() == false)

--- a/Client/mods/deathmatch/logic/CClientSoundManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientSoundManager.cpp
@@ -258,12 +258,14 @@ int CClientSoundManager::GetFxEffectFromName(const std::string& strEffectName)
 
 void CClientSoundManager::UpdateVolume()
 {
-    // set our master sound volume if the cvar changed
+    // set our mta or master sound volume if the cvar changed
     float fValue = 0.0f;
     if (!m_bMinimizeMuted)
     {
         if (g_pCore->GetCVars()->Get("mtavolume", fValue))
         {
+            fValue *= g_pCore->GetCVars()->GetValue<float>("mastervolume");
+
             if (fValue * 10000 == BASS_GetConfig(BASS_CONFIG_GVOL_STREAM))
                 return;
 

--- a/Client/mods/deathmatch/logic/CClientSoundManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientSoundManager.cpp
@@ -258,13 +258,16 @@ int CClientSoundManager::GetFxEffectFromName(const std::string& strEffectName)
 
 void CClientSoundManager::UpdateVolume()
 {
-    // set our mta or master sound volume if the cvar changed
+    // set our mta sound volume if mtavolume or mastervolume cvar changed
     float fValue = 0.0f;
+
     if (!m_bMinimizeMuted)
     {
+        float fMasterVolume = g_pCore->GetCVars()->GetValue<float>("mastervolume", 1.0f);
+
         if (g_pCore->GetCVars()->Get("mtavolume", fValue))
         {
-            fValue *= g_pCore->GetCVars()->GetValue<float>("mastervolume");
+            fValue *= fMasterVolume;
 
             if (fValue * 10000 == BASS_GetConfig(BASS_CONFIG_GVOL_STREAM))
                 return;
@@ -273,7 +276,7 @@ void CClientSoundManager::UpdateVolume()
         }
         else
         {
-            fValue = 1.0f;
+            fValue = fMasterVolume;
         }
     }
 


### PR DESCRIPTION
**Mantis Bug Tracker issue:**
[9896](https://bugs.multitheftauto.com/view.php?id=9896)

**Summary:**
- Added `mastervolume` and `mute_master_when_minimized` client variables;
- Affects all 4 different types: GTA radio, GTA SFX, MTA, MTA voice;
- Also fixed it so that when you press "Load defaults" in audio view, it resets the mute settings, and now it will also remember your mute settings upon cancel properly;
- Moved mute settings to right of the volume faders because it got a bit tight in there;
- Resets GTA volume levels back ignoring master level before quit.

**Localization:**
- `Master volume:`
- `Radio options`
- `Mute options`
- `Mute All sounds when minimized`

![settings_window](https://user-images.githubusercontent.com/22572159/42414384-04753f0c-823d-11e8-88b7-894214ee862d.jpg)