### PR TITLE
Fix #403: make colshapes cloneable

### DIFF
--- a/Server/mods/deathmatch/logic/CColCircle.cpp
+++ b/Server/mods/deathmatch/logic/CColCircle.cpp
@@ -23,6 +23,12 @@ CColCircle::CColCircle(CColManager* pManager, CElement* pParent, const CVector2D
     UpdateSpatialData();
 }
 
+CElement* CColCircle::Clone(bool* bAddEntity, CResource* pResource)
+{
+    CColCircle* pColCircle = new CColCircle(m_pManager, GetParentEntity(), m_vecPosition, m_fRadius);
+    return pColCircle;
+}
+
 bool CColCircle::DoHitDetection(const CVector& vecNowPosition)
 {
     // Do a simple distance check between now position and our position

--- a/Server/mods/deathmatch/logic/CColCircle.h
+++ b/Server/mods/deathmatch/logic/CColCircle.h
@@ -17,6 +17,7 @@ class CColCircle : public CColShape
 {
 public:
     CColCircle(CColManager* pManager, CElement* pParent, const CVector2D& vecPosition, float fRadius, bool bIsPartnered = false);
+    CElement* Clone(bool* bAddEntity, CResource* pResource) override;
 
     virtual CSphere GetWorldBoundingSphere();
 

--- a/Server/mods/deathmatch/logic/CColCuboid.cpp
+++ b/Server/mods/deathmatch/logic/CColCuboid.cpp
@@ -19,6 +19,12 @@ CColCuboid::CColCuboid(CColManager* pManager, CElement* pParent, const CVector& 
     UpdateSpatialData();
 }
 
+CElement* CColCuboid::Clone(bool* bAddEntity, CResource* pResource)
+{
+    CColCuboid* pColCuboid = new CColCuboid(m_pManager, GetParentEntity(), m_vecPosition, m_vecSize);
+    return pColCuboid;
+}
+
 bool CColCuboid::DoHitDetection(const CVector& vecNowPosition)
 {
     // FIXME: What about radius?

--- a/Server/mods/deathmatch/logic/CColCuboid.h
+++ b/Server/mods/deathmatch/logic/CColCuboid.h
@@ -17,6 +17,7 @@ class CColCuboid : public CColShape
 {
 public:
     CColCuboid(CColManager* pManager, CElement* pParent, const CVector& vecPosition, const CVector& vecSize);
+    CElement* Clone(bool* bAddEntity, CResource* pResource) override;
 
     virtual CSphere GetWorldBoundingSphere();
 

--- a/Server/mods/deathmatch/logic/CColPolygon.cpp
+++ b/Server/mods/deathmatch/logic/CColPolygon.cpp
@@ -24,6 +24,8 @@ CElement* CColPolygon::Clone(bool* bAddEntity, CResource* pResource)
 {
     CColPolygon* pColPolygon = new CColPolygon(m_pManager, GetParentEntity(), m_vecPosition);
     pColPolygon->m_Points = m_Points;
+    pColPolygon->m_fRadius = m_fRadius;
+    pColPolygon->SizeChanged();
     return pColPolygon;
 }
 

--- a/Server/mods/deathmatch/logic/CColPolygon.cpp
+++ b/Server/mods/deathmatch/logic/CColPolygon.cpp
@@ -20,6 +20,13 @@ CColPolygon::CColPolygon(CColManager* pManager, CElement* pParent, const CVector
     m_fRadius = 0.0f;
 }
 
+CElement* CColPolygon::Clone(bool* bAddEntity, CResource* pResource)
+{
+    CColPolygon* pColPolygon = new CColPolygon(m_pManager, GetParentEntity(), m_vecPosition);
+    pColPolygon->m_Points = m_Points;
+    return pColPolygon;
+}
+
 bool CColPolygon::DoHitDetection(const CVector& vecNowPosition)
 {
     if (!IsInBounds(vecNowPosition))

--- a/Server/mods/deathmatch/logic/CColPolygon.h
+++ b/Server/mods/deathmatch/logic/CColPolygon.h
@@ -19,6 +19,7 @@ class CColPolygon : public CColShape
 {
 public:
     CColPolygon(CColManager* pManager, CElement* pParent, const CVector& vecPosition);
+    CElement* Clone(bool* bAddEntity, CResource* pResource) override;
 
     virtual CSphere GetWorldBoundingSphere();
 

--- a/Server/mods/deathmatch/logic/CColRectangle.cpp
+++ b/Server/mods/deathmatch/logic/CColRectangle.cpp
@@ -21,6 +21,12 @@ CColRectangle::CColRectangle(CColManager* pManager, CElement* pParent, const CVe
     UpdateSpatialData();
 }
 
+CElement* CColRectangle::Clone(bool* bAddEntity, CResource* pResource)
+{
+    CColRectangle* pColRectangle = new CColRectangle(m_pManager, GetParentEntity(), m_vecPosition, m_vecSize);
+    return pColRectangle;
+}
+
 bool CColRectangle::DoHitDetection(const CVector& vecNowPosition)
 {
     // FIXME: What about radius?

--- a/Server/mods/deathmatch/logic/CColRectangle.h
+++ b/Server/mods/deathmatch/logic/CColRectangle.h
@@ -18,6 +18,7 @@ class CColRectangle : public CColShape
 {
 public:
     CColRectangle(CColManager* pManager, CElement* pParent, const CVector2D& vecPosition, const CVector2D& vecSize);
+    CElement* Clone(bool* bAddEntity, CResource* pResource) override;
 
     virtual CSphere GetWorldBoundingSphere();
 

--- a/Server/mods/deathmatch/logic/CColShape.h
+++ b/Server/mods/deathmatch/logic/CColShape.h
@@ -61,10 +61,10 @@ public:
 
 protected:
     CVector m_vecPosition;
+    class CColManager*  m_pManager;
 
 private:
     bool                m_bIsEnabled;
-    class CColManager*  m_pManager;
     class CColCallback* m_pCallback;
     bool                m_bAutoCallEvent;
 

--- a/Server/mods/deathmatch/logic/CColSphere.cpp
+++ b/Server/mods/deathmatch/logic/CColSphere.cpp
@@ -21,6 +21,12 @@ CColSphere::CColSphere(CColManager* pManager, CElement* pParent, const CVector& 
     UpdateSpatialData();
 }
 
+CElement* CColSphere::Clone(bool* bAddEntity, CResource* pResource)
+{
+    CColSphere* pColSphere = new CColSphere(m_pManager, GetParentEntity(), m_vecPosition, m_fRadius, IsPartnered());
+    return pColSphere;
+}
+
 bool CColSphere::DoHitDetection(const CVector& vecNowPosition)
 {
     // Do a simple distance check between now position and our position

--- a/Server/mods/deathmatch/logic/CColSphere.h
+++ b/Server/mods/deathmatch/logic/CColSphere.h
@@ -17,6 +17,7 @@ class CColSphere : public CColShape
 {
 public:
     CColSphere(CColManager* pManager, CElement* pParent, const CVector& vecPosition, float fRadius, bool bIsPartnered = false);
+    CElement*       Clone(bool* bAddEntity, CResource* pResource) override;
 
     virtual CSphere GetWorldBoundingSphere();
 

--- a/Server/mods/deathmatch/logic/CColTube.cpp
+++ b/Server/mods/deathmatch/logic/CColTube.cpp
@@ -19,6 +19,12 @@ CColTube::CColTube(CColManager* pManager, CElement* pParent, const CVector& vecP
     UpdateSpatialData();
 }
 
+CElement* CColTube::Clone(bool* bAddEntity, CResource* pResource)
+{
+    CColTube* pColTube = new CColTube(m_pManager, GetParentEntity(), m_vecPosition, m_fRadius, m_fHeight);
+    return pColTube;
+}
+
 bool CColTube::DoHitDetection(const CVector& vecNowPosition)
 {
     // FIXME: What about radius in height?

--- a/Server/mods/deathmatch/logic/CColTube.h
+++ b/Server/mods/deathmatch/logic/CColTube.h
@@ -17,6 +17,7 @@ class CColTube : public CColShape
 {
 public:
     CColTube(CColManager* pManager, CElement* pParent, const CVector& vecPosition, float fRadius, float fHeight);
+    CElement* Clone(bool* bAddEntity, CResource* pResource) override;
 
     virtual CSphere GetWorldBoundingSphere();
 

--- a/Server/mods/deathmatch/logic/CElement.cpp
+++ b/Server/mods/deathmatch/logic/CElement.cpp
@@ -138,6 +138,7 @@ bool CElement::IsCloneable()
         case CElement::PICKUP:
         case CElement::RADAR_AREA:
         case CElement::PATH_NODE_UNUSED:
+        case CElement::COLSHAPE:
             return true;
         default:
             return false;


### PR DESCRIPTION
Closes #403

- [x] Polygon points doesn't move when specifying a new position in cloneElement.

Test resource: 
[clone-colshapes.zip](https://github.com/multitheftauto/mtasa-blue/files/4081263/clone-colshapes.zip) (Commands are `cs` and `clone`)
