### PR TITLE
Fix getElementBoundingBox() OOP version returning 6 numbers instead of a 2 vectors

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -200,7 +200,7 @@ void CLuaElementDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "distanceFromCentreOfMassToBaseOfModel", NULL, "getElementDistanceFromCentreOfMassToBaseOfModel");
     lua_classvariable(luaVM, "radius", NULL, "getElementRadius");
     lua_classvariable(luaVM, "childrenCount", NULL, "getElementChildrenCount");
-    lua_classfunction(luaVM, "boundingBox", NULL, OOP_GetElementBoundingBox);
+    lua_classvariable(luaVM, "boundingBox", NULL, OOP_GetElementBoundingBox);
     lua_classvariable(luaVM, "position", SetElementPosition, OOP_GetElementPosition);
     lua_classvariable(luaVM, "rotation", OOP_SetElementRotation, OOP_GetElementRotation);
     lua_classvariable(luaVM, "matrix", SetElementMatrix, OOP_GetElementMatrix);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -1018,6 +1018,7 @@ int CLuaElementDefs::OOP_GetElementBoundingBox(lua_State* luaVM)
             {
                 lua_pushvector(luaVM, vecMin);
                 lua_pushvector(luaVM, vecMax);
+                return 2;
             }
             else
             {
@@ -1027,9 +1028,8 @@ int CLuaElementDefs::OOP_GetElementBoundingBox(lua_State* luaVM)
                 lua_pushnumber(luaVM, vecMax.fX);
                 lua_pushnumber(luaVM, vecMax.fY);
                 lua_pushnumber(luaVM, vecMax.fZ);
-            }
-            
-            return 6;
+                return 6;
+            }           
         }
     }
     else
@@ -1037,7 +1037,7 @@ int CLuaElementDefs::OOP_GetElementBoundingBox(lua_State* luaVM)
 
     // Failed
     lua_pushboolean(luaVM, false);
-  
+}
 
 int CLuaElementDefs::GetElementBoundingBox(lua_State* luaVM)
 {

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -12,7 +12,7 @@
 
 #include "StdInc.h"
 using std::list;
-#define MIN_CLIENT_REQ_GETBOUNDINGBOX_OOP      "1.5.5-9.13987" // Update this to the version number when merged
+#define MIN_CLIENT_REQ_GETBOUNDINGBOX_OOP      "1.5.5-9.13999"
 
 void CLuaElementDefs::LoadFunctions(void)
 {

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -129,7 +129,7 @@ void CLuaElementDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getChildrenCount", "getElementChildrenCount");
     lua_classfunction(luaVM, "getID", "getElementID");
     lua_classfunction(luaVM, "getParent", "getElementParent");
-    lua_classfunction(luaVM, "getBoundingBox", "getElementBoundingBox");
+    lua_classfunction(luaVM, "getBoundingBox", OOP_GetElementBoundingBox);
     lua_classfunction(luaVM, "getPosition", OOP_GetElementPosition);
     lua_classfunction(luaVM, "getRotation", OOP_GetElementRotation);
     lua_classfunction(luaVM, "getMatrix", OOP_GetElementMatrix);
@@ -199,6 +199,7 @@ void CLuaElementDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "distanceFromCentreOfMassToBaseOfModel", NULL, "getElementDistanceFromCentreOfMassToBaseOfModel");
     lua_classvariable(luaVM, "radius", NULL, "getElementRadius");
     lua_classvariable(luaVM, "childrenCount", NULL, "getElementChildrenCount");
+    lua_classfunction(luaVM, "boundingBox", NULL, OOP_GetElementBoundingBox);
     lua_classvariable(luaVM, "position", SetElementPosition, OOP_GetElementPosition);
     lua_classvariable(luaVM, "rotation", OOP_SetElementRotation, OOP_GetElementRotation);
     lua_classvariable(luaVM, "matrix", SetElementMatrix, OOP_GetElementMatrix);
@@ -999,6 +1000,46 @@ int CLuaElementDefs::GetElementDimension(lua_State* luaVM)
     lua_pushboolean(luaVM, false);
     return 1;
 }
