### PR TITLE
Fix doors state with setElementModel

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -19,10 +19,10 @@ extern CClientGame* g_pClientGame;
 #define M_PI 3.14159265358979323846
 #endif
 
-#define INVALID_VALUE 0xFFFFFFFF
+#define INVALID_VALUE   0xFFFFFFFF
 
-#define PED_INTERPOLATION_WARP_THRESHOLD 5                      // Minimal threshold
-#define PED_INTERPOLATION_WARP_THRESHOLD_FOR_SPEED 5            // Units to increment the threshold per speed unit
+#define PED_INTERPOLATION_WARP_THRESHOLD            5   // Minimal threshold
+#define PED_INTERPOLATION_WARP_THRESHOLD_FOR_SPEED  5   // Units to increment the threshold per speed unit
 
 enum eAnimGroups
 {
@@ -3929,17 +3929,17 @@ void CClientPed::_ChangeModel(void)
                 m_pPlayerPed->RebuildPlayer();
 
                 // ...and decrement the extra ref
-#ifdef NO_CRASH_FIX_TEST2
+            #ifdef NO_CRASH_FIX_TEST2
                 m_pPlayerPed->RemoveGeometryRef();
-#endif
+            #endif
             }
             else
             {
                 // When the local player changes to another (non CJ) model, the geometry gets an extra ref from somewhere, causing a memory leak.
                 // So decrement the extra ref here
-#ifdef NO_CRASH_FIX_TEST
+            #ifdef NO_CRASH_FIX_TEST
                 m_pPlayerPed->RemoveGeometryRef();
-#endif
+            #endif
                 // As we will have problem removing the geometry later, we might as well keep the model cached until exit
                 g_pCore->AddModelToPersistentCache((ushort)m_ulModel);
             }
@@ -6205,9 +6205,9 @@ void CClientPed::HandleWaitingForGroundToLoad(void)
     {
         // If not near any MTA objects, then don't bother waiting
         SetFrozenWaitingForGroundToLoad(false);
-#ifdef ASYNC_LOADING_DEBUG_OUTPUTA
+        #ifdef ASYNC_LOADING_DEBUG_OUTPUTA
         OutputDebugLine("[AsyncLoading]   FreezeUntilCollisionLoaded - Early stop");
-#endif
+        #endif
         return;
     }
 
@@ -6228,29 +6228,29 @@ void CClientPed::HandleWaitingForGroundToLoad(void)
     bool                  bASync = g_pGame->IsASyncLoadingEnabled();
     bool                  bMTAObjLimit = pObjectManager->IsObjectLimitReached();
     bool                  bHasModel = GetModelInfo() != NULL;
-#ifndef ASYNC_LOADING_DEBUG_OUTPUTA
+    #ifndef ASYNC_LOADING_DEBUG_OUTPUTA
     bool bMTALoaded = pObjectManager->ObjectsAroundPointLoaded(vecPosition, fUseRadius, m_usDimension);
-#else
+    #else
     SString strAround;
     bool    bMTALoaded = pObjectManager->ObjectsAroundPointLoaded(vecPosition, fUseRadius, m_usDimension, &strAround);
-#endif
+    #endif
 
-#ifdef ASYNC_LOADING_DEBUG_OUTPUTA
+    #ifdef ASYNC_LOADING_DEBUG_OUTPUTA
     SString status = SString(
         "%2.2f,%2.2f,%2.2f  bASync:%d   bHasModel:%d   bMTALoaded:%d   bMTAObjLimit:%d   m_fGroundCheckTolerance:%2.2f   m_fObjectsAroundTolerance:%2.2f  "
         "fUseRadius:%2.1f",
         vecPosition.fX, vecPosition.fY, vecPosition.fZ, bASync, bHasModel, bMTALoaded, bMTAObjLimit, m_fGroundCheckTolerance, m_fObjectsAroundTolerance,
         fUseRadius);
