### PR TITLE
Fix #580: createTrayNotification not working for Windows 10

### DIFF
--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -31,54 +31,6 @@ extern CCore* g_pCore;
 bool          g_bBoundsChecker = false;
 SString       g_strJingleBells;
 
-BOOL AC_RestrictAccess()
-{
-    EXPLICIT_ACCESS NewAccess;
-    PACL            pTempDacl;
-    HANDLE          hProcess;
-    DWORD           dwFlags;
-    DWORD           dwErr;
-
-    ///////////////////////////////////////////////
-    // Get the HANDLE to the current process.
-    hProcess = GetCurrentProcess();
-
-    ///////////////////////////////////////////////
-    // Setup which accesses we want to deny.
-    dwFlags = GENERIC_WRITE | PROCESS_ALL_ACCESS | WRITE_DAC | DELETE | WRITE_OWNER | READ_CONTROL;
-
-    ///////////////////////////////////////////////
-    // Build our EXPLICIT_ACCESS structure.
-    BuildExplicitAccessWithName(&NewAccess, "CURRENT_USER", dwFlags, DENY_ACCESS, NO_INHERITANCE);
-
-    ///////////////////////////////////////////////
-    // Create our Discretionary Access Control List.
-    if (ERROR_SUCCESS != (dwErr = SetEntriesInAcl(1, &NewAccess, NULL, &pTempDacl)))
-    {
-        #ifdef DEBUG
-//        pConsole->Con_Printf("Error at SetEntriesInAcl(): %i", dwErr);
-        #endif
-        return FALSE;
-    }
-
-    ////////////////////////////////////////////////
-    // Set the new DACL to our current process.
-    if (ERROR_SUCCESS != (dwErr = SetSecurityInfo(hProcess, SE_KERNEL_OBJECT, DACL_SECURITY_INFORMATION, NULL, NULL, pTempDacl, NULL)))
-    {
-        #ifdef DEBUG
-//        pConsole->Con_Printf("Error at SetSecurityInfo(): %i", dwErr);
-        #endif
-        return FALSE;
-    }
-
-    ////////////////////////////////////////////////
-    // Free the DACL (see msdn on SetEntriesInAcl)
-    LocalFree(pTempDacl);
-    CloseHandle(hProcess);
-
-    return TRUE;
-}
-
 template <>
 CCore* CSingleton<CCore>::m_pSingleton = NULL;
 
@@ -86,10 +38,6 @@ CCore::CCore()
 {
     // Initialize the global pointer
     g_pCore = this;
-
-    #if !defined(MTA_DEBUG) && !defined(MTA_ALLOW_DEBUG)
-    AC_RestrictAccess();
-    #endif
 
     m_pConfigFile = NULL;
 

--- a/Client/core/CTrayIcon.cpp
+++ b/Client/core/CTrayIcon.cpp
@@ -49,7 +49,7 @@ bool CTrayIcon::CreateTrayIcon()
     wcDummy.lpfnWndProc = ProcessNotificationsWindowMessage;
     wcDummy.cbClsExtra = 0;
     wcDummy.cbWndExtra = 0;
-    wcDummy.hInstance = GetModuleHandle(NULL);
+    wcDummy.hInstance = g_hModule;
     wcDummy.hIcon = LoadIcon(NULL, IDI_APPLICATION);
     wcDummy.hCursor = LoadCursor(NULL, IDC_ARROW);
     wcDummy.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
@@ -60,12 +60,12 @@ bool CTrayIcon::CreateTrayIcon()
         return false;
 
     // Create dummy notifications window
-    m_pNID->hWnd = CreateWindowExW(0, TRAY_DUMMY_WINDOW_NAME, L"", 0, CW_USEDEFAULT, CW_USEDEFAULT, 0, 0, NULL, NULL, wcDummy.hInstance, NULL);
+    m_pNID->hWnd = CreateWindowExW(0, TRAY_DUMMY_WINDOW_NAME, L"", 0, CW_USEDEFAULT, CW_USEDEFAULT, 0, 0, NULL, NULL, g_hModule, NULL);
     if (m_pNID->hWnd != NULL)
         SetWindowLongPtrW(m_pNID->hWnd, 0, reinterpret_cast<LONG_PTR>(this));
     else
     {
-        UnregisterClassW(TRAY_DUMMY_WINDOW_NAME, wcDummy.hInstance);
+        UnregisterClassW(TRAY_DUMMY_WINDOW_NAME, g_hModule);
         return false;
     }
 
@@ -95,7 +95,7 @@ void CTrayIcon::DestroyTrayIcon()
     if (IsWindow(m_pNID->hWnd))
         DestroyWindow(m_pNID->hWnd);
 
-    UnregisterClassW(TRAY_DUMMY_WINDOW_NAME, GetModuleHandle(NULL));
+    UnregisterClassW(TRAY_DUMMY_WINDOW_NAME, g_hModule);
 }
 
 bool CTrayIcon::CreateTrayBallon(SString strText, eTrayIconType trayIconType, bool useSound)

--- a/Client/core/CTrayIcon.cpp
+++ b/Client/core/CTrayIcon.cpp
@@ -13,11 +13,11 @@
 #include <strsafe.h>
 #include "resource.h"
 
+#define TRAY_DUMMY_WINDOW_NAME  L"NotificationsDummy"
 #define TRAY_BALLOON_TITLE      L"Notification from MTA:SA server"
 #define TRAY_ICON_TOOLTIP_TEXT  L"Multi Theft Auto: San Andreas"
 #define TRAY_BALLOON_INTERVAL   30000L // ms
 
