### PR TITLE
Fix #1279: driveby for peds

### DIFF
--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -2444,23 +2444,31 @@ bool CStaticFunctionDefinitions::SetPedAimTarget(CClientEntity& Entity, CVector&
                 fRotDiff = fRotDiff + PI * 2;
             }
 
-            // Find the aim anim and correct fArmX/fArmY (if not default anim)
+            // Find the aim anim and correct fArmX/fArmY
             if (fRotDiff > PI * 0.25 && fRotDiff < PI * 0.75)
             {
+                // Facing left
                 cInVehicleAimAnim = 1;
                 fArmX = fArmX - PI / 2;
                 fArmY = -fArmY;
             }
             else if (fRotDiff > PI * 0.75 || fRotDiff < -PI * 0.75)
             {
+                // Facing backwards
                 cInVehicleAimAnim = 2;
                 fArmX = fArmX + PI;
                 fArmY = -fArmY;
             }
             else if (fRotDiff < -PI * 0.25 && fRotDiff > -PI * 0.75)
             {
+                // Facing right
                 cInVehicleAimAnim = 3;
                 fArmX = fArmX + PI / 2;
+            }
+            else
+            {
+                // Facing forwards
+                // Do nothing, initial values are fine
             }
 
             // Set aim and target data without interpolation

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -2424,6 +2424,7 @@ bool CStaticFunctionDefinitions::SetPedAimTarget(CClientEntity& Entity, CVector&
         if (Ped.IsInVehicle())
         {
             // Driveby aim animation
+            // 0 = forwards, 1 = left, 2 = back, 3 = right
             unsigned char cInVehicleAimAnim = 0;
 
             // Ped rotation

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -2402,21 +2402,74 @@ bool CStaticFunctionDefinitions::SetPedAimTarget(CClientEntity& Entity, CVector&
         if (Ped.IsLocalPlayer())
             return false;
 
-        CVector vecOrigin;
-        Ped.GetPosition(vecOrigin);
-
-        // Move origin out a bit to avoid hitting ped collision
-        CVector vecDir = vecTarget - vecOrigin;
-        vecDir.Normalize();
-        vecOrigin += vecDir * 0.9f;
+        // Grab the gun muzzle position
+        CWeapon* pWeapon = Ped.GetWeapon(Ped.GetCurrentWeaponSlot());
+        CVector  vecOrigin;
+        if (!pWeapon)
+        {
+            Ped.GetPosition(vecOrigin);
+        }
+        else
+        {
+            CWeaponStat* pCurrentWeaponInfo = g_pGame->GetWeaponStatManager()->GetWeaponStatsFromSkillLevel(pWeapon->GetType(), 1000.0f);
+            CVector      vecFireOffset = *pCurrentWeaponInfo->GetFireOffset();
+            vecOrigin = vecFireOffset;
+            Ped.GetTransformedBonePosition(BONE_RIGHTWRIST, vecOrigin);
+        }
 
         // Arm direction
         float fArmX = -atan2(vecTarget.fX - vecOrigin.fX, vecTarget.fY - vecOrigin.fY),
               fArmY = -atan2(vecTarget.fZ - vecOrigin.fZ, DistanceBetweenPoints2D(vecTarget, vecOrigin));
 
-        // TODO: use gun muzzle for origin
-        Ped.SetTargetTarget(TICK_RATE, vecOrigin, vecTarget);
-        Ped.SetAim(fArmX, fArmY, 0);
+        if (Ped.IsInVehicle())
+        {
+            // Driveby aim animation
+            unsigned char cInVehicleAimAnim = 0;
+
+            // Ped rotation
+            CVector vecRot;
+            Ped.GetRotationRadians(vecRot);
+            float fRotZ = -vecRot.fZ;            // Counter-clockwise
+            fRotZ = (fRotZ > PI) ? fRotZ - PI * 2 : fRotZ;
+
+            // Rotation difference
+            float fRotDiff = fArmX - fRotZ;
+            if (fRotDiff > PI)
+            {
+                fRotDiff = -(PI - (fRotDiff - PI));
+            }
+            else if (fRotDiff < -PI)
+            {
+                fRotDiff = fRotDiff + PI * 2;
+            }
+
+            // Find the aim anim and correct fArmX/fArmY (if not default anim)
+            if (fRotDiff > PI * 0.25 && fRotDiff < PI * 0.75)
+            {
+                cInVehicleAimAnim = 1;
+                fArmX = fArmX - PI / 2;
+                fArmY = -fArmY;
+            }
+            else if (fRotDiff > PI * 0.75 || fRotDiff < -PI * 0.75)
+            {
+                cInVehicleAimAnim = 2;
+                fArmX = fArmX + PI;
+                fArmY = -fArmY;
+            }
+            else if (fRotDiff < -PI * 0.25 && fRotDiff > -PI * 0.75)
+            {
+                cInVehicleAimAnim = 3;
+                fArmX = fArmX + PI / 2;
+            }
+
+            // Set aim and target data without interpolation
+            Ped.SetAimingData(TICK_RATE, vecTarget, fArmX, fArmY, cInVehicleAimAnim, &vecOrigin, false);
+        }
+        else
+        {
+            Ped.SetTargetTarget(TICK_RATE, vecOrigin, vecTarget);
+            Ped.SetAim(fArmX, fArmY, 0);
+        }
 
         return true;
     }


### PR DESCRIPTION
Fixes #1279

- Driveby shooting didn't work for peds because ped target vectors are not updated (Ped::Interpolate) when he's in a vehicle. This is fixed by using Ped::SetAimingData instead of Ped::SetTargetTarget.

- All 4 driveby aim animations now work.

- Ped target origin is currently ped position instead of gun muzzle, so bullets appear to shoot from center of ped. I've changed it to gun muzzle, I don't think this should break any scripts?