### PR TITLE
Add getElementOffsetPosition function

### DIFF
--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -369,6 +369,14 @@ bool CStaticFunctionDefinitions::GetElementPosition(CClientEntity& Entity, CVect
     return true;
 }
 
+bool CStaticFunctionDefinitions::GetElementOffsetPosition(CClientEntity& Entity, CVector vecOffset, CVector& vecPosition)
+{
+    CMatrix matrix;
+    Entity.GetMatrix(matrix);
+    vecPosition = matrix.TransformVector(vecOffset);
+    return true;
+}
+
 bool CStaticFunctionDefinitions::GetElementRotation(CClientEntity& Entity, CVector& vecRotation, eEulerRotationOrder desiredRotOrder)
 {
     int iType = Entity.GetType();

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -56,6 +56,7 @@ public:
     static CClientEntity* GetElementChild(CClientEntity& Entity, unsigned int uiIndex);
     static bool           GetElementMatrix(CClientEntity& Entity, CMatrix& matrix);
     static bool           GetElementPosition(CClientEntity& Entity, CVector& vecPosition);
+    static bool           GetElementOffsetPosition(CClientEntity& Entity, CVector vecOffset, CVector& vecPosition);
     static bool           GetElementRotation(CClientEntity& Entity, CVector& vecRotation, eEulerRotationOrder rotationOrder);
     static bool           GetElementVelocity(CClientEntity& Entity, CVector& vecVelocity);
     static bool           GetElementTurnVelocity(CClientEntity& Entity, CVector& vecTurnVelocity);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -25,6 +25,7 @@ void CLuaElementDefs::LoadFunctions()
         {"getElementData", GetElementData},
         {"getElementMatrix", GetElementMatrix},
         {"getElementPosition", GetElementPosition},
+        {"getElementOffsetPosition", GetElementOffsetPosition},
         {"getElementRotation", GetElementRotation},
         {"getElementVelocity", GetElementVelocity},
         {"getElementAngularVelocity", GetElementTurnVelocity},
@@ -142,6 +143,7 @@ void CLuaElementDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getParent", "getElementParent");
     lua_classfunction(luaVM, "getBoundingBox", OOP_GetElementBoundingBox);
     lua_classfunction(luaVM, "getPosition", OOP_GetElementPosition);
+    lua_classfunction(luaVM, "getOffsetPosition", OOP_GetElementOffsetPosition);
     lua_classfunction(luaVM, "getRotation", OOP_GetElementRotation);
     lua_classfunction(luaVM, "getMatrix", OOP_GetElementMatrix);
     lua_classfunction(luaVM, "getVelocity", OOP_GetElementVelocity);
@@ -488,6 +490,64 @@ int CLuaElementDefs::GetElementPosition(lua_State* luaVM)
             lua_pushnumber(luaVM, vecPosition.fY);
             lua_pushnumber(luaVM, vecPosition.fZ);
             return 3;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    // Failed
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaElementDefs::GetElementOffsetPosition(lua_State* luaVM)
+{
+    // Verify the argument
+    CClientEntity*   pEntity = NULL;
+    CVector          vecOffset;
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pEntity);
+    argStream.ReadVector3D(vecOffset);
+
+    if (!argStream.HasErrors())
+    {
+        // Grab the position
+        CVector vecPosition;
+        if (CStaticFunctionDefinitions::GetElementOffsetPosition(*pEntity, vecOffset, vecPosition))
+        {
+            // Return it
+            lua_pushnumber(luaVM, vecPosition.fX);
+            lua_pushnumber(luaVM, vecPosition.fY);
+            lua_pushnumber(luaVM, vecPosition.fZ);
+            return 3;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    // Failed
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaElementDefs::OOP_GetElementOffsetPosition(lua_State* luaVM)
+{
+    // Verify the argument
+    CClientEntity*   pEntity = NULL;
+    CVector          vecOffset;
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pEntity);
+    argStream.ReadVector3D(vecOffset);
+
+    if (!argStream.HasErrors())
+    {
+        // Grab the position
+        CVector vecPosition;
+        if (CStaticFunctionDefinitions::GetElementOffsetPosition(*pEntity, vecOffset, vecPosition))
+        {
+            // Return it
+            lua_pushvector(luaVM, vecPosition);
+            return 1;
         }
     }
     else

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
@@ -30,6 +30,7 @@ public:
     LUA_DECLARE(GetElementParent);
     LUA_DECLARE_OOP(GetElementMatrix);
     LUA_DECLARE_OOP(GetElementPosition);
+    LUA_DECLARE_OOP(GetElementOffsetPosition);
     LUA_DECLARE_OOP(GetElementRotation);
     LUA_DECLARE_OOP(GetElementVelocity);
     LUA_DECLARE_OOP(GetElementTurnVelocity);

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -983,6 +983,14 @@ bool CStaticFunctionDefinitions::GetElementPosition(CElement* pElement, CVector&
     return true;
 }
 
+bool CStaticFunctionDefinitions::GetElementOffsetPosition(CElement* pElement, const CVector& vecOffset, CVector& vecPosition)
+{
+    CMatrix matrix;
+    pElement->GetMatrix(matrix);
+    vecPosition = matrix.TransformVector(vecOffset);
+    return true;
+}
+
 bool CStaticFunctionDefinitions::GetElementRotation(CElement* pElement, CVector& vecRotation, eEulerRotationOrder desiredRotOrder)
 {
     assert(pElement);

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -48,6 +48,7 @@ public:
     static CElement*      GetElementParent(CElement* pElement);
     static bool           GetElementMatrix(CElement* pElement, CMatrix& matrix);
     static bool           GetElementPosition(CElement* pElement, CVector& vecPosition);
+    static bool           GetElementOffsetPosition(CElement* pElement, const CVector& vecOffset, CVector& vecPosition);
     static bool           GetElementRotation(CElement* pElement, CVector& vecRotation, eEulerRotationOrder rotationOrder);
     static bool           GetElementVelocity(CElement* pElement, CVector& vecVelocity);
     static bool           GetElementTurnVelocity(CElement* pElement, CVector& vecTurnVelocity);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -39,6 +39,7 @@ void CLuaElementDefs::LoadFunctions()
         {"getElementParent", getElementParent},
         {"getElementMatrix", getElementMatrix},
         {"getElementPosition", getElementPosition},
+        {"getElementOffsetPosition", getElementOffsetPosition},
         {"getElementRotation", getElementRotation},
         {"getElementVelocity", getElementVelocity},
         {"getElementAngularVelocity", getElementTurnVelocity},
@@ -161,6 +162,7 @@ void CLuaElementDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getColShape", "getElementColShape");
     lua_classfunction(luaVM, "getData", "getElementData");
     lua_classfunction(luaVM, "getPosition", "getElementPosition", OOP_getElementPosition);
+    lua_classfunction(luaVM, "getOffsetPosition", "getElementOffsetPosition", OOP_getElementOffsetPosition);
     lua_classfunction(luaVM, "getRotation", "getElementRotation", OOP_getElementRotation);
     lua_classfunction(luaVM, "getMatrix", "getElementMatrix", OOP_getElementMatrix);
     lua_classfunction(luaVM, "getType", "getElementType");
@@ -603,6 +605,62 @@ int CLuaElementDefs::getElementPosition(lua_State* luaVM)
             lua_pushnumber(luaVM, vecPosition.fY);
             lua_pushnumber(luaVM, vecPosition.fZ);
             return 3;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaElementDefs::getElementOffsetPosition(lua_State* luaVM)
+{
+    //  float, float, float getElementOffsetPosition ( element theElement, float x, float y, float z )
+    CElement*        pElement;
+    CVector          vecOffset;
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pElement);
+    argStream.ReadVector3D(vecOffset);
+
+    if (!argStream.HasErrors())
+    {
+        // Grab the position
+        CVector vecPosition;
+        if (CStaticFunctionDefinitions::GetElementOffsetPosition(pElement, vecOffset, vecPosition))
+        {
+            // Return it
+            lua_pushnumber(luaVM, vecPosition.fX);
+            lua_pushnumber(luaVM, vecPosition.fY);
+            lua_pushnumber(luaVM, vecPosition.fZ);
+            return 3;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaElementDefs::OOP_getElementOffsetPosition(lua_State* luaVM)
+{
+    //  float, float, float getElementOffsetPosition ( element theElement, float x, float y, float z )
+    CElement*        pElement;
+    CVector          vecOffset;
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pElement);
+    argStream.ReadVector3D(vecOffset);
+
+    if (!argStream.HasErrors())
+    {
+        // Grab the position
+        CVector vecPosition;
+        if (CStaticFunctionDefinitions::GetElementOffsetPosition(pElement, vecOffset, vecPosition))
+        {
+            // Return it
+            lua_pushvector(luaVM, vecPosition);
+            return 1;
         }
     }
     else

--- a/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
@@ -38,6 +38,7 @@ public:
     LUA_DECLARE(getElementParent);
     LUA_DECLARE_OOP(getElementMatrix);
     LUA_DECLARE_OOP(getElementPosition);
+    LUA_DECLARE_OOP(getElementOffsetPosition);
     LUA_DECLARE_OOP(getElementRotation);
     LUA_DECLARE_OOP(getElementVelocity);
     LUA_DECLARE_OOP(getElementTurnVelocity);


### PR DESCRIPTION
function: `x,y,z = getElementOffsetPosition( element, offsetX, offsetY, offsetZ)`
oop: `vector3 = element:getOffsetPosition( offsetX, offsetY, offsetZ)`
It is the "useful function" getOffsetFromXYZ already availiable at wiki https://wiki.multitheftauto.com/wiki/GetOffsetFromXYZ.

I propose to add this function due is commonly used on many servers and example on wiki not working without matrix class. It is also faster because of c++ implementation.

Test resource draws cross for each vehicle and object. download: [offsetposition.zip]
(https://github.com/multitheftauto/mtasa-blue/files/3748052/offsetposition.zip)

Green lines are from oop variant.
![image](https://user-images.githubusercontent.com/22455534/67162532-28025a00-f365-11e9-93ef-43f402f6187d.png)
