### PR TITLE
0006962: Add missing isReadOnly functions for GUI Memos and Edit fields

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -128,10 +128,12 @@ void CLuaGUIDefs::LoadFunctions(void)
     CLuaCFunctions::AddFunction("guiEditSetMasked", GUIEditSetMasked);
     CLuaCFunctions::AddFunction("guiEditSetMaxLength", GUIEditSetMaxLength);
     CLuaCFunctions::AddFunction("guiEditSetReadOnly", GUIEditSetReadOnly);
+    CLuaCFunctions::AddFunction("guiEditIsReadOnly", GUIEditIsReadOnly);
 
     CLuaCFunctions::AddFunction("guiMemoSetCaretIndex", GUIMemoSetCaretIndex);
     CLuaCFunctions::AddFunction("guiMemoGetCaretIndex", GUIMemoGetCaretIndex);
     CLuaCFunctions::AddFunction("guiMemoSetReadOnly", GUIMemoSetReadOnly);
+    CLuaCFunctions::AddFunction("guiMemoIsReadOnly", GUIMemoIsReadOnly);
 
     CLuaCFunctions::AddFunction("guiLabelSetColor", GUILabelSetColor);
     CLuaCFunctions::AddFunction("guiLabelGetColor", GUILabelGetColor);
@@ -319,7 +321,7 @@ void CLuaGUIDefs::AddGuiMemoClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setReadOnly", "guiMemoSetReadOnly");
 
     lua_classvariable(luaVM, "caretIndex", "guiMemoSetCaretIndex", "guiMemoGetCaretIndex");
-    lua_classvariable(luaVM, "readOnly", "guiMemoSetReadOnly", NULL);
+    lua_classvariable(luaVM, "readOnly", "guiMemoSetReadOnly", "guiMemoIsReadOnly");
 
     lua_registerclass(luaVM, "GuiMemo", "GuiElement");
 }
@@ -2945,6 +2947,28 @@ int CLuaGUIDefs::GUIEditSetReadOnly(lua_State* luaVM)
     return 1;
 }
 
