### PR TITLE
Command aliases feature

### DIFF
--- a/Client/mods/deathmatch/logic/CRegisteredCommands.cpp
+++ b/Client/mods/deathmatch/logic/CRegisteredCommands.cpp
@@ -22,6 +22,49 @@ CRegisteredCommands::~CRegisteredCommands(void)
     ClearCommands();
 }
 
+bool CRegisteredCommands::AddAlias(CLuaMain* pLuaMain, const char* szKey, const char* szCommand)
+{
+    assert(pLuaMain);
+    assert(szKey);
+    assert(szCommand);
+
+    // Check if we already have this key and handler
+    SCommand* pCommand = GetCommand(szCommand, pLuaMain);
+
+    if (!pCommand)
+        return false;
+
+    bool isCreated = AddCommand(pLuaMain, szKey, pCommand->iLuaFunction, pCommand->bCaseSensitive);
+    if (isCreated)
+    {
+        SCommand* tpCommand = GetCommand(szKey, pLuaMain);
+        tpCommand->sParent = pCommand->strKey;
+    }
+    else
+        return false;
+
+    return true;
+}
+
+bool CRegisteredCommands::RemoveAlias(CLuaMain* pLuaMain, const char* szKey, const char* szCommand)
+{
+    assert(pLuaMain);
+    assert(szKey);
+    assert(szCommand);
+
+    // Check if we already have this key and handler
+    SCommand* pCommand = GetCommand(szKey, pLuaMain);
+
+    if (!pCommand || !GetCommand(szCommand, pLuaMain))
+        return false;
+
+    if (pCommand->sParent == szCommand)
+    {
+        RemoveCommand(pLuaMain, szKey);
+    }
+    return true;
+}
+
 bool CRegisteredCommands::AddCommand(CLuaMain* pLuaMain, const char* szKey, const CLuaFunctionRef& iLuaFunction, bool bCaseSensitive)
 {
     assert(pLuaMain);
@@ -41,6 +84,7 @@ bool CRegisteredCommands::AddCommand(CLuaMain* pLuaMain, const char* szKey, cons
     pCommand->strKey.AssignLeft(szKey, MAX_REGISTERED_COMMAND_LENGTH);
     pCommand->iLuaFunction = iLuaFunction;
     pCommand->bCaseSensitive = bCaseSensitive;
+    pCommand->sParent = "";
 
     // Add it to our list
     m_Commands.push_back(pCommand);
@@ -57,6 +101,7 @@ bool CRegisteredCommands::RemoveCommand(CLuaMain* pLuaMain, const char* szKey)
     list<SCommand*>::iterator iter = m_Commands.begin();
     int                       iCompareResult;
 
+    ClearAliases(pLuaMain, szKey);
     while (iter != m_Commands.end())
     {
         if ((*iter)->bCaseSensitive)
@@ -85,6 +130,23 @@ bool CRegisteredCommands::RemoveCommand(CLuaMain* pLuaMain, const char* szKey)
     }
 
     return bFound;
+}
+
+void CRegisteredCommands::ClearAliases(CLuaMain* pLuaMain, const char* szCommand)
+{
+    list<SCommand*>::const_iterator iter = m_Commands.begin();
+
+    while (iter != m_Commands.end())
+    {
+        if ((*iter)->pLuaMain == pLuaMain && (*iter)->sParent == szCommand)
+        {
+            // Delete the entry and remove it from the list
+            delete *iter;
+            iter = m_Commands.erase(iter);
+        }
+        else
+            ++iter;
+    }
 }
 
 void CRegisteredCommands::ClearCommands(void)

--- a/Client/mods/deathmatch/logic/CRegisteredCommands.cpp
+++ b/Client/mods/deathmatch/logic/CRegisteredCommands.cpp
@@ -151,7 +151,7 @@ void CRegisteredCommands::ClearAliases(CLuaMain* pLuaMain, const char* szCommand
 void CRegisteredCommands::ClearCommands(void)
 {
     // Delete all the commands
-    list<SCommand*>::iterator iter = m_Commands.begin();
+    list<SCommand*>::const_iterator iter = m_Commands.begin();
     for (; iter != m_Commands.end(); iter++)
     {
         delete *iter;

--- a/Client/mods/deathmatch/logic/CRegisteredCommands.cpp
+++ b/Client/mods/deathmatch/logic/CRegisteredCommands.cpp
@@ -133,7 +133,7 @@ bool CRegisteredCommands::RemoveCommand(CLuaMain* pLuaMain, const char* szKey)
 
 void CRegisteredCommands::ClearAliases(CLuaMain* pLuaMain, const char* szCommand)
 {
-    list<SCommand*>::const_iterator iter = m_Commands.begin();
+    list<SCommand*>::iterator iter = m_Commands.begin();
 
     while (iter != m_Commands.end())
     {
@@ -151,7 +151,7 @@ void CRegisteredCommands::ClearAliases(CLuaMain* pLuaMain, const char* szCommand
 void CRegisteredCommands::ClearCommands(void)
 {
     // Delete all the commands
-    list<SCommand*>::const_iterator iter = m_Commands.begin();
+    list<SCommand*>::iterator iter = m_Commands.begin();
     for (; iter != m_Commands.end(); iter++)
     {
         delete *iter;

--- a/Client/mods/deathmatch/logic/CRegisteredCommands.cpp
+++ b/Client/mods/deathmatch/logic/CRegisteredCommands.cpp
@@ -28,7 +28,6 @@ bool CRegisteredCommands::AddAlias(CLuaMain* pLuaMain, const char* szKey, const 
     assert(szKey);
     assert(szCommand);
 
-    // Check if we already have this key and handler
     SCommand* pCommand = GetCommand(szCommand, pLuaMain);
 
     if (!pCommand)
@@ -37,6 +36,7 @@ bool CRegisteredCommands::AddAlias(CLuaMain* pLuaMain, const char* szKey, const 
     bool isCreated = AddCommand(pLuaMain, szKey, pCommand->iLuaFunction, pCommand->bCaseSensitive);
     if (isCreated)
     {
+        // fast trick to set parent
         SCommand* tpCommand = GetCommand(szKey, pLuaMain);
         tpCommand->sParent = pCommand->strKey;
     }
@@ -52,7 +52,6 @@ bool CRegisteredCommands::RemoveAlias(CLuaMain* pLuaMain, const char* szKey, con
     assert(szKey);
     assert(szCommand);
 
-    // Check if we already have this key and handler
     SCommand* pCommand = GetCommand(szKey, pLuaMain);
 
     if (!pCommand || !GetCommand(szCommand, pLuaMain))

--- a/Client/mods/deathmatch/logic/CRegisteredCommands.h
+++ b/Client/mods/deathmatch/logic/CRegisteredCommands.h
@@ -24,15 +24,20 @@ class CRegisteredCommands
         SString         strKey;
         CLuaFunctionRef iLuaFunction;
         bool            bCaseSensitive;
+        SString         sParent;
     };
 
 public:
     CRegisteredCommands(void);
     ~CRegisteredCommands(void);
 
+    bool AddAlias(class CLuaMain* pLuaMain, const char* szKey, const char* szCommand);
+    bool RemoveAlias(class CLuaMain* pLuaMain, const char* szKey, const char* szCommand);
     bool AddCommand(class CLuaMain* pLuaMain, const char* szKey, const CLuaFunctionRef& iLuaFunction, bool bCaseSensitive);
     bool RemoveCommand(class CLuaMain* pLuaMain, const char* szKey);
+    
     void ClearCommands(void);
+    void ClearAliases(class CLuaMain* pLuaMain, const char* szCommand);
     void CleanUpForVM(class CLuaMain* pLuaMain);
 
     bool CommandExists(const char* szKey, class CLuaMain* pLuaMain = NULL);

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Commands.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Commands.cpp
@@ -10,6 +10,68 @@
 
 #include "StdInc.h"
 
+int CLuaFunctionDefs::AddCommandAlias(lua_State* luaVM)
+{
+    // bool addCommandAlias( string commandAlias, string commandName )
+    SString strKey, strCommand;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadString(strKey);
+    argStream.ReadString(strCommand);
+
+    if (strKey != strCommand)
+    {
+        if (!argStream.HasErrors())
+        {
+            CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+            if (pLuaMain)
+            {
+                if (m_pRegisteredCommands->CommandExists(strCommand, pLuaMain))
+                {
+                    if (m_pRegisteredCommands->AddAlias(pLuaMain, strKey, strCommand))
+                    {
+                        lua_pushboolean(luaVM, true);
+                        return 1;
+                    }
+                }
+            }
+        }
+        else
+            m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+    }
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFunctionDefs::RemoveCommandAlias(lua_State* luaVM)
+{
+    // bool removeCommandAlias( string commandAlias, string command )
+    SString strKey, strCommand;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadString(strKey);
+    argStream.ReadString(strCommand);
+
+    if (!argStream.HasErrors())
+    {
+        CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+        if (pLuaMain)
+        {
+            if (m_pRegisteredCommands->RemoveAlias(pLuaMain, strKey, strCommand))
+            {
+                lua_pushboolean(luaVM, true);
+                return 1;
+            }
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
 int CLuaFunctionDefs::AddCommandHandler(lua_State* luaVM)
 {
     //  bool addCommandHandler ( string commandName, function handlerFunction, [bool caseSensitive = true] )

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.h
@@ -197,6 +197,8 @@ public:
     LUA_DECLARE(ToggleAllControls);
 
     // Command funcs
+    LUA_DECLARE(AddCommandAlias);
+    LUA_DECLARE(RemoveCommandAlias);
     LUA_DECLARE(AddCommandHandler);
     LUA_DECLARE(RemoveCommandHandler);
     LUA_DECLARE(ExecuteCommandHandler);

--- a/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -369,6 +369,8 @@ void CLuaManager::LoadCFunctions(void)
     CLuaCFunctions::AddFunction("toggleAllControls", CLuaFunctionDefs::ToggleAllControls);
 
     // Command funcs
+    CLuaCFunctions::AddFunction("addCommandAlias", CLuaFunctionDefs::AddCommandAlias);
+    CLuaCFunctions::AddFunction("removeCommandAlias", CLuaFunctionDefs::RemoveCommandAlias);
     CLuaCFunctions::AddFunction("addCommandHandler", CLuaFunctionDefs::AddCommandHandler);
     CLuaCFunctions::AddFunction("removeCommandHandler", CLuaFunctionDefs::RemoveCommandHandler);
     CLuaCFunctions::AddFunction("executeCommandHandler", CLuaFunctionDefs::ExecuteCommandHandler);

--- a/Server/mods/deathmatch/logic/CRegisteredCommands.cpp
+++ b/Server/mods/deathmatch/logic/CRegisteredCommands.cpp
@@ -28,7 +28,6 @@ bool CRegisteredCommands::AddAlias(CLuaMain* pLuaMain, const char* szKey, const 
     assert(szKey);
     assert(szCommand);
 
-    // Check if we already have this key and handler
     SCommand* pCommand = GetCommand(szCommand, pLuaMain);
 
     if (!pCommand)
@@ -37,6 +36,7 @@ bool CRegisteredCommands::AddAlias(CLuaMain* pLuaMain, const char* szKey, const 
     bool isCreated = AddCommand(pLuaMain, szKey, pCommand->iLuaFunction, pCommand->bRestricted, pCommand->bCaseSensitive);
     if (isCreated)
     {
+        // fast trick to set parent
         SCommand* tpCommand = GetCommand(szKey, pLuaMain);
         tpCommand->sParent = pCommand->strKey;
     }
@@ -52,7 +52,6 @@ bool CRegisteredCommands::RemoveAlias(CLuaMain* pLuaMain, const char* szKey, con
     assert(szKey);
     assert(szCommand);
 
-    // Check if we already have this key and handler
     SCommand* pCommand = GetCommand(szKey, pLuaMain);
 
     if (!pCommand || !GetCommand(szCommand, pLuaMain))

--- a/Server/mods/deathmatch/logic/CRegisteredCommands.cpp
+++ b/Server/mods/deathmatch/logic/CRegisteredCommands.cpp
@@ -158,7 +158,7 @@ void CRegisteredCommands::ClearAliases(CLuaMain* pLuaMain, const char* szCommand
 void CRegisteredCommands::ClearCommands(void)
 {
     // Delete all the commands
-    list<SCommand*>::iterator iter = m_Commands.begin();
+    list<SCommand*>::const_iterator iter = m_Commands.begin();
 
     for (; iter != m_Commands.end(); iter++)
         delete *iter;

--- a/Server/mods/deathmatch/logic/CRegisteredCommands.cpp
+++ b/Server/mods/deathmatch/logic/CRegisteredCommands.cpp
@@ -140,7 +140,7 @@ bool CRegisteredCommands::RemoveCommand(CLuaMain* pLuaMain, const char* szKey, c
 
 void CRegisteredCommands::ClearAliases(CLuaMain* pLuaMain, const char* szCommand)
 {
-    list<SCommand*>::const_iterator iter = m_Commands.begin();
+    list<SCommand*>::iterator iter = m_Commands.begin();
 
     while (iter != m_Commands.end())
     {
@@ -158,7 +158,7 @@ void CRegisteredCommands::ClearAliases(CLuaMain* pLuaMain, const char* szCommand
 void CRegisteredCommands::ClearCommands(void)
 {
     // Delete all the commands
-    list<SCommand*>::const_iterator iter = m_Commands.begin();
+    list<SCommand*>::iterator iter = m_Commands.begin();
 
     for (; iter != m_Commands.end(); iter++)
         delete *iter;

--- a/Server/mods/deathmatch/logic/CRegisteredCommands.cpp
+++ b/Server/mods/deathmatch/logic/CRegisteredCommands.cpp
@@ -22,6 +22,49 @@ CRegisteredCommands::~CRegisteredCommands(void)
     ClearCommands();
 }
 
+bool CRegisteredCommands::AddAlias(CLuaMain* pLuaMain, const char* szKey, const char* szCommand)
+{
+    assert(pLuaMain);
+    assert(szKey);
+    assert(szCommand);
+
+    // Check if we already have this key and handler
+    SCommand* pCommand = GetCommand(szCommand, pLuaMain);
+
+    if (!pCommand)
+        return false;
+
+    bool isCreated = AddCommand(pLuaMain, szKey, pCommand->iLuaFunction, pCommand->bRestricted, pCommand->bCaseSensitive);
+    if (isCreated)
+    {
+        SCommand* tpCommand = GetCommand(szKey, pLuaMain);
+        tpCommand->sParent = pCommand->strKey;
+    }
+    else
+        return false;
+
+    return true;
+}
+
+bool CRegisteredCommands::RemoveAlias(CLuaMain* pLuaMain, const char* szKey, const char* szCommand)
+{
+    assert(pLuaMain);
+    assert(szKey);
+    assert(szCommand);
+
+    // Check if we already have this key and handler
+    SCommand* pCommand = GetCommand(szKey, pLuaMain);
+
+    if (!pCommand || !GetCommand(szCommand, pLuaMain))
+        return false;
+
+    if (pCommand->sParent == szCommand)
+    {
+        RemoveCommand(pLuaMain, szKey, pCommand->iLuaFunction);
+    }
+    return true;
+}
+
 bool CRegisteredCommands::AddCommand(CLuaMain* pLuaMain, const char* szKey, const CLuaFunctionRef& iLuaFunction, bool bRestricted, bool bCaseSensitive)
 {
     assert(pLuaMain);
@@ -40,6 +83,7 @@ bool CRegisteredCommands::AddCommand(CLuaMain* pLuaMain, const char* szKey, cons
     pCommand->iLuaFunction = iLuaFunction;
     pCommand->bRestricted = bRestricted;
     pCommand->bCaseSensitive = bCaseSensitive;
+    pCommand->sParent = "";
 
     // Add it to our list
     m_Commands.push_back(pCommand);
@@ -57,6 +101,7 @@ bool CRegisteredCommands::RemoveCommand(CLuaMain* pLuaMain, const char* szKey, c
     bool                      bFound = false;
     list<SCommand*>::iterator iter = m_Commands.begin();
 
+    ClearAliases(pLuaMain, szKey);
     while (iter != m_Commands.end())
     {
         if ((*iter)->bCaseSensitive)
@@ -92,6 +137,23 @@ bool CRegisteredCommands::RemoveCommand(CLuaMain* pLuaMain, const char* szKey, c
     }
 
     return bFound;
+}
+
+void CRegisteredCommands::ClearAliases(CLuaMain* pLuaMain, const char* szCommand)
+{
+    list<SCommand*>::const_iterator iter = m_Commands.begin();
+
+    while (iter != m_Commands.end())
+    {
+        if ((*iter)->pLuaMain == pLuaMain && (*iter)->sParent == szCommand)
+        {
+            // Delete the entry and remove it from the list
+            delete *iter;
+            iter = m_Commands.erase(iter);
+        }
+        else
+            ++iter;
+    }
 }
 
 void CRegisteredCommands::ClearCommands(void)

--- a/Server/mods/deathmatch/logic/CRegisteredCommands.h
+++ b/Server/mods/deathmatch/logic/CRegisteredCommands.h
@@ -25,15 +25,20 @@ class CRegisteredCommands
         CLuaFunctionRef iLuaFunction;
         bool            bRestricted;
         bool            bCaseSensitive;
+        SString         sParent;
     };
 
 public:
     CRegisteredCommands(class CAccessControlListManager* pACLManager);
     ~CRegisteredCommands(void);
 
+    bool AddAlias(class CLuaMain* pLuaMain, const char* szKey, const char* szCommand);
+    bool RemoveAlias(class CLuaMain* pLuaMain, const char* szKey, const char* szCommand);
     bool AddCommand(class CLuaMain* pLuaMain, const char* szKey, const CLuaFunctionRef& iLuaFunction, bool bRestricted, bool bCaseSensitive);
     bool RemoveCommand(class CLuaMain* pLuaMain, const char* szKey, const CLuaFunctionRef& iLuaFunction = CLuaFunctionRef());
+    
     void ClearCommands(void);
+    void ClearAliases(class CLuaMain* pLuaMain, const char* szCommand);
     void CleanUpForVM(class CLuaMain* pLuaMain);
 
     bool CommandExists(const char* szKey, class CLuaMain* pLuaMain = NULL);
@@ -44,11 +49,11 @@ public:
     bool ProcessCommand(const char* szKey, const char* szArguments, class CClient* pClient);
 
 private:
-    SCommand* GetCommand(const char* szKey, class CLuaMain* pLuaMain = NULL);
     void CallCommandHandler(class CLuaMain* pLuaMain, const CLuaFunctionRef& iLuaFunction, const char* szKey, const char* szArguments, class CClient* pClient);
 
     void TakeOutTheTrash(void);
 
+    SCommand*       GetCommand(const char* szKey, class CLuaMain* pLuaMain = NULL);
     list<SCommand*> m_Commands;
     list<SCommand*> m_TrashCan;
     bool            m_bIteratingList;

--- a/Server/mods/deathmatch/logic/lua/CLuaFunctionDefs.Server.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaFunctionDefs.Server.cpp
@@ -204,6 +204,68 @@ int CLuaFunctionDefs::OutputDebugString(lua_State* luaVM)
     return 1;
 }
 
+int CLuaFunctionDefs::AddCommandAlias(lua_State* luaVM)
+{
+    // bool addCommandAlias( string commandAlias, string commandName )
+    SString strKey, strCommand;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadString(strKey);
+    argStream.ReadString(strCommand);
+
+    if (strKey != strCommand)
+    {
+        if (!argStream.HasErrors())
+        {
+            CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+            if (pLuaMain)
+            {
+                if (m_pRegisteredCommands->CommandExists(strCommand, pLuaMain))
+                {
+                    if (m_pRegisteredCommands->AddAlias(pLuaMain, strKey, strCommand))
+                    {
+                        lua_pushboolean(luaVM, true);
+                        return 1;
+                    }
+                }
+            }
+        }
+        else
+            m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+    }
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFunctionDefs::RemoveCommandAlias(lua_State* luaVM)
+{
+    // bool removeCommandAlias( string commandAlias, string command )
+    SString strKey, strCommand;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadString(strKey);
+    argStream.ReadString(strCommand);
+
+    if (!argStream.HasErrors())
+    {
+        CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+        if (pLuaMain)
+        {
+            if (m_pRegisteredCommands->RemoveAlias(pLuaMain, strKey, strCommand))
+            {
+                lua_pushboolean(luaVM, true);
+                return 1;
+            }
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
 int CLuaFunctionDefs::AddCommandHandler(lua_State* luaVM)
 {
     //  bool addCommandHandler ( string commandName, function handlerFunction, [bool restricted = false, bool caseSensitive = true] )

--- a/Server/mods/deathmatch/logic/lua/CLuaFunctionDefs.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaFunctionDefs.h
@@ -93,6 +93,8 @@ public:
     LUA_DECLARE(SetWeaponClipAmmo);
 
     // Console functions
+    LUA_DECLARE(AddCommandAlias);
+    LUA_DECLARE(RemoveCommandAlias);
     LUA_DECLARE(AddCommandHandler);
     LUA_DECLARE(RemoveCommandHandler);
     LUA_DECLARE(ExecuteCommandHandler);

--- a/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -214,6 +214,8 @@ void CLuaManager::LoadCFunctions(void)
 #endif
 
     // Console funcs
+    CLuaCFunctions::AddFunction("addCommandAlias", CLuaFunctionDefs::AddCommandAlias);
+    CLuaCFunctions::AddFunction("removeCommandAlias", CLuaFunctionDefs::RemoveCommandAlias);
     CLuaCFunctions::AddFunction("addCommandHandler", CLuaFunctionDefs::AddCommandHandler);
     CLuaCFunctions::AddFunction("removeCommandHandler", CLuaFunctionDefs::RemoveCommandHandler);
     CLuaCFunctions::AddFunction("executeCommandHandler", CLuaFunctionDefs::ExecuteCommandHandler);


### PR DESCRIPTION
Added aliases to commands. Available on both sides ( client and server ), basic tested as well.

Functions:
- addCommandAlias( string alias, string command )
- removeCommandAlias( string alias, string command )
_in future:_
- isCommandAlias( string alias, string command )
- getCommandAliases( string command )

When we remove the command to which aliases are suppressed, the aliases'll be removed.
In next commit are planned:
- check if A command is an alias of B command;
- get all commands which aliases are suppressed;