### PR TITLE
getSoundBufferLength function

### DIFF
--- a/Client/mods/deathmatch/logic/CBassAudio.cpp
+++ b/Client/mods/deathmatch/logic/CBassAudio.cpp
@@ -521,7 +521,7 @@ void CBassAudio::SetPaused(bool bPaused)
 }
 
 // Non-streams only
-void CBassAudio::SetPlayPosition(double dPosition)
+bool CBassAudio::SetPlayPosition(double dPosition)
 {
     // Only relevant for non-streams, which are always ready if valid
     if (m_pSound)
@@ -529,8 +529,12 @@ void CBassAudio::SetPlayPosition(double dPosition)
         // Make sure position is in range
         QWORD bytePosition = BASS_ChannelSeconds2Bytes(m_pSound, dPosition);
         QWORD byteLength = BASS_ChannelGetLength(m_pSound, BASS_POS_BYTE);
-        BASS_ChannelSetPosition(m_pSound, Clamp<QWORD>(0, bytePosition, byteLength - 1), BASS_POS_BYTE);
+        if (BASS_ChannelSetPosition(m_pSound, Clamp<QWORD>(0, bytePosition, byteLength - 1), BASS_POS_BYTE))
+        {
+            return true;
+        }
     }
+    return false;
 }
 
 // Non-streams only
@@ -555,6 +559,22 @@ double CBassAudio::GetLength(void)
         QWORD length = BASS_ChannelGetLength(m_pSound, BASS_POS_BYTE);
         if (length != -1)
             return BASS_ChannelBytes2Seconds(m_pSound, length);
+    }
+    return 0;
+}
+
+// Non-streams only
+double CBassAudio::GetBufferLength(void)
+{
+    if (m_pSound)
+    {
+        QWORD length = BASS_ChannelGetLength(m_pSound, BASS_POS_BYTE);
+        if (length != -1)
+        {
+            QWORD bufferPosition = (BASS_StreamGetFilePosition(m_pSound, BASS_FILEPOS_START) + BASS_StreamGetFilePosition(m_pSound, BASS_FILEPOS_BUFFER));
+            QWORD bufferLength = static_cast<QWORD>(static_cast<double>(length) / BASS_StreamGetFilePosition(m_pSound, BASS_FILEPOS_SIZE) * bufferPosition);
+            return BASS_ChannelBytes2Seconds(m_pSound, bufferLength);
+        }
     }
     return 0;
 }

--- a/Client/mods/deathmatch/logic/CBassAudio.cpp
+++ b/Client/mods/deathmatch/logic/CBassAudio.cpp
@@ -521,7 +521,7 @@ void CBassAudio::SetPaused(bool bPaused)
 }
 
 // Non-streams only
-bool CBassAudio::SetPlayPosition(double dPosition)
+void CBassAudio::SetPlayPosition(double dPosition)
 {
     // Only relevant for non-streams, which are always ready if valid
     if (m_pSound)
@@ -529,12 +529,8 @@ bool CBassAudio::SetPlayPosition(double dPosition)
         // Make sure position is in range
         QWORD bytePosition = BASS_ChannelSeconds2Bytes(m_pSound, dPosition);
         QWORD byteLength = BASS_ChannelGetLength(m_pSound, BASS_POS_BYTE);
-        if (BASS_ChannelSetPosition(m_pSound, Clamp<QWORD>(0, bytePosition, byteLength - 1), BASS_POS_BYTE))
-        {
-            return true;
-        }
+        BASS_ChannelSetPosition(m_pSound, Clamp<QWORD>(0, bytePosition, byteLength - 1), BASS_POS_BYTE);
     }
-    return false;
 }
 
 // Non-streams only

--- a/Client/mods/deathmatch/logic/CBassAudio.cpp
+++ b/Client/mods/deathmatch/logic/CBassAudio.cpp
@@ -563,17 +563,21 @@ double CBassAudio::GetLength(void)
     return 0;
 }
 
