### PR TITLE
Fix #429: setCloudsEnabled affects moon and stars but not actual clouds

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1997,12 +1997,11 @@ void CMultiplayerSA::SetCloudsEnabled(bool bDisabled)
     else
         MemPut<BYTE>(0x716380, 0xC3);
 
-    // normal clouds
-    // 0071395A     90             NOP
+    // bottom clouds
     if (bDisabled)
-        MemPut<BYTE>(0x713950, 0x83);
+        MemPut<BYTE>(0x7154B0, 0x83);
     else
-        MemPut<BYTE>(0x713950, 0xC3);
+        MemPut<BYTE>(0x7154B0, 0xC3);
 
     // plane trails (not really clouds, but they're sort of vapour)
 

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1989,23 +1989,35 @@ void CMultiplayerSA::ResetSunSize()
     MemPut<BYTE>(0x55FA9F, 0x3C);
 }
 
-void CMultiplayerSA::SetCloudsEnabled(bool bDisabled)
+void CMultiplayerSA::SetCloudsEnabled(bool bEnabled)
 {
     // volumetric clouds
-    if (bDisabled)
+    if (bEnabled)
         MemPut<BYTE>(0x716380, 0xA1);
     else
         MemPut<BYTE>(0x716380, 0xC3);
 
     // bottom clouds
-    if (bDisabled)
+    if (bEnabled)
         MemPut<BYTE>(0x7154B0, 0x83);
     else
         MemPut<BYTE>(0x7154B0, 0xC3);
 
+    // skyline clouds
+    if (bEnabled)
+    {
+        MemPut<BYTE>(0x71411A, 0xD9);
+        MemPut<BYTE>(0x71411B, 0x41);
+        MemPut<BYTE>(0x71411C, 0x08);
+    }
+    else
+    {
+        MemSet((void*)0x71411A, 0x90, 3);
+    }
+
     // plane trails (not really clouds, but they're sort of vapour)
 
-    if (bDisabled)
+    if (bEnabled)
     {
         MemPut<BYTE>(0x717180, 0x83);
         MemPut<BYTE>(0x717181, 0xEC);


### PR DESCRIPTION
Fixes #429 

Fixed incorrect memory address of clouds render (2 lines)

**New behavior preview:**

<details><summary>Night</summary>
<img src="https://user-images.githubusercontent.com/923242/57562225-c0dd8400-7388-11e9-9d49-828fe65ffe6a.png">
</details>

<details><summary>Day</summary>
<img src="https://user-images.githubusercontent.com/923242/57562239-d6eb4480-7388-11e9-9d40-3a965cda9a86.png">
</details>
