### PR TITLE
Fix reset font in gridlist

### DIFF
--- a/Client/gui/CGUIGridList_Impl.cpp
+++ b/Client/gui/CGUIGridList_Impl.cpp
@@ -12,10 +12,10 @@
 #include "StdInc.h"
 
 #define CGUIGRIDLIST_NAME "CGUI/MultiColumnList"
-#define CGUIGRIDLISTNOFRAME_NAME "CGUI/MultiColumnList"            // MultiColumnListNoFrame
+#define CGUIGRIDLISTNOFRAME_NAME "CGUI/MultiColumnList" //MultiColumnListNoFrame
 #define CGUIGRIDLIST_SPACER "   "
 
-#define CGUIGRIDLIST_MAX_TEXT_LENGTH 256
+#define CGUIGRIDLIST_MAX_TEXT_LENGTH    256
 
 CGUIGridList_Impl::CGUIGridList_Impl(CGUI_Impl* pGUI, CGUIElement* pParent, bool bFrame)
 {

--- a/Client/gui/CGUIGridList_Impl.cpp
+++ b/Client/gui/CGUIGridList_Impl.cpp
@@ -12,10 +12,10 @@
 #include "StdInc.h"
 
 #define CGUIGRIDLIST_NAME "CGUI/MultiColumnList"
-#define CGUIGRIDLISTNOFRAME_NAME "CGUI/MultiColumnList" //MultiColumnListNoFrame
+#define CGUIGRIDLISTNOFRAME_NAME "CGUI/MultiColumnList"            // MultiColumnListNoFrame
 #define CGUIGRIDLIST_SPACER "   "
 
-#define CGUIGRIDLIST_MAX_TEXT_LENGTH    256
+#define CGUIGRIDLIST_MAX_TEXT_LENGTH 256
 
 CGUIGridList_Impl::CGUIGridList_Impl(CGUI_Impl* pGUI, CGUIElement* pParent, bool bFrame)
 {
@@ -364,7 +364,7 @@ void CGUIGridList_Impl::SetItemData(int iRow, int hColumn, const char* pszData)
     }
 }
 
