### PR TITLE
Add CVAR _beta_qc_rightclick_command

### DIFF
--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -350,6 +350,7 @@ void CClientVariables::LoadDefaults()
     DEFAULT("browser_remote_websites", true);                                         // Load remote websites?
     DEFAULT("browser_remote_javascript", true);                                       // Execute javascript on remote websites?
     DEFAULT("filter_duplicate_log_lines", true);                                      // Filter duplicate log lines for debug view and clientscript.log
+    DEFAULT("_beta_qc_rightclick_command", _S("reconnect"));                          // Command to run when right clicking quick connect (beta - can be removed at any time)
 
     if (!Exists("locale"))
     {

--- a/Client/core/CMainMenu.cpp
+++ b/Client/core/CMainMenu.cpp
@@ -205,7 +205,7 @@ CMainMenu::CMainMenu(CGUI* pManager)
     m_pMenuArea->SetSize(CVector2D(m_menuBX - m_menuAX, m_menuBY - m_menuAY) + BODGE_FACTOR_6, false);
     m_pMenuArea->SetAlpha(0);
     m_pMenuArea->SetZOrderingEnabled(false);
-    m_pMenuArea->SetClickHandler(GUI_CALLBACK(&CMainMenu::OnMenuClick, this));
+    m_pMenuArea->SetClickHandler(GUI_CALLBACK_MOUSE(&CMainMenu::OnMenuClick, this));
     m_pMenuArea->SetMouseEnterHandler(GUI_CALLBACK(&CMainMenu::OnMenuEnter, this));
     m_pMenuArea->SetMouseLeaveHandler(GUI_CALLBACK(&CMainMenu::OnMenuExit, this));
 
@@ -792,8 +792,10 @@ bool CMainMenu::OnMenuExit(CGUIElement* pElement)
     return true;
 }
 
