### PR TITLE
Disable forboden programs checks in debug mode

### DIFF
--- a/Client/loader/Main.cpp
+++ b/Client/loader/Main.cpp
@@ -78,7 +78,7 @@ MTAEXPORT int DoWinMain(HINSTANCE hLauncherInstance, HINSTANCE hPrevInstance, LP
 
     // Stuff
     HandleCustomStartMessage();
-    #if !defined(MTA_DEBUG)
+    #ifndef MTA_DEBUG
         ForbodenProgramsMessage();
     #endif
     CycleEventLog();

--- a/Client/loader/Main.cpp
+++ b/Client/loader/Main.cpp
@@ -78,7 +78,9 @@ MTAEXPORT int DoWinMain(HINSTANCE hLauncherInstance, HINSTANCE hPrevInstance, LP
 
     // Stuff
     HandleCustomStartMessage();
-    ForbodenProgramsMessage();
+    #if !defined(MTA_DEBUG)
+        ForbodenProgramsMessage();
+    #endif
     CycleEventLog();
     BsodDetectionPreLaunch();
     MaybeShowCopySettingsDialog();


### PR DESCRIPTION
The problem:
Every time i use cheat engine in debug mode, and i restart mta i must save everything, close cheat engine, run mta and open cheat engine again. Simply waste of time.

![image](https://user-images.githubusercontent.com/22455534/59621285-4514eb00-912f-11e9-9afe-0aae9950a00f.png)
