### PR TITLE
#251: merge the two fire extinguish functions into one extinguishFire

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
@@ -13,8 +13,7 @@
 void CLuaFireDefs::LoadFunctions(void)
 {
     CLuaCFunctions::AddFunction("createFire", CLuaFireDefs::CreateFire);
-    CLuaCFunctions::AddFunction("extinguishFireInRadius", CLuaFireDefs::ExtinguishFireInRadius);
-    CLuaCFunctions::AddFunction("extinguishAllFires", CLuaFireDefs::ExtinguishAllFires);
+    CLuaCFunctions::AddFunction("extinguishFire", CLuaFireDefs::ExtinguishFire);
 }
 
 int CLuaFireDefs::CreateFire(lua_State* luaVM)
@@ -42,34 +41,34 @@ int CLuaFireDefs::CreateFire(lua_State* luaVM)
     return 1;
 }
 
-int CLuaFireDefs::ExtinguishFireInRadius(lua_State* luaVM)
+int CLuaFireDefs::ExtinguishFire(lua_State* luaVM)
 {
-    // bool extinguishFireInRadius ( float x, float y, float z [, float radius = 1.0 ] )
-    CVector vecPosition;
-    float   fRadius;
-
+    // bool extinguishFire ( [ float x, float y, float z [, float radius = 1.0 ] ] )
     CScriptArgReader argStream(luaVM);
-    argStream.ReadVector3D(vecPosition);
-    argStream.ReadNumber(fRadius, 1.0f);
 
-    if (!argStream.HasErrors())
+    if (argStream.NextIsVector3D())
     {
-        if (CStaticFunctionDefinitions::ExtinguishFireInRadius(vecPosition, fRadius))
+        CVector vecPosition;
+        float   fRadius;
+
+        argStream.ReadVector3D(vecPosition);
+        argStream.ReadNumber(fRadius, 1.0f);
+
+        if (!argStream.HasErrors())
         {
-            lua_pushboolean(luaVM, true);
-            return 1;
+            if (CStaticFunctionDefinitions::ExtinguishFireInRadius(vecPosition, fRadius))
+            {
+                lua_pushboolean(luaVM, true);
+                return 1;
+            }
         }
+        else
+            m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+        lua_pushboolean(luaVM, false);
+        return 1;
     }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
 
-    lua_pushboolean(luaVM, false);
-    return 1;
-}
-
-int CLuaFireDefs::ExtinguishAllFires(lua_State* luaVM)
-{
-    // bool extinguishAllFires ( )
     lua_pushboolean(luaVM, CStaticFunctionDefinitions::ExtinguishAllFires());
     return 1;
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaFireDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaFireDefs.h
@@ -17,6 +17,5 @@ public:
     static void LoadFunctions(void);
 
     LUA_DECLARE(CreateFire);
-    LUA_DECLARE(ExtinguishFireInRadius);
-    LUA_DECLARE(ExtinguishAllFires);
+    LUA_DECLARE(ExtinguishFire);
 };


### PR DESCRIPTION
**GitHub issue:**
#251 

**Summary:**
- Replaced redundant [extinguishAllFires](https://wiki.multitheftauto.com/wiki/ExtinguishAllFires) and [extinguishFireInRadius](https://wiki.multitheftauto.com/wiki/ExtinguishFireInRadius) with _extinguishFire_;
- Does not require deprecation warnings as these functions are new to 1.5.6 anyway;
- Pretty small and simple fix, easy to test.