### PR TITLE
Improve debug info for garbage collected files

### DIFF
--- a/Client/mods/deathmatch/logic/CScriptFile.h
+++ b/Client/mods/deathmatch/logic/CScriptFile.h
@@ -48,7 +48,7 @@ public:
     // Get the owning resource
     CResource* GetResource(void);
 
-    // Only call functions belw this if you're sure that the file is loaded.
+    // Only call functions below this if you're sure that the file is loaded.
     // Or you will crash.
     bool IsEOF(void);
     long GetPointer(void);
@@ -59,6 +59,10 @@ public:
     void Flush(void);
     long Read(unsigned long ulSize, CBuffer& outBuffer);
     long Write(unsigned long ulSize, const char* pData);
+
+    // Debug info for garbage collected files
+    const SLuaDebugInfo& GetLuaDebugInfo(void) { return m_LuaDebugInfo; };
+    void SetLuaDebugInfo(const SLuaDebugInfo& luaDebugInfo) { m_LuaDebugInfo = luaDebugInfo; };
 
 private:
     void DoResourceFileCheck(void);
@@ -71,6 +75,7 @@ private:
     unsigned int          m_uiScriptId;
     CResource*            m_pResource;
     eAccessType           m_accessType;
+    SLuaDebugInfo         m_LuaDebugInfo;
 };
 
 #endif

--- a/Server/mods/deathmatch/logic/CScriptFile.h
+++ b/Server/mods/deathmatch/logic/CScriptFile.h
@@ -64,5 +64,5 @@ private:
     uint          m_uiScriptId;
     SString       m_strFilename;
     unsigned long m_ulMaxSize;
-    SLuaDebugInfo         m_LuaDebugInfo;
+    SLuaDebugInfo m_LuaDebugInfo;
 };

--- a/Server/mods/deathmatch/logic/CScriptFile.h
+++ b/Server/mods/deathmatch/logic/CScriptFile.h
@@ -54,10 +54,15 @@ public:
     long Read(unsigned long ulSize, CBuffer& outBuffer);
     long Write(unsigned long ulSize, const char* pData);
 
+    // Debug info for garbage collected files
+    const SLuaDebugInfo& GetLuaDebugInfo(void) { return m_LuaDebugInfo; };
+    void SetLuaDebugInfo(const SLuaDebugInfo& luaDebugInfo) { m_LuaDebugInfo = luaDebugInfo; };
+
 private:
     CResource*    m_pResource;
     FILE*         m_pFile;
     uint          m_uiScriptId;
     SString       m_strFilename;
     unsigned long m_ulMaxSize;
+    SLuaDebugInfo         m_LuaDebugInfo;
 };

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
@@ -929,17 +929,13 @@ int CLuaFileDefs::fileCloseGC(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
+        // This file wasn't closed, so we should warn
+        // the scripter that they forgot to close it.
         m_pScriptDebugging->LogWarning(pFile->GetLuaDebugInfo(), "Unclosed file (%s) was garbage collected. Check your resource for dereferenced files.", *pFile->GetFilePath());
+       
         // Close the file and delete it from elements
         pFile->Unload();
         m_pElementDeleter->Delete(pFile);
-
-        // This file wasn't closed, so we should warn
-        // the scripter that they forgot to close it.
-        //m_pScriptDebugging->LogWarning(luaVM, "Unclosed file (%s) was garbage collected. Check your resource for dereferenced files.", *pFile->GetFilePath());
-        // TODO: The debug info reported when Lua automatically garbage collects will
-        //       actually be the exact point Lua pauses for collection. Find a way to
-        //       remove the line number & script file completely.
 
         lua_pushboolean(luaVM, true);
         return 1;

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
@@ -206,6 +206,9 @@ int CLuaFileDefs::fileOpen(lua_State* luaVM)
 #ifdef MTA_CLIENT
                         // Make it a child of the resource's file root
                         pFile->SetParent(pResource->GetResourceDynamicEntity());
+                        pFile->SetLuaDebugInfo(g_pClientGame->GetScriptDebugging()->GetLuaDebugInfo(luaVM));
+#else
+                        pFile->SetLuaDebugInfo(g_pGame->GetScriptDebugging()->GetLuaDebugInfo(luaVM));
 #endif
                         // Grab its owner resource
                         CResource* pParentResource = pLuaMain->GetResource();
@@ -310,6 +313,9 @@ int CLuaFileDefs::fileCreate(lua_State* luaVM)
 #ifdef MTA_CLIENT
                     // Make it a child of the resource's file root
                     pFile->SetParent(pResource->GetResourceDynamicEntity());
+                    pFile->SetLuaDebugInfo(g_pClientGame->GetScriptDebugging()->GetLuaDebugInfo(luaVM));
+#else
+                    pFile->SetLuaDebugInfo(g_pGame->GetScriptDebugging()->GetLuaDebugInfo(luaVM));
 #endif
 
                     // Add it to the scrpt resource element group
@@ -923,13 +929,14 @@ int CLuaFileDefs::fileCloseGC(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        // Close the file and delete it
+        m_pScriptDebugging->LogWarning(pFile->GetLuaDebugInfo(), "Unclosed file (%s) was garbage collected. Check your resource for dereferenced files.", *pFile->GetFilePath());
+        // Close the file and delete it from elements
         pFile->Unload();
         m_pElementDeleter->Delete(pFile);
 
         // This file wasn't closed, so we should warn
         // the scripter that they forgot to close it.
-        m_pScriptDebugging->LogWarning(luaVM, "Unclosed file (%s) was garbage collected. Check your resource for dereferenced files.", *pFile->GetFilePath());
+        //m_pScriptDebugging->LogWarning(luaVM, "Unclosed file (%s) was garbage collected. Check your resource for dereferenced files.", *pFile->GetFilePath());
         // TODO: The debug info reported when Lua automatically garbage collects will
         //       actually be the exact point Lua pauses for collection. Find a way to
         //       remove the line number & script file completely.


### PR DESCRIPTION
Changed warnings for garbage collected files to display the line in which the file was opened via fileOpen or fileCreate instead of displaying useless information about Lua garbage collector.

This PR closes #309 