### PR TITLE
Initial version of new style Lua argument parsing

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDefs.h
@@ -74,10 +74,14 @@ protected:
         return CLuaFunctionParser<false, T>()(L, m_pScriptDebugging);
     }
 
-    template <auto T, auto U>
+    // Special cases for overloads
+    template <auto T, auto U, auto... Ts>
     static inline int ArgumentParserWarn(lua_State* L)
     {
-        return CLuaFunctionParser<false, CLuaOverloadParser<T, U>::Call>()(L, m_pScriptDebugging);
+        if constexpr (sizeof...(Ts) == 0)
+            return ArgumentParserWarn<CLuaOverloadParser<pad_func_with_func<T, U>::Call, pad_func_with_func<U, T>::Call>::Call>(L);
+        else
+            return ArgumentParserWarn<CLuaOverloadParser<pad_func_with_func<T, U>::Call, pad_func_with_func<U, T>::Call>::Call, Ts...>(L);
     }
 
     // New style: hard error on usage mistakes
@@ -88,9 +92,12 @@ protected:
     }
 
     // Overload variant
-    template <auto T, auto U>
+    template <auto T, auto U, auto... Ts>
     static inline int ArgumentParser(lua_State* L)
     {
-        return CLuaFunctionParser<true, CLuaOverloadParser<T, U>::Call>()(L, m_pScriptDebugging);
+        if constexpr (sizeof...(Ts) == 0)
+            return ArgumentParser<CLuaOverloadParser<pad_func_with_func<T, U>::Call, pad_func_with_func<U, T>::Call>::Call>(L);
+        else
+            return ArgumentParser<CLuaOverloadParser<pad_func_with_func<T, U>::Call, pad_func_with_func<U, T>::Call>::Call, Ts...>(L);
     }
 };

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDefs.h
@@ -64,4 +64,41 @@ public:
     static CClientDFFManager*         m_pDFFManager;
     static CClientColModelManager*    m_pColModelManager;
     static CRegisteredCommands*       m_pRegisteredCommands;
+
+protected:
+    // Old style: Only warn on failure. This should
+    // not be used for new functions
+    template <auto T>
+    static inline int ArgumentParserWarn(lua_State* L)
+    {
+        int iReturnValue = CLuaFunctionParser<T>()(L);
+        if (iReturnValue < 0)
+        {
+            m_pScriptDebugging->LogCustom(L, "todo fix error message");
+            lua_pushboolean(L, false);
+            return 1;
+        }
+        return iReturnValue;
+    }
+
+    // New style: hard error on usage mistakes
+    template <auto T>
+    static inline int ArgumentParser(lua_State* L)
+    {
+        try
+        {
+            int iReturnValue = CLuaFunctionParser<T>()(L);
+            if (iReturnValue < 0)
+            {
+                luaL_error(L, "todo fix error message");
+                return 1;
+            }
+            return iReturnValue;
+        }
+        catch (CLuaError& e)
+        {
+            luaL_error(L, e.what());
+            return 0;
+        }
+    }
 };

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDefs.h
@@ -71,34 +71,13 @@ protected:
     template <auto T>
     static inline int ArgumentParserWarn(lua_State* L)
     {
-        int iReturnValue = CLuaFunctionParser<T>()(L);
-        if (iReturnValue < 0)
-        {
-            m_pScriptDebugging->LogCustom(L, "todo fix error message");
-            lua_pushboolean(L, false);
-            return 1;
-        }
-        return iReturnValue;
+        return CLuaFunctionParser<false, T>()(L, m_pScriptDebugging);
     }
 
     // New style: hard error on usage mistakes
     template <auto T>
     static inline int ArgumentParser(lua_State* L)
     {
-        try
-        {
-            int iReturnValue = CLuaFunctionParser<T>()(L);
-            if (iReturnValue < 0)
-            {
-                luaL_error(L, "todo fix error message");
-                return 1;
-            }
-            return iReturnValue;
-        }
-        catch (CLuaError& e)
-        {
-            luaL_error(L, e.what());
-            return 0;
-        }
+        return CLuaFunctionParser<true, T>()(L, m_pScriptDebugging);
     }
 };

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDefs.h
@@ -74,10 +74,23 @@ protected:
         return CLuaFunctionParser<false, T>()(L, m_pScriptDebugging);
     }
 
+    template <auto T, auto U>
+    static inline int ArgumentParserWarn(lua_State* L)
+    {
+        return CLuaFunctionParser<false, CLuaOverloadParser<T, U>::Call>()(L, m_pScriptDebugging);
+    }
+
     // New style: hard error on usage mistakes
     template <auto T>
     static inline int ArgumentParser(lua_State* L)
     {
         return CLuaFunctionParser<true, T>()(L, m_pScriptDebugging);
+    }
+
+    // Overload variant
+    template <auto T, auto U>
+    static inline int ArgumentParser(lua_State* L)
+    {
+        return CLuaFunctionParser<true, CLuaOverloadParser<T, U>::Call>()(L, m_pScriptDebugging);
     }
 };

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDefs.h
@@ -87,7 +87,7 @@ protected:
         // Combine functions
         using Overload = CLuaOverloadParser<PaddedFunctionA::Call, PaddedFunctionB::Call>;
 
-        return ArgumentParserWarn<Ret, Overload::Call, Functions...>(L);
+        return ArgumentParserWarn<ReturnOnError, Overload::Call, Functions...>(L);
     }
 
     // New style: hard error on usage mistakes

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDefs.h
@@ -67,28 +67,29 @@ public:
 
 protected:
     // Old style: Only warn on failure. This should
-    // not be used for new functions
-    template <auto T>
+    // not be used for new functions. First template argument
+    // Is a value used as result on invalid argument
+    template <auto Ret, auto T>
     static inline int ArgumentParserWarn(lua_State* L)
     {
-        return CLuaFunctionParser<false, T>()(L, m_pScriptDebugging);
+        return CLuaFunctionParser<false, Ret, T>()(L, m_pScriptDebugging);
     }
 
     // Special cases for overloads
-    template <auto T, auto U, auto... Ts>
+    template <auto Ret, auto T, auto U, auto... Ts>
     static inline int ArgumentParserWarn(lua_State* L)
     {
         if constexpr (sizeof...(Ts) == 0)
-            return ArgumentParserWarn<CLuaOverloadParser<pad_func_with_func<T, U>::Call, pad_func_with_func<U, T>::Call>::Call>(L);
+            return ArgumentParserWarn<Ret, CLuaOverloadParser<pad_func_with_func<T, U>::Call, pad_func_with_func<U, T>::Call>::Call>(L);
         else
-            return ArgumentParserWarn<CLuaOverloadParser<pad_func_with_func<T, U>::Call, pad_func_with_func<U, T>::Call>::Call, Ts...>(L);
+            return ArgumentParserWarn<Ret, CLuaOverloadParser<pad_func_with_func<T, U>::Call, pad_func_with_func<U, T>::Call>::Call, Ts...>(L);
     }
 
     // New style: hard error on usage mistakes
     template <auto T>
     static inline int ArgumentParser(lua_State* L)
     {
-        return CLuaFunctionParser<true, T>()(L, m_pScriptDebugging);
+        return CLuaFunctionParser<true, nullptr, T>()(L, m_pScriptDebugging);
     }
 
     // Overload variant

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDefs.h
@@ -67,22 +67,27 @@ public:
 
 protected:
     // Old style: Only warn on failure. This should
-    // not be used for new functions. First template argument
-    // Is a value used as result on invalid argument
-    template <auto Ret, auto T>
+    // not be used for new functions. ReturnOnError 
+    // must be a value to use as result on invalid argument
+    template <auto ReturnOnError, auto T>
     static inline int ArgumentParserWarn(lua_State* L)
     {
-        return CLuaFunctionParser<false, Ret, T>()(L, m_pScriptDebugging);
+        return CLuaFunctionParser<false, ReturnOnError, T>()(L, m_pScriptDebugging);
     }
 
-    // Special cases for overloads
-    template <auto Ret, auto T, auto U, auto... Ts>
+    // Special case for overloads
+    // This combines multiple functions into one (via CLuaOverloadParser)
+    template <auto ReturnOnError, auto FunctionA, auto FunctionB, auto... Functions>
     static inline int ArgumentParserWarn(lua_State* L)
     {
-        if constexpr (sizeof...(Ts) == 0)
-            return ArgumentParserWarn<Ret, CLuaOverloadParser<pad_func_with_func<T, U>::Call, pad_func_with_func<U, T>::Call>::Call>(L);
-        else
-            return ArgumentParserWarn<Ret, CLuaOverloadParser<pad_func_with_func<T, U>::Call, pad_func_with_func<U, T>::Call>::Call, Ts...>(L);
+        // Pad functions to have the same number of parameters by 
+        // filling both up to the larger number of parameters with dummy_type arguments
+        using PaddedFunctionA = pad_func_with_func<FunctionA, FunctionB>;
+        using PaddedFunctionB = pad_func_with_func<FunctionB, FunctionA>;
+        // Combine functions
+        using Overload = CLuaOverloadParser<PaddedFunctionA::Call, PaddedFunctionB::Call>;
+
+        return ArgumentParserWarn<Ret, Overload::Call, Functions...>(L);
     }
 
     // New style: hard error on usage mistakes
