### PR TITLE
Don't queue a resource restart if resource is stopping

### DIFF
--- a/Server/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
@@ -607,7 +607,7 @@ int CLuaResourceDefs::restartResource(lua_State* luaVM)
         return 1;
     }
 
-    if (pResource->IsActive())
+    if (pResource->IsActive() && !pResource->IsStopping())
     {
         m_pResourceManager->QueueResource(pResource, CResourceManager::QUEUE_RESTART, &StartOptions);
         lua_pushboolean(luaVM, true);


### PR DESCRIPTION
myonlake on Discord:
> since it goes to the end of queue and resource is stopped at that point, no, it should return false
> you can't restart a stopped resource
> basically that's the end result