### PR TITLE
Fix #1357: discord crashes from a4f447ae8047b6d2d65077f093adff69

### DIFF
--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -57,6 +57,9 @@ CCore::CCore() : m_DiscordManager(new CDiscordManager())
     ApplyCoreInitSettings();
     g_pLocalization = new CLocalization;
 
+    // Initialize discord manager
+    m_DiscordManager->Initialize();
+
     // Create a logger instance.
     m_pConsoleLogger = new CConsoleLogger();
 
@@ -1006,9 +1009,6 @@ void CCore::CreateXML()
 
     // Load XML-dependant subsystems
     m_ClientVariables.Load();
-
-    // Initialize discord rich presence after client variables have been loaded completely as it is dependant on CVars
-    m_DiscordManager->Initialize();
 }
 
 void CCore::DestroyGame()

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -1006,6 +1006,9 @@ void CCore::CreateXML()
 
     // Load XML-dependant subsystems
     m_ClientVariables.Load();
+
+    // Initialize discord rich presence after client variables have been loaded completely as it is dependant on CVars
+    m_DiscordManager->Initialize();
 }
 
 void CCore::DestroyGame()

--- a/Client/core/CDiscordManager.cpp
+++ b/Client/core/CDiscordManager.cpp
@@ -18,11 +18,7 @@
 
 CDiscordManager::CDiscordManager() : m_DiscordCore(nullptr), m_Suicide(false), m_WaitingForServerName(false), m_StoredActivity{}
 {
-    Reconnect(true);            // Try to interact with discord on construction
-    m_Thread = new CThreadHandle(CDiscordManager::DiscordThread, this);
-
-    m_StoredActivity.GetAssets().SetLargeImage("mta_logo_round");            // Always thing
-    m_StoredActivity.GetAssets().SetLargeText("Playing MTA:SA");
+    
 }
 
 CDiscordManager::~CDiscordManager()
@@ -37,6 +33,15 @@ CDiscordManager::~CDiscordManager()
 
     delete m_Thread;
     SAFE_DELETE(m_DiscordCore);
+}
+
+void CDiscordManager::Initialize()
+{
+    Reconnect(true);            // Try to interact with discord on construction
+    m_Thread = new CThreadHandle(CDiscordManager::DiscordThread, this);
+
+    m_StoredActivity.GetAssets().SetLargeImage("mta_logo_round");            // Always thing
+    m_StoredActivity.GetAssets().SetLargeText("Playing MTA:SA");
 }
 
 // Establish connection with discord

--- a/Client/core/CDiscordManager.cpp
+++ b/Client/core/CDiscordManager.cpp
@@ -16,7 +16,7 @@
 #define DISCORD_CLIENT_ID 468493322583801867
 #endif
 
-CDiscordManager::CDiscordManager() : m_DiscordCore(nullptr), m_Suicide(false), m_WaitingForServerName(false), m_StoredActivity{}, m_bInitialized(false)
+CDiscordManager::CDiscordManager() : m_DiscordCore(nullptr), m_Suicide(false), m_WaitingForServerName(false), m_StoredActivity{}, m_Initialized(false)
 {
     
 }
@@ -43,7 +43,7 @@ void CDiscordManager::Initialize()
     m_StoredActivity.GetAssets().SetLargeImage("mta_logo_round");            // Always thing
     m_StoredActivity.GetAssets().SetLargeText("Playing MTA:SA");
 
-    m_bInitialized = true;
+    m_Initialized = true;
 }
 
 // Establish connection with discord
