### PR TITLE
Update curl from 7.63.0 to 7.64.0

### DIFF
--- a/vendor/curl/CHANGES
+++ b/vendor/curl/CHANGES
@@ -6,6 +6,1058 @@
 
                                   Changelog
 
+Version 7.64.0 (6 Feb 2019)
+
+Daniel Stenberg (6 Feb 2019)
+- RELEASE-NOTES: 7.64.0
+
+- RELEASE-PROCEDURE: update the release calendar
+
+- THANKS: 7.64.0 status
+
+Daniel Gustafsson (5 Feb 2019)
+- ROADMAP: remove already performed item
+  
+  Commit 7a09b52c98ac8d840a8a9907b1a1d9a9e684bcf5 introduced support
+  for the draft-ietf-httpbis-cookie-alone-01 cookie draft, and while
+  the entry was removed from the TODO it was mistakenly left here.
+  Fix by removing and rewording the entry slightly.
+  
+  Closes #3530
+  Reviewed-by: Daniel Stenberg <daniel@haxx.se>
+
+- [Etienne Simard brought this change]
+
+  CONTRIBUTE.md: Fix grammatical errors
+  
+  Fix grammatical errors making the document read better. Also fixes
+  a typo.
+  
+  Closes #3525
+  Reviewed-by: Daniel Gustafsson <daniel@yesql.se>
+
+Daniel Stenberg (4 Feb 2019)
+- [Julian Z brought this change]
+
+  docs: use $(INSTALL_DATA) to install man page
+  
+  Fixes #3518
+  Closes #3522
+
+Jay Satiro (4 Feb 2019)
+- [Ladar Levison brought this change]
+
+  runtests.pl: Fix perl call to include srcdir
+  
+  - Use explicit include opt for perl calls.
+  
+  Prior to this change some scripts couldn't find their dependencies.
+  
+  At the top, perl is called using with the "-Isrcdir" option, and it
+  works:
+  
+  https://github.com/curl/curl/blob/curl-7_63_0/tests/runtests.pl#L183
+  
+  But on line 3868, that option is omitted. This caused problems for me,
+  as the symbol-scan.pl script in particular couldn't find its
+  dependencies properly:
+  
+  https://github.com/curl/curl/blob/curl-7_63_0/tests/runtests.pl#L3868
+  
+  This patch fixes that oversight by making calls to perl sub-shells
+  uniform.
+  
+  Closes https://github.com/curl/curl/pull/3496
+
+Daniel Stenberg (4 Feb 2019)
+- [Daniel Gustafsson brought this change]
+
+  smtp: avoid risk of buffer overflow in strtol
+  
+  If the incoming len 5, but the buffer does not have a termination
+  after 5 bytes, the strtol() call may keep reading through the line
+  buffer until is exceeds its boundary. Fix by ensuring that we are
+  using a bounded read with a temporary buffer on the stack.
+  
+  Bug: https://curl.haxx.se/docs/CVE-2019-3823.html
+  Reported-by: Brian Carpenter (Geeknik Labs)
+  CVE-2019-3823
+
+- ntlm: fix *_type3_message size check to avoid buffer overflow
+  
+  Bug: https://curl.haxx.se/docs/CVE-2019-3822.html
+  Reported-by: Wenxiang Qian
+  CVE-2019-3822
+
+- NTLM: fix size check condition for type2 received data
+  
+  Bug: https://curl.haxx.se/docs/CVE-2018-16890.html
+  Reported-by: Wenxiang Qian
+  CVE-2018-16890
+
+Marcel Raad (1 Feb 2019)
+- [georgeok brought this change]
+
+  spnego_sspi: add support for channel binding
+  
+  Attempt to add support for Secure Channel binding when negotiate
+  authentication is used. The problem to solve is that by default IIS
+  accepts channel binding and curl doesn't utilise them. The result was a
+  401 response. Scope affects only the Schannel(winssl)-SSPI combination.
+  
+  Fixes https://github.com/curl/curl/issues/3503
+  Closes https://github.com/curl/curl/pull/3509
+
+Daniel Stenberg (1 Feb 2019)
+- RELEASE-NOTES: synced
+
+- schannel: stop calling it "winssl"
+  
+  Stick to "Schannel" everywhere. The configure option --with-winssl is
+  kept to allow existing builds to work but --with-schannel is added as an
+  alias.
+  
+  Closes #3504
+
+- multi: set the EXPIRE_*TIMEOUT timers at TIMER_STARTSINGLE time
+  
+  To make sure Curl_timeleft() also thinks the timeout has been reached
+  when one of the EXPIRE_*TIMEOUTs expires.
+  
+  Bug: https://curl.haxx.se/mail/lib-2019-01/0073.html
+  Reported-by: Zhao Yisha
+  Closes #3501
+
+- [John Marshall brought this change]
+
+  doc: use meaningless port number in CURLOPT_LOCALPORT example
+  
+  Use an ephemeral port number here; previously the example had 8080
+  which could be confusing as the common web server port number might
+  be misinterpreted as suggesting this option affects the remote port.
+  
+  URL: https://curl.haxx.se/mail/lib-2019-01/0084.html
+  Closes #3513
+
+GitHub (29 Jan 2019)
+- [Gisle Vanem brought this change]
+
+  Escape the '\'
+  
+  A backslash should be escaped in Roff / Troff.
+
+Jay Satiro (29 Jan 2019)
+- TODO: WinSSL: 'Add option to disable client cert auto-send'
+  
+  By default WinSSL selects and send a client certificate automatically,
+  but for privacy and consistency we should offer an option to disable the
+  default auto-send behavior.
+  
+  Reported-by: Jeroen Ooms
+  
+  Closes https://github.com/curl/curl/issues/2262
+
+Daniel Stenberg (28 Jan 2019)
+- [Jeremie Rapin brought this change]
+
+  sigpipe: if mbedTLS is used, ignore SIGPIPE
+  
+  mbedTLS doesn't have a sigpipe management. If a write/read occurs when
+  the remote closes the socket, the signal is raised and kills the
+  application.  Use the curl mecanisms fix this behavior.
+  
+  Signed-off-by: Jeremie Rapin <j.rapin@overkiz.com>
+  
+  Closes #3502
+
+- unit1653: make it survive torture tests
+
+Jay Satiro (28 Jan 2019)
+- [Michael Kujawa brought this change]
+
+  timeval: Disable MSVC Analyzer GetTickCount warning
+  
+  Compiling with msvc /analyze and a recent Windows SDK warns against
+  using GetTickCount (Suggests to use GetTickCount64 instead.)
+  
+  Since GetTickCount is only being used when GetTickCount64 isn't
+  available, I am disabling that warning.
+  
+  Fixes https://github.com/curl/curl/issues/3437
+  Closes https://github.com/curl/curl/pull/3440
+
+Daniel Stenberg (26 Jan 2019)
+- configure: rewrite --enable-code-coverage
+  
+  The previously used ax_code_coverage.m4 is not license compatible and
+  must not be used.
+  
+  Reported-by: William A. Rowe Jr
+  Fixes #3497
+  Closes #3499
+
+- [Felix Hädicke brought this change]
+
+  setopt: enable CURLOPT_SSH_KNOWNHOSTS and CURLOPT_SSH_KEYFUNCTION for libssh
+  
+  CURLOPT_SSH_KNOWNHOSTS and CURLOPT_SSH_KEYFUNCTION are supported for
+  libssh as well. So accepting these options only when compiling with
+  libssh2 is wrong here.
+  
+  Fixes #3493
+  Closes #3494
+
+- [Felix Hädicke brought this change]
+
+  libssh: do not let libssh create socket
+  
+  By default, libssh creates a new socket, instead of using the socket
+  created by curl for SSH connections.
+  
+  Pass the socket created by curl to libssh using ssh_options_set() with
+  SSH_OPTIONS_FD directly after ssh_new(). So libssh uses our socket
+  instead of creating a new one.
+  
+  This approach is very similar to what is done in the libssh2 code, where
+  the socket created by curl is passed to libssh2 when
+  libssh2_session_startup() is called.
+  
+  Fixes #3491
+  Closes #3495
+
+- RELEASE-NOTES: synced
+
+- [Archangel_SDY brought this change]
+
+  schannel: preserve original certificate path parameter
+  
+  Fixes #3480
+  Closes #3487
+
+- KNOWN_BUGS: tests not compatible with python3
+  
+  Closes #3289
+  [skip ci]
+
+Daniel Gustafsson (20 Jan 2019)
+- memcmp: avoid doing single char memcmp
+  
+  There is no real gain in performing memcmp() comparisons on single
+  characters, so change these to array subscript inspections which
+  saves a call and makes the code clearer.
+  
+  Closes #3486
+  Reviewed-by: Daniel Stenberg <daniel@haxx.se>
+  Reviewed-by: Jay Satiro <raysatiro@yahoo.com>
+
+Daniel Stenberg (19 Jan 2019)
+- COPYING: it's 2019
+  
+  [skip ci]
+
+- [hhb brought this change]
+
+  configure: fix recv/send/select detection on Android
+  
+  This reverts commit d4f25201fb7da03fc88f90d51101beb3d0026db9.
+  
+  The overloadable attribute is removed again starting from
+  NDK17. Actually they only exist in two NDK versions (15 and 16). With
+  overloadable, the first condition tried will succeed. Results in wrong
+  detection result.
+  
+  Closes #3484
+
+Marcel Raad (19 Jan 2019)
+- [georgeok brought this change]
+
+  ntlm_sspi: add support for channel binding
+  
+  Windows extended potection (aka ssl channel binding) is required
+  to login to ntlm IIS endpoint, otherwise the server returns 401
+  responses.
+  
+  Fixes #3280
+  Closes #3321
+
+Daniel Stenberg (18 Jan 2019)
+- schannel: on connection close there might not be a transfer
+  
+  Reported-by: Marcel Raad
+  Fixes #3412
+  Closes #3483
+
+- [Joel Depooter brought this change]
+
+  ssh: log the libssh2 error message when ssh session startup fails
+  
+  When a ssh session startup fails, it is useful to know why it has
+  failed. This commit changes the message from:
+     "Failure establishing ssh session"
+  to something like this, for example:
+     "Failure establishing ssh session: -5, Unable to exchange encryption keys"
+  
+  Closes #3481
+
+Alessandro Ghedini (16 Jan 2019)
+- Fix typo in manpage
+
+Daniel Stenberg (16 Jan 2019)
+- RELEASE-NOTES: synced
+
+Sergei Nikulov (16 Jan 2019)
+- cmake: updated check for HAVE_POLL_FINE to match autotools
+
+Daniel Stenberg (16 Jan 2019)
+- curl-compilers.m4: check for __ibmxl__ to detect xlclang
+  
+  Follow-up to 2fa0d57e2e3. The __xlc__ symbol is only defined there if a
+  particular flag is used for legacy macros.
+  
+  Fixes #3474
+  Closes #3479
+
+- openssl: fix the SSL_get_tlsext_status_ocsp_resp call
+  
+  .... to not pass in a const in the second argument as that's not how it
+  is supposed to be used and might cause compiler warnings.
+  
+  Reported-by: Pavel Pavlov
+  Fixes #3477
+  Closes #3478
+
+- curl-compilers.m4: detect xlclang
+  
+  Since it isn't totally clang compatible, we detect this IBM clang
+  front-end and if detected, avoids some clang specific magic.
+  
+  Reported-by: Kees Dekker
+  Fixes #3474
+  Closes #3476
+
+- README: add codacy code quality badge
+  
+  [skip ci]
+
+- extract_if_dead: follow-up to 54b201b48c90a
+  
+  extract_if_dead() dead is called from two functions, and only one of
+  them should get conn->data updated and now neither call path clears it.
+  
+  scan-build found a case where conn->data would be NULL dereferenced in
+  ConnectionExists() otherwise.
+  
+  Closes #3473
+
+- multi: remove "Dead assignment"
+  
+  Found by scan-build. Follow-up to 4c35574bb785ce.
+  
+  Closes #3471
+
+- tests: move objnames-* from lib into tests
+  
+  Since they're used purely for testing purposes, I think they should
+  rather be stored there.
+  
+  Closes #3470
+
+Sergei Nikulov (15 Jan 2019)
+- travis: added cmake build for osx
+
+Daniel Stenberg (14 Jan 2019)
+- [Frank Gevaerts brought this change]
+
+  cookie: fix comment typo (url_path_len -> uri_path_len)
+  
+  Closes #3469
+
+Marcel Raad (14 Jan 2019)
+- winbuild: conditionally use /DZLIB_WINAPI
+  
+  zlibwapi.lib (dynamic library) and zlibstat.lib (static library) have
+  the ZLIB_WINAPI define set by default. Using them requires that define
+  too.
+  
+  Ref: https://zlib.net/DLL_FAQ.txt
+  
+  Fixes https://github.com/curl/curl/issues/3133
+  Closes https://github.com/curl/curl/pull/3460
+
+Daniel Stenberg (14 Jan 2019)
+- src/Makefile: make 'tidy' target work for metalink builds
+
+- extract_if_dead: use a known working transfer when checking connections
+  
+  Make sure that this function sets a proper "live" transfer for the
+  connection before calling the protocol-specific connection check
+  function, and then clear it again afterward as a non-used connection has
+  no current transfer.
+  
+  Reported-by: Jeroen Ooms
+  Reviewed-by: Marcel Raad
+  Reviewed-by: Daniel Gustafsson
+  Fixes #3463
+  Closes #3464
+
+- openssl: adapt to 3.0.0, OpenSSL_version_num() is deprecated
+  
+  OpenSSL_version() replaces OpenSSL_version_num()
+  
+  Closes #3462
+
+Sergei Nikulov (11 Jan 2019)
+- cmake: added checks for HAVE_VARIADIC_MACROS_C99 and HAVE_VARIADIC_MACROS_GCC
+
+Daniel Stenberg (11 Jan 2019)
+- urldata: rename easy_conn to just conn
+  
+  We use "conn" everywhere to be a pointer to the connection.
+  
+  Introduces two functions that "attaches" and "detaches" the connection
+  to and from the transfer.
+  
+  Going forward, we should favour using "data->conn" (since a transfer
+  always only has a single connection or none at all) to "conn->data"
+  (since a connection can have none, one or many transfers associated with
+  it and updating conn->data to be correct is error prone and a frequent
+  reason for internal issues).
+  
+  Closes #3442
+
+- tool_cb_prg: avoid integer overflow
+  
+  When calculating the progress bar width.
+  
+  Reported-by: Peng Li
+  Fixes #3456
+  Closes #3458
+
+Daniel Gustafsson (11 Jan 2019)
+- travis: turn off copyright year checks in checksrc
+  
+  Invoking the maintainer intended COPYRIGHTYEAR check for everyone
+  in the PR pipeline is too invasive, especially at the turn of the
+  year when many files get affected. Remove and leave it as a tool
+  for maintainers to verify patches before commits.
+  
+  This reverts f7bdf4b2e1d81b2652b81b9b3029927589273b41.
+  
+  After discussion with: Daniel Stenberg
+
+Daniel Stenberg (10 Jan 2019)
+- KNOWN_BUGS: cmake makes unusable tool_hugehelp.c with MinGW
+  
+  Closes #3125
+
+- KNOWN_BUGS: Improve --data-urlencode space encoding
+  
+  Closes #3229
+
+Patrick Monnerat (10 Jan 2019)
+- os400: add a missing closing bracket
+  
+  See https://github.com/curl/curl/issues/3453#issuecomment-453054458
+  
+  Reported-by: jonrumsey on github
+
+- os400: fix extra parameter syntax error.
+  
+  Reported-by: jonrumsey on github
+  Closes #3453
+
+Daniel Stenberg (10 Jan 2019)
+- test1558: verify CURLINFO_PROTOCOL on file:// transfer
+  
+  Attempt to reproduce issue #3444.
+  
+  Closes #3447
+
+- RELEASE-NOTES: synced
+
+- xattr: strip credentials from any URL that is stored
+  
+  Both user and password are cleared uncondtitionally.
+  
+  Added unit test 1621 to verify.
+  
+  Fixes #3423
+  Closes #3433
+
+- cookies: allow secure override when done over HTTPS
+  
+  Added test 1562 to verify.
+  
+  Reported-by: Jeroen Ooms
+  Fixes #3445
+  Closes #3450
+
+- multi: multiplexing improvements
+  
+  Fixes #3436
+  Closes #3448
+  
+   Problem 1
+  
+  After LOTS of scratching my head, I eventually realized that even when doing
+  10 uploads in parallel, sometimes the socket callback to the application that
+  tells it what to wait for on the socket, looked like it would reflect the
+  status of just the single transfer that just changed state.
+  
+  Digging into the code revealed that this was indeed the truth. When multiple
+  transfers are using the same connection, the application did not correctly get
+  the *combined* flags for all transfers which then could make it switch to READ
+  (only) when in fact most transfers wanted to get told when the socket was
+  WRITEABLE.
+  
+   Problem 1b
+  
+  A separate but related regression had also been introduced by me when I
+  cleared connection/transfer association better a while ago, as now the logic
+  couldn't find the connection and see if that was marked as used by more
+  transfers and then it would also prematurely remove the socket from the socket
+  hash table even in times other transfers were still using it!
+  
+   Fix 1
+  
+  Make sure that each socket stored in the socket hash has a "combined" action
+  field of what to ask the application to wait for, that is potentially the ORed
+  action of multiple parallel transfers. And remove that socket hash entry only
+  if there are no transfers left using it.
+  
+   Problem 2
+  
+  The socket hash entry stored an association to a single transfer using that
+  socket - and when curl_multi_socket_action() was called to tell libcurl about
+  activities on that specific socket only that transfer was "handled".
+  
+  This was WRONG, as a single socket/connection can be used by numerous parallel
+  transfers and not necessarily a single one.
+  
+   Fix 2
+  
+  We now store a list of handles in the socket hashtable entry and when libcurl
+  is told there's traffic for a particular socket, it now iterates over all
+  known transfers using that single socket.
+
+- test1561: improve test name
+  
+  [skip ci]
+
+- [Katsuhiko YOSHIDA brought this change]
+
+  cookies: skip custom cookies when redirecting cross-site
+  
+  Closes #3417
+
+- THANKS: fixups and a dedupe
+  
+  [skip ci]
+
+- timediff: fix math for unsigned time_t
+  
+  Bug: https://curl.haxx.se/mail/lib-2018-12/0088.html
+  
+  Closes #3449
+
+- [Bernhard M. Wiedemann brought this change]
+
+  tests: allow tests to pass by 2037-02-12
+  
+  similar to commit f508d29f3902104018
+  
+  Closes #3443
+
+- RELEASE-NOTES: synced
+
+- [Brad Spencer brought this change]
+
+  curl_multi_remove_handle() don't block terminating c-ares requests
+  
+  Added Curl_resolver_kill() for all three resolver modes, which only
+  blocks when necessary, along with test 1592 to confirm
+  curl_multi_remove_handle() doesn't block unless it must.
+  
+  Closes #3428
+  Fixes #3371
+
+- Revert "http_negotiate: do not close connection until negotiation is completed"
+  
+  This reverts commit 07ebaf837843124ee670e5b8c218b80b92e06e47.
+  
+  This also reopens PR #3275 which brought the change now reverted.
+  
+  Fixes #3384
+  Closes #3439
+
+- curl/urlapi.h: include "curl.h" first
+  
+  This allows programs to include curl/urlapi.h directly.
+  
+  Reviewed-by: Daniel Gustafsson
+  Reported-by: Ben Kohler
+  Fixes #3438
+  Closes #3441
+
+Marcel Raad (6 Jan 2019)
+- VS projects: fix build warning
+  
+  Starting with Visual Studio 2017 Update 9, Visual Studio doesn't like
+  the MinimalRebuild option anymore and warns:
+  
+  cl : Command line warning D9035: option 'Gm' has been deprecated and
+  will be removed in a future release
+  
+  The option can be safely removed so that the default is used.
+  
+  Closes https://github.com/curl/curl/pull/3425
+
+- schannel: fix compiler warning
+  
+  When building with Unicode on MSVC, the compiler warns about freeing a
+  pointer to const in Curl_unicodefree. Fix this by declaring it as
+  non-const and casting the argument to Curl_convert_UTF8_to_tchar to
+  non-const too, like we do in all other places.
+  
+  Closes https://github.com/curl/curl/pull/3435
+
+Daniel Stenberg (4 Jan 2019)
+- [Rikard Falkeborn brought this change]
+
+  printf: introduce CURL_FORMAT_TIMEDIFF_T
+
+- [Rikard Falkeborn brought this change]
+
+  printf: fix format specifiers
+  
+  Closes #3426
+
+- libtest/stub_gssapi: use "real" snprintf
+  
+  ... since it doesn't link with libcurl.
+  
+  Reverts the commit dcd6f81025 changes from this file.
+  
+  Bug: https://curl.haxx.se/mail/lib-2019-01/0000.html
+  Reported-by: Shlomi Fish
+  Reviewed-by: Daniel Gustafsson
+  Reviewed-by: Kamil Dudka
+  
+  Closes #3434
+
+- INTERNALS: correct some outdated function names
+  
+  Closes #3431
+
+- docs/version.d: mention MultiSSL
+  
+  Reviewed-by: Daniel Gustafsson
+  Closes #3432
+
+Daniel Gustafsson (2 Jan 2019)
+- [Rikard Falkeborn brought this change]
+
+  examples: Update .gitignore
+  
+  Add a few missing examples to make `make examples` not leave the
+  workspace in a dirty state.
+  
+  Closes #3427
+  Reviewed-by: Daniel Gustafsson <daniel@yesql.se>
+
+- THANKS: add more missing names
+  
+  Add Adrian Burcea who made the artwork for the curl://up 2018 event
+  which was held in Stockholm, Sweden.
+
+- docs: mention potential leak in curl_slist_append
+  
+  When a non-empty list is appended to, and used as the returnvalue,
+  the list pointer can leak in case of an allocation failure in the
+  curl_slist_append() call. This is correctly handled in curl code
+  usage but we weren't explicitly pointing it out in the API call
+  documentation. Fix by extending the RETURNVALUE manpage section
+  and example code.
+  
+  Closes #3424
+  Reported-by: dnivras on github
+  Reviewed-by: Daniel Stenberg <daniel@haxx.se>
+
+Marcel Raad (1 Jan 2019)
+- tvnow: silence conversion warnings
+  
+  MinGW-w64 defaults to targeting Windows 7 now, so GetTickCount64 is
+  used and the milliseconds are represented as unsigned long long,
+  leading to a compiler warning when implicitly converting them to long.
+
+Daniel Stenberg (1 Jan 2019)
+- THANKS: dedupe more names
+  
+  Researched-by: Tae Wong
+
+Marcel Raad (1 Jan 2019)
+- [Markus Moeller brought this change]
+
+  ntlm: update selection of type 3 response
+  
+  NTLM2 did not work i.e. no NTLMv2 response was created. Changing the
+  check seems to work.
+  
+  Ref: https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-NLMP/[MS-NLMP].pdf
+  
+  Fixes https://github.com/curl/curl/issues/3286
+  Closes https://github.com/curl/curl/pull/3287
+  Closes https://github.com/curl/curl/pull/3415
+
+Daniel Stenberg (31 Dec 2018)
+- THANKS: added missing names from year <= 2000
+  
+  Due to a report of a missing name in THANKS I manually went through an
+  old CHANGES.0 file and added many previously missing names here.
+
+Daniel Gustafsson (30 Dec 2018)
+- urlapi: fix parsing ipv6 with zone index
+  
+  The previous fix for parsing IPv6 URLs with a zone index was a paddle
+  short for URLs without an explicit port. This patch fixes that case
+  and adds a unit test case.
+  
+  This bug was highlighted by issue #3408, and while it's not the full
+  fix for the problem there it is an isolated bug that should be fixed
+  regardless.
+  
+  Closes #3411
+  Reported-by: GitYuanQu on github
+  Reviewed-by: Daniel Stenberg <daniel@haxx.se>
+
+Daniel Stenberg (30 Dec 2018)
+- THANKS: dedupe Guenter Knauf
+  
+  Reported-by: Tae Wong
+
+- THANKS: missing name from the 6.3.1 release!
+
+Daniel Gustafsson (27 Dec 2018)
+- RELEASE-NOTES: synced
+
+- [Claes Jakobsson brought this change]
+
+  hostip: support wildcard hosts
+  
+  This adds support for wildcard hosts in CURLOPT_RESOLVE. These are
+  try-last so any non-wildcard entry is resolved first. If specified,
+  any host not matched by another CURLOPT_RESOLVE config will use this
+  as fallback.
+  
+  Example send a.com to 10.0.0.1 and everything else to 10.0.0.2:
+    curl --resolve *:443:10.0.0.2 --resolve a.com:443:10.0.0.1 \
+         https://a.com https://b.com
+  
+  This is probably quite similar to using:
+    --connect-to a.com:443:10.0.0.1:443 --connect-to :443:10.0.0.2:443
+  
+  Closes #3406
+  Reviewed-by: Daniel Stenberg <daniel@haxx.se>
+
+- url: fix incorrect indentation
+
+Patrick Monnerat (26 Dec 2018)
+- os400: upgrade ILE/RPG binding.
+  
+  - Trailer function support.
+  - http 0.9 option.
+  - curl_easy_upkeep.
+
+Daniel Gustafsson (25 Dec 2018)
+- FAQ: remove mention of sourceforge for github
+  
+  The project bug tracker is no longer hosted at sourceforge but is now
+  hosted on the curl Github page. Update the FAQ to reflect.
+  
+  Closes #3410
+  Reviewed-by: Daniel Stenberg <daniel@haxx.se>
+
+- openvms: fix typos in documentation
+
+- openvms: fix OpenSSL discovery on VAX
+  
+  The DCL code had a typo in one of the commands which would make the
+  OpenSSL discovery on VAX fail. The correct syntax is F$ENVIRONMENT.
+  
+  Closes #3407
+  Reviewed-by: Viktor Szakats <commit@vszakats.net>
+
+Daniel Stenberg (24 Dec 2018)
+- [Ruslan Baratov brought this change]
+
+  cmake: use lowercase for function name like the rest of the code
+  
+  Reviewed-by: Sergei Nikulov
+  
+  closes #3196
+
+- Revert "libssh: no data pointer == nothing to do"
+  
+  This reverts commit c98ee5f67f497195c9 since commit f3ce38739fa fixed the
+  problem in a more generic way.
+
+- disconnect: set conn->data for protocol disconnect
+  
+  Follow-up to fb445a1e18d: Set conn->data explicitly to point out the
+  current transfer when invoking the protocol-specific disconnect function
+  so that it can work correctly.
+  
+  Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=12173
+
+Jay Satiro (23 Dec 2018)
+- [Pavel Pavlov brought this change]
+
+  timeval: Use high resolution timestamps on Windows
+  
+  - Use QueryPerformanceCounter on Windows Vista+
+  
+  There is confusing info floating around that QueryPerformanceCounter
+  can leap etc, which might have been true long time ago, but no longer
+  the case nowadays (perhaps starting from WinXP?). Also, boost and
+  std::chrono::steady_clock use QueryPerformanceCounter in a similar way.
+  
+  Prior to this change GetTickCount or GetTickCount64 was used, which has
+  lower resolution. That is still the case for <= XP.
+  
+  Fixes https://github.com/curl/curl/issues/3309
+  Closes https://github.com/curl/curl/pull/3318
+
+Daniel Stenberg (22 Dec 2018)
+- libssh: no data pointer == nothing to do
+
+- conncache_unlock: avoid indirection by changing input argument type
+
+- disconnect: separate connections and easy handles better
+  
+  Do not assume/store assocation between a given easy handle and the
+  connection if it can be avoided.
+  
+  Long-term, the 'conn->data' pointer should probably be removed as it is a
+  little too error-prone. Still used very widely though.
+  
+  Reported-by: masbug on github
+  Fixes #3391
+  Closes #3400
+
+- libssh: free sftp_canonicalize_path() data correctly
+  
+  Assisted-by: Harry Sintonen
+  
+  Fixes #3402
+  Closes #3403
+
+- RELEASE-NOTES: synced
+
+- http: added options for allowing HTTP/0.9 responses
+  
+  Added CURLOPT_HTTP09_ALLOWED and --http0.9 for this purpose.
+  
+  For now, both the tool and library allow HTTP/0.9 by default.
+  docs/DEPRECATE.md lays out the plan for when to reverse that default: 6
+  months after the 7.64.0 release. The options are added already now so
+  that applications/scripts can start using them already now.
+  
+  Fixes #2873
+  Closes #3383
+
+- if2ip: remove unused function Curl_if_is_interface_name
+  
+  Closes #3401
+
+- http2: clear pause stream id if it gets closed
+  
+  Reported-by: Florian Pritz
+  
+  Fixes #3392
+  Closes #3399
+
+Daniel Gustafsson (20 Dec 2018)
+- [David Garske brought this change]
+
+  wolfssl: Perform cleanup
+  
+  This adds a cleanup callback for cyassl. Resolves possible memory leak
+  when using ECC fixed point cache.
+  
+  Closes #3395
+  Reviewed-by: Daniel Stenberg <daniel@haxx.se>
+  Reviewed-by: Daniel Gustafsson <daniel@yesql.se>
+
+Daniel Stenberg (20 Dec 2018)
+- mbedtls: follow-up VERIFYHOST fix from f097669248
+  
+  Fix-by: Eric Rosenquist
+  
+  Fixes #3376
+  Closes #3390
+
+- curlver: bump to 7.64.0 for next release
+
+Daniel Gustafsson (19 Dec 2018)
+- cookies: extend domain checks to non psl builds
+  
+  Ensure to perform the checks we have to enforce a sane domain in
+  the cookie request. The check for non-PSL enabled builds is quite
+  basic but it's better than nothing.
+  
+  Closes #2964
+  Reviewed-by: Daniel Stenberg <daniel@haxx.se>
+
+Daniel Stenberg (19 Dec 2018)
+- [Matus Uzak brought this change]
+
+  smb: fix incorrect path in request if connection reused
+  
+  Follow-up to 09e401e01bf9.  If connection gets reused, then data member
+  will be copied, but not the proto member.  As a result, in smb_do(),
+  path has been set from the original proto.share data.
+  
+  Closes #3388
+
+- curl -J: do not append to the destination file
+  
+  Reported-by: Kamil Dudka
+  Fixes #3380
+  Closes #3381
+
+- mbedtls: use VERIFYHOST
+  
+  Previously, VERIFYPEER would enable/disable all checks.
+  
+  Reported-by: Eric Rosenquist
+  Fixes #3376
+  Closes #3380
+
+- pingpong: change default response timeout to 120 seconds
+  
+  Previously it was 30 minutes
+
+- pingpong: ignore regular timeout in disconnect phase
+  
+  The timeout set with CURLOPT_TIMEOUT is no longer used when
+  disconnecting from one of the pingpong protocols (FTP, IMAP, SMTP,
+  POP3).
+  
+  Reported-by: jasal82 on github
+  
+  Fixes #3264
+  Closes #3374
+
+- TODO: Windows: set attribute 'archive' for completed downloads
+  
+  Closes #3354
+
+- RELEASE-NOTES: synced
+
+- http: minor whitespace cleanup from f464535b
+
+- [Ayoub Boudhar brought this change]
+
+  http: Implement trailing headers for chunked transfers
+  
+  This adds the CURLOPT_TRAILERDATA and CURLOPT_TRAILERFUNCTION
+  options that allow a callback based approach to sending trailing headers
+  with chunked transfers.
+  
+  The test server (sws) was updated to take into account the detection of the
+  end of transfer in the case of trailing headers presence.
+  
+  Test 1591 checks that trailing headers can be sent using libcurl.
+  
+  Closes #3350
+
+- darwinssl: accept setting max-tls with default min-tls
+  
+  Reported-by: Andrei Neculau
+  Fixes #3367
+  Closes #3373
+
+- gopher: fix memory leak from 9026083ddb2a9
+
+- [Leonardo Taccari brought this change]
+
+  test1201: Add a trailing `?' to the selector
+  
+  This verify that the `?' in the selector is kept as is.
+  
+  Verifies the fix in #3370
+
+- [Leonardo Taccari brought this change]
+
+  gopher: always include the entire gopher-path in request
+  
+  After the migration to URL API all octets in the selector after the
+  first `?' were interpreted as query and accidentally discarded and not
+  passed to the server.
+  
+  Add a gopherpath to always concatenate possible path and query URL
+  pieces.
+  
+  Fixes #3369
+  Closes #3370
+
+- [Leonardo Taccari brought this change]
+
+  urlapi: distinguish possibly empty query
+  
+  If just a `?' to indicate the query is passed always store a zero length
+  query instead of having a NULL query.
+  
+  This permits to distinguish URL with trailing `?'.
+  
+  Fixes #3369
+  Closes #3370
+
+Daniel Gustafsson (13 Dec 2018)
+- OS400: handle memory error in list conversion
+  
+  Curl_slist_append_nodup() returns NULL when it fails to create a new
+  item for the specified list, and since the coding here reassigned the
+  new list on top of the old list it would result in a dangling pointer
+  and lost memory. Also, in case we hit an allocation failure at some
+  point during the conversion, with allocation succeeding again on the
+  subsequent call(s) we will return a truncated list around the malloc
+  failure point. Fix by assigning to a temporary list pointer, which can
+  be checked (which is the common pattern for slist appending), and free
+  all the resources on allocation failure.
+  
+  Closes #3372
+  Reviewed-by: Daniel Stenberg <daniel@haxx.se>
+
+- cookies: leave secure cookies alone
+  
+  Only allow secure origins to be able to write cookies with the
+  'secure' flag set. This reduces the risk of non-secure origins
+  to influence the state of secure origins. This implements IETF
+  Internet-Draft draft-ietf-httpbis-cookie-alone-01 which updates
+  RFC6265.
+  
+  Closes #2956
+  Reviewed-by: Daniel Stenberg <daniel@haxx.se>
+
+Daniel Stenberg (13 Dec 2018)
+- docs: fix the --tls-max description
+  
+  Reported-by: Tobias Lindgren
+  Pointed out in #3367
+  
+  Closes #3368
+
+Daniel Gustafsson (12 Dec 2018)
+- urlapi: Fix port parsing of eol colon
+  
+  A URL with a single colon without a portnumber should use the default
+  port, discarding the colon. Fix, add a testcase and also do little bit
+  of comment wordsmithing.
+  
+  Closes #3365
+  Reviewed-by: Daniel Stenberg <daniel@haxx.se>
+
 Version 7.63.0 (12 Dec 2018)
 
 Daniel Stenberg (12 Dec 2018)
@@ -6695,848 +7747,3 @@ Daniel Stenberg (5 Mar 2018)
   WolfSSL: adding TLSv1.3
   
   Closes #2349
-
-- RELEASE-NOTES/THANKS: synced with cc1d4c505
-
-- [Richard Alcock brought this change]
-
-  winbuild: prefer documented zlib library names
-  
-  Check for existence of import and static libraries with documented names
-  and use them if they do. Fallback to previous names.
-  
-  According to
-  https://github.com/madler/zlib/blob/master/win32/README-WIN32.txt on
-  Windows, the names of the import library is "zdll.lib" and static
-  library is "zlib.lib".
-  
-  closes #2354
-
-Marcel Raad (4 Mar 2018)
-- krb5: use nondeprecated functions
-  
-  gss_seal/gss_unseal have been deprecated in favor of
-  gss_wrap/gss_unwrap with GSS-API v2 from January 1997 [1]. The first
-  version of "The Kerberos Version 5 GSS-API Mechanism" [2] from June
-  1996 already says "GSS_Wrap() (formerly GSS_Seal())" and
-  "GSS_Unwrap() (formerly GSS_Unseal())".
-  
-  Use the nondeprecated functions to avoid deprecation warnings.
-  
-  [1] https://tools.ietf.org/html/rfc2078
-  [2] https://tools.ietf.org/html/rfc1964
-  
-  Closes https://github.com/curl/curl/pull/2356
-
-Daniel Stenberg (4 Mar 2018)
-- curl.1: mention how to add numerical IP addresses in NO_PROXY
-
-- CURLOPT_NOPROXY.3: mention how to list numerical IPv6 addresses
-
-- NO_PROXY: fix for IPv6 numericals in the URL
-  
-  Added test 1265 that verifies.
-  
-  Reported-by: steelman on github
-  Fixes #2353
-  Closes #2355
-
-- build: get CFLAGS (including -werror) used for examples and tests
-  
-  ... so that the CI and more detects compiler warnings/errors properly!
-  
-  Closes #2337
-
-Marcel Raad (3 Mar 2018)
-- curl_ctype: fix macro redefinition warnings
-  
-  On MinGW and Cygwin, GCC and clang have been complaining about macro
-  redefinitions since 4272a0b0fc49a1ac0ceab5c4a365c9f6ab8bf8e2. Fix this
-  by undefining the macros before redefining them as suggested in
-  https://github.com/curl/curl/pull/2269.
-  
-  Suggested-by: Daniel Stenberg
-
-Dan Fandrich (2 Mar 2018)
-- unit1307: proper cleanup on OOM to fix torture tests
-
-Marcel Raad (28 Feb 2018)
-- unit1309: fix warning on Windows x64
-  
-  When targeting x64, MinGW-w64 complains about conversions between
-  32-bit long and 64-bit pointers. Fix this by reusing the
-  GNUTLS_POINTER_TO_SOCKET_CAST / GNUTLS_SOCKET_TO_POINTER_CAST logic
-  from gtls.c, moving it to warnless.h as CURLX_POINTER_TO_INTEGER_CAST /
-  CURLX_INTEGER_TO_POINTER_CAST.
-  
-  Closes https://github.com/curl/curl/pull/2341
-
-- travis: update compiler versions
-  
-  Update clang to version 3.9 and GCC to version 6.
-  
-  Closes https://github.com/curl/curl/pull/2345
-
-Daniel Stenberg (26 Feb 2018)
-- docs/MANUAL: formfind.pl is not accessible on the site anymore
-  
-  Fixes #2342
-
-Jay Satiro (24 Feb 2018)
-- curl-openssl.m4: Fix version check for OpenSSL 1.1.1
-  
-  - Add OpenSSL 1.1.1 to the header/library version lists.
-  
-  - Detect OpenSSL 1.1.1 library using its function ERR_clear_last_mark,
-    which was added in that version.
-  
-  Prior to this change an erroneous header/library mismatch was caused by
-  lack of OpenSSL 1.1.1 detection. I tested using openssl-1.1.1-pre1.
-
-Viktor Szakats (23 Feb 2018)
-- lib655: silence compiler warning
-  
-  Closes https://github.com/curl/curl/pull/2335
-
-- spelling fixes
-  
-  Detected using the `codespell` tool.
-  
-  Also contains one URL protocol upgrade.
-  
-  Closes https://github.com/curl/curl/pull/2334
-
-Daniel Stenberg (24 Feb 2018)
-- projects/README: remove reference to dead IDN link/package
-  
-  Reported-by: Stefan Kanthak and Rod Widdowson
-  
-  Fixes #2325
-
-Jay Satiro (23 Feb 2018)
-- [Rod Widdowson brought this change]
-
-  winbuild: Use macros for the names of some build utilities
-  
-  - Add macros to the top of the makefile for rc and mt utilities so that
-    it is easier to change their locations.
-  
-  Bug: https://curl.haxx.se/mail/lib-2018-02/0075.html
-  Reported-by: Stefan Kanthak
-  
-  Closes https://github.com/curl/curl/issues/2329
-
-Daniel Stenberg (23 Feb 2018)
-- TODO: remove "sha-256 digest", added in 2b5b37cb9109e7c2
-
-- curl_share_setopt.3: connection cache is shared within multi handles
-
-Jay Satiro (22 Feb 2018)
-- [Rod Widdowson brought this change]
-
-  winbuild: Use CALL to run batch scripts
-  
-  Co-authored-by: Stefan Kanthak
-  
-  Closes https://github.com/curl/curl/issues/2330
-  Closes https://github.com/curl/curl/pull/2331
-
-Patrick Monnerat (22 Feb 2018)
-- os400: add curl_resolver_start_callback type to ILE/RPG binding
-
-Daniel Stenberg (22 Feb 2018)
-- form.d: rephrased somewhat, added two example command lines
-
-Jay Satiro (21 Feb 2018)
-- [Francisco Sedano brought this change]
-
-  url: Add option CURLOPT_RESOLVER_START_FUNCTION
-  
-  - Add new option CURLOPT_RESOLVER_START_FUNCTION to set a callback that
-    will be called every time before a new resolve request is started
-    (ie before a host is resolved) with a pointer to backend-specific
-    resolver data. Currently this is only useful for ares.
-  
-  - Add new option CURLOPT_RESOLVER_START_DATA to set a user pointer to
-    pass to the resolver start callback.
-  
-  Closes https://github.com/curl/curl/pull/2311
-
-- lib: CURLOPT_HAPPY_EYEBALLS_TIMEOUT => CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS
-  
-  - In keeping with the naming of our other connect timeout options rename
-    CURLOPT_HAPPY_EYEBALLS_TIMEOUT to CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.
-  
-  This change adds the _MS suffix since the option expects milliseconds.
-  This is more intuitive for our users since other connect timeout options
-  that expect milliseconds use _MS such as CURLOPT_TIMEOUT_MS,
-  CURLOPT_CONNECTTIMEOUT_MS, CURLOPT_ACCEPTTIMEOUT_MS.
-  
-  The tool option already uses an -ms suffix, --happy-eyeballs-timeout-ms.
-  
-  Follow-up to 2427d94 which added the lib and tool option yesterday.
-  
-  Ref: https://github.com/curl/curl/pull/2260
-
-Patrick Monnerat (21 Feb 2018)
-- sasl: prefer PLAIN mechanism over LOGIN
-  
-  SASL PLAIN is a standard, LOGIN only a draft. The LOGIN draft says
-  PLAIN should be used instead if available.
-
-Daniel Stenberg (21 Feb 2018)
-- RELEASE-NOTES: synced with 2427d94c6
-
-Jay Satiro (20 Feb 2018)
-- [Anders Bakken brought this change]
-
-  url: Add option CURLOPT_HAPPY_EYEBALLS_TIMEOUT
-  
-  - Add new option CURLOPT_HAPPY_EYEBALLS_TIMEOUT to set libcurl's happy
-    eyeball timeout value.
-  
-  - Add new optval macro CURL_HET_DEFAULT to represent the default happy
-    eyeballs timeout value (currently 200 ms).
-  
-  - Add new tool option --happy-eyeballs-timeout-ms to expose
-    CURLOPT_HAPPY_EYEBALLS_TIMEOUT. The -ms suffix is used because the
-    other -timeout options in the tool expect seconds not milliseconds.
-  
-  Closes https://github.com/curl/curl/pull/2260
-
-- hostip: fix 'potentially uninitialized variable' warning
-  
-  Follow-up to 50d1b33.
-  
-  Caught by AppVeyor.
-
-Daniel Stenberg (20 Feb 2018)
-- TODO: warning if curl version is not in sync with libcurl version
-
-Jay Satiro (20 Feb 2018)
-- [Anders Bakken brought this change]
-
-  CURLOPT_RESOLVE: Add support for multiple IP addresses per entry
-  
-  This enables users to preresolve but still take advantage of happy
-  eyeballs and trying multiple addresses if some are not connecting.
-  
-  Ref: https://github.com/curl/curl/pull/2260
-
-Daniel Stenberg (20 Feb 2018)
-- [Sergio Borghese brought this change]
-
-  examples/sftpuploadresume: resume upload via CURLOPT_APPEND
-  
-  URL: https://curl.haxx.se/mail/lib-2018-02/0072.html
-
-- curl --version: show PSL if the run-time lib has it enabled
-  
-  ... not of the #define was set at build-time!
-
-- TODO: "Support in-memory certs/ca certs/keys"
-  
-  removed SSLKEYLOGFILE support (fixed)
-  
-  removed "consider SSL patches" (outdated)
-  
-  Closes #2310
-
-- CURLOPT_HEADER.3: clarify problems with different data sizes
-
-- test1556: verify >16KB headers to the header callback
-
-- header callback: don't chop headers into smaller pieces
-  
-  Reported-by: Guido Berhoerster
-  Fixes #2314
-  Closes #2316
-
-- test1154: verify that long HTTP headers get rejected
-
-- http: fix the max header length detection logic
-  
-  Previously, it would only check for max length if the existing alloc
-  buffer was to small to fit it, which often would make the header still
-  get used.
-  
-  Reported-by: Guido Berhoerster
-  Bug: https://curl.haxx.se/mail/lib-2018-02/0056.html
-  
-  Closes #2315
-
-- CURLOPT_HEADERFUNCTION.3: fix typo from d939226813
-  
-  Reported-by: Erik Johansson
-  Bug: https://github.com/curl/curl/commit/d9392268131c1b8d18dec3fa30e0bded833a5db7#commitcomment-27607495
-
-- CURLOPT_HEADERFUNCTION.3: mention folded headers
-
-- TODO: 1.1 Option to refuse usernames in URLs
-  
-  Also expanded the CURL_REFUSE_CLEARTEXT section with more ideas.
-
-- TODO: 1.7 Support HTTP/2 for HTTP(S) proxies
-
-- ssh: add two missing state names
-  
-  The list of state names (used in debug builds) was out of sync in
-  relation to the list of states (used in all builds).
-  
-  I now added an assert to make sure the sizes of the two lists match, to
-  aid in detecting this mistake better in the future.
-  
-  Regression since c92d2e14cf, shipped in 7.58.0.
-  
-  Reported-by: Somnath Kundu
-  
-  Fixes #2312
-  Closes #2313
-
-- Revert "KNOWN_BUGS: 2.5 curl should not offer "ALPN: h2" when using https-proxy"
-  
-  This reverts commit de9fac00c40db321d44fa6fbab6eb62ec4c83998.
-  
-  Reported-by: Jay Satiro
-
-Jay Satiro (15 Feb 2018)
-- non-ascii: fix implicit declaration warning
-  
-  Follow-up to b46cfbc.
-  
-  Caught by Travis CI.
-
-Daniel Stenberg (15 Feb 2018)
-- travis: add build with iconv enabled
-  
-  ... to verify it builds and works fine.
-  
-  Ref: https://curl.haxx.se/mail/lib-2017-09/0031.html
-  
-  Closes #1872
-
-- TODO: 18.18 retry on network is unreachable
-  
-  Closes #1603
-
-- KNOWN_BUGS: 2.5 curl should not offer "ALPN: h2" when using https-proxy
-  
-  Closes #1254
-
-Kamil Dudka (15 Feb 2018)
-- nss: use PK11_CreateManagedGenericObject() if available
-  
-  ... so that the memory allocated by applications using libcurl does not
-  grow per each TLS connection.
-  
-  Bug: https://bugzilla.redhat.com/1510247
-  
-  Closes #2297
-
-Daniel Stenberg (15 Feb 2018)
-- [Björn Stenberg brought this change]
-
-  TODO fixed: Detect when called from within callbacks
-  
-  Closes #2302
-
-- BINDINGS: fix curb link (and remove ruby-curl-multi)
-  
-  Reported-by: Klaus Stein
-
-- curl_gssapi: make sure this file too uses our *printf()
-
-- libcurl-security.3: separate file:// section
-  
-  ... just to make it more apparent. Even if it repeats
-  some pieces of information.
-
-- libcurl-security.3: the http://192.168.0.1/my_router_config case
-  
-  Mentioned-By: Rich Moore
-
-- libcurl-security.3: mention the URL standards problems too
-
-- libcurl-security.3: split out from libcurl-tutorial.3
-  
-  To make more accessible.
-  
-  Merged in some new language from "URLs are dangerous things" as discussed on
-  the mailing list a few days ago:
-  
-  Bug: https://curl.haxx.se/mail/lib-2018-02/0013.html
-
-- RELEASE-NOTES: synced with e551910f8
-
-Patrick Monnerat (13 Feb 2018)
-- tests: new tests for http raw mode
-  
-  Test 319 checks proper raw mode data with non-chunked gzip
-  transfer-encoded server data.
-  Test 326 checks raw mode with chunked server data.
-  
-  Bug: #2303
-  Closes #2308
-
-Kamil Dudka (12 Feb 2018)
-- tlsauthtype.d: works only if libcurl is built with TLS-SRP support
-  
-  Bug: https://bugzilla.redhat.com/1542256
-  
-  Closes #2306
-
-Patrick Monnerat (12 Feb 2018)
-- smtp: fix processing of initial dot in data
-  
-  RFC 5321 4.1.1.4 specifies the CRLF terminating the DATA command
-  should be taken into account when chasing the <CRLF>.<CRLF> end marker.
-  Thus a leading dot character in data is also subject to escaping.
-  
-  Tests 911 and test server are adapted to this situation.
-  New tests 951 and 952 check proper handling of initial dot in data.
-  
-  Closes #2304
-
-Daniel Stenberg (12 Feb 2018)
-- sha256: avoid redefine
-
-- [Douglas Mencken brought this change]
-
-  sha256: build with OpenSSL < 0.9.8 too
-  
-  support for SHA-2 was introduced in OpenSSL 0.9.8
-  
-  Closes #2305
-
-- [Bruno Grasselli brought this change]
-
-  README: language fix
-  
-  s/off/from
-  
-  Closes #2300
-
-Patrick Monnerat (12 Feb 2018)
-- http_chunks: don't write chunks twice with CURLOPT_HTTP_TRANSFER_DECODING on
-  
-  Bug: #2303
-  Reported-By: Henry Roeland
-
-Daniel Stenberg (9 Feb 2018)
-- get_posix_time: only check for overflows if they can happen!
-
-Michael Kaufmann (9 Feb 2018)
-- schannel: fix "no previous prototype" compiler warning
-
-Jay Satiro (9 Feb 2018)
-- [Mohammad AlSaleh brought this change]
-
-  content_encoding: Add "none" alias to "identity"
-  
-  Some servers return a "content-encoding" header with a non-standard
-  "none" value.
-  
-  Add "none" as an alias to "identity" as a work-around, to avoid
-  unrecognised content encoding type errors.
-  
-  Signed-off-by: Mohammad AlSaleh <CE.Mohammad.AlSaleh@gmail.com>
-  
-  Closes https://github.com/curl/curl/pull/2298
-
-Steve Holme (8 Feb 2018)
-- build-openssl.bat: Follow up to 648679ab8e to suppress copy/move output
-
-- build-openssl.bat: Fixed incorrect move if destination build folder exists
-
-Michael Kaufmann (8 Feb 2018)
-- schannel: fix compiler warnings
-  
-  Closes #2296
-
-Steve Holme (7 Feb 2018)
-- curl_addrinfo.c: Allow Unix Domain Sockets to compile under Windows
-  
-  Windows 10.0.17061 SDK introduces support for Unix Domain Sockets.
-  Added the necessary include file to curl_addrinfo.c.
-  
-  Note: The SDK (which is considered beta) has to be installed, VS 2017
-  project file has to be re-targeted for Windows 10.0.17061 and #define
-  enabled in config-win32.h.
-
-Patrick Monnerat (7 Feb 2018)
-- fnmatch: optimize processing of consecutive *s and ?s pattern characters
-  
-  Reported-By: Daniel Stenberg
-  Fixes #2291
-  Closes #2293
-
-Steve Holme (6 Feb 2018)
-- build-openssl.bat/build-wolfssl.bat: Build platform is optional
-  
-  Whilst the compiler parameter is mandatory, platform is optional as it
-  is automatically calculated by the :configure section.
-  
-  This partially reverts commit 6d62d2c55d.
-
-Daniel Stenberg (6 Feb 2018)
-- [Patrick Schlangen brought this change]
-
-  openssl: Don't add verify locations when verifypeer==0
-  
-  When peer verification is disabled, calling
-  SSL_CTX_load_verify_locations is not necessary. Only call it when
-  verification is enabled to save resources and increase performance.
-  
-  Closes #2290
-
-Steve Holme (5 Feb 2018)
-- build-wolfssl.bat: Extend VC15 support to include Enterprise and Professional
-  
-  ...and not just the Community Edition.
-
-- build-openssl.bat: Extend VC15 support to include Enterprise and Professional
-  
-  ...and not just the Community Edition.
-
-Michael Kaufmann (5 Feb 2018)
-- time-cond: fix reading the file modification time on Windows
-  
-  On Windows, stat() may adjust the unix file time by a daylight saving time
-  offset. Avoid this by calling GetFileTime() instead.
-  
-  Fixes #2164
-  Closes #2204
-
-Daniel Stenberg (5 Feb 2018)
-- formdata: use the mime-content type function
-  
-  Reduce code duplication by making Curl_mime_contenttype available and
-  used by the formdata function. This also makes the formdata function
-  recognize a set of more file extensions by default.
-  
-  PR #2280 brought this to my attention.
-  
-  Closes #2282
-
-- getdate: return -1 for out of range
-  
-  ...as that's how the function is documented to work.
-  
-  Reported-by: Michael Kaufmann
-  Bug found in an autobuild with 32 bit time_t
-  
-  Closes #2278
-
-- [Ben Greear brought this change]
-
-  build: fix termios issue on android cross-compile
-  
-  Bug: https://curl.haxx.se/mail/lib-2018-01/0122.html
-  Signed-off-by: Ben Greear <greearb@candelatech.com>
-
-- time_t-fixes: remove typecasts to 'long' for info.filetime
-  
-  They're now wrong.
-  
-  Reported-by: Michael Kaufmann
-  
-  Closes #2277
-
-- curl_setup: move the precautionary define of SIZEOF_TIME_T
-  
-  ... up to before it may be used for the TIME_T_MAX/MIN logic.
-  
-  Reported-by: Michael Kaufmann
-
-- parsedate: s/#if/#ifdef
-  
-  Reported-by: Michael Kaufmann
-  Bug: https://github.com/curl/curl/commit/1c39128d974666107fc6d9ea15f294036851f224#commitcomment-27246479
-
-Patrick Monnerat (31 Jan 2018)
-- fnmatch: pattern syntax can no longer fail
-  
-  Whenever an expected pattern syntax rule cannot be matched, the
-  character starting the rule loses its special meaning and the parsing
-  is resumed:
-  - backslash at the end of pattern string matches itself.
-  - Error in [:keyword:] results in set containing :\[dekorwy.
-  
-  Unit test 1307 updated for this new situation.
-  
-  Closes #2273
-
-- fnmatch: accept an alphanum to be followed by a non-alphanum in char set
-  
-  Also be more tolerant about set pattern syntax.
-  Update unit test 1307 accordingly.
-  
-  Bug: https://curl.haxx.se/mail/lib-2018-01/0114.html
-
-- fnmatch: do not match the empty string with a character set
-
-Jay Satiro (30 Jan 2018)
-- build: fix windows build methods for curl_ctype.c
-  
-  - Fix winbuild and the VS project generator to treat curl_ctype.{c,h} as
-    curlx files since they are required by both src and lib.
-  
-  Follow-up to 4272a0b which added curl_ctype.
-
-Daniel Stenberg (30 Jan 2018)
-- progress-bar.d: update to match implementation
-  
-  ... since commit 993dd5651a6
-  
-  Reported-by: Martin Dreher
-  Bug: https://github.com/curl/curl/pull/2242#issuecomment-361059228
-  
-  Closes #2271
-
-- http2: set DEBUG_HTTP2 to enable more HTTP/2 logging
-  
-  ... instead of doing it unconditionally in debug builds. It cluttered up
-  the output a little too much.
-
-- [Max Dymond brought this change]
-
-  file: Check the return code from Curl_range and bail out on error
-
-- [Max Dymond brought this change]
-
-  Curl_range: add check to ensure "from <= to"
-
-- [Max Dymond brought this change]
-
-  Curl_range: commonize FTP and FILE range handling
-  
-  Closes #2205
-
-- RELEASE-NOTES: synced with 811beab9f
-
-- curlver: next release will be 7.59.0
-
-- [Michał Janiszewski brought this change]
-
-  curl/curl.h: fix comment typo for CURLOPT_DNS_LOCAL_IP6
-  
-  Closes #2275
-
-- time: support > year 2038 time stamps for system with 32bit long
-  
-  ... with the introduction of CURLOPT_TIMEVALUE_LARGE and
-  CURLINFO_FILETIME_T.
-  
-  Fixes #2238
-  Closes #2264
-
-- curl_easy_reset: clear digest auth state
-  
-  Bug: https://curl.haxx.se/mail/lib-2018-01/0074.html
-  Reported-by: Ruurd Beerstra
-  Fixes #2255
-  Closes #2272
-
-- [Adam Marcionek brought this change]
-
-  winbuild: make linker generate proper PDB
-  
-  Link.exe requires /DEBUG to properly generate a full pdb file on release
-  builds.
-  
-  Closes #2274
-
-- curl: add --proxy-pinnedpubkey
-  
-  To verify a proxy's public key. For when using HTTPS proxies.
-  
-  Fixes #2192
-  Closes #2268
-
-- configure: set PATH_SEPARATOR to colon for PATH w/o separator
-  
-  The logic tries to figure out what the path separator in the $PATH
-  variable is, but if there's only one directory in the $PATH it
-  fails. This change make configure *guess* on colon instead of erroring
-  out, simply because that is probably the more common character.
-  
-  PATH_SEPARATOR can always be set by the user to override the guessing.
-  
-  (tricky bug to reproduce, as in my case for example the configure script
-  requires binaries in more than one directory so passing in a PATH with a
-  single dir fails.)
-  
-  Reported-by: Earnestly on github
-  Fixes #2202
-  Closes #2265
-
-- curl_ctype: private is*() type macros and functions
-  
-  ... since the libc provided one are locale dependent in a way we don't
-  want. Also, the "native" isalnum() (for example) works differently on
-  different platforms which caused test 1307 failures on macos only.
-  
-  Closes #2269
-
-Marcel Raad (29 Jan 2018)
-- build: open VC15 projects with VS 2017
-  
-  Previously, they were opened with Visual Studio 2015 by default, which
-  cannot build them.
-
-Daniel Stenberg (29 Jan 2018)
-- RELEASE-NOTES: synced with 094647fca
-
-- TODO: UTF-8 filenames in Content-Disposition
-  
-  Closes #1888
-
-- KNOWN_BUGS: DICT responses show the underlying protocol
-  
-  Closes #1809
-
-Jay Satiro (27 Jan 2018)
-- [Alessandro Ghedini brought this change]
-
-  docs: fix typos in man pages
-  
-  Closes https://github.com/curl/curl/pull/2266
-
-Patrick Monnerat (26 Jan 2018)
-- lib555: drop text conversion and encode data as ascii codes
-  
-  If CURL_DOES_CONVERSION is enabled, uploaded LFs are mapped to CRLFs,
-  giving a result that is different from what is expected.
-  This commit avoids using CURLOPT_TRANSFERTEXT and directly encodes data
-  to upload in ascii.
-  
-  Bug: https://github.com/curl/curl/pull/1872
-
-Daniel Stenberg (26 Jan 2018)
-- lib517: make variable static to avoid compiler warning
-  
-  ... with clang on macos
-
-Patrick Monnerat (26 Jan 2018)
-- lib544: sync ascii code data with textual data
-  
-  Data mismatch caused test 545 to fail when character encoding
-  conversion is enabled.
-  
-  Bug: https://github.com/curl/curl/pull/1872
-
-Daniel Stenberg (25 Jan 2018)
-- [Travis Burtrum brought this change]
-
-  GSKit: restore pinnedpubkey functionality
-  
-  inadvertently removed in 283babfaf8d8f3bab9d3c63cea94eb0b84e79c37
-  
-  Closes #2263
-
-- [Dair Grant brought this change]
-
-  darwinssl: Don't import client certificates into Keychain on macOS
-  
-  Closes #2085
-
-- configure: fix the check for unsigned time_t
-  
-  Assign the time_t variable negative value and then check if it is
-  greater than zero, which will evaluate true for unsigned time_t but
-  false for signed time_t.
-
-- parsedate: fix date parsing for systems with 32 bit long
-  
-  Make curl_getdate() handle dates before 1970 as well (returning negative
-  values).
-  
-  Make test 517 test dates for 64 bit time_t.
-  
-  This fixes bug (3) mentioned in #2238
-  
-  Closes #2250
-
-- [McDonough, Tim brought this change]
-
-  openssl: fix pinned public key build error in FIPS mode
-  
-  Here is a version that should work with all versions of openssl 0.9.7
-  through 1.1.0.
-  
-  Links to the docs:
-  https://www.openssl.org/docs/man1.0.2/crypto/EVP_DigestInit.html
-  https://www.openssl.org/docs/man1.1.0/crypto/EVP_DigestInit.html
-  
-  At the very bottom of the 1.1.0 documentation there is a history section
-  that states, " stack allocated EVP_MD_CTXs are no longer supported."
-  
-  If EVP_MD_CTX_create and EVP_MD_CTX_destroy are not defined, then a
-  simple mapping can be used as described here:
-  https://wiki.openssl.org/index.php/Talk:OpenSSL_1.1.0_Changes
-  
-  Closes #2258
-
-- [Travis Burtrum brought this change]
-
-  SChannel/WinSSL: Replace Curl_none_md5sum with Curl_schannel_md5sum
-
-- [Travis Burtrum brought this change]
-
-  SChannel/WinSSL: Implement public key pinning
-  
-  Closes #1429
-
-- bump: towards 7.58.1
-
-- cookies: remove verbose "cookie size:" output
-  
-  It was once used for some debugging/verifying logic but should never have
-  ended up in git!
-
-- TODO: hardcode the "localhost" addresses
-
-- TODO: CURL_REFUSE_CLEARTEXT
-  
-  An idea that popped up in discussions on twitter.
-
-- progress-bar: don't use stderr explicitly, use bar->out
-  
-  Reported-By: Gisle Vanem
-  Bug: https://github.com/curl/curl/commit/993dd5651a6c853bfe3870f6a69c7b329fa4e8ce#commitcomment-27070080
-
-GitHub (24 Jan 2018)
-- [Gisle Vanem brought this change]
-
-  Fixes for MSDOS etc.
-  
-  djgpp do have 'mkdir(dir, mode)'. Other DOS-compilers does not
-  But djgpp seems the only choice for MSDOS anyway.
-  
-  PellesC do have a 'F_OK' defined in it's <unistd.h>.
-  
-  Update year in Copyright.
-
-- [Gisle Vanem brought this change]
-
-  Fix small typo.
-
-Version 7.58.0 (23 Jan 2018)
-
-Daniel Stenberg (23 Jan 2018)
-- RELEASE: 7.58.0
-
-- [Gisle Vanem brought this change]
-
-  progress-bar: get screen width on windows
-
-- test1454: --connect-to with IPv6 address w/o IPv6 support!
-
-- CONNECT_TO: fail attempt to set an IPv6 numerical without IPv6 support
-  
-  Bug: https://curl.haxx.se/mail/lib-2018-01/0087.html
-  Reported-by: John Hascall
-  
-  Closes #2257
-
-- docs: fix man page syntax to make test 1140 OK again

--- a/vendor/curl/RELEASE-NOTES
+++ b/vendor/curl/RELEASE-NOTES
@@ -1,98 +1,97 @@
-curl and libcurl 7.63.0
+curl and libcurl 7.64.0
 
- Public curl releases:         178
- Command line options:         219
- curl_easy_setopt() options:   262
+ Public curl releases:         179
+ Command line options:         220
+ curl_easy_setopt() options:   265
  Public functions in libcurl:  80
- Contributors:                 1829
+ Contributors:                 1875
 
 This release includes the following changes:
 
- o curl: add %{stderr} and %{stdout} for --write-out [24]
- o curl: add undocumented option --dump-module-paths for win32 [19]
- o setopt: add CURLOPT_CURLU [27]
+ o cookies: leave secure cookies alone [3]
+ o hostip: support wildcard hosts [23]
+ o http: Implement trailing headers for chunked transfers [7]
+ o http: added options for allowing HTTP/0.9 responses [10]
+ o timeval: Use high resolution timestamps on Windows [19]
 
 This release includes the following bugfixes:
 
- o (lib)curl.rc: fixup for minor bugs [63]
- o CURLINFO_REDIRECT_URL: extract the Location: header field unvalidated [73]
- o CURLOPT_HEADERFUNCTION.3: match 'nitems' name in synopsis and description [45]
- o CURLOPT_WRITEFUNCTION.3: spell out that it gets called many times
- o Curl_follow: accept non-supported schemes for "fake" redirects [9]
- o KNOWN_BUGS: add --proxy-any connection issue [28]
- o NTLM: Remove redundant ifdef USE_OPENSSL [41]
- o NTLM: force the connection to HTTP/1.1 [67]
- o OS400: add URL API ccsid wrappers and sync ILE/RPG bindings
- o SECURITY-PROCESS: bountygraph shuts down again [50]
- o TODO: Have the URL API offer IDN decoding [22]
- o ares: remove fd from multi fd set when ares is about to close the fd [42]
- o axtls: removed [1]
- o checksrc: add COPYRIGHTYEAR check [62]
- o cmake: fix MIT/Heimdal Kerberos detection [53]
- o configure: include all libraries in ssl-libs fetch [55]
- o configure: show CFLAGS, LDFLAGS etc in summary [7]
- o connect: fix building for recent versions of Minix [52]
- o cookies: create the cookiejar even if no cookies to save [48]
- o cookies: expire "Max-Age=0" immediately [64]
- o curl: --local-port range was not "including" [29]
- o curl: fix --local-port integer overflow [25]
- o curl: fix memory leak reading --writeout from file [51]
- o curl: fixed UTF-8 in current console code page (Windows) [16]
- o curl_easy_perform: fix timeout handling [49]
- o curl_global_sslset(): id == -1 is not necessarily an error [68]
- o curl_multibyte: fix a malloc overcalculation [18]
- o curle: move deprecated error code to ifndef block [40]
- o docs: curl_formadd field and file names are now escaped [72]
- o docs: escape "\n" codes [26]
- o doh: fix memory leak in OOM situation [56]
- o doh: make it work for h2-disabled builds too [57]
- o examples/ephiperfifo: report error when epoll_ctl fails
- o ftp: avoid two unsigned int overflows in FTP listing parser [30]
- o host names: allow trailing dot in name resolve, then strip it [46]
- o http2: Upon HTTP_1_1_REQUIRED, retry the request with HTTP/1.1 [65]
- o http: don't set CURLINFO_CONDITION_UNMET for http status code 204 [70]
- o http: fix HTTP Digest auth to include query in URI [69]
- o http_negotiate: do not close connection until negotiation is completed [36]
- o impacket: add LICENSE [39]
- o infof: clearly indicate truncation [14]
- o ldap: fix LDAP URL parsing regressions [71]
- o libcurl: stop reading from paused transfers [20]
- o mprintf: avoid unsigned integer overflow warning [10]
- o netrc: don't ignore the login name specified with "--user" [17]
- o nss: Fall back to latest supported SSL version [60]
- o nss: Fix compatibility with nss versions 3.14 to 3.15 [61]
- o nss: fix fallthrough comment to fix picky compiler warning
- o nss: remove version selecting dead code [33]
- o nss: set default max-tls to 1.3/1.2 [32]
- o openssl: Remove SSLEAY leftovers [37]
- o openssl: do not log excess "TLS app data" lines for TLS 1.3 [34]
- o openssl: do not use file BIOs if not requested [59]
- o openssl: fix unused variable compiler warning with old openssl [66]
- o openssl: support session resume with TLS 1.3 [44]
- o openvms: fix example name [8]
- o os400: Add curl_easy_conn_upkeep() to ILE/RPG binding
- o os400: add CURLOPT_CURLU to ILE/RPG binding
- o os400: fix return type of curl_easy_pause() in ILE/RPG binding
- o packages: remove old leftover files and dirs [58]
- o pop3: only do APOP with a valid timestamp [35]
- o runtests: use the local curl for verifying [6]
- o schannel: be consistent in Schannel capitalization [23]
- o schannel: better CURLOPT_CERTINFO support [2]
- o schannel: use Curl_ prefix for global private symbols [4]
- o snprintf: renamed and we now only use msnprintf() [47]
- o ssl: fix compilation with OpenSSL 0.9.7 [43]
- o ssl: replace all internal uses of CURLE_SSL_CACERT [40]
- o symbols-in-versions: add missing CURLU_ symbols [15]
- o test328: verify Content-Encoding: none [54]
- o tests: disable SO_EXCLUSIVEADDRUSE for stunnel on Windows
- o tests: drop http_pipe.py script no longer used [5]
- o tool_cb_wrt: Silence function cast compiler warning [31]
- o tool_doswin: Fix uninitialized field warning [38]
- o travis: build with clang sanitizers [3]
- o travis: remove curl before a normal build [11]
- o url: a short host name + port is not a scheme [13]
- o url: fix IPv6 numeral address parser [12]
- o urlapi: only skip encoding the first '=' with APPENDQUERY set [21]
+ o CVE-2018-16890: NTLM type-2 out-of-bounds buffer read [67]
+ o CVE-2019-3822: NTLMv2 type-3 header stack buffer overflow [68]
+ o CVE-2019-3823: SMTP end-of-response out-of-bounds read [66]
+ o FAQ: remove mention of sourceforge for github [22]
+ o OS400: handle memory error in list conversion [4]
+ o OS400: upgrade ILE/RPG binding.
+ o README: add codacy code quality badge
+ o Revert http_negotiate: do not close connection [31]
+ o THANKS: added several missing names from year <= 2000
+ o build: make 'tidy' target work for metalink builds
+ o cmake: added checks for variadic macros [47]
+ o cmake: updated check for HAVE_POLL_FINE to match autotools [39]
+ o cmake: use lowercase for function name like the rest of the code [20]
+ o configure: detect xlclang separately from clang [41]
+ o configure: fix recv/send/select detection on Android [53]
+ o configure: rewrite --enable-code-coverage [61]
+ o conncache_unlock: avoid indirection by changing input argument type
+ o cookie: fix comment typo [44]
+ o cookies: allow secure override when done over HTTPS [34]
+ o cookies: extend domain checks to non psl builds [12]
+ o cookies: skip custom cookies when redirecting cross-site [36]
+ o curl --xattr: strip credentials from any URL that is stored [33]
+ o curl -J: refuse to append to the destination file [14]
+ o curl/urlapi.h: include "curl.h" first [30]
+ o curl_multi_remove_handle() don't block terminating c-ares requests [32]
+ o darwinssl: accept setting max-tls with default min-tls [6]
+ o disconnect: separate connections and easy handles better [18]
+ o disconnect: set conn->data for protocol disconnect
+ o docs/version.d: mention MultiSSL [26]
+ o docs: fix the --tls-max description [2]
+ o docs: use $(INSTALL_DATA) to install man page [64]
+ o docs: use meaningless port number in CURLOPT_LOCALPORT example [58]
+ o gopher: always include the entire gopher-path in request [5]
+ o http2: clear pause stream id if it gets closed [8]
+ o if2ip: remove unused function Curl_if_is_interface_name [9]
+ o libssh: do not let libssh create socket [63]
+ o libssh: enable CURLOPT_SSH_KNOWNHOSTS and CURLOPT_SSH_KEYFUNCTION for libssh [62]
+ o libssh: free sftp_canonicalize_path() data correctly [17]
+ o libtest/stub_gssapi: use "real" snprintf [27]
+ o mbedtls: use VERIFYHOST [15]
+ o multi: multiplexing improvements [35]
+ o multi: set the EXPIRE_*TIMEOUT timers at TIMER_STARTSINGLE time [57]
+ o ntlm: fix NTMLv2 compliance [25]
+ o ntlm_sspi: add support for channel binding [54]
+ o openssl: adapt to 3.0.0, OpenSSL_version_num() is deprecated [46]
+ o openssl: fix the SSL_get_tlsext_status_ocsp_resp call [40]
+ o openvms: fix OpenSSL discovery on VAX [21]
+ o openvms: fix typos in documentation
+ o os400: add a missing closing bracket [50]
+ o os400: fix extra parameter syntax error [50]
+ o pingpong: change default response timeout to 120 seconds
+ o pingpong: ignore regular timeout in disconnect phase [16]
+ o printf: fix format specifiers [28]
+ o runtests.pl: Fix perl call to include srcdir [65]
+ o schannel: fix compiler warning [29]
+ o schannel: preserve original certificate path parameter [52]
+ o schannel: stop calling it "winssl" [56]
+ o sigpipe: if mbedTLS is used, ignore SIGPIPE [59]
+ o smb: fix incorrect path in request if connection reused [13]
+ o ssh: log the libssh2 error message when ssh session startup fails [55]
+ o test1558: verify CURLINFO_PROTOCOL on file:// transfer [51]
+ o test1561: improve test name
+ o test1653: make it survive torture tests
+ o tests: allow tests to pass by 2037-02-12 [38]
+ o tests: move objnames-* from lib into tests [42]
+ o timediff: fix math for unsigned time_t [37]
+ o timeval: Disable MSVC Analyzer GetTickCount warning [60]
+ o tool_cb_prg: avoid integer overflow [49]
+ o travis: added cmake build for osx [43]
+ o urlapi: Fix port parsing of eol colon [1]
+ o urlapi: distinguish possibly empty query [5]
+ o urlapi: fix parsing ipv6 with zone index [24]
+ o urldata: rename easy_conn to just conn [48]
+ o winbuild: conditionally use /DZLIB_WINAPI [45]
+ o wolfssl: fix memory-leak in threaded use [11]
+ o spnego_sspi: add support for channel binding [69]
 
 This release includes the following known bugs:
 
@@ -101,94 +100,91 @@ This release includes the following known bugs:
 This release would not have looked like this without help, code, reports and
 advice from friends like these:
 
-  Alessandro Ghedini, Alexey Melnichuk, Antoni Villalonga, Ben Greear,
-  bobmitchell1956 on github, Brad King, Brian Carpenter, daboul on github,
-  Daniel Gustafsson, Daniel Stenberg, Dave Reisner, David Benjamin,
-  Dheeraj Sangamkar, dtmsecurity on github, Elia Tufarolo, Frank Gevaerts,
-  Gergely Nagy, Gisle Vanem, Hagai Auro, Han Han, infinnovation-dev on github,
-  James Knight, Jérémy Rocher, Jeroen Ooms, Jim Fuller, Johannes Schindelin,
-  Kamil Dudka, Konstantin Kushnir, Marcel Raad, Marc Hörsken, Marcos Diazr,
-  Michael Kaufmann, NTMan on Github, Patrick Monnerat, Paul Howarth,
-  Pavel Pavlov, Peter Wu, Ray Satiro, Rod Widdowson, Romain Fliedel,
-  Samuel Surtees, Sevan Janiyan, Stefan Kanthak, Sven Blumenstein, Tim Rühsen,
-  Tobias Hintze, Tomas Hoger, tonystz on Github, tpaukrt on github,
-  Viktor Szakats, Yasuhiro Matsumoto,
-  (51 contributors)
+  Alessandro Ghedini, Andrei Neculau, Archangel SDY, Ayoub Boudhar, Ben Kohler,
+  Bernhard M. Wiedemann, Brad Spencer, Brian Carpenter, Claes Jakobsson,
+  Daniel Gustafsson, Daniel Stenberg, David Garske, dnivras on github,
+  Eric Rosenquist, Etienne Simard, Felix Hädicke, Florian Pritz,
+  Frank Gevaerts, Giorgos Oikonomou, Gisle Vanem, GitYuanQu on github,
+  Haibo Huang, Harry Sintonen, Helge Klein, Huzaifa Sidhpurwala,
+  jasal82 on github, Jeremie Rapin, Jeroen Ooms, Joel Depooter, John Marshall,
+  jonrumsey on github, Julian Z, Kamil Dudka, Katsuhiko YOSHIDA, Kees Dekker,
+  Ladar Levison, Leonardo Taccari, Marcel Raad, Markus Moeller,
+  masbug on github, Matus Uzak, Michael Kujawa, Patrick Monnerat, Pavel Pavlov,
+  Peng Li, Ray Satiro, Rikard Falkeborn, Ruslan Baratov, Sergei Nikulov,
+  Shlomi Fish, Tobias Lindgren, Tom van der Woerdt, Viktor Szakats,
+  Wenxiang Qian, William A. Rowe Jr, Zhao Yisha,
+  (56 contributors)
 
         Thanks! (and sorry if I forgot to mention someone)
 
 References to bug reports and discussions on issues:
 
- [1] = https://curl.haxx.se/bug/?i=3194
- [2] = https://curl.haxx.se/bug/?i=3197
- [3] = https://curl.haxx.se/bug/?i=3190
- [4] = https://curl.haxx.se/bug/?i=3201
- [5] = https://curl.haxx.se/bug/?i=3204
- [6] = https://curl.haxx.se/mail/lib-2018-10/0118.html
- [7] = https://curl.haxx.se/bug/?i=3207
- [8] = https://curl.haxx.se/bug/?i=3217
- [9] = https://curl.haxx.se/bug/?i=3210
- [10] = https://curl.haxx.se/bug/?i=3184
- [11] = https://curl.haxx.se/bug/?i=3198
- [12] = https://curl.haxx.se/bug/?i=3218
- [13] = https://curl.haxx.se/bug/?i=3220
- [14] = https://curl.haxx.se/bug/?i=3216
- [15] = https://curl.haxx.se/bug/?i=3226
- [16] = https://curl.haxx.se/bug/?i=3211
- [17] = https://curl.haxx.se/bug/?i=3213
- [18] = https://curl.haxx.se/bug/?i=3209
- [19] = https://curl.haxx.se/bug/?i=3208
- [20] = https://curl.haxx.se/bug/?i=3240
- [21] = https://curl.haxx.se/bug/?i=3231
- [22] = https://curl.haxx.se/bug/?i=3232
- [23] = https://curl.haxx.se/bug/?i=3243
- [24] = https://curl.haxx.se/bug/?i=3115
- [25] = https://curl.haxx.se/bug/?i=3242
- [26] = https://curl.haxx.se/bug/?i=3246
- [27] = https://curl.haxx.se/bug/?i=3227
- [28] = https://curl.haxx.se/bug/?i=876
- [29] = https://curl.haxx.se/bug/?i=3251
- [30] = https://curl.haxx.se/bug/?i=3225
- [31] = https://curl.haxx.se/bug/?i=3263
- [32] = https://curl.haxx.se/bug/?i=3261
- [33] = https://curl.haxx.se/bug/?i=3262
- [34] = https://curl.haxx.se/bug/?i=3281
- [35] = https://curl.haxx.se/bug/?i=3278
- [36] = https://curl.haxx.se/bug/?i=3275
- [37] = https://curl.haxx.se/bug/?i=3270
- [38] = https://curl.haxx.se/bug/?i=3254
- [39] = https://curl.haxx.se/bug/?i=3276
- [40] = https://curl.haxx.se/bug/?i=3291
- [41] = https://curl.haxx.se/bug/?i=3269
- [42] = https://curl.haxx.se/bug/?i=3238
- [43] = https://curl.haxx.se/bug/?i=3266
- [44] = https://curl.haxx.se/bug/?i=3202
- [45] = https://curl.haxx.se/bug/?i=3295
- [46] = https://curl.haxx.se/bug/?i=3022
- [47] = https://curl.haxx.se/bug/?i=3296
- [48] = https://curl.haxx.se/bug/?i=3299
- [49] = https://curl.haxx.se/bug/?i=3305
- [50] = https://curl.haxx.se/bug/?i=3311
- [51] = https://curl.haxx.se/bug/?i=3322
- [52] = https://curl.haxx.se/bug/?i=3323
- [53] = https://curl.haxx.se/bug/?i=3316
- [54] = https://curl.haxx.se/bug/?i=3317
- [55] = https://curl.haxx.se/bug/?i=3193
- [56] = https://curl.haxx.se/bug/?i=3342
- [57] = https://curl.haxx.se/bug/?i=3325
- [58] = https://curl.haxx.se/bug/?i=3331
- [59] = https://curl.haxx.se/bug/?i=3339
- [60] = https://curl.haxx.se/bug/?i=3261
- [61] = https://curl.haxx.se/bug/?i=3337
- [62] = https://curl.haxx.se/bug/?i=3303
- [63] = https://curl.haxx.se/bug/?i=3348
- [64] = https://curl.haxx.se/bug/?i=3351
- [65] = https://curl.haxx.se/bug/?i=3349
- [66] = https://curl.haxx.se/bug/?i=3337
- [67] = https://curl.haxx.se/bug/?i=3345
- [68] = https://curl.haxx.se/bug/?i=3346
- [69] = https://curl.haxx.se/bug/?i=3353
- [70] = https://curl.haxx.se/bug/?i=3359
- [71] = https://curl.haxx.se/bug/?i=3362
- [72] = https://curl.haxx.se/bug/?i=3361
- [73] = https://curl.haxx.se/bug/?i=3340
+ [1] = https://curl.haxx.se/bug/?i=3365
+ [2] = https://curl.haxx.se/bug/?i=3368
+ [3] = https://curl.haxx.se/bug/?i=2956
+ [4] = https://curl.haxx.se/bug/?i=3372
+ [5] = https://curl.haxx.se/bug/?i=3369
+ [6] = https://curl.haxx.se/bug/?i=3367
+ [7] = https://curl.haxx.se/bug/?i=3350
+ [8] = https://curl.haxx.se/bug/?i=3392
+ [9] = https://curl.haxx.se/bug/?i=3401
+ [10] = https://curl.haxx.se/bug/?i=2873
+ [11] = https://curl.haxx.se/bug/?i=3395
+ [12] = https://curl.haxx.se/bug/?i=2964
+ [13] = https://curl.haxx.se/bug/?i=3388
+ [14] = https://curl.haxx.se/bug/?i=3380
+ [15] = https://curl.haxx.se/bug/?i=3376
+ [16] = https://curl.haxx.se/bug/?i=3264
+ [17] = https://curl.haxx.se/bug/?i=3402
+ [18] = https://curl.haxx.se/bug/?i=3400
+ [19] = https://curl.haxx.se/bug/?i=3318
+ [20] = https://curl.haxx.se/bug/?i=3196
+ [21] = https://curl.haxx.se/bug/?i=3407
+ [22] = https://curl.haxx.se/bug/?i=3410
+ [23] = https://curl.haxx.se/bug/?i=3406
+ [24] = https://curl.haxx.se/bug/?i=3411
+ [25] = https://curl.haxx.se/bug/?i=3286
+ [26] = https://curl.haxx.se/bug/?i=3432
+ [27] = https://curl.haxx.se/mail/lib-2019-01/0000.html
+ [28] = https://curl.haxx.se/bug/?i=3426
+ [29] = https://curl.haxx.se/bug/?i=3435
+ [30] = https://curl.haxx.se/bug/?i=3438
+ [31] = https://curl.haxx.se/bug/?i=3384
+ [32] = https://curl.haxx.se/bug/?i=3371
+ [33] = https://curl.haxx.se/bug/?i=3423
+ [34] = https://curl.haxx.se/bug/?i=3445
+ [35] = https://curl.haxx.se/bug/?i=3436
+ [36] = https://curl.haxx.se/bug/?i=3417
+ [37] = https://curl.haxx.se/bug/?i=3449
+ [38] = https://curl.haxx.se/bug/?i=3443
+ [39] = https://curl.haxx.se/bug/?i=3292
+ [40] = https://curl.haxx.se/bug/?i=3477
+ [41] = https://curl.haxx.se/bug/?i=3474
+ [42] = https://curl.haxx.se/bug/?i=3470
+ [43] = https://curl.haxx.se/bug/?i=3468
+ [44] = https://curl.haxx.se/bug/?i=3469
+ [45] = https://curl.haxx.se/bug/?i=3133
+ [46] = https://curl.haxx.se/bug/?i=3462
+ [47] = https://curl.haxx.se/bug/?i=3459
+ [48] = https://curl.haxx.se/bug/?i=3442
+ [49] = https://curl.haxx.se/bug/?i=3456
+ [50] = https://curl.haxx.se/bug/?i=3453
+ [51] = https://curl.haxx.se/bug/?i=3447
+ [52] = https://curl.haxx.se/bug/?i=3480
+ [53] = https://curl.haxx.se/bug/?i=3484
+ [54] = https://curl.haxx.se/bug/?i=3280
+ [55] = https://curl.haxx.se/bug/?i=3481
+ [56] = https://curl.haxx.se/bug/?i=3504
+ [57] = https://curl.haxx.se/mail/lib-2019-01/0073.html
+ [58] = https://curl.haxx.se/bug/?i=3513
+ [59] = https://curl.haxx.se/bug/?i=3502
+ [60] = https://curl.haxx.se/bug/?i=3437
+ [61] = https://curl.haxx.se/bug/?i=3497
+ [62] = https://curl.haxx.se/bug/?i=3493
+ [63] = https://curl.haxx.se/bug/?i=3491
+ [64] = https://curl.haxx.se/bug/?i=3518
+ [65] = https://curl.haxx.se/bug/?i=3496
+ [66] = https://curl.haxx.se/docs/CVE-2019-3823.html
+ [67] = https://curl.haxx.se/docs/CVE-2018-16890.html
+ [68] = https://curl.haxx.se/docs/CVE-2019-3822.html
+ [69] = https://curl.haxx.se/bug/?i=3503

--- a/vendor/curl/include/curl/curl.h
+++ b/vendor/curl/include/curl/curl.h
@@ -355,10 +355,20 @@ typedef int (*curl_seek_callback)(void *instream,
    signal libcurl to pause sending data on the current transfer. */
 #define CURL_READFUNC_PAUSE 0x10000001
 
+/* Return code for when the trailing headers' callback has terminated
+   without any errors*/
+#define CURL_TRAILERFUNC_OK 0
+/* Return code for when was an error in the trailing header's list and we
+  want to abort the request */
+#define CURL_TRAILERFUNC_ABORT 1
+
 typedef size_t (*curl_read_callback)(char *buffer,
                                       size_t size,
                                       size_t nitems,
                                       void *instream);
+
+typedef int (*curl_trailer_callback)(struct curl_slist **list,
+                                      void *userdata);
 
 typedef enum {
   CURLSOCKTYPE_IPCXN,  /* socket created for a specific IP connection */
@@ -1874,6 +1884,15 @@ typedef enum {
 
   /* Specify URL using CURL URL API. */
   CINIT(CURLU, OBJECTPOINT, 282),
+
+  /* add trailing data just after no more data is available */
+  CINIT(TRAILERFUNCTION, FUNCTIONPOINT, 283),
+
+  /* pointer to be passed to HTTP_TRAILER_FUNCTION */
+  CINIT(TRAILERDATA, OBJECTPOINT, 284),
+
+  /* set this to 1L to allow HTTP/0.9 responses or 0L to disallow */
+  CINIT(HTTP09_ALLOWED, LONG, 285),
 
   CURLOPT_LASTENTRY /* the last unused */
 } CURLoption;

--- a/vendor/curl/include/curl/curlver.h
+++ b/vendor/curl/include/curl/curlver.h
@@ -30,12 +30,12 @@
 
 /* This is the version number of the libcurl package from which this header
    file origins: */
-#define LIBCURL_VERSION "7.63.0"
+#define LIBCURL_VERSION "7.64.0"
 
 /* The numeric version number is also available "in parts" by using these
    defines: */
 #define LIBCURL_VERSION_MAJOR 7
-#define LIBCURL_VERSION_MINOR 63
+#define LIBCURL_VERSION_MINOR 64
 #define LIBCURL_VERSION_PATCH 0
 
 /* This is the numeric version of the libcurl version number, meant for easier
@@ -57,7 +57,7 @@
    CURL_VERSION_BITS() macro since curl's own configure script greps for it
    and needs it to contain the full number.
 */
-#define LIBCURL_VERSION_NUM 0x073f00
+#define LIBCURL_VERSION_NUM 0x074000
 
 /*
  * This is the date and time when the full source package was created. The
@@ -68,7 +68,7 @@
  *
  * "2007-11-23"
  */
-#define LIBCURL_TIMESTAMP "2018-12-12"
+#define LIBCURL_TIMESTAMP "2019-02-06"
 
 #define CURL_VERSION_BITS(x,y,z) ((x)<<16|(y)<<8|z)
 #define CURL_AT_LEAST_VERSION(x,y,z) \

--- a/vendor/curl/include/curl/urlapi.h
+++ b/vendor/curl/include/curl/urlapi.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2018 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -21,6 +21,8 @@
  * KIND, either express or implied.
  *
  ***************************************************************************/
+
+#include "curl.h"
 
 #ifdef  __cplusplus
 extern "C" {

--- a/vendor/curl/lib/asyn-ares.c
+++ b/vendor/curl/lib/asyn-ares.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -199,6 +199,17 @@ void Curl_resolver_cancel(struct connectdata *conn)
 }
 
 /*
+ * We're equivalent to Curl_resolver_cancel() for the c-ares resolver.  We
+ * never block.
+ */
+void Curl_resolver_kill(struct connectdata *conn)
+{
+  /* We don't need to check the resolver state because we can be called safely
+     at any time and we always do the same thing. */
+  Curl_resolver_cancel(conn);
+}
+
+/*
  * destroy_async_data() cleans up async resolver data.
  */
 static void destroy_async_data(struct Curl_async *async)
@@ -361,13 +372,13 @@ CURLcode Curl_resolver_is_resolved(struct connectdata *conn,
 /*
  * Curl_resolver_wait_resolv()
  *
- * waits for a resolve to finish. This function should be avoided since using
+ * Waits for a resolve to finish. This function should be avoided since using
  * this risk getting the multi interface to "hang".
  *
  * If 'entry' is non-NULL, make it point to the resolved dns entry
  *
- * Returns CURLE_COULDNT_RESOLVE_HOST if the host was not resolved, and
- * CURLE_OPERATION_TIMEDOUT if a time-out occurred.
+ * Returns CURLE_COULDNT_RESOLVE_HOST if the host was not resolved,
+ * CURLE_OPERATION_TIMEDOUT if a time-out occurred, or other errors.
  */
 CURLcode Curl_resolver_wait_resolv(struct connectdata *conn,
                                    struct Curl_dns_entry **entry)

--- a/vendor/curl/lib/asyn.h
+++ b/vendor/curl/lib/asyn.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2011, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -87,9 +87,24 @@ CURLcode Curl_resolver_duphandle(struct Curl_easy *easy, void **to,
  *
  * It is called from inside other functions to cancel currently performing
  * resolver request. Should also free any temporary resources allocated to
- * perform a request.
+ * perform a request.  This never waits for resolver threads to complete.
+ *
+ * It is safe to call this when conn is in any state.
  */
 void Curl_resolver_cancel(struct connectdata *conn);
+
+/*
+ * Curl_resolver_kill().
+ *
+ * This acts like Curl_resolver_cancel() except it will block until any threads
+ * associated with the resolver are complete.  This never blocks for resolvers
+ * that do not use threads.  This is intended to be the "last chance" function
+ * that cleans up an in-progress resolver completely (before its owner is about
+ * to die).
+ *
+ * It is safe to call this when conn is in any state.
+ */
+void Curl_resolver_kill(struct connectdata *conn);
 
 /* Curl_resolver_getsock()
  *
@@ -117,14 +132,13 @@ CURLcode Curl_resolver_is_resolved(struct connectdata *conn,
 /*
  * Curl_resolver_wait_resolv()
  *
- * waits for a resolve to finish. This function should be avoided since using
+ * Waits for a resolve to finish. This function should be avoided since using
  * this risk getting the multi interface to "hang".
  *
  * If 'entry' is non-NULL, make it point to the resolved dns entry
  *
- * Returns CURLE_COULDNT_RESOLVE_HOST if the host was not resolved, and
- * CURLE_OPERATION_TIMEDOUT if a time-out occurred.
-
+ * Returns CURLE_COULDNT_RESOLVE_HOST if the host was not resolved,
+ * CURLE_OPERATION_TIMEDOUT if a time-out occurred, or other errors.
  */
 CURLcode Curl_resolver_wait_resolv(struct connectdata *conn,
                                    struct Curl_dns_entry **dnsentry);
@@ -148,6 +162,7 @@ Curl_addrinfo *Curl_resolver_getaddrinfo(struct connectdata *conn,
 #ifndef CURLRES_ASYNCH
 /* convert these functions if an asynch resolver isn't used */
 #define Curl_resolver_cancel(x) Curl_nop_stmt
+#define Curl_resolver_kill(x) Curl_nop_stmt
 #define Curl_resolver_is_resolved(x,y) CURLE_COULDNT_RESOLVE_HOST
 #define Curl_resolver_wait_resolv(x,y) CURLE_COULDNT_RESOLVE_HOST
 #define Curl_resolver_getsock(x,y,z) 0

--- a/vendor/curl/lib/conncache.c
+++ b/vendor/curl/lib/conncache.c
@@ -6,7 +6,7 @@
  *                             \___|\___/|_| \_\_____|
  *
  * Copyright (C) 2012 - 2016, Linus Nielsen Feltzing, <linus@haxx.se>
- * Copyright (C) 2012 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2012 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -178,9 +178,9 @@ static void hashkey(struct connectdata *conn, char *buf,
   msnprintf(buf, len, "%ld%s", conn->port, hostname);
 }
 
-void Curl_conncache_unlock(struct connectdata *conn)
+void Curl_conncache_unlock(struct Curl_easy *data)
 {
-  CONN_UNLOCK(conn->data);
+  CONN_UNLOCK(data);
 }
 
 /* Returns number of connections currently held in the connection cache.
@@ -302,9 +302,14 @@ CURLcode Curl_conncache_add_conn(struct conncache *connc,
   return result;
 }
 
-void Curl_conncache_remove_conn(struct connectdata *conn, bool lock)
+/*
+ * Removes the connectdata object from the connection cache *and* clears the
+ * ->data pointer association. Pass TRUE/FALSE in the 'lock' argument
+ * depending on if the parent function already holds the lock or not.
+ */
+void Curl_conncache_remove_conn(struct Curl_easy *data,
+                                struct connectdata *conn, bool lock)
 {
-  struct Curl_easy *data = conn->data;
   struct connectbundle *bundle = conn->bundle;
   struct conncache *connc = data->state.conn_cache;
 
@@ -323,6 +328,7 @@ void Curl_conncache_remove_conn(struct connectdata *conn, bool lock)
       DEBUGF(infof(data, "The cache now contains %zu members\n",
                    connc->num_conn));
     }
+    conn->data = NULL; /* clear the association */
     if(lock) {
       CONN_UNLOCK(data);
     }
@@ -566,8 +572,6 @@ void Curl_conncache_close_all_connections(struct conncache *connc)
     conn->data = connc->closure_handle;
 
     sigpipe_ignore(conn->data, &pipe_st);
-    conn->data->easy_conn = NULL; /* clear the easy handle's connection
-                                     pointer */
     /* This will remove the connection from the cache */
     connclose(conn, "kill all");
     (void)Curl_disconnect(connc->closure_handle, conn, FALSE);

--- a/vendor/curl/lib/conncache.h
+++ b/vendor/curl/lib/conncache.h
@@ -56,7 +56,7 @@ void Curl_conncache_destroy(struct conncache *connc);
 /* return the correct bundle, to a host or a proxy */
 struct connectbundle *Curl_conncache_find_bundle(struct connectdata *conn,
                                                  struct conncache *connc);
-void Curl_conncache_unlock(struct connectdata *conn);
+void Curl_conncache_unlock(struct Curl_easy *data);
 /* returns number of connections currently held in the connection cache */
 size_t Curl_conncache_size(struct Curl_easy *data);
 size_t Curl_conncache_bundle_size(struct connectdata *conn);
@@ -64,7 +64,8 @@ size_t Curl_conncache_bundle_size(struct connectdata *conn);
 bool Curl_conncache_return_conn(struct connectdata *conn);
 CURLcode Curl_conncache_add_conn(struct conncache *connc,
                                  struct connectdata *conn) WARN_UNUSED_RESULT;
-void Curl_conncache_remove_conn(struct connectdata *conn,
+void Curl_conncache_remove_conn(struct Curl_easy *data,
+                                struct connectdata *conn,
                                 bool lock);
 bool Curl_conncache_foreach(struct Curl_easy *data,
                             struct conncache *connc,

--- a/vendor/curl/lib/cookie.h
+++ b/vendor/curl/lib/cookie.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -85,7 +85,8 @@ struct Curl_easy;
 struct Cookie *Curl_cookie_add(struct Curl_easy *data,
                                struct CookieInfo *, bool header, bool noexpiry,
                                char *lineptr,
-                               const char *domain, const char *path);
+                               const char *domain, const char *path,
+                               bool secure);
 
 struct Cookie *Curl_cookie_getlist(struct CookieInfo *, const char *,
                                    const char *, bool);

--- a/vendor/curl/lib/curl_sasl.c
+++ b/vendor/curl/lib/curl_sasl.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2012 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2012 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -300,8 +300,7 @@ CURLcode Curl_sasl_start(struct SASL *sasl, struct connectdata *conn,
         result = Curl_auth_create_gssapi_user_message(data, conn->user,
                                                       conn->passwd,
                                                       service,
-                                                      data->easy_conn->
-                                                            host.name,
+                                                      data->conn->host.name,
                                                       sasl->mutual_auth,
                                                       NULL, &conn->krb5,
                                                       &resp, &len);
@@ -517,7 +516,7 @@ CURLcode Curl_sasl_continue(struct SASL *sasl, struct connectdata *conn,
     result = Curl_auth_create_gssapi_user_message(data, conn->user,
                                                   conn->passwd,
                                                   service,
-                                                  data->easy_conn->host.name,
+                                                  data->conn->host.name,
                                                   sasl->mutual_auth, NULL,
                                                   &conn->krb5,
                                                   &resp, &len);

--- a/vendor/curl/lib/curl_setup.h
+++ b/vendor/curl/lib/curl_setup.h
@@ -96,11 +96,7 @@
 #  include "config-vxworks.h"
 #endif
 
-#ifdef __linux__
-#  include "config-linux.h"
-#endif
-
-#if defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
 #  include "config-linux.h"
 #endif
 

--- a/vendor/curl/lib/doh.c
+++ b/vendor/curl/lib/doh.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2018 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -160,7 +160,7 @@ static int Curl_doh_done(struct Curl_easy *doh, CURLcode result)
   struct Curl_easy *data = doh->set.dohfor;
   /* so one of the DOH request done for the 'data' transfer is now complete! */
   data->req.doh.pending--;
-  infof(data, "a DOH request is completed, %d to go\n", data->req.doh.pending);
+  infof(data, "a DOH request is completed, %u to go\n", data->req.doh.pending);
   if(result)
     infof(data, "DOH request %s\n", curl_easy_strerror(result));
 

--- a/vendor/curl/lib/easy.c
+++ b/vendor/curl/lib/easy.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -1060,7 +1060,7 @@ CURLcode curl_easy_pause(struct Curl_easy *data, int action)
     unsigned int i;
     unsigned int count = data->state.tempcount;
     struct tempbuf writebuf[3]; /* there can only be three */
-    struct connectdata *conn = data->easy_conn;
+    struct connectdata *conn = data->conn;
     struct Curl_easy *saved_data = NULL;
 
     /* copy the structs to allow for immediate re-pausing */

--- a/vendor/curl/lib/ftp.c
+++ b/vendor/curl/lib/ftp.c
@@ -655,7 +655,7 @@ CURLcode Curl_GetFTPResponse(ssize_t *nreadp, /* return number of bytes read */
 
   while(!*ftpcode && !result) {
     /* check and reset timeout value every lap */
-    time_t timeout = Curl_pp_state_timeout(pp); /* timeout in milliseconds */
+    time_t timeout = Curl_pp_state_timeout(pp, FALSE);
     time_t interval_ms;
 
     if(timeout <= 0) {
@@ -3054,7 +3054,7 @@ static CURLcode ftp_multi_statemach(struct connectdata *conn,
                                     bool *done)
 {
   struct ftp_conn *ftpc = &conn->proto.ftpc;
-  CURLcode result = Curl_pp_statemach(&ftpc->pp, FALSE);
+  CURLcode result = Curl_pp_statemach(&ftpc->pp, FALSE, FALSE);
 
   /* Check for the state outside of the Curl_socket_check() return code checks
      since at times we are in fact already in this state when this function
@@ -3071,7 +3071,7 @@ static CURLcode ftp_block_statemach(struct connectdata *conn)
   CURLcode result = CURLE_OK;
 
   while(ftpc->state != FTP_STOP) {
-    result = Curl_pp_statemach(pp, TRUE);
+    result = Curl_pp_statemach(pp, TRUE, TRUE /* disconnecting */);
     if(result)
       break;
   }

--- a/vendor/curl/lib/getinfo.c
+++ b/vendor/curl/lib/getinfo.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -390,7 +390,7 @@ static CURLcode getinfo_slist(struct Curl_easy *data, CURLINFO info,
                                           param_slistp;
       struct curl_tlssessioninfo *tsi = &data->tsi;
 #ifdef USE_SSL
-      struct connectdata *conn = data->easy_conn;
+      struct connectdata *conn = data->conn;
 #endif
 
       *tsip = tsi;

--- a/vendor/curl/lib/hostip.c
+++ b/vendor/curl/lib/hostip.c
@@ -312,6 +312,26 @@ fetch_addr(struct connectdata *conn,
   /* See if its already in our dns cache */
   dns = Curl_hash_pick(data->dns.hostcache, entry_id, entry_len + 1);
 
+  /* No entry found in cache, check if we might have a wildcard entry */
+  if(!dns && data->change.wildcard_resolve) {
+    /*
+     * Free the previous entry_id before requesting a new one to avoid leaking
+     * memory
+     */
+    free(entry_id);
+
+    entry_id = create_hostcache_id("*", port);
+
+    /* If we can't create the entry id, fail */
+    if(!entry_id)
+      return dns;
+
+    entry_len = strlen(entry_id);
+
+    /* See if it's already in our dns cache */
+    dns = Curl_hash_pick(data->dns.hostcache, entry_id, entry_len + 1);
+  }
+
   if(dns && (data->set.dns_cache_timeout != -1)) {
     /* See whether the returned entry is stale. Done before we release lock */
     struct hostcache_prune_data user;
@@ -872,6 +892,9 @@ CURLcode Curl_loadhostpairs(struct Curl_easy *data)
   char hostname[256];
   int port = 0;
 
+  /* Default is no wildcard found */
+  data->change.wildcard_resolve = false;
+
   for(hostp = data->change.resolve; hostp; hostp = hostp->next) {
     if(!hostp->data)
       continue;
@@ -1052,6 +1075,13 @@ CURLcode Curl_loadhostpairs(struct Curl_easy *data)
       }
       infof(data, "Added %s:%d:%s to DNS cache\n",
             hostname, port, addresses);
+
+      /* Wildcard hostname */
+      if(hostname[0] == '*' && hostname[1] == '\0') {
+        infof(data, "RESOLVE %s:%d is wildcard, enabling wildcard checks\n",
+              hostname, port);
+        data->change.wildcard_resolve = true;
+      }
     }
   }
   data->change.resolve = NULL; /* dealt with now */

--- a/vendor/curl/lib/http.h
+++ b/vendor/curl/lib/http.h
@@ -74,6 +74,9 @@ CURLcode Curl_add_timecondition(struct Curl_easy *data,
 CURLcode Curl_add_custom_headers(struct connectdata *conn,
                                  bool is_connect,
                                  Curl_send_buffer *req_buffer);
+CURLcode Curl_http_compile_trailers(struct curl_slist *trailers,
+                                    Curl_send_buffer *buffer,
+                                    struct Curl_easy *handle);
 
 /* protocol-specific functions set up to be called by the main engine */
 CURLcode Curl_http(struct connectdata *conn, bool *done);

--- a/vendor/curl/lib/http2.c
+++ b/vendor/curl/lib/http2.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -800,7 +800,7 @@ static int on_data_chunk_recv(nghttp2_session *session, uint8_t flags,
     H2BUGF(infof(data_s, "NGHTTP2_ERR_PAUSE - %zu bytes out of buffer"
                  ", stream %u\n",
                  len - nread, stream_id));
-    data_s->easy_conn->proto.httpc.pause_stream_id = stream_id;
+    data_s->conn->proto.httpc.pause_stream_id = stream_id;
 
     return NGHTTP2_ERR_PAUSE;
   }
@@ -808,7 +808,7 @@ static int on_data_chunk_recv(nghttp2_session *session, uint8_t flags,
   /* pause execution of nghttp2 if we received data for another handle
      in order to process them first. */
   if(conn->data != data_s) {
-    data_s->easy_conn->proto.httpc.pause_stream_id = stream_id;
+    data_s->conn->proto.httpc.pause_stream_id = stream_id;
 
     return NGHTTP2_ERR_PAUSE;
   }
@@ -853,6 +853,10 @@ static int on_stream_close(nghttp2_session *session, int32_t stream_id,
       infof(data_s, "http/2: failed to clear user_data for stream %d!\n",
             stream_id);
       DEBUGASSERT(0);
+    }
+    if(stream_id == httpc->pause_stream_id) {
+      H2BUGF(infof(data_s, "Stopped the pause stream!\n"));
+      httpc->pause_stream_id = 0;
     }
     H2BUGF(infof(data_s, "Removed stream %u hash!\n", stream_id));
     stream->stream_id = 0; /* cleared */

--- a/vendor/curl/lib/http_negotiate.c
+++ b/vendor/curl/lib/http_negotiate.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -49,7 +49,6 @@ CURLcode Curl_input_negotiate(struct connectdata *conn, bool proxy,
 
   /* Point to the correct struct with this */
   struct negotiatedata *neg_ctx;
-  struct auth *authp;
 
   if(proxy) {
     userp = conn->http_proxy.user;
@@ -58,7 +57,6 @@ CURLcode Curl_input_negotiate(struct connectdata *conn, bool proxy,
               data->set.str[STRING_PROXY_SERVICE_NAME] : "HTTP";
     host = conn->http_proxy.host.name;
     neg_ctx = &data->state.proxyneg;
-    authp = &conn->data->state.authproxy;
   }
   else {
     userp = conn->user;
@@ -67,7 +65,6 @@ CURLcode Curl_input_negotiate(struct connectdata *conn, bool proxy,
               data->set.str[STRING_SERVICE_NAME] : "HTTP";
     host = conn->host.name;
     neg_ctx = &data->state.negotiate;
-    authp = &conn->data->state.authhost;
   }
 
   /* Not set means empty */
@@ -92,17 +89,17 @@ CURLcode Curl_input_negotiate(struct connectdata *conn, bool proxy,
     }
   }
 
+  /* Supports SSL channel binding for Windows ISS extended protection */
+#if defined(USE_WINDOWS_SSPI) && defined(SECPKG_ATTR_ENDPOINT_BINDINGS)
+  neg_ctx->sslContext = conn->sslContext;
+#endif
+
   /* Initialize the security context and decode our challenge */
   result = Curl_auth_decode_spnego_message(data, userp, passwdp, service,
                                            host, header, neg_ctx);
 
   if(result)
     Curl_auth_spnego_cleanup(neg_ctx);
-  else
-    /* If the status is different than 0 and we encountered no errors
-    it means we have to continue. 0 is the OK value for both GSSAPI
-    (GSS_S_COMPLETE) and SSPI (SEC_E_OK) */
-    authp->done = !neg_ctx->status;
 
   return result;
 }

--- a/vendor/curl/lib/http_ntlm.c
+++ b/vendor/curl/lib/http_ntlm.c
@@ -175,6 +175,9 @@ CURLcode Curl_output_ntlm(struct connectdata *conn, bool proxy)
     if(s_hSecDll == NULL)
       return err;
   }
+#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
+  ntlm->sslContext = conn->sslContext;
+#endif
 #endif
 
   switch(ntlm->state) {

--- a/vendor/curl/lib/http_proxy.c
+++ b/vendor/curl/lib/http_proxy.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -643,7 +643,7 @@ static CURLcode CONNECT(struct connectdata *conn,
 
 void Curl_connect_free(struct Curl_easy *data)
 {
-  struct connectdata *conn = data->easy_conn;
+  struct connectdata *conn = data->conn;
   struct http_connect_state *s = conn->connect_state;
   if(s) {
     free(s);

--- a/vendor/curl/lib/if2ip.c
+++ b/vendor/curl/lib/if2ip.c
@@ -96,24 +96,6 @@ unsigned int Curl_ipv6_scope(const struct sockaddr *sa)
 
 #if defined(HAVE_GETIFADDRS)
 
-bool Curl_if_is_interface_name(const char *interf)
-{
-  bool result = FALSE;
-
-  struct ifaddrs *iface, *head;
-
-  if(getifaddrs(&head) >= 0) {
-    for(iface = head; iface != NULL; iface = iface->ifa_next) {
-      if(strcasecompare(iface->ifa_name, interf)) {
-        result = TRUE;
-        break;
-      }
-    }
-    freeifaddrs(head);
-  }
-  return result;
-}
-
 if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
                           unsigned int remote_scope_id, const char *interf,
                           char *buf, int buf_size)
@@ -196,15 +178,6 @@ if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
 
 #elif defined(HAVE_IOCTL_SIOCGIFADDR)
 
-bool Curl_if_is_interface_name(const char *interf)
-{
-  /* This is here just to support the old interfaces */
-  char buf[256];
-
-  return (Curl_if2ip(AF_INET, 0 /* unused */, 0, interf, buf, sizeof(buf)) ==
-          IF2IP_NOT_FOUND) ? FALSE : TRUE;
-}
-
 if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
                           unsigned int remote_scope_id, const char *interf,
                           char *buf, int buf_size)
@@ -250,13 +223,6 @@ if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
 }
 
 #else
-
-bool Curl_if_is_interface_name(const char *interf)
-{
-  (void) interf;
-
-  return FALSE;
-}
 
 if2ip_result_t Curl_if2ip(int af, unsigned int remote_scope,
                           unsigned int remote_scope_id, const char *interf,

--- a/vendor/curl/lib/if2ip.h
+++ b/vendor/curl/lib/if2ip.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -31,8 +31,6 @@
 #define IPV6_SCOPE_NODELOCAL    4       /* Loopback. */
 
 unsigned int Curl_ipv6_scope(const struct sockaddr *sa);
-
-bool Curl_if_is_interface_name(const char *interf);
 
 typedef enum {
   IF2IP_NOT_FOUND = 0, /* Interface not found */

--- a/vendor/curl/lib/imap.c
+++ b/vendor/curl/lib/imap.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -316,7 +316,7 @@ static bool imap_endofresp(struct connectdata *conn, char *line, size_t len,
      a space and optionally some text as per RFC-3501 for the AUTHENTICATE and
      APPEND commands and as outlined in Section 4. Examples of RFC-4959 but
      some e-mail servers ignore this and only send a single + instead. */
-  if(imap && !imap->custom && ((len == 3 && !memcmp("+", line, 1)) ||
+  if(imap && !imap->custom && ((len == 3 && line[0] == '+') ||
      (len >= 2 && !memcmp("+ ", line, 2)))) {
     switch(imapc->state) {
       /* States which are interested in continuation responses */
@@ -1362,19 +1362,20 @@ static CURLcode imap_multi_statemach(struct connectdata *conn, bool *done)
       return result;
   }
 
-  result = Curl_pp_statemach(&imapc->pp, FALSE);
+  result = Curl_pp_statemach(&imapc->pp, FALSE, FALSE);
   *done = (imapc->state == IMAP_STOP) ? TRUE : FALSE;
 
   return result;
 }
 
-static CURLcode imap_block_statemach(struct connectdata *conn)
+static CURLcode imap_block_statemach(struct connectdata *conn,
+                                     bool disconnecting)
 {
   CURLcode result = CURLE_OK;
   struct imap_conn *imapc = &conn->proto.imapc;
 
   while(imapc->state != IMAP_STOP && !result)
-    result = Curl_pp_statemach(&imapc->pp, TRUE);
+    result = Curl_pp_statemach(&imapc->pp, TRUE, disconnecting);
 
   return result;
 }
@@ -1497,7 +1498,7 @@ static CURLcode imap_done(struct connectdata *conn, CURLcode status,
        non-blocking DONE operations!
     */
     if(!result)
-      result = imap_block_statemach(conn);
+      result = imap_block_statemach(conn, FALSE);
   }
 
   /* Cleanup our per-request based variables */
@@ -1635,7 +1636,7 @@ static CURLcode imap_disconnect(struct connectdata *conn, bool dead_connection)
      point! */
   if(!dead_connection && imapc->pp.conn && imapc->pp.conn->bits.protoconnstart)
     if(!imap_perform_logout(conn))
-      (void)imap_block_statemach(conn); /* ignore errors on LOGOUT */
+      (void)imap_block_statemach(conn, TRUE); /* ignore errors on LOGOUT */
 
   /* Disconnect from the server */
   Curl_pp_disconnect(&imapc->pp);

--- a/vendor/curl/lib/multi.c
+++ b/vendor/curl/lib/multi.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -114,7 +114,7 @@ static void Curl_init_completed(struct Curl_easy *data)
 
   /* Important: reset the conn pointer so that we don't point to memory
      that could be freed anytime */
-  data->easy_conn = NULL;
+  Curl_detach_connnection(data);
   Curl_expire_clear(data); /* stop all timers */
 }
 
@@ -163,8 +163,8 @@ static void mstate(struct Curl_easy *data, CURLMstate state
      data->mstate < CURLM_STATE_COMPLETED) {
     long connection_id = -5000;
 
-    if(data->easy_conn)
-      connection_id = data->easy_conn->connection_id;
+    if(data->conn)
+      connection_id = data->conn->connection_id;
 
     infof(data,
           "STATE: %s => %s handle %p; line %d (connection #%ld)\n",
@@ -189,14 +189,17 @@ static void mstate(struct Curl_easy *data, CURLMstate state
 #endif
 
 /*
- * We add one of these structs to the sockhash for a particular socket
+ * We add one of these structs to the sockhash for each socket
  */
 
 struct Curl_sh_entry {
-  struct Curl_easy *easy;
-  int action;  /* what action READ/WRITE this socket waits for */
-  curl_socket_t socket; /* mainly to ease debugging */
+  struct curl_llist list; /* list of easy handles using this socket */
+  unsigned int action;  /* what combined action READ/WRITE this socket waits
+                           for */
   void *socketp; /* settable by users with curl_multi_assign() */
+  unsigned int users; /* number of transfers using this */
+  unsigned int readers; /* this many transfers want to read */
+  unsigned int writers; /* this many transfers want to write */
 };
 /* bits for 'action' having no bits means this socket is not expecting any
    action */
@@ -215,8 +218,7 @@ static struct Curl_sh_entry *sh_getentry(struct curl_hash *sh,
 
 /* make sure this socket is present in the hash for this handle */
 static struct Curl_sh_entry *sh_addentry(struct curl_hash *sh,
-                                         curl_socket_t s,
-                                         struct Curl_easy *data)
+                                         curl_socket_t s)
 {
   struct Curl_sh_entry *there = sh_getentry(sh, s);
   struct Curl_sh_entry *check;
@@ -230,8 +232,7 @@ static struct Curl_sh_entry *sh_addentry(struct curl_hash *sh,
   if(!check)
     return NULL; /* major failure */
 
-  check->easy = data;
-  check->socket = s;
+  Curl_llist_init(&check->list, NULL);
 
   /* make/add new hash entry */
   if(!Curl_hash_add(sh, (char *)&s, sizeof(curl_socket_t), check)) {
@@ -516,20 +517,14 @@ static void debug_print_sock_hash(void *p)
 }
 #endif
 
-static CURLcode multi_done(struct connectdata **connp,
-                          CURLcode status,  /* an error if this is called
-                                               after an error was detected */
-                          bool premature)
+static CURLcode multi_done(struct Curl_easy *data,
+                           CURLcode status,  /* an error if this is called
+                                                after an error was detected */
+                           bool premature)
 {
   CURLcode result;
-  struct connectdata *conn;
-  struct Curl_easy *data;
+  struct connectdata *conn = data->conn;
   unsigned int i;
-
-  DEBUGASSERT(*connp);
-
-  conn = *connp;
-  data = conn->data;
 
   DEBUGF(infof(data, "multi_done\n"));
 
@@ -537,10 +532,8 @@ static CURLcode multi_done(struct connectdata **connp,
     /* Stop if multi_done() has already been called */
     return CURLE_OK;
 
-  if(data->mstate == CURLM_STATE_WAITRESOLVE) {
-    /* still waiting for the resolve to complete */
-    (void)Curl_resolver_wait_resolv(conn, NULL);
-  }
+  /* Stop the resolver and free its own resources (but not dns_entry yet). */
+  Curl_resolver_kill(conn);
 
   Curl_getoff_all_pipelines(data, conn);
 
@@ -579,7 +572,7 @@ static CURLcode multi_done(struct connectdata **connp,
 
   if(conn->send_pipe.size || conn->recv_pipe.size) {
     /* Stop if pipeline is not empty . */
-    data->easy_conn = NULL;
+    Curl_detach_connnection(data);
     DEBUGF(infof(data, "Connection still in use %zu/%zu, "
                  "no more multi_done now!\n",
                  conn->send_pipe.size, conn->recv_pipe.size));
@@ -587,7 +580,6 @@ static CURLcode multi_done(struct connectdata **connp,
   }
 
   data->state.done = TRUE; /* called just now! */
-  Curl_resolver_cancel(conn);
 
   if(conn->dns_entry) {
     Curl_resolv_unlock(data, conn->dns_entry); /* done with this */
@@ -653,10 +645,7 @@ static CURLcode multi_done(struct connectdata **connp,
       data->state.lastconnect = NULL;
   }
 
-  *connp = NULL; /* to make the caller of this function better detect that
-                    this was either closed or handed over to the connection
-                    cache here, and therefore cannot be used from this point on
-                 */
+  Curl_detach_connnection(data);
   Curl_free_request_state(data);
   return result;
 }
@@ -685,7 +674,7 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
     return CURLM_RECURSIVE_API_CALL;
 
   premature = (data->mstate < CURLM_STATE_COMPLETED) ? TRUE : FALSE;
-  easy_owns_conn = (data->easy_conn && (data->easy_conn->data == easy)) ?
+  easy_owns_conn = (data->conn && (data->conn->data == easy)) ?
     TRUE : FALSE;
 
   /* If the 'state' is not INIT or COMPLETED, we might need to do something
@@ -696,16 +685,16 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
     multi->num_alive--;
   }
 
-  if(data->easy_conn &&
+  if(data->conn &&
      data->mstate > CURLM_STATE_DO &&
      data->mstate < CURLM_STATE_COMPLETED) {
     /* Set connection owner so that the DONE function closes it.  We can
        safely do this here since connection is killed. */
-    data->easy_conn->data = easy;
+    data->conn->data = easy;
     /* If the handle is in a pipeline and has started sending off its
        request but not received its response yet, we need to close
        connection. */
-    streamclose(data->easy_conn, "Removed with partial response");
+    streamclose(data->conn, "Removed with partial response");
     easy_owns_conn = TRUE;
   }
 
@@ -714,7 +703,7 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
      curl_easy_cleanup is called. */
   Curl_expire_clear(data);
 
-  if(data->easy_conn) {
+  if(data->conn) {
 
     /* we must call multi_done() here (if we still own the connection) so that
        we don't leave a half-baked one around */
@@ -725,11 +714,11 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
 
          Note that this ignores the return code simply because there's
          nothing really useful to do with it anyway! */
-      (void)multi_done(&data->easy_conn, data->result, premature);
+      (void)multi_done(data, data->result, premature);
     }
     else
       /* Clear connection pipelines, if multi_done above was not called */
-      Curl_getoff_all_pipelines(data, data->easy_conn);
+      Curl_getoff_all_pipelines(data, data->conn);
   }
 
   if(data->connect_queue.ptr)
@@ -761,9 +750,9 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
                                 vanish with this handle */
 
   /* Remove the association between the connection and the handle */
-  if(data->easy_conn) {
-    data->easy_conn->data = NULL;
-    data->easy_conn = NULL;
+  if(data->conn) {
+    data->conn->data = NULL;
+    Curl_detach_connnection(data);
   }
 
 #ifdef USE_LIBPSL
@@ -813,9 +802,19 @@ bool Curl_pipeline_wanted(const struct Curl_multi *multi, int bits)
   return (multi && (multi->pipelining & bits)) ? TRUE : FALSE;
 }
 
-void Curl_multi_handlePipeBreak(struct Curl_easy *data)
+/* This is the only function that should clear data->conn. This will
+   occasionally be called with the pointer already cleared. */
+void Curl_detach_connnection(struct Curl_easy *data)
 {
-  data->easy_conn = NULL;
+  data->conn = NULL;
+}
+
+/* This is the only function that should assign data->conn */
+void Curl_attach_connnection(struct Curl_easy *data,
+                             struct connectdata *conn)
+{
+  DEBUGASSERT(!data->conn);
+  data->conn = conn;
 }
 
 static int waitconnect_getsock(struct connectdata *conn,
@@ -879,13 +878,13 @@ static int multi_getsock(struct Curl_easy *data,
   /* The no connection case can happen when this is called from
      curl_multi_remove_handle() => singlesocket() => multi_getsock().
   */
-  if(!data->easy_conn)
+  if(!data->conn)
     return 0;
 
   if(data->mstate > CURLM_STATE_CONNECT &&
      data->mstate < CURLM_STATE_COMPLETED) {
     /* Set up ownership correctly */
-    data->easy_conn->data = data;
+    data->conn->data = data;
   }
 
   switch(data->mstate) {
@@ -906,31 +905,31 @@ static int multi_getsock(struct Curl_easy *data,
     return 0;
 
   case CURLM_STATE_WAITRESOLVE:
-    return Curl_resolv_getsock(data->easy_conn, socks, numsocks);
+    return Curl_resolv_getsock(data->conn, socks, numsocks);
 
   case CURLM_STATE_PROTOCONNECT:
   case CURLM_STATE_SENDPROTOCONNECT:
-    return Curl_protocol_getsock(data->easy_conn, socks, numsocks);
+    return Curl_protocol_getsock(data->conn, socks, numsocks);
 
   case CURLM_STATE_DO:
   case CURLM_STATE_DOING:
-    return Curl_doing_getsock(data->easy_conn, socks, numsocks);
+    return Curl_doing_getsock(data->conn, socks, numsocks);
 
   case CURLM_STATE_WAITPROXYCONNECT:
-    return waitproxyconnect_getsock(data->easy_conn, socks, numsocks);
+    return waitproxyconnect_getsock(data->conn, socks, numsocks);
 
   case CURLM_STATE_WAITCONNECT:
-    return waitconnect_getsock(data->easy_conn, socks, numsocks);
+    return waitconnect_getsock(data->conn, socks, numsocks);
 
   case CURLM_STATE_DO_MORE:
-    return domore_getsock(data->easy_conn, socks, numsocks);
+    return domore_getsock(data->conn, socks, numsocks);
 
   case CURLM_STATE_DO_DONE: /* since is set after DO is completed, we switch
                                to waiting for the same as the *PERFORM
                                states */
   case CURLM_STATE_PERFORM:
   case CURLM_STATE_WAITPERFORM:
-    return Curl_single_getsock(data->easy_conn, socks, numsocks);
+    return Curl_single_getsock(data->conn, socks, numsocks);
   }
 
 }
@@ -1202,17 +1201,16 @@ CURLMcode Curl_multi_add_perform(struct Curl_multi *multi,
 
     /* take this handle to the perform state right away */
     multistate(data, CURLM_STATE_PERFORM);
-    data->easy_conn = conn;
+    Curl_attach_connnection(data, conn);
     k->keepon |= KEEP_RECV; /* setup to receive! */
   }
   return rc;
 }
 
-static CURLcode multi_reconnect_request(struct connectdata **connp)
+static CURLcode multi_reconnect_request(struct Curl_easy *data)
 {
   CURLcode result = CURLE_OK;
-  struct connectdata *conn = *connp;
-  struct Curl_easy *data = conn->data;
+  struct connectdata *conn = data->conn;
 
   /* This was a re-use of a connection and we got a write error in the
    * DO-phase. Then we DISCONNECT this connection and have another attempt to
@@ -1223,11 +1221,9 @@ static CURLcode multi_reconnect_request(struct connectdata **connp)
   infof(data, "Re-used connection seems dead, get a new one\n");
 
   connclose(conn, "Reconnect dead connection"); /* enforce close */
-  result = multi_done(&conn, result, FALSE); /* we are so done with this */
+  result = multi_done(data, result, FALSE); /* we are so done with this */
 
-  /* conn may no longer be a good pointer, clear it to avoid mistakes by
-     parent functions */
-  *connp = NULL;
+  /* data->conn was detached in multi_done() */
 
   /*
    * We need to check for CURLE_SEND_ERROR here as well. This could happen
@@ -1239,11 +1235,11 @@ static CURLcode multi_reconnect_request(struct connectdata **connp)
     bool protocol_done = TRUE;
 
     /* Now, redo the connect and get a new connection */
-    result = Curl_connect(data, connp, &async, &protocol_done);
+    result = Curl_connect(data, &async, &protocol_done);
     if(!result) {
       /* We have connected or sent away a name resolve query fine */
 
-      conn = *connp; /* setup conn to again point to something nice */
+      conn = data->conn; /* in case it was updated */
       if(async) {
         /* Now, if async is TRUE here, we need to wait for the name
            to resolve */
@@ -1276,11 +1272,10 @@ static void do_complete(struct connectdata *conn)
   Curl_pgrsTime(conn->data, TIMER_PRETRANSFER);
 }
 
-static CURLcode multi_do(struct connectdata **connp, bool *done)
+static CURLcode multi_do(struct Curl_easy *data, bool *done)
 {
   CURLcode result = CURLE_OK;
-  struct connectdata *conn = *connp;
-  struct Curl_easy *data = conn->data;
+  struct connectdata *conn = data->conn;
 
   if(conn->handler->do_it) {
     /* generic protocol-specific function pointer set in curl_connect() */
@@ -1294,12 +1289,12 @@ static CURLcode multi_do(struct connectdata **connp, bool *done)
        * figure out how to re-establish the connection.
        */
       if(!data->multi) {
-        result = multi_reconnect_request(connp);
+        result = multi_reconnect_request(data);
 
         if(!result) {
           /* ... finally back to actually retry the DO phase */
-          conn = *connp; /* re-assign conn since multi_reconnect_request
-                            creates a new connection */
+          conn = data->conn; /* re-assign conn since multi_reconnect_request
+                                creates a new connection */
           result = conn->handler->do_it(conn, done);
         }
       }
@@ -1368,13 +1363,13 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
     bool stream_error = FALSE;
     rc = CURLM_OK;
 
-    if(!data->easy_conn &&
+    if(!data->conn &&
        data->mstate > CURLM_STATE_CONNECT &&
        data->mstate < CURLM_STATE_DONE) {
-      /* In all these states, the code will blindly access 'data->easy_conn'
+      /* In all these states, the code will blindly access 'data->conn'
          so this is precaution that it isn't NULL. And it silences static
          analyzers. */
-      failf(data, "In state %d with no easy_conn, bail out!\n", data->mstate);
+      failf(data, "In state %d with no conn, bail out!\n", data->mstate);
       return CURLM_INTERNAL_ERROR;
     }
 
@@ -1383,13 +1378,13 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       process_pending_handles(multi); /* pipelined/multiplexed */
     }
 
-    if(data->easy_conn && data->mstate > CURLM_STATE_CONNECT &&
+    if(data->conn && data->mstate > CURLM_STATE_CONNECT &&
        data->mstate < CURLM_STATE_COMPLETED) {
       /* Make sure we set the connection's current owner */
-      data->easy_conn->data = data;
+      data->conn->data = data;
     }
 
-    if(data->easy_conn &&
+    if(data->conn &&
        (data->mstate >= CURLM_STATE_CONNECT) &&
        (data->mstate < CURLM_STATE_COMPLETED)) {
       /* we need to wait for the connect state as only then is the start time
@@ -1401,23 +1396,26 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       if(timeout_ms < 0) {
         /* Handle timed out */
         if(data->mstate == CURLM_STATE_WAITRESOLVE)
-          failf(data, "Resolving timed out after %ld milliseconds",
+          failf(data, "Resolving timed out after %" CURL_FORMAT_TIMEDIFF_T
+                " milliseconds",
                 Curl_timediff(now, data->progress.t_startsingle));
         else if(data->mstate == CURLM_STATE_WAITCONNECT)
-          failf(data, "Connection timed out after %ld milliseconds",
+          failf(data, "Connection timed out after %" CURL_FORMAT_TIMEDIFF_T
+                " milliseconds",
                 Curl_timediff(now, data->progress.t_startsingle));
         else {
           k = &data->req;
           if(k->size != -1) {
-            failf(data, "Operation timed out after %ld milliseconds with %"
-                  CURL_FORMAT_CURL_OFF_T " out of %"
+            failf(data, "Operation timed out after %" CURL_FORMAT_TIMEDIFF_T
+                  " milliseconds with %" CURL_FORMAT_CURL_OFF_T " out of %"
                   CURL_FORMAT_CURL_OFF_T " bytes received",
                   Curl_timediff(now, data->progress.t_startsingle),
                   k->bytecount, k->size);
           }
           else {
-            failf(data, "Operation timed out after %ld milliseconds with %"
-                  CURL_FORMAT_CURL_OFF_T " bytes received",
+            failf(data, "Operation timed out after %" CURL_FORMAT_TIMEDIFF_T
+                  " milliseconds with %" CURL_FORMAT_CURL_OFF_T
+                  " bytes received",
                   Curl_timediff(now, data->progress.t_startsingle),
                   k->bytecount);
           }
@@ -1425,11 +1423,11 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 
         /* Force connection closed if the connection has indeed been used */
         if(data->mstate > CURLM_STATE_DO) {
-          streamclose(data->easy_conn, "Disconnected with pending data");
+          streamclose(data->conn, "Disconnected with pending data");
           stream_error = TRUE;
         }
         result = CURLE_OPERATION_TIMEDOUT;
-        (void)multi_done(&data->easy_conn, result, TRUE);
+        (void)multi_done(data, result, TRUE);
         /* Skip the statemachine and go directly to error handling section. */
         goto statemachine_end;
       }
@@ -1456,8 +1454,13 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
     case CURLM_STATE_CONNECT:
       /* Connect. We want to get a connection identifier filled in. */
       Curl_pgrsTime(data, TIMER_STARTSINGLE);
-      result = Curl_connect(data, &data->easy_conn,
-                            &async, &protocol_connect);
+      if(data->set.timeout)
+        Curl_expire(data, data->set.timeout, EXPIRE_TIMEOUT);
+
+      if(data->set.connecttimeout)
+        Curl_expire(data, data->set.connecttimeout, EXPIRE_CONNECTTIMEOUT);
+
+      result = Curl_connect(data, &async, &protocol_connect);
       if(CURLE_NO_CONNECTION_AVAILABLE == result) {
         /* There was no connection available. We will go to the pending
            state and wait for an available connection. */
@@ -1472,7 +1475,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 
       if(!result) {
         /* Add this handle to the send or pend pipeline */
-        result = Curl_add_handle_to_pipeline(data, data->easy_conn);
+        result = Curl_add_handle_to_pipeline(data, data->conn);
         if(result)
           stream_error = TRUE;
         else {
@@ -1490,7 +1493,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
                          CURLM_STATE_WAITDO:CURLM_STATE_DO);
             else {
 #ifndef CURL_DISABLE_HTTP
-              if(Curl_connect_ongoing(data->easy_conn))
+              if(Curl_connect_ongoing(data->conn))
                 multistate(data, CURLM_STATE_WAITPROXYCONNECT);
               else
 #endif
@@ -1505,7 +1508,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       /* awaiting an asynch name resolve to complete */
     {
       struct Curl_dns_entry *dns = NULL;
-      struct connectdata *conn = data->easy_conn;
+      struct connectdata *conn = data->conn;
       const char *hostname;
 
       if(conn->bits.httpproxy)
@@ -1528,7 +1531,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       }
 
       if(!dns)
-        result = Curl_resolv_check(data->easy_conn, &dns);
+        result = Curl_resolv_check(data->conn, &dns);
 
       /* Update sockets here, because the socket(s) may have been
          closed and the application thus needs to be told, even if it
@@ -1541,12 +1544,12 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       if(dns) {
         /* Perform the next step in the connection phase, and then move on
            to the WAITCONNECT state */
-        result = Curl_once_resolved(data->easy_conn, &protocol_connect);
+        result = Curl_once_resolved(data->conn, &protocol_connect);
 
         if(result)
           /* if Curl_once_resolved() returns failure, the connection struct
              is already freed and gone */
-          data->easy_conn = NULL;           /* no more connection */
+          Curl_detach_connnection(data); /* no more connection */
         else {
           /* call again please so that we get the next socket setup */
           rc = CURLM_CALL_MULTI_PERFORM;
@@ -1555,7 +1558,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
                        CURLM_STATE_WAITDO:CURLM_STATE_DO);
           else {
 #ifndef CURL_DISABLE_HTTP
-            if(Curl_connect_ongoing(data->easy_conn))
+            if(Curl_connect_ongoing(data->conn))
               multistate(data, CURLM_STATE_WAITPROXYCONNECT);
             else
 #endif
@@ -1575,19 +1578,19 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 #ifndef CURL_DISABLE_HTTP
     case CURLM_STATE_WAITPROXYCONNECT:
       /* this is HTTP-specific, but sending CONNECT to a proxy is HTTP... */
-      result = Curl_http_connect(data->easy_conn, &protocol_connect);
+      result = Curl_http_connect(data->conn, &protocol_connect);
 
-      if(data->easy_conn->bits.proxy_connect_closed) {
+      if(data->conn->bits.proxy_connect_closed) {
         rc = CURLM_CALL_MULTI_PERFORM;
         /* connect back to proxy again */
         result = CURLE_OK;
-        multi_done(&data->easy_conn, CURLE_OK, FALSE);
+        multi_done(data, CURLE_OK, FALSE);
         multistate(data, CURLM_STATE_CONNECT);
       }
       else if(!result) {
-        if((data->easy_conn->http_proxy.proxytype != CURLPROXY_HTTPS ||
-           data->easy_conn->bits.proxy_ssl_connected[FIRSTSOCKET]) &&
-           Curl_connect_complete(data->easy_conn)) {
+        if((data->conn->http_proxy.proxytype != CURLPROXY_HTTPS ||
+           data->conn->bits.proxy_ssl_connected[FIRSTSOCKET]) &&
+           Curl_connect_complete(data->conn)) {
           rc = CURLM_CALL_MULTI_PERFORM;
           /* initiate protocol connect phase */
           multistate(data, CURLM_STATE_SENDPROTOCONNECT);
@@ -1600,18 +1603,18 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 
     case CURLM_STATE_WAITCONNECT:
       /* awaiting a completion of an asynch TCP connect */
-      result = Curl_is_connected(data->easy_conn, FIRSTSOCKET, &connected);
+      result = Curl_is_connected(data->conn, FIRSTSOCKET, &connected);
       if(connected && !result) {
 #ifndef CURL_DISABLE_HTTP
-        if((data->easy_conn->http_proxy.proxytype == CURLPROXY_HTTPS &&
-            !data->easy_conn->bits.proxy_ssl_connected[FIRSTSOCKET]) ||
-           Curl_connect_ongoing(data->easy_conn)) {
+        if((data->conn->http_proxy.proxytype == CURLPROXY_HTTPS &&
+            !data->conn->bits.proxy_ssl_connected[FIRSTSOCKET]) ||
+           Curl_connect_ongoing(data->conn)) {
           multistate(data, CURLM_STATE_WAITPROXYCONNECT);
           break;
         }
 #endif
         rc = CURLM_CALL_MULTI_PERFORM;
-        multistate(data, data->easy_conn->bits.tunnel_proxy?
+        multistate(data, data->conn->bits.tunnel_proxy?
                    CURLM_STATE_WAITPROXYCONNECT:
                    CURLM_STATE_SENDPROTOCONNECT);
       }
@@ -1624,7 +1627,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       break;
 
     case CURLM_STATE_SENDPROTOCONNECT:
-      result = Curl_protocol_connect(data->easy_conn, &protocol_connect);
+      result = Curl_protocol_connect(data->conn, &protocol_connect);
       if(!result && !protocol_connect)
         /* switch to waiting state */
         multistate(data, CURLM_STATE_PROTOCONNECT);
@@ -1637,14 +1640,14 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       else if(result) {
         /* failure detected */
         Curl_posttransfer(data);
-        multi_done(&data->easy_conn, result, TRUE);
+        multi_done(data, result, TRUE);
         stream_error = TRUE;
       }
       break;
 
     case CURLM_STATE_PROTOCONNECT:
       /* protocol-specific connect phase */
-      result = Curl_protocol_connecting(data->easy_conn, &protocol_connect);
+      result = Curl_protocol_connecting(data->conn, &protocol_connect);
       if(!result && protocol_connect) {
         /* after the connect has completed, go WAITDO or DO */
         multistate(data, Curl_pipeline_wanted(multi, CURLPIPE_HTTP1)?
@@ -1654,14 +1657,14 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       else if(result) {
         /* failure detected */
         Curl_posttransfer(data);
-        multi_done(&data->easy_conn, result, TRUE);
+        multi_done(data, result, TRUE);
         stream_error = TRUE;
       }
       break;
 
     case CURLM_STATE_WAITDO:
       /* Wait for our turn to DO when we're pipelining requests */
-      if(Curl_pipeline_checkget_write(data, data->easy_conn)) {
+      if(Curl_pipeline_checkget_write(data, data->conn)) {
         /* Grabbed the channel */
         multistate(data, CURLM_STATE_DO);
         rc = CURLM_CALL_MULTI_PERFORM;
@@ -1671,16 +1674,16 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
     case CURLM_STATE_DO:
       if(data->set.connect_only) {
         /* keep connection open for application to use the socket */
-        connkeep(data->easy_conn, "CONNECT_ONLY");
+        connkeep(data->conn, "CONNECT_ONLY");
         multistate(data, CURLM_STATE_DONE);
         result = CURLE_OK;
         rc = CURLM_CALL_MULTI_PERFORM;
       }
       else {
         /* Perform the protocol's DO action */
-        result = multi_do(&data->easy_conn, &dophase_done);
+        result = multi_do(data, &dophase_done);
 
-        /* When multi_do() returns failure, data->easy_conn might be NULL! */
+        /* When multi_do() returns failure, data->conn might be NULL! */
 
         if(!result) {
           if(!dophase_done) {
@@ -1689,7 +1692,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
               struct WildcardData *wc = &data->wildcard;
               if(wc->state == CURLWC_DONE || wc->state == CURLWC_SKIP) {
                 /* skip some states if it is important */
-                multi_done(&data->easy_conn, CURLE_OK, FALSE);
+                multi_done(data, CURLE_OK, FALSE);
                 multistate(data, CURLM_STATE_DONE);
                 rc = CURLM_CALL_MULTI_PERFORM;
                 break;
@@ -1702,7 +1705,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
           }
 
           /* after DO, go DO_DONE... or DO_MORE */
-          else if(data->easy_conn->bits.do_more) {
+          else if(data->conn->bits.do_more) {
             /* we're supposed to do more, but we need to sit down, relax
                and wait a little while first */
             multistate(data, CURLM_STATE_DO_MORE);
@@ -1715,7 +1718,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
           }
         }
         else if((CURLE_SEND_ERROR == result) &&
-                data->easy_conn->bits.reuse) {
+                data->conn->bits.reuse) {
           /*
            * In this situation, a connection that we were trying to use
            * may have unexpectedly died.  If possible, send the connection
@@ -1725,7 +1728,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
           followtype follow = FOLLOW_NONE;
           CURLcode drc;
 
-          drc = Curl_retry_request(data->easy_conn, &newurl);
+          drc = Curl_retry_request(data->conn, &newurl);
           if(drc) {
             /* a failure here pretty much implies an out of memory */
             result = drc;
@@ -1733,7 +1736,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
           }
 
           Curl_posttransfer(data);
-          drc = multi_done(&data->easy_conn, result, FALSE);
+          drc = multi_done(data, result, FALSE);
 
           /* When set to retry the connection, we must to go back to
            * the CONNECT state */
@@ -1765,8 +1768,8 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
         else {
           /* failure detected */
           Curl_posttransfer(data);
-          if(data->easy_conn)
-            multi_done(&data->easy_conn, result, FALSE);
+          if(data->conn)
+            multi_done(data, result, FALSE);
           stream_error = TRUE;
         }
       }
@@ -1774,12 +1777,12 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 
     case CURLM_STATE_DOING:
       /* we continue DOING until the DO phase is complete */
-      result = Curl_protocol_doing(data->easy_conn,
+      result = Curl_protocol_doing(data->conn,
                                    &dophase_done);
       if(!result) {
         if(dophase_done) {
           /* after DO, go DO_DONE or DO_MORE */
-          multistate(data, data->easy_conn->bits.do_more?
+          multistate(data, data->conn->bits.do_more?
                      CURLM_STATE_DO_MORE:
                      CURLM_STATE_DO_DONE);
           rc = CURLM_CALL_MULTI_PERFORM;
@@ -1788,7 +1791,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       else {
         /* failure detected */
         Curl_posttransfer(data);
-        multi_done(&data->easy_conn, result, FALSE);
+        multi_done(data, result, FALSE);
         stream_error = TRUE;
       }
       break;
@@ -1797,7 +1800,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       /*
        * When we are connected, DO MORE and then go DO_DONE
        */
-      result = multi_do_more(data->easy_conn, &control);
+      result = multi_do_more(data->conn, &control);
 
       /* No need to remove this handle from the send pipeline here since that
          is done in multi_done() */
@@ -1817,27 +1820,27 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       else {
         /* failure detected */
         Curl_posttransfer(data);
-        multi_done(&data->easy_conn, result, FALSE);
+        multi_done(data, result, FALSE);
         stream_error = TRUE;
       }
       break;
 
     case CURLM_STATE_DO_DONE:
       /* Move ourselves from the send to recv pipeline */
-      Curl_move_handle_from_send_to_recv_pipe(data, data->easy_conn);
+      Curl_move_handle_from_send_to_recv_pipe(data, data->conn);
 
-      if(data->easy_conn->bits.multiplex || data->easy_conn->send_pipe.size)
+      if(data->conn->bits.multiplex || data->conn->send_pipe.size)
         /* Check if we can move pending requests to send pipe */
         process_pending_handles(multi); /*  pipelined/multiplexed */
 
       /* Only perform the transfer if there's a good socket to work with.
          Having both BAD is a signal to skip immediately to DONE */
-      if((data->easy_conn->sockfd != CURL_SOCKET_BAD) ||
-         (data->easy_conn->writesockfd != CURL_SOCKET_BAD))
+      if((data->conn->sockfd != CURL_SOCKET_BAD) ||
+         (data->conn->writesockfd != CURL_SOCKET_BAD))
         multistate(data, CURLM_STATE_WAITPERFORM);
       else {
         if(data->state.wildcardmatch &&
-           ((data->easy_conn->handler->flags & PROTOPT_WILDCARD) == 0)) {
+           ((data->conn->handler->flags & PROTOPT_WILDCARD) == 0)) {
            data->wildcard.state = CURLWC_DONE;
         }
         multistate(data, CURLM_STATE_DONE);
@@ -1847,7 +1850,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 
     case CURLM_STATE_WAITPERFORM:
       /* Wait for our turn to PERFORM */
-      if(Curl_pipeline_checkget_read(data, data->easy_conn)) {
+      if(Curl_pipeline_checkget_read(data, data->conn)) {
         /* Grabbed the channel */
         multistate(data, CURLM_STATE_PERFORM);
         rc = CURLM_CALL_MULTI_PERFORM;
@@ -1856,7 +1859,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 
     case CURLM_STATE_TOOFAST: /* limit-rate exceeded in either direction */
       /* if both rates are within spec, resume transfer */
-      if(Curl_pgrsUpdate(data->easy_conn))
+      if(Curl_pgrsUpdate(data->conn))
         result = CURLE_ABORTED_BY_CALLBACK;
       else
         result = Curl_speedcheck(data, now);
@@ -1926,24 +1929,24 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       }
 
       /* read/write data if it is ready to do so */
-      result = Curl_readwrite(data->easy_conn, data, &done, &comeback);
+      result = Curl_readwrite(data->conn, data, &done, &comeback);
 
       k = &data->req;
 
       if(!(k->keepon & KEEP_RECV))
         /* We're done receiving */
-        Curl_pipeline_leave_read(data->easy_conn);
+        Curl_pipeline_leave_read(data->conn);
 
       if(!(k->keepon & KEEP_SEND))
         /* We're done sending */
-        Curl_pipeline_leave_write(data->easy_conn);
+        Curl_pipeline_leave_write(data->conn);
 
       if(done || (result == CURLE_RECV_ERROR)) {
         /* If CURLE_RECV_ERROR happens early enough, we assume it was a race
          * condition and the server closed the re-used connection exactly when
          * we wanted to use it, so figure out if that is indeed the case.
          */
-        CURLcode ret = Curl_retry_request(data->easy_conn, &newurl);
+        CURLcode ret = Curl_retry_request(data->conn, &newurl);
         if(!ret)
           retry = (newurl)?TRUE:FALSE;
         else if(!result)
@@ -1957,8 +1960,8 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
         }
       }
       else if((CURLE_HTTP2_STREAM == result) &&
-                Curl_h2_http_1_1_error(data->easy_conn)) {
-        CURLcode ret = Curl_retry_request(data->easy_conn, &newurl);
+                Curl_h2_http_1_1_error(data->conn)) {
+        CURLcode ret = Curl_retry_request(data->conn, &newurl);
 
         infof(data, "Forcing HTTP/1.1 for NTLM");
         data->set.httpversion = CURL_HTTP_VERSION_1_1;
@@ -1985,12 +1988,12 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
          * happened in the data connection.
          */
 
-        if(!(data->easy_conn->handler->flags & PROTOPT_DUAL) &&
+        if(!(data->conn->handler->flags & PROTOPT_DUAL) &&
            result != CURLE_HTTP2_STREAM)
-          streamclose(data->easy_conn, "Transfer returned error");
+          streamclose(data->conn, "Transfer returned error");
 
         Curl_posttransfer(data);
-        multi_done(&data->easy_conn, result, TRUE);
+        multi_done(data, result, TRUE);
       }
       else if(done) {
         followtype follow = FOLLOW_NONE;
@@ -1999,11 +2002,11 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
         Curl_posttransfer(data);
 
         /* we're no longer receiving */
-        Curl_removeHandleFromPipeline(data, &data->easy_conn->recv_pipe);
+        Curl_removeHandleFromPipeline(data, &data->conn->recv_pipe);
 
         /* expire the new receiving pipeline head */
-        if(data->easy_conn->recv_pipe.head)
-          Curl_expire(data->easy_conn->recv_pipe.head->ptr, 0, EXPIRE_RUN_NOW);
+        if(data->conn->recv_pipe.head)
+          Curl_expire(data->conn->recv_pipe.head->ptr, 0, EXPIRE_RUN_NOW);
 
         /* When we follow redirects or is set to retry the connection, we must
            to go back to the CONNECT state */
@@ -2018,7 +2021,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
           }
           else
             follow = FOLLOW_RETRY;
-          result = multi_done(&data->easy_conn, CURLE_OK, FALSE);
+          result = multi_done(data, CURLE_OK, FALSE);
           if(!result) {
             result = Curl_follow(data, newurl, follow);
             if(!result) {
@@ -2041,7 +2044,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
             free(newurl);
             if(result) {
               stream_error = TRUE;
-              result = multi_done(&data->easy_conn, result, TRUE);
+              result = multi_done(data, result, TRUE);
             }
           }
 
@@ -2060,18 +2063,18 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       /* this state is highly transient, so run another loop after this */
       rc = CURLM_CALL_MULTI_PERFORM;
 
-      if(data->easy_conn) {
+      if(data->conn) {
         CURLcode res;
 
         /* Remove ourselves from the receive pipeline, if we are there. */
-        Curl_removeHandleFromPipeline(data, &data->easy_conn->recv_pipe);
+        Curl_removeHandleFromPipeline(data, &data->conn->recv_pipe);
 
-        if(data->easy_conn->bits.multiplex || data->easy_conn->send_pipe.size)
+        if(data->conn->bits.multiplex || data->conn->send_pipe.size)
           /* Check if we can move pending requests to connection */
           process_pending_handles(multi); /* pipelined/multiplexing */
 
         /* post-transfer command */
-        res = multi_done(&data->easy_conn, result, FALSE);
+        res = multi_done(data, result, FALSE);
 
         /* allow a previously set error code take precedence */
         if(!result)
@@ -2079,12 +2082,12 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 
         /*
          * If there are other handles on the pipeline, multi_done won't set
-         * easy_conn to NULL.  In such a case, curl_multi_remove_handle() can
+         * conn to NULL.  In such a case, curl_multi_remove_handle() can
          * access free'd data, if the connection is free'd and the handle
          * removed before we perform the processing in CURLM_STATE_COMPLETED
          */
-        if(data->easy_conn)
-          data->easy_conn = NULL;
+        if(data->conn)
+          Curl_detach_connnection(data);
       }
 
       if(data->state.wildcardmatch) {
@@ -2126,23 +2129,23 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
         /* Check if we can move pending requests to send pipe */
         process_pending_handles(multi); /* connection */
 
-        if(data->easy_conn) {
+        if(data->conn) {
           /* if this has a connection, unsubscribe from the pipelines */
-          Curl_pipeline_leave_write(data->easy_conn);
-          Curl_pipeline_leave_read(data->easy_conn);
-          Curl_removeHandleFromPipeline(data, &data->easy_conn->send_pipe);
-          Curl_removeHandleFromPipeline(data, &data->easy_conn->recv_pipe);
+          Curl_pipeline_leave_write(data->conn);
+          Curl_pipeline_leave_read(data->conn);
+          Curl_removeHandleFromPipeline(data, &data->conn->send_pipe);
+          Curl_removeHandleFromPipeline(data, &data->conn->recv_pipe);
 
           if(stream_error) {
             /* Don't attempt to send data over a connection that timed out */
             bool dead_connection = result == CURLE_OPERATION_TIMEDOUT;
             /* disconnect properly */
-            Curl_disconnect(data, data->easy_conn, dead_connection);
+            Curl_disconnect(data, data->conn, dead_connection);
 
-            /* This is where we make sure that the easy_conn pointer is reset.
+            /* This is where we make sure that the conn pointer is reset.
                We don't have to do this in every case block above where a
                failure is detected */
-            data->easy_conn = NULL;
+            Curl_detach_connnection(data);
           }
         }
         else if(data->mstate == CURLM_STATE_CONNECT) {
@@ -2154,11 +2157,11 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
         rc = CURLM_CALL_MULTI_PERFORM;
       }
       /* if there's still a connection to use, call the progress function */
-      else if(data->easy_conn && Curl_pgrsUpdate(data->easy_conn)) {
+      else if(data->conn && Curl_pgrsUpdate(data->conn)) {
         /* aborted due to progress callback return code must close the
            connection */
         result = CURLE_ABORTED_BY_CALLBACK;
-        streamclose(data->easy_conn, "Aborted by callback");
+        streamclose(data->conn, "Aborted by callback");
 
         /* if not yet in DONE state, go there, otherwise COMPLETED */
         multistate(data, (data->mstate < CURLM_STATE_DONE)?
@@ -2181,7 +2184,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
         msg->extmsg.data.result = result;
 
         rc = multi_addmsg(multi, msg);
-        DEBUGASSERT(!data->easy_conn);
+        DEBUGASSERT(!data->conn);
       }
       multistate(data, CURLM_STATE_MSGSENT);
     }
@@ -2261,9 +2264,9 @@ CURLMcode curl_multi_cleanup(struct Curl_multi *multi)
     data = multi->easyp;
     while(data) {
       nextdata = data->next;
-      if(!data->state.done && data->easy_conn)
+      if(!data->state.done && data->conn)
         /* if DONE was never called for this handle */
-        (void)multi_done(&data->easy_conn, CURLE_OK, TRUE);
+        (void)multi_done(data, CURLE_OK, TRUE);
       if(data->dns.hostcachetype == HCACHE_MULTI) {
         /* clear out the usage of the shared DNS cache */
         Curl_hostcache_clean(data, data->dns.hostcache);
@@ -2356,6 +2359,9 @@ static CURLMcode singlesocket(struct Curl_multi *multi,
   curl_socket_t s;
   int num;
   unsigned int curraction;
+  int actions[MAX_SOCKSPEREASYHANDLE];
+  unsigned int comboaction;
+  bool sincebefore = FALSE;
 
   for(i = 0; i< MAX_SOCKSPEREASYHANDLE; i++)
     socks[i] = CURL_SOCKET_BAD;
@@ -2372,7 +2378,8 @@ static CURLMcode singlesocket(struct Curl_multi *multi,
   for(i = 0; (i< MAX_SOCKSPEREASYHANDLE) &&
         (curraction & (GETSOCK_READSOCK(i) | GETSOCK_WRITESOCK(i)));
       i++) {
-    int action = CURL_POLL_NONE;
+    unsigned int action = CURL_POLL_NONE;
+    unsigned int prevaction = 0;
 
     s = socks[i];
 
@@ -2384,29 +2391,70 @@ static CURLMcode singlesocket(struct Curl_multi *multi,
     if(curraction & GETSOCK_WRITESOCK(i))
       action |= CURL_POLL_OUT;
 
+    actions[i] = action;
     if(entry) {
-      /* yeps, already present so check if it has the same action set */
-      if(entry->action == action)
-        /* same, continue */
-        continue;
+      /* check if new for this transfer */
+      for(i = 0; i< data->numsocks; i++) {
+        if(s == data->sockets[i]) {
+          prevaction = data->actions[i];
+          sincebefore = TRUE;
+          break;
+        }
+      }
+
     }
     else {
-      /* this is a socket we didn't have before, add it! */
-      entry = sh_addentry(&multi->sockhash, s, data);
+      /* this is a socket we didn't have before, add it to the hash! */
+      entry = sh_addentry(&multi->sockhash, s);
       if(!entry)
         /* fatal */
         return CURLM_OUT_OF_MEMORY;
     }
+    if(sincebefore && (prevaction != action)) {
+      /* Socket was used already, but different action now */
+      if(prevaction & CURL_POLL_IN)
+        entry->readers--;
+      if(prevaction & CURL_POLL_OUT)
+        entry->writers--;
+      if(action & CURL_POLL_IN)
+        entry->readers++;
+      if(action & CURL_POLL_OUT)
+        entry->writers++;
+    }
+    else if(!sincebefore) {
+      /* a new user */
+      entry->users++;
+      if(action & CURL_POLL_IN)
+        entry->readers++;
+      if(action & CURL_POLL_OUT)
+        entry->writers++;
+
+      /* add 'data' to the list of handles using this socket! */
+      Curl_llist_insert_next(&entry->list, entry->list.tail,
+                             data, &data->sh_queue);
+    }
+
+    comboaction = (entry->writers? CURL_POLL_OUT : 0) |
+      (entry->readers ? CURL_POLL_IN : 0);
+
+#if 0
+    infof(data, "--- Comboaction: %u readers %u writers\n",
+          entry->readers, entry->writers);
+#endif
+    /* check if it has the same action set */
+    if(entry->action == comboaction)
+      /* same, continue */
+      continue;
 
     /* we know (entry != NULL) at this point, see the logic above */
     if(multi->socket_cb)
       multi->socket_cb(data,
                        s,
-                       action,
+                       comboaction,
                        multi->socket_userp,
                        entry->socketp);
 
-    entry->action = action; /* store the current action state */
+    entry->action = comboaction; /* store the current action state */
   }
 
   num = i; /* number of sockets */
@@ -2415,73 +2463,45 @@ static CURLMcode singlesocket(struct Curl_multi *multi,
      make sure to detect sockets that are removed */
   for(i = 0; i< data->numsocks; i++) {
     int j;
+    bool stillused = FALSE;
     s = data->sockets[i];
-    for(j = 0; j<num; j++) {
+    for(j = 0; j < num; j++) {
       if(s == socks[j]) {
         /* this is still supervised */
-        s = CURL_SOCKET_BAD;
+        stillused = TRUE;
         break;
       }
     }
+    if(stillused)
+      continue;
 
     entry = sh_getentry(&multi->sockhash, s);
+    /* if this is NULL here, the socket has been closed and notified so
+       already by Curl_multi_closed() */
     if(entry) {
-      /* this socket has been removed. Tell the app to remove it */
-      bool remove_sock_from_hash = TRUE;
-
-      /* check if the socket to be removed serves a connection which has
-         other easy-s in a pipeline. In this case the socket should not be
-         removed. */
-      struct connectdata *easy_conn = data->easy_conn;
-      if(easy_conn) {
-        if(easy_conn->recv_pipe.size > 1) {
-          /* the handle should not be removed from the pipe yet */
-          remove_sock_from_hash = FALSE;
-
-          /* Update the sockhash entry to instead point to the next in line
-             for the recv_pipe, or the first (in case this particular easy
-             isn't already) */
-          if(entry->easy == data) {
-            if(Curl_recvpipe_head(data, easy_conn))
-              entry->easy = easy_conn->recv_pipe.head->next->ptr;
-            else
-              entry->easy = easy_conn->recv_pipe.head->ptr;
-          }
-        }
-        if(easy_conn->send_pipe.size > 1) {
-          /* the handle should not be removed from the pipe yet */
-          remove_sock_from_hash = FALSE;
-
-          /* Update the sockhash entry to instead point to the next in line
-             for the send_pipe, or the first (in case this particular easy
-             isn't already) */
-          if(entry->easy == data) {
-            if(Curl_sendpipe_head(data, easy_conn))
-              entry->easy = easy_conn->send_pipe.head->next->ptr;
-            else
-              entry->easy = easy_conn->send_pipe.head->ptr;
-          }
-        }
-        /* Don't worry about overwriting recv_pipe head with send_pipe_head,
-           when action will be asked on the socket (see multi_socket()), the
-           head of the correct pipe will be taken according to the
-           action. */
-      }
-
-      if(remove_sock_from_hash) {
-        /* in this case 'entry' is always non-NULL */
+      int oldactions = data->actions[i];
+      /* this socket has been removed. Decrease user count */
+      entry->users--;
+      if(oldactions & CURL_POLL_OUT)
+        entry->writers--;
+      if(oldactions & CURL_POLL_IN)
+        entry->readers--;
+      if(!entry->users) {
         if(multi->socket_cb)
-          multi->socket_cb(data,
-                           s,
-                           CURL_POLL_REMOVE,
+          multi->socket_cb(data, s, CURL_POLL_REMOVE,
                            multi->socket_userp,
                            entry->socketp);
         sh_delentry(&multi->sockhash, s);
       }
-    } /* if sockhash entry existed */
+      else {
+        /* remove this transfer as a user of this socket */
+        Curl_llist_remove(&entry->list, &data->sh_queue, NULL);
+      }
+    }
   } /* for loop over numsocks */
 
   memcpy(data->sockets, socks, num*sizeof(curl_socket_t));
+  memcpy(data->actions, actions, num*sizeof(int));
   data->numsocks = num;
   return CURLM_OK;
 }
@@ -2621,46 +2641,50 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
          and just move on. */
       ;
     else {
+      struct curl_llist *list = &entry->list;
+      struct curl_llist_element *e;
       SIGPIPE_VARIABLE(pipe_st);
 
-      data = entry->easy;
+      /* the socket can be shared by many transfers, iterate */
+      for(e = list->head; e; e = e->next) {
+        data = (struct Curl_easy *)e->ptr;
 
-      if(data->magic != CURLEASY_MAGIC_NUMBER)
-        /* bad bad bad bad bad bad bad */
-        return CURLM_INTERNAL_ERROR;
+        if(data->magic != CURLEASY_MAGIC_NUMBER)
+          /* bad bad bad bad bad bad bad */
+          return CURLM_INTERNAL_ERROR;
 
-      /* If the pipeline is enabled, take the handle which is in the head of
-         the pipeline. If we should write into the socket, take the send_pipe
-         head.  If we should read from the socket, take the recv_pipe head. */
-      if(data->easy_conn) {
-        if((ev_bitmask & CURL_POLL_OUT) &&
-           data->easy_conn->send_pipe.head)
-          data = data->easy_conn->send_pipe.head->ptr;
-        else if((ev_bitmask & CURL_POLL_IN) &&
-                data->easy_conn->recv_pipe.head)
-          data = data->easy_conn->recv_pipe.head->ptr;
-      }
+        /* If the pipeline is enabled, take the handle which is in the head of
+           the pipeline. If we should write into the socket, take the
+           send_pipe head. If we should read from the socket, take the
+           recv_pipe head. */
+        if(data->conn) {
+          if((ev_bitmask & CURL_POLL_OUT) &&
+             data->conn->send_pipe.head)
+            data = data->conn->send_pipe.head->ptr;
+          else if((ev_bitmask & CURL_POLL_IN) &&
+                  data->conn->recv_pipe.head)
+            data = data->conn->recv_pipe.head->ptr;
+        }
 
-      if(data->easy_conn &&
-         !(data->easy_conn->handler->flags & PROTOPT_DIRLOCK))
-        /* set socket event bitmask if they're not locked */
-        data->easy_conn->cselect_bits = ev_bitmask;
+        if(data->conn && !(data->conn->handler->flags & PROTOPT_DIRLOCK))
+          /* set socket event bitmask if they're not locked */
+          data->conn->cselect_bits = ev_bitmask;
 
-      sigpipe_ignore(data, &pipe_st);
-      result = multi_runsingle(multi, now, data);
-      sigpipe_restore(&pipe_st);
+        sigpipe_ignore(data, &pipe_st);
+        result = multi_runsingle(multi, now, data);
+        sigpipe_restore(&pipe_st);
 
-      if(data->easy_conn &&
-         !(data->easy_conn->handler->flags & PROTOPT_DIRLOCK))
-        /* clear the bitmask only if not locked */
-        data->easy_conn->cselect_bits = 0;
+        if(data->conn && !(data->conn->handler->flags & PROTOPT_DIRLOCK))
+          /* clear the bitmask only if not locked */
+          data->conn->cselect_bits = 0;
 
-      if(CURLM_OK >= result) {
-        /* get the socket(s) and check if the state has been changed since
-           last */
-        result = singlesocket(multi, data);
-        if(result)
-          return result;
+        if(CURLM_OK >= result) {
+          /* get the socket(s) and check if the state has been changed since
+             last */
+          result = singlesocket(multi, data);
+          if(result)
+            return result;
+        }
       }
 
       /* Now we fall-through and do the timer-based stuff, since we don't want
@@ -3004,6 +3028,9 @@ void Curl_expire(struct Curl_easy *data, time_t milli, expire_id id)
 
   DEBUGASSERT(id < EXPIRE_LAST);
 
+  infof(data, "Expire in %ld ms for %x (transfer %p)\n",
+        (long)milli, id, data);
+
   set = Curl_now();
   set.tv_sec += milli/1000;
   set.tv_usec += (unsigned int)(milli%1000)*1000;
@@ -3095,7 +3122,7 @@ void Curl_expire_clear(struct Curl_easy *data)
     }
 
 #ifdef DEBUGBUILD
-    infof(data, "Expire cleared\n");
+    infof(data, "Expire cleared (transfer %p)\n", data);
 #endif
     nowp->tv_sec = 0;
     nowp->tv_usec = 0;

--- a/vendor/curl/lib/multiif.h
+++ b/vendor/curl/lib/multiif.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -31,7 +31,9 @@ void Curl_expire(struct Curl_easy *data, time_t milli, expire_id);
 void Curl_expire_clear(struct Curl_easy *data);
 void Curl_expire_done(struct Curl_easy *data, expire_id id);
 bool Curl_pipeline_wanted(const struct Curl_multi* multi, int bits);
-void Curl_multi_handlePipeBreak(struct Curl_easy *data);
+void Curl_detach_connnection(struct Curl_easy *data);
+void Curl_attach_connnection(struct Curl_easy *data,
+                             struct connectdata *conn);
 void Curl_set_in_callback(struct Curl_easy *data, bool value);
 bool Curl_is_in_callback(struct Curl_easy *easy);
 

--- a/vendor/curl/lib/pingpong.h
+++ b/vendor/curl/lib/pingpong.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -81,14 +81,15 @@ struct pingpong {
  * called repeatedly until done. Set 'wait' to make it wait a while on the
  * socket if there's no traffic.
  */
-CURLcode Curl_pp_statemach(struct pingpong *pp, bool block);
+CURLcode Curl_pp_statemach(struct pingpong *pp, bool block,
+                           bool disconnecting);
 
 /* initialize stuff to prepare for reading a fresh new response */
 void Curl_pp_init(struct pingpong *pp);
 
 /* Returns timeout in ms. 0 or negative number means the timeout has already
    triggered */
-time_t Curl_pp_state_timeout(struct pingpong *pp);
+time_t Curl_pp_state_timeout(struct pingpong *pp, bool disconnecting);
 
 
 /***********************************************************************

--- a/vendor/curl/lib/pop3.c
+++ b/vendor/curl/lib/pop3.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -208,7 +208,7 @@ static bool pop3_endofresp(struct connectdata *conn, char *line, size_t len,
   /* Are we processing CAPA command responses? */
   if(pop3c->state == POP3_CAPA) {
     /* Do we have the terminating line? */
-    if(len >= 1 && !memcmp(line, ".", 1))
+    if(len >= 1 && line[0] == '.')
       /* Treat the response as a success */
       *resp = '+';
     else
@@ -226,7 +226,7 @@ static bool pop3_endofresp(struct connectdata *conn, char *line, size_t len,
   }
 
   /* Do we have a continuation response? */
-  if(len >= 1 && !memcmp("+", line, 1)) {
+  if(len >= 1 && line[0] == '+') {
     *resp = '*';
 
     return TRUE;
@@ -1025,19 +1025,20 @@ static CURLcode pop3_multi_statemach(struct connectdata *conn, bool *done)
       return result;
   }
 
-  result = Curl_pp_statemach(&pop3c->pp, FALSE);
+  result = Curl_pp_statemach(&pop3c->pp, FALSE, FALSE);
   *done = (pop3c->state == POP3_STOP) ? TRUE : FALSE;
 
   return result;
 }
 
-static CURLcode pop3_block_statemach(struct connectdata *conn)
+static CURLcode pop3_block_statemach(struct connectdata *conn,
+                                     bool disconnecting)
 {
   CURLcode result = CURLE_OK;
   struct pop3_conn *pop3c = &conn->proto.pop3c;
 
   while(pop3c->state != POP3_STOP && !result)
-    result = Curl_pp_statemach(&pop3c->pp, TRUE);
+    result = Curl_pp_statemach(&pop3c->pp, TRUE, disconnecting);
 
   return result;
 }
@@ -1235,7 +1236,7 @@ static CURLcode pop3_disconnect(struct connectdata *conn, bool dead_connection)
      point! */
   if(!dead_connection && pop3c->pp.conn && pop3c->pp.conn->bits.protoconnstart)
     if(!pop3_perform_quit(conn))
-      (void)pop3_block_statemach(conn); /* ignore errors on QUIT */
+      (void)pop3_block_statemach(conn, TRUE); /* ignore errors on QUIT */
 
   /* Disconnect from the server */
   Curl_pp_disconnect(&pop3c->pp);

--- a/vendor/curl/lib/setopt.c
+++ b/vendor/curl/lib/setopt.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -803,12 +803,12 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option,
         if(checkprefix("Set-Cookie:", argptr))
           /* HTTP Header format line */
           Curl_cookie_add(data, data->cookies, TRUE, FALSE, argptr + 11, NULL,
-                          NULL);
+                          NULL, TRUE);
 
         else
           /* Netscape format line */
           Curl_cookie_add(data, data->cookies, FALSE, FALSE, argptr, NULL,
-                          NULL);
+                          NULL, TRUE);
 
         Curl_share_unlock(data, CURL_LOCK_DATA_COOKIE);
         free(argptr);
@@ -860,6 +860,12 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option,
     data->set.expect_100_timeout = arg;
     break;
 
+  case CURLOPT_HTTP09_ALLOWED:
+    arg = va_arg(param, unsigned long);
+    if(arg > 1L)
+      return CURLE_BAD_FUNCTION_ARGUMENT;
+    data->set.http09_allowed = arg ? TRUE : FALSE;
+    break;
 #endif   /* CURL_DISABLE_HTTP */
 
   case CURLOPT_HTTPAUTH:
@@ -1693,8 +1699,8 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option,
       TRUE : FALSE;
 
     /* Update the current connection ssl_config. */
-    if(data->easy_conn) {
-      data->easy_conn->ssl_config.verifypeer =
+    if(data->conn) {
+      data->conn->ssl_config.verifypeer =
         data->set.ssl.primary.verifypeer;
     }
     break;
@@ -1706,8 +1712,8 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option,
       (0 != va_arg(param, long))?TRUE:FALSE;
 
     /* Update the current connection proxy_ssl_config. */
-    if(data->easy_conn) {
-      data->easy_conn->proxy_ssl_config.verifypeer =
+    if(data->conn) {
+      data->conn->proxy_ssl_config.verifypeer =
         data->set.proxy_ssl.primary.verifypeer;
     }
     break;
@@ -1730,8 +1736,8 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option,
     data->set.ssl.primary.verifyhost = (0 != arg) ? TRUE : FALSE;
 
     /* Update the current connection ssl_config. */
-    if(data->easy_conn) {
-      data->easy_conn->ssl_config.verifyhost =
+    if(data->conn) {
+      data->conn->ssl_config.verifyhost =
         data->set.ssl.primary.verifyhost;
     }
     break;
@@ -1754,8 +1760,8 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option,
     data->set.proxy_ssl.primary.verifyhost = (0 != arg)?TRUE:FALSE;
 
     /* Update the current connection proxy_ssl_config. */
-    if(data->easy_conn) {
-      data->easy_conn->proxy_ssl_config.verifyhost =
+    if(data->conn) {
+      data->conn->proxy_ssl_config.verifyhost =
         data->set.proxy_ssl.primary.verifyhost;
     }
     break;
@@ -1772,8 +1778,8 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option,
       TRUE : FALSE;
 
     /* Update the current connection ssl_config. */
-    if(data->easy_conn) {
-      data->easy_conn->ssl_config.verifystatus =
+    if(data->conn) {
+      data->conn->ssl_config.verifystatus =
         data->set.ssl.primary.verifystatus;
     }
     break;
@@ -2231,7 +2237,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option,
     result = Curl_setstropt(&data->set.str[STRING_SSH_HOST_PUBLIC_KEY_MD5],
                             va_arg(param, char *));
     break;
-#ifdef HAVE_LIBSSH2_KNOWNHOST_API
+
   case CURLOPT_SSH_KNOWNHOSTS:
     /*
      * Store the file name to read known hosts from.
@@ -2252,7 +2258,6 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option,
      */
     data->set.ssh_keyfunc_userp = va_arg(param, void *);
     break;
-#endif /* HAVE_LIBSSH2_KNOWNHOST_API */
 #endif /* USE_LIBSSH2 */
 
   case CURLOPT_HTTP_TRANSFER_DECODING:
@@ -2635,6 +2640,16 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option,
     if(arg < 0)
       return CURLE_BAD_FUNCTION_ARGUMENT;
     data->set.upkeep_interval_ms = arg;
+    break;
+  case CURLOPT_TRAILERFUNCTION:
+#ifndef CURL_DISABLE_HTTP
+    data->set.trailer_callback = va_arg(param, curl_trailer_callback);
+#endif
+    break;
+  case CURLOPT_TRAILERDATA:
+#ifndef CURL_DISABLE_HTTP
+    data->set.trailer_data = va_arg(param, void *);
+#endif
     break;
   default:
     /* unknown tag and its companion, just ignore: */

--- a/vendor/curl/lib/sigpipe.h
+++ b/vendor/curl/lib/sigpipe.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2013, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -23,7 +23,8 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-#if defined(HAVE_SIGNAL_H) && defined(HAVE_SIGACTION) && defined(USE_OPENSSL)
+#if defined(HAVE_SIGNAL_H) && defined(HAVE_SIGACTION) &&        \
+  (defined(USE_OPENSSL) || defined(USE_MBEDTLS))
 #include <signal.h>
 
 struct sigpipe_ignore {

--- a/vendor/curl/lib/smb.c
+++ b/vendor/curl/lib/smb.c
@@ -947,15 +947,10 @@ static int smb_getsock(struct connectdata *conn, curl_socket_t *socks,
 static CURLcode smb_do(struct connectdata *conn, bool *done)
 {
   struct smb_conn *smbc = &conn->proto.smbc;
-  struct smb_request *req = conn->data->req.protop;
 
   *done = FALSE;
   if(smbc->share) {
-    req->path = strchr(smbc->share, '\0');
-    if(req->path) {
-      req->path++;
-      return CURLE_OK;
-    }
+    return CURLE_OK;
   }
   return CURLE_URL_MALFORMAT;
 }
@@ -964,6 +959,7 @@ static CURLcode smb_parse_url_path(struct connectdata *conn)
 {
   CURLcode result = CURLE_OK;
   struct Curl_easy *data = conn->data;
+  struct smb_request *req = data->req.protop;
   struct smb_conn *smbc = &conn->proto.smbc;
   char *path;
   char *slash;
@@ -992,6 +988,7 @@ static CURLcode smb_parse_url_path(struct connectdata *conn)
   /* Parse the path for the file path converting any forward slashes into
      backslashes */
   *slash++ = 0;
+  req->path = slash;
 
   for(; *slash; slash++) {
     if(*slash == '/')

--- a/vendor/curl/lib/ssh.c
+++ b/vendor/curl/lib/ssh.c
@@ -667,7 +667,10 @@ static CURLcode ssh_statemach_act(struct connectdata *conn, bool *block)
         break;
       }
       if(rc) {
-        failf(data, "Failure establishing ssh session");
+        char *err_msg = NULL;
+        (void)libssh2_session_last_error(sshc->ssh_session, &err_msg, NULL, 0);
+        failf(data, "Failure establishing ssh session: %d, %s", rc, err_msg);
+
         state(conn, SSH_SESSION_FREE);
         sshc->actualcode = CURLE_FAILED_INIT;
         break;

--- a/vendor/curl/lib/timeval.c
+++ b/vendor/curl/lib/timeval.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -21,29 +21,45 @@
  ***************************************************************************/
 
 #include "timeval.h"
+#include "system_win32.h"
 
 #if defined(WIN32) && !defined(MSDOS)
 
 struct curltime Curl_now(void)
 {
-  /*
-  ** GetTickCount() is available on _all_ Windows versions from W95 up
-  ** to nowadays. Returns milliseconds elapsed since last system boot,
-  ** increases monotonically and wraps once 49.7 days have elapsed.
-  */
   struct curltime now;
-#if !defined(_WIN32_WINNT) || !defined(_WIN32_WINNT_VISTA) || \
-    (_WIN32_WINNT < _WIN32_WINNT_VISTA) || \
-    (defined(__MINGW32__) && !defined(__MINGW64_VERSION_MAJOR))
-  DWORD milliseconds = GetTickCount();
-  now.tv_sec = milliseconds / 1000;
-  now.tv_usec = (milliseconds % 1000) * 1000;
-#else
-  ULONGLONG milliseconds = GetTickCount64();
-  now.tv_sec = (time_t) (milliseconds / 1000);
-  now.tv_usec = (unsigned int) (milliseconds % 1000) * 1000;
+  static LARGE_INTEGER freq;
+  static int isVistaOrGreater = -1;
+  if(isVistaOrGreater == -1) {
+    if(Curl_verify_windows_version(6, 0, PLATFORM_WINNT,
+                                   VERSION_GREATER_THAN_EQUAL)) {
+      isVistaOrGreater = 1;
+      QueryPerformanceFrequency(&freq);
+    }
+    else
+      isVistaOrGreater = 0;
+  }
+  if(isVistaOrGreater == 1) { /* QPC timer might have issues pre-Vista */
+    LARGE_INTEGER count;
+    QueryPerformanceCounter(&count);
+    now.tv_sec = (time_t)(count.QuadPart / freq.QuadPart);
+    now.tv_usec =
+      (int)((count.QuadPart % freq.QuadPart) * 1000000 / freq.QuadPart);
+  }
+  else {
+    /* Disable /analyze warning that GetTickCount64 is preferred  */
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:28159)
+#endif
+    DWORD milliseconds = GetTickCount();
+#if defined(_MSC_VER)
+#pragma warning(pop)
 #endif
 
+    now.tv_sec = milliseconds / 1000;
+    now.tv_usec = (milliseconds % 1000) * 1000;
+  }
   return now;
 }
 
@@ -180,7 +196,7 @@ struct curltime Curl_now(void)
  */
 timediff_t Curl_timediff(struct curltime newer, struct curltime older)
 {
-  timediff_t diff = newer.tv_sec-older.tv_sec;
+  timediff_t diff = (timediff_t)newer.tv_sec-older.tv_sec;
   if(diff >= (TIME_MAX/1000))
     return TIME_MAX;
   else if(diff <= (TIME_MIN/1000))
@@ -194,7 +210,7 @@ timediff_t Curl_timediff(struct curltime newer, struct curltime older)
  */
 timediff_t Curl_timediff_us(struct curltime newer, struct curltime older)
 {
-  timediff_t diff = newer.tv_sec-older.tv_sec;
+  timediff_t diff = (timediff_t)newer.tv_sec-older.tv_sec;
   if(diff >= (TIME_MAX/1000000))
     return TIME_MAX;
   else if(diff <= (TIME_MIN/1000000))

--- a/vendor/curl/lib/timeval.h
+++ b/vendor/curl/lib/timeval.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -26,8 +26,10 @@
 
 #if SIZEOF_TIME_T < 8
 typedef int timediff_t;
+#define CURL_FORMAT_TIMEDIFF_T "d"
 #else
 typedef curl_off_t timediff_t;
+#define CURL_FORMAT_TIMEDIFF_T CURL_FORMAT_CURL_OFF_T
 #endif
 
 struct curltime {

--- a/vendor/curl/lib/transfer.c
+++ b/vendor/curl/lib/transfer.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -117,6 +117,35 @@ CURLcode Curl_get_upload_buffer(struct Curl_easy *data)
   return CURLE_OK;
 }
 
+#ifndef CURL_DISABLE_HTTP
+/*
+ * This function will be called to loop through the trailers buffer
+ * until no more data is available for sending.
+ */
+static size_t Curl_trailers_read(char *buffer, size_t size, size_t nitems,
+                                 void *raw)
+{
+  struct Curl_easy *data = (struct Curl_easy *)raw;
+  Curl_send_buffer *trailers_buf = data->state.trailers_buf;
+  size_t bytes_left = trailers_buf->size_used-data->state.trailers_bytes_sent;
+  size_t to_copy = (size*nitems < bytes_left) ? size*nitems : bytes_left;
+  if(to_copy) {
+    memcpy(buffer,
+           &trailers_buf->buffer[data->state.trailers_bytes_sent],
+           to_copy);
+    data->state.trailers_bytes_sent += to_copy;
+  }
+  return to_copy;
+}
+
+static size_t Curl_trailers_left(void *raw)
+{
+  struct Curl_easy *data = (struct Curl_easy *)raw;
+  Curl_send_buffer *trailers_buf = data->state.trailers_buf;
+  return trailers_buf->size_used - data->state.trailers_bytes_sent;
+}
+#endif
+
 /*
  * This function will call the read callback to fill our buffer with data
  * to upload.
@@ -127,6 +156,17 @@ CURLcode Curl_fillreadbuffer(struct connectdata *conn, size_t bytes,
   struct Curl_easy *data = conn->data;
   size_t buffersize = bytes;
   size_t nread;
+
+#ifndef CURL_DISABLE_HTTP
+  struct curl_slist *trailers = NULL;
+  CURLcode c;
+  int trailers_ret_code;
+#endif
+
+  curl_read_callback readfunc = NULL;
+  void *extra_data = NULL;
+  bool added_crlf = FALSE;
+
 #ifdef CURL_DOES_CONVERSIONS
   bool sending_http_headers = FALSE;
 
@@ -140,15 +180,71 @@ CURLcode Curl_fillreadbuffer(struct connectdata *conn, size_t bytes,
   }
 #endif
 
-  if(data->req.upload_chunky) {
+#ifndef CURL_DISABLE_HTTP
+  if(data->state.trailers_state == TRAILERS_INITIALIZED) {
+    /* at this point we already verified that the callback exists
+       so we compile and store the trailers buffer, then proceed */
+    infof(data,
+          "Moving trailers state machine from initialized to sending.\n");
+    data->state.trailers_state = TRAILERS_SENDING;
+    data->state.trailers_buf = Curl_add_buffer_init();
+    if(!data->state.trailers_buf) {
+      failf(data, "Unable to allocate trailing headers buffer !");
+      return CURLE_OUT_OF_MEMORY;
+    }
+    data->state.trailers_bytes_sent = 0;
+    Curl_set_in_callback(data, true);
+    trailers_ret_code = data->set.trailer_callback(&trailers,
+                                                   data->set.trailer_data);
+    Curl_set_in_callback(data, false);
+    if(trailers_ret_code == CURL_TRAILERFUNC_OK) {
+      c = Curl_http_compile_trailers(trailers, data->state.trailers_buf, data);
+    }
+    else {
+      failf(data, "operation aborted by trailing headers callback");
+      *nreadp = 0;
+      c = CURLE_ABORTED_BY_CALLBACK;
+    }
+    if(c != CURLE_OK) {
+      Curl_add_buffer_free(&data->state.trailers_buf);
+      curl_slist_free_all(trailers);
+      return c;
+    }
+    infof(data, "Successfully compiled trailers.\r\n");
+    curl_slist_free_all(trailers);
+  }
+#endif
+
+  /* if we are transmitting trailing data, we don't need to write
+     a chunk size so we skip this */
+  if(data->req.upload_chunky &&
+     data->state.trailers_state == TRAILERS_NONE) {
     /* if chunked Transfer-Encoding */
     buffersize -= (8 + 2 + 2);   /* 32bit hex + CRLF + CRLF */
     data->req.upload_fromhere += (8 + 2); /* 32bit hex + CRLF */
   }
 
+#ifndef CURL_DISABLE_HTTP
+  if(data->state.trailers_state == TRAILERS_SENDING) {
+    /* if we're here then that means that we already sent the last empty chunk
+       but we didn't send a final CR LF, so we sent 0 CR LF. We then start
+       pulling trailing data until we ²have no more at which point we
+       simply return to the previous point in the state machine as if
+       nothing happened.
+       */
+    readfunc = Curl_trailers_read;
+    extra_data = (void *)data;
+  }
+  else
+#endif
+  {
+    readfunc = data->state.fread_func;
+    extra_data = data->state.in;
+  }
+
   Curl_set_in_callback(data, true);
-  nread = data->state.fread_func(data->req.upload_fromhere, 1,
-                                 buffersize, data->state.in);
+  nread = readfunc(data->req.upload_fromhere, 1,
+                   buffersize, extra_data);
   Curl_set_in_callback(data, false);
 
   if(nread == CURL_READFUNC_ABORT) {
@@ -203,7 +299,7 @@ CURLcode Curl_fillreadbuffer(struct connectdata *conn, size_t bytes,
     char hexbuffer[11];
     const char *endofline_native;
     const char *endofline_network;
-    int hexlen;
+    int hexlen = 0;
 
     if(
 #ifdef CURL_DO_LINEEND_CONV
@@ -218,20 +314,36 @@ CURLcode Curl_fillreadbuffer(struct connectdata *conn, size_t bytes,
       endofline_native  = "\r\n";
       endofline_network = "\x0d\x0a";
     }
-    hexlen = msnprintf(hexbuffer, sizeof(hexbuffer),
-                       "%x%s", nread, endofline_native);
 
-    /* move buffer pointer */
-    data->req.upload_fromhere -= hexlen;
-    nread += hexlen;
+    /* if we're not handling trailing data, proceed as usual */
+    if(data->state.trailers_state != TRAILERS_SENDING) {
+      hexlen = msnprintf(hexbuffer, sizeof(hexbuffer),
+                         "%zx%s", nread, endofline_native);
 
-    /* copy the prefix to the buffer, leaving out the NUL */
-    memcpy(data->req.upload_fromhere, hexbuffer, hexlen);
+      /* move buffer pointer */
+      data->req.upload_fromhere -= hexlen;
+      nread += hexlen;
 
-    /* always append ASCII CRLF to the data */
-    memcpy(data->req.upload_fromhere + nread,
-           endofline_network,
-           strlen(endofline_network));
+      /* copy the prefix to the buffer, leaving out the NUL */
+      memcpy(data->req.upload_fromhere, hexbuffer, hexlen);
+
+      /* always append ASCII CRLF to the data unless
+         we have a valid trailer callback */
+#ifndef CURL_DISABLE_HTTP
+      if((nread-hexlen) == 0 &&
+          data->set.trailer_callback != NULL &&
+          data->state.trailers_state == TRAILERS_NONE) {
+        data->state.trailers_state = TRAILERS_INITIALIZED;
+      }
+      else
+#endif
+      {
+        memcpy(data->req.upload_fromhere + nread,
+               endofline_network,
+               strlen(endofline_network));
+        added_crlf = TRUE;
+      }
+    }
 
 #ifdef CURL_DOES_CONVERSIONS
     {
@@ -251,13 +363,29 @@ CURLcode Curl_fillreadbuffer(struct connectdata *conn, size_t bytes,
     }
 #endif /* CURL_DOES_CONVERSIONS */
 
-    if((nread - hexlen) == 0) {
-      /* mark this as done once this chunk is transferred */
+#ifndef CURL_DISABLE_HTTP
+    if(data->state.trailers_state == TRAILERS_SENDING &&
+       !Curl_trailers_left(data)) {
+      Curl_add_buffer_free(&data->state.trailers_buf);
+      data->state.trailers_state = TRAILERS_DONE;
+      data->set.trailer_data = NULL;
+      data->set.trailer_callback = NULL;
+      /* mark the transfer as done */
       data->req.upload_done = TRUE;
-      infof(data, "Signaling end of chunked upload via terminating chunk.\n");
+      infof(data, "Signaling end of chunked upload after trailers.\n");
     }
+    else
+#endif
+      if((nread - hexlen) == 0 &&
+         data->state.trailers_state != TRAILERS_INITIALIZED) {
+        /* mark this as done once this chunk is transferred */
+        data->req.upload_done = TRUE;
+        infof(data,
+              "Signaling end of chunked upload via terminating chunk.\n");
+      }
 
-    nread += strlen(endofline_native); /* for the added end of line */
+    if(added_crlf)
+      nread += strlen(endofline_network); /* for the added end of line */
   }
 #ifdef CURL_DOES_CONVERSIONS
   else if((data->set.prefer_ascii) && (!sending_http_headers)) {
@@ -925,7 +1053,6 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
   *didwhat |= KEEP_SEND;
 
   do {
-
     /* only read more data if there's no upload data already
        present in the upload buffer */
     if(0 == k->upload_present) {
@@ -950,7 +1077,6 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
           k->keepon &= ~KEEP_SEND;         /* disable writing */
           k->start100 = Curl_now();       /* timeout count starts now */
           *didwhat &= ~KEEP_SEND;  /* we didn't write anything actually */
-
           /* set a timeout for the multi interface */
           Curl_expire(data, data->set.expect_100_timeout, EXPIRE_100_TIMEOUT);
           break;
@@ -1224,15 +1350,15 @@ CURLcode Curl_readwrite(struct connectdata *conn,
   if(k->keepon) {
     if(0 > Curl_timeleft(data, &k->now, FALSE)) {
       if(k->size != -1) {
-        failf(data, "Operation timed out after %ld milliseconds with %"
-              CURL_FORMAT_CURL_OFF_T " out of %"
+        failf(data, "Operation timed out after %" CURL_FORMAT_TIMEDIFF_T
+              " milliseconds with %" CURL_FORMAT_CURL_OFF_T " out of %"
               CURL_FORMAT_CURL_OFF_T " bytes received",
               Curl_timediff(k->now, data->progress.t_startsingle),
               k->bytecount, k->size);
       }
       else {
-        failf(data, "Operation timed out after %ld milliseconds with %"
-              CURL_FORMAT_CURL_OFF_T " bytes received",
+        failf(data, "Operation timed out after %" CURL_FORMAT_TIMEDIFF_T
+              " milliseconds with %" CURL_FORMAT_CURL_OFF_T " bytes received",
               Curl_timediff(k->now, data->progress.t_startsingle),
               k->bytecount);
       }
@@ -1431,12 +1557,6 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
     Curl_initinfo(data); /* reset session-specific information "variables" */
     Curl_pgrsResetTransferSizes(data);
     Curl_pgrsStartNow(data);
-
-    if(data->set.timeout)
-      Curl_expire(data, data->set.timeout, EXPIRE_TIMEOUT);
-
-    if(data->set.connecttimeout)
-      Curl_expire(data, data->set.connecttimeout, EXPIRE_CONNECTTIMEOUT);
 
     /* In case the handle is re-used and an authentication method was picked
        in the session we need to make sure we only use the one(s) we now

--- a/vendor/curl/lib/url.h
+++ b/vendor/curl/lib/url.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -52,8 +52,7 @@ void Curl_freeset(struct Curl_easy * data);
 void Curl_up_free(struct Curl_easy *data);
 CURLcode Curl_uc_to_curlcode(CURLUcode uc);
 CURLcode Curl_close(struct Curl_easy *data); /* opposite of curl_open() */
-CURLcode Curl_connect(struct Curl_easy *, struct connectdata **,
-                      bool *async, bool *protocol_connect);
+CURLcode Curl_connect(struct Curl_easy *, bool *async, bool *protocol_connect);
 CURLcode Curl_disconnect(struct Curl_easy *data,
                          struct connectdata *, bool dead_connection);
 CURLcode Curl_protocol_connect(struct connectdata *conn, bool *done);

--- a/vendor/curl/lib/urlapi.c
+++ b/vendor/curl/lib/urlapi.c
@@ -510,8 +510,11 @@ UNITTEST CURLUcode Curl_parse_port(struct Curl_URL *u, char *hostname)
       portptr = &hostname[len];
     else if('%' == endbracket) {
       int zonelen = len;
-      if(1 == sscanf(hostname + zonelen, "25%*[^]]]%c%n", &endbracket, &len))
-        portptr = &hostname[--zonelen + len];
+      if(1 == sscanf(hostname + zonelen, "25%*[^]]%c%n", &endbracket, &len)) {
+        if(']' != endbracket)
+          return CURLUE_MALFORMED_INPUT;
+        portptr = &hostname[--zonelen + len + 1];
+      }
       else
         return CURLUE_MALFORMED_INPUT;
     }
@@ -534,6 +537,14 @@ UNITTEST CURLUcode Curl_parse_port(struct Curl_URL *u, char *hostname)
     long port;
     char portbuf[7];
 
+    /* Browser behavior adaptation. If there's a colon with no digits after,
+       just cut off the name there which makes us ignore the colon and just
+       use the default port. Firefox, Chrome and Safari all do that. */
+    if(!portptr[1]) {
+      *portptr = '\0';
+      return CURLUE_OK;
+    }
+
     if(!ISDIGIT(portptr[1]))
       return CURLUE_BAD_PORT_NUMBER;
 
@@ -547,22 +558,14 @@ UNITTEST CURLUcode Curl_parse_port(struct Curl_URL *u, char *hostname)
     if(rest[0])
       return CURLUE_BAD_PORT_NUMBER;
 
-    if(rest != &portptr[1]) {
-      *portptr++ = '\0'; /* cut off the name there */
-      *rest = 0;
-      /* generate a new to get rid of leading zeroes etc */
-      msnprintf(portbuf, sizeof(portbuf), "%ld", port);
-      u->portnum = port;
-      u->port = strdup(portbuf);
-      if(!u->port)
-        return CURLUE_OUT_OF_MEMORY;
-    }
-    else {
-      /* Browser behavior adaptation. If there's a colon with no digits after,
-         just cut off the name there which makes us ignore the colon and just
-         use the default port. Firefox and Chrome both do that. */
-      *portptr = '\0';
-    }
+    *portptr++ = '\0'; /* cut off the name there */
+    *rest = 0;
+    /* generate a new port number string to get rid of leading zeroes etc */
+    msnprintf(portbuf, sizeof(portbuf), "%ld", port);
+    u->portnum = port;
+    u->port = strdup(portbuf);
+    if(!u->port)
+      return CURLUE_OUT_OF_MEMORY;
   }
 
   return CURLUE_OK;
@@ -864,7 +867,7 @@ static CURLUcode seturl(const char *url, CURLU *u, unsigned int flags)
       return CURLUE_OUT_OF_MEMORY;
   }
 
-  if(query && query[0]) {
+  if(query) {
     u->query = strdup(query);
     if(!u->query)
       return CURLUE_OUT_OF_MEMORY;
@@ -1071,8 +1074,8 @@ CURLUcode curl_url_get(CURLU *u, CURLUPart what,
                     port ? port : "",
                     (u->path && (u->path[0] != '/')) ? "/": "",
                     u->path ? u->path : "/",
-                    u->query? "?": "",
-                    u->query? u->query : "",
+                    (u->query && u->query[0]) ? "?": "",
+                    (u->query && u->query[0]) ? u->query : "",
                     u->fragment? "#": "",
                     u->fragment? u->fragment : "");
     }

--- a/vendor/curl/lib/urldata.h
+++ b/vendor/curl/lib/urldata.h
@@ -7,7 +7,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -77,7 +77,7 @@
 /* Default FTP/IMAP etc response timeout in milliseconds.
    Symbian OS panics when given a timeout much greater than 1/2 hour.
 */
-#define RESP_TIMEOUT (1800*1000)
+#define RESP_TIMEOUT (120*1000)
 
 #include "cookie.h"
 #include "psl.h"
@@ -328,6 +328,12 @@ struct kerberos5data {
 struct ntlmdata {
   curlntlm state;
 #ifdef USE_WINDOWS_SSPI
+/* The sslContext is used for the Schannel bindings. The
+ * api is available on the Windows 7 SDK and later.
+ */
+#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
+  CtxtHandle *sslContext;
+#endif
   CredHandle *credentials;
   CtxtHandle *context;
   SEC_WINNT_AUTH_IDENTITY identity;
@@ -358,6 +364,9 @@ struct negotiatedata {
   gss_buffer_desc output_token;
 #else
 #ifdef USE_WINDOWS_SSPI
+#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
+  CtxtHandle *sslContext;
+#endif
   DWORD status;
   CredHandle *credentials;
   CtxtHandle *context;
@@ -974,6 +983,9 @@ struct connectdata {
   void *seek_client;            /* pointer to pass to the seek() above */
 
   /*************** Request - specific items ************/
+#if defined(USE_WINDOWS_SSPI) && defined(SECPKG_ATTR_ENDPOINT_BINDINGS)
+  CtxtHandle *sslContext;
+#endif
 
 #if defined(USE_NTLM)
   struct ntlmdata ntlm;     /* NTLM differs from other authentication schemes
@@ -1216,6 +1228,15 @@ typedef enum {
   EXPIRE_LAST /* not an actual timer, used as a marker only */
 } expire_id;
 
+
+typedef enum {
+  TRAILERS_NONE,
+  TRAILERS_INITIALIZED,
+  TRAILERS_SENDING,
+  TRAILERS_DONE
+} trailers_state;
+
+
 /*
  * One instance for each timeout an easy handle can set.
  */
@@ -1362,6 +1383,13 @@ struct UrlState {
 #endif
   CURLU *uh; /* URL handle for the current parsed URL */
   struct urlpieces up;
+#ifndef CURL_DISABLE_HTTP
+  size_t trailers_bytes_sent;
+  Curl_send_buffer *trailers_buf; /* a buffer containing the compiled trailing
+                                  headers */
+#endif
+  trailers_state trailers_state; /* whether we are sending trailers
+                                       and what stage are we at */
 };
 
 
@@ -1381,6 +1409,7 @@ struct DynamicStatic {
                                     curl_easy_setopt(COOKIEFILE) calls */
   struct curl_slist *resolve; /* set to point to the set.resolve list when
                                  this should be dealt with in pretransfer */
+  bool wildcard_resolve; /* Set to true if any resolve change is a wildcard */
 };
 
 /*
@@ -1727,9 +1756,12 @@ struct UserDefined {
   long upkeep_interval_ms;      /* Time between calls for connection upkeep. */
   bool doh; /* DNS-over-HTTPS enabled */
   bool doh_get; /* use GET for DoH requests, instead of POST */
+  bool http09_allowed; /* allow HTTP/0.9 responses */
   multidone_func fmultidone;
   struct Curl_easy *dohfor; /* this is a DoH request for that transfer */
   CURLU *uh; /* URL handle for the current parsed URL */
+  void *trailer_data; /* pointer to pass to trailer data callback */
+  curl_trailer_callback trailer_callback; /* trailing data callback */
 };
 
 struct Names {
@@ -1757,9 +1789,10 @@ struct Curl_easy {
   struct Curl_easy *next;
   struct Curl_easy *prev;
 
-  struct connectdata *easy_conn;     /* the "unit's" connection */
+  struct connectdata *conn;
   struct curl_llist_element connect_queue;
   struct curl_llist_element pipeline_queue;
+  struct curl_llist_element sh_queue; /* list per Curl_sh_entry */
 
   CURLMstate mstate;  /* the handle's state */
   CURLcode result;   /* previous result */
@@ -1771,6 +1804,8 @@ struct Curl_easy {
      the state etc are also kept. This array is mostly used to detect when a
      socket is to be removed from the hash. See singlesocket(). */
   curl_socket_t sockets[MAX_SOCKSPEREASYHANDLE];
+  int actions[MAX_SOCKSPEREASYHANDLE]; /* action for each socket in
+                                          sockets[] */
   int numsocks;
 
   struct Names dns;

--- a/vendor/curl/lib/vauth/digest_sspi.c
+++ b/vendor/curl/lib/vauth/digest_sspi.c
@@ -6,7 +6,7 @@
  *                             \___|\___/|_| \_\_____|
  *
  * Copyright (C) 2014 - 2016, Steve Holme, <steve_holme@hotmail.com>.
- * Copyright (C) 2015 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2015 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -146,7 +146,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
   }
 
   /* Generate our SPN */
-  spn = Curl_auth_build_spn(service, data->easy_conn->host.name, NULL);
+  spn = Curl_auth_build_spn(service, data->conn->host.name, NULL);
   if(!spn) {
     free(output_token);
     free(input_token);

--- a/vendor/curl/lib/vauth/ntlm_sspi.c
+++ b/vendor/curl/lib/vauth/ntlm_sspi.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2017, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -249,7 +249,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
                                              char **outptr, size_t *outlen)
 {
   CURLcode result = CURLE_OK;
-  SecBuffer type_2_buf;
+  SecBuffer type_2_bufs[2];
   SecBuffer type_3_buf;
   SecBufferDesc type_2_desc;
   SecBufferDesc type_3_desc;
@@ -261,12 +261,39 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   (void) userp;
 
   /* Setup the type-2 "input" security buffer */
-  type_2_desc.ulVersion = SECBUFFER_VERSION;
-  type_2_desc.cBuffers  = 1;
-  type_2_desc.pBuffers  = &type_2_buf;
-  type_2_buf.BufferType = SECBUFFER_TOKEN;
-  type_2_buf.pvBuffer   = ntlm->input_token;
-  type_2_buf.cbBuffer   = curlx_uztoul(ntlm->input_token_len);
+  type_2_desc.ulVersion     = SECBUFFER_VERSION;
+  type_2_desc.cBuffers      = 1;
+  type_2_desc.pBuffers      = &type_2_bufs[0];
+  type_2_bufs[0].BufferType = SECBUFFER_TOKEN;
+  type_2_bufs[0].pvBuffer   = ntlm->input_token;
+  type_2_bufs[0].cbBuffer   = curlx_uztoul(ntlm->input_token_len);
+
+#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
+  /* ssl context comes from schannel.
+  * When extended protection is used in IIS server,
+  * we have to pass a second SecBuffer to the SecBufferDesc
+  * otherwise IIS will not pass the authentication (401 response).
+  * Minimum supported version is Windows 7.
+  * https://docs.microsoft.com/en-us/security-updates
+  * /SecurityAdvisories/2009/973811
+  */
+  if(ntlm->sslContext) {
+    SEC_CHANNEL_BINDINGS channelBindings;
+    SecPkgContext_Bindings pkgBindings;
+    pkgBindings.Bindings = &channelBindings;
+    status = s_pSecFn->QueryContextAttributes(
+      ntlm->sslContext,
+      SECPKG_ATTR_ENDPOINT_BINDINGS,
+      &pkgBindings
+    );
+    if(status == SEC_E_OK) {
+      type_2_desc.cBuffers++;
+      type_2_bufs[1].BufferType = SECBUFFER_CHANNEL_BINDINGS;
+      type_2_bufs[1].cbBuffer = pkgBindings.BindingsLength;
+      type_2_bufs[1].pvBuffer = pkgBindings.Bindings;
+    }
+  }
+#endif
 
   /* Setup the type-3 "output" security buffer */
   type_3_desc.ulVersion = SECBUFFER_VERSION;

--- a/vendor/curl/lib/vauth/spnego_sspi.c
+++ b/vendor/curl/lib/vauth/spnego_sspi.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) 1998 - 2016, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -92,7 +92,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
   size_t chlglen = 0;
   unsigned char *chlg = NULL;
   PSecPkgInfo SecurityPackage;
-  SecBuffer chlg_buf;
+  SecBuffer chlg_buf[2];
   SecBuffer resp_buf;
   SecBufferDesc chlg_desc;
   SecBufferDesc resp_desc;
@@ -189,12 +189,39 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
     }
 
     /* Setup the challenge "input" security buffer */
-    chlg_desc.ulVersion = SECBUFFER_VERSION;
-    chlg_desc.cBuffers  = 1;
-    chlg_desc.pBuffers  = &chlg_buf;
-    chlg_buf.BufferType = SECBUFFER_TOKEN;
-    chlg_buf.pvBuffer   = chlg;
-    chlg_buf.cbBuffer   = curlx_uztoul(chlglen);
+    chlg_desc.ulVersion    = SECBUFFER_VERSION;
+    chlg_desc.cBuffers     = 1;
+    chlg_desc.pBuffers     = &chlg_buf[0];
+    chlg_buf[0].BufferType = SECBUFFER_TOKEN;
+    chlg_buf[0].pvBuffer   = chlg;
+    chlg_buf[0].cbBuffer   = curlx_uztoul(chlglen);
+
+#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
+    /* ssl context comes from Schannel.
+    * When extended protection is used in IIS server,
+    * we have to pass a second SecBuffer to the SecBufferDesc
+    * otherwise IIS will not pass the authentication (401 response).
+    * Minimum supported version is Windows 7.
+    * https://docs.microsoft.com/en-us/security-updates
+    * /SecurityAdvisories/2009/973811
+    */
+    if(nego->sslContext) {
+      SEC_CHANNEL_BINDINGS channelBindings;
+      SecPkgContext_Bindings pkgBindings;
+      pkgBindings.Bindings = &channelBindings;
+      nego->status = s_pSecFn->QueryContextAttributes(
+          nego->sslContext,
+          SECPKG_ATTR_ENDPOINT_BINDINGS,
+          &pkgBindings
+      );
+      if(nego->status == SEC_E_OK) {
+        chlg_desc.cBuffers++;
+        chlg_buf[1].BufferType = SECBUFFER_CHANNEL_BINDINGS;
+        chlg_buf[1].cbBuffer   = pkgBindings.BindingsLength;
+        chlg_buf[1].pvBuffer   = pkgBindings.Bindings;
+      }
+    }
+#endif
   }
 
   /* Setup the response "output" security buffer */
@@ -222,7 +249,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
 
   if(GSS_ERROR(nego->status)) {
     failf(data, "InitializeSecurityContext failed: %s",
-          Curl_sspi_strerror(data->easy_conn, nego->status));
+          Curl_sspi_strerror(data->conn, nego->status));
     return CURLE_OUT_OF_MEMORY;
   }
 

--- a/vendor/curl/lib/vtls/cyassl.c
+++ b/vendor/curl/lib/vtls/cyassl.c
@@ -794,6 +794,12 @@ static int Curl_cyassl_init(void)
 }
 
 
+static void Curl_cyassl_cleanup(void)
+{
+  CyaSSL_Cleanup();
+}
+
+
 static bool Curl_cyassl_data_pending(const struct connectdata* conn,
                                      int connindex)
 {
@@ -1004,7 +1010,7 @@ const struct Curl_ssl Curl_ssl_cyassl = {
   sizeof(struct ssl_backend_data),
 
   Curl_cyassl_init,                /* init */
-  Curl_none_cleanup,               /* cleanup */
+  Curl_cyassl_cleanup,             /* cleanup */
   Curl_cyassl_version,             /* version */
   Curl_none_check_cxn,             /* check_cxn */
   Curl_cyassl_shutdown,            /* shutdown */

--- a/vendor/curl/lib/vtls/darwinssl.c
+++ b/vendor/curl/lib/vtls/darwinssl.c
@@ -1298,7 +1298,6 @@ set_ssl_version_min_max(struct connectdata *conn, int sockindex)
     case CURL_SSLVERSION_DEFAULT:
     case CURL_SSLVERSION_TLSv1:
       ssl_version = CURL_SSLVERSION_TLSv1_0;
-      ssl_version_max = max_supported_version_by_os;
       break;
   }
 
@@ -1430,7 +1429,6 @@ static CURLcode darwinssl_connect_step1(struct connectdata *conn,
 #if CURL_BUILD_MAC_10_8 || CURL_BUILD_IOS
   if(SSLSetProtocolVersionMax != NULL) {
     switch(conn->ssl_config.version) {
-    case CURL_SSLVERSION_DEFAULT:
     case CURL_SSLVERSION_TLSv1:
       (void)SSLSetProtocolVersionMin(BACKEND->ssl_ctx, kTLSProtocol1);
 #if (CURL_BUILD_MAC_10_13 || CURL_BUILD_IOS_11) && HAVE_BUILTIN_AVAILABLE == 1
@@ -1445,6 +1443,7 @@ static CURLcode darwinssl_connect_step1(struct connectdata *conn,
 #endif /* (CURL_BUILD_MAC_10_13 || CURL_BUILD_IOS_11) &&
           HAVE_BUILTIN_AVAILABLE == 1 */
       break;
+    case CURL_SSLVERSION_DEFAULT:
     case CURL_SSLVERSION_TLSv1_0:
     case CURL_SSLVERSION_TLSv1_1:
     case CURL_SSLVERSION_TLSv1_2:

--- a/vendor/curl/lib/vtls/mbedtls.c
+++ b/vendor/curl/lib/vtls/mbedtls.c
@@ -6,7 +6,7 @@
  *                             \___|\___/|_| \_\_____|
  *
  * Copyright (C) 2010 - 2011, Hoi-Ho Chan, <hoiho.chan@gmail.com>
- * Copyright (C) 2012 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2012 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -373,7 +373,7 @@ mbed_connect_step1(struct connectdata *conn,
     }
   }
 
-  infof(data, "mbedTLS: Connecting to %s:%d\n", hostname, port);
+  infof(data, "mbedTLS: Connecting to %s:%ld\n", hostname, port);
 
   mbedtls_ssl_config_init(&BACKEND->config);
 
@@ -574,19 +574,21 @@ mbed_connect_step2(struct connectdata *conn,
 
   ret = mbedtls_ssl_get_verify_result(&BACKEND->ssl);
 
+  if(!SSL_CONN_CONFIG(verifyhost))
+    /* Ignore hostname errors if verifyhost is disabled */
+    ret &= ~MBEDTLS_X509_BADCERT_CN_MISMATCH;
+
   if(ret && SSL_CONN_CONFIG(verifypeer)) {
     if(ret & MBEDTLS_X509_BADCERT_EXPIRED)
       failf(data, "Cert verify failed: BADCERT_EXPIRED");
 
-    if(ret & MBEDTLS_X509_BADCERT_REVOKED) {
+    else if(ret & MBEDTLS_X509_BADCERT_REVOKED)
       failf(data, "Cert verify failed: BADCERT_REVOKED");
-      return CURLE_PEER_FAILED_VERIFICATION;
-    }
 
-    if(ret & MBEDTLS_X509_BADCERT_CN_MISMATCH)
+    else if(ret & MBEDTLS_X509_BADCERT_CN_MISMATCH)
       failf(data, "Cert verify failed: BADCERT_CN_MISMATCH");
 
-    if(ret & MBEDTLS_X509_BADCERT_NOT_TRUSTED)
+    else if(ret & MBEDTLS_X509_BADCERT_NOT_TRUSTED)
       failf(data, "Cert verify failed: BADCERT_NOT_TRUSTED");
 
     return CURLE_PEER_FAILED_VERIFICATION;

--- a/vendor/curl/lib/vtls/schannel_verify.c
+++ b/vendor/curl/lib/vtls/schannel_verify.c
@@ -7,7 +7,7 @@
  *
  * Copyright (C) 2012 - 2016, Marc Hoersken, <info@marc-hoersken.de>
  * Copyright (C) 2012, Mark Salisbury, <mark.salisbury@hp.com>
- * Copyright (C) 2012 - 2018, Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) 2012 - 2019, Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms
@@ -87,14 +87,14 @@ static CURLcode add_certs_to_store(HCERTSTORE trust_store,
   LARGE_INTEGER file_size;
   char *ca_file_buffer = NULL;
   char *current_ca_file_ptr = NULL;
-  const TCHAR *ca_file_tstr = NULL;
+  TCHAR *ca_file_tstr = NULL;
   size_t ca_file_bufsize = 0;
   DWORD total_bytes_read = 0;
   bool more_certs = 0;
   int num_certs = 0;
   size_t END_CERT_LEN;
 
-  ca_file_tstr = Curl_convert_UTF8_to_tchar(ca_file);
+  ca_file_tstr = Curl_convert_UTF8_to_tchar((char *)ca_file);
   if(!ca_file_tstr) {
     failf(data,
           "schannel: invalid path name for CA file '%s': %s",


### PR DESCRIPTION
## Summary
- Contains various bug fixes, security patches and some other minor changes, most shouldn't have an effect on us, but nice to have anyhow
- Latest changelog: https://curl.haxx.se/changes.html#7_64_0
- 7.64.0: [maintainer's blog post](https://daniel.haxx.se/blog/2019/02/06/curl-7-64-0-like-theres-no-tomorrow/), [curl-users mailing list](https://curl.haxx.se/mail/lib-2019-02/0021.html)

## Tests
- [test_fetchRemote.zip](https://github.com/multitheftauto/mtasa-blue/files/2873053/test_fetchRemote.zip) (v1.0.1) (preferable not to run client and server simultaneously)
- [fetchRemote](https://wiki.multitheftauto.com/wiki/FetchRemote) URL for unauthenticated requests: http://ptsv2.com/t/mtasa-test-fetchRemote
- [fetchRemote](https://wiki.multitheftauto.com/wiki/FetchRemote) URL for authenticated requests: http://ptsv2.com/t/mtasa-test-fetchRemote-auth
- [test_callRemote.zip](https://github.com/multitheftauto/mtasa-blue/files/2873055/test_callRemote.zip) (v1.0.2)
- [callRemote](https://wiki.multitheftauto.com/wiki/CallRemote) URL for unauthenticated requests: http://ptsv2.com/t/mtasa-test-callRemote
- [callRemote](https://wiki.multitheftauto.com/wiki/CallRemote) URL for authenticated requests: http://ptsv2.com/t/mtasa-test-callRemote-auth
- **Please flush all your requests from ptsv2.com after testing!**

## Validation
To help validate the integrity of the update I have created the following bash script that diffs between my PR branch and the official package provided from the [curl website](https://curl.haxx.se/download.html).
```bash
#!/bin/bash

