### PR TITLE
Add kikito's inspect.lua to credits

### DIFF
--- a/Client/core/CCredits.cpp
+++ b/Client/core/CCredits.cpp
@@ -220,7 +220,8 @@ CCredits::CCredits()
         "PortAudio (http://www.portaudio.com/)\n"
         "speex (http://www.speex.org/)\n"
         "breakpad (https://chromium.googlesource.com/breakpad/breakpad/)\n"
-        "CEF (https://bitbucket.org/chromiumembedded/cef/)\n";
+        "CEF (https://bitbucket.org/chromiumembedded/cef/)\n"
+        "inspect.lua by kikito (https://github.com/kikito/inspect.lua)\n";
 
     // Create our window
     CVector2D RelativeWindow = CVector2D(fWindowX / pManager->GetResolution().fX, fWindowY / pManager->GetResolution().fY);


### PR DESCRIPTION
This library provides the `inspect` function.

other notes for the future (not in this pr):
- for another pr: we should also update to the latest inspect version here https://github.com/kikito/inspect.lua
- for another issue: tbh i don't think what we have now with just linking the library website is enough, maybe add an extra tab with the licenses for all the software?

review accepted from anyone who has write perms (not necessarily push perms)