### PR TITLE
Fix compiler warning about signed/unsigned mismatch in CPrimitiveMaterialBatcher

### DIFF
--- a/Client/core/Graphics/CPrimitiveMaterialBatcher.cpp
+++ b/Client/core/Graphics/CPrimitiveMaterialBatcher.cpp
@@ -143,7 +143,7 @@ void CPrimitiveMaterialBatcher::Flush(void)
     // Cache last used material, so we don't set directx parameters needlessly
     CMaterialItem* pLastMaterial = nullptr;
 
-    for (int i = 0; i < m_primitiveList.size(); i++)
+    for (uint i = 0; i < m_primitiveList.size(); i++)
     {
         sDrawQueuePrimitiveMaterial primitive = m_primitiveList[i];
         // uint PrimitiveCount = m_triangleList.size () / 3;


### PR DESCRIPTION
`CPrimitiveMaterialBatcher::Flush` has a for-loop which is using an `int` instead of an `uint` when iterating using `m_primitiveList.size()`, this causes a compiler warning about signed/unsigned mismatch, as the size is an unsigned value. Tiiiiiny quality of life change, but let's avoid warnings in compiler.