-// Non-streams only
+// Streams only
 double CBassAudio::GetBufferLength(void)
 {
-    if (m_pSound)
+    if (m_bStream && m_pSound)
     {
         QWORD length = BASS_ChannelGetLength(m_pSound, BASS_POS_BYTE);
         if (length != -1)
         {
-            QWORD bufferPosition = (BASS_StreamGetFilePosition(m_pSound, BASS_FILEPOS_START) + BASS_StreamGetFilePosition(m_pSound, BASS_FILEPOS_BUFFER));
-            QWORD bufferLength = static_cast<QWORD>(static_cast<double>(length) / BASS_StreamGetFilePosition(m_pSound, BASS_FILEPOS_SIZE) * bufferPosition);
-            return BASS_ChannelBytes2Seconds(m_pSound, bufferLength);
+            QWORD fileSize = BASS_StreamGetFilePosition(m_pSound, BASS_FILEPOS_SIZE);
+            if (fileSize > 0)
+            {
+                QWORD bufferPosition = (BASS_StreamGetFilePosition(m_pSound, BASS_FILEPOS_START) + BASS_StreamGetFilePosition(m_pSound, BASS_FILEPOS_BUFFER));
+                QWORD bufferLength = static_cast<QWORD>(static_cast<double>(length) / fileSize * bufferPosition);
+                return BASS_ChannelBytes2Seconds(m_pSound, bufferLength);
+            }
         }
     }
     return 0;

--- a/Client/mods/deathmatch/logic/CBassAudio.h
+++ b/Client/mods/deathmatch/logic/CBassAudio.h
@@ -54,9 +54,10 @@ public:
     bool BeginLoadingMedia(void);
 
     void   SetPaused(bool bPaused);
-    void   SetPlayPosition(double dPosition);
+    bool   SetPlayPosition(double dPosition);
     double GetPlayPosition(void);
     double GetLength(void);
+    double GetBufferLength(void);
     void   SetVolume(float fVolume);
     void   SetPlaybackSpeed(float fSpeed);
     void   SetPosition(const CVector& vecPosition);

--- a/Client/mods/deathmatch/logic/CBassAudio.h
+++ b/Client/mods/deathmatch/logic/CBassAudio.h
@@ -54,7 +54,7 @@ public:
     bool BeginLoadingMedia(void);
 
     void   SetPaused(bool bPaused);
-    bool   SetPlayPosition(double dPosition);
+    void   SetPlayPosition(double dPosition);
     double GetPlayPosition(void);
     double GetLength(void);
     double GetBufferLength(void);

--- a/Client/mods/deathmatch/logic/CClientSound.cpp
+++ b/Client/mods/deathmatch/logic/CClientSound.cpp
@@ -293,18 +293,20 @@ void CClientSound::PlayStream(const SString& strURL, bool bLoop, bool bThrottle,
 //
 //
 ////////////////////////////////////////////////////////////
-void CClientSound::SetPlayPosition(double dPosition)
+bool CClientSound::SetPlayPosition(double dPosition)
 {
     if (m_pAudio)
     {
         // Use actual audio if active
-        m_pAudio->SetPlayPosition(dPosition);
+        return m_pAudio->SetPlayPosition(dPosition);
     }
     else
     {
         // Use simulation if not active
         m_SimulatedPlayPosition.SetPlayPositionNow(dPosition);
+        return true;
     }
+    return false;
 }
 
 double CClientSound::GetPlayPosition(void)
@@ -354,6 +356,16 @@ double CClientSound::GetLength(bool bAvoidLoad)
     }
 
     return m_dLength;
+}
+
+double CClientSound::GetBufferLength()
+{
+    if (!m_bStream && m_pAudio)
+    {
+        return 0;
+    }
+
+    return m_pAudio->GetBufferLength();
 }
 
 float CClientSound::GetVolume(void)