-#endif
+    #endif
 
     // See if ground is ready
     if ((!bHasModel || !bMTALoaded) && m_fObjectsAroundTolerance < 1.f)
     {
         m_fGroundCheckTolerance = 0.f;
         m_fObjectsAroundTolerance = std::min(1.f, m_fObjectsAroundTolerance + 0.01f);
-#ifdef ASYNC_LOADING_DEBUG_OUTPUTA
+        #ifdef ASYNC_LOADING_DEBUG_OUTPUTA
         status += ("  FreezeUntilCollisionLoaded - wait");
-#endif
+        #endif
     }
     else
     {
@@ -6263,16 +6263,16 @@ void CClientPed::HandleWaitingForGroundToLoad(void)
         if (fUseDist > -0.2f && fUseDist < 1.5f)
             SetFrozenWaitingForGroundToLoad(false);
 
-#ifdef ASYNC_LOADING_DEBUG_OUTPUTA
+        #ifdef ASYNC_LOADING_DEBUG_OUTPUTA
         status += (SString("  GetDistanceFromGround:  fDist:%2.2f   fUseDist:%2.2f", fDist, fUseDist));
-#endif
+        #endif
 
         // Stop waiting after 3 frames, if the object limit has not been reached. (bASync should always be false here)
         if (m_fGroundCheckTolerance > 0.03f && !bMTAObjLimit && !bASync)
             SetFrozenWaitingForGroundToLoad(false);
     }
 
-#ifdef ASYNC_LOADING_DEBUG_OUTPUTA
+    #ifdef ASYNC_LOADING_DEBUG_OUTPUTA
     OutputDebugLine(SStringX("[AsyncLoading] ")++ status);
     g_pCore->GetGraphics()->DrawString(10, 220, -1, 1, status);
 
@@ -6280,7 +6280,7 @@ void CClientPed::HandleWaitingForGroundToLoad(void)
     strAround.Split("\n", lineList);
     for (unsigned int i = 0; i < lineList.size(); i++)
         g_pCore->GetGraphics()->DrawString(10, 230 + i * 10, -1, 1, lineList[i]);
-#endif
+    #endif
 }
 
 //

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -19,10 +19,10 @@ extern CClientGame* g_pClientGame;
 #define M_PI 3.14159265358979323846
 #endif
 
-#define INVALID_VALUE   0xFFFFFFFF
+#define INVALID_VALUE 0xFFFFFFFF
 
-#define PED_INTERPOLATION_WARP_THRESHOLD            5   // Minimal threshold
-#define PED_INTERPOLATION_WARP_THRESHOLD_FOR_SPEED  5   // Units to increment the threshold per speed unit
+#define PED_INTERPOLATION_WARP_THRESHOLD 5                      // Minimal threshold
+#define PED_INTERPOLATION_WARP_THRESHOLD_FOR_SPEED 5            // Units to increment the threshold per speed unit
 
 enum eAnimGroups
 {
@@ -2106,19 +2106,32 @@ bool CClientPed::SetCurrentWeaponSlot(eWeaponSlot weaponSlot)
                     DWORD       ammoInClip = oldWeapon->GetAmmoInClip();
                     DWORD       ammoInTotal = oldWeapon->GetAmmoTotal();
                     eWeaponType weaponType = oldWeapon->GetType();
-                    RemoveWeapon(oldWeapon->GetType());
+                    if (weaponSlot != WEAPONSLOT_TYPE_PARACHUTE && weaponType != WEAPONTYPE_NIGHTVISION && weaponType != WEAPONTYPE_INFRARED)
+                    {
+                        RemoveWeapon(oldWeapon->GetType());
 
-                    m_pPlayerPed->SetCurrentWeaponSlot(WEAPONSLOT_TYPE_UNARMED);
+                        m_pPlayerPed->SetCurrentWeaponSlot(WEAPONSLOT_TYPE_UNARMED);
 
-                    CWeapon* newWeapon = GiveWeapon(weaponType, ammoInTotal);
-                    newWeapon->SetAmmoInClip(ammoInClip);
-                    newWeapon->SetAmmoTotal(ammoInTotal);
+                        CWeapon* newWeapon = GiveWeapon(weaponType, ammoInTotal);
+                        newWeapon->SetAmmoInClip(ammoInClip);
+                        newWeapon->SetAmmoTotal(ammoInTotal);
 
-                    // Don't allow doing gang driveby while unarmed
-                    if (IsDoingGangDriveby())
-                        SetDoingGangDriveby(false);
-                    m_CurrentWeaponSlot = weaponSlot;
-                    return true;
+                        // Don't allow doing gang driveby while unarmed
+                        if (IsDoingGangDriveby())
+                            SetDoingGangDriveby(false);
+                        m_CurrentWeaponSlot = weaponSlot;
+                        return true;
+                    }
+                    else
+                    {
+                        m_pPlayerPed->SetCurrentWeaponSlot(WEAPONSLOT_TYPE_UNARMED);
+
+                        // Don't allow doing gang driveby while unarmed
+                        if (IsDoingGangDriveby())
+                            SetDoingGangDriveby(false);
+                        m_CurrentWeaponSlot = weaponSlot;
+                        return true;
+                    }
                 }
                 else
                 {
@@ -3916,17 +3929,17 @@ void CClientPed::_ChangeModel(void)
                 m_pPlayerPed->RebuildPlayer();
 
                 // ...and decrement the extra ref
-            #ifdef NO_CRASH_FIX_TEST2
+#ifdef NO_CRASH_FIX_TEST2
                 m_pPlayerPed->RemoveGeometryRef();
-            #endif
+#endif
             }
             else
             {
                 // When the local player changes to another (non CJ) model, the geometry gets an extra ref from somewhere, causing a memory leak.
                 // So decrement the extra ref here
-            #ifdef NO_CRASH_FIX_TEST
+#ifdef NO_CRASH_FIX_TEST
                 m_pPlayerPed->RemoveGeometryRef();
-            #endif
+#endif
                 // As we will have problem removing the geometry later, we might as well keep the model cached until exit
                 g_pCore->AddModelToPersistentCache((ushort)m_ulModel);
             }
