### PR TITLE
Add option to create shader from raw data

### DIFF
--- a/Client/core/DXHook/CProxyDirect3DEffect.cpp
+++ b/Client/core/DXHook/CProxyDirect3DEffect.cpp
@@ -116,3 +116,22 @@ HRESULT WINAPI MyD3DXCreateEffectFromFile(LPDIRECT3DDEVICE9 pDevice, LPCSTR pSrc
     }
     return hr;
 }
+
+/////////////////////////////////////////////////////////////
+//
+// D3DXCreateEffect
+//
+// Wrap result of orignal function
+//
+/////////////////////////////////////////////////////////////
+HRESULT WINAPI MyD3DXCreateEffect(LPDIRECT3DDEVICE9 pDevice, LPCVOID pSrcData, UINT SrcDataLen, CONST D3DXMACRO* pDefines, LPD3DXINCLUDE pInclude, DWORD Flags,
+    LPD3DXEFFECTPOOL pPool, LPD3DXEFFECT* ppEffect, LPD3DXBUFFER* ppCompilationErrors)
+{
+    HRESULT hr = D3DXCreateEffect(pDevice, pSrcData, SrcDataLen, pDefines, pInclude, Flags, pPool, ppEffect, ppCompilationErrors);
+    if (SUCCEEDED(hr))
+    {
+        // Create proxy so we can track when it's finished with
+        *ppEffect = new CProxyDirect3DEffect(pDevice, *ppEffect);
+    }
+    return hr;
+}

--- a/Client/core/DXHook/CProxyDirect3DEffect.h
+++ b/Client/core/DXHook/CProxyDirect3DEffect.h
@@ -172,3 +172,6 @@ protected:
 
 HRESULT WINAPI MyD3DXCreateEffectFromFile(LPDIRECT3DDEVICE9 pDevice, LPCSTR pSrcFile, CONST D3DXMACRO* pDefines, LPD3DXINCLUDE pInclude, DWORD Flags,
                                           LPD3DXEFFECTPOOL pPool, LPD3DXEFFECT* ppEffect, LPD3DXBUFFER* ppCompilationErrors);
+
+HRESULT WINAPI MyD3DXCreateEffect(LPDIRECT3DDEVICE9 pDevice, LPCVOID pSrcData, UINT SrcDataLen, CONST D3DXMACRO* pDefines, LPD3DXINCLUDE pInclude, DWORD Flags,
+    LPD3DXEFFECTPOOL pPool, LPD3DXEFFECT* ppEffect, LPD3DXBUFFER* ppCompilationErrors);

--- a/Client/core/Graphics/CRenderItem.EffectCloner.cpp
+++ b/Client/core/Graphics/CRenderItem.EffectCloner.cpp
@@ -31,17 +31,17 @@ CEffectCloner::CEffectCloner(CRenderItemManager* pManager)
 //
 //
 ////////////////////////////////////////////////////////////////
