### PR TITLE
0009433: Again - Remove incompatible spoiler

### DIFF
--- a/Client/mods/deathmatch/logic/CVehicleUpgrades.cpp
+++ b/Client/mods/deathmatch/logic/CVehicleUpgrades.cpp
@@ -79,13 +79,6 @@ bool CVehicleUpgrades::IsUpgradeCompatible(unsigned short usUpgrade)
     if (us == VEHICLEUPGRADE_NITRO_5X || us == VEHICLEUPGRADE_NITRO_2X || us == VEHICLEUPGRADE_NITRO_10X || us == VEHICLEUPGRADE_HYDRAULICS)
         return true;
 
-    if (us == 1000 || us == 1001 || us == 1002 || us == 1003 || us == 1014 || /* spoiler */
-        us == 1015 || us == 1016 || us == 1023 || us == 1049 || us == 1050 || us == 1058 || us == 1060 || us == 1138 || us == 1139 || us == 1146 ||
-        us == 1147 || us == 1158 || us == 1162 || us == 1163 || us == 116)
-    {
-        return true;
-    }
-
     bool bReturn = false;
     switch (usModel)
     {

--- a/Server/mods/deathmatch/logic/CVehicleUpgrades.cpp
+++ b/Server/mods/deathmatch/logic/CVehicleUpgrades.cpp
@@ -84,13 +84,6 @@ bool CVehicleUpgrades::IsUpgradeCompatible(unsigned short usUpgrade)
     if (us == VEHICLEUPGRADE_NITRO_5X || us == VEHICLEUPGRADE_NITRO_2X || us == VEHICLEUPGRADE_NITRO_10X || us == VEHICLEUPGRADE_HYDRAULICS)
         return true;
 
-    if (us == 1000 || us == 1001 || us == 1002 || us == 1003 || us == 1014 || /* spoiler */
-        us == 1015 || us == 1016 || us == 1023 || us == 1049 || us == 1050 || us == 1058 || us == 1060 || us == 1138 || us == 1139 || us == 1146 ||
-        us == 1147 || us == 1158 || us == 1162 || us == 1163 || us == 116)
-    {
-        return true;
-    }
-
     switch (usModel)
     {
         case 400:


### PR DESCRIPTION
Bugtracker:
https://bugs.mtasa.com/view.php?id=9433

Seems like the solution wasn't adding the serversided spoilers listed in isUpgradeCompatible to clientside. Dutchman wrote that incompatible spoilers are buggy and cause a memleak (and more).
So it wasn't "forgotten at clientside", it was just "forgotton to remove at serverside".