### PR TITLE
Don't call onClientElementStreamIn for already streamed-in elements

### DIFF
--- a/Client/mods/deathmatch/logic/CClientStreamElement.cpp
+++ b/Client/mods/deathmatch/logic/CClientStreamElement.cpp
@@ -95,11 +95,14 @@ void CClientStreamElement::NotifyCreate()
         m_bDoubleSided = IsDoubleSided();
     SetDoubleSided(m_bDoubleSided);
 
-    m_bStreamedIn = true;
-    m_bAttemptingToStreamIn = false;
+    if (!m_bStreamedIn)
+    {
+        m_bStreamedIn = true;
+        m_bAttemptingToStreamIn = false;
 
-    CLuaArguments Arguments;
-    CallEvent("onClientElementStreamIn", Arguments, true);
+        CLuaArguments Arguments;
+        CallEvent("onClientElementStreamIn", Arguments, true);
+    }
 }
 
 void CClientStreamElement::NotifyUnableToCreate()


### PR DESCRIPTION
This pull request prevents **onClientElementStreamIn** being triggered multiple times due to model changes, when the element is already streamed-in.

This is a companion pull request for PR #824.