@@ -175,7 +175,7 @@ void* CDiscordManager::DiscordThread(void* arg)
 // establishing connection with discord is sometimes time-consuming, especially when it's not running
 void CDiscordManager::DoPulse()
 {
-    if (!m_bInitialized) return; // Wait until initialization
+    if (!m_Initialized) return; // Wait until initialization
 
     if (!m_DiscordCore)
     {

--- a/Client/core/CDiscordManager.cpp
+++ b/Client/core/CDiscordManager.cpp
@@ -16,11 +16,6 @@
 #define DISCORD_CLIENT_ID 468493322583801867
 #endif
 
-CDiscordManager::CDiscordManager() : m_DiscordCore(nullptr), m_Suicide(false), m_WaitingForServerName(false), m_StoredActivity{}, m_Initialized(false), m_Thread(nullptr)
-{
-    
-}
-
 CDiscordManager::~CDiscordManager()
 {
     m_Suicide = true;

--- a/Client/core/CDiscordManager.cpp
+++ b/Client/core/CDiscordManager.cpp
@@ -16,7 +16,7 @@
 #define DISCORD_CLIENT_ID 468493322583801867
 #endif
 
-CDiscordManager::CDiscordManager() : m_DiscordCore(nullptr), m_Suicide(false), m_WaitingForServerName(false), m_StoredActivity{}
+CDiscordManager::CDiscordManager() : m_DiscordCore(nullptr), m_Suicide(false), m_WaitingForServerName(false), m_StoredActivity{}, m_bInitialized(false)
 {
     
 }
@@ -42,6 +42,8 @@ void CDiscordManager::Initialize()
 
     m_StoredActivity.GetAssets().SetLargeImage("mta_logo_round");            // Always thing
     m_StoredActivity.GetAssets().SetLargeText("Playing MTA:SA");
+
+    m_bInitialized = true;
 }
 
 // Establish connection with discord
@@ -173,6 +175,8 @@ void* CDiscordManager::DiscordThread(void* arg)
 // establishing connection with discord is sometimes time-consuming, especially when it's not running
 void CDiscordManager::DoPulse()
 {
+    if (!m_bInitialized) return; // Wait until initialization
+
     if (!m_DiscordCore)
     {
         // Discord is not initialized, maybe it's not installed or not yet running

--- a/Client/core/CDiscordManager.h
+++ b/Client/core/CDiscordManager.h
@@ -20,13 +20,7 @@ public:
     CDiscordManager();
     ~CDiscordManager();
 
-    static void  DiscordLogCallback(discord::LogLevel level, const char* message);
-    static void  OnActivityJoin(const char* joinSecret);
-    static void* DiscordThread(void* arg);
-
     void Initialize();
-    void Reconnect(bool bOnInitialization = false);
-    void DoPulse();
 
     // ActivityManager
     void UpdateActivity(SDiscordActivity& activity, std::function<void(EDiscordRes)> callback);            // Change it all, or ...
@@ -41,16 +35,19 @@ public:
     void RegisterPlay(bool connected);
     void Disconnect();
 
-    discord::Activity GetStoredActivity() const { return m_StoredActivity; }            // For retrieving stored information in rich presence
-
-    bool NeedsSuicide() const { return m_Suicide; }
-    void SetDead() { m_Suicide = false; }
-    void DisconnectNotification();
-
     SString GetJoinSecret();
 
 private:
+    void Reconnect(bool bOnInitialization = false);
+    void DoPulse();
     void Restore();
+
+    static void  DiscordLogCallback(discord::LogLevel level, const char* message);
+    static void  OnActivityJoin(const char* joinSecret);
+    static void* DiscordThread(void* arg);
+
+    bool NeedsSuicide() const { return m_Suicide; }
+    void SetDead() { m_Suicide = false; }
 
     discord::Core*    m_DiscordCore;
     discord::Activity m_StoredActivity;

--- a/Client/core/CDiscordManager.h
+++ b/Client/core/CDiscordManager.h
@@ -17,7 +17,6 @@
 class CDiscordManager : public CDiscordManagerInterface
 {
 public:
-    CDiscordManager::CDiscordManager() : m_DiscordCore(nullptr), m_Suicide(false), m_WaitingForServerName(false), m_StoredActivity{}, m_Initialized(false), m_Thread(nullptr) {}
     ~CDiscordManager();
 
     void Initialize();
@@ -49,16 +48,16 @@ private:
     bool NeedsSuicide() const { return m_Suicide; }
     void SetDead() { m_Suicide = false; }
 
-    discord::Core*    m_DiscordCore;
-    discord::Activity m_StoredActivity;
+    discord::Core*    m_DiscordCore = nullptr;
+    discord::Activity m_StoredActivity{};
 
-    bool m_WaitingForServerName;
-    bool m_Initialized;
+    bool m_WaitingForServerName = false;
+    bool m_Initialized = false;
 
-    volatile bool m_Suicide;            // Thread kill command
+    volatile bool m_Suicide = false;            // Thread kill command
 
     std::mutex                 m_ThreadSafety;
-    SharedUtil::CThreadHandle* m_Thread;
+    SharedUtil::CThreadHandle* m_Thread = nullptr;
 
     CElapsedTime   m_TimeForReconnection;
     CQueryReceiver m_QueryReceiver;

--- a/Client/core/CDiscordManager.h
+++ b/Client/core/CDiscordManager.h
@@ -56,6 +56,7 @@ private:
     discord::Activity m_StoredActivity;
 
     bool m_WaitingForServerName;
+    bool m_bInitialized;
 
     volatile bool m_Suicide;            // Thread kill command
 

--- a/Client/core/CDiscordManager.h
+++ b/Client/core/CDiscordManager.h
@@ -56,7 +56,7 @@ private:
     discord::Activity m_StoredActivity;
 
     bool m_WaitingForServerName;
-    bool m_bInitialized;
+    bool m_Initialized;
 
     volatile bool m_Suicide;            // Thread kill command
 

--- a/Client/core/CDiscordManager.h
+++ b/Client/core/CDiscordManager.h
@@ -24,6 +24,7 @@ public:
     static void  OnActivityJoin(const char* joinSecret);
     static void* DiscordThread(void* arg);
 
+    void Initialize();
     void Reconnect(bool bOnInitialization = false);
     void DoPulse();
 

--- a/Client/core/CDiscordManager.h
+++ b/Client/core/CDiscordManager.h
@@ -17,7 +17,7 @@
 class CDiscordManager : public CDiscordManagerInterface
 {
 public:
-    CDiscordManager();
+    CDiscordManager::CDiscordManager() : m_DiscordCore(nullptr), m_Suicide(false), m_WaitingForServerName(false), m_StoredActivity{}, m_Initialized(false), m_Thread(nullptr) {}
     ~CDiscordManager();
 
     void Initialize();


### PR DESCRIPTION
This fixes https://github.com/multitheftauto/mtasa-blue/issues/1357
and
https://github.com/multitheftauto/mtasa-blue/issues/1349#issuecomment-610178080

I still need feedback on this @Dutchman101 but I'm guessing this is totally bug-free now because I spent hours evaluating this crashy part and I actually forgot them because my PR was large and merged with a huge delay, this mess up was caused by not having the free time to actually test the code and just fixed it as quick as I could, now I've spent a lot of time reading everything. Hope this addresses all the crashes now.