-extern CCore*    g_pCore;
 extern HINSTANCE g_hModule;
 
 CTrayIcon::CTrayIcon() : m_bTrayIconExists{false}, m_pNID{new NOTIFYICONDATAW{0}}, m_llLastBalloonTime{0L}
@@ -42,12 +42,38 @@ bool CTrayIcon::CreateTrayIcon()
     if (m_bTrayIconExists)
         return true;
 
+    // Register window class for dummy notifications window
+    WNDCLASSEXW wcDummy;
+    wcDummy.cbSize = sizeof(WNDCLASSEXW);
+    wcDummy.style = 0;
+    wcDummy.lpfnWndProc = ProcessNotificationsWindowMessage;
+    wcDummy.cbClsExtra = 0;
+    wcDummy.cbWndExtra = 0;
+    wcDummy.hInstance = GetModuleHandle(NULL);
+    wcDummy.hIcon = LoadIcon(NULL, IDI_APPLICATION);
+    wcDummy.hCursor = LoadCursor(NULL, IDC_ARROW);
+    wcDummy.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
+    wcDummy.lpszMenuName = NULL;
+    wcDummy.lpszClassName = TRAY_DUMMY_WINDOW_NAME;
+    wcDummy.hIconSm = LoadIcon(NULL, IDI_APPLICATION);
+    if (!RegisterClassExW(&wcDummy))
+        return false;
+
+    // Create dummy notifications window
+    m_pNID->hWnd = CreateWindowExW(0, TRAY_DUMMY_WINDOW_NAME, L"", 0, CW_USEDEFAULT, CW_USEDEFAULT, 0, 0, NULL, NULL, wcDummy.hInstance, NULL);
+    if (m_pNID->hWnd != NULL)
+        SetWindowLongPtrW(m_pNID->hWnd, 0, reinterpret_cast<LONG_PTR>(this));
+    else
+    {
+        UnregisterClassW(TRAY_DUMMY_WINDOW_NAME, wcDummy.hInstance);
+        return false;
+    }
+
     // The handle to the core.dll is neccessary here,
     // because Windows will search for the ICON in the executable and not in the DLL
     // Note: Changing the size will not show a higher quality icon in the balloon
     auto hIcon = LoadImage(g_hModule, MAKEINTRESOURCE(IDI_ICON1), IMAGE_ICON, LR_DEFAULTSIZE, LR_DEFAULTSIZE, LR_SHARED | LR_LOADTRANSPARENT);
 
-    m_pNID->hWnd = g_pCore->GetHookedWindow();
     m_pNID->uFlags = NIF_ICON | NIF_TIP;
     m_pNID->hIcon = (hIcon != NULL) ? ((HICON)hIcon) : LoadIcon(NULL, IDI_APPLICATION);
     m_bTrayIconExists = Shell_NotifyIconW(NIM_ADD, m_pNID) == TRUE;
@@ -64,6 +90,12 @@ void CTrayIcon::DestroyTrayIcon()
     m_pNID->dwInfoFlags = 0;
     Shell_NotifyIconW(NIM_DELETE, m_pNID);
     m_bTrayIconExists = false;
+
+    // Destroy the dummy window
+    if (IsWindow(m_pNID->hWnd))
+        DestroyWindow(m_pNID->hWnd);
+
+    UnregisterClassW(TRAY_DUMMY_WINDOW_NAME, GetModuleHandle(NULL));
 }
 
 bool CTrayIcon::CreateTrayBallon(SString strText, eTrayIconType trayIconType, bool useSound)
@@ -103,4 +135,24 @@ bool CTrayIcon::CreateTrayBallon(SString strText, eTrayIconType trayIconType, bo
         m_pNID->dwInfoFlags |= NIIF_NOSOUND;
 
     return Shell_NotifyIconW(NIM_MODIFY, m_pNID) == TRUE;
+}
+
+LRESULT CALLBACK CTrayIcon::ProcessNotificationsWindowMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    switch (uMsg)
+    {
+        case WM_DESTROY:
+        case WM_NCDESTROY:
+        {
+            // Destroy the tray icon if dummy window was destroyed
+            // In case of unexpected window crash
+            CTrayIcon* pThis = reinterpret_cast<CTrayIcon*>(GetWindowLongPtrW(hwnd, 0));
+            if (pThis != NULL)
+                pThis->DestroyTrayIcon();
+            break;
+        }
+        default:
+            return DefWindowProc(hwnd, uMsg, wParam, lParam);
+    }
+    return 0;
 }

--- a/Client/core/CTrayIcon.h
+++ b/Client/core/CTrayIcon.h
@@ -23,6 +23,8 @@ public:
     void DestroyTrayIcon();
     bool CreateTrayBallon(SString strText, eTrayIconType trayIconType, bool useSound);
 
+    static LRESULT CALLBACK ProcessNotificationsWindowMessage(HWND hwnd, UINT uMsg, WPARAM wPAram, LPARAM lParam);
+
 private:
     NOTIFYICONDATAW* m_pNID;
     bool             m_bTrayIconExists;


### PR DESCRIPTION
Fixes #580 

Added extra hidden unicode window to handle tray notifications.

Note: "Quiet hours" mode should be disabled to receive notifications.

New behavior preview: https://imgur.com/HQe3Dln