### PR TITLE
Fix #1362: xmlLoadString doesn't work

### DIFF
--- a/Shared/XML/CXMLImpl.cpp
+++ b/Shared/XML/CXMLImpl.cpp
@@ -46,7 +46,8 @@ CXMLNode* CXMLImpl::ParseString(const char* strXmlContent)
     TiXmlDocument* xmlDoc = new TiXmlDocument();
     if (xmlDoc)
     {   
-        if (xmlDoc->Parse(strXmlContent, 0, TIXML_ENCODING_UTF8))
+        xmlDoc->Parse(strXmlContent, 0, TIXML_ENCODING_UNKNOWN);
+        if (!xmlDoc->Error())
         {
             TiXmlElement* xmlDocumentRoot = xmlDoc->RootElement();
             CXMLNodeImpl* xmlBaseNode = new CXMLNodeImpl(nullptr, nullptr, *xmlDocumentRoot);
@@ -65,8 +66,11 @@ CXMLNode* CXMLImpl::BuildNode(CXMLNodeImpl* xmlParent, TiXmlNode* xmlNode)
     while (xmlChild = xmlNode->IterateChildren(xmlChild))
     {
         xmlChildElement = xmlChild->ToElement();
-        xmlChildNode = new CXMLNodeImpl(nullptr, xmlParent, *xmlChildElement);
-        CXMLImpl::BuildNode(xmlChildNode, xmlChildElement);
+        if (xmlChildElement)
+        {
+            xmlChildNode = new CXMLNodeImpl(nullptr, xmlParent, *xmlChildElement);
+            CXMLImpl::BuildNode(xmlChildNode, xmlChildElement);
+        }
     }
     return xmlParent;
 }

--- a/Shared/XML/CXMLImpl.cpp
+++ b/Shared/XML/CXMLImpl.cpp
@@ -46,7 +46,7 @@ CXMLNode* CXMLImpl::ParseString(const char* strXmlContent)
     TiXmlDocument* xmlDoc = new TiXmlDocument();
     if (xmlDoc)
     {   
-        xmlDoc->Parse(strXmlContent, 0, TIXML_ENCODING_UNKNOWN);
+        xmlDoc->Parse(strXmlContent, 0, TIXML_DEFAULT_ENCODING);
         if (!xmlDoc->Error())
         {
             TiXmlElement* xmlDocumentRoot = xmlDoc->RootElement();


### PR DESCRIPTION
Fixes #1362.

The change in `CXMLImpl::ParseString` allows `<animals> <f></f> <g/> </animals>` to work.

The change to `CXMLImpl::BuildNode` allows `<f>hi</f>` to work.

There is probably a better fix. I guess we are creating our XML node the wrong way - otherwise opening normal XML files would maybe be broken.

<details><summary>Tested with this code</summary>

```lua
function print_tree(x)
	print(x.name, x.value)
	for i, n in ipairs(x.children) do
		print(i)
		print_tree(n)
	end
end

local rootNode = xmlLoadString("<animals> <f>hi</f> <g/> </animals>")
if rootNode then
	print("Success")
	print_tree(rootNode)
else
	print("RIP")
end
```

</details>

In resource form: [x.zip](https://github.com/multitheftauto/mtasa-blue/files/4465204/x.zip)
