### PR TITLE
Add ability to get raw controller analog value

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPad.cpp
+++ b/Client/mods/deathmatch/logic/CClientPad.cpp
@@ -473,7 +473,7 @@ bool CClientPad::GetAnalogControlState(const char* szName, CControllerState& cs,
     unsigned int uiIndex;
     if (GetAnalogControlIndex(szName, uiIndex))
     {
-        // Do we have a script override?
+        // If we are not ignoring overrides and have a script override
         if (!bIgnoreOverrides && m_sScriptedStates[uiIndex] != CS_NAN)
             switch (uiIndex)
             {

--- a/Client/mods/deathmatch/logic/CClientPad.cpp
+++ b/Client/mods/deathmatch/logic/CClientPad.cpp
@@ -468,13 +468,13 @@ bool CClientPad::GetAnalogControlIndex(const char* szName, unsigned int& uiIndex
 }
 
 // Get the analog control state directly from a pad state.  Use for players.
-bool CClientPad::GetAnalogControlState(const char* szName, CControllerState& cs, bool bOnFoot, float& fState)
+bool CClientPad::GetAnalogControlState(const char* szName, CControllerState& cs, bool bOnFoot, float& fState, bool bIgnoreOverrides)
 {
     unsigned int uiIndex;
     if (GetAnalogControlIndex(szName, uiIndex))
     {
         // Do we have a script override?
-        if (m_sScriptedStates[uiIndex] != CS_NAN)
+        if (!bIgnoreOverrides && m_sScriptedStates[uiIndex] != CS_NAN)
             switch (uiIndex)
             {
                 case 0:

--- a/Client/mods/deathmatch/logic/CClientPad.h
+++ b/Client/mods/deathmatch/logic/CClientPad.h
@@ -34,7 +34,7 @@ public:
 
     void DoPulse(CClientPed* pPed);
 
-    static bool GetAnalogControlState(const char* szName, CControllerState& cs, bool bOnFoot, float& fState);
+    static bool GetAnalogControlState(const char* szName, CControllerState& cs, bool bOnFoot, float& fState, bool bIgnoreOverrides);
     static bool SetAnalogControlState(const char* szName, float fState);
     static void RemoveSetAnalogControlState(const char* szName);
 

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -214,6 +214,7 @@ void CClientPed::Init(CClientManager* pManager, unsigned long ulModelID, bool bI
         m_remoteDataStorage = NULL;
         m_shotSyncData = g_pMultiplayer->GetLocalShotSyncData();
         m_currentControllerState = NULL;
+        m_rawControllerState = CControllerState();
         m_lastControllerState = NULL;
         m_stats = NULL;
 
@@ -233,6 +234,7 @@ void CClientPed::Init(CClientManager* pManager, unsigned long ulModelID, bool bI
         m_remoteDataStorage->SetProcessPlayerWeapon(true);
         m_shotSyncData = m_remoteDataStorage->ShotSyncData();
         m_currentControllerState = m_remoteDataStorage->CurrentControllerState();
+        m_rawControllerState = CControllerState();
         m_lastControllerState = m_remoteDataStorage->LastControllerState();
         m_stats = m_remoteDataStorage->Stats();
         // ### remember if you want to set Int flags, subtract STATS_OFFSET from the enum ID ###
@@ -2652,6 +2654,7 @@ void CClientPed::StreamedInPulse(bool bDoStandardPulses)
             // ControllerState checks and fixes only
             CControllerState Current;
             GetControllerState(Current);
+            m_rawControllerState = Current;
 
             ApplyControllerStateFixes(Current);
 
@@ -2686,6 +2689,7 @@ void CClientPed::StreamedInPulse(bool bDoStandardPulses)
 
         CControllerState Current;
         GetControllerState(Current);
+        m_rawControllerState = Current;
 
         if (bDoControllerStateFixPulse)
             ApplyControllerStateFixes(Current);

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -573,7 +573,7 @@ public:
     CStatsData*                              m_stats;
     CControllerState*                        m_currentControllerState;
     CControllerState*                        m_lastControllerState;
-    CControllerState                         m_rawControllerState;
+    CControllerState                         m_rawControllerState; // copy of lastControllerState before CClientPed::ApplyControllerStateFixes is applied (modifies states to prevent stuff like rapid input glitch)
     CRemoteDataStorage*                      m_remoteDataStorage;
     unsigned long                            m_ulLastTimeFired;
     unsigned long                            m_ulLastTimeBeganAiming;

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -573,6 +573,7 @@ public:
     CStatsData*                              m_stats;
     CControllerState*                        m_currentControllerState;
     CControllerState*                        m_lastControllerState;
+    CControllerState                         m_rawControllerState;
     CRemoteDataStorage*                      m_remoteDataStorage;
     unsigned long                            m_ulLastTimeFired;
     unsigned long                            m_ulLastTimeBeganAiming;

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1638,7 +1638,7 @@ bool CStaticFunctionDefinitions::GetPedControlState(CClientPed& Ped, const char*
         // Check it's Analog
         if (CClientPad::GetAnalogControlIndex(szControl, uiIndex))
         {
-            if (CClientPad::GetAnalogControlState(szControl, cs, bOnFoot, fState))
+            if (CClientPad::GetAnalogControlState(szControl, cs, bOnFoot, fState, false))
             {
                 bState = fState > 0;
                 return true;
@@ -1660,7 +1660,7 @@ bool CStaticFunctionDefinitions::GetPedControlState(CClientPed& Ped, const char*
     return false;
 }
 
-bool CStaticFunctionDefinitions::GetPedAnalogControlState(CClientPed& Ped, const char* szControl, float& fState)
+bool CStaticFunctionDefinitions::GetPedAnalogControlState(CClientPed& Ped, const char* szControl, float& fState, bool bRawInput)
 {
     if (Ped.GetType() == CCLIENTPLAYER)
     {
@@ -1668,9 +1668,13 @@ bool CStaticFunctionDefinitions::GetPedAnalogControlState(CClientPed& Ped, const
         Ped.GetControllerState(cs);
         bool         bOnFoot = (!Ped.GetRealOccupiedVehicle());
         unsigned int uiIndex;
+
+        if (bRawInput)
+            cs = Ped.m_rawControllerState;
+
         // check it's analog or use binary.
         if (CClientPad::GetAnalogControlIndex(szControl, uiIndex))
-            CClientPad::GetAnalogControlState(szControl, cs, bOnFoot, fState);
+            CClientPad::GetAnalogControlState(szControl, cs, bOnFoot, fState, bRawInput);
         else
             fState = CClientPad::GetControlState(szControl, cs, bOnFoot) == true ? 1.0f : 0.0f;
 
@@ -6986,7 +6990,7 @@ bool CStaticFunctionDefinitions::GetControlState(const char* szControl, bool& bS
 
     float fState;
     // Analog
-    if (CStaticFunctionDefinitions::GetAnalogControlState(szControl, fState))
+    if (CStaticFunctionDefinitions::GetAnalogControlState(szControl, fState, false))
     {
         bState = fState > 0;
         return true;
@@ -7005,13 +7009,17 @@ bool CStaticFunctionDefinitions::GetControlState(const char* szControl, bool& bS
     return false;
 }
 
-bool CStaticFunctionDefinitions::GetAnalogControlState(const char* szControl, float& fState)
+bool CStaticFunctionDefinitions::GetAnalogControlState(const char* szControl, float& fState, bool bRawInput)
 {
     CControllerState cs;
     CClientPlayer*   pLocalPlayer = m_pPlayerManager->GetLocalPlayer();
     pLocalPlayer->GetControllerState(cs);
     bool bOnFoot = (!pLocalPlayer->GetRealOccupiedVehicle());
-    if (CClientPad::GetAnalogControlState(szControl, cs, bOnFoot, fState))
+
+    if (bRawInput)
+        cs = pLocalPlayer->m_rawControllerState;
+
+    if (CClientPad::GetAnalogControlState(szControl, cs, bOnFoot, fState, bRawInput))
     {
         return true;
     }

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1665,12 +1665,13 @@ bool CStaticFunctionDefinitions::GetPedAnalogControlState(CClientPed& Ped, const
     if (Ped.GetType() == CCLIENTPLAYER)
     {
         CControllerState cs;
-        Ped.GetControllerState(cs);
         bool         bOnFoot = (!Ped.GetRealOccupiedVehicle());
         unsigned int uiIndex;
 
         if (bRawInput)
-            cs = Ped.m_rawControllerState;
+            cs = Ped.m_rawControllerState; // use the raw controller values without MTA glitch fixes modifying our raw inputs
+        else
+            Ped.GetControllerState(cs);
 
         // check it's analog or use binary.
         if (CClientPad::GetAnalogControlIndex(szControl, uiIndex))
@@ -7013,11 +7014,12 @@ bool CStaticFunctionDefinitions::GetAnalogControlState(const char* szControl, fl
 {
     CControllerState cs;
     CClientPlayer*   pLocalPlayer = m_pPlayerManager->GetLocalPlayer();
-    pLocalPlayer->GetControllerState(cs);
     bool bOnFoot = (!pLocalPlayer->GetRealOccupiedVehicle());
 
     if (bRawInput)
-        cs = pLocalPlayer->m_rawControllerState;
+        cs = pLocalPlayer->m_rawControllerState; // use the raw controller values without MTA glitch fixes modifying our raw inputs
+    else
+        pLocalPlayer->GetControllerState(cs);
 
     if (CClientPad::GetAnalogControlState(szControl, cs, bOnFoot, fState, bRawInput))
     {

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -139,7 +139,7 @@ public:
     static bool           GetPedBonePosition(CClientPed& Ped, eBone bone, CVector& vecPosition);
     static bool           GetPedClothes(CClientPed& Ped, unsigned char ucType, SString& strOutTexture, SString& strOutModel);
     static bool           GetPedControlState(CClientPed& Ped, const char* szControl, bool& bState);
-    static bool           GetPedAnalogControlState(CClientPed& Ped, const char* szControl, float& fState);
+    static bool           GetPedAnalogControlState(CClientPed& Ped, const char* szControl, float& fState, bool bRawInput);
     static bool           IsPedDoingGangDriveby(CClientPed& Ped, bool& bDoingGangDriveby);
     static bool           GetPedFightingStyle(CClientPed& Ped, unsigned char& ucStyle);
     static bool           GetPedAnimation(CClientPed& Ped, SString& strOutBlockName, SString& strOutAnimName);
@@ -643,7 +643,7 @@ public:
     static bool UnbindKey(const char* szKey, const char* szHitState, const char* szCommandName, const char* szResource);
     static bool GetKeyState(const char* szKey, bool& bState);
     static bool GetControlState(const char* szControl, bool& bState);
-    static bool GetAnalogControlState(const char* szControl, float& fState);
+    static bool GetAnalogControlState(const char* szControl, float& fState, bool bRawInput);
     static bool IsControlEnabled(const char* szControl, bool& bEnabled);
 
     static bool SetControlState(const char* szControl, bool bState);

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Input.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Input.cpp
@@ -278,13 +278,15 @@ int CLuaFunctionDefs::GetKeyState(lua_State* luaVM)
 int CLuaFunctionDefs::GetAnalogControlState(lua_State* luaVM)
 {
     SString          strControlState = "";
+    bool             bRawInput;
     CScriptArgReader argStream(luaVM);
     argStream.ReadString(strControlState);
+    argStream.ReadBool(bRawInput, false);
 
     if (!argStream.HasErrors())
     {
         float fState;
-        if (CStaticFunctionDefinitions::GetAnalogControlState(strControlState, fState))
+        if (CStaticFunctionDefinitions::GetAnalogControlState(strControlState, fState, bRawInput))
         {
             lua_pushnumber(luaVM, fState);
             return 1;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -1132,14 +1132,16 @@ int CLuaPedDefs::GetPedAnalogControlState(lua_State* luaVM)
     SString          strControlState = "";
     float            fState = 0.0f;
     CClientPed*      pPed = NULL;
+    bool             bRawInput;
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pPed);
     argStream.ReadString(strControlState);
+    argStream.ReadBool(bRawInput, false);
 
     if (!argStream.HasErrors())
     {
         float fState;
-        if (CStaticFunctionDefinitions::GetPedAnalogControlState(*pPed, strControlState, fState))
+        if (CStaticFunctionDefinitions::GetPedAnalogControlState(*pPed, strControlState, fState, bRawInput))
         {
             lua_pushnumber(luaVM, fState);
             return 1;


### PR DESCRIPTION
Adds a bool parameter to [getAnalogControlValue](https://wiki.multitheftauto.com/wiki/GetAnalogControlState) and [getPedAnalogControlValue](https://wiki.multitheftauto.com/wiki/GetPedAnalogControlState) to poll for raw controller input for a given control value, ignoring scripted overrides, control toggles, etc.

This allows scripts to do things like mirroring analog input for accelerate onto `brake_reverse`. This will ignore non-analog inputs for the control, in other words, it'll return 0 for `accelerate` when pressing `W` on the keyboard unless you're actually pressing on a controller trigger (or whichever axis is bound to "accelerate").