### PR TITLE
Increase max characters for kick and ban reason to 128

### DIFF
--- a/Client/mods/deathmatch/logic/Config.h
+++ b/Client/mods/deathmatch/logic/Config.h
@@ -84,14 +84,6 @@ public:
 #define MIN_DISCONNECT_REASON_LENGTH 1
 #define MAX_DISCONNECT_REASON_LENGTH 127
 
-// Max kick string length that can be sent
-#define MIN_KICK_REASON_LENGTH 1
-#define MAX_KICK_REASON_LENGTH 64
-
-// Max ban string length that can be sent
-#define MIN_BAN_REASON_LENGTH 1
-#define MAX_BAN_REASON_LENGTH 64
-
 // Couple of defines to ensure proper configuration
 #if MAX_CHAT_LENGTH > 255
     #error MAX_CHAT_LENGTH "macro can't exceed 255"

--- a/Server/mods/deathmatch/Config.h
+++ b/Server/mods/deathmatch/Config.h
@@ -94,12 +94,12 @@ public:
 
 // Max kick string length that can be sent
 #define MIN_KICK_REASON_LENGTH      1
-#define MAX_KICK_REASON_LENGTH      64
+#define MAX_KICK_REASON_LENGTH      128
 #define MAX_KICK_RESPONSIBLE_LENGTH 30
 
 // Max ban string length that can be sent
 #define MIN_BAN_REASON_LENGTH      1
-#define MAX_BAN_REASON_LENGTH      64
+#define MAX_BAN_REASON_LENGTH      128
 #define MAX_BAN_RESPONSIBLE_LENGTH 30
 
 // Couple of defines to ensure proper configuration


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/8400907/64480586-a3031d00-d1ca-11e9-8c30-fca5f7c817b0.png)
After:
![image](https://user-images.githubusercontent.com/8400907/64480588-ae564880-d1ca-11e9-973a-74d771b368c7.png)

Fixes #1068