--- a/Client/mods/deathmatch/logic/CClientSound.cpp
+++ b/Client/mods/deathmatch/logic/CClientSound.cpp
@@ -293,20 +293,18 @@ void CClientSound::PlayStream(const SString& strURL, bool bLoop, bool bThrottle,
 //
 //
 ////////////////////////////////////////////////////////////
-bool CClientSound::SetPlayPosition(double dPosition)
+void CClientSound::SetPlayPosition(double dPosition)
 {
     if (m_pAudio)
     {
         // Use actual audio if active
-        return m_pAudio->SetPlayPosition(dPosition);
+        m_pAudio->SetPlayPosition(dPosition);
     }
     else
     {
         // Use simulation if not active
         m_SimulatedPlayPosition.SetPlayPositionNow(dPosition);
-        return true;
     }
-    return false;
 }
 
 double CClientSound::GetPlayPosition(void)

--- a/Client/mods/deathmatch/logic/CClientSound.cpp
+++ b/Client/mods/deathmatch/logic/CClientSound.cpp
@@ -360,12 +360,11 @@ double CClientSound::GetLength(bool bAvoidLoad)
 
 double CClientSound::GetBufferLength()
 {
-    if (!m_bStream && m_pAudio)
+    if (m_bStream && m_pAudio)
     {
-        return 0;
+        return m_pAudio->GetBufferLength();
     }
-
-    return m_pAudio->GetBufferLength();
+    return 0;
 }
 
 float CClientSound::GetVolume(void)

--- a/Client/mods/deathmatch/logic/CClientSound.h
+++ b/Client/mods/deathmatch/logic/CClientSound.h
@@ -39,10 +39,11 @@ public:
     void SetPaused(bool bPaused);
     bool IsPaused(void);
 
-    void   SetPlayPosition(double dPosition);
+    bool   SetPlayPosition(double dPosition);
     double GetPlayPosition(void);
 
     double GetLength(bool bAvoidLoad = false);
+    double GetBufferLength();
 
     void  SetVolume(float fVolume, bool bStore = true);
     float GetVolume(void);

--- a/Client/mods/deathmatch/logic/CClientSound.h
+++ b/Client/mods/deathmatch/logic/CClientSound.h
@@ -39,7 +39,7 @@ public:
     void SetPaused(bool bPaused);
     bool IsPaused(void);
 
-    bool   SetPlayPosition(double dPosition);
+    void   SetPlayPosition(double dPosition);
     double GetPlayPosition(void);
 
     double GetLength(bool bAvoidLoad = false);

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -7586,11 +7586,7 @@ bool CStaticFunctionDefinitions::StopSound(CClientSound& Sound)
 
 bool CStaticFunctionDefinitions::SetSoundPosition(CClientSound& Sound, double dPosition)
 {
-    if (Sound.IsSoundStream())
-        return false;
-
-    Sound.SetPlayPosition(dPosition);
-    return true;
+    return Sound.SetPlayPosition(dPosition);;
 }
 
 bool CStaticFunctionDefinitions::SetSoundPosition(CClientPlayer& Player, double dPosition)
@@ -7638,6 +7634,12 @@ bool CStaticFunctionDefinitions::GetSoundLength(CClientPlayer& Player, double& d
         return true;
     }
     return false;
+}
+
+bool CStaticFunctionDefinitions::GetSoundBufferLength(CClientSound& Sound, double& dBufferLength)
+{
+    dBufferLength = Sound.GetBufferLength();
+    return true;
 }
 
 bool CStaticFunctionDefinitions::SetSoundPaused(CClientSound& Sound, bool bPaused)

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -7638,8 +7638,12 @@ bool CStaticFunctionDefinitions::GetSoundLength(CClientPlayer& Player, double& d
 
 bool CStaticFunctionDefinitions::GetSoundBufferLength(CClientSound& Sound, double& dBufferLength)
 {
-    dBufferLength = Sound.GetBufferLength();
-    return true;
+    if (Sound.IsSoundStream())
+    {
+        dBufferLength = Sound.GetBufferLength();
+        return true;
+    }
+    return false;
 }
 
 bool CStaticFunctionDefinitions::SetSoundPaused(CClientSound& Sound, bool bPaused)

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -5431,7 +5431,7 @@ int CStaticFunctionDefinitions::GUIComboBoxGetItemCount(CClientEntity& Entity)
             return static_cast<CGUIComboBox*>(GUIElement.GetCGUIElement())->GetItemCount();
         }
     }
-    
+
     return 0;
 }
 
@@ -5458,7 +5458,7 @@ bool CStaticFunctionDefinitions::GUIComboBoxSetOpen(CClientEntity& Entity, bool 
             return true;
         }
     }
-    
+
     return false;
 }
 
@@ -5468,14 +5468,14 @@ bool CStaticFunctionDefinitions::GUIComboBoxIsOpen(CClientEntity& Entity)
     if (IS_GUI(&Entity))
     {
         CClientGUIElement& GUIElement = static_cast<CClientGUIElement&>(Entity);
-        
+
         // Are we a combobox?
         if (IS_CGUIELEMENT_COMBOBOX(&GUIElement))
         {
             return static_cast<CGUIComboBox*>(GUIElement.GetCGUIElement())->IsOpen();
         }
     }