-bool CMainMenu::OnMenuClick(CGUIElement* pElement)
+bool CMainMenu::OnMenuClick(CGUIMouseEventArgs Args)
 {
+    CGUIElement* pElement = Args.pWindow;
+
     // Handle all our clicks to the menu from here
     if (m_pHoveredItem)
     {

--- a/Client/core/CMainMenu.cpp
+++ b/Client/core/CMainMenu.cpp
@@ -796,74 +796,80 @@ bool CMainMenu::OnMenuClick(CGUIMouseEventArgs Args)
 {
     CGUIElement* pElement = Args.pWindow;
 
-    // Handle all our clicks to the menu from here
-    if (m_pHoveredItem)
+    // Only handle all our clicks to the menu from here
+    if (!m_pHoveredItem)
+        return true;
+
+    if (Args.button != LeftButton && m_pHoveredItem->menuType != MENU_ITEM_QUICK_CONNECT)
+        return true;
+
+    // For detecting startup problems
+    WatchDogUserDidInteractWithMenu();
+
+    // Possible disconnect question for user
+    if (g_pCore->IsConnected())
     {
-        // For detecting startup problems
-        WatchDogUserDidInteractWithMenu();
-
-        // Possible disconnect question for user
-        if (g_pCore->IsConnected())
-        {
-            switch (m_pHoveredItem->menuType)
-            {
-                case MENU_ITEM_HOST_GAME:
-                case MENU_ITEM_MAP_EDITOR:
-                    AskUserIfHeWantsToDisconnect(m_pHoveredItem->menuType);
-                    return true;
-                default:
-                    break;
-            }
-        }
-
         switch (m_pHoveredItem->menuType)
         {
-            case MENU_ITEM_DISCONNECT:
-                OnDisconnectButtonClick(pElement);
-                break;
-            case MENU_ITEM_QUICK_CONNECT:
-                OnQuickConnectButtonClick(pElement);
-                break;
-            case MENU_ITEM_BROWSE_SERVERS:
-                OnBrowseServersButtonClick(pElement);
-                break;
             case MENU_ITEM_HOST_GAME:
-                OnHostGameButtonClick();
-                break;
             case MENU_ITEM_MAP_EDITOR:
-                OnEditorButtonClick();
-                break;
-            case MENU_ITEM_SETTINGS:
-                OnSettingsButtonClick(pElement);
-                break;
-            case MENU_ITEM_ABOUT:
-                OnAboutButtonClick(pElement);
-                break;
-            case MENU_ITEM_QUIT:
-                OnQuitButtonClick(pElement);
-                break;
+                AskUserIfHeWantsToDisconnect(m_pHoveredItem->menuType);
+                return true;
             default:
                 break;
         }
     }
+
+    switch (m_pHoveredItem->menuType)
+    {
+        case MENU_ITEM_DISCONNECT:
+            OnDisconnectButtonClick(pElement);
+            break;
+        case MENU_ITEM_QUICK_CONNECT:
+            OnQuickConnectButtonClick(pElement, Args.button == LeftButton);
+            break;
+        case MENU_ITEM_BROWSE_SERVERS:
+            OnBrowseServersButtonClick(pElement);
+            break;
+        case MENU_ITEM_HOST_GAME:
+            OnHostGameButtonClick();
+            break;
+        case MENU_ITEM_MAP_EDITOR:
+            OnEditorButtonClick();
+            break;
+        case MENU_ITEM_SETTINGS:
+            OnSettingsButtonClick(pElement);
+            break;
+        case MENU_ITEM_ABOUT:
+            OnAboutButtonClick(pElement);
+            break;
+        case MENU_ITEM_QUIT:
+            OnQuitButtonClick(pElement);
+            break;
+        default:
+            break;
+    }
+
     return true;
 }
 
-bool CMainMenu::OnQuickConnectButtonClick(CGUIElement* pElement)
+bool CMainMenu::OnQuickConnectButtonClick(CGUIElement* pElement, bool left)
 {
     // Return if we haven't faded in yet
     if (m_ucFade != FADE_VISIBLE)
         return false;
 
+    // If we're right clicking, execute special command
+    if (!left)
+    {
+        std::string command;
+        CVARS_GET("_beta_qc_rightclick_command", command);
+        g_pCore->GetCommands()->Execute(command.data());
+        return true;
+    }
+
     m_ServerBrowser.SetVisible(true);
     m_ServerBrowser.OnQuickConnectButtonClick();
-    /*
-    //    if ( !m_bIsInSubWindow )
-        {
-            m_QuickConnect.SetVisible ( true );
-    //        m_bIsInSubWindow = true;
-        }
-    */
     return true;
 }
 

--- a/Client/core/CMainMenu.h
+++ b/Client/core/CMainMenu.h
@@ -82,7 +82,7 @@ private:
     bool OnMenuEnter(CGUIElement* pElement);
     bool OnMenuExit(CGUIElement* pElement);
     bool OnMenuClick(CGUIMouseEventArgs Args);
-    bool OnQuickConnectButtonClick(CGUIElement* pElement);
+    bool OnQuickConnectButtonClick(CGUIElement* pElement, bool left);
     bool OnResumeButtonClick(CGUIElement* pElement);
     bool OnBrowseServersButtonClick(CGUIElement* pElement);
     bool OnHostGameButtonClick();

--- a/Client/core/CMainMenu.h
+++ b/Client/core/CMainMenu.h
@@ -81,7 +81,7 @@ private:
 
     bool OnMenuEnter(CGUIElement* pElement);
     bool OnMenuExit(CGUIElement* pElement);
-    bool OnMenuClick(CGUIElement* pElement);
+    bool OnMenuClick(CGUIMouseEventArgs Args);
     bool OnQuickConnectButtonClick(CGUIElement* pElement);
     bool OnResumeButtonClick(CGUIElement* pElement);
     bool OnBrowseServersButtonClick(CGUIElement* pElement);

--- a/Client/gui/CGUIElement_Impl.cpp
+++ b/Client/gui/CGUIElement_Impl.cpp
@@ -495,6 +495,11 @@ void CGUIElement_Impl::SetClickHandler(GUI_CALLBACK Callback)
     m_OnClick = Callback;
 }
 
+void CGUIElement_Impl::SetClickHandler(const GUI_CALLBACK_MOUSE& Callback)
+{
+    m_OnClickWithArgs = Callback;
+}
+
 void CGUIElement_Impl::SetDoubleClickHandler(GUI_CALLBACK Callback)
 {
     m_OnDoubleClick = Callback;
@@ -565,10 +570,29 @@ bool CGUIElement_Impl::Event_OnSized(const CEGUI::EventArgs& e)
     return true;
 }
 
-bool CGUIElement_Impl::Event_OnClick()
+bool CGUIElement_Impl::Event_OnClick(const CEGUI::EventArgs& eBase)
 {
+    const CEGUI::MouseEventArgs& e = reinterpret_cast<const CEGUI::MouseEventArgs&>(eBase);
+    CGUIElement*               pElement = reinterpret_cast<CGUIElement*>(this);
+
     if (m_OnClick)
-        m_OnClick(reinterpret_cast<CGUIElement*>(this));
+        m_OnClick(pElement);
+
+    if (m_OnClickWithArgs)
+    {
+        CGUIMouseEventArgs NewArgs;
+
+        // copy the variables
+        NewArgs.button = static_cast<CGUIMouse::MouseButton>(e.button);
+        NewArgs.moveDelta = CVector2D(e.moveDelta.d_x, e.moveDelta.d_y);
+        NewArgs.position = CGUIPosition(e.position.d_x, e.position.d_y);
+        NewArgs.sysKeys = e.sysKeys;
+        NewArgs.wheelChange = e.wheelChange;
+        NewArgs.pWindow = pElement;
+
+        m_OnClickWithArgs(NewArgs);
+    }
+
     return true;
 }
 

--- a/Client/gui/CGUIElement_Impl.h
+++ b/Client/gui/CGUIElement_Impl.h
@@ -103,6 +103,7 @@ public:
     void SetMovedHandler(GUI_CALLBACK Callback);
     void SetSizedHandler(GUI_CALLBACK Callback);
     void SetClickHandler(GUI_CALLBACK Callback);
+    void SetClickHandler(const GUI_CALLBACK_MOUSE& Callback);
     void SetDoubleClickHandler(GUI_CALLBACK Callback);
     void SetMouseEnterHandler(GUI_CALLBACK Callback);
     void SetMouseLeaveHandler(GUI_CALLBACK Callback);
@@ -113,7 +114,7 @@ public:
     void SetKeyDownHandler(const GUI_CALLBACK_KEY& Callback);
     void SetEnterKeyHandler(GUI_CALLBACK Callback);
 
-    bool Event_OnClick();
+    bool Event_OnClick(const CEGUI::EventArgs& e);
     bool Event_OnDoubleClick();
     bool Event_OnMouseEnter();
     bool Event_OnMouseLeave();
@@ -143,16 +144,18 @@ protected:
 
     std::list<CGUIProperty*> m_Properties;
 
-    GUI_CALLBACK     m_OnClick;
-    GUI_CALLBACK     m_OnDoubleClick;
-    GUI_CALLBACK     m_OnMoved;
-    GUI_CALLBACK     m_OnSized;
-    GUI_CALLBACK     m_OnMouseEnter;
-    GUI_CALLBACK     m_OnMouseLeave;
-    GUI_CALLBACK     m_OnMouseDown;
-    GUI_CALLBACK     m_OnActivate;
-    GUI_CALLBACK     m_OnDeactivate;
-    GUI_CALLBACK     m_OnKeyDown;
-    GUI_CALLBACK     m_OnEnter;
-    GUI_CALLBACK_KEY m_OnKeyDownWithArgs;
+    GUI_CALLBACK m_OnClick;
+    GUI_CALLBACK m_OnDoubleClick;
+    GUI_CALLBACK m_OnMoved;
+    GUI_CALLBACK m_OnSized;
+    GUI_CALLBACK m_OnMouseEnter;
+    GUI_CALLBACK m_OnMouseLeave;
+    GUI_CALLBACK m_OnMouseDown;
+    GUI_CALLBACK m_OnActivate;
+    GUI_CALLBACK m_OnDeactivate;
+    GUI_CALLBACK m_OnKeyDown;
+    GUI_CALLBACK m_OnEnter;
+
+    GUI_CALLBACK_MOUSE m_OnClickWithArgs;
+    GUI_CALLBACK_KEY   m_OnKeyDownWithArgs;
 };