CURL_UPDATE_VERSION=7.64.0
CURL_PATH_NAME=curl-$CURL_UPDATE_VERSION

GIT_REPO_BRANCH=vendor/curl-$CURL_UPDATE_VERSION
GIT_REPO_URL=git@github.com:patrikjuvonen/mtasa-blue.git
GIT_DEST_DIR=mtasa-blue
GIT_REPO_CURL_PATH=$GIT_DEST_DIR/vendor/curl/

echo 1. Download and extract $CURL_PATH_NAME...
curl https://curl.haxx.se/download/$CURL_PATH_NAME.tar.bz2 | tar -xj

echo 2. Clone the vendor update branch $GIT_REPO_BRANCH from $GIT_REPO_URL into $GIT_DEST_DIR...
git clone --depth 1 -b $GIT_REPO_BRANCH $GIT_REPO_URL $GIT_DEST_DIR

echo 3. Start checking integrity...
diff -r $GIT_REPO_CURL_PATH $CURL_PATH_NAME

echo 4. Completed.
```

## Past curl updates in MTA
- January 2019: 7.61.1 to 7.63.0 (#744)
- September 2018: 7.61.0 to 7.61.1 (#428)
- August 2018: 7.59.0 to 7.61.0 (#271)
- March 2018: 7.54.0 to 7.59.0 (https://github.com/multitheftauto/mtasa-blue/commit/b99e343db34e27954fcc6dea5909fafcb06cf695)
- June 2017: to 7.32.0 to 7.54.0 (https://github.com/multitheftauto/mtasa-blue/commit/c15d999d15ecfedf3e0ad5c9916b1886c489bff5)
- August 2013: 7.19.4 to 7.32.0 (https://github.com/multitheftauto/mtasa-blue/commit/aaf3e21de2b35d924463874b8d2af3a094dfa1f2)

## Copy of curl changelog
### Fixed in 7.64.0 - February 6 2019
```
Changes:

cookies: leave secure cookies alone
hostip: support wildcard hosts
http: Implement trailing headers for chunked transfers
http: added options for allowing HTTP/0.9 responses
timeval: Use high resolution timestamps on Windows

Bugfixes:

CVE-2018-16890: NTLM type-2 out-of-bounds buffer read
CVE-2019-3822: NTLMv2 type-3 header stack buffer overflow
CVE-2019-3823: SMTP end-of-response out-of-bounds read
FAQ: remove mention of sourceforge for github
OS400: handle memory error in list conversion
OS400: upgrade ILE/RPG binding.
README: add codacy code quality badge
Revert http_negotiate: do not close connection
THANKS: added several missing names from year <= 2000
build: make 'tidy' target work for metalink builds
cmake: added checks for variadic macros
cmake: updated check for HAVE_POLL_FINE to match autotools
cmake: use lowercase for function name like the rest of the code
configure: detect xlclang separately from clang
configure: fix recv/send/select detection on Android
configure: rewrite --enable-code-coverage
conncache_unlock: avoid indirection by changing input argument type
cookie: fix comment typo
cookies: allow secure override when done over HTTPS
cookies: extend domain checks to non psl builds
cookies: skip custom cookies when redirecting cross-site
curl --xattr: strip credentials from any URL that is stored
curl -J: refuse to append to the destination file
curl/urlapi.h: include "curl.h" first
curl_multi_remove_handle() don't block terminating c-ares requests
darwinssl: accept setting max-tls with default min-tls
disconnect: separate connections and easy handles better
disconnect: set conn->data for protocol disconnect
docs/version.d: mention MultiSSL
docs: fix the --tls-max description
docs: use $(INSTALL_DATA) to install man page
docs: use meaningless port number in CURLOPT_LOCALPORT example
gopher: always include the entire gopher-path in request
http2: clear pause stream id if it gets closed
if2ip: remove unused function Curl_if_is_interface_name
libssh: do not let libssh create socket
libssh: enable CURLOPT_SSH_KNOWNHOSTS and CURLOPT_SSH_KEYFUNCTION for libssh
libssh: free sftp_canonicalize_path() data correctly
libtest/stub_gssapi: use "real" snprintf
mbedtls: use VERIFYHOST
multi: multiplexing improvements
multi: set the EXPIRE_*TIMEOUT timers at TIMER_STARTSINGLE time
ntlm: fix NTMLv2 compliance
ntlm_sspi: add support for channel binding
openssl: adapt to 3.0.0, OpenSSL_version_num() is deprecated
openssl: fix the SSL_get_tlsext_status_ocsp_resp call
openvms: fix OpenSSL discovery on VAX
openvms: fix typos in documentation
os400: add a missing closing bracket
os400: fix extra parameter syntax error
pingpong: change default response timeout to 120 seconds
pingpong: ignore regular timeout in disconnect phase
printf: fix format specifiers
runtests.pl: Fix perl call to include srcdir
schannel: fix compiler warning
schannel: preserve original certificate path parameter
schannel: stop calling it "winssl"
sigpipe: if mbedTLS is used, ignore SIGPIPE
smb: fix incorrect path in request if connection reused
ssh: log the libssh2 error message when ssh session startup fails
test1558: verify CURLINFO_PROTOCOL on file:// transfer
test1561: improve test name
test1653: make it survive torture tests
tests: allow tests to pass by 2037-02-12
tests: move objnames-* from lib into tests
timediff: fix math for unsigned time_t
timeval: Disable MSVC Analyzer GetTickCount warning
tool_cb_prg: avoid integer overflow
travis: added cmake build for osx
urlapi: Fix port parsing of eol colon
urlapi: distinguish possibly empty query
urlapi: fix parsing ipv6 with zone index
urldata: rename easy_conn to just conn
winbuild: conditionally use /DZLIB_WINAPI
wolfssl: fix memory-leak in threaded use
spnego_sspi: add support for channel binding
```