### PR TITLE
Fix #1256: Added missing destroy method to DxFont

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -103,6 +103,7 @@ void CLuaDrawingDefs::AddDxFontClass(lua_State* luaVM)
     lua_newclass(luaVM);
 
     lua_classfunction(luaVM, "create", "dxCreateFont");
+    lua_classfunction(luaVM, "destroy", "destroyElement");
 
     lua_classfunction(luaVM, "getHeight", OOP_DxGetFontHeight);
     lua_classfunction(luaVM, "getTextWidth", OOP_DxGetTextWidth);


### PR DESCRIPTION
Fixes #1256 by adding the missing destroy OOP method to DxFont.