### PR TITLE
Ignore colorcodes while tabbing in chatbox

### DIFF
--- a/Client/core/CChat.cpp
+++ b/Client/core/CChat.cpp
@@ -628,7 +628,7 @@ bool CChat::CharacterKeyHandler(CGUIKeyEventArgs KeyboardArgs)
                             }
 
                             // Check namepart
-                            if (!strPlayerName.BeginsWith(strPlayerNamePart))
+                            if (!RemoveColorCodes(strPlayerName).BeginsWith(strPlayerNamePart))
                                 continue;
                             else
                             {


### PR DESCRIPTION
Tabbing lets you auto-fill the nickname of a player based on how it starts (like tabbing in command line, which lets you cycle through commands). MTA already does that, but if you have colorcodes in your nickname, it gets really annoying since you have to write the colorcode too, that is if for example you have it at the beginning of your nickname.

For example, if there is someone called `#FF0000abc`; in the current version, if you write `ab`, it won't work. Now it should.