### PR TITLE
Raw data loading option for engineLoadIFP

### DIFF
--- a/Client/mods/deathmatch/logic/CClientIFP.cpp
+++ b/Client/mods/deathmatch/logic/CClientIFP.cpp
@@ -24,12 +24,12 @@ CClientIFP::CClientIFP(class CClientManager* pManager, ElementID ID) : CClientEn
     m_u32Hashkey = 0;
 }
 
-bool CClientIFP::LoadIFP(const SString& strFilePath, const SString& strBlockName)
+bool CClientIFP::LoadIFP(const SString& strFile, const bool isRawData, const SString& strBlockName)
 {
     m_strBlockName = strBlockName;
     m_pVecAnimations = &m_pIFPAnimations->vecAnimations;
 
-    if (LoadIFPFile(strFilePath))
+    if (LoadIFPFile(strFile, isRawData))
     {
         m_u32Hashkey = HashString(strBlockName.ToLower());
         return true;
@@ -37,9 +37,9 @@ bool CClientIFP::LoadIFP(const SString& strFilePath, const SString& strBlockName
     return false;
 }
 
-bool CClientIFP::LoadIFPFile(const SString& strFilePath)
+bool CClientIFP::LoadIFPFile(const SString& strFile, const bool isRawData)
 {
-    if (LoadFileToMemory(strFilePath))
+    if (isRawData ? LoadDataBufferToMemory(strFile) : LoadFileToMemory(strFile))
     {
         if (ReadIFPByVersion())
         {

--- a/Client/mods/deathmatch/logic/CClientIFP.h
+++ b/Client/mods/deathmatch/logic/CClientIFP.h
@@ -205,7 +205,7 @@ public:
     void MarkAsUnloading(void) { m_bUnloading = true; }
     bool IsUnloading(void) { return m_bUnloading; }
 
-    bool LoadIFP(const SString& strFilePath, const SString& strBlockName);
+    bool LoadIFP(const SString& strFile, const bool isRawData, const SString& strBlockName);
 
     const SString&      GetBlockName(void) { return m_strBlockName; }
     const unsigned int& GetBlockNameHash(void) { return m_u32Hashkey; }
@@ -219,7 +219,7 @@ public:
     void SetPosition(const CVector& vecPosition){};
 
 private:
-    bool LoadIFPFile(const SString& strFilePath);
+    bool LoadIFPFile(const SString& strFile, const bool isRawData);
     bool ReadIFPByVersion(void);
     void ReadIFPVersion1(void);
     void ReadIFPVersion2(bool bAnp3);

--- a/Client/mods/deathmatch/logic/CFileReader.cpp
+++ b/Client/mods/deathmatch/logic/CFileReader.cpp
@@ -59,3 +59,19 @@ bool CFileReader::LoadFileToMemory(const SString& strFilePath)
     }
     return false;
 }
+
+bool CFileReader::LoadDataBufferToMemory(const SString& buffer)
+{
+    std::streamsize m_BufferSize = buffer.size();
+    if (m_BufferSize == eIFSTREAM::SIZE_ERROR)
+    {
+        return false;
+    }
+
+    m_vecFileDataBuffer.reserve(static_cast<size_t>(m_BufferSize));
+    if (std::copy(buffer.begin(), buffer.end(), m_vecFileDataBuffer.data()))
+    {
+        return true;
+    }
+    return false;
+}

--- a/Client/mods/deathmatch/logic/CFileReader.cpp
+++ b/Client/mods/deathmatch/logic/CFileReader.cpp
@@ -45,15 +45,15 @@ void CFileReader::SkipBytes(const std::uint32_t u32BytesToSkip)
 bool CFileReader::LoadFileToMemory(const SString& strFilePath)
 {
     std::ifstream   fileStream(FromUTF8(strFilePath), std::ios::binary | std::ios::ate);
-    std::streamsize m_iFileSize = fileStream.tellg();
-    if (m_iFileSize == eIFSTREAM::SIZE_ERROR)
+    std::streamsize iFileSize = fileStream.tellg();
+    if (iFileSize == eIFSTREAM::SIZE_ERROR)
     {
         return false;
     }
 
     fileStream.seekg(0, std::ios::beg);
-    m_vecFileDataBuffer.reserve(static_cast<size_t>(m_iFileSize));
-    if (fileStream.read(m_vecFileDataBuffer.data(), m_iFileSize))
+    m_vecFileDataBuffer.reserve(static_cast<size_t>(iFileSize));
+    if (fileStream.read(m_vecFileDataBuffer.data(), iFileSize))
     {
         return true;
     }
@@ -62,13 +62,13 @@ bool CFileReader::LoadFileToMemory(const SString& strFilePath)
 
 bool CFileReader::LoadDataBufferToMemory(const SString& buffer)
 {
-    std::streamsize m_BufferSize = buffer.size();
-    if (m_BufferSize == eIFSTREAM::SIZE_ERROR)
+    std::streamsize iBufferSize = buffer.size();
+    if (iBufferSize == eIFSTREAM::SIZE_ERROR)
     {
         return false;
     }
 
-    m_vecFileDataBuffer.reserve(static_cast<size_t>(m_BufferSize));
+    m_vecFileDataBuffer.reserve(static_cast<size_t>(iBufferSize));
     if (std::copy(buffer.begin(), buffer.end(), m_vecFileDataBuffer.data()))
     {
         return true;

--- a/Client/mods/deathmatch/logic/CFileReader.h
+++ b/Client/mods/deathmatch/logic/CFileReader.h
@@ -24,6 +24,7 @@ public:
 
     CFileReader(void);
     bool LoadFileToMemory(const SString& strFilePath);
+    bool LoadDataBufferToMemory(const SString& buffer);
     // Do not call any file reader functions after calling this function
     void FreeFileReaderMemory(void);
 

--- a/Client/mods/deathmatch/logic/CIFPEngine.cpp
+++ b/Client/mods/deathmatch/logic/CIFPEngine.cpp
@@ -10,7 +10,7 @@
 
 #include <StdInc.h>
 
-std::shared_ptr<CClientIFP> CIFPEngine::EngineLoadIFP(CResource* pResource, CClientManager* pManager, const SString& strPath, const SString& strBlockName)
+std::shared_ptr<CClientIFP> CIFPEngine::EngineLoadIFP(CResource* pResource, CClientManager* pManager, const SString& strFile, bool bIsRawData, const SString& strBlockName)
 {
     // Grab the resource root entity
     CClientEntity*     pRoot = pResource->GetResourceIFPRoot();
@@ -23,7 +23,7 @@ std::shared_ptr<CClientIFP> CIFPEngine::EngineLoadIFP(CResource* pResource, CCli
         std::shared_ptr<CClientIFP> pIFP(new CClientIFP(pManager, INVALID_ELEMENT_ID));
 
         // Try to load the IFP file
-        if (pIFP->LoadIFP(strPath, strBlockName))
+        if (pIFP->LoadIFP(strFile, bIsRawData, strBlockName))
         {
             // We can use the map to retrieve correct IFP by block name later
             g_pClientGame->InsertIFPPointerToMap(u32BlockNameHash, pIFP);
@@ -98,4 +98,10 @@ bool CIFPEngine::EngineRestoreAnimation(CClientEntity* pEntity, const SString& s
         }
     }
     return false;
+}
+
+// Return true if data looks like IFP file contents
+bool CIFPEngine::IsIFPData(const SString& strData)
+{
+    return strData.length() > 32 && memcmp(strData, "\x41\x4E\x50", 3) == 0;
 }

--- a/Client/mods/deathmatch/logic/CIFPEngine.h
+++ b/Client/mods/deathmatch/logic/CIFPEngine.h
@@ -25,11 +25,12 @@ public:
         ALL
     };
 
-    static std::shared_ptr<CClientIFP> EngineLoadIFP(CResource* pResource, CClientManager* pManager, const SString& strPath, const SString& strBlockName);
+    static std::shared_ptr<CClientIFP> EngineLoadIFP(CResource* pResource, CClientManager* pManager, const SString& strFile, bool bIsRawData, const SString& strBlockName);
     static bool                        EngineReplaceAnimation(CClientEntity* pEntity, const SString& strInternalBlockName, const SString& strInternalAnimName,
                                                               const SString& strCustomBlockName, const SString& strCustomAnimName);
     static bool                        EngineRestoreAnimation(CClientEntity* pEntity, const SString& strInternalBlockName, const SString& strInternalAnimName,
                                                               const eRestoreAnimation& eRestoreType);
+    static bool                        IsIFPData(const SString& strData);
 };
 
 #endif

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -297,11 +297,12 @@ int CLuaEngineDefs::EngineLoadIFP(lua_State* luaVM)
             CResource* pResource = pLuaMain->GetResource();
             if (pResource)
             {
+                bool bIsRawData = CIFPEngine::IsIFPData(strFile);
                 SString strPath;
                 // Is this a legal filepath?
-                if (CResourceManager::ParseResourcePathInput(strFile, pResource, &strPath))
+                if (bIsRawData || CResourceManager::ParseResourcePathInput(strFile, pResource, &strPath))
                 {
-                    std::shared_ptr<CClientIFP> pIFP = CIFPEngine::EngineLoadIFP(pResource, m_pManager, strPath, strBlockName);
+                    std::shared_ptr<CClientIFP> pIFP = CIFPEngine::EngineLoadIFP(pResource, m_pManager, bIsRawData ? strFile : strPath, bIsRawData, strBlockName);
                     if (pIFP != nullptr)
                     {
                         // Return the IFP element
@@ -309,10 +310,10 @@ int CLuaEngineDefs::EngineLoadIFP(lua_State* luaVM)
                         return 1;
                     }
                     else
-                        argStream.SetCustomError(strFile, "Error loading IFP");
+                        argStream.SetCustomError(bIsRawData ? "raw data" : strFile, "Error loading IFP");
                 }
                 else
-                    argStream.SetCustomError(strFile, "Bad file path");
+                    argStream.SetCustomError(bIsRawData ? "raw data" : strFile, "Bad file path");
             }
         }
     }


### PR DESCRIPTION
Modified function: [engineLoadIFP](https://wiki.multitheftauto.com/wiki/EngineLoadIFP)

New syntax: engineLoadIFP ( string ifp_file / string raw_data, string CustomBlockName )

Added option to use raw data instead of a file name.