--- a/Client/gui/CGUIElement_Inc.h
+++ b/Client/gui/CGUIElement_Inc.h
@@ -248,6 +248,10 @@ void SetClickHandler(GUI_CALLBACK Callback)
 {
     CGUIElement_Impl::SetClickHandler(Callback);
 };
+void SetClickHandler(const GUI_CALLBACK_MOUSE& Callback)
+{
+    CGUIElement_Impl::SetClickHandler(Callback);
+};
 void SetDoubleClickHandler(GUI_CALLBACK Callback)
 {
     CGUIElement_Impl::SetDoubleClickHandler(Callback);
@@ -293,9 +297,9 @@ void SetEnterKeyHandler(GUI_CALLBACK Callback)
     CGUIElement_Impl::SetEnterKeyHandler(Callback);
 };
 
-bool Event_OnClick()
+bool Event_OnClick(const CEGUI::EventArgs& e)
 {
-    return CGUIElement_Impl::Event_OnClick();
+    return CGUIElement_Impl::Event_OnClick(e);
 };
 bool Event_OnDoubleClick()
 {

--- a/Client/gui/CGUI_Impl.cpp
+++ b/Client/gui/CGUI_Impl.cpp
@@ -1041,7 +1041,7 @@ bool CGUI_Impl::Event_MouseClick(const CEGUI::EventArgs& Args)
 
     // Call global and object handlers
     if (pElement)
-        pElement->Event_OnClick();
+        pElement->Event_OnClick(Args);
 
     if (m_MouseClickHandlers[m_Channel])
     {

--- a/Client/sdk/gui/CGUIElement.h
+++ b/Client/sdk/gui/CGUIElement.h
@@ -18,6 +18,12 @@ class CGUIElement;
 #include <string>
 #include "CGUITypes.h"
 
+// Forward declaration
+namespace CEGUI
+{
+    class EventArgs;
+}
+
 enum eCGUIType
 {
     CGUI_BUTTON,
@@ -119,6 +125,7 @@ public:
     virtual void SetMovedHandler(GUI_CALLBACK Callback) = 0;
     virtual void SetSizedHandler(GUI_CALLBACK Callback) = 0;
     virtual void SetClickHandler(GUI_CALLBACK Callback) = 0;
+    virtual void SetClickHandler(const GUI_CALLBACK_MOUSE& Callback) = 0;
     virtual void SetDoubleClickHandler(GUI_CALLBACK Callback) = 0;
     virtual void SetMouseEnterHandler(GUI_CALLBACK Callback) = 0;
     virtual void SetMouseLeaveHandler(GUI_CALLBACK Callback) = 0;
@@ -129,7 +136,7 @@ public:
     virtual void SetKeyDownHandler(const GUI_CALLBACK_KEY& Callback) = 0;
     virtual void SetEnterKeyHandler(GUI_CALLBACK Callback) = 0;
 
-    virtual bool Event_OnClick() = 0;
+    virtual bool Event_OnClick(const CEGUI::EventArgs& e) = 0;
     virtual bool Event_OnDoubleClick() = 0;
     virtual bool Event_OnMouseEnter() = 0;
     virtual bool Event_OnMouseLeave() = 0;


### PR DESCRIPTION
This adds a new console variable `_beta_qc_rightclick_command` that lets you execute a command of your choice when you right click the "quick connect" button.

By default this CVAR is set to `reconnect`, but you can set it to anything - `connect orange.mtasa.com` or `nick timw0w`.

This pull request replaces #1072 and improves on it by providing a solution for:
- reconnecting to your most recent server (default, requested by someone on Discord)
- connecting to a server of choice (https://github.com/multitheftauto/mtasa-blue/pull/1072#issuecomment-526922086, requested by @ArranTuna)
- executing any other command

I'd say it's a "power tool" and if this eventually exposed in the settings menu, we can change the cvar to something neater.

### How to use

#### To get the current value of the CVAR

Open the console, type `_beta_qc_rightclick_command` and press enter.

![image](https://user-images.githubusercontent.com/923242/77218574-a9ccfe00-6b24-11ea-9abf-5748eb874c7f.png)

#### To change the value of the CVAR

Open the console, type `_beta_qc_rightclick_command=YOUR COMMAND HERE`, and press enter.

For example, `_beta_qc_rightclick_command=nick timw0w`.

![image](https://user-images.githubusercontent.com/923242/77218567-928e1080-6b24-11ea-9587-c2b95f42b91c.png)


#### How to make it work

Right click the "quick connect" button and it will execute the value of the setting as a command.

![image](https://user-images.githubusercontent.com/923242/77218516-f49a4600-6b23-11ea-8917-e76314fd11dc.png)
