### PR TITLE
Fix #712: Server information window not hiding when you back to game

### DIFF
--- a/Client/core/CMainMenu.cpp
+++ b/Client/core/CMainMenu.cpp
@@ -672,6 +672,7 @@ void CMainMenu::Hide()
 void CMainMenu::OnEscapePressedOffLine()
 {
     m_ServerBrowser.SetVisible(false);
+    m_ServerInfo.Hide();
     m_Credits.SetVisible(false);
     m_pNewsBrowser->SetVisible(false);
 }
@@ -697,6 +698,7 @@ void CMainMenu::SetVisible(bool bVisible, bool bOverlay, bool bFrameDelay)
         SetMenuUnhovered();
         m_QuickConnect.SetVisible(false);
         m_ServerBrowser.SetVisible(false);
+        m_ServerInfo.Hide();
         m_Settings.SetVisible(false);
         m_Credits.SetVisible(false);
         m_pNewsBrowser->SetVisible(false);

--- a/Client/core/CMainMenu.cpp
+++ b/Client/core/CMainMenu.cpp
@@ -672,7 +672,6 @@ void CMainMenu::Hide()
 void CMainMenu::OnEscapePressedOffLine()
 {
     m_ServerBrowser.SetVisible(false);
-    m_ServerInfo.Hide();
     m_Credits.SetVisible(false);
     m_pNewsBrowser->SetVisible(false);
 }
@@ -698,7 +697,6 @@ void CMainMenu::SetVisible(bool bVisible, bool bOverlay, bool bFrameDelay)
         SetMenuUnhovered();
         m_QuickConnect.SetVisible(false);
         m_ServerBrowser.SetVisible(false);
-        m_ServerInfo.Hide();
         m_Settings.SetVisible(false);
         m_Credits.SetVisible(false);
         m_pNewsBrowser->SetVisible(false);

--- a/Client/core/ServerBrowser/CServerBrowser.cpp
+++ b/Client/core/ServerBrowser/CServerBrowser.cpp
@@ -761,6 +761,7 @@ void CServerBrowser::SetVisible(bool bVisible)
         // Hide information windows.
         m_pGeneralHelpWindow->SetVisible(false);
         m_pQuickConnectHelpWindow->SetVisible(false);
+        CServerInfo::GetSingletonPtr()->Hide();
     }
 }
 


### PR DESCRIPTION
Fixes #712 and additionally closes server information window when escape is pressed offline (i.e when not connected to a server)