### PR TITLE
Add xmlLoadString function

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -369,29 +369,36 @@ CXMLNode* CLuaMain::ParseString(const char* strXmlContent)
     return xmlNode;
 }
 
-void CLuaMain::DestroyXML(CXMLFile* pFile)
+bool CLuaMain::DestroyXML(CXMLFile* pFile)
 {
-    if (!m_XMLFiles.empty())
-        m_XMLFiles.remove(pFile);
-    delete pFile;
+	if (!m_XMLFiles.empty()) {
+		m_XMLFiles.remove(pFile);
+		delete pFile;
+		return true;
+	}
+    return false;
 }
 
-void CLuaMain::DestroyXML(CXMLNode* pRootNode)
+bool CLuaMain::DestroyXML(CXMLNode* pRootNode)
 {
-    list<CXMLFile*>::iterator iter;
-    for (iter = m_XMLFiles.begin(); iter != m_XMLFiles.end(); iter++)
-    {
-        CXMLFile* file = (*iter);
-        if (file)
-        {
-            if (file->GetRootNode() == pRootNode)
-            {
-                delete file;
-                m_XMLFiles.erase(iter);
-                break;
-            }
-        }
-    }
+	if (!m_XMLFiles.empty()) {
+		list<CXMLFile*>::iterator iter;
+		for (iter = m_XMLFiles.begin(); iter != m_XMLFiles.end(); iter++)
+		{
+			CXMLFile* file = (*iter);
+			if (file)
+			{
+				if (file->GetRootNode() == pRootNode)
+				{
+					delete file;
+					m_XMLFiles.erase(iter);
+					break;
+				}
+			}
+		}
+		return true;
+	} 
+    return false;
 }
 
 bool CLuaMain::SaveXML(CXMLNode* pRootNode)

