### PR TITLE
0008540: fix spawnPlayer rotation not setting if an object is near the spawn point

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -722,7 +722,7 @@ void CClientPed::Spawn(const CVector& vecPosition, float fRotation, unsigned sho
     // Set some states
     SetFrozen(false);
     Teleport(vecPosition);
-    SetCurrentRotation(fRotation);
+    SetCurrentRotationNew(fRotation);
     SetHealth(GetMaxHealth());
     RemoveAllWeapons();
     SetArmor(0);


### PR DESCRIPTION
**Mantis Bug Tracker issue:**
[8540](https://bugs.multitheftauto.com/view.php?id=8540)

**Summary:**
- It seems using `SetCurrentRotationNew` instead of `SetCurrentRotation` fixes the problem (could it be about the angles? Super weird, as it (only?) happens with an object near the spawn point);
- Pretty small and simple fix, easy to test.