### PR TITLE
Fix of issue #992

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -795,14 +795,22 @@ int CLuaGUIDefs::GUICreateStaticImage(lua_State* luaVM)
             SString    strPath;
             if (CResourceManager::ParseResourcePathInput(path, pResource, &strPath))
             {
-                CClientGUIElement* pGUIElement = CStaticFunctionDefinitions::GUICreateStaticImage(*pLuaMain, position, size, strPath, relative, parent);
-                if (pGUIElement != NULL)
+                if (FileExists(strPath))
                 {
-                    lua_pushelement(luaVM, pGUIElement);
-                    return 1;
+                    CClientGUIElement* pGUIElement = CStaticFunctionDefinitions::GUICreateStaticImage(*pLuaMain, position, size, strPath, relative, parent);
+                    if (pGUIElement != NULL)
+                    {
+                        lua_pushelement(luaVM, pGUIElement);
+                        return 1;
+                    }
+                    else
+                        argStream.SetCustomError(path, "Failed to create static image");
                 }
+                else 
+                    argStream.SetCustomError(path, "File not found");
             }
-            argStream.SetCustomError(path, "Bad file path");
+            else
+                argStream.SetCustomError(path, "Bad file path");
         }
     }
     if (argStream.HasErrors())

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -798,7 +798,7 @@ int CLuaGUIDefs::GUICreateStaticImage(lua_State* luaVM)
                 if (FileExists(strPath))
                 {
                     CClientGUIElement* pGUIElement = CStaticFunctionDefinitions::GUICreateStaticImage(*pLuaMain, position, size, strPath, relative, parent);
-                    if (pGUIElement != NULL)
+                    if (pGUIElement != nullptr)
                     {
                         lua_pushelement(luaVM, pGUIElement);
                         return 1;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -795,11 +795,13 @@ int CLuaGUIDefs::GUICreateStaticImage(lua_State* luaVM)
             if (CResourceManager::ParseResourcePathInput(path, pResource, &strPath))
             {
                 CClientGUIElement* pGUIElement = CStaticFunctionDefinitions::GUICreateStaticImage(*pLuaMain, position, size, strPath, relative, parent);
-                lua_pushelement(luaVM, pGUIElement);
-                return 1;
+                if (pGUIElement != NULL)
+                {
+                    lua_pushelement(luaVM, pGUIElement);
+                    return 1;
+                }
             }
-            else
-                argStream.SetCustomError(path, "Bad file path");
+            argStream.SetCustomError(path, "Bad file path");
         }
     }
     if (argStream.HasErrors())


### PR DESCRIPTION
It fix issue #992, now guiCreateStaticImage throw warning if image don't exists

Also this will throw error for default admin panel due path `gui\\images\\dot.png` is wrong, correct is `client\\images\\dot.png` 

![image](https://user-images.githubusercontent.com/22455534/62555029-7e85ef00-b872-11e9-9dd1-a039e5277f9c.png)

```lua
guiCreateStaticImage(0.35, 0.68, 0.1, 0.1, "consider.png", true)
guiCreateStaticImage(0.35, 0.78, 0.1, 0.1, "invalidImage.png", true) // throw error
```

Full test resource:
[static image.zip](https://github.com/multitheftauto/mtasa-blue/files/3473065/static.image.zip)
