### PR TITLE
#649: Added error message for resource meta.xml parsing fail

### DIFF
--- a/Server/mods/deathmatch/logic/CResource.cpp
+++ b/Server/mods/deathmatch/logic/CResource.cpp
@@ -361,14 +361,12 @@ bool CResource::Load(void)
             SString strError;
             metaFile->GetLastError(strError);
 
-            char szBuffer[255] = {0};
-            if (!strError.empty())
-                snprintf(szBuffer, 254, "Couldn't parse meta file for resource '%s' [%s]\n", m_strResourceName.c_str(), strError.c_str());
+            if (strError.empty())
+                m_strFailureReason = SString("Couldn't parse meta file for resource '%s'\n", m_strResourceName.c_str());
             else
-                snprintf(szBuffer, 254, "Couldn't parse meta file for resource '%s'\n", m_strResourceName.c_str());
+                m_strFailureReason = SString("Couldn't parse meta file for resource '%s' [%s]\n", m_strResourceName.c_str(), strError.c_str());
 
-            m_strFailureReason = szBuffer;
-            CLogger::ErrorPrintf(szBuffer);
+            CLogger::ErrorPrintf(m_strFailureReason.c_str());
 
             // Delete the XML file if we somehow got to load it halfway
             if (metaFile)

--- a/Server/mods/deathmatch/logic/CResource.cpp
+++ b/Server/mods/deathmatch/logic/CResource.cpp
@@ -358,8 +358,15 @@ bool CResource::Load(void)
         }
         else
         {
+            SString strError;
+            metaFile->GetLastError(strError);
+
             char szBuffer[255] = {0};
-            snprintf(szBuffer, 254, "Couldn't parse meta file for resource '%s'\n", m_strResourceName.c_str());
+            if (!strError.empty())
+                snprintf(szBuffer, 254, "Couldn't parse meta file for resource '%s' [%s]\n", m_strResourceName.c_str(), strError.c_str());
+            else
+                snprintf(szBuffer, 254, "Couldn't parse meta file for resource '%s'\n", m_strResourceName.c_str());
+
             m_strFailureReason = szBuffer;
             CLogger::ErrorPrintf(szBuffer);
 


### PR DESCRIPTION
This PR fixes #649.

Adds xmlLoadFile\-style parsing error details to the resource failure reason message.

> start: Resource 'res' start was requested (Couldn't parse meta file for resource 'res' [Line 4: Error reading end tag.])

The text between the brackets might be clipped to 254 characters if it's longer. This gives up to 209 characters (if the resource name is 1 character long) for parsing error message itself, which should be enough.