### PR TITLE
Fix mem leak in LuaManager

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -47,6 +47,9 @@ CLuaManager::~CLuaManager()
         delete (*iter);
     }
 
+	// Close and remove LVM from memory
+	ProcessPendingDeleteList();
+
     // Clear the C functions
     CLuaCFunctions::RemoveAllFunctions();
 }


### PR DESCRIPTION
After disconnecting from the server, the CLuaManager should cleanup LuaVM, but does not


_With love from NEXTRP Team_