### PR TITLE
Addendum to #248: fix a tiny typo in comment

### DIFF
--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -5578,7 +5578,7 @@ void CStaticFunctionDefinitions::GUIMemoSetVerticalScrollPosition(CClientEntity&
     {
         CClientGUIElement& GUIElement = static_cast<CClientGUIElement&>(Entity);
 
-        // Are we a gridlist?
+        // Are we a memo?
         if (IS_CGUIELEMENT_MEMO(&GUIElement))
         {
             CGUIMemo* guiMemo = static_cast<CGUIMemo*>(GUIElement.GetCGUIElement());


### PR DESCRIPTION
Made a small typo in a code comment, _gridlist_ should be _memo_.