-    
+
     return false;
 }
 
@@ -7586,7 +7586,11 @@ bool CStaticFunctionDefinitions::StopSound(CClientSound& Sound)
 
 bool CStaticFunctionDefinitions::SetSoundPosition(CClientSound& Sound, double dPosition)
 {
-    return Sound.SetPlayPosition(dPosition);
+    if (Sound.IsSoundStream())
+        return false;
+
+    Sound.SetPlayPosition(dPosition);
+    return true;
 }
 
 bool CStaticFunctionDefinitions::SetSoundPosition(CClientPlayer& Player, double dPosition)

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -5431,7 +5431,7 @@ int CStaticFunctionDefinitions::GUIComboBoxGetItemCount(CClientEntity& Entity)
             return static_cast<CGUIComboBox*>(GUIElement.GetCGUIElement())->GetItemCount();
         }
     }
-
+    
     return 0;
 }
 
@@ -5458,7 +5458,7 @@ bool CStaticFunctionDefinitions::GUIComboBoxSetOpen(CClientEntity& Entity, bool 
             return true;
         }
     }
-
+    
     return false;
 }
 
@@ -5468,14 +5468,14 @@ bool CStaticFunctionDefinitions::GUIComboBoxIsOpen(CClientEntity& Entity)
     if (IS_GUI(&Entity))
     {
         CClientGUIElement& GUIElement = static_cast<CClientGUIElement&>(Entity);
-
+        
         // Are we a combobox?
         if (IS_CGUIELEMENT_COMBOBOX(&GUIElement))
         {
             return static_cast<CGUIComboBox*>(GUIElement.GetCGUIElement())->IsOpen();
         }
     }
-
+    
     return false;
 }
 

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -7586,7 +7586,7 @@ bool CStaticFunctionDefinitions::StopSound(CClientSound& Sound)
 
 bool CStaticFunctionDefinitions::SetSoundPosition(CClientSound& Sound, double dPosition)
 {
-    return Sound.SetPlayPosition(dPosition);;
+    return Sound.SetPlayPosition(dPosition);
 }
 
 bool CStaticFunctionDefinitions::SetSoundPosition(CClientPlayer& Player, double dPosition)

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -718,6 +718,7 @@ public:
     static bool          SetSoundPosition(CClientSound& Sound, double dPosition);
     static bool          GetSoundPosition(CClientSound& Sound, double& dPosition);
     static bool          GetSoundLength(CClientSound& Sound, double& dLength);
+    static bool          GetSoundBufferLength(CClientSound& Sound, double& dBufferLength);
     static bool          SetSoundPaused(CClientSound& Sound, bool bPaused);
     static bool          IsSoundPaused(CClientSound& Sound, bool& bPaused);
     static bool          SetSoundVolume(CClientSound& Sound, float fVolume);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
@@ -407,23 +407,10 @@ int CLuaAudioDefs::GetSoundLength(lua_State* luaVM)
 
 int CLuaAudioDefs::GetSoundBufferLength(lua_State* luaVM)
 {
-    CClientPlayer*   pPlayer = NULL;
-    CClientSound*    pSound = NULL;
+    CClientSound*    pSound;
+
     CScriptArgReader argStream(luaVM);
-    if (argStream.NextIsUserDataOfType<CClientSound>())
-    {
-        argStream.ReadUserData(pSound);
-    }
-    else if (argStream.NextIsUserDataOfType<CClientPlayer>())
-    {
-        argStream.ReadUserData(pPlayer);
-    }
-    else
-    {
-        m_pScriptDebugging->LogBadPointer(luaVM, "sound/player", 1);
-        lua_pushboolean(luaVM, false);
-        return false;
-    }
+    argStream.ReadUserData(pSound);
 
     if (!argStream.HasErrors())
     {
@@ -435,15 +422,6 @@ int CLuaAudioDefs::GetSoundBufferLength(lua_State* luaVM)
                 lua_pushnumber(luaVM, dBufferLength);
                 return 1;
             }
-        }
-        else if (pPlayer)
-        {
-            //double dLength = 0;
-            //if (CStaticFunctionDefinitions::GetSoundBufferLength(*pPlayer, dLength))
-            //{
-            //    lua_pushnumber(luaVM, dLength);
-            //    return 1;
-            //}
         }
     }
     else

