### PR TITLE
Enable safe Lua os.* functions

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -74,20 +74,17 @@ void CLuaMain::ResetInstructionCount(void)
 void CLuaMain::InitSecurity(void)
 {
     // Disable dangerous Lua Os library functions
-    lua_getglobal(m_luaVM, "os");
-    lua_pushnil(m_luaVM);
-    lua_setfield(m_luaVM, -2, "execute");
-    lua_pushnil(m_luaVM);
-    lua_setfield(m_luaVM, -2, "rename");
-    lua_pushnil(m_luaVM);
-    lua_setfield(m_luaVM, -2, "remove");
-    lua_pushnil(m_luaVM);
-    lua_setfield(m_luaVM, -2, "exit");
-    lua_pushnil(m_luaVM);
-    lua_setfield(m_luaVM, -2, "getenv");
-    lua_pushnil(m_luaVM);
-    lua_setfield(m_luaVM, -2, "tmpname");
-    lua_pop(m_luaVM, 1);
+    static const luaL_reg osfuncs[] =
+    {
+        { "execute", CLuaUtilDefs::DisabledFunction },
+        { "rename", CLuaUtilDefs::DisabledFunction },
+        { "remove", CLuaUtilDefs::DisabledFunction },
+        { "exit", CLuaUtilDefs::DisabledFunction },
+        { "getenv", CLuaUtilDefs::DisabledFunction },
+        { "tmpname", CLuaUtilDefs::DisabledFunction },
+        { NULL, NULL }
+    };
+    luaL_register(m_luaVM, "os", osfuncs);
 
     lua_register(m_luaVM, "dofile", CLuaUtilDefs::DisabledFunction);
     lua_register(m_luaVM, "loadfile", CLuaUtilDefs::DisabledFunction);

--- a/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -73,6 +73,22 @@ void CLuaMain::ResetInstructionCount(void)
 
 void CLuaMain::InitSecurity(void)
 {
+    // Disable dangerous Lua Os library functions
+    lua_getglobal(m_luaVM, "os");
+    lua_pushnil(m_luaVM);
+    lua_setfield(m_luaVM, -2, "execute");
+    lua_pushnil(m_luaVM);
+    lua_setfield(m_luaVM, -2, "rename");
+    lua_pushnil(m_luaVM);
+    lua_setfield(m_luaVM, -2, "remove");
+    lua_pushnil(m_luaVM);
+    lua_setfield(m_luaVM, -2, "exit");
+    lua_pushnil(m_luaVM);
+    lua_setfield(m_luaVM, -2, "getenv");
+    lua_pushnil(m_luaVM);
+    lua_setfield(m_luaVM, -2, "tmpname");
+    lua_pop(m_luaVM, 1);
+
     lua_register(m_luaVM, "dofile", CLuaUtilDefs::DisabledFunction);
     lua_register(m_luaVM, "loadfile", CLuaUtilDefs::DisabledFunction);
     lua_register(m_luaVM, "require", CLuaUtilDefs::DisabledFunction);
@@ -141,6 +157,7 @@ void CLuaMain::InitVM(void)
     luaopen_table(m_luaVM);
     luaopen_debug(m_luaVM);
     luaopen_utf8(m_luaVM);
+    luaopen_os(m_luaVM);
 
     // Initialize security restrictions. Very important to prevent lua trojans and viruses!
     InitSecurity();

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -108,6 +108,22 @@ void CLuaMain::ResetInstructionCount(void)
 
 void CLuaMain::InitSecurity(void)
 {
+    // Disable dangerous Lua Os library functions
+    lua_getglobal(m_luaVM, "os");
+    lua_pushnil(m_luaVM);
+    lua_setfield(m_luaVM, -2, "execute");
+    lua_pushnil(m_luaVM);
+    lua_setfield(m_luaVM, -2, "rename");
+    lua_pushnil(m_luaVM);
+    lua_setfield(m_luaVM, -2, "remove");
+    lua_pushnil(m_luaVM);
+    lua_setfield(m_luaVM, -2, "exit");
+    lua_pushnil(m_luaVM);
+    lua_setfield(m_luaVM, -2, "getenv");
+    lua_pushnil(m_luaVM);
+    lua_setfield(m_luaVM, -2, "tmpname");
+    lua_pop(m_luaVM, 1);
+
     lua_register(m_luaVM, "dofile", CLuaUtilDefs::DisabledFunction);
     lua_register(m_luaVM, "loadfile", CLuaUtilDefs::DisabledFunction);
     lua_register(m_luaVM, "require", CLuaUtilDefs::DisabledFunction);
@@ -173,22 +189,6 @@ void CLuaMain::InitVM(void)
     luaopen_debug(m_luaVM);
     luaopen_utf8(m_luaVM);
     luaopen_os(m_luaVM);
-
-    // Disable dangerous Lua Os library functions
-    lua_getglobal(m_luaVM, "os");
-    lua_pushnil(m_luaVM);
-    lua_setfield(m_luaVM, -2, "execute");
-    lua_pushnil(m_luaVM);
-    lua_setfield(m_luaVM, -2, "rename");
-    lua_pushnil(m_luaVM);
-    lua_setfield(m_luaVM, -2, "remove");
-    lua_pushnil(m_luaVM);
-    lua_setfield(m_luaVM, -2, "exit");
-    lua_pushnil(m_luaVM);
-    lua_setfield(m_luaVM, -2, "getenv");
-    lua_pushnil(m_luaVM);
-    lua_setfield(m_luaVM, -2, "tmpname");
-    lua_pop(m_luaVM, 1);
 
     // Initialize security restrictions. Very important to prevent lua trojans and viruses!
     InitSecurity();

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -172,6 +172,23 @@ void CLuaMain::InitVM(void)
     luaopen_table(m_luaVM);
     luaopen_debug(m_luaVM);
     luaopen_utf8(m_luaVM);
+    luaopen_os(m_luaVM);
+
+    // Disable dangerous Lua Os library functions
+    lua_getglobal(m_luaVM, "os");
+    lua_pushnil(m_luaVM);
+    lua_setfield(m_luaVM, -2, "execute");
+    lua_pushnil(m_luaVM);
+    lua_setfield(m_luaVM, -2, "rename");
+    lua_pushnil(m_luaVM);
+    lua_setfield(m_luaVM, -2, "remove");
+    lua_pushnil(m_luaVM);
+    lua_setfield(m_luaVM, -2, "exit");
+    lua_pushnil(m_luaVM);
+    lua_setfield(m_luaVM, -2, "getenv");
+    lua_pushnil(m_luaVM);
+    lua_setfield(m_luaVM, -2, "tmpname");
+    lua_pop(m_luaVM, 1);
 
     // Initialize security restrictions. Very important to prevent lua trojans and viruses!
     InitSecurity();

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -109,20 +109,17 @@ void CLuaMain::ResetInstructionCount(void)
 void CLuaMain::InitSecurity(void)
 {
     // Disable dangerous Lua Os library functions
-    lua_getglobal(m_luaVM, "os");
-    lua_pushnil(m_luaVM);
-    lua_setfield(m_luaVM, -2, "execute");
-    lua_pushnil(m_luaVM);
-    lua_setfield(m_luaVM, -2, "rename");
-    lua_pushnil(m_luaVM);
-    lua_setfield(m_luaVM, -2, "remove");
-    lua_pushnil(m_luaVM);
-    lua_setfield(m_luaVM, -2, "exit");
-    lua_pushnil(m_luaVM);
-    lua_setfield(m_luaVM, -2, "getenv");
-    lua_pushnil(m_luaVM);
-    lua_setfield(m_luaVM, -2, "tmpname");
-    lua_pop(m_luaVM, 1);
+    static const luaL_reg osfuncs[] =
+    {
+        { "execute", CLuaUtilDefs::DisabledFunction },
+        { "rename", CLuaUtilDefs::DisabledFunction },
+        { "remove", CLuaUtilDefs::DisabledFunction },
+        { "exit", CLuaUtilDefs::DisabledFunction },
+        { "getenv", CLuaUtilDefs::DisabledFunction },
+        { "tmpname", CLuaUtilDefs::DisabledFunction },
+        { NULL, NULL }
+    };
+    luaL_register(m_luaVM, "os", osfuncs);
 
     lua_register(m_luaVM, "dofile", CLuaUtilDefs::DisabledFunction);
     lua_register(m_luaVM, "loadfile", CLuaUtilDefs::DisabledFunction);


### PR DESCRIPTION
Loads Lua Os library and **disables** the following functions:

- os.execute
- os.rename
- os.remove
- os.exit
- os.getenv
- os.tmpname

The following functions are **enabled**:

- os.clock
- os.date
- os.difftime
- os.setlocale
- os.time

These functions are much faster than MTA's substitute functions.
Here's how os.clock compares with getTickCount:
```
local startTime = getTickCount()
for i = 1, 1000000 do
    local a = getTickCount()
end
print("getTickCount", getTickCount() - startTime)

startTime = getTickCount()
for i = 1, 1000000 do
    local a = os.clock()
end
print("os.clock", getTickCount() - startTime)
```

Result:
INFO: getTickCount    3926
INFO: os.clock    418

Almost 10 times faster than getTickCount. Considering that functions such as getTickCount or getRealTime are often used onClientRender, this may allow scripters to slightly increase script performance.

This would also help accommodate people who have knowledge of Lua, but are new to MTA.