### PR TITLE
Fixed false elements in getElementsWithinRange

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -952,7 +952,7 @@ int CLuaElementDefs::GetElementsWithinRange(lua_State* luaVM)
 
         for (CClientEntity* entity : result)
         {
-            if (elementType.empty() || elementType == entity->GetTypeName())
+            if ((elementType.empty() || elementType == entity->GetTypeName()) && !entity->IsBeingDeleted())
             {
                 lua_pushnumber(luaVM, ++index);
                 lua_pushelement(luaVM, entity);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -1010,7 +1010,7 @@ int CLuaElementDefs::getElementsWithinRange(lua_State* luaVM)
 
         for (CElement* entity : result)
         {
-            if (elementType.empty() || elementType == entity->GetTypeName())
+            if ((elementType.empty() || elementType == entity->GetTypeName()) && !entity->IsBeingDeleted())
             {
                 lua_pushnumber(luaVM, ++index);
                 lua_pushelement(luaVM, entity);


### PR DESCRIPTION
Some elements may be 'false' within a resulting table.
