### PR TITLE
Update sqlite from 3.29.0 to 3.30.1

### DIFF
--- a/vendor/sqlite/sqlite3.h
+++ b/vendor/sqlite/sqlite3.h
@@ -123,9 +123,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.29.0"
-#define SQLITE_VERSION_NUMBER 3029000
-#define SQLITE_SOURCE_ID      "2019-07-10 17:32:03 fc82b73eaac8b36950e527f12c4b5dc1e147e6f4ad2217ae43ad82882a88bfa6"
+#define SQLITE_VERSION        "3.30.1"
+#define SQLITE_VERSION_NUMBER 3030001
+#define SQLITE_SOURCE_ID      "2019-10-10 20:19:45 18db032d058f1436ce3dea84081f4ee5a0f2259ad97301d43c426bc7f3df1b0b"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -2093,6 +2093,17 @@ struct sqlite3_mem_methods {
 ** following this call.  The second parameter may be a NULL pointer, in
 ** which case the trigger setting is not reported back. </dd>
 **
+** [[SQLITE_DBCONFIG_ENABLE_VIEW]]
+** <dt>SQLITE_DBCONFIG_ENABLE_VIEW</dt>
+** <dd> ^This option is used to enable or disable [CREATE VIEW | views].
+** There should be two additional arguments.
+** The first argument is an integer which is 0 to disable views,
+** positive to enable views or negative to leave the setting unchanged.
+** The second parameter is a pointer to an integer into which
+** is written 0 or 1 to indicate whether views are disabled or enabled
+** following this call.  The second parameter may be a NULL pointer, in
+** which case the view setting is not reported back. </dd>
+**
 ** [[SQLITE_DBCONFIG_ENABLE_FTS3_TOKENIZER]]
 ** <dt>SQLITE_DBCONFIG_ENABLE_FTS3_TOKENIZER</dt>
 ** <dd> ^This option is used to enable or disable the
