### PR TITLE
0008957: add missing vertical scrollbar functions to gui memo element

### DIFF
--- a/Client/gui/CGUIMemo_Impl.cpp
+++ b/Client/gui/CGUIMemo_Impl.cpp
@@ -111,6 +111,11 @@ void CGUIMemo_Impl::SetVerticalScrollPosition(float fPosition)
     }
 }
 
+float CGUIMemo_Impl::GetMaxVerticalScrollPosition(void)
+{
+    return GetScrollbarDocumentSize() - GetScrollbarPageSize();
+}
+
 float CGUIMemo_Impl::GetScrollbarDocumentSize(void)
 {
     CEGUI::Scrollbar* pScrollbar = reinterpret_cast<CEGUI::MultiLineEditbox*>(m_pWindow)->d_vertScrollbar;

--- a/Client/gui/CGUIMemo_Impl.h
+++ b/Client/gui/CGUIMemo_Impl.h
@@ -29,6 +29,7 @@ public:
 
     float GetVerticalScrollPosition(void);
     void  SetVerticalScrollPosition(float fPosition);
+    float GetMaxVerticalScrollPosition(void);
     float GetScrollbarDocumentSize(void);
     float GetScrollbarPageSize(void);
 

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -5569,6 +5569,24 @@ void CStaticFunctionDefinitions::GUIMemoSetCaretIndex(CClientEntity& Entity, uns
     }
 }
 
+void CStaticFunctionDefinitions::GUIMemoSetVerticalScrollPosition(CClientEntity& Entity, float fPosition)
+{
+    RUN_CHILDREN(GUIMemoSetVerticalScrollPosition(**iter, fPosition))
+
+    // Are we a GUI element?
+    if (IS_GUI(&Entity))
+    {
+        CClientGUIElement& GUIElement = static_cast<CClientGUIElement&>(Entity);
+
+        // Are we a gridlist?
+        if (IS_CGUIELEMENT_MEMO(&GUIElement))
+        {
+            CGUIMemo* guiMemo = static_cast<CGUIMemo*>(GUIElement.GetCGUIElement());
+            guiMemo->SetVerticalScrollPosition(fPosition / 100.0f * guiMemo->GetMaxVerticalScrollPosition());
+        }
+    }
+}
+
 void CStaticFunctionDefinitions::GUIGridListSetSortingEnabled(CClientEntity& Entity, bool bEnabled)
 {
     RUN_CHILDREN(GUIGridListSetSortingEnabled(**iter, bEnabled))

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -460,6 +460,7 @@ public:
 
     static void GUIMemoSetReadOnly(CClientEntity& Element, bool bFlag);
     static void GUIMemoSetCaretIndex(CClientEntity& Element, unsigned int iCaret);
+    static void GUIMemoSetVerticalScrollPosition(CClientEntity& Element, float fPosition);
 
     static void                GUIGridListSetSortingEnabled(CClientEntity& Element, bool bEnabled);
     static inline unsigned int GUIGridListAddColumn(CClientGUIElement& GUIElement, const char* szTitle, float fWidth)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -136,7 +136,6 @@ void CLuaGUIDefs::LoadFunctions(void)
     CLuaCFunctions::AddFunction("guiMemoIsReadOnly", GUIMemoIsReadOnly);
     CLuaCFunctions::AddFunction("guiMemoSetVerticalScrollPosition", GUIMemoSetVerticalScrollPosition);
     CLuaCFunctions::AddFunction("guiMemoGetVerticalScrollPosition", GUIMemoGetVerticalScrollPosition);
-    CLuaCFunctions::AddFunction("guiMemoGetMaxVerticalScrollPosition", GUIMemoGetMaxVerticalScrollPosition);
 
     CLuaCFunctions::AddFunction("guiLabelSetColor", GUILabelSetColor);
     CLuaCFunctions::AddFunction("guiLabelGetColor", GUILabelGetColor);
@@ -324,7 +323,6 @@ void CLuaGUIDefs::AddGuiMemoClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setReadOnly", "guiMemoSetReadOnly");
 
     lua_classfunction(luaVM, "getVerticalScrollPosition", "guiMemoGetVerticalScrollPosition");
-    lua_classfunction(luaVM, "getMaxVerticalScrollPosition", "guiMemoGetMaxVerticalScrollPosition");
 
     lua_classfunction(luaVM, "setVerticalScrollPosition", "guiMemoSetVerticalScrollPosition");
 
@@ -332,7 +330,6 @@ void CLuaGUIDefs::AddGuiMemoClass(lua_State* luaVM)
     lua_classvariable(luaVM, "readOnly", "guiMemoSetReadOnly", "guiMemoIsReadOnly");
 
     lua_classvariable(luaVM, "verticalScrollPosition", "guiMemoSetVerticalScrollPosition", "guiMemoGetVerticalScrollPosition");
-    lua_classvariable(luaVM, "maxVerticalScrollPosition", NULL, "guiMemoGetMaxVerticalScrollPosition");
 
     lua_registerclass(luaVM, "GuiMemo", "GuiElement");
 }