+int CLuaGUIDefs::GUIEditIsReadOnly(lua_State* luaVM)
+{
+    // bool guiEditIsReadOnly( element editField )
+    CClientGUIElement* editField;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData<CGUIEdit>(editField);
+
+    if (!argStream.HasErrors())
+    {
+        bool readOnly = static_cast<CGUIEdit*>(editField->GetCGUIElement())->IsReadOnly();
+        lua_pushboolean(luaVM, readOnly);
+        return 1;
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    // error: bad arguments
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
 int CLuaGUIDefs::GUIMemoSetReadOnly(lua_State* luaVM)
 {
     //  bool guiMemoSetReadOnly ( gui-memo theMemo, bool status )
@@ -2959,6 +2983,28 @@ int CLuaGUIDefs::GUIMemoSetReadOnly(lua_State* luaVM)
     {
         CStaticFunctionDefinitions::GUIMemoSetReadOnly(*theMemo, status);
         lua_pushboolean(luaVM, true);
+        return 1;
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    // error: bad arguments
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaGUIDefs::GUIMemoIsReadOnly(lua_State* luaVM)
+{
+    // bool guiMemoIsReadOnly( gui-memo theMemo )
+    CClientGUIElement* theMemo;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData<CGUIMemo>(theMemo);
+
+    if (!argStream.HasErrors())
+    {
+        bool readOnly = static_cast<CGUIMemo*>(theMemo->GetCGUIElement())->IsReadOnly();
+        lua_pushboolean(luaVM, readOnly);
         return 1;
     }
     else

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -278,7 +278,7 @@ void CLuaGUIDefs::AddGuiEditClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setMaxLength", "guiEditSetMaxLength");
 
     lua_classvariable(luaVM, "caretIndex", "guiEditSetCaretIndex", "guiEditGetCaretIndex");
-    lua_classvariable(luaVM, "readOnly", "guiEditSetReadOnly", NULL);
+    lua_classvariable(luaVM, "readOnly", "guiEditSetReadOnly", "guiEditIsReadOnly");
     lua_classvariable(luaVM, "masked", "guiEditSetMasked", NULL);
     lua_classvariable(luaVM, "maxLength", "guiEditSetMaxLength", NULL);
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -2953,7 +2953,7 @@ int CLuaGUIDefs::GUIEditIsReadOnly(lua_State* luaVM)
     CClientGUIElement* editField;
 
     CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData<CGUIEdit>(editField);
+    argStream.ReadUserData(editField);
 
     if (!argStream.HasErrors())
     {
@@ -2965,7 +2965,7 @@ int CLuaGUIDefs::GUIEditIsReadOnly(lua_State* luaVM)
         m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
 
     // error: bad arguments
-    lua_pushboolean(luaVM, false);
+    lua_pushnil(luaVM);
     return 1;
 }
 
@@ -2989,7 +2989,7 @@ int CLuaGUIDefs::GUIMemoSetReadOnly(lua_State* luaVM)
         m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
 
     // error: bad arguments
-    lua_pushboolean(luaVM, false);
+    lua_pushnil(luaVM);
     return 1;
 }
 
@@ -2999,7 +2999,7 @@ int CLuaGUIDefs::GUIMemoIsReadOnly(lua_State* luaVM)
     CClientGUIElement* theMemo;
 
     CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData<CGUIMemo>(theMemo);
+    argStream.ReadUserData(theMemo);
 
     if (!argStream.HasErrors())
     {

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -2989,7 +2989,7 @@ int CLuaGUIDefs::GUIMemoSetReadOnly(lua_State* luaVM)
         m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
 
     // error: bad arguments
-    lua_pushnil(luaVM);
+    lua_pushboolean(luaVM, false);
     return 1;
 }
 
@@ -3011,7 +3011,7 @@ int CLuaGUIDefs::GUIMemoIsReadOnly(lua_State* luaVM)
         m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
 
     // error: bad arguments
-    lua_pushboolean(luaVM, false);
+    lua_pushnil(luaVM);
     return 1;
 }
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -2953,7 +2953,7 @@ int CLuaGUIDefs::GUIEditIsReadOnly(lua_State* luaVM)
     CClientGUIElement* editField;
 
     CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(editField);
+    argStream.ReadUserData<CGUIEdit>(editField);
 
     if (!argStream.HasErrors())
     {
@@ -2999,7 +2999,7 @@ int CLuaGUIDefs::GUIMemoIsReadOnly(lua_State* luaVM)
     CClientGUIElement* theMemo;
 
     CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(theMemo);
+    argStream.ReadUserData<CGUIMemo>(theMemo);
 
     if (!argStream.HasErrors())
     {

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
@@ -114,11 +114,13 @@ public:
     LUA_DECLARE(GUIProgressBarSetProgress);
     LUA_DECLARE(GUIProgressBarGetProgress);
     LUA_DECLARE(GUIEditSetReadOnly);
+    LUA_DECLARE(GUIEditIsReadOnly);
     LUA_DECLARE(GUIEditSetMasked);
     LUA_DECLARE(GUIEditSetMaxLength);
     LUA_DECLARE(GUIEditSetCaretIndex);
     LUA_DECLARE(GUIEditGetCaretIndex);
     LUA_DECLARE(GUIMemoSetReadOnly);
+    LUA_DECLARE(GUIMemoIsReadOnly);
     LUA_DECLARE(GUIMemoSetCaretIndex);
     LUA_DECLARE(GUIMemoGetCaretIndex);
     LUA_DECLARE(GUIWindowSetMovable);


### PR DESCRIPTION
**Mantis Bug Tracker Issue:**
[#6962](https://bugs.multitheftauto.com/view.php?id=6962)

guiMemoIsReadOnly & guiEditIsReadOnly

**Syntax**
`bool guiMemoIsReadOnly(element theMemo)`
`bool guiEditIsReadOnly(element editField)`
 