@@ -92,13 +97,18 @@ protected:
         return CLuaFunctionParser<true, nullptr, T>()(L, m_pScriptDebugging);
     }
 
-    // Overload variant
-    template <auto T, auto U, auto... Ts>
+    // Special case for overloads
+    // This combines multiple functions into one (via CLuaOverloadParser)
+    template <auto FunctionA, auto FunctionB, auto... Functions>
     static inline int ArgumentParser(lua_State* L)
     {
-        if constexpr (sizeof...(Ts) == 0)
-            return ArgumentParser<CLuaOverloadParser<pad_func_with_func<T, U>::Call, pad_func_with_func<U, T>::Call>::Call>(L);
-        else
-            return ArgumentParser<CLuaOverloadParser<pad_func_with_func<T, U>::Call, pad_func_with_func<U, T>::Call>::Call, Ts...>(L);
+        // Pad functions to have the same number of parameters by
+        // filling both up to the larger number of parameters with dummy_type arguments
+        using PaddedFunctionA = pad_func_with_func<FunctionA, FunctionB>;
+        using PaddedFunctionB = pad_func_with_func<FunctionB, FunctionA>;
+        // Combine functions
+        using Overload = CLuaOverloadParser<PaddedFunctionA::Call, PaddedFunctionB::Call>;
+
+        return ArgumentParser<Overload::Call, Functions...>(L);
     }
 };

--- a/Server/mods/deathmatch/StdInc.h
+++ b/Server/mods/deathmatch/StdInc.h
@@ -113,6 +113,9 @@ struct SAclRequest;
 #include "packets/CServerInfoSyncPacket.h"
 #include "packets/CDiscordJoinPacket.h"
 
+// has to be included early to prevent "unknown type name 'CRemoteCall'" in CLuaFunctionParser.h
+#include "CRemoteCalls.h"
+
 // Lua function definitions
 #include "luadefs/CLuaElementDefs.h"
 #include "luadefs/CLuaAccountDefs.h"
@@ -141,9 +144,6 @@ struct SAclRequest;
 #include "luadefs/CLuaVoiceDefs.h"
 #include "luadefs/CLuaWaterDefs.h"
 #include "luadefs/CLuaWorldDefs.h"
-
-// has to be included before CLuaFunctionParseHelpers to prevent "invalid use of incomplete type ‘class CRemoteCalls´
-#include "CRemoteCalls.h"
 
 // Lua includes
 #include "lua/LuaCommon.h"

--- a/Server/mods/deathmatch/logic/CGame.h
+++ b/Server/mods/deathmatch/logic/CGame.h
@@ -57,6 +57,7 @@ class CGame;
 #include "lua/CLuaManager.h"
 
 #include "CLightsyncManager.h"
+#include "CBanManager.h"
 
 // Forward declarations
 class ASE;

--- a/Server/mods/deathmatch/logic/CGame.h
+++ b/Server/mods/deathmatch/logic/CGame.h
@@ -63,7 +63,6 @@ class CGame;
 class ASE;
 class CAccessControlListManager;
 class CAccountManager;
-class CBanManager;
 class CBlipManager;
 class CClock;
 class CColManager;

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDefs.h
@@ -88,28 +88,29 @@ protected:
 
 protected:
     // Old style: Only warn on failure. This should
-    // not be used for new functions
-    template <auto T>
+    // not be used for new functions. First template argument 
+    // Is a value used as result on invalid argument
+    template <auto Ret, auto T>
     static inline int ArgumentParserWarn(lua_State* L)
     {
-        return CLuaFunctionParser<false, T>()(L, m_pScriptDebugging);
+        return CLuaFunctionParser<false, Ret, T>()(L, m_pScriptDebugging);
     }
 
     // Special cases for overloads
-    template <auto T, auto U, auto... Ts>
+    template <auto Ret, auto T, auto U, auto... Ts>
     static inline int ArgumentParserWarn(lua_State* L)
     {
         if constexpr (sizeof...(Ts) == 0)
-            return ArgumentParserWarn<CLuaOverloadParser<pad_func_with_func<T, U>::Call, pad_func_with_func<U, T>::Call>::Call>(L);
+            return ArgumentParserWarn<Ret, CLuaOverloadParser<pad_func_with_func<T, U>::Call, pad_func_with_func<U, T>::Call>::Call>(L);
         else
-            return ArgumentParserWarn<CLuaOverloadParser<pad_func_with_func<T, U>::Call, pad_func_with_func<U, T>::Call>::Call, Ts...>(L);
+            return ArgumentParserWarn<Ret, CLuaOverloadParser<pad_func_with_func<T, U>::Call, pad_func_with_func<U, T>::Call>::Call, Ts...>(L);
     }
 
     // New style: hard error on usage mistakes
     template <auto T>
     static inline int ArgumentParser(lua_State* L)
     {
-        return CLuaFunctionParser<true, T>()(L, m_pScriptDebugging);
+        return CLuaFunctionParser<true, nullptr, T>()(L, m_pScriptDebugging);
     }
 
     // Overload variant

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDefs.h
@@ -108,7 +108,7 @@ protected:
         // Combine functions
         using Overload = CLuaOverloadParser<PaddedFunctionA::Call, PaddedFunctionB::Call>;
 
-        return ArgumentParserWarn<Ret, Overload::Call, Functions...>(L);
+        return ArgumentParserWarn<ReturnOnError, Overload::Call, Functions...>(L);
     }
 
     // New style: hard error on usage mistakes

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDefs.h
@@ -84,4 +84,41 @@ protected:
     static CResourceManager*          m_pResourceManager;
     static CAccessControlListManager* m_pACLManager;
     static CMainConfig*               m_pMainConfig;
+
+protected:
+    // Old style: Only warn on failure. This should
+    // not be used for new functions
+    template <auto T>
+    static inline int ArgumentParserWarn(lua_State* L)
+    {
+        int iReturnValue = CLuaFunctionParser<T>()(L);
+        if (iReturnValue < 0)
+        {
+            m_pScriptDebugging->LogCustom(L, "todo fix error message");
+            lua_pushboolean(L, false);
+            return 1;
+        }
+        return iReturnValue;
+    }
+
+    // New style: hard error on usage mistakes
+    template <auto T>
+    static inline int ArgumentParser(lua_State* L)
+    {
+        try
+        {
+            int iReturnValue = CLuaFunctionParser<T>()(L);
+            if (iReturnValue < 0)
+            {
+                luaL_error(L, "todo fix error message");
+                return 1;
+            }
+            return iReturnValue;
+        }
+        catch (CLuaError& e)
+        {
+            luaL_error(L, e.what());
+            return 0;
+        }
+    }
 };

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDefs.h
@@ -91,34 +91,13 @@ protected:
     template <auto T>
     static inline int ArgumentParserWarn(lua_State* L)
     {
-        int iReturnValue = CLuaFunctionParser<T>()(L);
-        if (iReturnValue < 0)
-        {
-            m_pScriptDebugging->LogCustom(L, "todo fix error message");
-            lua_pushboolean(L, false);
-            return 1;
-        }
-        return iReturnValue;
+        return CLuaFunctionParser<false, T>()(L, m_pScriptDebugging);
     }
 
     // New style: hard error on usage mistakes
     template <auto T>
     static inline int ArgumentParser(lua_State* L)
     {
-        try
-        {
-            int iReturnValue = CLuaFunctionParser<T>()(L);
-            if (iReturnValue < 0)
-            {
-                luaL_error(L, "todo fix error message");
-                return 1;
-            }
-            return iReturnValue;
-        }
-        catch (CLuaError& e)
-        {
-            luaL_error(L, e.what());
-            return 0;
-        }
+        return CLuaFunctionParser<true, T>()(L, m_pScriptDebugging);
     }
 };

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDefs.h
@@ -95,10 +95,14 @@ protected:
         return CLuaFunctionParser<false, T>()(L, m_pScriptDebugging);
     }
 
-    template <auto T, auto U>
+    // Special cases for overloads
+    template <auto T, auto U, auto... Ts>
     static inline int ArgumentParserWarn(lua_State* L)
     {
-        return CLuaFunctionParser<false, CLuaOverloadParser<T, U>::Call>()(L, m_pScriptDebugging);
+        if constexpr (sizeof...(Ts) == 0)
+            return ArgumentParserWarn<CLuaOverloadParser<pad_func_with_func<T, U>::Call, pad_func_with_func<U, T>::Call>::Call>(L);
+        else
+            return ArgumentParserWarn<CLuaOverloadParser<pad_func_with_func<T, U>::Call, pad_func_with_func<U, T>::Call>::Call, Ts...>(L);
     }
 
     // New style: hard error on usage mistakes
@@ -109,9 +113,12 @@ protected:
     }
 
     // Overload variant
