### PR TITLE
Add "ok" result to getElementData

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -326,47 +326,6 @@ int CLuaElementDefs::GetElementByIndex(lua_State* luaVM)
     return 1;
 }
 
-int CLuaElementDefs::GetElementData(lua_State* luaVM)
-{
-    //  var getElementData ( element theElement, string key [, inherit = true] )
-    CClientEntity* pEntity;
-    SString        strKey;
-    bool           bInherit;
-
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pEntity);
-    argStream.ReadString(strKey);
-    argStream.ReadBool(bInherit, true);
-
-    if (!argStream.HasErrors())
-    {
-        CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
-        if (pLuaMain)
-        {
-            if (strKey.length() > MAX_CUSTOMDATA_NAME_LENGTH)
-            {
-                // Warn and truncate if key is too long
-                m_pScriptDebugging->LogCustom(luaVM, SString("Truncated argument @ '%s' [%s]", lua_tostring(luaVM, lua_upvalueindex(1)),
-                                                             *SString("string length reduced to %d characters at argument 2", MAX_CUSTOMDATA_NAME_LENGTH)));
-                strKey = strKey.Left(MAX_CUSTOMDATA_NAME_LENGTH);
-            }
-
-            CLuaArgument* pVariable = pEntity->GetCustomData(strKey, bInherit);
-            if (pVariable)
-            {
-                pVariable->Push(luaVM);
-                return 1;
-            }
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    // Failed
-    lua_pushboolean(luaVM, false);
-    return 1;
-}
-
 int CLuaElementDefs::GetElementMatrix(lua_State* luaVM)
 {
     CClientEntity* pEntity = NULL;
@@ -1092,7 +1051,7 @@ int CLuaElementDefs::OOP_GetElementBoundingBox(lua_State* luaVM)
                 lua_pushvector(luaVM, vecMin);
                 lua_pushvector(luaVM, vecMax);
                 return 2;
-            }           
+            }
         }
     }
     else

--- a/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -68,7 +68,7 @@ void CLuaElementDefs::LoadFunctions()
         {"getElementAttachedOffsets", getElementAttachedOffsets},
 
         // Element data
-        {"getElementData", getElementData},
+        {"getElementData", GetElementData},
         {"setElementData", setElementData},
         {"removeElementData", removeElementData},
 
@@ -487,46 +487,6 @@ int CLuaElementDefs::getElementByIndex(lua_State* luaVM)
         {
             lua_pushelement(luaVM, pElement);
             return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
-}
-
-int CLuaElementDefs::getElementData(lua_State* luaVM)
-{
-    //  var getElementData ( element theElement, string key [, inherit = true] )
-    CElement* pElement;
-    SString   strKey;
-    bool      bInherit;
-
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pElement);
-    argStream.ReadString(strKey);
-    argStream.ReadBool(bInherit, true);
-
-    if (!argStream.HasErrors())
-    {
-        CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
-        if (pLuaMain)
-        {
-            if (strKey.length() > MAX_CUSTOMDATA_NAME_LENGTH)
-            {
-                // Warn and truncate if key is too long
-                m_pScriptDebugging->LogCustom(luaVM, SString("Truncated argument @ '%s' [%s]", lua_tostring(luaVM, lua_upvalueindex(1)),
-                                                             *SString("string length reduced to %d characters at argument 2", MAX_CUSTOMDATA_NAME_LENGTH)));
-                strKey = strKey.Left(MAX_CUSTOMDATA_NAME_LENGTH);
-            }
-
-            CLuaArgument* pVariable = CStaticFunctionDefinitions::GetElementData(pElement, strKey, bInherit);
-            if (pVariable)
-            {
-                pVariable->Push(luaVM);
-                return 1;
-            }
         }
     }
     else

--- a/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
@@ -67,7 +67,7 @@ public:
     LUA_DECLARE(setElementVisibleTo);
 
     // Element data
-    LUA_DECLARE(getElementData);
+    LUA_DECLARE(GetElementData);
     LUA_DECLARE(setElementData);
     LUA_DECLARE(removeElementData);
 

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaElementDefsShared.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaElementDefsShared.cpp
@@ -1,0 +1,51 @@
+#include "StdInc.h"
+
+int CLuaElementDefs::GetElementData(lua_State* luaVM)
+{
+    //  var getElementData ( element theElement, string key [, inherit = true] )
+
+#ifdef MTA_CLIENT
+    CClientEntity* pElement;
+#else
+    CElement* pElement;
+#endif
+    SString strKey;
+    bool    bInherit;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pElement);
+    argStream.ReadString(strKey);
+    argStream.ReadBool(bInherit, true);
+
+    if (!argStream.HasErrors())
+    {
+        CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+        if (pLuaMain)
+        {
+            if (strKey.length() > MAX_CUSTOMDATA_NAME_LENGTH)
+            {
+                // Warn and truncate if key is too long
+                m_pScriptDebugging->LogCustom(luaVM, SString("Truncated argument @ '%s' [%s]", lua_tostring(luaVM, lua_upvalueindex(1)),
+                                                             *SString("string length reduced to %d characters at argument 2", MAX_CUSTOMDATA_NAME_LENGTH)));
+                strKey = strKey.Left(MAX_CUSTOMDATA_NAME_LENGTH);
+            }
+
+#ifdef MTA_CLIENT
+            CLuaArgument* pVariable = pElement->GetCustomData(strKey, bInherit);
+#else
+            CLuaArgument* pVariable = CStaticFunctionDefinitions::GetElementData(pElement, strKey, bInherit);
+#endif
+            if (pVariable)
+            {
+                pVariable->Push(luaVM);
+                return 1;
+            }
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    // Failed
+    lua_pushboolean(luaVM, false);
+    return 1;
+}

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaElementDefsShared.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaElementDefsShared.cpp
@@ -2,7 +2,7 @@
 
 int CLuaElementDefs::GetElementData(lua_State* luaVM)
 {
-    //  var getElementData ( element theElement, string key [, inherit = true] )
+    // any someVal, bool ok = getElementData ( element theElement, string key [, inherit = true] )
 
 #ifdef MTA_CLIENT
     CClientEntity* pElement;
@@ -37,8 +37,9 @@ int CLuaElementDefs::GetElementData(lua_State* luaVM)
 #endif
             if (pVariable)
             {
-                pVariable->Push(luaVM);
-                return 1;
+                pVariable->Push(luaVM);            // there is an associated warning here. read this function!
+                lua_pushboolean(luaVM, true);
+                return 2;
             }
         }
     }
@@ -47,5 +48,6 @@ int CLuaElementDefs::GetElementData(lua_State* luaVM)
 
     // Failed
     lua_pushboolean(luaVM, false);
-    return 1;
+    lua_pushboolean(luaVM, false);
+    return 2;
 }


### PR DESCRIPTION
This resolves #1060 and replaces #1163. 

A simple case:

![image](https://user-images.githubusercontent.com/923242/71934915-63126d80-319d-11ea-890f-425dbb963e61.png)

Which is useful if you've set something to `false`:

![image](https://user-images.githubusercontent.com/923242/71934936-76bdd400-319d-11ea-91f2-bd7bc96394b0.png)

/cc @patrikjuvonen 