### PR TITLE
Fix duplicate enum usage in #1177 (NVidia Optimus Dialog)

### DIFF
--- a/Client/loader/loader.rc
+++ b/Client/loader/loader.rc
@@ -149,7 +149,7 @@ BEGIN
     GROUPBOX        "",IDC_STATIC,22,50,195,119
     CTEXT           "If you get desperate, this might help:",IDC_OPTIMUS_TEXT3,58,173,131,10
     CONTROL         " Force windowed mode",IDC_CHECK_FORCE_WINDOWED,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,75,185,100,10 
-    CTEXT           "If you have already selected an option that works, this might help:", IDC_OPTIMUS_TEXT3,27,205,180,20
+    CTEXT           "If you have already selected an option that works, this might help:", IDC_OPTIMUS_TEXT4,27,205,180,20
     CONTROL         " Don't show again",IDC_CHECK_REMEMBER,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,80,225,100,8
 END
 


### PR DESCRIPTION
This fixes a small issue with PR #1177 (merged) where an enum was being used twice for two different labels.
