### PR TITLE
Fix #1294: enable enter_exit for peds to fix alternative attack

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPad.cpp
+++ b/Client/mods/deathmatch/logic/CClientPad.cpp
@@ -242,6 +242,8 @@ void CClientPad::DoPulse(CClientPed* pPed)
                     (short)(((m_fStates[5] && m_fStates[6]) || (!m_fStates[5] && !m_fStates[6])) ? 0
                                                                                                  : (m_fStates[5]) ? m_fStates[5] * -128 : m_fStates[6] * 128);
 
+                cs.ButtonTriangle = (m_fStates[9]) ? 255 : 0;            // Get in/out and alternative fighting styles
+
                 cs.ButtonSquare = (m_fStates[11]) ? 255 : 0;            // Jump
 
                 cs.ButtonCross = (m_fStates[12]) ? 255 : 0;            // Sprint


### PR DESCRIPTION
This PR simply enables enter_exit control for peds on foot, which allows them to perform alternative attacks.

Tested with vehicles around to make sure nothing funky happens.