### PR TITLE
WIP: Make the quick connect button a reconnect button

### DIFF
--- a/Client/core/CMainMenu.cpp
+++ b/Client/core/CMainMenu.cpp
@@ -853,15 +853,9 @@ bool CMainMenu::OnQuickConnectButtonClick(CGUIElement* pElement)
     if (m_ucFade != FADE_VISIBLE)
         return false;
 
-    m_ServerBrowser.SetVisible(true);
-    m_ServerBrowser.OnQuickConnectButtonClick();
-    /*
-    //    if ( !m_bIsInSubWindow )
-        {
-            m_QuickConnect.SetVisible ( true );
-    //        m_bIsInSubWindow = true;
-        }
-    */
+    // TODO(qaisjp): refactor out of CCommandFuncs::Reconnect
+    CCommandFuncs::Reconnect(nullptr);
+
     return true;
 }
 

--- a/Client/core/ServerBrowser/CServerBrowser.cpp
+++ b/Client/core/ServerBrowser/CServerBrowser.cpp
@@ -56,7 +56,6 @@ CServerBrowser::CServerBrowser()
     m_PrevServerBrowserType = ServerBrowserTypes::INTERNET;
 
     m_bFocusTextEdit = false;
-    m_uiShownQuickConnectHelpCount = 0;
     m_uiIsUsingTempTab = 0;
     m_BeforeTempServerBrowserType = ServerBrowserTypes::INTERNET;
     m_llLastGeneralHelpTime = 0;
@@ -160,41 +159,6 @@ CServerBrowser::CServerBrowser()
     CVector2D helpPos;
     helpPos.fX = resolution.fX * (512 / 1024.f);
     helpPos.fY = widgetPosition.fY + (115 - 58);
-
-    m_pQuickConnectHelpWindow = reinterpret_cast<CGUIWindow*>(pManager->CreateWnd(NULL, ""));
-    m_pQuickConnectHelpWindow->SetMovable(false);
-    m_pQuickConnectHelpWindow->SetPosition(helpPos);
-    m_pQuickConnectHelpWindow->SetSize(CVector2D(320, 150));
-    m_pQuickConnectHelpWindow->SetAlwaysOnTop(true);
-    m_pQuickConnectHelpWindow->SetFrameEnabled(false);
-    m_pQuickConnectHelpWindow->SetTitlebarEnabled(false);
-    m_pQuickConnectHelpWindow->SetCloseButtonEnabled(false);
-    m_pQuickConnectHelpWindow->SetVisible(false);
-
-    // Quick connect help label
-    {
-        CGUILabel* pLabel = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(m_pQuickConnectHelpWindow, ""));
-        pLabel->SetPosition(CVector2D(5, 0));
-        pLabel->SetSize(CVector2D(310, 150));
-        pLabel->SetVerticalAlign(CGUI_ALIGN_VERTICALCENTER);
-        pLabel->SetHorizontalAlign(CGUI_ALIGN_HORIZONTALCENTER_WORDWRAP);
-        pLabel->SetProperty("BackgroundEnabled", "True");
-
-        // Create second slightly smaller label so wrapped text looks better
-        pLabel = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(m_pQuickConnectHelpWindow, ""));
-        pLabel->SetPosition(CVector2D(5 + 10, 0));
-        pLabel->SetSize(CVector2D(310 - 10 * 2, 150));
-        pLabel->SetVerticalAlign(CGUI_ALIGN_VERTICALCENTER);
-        pLabel->SetHorizontalAlign(CGUI_ALIGN_HORIZONTALCENTER_WORDWRAP);
-
-        SString strHelpMessage =
-            _("FOR QUICK CONNECT:\n"
-              "\n"
-              "Type the address and port into the address bar.\n"
-              "Or select a server from the history list and press 'Connect'");
-
-        pLabel->SetText(strHelpMessage);
-    }
 
     // General help
     CVector2D helpButtonSize = m_pButtonGeneralHelp[0]->GetSize();
@@ -759,7 +723,6 @@ void CServerBrowser::SetVisible(bool bVisible)
     {
         // Hide information windows.
         m_pGeneralHelpWindow->SetVisible(false);
-        m_pQuickConnectHelpWindow->SetVisible(false);
         CServerInfo::GetSingletonPtr()->Hide();
     }
 }
@@ -1422,9 +1385,6 @@ bool CServerBrowser::OnHistorySelected(CGUIElement* pElement)
 
 bool CServerBrowser::OnHistoryDropListRemove(CGUIElement* pElementx)
 {
-    // Hide quick connect help if visible
-    m_pQuickConnectHelpWindow->SetVisible(false);
-
     // Grab our cursor position
     tagPOINT cursor;
     GetCursorPos(&cursor);
@@ -2196,13 +2156,6 @@ void CServerBrowser::SetNextHistoryText(bool bDown)
 
 void CServerBrowser::OnQuickConnectButtonClick()
 {
-    // Show help text
-    if (m_uiShownQuickConnectHelpCount < 1)
-    {
-        m_pQuickConnectHelpWindow->SetVisible(true);
-        m_pQuickConnectHelpWindow->BringToFront();
-        m_uiShownQuickConnectHelpCount++;
-    }
 
     // Switch to LAN tab, but don't save it as selected
     if (!m_uiIsUsingTempTab)

--- a/Client/core/ServerBrowser/CServerBrowser.h
+++ b/Client/core/ServerBrowser/CServerBrowser.h
@@ -250,10 +250,8 @@ private:
     std::map<SString, int> m_blockedVersionMap;
     std::map<SString, int> m_allowedVersionMap;
 
-    CGUIWindow* m_pQuickConnectHelpWindow;
     bool        m_bFocusTextEdit;
 
-    uint              m_uiShownQuickConnectHelpCount;
     uint              m_uiIsUsingTempTab;
     ServerBrowserType m_BeforeTempServerBrowserType;
     CGUIWindow*       m_pGeneralHelpWindow;


### PR DESCRIPTION
Someone said:

![image](https://user-images.githubusercontent.com/923242/63641961-2000a380-c6af-11e9-9d20-72fffff47633.png)

Currently that button only opens the Server Browser and says "_yo, you can copy it into the box up here_".

It's a relic from when the quick connect button used to open a small window and ask you for the host/port.

So now the button simply reconnects.