### PR TITLE
Fix #1282: getCameraMatrix fov is inaccurate

### DIFF
--- a/Client/mods/deathmatch/logic/CClientCamera.h
+++ b/Client/mods/deathmatch/logic/CClientCamera.h
@@ -49,6 +49,7 @@ public:
     void  GetFixedTarget(CVector& vecTarget, float* pfRoll = NULL) const;
     void  SetFixedTarget(const CVector& vecPosition, float fRoll = 0);
     float GetFOV() { return m_fFOV; }
+    float GetRealtimeFOV() { return m_pCamera->GetCam(m_pCamera->GetActiveCam())->GetFOV(); }
     void  SetFOV(float fFOV) { m_fFOV = fFOV; }
     void  SetOrbitTarget(const CVector& vecPosition);
     void  AttachTo(CClientEntity* pElement);

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -4767,7 +4767,7 @@ bool CStaticFunctionDefinitions::GetCameraMatrix(CVector& vecPosition, CVector& 
 {
     m_pCamera->GetPosition(vecPosition);
     m_pCamera->GetFixedTarget(vecLookAt, &fRoll);
-    fFOV = m_pCamera->GetFOV();
+    fFOV = m_pCamera->GetRealtimeFOV();
     return true;
 }
 


### PR DESCRIPTION
**How to test** (using [multitheftauto/mtasa-resources#186](https://github.com/multitheftauto/mtasa-resources/pull/186))

1. `start runcode`
2. `crun runcode.watch("matrix", getCameraMatrix)`
3. Observe default fov (possibly `70`) in the list
4. Get into car and drive on a straight road
5. Observe `70` progressively increase to `100`