### PR TITLE
Add data installation to CI build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,9 @@ jobs:
 
       - name: Install CEF
         run: utils\premake5 install_cef
+        
+      - name: Install data files
+        run: utils\premake5 install_data
 
       - name: Run Build
         run: win-build.bat


### PR DESCRIPTION
This is a fix for the missing files problem in CI artifacts such as netc.dll.