### PR TITLE
Upgrade radar image quality

### DIFF
--- a/Client/mods/deathmatch/logic/CRadarMap.cpp
+++ b/Client/mods/deathmatch/logic/CRadarMap.cpp
@@ -56,7 +56,7 @@ CRadarMap::CRadarMap(CClientManager* pManager)
 
     // Create the radar and local player blip images
     m_pRadarImage =
-        g_pCore->GetGraphics()->GetRenderItemManager()->CreateTexture(CalcMTASAPath("MTA\\cgui\\images\\radar.jpg"), NULL, false, 1024, 1024, RFORMAT_DXT1);
+        g_pCore->GetGraphics()->GetRenderItemManager()->CreateTexture(CalcMTASAPath("MTA\\cgui\\images\\radar.jpg"), NULL, false, 6000, 6000, RFORMAT_DXT1);
     m_pLocalPlayerBlip = g_pCore->GetGraphics()->GetRenderItemManager()->CreateTexture(CalcMTASAPath("MTA\\cgui\\images\\radarset\\02.png"));
 
     // Create the marker textures


### PR DESCRIPTION
This PR replaces the radar image with a higher quality one, the size of which is 6000x6000. This is the highest resolution version of this image that I could find.
The file size is considerably larger, however the benefit is that you can use the zoom-in feature and still view the map in detail.

Here are some comparisons:
![2](https://user-images.githubusercontent.com/11979849/62876857-8809ce00-bd2e-11e9-9061-015460d3e2cd.png)
![1](https://user-images.githubusercontent.com/11979849/62876858-8809ce00-bd2e-11e9-8975-eac4a23efb6a.png)