-    template <auto T, auto U>
+    template <auto T, auto U, auto... Ts>
     static inline int ArgumentParser(lua_State* L)
     {
-        return CLuaFunctionParser<true, CLuaOverloadParser<T, U>::Call>()(L, m_pScriptDebugging);
+        if constexpr (sizeof...(Ts) == 0)
+            return ArgumentParser<CLuaOverloadParser<pad_func_with_func<T, U>::Call, pad_func_with_func<U, T>::Call>::Call>(L);
+        else
+            return ArgumentParser<CLuaOverloadParser<pad_func_with_func<T, U>::Call, pad_func_with_func<U, T>::Call>::Call, Ts...>(L);
     }
 };

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDefs.h
@@ -31,6 +31,7 @@
 #include "../CVehicleManager.h"
 #include "../CRegistry.h"
 #include "../CDatabaseManager.h"
+#include <lua/CLuaFunctionParser.h>
 
 // Used by script handlers to verify elements
 #define SCRIPT_VERIFY_BLIP(blip) (m_pBlipManager->Exists(blip)&&!blip->IsBeingDeleted())

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDefs.h
@@ -95,10 +95,23 @@ protected:
         return CLuaFunctionParser<false, T>()(L, m_pScriptDebugging);
     }
 
+    template <auto T, auto U>
+    static inline int ArgumentParserWarn(lua_State* L)
+    {
+        return CLuaFunctionParser<false, CLuaOverloadParser<T, U>::Call>()(L, m_pScriptDebugging);
+    }
+
     // New style: hard error on usage mistakes
     template <auto T>
     static inline int ArgumentParser(lua_State* L)
     {
         return CLuaFunctionParser<true, T>()(L, m_pScriptDebugging);
+    }
+
+    // Overload variant
+    template <auto T, auto U>
+    static inline int ArgumentParser(lua_State* L)
+    {
+        return CLuaFunctionParser<true, CLuaOverloadParser<T, U>::Call>()(L, m_pScriptDebugging);
     }
 };

--- a/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
@@ -12,6 +12,7 @@
 #include <variant>
 #include <SharedUtil.Template.h>
 #include "lua/CLuaFunctionParseHelpers.h"
+#include "lua/CLuaStackChecker.h"
 #include "lua/LuaBasic.h"
 
 template <bool, auto*>
@@ -246,6 +247,8 @@ struct CLuaFunctionParser<ErrorOnFailure, Func>
     template <typename T>
     inline T PopUnsafe(lua_State* L, std::size_t& index)
     {
+        // Expect no change in stack size
+        LUA_STACK_EXPECT(0); 
         // trivial types are directly popped
         if constexpr (std::is_same_v<T, std::string> || std::is_same_v<T, int> || std::is_same_v<T, float> || std::is_same_v<T, double> ||
                       std::is_same_v<T, short> || std::is_same_v<T, unsigned int> || std::is_same_v<T, unsigned short> || std::is_same_v<T, bool>)

--- a/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
@@ -11,6 +11,7 @@
 #include <optional>
 #include <variant>
 #include <SharedUtil.Template.h>
+#include "lua/CLuaOverloadParser.h"
 #include "lua/CLuaFunctionParseHelpers.h"
 #include "lua/CLuaStackChecker.h"
 #include "lua/LuaBasic.h"

--- a/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
@@ -376,13 +376,13 @@ struct CLuaFunctionParserBase
     }
 };
 
-template <bool, auto*>
+template <bool, auto, auto*>
 struct CLuaFunctionParser
 {
 };
 
-template <bool ErrorOnFailure, typename Ret, typename... Args, auto (*Func)(Args...)->Ret>
-struct CLuaFunctionParser<ErrorOnFailure, Func> : CLuaFunctionParserBase
+template <bool ErrorOnFailure, auto ReturnOnFailure, typename Ret, typename... Args, auto (*Func)(Args...)->Ret>
+struct CLuaFunctionParser<ErrorOnFailure, ReturnOnFailure, Func> : CLuaFunctionParserBase
 {
     template <typename... Params>
     inline auto Call(lua_State* L, Params&&... ps)
@@ -429,7 +429,7 @@ struct CLuaFunctionParser<ErrorOnFailure, Func> : CLuaFunctionParserBase
             else
             {
                 pScriptDebugging->LogCustom(L, strError.c_str());
-                lua_pushboolean(L, false);
+                lua::Push(L, ReturnOnFailure);
             }
             return 1;
         }

--- a/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
@@ -1,0 +1,223 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#include <optional>
+#include <variant>
+#include <SharedUtil.Template.h>
+#include "lua/LuaBasic.h"
+
+template <auto*>
+struct CLuaFunctionParser
+{
+};
+
+template <typename Ret, typename... Args, auto (*Func)(Args...)->Ret>
+struct CLuaFunctionParser<Func>
+{
+    std::size_t iIndex = 1;
+    bool        bFailed = false;
+
+    // Pop should remove a T from the Lua Stack after verifying that it is a valid type
+    // Pop may also throw a LuaArgumentError to indicate failure
+    template <typename T>
+    inline T Pop(lua_State* L, std::size_t& index)
+    {
+        if (!TypeMatch<T>(L, index))
+        {
+            // TODO: resolve error
+            bFailed = true;
+            return T{};
+        }
+        return PopUnsafe<T>(L, index);
+    }
+
+    // TypeMatch<T> should return true if the value on top of the Lua stack can be popped via
+    // PopUnsafe<T>. This must accurately reflect the associated PopUnsafe. Note that TypeMatch
+    // should only check for obvious type violations (e.g. false is not a string) but not
+    // for internal type errors (passing a vehicle to a function expecting a ped)
+    template <typename T>
+    inline bool TypeMatch(lua_State* L, std::size_t index)
+    {
+        int iArgument = lua_type(L, index);
+        // trivial types
+        if constexpr (std::is_same_v<T, std::string>)
+            return (iArgument == LUA_TSTRING || iArgument == LUA_TNUMBER);
+        if constexpr (std::is_same_v<T, int> || std::is_same_v<T, float> || std::is_same_v<T, double> || std::is_same_v<T, short> ||
+                      std::is_same_v<T, unsigned int> || std::is_same_v<T, unsigned short>)
+            return (iArgument == LUA_TSTRING || iArgument == LUA_TNUMBER);
+
+        // advanced types
+        // Enums are represented as strings to Lua
+        if constexpr (std::is_enum_v<T>)
+            return iArgument == LUA_TSTRING;
+        // std::optional is used for optional parameters
+        // which may also be in the middle of a parameter list
+        // therefore it is always valid to attempt to read an
+        // optional
+        if constexpr (is_specialization<T, std::optional>::value)
+            return true;
+
+        // std::vector is used for arrays built from tables
+        if constexpr (is_2specialization<T, std::vector>::value)
+            return iArgument == LUA_TTABLE;
+
+        // std::unordered_map<k,v> is used for maps built from tables
+        if constexpr (is_5specialization<T, std::unordered_map>::value)
+            return iArgument == LUA_TTABLE;
+
+        // CLuaFunctionRef is used for functions
+        if constexpr (std::is_same_v<T, CLuaFunctionRef>)
+            return iArgument == LUA_TFUNCTION;
+
+        // lua_State* can be taken as argument anywhere
+        if constexpr (std::is_same_v<T, lua_State*>)
+            return true;
+
+        // Catch all for class pointer types, assume all classes are valid script entities
+        // and can be fetched from a userdata
+        if constexpr (std::is_pointer_v<T> && std::is_class_v<std::remove_pointer_t<T>>)
+            return iArgument == LUA_TUSERDATA || iArgument == LUA_TLIGHTUSERDATA;
+    }
+
+    template <typename T>
+    inline T PopUnsafe(lua_State* L, std::size_t& index)
+    {
+        // trivial types are directly popped
+        if constexpr (std::is_same_v<T, std::string> || std::is_same_v<T, int> || std::is_same_v<T, float> || std::is_same_v<T, double> ||
+                      std::is_same_v<T, short> || std::is_same_v<T, unsigned int> || std::is_same_v<T, unsigned short>)
+            return lua::PopTrivial<T>(L, index);
+        else if constexpr (std::is_enum_v<T>)
+        {
+            // Enums are considered strings in Lua
+            std::string strValue = lua::PopTrivial<std::string>(L, index);
+            T           eValue;
+            if (StringToEnum(strValue, eValue))
+                return eValue;
+            else
+            {
+                bFailed = true;
+                // TODO: resolve error
+                return static_cast<T>(0);
+            }
+        }
+        else if constexpr (is_specialization<T, std::optional>::value)
+        {
+            // optionals may either type match the desired value, or be nullopt
+            using param = typename is_specialization<T, std::optional>::param_t;
+            if (TypeMatch<param>(L, index))
+                return PopUnsafe<param>(L, index);
+            else
+                return std::nullopt;
+        }
+
+        else if constexpr (is_2specialization<T, std::vector>::value)            // 2 specialization due to allocator
+        {
+            using param = typename is_2specialization<T, std::vector>::param1_t;
+            T vecData;
+            lua_pushnil(L); /* first key */
+            while (lua_next(L, index) != 0)
+            {
+                if (!TypeMatch<param>(L, -1) || !TypeMatch<int>(L, -2))
+                {
+                    bFailed = true;
+                    // TODO: resolve error
+                    return vecData;
+                }
+
+                std::size_t i = -1;
+                vecData.emplace_back(PopUnsafe<param>(L, i));
+                lua_pop(L, 1);            // drop value, keep key for lua_next
+            }
+            ++index;
+            return vecData;
+        }
+        else if constexpr (is_5specialization<T, std::unordered_map>::value)
+        {
+            using key_t = typename is_5specialization<T, std::unordered_map>::param1_t;
+            using value_t = typename is_5specialization<T, std::unordered_map>::param2_t;
+            T map;
+            lua_pushnil(L); /* first key */
+            while (lua_next(L, index) != 0)
+            {
+                if (!TypeMatch<value_t>(L, -1) || !TypeMatch<key_t>(L, -2))
+                {
+                    bFailed = true;
+                    // TODO: resolve error
+                    return map;
+                }
+                
+
+                std::size_t i = -2;
+                auto        k = PopUnsafe<key_t>(L, i);
+                auto        v = PopUnsafe<value_t>(L, i);
+                map.emplace(std::move(k), std::move(v));
+                lua_pop(L, 1);            // drop value, keep key for lua_next
+            }
+            ++index;
+            return map;
+        }
+        else if constexpr (std::is_same_v<T, CLuaFunctionRef>)
+        {
+            return luaM_toref(L, index++);
+        }
+        if constexpr (std::is_same_v<T, lua_State*>)
+            return L;
+        // Catch all for class pointer types, assume all classes are valid script entities
+        // and can be fetched from a userdata
+        else if constexpr (std::is_pointer_v<T> && std::is_class_v<std::remove_pointer_t<T>>)
+        {
+            bool  isLightUserData = lua_type(L, index) == LUA_TLIGHTUSERDATA;
+            void* pValue = PopTrivial<void*>(L, index);
+            using class_t = std::remove_pointer_t<T>;
+            T result = nullptr;
+            if (isLightUserData)
+            {
+                result = UserDataCast<class_t>((class_t*)0, pValue, L);
+            }
+            else
+            {
+                result = UserDataCast<class_t>((class_t*)0, *reinterpret_cast<void**>(pValue), L);
+            }
+            if (result == nullptr)
+            {
+                bFailed = true;
+                // TODO: resolve error
+                return nullptr;
+            }
+            return result;
+        }
+    }
+
+    template <typename... Params>
+    inline auto Call(lua_State* L, Params&&... ps)
+    {
+        if (bFailed)
+        {
+            return -1;
+        }
+        if constexpr (sizeof...(Params) == sizeof...(Args))
+        {
+            if constexpr (std::is_same_v<Ret, void>)
+            {
+                Func(std::forward<Params>(ps)...);
+                return 0;
+            }
+            else
+            {
+                return lua::Push(L, Func(std::forward<Params>(ps)...));
+            }
+        }
+        else
+        {
+            return Call(L, ps..., Pop<typename nth_element_impl<sizeof...(Params), Args...>::type>(L, iIndex));
+        }
+    }
+
+    inline auto operator()(lua_State* L) { return Call(L); }
+};

