### PR TITLE
Fix premake executable path on windows

### DIFF
--- a/win-create-projects.bat
+++ b/win-create-projects.bat
@@ -1,10 +1,10 @@
 @echo off
 
 rem Update CEF eventually
-utils\premake5 install_cef
+utils\premake5.exe install_cef
 
 rem Generate solutions
-utils\premake5 vs2017
+utils\premake5.exe vs2017
 
 rem Create a shortcut to the solution - http://superuser.com/questions/392061/how-to-make-a-shortcut-from-cmd
 set SCRIPTFILE="%TEMP%\CreateMyShortcut.vbs"


### PR DESCRIPTION
Call .exe explicitly to prevent the following error on some systems:

```
'utils\premake5' is not recognized as an internal or external command,
operable program or batch file.
'utils\premake5' is not recognized as an internal or external command,
operable program or batch file.
Press any key to continue . . .
```