@@ -3177,28 +3174,6 @@ int CLuaGUIDefs::GUIMemoGetCaretIndex(lua_State* luaVM)
     if (!argStream.HasErrors())
     {
         lua_pushnumber(luaVM, static_cast<CGUIMemo*>(theMemo->GetCGUIElement())->GetCaretIndex());
-        return 1;
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    // error: bad arguments
-    lua_pushboolean(luaVM, false);
-    return 1;
-}
-
-int CLuaGUIDefs::GUIMemoGetMaxVerticalScrollPosition(lua_State* luaVM)
-{
-    //  float guiMemoGetMaxVerticalScrollPosition ( gui-memo theMemo )
-    CClientGUIElement* theMemo;
-
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData<CGUIMemo>(theMemo);
-
-    if (!argStream.HasErrors())
-    {
-        float fPos = static_cast<CGUIMemo*>(theMemo->GetCGUIElement())->GetMaxVerticalScrollPosition();
-        lua_pushnumber(luaVM, fPos);
         return 1;
     }
     else

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -134,6 +134,9 @@ void CLuaGUIDefs::LoadFunctions(void)
     CLuaCFunctions::AddFunction("guiMemoGetCaretIndex", GUIMemoGetCaretIndex);
     CLuaCFunctions::AddFunction("guiMemoSetReadOnly", GUIMemoSetReadOnly);
     CLuaCFunctions::AddFunction("guiMemoIsReadOnly", GUIMemoIsReadOnly);
+    CLuaCFunctions::AddFunction("guiMemoSetVerticalScrollPosition", GUIMemoSetVerticalScrollPosition);
+    CLuaCFunctions::AddFunction("guiMemoGetVerticalScrollPosition", GUIMemoGetVerticalScrollPosition);
+    CLuaCFunctions::AddFunction("guiMemoGetMaxVerticalScrollPosition", GUIMemoGetMaxVerticalScrollPosition);
 
     CLuaCFunctions::AddFunction("guiLabelSetColor", GUILabelSetColor);
     CLuaCFunctions::AddFunction("guiLabelGetColor", GUILabelGetColor);
@@ -320,8 +323,16 @@ void CLuaGUIDefs::AddGuiMemoClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setCaretIndex", "guiMemoSetCaretIndex");
     lua_classfunction(luaVM, "setReadOnly", "guiMemoSetReadOnly");
 
+    lua_classfunction(luaVM, "getVerticalScrollPosition", "guiMemoGetVerticalScrollPosition");
+    lua_classfunction(luaVM, "getMaxVerticalScrollPosition", "guiMemoGetMaxVerticalScrollPosition");
+
+    lua_classfunction(luaVM, "setVerticalScrollPosition", "guiMemoSetVerticalScrollPosition");
+
     lua_classvariable(luaVM, "caretIndex", "guiMemoSetCaretIndex", "guiMemoGetCaretIndex");
     lua_classvariable(luaVM, "readOnly", "guiMemoSetReadOnly", "guiMemoIsReadOnly");
+
+    lua_classvariable(luaVM, "verticalScrollPosition", "guiMemoSetVerticalScrollPosition", "guiMemoGetVerticalScrollPosition");
+    lua_classvariable(luaVM, "maxVerticalScrollPosition", NULL, "guiMemoGetMaxVerticalScrollPosition");
 
     lua_registerclass(luaVM, "GuiMemo", "GuiElement");
 }
@@ -3132,6 +3143,29 @@ int CLuaGUIDefs::GUIMemoSetCaretIndex(lua_State* luaVM)
     return 1;
 }
 