@@ -6192,9 +6205,9 @@ void CClientPed::HandleWaitingForGroundToLoad(void)
     {
         // If not near any MTA objects, then don't bother waiting
         SetFrozenWaitingForGroundToLoad(false);
-        #ifdef ASYNC_LOADING_DEBUG_OUTPUTA
+#ifdef ASYNC_LOADING_DEBUG_OUTPUTA
         OutputDebugLine("[AsyncLoading]   FreezeUntilCollisionLoaded - Early stop");
-        #endif
+#endif
         return;
     }
 
@@ -6215,29 +6228,29 @@ void CClientPed::HandleWaitingForGroundToLoad(void)
     bool                  bASync = g_pGame->IsASyncLoadingEnabled();
     bool                  bMTAObjLimit = pObjectManager->IsObjectLimitReached();
     bool                  bHasModel = GetModelInfo() != NULL;
-    #ifndef ASYNC_LOADING_DEBUG_OUTPUTA
+#ifndef ASYNC_LOADING_DEBUG_OUTPUTA
     bool bMTALoaded = pObjectManager->ObjectsAroundPointLoaded(vecPosition, fUseRadius, m_usDimension);
-    #else
+#else
     SString strAround;
     bool    bMTALoaded = pObjectManager->ObjectsAroundPointLoaded(vecPosition, fUseRadius, m_usDimension, &strAround);
-    #endif
+#endif
 
-    #ifdef ASYNC_LOADING_DEBUG_OUTPUTA
+#ifdef ASYNC_LOADING_DEBUG_OUTPUTA
     SString status = SString(
         "%2.2f,%2.2f,%2.2f  bASync:%d   bHasModel:%d   bMTALoaded:%d   bMTAObjLimit:%d   m_fGroundCheckTolerance:%2.2f   m_fObjectsAroundTolerance:%2.2f  "
         "fUseRadius:%2.1f",
         vecPosition.fX, vecPosition.fY, vecPosition.fZ, bASync, bHasModel, bMTALoaded, bMTAObjLimit, m_fGroundCheckTolerance, m_fObjectsAroundTolerance,
         fUseRadius);
-    #endif
+#endif
 
     // See if ground is ready
     if ((!bHasModel || !bMTALoaded) && m_fObjectsAroundTolerance < 1.f)
     {
         m_fGroundCheckTolerance = 0.f;
         m_fObjectsAroundTolerance = std::min(1.f, m_fObjectsAroundTolerance + 0.01f);
-        #ifdef ASYNC_LOADING_DEBUG_OUTPUTA
+#ifdef ASYNC_LOADING_DEBUG_OUTPUTA
         status += ("  FreezeUntilCollisionLoaded - wait");
-        #endif
+#endif
     }
     else
     {
@@ -6250,16 +6263,16 @@ void CClientPed::HandleWaitingForGroundToLoad(void)
         if (fUseDist > -0.2f && fUseDist < 1.5f)
             SetFrozenWaitingForGroundToLoad(false);
 
-        #ifdef ASYNC_LOADING_DEBUG_OUTPUTA
+#ifdef ASYNC_LOADING_DEBUG_OUTPUTA
         status += (SString("  GetDistanceFromGround:  fDist:%2.2f   fUseDist:%2.2f", fDist, fUseDist));
-        #endif
+#endif
 
         // Stop waiting after 3 frames, if the object limit has not been reached. (bASync should always be false here)
         if (m_fGroundCheckTolerance > 0.03f && !bMTAObjLimit && !bASync)
             SetFrozenWaitingForGroundToLoad(false);
     }
 
