### PR TITLE
0006455: use Clamp as requested, related to PR #232

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
@@ -88,8 +88,8 @@ int CLuaBlipDefs::CreateBlip(lua_State* luaVM)
             CResource* pResource = pLuaMain->GetResource();
             if (pResource)
             {
-                short          sOrdering = std::max(-32768, std::min(32767, iOrdering));
-                unsigned short usVisibleDistance = std::max(0, std::min(65535, iVisibleDistance));
+                short          sOrdering = Clamp(-32768, iOrdering, 32767);
+                unsigned short usVisibleDistance = Clamp(0, iVisibleDistance, 65535);
 
                 // Create the blip
                 CClientRadarMarker* pMarker =
@@ -148,8 +148,8 @@ int CLuaBlipDefs::CreateBlipAttachedTo(lua_State* luaVM)
             CResource* pResource = pLuaMain->GetResource();
             if (pResource)
             {
-                short          sOrdering = std::max(-32768, std::min(32767, iOrdering));
-                unsigned short usVisibleDistance = std::max(0, std::min(65535, iVisibleDistance));
+                short          sOrdering = Clamp(-32768, iOrdering, 32767);
+                unsigned short usVisibleDistance = Clamp(0, iVisibleDistance, 65535);
 
                 // Create the blip
                 CClientRadarMarker* pMarker =
@@ -359,7 +359,7 @@ int CLuaBlipDefs::SetBlipOrdering(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        short sOrdering = std::max(-32768, std::min(32767, iOrdering));
+        short sOrdering = Clamp(-32768, iOrdering, 32767);
 
         if (CStaticFunctionDefinitions::SetBlipOrdering(*pEntity, sOrdering))
         {
@@ -384,7 +384,7 @@ int CLuaBlipDefs::SetBlipVisibleDistance(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        unsigned short usVisibleDistance = std::max(0, std::min(65535, iVisibleDistance));
+        unsigned short usVisibleDistance = Clamp(0, iVisibleDistance, 65535);
 
         if (CStaticFunctionDefinitions::SetBlipVisibleDistance(*pEntity, usVisibleDistance))
         {

--- a/Server/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
@@ -97,8 +97,8 @@ int CLuaBlipDefs::CreateBlip(lua_State* luaVM)
             CResource* pResource = pLuaMain->GetResource();
             if (pResource)
             {
-                short          sOrdering = std::max(-32768, std::min(32767, iOrdering));
-                unsigned short usVisibleDistance = std::max(0, std::min(65535, iVisibleDistance));
+                short          sOrdering = Clamp(-32768, iOrdering, 32767);
+                unsigned short usVisibleDistance = Clamp(0, iVisibleDistance, 65535);
 
                 // Create the blip
                 CBlip* pBlip = CStaticFunctionDefinitions::CreateBlip(pResource, vecPosition, ucIcon, ucSize, color, sOrdering, usVisibleDistance, pVisibleTo);
@@ -156,8 +156,8 @@ int CLuaBlipDefs::CreateBlipAttachedTo(lua_State* luaVM)
         CResource* resource = m_pLuaManager->GetVirtualMachineResource(luaVM);
         if (resource)
         {
-            short          sOrdering = std::max(-32768, std::min(32767, iOrdering));
-            unsigned short usVisibleDistance = std::max(0, std::min(65535, iVisibleDistance));
+            short          sOrdering = Clamp(-32768, iOrdering, 32767);
+            unsigned short usVisibleDistance = Clamp(0, iVisibleDistance, 65535);
 
             // Create the blip
             CBlip* pBlip =
@@ -385,7 +385,7 @@ int CLuaBlipDefs::SetBlipOrdering(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        short sOrdering = std::max(-32768, std::min(32767, iOrdering));
+        short sOrdering = Clamp(-32768, iOrdering, 32767);
 
         if (CStaticFunctionDefinitions::SetBlipOrdering(pElement, sOrdering))
         {
@@ -411,7 +411,7 @@ int CLuaBlipDefs::SetBlipVisibleDistance(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        unsigned short usVisibleDistance = std::max(0, std::min(65535, iVisibleDistance));
+        unsigned short usVisibleDistance = Clamp(0, iVisibleDistance, 65535);
 
         if (CStaticFunctionDefinitions::SetBlipVisibleDistance(pElement, usVisibleDistance))
         {


### PR DESCRIPTION
**Mantis Bug Tracker issue:**
[6455](https://bugs.multitheftauto.com/view.php?id=6455)

**Summary:**
- Related/addendum to PR #232;
- Changes requested by @qaisjp on Discord;
- Changed `std::max` and `std::min` to `Clamp` instead.