--- a/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
@@ -6,6 +6,7 @@
  *  Multi Theft Auto is available from http://www.multitheftauto.com/
  *
  *****************************************************************************/
+#pragma once 
 
 #include <optional>
 #include <variant>

--- a/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
@@ -11,6 +11,7 @@
 #include <optional>
 #include <variant>
 #include <SharedUtil.Template.h>
+#include "lua/CLuaFunctionParseHelpers.h"
 #include "lua/LuaBasic.h"
 
 template <bool, auto*>
@@ -240,7 +241,7 @@ struct CLuaFunctionParser<ErrorOnFailure, Func>
         else if constexpr (std::is_pointer_v<T> && std::is_class_v<std::remove_pointer_t<T>>)
         {
             bool  isLightUserData = lua_type(L, index) == LUA_TLIGHTUSERDATA;
-            void* pValue = PopTrivial<void*>(L, index);
+            void* pValue = lua::PopTrivial<void*>(L, index);
             using class_t = std::remove_pointer_t<T>;
             T result = nullptr;
             if (isLightUserData)

--- a/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
@@ -268,9 +268,7 @@ struct CLuaFunctionParserBase
             T value = lua::PopPrimitive<T>(L, index);
             if (std::isnan(value))
             {
-                SString strMessage("Expected number at argument %d, got NaN", index);
-                SString strMessage("Bad argument @ '%s' [Expected number at argument %d, got NaN]", lua_tostring(L, lua_upvalueindex(1)), strExpected.c_str(),
-                                   index);
+                SString strMessage("Bad argument @ '%s' [Expected number at argument %d, got NaN]", lua_tostring(L, lua_upvalueindex(1)), index);
                 strError = strMessage;
             }
             return value;

--- a/Shared/mods/deathmatch/logic/lua/CLuaOverloadParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaOverloadParser.h
@@ -1,0 +1,90 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+#pragma once
+
+#include <SharedUtil.Template.h>
+#include <type_traits>
+#include <variant>
+
+template <auto*, auto*>
+struct CLuaOverloadParser
+{
+};
+
+template <typename Ret, typename Ret2, typename... Args, typename... Args2, auto (*Func)(Args...)->Ret, auto (*Func2)(Args2...)->Ret2>
+struct CLuaOverloadParser<Func, Func2>
+{
+private:
+    enum class ChosenFunction
+    {
+        FUNCA,
+        FUNCB,
+        COMMON,
+        FAIL
+    };
+
+    template <std::size_t N, typename... Ts, typename... Us>
+    static ChosenFunction MakeAllChoice(std::variant<Ts...> var, Us... us)
+    {
+        ChosenFunction result = MakeChoice<0>(var);
+        if constexpr (sizeof...(Us) == 0)
+            return result;
+        else
+        {
+            ChosenFunction rest = MakeAllChoice<N + 1>(us...);
+            // If types match for overload X, use overload X
+            if (result == rest)
+                return result;
+            // If types don't match, check if this variable matches
+            // both. If so, use the other type
+            else if (result == ChosenFunction::COMMON)
+                return rest;
+            // If the rest matches both overloads, use the current one
+            else if (rest == ChosenFunction::COMMON)
+                return result;
+            // result != rest && result != 0 && rest != 0
+            // Type error
+            return ChosenFunction::FAIL;
+        }
+    }
+
+    // Chose an overload that the Nth paramter matches
+    template <std::size_t N, typename... T>
+    static ChosenFunction MakeChoice(std::variant<T...> var)
+    {
+        return std::visit(
+            [](auto&& f) {
+                using ft = decltype(f);
+                if constexpr (!std::is_convertible_v<ft, nth_element_t<N, Args...>>)
+                    return ChosenFunction::FUNCB;            // if it cannot match A, B it is
+                if constexpr (!std::is_convertible_v<ft, nth_element_t<N, Args2...>>)
+                    return ChosenFunction::FUNCA;            // if it cannot match A, B it is
+                return ChosenFunction::COMMON;               // Both match
+            },
+            var);
+    }
+
+public:
+    typename common_variant<Ret, Ret2>::type
+    static Call(typename common_variant<Args, Args2>::type... args)
+    {
+        ChosenFunction choice = MakeAllChoice<0>(args...);
+        if (choice == ChosenFunction::FUNCA)
+            return Func(std::get<Args>(args)...);
+        else if (choice == ChosenFunction::FUNCB)
+            return Func2(std::get<Args2>(args)...);
+        else if (choice == ChosenFunction::FAIL)
+        {
+            // User provided incorrect arguments
+            throw std::invalid_argument("Overload resolution failed.");
+        }
+        // If this exception is thrown, there is a bug in the overload, as they are not unique
+        throw std::invalid_argument("MTA:SA Bug. Please file an issue with the parameters used for calling.");
+    }
+};

--- a/Shared/mods/deathmatch/logic/lua/CLuaOverloadParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaOverloadParser.h
@@ -32,7 +32,7 @@ private:
     template <std::size_t N, typename... Ts, typename... Us>
     static ChosenFunction MakeAllChoice(std::variant<Ts...> var, Us... us)
     {
-        ChosenFunction result = MakeChoice<0>(var);
+        ChosenFunction result = MakeChoice<N>(var);
         if constexpr (sizeof...(Us) == 0)
             return result;
         else

--- a/Shared/mods/deathmatch/logic/lua/CLuaOverloadParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaOverloadParser.h
@@ -64,7 +64,7 @@ private:
                 if constexpr (!std::is_convertible_v<ft, nth_element_t<N, Args...>>)
                     return ChosenFunction::FUNCB;            // if it cannot match A, B it is
                 if constexpr (!std::is_convertible_v<ft, nth_element_t<N, Args2...>>)
-                    return ChosenFunction::FUNCA;            // if it cannot match A, B it is
+                    return ChosenFunction::FUNCA;            // if it cannot match B, A it is
                 return ChosenFunction::COMMON;               // Both match
             },
             var);