-CEffectWrap* CEffectCloner::CreateD3DEffect(const SString& strFilename, const SString& strRootPath, SString& strOutStatus, bool bDebug)
+CEffectWrap* CEffectCloner::CreateD3DEffect(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug)
 {
     // Do we have a match with the initial path
-    CEffectTemplate* pEffectTemplate = MapFindRef(m_ValidMap, ConformPathForSorting(strFilename));
+    CEffectTemplate* pEffectTemplate = MapFindRef(m_ValidMap, ConformPathForSorting(strFile));
     if (pEffectTemplate)
     {
         // Have files changed since create?
         if (pEffectTemplate->HaveFilesChanged())
         {
             // EffectTemplate is no good for cloning now, so move it to the old list
-            MapRemove(m_ValidMap, ConformPathForSorting(strFilename));
+            MapRemove(m_ValidMap, ConformPathForSorting(strFile));
             m_OldList.push_back(pEffectTemplate);
             pEffectTemplate = NULL;
         }
@@ -57,7 +57,7 @@ CEffectWrap* CEffectCloner::CreateD3DEffect(const SString& strFilename, const SS
         HRESULT hr;
         for (uint i = 0; i < 2; i++)
         {
-            pEffectTemplate = NewEffectTemplate(m_pManager, strFilename, strRootPath, strOutStatus, bDebug, hr);
+            pEffectTemplate = NewEffectTemplate(m_pManager, strFile, strRootPath, bIsRawData, strOutStatus, bDebug, hr);
             if (pEffectTemplate || hr != E_OUTOFMEMORY || i > 0)
             {
                 if (pEffectTemplate && i > 0)
@@ -75,14 +75,14 @@ CEffectWrap* CEffectCloner::CreateD3DEffect(const SString& strFilename, const SS
         else
         {
             // Add to active map
-            MapSet(m_ValidMap, ConformPathForSorting(strFilename), pEffectTemplate);
+            MapSet(m_ValidMap, ConformPathForSorting(strFile), pEffectTemplate);
         }
 
         if (!strReport.empty())
         {
             strReport += SString("[effects cur:%d created:%d dest:%d]", g_pDeviceState->MemoryState.Effect.iCurrentCount,
                                  g_pDeviceState->MemoryState.Effect.iCreatedCount, g_pDeviceState->MemoryState.Effect.iDestroyedCount);
-            AddReportLog(7544, SString("NewEffectTemplate (call:%d) %s %s", uiCallCount, *strReport, *strFilename));
+            AddReportLog(7544, SString("NewEffectTemplate (call:%d) %s %s", uiCallCount, *strReport, *strFile));
         }
         if (!pEffectTemplate)
             return NULL;

--- a/Client/core/Graphics/CRenderItem.EffectCloner.h
+++ b/Client/core/Graphics/CRenderItem.EffectCloner.h
@@ -19,7 +19,7 @@ class CEffectCloner
 public:
     CEffectCloner(CRenderItemManager* pManager);
     void         DoPulse(void);
-    CEffectWrap* CreateD3DEffect(const SString& strFilename, const SString& strRootPath, SString& strOutStatus, bool bDebug);
+    CEffectWrap* CreateD3DEffect(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug);
     void         ReleaseD3DEffect(CEffectWrap* pD3DEffect);
     void         MaybeTidyUp(bool bForceDrasticMeasures = false);
 

--- a/Client/core/Graphics/CRenderItem.EffectTemplate.h
+++ b/Client/core/Graphics/CRenderItem.EffectTemplate.h
@@ -20,7 +20,7 @@ class CEffectTemplate : public CEffectParameters
 {
     DECLARE_CLASS(CEffectTemplate, CEffectParameters)
     CEffectTemplate(void) : ClassInit(this) {}
-    virtual void PostConstruct(CRenderItemManager* pManager, const SString& strFilename, const SString& strRootPath, SString& strOutStatus, bool bDebug);
+    virtual void PostConstruct(CRenderItemManager* pManager, const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug);
     virtual void PreDestruct(void);
     virtual bool IsValid(void);
     virtual void OnLostDevice(void);
@@ -29,7 +29,7 @@ class CEffectTemplate : public CEffectParameters
     int          GetTicksSinceLastUsed(void);
     CEffectWrap* CloneD3DEffect(SString& strOutStatus);
     void         UnCloneD3DEffect(CEffectWrap* pD3DEffect);
-    void         CreateUnderlyingData(const SString& strFilename, const SString& strRootPath, SString& strOutStatus, bool bDebug);
+    void         CreateUnderlyingData(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug);
     void         ReleaseUnderlyingData(void);
     bool         ValidateDepthBufferUsage(D3DXHANDLE hTechnique, SString& strOutErrorExtra);
 
@@ -41,5 +41,5 @@ class CEffectTemplate : public CEffectParameters
     HRESULT                    m_CreateHResult;
 };
 
-CEffectTemplate* NewEffectTemplate(CRenderItemManager* pManager, const SString& strFilename, const SString& strRootPath, SString& strOutStatus, bool bDebug,
+CEffectTemplate* NewEffectTemplate(CRenderItemManager* pManager, const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug,
                                    HRESULT& outHResult);

--- a/Client/core/Graphics/CRenderItem.Shader.cpp
+++ b/Client/core/Graphics/CRenderItem.Shader.cpp
@@ -20,7 +20,7 @@ uint CShaderItem::ms_uiCreateTimeCounter = 0;
 //
 //
 ////////////////////////////////////////////////////////////////
-void CShaderItem::PostConstruct(CRenderItemManager* pManager, const SString& strFilename, const SString& strRootPath, SString& strOutStatus, float fPriority,
+void CShaderItem::PostConstruct(CRenderItemManager* pManager, const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority,
                                 float fMaxDistance, bool bLayered, bool bDebug, int iTypeMask)
 {
     m_fPriority = fPriority;
@@ -32,7 +32,7 @@ void CShaderItem::PostConstruct(CRenderItemManager* pManager, const SString& str
     Super::PostConstruct(pManager);
 
     // Initial creation of d3d data
-    CreateUnderlyingData(strFilename, strRootPath, strOutStatus, bDebug);
+    CreateUnderlyingData(strFile, strRootPath, bIsRawData, strOutStatus, bDebug);
 }
 
 ////////////////////////////////////////////////////////////////
@@ -91,12 +91,12 @@ void CShaderItem::OnResetDevice(void)
 //
 //
 ////////////////////////////////////////////////////////////////
-void CShaderItem::CreateUnderlyingData(const SString& strFilename, const SString& strRootPath, SString& strOutStatus, bool bDebug)
+void CShaderItem::CreateUnderlyingData(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug)
 {
     assert(!m_pEffectWrap);
     assert(!m_pShaderInstance);
 
-    m_pEffectWrap = m_pManager->GetEffectCloner()->CreateD3DEffect(strFilename, strRootPath, strOutStatus, bDebug);
+    m_pEffectWrap = m_pManager->GetEffectCloner()->CreateD3DEffect(strFile, strRootPath, bIsRawData, strOutStatus, bDebug);
     if (!m_pEffectWrap)
         return;
 

--- a/Client/core/Graphics/CRenderItemManager.cpp
+++ b/Client/core/Graphics/CRenderItemManager.cpp
@@ -231,7 +231,7 @@ CWebBrowserItem* CRenderItemManager::CreateWebBrowser(uint uiSizeX, uint uiSizeY
 // Create a D3DX effect from .fx file
 //
 ////////////////////////////////////////////////////////////////
-CShaderItem* CRenderItemManager::CreateShader(const SString& strFullFilePath, const SString& strRootPath, SString& strOutStatus, float fPriority,
+CShaderItem* CRenderItemManager::CreateShader(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority,
                                               float fMaxDistance, bool bLayered, bool bDebug, int iTypeMask)
 {
     if (!CanCreateRenderItem(CShaderItem::GetClassId()))
@@ -240,7 +240,7 @@ CShaderItem* CRenderItemManager::CreateShader(const SString& strFullFilePath, co
     strOutStatus = "";
 
     CShaderItem* pShaderItem = new CShaderItem();
-    pShaderItem->PostConstruct(this, strFullFilePath, strRootPath, strOutStatus, fPriority, fMaxDistance, bLayered, bDebug, iTypeMask);
+    pShaderItem->PostConstruct(this, strFile, strRootPath, bIsRawData, strOutStatus, fPriority, fMaxDistance, bLayered, bDebug, iTypeMask);
 
     if (!pShaderItem->IsValid())
     {

--- a/Client/core/Graphics/CRenderItemManager.h
+++ b/Client/core/Graphics/CRenderItemManager.h
@@ -28,7 +28,7 @@ public:
     virtual CTextureItem* CreateTexture(const SString& strFullFilePath, const CPixels* pPixels, bool bMipMaps = true, uint uiSizeX = RDEFAULT,
                                         uint uiSizeY = RDEFAULT, ERenderFormat format = RFORMAT_UNKNOWN, ETextureAddress textureAddress = TADDRESS_WRAP,
                                         ETextureType textureType = TTYPE_TEXTURE, uint uiVolumeDepth = 1);
-    virtual CShaderItem*  CreateShader(const SString& strFullFilePath, const SString& strRootPath, SString& strOutStatus, float fPriority, float fMaxDistance,
+    virtual CShaderItem*  CreateShader(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority, float fMaxDistance,
                                        bool bLayered, bool bDebug, int iTypeMask);
     virtual CRenderTargetItem* CreateRenderTarget(uint uiSizeX, uint uiSizeY, bool bWithAlphaChannel, bool bForce = false);
     virtual CScreenSourceItem* CreateScreenSource(uint uiSizeX, uint uiSizeY);

--- a/Client/mods/deathmatch/logic/CClientRenderElementManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientRenderElementManager.cpp
@@ -135,12 +135,12 @@ CClientTexture* CClientRenderElementManager::CreateTexture(const SString& strFul
 //
 //
 ////////////////////////////////////////////////////////////////
-CClientShader* CClientRenderElementManager::CreateShader(const SString& strFullFilePath, const SString& strRootPath, SString& strOutStatus, float fPriority,
+CClientShader* CClientRenderElementManager::CreateShader(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority,
                                                          float fMaxDistance, bool bLayered, bool bDebug, int iTypeMask)
 {
     // Create the item
     CShaderItem* pShaderItem =
-        m_pRenderItemManager->CreateShader(strFullFilePath, strRootPath, strOutStatus, fPriority, fMaxDistance, bLayered, bDebug, iTypeMask);
+        m_pRenderItemManager->CreateShader(strFile, strRootPath, bIsRawData, strOutStatus, fPriority, fMaxDistance, bLayered, bDebug, iTypeMask);
 
     // Check create worked
     if (!pShaderItem)

--- a/Client/mods/deathmatch/logic/CClientRenderElementManager.h
+++ b/Client/mods/deathmatch/logic/CClientRenderElementManager.h
@@ -29,7 +29,7 @@ public:
     CClientTexture*      CreateTexture(const SString& strFullFilePath, const CPixels* pPixels = NULL, bool bMipMaps = true, uint uiSizeX = RDEFAULT,
                                        uint uiSizeY = RDEFAULT, ERenderFormat format = RFORMAT_UNKNOWN, ETextureAddress textureAddress = TADDRESS_WRAP,
                                        ETextureType textureType = TTYPE_TEXTURE, uint uiVolumeDepth = 1);
-    CClientShader*       CreateShader(const SString& strFullFilePath, const SString& strRootPath, SString& strOutStatus, float fPriority, float fMaxDistance,
+    CClientShader*       CreateShader(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority, float fMaxDistance,
                                       bool bLayered, bool bDebug, int iTypeMask);
     CClientRenderTarget* CreateRenderTarget(uint uiSizeX, uint uiSizeY, bool bWithAlphaChannel);
     CClientScreenSource* CreateScreenSource(uint uiSizeX, uint uiSizeY);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -980,16 +980,16 @@ int CLuaDrawingDefs::DxCreateTexture(lua_State* luaVM)
 
 int CLuaDrawingDefs::DxCreateShader(lua_State* luaVM)
 {
-    //  element dxCreateShader( string filepath [, float priority = 0, float maxdistance = 0, bool layered = false, string elementTypes =
+    //  element dxCreateShader( string filepath / string raw_data [, float priority = 0, float maxdistance = 0, bool layered = false, string elementTypes =
     //  "world,vehicle,object,other" ] )
-    SString                      strFilePath;
+    SString                      strFile;
     float                        fPriority;
     float                        fMaxDistance;
     bool                         bLayered;
     std::vector<EEntityTypeMask> elementTypeList;
 
     CScriptArgReader argStream(luaVM);
-    argStream.ReadString(strFilePath);
+    argStream.ReadString(strFile);
     argStream.ReadNumber(fPriority, 0.0f);
     argStream.ReadNumber(fMaxDistance, 0.0f);
     argStream.ReadBool(bLayered, false);
@@ -1006,37 +1006,36 @@ int CLuaDrawingDefs::DxCreateShader(lua_State* luaVM)
         {
             CResource* pParentResource = pLuaMain->GetResource();
             CResource* pFileResource = pParentResource;
-            SString    strPath, strMetaPath;
-            if (CResourceManager::ParseResourcePathInput(strFilePath, pFileResource, &strPath, &strMetaPath))
+            SString    strPath, strMetaPath, strRootPath, strStatus;
+
+            // If we can't parse path input or file doesn't exists then consider strFile as a raw data
+            bool bIsRawData = !CResourceManager::ParseResourcePathInput(strFile, pFileResource, &strPath, &strMetaPath) || !FileExists(strPath);
+            if (bIsRawData)
             {
-                if (FileExists(strPath))
-                {
-                    SString        strRootPath = strPath.Left(strPath.length() - strMetaPath.length());
-                    SString        strStatus;
-                    CClientShader* pShader = g_pClientGame->GetManager()->GetRenderElementManager()->CreateShader(
-                        strPath, strRootPath, strStatus, fPriority, fMaxDistance, bLayered, false, iEntityTypeMaskResult);
-                    if (pShader)
-                    {
-                        // Make it a child of the resource's file root ** CHECK  Should parent be pFileResource, and element added to pParentResource's
-                        // ElementGroup? **
-                        pShader->SetParent(pParentResource->GetResourceDynamicEntity());
-                        lua_pushelement(luaVM, pShader);
-                        lua_pushstring(luaVM, strStatus);            // String containing name of technique being used.
-                        return 2;
-                    }
-                    else
-                    {
-                        // Replace any path in the error message with our own one
-                        SString strRootPathWithoutResource = strRootPath.Left(strRootPath.TrimEnd("\\").length() - SStringX(pFileResource->GetName()).length());
-                        strStatus = strStatus.ReplaceI(strRootPathWithoutResource, "");
-                        argStream.SetCustomError(strFilePath, strStatus);
-                    }
-                }
-                else
-                    argStream.SetCustomError(strFilePath, "File not found");
+                strPath = strFile;
+                strRootPath = pFileResource->GetResourceDirectoryPath(ACCESS_PUBLIC, NULL);
             }
             else
-                argStream.SetCustomError(strFilePath, "Bad file path");
+                strRootPath = strPath.Left(strPath.length() - strMetaPath.length());
+
+            CClientShader* pShader = g_pClientGame->GetManager()->GetRenderElementManager()->CreateShader(
+                strPath, strRootPath, bIsRawData, strStatus, fPriority, fMaxDistance, bLayered, false, iEntityTypeMaskResult);
+            if (pShader)
+            {
+                // Make it a child of the resource's file root ** CHECK  Should parent be pFileResource, and element added to pParentResource's
+                // ElementGroup? **
+                pShader->SetParent(pParentResource->GetResourceDynamicEntity());
+                lua_pushelement(luaVM, pShader);
+                lua_pushstring(luaVM, strStatus);            // String containing name of technique being used.
+                return 2;
+            }
+            else
+            {
+                // Replace any path in the error message with our own one
+                SString strRootPathWithoutResource = strRootPath.Left(strRootPath.TrimEnd("\\").length() - SStringX(pFileResource->GetName()).length());
+                strStatus = strStatus.ReplaceI(strRootPathWithoutResource, "");
+                argStream.SetCustomError(bIsRawData ? "raw data" : strFile, strStatus);
+            }
         }
     }
     if (argStream.HasErrors())

--- a/Client/sdk/core/CRenderItemManagerInterface.h
+++ b/Client/sdk/core/CRenderItemManagerInterface.h
@@ -148,7 +148,7 @@ public:
     virtual CTextureItem* CreateTexture(const SString& strFullFilePath, const CPixels* pPixels = NULL, bool bMipMaps = true, uint uiSizeX = RDEFAULT,
                                         uint uiSizeY = RDEFAULT, ERenderFormat format = RFORMAT_UNKNOWN, ETextureAddress textureAddress = TADDRESS_WRAP,
                                         ETextureType textureType = TTYPE_TEXTURE, uint uiVolumeDepth = 1) = 0;
-    virtual CShaderItem*  CreateShader(const SString& strFullFilePath, const SString& strRootPath, SString& strOutStatus, float fPriority, float fMaxDistance,
+    virtual CShaderItem*  CreateShader(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority, float fMaxDistance,
                                        bool bLayered, bool bDebug, int iTypeMask) = 0;
     virtual CRenderTargetItem* CreateRenderTarget(uint uiSizeX, uint uiSizeY, bool bWithAlphaChannel, bool bForce = false) = 0;
     virtual CScreenSourceItem* CreateScreenSource(uint uiSizeX, uint uiSizeY) = 0;
@@ -352,13 +352,13 @@ class CShaderItem : public CMaterialItem
 {
     DECLARE_CLASS(CShaderItem, CMaterialItem)
     CShaderItem(void) : ClassInit(this) {}
-    virtual void PostConstruct(CRenderItemManager* pManager, const SString& strFilename, const SString& strRootPath, SString& strOutStatus, float fPriority,
+    virtual void PostConstruct(CRenderItemManager* pManager, const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority,
                                float fMaxDistance, bool bLayered, bool bDebug, int iTypeMask);
     virtual void PreDestruct(void);
     virtual bool IsValid(void);
     virtual void OnLostDevice(void);
     virtual void OnResetDevice(void);
-    void         CreateUnderlyingData(const SString& strFilename, const SString& strRootPath, SString& strOutStatus, bool bDebug);
+    void         CreateUnderlyingData(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug);
     void         ReleaseUnderlyingData(void);
     virtual bool SetValue(const SString& strName, CTextureItem* pTextureItem);
     virtual bool SetValue(const SString& strName, bool bValue);


### PR DESCRIPTION
This PR closes #430 

New syntax ([dxCreateShader](https://wiki.multitheftauto.com/wiki/DxCreateShader)):
> element, string dxCreateShader ( string filepath / string raw_data [, float priority = 0, float maxDistance = 0, bool layered = false, string elementTypes = "world,vehicle,object,other" ] )

Like AlexTMjugador mentioned on Mantis it would be good to have option to generate shaders dynamically and load it without i/o.

It also supports #includes directives inside raw data. The base directory for includes - resource root directory.