@@ -2265,7 +2276,8 @@ struct sqlite3_mem_methods {
 #define SQLITE_DBCONFIG_LEGACY_ALTER_TABLE    1012 /* int int* */
 #define SQLITE_DBCONFIG_DQS_DML               1013 /* int int* */
 #define SQLITE_DBCONFIG_DQS_DDL               1014 /* int int* */
-#define SQLITE_DBCONFIG_MAX                   1014 /* Largest DBCONFIG */
+#define SQLITE_DBCONFIG_ENABLE_VIEW           1015 /* int int* */
+#define SQLITE_DBCONFIG_MAX                   1015 /* Largest DBCONFIG */
 
 /*
 ** CAPI3REF: Enable Or Disable Extended Result Codes
@@ -3814,7 +3826,7 @@ SQLITE_API int sqlite3_limit(sqlite3*, int id, int newVal);
 ** ^The specific value of WHERE-clause [parameter] might influence the 
 ** choice of query plan if the parameter is the left-hand side of a [LIKE]
 ** or [GLOB] operator or if the parameter is compared to an indexed column
-** and the [SQLITE_ENABLE_STAT3] compile-time option is enabled.
+** and the [SQLITE_ENABLE_STAT4] compile-time option is enabled.
 ** </li>
 ** </ol>
 **
@@ -4849,6 +4861,12 @@ SQLITE_API int sqlite3_reset(sqlite3_stmt *pStmt);
 ** perform additional optimizations on deterministic functions, so use
 ** of the [SQLITE_DETERMINISTIC] flag is recommended where possible.
 **
+** ^The fourth parameter may also optionally include the [SQLITE_DIRECTONLY]
+** flag, which if present prevents the function from being invoked from
+** within VIEWs or TRIGGERs.  For security reasons, the [SQLITE_DIRECTONLY]
+** flag is recommended for any application-defined SQL function that has
+** side-effects.
+**
 ** ^(The fifth parameter is an arbitrary pointer.  The implementation of the
 ** function can gain access to this pointer using [sqlite3_user_data()].)^
 **
@@ -4965,8 +4983,30 @@ SQLITE_API int sqlite3_create_window_function(
 ** [SQLITE_UTF8 | preferred text encoding] as the fourth argument
 ** to [sqlite3_create_function()], [sqlite3_create_function16()], or
 ** [sqlite3_create_function_v2()].
+**
+** The SQLITE_DETERMINISTIC flag means that the new function will always
+** maps the same inputs into the same output.  The abs() function is
+** deterministic, for example, but randomblob() is not.
+**
+** The SQLITE_DIRECTONLY flag means that the function may only be invoked
+** from top-level SQL, and cannot be used in VIEWs or TRIGGERs.  This is
+** a security feature which is recommended for all 
+** [application-defined SQL functions] that have side-effects.  This flag 
+** prevents an attacker from adding triggers and views to a schema then 
+** tricking a high-privilege application into causing unintended side-effects
+** while performing ordinary queries.
+**
+** The SQLITE_SUBTYPE flag indicates to SQLite that a function may call
+** [sqlite3_value_subtype()] to inspect the sub-types of its arguments.
+** Specifying this flag makes no difference for scalar or aggregate user
+** functions. However, if it is not specified for a user-defined window
+** function, then any sub-types belonging to arguments passed to the window
+** function may be discarded before the window function is called (i.e.
+** sqlite3_value_subtype() will always return 0).
 */
-#define SQLITE_DETERMINISTIC    0x800
+#define SQLITE_DETERMINISTIC    0x000000800
+#define SQLITE_DIRECTONLY       0x000080000
+#define SQLITE_SUBTYPE          0x000100000
 
 /*
 ** CAPI3REF: Deprecated Functions
@@ -6612,6 +6652,12 @@ struct sqlite3_index_info {
 ** ^The sqlite3_create_module()
 ** interface is equivalent to sqlite3_create_module_v2() with a NULL
 ** destructor.
+**
+** ^If the third parameter (the pointer to the sqlite3_module object) is
+** NULL then no new module is create and any existing modules with the
+** same name are dropped.
+**
+** See also: [sqlite3_drop_modules()]
 */
 SQLITE_API int sqlite3_create_module(
   sqlite3 *db,               /* SQLite connection to register module with */
@@ -6625,6 +6671,23 @@ SQLITE_API int sqlite3_create_module_v2(
   const sqlite3_module *p,   /* Methods for the module */
   void *pClientData,         /* Client data for xCreate/xConnect */
   void(*xDestroy)(void*)     /* Module destructor function */
+);
+
+/*
+** CAPI3REF: Remove Unnecessary Virtual Table Implementations
+** METHOD: sqlite3
+**
+** ^The sqlite3_drop_modules(D,L) interface removes all virtual
+** table modules from database connection D except those named on list L.
+** The L parameter must be either NULL or a pointer to an array of pointers
+** to strings where the array is terminated by a single NULL pointer.
+** ^If the L parameter is NULL, then all virtual table modules are removed.
+**
+** See also: [sqlite3_create_module()]
+*/
+SQLITE_API int sqlite3_drop_modules(
+  sqlite3 *db,                /* Remove modules from this connection */
+  const char **azKeep         /* Except, do not remove the ones named here */
 );
 
 /*
@@ -7335,7 +7398,7 @@ SQLITE_API int sqlite3_test_control(int op, ...);
 #define SQLITE_TESTCTRL_FIRST                    5
 #define SQLITE_TESTCTRL_PRNG_SAVE                5
 #define SQLITE_TESTCTRL_PRNG_RESTORE             6
-#define SQLITE_TESTCTRL_PRNG_RESET               7
+#define SQLITE_TESTCTRL_PRNG_RESET               7  /* NOT USED */
 #define SQLITE_TESTCTRL_BITVEC_TEST              8
 #define SQLITE_TESTCTRL_FAULT_INSTALL            9
 #define SQLITE_TESTCTRL_BENIGN_MALLOC_HOOKS     10
@@ -7358,7 +7421,9 @@ SQLITE_API int sqlite3_test_control(int op, ...);
 #define SQLITE_TESTCTRL_IMPOSTER                25
 #define SQLITE_TESTCTRL_PARSER_COVERAGE         26
 #define SQLITE_TESTCTRL_RESULT_INTREAL          27
-#define SQLITE_TESTCTRL_LAST                    27  /* Largest TESTCTRL */
+#define SQLITE_TESTCTRL_PRNG_SEED               28
+#define SQLITE_TESTCTRL_EXTRA_SCHEMA_CHECKS     29
+#define SQLITE_TESTCTRL_LAST                    29  /* Largest TESTCTRL */
 
 /*
 ** CAPI3REF: SQL Keyword Checking

--- a/vendor/sqlite/sqlite3ext.h
+++ b/vendor/sqlite/sqlite3ext.h
@@ -322,6 +322,8 @@ struct sqlite3_api_routines {
   /* Version 3.28.0 and later */
   int (*stmt_isexplain)(sqlite3_stmt*);
   int (*value_frombind)(sqlite3_value*);
+  /* Version 3.30.0 and later */
+  int (*drop_modules)(sqlite3*,const char**);
 };
 
 /*
@@ -614,6 +616,8 @@ typedef int (*sqlite3_loadext_entry)(
 /* Version 3.28.0 and later */
 #define sqlite3_stmt_isexplain         sqlite3_api->isexplain
 #define sqlite3_value_frombind         sqlite3_api->frombind
+/* Version 3.30.0 and later */
+#define sqlite3_drop_modules           sqlite3_api->drop_modules
 #endif /* !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION) */
 
 #if !defined(SQLITE_CORE) && !defined(SQLITE_OMIT_LOAD_EXTENSION)


### PR DESCRIPTION
## Summary
- Contains various additions and some other minor changes
- Changelogs
  - https://www.sqlite.org/changes.html#version_3_30_1
  - https://www.sqlite.org/changes.html#version_3_30_0

## Tests
Tested with [test_sqlite.zip](https://github.com/multitheftauto/mtasa-blue/files/2872064/test_sqlite.zip) (cheers @botder)

## Validation
To help validate the integrity of the update I have created the following bash script that diffs between my PR branch and the official package provided from the [SQLite website](https://www.sqlite.org/download.html).
```bash
#!/bin/bash

SQLITE_UPDATE_VERSION=3.30.1
SQLITE_PATH_NAME=sqlite-$SQLITE_UPDATE_VERSION

GIT_REPO_BRANCH=vendor/sqlite-$SQLITE_UPDATE_VERSION
GIT_REPO_URL=https://github.com/patrikjuvonen/mtasa-blue.git
GIT_DEST_DIR=mtasa-blue
GIT_REPO_SQLITE_PATH=$GIT_DEST_DIR/vendor/sqlite/

echo 1. Download and extract $SQLITE_PATH_NAME...
curl https://www.sqlite.org/2019/sqlite-autoconf-3300100.tar.gz | tar -xz

echo 2. Clone the vendor update branch $GIT_REPO_BRANCH from $GIT_REPO_URL into $GIT_DEST_DIR...
git clone --depth 1 -b $GIT_REPO_BRANCH $GIT_REPO_URL $GIT_DEST_DIR

echo 3. Start checking integrity...
diff -r $GIT_REPO_SQLITE_PATH sqlite-*

echo 4. Completed.
```

## Past SQLite updates in MTA
| Date | From | To | Link |
| :--- | :--- | :--- | :--- |
| August 2019 | 3.28.0 | 3.29.0 (current) | #1028 |
| May 2019 | 3.27.1 | 3.28.0 | #913 |
| February 2019 | 3.24.0 | 3.27.1 | #818 |
| July 2018 | 3.13.0 | 3.24.0 | #245 |
| August 2016 | 3.7.17 | 3.13.0 | 3aa17532867c66818cc3a602c4b1ac2143694066 |
| August 2013 | 3.7.8 | 3.7.17 | fd195b799498f75496fe0c15adac3cab3aecb639 |
| October 2011 | 3.6.14 | 3.7.8 | ca063630631d56d5ba9aba5bf6771fe0299f5a9f |

## Changelog
### 2019-10-11 (3.30.1)
- Fix a bug in the query flattener that might cause a segfault for nested queries that use the new FILTER clause on aggregate functions. Ticket 1079ad19993d13fa
- Cherrypick fixes for other obscure problems found since the 3.30.0 release

### 2019-10-04 (3.30.0)
- Add support for the FILTER clause on aggregate functions.
- Add support for the NULLS FIRST and NULLS LAST syntax in ORDER BY clauses.
- The index_info and index_xinfo pragmas are enhanced to provide information about the on-disk representation of WITHOUT ROWID tables.
- Add the sqlite3_drop_modules() interface, allowing applications to disable automatically loaded virtual tables that they do not need.
- Improvements to the .recover dot-command in the CLI so that it recovers more content from corrupt database files.
- Enhance the RBU extension to support indexes on expressions.
- Change the schema parser so that it will error out if any of the type, name, and tbl_name columns of the sqlite_master table have been corrupted and the database connection is not in writable_schema mode.
- The PRAGMA function_list, PRAGMA module_list, and PRAGMA pragma_list commands are now enabled in all builds by default. Disable them using -DSQLITE_OMIT_INTROSPECTION_PRAGMAS.
- Add the SQLITE_DBCONFIG_ENABLE_VIEW option for sqlite3_db_config().
- Added the TCL Interface config method in order to be able to disable SQLITE_DBCONFIG_ENABLE_VIEW as well as control other sqlite3_db_config() options from TCL.
- Added the SQLITE_DIRECTONLY flag for application-defined SQL functions to prevent those functions from being used inside triggers and views.
- The legacy SQLITE_ENABLE_STAT3 compile-time option is now a no-op.