+
+int CLuaElementDefs::OOP_GetElementBoundingBox(lua_State* luaVM)
+{
+    // Verify the argument
+    CClientEntity*   pEntity;
+    bool             bLegacy;
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pEntity);
+    argStream.ReadBool(bLegacy, true);
+
+    if (!argStream.HasErrors())
+    {
+        // Grab the bounding box and return it
+        CVector vecMin, vecMax;
+        if (CStaticFunctionDefinitions::GetElementBoundingBox(*pEntity, vecMin, vecMax))
+        {
+            if (!bLegacy)
+            {
+                lua_pushvector(luaVM, vecMin)
+                lua_pushvector(luaVM, vecMax)
+            }
+            else
+            {
+                lua_pushnumber(luaVM, vecMin.fX);
+                lua_pushnumber(luaVM, vecMin.fY);
+                lua_pushnumber(luaVM, vecMin.fZ);
+                lua_pushnumber(luaVM, vecMax.fX);
+                lua_pushnumber(luaVM, vecMax.fY);
+                lua_pushnumber(luaVM, vecMax.fZ);
+            }
+            
+            return 6;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    // Failed
+    lua_pushboolean(luaVM, false);
+  
 
 int CLuaElementDefs::GetElementBoundingBox(lua_State* luaVM)
 {

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -12,6 +12,7 @@
 
 #include "StdInc.h"
 using std::list;
+#define MIN_CLIENT_REQ_GETBOUNDINGBOX_OOP      "1.5.5-9.13987" // Update this to the version number when merged
 
 void CLuaElementDefs::LoadFunctions(void)
 {
@@ -1003,12 +1004,9 @@ int CLuaElementDefs::GetElementDimension(lua_State* luaVM)
 
 int CLuaElementDefs::OOP_GetElementBoundingBox(lua_State* luaVM)
 {
-    // Verify the argument
     CClientEntity*   pEntity;
-    bool             bLegacy;
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pEntity);
-    argStream.ReadBool(bLegacy, true);
 
     if (!argStream.HasErrors())
     {
@@ -1016,10 +1014,10 @@ int CLuaElementDefs::OOP_GetElementBoundingBox(lua_State* luaVM)
         CVector vecMin, vecMax;
         if (CStaticFunctionDefinitions::GetElementBoundingBox(*pEntity, vecMin, vecMax))
         {
-            if (!bLegacy)
+            if (!MinClientReqCheck(argStream, MIN_CLIENT_REQ_GETBOUNDINGBOX_OOP))
             {
-                lua_pushvector(luaVM, vecMin)
-                lua_pushvector(luaVM, vecMax)
+                lua_pushvector(luaVM, vecMin);
+                lua_pushvector(luaVM, vecMax);
             }
             else
             {

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
@@ -42,7 +42,6 @@ public:
     LUA_DECLARE(GetElementDimension);
     LUA_DECLARE(GetElementZoneName);
     LUA_DECLARE(GetElementBoundingBox);
-    LUA_DECLARE_OOP(GetElementBoundingBox);// Probably wrong, tell me how to declare the OOP version of this.
     LUA_DECLARE(GetElementRadius);
     LUA_DECLARE(IsElementAttached);
     LUA_DECLARE(GetElementAttachedTo);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
@@ -41,7 +41,8 @@ public:
     LUA_DECLARE(GetElementsWithinRange);
     LUA_DECLARE(GetElementDimension);
     LUA_DECLARE(GetElementZoneName);
-    LUA_DECLARE(GetElementBoundingBox);
+    // DECLARE_OOP Declares both the normal and a OOP_ version of a given funciton, just for furtherer reference.
+    LUA_DECLARE_OOP(GetElementBoundingBox);
     LUA_DECLARE(GetElementRadius);
     LUA_DECLARE(IsElementAttached);
     LUA_DECLARE(GetElementAttachedTo);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
@@ -42,6 +42,7 @@ public:
     LUA_DECLARE(GetElementDimension);
     LUA_DECLARE(GetElementZoneName);
     LUA_DECLARE(GetElementBoundingBox);
+    LUA_DECLARE_OOP(GetElementBoundingBox);// Probably wrong, tell me how to declare the OOP version of this.
     LUA_DECLARE(GetElementRadius);
     LUA_DECLARE(IsElementAttached);
     LUA_DECLARE(GetElementAttachedTo);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
@@ -41,7 +41,6 @@ public:
     LUA_DECLARE(GetElementsWithinRange);
     LUA_DECLARE(GetElementDimension);
     LUA_DECLARE(GetElementZoneName);
-    // DECLARE_OOP Declares both the normal and a OOP_ version of a given funciton, just for furtherer reference.
     LUA_DECLARE_OOP(GetElementBoundingBox);
     LUA_DECLARE(GetElementRadius);
     LUA_DECLARE(IsElementAttached);


### PR DESCRIPTION
Small'n'Easy to test.
Fixes the OOP version of getElementBoudingBox.
1. Now it returns 2 vectors if MinClientReqCheck passed
2. Now it's available as a class variable too
