### PR TITLE
Update SQLite from 3.27.1 to 3.28.0

### DIFF
--- a/vendor/sqlite/premake5.lua
+++ b/vendor/sqlite/premake5.lua
@@ -1,10 +1,10 @@
 project "sqlite"
-	language "C++"
+	language "C"
 	kind "StaticLib"
 	targetname "sqlite"
 	
 	vpaths { 
-		["Headers/*"] = "**.h",
+		["Headers/*"] = "*.h",
 		["Sources/*"] = "*.c",
 		["*"] = "premake5.lua"
 	}

--- a/vendor/sqlite/sqlite3.h
+++ b/vendor/sqlite/sqlite3.h
@@ -123,9 +123,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.27.1"
-#define SQLITE_VERSION_NUMBER 3027001
-#define SQLITE_SOURCE_ID      "2019-02-08 13:17:39 0eca3dd3d38b31c92b49ca2d311128b74584714d9e7de895b1a6286ef959a1dd"
+#define SQLITE_VERSION        "3.28.0"
+#define SQLITE_VERSION_NUMBER 3028000
+#define SQLITE_SOURCE_ID      "2019-04-16 19:49:53 884b4b7e502b4e991677b53971277adfaf0a04a284f8e483e2553d0f83156b50"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -189,6 +189,9 @@ SQLITE_API int sqlite3_libversion_number(void);
 #ifndef SQLITE_OMIT_COMPILEOPTION_DIAGS
 SQLITE_API int sqlite3_compileoption_used(const char *zOptName);
 SQLITE_API const char *sqlite3_compileoption_get(int N);
+#else
+# define sqlite3_compileoption_used(X) 0
+# define sqlite3_compileoption_get(X)  ((void*)0)
 #endif
 
 /*
@@ -2086,8 +2089,8 @@ struct sqlite3_mem_methods {
 **
 ** [[SQLITE_DBCONFIG_ENABLE_FTS3_TOKENIZER]]
 ** <dt>SQLITE_DBCONFIG_ENABLE_FTS3_TOKENIZER</dt>
-** <dd> ^This option is used to enable or disable the two-argument
-** version of the [fts3_tokenizer()] function which is part of the
+** <dd> ^This option is used to enable or disable the
+** [fts3_tokenizer()] function which is part of the
 ** [FTS3] full-text search engine extension.
 ** There should be two additional arguments.
 ** The first argument is an integer which is 0 to disable fts3_tokenizer() or
@@ -2199,6 +2202,17 @@ struct sqlite3_mem_methods {
 ** <li> Direct writes to [shadow tables].
 ** </ul>
 ** </dd>
+**
+** [[SQLITE_DBCONFIG_WRITABLE_SCHEMA]] <dt>SQLITE_DBCONFIG_WRITABLE_SCHEMA</dt>
+** <dd>The SQLITE_DBCONFIG_WRITABLE_SCHEMA option activates or deactivates the
+** "writable_schema" flag. This has the same effect and is logically equivalent
+** to setting [PRAGMA writable_schema=ON] or [PRAGMA writable_schema=OFF].
+** The first argument to this setting is an integer which is 0 to disable 
+** the writable_schema, positive to enable writable_schema, or negative to
+** leave the setting unchanged. The second parameter is a pointer to an
+** integer into which is written 0 or 1 to indicate whether the writable_schema
+** is enabled or disabled following this call.
+** </dd>
 ** </dl>
 */
 #define SQLITE_DBCONFIG_MAINDBNAME            1000 /* const char* */