+int CLuaGUIDefs::GUIMemoSetVerticalScrollPosition(lua_State* luaVM)
+{
+    //  bool guiMemoSetVerticalScrollPosition ( gui-memo theMemo, float fPosition )
+    CClientGUIElement* theMemo;
+    float              fPosition;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData<CGUIMemo>(theMemo);
+    argStream.ReadNumber(fPosition);
+
+    if (!argStream.HasErrors())
+    {
+        CStaticFunctionDefinitions::GUIMemoSetVerticalScrollPosition(*theMemo, fPosition);
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
 int CLuaGUIDefs::GUIMemoGetCaretIndex(lua_State* luaVM)
 {
     //  bool guiMemoGetCaretIndex ( gui-memo theMemo )
@@ -3143,6 +3177,51 @@ int CLuaGUIDefs::GUIMemoGetCaretIndex(lua_State* luaVM)
     if (!argStream.HasErrors())
     {
         lua_pushnumber(luaVM, static_cast<CGUIMemo*>(theMemo->GetCGUIElement())->GetCaretIndex());
+        return 1;
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    // error: bad arguments
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaGUIDefs::GUIMemoGetMaxVerticalScrollPosition(lua_State* luaVM)
+{
+    //  float guiMemoGetMaxVerticalScrollPosition ( gui-memo theMemo )
+    CClientGUIElement* theMemo;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData<CGUIMemo>(theMemo);
+
+    if (!argStream.HasErrors())
+    {
+        float fPos = static_cast<CGUIMemo*>(theMemo->GetCGUIElement())->GetMaxVerticalScrollPosition();
+        lua_pushnumber(luaVM, fPos);
+        return 1;
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    // error: bad arguments
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaGUIDefs::GUIMemoGetVerticalScrollPosition(lua_State* luaVM)
+{
+    //  float guiMemoGetVerticalScrollPosition ( gui-memo theMemo )
+    CClientGUIElement* theMemo;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData<CGUIMemo>(theMemo);
+
+    if (!argStream.HasErrors())
+    {
+        CGUIMemo* guiMemo = static_cast<CGUIMemo*>(theMemo->GetCGUIElement());
+        float     fPos = guiMemo->GetVerticalScrollPosition() / guiMemo->GetMaxVerticalScrollPosition() * 100.0f;
+        lua_pushnumber(luaVM, fPos);
         return 1;
     }
     else

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -318,18 +318,15 @@ void CLuaGUIDefs::AddGuiMemoClass(lua_State* luaVM)
     lua_classfunction(luaVM, "create", "guiCreateMemo");
 
     lua_classfunction(luaVM, "getCaretIndex", "guiMemoGetCaretIndex");
-
-    lua_classfunction(luaVM, "setCaretIndex", "guiMemoSetCaretIndex");
-    lua_classfunction(luaVM, "setReadOnly", "guiMemoSetReadOnly");
-
     lua_classfunction(luaVM, "getVerticalScrollPosition", "guiMemoGetVerticalScrollPosition");
 
+    lua_classfunction(luaVM, "setCaretIndex", "guiMemoSetCaretIndex");
     lua_classfunction(luaVM, "setVerticalScrollPosition", "guiMemoSetVerticalScrollPosition");
+    lua_classfunction(luaVM, "setReadOnly", "guiMemoSetReadOnly");
 
     lua_classvariable(luaVM, "caretIndex", "guiMemoSetCaretIndex", "guiMemoGetCaretIndex");
-    lua_classvariable(luaVM, "readOnly", "guiMemoSetReadOnly", "guiMemoIsReadOnly");
-
     lua_classvariable(luaVM, "verticalScrollPosition", "guiMemoSetVerticalScrollPosition", "guiMemoGetVerticalScrollPosition");
+    lua_classvariable(luaVM, "readOnly", "guiMemoSetReadOnly", "guiMemoIsReadOnly");
 
     lua_registerclass(luaVM, "GuiMemo", "GuiElement");
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
@@ -125,7 +125,6 @@ public:
     LUA_DECLARE(GUIMemoGetCaretIndex);
     LUA_DECLARE(GUIMemoGetVerticalScrollPosition);
     LUA_DECLARE(GUIMemoSetVerticalScrollPosition);
-    LUA_DECLARE(GUIMemoGetMaxVerticalScrollPosition);
     LUA_DECLARE(GUIWindowSetMovable);
     LUA_DECLARE(GUIWindowSetSizable);
     LUA_DECLARE(GUIWindowGetMovable);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
@@ -123,6 +123,9 @@ public:
     LUA_DECLARE(GUIMemoIsReadOnly);
     LUA_DECLARE(GUIMemoSetCaretIndex);
     LUA_DECLARE(GUIMemoGetCaretIndex);
+    LUA_DECLARE(GUIMemoGetVerticalScrollPosition);
+    LUA_DECLARE(GUIMemoSetVerticalScrollPosition);
+    LUA_DECLARE(GUIMemoGetMaxVerticalScrollPosition);
     LUA_DECLARE(GUIWindowSetMovable);
     LUA_DECLARE(GUIWindowSetSizable);
     LUA_DECLARE(GUIWindowGetMovable);

--- a/Client/sdk/gui/CGUIMemo.h
+++ b/Client/sdk/gui/CGUIMemo.h
@@ -28,6 +28,7 @@ public:
 
     virtual float GetVerticalScrollPosition(void) = 0;
     virtual void  SetVerticalScrollPosition(float fPosition) = 0;
+    virtual float GetMaxVerticalScrollPosition(void) = 0;
     virtual float GetScrollbarDocumentSize(void) = 0;
     virtual float GetScrollbarPageSize(void) = 0;
 


### PR DESCRIPTION
**Mantis Bug Tracker issue:**
[8957](https://bugs.multitheftauto.com/view.php?id=8957)

**Summary:**
- Added `guiMemoSetVerticalScrollPosition` and `guiMemoGetVerticalScrollPosition`;
- `guiMemoSetVerticalScrollPosition` takes in a float between 0 and 100;
- `guiMemoGetVerticalScrollPosition` returns a float between 0 and 100;
- Pretty small and simple addition, easy to test.

**Note about guiMemoGetMaxVerticalScrollPosition (1a8dc0e):**
- Was about to add `guiMemoGetMaxVerticalScrollPosition`, which would return `(document size - page size)`. However, @qaisjp and I ended up thinking it is unnecessary for now. If we ever want to implement it, the code is ready in 1a8dc0e.