--- a/Shared/mods/deathmatch/logic/lua/CLuaOverloadParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaOverloadParser.h
@@ -85,6 +85,6 @@ public:
             throw std::invalid_argument("Overload resolution failed.");
         }
         // If this exception is thrown, there is a bug in the overload, as they are not unique
-        throw std::invalid_argument("MTA:SA Bug. Please file an issue with the parameters used for calling.");
+        throw std::invalid_argument("MTA:SA Bug. Please file an issue at https://git.io/blue-issues with the parameters used for calling.");
     }
 };

--- a/Shared/mods/deathmatch/logic/lua/CLuaStackChecker.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaStackChecker.h
@@ -1,0 +1,56 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+#pragma once
+#include <stdexcept>
+/*
+ * Simple utility to verify the Lua stack.
+ * The general idea is to simply write
+ *   LUA_STACK_EXPECT(N);
+ * at the beginning of a function, where N
+ * is the expected amount of change in the Lua
+ * stack size.
+ *
+ * As an example: A __index metamethod receives
+ * two parameters on the stack and returns a
+ * single value. Therefor each __index
+ * implementation should decrease the Lua stack
+ * size by one. Therefore write:
+ *   LUA_STACK_EXPECT(-1);
+ */
+namespace lua
+{
+    struct CLuaStackChecker
+    {
+        lua_State* L;
+        int        m_iTop = 0;
+        int        m_iExpected = 0;
+        CLuaStackChecker(lua_State* L, int expected) : L(L)
+        {
+            m_iTop = lua_gettop(L);
+            m_iExpected = expected;
+        }
+
+        ~CLuaStackChecker() noexcept(false)
+        {
+            int iNewtop = lua_gettop(L);
+            int iChange = iNewtop - m_iTop;
+            if (iChange != m_iExpected)
+            {
+                printf("Lua Stack Error: top should be %d is %d (change should be %d is %d)\n", m_iTop + m_iExpected, iNewtop, m_iExpected, iChange);
+                throw std::runtime_error("Lua Stack Error");
+            }
+        }
+    };
+}            // namespace lua
+
+#ifdef MTA_DEBUG
+#define LUA_STACK_EXPECT(i) lua::CLuaStackChecker invalidHiddenName(L, i)
+#else
+#define LUA_STACK_EXPECT(i)
+#endif

--- a/Shared/mods/deathmatch/logic/lua/LuaBasic.cpp
+++ b/Shared/mods/deathmatch/logic/lua/LuaBasic.cpp
@@ -1,0 +1,53 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+#include <StdInc.h>
+#include "LuaBasic.h"
+
+namespace lua
+{
+    int Push(lua_State* L, int value)
+    {
+        lua_pushnumber(L, value);
+        return 1;
+    }
+
+    int Push(lua_State* L, bool value)
+    {
+        lua_pushboolean(L, value);
+        return 1;
+    }
+
+    int Push(lua_State* L, const std::string& value)
+    {
+        lua_pushlstring(L, value.data(), value.length());
+        return 1;
+    }
+
+
+    template <>
+    std::string PopTrivial<std::string>(lua_State* L, std::size_t& index)
+    {
+        uint        uiLength = lua_strlen(L, index);
+        std::string outValue;
+        outValue.assign(lua_tostring(L, index++), uiLength);
+        return outValue;
+    }
+
+    template <>
+    int PopTrivial<int>(lua_State* L, std::size_t& index)
+    {
+        return static_cast<int>(lua_tonumber(L, index++));
+    }
+
+    template <>
+    void* PopTrivial<void*>(lua_State* L, std::size_t& index)
+    {
+        return lua_touserdata(L, index++);
+    }
+}            // namespace mta::impl

--- a/Shared/mods/deathmatch/logic/lua/LuaBasic.cpp
+++ b/Shared/mods/deathmatch/logic/lua/LuaBasic.cpp
@@ -52,7 +52,7 @@ namespace lua
 
 
     template <>
-    std::string PopTrivial<std::string>(lua_State* L, std::size_t& index)
+    std::string PopPrimitive<std::string>(lua_State* L, std::size_t& index)
     {
         uint        uiLength = lua_strlen(L, index);
         std::string outValue;
@@ -61,37 +61,37 @@ namespace lua
     }
 
     template <>
-    int PopTrivial<int>(lua_State* L, std::size_t& index)
+    int PopPrimitive<int>(lua_State* L, std::size_t& index)
     {
         return static_cast<int>(lua_tonumber(L, index++));
     }
 
     template <>
-    unsigned int PopTrivial<unsigned int>(lua_State* L, std::size_t& index)
+    unsigned int PopPrimitive<unsigned int>(lua_State* L, std::size_t& index)
     {
         return static_cast<unsigned int>(lua_tonumber(L, index++));
     }
 
     template <>
-    float PopTrivial<float>(lua_State* L, std::size_t& index)
+    float PopPrimitive<float>(lua_State* L, std::size_t& index)
     {
         return static_cast<float>(lua_tonumber(L, index++));
     }
 
     template <>
-    double PopTrivial<double>(lua_State* L, std::size_t& index)
+    double PopPrimitive<double>(lua_State* L, std::size_t& index)
     {
         return static_cast<double>(lua_tonumber(L, index++));
     }
     
     template <>
-    bool PopTrivial<bool>(lua_State* L, std::size_t& index)
+    bool PopPrimitive<bool>(lua_State* L, std::size_t& index)
     {
         return static_cast<bool>(lua_toboolean(L, index++));
     }
 
     template <>
-    void* PopTrivial<void*>(lua_State* L, std::size_t& index)
+    void* PopPrimitive<void*>(lua_State* L, std::size_t& index)
     {
         return lua_touserdata(L, index++);
     }

--- a/Shared/mods/deathmatch/logic/lua/LuaBasic.cpp
+++ b/Shared/mods/deathmatch/logic/lua/LuaBasic.cpp
@@ -16,10 +16,31 @@ namespace lua
         lua_pushnumber(L, value);
         return 1;
     }
+    int Push(lua_State* L, unsigned int value)
+    {
+        lua_pushnumber(L, value);
+        return 1;
+    }
+    int Push(lua_State* L, float value)
+    {
+        lua_pushnumber(L, value);
+        return 1;
+    }
+    int Push(lua_State* L, double value)
+    {
+        lua_pushnumber(L, value);
+        return 1;
+    }
 
     int Push(lua_State* L, bool value)
     {
         lua_pushboolean(L, value);
+        return 1;
+    }
+
+    int Push(lua_State* L, nullptr_t)
+    {
+        lua_pushnil(L);
         return 1;
     }
 
@@ -43,6 +64,30 @@ namespace lua
     int PopTrivial<int>(lua_State* L, std::size_t& index)
     {
         return static_cast<int>(lua_tonumber(L, index++));
+    }
+
+    template <>
+    unsigned int PopTrivial<unsigned int>(lua_State* L, std::size_t& index)
+    {
+        return static_cast<unsigned int>(lua_tonumber(L, index++));
+    }
+
+    template <>
+    float PopTrivial<float>(lua_State* L, std::size_t& index)
+    {
+        return static_cast<float>(lua_tonumber(L, index++));
+    }
+
+    template <>
+    double PopTrivial<double>(lua_State* L, std::size_t& index)
+    {
+        return static_cast<double>(lua_tonumber(L, index++));
+    }
+    
+    template <>
+    bool PopTrivial<bool>(lua_State* L, std::size_t& index)
+    {
+        return static_cast<bool>(lua_toboolean(L, index++));
     }
 
     template <>