@@ -2212,7 +2226,8 @@ struct sqlite3_mem_methods {
 #define SQLITE_DBCONFIG_TRIGGER_EQP           1008 /* int int* */
 #define SQLITE_DBCONFIG_RESET_DATABASE        1009 /* int int* */
 #define SQLITE_DBCONFIG_DEFENSIVE             1010 /* int int* */
-#define SQLITE_DBCONFIG_MAX                   1010 /* Largest DBCONFIG */
+#define SQLITE_DBCONFIG_WRITABLE_SCHEMA       1011 /* int int* */
+#define SQLITE_DBCONFIG_MAX                   1011 /* Largest DBCONFIG */
 
 /*
 ** CAPI3REF: Enable Or Disable Extended Result Codes
@@ -2369,7 +2384,7 @@ SQLITE_API int sqlite3_changes(sqlite3*);
 ** not. ^Changes to a view that are intercepted by INSTEAD OF triggers 
 ** are not counted.
 **
-** This the [sqlite3_total_changes(D)] interface only reports the number
+** The [sqlite3_total_changes(D)] interface only reports the number
 ** of rows that changed due to SQL statement run against database
 ** connection D.  Any changes by other database connections are ignored.
 ** To detect changes against a database file from other database
@@ -3895,6 +3910,18 @@ SQLITE_API const char *sqlite3_normalized_sql(sqlite3_stmt *pStmt);
 SQLITE_API int sqlite3_stmt_readonly(sqlite3_stmt *pStmt);
 
 /*
+** CAPI3REF: Query The EXPLAIN Setting For A Prepared Statement
+** METHOD: sqlite3_stmt
+**
+** ^The sqlite3_stmt_isexplain(S) interface returns 1 if the
+** prepared statement S is an EXPLAIN statement, or 2 if the
+** statement S is an EXPLAIN QUERY PLAN.
+** ^The sqlite3_stmt_isexplain(S) interface returns 0 if S is
+** an ordinary statement or a NULL pointer.
+*/
+SQLITE_API int sqlite3_stmt_isexplain(sqlite3_stmt *pStmt);
+
+/*
 ** CAPI3REF: Determine If A Prepared Statement Has Been Reset
 ** METHOD: sqlite3_stmt
 **
@@ -4033,7 +4060,9 @@ typedef struct sqlite3_context sqlite3_context;
 ** ^The fifth argument to the BLOB and string binding interfaces
 ** is a destructor used to dispose of the BLOB or
 ** string after SQLite has finished with it.  ^The destructor is called
-** to dispose of the BLOB or string even if the call to bind API fails.
+** to dispose of the BLOB or string even if the call to the bind API fails,
+** except the destructor is not called if the third parameter is a NULL
+** pointer or the fourth parameter is negative.
 ** ^If the fifth argument is
 ** the special value [SQLITE_STATIC], then SQLite assumes that the
 ** information is in static, unmanaged space and does not need to be freed.
@@ -4950,6 +4979,8 @@ SQLITE_API SQLITE_DEPRECATED int sqlite3_memory_alarm(void(*)(void*,sqlite3_int6
 ** <tr><td><b>sqlite3_value_nochange&nbsp;&nbsp;</b>
 ** <td>&rarr;&nbsp;&nbsp;<td>True if the column is unchanged in an UPDATE
 ** against a virtual table.
+** <tr><td><b>sqlite3_value_frombind&nbsp;&nbsp;</b>
+** <td>&rarr;&nbsp;&nbsp;<td>True if value originated from a [bound parameter]
 ** </table></blockquote>
 **
 ** <b>Details:</b>
@@ -5011,6 +5042,11 @@ SQLITE_API SQLITE_DEPRECATED int sqlite3_memory_alarm(void(*)(void*,sqlite3_int6
 ** than within an [xUpdate] method call for an UPDATE statement, then
 ** the return value is arbitrary and meaningless.
 **
+** ^The sqlite3_value_frombind(X) interface returns non-zero if the
+** value X originated from one of the [sqlite3_bind_int|sqlite3_bind()]
+** interfaces.  ^If X comes from an SQL literal value, or a table column,
+** and expression, then sqlite3_value_frombind(X) returns zero.
+**
 ** Please pay particular attention to the fact that the pointer returned
 ** from [sqlite3_value_blob()], [sqlite3_value_text()], or
 ** [sqlite3_value_text16()] can be invalidated by a subsequent call to
@@ -5056,6 +5092,7 @@ SQLITE_API int sqlite3_value_bytes16(sqlite3_value*);
 SQLITE_API int sqlite3_value_type(sqlite3_value*);
 SQLITE_API int sqlite3_value_numeric_type(sqlite3_value*);
 SQLITE_API int sqlite3_value_nochange(sqlite3_value*);
+SQLITE_API int sqlite3_value_frombind(sqlite3_value*);
 
 /*
 ** CAPI3REF: Finding The Subtype Of SQL Values
@@ -5791,7 +5828,7 @@ SQLITE_API sqlite3 *sqlite3_db_handle(sqlite3_stmt*);
 ** associated with database N of connection D.  ^The main database file
 ** has the name "main".  If there is no attached database N on the database
 ** connection D, or if database N is a temporary or in-memory database, then
-** a NULL pointer is returned.
+** this function will return either a NULL pointer or an empty string.
 **
 ** ^The filename returned by this function is the output of the
 ** xFullPathname method of the [VFS].  ^In other words, the filename
@@ -10892,7 +10929,7 @@ SQLITE_API int sqlite3rebaser_configure(
 ** in size. This function allocates and populates a buffer with a copy
 ** of the changeset rebased rebased according to the configuration of the
 ** rebaser object passed as the first argument. If successful, (*ppOut)
-** is set to point to the new buffer containing the rebased changset and 
+** is set to point to the new buffer containing the rebased changeset and 
 ** (*pnOut) to its size in bytes and SQLITE_OK returned. It is the
 ** responsibility of the caller to eventually free the new buffer using
 ** sqlite3_free(). Otherwise, if an error occurs, (*ppOut) and (*pnOut)
@@ -11301,7 +11338,7 @@ struct Fts5PhraseIter {
 **   Save the pointer passed as the second argument as the extension functions 
 **   "auxiliary data". The pointer may then be retrieved by the current or any
 **   future invocation of the same fts5 extension function made as part of
-**   of the same MATCH query using the xGetAuxdata() API.
+**   the same MATCH query using the xGetAuxdata() API.
 **
 **   Each extension function is allocated a single auxiliary data slot for
 **   each FTS query (MATCH expression). If the extension function is invoked 
@@ -11316,7 +11353,7 @@ struct Fts5PhraseIter {
 **   The xDelete callback, if one is specified, is also invoked on the
 **   auxiliary data pointer after the FTS5 query has finished.
 **
-**   If an error (e.g. an OOM condition) occurs within this function, an
+**   If an error (e.g. an OOM condition) occurs within this function,
 **   the auxiliary data is set to NULL and an error code returned. If the
 **   xDelete parameter was not NULL, it is invoked on the auxiliary data
 **   pointer before returning.

--- a/vendor/sqlite/sqlite3ext.h
+++ b/vendor/sqlite/sqlite3ext.h
@@ -319,6 +319,9 @@ struct sqlite3_api_routines {
                             void(*xDestroy)(void*));
   /* Version 3.26.0 and later */
   const char *(*normalized_sql)(sqlite3_stmt*);
+  /* Version 3.28.0 and later */
+  int (*stmt_isexplain)(sqlite3_stmt*);
+  int (*value_frombind)(sqlite3_value*);
 };
 
 /*
@@ -608,6 +611,9 @@ typedef int (*sqlite3_loadext_entry)(
 #define sqlite3_create_window_function sqlite3_api->create_window_function
 /* Version 3.26.0 and later */
 #define sqlite3_normalized_sql         sqlite3_api->normalized_sql
