### PR TITLE
Add new contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,16 +120,19 @@ Since you can only react to comments, not commits, feel free to create
 the initial \"+1\" comment in response to a commit. However, future
 reactions to a commit should be to the first response comment.
 
-## Gaining and losing commit access
+## Gaining and losing merge rights
 
-We grant commit access after you have proven yourself to be competent,
+Merge rights allow you to merge your own approved pull requests and 
+review other people's pull requests.
+
+We grant merge rights after you have proven yourself to be competent,
 this is generally after 3-5 pull requests, but it's not fixed and depends
 on the extent of your contributions.
 
-The subject matter of the patches do not matter—we are more interested in,
-once granted commit access, whether you are capable of maintaining
+The subject matter of your PRs do not matter—we are more interested in,
+once granted merge rights, whether you are capable of maintaining
 a high standard of code and remaining cohesive with other project collaborators.
 
-After gaining commit access, if your commits are of a consistently low standard,
-or the user fails to stick to the rules, their commit access will be stripped
-and will be required to submit pull requests again.
+After gaining merge rights, if your contributions are of a consistently low standard,
+or you fail to stick to the rules, your permissions will be stripped and will no longer
+be able to merge submitted pull requests or create your own branches.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,8 @@ Our project's code repository can be found on the [multitheftauto/mtasa-blue](ht
 * [Nightly Builds](https://nightly.mtasa.com/)
 * [Issue Tracker](https://github.com/multitheftauto/mtasa-blue/issues)
 * [Wiki Roadmap](https://wiki.mtasa.com/wiki/Roadmap) <!--TODO: this page is mostly useless now -->
+* Patches can be submitted using [GitHub's pull request
+system](https://github.com/multitheftauto/mtasa-blue/pull/new)
 
 ## Directory Structure
 
@@ -51,6 +53,7 @@ It feels out of place. -->
 
 Generally, developers should try to only send pull requests that resolve existing
 [issues](https://github.com/multitheftauto/mtasa-blue/issues).
+This requires you to fork our repository and make commits to your own branch.
 
 If you're looking for something to work on, take a look at:
 - our ["good first issue"] label, and
@@ -117,22 +120,16 @@ Since you can only react to comments, not commits, feel free to create
 the initial \"+1\" comment in response to a commit. However, future
 reactions to a commit should be to the first response comment.
 
-
 ## Gaining and losing commit access
 
-Commit access is granted after pull requests have been submitted, and the
-coder has proven themselves to be competent. The subject matter of the patches does
-not matter, we are more interested in whether if you are granted commit
-access, you will be capable of maintaining a high standard of code and
-remaining cohesive with other project collaborators.
+We grant commit access after you have proven yourself to be competent,
+this is generally after 3-5 pull requests, but it's not fixed and depends
+on the extent of your contributions.
 
-Patches can be submitted using [GitHub's pull request
-system](https://github.com/multitheftauto/mtasa-blue/pull/new). Usually
-commit access is gained after 2-3 pull requests, but this is not fixed and
-depends on the extent of the contributions. This requires you to fork
-our repository and make commits to your own branch first.
+The subject matter of the patches do not matter—we are more interested in,
+once granted commit access, whether you are capable of maintaining
+a high standard of code and remaining cohesive with other project collaborators.
 
-After gaining commit access, if the contributor's commits are of a
-consistently low standard, or the user fails to stick to the rules,
-their commit access will be stripped and will be required to submit pull
-requests again.
+After gaining commit access, if your commits are of a consistently low standard,
+or the user fails to stick to the rules, their commit access will be stripped
+and will be required to submit pull requests again.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Our project's code repository can be found on the [multitheftauto/mtasa-blue](ht
 
 * [Nightly Builds](https://nightly.mtasa.com/)
 * [Issue Tracker](https://github.com/multitheftauto/mtasa-blue/issues)
-* [Wiki Roadmap](https://wiki.mtasa.com/wiki/Roadmap)
+* [Wiki Roadmap](https://wiki.mtasa.com/wiki/Roadmap) <!--TODO: this page is mostly useless now -->
 
 # Overview
 
@@ -142,82 +142,87 @@ Also, consider moving this to its own document on the wiki? It seems too long.
 -   We use 4 spaces instead of tabs.
 -   Hungarian notation for variable names.
 
-`float         fValue;               // Local variable`\
-`unsigned char m_ucValue;            // Class member variable`\
-`char          ms_cValue;            // Class static variable`\
-`bool          g_bCrashTwiceAnHour;  // Global variable`\
-`char*         szUsername;           // Zero terminated string`\
-`SString       strUsername;          // String`\
-`CVector       vecPosition;          // 3D Vector`
+    ```cpp
+    float         fValue;               // Local variable
+    unsigned char m_ucValue;            // Class member variable
+    char          ms_cValue;            // Class static variable
+    bool          g_bCrashTwiceAnHour;  // Global variable
+    char*         szUsername;           // Zero terminated string
+    SString       strUsername;          // String
+    CVector       vecPosition;          // 3D Vector
+    ```
 
 -   Lower camel case for variable names of types like custom structs and
     enums:
 
-`SSomeStruct   valueOne;`\
-`ESomeEnum     m_valueTwo;`
+    ```cpp
+    SSomeStruct   valueOne;
+    ESomeEnum     m_valueTwo;
+    ```
 
 -   Function names use UpperCamelCase:
 
-`void UpperCamelCase()`
+    ```cpp
+    void UpperCamelCase()
+    ```
 
 -   Functions with no arguments are declared and defined with (), and
     called with ()
 
-`void MyTest();`\
-`void MyTest() { return; }`\
-`MyTest();`
+    ```cpp
+    void MyTest();
+    void MyTest() { return; }
+    MyTest();
+    ```
 
 -   Do not use nested structures without braces:
 
-`// This is disallowed:`\
-`for (dont)`\
-`    for (do)`\
-`        for (this)`\
-`            ...`\
-\
-`// Either of these are allowed`\
-`if (x) {`\
-`    y;`\
-`}`\
-\
-`if (x)`\
-`    y;`
+    ```cpp
+    // This is disallowed:
+    for (dont)
+        for (do)
+            for (this)
+                ...
 
--   Put *\#pragma once* preprocessor directive next to the copyright
+    // Either of these are allowed
+    if (x) {
+        y;
+    }
+
+    if (x)
+        y;
+    ```
+
+-   Put `#pragma once` preprocessor directive next to the copyright
     comment for new header files and the ones you are modifying for the
     pull request. Make sure to remove include guard if you are using
-    *\#pragma once*:
+    `#pragma once`:
 
-` /*****************************************************************************`\
-``\
-` *`\
-` *  PROJECT:     Multi Theft Auto`\
-` *  LICENSE:     See LICENSE in the top level directory`\
-` *  FILE:        Client/mods/deathmatch/logic/CClientIFP.h`\
-` *`\
-` *  Multi Theft Auto is available from http://www.multitheftauto.com/`\
-` *`\
-` *****************************************************************************/`\
-``\
-` #pragma once`
+    ```cpp
+    /*****************************************************************************
+    \
+    *
+    *  PROJECT:     Multi Theft Auto`\
+    *  LICENSE:     See LICENSE in the top level directory`\
+    *  FILE:        Client/mods/deathmatch/logic/CClientIFP.h`\
+    *
+    *  Multi Theft Auto is available from http://www.multitheftauto.com/`\
+    *
+    *****************************************************************************/
 
--   Once you\'re done writing code, and you\'re about to create a pull
+    #pragma once
+    ```
+
+-   Once you're done writing code, and you're about to create a pull
     request, apply clang formatting:
     -   Download
         [clang-format-r325576.exe](http://prereleases.llvm.org/win-snapshots/clang-format-r325576.exe),
         and move it to **utils** folder.
     -   Download [fnr.zip](http://findandreplace.io/downloads/fnr.zip),
         extract fnr.exe to **utils** folder.
-    -   Run **utils\\win-apply-clang-format.bat**.
+    -   Run `utils/win-apply-clang-format.bat` <!-- TODO: this updates all files. we shouldn't recommend this. -->
 
-```{=html}
-<!-- -->
-```
 -   For anything else, follow the style of the code that already exists.
 
-```{=html}
-<!-- -->
-```
--   Tip: In Visual Studio go to Tools -\> Options -\> Text Editor -\>
-    C/C++ -\> Formatting -\> Spacing and you can configure it to
-    automatically apply the right spacing.
+-   Tip: In Visual Studio go to `Tools -> Options -> Text Editor -> C/C++ -> Formatting -> Spacing`
+    and you can configure it to automatically apply the right spacing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,5 +184,5 @@ Branch protection is **not enforced** for repository administrators,
 and those people are therefore not required to send pull requests. Individual repository admins may,
 for the greater good, pledge to submit pull requests despite this lack of enforcement.
 
-For informational purposes, the current repository administrators are a _subset of_
-[those listed here](https://forum.mtasa.com/staff/)—it is not an authoritative list.
+For informational purposes, the current repository administrators are those marked as _The MTA Team_ on
+[this list](https://forum.mtasa.com/staff/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,14 +68,6 @@ and submit it.
 
 ## Committing code
 
-<!-- TODO: below clashes a bit with the 'What to code' section -->
-<!-- oh and it's also referring to mantis which we don't use -->
-Keep in mind that your commits should initially be fixing or
-implementing existing issues on our [bug
-tracker](http://bugs.mtasa.com). The
-[roadmap](http://bugs.mtasa.com/roadmap_page.php) is particularly
-important since it allows contributors to track down priority issues.
-
 Please follow these guidelines for all your contributions:
 
 -   Commits should be thoroughly tested when added to master. Commits

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,218 @@
+So you've decided to become a contributor to our project. Excellent!
+But before we can start accepting your code, there are a couple of
+things you should know about how we work. These are mostly guidelines
+and rules as to how your code should be structured and how it can be
+committed without upsetting any fellow contributors.
+
 Our project's code repository can be found on the [multitheftauto/mtasa-blue](https://github.com/multitheftauto/mtasa-blue/) Git repository at [GitHub](https://github.com/). We are always looking for new developers, so if you're interested, here are some useful links:
 
 * [Nightly Builds](https://nightly.mtasa.com/)
 * [Issue Tracker](https://github.com/multitheftauto/mtasa-blue/issues)
 * [Wiki Roadmap](https://wiki.mtasa.com/wiki/Roadmap)
 
-Before committing, please review the [coding guidelines](https://wiki.mtasa.com/index.php?title=Coding_guidelines).
+# Coding Guidelines
+
+Introduction
+============
+
+Code repository {#code_repository}
+===============
+
+Structure
+---------
+
+Our code repository uses Git and is structured into number of different
+directories, which serve different purposes:
+
+-   **Client**
+-   **Server**
+-   **Shared**: contains code shared between both the client and the
+    server
+-   **irc**: bot code for the Multi Theft Auto IRC channels
+-   **m4**
+-   **utils**: utilities used to automate certain tasks
+-   **vendor**: unmodified third-party code and libraries (optionally
+    linked to the appropriate third-party Git repository through Git
+    submodules).
+
+Our branches contain groundbreaking research, radical ideas and other
+work-in-progress that is meant to be merged into the trunk at a later
+point, but also contains project milestones:
+
+-   The master branch is the main development branch (containing the
+    latest, bleeding-edge code)
+-   Project milestones are kept away from the trunk for stability
+    reasons, but the latest version branch can be used by any regular
+    player who has enabled nightly builds. Make sure that only well
+    tested code is added to the latest version branch.
+
+Gaining and Losing Commit access {#gaining_and_losing_commit_access}
+--------------------------------
+
+Commit access is granted after patches have been submitted, and the
+coder has proven to be competent. The subject matter of the patches does
+not matter, we are more interested in whether if you are granted commit
+access, you will be capable of maintaining a high standard of code and
+remaining cohesive with other project contributors.
+
+Patches can be submitted using [GitHub\'s pull request
+system](https://github.com/multitheftauto/mtasa-blue/pull/new). Usually
+commit access is gained after 2-3 patches, but this is not fixed and
+depends on the extent of the contributions. This requires you to fork
+our repository and make commits to your own branch first.
+
+After gaining commit access, if the contributor\'s commits are of a
+consistently low standard, or the user fails to stick to the rules,
+their commit access will be stripped and will be required to submit pull
+requests again.
+
+Committing code {#committing_code}
+---------------
+
+Keep in mind that your commits should initially be fixing or
+implementing existing issues on our [bug
+tracker](http://bugs.mtasa.com). The
+[roadmap](http://bugs.mtasa.com/roadmap_page.php) is particularly
+important since it allows contributors to track down priority issues.
+
+Please follow these guidelines for all your contributions:
+
+-   Commits should be thoroughly tested when added to master. Commits
+    that \'need to be fixed later\' which directly affect the state of
+    the mod will be reverted other than in exceptional circumstances.
+-   If writing unstable or experimental code, a private branch should be
+    added in your own fork. Branches should not be \"personal\" to each
+    user. This means that a branch should be created for a new feature,
+    not for a user specific playground.
+-   Commit messages should always give a clear indication of the content
+    of the change, without having to look at the code at all. Where
+    appropriate, include the Mantis Issue number in your log message and
+    keep your log messages consistent, e.g. **Fix \#1234: description
+    and notes here**. [Follow the seven rules identified
+    here.](http://chris.beams.io/posts/git-commit/)
+-   When committing updates to previous commits, include the previous
+    commit SHA (and a summarised commit message) in the new commit
+    message. Doing this will help identify related commits if they are
+    viewed at a later date.
+
+Ratings and comments {#ratings_and_comments}
+--------------------
+
+Ratings and comments are open for the public to review code and provide
+feedback. Please be mature and civilised when posting comments.
+Developers should try to review other contributor\'s commits and provide
+feedback as much as possible.
+
+Make sure you make appropriate use of the GitHub Reactions feature to
+rate commits or express agreement/disagreement to a comment. This avoids
+spammy comments such as \"+1\", \"-1\", \"Nice one!\", etc.
+
+Since you can only react to comments, not commits, feel free to create
+the initial \"+1\" comment in response to a commit. However, future
+reactions to a commit should be to the first response comment.
+
+What to code {#what_to_code}
+------------
+
+Generally, developers should try to stick to the
+[roadmap](http://bugs.mtasa.com/roadmap_page.php) when coding. This
+lists the issues required to be resolved for the next release. Of
+course, if you\'re interested in something else, feel free to experiment
+and submit it.
+
+Style
+-----
+
+-   We use 4 spaces instead of tabs.
+-   Hungarian notation for variable names.
+
+`float         fValue;               // Local variable`\
+`unsigned char m_ucValue;            // Class member variable`\
+`char          ms_cValue;            // Class static variable`\
+`bool          g_bCrashTwiceAnHour;  // Global variable`\
+`char*         szUsername;           // Zero terminated string`\
+`SString       strUsername;          // String`\
+`CVector       vecPosition;          // 3D Vector`
+
+-   Lower camel case for variable names of types like custom structs and
+    enums:
+
+`SSomeStruct   valueOne;`\
+`ESomeEnum     m_valueTwo;`
+
+-   Function names use UpperCamelCase:
+
+`void UpperCamelCase()`
+
+-   Functions with no arguments are declared and defined with (), and
+    called with ()
+
+`void MyTest();`\
+`void MyTest() { return; }`\
+`MyTest();`
+
+-   Do not use nested structures without braces:
+
+`// This is disallowed:`\
+`for (dont)`\
+`    for (do)`\
+`        for (this)`\
+`            ...`\
+\
+`// Either of these are allowed`\
+`if (x) {`\
+`    y;`\
+`}`\
+\
+`if (x)`\
+`    y;`
+
+-   Put *\#pragma once* preprocessor directive next to the copyright
+    comment for new header files and the ones you are modifying for the
+    pull request. Make sure to remove include guard if you are using
+    *\#pragma once*:
+
+` /*****************************************************************************`\
+``\
+` *`\
+` *  PROJECT:     Multi Theft Auto`\
+` *  LICENSE:     See LICENSE in the top level directory`\
+` *  FILE:        Client/mods/deathmatch/logic/CClientIFP.h`\
+` *`\
+` *  Multi Theft Auto is available from http://www.multitheftauto.com/`\
+` *`\
+` *****************************************************************************/`\
+``\
+` #pragma once`
+
+-   Once you\'re done writing code, and you\'re about to create a pull
+    request, apply clang formatting:
+    -   Download
+        [clang-format-r325576.exe](http://prereleases.llvm.org/win-snapshots/clang-format-r325576.exe),
+        and move it to **utils** folder.
+    -   Download [fnr.zip](http://findandreplace.io/downloads/fnr.zip),
+        extract fnr.exe to **utils** folder.
+    -   Run **utils\\win-apply-clang-format.bat**.
+
+```{=html}
+<!-- -->
+```
+-   For anything else, follow the style of the code that already exists.
+
+```{=html}
+<!-- -->
+```
+-   Tip: In Visual Studio go to Tools -\> Options -\> Text Editor -\>
+    C/C++ -\> Formatting -\> Spacing and you can configure it to
+    automatically apply the right spacing.
+
+Coding info {#coding_info}
+-----------
+
+Check out the [Coding info](Coding_info "wikilink") page and feel free
+to add more coding info to it.
+
+[hu:HU/Coding guidelines](hu:HU/Coding_guidelines "wikilink")
+
+[Category: Development](Category:_Development "wikilink")
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,6 @@ leaving the pull request clean.
     value of the CVAR.
     ```
 
-
 3.  Here we say `Fix #1115` so that GitHub automatically closes issue #1115. There's no description.
     ```
     Fix #1115: add async encode/decodeString
@@ -186,3 +185,8 @@ for the greater good, pledge to submit pull requests despite this lack of enforc
 
 For informational purposes, the current repository administrators are those marked as _The MTA Team_ on
 [this list](https://forum.mtasa.com/staff/).
+
+**Merge button**
+
+Generally use the "Squash and merge" button. If multiple commits are needed because you think
+having the separate commits are useful, use "Rebase and merge".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,46 +16,36 @@ system](https://github.com/multitheftauto/mtasa-blue/pull/new)
 
 **TODO: wiki roadmap page is mostly useless now**
 
-## Directory Structure
+## How to code
 
-Our project is organised into a number of different
-directories which serve different purposes:
-
--   **Client**
--   **Server**
--   **Shared**: contains code shared between both the client and the
-    server
--   **utils**: utilities used to automate certain tasks
--   **vendor**: unmodified third-party code and libraries (optionally
-    linked to the appropriate third-party Git repository through Git
-    submodules).
-
-Our branches contain groundbreaking research, radical ideas and other
-work-in-progress changes that are meant to be merged into `master` at
-a later point in time.
-
-The master branch is the main development branch containing the
-latest, bleeding-edge code.
-
-Additional information can befound on our "[Coding info]" page,
+Starter coding information can be found on our "[Coding info]" page,
 including stuff like:
 
+- folder explanation
 - individual projects (modules) within the above folders
 - simplification of data types
 - debug commands
 - more
 
-**TODO: consider moving 'Coding info' to GitHub wiki.
-Also, the above directory structure should just be merged into the 'Coding info' page.
-It feels out of place.**
-
 [Coding info]: https://wiki.multitheftauto.com/wiki/Coding_info
+
+## Where to code
+
+As a new potential contributor, you will need to fork our repository and make
+commits to your own "branch". Then you can send us a pull request.
+
+Our _`master`_ branch is the main development branch containing the
+latest, bleeding-edge code.
+
+
+Our _other_ branches contain groundbreaking research, radical ideas and other
+work-in-progress changes that are meant to be merged into `master` at
+a later point in time.
 
 ## What to code
 
-Generally, developers should try to only send pull requests that resolve existing
+Generally, developers should try to only submit pull requests that resolve existing
 [issues](https://github.com/multitheftauto/mtasa-blue/issues).
-This requires you to fork our repository and make commits to your own branch.
 
 If you're looking for something to work on, take a look at:
 - our ["good first issue"] label, and
@@ -92,7 +82,7 @@ Please follow these guidelines for all your contributions:
     viewed at a later date.
 -   Follow the [Style Guide](https://github.com/multitheftauto/mtasa-blue/wiki/Style-Guide)
 
-## Ratings and comments
+## Reviewing code
 
 **TODO: needs review guide, needs content from: https://github.com/thoughtbot/guides/tree/master/code-review and https://gist.github.com/mrsasha/8d511770ad9b282f3a5d0f5c8acdd10e**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ The most important of the [seven rules](http://chris.beams.io/posts/git-commit/)
 4. Use the body to explain what and why vs. how
 
 **Follow up (addendum) commits should refer to the previous commit.** Do this by 
-including the previous commit-identifier SHA and a summarised commit message in
+including the previous commit-identifier SHA and, if there's space, a summarised commit message in
 the new commit message. Doing this will help identify related commits
 if they are viewed at a later date.
 
@@ -81,6 +81,52 @@ to make atomic commits and then cherry-pick those commits into separate branches
 leaving the pull request clean.
 
 **Read the ["Code Review"] guide** for more guidelines about the code review process.
+
+**Examples**. Here are some examples of commit messages with a short and descriptive title in the imperative mood.
+
+1.  Here we also have a description that explains the content of the commit.
+    ```
+    Fix vehicle model memory leaks in engineReplaceModel
+    
+    Fixed 3 memory leaks:
+    - clump model leak
+    - vehicle visual data (dummies) leak
+    - engineReplaceModel added extra references to TXD, and this was not getting unloaded at times
+    ```
+
+2.  Here we have a longer description that explains how to use the feature. The body is wrapped at 72 characters.
+    ```
+    Add "beta" CVAR "_beta_qc_rightclick_command"
+    
+    This variable lets you execute a command of your choice when you right
+    click the "quick connect" button.
+    
+    By default this CVAR is set to "reconnect", but you can set it to
+    anything - "connect orange.mtasa.com" or "nick timw0w".
+    
+    In the console, type "_beta_qc_rightclick_command" and press enter. This
+    will tell you the current value of the CVAR.
+    
+    You can do "_beta_qc_rightclick_command=nick timw0w" to change the
+    value of the CVAR.
+    ```
+
+
+3.  Here we say `Fix #1115` so that GitHub automatically closes issue #1115. There's no description.
+    ```
+    Fix #1115: add async encode/decodeString
+    ```
+
+4.  There was no specific issue being fixed here, but GitHub's squash-merge feature automatically appended `(#1177)`,
+    telling us which PR created this commit. There's no description.
+    ```
+    Add "remember this option" checkbox to NVidia Optimus dialog (#1177)
+    ```
+
+5.  Here we refer to a previous commit.
+    ```
+    Addendum to a80f8d6: fix Windows build error
+    ```
 
 ## Reviewing code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,65 +10,66 @@ Our project's code repository can be found on the [multitheftauto/mtasa-blue](ht
 * [Issue Tracker](https://github.com/multitheftauto/mtasa-blue/issues)
 * [Wiki Roadmap](https://wiki.mtasa.com/wiki/Roadmap)
 
-# Coding Guidelines
+# Overview
 
-Introduction
-============
+## Directory Structure
 
-Code repository {#code_repository}
-===============
-
-Structure
----------
-
-Our code repository uses Git and is structured into number of different
-directories, which serve different purposes:
+Our project is organised into a number of different
+directories which serve different purposes:
 
 -   **Client**
 -   **Server**
 -   **Shared**: contains code shared between both the client and the
     server
--   **irc**: bot code for the Multi Theft Auto IRC channels
--   **m4**
 -   **utils**: utilities used to automate certain tasks
 -   **vendor**: unmodified third-party code and libraries (optionally
     linked to the appropriate third-party Git repository through Git
     submodules).
 
 Our branches contain groundbreaking research, radical ideas and other
-work-in-progress that is meant to be merged into the trunk at a later
-point, but also contains project milestones:
+work-in-progress changes that are meant to be merged into `master` at
+a later point in time.
 
--   The master branch is the main development branch (containing the
-    latest, bleeding-edge code)
--   Project milestones are kept away from the trunk for stability
-    reasons, but the latest version branch can be used by any regular
-    player who has enabled nightly builds. Make sure that only well
-    tested code is added to the latest version branch.
+The master branch is the main development branch containing the
+latest, bleeding-edge code.
 
-Gaining and Losing Commit access {#gaining_and_losing_commit_access}
---------------------------------
+Additional information can befound on our "[Coding info]" page,
+including stuff like:
 
-Commit access is granted after patches have been submitted, and the
-coder has proven to be competent. The subject matter of the patches does
+- individual projects (modules) within the above folders
+- simplification of data types
+- debug commands
+- more
+
+<!-- TODO: consider moving 'Coding info' to GitHub wiki.
+Also, the above directory structure should just be merged into the 'Coding info' page.
+It feels out of place. -->
+
+[Coding info]: https://wiki.multitheftauto.com/wiki/Coding_info
+
+## Gaining and losing commit access
+
+Commit access is granted after pull requests have been submitted, and the
+coder has proven themselves to be competent. The subject matter of the patches does
 not matter, we are more interested in whether if you are granted commit
 access, you will be capable of maintaining a high standard of code and
-remaining cohesive with other project contributors.
+remaining cohesive with other project collaborators.
 
-Patches can be submitted using [GitHub\'s pull request
+Patches can be submitted using [GitHub's pull request
 system](https://github.com/multitheftauto/mtasa-blue/pull/new). Usually
-commit access is gained after 2-3 patches, but this is not fixed and
+commit access is gained after 2-3 pull requests, but this is not fixed and
 depends on the extent of the contributions. This requires you to fork
 our repository and make commits to your own branch first.
 
-After gaining commit access, if the contributor\'s commits are of a
+After gaining commit access, if the contributor's commits are of a
 consistently low standard, or the user fails to stick to the rules,
 their commit access will be stripped and will be required to submit pull
 requests again.
 
-Committing code {#committing_code}
----------------
+## Committing code
 
+<!-- TODO: below clashes a bit with the 'What to code' section -->
+<!-- oh and it's also referring to mantis which we don't use -->
 Keep in mind that your commits should initially be fixing or
 implementing existing issues on our [bug
 tracker](http://bugs.mtasa.com). The
@@ -95,8 +96,9 @@ Please follow these guidelines for all your contributions:
     message. Doing this will help identify related commits if they are
     viewed at a later date.
 
-Ratings and comments {#ratings_and_comments}
---------------------
+## Ratings and comments
+
+<!-- TODO: needs review guide -->
 
 Ratings and comments are open for the public to review code and provide
 feedback. Please be mature and civilised when posting comments.
@@ -111,17 +113,31 @@ Since you can only react to comments, not commits, feel free to create
 the initial \"+1\" comment in response to a commit. However, future
 reactions to a commit should be to the first response comment.
 
-What to code {#what_to_code}
-------------
+## What to code
 
-Generally, developers should try to stick to the
-[roadmap](http://bugs.mtasa.com/roadmap_page.php) when coding. This
-lists the issues required to be resolved for the next release. Of
-course, if you\'re interested in something else, feel free to experiment
+Generally, developers should try to only send pull requests that resolve existing
+[issues](https://github.com/multitheftauto/mtasa-blue/issues).
+
+If you're looking for something to work on, take a look at:
+- our ["good first issue"] label, and
+- our [milestones]
+
+["good first issue"]: https://github.com/multitheftauto/mtasa-blue/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22
+[milestones]: https://github.com/multitheftauto/mtasa-blue/milestones?direction=asc&sort=due_date
+
+<!-- TODO: below may need to be rephrased -->
+Of course, if you're interested in something else, feel free to experiment
 and submit it.
 
-Style
------
+## Style
+
+<!--
+
+TODO: talk about editorconfig.
+
+Also, consider moving this to its own document on the wiki? It seems too long.
+
+-->
 
 -   We use 4 spaces instead of tabs.
 -   Hungarian notation for variable names.
@@ -205,14 +221,3 @@ Style
 -   Tip: In Visual Studio go to Tools -\> Options -\> Text Editor -\>
     C/C++ -\> Formatting -\> Spacing and you can configure it to
     automatically apply the right spacing.
-
-Coding info {#coding_info}
------------
-
-Check out the [Coding info](Coding_info "wikilink") page and feel free
-to add more coding info to it.
-
-[hu:HU/Coding guidelines](hu:HU/Coding_guidelines "wikilink")
-
-[Category: Development](Category:_Development "wikilink")
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,24 +47,21 @@ It feels out of place. -->
 
 [Coding info]: https://wiki.multitheftauto.com/wiki/Coding_info
 
-## Gaining and losing commit access
+## What to code
 
-Commit access is granted after pull requests have been submitted, and the
-coder has proven themselves to be competent. The subject matter of the patches does
-not matter, we are more interested in whether if you are granted commit
-access, you will be capable of maintaining a high standard of code and
-remaining cohesive with other project collaborators.
+Generally, developers should try to only send pull requests that resolve existing
+[issues](https://github.com/multitheftauto/mtasa-blue/issues).
 
-Patches can be submitted using [GitHub's pull request
-system](https://github.com/multitheftauto/mtasa-blue/pull/new). Usually
-commit access is gained after 2-3 pull requests, but this is not fixed and
-depends on the extent of the contributions. This requires you to fork
-our repository and make commits to your own branch first.
+If you're looking for something to work on, take a look at:
+- our ["good first issue"] label, and
+- our [milestones]
 
-After gaining commit access, if the contributor's commits are of a
-consistently low standard, or the user fails to stick to the rules,
-their commit access will be stripped and will be required to submit pull
-requests again.
+["good first issue"]: https://github.com/multitheftauto/mtasa-blue/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22
+[milestones]: https://github.com/multitheftauto/mtasa-blue/milestones?direction=asc&sort=due_date
+
+<!-- TODO: below may need to be rephrased -->
+Of course, if you're interested in something else, feel free to experiment
+and submit it.
 
 ## Committing code
 
@@ -99,7 +96,13 @@ Please follow these guidelines for all your contributions:
 
 ## Ratings and comments
 
-<!-- TODO: needs review guide -->
+<!-- TODO: needs review guide
+
+needs content from:
+- https://github.com/thoughtbot/guides/tree/master/code-review
+- https://gist.github.com/mrsasha/8d511770ad9b282f3a5d0f5c8acdd10e
+
+-->
 
 Ratings and comments are open for the public to review code and provide
 feedback. Please be mature and civilised when posting comments.
@@ -114,18 +117,22 @@ Since you can only react to comments, not commits, feel free to create
 the initial \"+1\" comment in response to a commit. However, future
 reactions to a commit should be to the first response comment.
 
-## What to code
 
-Generally, developers should try to only send pull requests that resolve existing
-[issues](https://github.com/multitheftauto/mtasa-blue/issues).
+## Gaining and losing commit access
 
-If you're looking for something to work on, take a look at:
-- our ["good first issue"] label, and
-- our [milestones]
+Commit access is granted after pull requests have been submitted, and the
+coder has proven themselves to be competent. The subject matter of the patches does
+not matter, we are more interested in whether if you are granted commit
+access, you will be capable of maintaining a high standard of code and
+remaining cohesive with other project collaborators.
 
-["good first issue"]: https://github.com/multitheftauto/mtasa-blue/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22
-[milestones]: https://github.com/multitheftauto/mtasa-blue/milestones?direction=asc&sort=due_date
+Patches can be submitted using [GitHub's pull request
+system](https://github.com/multitheftauto/mtasa-blue/pull/new). Usually
+commit access is gained after 2-3 pull requests, but this is not fixed and
+depends on the extent of the contributions. This requires you to fork
+our repository and make commits to your own branch first.
 
-<!-- TODO: below may need to be rephrased -->
-Of course, if you're interested in something else, feel free to experiment
-and submit it.
+After gaining commit access, if the contributor's commits are of a
+consistently low standard, or the user fails to stick to the rules,
+their commit access will be stripped and will be required to submit pull
+requests again.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ a later point in time.
 If you're a collaborator, it's your choice whether to push branches to this
 repository or to your own fork.
 
-**Branches are "topical" and snd should not be "personal" to each
+**Branches are "topical" and should not be "personal" to each
 user.** This means that a branch should be created for a new feature,
 not for a user specific playground.
 
@@ -71,14 +71,14 @@ The most important of the [seven rules](http://chris.beams.io/posts/git-commit/)
 4. Use the body to explain what and why vs. how
 
 **Follow up (addendum) commits should refer to the previous commit.** Do this by 
-including the previous commit SHA and a summarised commit message in
+including the previous commit-identifier SHA and a summarised commit message in
 the new commit message. Doing this will help identify related commits
 if they are viewed at a later date.
 
-**Try to keep PRs small — they should be about one thing.** you do multiple things
-in one PR, it's hard to review. If you're fixing stuff as you go, you might want
+**Try to keep pull requests small — they should be about one thing.** you do multiple things
+in one pull request, it's hard to review. If you're fixing stuff as you go, you might want
 to make atomic commits and then cherry-pick those commits into separate branches,
-leaving the PR clean.
+leaving the pull request clean.
 
 **Read the ["Code Review"] guide** for more guidelines about the code review process.
 
@@ -117,12 +117,12 @@ We grant merge rights after you have proven yourself to be competent,
 which is generally after 3-5 pull requests. This is not fixed and depends
 on the extent of your contributions, community status and other factors.
 
-The subject matter of your PRs do not matter—we are more interested in,
+The subject matter of your pull requests do not matter — we are more interested in,
 once granted merge rights, whether you are capable of maintaining
 a high standard of code and remaining cohesive with other project collaborators.
 
 After gaining merge rights, if your contributions are of a consistently low standard,
-or you fail to stick to the rules, your permissions will be stripped.
+or you fail to stick to the rules, your permissions will be revoked.
 
 ## Merging pull requests
 
@@ -135,7 +135,7 @@ This isn't enforced via branch protection, but please try and stick to this conv
 (... unless nobody else is reviewing your PR).
 
 Branch protection is **not enforced** for repository administrators,
-and those people are therefore not required to send pull requests. Individual repo admins may,
+and those people are therefore not required to send pull requests. Individual repository admins may,
 for the greater good, pledge to submit pull requests despite this lack of enforcement.
 
 For informational purposes, the current repository administrators are a _subset of_

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,3 +125,5 @@ Before merging, pull requests require:
 
 If the pull request is large, requiring at least 2 pull request reviews.
 This isn't enforced via GitHub's interface, but you should try and stick to this convention.
+
+Pull requests are required from anyone who is not a member of the MTA Team.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ The most important of the [seven rules](http://chris.beams.io/posts/git-commit/)
 3. Use the imperative mood in the subject line
 4. Use the body to explain what and why vs. how
 
-**Follow up commits should refer to the previous commit.** Do this by 
+**Follow up (addendum) commits should refer to the previous commit.** Do this by 
 including the previous commit SHA and a summarised commit message in
 the new commit message. Doing this will help identify related commits
 if they are viewed at a later date.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,11 @@ Our project's code repository can be found on the [multitheftauto/mtasa-blue](ht
 
 * [Nightly Builds](https://nightly.mtasa.com/)
 * [Issue Tracker](https://github.com/multitheftauto/mtasa-blue/issues)
-* [Wiki Roadmap](https://wiki.mtasa.com/wiki/Roadmap) <!--TODO: this page is mostly useless now -->
+* [Wiki Roadmap](https://wiki.mtasa.com/wiki/Roadmap)
 * Patches can be submitted using [GitHub's pull request
 system](https://github.com/multitheftauto/mtasa-blue/pull/new)
+
+**TODO: wiki roadmap page is mostly useless now**
 
 ## Directory Structure
 
@@ -43,9 +45,9 @@ including stuff like:
 - debug commands
 - more
 
-<!-- TODO: consider moving 'Coding info' to GitHub wiki.
+**TODO: consider moving 'Coding info' to GitHub wiki.
 Also, the above directory structure should just be merged into the 'Coding info' page.
-It feels out of place. -->
+It feels out of place.**
 
 [Coding info]: https://wiki.multitheftauto.com/wiki/Coding_info
 
@@ -62,7 +64,8 @@ If you're looking for something to work on, take a look at:
 ["good first issue"]: https://github.com/multitheftauto/mtasa-blue/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22
 [milestones]: https://github.com/multitheftauto/mtasa-blue/milestones?direction=asc&sort=due_date
 
-<!-- TODO: below may need to be rephrased -->
+**TODO: below may need to be rephrased**
+
 Of course, if you're interested in something else, feel free to experiment
 and submit it.
 
@@ -91,13 +94,7 @@ Please follow these guidelines for all your contributions:
 
 ## Ratings and comments
 
-<!-- TODO: needs review guide
-
-needs content from:
-- https://github.com/thoughtbot/guides/tree/master/code-review
-- https://gist.github.com/mrsasha/8d511770ad9b282f3a5d0f5c8acdd10e
-
--->
+**TODO: needs review guide, needs content from: https://github.com/thoughtbot/guides/tree/master/code-review and https://gist.github.com/mrsasha/8d511770ad9b282f3a5d0f5c8acdd10e**
 
 Ratings and comments are open for the public to review code and provide
 feedback. Please be mature and civilised when posting comments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,17 +172,9 @@ or you fail to stick to the rules, your permissions will be revoked.
 
 ## Merging pull requests
 
-Before merging, enforced by GitHub's branch protection, pull requests **require**:
-- Linux and Windows status checks to pass
-- 1 pull request review
+Before merging, pull requests _should_ have:
+- Linux and Windows status checks passing, and
+- 1 pull request review, or 2 reviews for large pull requests
 
-If the pull request is large, try and only merge if there at least 2 pull request reviews.
-This isn't enforced via branch protection, but please try and stick to this convention
-(... unless nobody else is reviewing your PR).
-
-Branch protection is **not enforced** for repository administrators,
-and those people are therefore not required to send pull requests. Individual repository admins may,
-for the greater good, pledge to submit pull requests despite this lack of enforcement.
-
-For informational purposes, the current repository administrators are a _subset of_
-[those listed here](https://forum.mtasa.com/staff/)—it is not an authoritative list.
+These rules are not enforced via branch protection but, for the greater good,
+please try and stick to this convention (... unless nobody is reviewing your PR).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ feedback as much as possible.
 
 Please read our ["Code Review"] article for information on how to review code effectively.
 
-["Code Review"]: (https://github.com/multitheftauto/mtasa-blue/wiki/Code-Review)
+["Code Review"]: https://github.com/multitheftauto/mtasa-blue/wiki/Code-Review
 
 <!--
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+# Contributors Guide
+
 So you've decided to become a contributor to our project. Excellent!
 But before we can start accepting your code, there are a couple of
 things you should know about how we work. These are mostly guidelines
@@ -9,8 +11,6 @@ Our project's code repository can be found on the [multitheftauto/mtasa-blue](ht
 * [Nightly Builds](https://nightly.mtasa.com/)
 * [Issue Tracker](https://github.com/multitheftauto/mtasa-blue/issues)
 * [Wiki Roadmap](https://wiki.mtasa.com/wiki/Roadmap) <!--TODO: this page is mostly useless now -->
-
-# Overview
 
 ## Directory Structure
 
@@ -95,6 +95,7 @@ Please follow these guidelines for all your contributions:
     commit SHA (and a summarised commit message) in the new commit
     message. Doing this will help identify related commits if they are
     viewed at a later date.
+-   Follow the [Style Guide](https://github.com/multitheftauto/mtasa-blue/wiki/Style-Guide)
 
 ## Ratings and comments
 
@@ -128,101 +129,3 @@ If you're looking for something to work on, take a look at:
 <!-- TODO: below may need to be rephrased -->
 Of course, if you're interested in something else, feel free to experiment
 and submit it.
-
-## Style
-
-<!--
-
-TODO: talk about editorconfig.
-
-Also, consider moving this to its own document on the wiki? It seems too long.
-
--->
-
--   We use 4 spaces instead of tabs.
--   Hungarian notation for variable names.
-
-    ```cpp
-    float         fValue;               // Local variable
-    unsigned char m_ucValue;            // Class member variable
-    char          ms_cValue;            // Class static variable
-    bool          g_bCrashTwiceAnHour;  // Global variable
-    char*         szUsername;           // Zero terminated string
-    SString       strUsername;          // String
-    CVector       vecPosition;          // 3D Vector
-    ```
-
--   Lower camel case for variable names of types like custom structs and
-    enums:
-
-    ```cpp
-    SSomeStruct   valueOne;
-    ESomeEnum     m_valueTwo;
-    ```
-
--   Function names use UpperCamelCase:
-
-    ```cpp
-    void UpperCamelCase()
-    ```
-
--   Functions with no arguments are declared and defined with (), and
-    called with ()
-
-    ```cpp
-    void MyTest();
-    void MyTest() { return; }
-    MyTest();
-    ```
-
--   Do not use nested structures without braces:
-
-    ```cpp
-    // This is disallowed:
-    for (dont)
-        for (do)
-            for (this)
-                ...
-
-    // Either of these are allowed
-    if (x) {
-        y;
-    }
-
-    if (x)
-        y;
-    ```
-
--   Put `#pragma once` preprocessor directive next to the copyright
-    comment for new header files and the ones you are modifying for the
-    pull request. Make sure to remove include guard if you are using
-    `#pragma once`:
-
-    ```cpp
-    /*****************************************************************************
-    \
-    *
-    *  PROJECT:     Multi Theft Auto
-    *  LICENSE:     See LICENSE in the top level directory
-    *  FILE:        Client/mods/deathmatch/logic/CClientIFP.h
-    *
-    *  Multi Theft Auto is available from http://www.multitheftauto.com/
-    *
-    *****************************************************************************/
-
-    #pragma once
-    ```
-
--   Once you're done writing code, and you're about to create a pull
-    request, apply clang formatting:
-    -   Download
-        [clang-format-r325576.exe](http://prereleases.llvm.org/win-snapshots/clang-format-r325576.exe),
-        and move it to **utils** folder.
-    -   Download [fnr.zip](http://findandreplace.io/downloads/fnr.zip),
-        extract fnr.exe to **utils** folder.
-    -   Run `utils/win-apply-clang-format.bat` <!-- TODO: this updates all files. we shouldn't recommend this. -->
-
--   For anything else, follow the style of the code that already exists.
-
--   Tip: In Visual Studio go to `Tools -> Options -> Text Editor -> C/C++ -> Formatting -> Spacing`
-    and you can configure it to automatically apply the right spacing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,20 +77,28 @@ if they are viewed at a later date.
 
 ## Reviewing code
 
-**TODO: needs review guide, needs content from: https://github.com/thoughtbot/guides/tree/master/code-review and https://gist.github.com/mrsasha/8d511770ad9b282f3a5d0f5c8acdd10e**
+Contributors should try to review other contributor's commits and provide
+feedback as much as possible.
+
+Please read our ["Code Review'](https://github.com/multitheftauto/mtasa-blue/wiki/Code-Review)
+article for information on how to review code effectively.
+
+<!--
+
+TODO: this should be part of a code of conduct instead
 
 Ratings and comments are open for the public to review code and provide
 feedback. Please be mature and civilised when posting comments.
-Developers should try to review other contributor\'s commits and provide
-feedback as much as possible.
 
 Make sure you make appropriate use of the GitHub Reactions feature to
 rate commits or express agreement/disagreement to a comment. This avoids
-spammy comments such as \"+1\", \"-1\", \"Nice one!\", etc.
+spammy comments such as "+1", "-1", "Nice one!", etc.
 
 Since you can only react to comments, not commits, feel free to create
-the initial \"+1\" comment in response to a commit. However, future
-reactions to a commit should be to the first response comment.
+the initial "+1" comment in response to a commit. However, future
+similar reactions to a commit should be to the first response comment.
+
+-->
 
 ## Gaining and losing merge rights
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,5 @@ Branch protection is **not enforced** for repository administrators,
 and those people are therefore not required to send pull requests. Individual repo admins may,
 for the greater good, pledge to submit pull requests despite this lack of enforcement.
 
-For informational purposes, the current repository administrators are a _subset of_ [those listed here].
-It is not an authoritative list.
-
-[forum admins]: https://forum.mtasa.com/staff/
+For informational purposes, the current repository administrators are a _subset of_
+[those listed here](https://forum.mtasa.com/staff/)—it is not an authoritative list.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,3 +116,12 @@ a high standard of code and remaining cohesive with other project collaborators.
 After gaining merge rights, if your contributions are of a consistently low standard,
 or you fail to stick to the rules, your permissions will be stripped and will no longer
 be able to merge submitted pull requests or create your own branches.
+
+## Merging pull requests
+
+Before merging, pull requests require:
+- Linux and Windows status checks to pass
+- 1 pull request review
+
+If the pull request is large, requiring at least 2 pull request reviews.
+This isn't enforced via GitHub's interface, but you should try and stick to this convention.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ the mod will be reverted other than in exceptional circumstances.
 The most important of the [seven rules](http://chris.beams.io/posts/git-commit/) has been copied below, but please read the article:
 
 1. Separate subject from body with a blank line
-2. Limit the subject line to 50 characters
+2. Limit the subject line to around 60-80 characters (the [seven rules] say 50, but we think ~70 is okay)
 3. Use the imperative mood in the subject line
 4. Use the body to explain what and why vs. how
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,13 +75,21 @@ including the previous commit SHA and a summarised commit message in
 the new commit message. Doing this will help identify related commits
 if they are viewed at a later date.
 
+**Try to keep PRs small — they should be about one thing.** you do multiple things
+in one PR, it's hard to review. If you're fixing stuff as you go, you might want
+to make atomic commits and then cherry-pick those commits into separate branches,
+leaving the PR clean.
+
+**Read the ["Code Review"] guide** for more guidelines about the code review process.
+
 ## Reviewing code
 
 Contributors should try to review other contributor's commits and provide
 feedback as much as possible.
 
-Please read our ["Code Review'](https://github.com/multitheftauto/mtasa-blue/wiki/Code-Review)
-article for information on how to review code effectively.
+Please read our ["Code Review"] article for information on how to review code effectively.
+
+["Code Review"]: (https://github.com/multitheftauto/mtasa-blue/wiki/Code-Review)
 
 <!--
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ label, or our [milestones].
 
 Of course, if you're interested in something else, feel free to experiment
 and submit it. But discussing the feature beforehand, in an issue, will
-make your PR more likely to be merged in a timely fashion.
+make your pull request more likely to be merged in a timely fashion.
 
 ## Committing code
 
@@ -118,7 +118,7 @@ leaving the pull request clean.
     ```
 
 4.  There was no specific issue being fixed here, but GitHub's squash-merge feature automatically appended `(#1177)`,
-    telling us which PR created this commit. There's no description.
+    telling us which pull request created this commit. There's no description.
     ```
     Add "remember this option" checkbox to NVidia Optimus dialog (#1177)
     ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,7 +138,7 @@ Branch protection is **not enforced** for repository administrators,
 and those people are therefore not required to send pull requests. Individual repo admins may,
 for the greater good, pledge to submit pull requests despite this lack of enforcement.
 
-For informational purposes, the current repository administrators are a _subset of_ [forum admins].
+For informational purposes, the current repository administrators are a _subset of_ [those listed here].
 It is not an authoritative list.
 
 [forum admins]: https://forum.mtasa.com/staff/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,16 @@
 # Contributors Guide
 
 So you've decided to become a contributor to our project. Excellent!
+
+We are always looking for new developers, so if you're new,
+please check out our Getting Started guide.
+
 But before we can start accepting your code, there are a couple of
-things you should know about how we work. These are mostly guidelines
-and rules as to how your code should be structured and how it can be
-committed without upsetting any fellow contributors.
+things you should know about how we work. 
 
-Our project's code repository can be found on the [multitheftauto/mtasa-blue](https://github.com/multitheftauto/mtasa-blue/) Git repository at [GitHub](https://github.com/). We are always looking for new developers, so if you're interested, here are some useful links:
-
-* [Nightly Builds](https://nightly.mtasa.com/)
-* [Issue Tracker](https://github.com/multitheftauto/mtasa-blue/issues)
-* [Wiki Roadmap](https://wiki.mtasa.com/wiki/Roadmap)
-* Patches can be submitted using [GitHub's pull request
-system](https://github.com/multitheftauto/mtasa-blue/pull/new)
-
-**TODO: wiki roadmap page is mostly useless now**
+This document mostly contains guidelines and rules as to how your
+code should be structured and how it can be committed without
+upsetting any fellow contributors.
 
 ## How to code
 
@@ -36,7 +32,6 @@ commits to your own "branch". Then you can send us a pull request.
 
 Our _`master`_ branch is the main development branch containing the
 latest, bleeding-edge code.
-
 
 Our _other_ branches contain groundbreaking research, radical ideas and other
 work-in-progress changes that are meant to be merged into `master` at
@@ -64,18 +59,19 @@ and submit it.
 Please follow these guidelines for all your contributions:
 
 -   Commits should be thoroughly tested when added to master. Commits
-    that \'need to be fixed later\' which directly affect the state of
+    that 'need to be fixed later' which directly affect the state of
     the mod will be reverted other than in exceptional circumstances.
 -   If writing unstable or experimental code, a private branch should be
-    added in your own fork. Branches should not be \"personal\" to each
+    added in your own fork. Branches should not be "personal" to each
     user. This means that a branch should be created for a new feature,
     not for a user specific playground.
 -   Commit messages should always give a clear indication of the content
     of the change, without having to look at the code at all. Where
-    appropriate, include the Mantis Issue number in your log message and
-    keep your log messages consistent, e.g. **Fix \#1234: description
-    and notes here**. [Follow the seven rules identified
-    here.](http://chris.beams.io/posts/git-commit/)
+    appropriate, include the issue number in your log message and
+    keep your log messages consistent, e.g. **Fix #1234: description
+    and notes here**.
+-   Don't forget to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
+-   [Follow the seven rules identified here.](http://chris.beams.io/posts/git-commit/)
 -   When committing updates to previous commits, include the previous
     commit SHA (and a summarised commit message) in the new commit
     message. Doing this will help identify related commits if they are

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,11 +202,11 @@ Also, consider moving this to its own document on the wiki? It seems too long.
     /*****************************************************************************
     \
     *
-    *  PROJECT:     Multi Theft Auto`\
-    *  LICENSE:     See LICENSE in the top level directory`\
-    *  FILE:        Client/mods/deathmatch/logic/CClientIFP.h`\
+    *  PROJECT:     Multi Theft Auto
+    *  LICENSE:     See LICENSE in the top level directory
+    *  FILE:        Client/mods/deathmatch/logic/CClientIFP.h
     *
-    *  Multi Theft Auto is available from http://www.multitheftauto.com/`\
+    *  Multi Theft Auto is available from http://www.multitheftauto.com/
     *
     *****************************************************************************/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,8 +134,11 @@ If the pull request is large, try and only merge if there at least 2 pull reques
 This isn't enforced via branch protection, but please try and stick to this convention
 (... unless nobody else is reviewing your PR).
 
-Branch protection is **not enforced** for repository administrators (a subset of [forum admins]),
+Branch protection is **not enforced** for repository administrators,
 and those people are therefore not required to send pull requests. Individual repo admins may,
 for the greater good, pledge to submit pull requests despite this lack of enforcement.
+
+For informational purposes, the current repository administrators are a _subset of_ [forum admins].
+It is not an authoritative list.
 
 [forum admins]: https://forum.mtasa.com/staff/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ Please read our ["Code Review"] article for information on how to review code ef
 
 <!--
 
-TODO: this should be part of a code of conduct instead
+TODO(qaisjp): the below content should be part of a code of conduct instead
 
 Ratings and comments are open for the public to review code and provide
 feedback. Please be mature and civilised when posting comments.
@@ -114,24 +114,28 @@ Merge rights allow you to merge your own approved pull requests and
 review other people's pull requests.
 
 We grant merge rights after you have proven yourself to be competent,
-this is generally after 3-5 pull requests, but it's not fixed and depends
-on the extent of your contributions.
+which is generally after 3-5 pull requests. This is not fixed and depends
+on the extent of your contributions, community status and other factors.
 
 The subject matter of your PRs do not matter—we are more interested in,
 once granted merge rights, whether you are capable of maintaining
 a high standard of code and remaining cohesive with other project collaborators.
 
 After gaining merge rights, if your contributions are of a consistently low standard,
-or you fail to stick to the rules, your permissions will be stripped and will no longer
-be able to merge submitted pull requests or create your own branches.
+or you fail to stick to the rules, your permissions will be stripped.
 
 ## Merging pull requests
 
-Before merging, pull requests require:
+Before merging, enforced by GitHub's branch protection, pull requests **require**:
 - Linux and Windows status checks to pass
 - 1 pull request review
 
-If the pull request is large, requiring at least 2 pull request reviews.
-This isn't enforced via GitHub's interface, but you should try and stick to this convention.
+If the pull request is large, try and only merge if there at least 2 pull request reviews.
+This isn't enforced via branch protection, but please try and stick to this convention
+(... unless nobody else is reviewing your PR).
 
-Pull requests are required from anyone who is not a member of the MTA Team.
+Branch protection is **not enforced** for repository administrators (a subset of [forum admins]),
+and those people are therefore not required to send pull requests. Individual repo admins may,
+for the greater good, pledge to submit pull requests despite this lack of enforcement.
+
+[forum admins]: https://forum.mtasa.com/staff/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,14 +61,14 @@ the mod will be reverted other than in exceptional circumstances.
 - be consistent
 - always give a clear indication of what has been changed without having to look at the code
 - include issue numbers, using [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) where necessary
-- [follow the seven rules identified here](http://chris.beams.io/posts/git-commit/).
+- [follow the seven rules identified here](http://chris.beams.io/posts/git-commit/)
     
-    The most important has been copied below, but please read the article.
-        
-    1. Separate subject from body with a blank line
-    2. Limit the subject line to 50 characters
-    3. Use the imperative mood in the subject line
-    4. Use the body to explain what and why vs. how
+The most important of the [seven rules](http://chris.beams.io/posts/git-commit/) has been copied below, but please read the article:
+
+1. Separate subject from body with a blank line
+2. Limit the subject line to 50 characters
+3. Use the imperative mood in the subject line
+4. Use the body to explain what and why vs. how
 
 **Follow up commits should refer to the previous commit.** Do this by 
 including the previous commit SHA and a summarised commit message in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,9 +172,17 @@ or you fail to stick to the rules, your permissions will be revoked.
 
 ## Merging pull requests
 
-Before merging, pull requests _should_ have:
-- Linux and Windows status checks passing, and
-- 1 pull request review, or 2 reviews for large pull requests
+Before merging, enforced by GitHub's branch protection, pull requests **require**:
+- Linux and Windows status checks to pass
+- 1 pull request review
 
-These rules are not enforced via branch protection but, for the greater good,
-please try and stick to this convention (... unless nobody is reviewing your PR).
+If the pull request is large, try and only merge if there at least 2 pull request reviews.
+This isn't enforced via branch protection, but please try and stick to this convention
+(... unless nobody else is reviewing your PR).
+
+Branch protection is **not enforced** for repository administrators,
+and those people are therefore not required to send pull requests. Individual repository admins may,
+for the greater good, pledge to submit pull requests despite this lack of enforcement.
+
+For informational purposes, the current repository administrators are a _subset of_
+[those listed here](https://forum.mtasa.com/staff/)—it is not an authoritative list.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 So you've decided to become a contributor to our project. Excellent!
 
 We are always looking for new developers, so if you're new,
-please check out our Getting Started guide.
+please check out our [Getting Started guide](https://wiki.multitheftauto.com/wiki/Coding_info).
 
 But before we can start accepting your code, there are a couple of
 things you should know about how we work. 
@@ -11,19 +11,6 @@ things you should know about how we work.
 This document mostly contains guidelines and rules as to how your
 code should be structured and how it can be committed without
 upsetting any fellow contributors.
-
-## How to code
-
-Starter coding information can be found on our "[Coding info]" page,
-including stuff like:
-
-- folder explanation
-- individual projects (modules) within the above folders
-- simplification of data types
-- debug commands
-- more
-
-[Coding info]: https://wiki.multitheftauto.com/wiki/Coding_info
 
 ## Where to code
 
@@ -37,46 +24,56 @@ Our _other_ branches contain groundbreaking research, radical ideas and other
 work-in-progress changes that are meant to be merged into `master` at
 a later point in time.
 
+If you're a collaborator, it's your choice whether to push branches to this
+repository or to your own fork.
+
+**Branches are "topical" and snd should not be "personal" to each
+user.** This means that a branch should be created for a new feature,
+not for a user specific playground.
+
 ## What to code
 
-Generally, developers should try to only submit pull requests that resolve existing
+Generally, please try submit pull requests that resolve existing
 [issues](https://github.com/multitheftauto/mtasa-blue/issues).
 
-If you're looking for something to work on, take a look at:
-- our ["good first issue"] label, and
-- our [milestones]
+If you're looking for something to work on, take a look at the ["good first issue"]
+label, or our [milestones].
 
 ["good first issue"]: https://github.com/multitheftauto/mtasa-blue/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22good+first+issue%22
 [milestones]: https://github.com/multitheftauto/mtasa-blue/milestones?direction=asc&sort=due_date
 
-**TODO: below may need to be rephrased**
-
 Of course, if you're interested in something else, feel free to experiment
-and submit it.
+and submit it. But discussing the feature beforehand, in an issue, will
+make your PR more likely to be merged in a timely fashion.
 
 ## Committing code
 
-Please follow these guidelines for all your contributions:
+**Make sure your code contributions follow the [Style Guide]**.
 
--   Commits should be thoroughly tested when added to master. Commits
-    that 'need to be fixed later' which directly affect the state of
-    the mod will be reverted other than in exceptional circumstances.
--   If writing unstable or experimental code, a private branch should be
-    added in your own fork. Branches should not be "personal" to each
-    user. This means that a branch should be created for a new feature,
-    not for a user specific playground.
--   Commit messages should always give a clear indication of the content
-    of the change, without having to look at the code at all. Where
-    appropriate, include the issue number in your log message and
-    keep your log messages consistent, e.g. **Fix #1234: description
-    and notes here**.
--   Don't forget to use [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
--   [Follow the seven rules identified here.](http://chris.beams.io/posts/git-commit/)
--   When committing updates to previous commits, include the previous
-    commit SHA (and a summarised commit message) in the new commit
-    message. Doing this will help identify related commits if they are
-    viewed at a later date.
--   Follow the [Style Guide](https://github.com/multitheftauto/mtasa-blue/wiki/Style-Guide)
+[Style Guide]: https://github.com/multitheftauto/mtasa-blue/wiki/Style-Guide
+
+**Commits should be tested when added to master.** Commits
+that 'need to be fixed later' which directly affect the state of
+the mod will be reverted other than in exceptional circumstances.
+
+**Commit messages should**
+
+- be consistent
+- always give a clear indication of what has been changed without having to look at the code
+- include issue numbers, using [GitHub keywords](https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) where necessary
+- [follow the seven rules identified here](http://chris.beams.io/posts/git-commit/).
+    
+    The most important has been copied below, but please read the article.
+        
+    1. Separate subject from body with a blank line
+    2. Limit the subject line to 50 characters
+    3. Use the imperative mood in the subject line
+    4. Use the body to explain what and why vs. how
+
+**Follow up commits should refer to the previous commit.** Do this by 
+including the previous commit SHA and a summarised commit message in
+the new commit message. Doing this will help identify related commits
+if they are viewed at a later date.
 
 ## Reviewing code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ including the previous commit-identifier SHA and a summarised commit message in
 the new commit message. Doing this will help identify related commits
 if they are viewed at a later date.
 
-**Try to keep pull requests small — they should be about one thing.** you do multiple things
+**Try to keep pull requests small — they should be about one thing.** When you do multiple things
 in one pull request, it's hard to review. If you're fixing stuff as you go, you might want
 to make atomic commits and then cherry-pick those commits into separate branches,
 leaving the pull request clean.


### PR DESCRIPTION
This pull request adds contributing guidelines that should make this project more suitable for greater numbers of collaborators.

I am looking for feedback on:
- [the "Contributing" guide](https://github.com/multitheftauto/mtasa-blue/blob/feature/new-contributing-guidelines/CONTRIBUTING.md) - these are rules
- [the "Code Review" guide](https://github.com/multitheftauto/mtasa-blue/wiki/Code-Review) - these are guidelines

This is opinionated, so if you disagree with anything, please suggest improvements.

----

~~**The below change has been abandoned.**~~ It _was_ abandoned in the hope to attract more reviews, but it didn't work. So I'm sticking to my guns. 

One major _point of contention_ is the final **Merging pull requests** section, specifically the part about enabling GitHub's _branch protection_.

This change means that, the following people that can currently commit directly to `master`, will now have to submit PRs: @Ligushka, @lopezloo, @patrikjuvonen and @Dutchman101.

It is not possible to disable branch protection for individual users without disabling branch protection for everyone. This is a GitHub limitation.

Please argue for or against -- and then we can bring on some more collaborators! [**Anyone can send a review by clicking "Review changes" here.**](https://github.com/multitheftauto/mtasa-blue/pull/1308/files)