--- a/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
@@ -33,6 +33,7 @@ void CLuaAudioDefs::LoadFunctions(void)
         {"setSoundPosition", SetSoundPosition},
         {"getSoundPosition", GetSoundPosition},
         {"getSoundLength", GetSoundLength},
+        {"getSoundBufferLength", GetSoundBufferLength},
         {"setSoundPaused", SetSoundPaused},
         {"isSoundPaused", IsSoundPaused},
         {"setSoundVolume", SetSoundVolume},
@@ -90,6 +91,7 @@ void CLuaAudioDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setProperties", "setSoundProperties");
 
     lua_classfunction(luaVM, "getLength", "getSoundLength");
+    lua_classfunction(luaVM, "getBufferLength", "getSoundBufferLength");
     lua_classfunction(luaVM, "getMetaTags", "getSoundMetaTags");
     lua_classfunction(luaVM, "getBPM", "getSoundBPM");
     lua_classfunction(luaVM, "getFFTData", "getSoundFFTData");
@@ -110,6 +112,7 @@ void CLuaAudioDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "pan", "setSoundPan", "getSoundPan");
     lua_classvariable(luaVM, "panningEnabled", "setSoundPanningEnabled", "isSoundPanningEnabled");
     lua_classvariable(luaVM, "length", NULL, "getSoundLength");
+    lua_classvariable(luaVM, "bufferLength", NULL, "getSoundBufferLength");
 
     lua_registerclass(luaVM, "Sound", "Element");
 
@@ -393,6 +396,54 @@ int CLuaAudioDefs::GetSoundLength(lua_State* luaVM)
                 lua_pushnumber(luaVM, dLength);
                 return 1;
             }
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaAudioDefs::GetSoundBufferLength(lua_State* luaVM)
+{
+    CClientPlayer*   pPlayer = NULL;
+    CClientSound*    pSound = NULL;
+    CScriptArgReader argStream(luaVM);
+    if (argStream.NextIsUserDataOfType<CClientSound>())
+    {
+        argStream.ReadUserData(pSound);
+    }
+    else if (argStream.NextIsUserDataOfType<CClientPlayer>())
+    {
+        argStream.ReadUserData(pPlayer);
+    }
+    else
+    {
+        m_pScriptDebugging->LogBadPointer(luaVM, "sound/player", 1);
+        lua_pushboolean(luaVM, false);
+        return false;
+    }
+
+    if (!argStream.HasErrors())
+    {
+        if (pSound)
+        {
+            double dBufferLength = 0;
+            if (CStaticFunctionDefinitions::GetSoundBufferLength(*pSound, dBufferLength))
+            {
+                lua_pushnumber(luaVM, dBufferLength);
+                return 1;
+            }
+        }
+        else if (pPlayer)
+        {
+            //double dLength = 0;
+            //if (CStaticFunctionDefinitions::GetSoundBufferLength(*pPlayer, dLength))
+            //{
+            //    lua_pushnumber(luaVM, dLength);
+            //    return 1;
+            //}
         }
     }
     else

--- a/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
@@ -422,12 +422,17 @@ int CLuaAudioDefs::GetSoundBufferLength(lua_State* luaVM)
                 lua_pushnumber(luaVM, dBufferLength);
                 return 1;
             }
+            else
+            {
+                lua_pushboolean(luaVM, false);
+                return 1;
+            }
         }
     }
     else
         m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
 
-    lua_pushboolean(luaVM, false);
+    lua_pushnil(luaVM);
     return 1;
 }
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.h
@@ -37,6 +37,7 @@ public:
     LUA_DECLARE(SetSoundPosition);
     LUA_DECLARE(GetSoundPosition);
     LUA_DECLARE(GetSoundLength);
+    LUA_DECLARE(GetSoundBufferLength);
     LUA_DECLARE(SetSoundPaused);
     LUA_DECLARE(IsSoundPaused);
     LUA_DECLARE(SetSoundVolume);


### PR DESCRIPTION
Added new function **getSoundBufferLength(sound)** that returns the buffer length (playback length of the downloaded part) of the streamed sound file.

Test resource:
[sounds.zip](https://github.com/multitheftauto/mtasa-blue/files/2527220/sounds.zip)
