### PR TITLE
Add reference counter increment/decrement on vehicle dummies changes

### DIFF
--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -955,6 +955,8 @@ void CModelInfoSA::SetVehicleDummyPosition(eVehicleDummies eDummy, const CVector
     if (iter == ms_ModelDefaultDummiesPosition.end())
     {
         ms_ModelDefaultDummiesPosition.insert({pVehicleModel, std::map<eVehicleDummies, CVector>()});
+        // Increment this model references count, so we don't unload it before we have a chance to reset the positions
+        m_pInterface->usNumberOfRefs++;
     }
 
     if (ms_ModelDefaultDummiesPosition[pVehicleModel].find(eDummy) == ms_ModelDefaultDummiesPosition[pVehicleModel].end())
@@ -976,6 +978,8 @@ void CModelInfoSA::ResetAllVehicleDummies()
             pVehicleModel->pVisualInfo->vecDummies[dummy.first] = dummy.second;
         }
         ms_ModelDefaultDummiesPosition[pVehicleModel].clear();
+        // Decrement reference counter, since we reverted all position changes, the model can be safely unloaded
+        info.first->usNumberOfRefs--;
     }
     ms_ModelDefaultDummiesPosition.clear();
 }


### PR DESCRIPTION
Should fix #1009 as per [this ](https://github.com/multitheftauto/mtasa-blue/issues/1009#issuecomment-506022817)Saml1er comment, the issue must have been present before the dummies altering ability was added, as the old system didn't change the reference counter either. Big thanks to @Saml1er for suggesting what could be the cause, as the crash has no easily reproducible reason, still can't be 100% sure if it's this, but can't think of anything else that could be causing it.