-int CGUIGridList_Impl::SetItemText(int iRow, int hColumn, const char* szText, bool bNumber, bool bSection, bool bFast, const char* szSortText)
+int CGUIGridList_Impl::SetItemText(int iRow, int hColumn, const char* szText, bool bNumber, bool bSection, bool bChangeFont, bool bFast, const char* szSortText)
 {
     try
     {
@@ -377,13 +377,18 @@ int CGUIGridList_Impl::SetItemText(int iRow, int hColumn, const char* szText, bo
             if (bSection)
             {
                 // Set section properties
-                pItem->SetFont("default-bold-small");
+                // check if user change font with guiSetFont
+                if (!bChangeFont)
+                    pItem->SetFont("default-bold-small");
                 pItem->SetDisabled(true);
                 pItem->SetText(szText, szSortText);
             }
             else
             {
-                pItem->SetFont("default-normal");
+                // check if user change font with guiSetFont
+                if (!bChangeFont)
+                    pItem->SetFont("default-normal");
+
                 pItem->SetDisabled(false);
 
                 if (GetColumnIndex(hColumn) == 0)
@@ -427,7 +432,9 @@ int CGUIGridList_Impl::SetItemText(int iRow, int hColumn, const char* szText, bo
             if (bSection)
             {
                 // Set section properties
-                pItem->SetFont("default-bold-small");
+                // check if user change font with guiSetFont
+                if (!bChangeFont)
+                    pItem->SetFont("default-bold-small");
                 pItem->SetDisabled(true);
             }
             else if (GetColumnIndex(hColumn) == 0)

--- a/Client/gui/CGUIGridList_Impl.h
+++ b/Client/gui/CGUIGridList_Impl.h
@@ -89,8 +89,6 @@ private:
 
     int m_iIndex;
 
-    SString& m_Font;
-
     unsigned int       GetUniqueHandle(void);
     CGUIListItem_Impl* GetListItem(CEGUI::ListboxItem* pItem);
     unsigned int       m_hUniqueHandle;

--- a/Client/gui/CGUIGridList_Impl.h
+++ b/Client/gui/CGUIGridList_Impl.h
@@ -40,7 +40,7 @@ public:
     void          Clear(void);
     CGUIListItem* GetItem(int iRow, int hColumn);
     const char*   GetItemText(int iRow, int hColumn);
-    int  SetItemText(int iRow, int hColumn, const char* szText, bool bNumber = false, bool bSection = false, bool bFast = false, const char* szSortText = NULL);
+    int  SetItemText(int iRow, int hColumn, const char* szText, bool bNumber = false, bool bSection = false, bool bChangeFont = false, bool bFast = false, const char* szSortText = NULL);
     void SetItemData(int iRow, int hColumn, void* pData, CGUICallback<void, void*> deleteDataCallback = NULL);
     void SetItemData(int iRow, int hColumn, const char* pszData);
     void* GetItemData(int iRow, int hColumn);
@@ -88,6 +88,8 @@ private:
     bool Event_OnSortColumn(const CEGUI::EventArgs& e);
 
     int m_iIndex;
+
+    SString& m_Font;
 
     unsigned int       GetUniqueHandle(void);
     CGUIListItem_Impl* GetListItem(CEGUI::ListboxItem* pItem);

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -515,9 +515,9 @@ public:
         static_cast<CGUIGridList*>(GUIElement.GetCGUIElement())->AutoSizeColumn(uiColumn);
     };
     static void        GUIGridListClear(CClientEntity& Element);
-    static inline void GUIGridListSetItemText(CClientGUIElement& GUIElement, int iRow, int iColumn, const char* szText, bool bSection, bool bNumber, bool bFast)
+    static inline void GUIGridListSetItemText(CClientGUIElement& GUIElement, int iRow, int iColumn, const char* szText, bool bSection, bool bNumber, bool bChangeFont, bool bFast)
     {
-        static_cast<CGUIGridList*>(GUIElement.GetCGUIElement())->SetItemText(iRow, iColumn, szText, bNumber, bSection, bFast);
+        static_cast<CGUIGridList*>(GUIElement.GetCGUIElement())->SetItemText(iRow, iColumn, szText, bNumber, bSection, bChangeFont, bFast);
     };
     static void        GUIGridListSetItemData(CClientGUIElement& GUIElement, int iRow, int iColumn, CLuaArgument* Variable);
     static void        GUIItemDataDestroyCallback(void* m_data);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -11,26 +11,28 @@
 
 #include "StdInc.h"
 
-static const SFixedArray<const char*, MAX_CHATBOX_LAYOUT_CVARS> g_chatboxLayoutCVars = {{"chat_font",
-                                                                                         "chat_lines",
-                                                                                         "chat_color",
-                                                                                         "chat_text_color",
-                                                                                         "chat_input_color",
-                                                                                         "chat_input_prefix_color",
-                                                                                         "chat_input_text_color",
-                                                                                         "chat_scale",
-                                                                                         "chat_position_offset_x",
-                                                                                         "chat_position_offset_y",
-                                                                                         "chat_position_horizontal",
-                                                                                         "chat_position_vertical",
-                                                                                         "chat_text_alignment",
-                                                                                         "chat_width",
-                                                                                         "chat_css_style_text",
-                                                                                         "chat_css_style_background",
-                                                                                         "chat_line_life",
-                                                                                         "chat_line_fade_out",
-                                                                                         "chat_use_cegui",
-                                                                                         "text_scale"}};
+static const SFixedArray<const char*, MAX_CHATBOX_LAYOUT_CVARS> g_chatboxLayoutCVars = {{
+    "chat_font",
+    "chat_lines",
+    "chat_color",
+    "chat_text_color",
+    "chat_input_color",
+    "chat_input_prefix_color",
+    "chat_input_text_color",
+    "chat_scale",
+    "chat_position_offset_x",
+    "chat_position_offset_y",
+    "chat_position_horizontal",
+    "chat_position_vertical",
+    "chat_text_alignment",
+    "chat_width",
+    "chat_css_style_text",
+    "chat_css_style_background",
+    "chat_line_life",
+    "chat_line_fade_out",
+    "chat_use_cegui",
+    "text_scale"
+}};
 
 void CLuaGUIDefs::LoadFunctions(void)
 {
@@ -3093,12 +3095,12 @@ int CLuaGUIDefs::GUIEditSetMasked(lua_State* luaVM)
 
 int CLuaGUIDefs::GUIEditIsMasked(lua_State* luaVM)
 {
-    // bool guiEditIsMasked(element theElement)
+    //bool guiEditIsMasked(element theElement)
     CClientGUIElement* theElement;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData<CGUIEdit>(theElement);
-
+    
     if (!argStream.HasErrors())
     {
         bool masked = static_cast<CGUIEdit*>(theElement->GetCGUIElement())->IsMasked();
@@ -3380,7 +3382,7 @@ int CLuaGUIDefs::GUIWindowIsSizable(lua_State* luaVM)
     }
     else
         m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
+    
     // error: bad arguments
     lua_pushnil(luaVM);
     return 1;
@@ -3582,8 +3584,11 @@ int CLuaGUIDefs::GUIGetChatboxLayout(lua_State* luaVM)
             if (bAll || !stricmp(g_chatboxLayoutCVars[i], strCVarArg))
             {
                 // Push color values into a table
-                if (g_chatboxLayoutCVars[i] == "chat_color" || g_chatboxLayoutCVars[i] == "chat_text_color" || g_chatboxLayoutCVars[i] == "chat_input_color" ||
-                    g_chatboxLayoutCVars[i] == "chat_input_prefix_color" || g_chatboxLayoutCVars[i] == "chat_input_text_color")
+                if (g_chatboxLayoutCVars[i] == "chat_color" ||
+                    g_chatboxLayoutCVars[i] == "chat_text_color" ||
+                    g_chatboxLayoutCVars[i] == "chat_input_color" ||
+                    g_chatboxLayoutCVars[i] == "chat_input_prefix_color" ||
+                    g_chatboxLayoutCVars[i] == "chat_input_text_color")
                 {
                     pCVars->Get(g_chatboxLayoutCVars[i], strCVarValue);
                     if (!strCVarValue.empty())
@@ -3633,7 +3638,7 @@ int CLuaGUIDefs::GUIGetChatboxLayout(lua_State* luaVM)
                     else
                         lua_pushnumber(luaVM, fNumber);
                 }
-
+                
                 // If we are asking for all CVars, push this into the table with its CVar name, otherwise just stop here
                 if (bAll)
                     lua_setfield(luaVM, -2, g_chatboxLayoutCVars[i]);
@@ -3853,7 +3858,7 @@ int CLuaGUIDefs::GUIComboBoxGetItemCount(lua_State* luaVM)
 {
     // int guiComboBoxGetItemCount( element comboBox )
     CClientGUIElement* comboBox;
-    CScriptArgReader   argStream(luaVM);
+    CScriptArgReader argStream(luaVM);
     argStream.ReadUserData<CGUIComboBox>(comboBox);
 
     if (!argStream.HasErrors())
@@ -3874,8 +3879,8 @@ int CLuaGUIDefs::GUIComboBoxSetOpen(lua_State* luaVM)
 {
     // bool guiComboBoxSetOpen( element comboBox, bool state)
     CClientGUIElement* comboBox;
-    bool               state;
-    CScriptArgReader   argStream(luaVM);
+    bool state;
+    CScriptArgReader argStream(luaVM);
     argStream.ReadUserData<CGUIComboBox>(comboBox);
     argStream.ReadBool(state);
 
@@ -3896,7 +3901,7 @@ int CLuaGUIDefs::GUIComboBoxIsOpen(lua_State* luaVM)
 {
     // bool guiComboBoxIsOpen( element comboBox )
     CClientGUIElement* comboBox;
-    CScriptArgReader   argStream(luaVM);
+    CScriptArgReader argStream(luaVM);
     argStream.ReadUserData<CGUIComboBox>(comboBox);
 
     if (!argStream.HasErrors())

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -11,28 +11,26 @@
 
 #include "StdInc.h"
 
-static const SFixedArray<const char*, MAX_CHATBOX_LAYOUT_CVARS> g_chatboxLayoutCVars = {{
-    "chat_font",
-    "chat_lines",
-    "chat_color",
-    "chat_text_color",
-    "chat_input_color",
-    "chat_input_prefix_color",
-    "chat_input_text_color",
-    "chat_scale",
-    "chat_position_offset_x",
-    "chat_position_offset_y",
-    "chat_position_horizontal",
-    "chat_position_vertical",
-    "chat_text_alignment",
-    "chat_width",
-    "chat_css_style_text",
-    "chat_css_style_background",
-    "chat_line_life",
-    "chat_line_fade_out",
-    "chat_use_cegui",
-    "text_scale"
-}};
+static const SFixedArray<const char*, MAX_CHATBOX_LAYOUT_CVARS> g_chatboxLayoutCVars = {{"chat_font",
+                                                                                         "chat_lines",
+                                                                                         "chat_color",
+                                                                                         "chat_text_color",
+                                                                                         "chat_input_color",
+                                                                                         "chat_input_prefix_color",
+                                                                                         "chat_input_text_color",
+                                                                                         "chat_scale",
+                                                                                         "chat_position_offset_x",
+                                                                                         "chat_position_offset_y",
+                                                                                         "chat_position_horizontal",
+                                                                                         "chat_position_vertical",
+                                                                                         "chat_text_alignment",
+                                                                                         "chat_width",
+                                                                                         "chat_css_style_text",
+                                                                                         "chat_css_style_background",
+                                                                                         "chat_line_life",
+                                                                                         "chat_line_fade_out",
+                                                                                         "chat_use_cegui",
+                                                                                         "text_scale"}};
 
 void CLuaGUIDefs::LoadFunctions(void)
 {
@@ -2739,13 +2737,14 @@ int CLuaGUIDefs::GUIGridListGetVerticalScrollPosition(lua_State* luaVM)
 
 int CLuaGUIDefs::GUIGridListSetItemText(lua_State* luaVM)
 {
-    //  bool guiGridListSetItemText ( element gridList, int rowIndex, int columnIndex, string text, bool section, bool number )
+    //  bool guiGridListSetItemText ( element gridList, int rowIndex, int columnIndex, string text, bool section, bool number, bool changeFont )
     CClientGUIElement* guiGridlist;
     int                rowIndex;
     int                columnIndex;
     SString            text;
     bool               section;
     bool               number;
+    bool               changeFont;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData<CGUIGridList>(guiGridlist);
@@ -2754,10 +2753,11 @@ int CLuaGUIDefs::GUIGridListSetItemText(lua_State* luaVM)
     argStream.ReadString(text);
     argStream.ReadBool(section);
     argStream.ReadBool(number);
+    argStream.ReadBool(changeFont);
 
     if (!argStream.HasErrors())
     {
-        CStaticFunctionDefinitions::GUIGridListSetItemText(*guiGridlist, rowIndex, columnIndex, text, section, number, true);
+        CStaticFunctionDefinitions::GUIGridListSetItemText(*guiGridlist, rowIndex, columnIndex, text, section, number, changeFont, true);
         m_pGUIManager->QueueGridListUpdate(guiGridlist);
         lua_pushboolean(luaVM, true);
         return 1;
@@ -3093,12 +3093,12 @@ int CLuaGUIDefs::GUIEditSetMasked(lua_State* luaVM)
 
 int CLuaGUIDefs::GUIEditIsMasked(lua_State* luaVM)
 {
-    //bool guiEditIsMasked(element theElement)
+    // bool guiEditIsMasked(element theElement)
     CClientGUIElement* theElement;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData<CGUIEdit>(theElement);
-    
+
     if (!argStream.HasErrors())
     {
         bool masked = static_cast<CGUIEdit*>(theElement->GetCGUIElement())->IsMasked();
@@ -3380,7 +3380,7 @@ int CLuaGUIDefs::GUIWindowIsSizable(lua_State* luaVM)
     }
     else
         m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-    
+
     // error: bad arguments
     lua_pushnil(luaVM);
     return 1;
@@ -3582,11 +3582,8 @@ int CLuaGUIDefs::GUIGetChatboxLayout(lua_State* luaVM)
             if (bAll || !stricmp(g_chatboxLayoutCVars[i], strCVarArg))
             {
                 // Push color values into a table
-                if (g_chatboxLayoutCVars[i] == "chat_color" ||
-                    g_chatboxLayoutCVars[i] == "chat_text_color" ||
-                    g_chatboxLayoutCVars[i] == "chat_input_color" ||
-                    g_chatboxLayoutCVars[i] == "chat_input_prefix_color" ||
-                    g_chatboxLayoutCVars[i] == "chat_input_text_color")
+                if (g_chatboxLayoutCVars[i] == "chat_color" || g_chatboxLayoutCVars[i] == "chat_text_color" || g_chatboxLayoutCVars[i] == "chat_input_color" ||
+                    g_chatboxLayoutCVars[i] == "chat_input_prefix_color" || g_chatboxLayoutCVars[i] == "chat_input_text_color")
                 {
                     pCVars->Get(g_chatboxLayoutCVars[i], strCVarValue);
                     if (!strCVarValue.empty())
@@ -3636,7 +3633,7 @@ int CLuaGUIDefs::GUIGetChatboxLayout(lua_State* luaVM)
                     else
                         lua_pushnumber(luaVM, fNumber);
                 }
-                
+
                 // If we are asking for all CVars, push this into the table with its CVar name, otherwise just stop here
                 if (bAll)
                     lua_setfield(luaVM, -2, g_chatboxLayoutCVars[i]);
@@ -3856,7 +3853,7 @@ int CLuaGUIDefs::GUIComboBoxGetItemCount(lua_State* luaVM)
 {
     // int guiComboBoxGetItemCount( element comboBox )
     CClientGUIElement* comboBox;
-    CScriptArgReader argStream(luaVM);
+    CScriptArgReader   argStream(luaVM);
     argStream.ReadUserData<CGUIComboBox>(comboBox);
 
     if (!argStream.HasErrors())
@@ -3877,8 +3874,8 @@ int CLuaGUIDefs::GUIComboBoxSetOpen(lua_State* luaVM)
 {
     // bool guiComboBoxSetOpen( element comboBox, bool state)
     CClientGUIElement* comboBox;
-    bool state;
-    CScriptArgReader argStream(luaVM);
+    bool               state;
+    CScriptArgReader   argStream(luaVM);
     argStream.ReadUserData<CGUIComboBox>(comboBox);
     argStream.ReadBool(state);
 
@@ -3899,7 +3896,7 @@ int CLuaGUIDefs::GUIComboBoxIsOpen(lua_State* luaVM)
 {
     // bool guiComboBoxIsOpen( element comboBox )
     CClientGUIElement* comboBox;
-    CScriptArgReader argStream(luaVM);
+    CScriptArgReader   argStream(luaVM);
     argStream.ReadUserData<CGUIComboBox>(comboBox);
 
     if (!argStream.HasErrors())

--- a/Client/sdk/gui/CGUIGridList.h
+++ b/Client/sdk/gui/CGUIGridList.h
@@ -69,7 +69,7 @@ public:
     virtual void          Clear(void) = 0;
     virtual CGUIListItem* GetItem(int iRow, int hColumn) = 0;
     virtual const char*   GetItemText(int iRow, int hColumn) = 0;
-    virtual int           SetItemText(int iRow, int hColumn, const char* szText, bool bNumber = false, bool bSection = false, bool bChangeFont, bool bFast = false,
+    virtual int           SetItemText(int iRow, int hColumn, const char* szText, bool bNumber = false, bool bSection = false, bool bChangeFont = false, bool bFast = false,
                                       const char* szSortText = NULL) = 0;
     virtual void          SetItemData(int iRow, int hColumn, void* pData, CGUICallback<void, void*> deleteDataCallback = NULL) = 0;
     virtual void          SetItemData(int iRow, int hColumn, const char* pszData) = 0;

--- a/Client/sdk/gui/CGUIGridList.h
+++ b/Client/sdk/gui/CGUIGridList.h
@@ -69,7 +69,7 @@ public:
     virtual void          Clear(void) = 0;
     virtual CGUIListItem* GetItem(int iRow, int hColumn) = 0;
     virtual const char*   GetItemText(int iRow, int hColumn) = 0;
-    virtual int           SetItemText(int iRow, int hColumn, const char* szText, bool bNumber = false, bool bSection = false, bool bFast = false,
+    virtual int           SetItemText(int iRow, int hColumn, const char* szText, bool bNumber = false, bool bSection = false, bool bChangeFont, bool bFast = false,
                                       const char* szSortText = NULL) = 0;
     virtual void          SetItemData(int iRow, int hColumn, void* pData, CGUICallback<void, void*> deleteDataCallback = NULL) = 0;
     virtual void          SetItemData(int iRow, int hColumn, const char* pszData) = 0;


### PR DESCRIPTION
Fixes #622 

**New syntax**
```lua
guiGridListSetItemText( element gridList, int rowIndex, int columnIndex, string text, bool section, bool number, bool changeFont)
```

***changeFont*** - If you changed gridlist font with guiSetFont, set this parameter to true, if no, set to false.