### PR TITLE
Add setVehicleRespawnRotation function and tweaked OOP variants

### DIFF
--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -6726,17 +6726,31 @@ bool CStaticFunctionDefinitions::GetVehicleRespawnPosition(CElement* pElement, C
     return false;
 }
 
-bool CStaticFunctionDefinitions::SetVehicleRespawnPosition(CElement* pElement, const CVector& vecPosition, const CVector& vecRotation)
+bool CStaticFunctionDefinitions::SetVehicleRespawnRotation(CElement* pElement, const CVector& vecRotation)
 {
     assert(pElement);
-    RUN_CHILDREN(SetVehicleRespawnPosition(*iter, vecPosition, vecRotation))
+    RUN_CHILDREN(SetVehicleRespawnRotation(*iter, vecRotation))
 
     if (IS_VEHICLE(pElement))
     {
         CVehicle* pVehicle = static_cast<CVehicle*>(pElement);
-
-        pVehicle->SetRespawnPosition(vecPosition);
         pVehicle->SetRespawnRotationDegrees(vecRotation);
+
+        return true;
+    }
+
+    return false;
+}
+
+bool CStaticFunctionDefinitions::SetVehicleRespawnPosition(CElement* pElement, const CVector& vecPosition)
+{
+    assert(pElement);
+    RUN_CHILDREN(SetVehicleRespawnPosition(*iter, vecPosition))
+
+    if (IS_VEHICLE(pElement))
+    {
+        CVehicle* pVehicle = static_cast<CVehicle*>(pElement);
+        pVehicle->SetRespawnPosition(vecPosition);
 
         return true;
     }

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -303,7 +303,8 @@ public:
     static bool SetVehicleRespawnDelay(CElement* pElement, unsigned long ulTime);
     static bool GetVehicleRespawnPosition(CElement* pElement, CVector& vecPosition);
     static bool GetVehicleRespawnRotation(CElement* pElement, CVector& vecRotation);
-    static bool SetVehicleRespawnPosition(CElement* pElement, const CVector& vecPosition, const CVector& vecRotation);
+    static bool SetVehicleRespawnRotation(CElement* pElement, const CVector& vecRotation);
+    static bool SetVehicleRespawnPosition(CElement* pElement, const CVector& vecPosition);
     static bool ToggleVehicleRespawn(CElement* pElement, bool bRespawn);
     static bool ResetVehicleExplosionTime(CElement* pElement);
     static bool ResetVehicleIdleTime(CElement* pElement);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -2363,7 +2363,24 @@ int CLuaVehicleDefs::SetVehicleRespawnPosition(lua_State* luaVM)
     argStream.ReadUserData(pElement);
     argStream.ReadVector3D(vecPosition);
 
-    if (!argStream.HasErrors())
+    if (argStream.NextIsVector3D())
+    {
+        CVector vecRotation;
+        argStream.ReadVector3D(vecRotation);
+
+        if (!argStream.HasErrors())
+        {
+            if (CStaticFunctionDefinitions::SetVehicleRespawnPosition(pElement, vecPosition) &&
+                CStaticFunctionDefinitions::SetVehicleRespawnRotation(pElement, vecRotation))
+            {
+                lua_pushboolean(luaVM, true);
+                return 1;
+            }
+        }
+        else
+            m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+    }
+    else if (!argStream.HasErrors())
     {
         if (CStaticFunctionDefinitions::SetVehicleRespawnPosition(pElement, vecPosition))
         {

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -2303,6 +2303,47 @@ int CLuaVehicleDefs::GetVehicleRespawnRotation(lua_State* luaVM)
     return 1;
 }
 
+int CLuaVehicleDefs::SetVehicleRespawnPosition(lua_State* luaVM)
+{
+    CElement* pElement;
+    CVector   vecPosition;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pElement);
+    argStream.ReadVector3D(vecPosition);
+
+    if (argStream.NextIsVector3D())
+    {
+        CVector vecRotation;
+        argStream.ReadVector3D(vecRotation);
+
+        if (!argStream.HasErrors())
+        {
+            if (CStaticFunctionDefinitions::SetVehicleRespawnPosition(pElement, vecPosition) &&
+                CStaticFunctionDefinitions::SetVehicleRespawnRotation(pElement, vecRotation))
+            {
+                lua_pushboolean(luaVM, true);
+                return 1;
+            }
+        }
+        else
+            m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+    }
+    else if (!argStream.HasErrors())
+    {
+        if (CStaticFunctionDefinitions::SetVehicleRespawnPosition(pElement, vecPosition))
+        {
+            lua_pushboolean(luaVM, true);
+            return 1;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
 int CLuaVehicleDefs::GetVehicleRespawnPosition(lua_State* luaVM)
 {
     // float, float, float getVehicleRespawnPosition( vehicle theVehicle )
@@ -2342,47 +2383,6 @@ int CLuaVehicleDefs::SetVehicleRespawnRotation(lua_State* luaVM)
     if (!argStream.HasErrors())
     {
         if (CStaticFunctionDefinitions::SetVehicleRespawnRotation(pElement, vecRotation))
-        {
-            lua_pushboolean(luaVM, true);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
-}
-
-int CLuaVehicleDefs::SetVehicleRespawnPosition(lua_State* luaVM)
-{
-    CElement* pElement;
-    CVector   vecPosition;
-
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pElement);
-    argStream.ReadVector3D(vecPosition);
-
-    if (argStream.NextIsVector3D())
-    {
-        CVector vecRotation;
-        argStream.ReadVector3D(vecRotation);
-
-        if (!argStream.HasErrors())
-        {
-            if (CStaticFunctionDefinitions::SetVehicleRespawnPosition(pElement, vecPosition) &&
-                CStaticFunctionDefinitions::SetVehicleRespawnRotation(pElement, vecRotation))
-            {
-                lua_pushboolean(luaVM, true);
-                return 1;
-            }
-        }
-        else
-            m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-    }
-    else if (!argStream.HasErrors())
-    {
-        if (CStaticFunctionDefinitions::SetVehicleRespawnPosition(pElement, vecPosition))
         {
             lua_pushboolean(luaVM, true);
             return 1;

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -84,6 +84,7 @@ void CLuaVehicleDefs::LoadFunctions()
     CLuaCFunctions::AddFunction("setVehicleRespawnDelay", SetVehicleRespawnDelay);
     CLuaCFunctions::AddFunction("setVehicleIdleRespawnDelay", SetVehicleIdleRespawnDelay);
     CLuaCFunctions::AddFunction("setVehicleRespawnPosition", SetVehicleRespawnPosition);
+    CLuaCFunctions::AddFunction("setVehicleRespawnRotation", SetVehicleRespawnRotation);
     CLuaCFunctions::AddFunction("getVehicleRespawnPosition", GetVehicleRespawnPosition);
     CLuaCFunctions::AddFunction("getVehicleRespawnRotation", GetVehicleRespawnRotation);
     CLuaCFunctions::AddFunction("respawnVehicle", RespawnVehicle);
@@ -186,6 +187,8 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getWheelStates", "getVehicleWheelStates");
     lua_classfunction(luaVM, "getDoorOpenRatio", "getVehicleDoorOpenRatio");
     lua_classfunction(luaVM, "getHandling", "getVehicleHandling");
+    lua_classfunction(luaVM, "getRespawnPosition", "getVehicleRespawnPosition");
+    lua_classfunction(luaVM, "getRespawnRotation", "getVehicleRespawnRotation");
 
     lua_classfunction(luaVM, "setColor", "setVehicleColor");
     lua_classfunction(luaVM, "setDamageProof", "setVehicleDamageProof");
@@ -202,6 +205,7 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setPanelState", "setVehiclePanelState");
     lua_classfunction(luaVM, "setRespawnDelay", "setVehicleRespawnDelay");
     lua_classfunction(luaVM, "setRespawnPosition", "setVehicleRespawnPosition");
+    lua_classfunction(luaVM, "setRespawnRotation", "setVehicleRespawnRotation");
     lua_classfunction(luaVM, "setSirensOn", "setVehicleSirensOn");
     lua_classfunction(luaVM, "setTurretPosition", "setVehicleTurretPosition");
     lua_classfunction(luaVM, "setDoorOpenRatio", "setVehicleDoorOpenRatio");
@@ -251,7 +255,7 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "idleRespawnDelay", "setVehicleIdleRespawnDelay", NULL);
     lua_classvariable(luaVM, "respawnDelay", "setVehicleRespawnDelay", NULL);
     lua_classvariable(luaVM, "respawnPosition", "setVehicleRespawnPosition", "getVehicleRespawnPosition", SetVehicleRespawnPosition, OOP_GetVehicleRespawnPosition);
-    lua_classvariable(luaVM, "respawnRotation", NULL, "getVehicleRespawnRotation", NULL, OOP_GetVehicleRespawnRotation);
+    lua_classvariable(luaVM, "respawnRotation", "setVehicleRespawnRotation", "getVehicleRespawnRotation", SetVehicleRespawnRotation, OOP_GetVehicleRespawnRotation);
     lua_classvariable(luaVM, "onGround", NULL, "isVehicleOnGround");
     lua_classvariable(luaVM, "name", NULL, "getVehicleName");
     lua_classvariable(luaVM, "vehicleType", NULL, "getVehicleType");
@@ -2326,20 +2330,42 @@ int CLuaVehicleDefs::GetVehicleRespawnPosition(lua_State* luaVM)
     return 1;
 }
 
-int CLuaVehicleDefs::SetVehicleRespawnPosition(lua_State* luaVM)
+int CLuaVehicleDefs::SetVehicleRespawnRotation(lua_State* luaVM)
 {
     CElement* pElement;
-    CVector   vecPosition;
     CVector   vecRotation;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pElement);
-    argStream.ReadVector3D(vecPosition);
     argStream.ReadVector3D(vecRotation, CVector());
 
     if (!argStream.HasErrors())
     {
-        if (CStaticFunctionDefinitions::SetVehicleRespawnPosition(pElement, vecPosition, vecRotation))
+        if (CStaticFunctionDefinitions::SetVehicleRespawnRotation(pElement, vecRotation))
+        {
+            lua_pushboolean(luaVM, true);
+            return 1;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaVehicleDefs::SetVehicleRespawnPosition(lua_State* luaVM)
+{
+    CElement* pElement;
+    CVector   vecPosition;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pElement);
+    argStream.ReadVector3D(vecPosition);
+
+    if (!argStream.HasErrors())
+    {
+        if (CStaticFunctionDefinitions::SetVehicleRespawnPosition(pElement, vecPosition))
         {
             lua_pushboolean(luaVM, true);
             return 1;

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -2378,7 +2378,7 @@ int CLuaVehicleDefs::SetVehicleRespawnRotation(lua_State* luaVM)
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pElement);
-    argStream.ReadVector3D(vecRotation, CVector());
+    argStream.ReadVector3D(vecRotation);
 
     if (!argStream.HasErrors())
     {

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -90,6 +90,7 @@ public:
     LUA_DECLARE(SetVehicleIdleRespawnDelay);
     LUA_DECLARE(SetVehicleRespawnDelay);
     LUA_DECLARE(SetVehicleRespawnPosition);
+    LUA_DECLARE(SetVehicleRespawnRotation);
     LUA_DECLARE_OOP(GetVehicleRespawnPosition);
     LUA_DECLARE_OOP(GetVehicleRespawnRotation);
     LUA_DECLARE(ToggleVehicleRespawn);


### PR DESCRIPTION
function **setVehicleRespawnPosition** has been changed to:
- setVehicleRespawnPosition( vehicle theVehicle, x, y, z [, rx, ry, rz ] )
- setVehicleRespawnRotation( vehicle theVehicle, rx, ry, rz )
- getVehicleRespawnPosition( vehicle theVehicle )
- getVehicleRespawnRotation( vehicle theVehicle )

adapted under OOP:
- vehicle:setRespawnPosition( x, y, z )
- vehicle:setRespawnRotation( x, y, z )
- vehicle:getRespawnPosition( )
- vehicle:getRespawnRotation( )

lua class variables inherit to vehicle element
- vehicle.respawnPosition
- vehicle.respawnRotation