--- a/Shared/mods/deathmatch/logic/lua/LuaBasic.cpp
+++ b/Shared/mods/deathmatch/logic/lua/LuaBasic.cpp
@@ -11,46 +11,6 @@
 
 namespace lua
 {
-    int Push(lua_State* L, int value)
-    {
-        lua_pushnumber(L, value);
-        return 1;
-    }
-    int Push(lua_State* L, unsigned int value)
-    {
-        lua_pushnumber(L, value);
-        return 1;
-    }
-    int Push(lua_State* L, float value)
-    {
-        lua_pushnumber(L, value);
-        return 1;
-    }
-    int Push(lua_State* L, double value)
-    {
-        lua_pushnumber(L, value);
-        return 1;
-    }
-
-    int Push(lua_State* L, bool value)
-    {
-        lua_pushboolean(L, value);
-        return 1;
-    }
-
-    int Push(lua_State* L, nullptr_t)
-    {
-        lua_pushnil(L);
-        return 1;
-    }
-
-    int Push(lua_State* L, const std::string& value)
-    {
-        lua_pushlstring(L, value.data(), value.length());
-        return 1;
-    }
-
-
     template <>
     std::string PopPrimitive<std::string>(lua_State* L, std::size_t& index)
     {

--- a/Shared/mods/deathmatch/logic/lua/LuaBasic.cpp
+++ b/Shared/mods/deathmatch/logic/lua/LuaBasic.cpp
@@ -73,6 +73,12 @@ namespace lua
     }
 
     template <>
+    std::size_t PopPrimitive<std::size_t>(lua_State* L, std::size_t& index)
+    {
+        return static_cast<std::size_t>(lua_tonumber(L, index++));
+    }
+
+    template <>
     float PopPrimitive<float>(lua_State* L, std::size_t& index)
     {
         return static_cast<float>(lua_tonumber(L, index++));

--- a/Shared/mods/deathmatch/logic/lua/LuaBasic.cpp
+++ b/Shared/mods/deathmatch/logic/lua/LuaBasic.cpp
@@ -60,6 +60,15 @@ namespace lua
         return outValue;
     }
 
+    
+    template <>
+    std::string_view PopPrimitive<std::string_view>(lua_State* L, std::size_t& index)
+    {
+        uint        uiLength = lua_strlen(L, index);
+        std::string_view outValue(lua_tostring(L, index++), uiLength);
+        return outValue;
+    }
+
     template <>
     int PopPrimitive<int>(lua_State* L, std::size_t& index)
     {
@@ -73,9 +82,9 @@ namespace lua
     }
 
     template <>
-    std::size_t PopPrimitive<std::size_t>(lua_State* L, std::size_t& index)
+    uint64_t PopPrimitive<uint64_t>(lua_State* L, std::size_t& index)
     {
-        return static_cast<std::size_t>(lua_tonumber(L, index++));
+        return static_cast<uint64_t>(lua_tonumber(L, index++));
     }
 
     template <>

--- a/Shared/mods/deathmatch/logic/lua/LuaBasic.h
+++ b/Shared/mods/deathmatch/logic/lua/LuaBasic.h
@@ -30,6 +30,16 @@ namespace lua
     // The return value must be the amount of items pushed to the stack, which should
     // be 1 for trivial types (e.g. Push<int>) but may be any number for special cases
     // like tuples
+    
+    int Push(lua_State* L, int val);
+    int Push(lua_State* L, const std::string& val);
+    int Push(lua_State* L, bool val);
+    int Push(lua_State* L, std::nullptr_t);
+    int Push(lua_State* L, float val);
+    int Push(lua_State* L, double val);
+    int Push(lua_State* L, unsigned int val);
+    int Push(lua_State* L, unsigned short val);
+
 
     template <typename... Ts>
     int Push(lua_State* L, const std::variant<Ts...>&& val)
@@ -86,12 +96,4 @@ namespace lua
         return 1;
     }
 
-    int Push(lua_State* L, int val);
-    int Push(lua_State* L, const std::string& val);
-    int Push(lua_State* L, bool val);
-    int Push(lua_State* L, nullptr_t);
-    int Push(lua_State* L, float val);
-    int Push(lua_State* L, double val);
-    int Push(lua_State* L, unsigned int val);
-    int Push(lua_State* L, unsigned short val);
 }

--- a/Shared/mods/deathmatch/logic/lua/LuaBasic.h
+++ b/Shared/mods/deathmatch/logic/lua/LuaBasic.h
@@ -1,0 +1,97 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+#pragma once
+#include <optional>
+#include <variant>
+
+/*
+    Basic Lua operations:
+        int Push(L, T value)
+        T PopTrivial(L, std::size_t stackIndex)
+        bool TypeMatch(L, std::size_t stackIndex)
+*/
+
+
+namespace lua
+{
+    // PopTrival should read a simple value of type T from the stack without extra type checks
+    // If whatever is at that point in the stack is not convertible to T, the behavior is undefined
+    template <typename T>
+    inline T PopTrivial(lua_State* L, std::size_t& index);
+
+
+    // Push should push a value of type T to the Lua Stack
+    // The return value must be the amount of items pushed to the stack, which should
+    // be 1 for trivial types (e.g. Push<int>) but may be any number for special cases
+    // like tuples
+
+    template <typename... Ts>
+    int Push(lua_State* L, const std::variant<Ts...>&& val)
+    {
+        return std::visit([L](auto&& value) -> int { return Push(L, value); }, val);
+    }
+
+    template <typename T>
+    int Push(lua_State* L, const std::optional<T>&& val)
+    {
+        if (val.has_value())
+            return Push(L, val.value());
+        else
+            return Push(L, nullptr);
+     }
+
+    template <typename T>
+    int Push(lua_State* L, const std::vector<T>&& val)
+    {
+        lua_newtable(L);
+        int i = 1;
+        for (auto&& v : val)
+        {
+            Push(L, i++);
+            Push(L, v);
+            lua_settable(L, -3);
+        }
+        return 1;
+    }
+
+    template <typename K, typename V>
+    int Push(lua_State* L, const std::unordered_map<K, V>&& val)
+    {
+        lua_newtable(L);
+        for (auto&& [k, v] : val)
+        {
+            Push(L, k);
+            Push(L, v);
+            lua_settable(L, -3);
+        }
+        return 1;
+    }
+
+    template <typename T>
+    typename std::enable_if_t<std::is_enum_v<T>, int> Push(lua_State* L, const T&& val)
+    {
+        return Push(L, EnumToString(val));
+    }
+
+    template <typename T>
+    typename std::enable_if_t<(std::is_pointer_v<T> && std::is_class_v<std::remove_pointer_t<T>>), int> Push(lua_State* L, const T&& val)
+    {
+        lua_pushelement(L, val);
+        return 1;
+    }
+
+    int Push(lua_State* L, int val);
+    int Push(lua_State* L, const std::string& val);
+    int Push(lua_State* L, bool val);
+    int Push(lua_State* L, nullptr_t);
+    int Push(lua_State* L, float val);
+    int Push(lua_State* L, double val);
+    int Push(lua_State* L, unsigned int val);
+    int Push(lua_State* L, unsigned short val);
+}

--- a/Shared/mods/deathmatch/logic/lua/LuaBasic.h
+++ b/Shared/mods/deathmatch/logic/lua/LuaBasic.h
@@ -29,16 +29,44 @@ namespace lua
     // The return value must be the net amount of items pushed to the stack, which should
     // be 1 for most types (e.g. Push<int>) but may be any number for special cases
     // like tuples, in order to allow returning multiple values from a function
-    
-    int Push(lua_State* L, int val);
-    int Push(lua_State* L, const std::string& val);
-    int Push(lua_State* L, bool val);
-    int Push(lua_State* L, std::nullptr_t);
-    int Push(lua_State* L, float val);
-    int Push(lua_State* L, double val);
-    int Push(lua_State* L, unsigned int val);
-    int Push(lua_State* L, unsigned short val);
+    inline int Push(lua_State* L, int value)
+    {
+        lua_pushnumber(L, value);
+        return 1;
+    }
+    inline int Push(lua_State* L, unsigned int value)
+    {
+        lua_pushnumber(L, value);
+        return 1;
+    }
+    inline int Push(lua_State* L, float value)
+    {
+        lua_pushnumber(L, value);
+        return 1;
+    }
+    inline int Push(lua_State* L, double value)
+    {
+        lua_pushnumber(L, value);
+        return 1;
+    }
 
+    inline int Push(lua_State* L, bool value)
+    {
+        lua_pushboolean(L, value);
+        return 1;
+    }
+
+    inline int Push(lua_State* L, nullptr_t)
+    {
+        lua_pushnil(L);
+        return 1;
+    }
+
+    inline int Push(lua_State* L, const std::string& value)
+    {
+        lua_pushlstring(L, value.data(), value.length());
+        return 1;
+    }
 
     template <typename... Ts>
     int Push(lua_State* L, const std::variant<Ts...>&& val)

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
@@ -35,7 +35,6 @@ void CLuaCryptDefs::LoadFunctions()
     }
 }
 
