### PR TITLE
0009914: Having a variable called 'type' breaks exports.lua

### DIFF
--- a/Shared/mods/deathmatch/logic/luascripts/exports.lua.h
+++ b/Shared/mods/deathmatch/logic/luascripts/exports.lua.h
@@ -13,6 +13,7 @@ namespace EmbeddedLuaCode
 
 -- Protect some functions from modifications by resources
 local type = type
+local setmetatable = setmetatable
 local getResourceRootElement = getResourceRootElement
 local call = call
 local getResourceFromName = getResourceFromName

--- a/Shared/mods/deathmatch/logic/luascripts/exports.lua.h
+++ b/Shared/mods/deathmatch/logic/luascripts/exports.lua.h
@@ -12,6 +12,7 @@ namespace EmbeddedLuaCode
 --]]
 
 -- Protect some functions from modifications by resources
+local type = type
 local getResourceRootElement = getResourceRootElement
 local call = call
 local getResourceFromName = getResourceFromName


### PR DESCRIPTION
There's really nothing to review. :P 

Mantis Bug Tracker: https://bugs.mtasa.com/view.php?id=9914