### PR TITLE
ci: upload windows build to nightlytest page

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,6 +61,7 @@ jobs:
   pool:
     vmImage: 'ubuntu-latest'
   dependsOn: windows
+  condition: ne(variables['Build.Reason'], 'PullRequest')
   variables:
     MTA_WINDOWS_ARTIFACT: 'Windows'
     INSTALL_ZIP_FILE: '$(Pipeline.Workspace)/$(MTA_WINDOWS_ARTIFACT)/InstallFiles.zip'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,5 +70,5 @@ jobs:
   - download: current
     artifact: $(MTA_WINDOWS_ARTIFACT)
     displayName: 'Fetch installation files for Windows'
-  - script: curl -i -F "branch_name=$(REPO_BRANCH)" -F "commit_hash=$(REPO_COMMIT_HASH)" -F "commit_title=$(REPO_COMMIT_TITLE)" -F build_type=$(BUILD_TYPE) -F "secret=$(UPLOAD_SECRET)" -F build_upload=@$(INSTALL_ZIP_FILE) $(NIGHTLY_API)
+  - script: curl -i -F "branch_name=$(REPO_BRANCH)" -F "commit_hash=$(REPO_COMMIT_HASH)" -F "commit_title=$(REPO_COMMIT_TITLE)" -F "build_type=$(BUILD_TYPE)" -F "secret=$(UPLOAD_SECRET)" -F "build_upload=@$(INSTALL_ZIP_FILE)" $(NIGHTLY_API)
     displayName: 'Upload zip file to MTA builds'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,12 @@ resources:
   containers:
   - container: ci
     image: sbx320/mtasa-blue-azure:latest
+    
+variables:
+  REPO_BRANCH: '$(Build.SourceBranchName)'
+  REPO_COMMIT_HASH: '$(Build.SourceVersion)'
+  REPO_COMMIT_TITLE: '$(Build.SourceVersionMessage)'
+  NIGHTLY_API: 'https://nightlytest.mtasa.com/api/upload'
 
 jobs:
 - job: macOS
@@ -43,3 +49,25 @@ jobs:
     inputs:
       solution: '$(solution)'
       configuration: '$(buildConfiguration)'
+  - script: utils\premake5 compose_files
+    displayName: 'Compose installation files'
+  - script: 7z a InstallFiles.zip InstallFiles
+    displayName: 'Compress installation files'
+  - publish: $(System.DefaultWorkingDirectory)/InstallFiles.zip
+    artifact: Windows
+    displayName: 'Save installation files'
+  
+- job: windows_deployment
+  pool:
+    vmImage: 'ubuntu-latest'
+  dependsOn: windows
+  variables:
+    MTA_WINDOWS_ARTIFACT: 'Windows'
+    INSTALL_ZIP_FILE: '$(Pipeline.Workspace)/$(MTA_WINDOWS_ARTIFACT)/InstallFiles.zip'
+    BUILD_TYPE: 'windows32'
+  steps:
+  - download: current
+    artifact: $(MTA_WINDOWS_ARTIFACT)
+    displayName: 'Fetch installation files for Windows'
+  - script: curl -i -F "branch_name=$(REPO_BRANCH)" -F "commit_hash=$(REPO_COMMIT_HASH)" -F "commit_title=$(REPO_COMMIT_TITLE)" -F build_type=$(BUILD_TYPE) -F "secret=$(UPLOAD_SECRET)" -F build_upload=@$(INSTALL_ZIP_FILE) $(NIGHTLY_API)
+    displayName: 'Upload zip file to MTA builds'


### PR DESCRIPTION
It needs to set up environment variable `UPLOAD_SECRET` in azure pipeline