--- a/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -403,10 +403,8 @@ bool CLuaMain::DestroyXML(CXMLNode* pRootNode)
 
 bool CLuaMain::SaveXML(CXMLNode* pRootNode)
 {
-    list<CXMLFile*>::iterator iter;
-    for (iter = m_XMLFiles.begin(); iter != m_XMLFiles.end(); iter++)
+    for (CXMLFile* file : m_XMLFiles)
     {
-        CXMLFile* file = (*iter);
         if (file)
         {
             if (file->GetRootNode() == pRootNode)

--- a/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -362,6 +362,13 @@ CXMLFile* CLuaMain::CreateXML(const char* szFilename, bool bUseIDs, bool bReadOn
     return pFile;
 }
 
+CXMLNode* CLuaMain::ParseString(const char* strXmlContent)
+{
+    CXMLNode* xmlNode = g_pCore->GetXML()->ParseString(strXmlContent);
+
+    return xmlNode;
+}
+
 void CLuaMain::DestroyXML(CXMLFile* pFile)
 {
     if (!m_XMLFiles.empty())

--- a/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -1,10 +1,11 @@
 /*****************************************************************************
  *
- *  PROJECT:     Multi Theft Auto v1.0
- *               (Shared logic for modifications)
+ *  PROJECT:     Multi Theft Auto
  *  LICENSE:     See LICENSE in the top level directory
- *  FILE:        mods/shared_logic/lua/CLuaMain.cpp
+ *  FILE:        mods/deathmatch/logic/lua/CLuaMain.cpp
  *  PURPOSE:     Lua main
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
  *
  *****************************************************************************/
 
@@ -365,15 +366,13 @@ CXMLFile* CLuaMain::CreateXML(const char* szFilename, bool bUseIDs, bool bReadOn
 CXMLNode* CLuaMain::ParseString(const char* strXmlContent)
 {
     CXMLNode* xmlNode = g_pCore->GetXML()->ParseString(strXmlContent);
-
     return xmlNode;
 }
 
 bool CLuaMain::DestroyXML(CXMLFile* pFile)
 {
-    if (m_XMLFiles.empty()) {
+    if (m_XMLFiles.empty())
         return false;
-    }
     m_XMLFiles.remove(pFile);
     delete pFile;
     return true;
@@ -381,19 +380,16 @@ bool CLuaMain::DestroyXML(CXMLFile* pFile)
 
 bool CLuaMain::DestroyXML(CXMLNode* pRootNode)
 {
-    if (m_XMLFiles.empty()) {
+    if (m_XMLFiles.empty())
         return false;
-    }
-    list<CXMLFile*>::iterator iter;
-    for (iter = m_XMLFiles.begin(); iter != m_XMLFiles.end(); iter++)
+    for (CXMLFile* pFile : m_XMLFiles)
     {
-        CXMLFile* file = (*iter);
-        if (file)
+        if (pFile)
         {
-            if (file->GetRootNode() == pRootNode)
+            if (pFile->GetRootNode() == pRootNode)
             {
-                delete file;
-                m_XMLFiles.erase(iter);
+                m_XMLFiles.remove(pFile);
+                delete pFile;
                 break;
             }
         }
@@ -403,16 +399,10 @@ bool CLuaMain::DestroyXML(CXMLNode* pRootNode)
 
 bool CLuaMain::SaveXML(CXMLNode* pRootNode)
 {
-    for (CXMLFile* file : m_XMLFiles)
-    {
-        if (file)
-        {
-            if (file->GetRootNode() == pRootNode)
-            {
-                return file->Write();
-            }
-        }
-    }
+    for (CXMLFile* pFile : m_XMLFiles)
+        if (pFile)
+            if (pFile->GetRootNode() == pRootNode)
+                return pFile->Write();
     if (m_pResource)
     {
         list<CResourceConfigItem*>::iterator iter = m_pResource->ConfigIterBegin();
@@ -423,9 +413,7 @@ bool CLuaMain::SaveXML(CXMLNode* pRootNode)
             {
                 CXMLFile* pFile = pConfigItem->GetFile();
                 if (pFile)
-                {
                     return pFile->Write();
-                }
                 return false;
             }
         }

--- a/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -371,34 +371,34 @@ CXMLNode* CLuaMain::ParseString(const char* strXmlContent)
 
 bool CLuaMain::DestroyXML(CXMLFile* pFile)
 {
-	if (m_XMLFiles.empty()) {
-		return false;
-	}
-	m_XMLFiles.remove(pFile);
-	delete pFile;
-	return true;
+    if (m_XMLFiles.empty()) {
+        return false;
+    }
+    m_XMLFiles.remove(pFile);
+    delete pFile;
+    return true;
 }
 
 bool CLuaMain::DestroyXML(CXMLNode* pRootNode)
 {
-	if (m_XMLFiles.empty()) {
-		return false;
-	}
-	list<CXMLFile*>::iterator iter;
-	for (iter = m_XMLFiles.begin(); iter != m_XMLFiles.end(); iter++)
-	{
-		CXMLFile* file = (*iter);
-		if (file)
-		{
-			if (file->GetRootNode() == pRootNode)
-			{
-				delete file;
-				m_XMLFiles.erase(iter);
-				break;
-			}
-		}
-	}
-	return true;
+    if (m_XMLFiles.empty()) {
+        return false;
+    }
+    list<CXMLFile*>::iterator iter;
+    for (iter = m_XMLFiles.begin(); iter != m_XMLFiles.end(); iter++)
+    {
+        CXMLFile* file = (*iter);
+        if (file)
+        {
+            if (file->GetRootNode() == pRootNode)
+            {
+                delete file;
+                m_XMLFiles.erase(iter);
+                break;
+            }
+        }
+    }
+    return true;
 }
 
 bool CLuaMain::SaveXML(CXMLNode* pRootNode)

--- a/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -371,34 +371,34 @@ CXMLNode* CLuaMain::ParseString(const char* strXmlContent)
 
 bool CLuaMain::DestroyXML(CXMLFile* pFile)
 {
-	if (!m_XMLFiles.empty()) {
-		m_XMLFiles.remove(pFile);
-		delete pFile;
-		return true;
+	if (m_XMLFiles.empty()) {
+		return false;
 	}
-    return false;
+	m_XMLFiles.remove(pFile);
+	delete pFile;
+	return true;
 }
 
 bool CLuaMain::DestroyXML(CXMLNode* pRootNode)
 {
-	if (!m_XMLFiles.empty()) {
-		list<CXMLFile*>::iterator iter;
-		for (iter = m_XMLFiles.begin(); iter != m_XMLFiles.end(); iter++)
+	if (m_XMLFiles.empty()) {
+		return false;
+	}
+	list<CXMLFile*>::iterator iter;
+	for (iter = m_XMLFiles.begin(); iter != m_XMLFiles.end(); iter++)
+	{
+		CXMLFile* file = (*iter);
+		if (file)
 		{
-			CXMLFile* file = (*iter);
-			if (file)
+			if (file->GetRootNode() == pRootNode)
 			{
-				if (file->GetRootNode() == pRootNode)
-				{
-					delete file;
-					m_XMLFiles.erase(iter);
-					break;
-				}
+				delete file;
+				m_XMLFiles.erase(iter);
+				break;
 			}
 		}
-		return true;
-	} 
-    return false;
+	}
+	return true;
 }
 
 bool CLuaMain::SaveXML(CXMLNode* pRootNode)

--- a/Client/mods/deathmatch/logic/lua/CLuaMain.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaMain.h
@@ -62,6 +62,7 @@ public:
     class CResource* GetResource() { return m_pResource; }
 
     CXMLFile*     CreateXML(const char* szFilename, bool bUseIDs = true, bool bReadOnly = false);
+    CXMLNode*     ParseString(const char* strXmlContent);
     void          DestroyXML(CXMLFile* pFile);
     void          DestroyXML(CXMLNode* pRootNode);
     bool          SaveXML(CXMLNode* pRootNode);

--- a/Client/mods/deathmatch/logic/lua/CLuaMain.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaMain.h
@@ -63,8 +63,8 @@ public:
 
     CXMLFile*     CreateXML(const char* szFilename, bool bUseIDs = true, bool bReadOnly = false);
     CXMLNode*     ParseString(const char* strXmlContent);
-    void          DestroyXML(CXMLFile* pFile);
-    void          DestroyXML(CXMLNode* pRootNode);
+    bool          DestroyXML(CXMLFile* pFile);
+    bool          DestroyXML(CXMLNode* pRootNode);
     bool          SaveXML(CXMLNode* pRootNode);
     unsigned long GetXMLFileCount() const { return m_XMLFiles.size(); };
     unsigned long GetTimerCount() const { return m_pLuaTimerManager ? m_pLuaTimerManager->GetTimerCount() : 0; };

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -418,42 +418,42 @@ CXMLFile* CLuaMain::CreateXML(const char* szFilename, bool bUseIDs, bool bReadOn
 
 CXMLNode* CLuaMain::ParseString(const char* strXmlContent)
 {
-	CXMLNode* xmlNode = g_pServerInterface->GetXML()->ParseString(strXmlContent);
+    CXMLNode* xmlNode = g_pServerInterface->GetXML()->ParseString(strXmlContent);
 
-	return xmlNode;
+    return xmlNode;
 }
 
 
 bool CLuaMain::DestroyXML(CXMLFile* pFile)
 {
-	if (m_XMLFiles.empty()) {
-		return false;
-	}
-	m_XMLFiles.remove(pFile);
-	delete pFile;
-	return true;
+    if (m_XMLFiles.empty()) {
+        return false;
+    }
+    m_XMLFiles.remove(pFile);
+    delete pFile;
+    return true;
 }
 
 bool CLuaMain::DestroyXML(CXMLNode* pRootNode)
 {
-	if (m_XMLFiles.empty()) {
-		return false;
-	}
-	list<CXMLFile*>::iterator iter;
-	for (iter = m_XMLFiles.begin(); iter != m_XMLFiles.end(); ++iter)
-	{
-		CXMLFile* file = (*iter);
-		if (file)
-		{
-			if (file->GetRootNode() == pRootNode)
-			{
-				m_XMLFiles.erase(iter);
-				delete file;
-				break;
-			}
-		}
-	}
-	return true;
+    if (m_XMLFiles.empty()) {
+        return false;
+    }
+    list<CXMLFile*>::iterator iter;
+    for (iter = m_XMLFiles.begin(); iter != m_XMLFiles.end(); ++iter)
+    {
+        CXMLFile* file = (*iter);
+        if (file)
+        {
+            if (file->GetRootNode() == pRootNode)
+            {
+                m_XMLFiles.erase(iter);
+                delete file;
+                break;
+            }
+        }
+    }
+    return true;
 }
 
 bool CLuaMain::SaveXML(CXMLNode* pRootNode)

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
  *
- *  PROJECT:     Multi Theft Auto v1.0
+ *  PROJECT:     Multi Theft Auto
  *  LICENSE:     See LICENSE in the top level directory
  *  FILE:        mods/deathmatch/logic/lua/CLuaMain.cpp
  *  PURPOSE:     Lua virtual machine container class
@@ -419,16 +419,13 @@ CXMLFile* CLuaMain::CreateXML(const char* szFilename, bool bUseIDs, bool bReadOn
 CXMLNode* CLuaMain::ParseString(const char* strXmlContent)
 {
     CXMLNode* xmlNode = g_pServerInterface->GetXML()->ParseString(strXmlContent);
-
     return xmlNode;
 }
 
-
 bool CLuaMain::DestroyXML(CXMLFile* pFile)
 {
-    if (m_XMLFiles.empty()) {
+    if (m_XMLFiles.empty())
         return false;
-    }
     m_XMLFiles.remove(pFile);
     delete pFile;
     return true;
@@ -436,19 +433,16 @@ bool CLuaMain::DestroyXML(CXMLFile* pFile)
 
 bool CLuaMain::DestroyXML(CXMLNode* pRootNode)
 {
-    if (m_XMLFiles.empty()) {
+    if (m_XMLFiles.empty())
         return false;
-    }
-    list<CXMLFile*>::iterator iter;
-    for (iter = m_XMLFiles.begin(); iter != m_XMLFiles.end(); ++iter)
+    for (CXMLFile* pFile : m_XMLFiles)
     {
-        CXMLFile* file = (*iter);
-        if (file)
+        if (pFile)
         {
-            if (file->GetRootNode() == pRootNode)
+            if (pFile->GetRootNode() == pRootNode)
             {
-                m_XMLFiles.erase(iter);
-                delete file;
+                m_XMLFiles.remove(pFile);
+                delete pFile;
                 break;
             }
         }
@@ -458,16 +452,10 @@ bool CLuaMain::DestroyXML(CXMLNode* pRootNode)
 
 bool CLuaMain::SaveXML(CXMLNode* pRootNode)
 {
-    for (CXMLFile* file : m_XMLFiles)
-    {
-        if (file)
-        {
-            if (file->GetRootNode() == pRootNode)
-            {
-                return file->Write();
-            }
-        }
-    }
+    for (CXMLFile* pFile : m_XMLFiles)
+        if (pFile)
+            if (pFile->GetRootNode() == pRootNode)
+                return pFile->Write();
     if (m_pResource)
     {
         list<CResourceFile*>::iterator iter = m_pResource->IterBegin();
@@ -481,9 +469,7 @@ bool CLuaMain::SaveXML(CXMLNode* pRootNode)
                 {
                     CXMLFile* pFile = pConfigItem->GetFile();
                     if (pFile)
-                    {
                         return pFile->Write();
-                    }
                     return false;
                 }
             }

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -418,7 +418,9 @@ CXMLFile* CLuaMain::CreateXML(const char* szFilename, bool bUseIDs, bool bReadOn
 
 CXMLNode* CLuaMain::ParseString(const char* strXmlContent)
 {
-    return g_pServerInterface->GetXML()->CreateDummyNode();
+	CXMLNode* xmlNode = g_pServerInterface->GetXML()->ParseString(strXmlContent);
+
+	return xmlNode;
 }
 
 

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -426,34 +426,34 @@ CXMLNode* CLuaMain::ParseString(const char* strXmlContent)
 
 bool CLuaMain::DestroyXML(CXMLFile* pFile)
 {
-	if (!m_XMLFiles.empty()) {
-		m_XMLFiles.remove(pFile);
-		delete pFile;
-		return true;
+	if (m_XMLFiles.empty()) {
+		return false;
 	}
-	return false;
+	m_XMLFiles.remove(pFile);
+	delete pFile;
+	return true;
 }
 
 bool CLuaMain::DestroyXML(CXMLNode* pRootNode)
 {
-	if (!m_XMLFiles.empty()) {
-		list<CXMLFile*>::iterator iter;
-		for (iter = m_XMLFiles.begin(); iter != m_XMLFiles.end(); ++iter)
+	if (m_XMLFiles.empty()) {
+		return false;
+	}
+	list<CXMLFile*>::iterator iter;
+	for (iter = m_XMLFiles.begin(); iter != m_XMLFiles.end(); ++iter)
+	{
+		CXMLFile* file = (*iter);
+		if (file)
 		{
-			CXMLFile* file = (*iter);
-			if (file)
+			if (file->GetRootNode() == pRootNode)
 			{
-				if (file->GetRootNode() == pRootNode)
-				{
-					m_XMLFiles.erase(iter);
-					delete file;
-					break;
-				}
+				m_XMLFiles.erase(iter);
+				delete file;
+				break;
 			}
 		}
-		return true;
 	}
-	return false;
+	return true;
 }
 
 bool CLuaMain::SaveXML(CXMLNode* pRootNode)

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -458,10 +458,8 @@ bool CLuaMain::DestroyXML(CXMLNode* pRootNode)
 
 bool CLuaMain::SaveXML(CXMLNode* pRootNode)
 {
-    list<CXMLFile*>::iterator iter;
-    for (iter = m_XMLFiles.begin(); iter != m_XMLFiles.end(); ++iter)
+    for (CXMLFile* file : m_XMLFiles)
     {
-        CXMLFile* file = (*iter);
         if (file)
         {
             if (file->GetRootNode() == pRootNode)

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -416,6 +416,12 @@ CXMLFile* CLuaMain::CreateXML(const char* szFilename, bool bUseIDs, bool bReadOn
     return pFile;
 }
 
+CXMLNode* CLuaMain::ParseString(const char* strXmlContent)
+{
+    return g_pServerInterface->GetXML()->CreateDummyNode();
+}
+
+
 void CLuaMain::DestroyXML(CXMLFile* pFile)
 {
     m_XMLFiles.remove(pFile);

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -424,28 +424,36 @@ CXMLNode* CLuaMain::ParseString(const char* strXmlContent)
 }
 
 
-void CLuaMain::DestroyXML(CXMLFile* pFile)
+bool CLuaMain::DestroyXML(CXMLFile* pFile)
 {
-    m_XMLFiles.remove(pFile);
-    delete pFile;
+	if (!m_XMLFiles.empty()) {
+		m_XMLFiles.remove(pFile);
+		delete pFile;
+		return true;
+	}
+	return false;
 }
 
-void CLuaMain::DestroyXML(CXMLNode* pRootNode)
+bool CLuaMain::DestroyXML(CXMLNode* pRootNode)
 {
-    list<CXMLFile*>::iterator iter;
-    for (iter = m_XMLFiles.begin(); iter != m_XMLFiles.end(); ++iter)
-    {
-        CXMLFile* file = (*iter);
-        if (file)
-        {
-            if (file->GetRootNode() == pRootNode)
-            {
-                m_XMLFiles.erase(iter);
-                delete file;
-                break;
-            }
-        }
-    }
+	if (!m_XMLFiles.empty()) {
+		list<CXMLFile*>::iterator iter;
+		for (iter = m_XMLFiles.begin(); iter != m_XMLFiles.end(); ++iter)
+		{
+			CXMLFile* file = (*iter);
+			if (file)
+			{
+				if (file->GetRootNode() == pRootNode)
+				{
+					m_XMLFiles.erase(iter);
+					delete file;
+					break;
+				}
+			}
+		}
+		return true;
+	}
+	return false;
 }
 
 bool CLuaMain::SaveXML(CXMLNode* pRootNode)

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.h
@@ -67,6 +67,7 @@ public:
     CMapManager*     GetMapManager() const { return m_pMapManager; };
 
     CXMLFile*     CreateXML(const char* szFilename, bool bUseIDs = true, bool bReadOnly = false);
+	CXMLNode*     ParseString(const char* strXmlContent);
     void          DestroyXML(CXMLFile* pFile);
     void          DestroyXML(CXMLNode* pRootNode);
     bool          SaveXML(CXMLNode* pRootNode);

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.h
@@ -67,7 +67,7 @@ public:
     CMapManager*     GetMapManager() const { return m_pMapManager; };
 
     CXMLFile*     CreateXML(const char* szFilename, bool bUseIDs = true, bool bReadOnly = false);
-	CXMLNode*     ParseString(const char* strXmlContent);
+    CXMLNode*     ParseString(const char* strXmlContent);
     void          DestroyXML(CXMLFile* pFile);
     void          DestroyXML(CXMLNode* pRootNode);
     bool          SaveXML(CXMLNode* pRootNode);

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.h
@@ -68,8 +68,8 @@ public:
 
     CXMLFile*     CreateXML(const char* szFilename, bool bUseIDs = true, bool bReadOnly = false);
     CXMLNode*     ParseString(const char* strXmlContent);
-    void          DestroyXML(CXMLFile* pFile);
-    void          DestroyXML(CXMLNode* pRootNode);
+    bool          DestroyXML(CXMLFile* pFile);
+    bool          DestroyXML(CXMLNode* pRootNode);
     bool          SaveXML(CXMLNode* pRootNode);
     bool          XMLExists(CXMLFile* pFile);
     unsigned long GetXMLFileCount() const { return m_XMLFiles.size(); };

--- a/Shared/XML/CXMLImpl.cpp
+++ b/Shared/XML/CXMLImpl.cpp
@@ -46,33 +46,50 @@ void CXMLImpl::DeleteXML(CXMLFile* pFile)
 
 CXMLNode* CXMLImpl::ParseString(const char* strXmlContent)
 {
-    TiXmlElement    *xmlRoot;
-    TiXmlNode       *xmlChild;
-    CXMLNodeImpl    *xmlRootNode;
-    CXMLNode        *xmlChildNode;
-
+    TiXmlElement    *xmlDocumentRoot;
+    CXMLNodeImpl    *xmlBaseNode;
+    CXMLNode    *xmlRootNode;
+    
     TiXmlDocument*  xmlDoc = new TiXmlDocument();
 
     if (xmlDoc)
-    {
-        xmlDoc->Parse(strXmlContent, 0, TIXML_ENCODING_UTF8);
-
-        xmlRoot = xmlDoc->RootElement();
-
-        xmlRootNode = new CXMLNodeImpl(NULL, NULL, *xmlRoot);
-
-        xmlChild = 0;
-        while (xmlChild = xmlRoot->IterateChildren(xmlChild))
+    {   
+        if (xmlDoc->Parse(strXmlContent, 0, TIXML_ENCODING_UTF8))
         {
-            xmlChildNode = new CXMLNodeImpl(NULL, xmlRootNode, *xmlChild->ToElement());
-        }
+            xmlDocumentRoot = xmlDoc->RootElement();
 
-        return xmlRootNode;
+            xmlBaseNode = new CXMLNodeImpl(NULL, NULL, *xmlDocumentRoot);
+
+            xmlRootNode = CXMLImpl::BuildNode(xmlBaseNode, xmlDocumentRoot);
+
+            return xmlRootNode;
+        }
+        else
+            return NULL;
     }
     else
     {
         return NULL;
     }
+}
+
+CXMLNode* CXMLImpl::BuildNode(CXMLNodeImpl* xmlParent, TiXmlNode* xmlNode)
+{
+    TiXmlNode       *xmlChild;
+    TiXmlElement    *xmlChildElement;
+    CXMLNodeImpl    *xmlChildNode;
+
+    xmlChild = 0;
+    while (xmlChild = xmlNode->IterateChildren(xmlChild))
+    {
+        xmlChildElement = xmlChild->ToElement();
+
+        xmlChildNode = new CXMLNodeImpl(NULL, xmlParent, *xmlChildElement);
+
+        CXMLImpl::BuildNode(xmlChildNode, xmlChildElement);
+    }
+
+    return xmlParent;
 }
 
 CXMLNode* CXMLImpl::CreateDummyNode()

--- a/Shared/XML/CXMLImpl.cpp
+++ b/Shared/XML/CXMLImpl.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
  *
- *  PROJECT:     Multi Theft Auto v1.0
+ *  PROJECT:     Multi Theft Auto
  *  LICENSE:     See LICENSE in the top level directory
  *  FILE:        xml/CXMLImpl.cpp
  *  PURPOSE:     XML handler class
@@ -32,11 +32,8 @@ CXMLFile* CXMLImpl::CreateXML(const char* szFilename, bool bUseIDs, bool bReadOn
     CXMLFile* xmlFile = new CXMLFileImpl(szFilename, bUseIDs, bReadOnly);
     if (xmlFile->IsValid())
         return xmlFile;
-    else
-    {
-        delete xmlFile;
-        return NULL;
-    }
+    delete xmlFile;
+    return nullptr;
 }
 
 void CXMLImpl::DeleteXML(CXMLFile* pFile)
@@ -46,62 +43,41 @@ void CXMLImpl::DeleteXML(CXMLFile* pFile)
 
 CXMLNode* CXMLImpl::ParseString(const char* strXmlContent)
 {
-    TiXmlElement    *xmlDocumentRoot;
-    CXMLNodeImpl    *xmlBaseNode;
-    CXMLNode        *xmlRootNode;
-    
-    TiXmlDocument*  xmlDoc = new TiXmlDocument();
-
+    TiXmlDocument* xmlDoc = new TiXmlDocument();
     if (xmlDoc)
     {   
         if (xmlDoc->Parse(strXmlContent, 0, TIXML_ENCODING_UTF8))
         {
-            xmlDocumentRoot = xmlDoc->RootElement();
-
-            xmlBaseNode = new CXMLNodeImpl(NULL, NULL, *xmlDocumentRoot);
-
-            xmlRootNode = CXMLImpl::BuildNode(xmlBaseNode, xmlDocumentRoot);
-
+            TiXmlElement* xmlDocumentRoot = xmlDoc->RootElement();
+            CXMLNodeImpl* xmlBaseNode = new CXMLNodeImpl(nullptr, nullptr, *xmlDocumentRoot);
+            CXMLNode*     xmlRootNode = CXMLImpl::BuildNode(xmlBaseNode, xmlDocumentRoot);
             return xmlRootNode;
         }
-        else
-            return NULL;
     }
-    else
-    {
-        return NULL;
-    }
+    return nullptr;
 }
 
 CXMLNode* CXMLImpl::BuildNode(CXMLNodeImpl* xmlParent, TiXmlNode* xmlNode)
 {
-    TiXmlNode       *xmlChild;
-    TiXmlElement    *xmlChildElement;
-    CXMLNodeImpl    *xmlChildNode;
-
-    xmlChild = 0;
+    TiXmlNode*    xmlChild = nullptr;
+    TiXmlElement* xmlChildElement;
+    CXMLNodeImpl* xmlChildNode;
     while (xmlChild = xmlNode->IterateChildren(xmlChild))
     {
         xmlChildElement = xmlChild->ToElement();
-
-        xmlChildNode = new CXMLNodeImpl(NULL, xmlParent, *xmlChildElement);
-
+        xmlChildNode = new CXMLNodeImpl(nullptr, xmlParent, *xmlChildElement);
         CXMLImpl::BuildNode(xmlChildNode, xmlChildElement);
     }
-
     return xmlParent;
 }
 
 CXMLNode* CXMLImpl::CreateDummyNode()
 {
-    CXMLNode* xmlNode = new CXMLNodeImpl(NULL, NULL, *new TiXmlElement("dummy_storage"));
+    CXMLNode* xmlNode = new CXMLNodeImpl(nullptr, nullptr, *new TiXmlElement("dummy_storage"));
     if (xmlNode->IsValid())
         return xmlNode;
-    else
-    {
-        delete xmlNode;
-        return NULL;
-    }
+    delete xmlNode;
+    return nullptr;
 }
 
 CXMLAttribute* CXMLImpl::GetAttrFromID(unsigned long ulID)
@@ -109,12 +85,10 @@ CXMLAttribute* CXMLImpl::GetAttrFromID(unsigned long ulID)
     // Grab it and verify the type
     CXMLCommon* pCommon = CXMLArray::GetEntry(ulID);
     if (pCommon && pCommon->GetClassType() == CXML_ATTR)
-    {
         return reinterpret_cast<CXMLAttribute*>(pCommon);
-    }
 
     // Doesn't exist or bad type
-    return NULL;
+    return nullptr;
 }
 
 CXMLFile* CXMLImpl::GetFileFromID(unsigned long ulID)
@@ -122,12 +96,10 @@ CXMLFile* CXMLImpl::GetFileFromID(unsigned long ulID)
     // Grab it and verify the type
     CXMLCommon* pCommon = CXMLArray::GetEntry(ulID);
     if (pCommon && pCommon->GetClassType() == CXML_FILE)
-    {
         return reinterpret_cast<CXMLFile*>(pCommon);
-    }
 
     // Doesn't exist or bad type
-    return NULL;
+    return nullptr;
 }
 
 CXMLNode* CXMLImpl::GetNodeFromID(unsigned long ulID)
@@ -135,10 +107,8 @@ CXMLNode* CXMLImpl::GetNodeFromID(unsigned long ulID)
     // Grab it and verify the type
     CXMLCommon* pCommon = CXMLArray::GetEntry(ulID);
     if (pCommon && pCommon->GetClassType() == CXML_NODE)
-    {
         return reinterpret_cast<CXMLNode*>(pCommon);
-    }
 
     // Doesn't exist or bad type
-    return NULL;
+    return nullptr;
 }

--- a/Shared/XML/CXMLImpl.cpp
+++ b/Shared/XML/CXMLImpl.cpp
@@ -48,7 +48,7 @@ CXMLNode* CXMLImpl::ParseString(const char* strXmlContent)
 {
     TiXmlElement    *xmlDocumentRoot;
     CXMLNodeImpl    *xmlBaseNode;
-    CXMLNode    *xmlRootNode;
+    CXMLNode        *xmlRootNode;
     
     TiXmlDocument*  xmlDoc = new TiXmlDocument();
 

--- a/Shared/XML/CXMLImpl.cpp
+++ b/Shared/XML/CXMLImpl.cpp
@@ -46,14 +46,28 @@ void CXMLImpl::DeleteXML(CXMLFile* pFile)
 
 CXMLNode* CXMLImpl::ParseString(const char* strXmlContent)
 {
-    TiXmlDocument* xmlDoc = new TiXmlDocument;
+    TiXmlElement    *xmlRoot;
+    TiXmlNode       *xmlChild;
+    CXMLNodeImpl    *xmlRootNode;
+    CXMLNode        *xmlChildNode;
+
+    TiXmlDocument*  xmlDoc = new TiXmlDocument();
+
     if (xmlDoc)
     {
         xmlDoc->Parse(strXmlContent, 0, TIXML_ENCODING_UTF8);
 
-        CXMLNode* rootNode = new CXMLNodeImpl(NULL, NULL, *xmlDoc->RootElement());
+        xmlRoot = xmlDoc->RootElement();
 
-        return rootNode;
+        xmlRootNode = new CXMLNodeImpl(NULL, NULL, *xmlRoot);
+
+        xmlChild = 0;
+        while (xmlChild = xmlRoot->IterateChildren(xmlChild))
+        {
+            xmlChildNode = new CXMLNodeImpl(NULL, xmlRootNode, *xmlChild->ToElement());
+        }
+
+        return xmlRootNode;
     }
     else
     {

--- a/Shared/XML/CXMLImpl.cpp
+++ b/Shared/XML/CXMLImpl.cpp
@@ -44,6 +44,23 @@ void CXMLImpl::DeleteXML(CXMLFile* pFile)
     delete pFile;
 }
 
+CXMLNode* CXMLImpl::ParseString(const char* strXmlContent)
+{
+    TiXmlDocument* xmlDoc = new TiXmlDocument;
+    if (xmlDoc)
+    {
+        xmlDoc->Parse(strXmlContent, 0, TIXML_ENCODING_UTF8);
+
+        CXMLNode* rootNode = new CXMLNodeImpl(NULL, NULL, *xmlDoc->RootElement());
+
+        return rootNode;
+    }
+    else
+    {
+        return NULL;
+    }
+}
+
 CXMLNode* CXMLImpl::CreateDummyNode()
 {
     CXMLNode* xmlNode = new CXMLNodeImpl(NULL, NULL, *new TiXmlElement("dummy_storage"));

--- a/Shared/XML/CXMLImpl.h
+++ b/Shared/XML/CXMLImpl.h
@@ -21,6 +21,7 @@ public:
 
     CXMLFile* CreateXML(const char* szFilename, bool bUseIDs, bool bReadOnly);
     CXMLNode* ParseString(const char* strXmlContent);
+    CXMLNode* BuildNode(CXMLNodeImpl* xmlParent, TiXmlNode* xmlNode);
     void      DeleteXML(CXMLFile* pFile);
 
     CXMLNode* CreateDummyNode();

--- a/Shared/XML/CXMLImpl.h
+++ b/Shared/XML/CXMLImpl.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
  *
- *  PROJECT:     Multi Theft Auto v1.0
+ *  PROJECT:     Multi Theft Auto
  *  LICENSE:     See LICENSE in the top level directory
  *  FILE:        xml/CXMLImpl.h
  *  PURPOSE:     XML handler class

--- a/Shared/XML/CXMLImpl.h
+++ b/Shared/XML/CXMLImpl.h
@@ -20,6 +20,7 @@ public:
     virtual ~CXMLImpl();
 
     CXMLFile* CreateXML(const char* szFilename, bool bUseIDs, bool bReadOnly);
+    CXMLNode* ParseString(const char* strXmlContent);
     void      DeleteXML(CXMLFile* pFile);
 
     CXMLNode* CreateDummyNode();

--- a/Shared/XML/CXMLNodeImpl.cpp
+++ b/Shared/XML/CXMLNodeImpl.cpp
@@ -14,7 +14,7 @@
 using std::list;
 
 CXMLNodeImpl::CXMLNodeImpl(CXMLFileImpl* pFile, CXMLNodeImpl* pParent, TiXmlElement& Node)
-    : m_ulID(INVALID_XML_ID), m_bUsingIDs(pFile && pFile->IsUsingIDs()), m_pNode(&Node), m_Attributes(Node, pFile && pFile->IsUsingIDs())
+    : m_ulID(INVALID_XML_ID), m_bUsingIDs((!pFile) || pFile && pFile->IsUsingIDs()), m_pNode(&Node), m_Attributes(Node, (!pFile) || pFile && pFile->IsUsingIDs())
 {
     // Init
     m_pFile = pFile;

--- a/Shared/XML/CXMLNodeImpl.h
+++ b/Shared/XML/CXMLNodeImpl.h
@@ -59,7 +59,7 @@ public:
     eXMLClass     GetClassType() { return CXML_NODE; };
     unsigned long GetID()
     {
-        //dassert(m_pFile && m_pFile->IsUsingIDs());
+        dassert((!m_pFile) || m_pFile && m_pFile->IsUsingIDs());
         return m_ulID;
     };
     bool IsUsingIDs() { return m_bUsingIDs; };

--- a/Shared/XML/CXMLNodeImpl.h
+++ b/Shared/XML/CXMLNodeImpl.h
@@ -59,7 +59,7 @@ public:
     eXMLClass     GetClassType() { return CXML_NODE; };
     unsigned long GetID()
     {
-        dassert(m_pFile && m_pFile->IsUsingIDs());
+        //dassert(m_pFile && m_pFile->IsUsingIDs());
         return m_ulID;
     };
     bool IsUsingIDs() { return m_bUsingIDs; };

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
@@ -371,11 +371,11 @@ int CLuaXMLDefs::xmlUnloadFile(lua_State* luaVM)
         CLuaMain* luaMain = m_pLuaManager->GetVirtualMachine(luaVM);
         if (luaMain)
         {
-			if (luaMain->DestroyXML(pNode))
-			{
-				lua_pushboolean(luaVM, true);
-				return 1;
-			} 
+            if (luaMain->DestroyXML(pNode))
+            {
+                lua_pushboolean(luaVM, true);
+                return 1;
+            }
         }
     }
     else

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
@@ -241,7 +241,7 @@ int CLuaXMLDefs::xmlLoadString(lua_State* luaVM)
         }
     }
     else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+        return luaL_error(luaVM, argStream.GetFullErrorMessage());
 
     lua_pushboolean(luaVM, false);
     return 1;

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
@@ -368,9 +368,11 @@ int CLuaXMLDefs::xmlUnloadFile(lua_State* luaVM)
         CLuaMain* luaMain = m_pLuaManager->GetVirtualMachine(luaVM);
         if (luaMain)
         {
-            luaMain->DestroyXML(pNode);
-            lua_pushboolean(luaVM, true);
-            return 1;
+			if (luaMain->DestroyXML(pNode))
+			{
+				lua_pushboolean(luaVM, true);
+				return 1;
+			} 
         }
     }
     else

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
@@ -223,25 +223,23 @@ int CLuaXMLDefs::xmlLoadString(lua_State* luaVM)
     CScriptArgReader argStream(luaVM);
     argStream.ReadString(strXmlContent);
 
-    if (!argStream.HasErrors())
-    {
-        // Grab our resource
-        CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
-        if (pLuaMain)
-        {
-            CXMLNode* rootNode = pLuaMain->ParseString(strXmlContent);
-
-            if (rootNode && rootNode->IsValid())
-            {
-                lua_pushxmlnode(luaVM, rootNode);
-                return 1;
-            }
-            else
-                m_pScriptDebugging->LogCustom(luaVM, "Unable to load XML string");
-        }
-    }
-    else
+    if (argStream.HasErrors())
         return luaL_error(luaVM, argStream.GetFullErrorMessage());
+
+    // Grab our resource
+    CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+    if (pLuaMain)
+    {
+        CXMLNode* rootNode = pLuaMain->ParseString(strXmlContent);
+
+        if (rootNode && rootNode->IsValid())
+        {
+            lua_pushxmlnode(luaVM, rootNode);
+            return 1;
+        }
+        else
+            m_pScriptDebugging->LogCustom(luaVM, "Unable to load XML string");
+    }
 
     lua_pushboolean(luaVM, false);
     return 1;

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
@@ -230,11 +230,14 @@ int CLuaXMLDefs::xmlLoadString(lua_State* luaVM)
         if (pLuaMain)
         {
             CXMLNode* rootNode = pLuaMain->ParseString(strXmlContent);
-            if (rootNode->IsValid())
+
+            if (rootNode && rootNode->IsValid())
             {
                 lua_pushxmlnode(luaVM, rootNode);
                 return 1;
             }
+            else
+                m_pScriptDebugging->LogCustom(luaVM, "Unable to load XML string");
         }
     }
     else

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.h
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.h
@@ -19,6 +19,7 @@ public:
 
     LUA_DECLARE(xmlCreateFile);
     LUA_DECLARE(xmlLoadFile);
+    LUA_DECLARE(xmlLoadString);
     LUA_DECLARE(xmlCopyFile);
     LUA_DECLARE(xmlSaveFile);
     LUA_DECLARE(xmlUnloadFile);

--- a/Shared/sdk/xml/CXML.h
+++ b/Shared/sdk/xml/CXML.h
@@ -19,6 +19,7 @@ class CXML
 {
 public:
     virtual CXMLFile* CreateXML(const char* szFilename, bool bUseIDs = false, bool bReadOnly = false) = 0;
+    virtual CXMLNode* ParseString(const char* strXmlContent) = 0;
     virtual void      DeleteXML(CXMLFile* pFile) = 0;
     virtual CXMLNode* CreateDummyNode() = 0;
 


### PR DESCRIPTION
Currently, if you want to read XML data that is compatible with the other xml* functions, you need to create a file with the XML data (using `fileCreate`), then read that file using `xmlLoadFile`

This will allow you to read XML data via string using `xmlLoadString(xmlString)`

Example (client):

```lua
function init()
	print("Loading XML String [client]")

	local rootNode = xmlLoadString("<animals test='x'><monkey name='crosroad'></monkey> <turtle name='luxy'></turtle></animals>")

	if rootNode then
		local rootAttributes = xmlNodeGetAttributes(rootNode)
		print("Root Node", "Name: "..xmlNodeGetName(rootNode),  "Attributes :"..toJSON(rootAttributes))
		
		local children = xmlNodeGetChildren(rootNode)
		
		for i, childNode in ipairs(children) do
			local attributes = xmlNodeGetAttributes(childNode)
			
			print("Child #"..i, "Name: "..xmlNodeGetName(childNode), "Attributes :"..toJSON(attributes))
		end
	end
end
addEventHandler("onClientResourceStart", resourceRoot, init)
```

My only concerns in this commit are the following (someone who actually knows what they are doing should verify this):

Shared/XML/CXMLNodeImpl.cpp:17
Shared/XML/CXMLNodeImpl.h:62

First time looking into MTA's code, and hardly worked with C++ too, so let me know of anything dumb in my commit!

Note: I have been made aware of a branch which is ready to test, pugixml, so more than anything I am hoping this PR will speed that process up ;)