### PR TITLE
Make kickPlayer accept the Console element

### DIFF
--- a/Server/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
@@ -9,6 +9,7 @@
  *****************************************************************************/
 #pragma once
 #include "CElementIDs.h"
+#include "CConsoleClient.h"
 
 // Forward declare enum reflection stuff
 enum eLuaType
@@ -118,6 +119,10 @@ inline eEntityType GetClassType(class CCustomWeapon*)
 inline SString GetClassTypeName(CElement*)
 {
     return "element";
+}
+inline SString GetClassTypeName(CClient*)
+{
+    return "client";
 }
 inline SString GetClassTypeName(CPlayer*)
 {
@@ -435,6 +440,24 @@ CPlayer* UserDataCast(CPlayer*, void* ptr, lua_State*)
     if (!pElement || pElement->IsBeingDeleted() || (pElement->GetType() != CElement::PLAYER))
         return NULL;
     return (CPlayer*)pElement;
+}
+
+// CClient from CConsoleClient or a CPlayer
+template <class T>
+CClient* UserDataCast(CClient*, void* ptr, lua_State*)
+{
+    ElementID ID = TO_ELEMENTID(ptr);
+    CElement* pElement = CElementIDs::GetElement(ID);
+    if (!pElement || pElement->IsBeingDeleted())
+        return nullptr;
+
+    CClient* pClient = nullptr;
+    if (pElement->GetType() == CElement::PLAYER)
+        pClient = reinterpret_cast<CPlayer*>(pElement);
+    else if (pElement->GetType() == CElement::CONSOLE)
+        pClient = reinterpret_cast<CConsoleClient*>(pElement);
+
+    return pClient;
 }
 
 //

--- a/Server/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
@@ -2012,7 +2012,7 @@ int CLuaPlayerDefs::KickPlayer(lua_State* luaVM)
 
     if (argStream.NextIsUserData())
     {
-        CPlayer* pResponsible;
+        CClient* pResponsible;
         argStream.ReadUserData(pResponsible);
         if (!argStream.HasErrors())
         {


### PR DESCRIPTION
Fixes #1301 

Tested with:

- `run kickPlayer(me)`
- `run kickPlayer(me, getElementByIndex("console", 0))`
- `run kickPlayer(me, "reason")`
- `run kickPlayer(me, "someone", "reason")`
- `run kickPlayer(me, me)`

**Please review only - needs merge commit**