### PR TITLE
Add getElementSpeed function

### DIFF
--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -491,6 +491,46 @@ bool CStaticFunctionDefinitions::GetElementVelocity(CClientEntity& Entity, CVect
     return true;
 }
 
+int CStaticFunctionDefinitions::GetElementSpeed(CClientEntity& Entity, unsigned char ucUnit, float& fSpeed)
+{
+    // Is in in the range of [0, 2]?
+    if (ucUnit<=2) 
+    {
+        // Figure out the multiplier
+        float fMultiplier;
+        switch (ucUnit)
+        {
+            case 0: // m/s
+            {
+                fMultiplier = 50.0f;
+                break
+            }
+            case 1: // km/h
+            {
+                fMultiplier = 180.0f;
+                break;
+            }
+            case 2; // mph
+            {
+                fMultiplier = 111.84681456f;
+                break
+            }
+            default:
+                return false;
+        }
+        // Grab it's velocity
+        CVector* vecVelocity;
+        if (GetElementVelocity(Entity, vecVelocity))
+        {
+            // Get the actual speed
+            fSpeed = (*pVector1 * fValue)->Length();
+            return true
+        }
+    }
+
+    return false;
+}
+
 bool CStaticFunctionDefinitions::GetElementInterior(CClientEntity& Entity, unsigned char& ucInterior)
 {
     ucInterior = Entity.GetInterior();

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -58,6 +58,7 @@ public:
     static bool           GetElementPosition(CClientEntity& Entity, CVector& vecPosition);
     static bool           GetElementRotation(CClientEntity& Entity, CVector& vecRotation, eEulerRotationOrder rotationOrder);
     static bool           GetElementVelocity(CClientEntity& Entity, CVector& vecVelocity);
+    static bool           GetElementSpeed(CClientEntity& Entity, unsigned char ucUnit, float& fSpeed);
     static bool           GetElementInterior(CClientEntity& Entity, unsigned char& ucInterior);
     static bool           GetElementBoundingBox(CClientEntity& Entity, CVector& vecMin, CVector& vecMax);
     static bool           GetElementRadius(CClientEntity& Entity, float& fRadius);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
@@ -32,6 +32,7 @@ public:
     LUA_DECLARE_OOP(GetElementPosition);
     LUA_DECLARE_OOP(GetElementRotation);
     LUA_DECLARE_OOP(GetElementVelocity);
+    LUA_DECLARE(GetElementSpeed);
     LUA_DECLARE(GetElementType);
     LUA_DECLARE(GetElementsByType);
     LUA_DECLARE(GetElementInterior);


### PR DESCRIPTION
Just a simple getElementSpeed function which was already available as a useful function, but it's much faster if it's written in cpp, also, it can be used everywhere, unlike the useful function(I mean, having this in the source code reduces redundancy).
Also, the same arguments can be passed as to setElementSpeed, so no scripts will be broken(actually, functions defined inside scripts will override the default ones in MTA).
Wanted to do setElementSpeed too, but when I tested the useful function from the Wiki it produced some weird things, so added that as todo. 