### PR TITLE
0006455: clamp blip order and distance to avoid integer overflow

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
@@ -62,8 +62,8 @@ int CLuaBlipDefs::CreateBlip(lua_State* luaVM)
     unsigned char    ucIcon = 0;
     unsigned char    ucSize = 2;
     SColorRGBA       color(255, 0, 0, 255);
-    short            sOrdering = 0;
-    unsigned short   usVisibleDistance = 16383;
+    int              iOrdering = 0;
+    int              iVisibleDistance = 16383;
     CScriptArgReader argStream(luaVM);
     argStream.ReadVector3D(vecPosition);
     argStream.ReadNumber(ucIcon, 0);
@@ -72,8 +72,8 @@ int CLuaBlipDefs::CreateBlip(lua_State* luaVM)
     argStream.ReadNumber(color.G, 0);
     argStream.ReadNumber(color.B, 0);
     argStream.ReadNumber(color.A, 255);
-    argStream.ReadNumber(sOrdering, 0);
-    argStream.ReadNumber(usVisibleDistance, 16383);
+    argStream.ReadNumber(iOrdering, 0);
+    argStream.ReadNumber(iVisibleDistance, 16383);
 
     if (!CClientRadarMarkerManager::IsValidIcon(ucIcon))
     {
@@ -88,6 +88,9 @@ int CLuaBlipDefs::CreateBlip(lua_State* luaVM)
             CResource* pResource = pLuaMain->GetResource();
             if (pResource)
             {
+                short          sOrdering = std::max(-32768, std::min(32767, iOrdering));
+                unsigned short usVisibleDistance = std::max(0, std::min(65535, iVisibleDistance));
+
                 // Create the blip
                 CClientRadarMarker* pMarker =
                     CStaticFunctionDefinitions::CreateBlip(*pResource, vecPosition, ucIcon, ucSize, color, sOrdering, usVisibleDistance);
@@ -119,8 +122,8 @@ int CLuaBlipDefs::CreateBlipAttachedTo(lua_State* luaVM)
     unsigned char    ucIcon = 0;
     unsigned char    ucSize = 2;
     SColorRGBA       color(255, 0, 0, 255);
-    short            sOrdering = 0;
-    unsigned short   usVisibleDistance = 16383;
+    int              iOrdering = 0;
+    int              iVisibleDistance = 16383;
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pEntity);
     argStream.ReadNumber(ucIcon, 0);
@@ -129,8 +132,8 @@ int CLuaBlipDefs::CreateBlipAttachedTo(lua_State* luaVM)
     argStream.ReadNumber(color.G, 0);
     argStream.ReadNumber(color.B, 0);
     argStream.ReadNumber(color.A, 255);
-    argStream.ReadNumber(sOrdering, 0);
-    argStream.ReadNumber(usVisibleDistance, 16383);
+    argStream.ReadNumber(iOrdering, 0);
+    argStream.ReadNumber(iVisibleDistance, 16383);
 
     if (!CClientRadarMarkerManager::IsValidIcon(ucIcon))
     {
@@ -145,6 +148,9 @@ int CLuaBlipDefs::CreateBlipAttachedTo(lua_State* luaVM)
             CResource* pResource = pLuaMain->GetResource();
             if (pResource)
             {
+                short          sOrdering = std::max(-32768, std::min(32767, iOrdering));
+                unsigned short usVisibleDistance = std::max(0, std::min(65535, iVisibleDistance));
+
                 // Create the blip
                 CClientRadarMarker* pMarker =
                     CStaticFunctionDefinitions::CreateBlipAttachedTo(*pResource, *pEntity, ucIcon, ucSize, color, sOrdering, usVisibleDistance);
@@ -346,13 +352,15 @@ int CLuaBlipDefs::SetBlipColor(lua_State* luaVM)
 int CLuaBlipDefs::SetBlipOrdering(lua_State* luaVM)
 {
     CClientEntity*   pEntity = NULL;
-    short            sOrdering;
+    int              iOrdering;
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pEntity);
-    argStream.ReadNumber(sOrdering);
+    argStream.ReadNumber(iOrdering);
 
     if (!argStream.HasErrors())
     {
+        short sOrdering = std::max(-32768, std::min(32767, iOrdering));
+
         if (CStaticFunctionDefinitions::SetBlipOrdering(*pEntity, sOrdering))
         {
             lua_pushboolean(luaVM, true);
@@ -369,13 +377,15 @@ int CLuaBlipDefs::SetBlipOrdering(lua_State* luaVM)
 int CLuaBlipDefs::SetBlipVisibleDistance(lua_State* luaVM)
 {
     CClientEntity*   pEntity = NULL;
-    unsigned short   usVisibleDistance;
+    int              iVisibleDistance;
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pEntity);
-    argStream.ReadNumber(usVisibleDistance);
+    argStream.ReadNumber(iVisibleDistance);
 
     if (!argStream.HasErrors())
     {
+        unsigned short usVisibleDistance = std::max(0, std::min(65535, iVisibleDistance));
+
         if (CStaticFunctionDefinitions::SetBlipVisibleDistance(*pEntity, usVisibleDistance))
         {
             lua_pushboolean(luaVM, true);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
@@ -62,12 +62,12 @@ void CLuaBlipDefs::AddClass(lua_State* luaVM)
 
 int CLuaBlipDefs::CreateBlip(lua_State* luaVM)
 {
-    CVector        vecPosition;
-    unsigned char  ucIcon, ucSize;
-    SColorRGBA     color(255, 0, 0, 255);
-    short          sOrdering;
-    unsigned short usVisibleDistance;
-    CElement*      pVisibleTo;
+    CVector       vecPosition;
+    unsigned char ucIcon, ucSize;
+    SColorRGBA    color(255, 0, 0, 255);
+    int           iOrdering;
+    int           iVisibleDistance;
+    CElement*     pVisibleTo;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadVector3D(vecPosition);
@@ -77,8 +77,8 @@ int CLuaBlipDefs::CreateBlip(lua_State* luaVM)
     argStream.ReadNumber(color.G, color.G);
     argStream.ReadNumber(color.B, color.B);
     argStream.ReadNumber(color.A, color.A);
-    argStream.ReadNumber(sOrdering, 0);
-    argStream.ReadNumber(usVisibleDistance, 16383);
+    argStream.ReadNumber(iOrdering, 0);
+    argStream.ReadNumber(iVisibleDistance, 16383);
     if (argStream.NextIsBool() || argStream.NextIsNil())
         pVisibleTo = NULL;
     else
@@ -97,6 +97,9 @@ int CLuaBlipDefs::CreateBlip(lua_State* luaVM)
             CResource* pResource = pLuaMain->GetResource();
             if (pResource)
             {
+                short          sOrdering = std::max(-32768, std::min(32767, iOrdering));
+                unsigned short usVisibleDistance = std::max(0, std::min(65535, iVisibleDistance));
+
                 // Create the blip
                 CBlip* pBlip = CStaticFunctionDefinitions::CreateBlip(pResource, vecPosition, ucIcon, ucSize, color, sOrdering, usVisibleDistance, pVisibleTo);
                 if (pBlip)
@@ -121,12 +124,12 @@ int CLuaBlipDefs::CreateBlip(lua_State* luaVM)
 
 int CLuaBlipDefs::CreateBlipAttachedTo(lua_State* luaVM)
 {
-    CElement*      pElement;
-    unsigned char  ucIcon, ucSize;
-    SColorRGBA     color(255, 0, 0, 255);
-    short          sOrdering;
-    unsigned short usVisibleDistance;
-    CElement*      pVisibleTo;
+    CElement*     pElement;
+    unsigned char ucIcon, ucSize;
+    SColorRGBA    color(255, 0, 0, 255);
+    int           iOrdering;
+    int           iVisibleDistance;
+    CElement*     pVisibleTo;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pElement);
@@ -136,8 +139,8 @@ int CLuaBlipDefs::CreateBlipAttachedTo(lua_State* luaVM)
     argStream.ReadNumber(color.G, color.G);
     argStream.ReadNumber(color.B, color.B);
     argStream.ReadNumber(color.A, color.A);
-    argStream.ReadNumber(sOrdering, 0);
-    argStream.ReadNumber(usVisibleDistance, 16383);
+    argStream.ReadNumber(iOrdering, 0);
+    argStream.ReadNumber(iVisibleDistance, 16383);
     if (argStream.NextIsBool() || argStream.NextIsNil())
         pVisibleTo = NULL;
     else
@@ -153,6 +156,9 @@ int CLuaBlipDefs::CreateBlipAttachedTo(lua_State* luaVM)
         CResource* resource = m_pLuaManager->GetVirtualMachineResource(luaVM);
         if (resource)
         {
+            short          sOrdering = std::max(-32768, std::min(32767, iOrdering));
+            unsigned short usVisibleDistance = std::max(0, std::min(65535, iVisibleDistance));
+
             // Create the blip
             CBlip* pBlip =
                 CStaticFunctionDefinitions::CreateBlipAttachedTo(resource, pElement, ucIcon, ucSize, color, sOrdering, usVisibleDistance, pVisibleTo);
@@ -371,14 +377,16 @@ int CLuaBlipDefs::SetBlipColor(lua_State* luaVM)
 int CLuaBlipDefs::SetBlipOrdering(lua_State* luaVM)
 {
     CElement* pElement;
-    short     sOrdering;
+    int       iOrdering;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pElement);
-    argStream.ReadNumber(sOrdering);
+    argStream.ReadNumber(iOrdering);
 
     if (!argStream.HasErrors())
     {
+        short sOrdering = std::max(-32768, std::min(32767, iOrdering));
+
         if (CStaticFunctionDefinitions::SetBlipOrdering(pElement, sOrdering))
         {
             lua_pushboolean(luaVM, true);
@@ -394,15 +402,17 @@ int CLuaBlipDefs::SetBlipOrdering(lua_State* luaVM)
 
 int CLuaBlipDefs::SetBlipVisibleDistance(lua_State* luaVM)
 {
-    CElement*      pElement;
-    unsigned short usVisibleDistance;
+    CElement* pElement;
+    int       iVisibleDistance;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pElement);
-    argStream.ReadNumber(usVisibleDistance);
+    argStream.ReadNumber(iVisibleDistance);
 
     if (!argStream.HasErrors())
     {
+        unsigned short usVisibleDistance = std::max(0, std::min(65535, iVisibleDistance));
+
         if (CStaticFunctionDefinitions::SetBlipVisibleDistance(pElement, usVisibleDistance))
         {
             lua_pushboolean(luaVM, true);


### PR DESCRIPTION
**Mantis Bug Tracker issue:**
[6455](https://bugs.multitheftauto.com/view.php?id=6455)

**Summary:**
- At the moment you can go over the limits advertised on Wiki, causing an integer overflow that may cause unexpected behavior;
- As for backwards compatibility, I don't think anyone reasonable would ever take advantage of integer overflows in cases like these;
- Affected functions: [createBlip](https://wiki.multitheftauto.com/wiki/CreateBlip), [createBlipAttachedTo](https://wiki.multitheftauto.com/wiki/CreateBlipAttachedTo), [setBlipOrdering](https://wiki.multitheftauto.com/wiki/SetBlipOrdering), [setBlipVisibleDistance](https://wiki.multitheftauto.com/wiki/SetBlipVisibleDistance);
- Pretty small and simple fix, easy to test.

Is there a preferred way to handle these cases / clamp values in MTA codebase / C++?