### PR TITLE
Re-fit mute options in the audio tab

### DIFF
--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -538,7 +538,7 @@ void CSettings::CreateGUI(void)
     m_pLabelUserTrackMode->AutoSize();
 
     m_pComboUsertrackMode = reinterpret_cast<CGUIComboBox*>(pManager->CreateComboBox(pTabAudio, ""));
-    m_pComboUsertrackMode->SetPosition(CVector2D(vecTemp.fX + fIndentX + 5.0f, vecTemp.fY));
+    m_pComboUsertrackMode->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 20.0f));
     m_pComboUsertrackMode->SetSize(CVector2D(160.0f, 80.0f));
     m_pComboUsertrackMode->AddItem(_("Radio"))->SetData((void*)0);
     m_pComboUsertrackMode->AddItem(_("Random"))->SetData((void*)1);
@@ -546,13 +546,14 @@ void CSettings::CreateGUI(void)
     m_pComboUsertrackMode->SetReadOnly(true);
 
     m_pCheckBoxUserAutoscan = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabAudio, _("Automatic Media Scan"), true));
-    m_pCheckBoxUserAutoscan->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 32.0f));
+    m_pCheckBoxUserAutoscan->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 52.0f));
     m_pCheckBoxUserAutoscan->AutoSize(NULL, 20.0f);
     m_pCheckBoxUserAutoscan->GetPosition(vecTemp, false);
 
-    vecTemp.fX = fIndentX + 260;
+    m_pAudioRadioLabel->GetPosition(vecTemp, false);
+    vecTemp.fX = fIndentX + 173;
     m_pAudioMuteLabel = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabAudio, _("Mute options")));
-    m_pAudioMuteLabel->SetPosition(CVector2D(vecTemp.fX, 13.0f));
+    m_pAudioMuteLabel->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 52.0f));
     m_pAudioMuteLabel->GetPosition(vecTemp, false);
     m_pAudioMuteLabel->AutoSize(NULL, 5.0f);
     m_pAudioMuteLabel->SetFont("default-bold-small");


### PR DESCRIPTION
Mute checkbox elements wouldn't fit the audio tab menu, a bug introduced in #228. This bug only affected some localizations, such as Russian and Greek.

Elements have now been re-fit into the menu and they fit every localization, though some have only a couple pixels space left.

Not much we can do due to the limitations of our CEGUI version and general style in the Settings menu. Instead of revamping the menus in CEGUI, we should instead move to using CEF for more flexibility.

Thanks for the heads-up **Icensow#9538** on Discord for reaching out to me about this issue.

**Must be merged into 1.5.6 due to #228 being a new 1.5.6 feature.**

This is a small tweak.

**New version:**
![new_fit](https://user-images.githubusercontent.com/22572159/44881780-83810c80-acb9-11e8-851c-6b4ecc0b8e34.png)
