### PR TITLE
Backward compatibility fix for OOP_GetElementBoundingBox returning vectors post-r13998

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -1016,12 +1016,6 @@ int CLuaElementDefs::OOP_GetElementBoundingBox(lua_State* luaVM)
         {
             if (!MinClientReqCheck(argStream, MIN_CLIENT_REQ_GETBOUNDINGBOX_OOP))
             {
-                lua_pushvector(luaVM, vecMin);
-                lua_pushvector(luaVM, vecMax);
-                return 2;
-            }
-            else
-            {
                 lua_pushnumber(luaVM, vecMin.fX);
                 lua_pushnumber(luaVM, vecMin.fY);
                 lua_pushnumber(luaVM, vecMin.fZ);
@@ -1029,6 +1023,12 @@ int CLuaElementDefs::OOP_GetElementBoundingBox(lua_State* luaVM)
                 lua_pushnumber(luaVM, vecMax.fY);
                 lua_pushnumber(luaVM, vecMax.fZ);
                 return 6;
+            }
+            else
+            {
+                lua_pushvector(luaVM, vecMin);
+                lua_pushvector(luaVM, vecMax);
+                return 2;
             }           
         }
     }

--- a/Server/mods/deathmatch/logic/CResourceChecker.Data.h
+++ b/Server/mods/deathmatch/logic/CResourceChecker.Data.h
@@ -333,6 +333,8 @@ namespace
         {false, "getComponentPosition", "will return 3 floats instead of a Vector3", "1.5.5-9.11710"},
         {false, "getComponentRotation", "will return 3 floats instead of a Vector3", "1.5.5-9.11710"},
 
+        {false, "getBoundingBox", "will return 6 floats instead of 2 Vector3", "1.5.5-9.13999"},
+
         // Ped jetpacks
         {false, "doesPedHaveJetPack", "isPedWearingJetpack"},
     };


### PR DESCRIPTION
After #305 was merged, getBoundingBox OOP method started returning vectors in old code when run on the new client, instead of returning 6 floats as was previously the case.
The backward compatibility check was inverted, as the function returned the 6 legacy floats if min_mta_version was **_higher_** than r13999 where it should do so only if it was lower. Additionally, it lacked any warnings or info about this change in behaviour.

This PR fixes MinClientReqCheck which was wrong way round in OOP_GetElementBoundingBox.

It also adds a warning on the server console about modified functionality after 1.5.5-9.13999, consistent with getComponentPosition and getComponentRotation OOP return modifications.
> WARNING: resource/scriptfile (Line x) [Client] getBoundingBox will return 6 floats instead of 2 Vector3 because <min_mta_version> Client setting in meta.xml is below 1.5.5-9.13999

**New behaviour:**
OOP getBoundingBox() method will continue to return 6 floats _**unless**_ min_mta_version client is set to 1.5.5-9.13999 or higher in the meta.xml, in which case it'll return vectors