### PR TITLE
#278: fix blip code inconsistencies and clamp size value for backwards compatibility

### DIFF
--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -4224,43 +4224,59 @@ bool CStaticFunctionDefinitions::GetSFXStatus(eAudioLookupIndex containerIndex, 
 CClientRadarMarker* CStaticFunctionDefinitions::CreateBlip(CResource& Resource, const CVector& vecPosition, unsigned char ucIcon, unsigned char ucSize,
                                                            const SColor color, short sOrdering, unsigned short usVisibleDistance)
 {
-    CClientRadarMarker* pBlip = new CClientRadarMarker(m_pManager, INVALID_ELEMENT_ID, sOrdering, usVisibleDistance);
-    if (pBlip)
+    // Valid icon and size?
+    if (CClientRadarMarkerManager::IsValidIcon(ucIcon) && ucSize <= 25)
     {
-        pBlip->SetParent(Resource.GetResourceDynamicEntity());
-        pBlip->SetPosition(vecPosition);
-        pBlip->SetSprite(ucIcon);
-        pBlip->SetScale(ucSize);
-        pBlip->SetColor(color);
+        CClientRadarMarker* pBlip = new CClientRadarMarker(m_pManager, INVALID_ELEMENT_ID, sOrdering, usVisibleDistance);
+        if (pBlip)
+        {
+            pBlip->SetParent(Resource.GetResourceDynamicEntity());
+            pBlip->SetPosition(vecPosition);
+            pBlip->SetSprite(ucIcon);
+            pBlip->SetScale(ucSize);
+            pBlip->SetColor(color);
+        }
+        return pBlip;
     }
-    return pBlip;
+
+    return nullptr;
 }
 
 CClientRadarMarker* CStaticFunctionDefinitions::CreateBlipAttachedTo(CResource& Resource, CClientEntity& Entity, unsigned char ucIcon, unsigned char ucSize,
                                                                      const SColor color, short sOrdering, unsigned short usVisibleDistance)
 {
-    CClientRadarMarker* pBlip = new CClientRadarMarker(m_pManager, INVALID_ELEMENT_ID, sOrdering, usVisibleDistance);
-    if (pBlip)
+    assert(&Entity);
+    // Valid icon and size?
+    if (CClientRadarMarkerManager::IsValidIcon(ucIcon) && ucSize <= 25)
     {
-        pBlip->SetParent(Resource.GetResourceDynamicEntity());
-        pBlip->AttachTo(&Entity);
-        pBlip->SetSprite(ucIcon);
-        pBlip->SetScale(ucSize);
-        pBlip->SetColor(color);
+        CClientRadarMarker* pBlip = new CClientRadarMarker(m_pManager, INVALID_ELEMENT_ID, sOrdering, usVisibleDistance);
+        if (pBlip)
+        {
+            pBlip->SetParent(Resource.GetResourceDynamicEntity());
+            pBlip->AttachTo(&Entity);
+            pBlip->SetSprite(ucIcon);
+            pBlip->SetScale(ucSize);
+            pBlip->SetColor(color);
+        }
+        return pBlip;
     }
-    return pBlip;
+
+    return nullptr;
 }
 
 bool CStaticFunctionDefinitions::SetBlipIcon(CClientEntity& Entity, unsigned char ucIcon)
 {
-    RUN_CHILDREN(SetBlipIcon(**iter, ucIcon))
-
-    if (IS_RADARMARKER(&Entity))
+    if (CClientRadarMarkerManager::IsValidIcon(ucIcon))
     {
-        CClientRadarMarker& Marker = static_cast<CClientRadarMarker&>(Entity);
+        RUN_CHILDREN(SetBlipIcon(**iter, ucIcon))
 
-        Marker.SetSprite(ucIcon);
-        return true;
+        if (IS_RADARMARKER(&Entity))
+        {
+            CClientRadarMarker& Marker = static_cast<CClientRadarMarker&>(Entity);
+
+            Marker.SetSprite(ucIcon);
+            return true;
+        }
     }
 
     return false;
@@ -4268,14 +4284,17 @@ bool CStaticFunctionDefinitions::SetBlipIcon(CClientEntity& Entity, unsigned cha
 
 bool CStaticFunctionDefinitions::SetBlipSize(CClientEntity& Entity, unsigned char ucSize)
 {
-    RUN_CHILDREN(SetBlipSize(**iter, ucSize))
-
-    if (IS_RADARMARKER(&Entity))
+    if (ucSize <= 25)
     {
-        CClientRadarMarker& Marker = static_cast<CClientRadarMarker&>(Entity);
+        RUN_CHILDREN(SetBlipSize(**iter, ucSize))
 
-        Marker.SetScale(ucSize);
-        return true;
+        if (IS_RADARMARKER(&Entity))
+        {
+            CClientRadarMarker& Marker = static_cast<CClientRadarMarker&>(Entity);
+
+            Marker.SetScale(ucSize);
+            return true;
+        }
     }
 
     return false;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
@@ -80,6 +80,9 @@ int CLuaBlipDefs::CreateBlip(lua_State* luaVM)
         argStream.SetCustomError("Invalid icon");
     }
 
+    if (iSize < 0 || iSize > 25)
+        argStream.SetCustomWarning(SString("Blip size beyond 25 is no longer supported (got %i). It will be clamped between 0 and 25.", iSize));
+
     if (!argStream.HasErrors())
     {
         CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
@@ -140,6 +143,9 @@ int CLuaBlipDefs::CreateBlipAttachedTo(lua_State* luaVM)
     {
         argStream.SetCustomError("Invalid icon");
     }
+
+    if (iSize < 0 || iSize > 25)
+        argStream.SetCustomWarning(SString("Blip size beyond 25 is no longer supported (got %i). It will be clamped between 0 and 25.", iSize));
 
     if (!argStream.HasErrors())
     {
@@ -309,6 +315,9 @@ int CLuaBlipDefs::SetBlipSize(lua_State* luaVM)
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pEntity);
     argStream.ReadNumber(iSize);
+
+    if (iSize < 0 || iSize > 25)
+        argStream.SetCustomWarning(SString("Blip size beyond 25 is no longer supported (got %i). It will be clamped between 0 and 25.", iSize));
 
     if (!argStream.HasErrors())
     {

--- a/Client/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
@@ -60,14 +60,14 @@ int CLuaBlipDefs::CreateBlip(lua_State* luaVM)
 {
     CVector          vecPosition;
     unsigned char    ucIcon = 0;
-    unsigned char    ucSize = 2;
+    int              iSize = 2;
     SColorRGBA       color(255, 0, 0, 255);
     int              iOrdering = 0;
     int              iVisibleDistance = 16383;
     CScriptArgReader argStream(luaVM);
     argStream.ReadVector3D(vecPosition);
     argStream.ReadNumber(ucIcon, 0);
-    argStream.ReadNumber(ucSize, 2);
+    argStream.ReadNumber(iSize, 2);
     argStream.ReadNumber(color.R, 255);
     argStream.ReadNumber(color.G, 0);
     argStream.ReadNumber(color.B, 0);
@@ -88,6 +88,7 @@ int CLuaBlipDefs::CreateBlip(lua_State* luaVM)
             CResource* pResource = pLuaMain->GetResource();
             if (pResource)
             {
+                unsigned char  ucSize = Clamp(0, iSize, 25);
                 short          sOrdering = Clamp(-32768, iOrdering, 32767);
                 unsigned short usVisibleDistance = Clamp(0, iVisibleDistance, 65535);
 
@@ -120,14 +121,14 @@ int CLuaBlipDefs::CreateBlipAttachedTo(lua_State* luaVM)
     CClientEntity* pEntity = NULL;
     // Default colors and size
     unsigned char    ucIcon = 0;
-    unsigned char    ucSize = 2;
+    int              iSize = 2;
     SColorRGBA       color(255, 0, 0, 255);
     int              iOrdering = 0;
     int              iVisibleDistance = 16383;
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pEntity);
     argStream.ReadNumber(ucIcon, 0);
-    argStream.ReadNumber(ucSize, 2);
+    argStream.ReadNumber(iSize, 2);
     argStream.ReadNumber(color.R, 255);
     argStream.ReadNumber(color.G, 0);
     argStream.ReadNumber(color.B, 0);
@@ -148,6 +149,7 @@ int CLuaBlipDefs::CreateBlipAttachedTo(lua_State* luaVM)
             CResource* pResource = pLuaMain->GetResource();
             if (pResource)
             {
+                unsigned char  ucSize = Clamp(0, iSize, 25);
                 short          sOrdering = Clamp(-32768, iOrdering, 32767);
                 unsigned short usVisibleDistance = Clamp(0, iVisibleDistance, 65535);
 
@@ -303,13 +305,15 @@ int CLuaBlipDefs::SetBlipIcon(lua_State* luaVM)
 int CLuaBlipDefs::SetBlipSize(lua_State* luaVM)
 {
     CClientEntity*   pEntity = NULL;
-    unsigned char    ucSize = 0;
+    int              iSize = 0;
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pEntity);
-    argStream.ReadNumber(ucSize);
+    argStream.ReadNumber(iSize);
 
     if (!argStream.HasErrors())
     {
+        unsigned char ucSize = Clamp(0, iSize, 25);
+
         if (CStaticFunctionDefinitions::SetBlipSize(*pEntity, ucSize))
         {
             lua_pushboolean(luaVM, true);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
@@ -63,7 +63,8 @@ void CLuaBlipDefs::AddClass(lua_State* luaVM)
 int CLuaBlipDefs::CreateBlip(lua_State* luaVM)
 {
     CVector       vecPosition;
-    unsigned char ucIcon, ucSize;
+    unsigned char ucIcon;
+    int           iSize;
     SColorRGBA    color(255, 0, 0, 255);
     int           iOrdering;
     int           iVisibleDistance;
@@ -72,7 +73,7 @@ int CLuaBlipDefs::CreateBlip(lua_State* luaVM)
     CScriptArgReader argStream(luaVM);
     argStream.ReadVector3D(vecPosition);
     argStream.ReadNumber(ucIcon, 0);
-    argStream.ReadNumber(ucSize, 2);
+    argStream.ReadNumber(iSize, 2);
     argStream.ReadNumber(color.R, color.R);
     argStream.ReadNumber(color.G, color.G);
     argStream.ReadNumber(color.B, color.B);
@@ -97,6 +98,7 @@ int CLuaBlipDefs::CreateBlip(lua_State* luaVM)
             CResource* pResource = pLuaMain->GetResource();
             if (pResource)
             {
+                unsigned char  ucSize = Clamp(0, iSize, 25);
                 short          sOrdering = Clamp(-32768, iOrdering, 32767);
                 unsigned short usVisibleDistance = Clamp(0, iVisibleDistance, 65535);
 
@@ -125,7 +127,8 @@ int CLuaBlipDefs::CreateBlip(lua_State* luaVM)
 int CLuaBlipDefs::CreateBlipAttachedTo(lua_State* luaVM)
 {
     CElement*     pElement;
-    unsigned char ucIcon, ucSize;
+    unsigned char ucIcon;
+    int           iSize;
     SColorRGBA    color(255, 0, 0, 255);
     int           iOrdering;
     int           iVisibleDistance;
@@ -134,7 +137,7 @@ int CLuaBlipDefs::CreateBlipAttachedTo(lua_State* luaVM)
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pElement);
     argStream.ReadNumber(ucIcon, 0);
-    argStream.ReadNumber(ucSize, 2);
+    argStream.ReadNumber(iSize, 2);
     argStream.ReadNumber(color.R, color.R);
     argStream.ReadNumber(color.G, color.G);
     argStream.ReadNumber(color.B, color.B);
@@ -156,6 +159,7 @@ int CLuaBlipDefs::CreateBlipAttachedTo(lua_State* luaVM)
         CResource* resource = m_pLuaManager->GetVirtualMachineResource(luaVM);
         if (resource)
         {
+            unsigned char  ucSize = Clamp(0, iSize, 25);
             short          sOrdering = Clamp(-32768, iOrdering, 32767);
             unsigned short usVisibleDistance = Clamp(0, iVisibleDistance, 65535);
 
@@ -325,15 +329,17 @@ int CLuaBlipDefs::SetBlipIcon(lua_State* luaVM)
 
 int CLuaBlipDefs::SetBlipSize(lua_State* luaVM)
 {
-    CElement*     pElement;
-    unsigned char ucSize;
+    CElement* pElement;
+    int       iSize;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pElement);
-    argStream.ReadNumber(ucSize);
+    argStream.ReadNumber(iSize);
 
     if (!argStream.HasErrors())
     {
+        unsigned char ucSize = Clamp(0, iSize, 25);
+
         if (CStaticFunctionDefinitions::SetBlipSize(pElement, ucSize))
         {
             lua_pushboolean(luaVM, true);


### PR DESCRIPTION
**GitHub issue:**
#278

**Summary:**
- Discovered by **zHooP** on Discord. Thanks.
- This bug has been in the client code forever.
- Code never checked if blip icon is valid.
- Code allowed any blip size.
- Made backwards compatible by clamping size value between 0 and 25 instead of returning false upon invalid size.
- If size is out of bounds client-side, it will output a debug warning about clamping that might affect behavior.