### PR TITLE
Set missing spawned and dead state for cloned peds

### DIFF
--- a/Server/mods/deathmatch/logic/CPed.cpp
+++ b/Server/mods/deathmatch/logic/CPed.cpp
@@ -112,7 +112,8 @@ CElement* CPed::Clone(bool* bAddEntity, CResource* pResource)
         pTemp->SetHealth(GetHealth());
         pTemp->SetArmor(GetArmor());
         pTemp->SetSyncable(IsSyncable());
-        pTemp->SetSpawned(true);
+        pTemp->SetSpawned(IsSpawned());
+        pTemp->SetIsDead(IsDead());
     }
 
     return pTemp;

--- a/Server/mods/deathmatch/logic/CPed.cpp
+++ b/Server/mods/deathmatch/logic/CPed.cpp
@@ -112,6 +112,7 @@ CElement* CPed::Clone(bool* bAddEntity, CResource* pResource)
         pTemp->SetHealth(GetHealth());
         pTemp->SetArmor(GetArmor());
         pTemp->SetSyncable(IsSyncable());
+        pTemp->SetSpawned(true);
     }
 
     return pTemp;


### PR DESCRIPTION
Some functions (setElementDimension, setElementHealth, setPedArmor, ... ) do not work with cloned peds. This is fix for it.