+/* Version 3.28.0 and later */
+#define sqlite3_stmt_isexplain         sqlite3_api->isexplain
+#define sqlite3_value_frombind         sqlite3_api->frombind
 #endif /* !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION) */
 
 #if !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION)


### PR DESCRIPTION
## Summary
- Contains various bug fixes, optimizations and some other minor changes and additions that can be useful (e.g. some improvements to window functions that we got to use since #818)
- Latest changelog: https://www.sqlite.org/changes.html#version_3_28_0

## Tests
Tested with [test_sqlite.zip](https://github.com/multitheftauto/mtasa-blue/files/2872064/test_sqlite.zip) (cheers @botder)

## Validation
To help validate the integrity of the update I have created the following bash script that diffs between my PR branch and the official package provided from the [SQLite website](https://www.sqlite.org/download.html).
```bash
#!/bin/bash

SQLITE_UPDATE_VERSION=3.28.0
SQLITE_PATH_NAME=sqlite-$SQLITE_UPDATE_VERSION

GIT_REPO_BRANCH=vendor/sqlite-$SQLITE_UPDATE_VERSION
GIT_REPO_URL=https://github.com/patrikjuvonen/mtasa-blue.git
GIT_DEST_DIR=mtasa-blue
GIT_REPO_SQLITE_PATH=$GIT_DEST_DIR/vendor/sqlite/

echo 1. Download and extract $SQLITE_PATH_NAME...
curl https://www.sqlite.org/2019/sqlite-autoconf-3280000.tar.gz | tar -xz

echo 2. Clone the vendor update branch $GIT_REPO_BRANCH from $GIT_REPO_URL into $GIT_DEST_DIR...
git clone --depth 1 -b $GIT_REPO_BRANCH $GIT_REPO_URL $GIT_DEST_DIR

echo 3. Start checking integrity...
diff -r $GIT_REPO_SQLITE_PATH sqlite-*

echo 4. Completed.
```

## Past SQLite updates in MTA
| Date | From | To | Link |
| :--- | :--- | :--- | :--- |
| February 2019 | 3.24.0 | 3.27.1 (current) | #818 |
| July 2018 | 3.13.0 | 3.24.0 | #245 |
| August 2016 | 3.7.17 | 3.13.0 | 3aa17532867c66818cc3a602c4b1ac2143694066 |
| August 2013 | 3.7.8 | 3.7.17 | fd195b799498f75496fe0c15adac3cab3aecb639 |
| October 2011 | 3.6.14 | 3.7.8 | ca063630631d56d5ba9aba5bf6771fe0299f5a9f |

## Changelog
### 2019-04-16 (3.28.0)

1. Enhanced window functions:
    - Add support the EXCLUDE clause.
    - Add support for window chaining.
    - Add support for GROUPS frames.
    - Add support for "<expr> PRECEDING" and "<expr> FOLLOWING" boundaries in RANGE frames.
6. Added the new sqlite3_stmt_isexplain(S) interface for determining whether or not a prepared statement is an EXPLAIN.
7. Enhanced VACUUM INTO so that it works for read-only databases.
8. New query optimizations:
    - Enable the LIKE optimization for cases when the ESCAPE keyword is present and PRAGMA case_sensitive_like is on.
    - In queries that are driven by a partial index, avoid unnecessary tests of the constraint named in the WHERE clause of the partial index, since we know that constraint must always be true.
11. Enhancements to the TCL Interface:
    - Added the -returntype option to the function method.
    - Added the new bind_fallback method.
14. Enhancements to the CLI:
    - Added support for bound parameters and the .parameter command.
    - Fix the readfile() function so that it returns an empty BLOB rather than throwing an out-of-memory error when reading an empty file.
    - Fix the writefile() function so that when it creates new directories along the path of a new file, it gives them umask permissions rather than the same permissions as the file.
    - Change --update option in the .archive command so that it skips files that are already in the archive and are unchanged. Add the new --insert option that works like --update used to work.
19. Added the fossildelta.c extension that can create, apply, and deconstruct the Fossil DVCS file delta format that is used by the RBU extension.
20. Added the SQLITE_DBCONFIG_WRITABLE_SCHEMA verb for the sqlite3_db_config() interface, that does the same work as PRAGMA writable_schema without using the SQL parser.
21. Added the sqlite3_value_frombind() API for determining if the argument to an SQL function is from a bound parameter.
22. Security and compatibilities enhancements to fts3_tokenizer():
    - The fts3_tokenizer() function always returns NULL unless either the legacy application-defined FTS3 tokenizers interface are enabled using the sqlite3_db_config(SQLITE_DBCONFIG_ENABLE_FTS3_TOKENIZER) setting, or unless the first argument to fts3_tokenizer() is a bound parameter.
    - The two-argument version of fts3_tokenizer() accepts a pointer to the tokenizer method object even without the sqlite3_db_config(SQLITE_DBCONFIG_ENABLE_FTS3_TOKENIZER) setting if the second argument is a bound parameter
25. Improved robustness against corrupt database files.
26. Miscellaneous performance enhancements
27. Established a Git mirror of the offical SQLite source tree. The canonical sources for SQLite are maintained using the Fossil DVCS at https://sqlite.org/src. The Git mirror can be seen at https://github.com/sqlite/sqlite.

### 2019-02-25 (3.27.2)

1. Fix a bug in the IN operator that was introduced by an attempted optimization in version 3.27.0. Ticket df46dfb631f75694
2. Fix a bug causing a crash when a window function is misused. Ticket 4feb3159c6bc3f7e33959.
3. Fix various documentation typos