-
 std::string CLuaCryptDefs::Md5(std::string strMd5)
 {
     MD5        md5bytes;

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
@@ -63,10 +63,10 @@ std::string CLuaCryptDefs::TeaEncode(std::string str, std::string key)
 
 std::string CLuaCryptDefs::TeaDecode(std::string str, std::string key)
 {
-    SString fixme = str;
     SString result = SharedUtil::Base64decode(str);
-    SharedUtil::TeaDecode(result, key, &fixme);
-    return fixme;
+    SString strOutResult;
+    SharedUtil::TeaDecode(result, key, &strOutResult);
+    return strOutResult;
 }
 
 std::string CLuaCryptDefs::Base64encode(std::string str)

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
@@ -11,7 +11,6 @@
 #include <SharedUtil.Crypto.h>
 #include <lua/CLuaFunctionParser.h>
 
-
 void CLuaCryptDefs::LoadFunctions()
 {
     std::map<const char*, lua_CFunction> functions{

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
@@ -14,13 +14,13 @@
 void CLuaCryptDefs::LoadFunctions()
 {
     std::map<const char*, lua_CFunction> functions{
-        {"md5", ArgumentParserWarn<Md5>},
-        {"sha256", ArgumentParserWarn<Sha256>},
-        {"hash", ArgumentParserWarn<Hash>},
-        {"teaEncode", ArgumentParserWarn<TeaEncode>},
-        {"teaDecode", ArgumentParserWarn<TeaDecode>},
-        {"base64Encode", ArgumentParserWarn<Base64encode>},
-        {"base64Decode", ArgumentParserWarn<Base64decode>},
+        {"md5", ArgumentParserWarn<false, Md5>},
+        {"sha256", ArgumentParserWarn<false, Sha256>},
+        {"hash", ArgumentParserWarn<false, Hash>},
+        {"teaEncode", ArgumentParserWarn<false, TeaEncode>},
+        {"teaDecode", ArgumentParserWarn<false, TeaDecode>},
+        {"base64Encode", ArgumentParserWarn<false, Base64encode>},
+        {"base64Decode", ArgumentParserWarn<false, Base64decode>},
         {"passwordHash", PasswordHash},
         {"passwordVerify", PasswordVerify},
         {"encodeString", EncodeString},

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.h
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.h
@@ -10,20 +10,26 @@
 
 #pragma once
 #include "luadefs/CLuaDefs.h"
+#include <optional>
+#include <variant>
 
 class CLuaCryptDefs : public CLuaDefs
 {
 public:
     static void LoadFunctions();
 
-    LUA_DECLARE(Md5);
-    LUA_DECLARE(Sha256);
-    LUA_DECLARE(Hash);
-    LUA_DECLARE(TeaEncode);
-    LUA_DECLARE(TeaDecode);
-    LUA_DECLARE(Base64encode);
-    LUA_DECLARE(Base64decode);
-    LUA_DECLARE(PasswordHash);
+    static std::string Md5(std::string strMd5);
+
+    static std::string Hash(EHashFunctionType hashFunction, std::string strSourceData);
+
+    static std::string TeaEncode(std::string str, std::string key);
+    static std::string TeaDecode(std::string str, std::string key);
+    static std::string Base64encode(std::string str);
+    static std::string Base64decode(std::string str);
+    static std::variant<std::string, bool> PasswordHash(lua_State* luaVM, std::string password, PasswordHashFunction algorithm,
+                                                        std::unordered_map<std::string, std::string> options,
+                             std::optional<CLuaFunctionRef> luaFunctionRef);
+    static std::string Sha256(std::string strSourceData);
     LUA_DECLARE(PasswordVerify);
     LUA_DECLARE(EncodeString);
     LUA_DECLARE(DecodeString);

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.h
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.h
@@ -26,9 +26,7 @@ public:
     static std::string TeaDecode(std::string str, std::string key);
     static std::string Base64encode(std::string str);
     static std::string Base64decode(std::string str);
-    static std::variant<std::string, bool> PasswordHash(lua_State* luaVM, std::string password, PasswordHashFunction algorithm,
-                                                        std::unordered_map<std::string, std::string> options,
-                             std::optional<CLuaFunctionRef> luaFunctionRef);
+    LUA_DECLARE(PasswordHash);
     static std::string Sha256(std::string strSourceData);
     LUA_DECLARE(PasswordVerify);
     LUA_DECLARE(EncodeString);

--- a/Shared/sdk/SharedUtil.Template.h
+++ b/Shared/sdk/SharedUtil.Template.h
@@ -9,6 +9,23 @@
     Note: Take care of optional parameters. For example std::unordered_map
     has 5 template arguments, thus is_5specialization needs to be used, rather
     than is_2specialization (Key, Value).
+
+    Usage can be the following:
+    if constexpr(is_2specialization<std::vector, T>::value)
+    {
+        // T is a vector!
+        using param_t = typename is_2specialization<std::vector, T>::param_t
+        // param_t is the type of the content of the vector
+    }
+
+    For each version of is_Nspecialization we have two class templates: 
+        - The first one (inheriting from std::false_type) is used to provide a 
+          default case, where something isn't a match. It does not impose restrictions
+          on anything apart from the Test parameter (which is required to take N template 
+          parameters). Thus it matches anything.
+
+        - The second one (std::true_type) is used to perform the actual match
+          by specializting the template for Test<Arg, Arg2>
 **/
 
 template <typename Test, template <typename> class Ref>
@@ -44,8 +61,16 @@ struct is_5specialization<Ref<Arg1, Arg2, Arg3, Arg4, Arg5>, Ref> : std::true_ty
 {
     using param1_t = Arg1;
     using param2_t = Arg2;
+    using param3_t = Arg3;
+    using param4_t = Arg4;
+    using param5_t = Arg5;
 };
 
+// is_variant
+//  Returns whether a T is a variant
+//  If T is a variant, it also allows accessing the individual types
+//  of the variant via param1_t (first type) and rest_t (which is a 
+//  variant of the remaining types).
 template <typename Test>
 struct is_variant : std::false_type
 {
@@ -62,15 +87,22 @@ struct is_variant<std::variant<Arg1, Args...>> : std::true_type
 /**
     nth_element
 
-    Returns the nth element of a parameter pack
+    Returns the nth element of a parameter pack by recursively 
+    discarding and counting down until the index is zero, at which
+    point the type is returned
 **/
 
+// Recursive case, I is larger than 1, therefore
+// we need to look at the I-1 case by discarding the
+// first type. 
 template <std::size_t I, typename T, typename... Ts>
 struct nth_element_impl
 {
     using type = typename nth_element_impl<I - 1, Ts...>::type;
 };
 
+// Base case: If we ask for the 0th element, the current element
+// is the one we're looking for
 template <typename T, typename... Ts>
 struct nth_element_impl<0, T, Ts...>
 {
@@ -120,6 +152,7 @@ struct common_variant<std::variant<Ts...>, std::variant<>>
 {
     using type = std::variant<Ts...>;
 };
+
 // Empty + Variant = Variant
 template <typename... Ts>
 struct common_variant<std::variant<>, std::variant<Ts...>>
@@ -127,18 +160,26 @@ struct common_variant<std::variant<>, std::variant<Ts...>>
     using type = std::variant<Ts...>;
 };
 
+// T + Variant = Variant or a new variant consisting of T + Variant
+// This is done by checking if T is convertible to the variant
 template <typename T, typename... Ts>
 struct common_variant<T, std::variant<Ts...>>
 {
     using type = std::conditional_t<std::is_convertible_v<T, std::variant<Ts...>>, std::variant<Ts...>, std::variant<T, Ts...>>;
 };
 
+// Variant + T = Variant or a new variant consisting of T + Variant
+// Simply calls the above case
 template <typename T, typename... Ts>
 struct common_variant<std::variant<Ts...>, T>
 {
     using type = typename common_variant<T, std::variant<Ts...>>::type;
 };
 
+
+// Variant + Variant = Combined Variant
+// This recursively calls itself and deconstructs the first variant, while 
+// adding the first type in the first variant to the second variant (via the T + variant overload)
 template <typename T, typename... Ts, typename... Us>
 struct common_variant<std::variant<T, Ts...>, std::variant<Us...>>
 {
@@ -152,17 +193,20 @@ struct dummy_type
 };
 
 
-// n_tuple: Constructs a tuple of size N
+// n_tuple: Constructs a tuple of size N (with dummy_type as parameter types)
 //  n_tuple<2>::type == std::tuple<dummy_type, dummy_type>
-template <std::size_t, bool B = false, typename... Args>
+template <std::size_t, bool HasEnough = false, typename... Args>
 struct n_tuple;
 
+// Second parameter is true -> We have reached N types in Args
 template <std::size_t N, typename... Args>
 struct n_tuple<N, true, Args...>
 {
     using type = std::tuple<Args...>;
 };
 
+// Second parameter is false -> Add a dummy type and 
+// decide if sizeof...(Args) + 1 is enough
 template <std::size_t N, typename... Args>
 struct n_tuple<N, false, Args...>
 {
@@ -176,6 +220,11 @@ template <auto* Func, typename T>
 struct pad_func_with_func_impl
 {
 };
+
+// pad_func_with_func_impl takes a tuple of additional arguments, which are then 
+// taken as parameter. This allows us to discard exactly sizeof...(Ts) function
+// arguments. Effectively this means Call is a function that is identical in behavior
+// to Func, but takes additional sizeof...(Ts) dummy arguments that are discarded.
 template <typename... Ts, typename Ret, typename... Args, auto (*Func)(Args...)->Ret>
 struct pad_func_with_func_impl<Func, std::tuple<Ts...>>
 {
@@ -186,6 +235,11 @@ template <auto*, auto*>
 struct pad_func_with_func
 {
 };
+
+// pad_func_with_func initially needs to figure out the maximum number of parameters for the two functions
+// It then determines how many parameters need to be added to Func, in order to have parity in argument count
+// By using n_tuple, we build a Tuple of exactly the amout of parameters that need to be added to Func, which 
+// is then applied via the impl function above
 template <typename Ret, typename... Args, auto (*Func)(Args...)->Ret, typename RetB, typename... ArgsB, auto (*FuncB)(ArgsB...)->RetB>
 struct pad_func_with_func<Func, FuncB> : pad_func_with_func_impl<Func, typename n_tuple<std::max(sizeof...(Args), sizeof...(ArgsB)) - sizeof...(Args),
                                                                                         std::max(sizeof...(Args), sizeof...(ArgsB)) - sizeof...(Args) == 0>::type>

--- a/Shared/sdk/SharedUtil.Template.h
+++ b/Shared/sdk/SharedUtil.Template.h
@@ -3,12 +3,12 @@
 /**
     is_Nspecialization
 
-    These structs allow testing whether a type is a specialization of a 
+    These structs allow testing whether a type is a specialization of a
     class template
 
-    Note: Take care of optional parameters. For example std::unordered_map 
+    Note: Take care of optional parameters. For example std::unordered_map
     has 5 template arguments, thus is_5specialization needs to be used, rather
-    than is_2specialization (Key, Value). 
+    than is_2specialization (Key, Value).
 **/
 
 template <typename Test, template <typename> class Ref>
@@ -44,6 +44,19 @@ struct is_5specialization<Ref<Arg1, Arg2, Arg3, Arg4, Arg5>, Ref> : std::true_ty
 {
     using param1_t = Arg1;
     using param2_t = Arg2;
+};
+
+template <typename Test>
+struct is_variant : std::false_type
+{
+};
+
+template <typename Arg1, typename... Args>
+struct is_variant<std::variant<Arg1, Args...>> : std::true_type
+{
+    using param1_t = Arg1;
+    using rest_t = std::variant<Args...>;
+    static constexpr auto count = sizeof...(Args) + 1;
 };
 
 /**

--- a/Shared/sdk/SharedUtil.Template.h
+++ b/Shared/sdk/SharedUtil.Template.h
@@ -1,0 +1,68 @@
+#pragma once
+
+/**
+    is_Nspecialization
+
+    These structs allow testing whether a type is a specialization of a 
+    class template
+
+    Note: Take care of optional parameters. For example std::unordered_map 
+    has 5 template arguments, thus is_5specialization needs to be used, rather
+    than is_2specialization (Key, Value). 
+**/
+
+template <typename Test, template <typename> class Ref>
+struct is_specialization : std::false_type
+{
+};
+
+template <template <typename> class Ref, typename Args>
+struct is_specialization<Ref<Args>, Ref> : std::true_type
+{
+    using param_t = Args;
+};
+
+template <typename Test, template <typename, typename> class Ref>
+struct is_2specialization : std::false_type
+{
+};
+
+template <template <typename, typename> class Ref, typename Arg1, typename Arg2>
+struct is_2specialization<Ref<Arg1, Arg2>, Ref> : std::true_type
+{
+    using param1_t = Arg1;
+    using param2_t = Arg2;
+};
+
+template <typename Test, template <typename, typename, typename, typename, typename> class Ref>
+struct is_5specialization : std::false_type
+{
+};
+
+template <template <typename, typename, typename, typename, typename> class Ref, typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5>
+struct is_5specialization<Ref<Arg1, Arg2, Arg3, Arg4, Arg5>, Ref> : std::true_type
+{
+    using param1_t = Arg1;
+    using param2_t = Arg2;
+};
+
+/**
+    nth_element
+
+    Returns the nth element of a parameter pack
+**/
+
+template <std::size_t I, typename T, typename... Ts>
+struct nth_element_impl
+{
+    using type = typename nth_element_impl<I - 1, Ts...>::type;
+};
+
+template <typename T, typename... Ts>
+struct nth_element_impl<0, T, Ts...>
+{
+    using type = T;
+};
+
+template <std::size_t I, typename... Ts>
+using nth_element = typename nth_element_impl<I, Ts...>::type;

--- a/Shared/sdk/SharedUtil.Template.h
+++ b/Shared/sdk/SharedUtil.Template.h
@@ -78,4 +78,69 @@ struct nth_element_impl<0, T, Ts...>
 };
 
 template <std::size_t I, typename... Ts>
-using nth_element = typename nth_element_impl<I, Ts...>::type;
+using nth_element_t = typename nth_element_impl<I, Ts...>::type;
+
+
+// common_variant
+// common_variant builds a single variant from types or variants
+//  bool, bool -> variant<bool>
+//  int, bool -> variant<int, bool>
+//  variant<int, bool>, bool -> variant<int, bool>
+//  variant<int, bool>, float -> variant<int, bool, float>
+//  variant<int, bool>, variant<bool, float> -> variant<int, bool, float>
+//  variant<int, bool>, variant<bool, float, double> -> variant<int, bool, float, double>
+
+// Two different types
+//  int, bool -> variant<int, bool>
+template <typename T, typename U>
+struct common_variant
+{
+    using type = std::variant<T, U>;
+};
+
+// Identical types
+//  int, int -> variant<int>
+template <typename T>
+struct common_variant<T, T>
+{
+    using type = std::variant<T>;
+};
+
+// Type + Variant which starts with the Type
+//  int, variant<int> -> variant<int>
+template <typename T, typename... Ts>
+struct common_variant<T, std::variant<T, Ts...>>
+{
+    using type = std::variant<T, Ts...>;
+};
+
+// Variant + Empty = Variant
+template <typename... Ts>
+struct common_variant<std::variant<Ts...>, std::variant<>>
+{
+    using type = std::variant<Ts...>;
+};
+// Empty + Variant = Variant
+template <typename... Ts>
+struct common_variant<std::variant<>, std::variant<Ts...>>
+{
+    using type = std::variant<Ts...>;
+};
+
+template <typename T, typename... Ts>
+struct common_variant<T, std::variant<Ts...>>
+{
+    using type = std::conditional_t<std::is_convertible_v<T, std::variant<Ts...>>, std::variant<Ts...>, std::variant<T, Ts...>>;
+};
+
+template <typename T, typename... Ts>
+struct common_variant<std::variant<Ts...>, T>
+{
+    using type = typename common_variant<T, std::variant<Ts...>>::type;
+};
+
+template <typename T, typename... Ts, typename... Us>
+struct common_variant<std::variant<T, Ts...>, std::variant<Us...>>
+{
+    using type = typename common_variant<std::variant<Ts...>, typename common_variant<T, std::variant<Us...>>::type>::type;
+};


### PR DESCRIPTION
Initial stuff for automated Lua argument parsing by applying template magic.

Basically this allows us to directly use C++ functions without needing to handle the argument parsing via argstreams. For example
```cpp
int CLuaCryptDefs::Hash(lua_State* luaVM)
{
    //  string hash ( string type, string data )
    EHashFunctionType hashFunction;
    SString           strSourceData;

    CScriptArgReader argStream(luaVM);
    argStream.ReadEnumString(hashFunction);
    argStream.ReadString(strSourceData);

    if (!argStream.HasErrors())
    {
        SString strResult = GenerateHashHexString(hashFunction, strSourceData);
        lua_pushstring(luaVM, strResult.ToLower());
        return 1;
    }
    else
        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());

    lua_pushboolean(luaVM, false);
    return 1;
}
```
becomes 
```cpp
std::string CLuaCryptDefs::Hash(EHashFunctionType hashFunction, std::string strSourceData)
{
    return GenerateHashHexString(hashFunction, strSourceData);
}
```
which avoids error and reduces the required amount of code massively. 

This PR also allows registering functions via the ArgumentParser template (rather than the ArgumentParserWarn template), which causes usage mistakes to be considered a hard error in accordance with #821. As a usage example I mostly converted CLuaCryptDefs to use the new style. 

## Supported Types:

- `bool`
- `int`, (todo: ushort, char, uchar)
- `std::string` (todo: SString?)
- `CLuaFunctionRef` (argument only)
- enums (with StringToEnum)
- Script entities (via UserDataCast) 
- `std::vector<T>` if T is supported (expects a table with consistent value types) (todo: as result)
- `std::unordered_map<K, V>` if K and V are supported (todo: as result)
- `std::optional<T>` if T is supported (expects either a T or nil/none) (todo: as result)
- `std::variant<Ts...>` if all Ts... are supported
- `nullptr` (return type only) to indicate `nil`

Additionally a lua_State* may be taken as an argument, which will be passed through directly. (We use that in some places to access things based on the running script VM)

## Restrictions:

- Currently this only supports default-constructible complex types. For example one can not read a `std::unique_ptr` (unlikely to change)
- ~~No full support for overloads yet. Using `std::variant` and `std::optional` we have some support for overloading, but a function that expects very different types is not fun to handle~~
- No vararg support (yet)

## Notes:
- See CLuaCryptDefs for usage examples
- Functions may throw a `std::invalid_argument` exception to indicate argument failures inside the functions. 
- This requires VS2019 on Windows with the v142 toolset (VS2017 does *not* work due to compiler bugs)

## Todos:

- [x] Add debug assertions for Lua stack manipulation (compare gettop vs the expected value)
- [x] Support additional types (see above, maybe more?)
- [x] Figure out a way to handle overloads nicely
- [x] Error messages are not generated yet
- [x] Test on Linux
- [x] Figure out why LuaBasic.h is detected as ObjectiveC by clang format (help?)