-    #ifdef ASYNC_LOADING_DEBUG_OUTPUTA
+#ifdef ASYNC_LOADING_DEBUG_OUTPUTA
     OutputDebugLine(SStringX("[AsyncLoading] ")++ status);
     g_pCore->GetGraphics()->DrawString(10, 220, -1, 1, status);
 
@@ -6267,7 +6280,7 @@ void CClientPed::HandleWaitingForGroundToLoad(void)
     strAround.Split("\n", lineList);
     for (unsigned int i = 0; i < lineList.size(); i++)
         g_pCore->GetGraphics()->DrawString(10, 230 + i * 10, -1, 1, lineList[i]);
-    #endif
+#endif
 }
 
 //

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -3547,32 +3547,12 @@ void CClientVehicle::Interpolate(void)
 
 void CClientVehicle::GetInitialDoorStates(SFixedArray<unsigned char, MAX_DOORS>& ucOutDoorStates)
 {
-    switch (m_usModel)
-    {
-        case VT_BAGGAGE:
-        case VT_BANDITO:
-        case VT_BFINJECT:
-        case VT_CADDY:
-        case VT_DOZER:
-        case VT_FORKLIFT:
-        case VT_KART:
-        case VT_MOWER:
-        case VT_QUAD:
-        case VT_RCBANDIT:
-        case VT_RCCAM:
-        case VT_RCGOBLIN:
-        case VT_RCRAIDER:
-        case VT_RCTIGER:
-        case VT_TRACTOR:
-        case VT_VORTEX:
-            memset(&ucOutDoorStates[0], DT_DOOR_MISSING, MAX_DOORS);
+    memset(&ucOutDoorStates[0], DT_DOOR_INTACT, MAX_DOORS);
 
-            // Keep the bonet and boot intact
-            ucOutDoorStates[0] = ucOutDoorStates[1] = DT_DOOR_INTACT;
-            break;
-        default:
-            memset(&ucOutDoorStates[0], DT_DOOR_INTACT, MAX_DOORS);
-    }
+    // Keep the bonet and boot intact
+    ucOutDoorStates[0] = ucOutDoorStates[1] = DT_DOOR_INTACT;
+
+    memset(&ucOutDoorStates[0], DT_DOOR_INTACT, MAX_DOORS);
 }
 
 void CClientVehicle::SetTargetPosition(const CVector& vecTargetPosition, unsigned long ulDelay, bool bValidVelocityZ, float fVelocityZ)

--- a/Server/mods/deathmatch/logic/CVehicle.cpp
+++ b/Server/mods/deathmatch/logic/CVehicle.cpp
@@ -777,32 +777,12 @@ void CVehicle::SetPaintjob(unsigned char ucPaintjob)
 
 void CVehicle::GetInitialDoorStates(SFixedArray<unsigned char, MAX_DOORS>& ucOutDoorStates)
 {
-    switch (m_usModel)
-    {
-        case VT_BAGGAGE:
-        case VT_BANDITO:
-        case VT_BFINJECT:
-        case VT_CADDY:
-        case VT_DOZER:
-        case VT_FORKLIFT:
-        case VT_KART:
-        case VT_MOWER:
-        case VT_QUAD:
-        case VT_RCBANDIT:
-        case VT_RCCAM:
-        case VT_RCGOBLIN:
-        case VT_RCRAIDER:
-        case VT_RCTIGER:
-        case VT_TRACTOR:
-        case VT_VORTEX:
-            memset(&ucOutDoorStates[0], DT_DOOR_MISSING, MAX_DOORS);
+    memset(&ucOutDoorStates[0], DT_DOOR_INTACT, MAX_DOORS);
 
-            // Keep the bonet and boot intact
-            ucOutDoorStates[0] = ucOutDoorStates[1] = DT_DOOR_INTACT;
-            break;
-        default:
-            memset(&ucOutDoorStates[0], DT_DOOR_INTACT, MAX_DOORS);
-    }
+    // Keep the bonet and boot intact
+    ucOutDoorStates[0] = ucOutDoorStates[1] = DT_DOOR_INTACT;
+
+    memset(&ucOutDoorStates[0], DT_DOOR_INTACT, MAX_DOORS);
 }
 
 void CVehicle::GenerateHandlingData(void)


### PR DESCRIPTION
Fixes #578 

**Bug description**
Changing vehicle model from doorless or "doorful" causes doors to fall off.

**To reproduce**
1. Take a tractor.
2. Set its model to a 4 door vehicle.
3. Doors fall off.

Now all vehicles without doors (tractor, baggage, etc.) will returns doors state as 0, because haven't doors. Now this vehicles returns doors state as 4 (missing).