### PR TITLE
0009522: reset jetpack and choking states upon animation - and the other way around

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -4320,6 +4320,9 @@ void CClientPed::SetChoking(bool bChoking)
                 if (HasJetPack())
                     SetHasJetPack(false);
 
+                // Let's kill any animation
+                KillAnimation();
+
                 // Create the choking task
                 CTaskSimpleChoking* pTask = g_pGame->GetTasks()->CreateTaskSimpleChoking(NULL, true);
                 if (pTask)

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -3863,6 +3863,10 @@ bool CStaticFunctionDefinitions::GivePedJetPack(CElement* pElement)
         CPed* pPed = static_cast<CPed*>(pElement);
         if (pPed->IsSpawned() && !pPed->GetOccupiedVehicle() && !pPed->HasJetPack())
         {
+            // Remove choking state
+            if (pPed->IsChoking())
+                pPed->SetChoking(false);
+
             pPed->SetHasJetPack(true);
 
             CBitStream BitStream;
@@ -3992,6 +3996,10 @@ bool CStaticFunctionDefinitions::SetPedChoking(CElement* pElement, bool bChoking
                 // Not already (not) choking?
                 if (bChoking != pPed->IsChoking())
                 {
+                    // Remove jetpack now so it doesn't stay on (#9522#c25612)
+                    if (pPed->HasJetPack())
+                        pPed->SetHasJetPack(false);
+                    
                     pPed->SetChoking(bChoking);
 
                     CBitStream bitStream;
@@ -4203,6 +4211,14 @@ bool CStaticFunctionDefinitions::SetPedAnimation(CElement* pElement, const char*
         CPed* pPed = static_cast<CPed*>(pElement);
         if (pPed->IsSpawned())
         {
+            // Remove jetpack now so it doesn't stay on (#9522#c25612)
+            if (pPed->HasJetPack())
+                pPed->SetHasJetPack(false);
+
+            // Remove choking state
+            if (pPed->IsChoking())
+                pPed->SetChoking(false);
+
             // TODO: save their animation?
 
             // Tell the players


### PR DESCRIPTION
## Mantis Bug Tracker issue
[9522](https://bugs.multitheftauto.com/view.php?id=9522)

## Summary
- Fixes many bugs related to animations, jetpack and choking;
- Pretty small and simple fix, easy to test.

## Tests
Note, that tests 1 and 2 on either category will not function as expected for Ped elements (in either case, choking/jetpack will stay on). You should use yourself or another Player element for testing. Cause for this behavior is [this if statement](https://github.com/multitheftauto/mtasa-blue/blob/c39e2cbf9ef355e8720d98c7de7cda93fc25d735/Client/mods/deathmatch/logic/rpc/CElementRPCs.cpp#L134). Changing it now would make it backwards incompatible. In my opinion this should have been unified for both elements in the first place.

### Jetpack
----
#### Test 1
1. Give ped a jetpack.
2. Set their position to something with _warp_ enabled.
3. Expectation: jetpack should be removed.
----
#### Test 2
1. Give ped a jetpack.
2. Set their position to something with _warp_ disabled.
3. Expectation: jetpack should not be removed.
----
#### Test 3
1. Give ped a jetpack.
2. Freeze them.
3. Expectation: jetpack should not be removed.
----
#### Test 4
1. Give ped a jetpack.
2. Set their animation.
3. Expectation: jetpack should be removed.
----
#### Test 5
1. Give ped a jetpack.
2. Set their animation.
3. Give them a jetpack.
4. Expectation: they should now be on a jetpack.
----
#### Test 6
1. Give ped a jetpack.
2. Set their animation.
3. Give them a jetpack.
4. Remove their jetpack.
5. Set their model to something else.
6. Expectation: they should not be doing the animation you set them in step 2.
----
#### Test 7
1. Give ped a jetpack.
2. Set them choking.
3. Expectation: jetpack should be removed.
----
#### Test 8
1. Give ped a jetpack.
2. Set them choking.
3. Give them a jetpack.
4. Expectation: they should now be on a jetpack.
----
### Choking
----
#### Test 1
1. Choke a ped.
2. Set their position to something with _warp_ enabled.
3. Expectation: they should no longer be choking.
----
#### Test 2
1. Choke a ped.
2. Set their position to something with _warp_ disabled.
3. Expectation: they should be choking.
----
#### Test 3
1. Choke a ped.
2. Freeze them.
3. Expectation: they should be choking.
----
#### Test 4
1. Choke a ped.
2. Set their animation.
3. Expectation: they should no longer be choking.
----
#### Test 5
1. Choke a ped.
2. Set their animation.
3. Set them choking.
3. Expectation: they should be choking.
----
#### Test 6
1. Choke a ped.
2. Set their animation.
3. Set them choking.
4. Remove their jetpack.
5. Set their model to something else.
6. Expectation: they should not be doing the animation you set them in step 2.