### PR TITLE
Refactor LuaDef::LoadFunctions() to use array instead of map for inlining

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -151,7 +151,7 @@ CLuaMain* CLuaManager::GetVirtualMachine(lua_State* luaVM)
 
 void CLuaManager::LoadCFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // ** BACKWARDS COMPATIBILITY FUNCS. SHOULD BE REMOVED BEFORE FINAL RELEASE! **
         {"getPlayerRotation", CLuaPedDefs::GetPedRotation},
         {"canPlayerBeKnockedOffBike", CLuaPedDefs::CanPedBeKnockedOffBike},

--- a/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -405,10 +405,8 @@ void CLuaManager::LoadCFunctions()
     };
 
     // Add all functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 
     // Luadef definitions
     CLuaAudioDefs::LoadFunctions();

--- a/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -405,8 +405,8 @@ void CLuaManager::LoadCFunctions()
     };
 
     // Add all functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 
     // Luadef definitions
     CLuaAudioDefs::LoadFunctions();

--- a/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
@@ -65,8 +65,8 @@ void CLuaAudioDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaAudioDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
@@ -65,10 +65,8 @@ void CLuaAudioDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaAudioDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaAudioDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Audio funcs
         {"playSoundFrontEnd", PlaySoundFrontEnd},
         {"setAmbientSoundEnabled", SetAmbientSoundEnabled},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
@@ -30,8 +30,8 @@ void CLuaBlipDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaBlipDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
@@ -30,10 +30,8 @@ void CLuaBlipDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaBlipDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaBlipDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"createBlip", CreateBlip},
         {"createBlipAttachedTo", CreateBlipAttachedTo},
         {"getBlipIcon", GetBlipIcon},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.cpp
@@ -49,10 +49,8 @@ void CLuaBrowserDefs::LoadFunctions()
     };
 
     // Add browser functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaBrowserDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.cpp
@@ -14,7 +14,7 @@
 void CLuaBrowserDefs::LoadFunctions()
 {
     // Define browser functions
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"createBrowser", CreateBrowser},
         {"requestBrowserDomains", RequestBrowserDomains},
         {"loadBrowserURL", LoadBrowserURL},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.cpp
@@ -49,8 +49,8 @@ void CLuaBrowserDefs::LoadFunctions()
     };
 
     // Add browser functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaBrowserDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
@@ -39,8 +39,8 @@ void CLuaCameraDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaCameraDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
@@ -39,10 +39,8 @@ void CLuaCameraDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaCameraDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
@@ -14,7 +14,7 @@
 
 void CLuaCameraDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Cam get funcs
         {"getCamera", GetCamera},
         {"getCameraViewMode", GetCameraViewMode},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
@@ -36,10 +36,8 @@ void CLuaColShapeDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaColShapeDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
@@ -36,8 +36,8 @@ void CLuaColShapeDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaColShapeDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaColShapeDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"createColCircle", CreateColCircle},
         {"createColCuboid", CreateColCuboid},
         {"createColSphere", CreateColSphere},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -15,7 +15,7 @@ extern bool g_bAllowAspectRatioAdjustment;
 
 void CLuaDrawingDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"dxDrawLine", DxDrawLine},
         {"dxDrawMaterialLine3D", DxDrawMaterialLine3D},
         {"dxDrawMaterialSectionLine3D", DxDrawMaterialSectionLine3D},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -61,8 +61,8 @@ void CLuaDrawingDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaDrawingDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -61,10 +61,8 @@ void CLuaDrawingDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaDrawingDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEffectDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEffectDefs.cpp
@@ -36,10 +36,8 @@ void CLuaEffectDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaEffectDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEffectDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEffectDefs.cpp
@@ -36,8 +36,8 @@ void CLuaEffectDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaEffectDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEffectDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEffectDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaEffectDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"fxAddBlood", fxAddBlood},
         {"fxAddWood", fxAddWood},
         {"fxAddSparks", fxAddSparks},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -98,8 +98,8 @@ void CLuaElementDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaElementDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -16,7 +16,7 @@ using std::list;
 
 void CLuaElementDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Element get funcs
         {"getRootElement", GetRootElement},
         {"isElement", IsElement},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -98,10 +98,8 @@ void CLuaElementDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaElementDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -59,10 +59,8 @@ void CLuaEngineDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaEngineDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaEngineDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"engineFreeModel", EngineFreeModel},
         {"engineLoadTXD", EngineLoadTXD},
         {"engineLoadCOL", EngineLoadCOL},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -59,8 +59,8 @@ void CLuaEngineDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaEngineDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
@@ -12,7 +12,7 @@
 
 void CLuaFireDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"createFire", CreateFire},
         {"extinguishFire", ExtinguishFire},
     };

--- a/Client/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
@@ -18,10 +18,8 @@ void CLuaFireDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 int CLuaFireDefs::CreateFire(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaFireDefs.cpp
@@ -18,8 +18,8 @@ void CLuaFireDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 int CLuaFireDefs::CreateFire(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -195,8 +195,8 @@ void CLuaGUIDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaGUIDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -36,7 +36,7 @@ static const SFixedArray<const char*, MAX_CHATBOX_LAYOUT_CVARS> g_chatboxLayoutC
 
 void CLuaGUIDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"guiGetInputEnabled", GUIGetInputEnabled},
         {"guiSetInputEnabled", GUISetInputEnabled},
         {"guiGetInputMode", GUIGetInputMode},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -195,10 +195,8 @@ void CLuaGUIDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaGUIDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaMarkerDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaMarkerDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaMarkerDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"createMarker", CreateMarker},
 
         {"getMarkerCount", GetMarkerCount},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaMarkerDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaMarkerDefs.cpp
@@ -31,10 +31,8 @@ void CLuaMarkerDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaMarkerDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaMarkerDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaMarkerDefs.cpp
@@ -31,8 +31,8 @@ void CLuaMarkerDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaMarkerDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
@@ -38,8 +38,8 @@ void CLuaObjectDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaObjectDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaObjectDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Object create/destroy funcs
         {"createObject", CreateObject},
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
@@ -38,10 +38,8 @@ void CLuaObjectDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaObjectDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -92,10 +92,8 @@ void CLuaPedDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaPedDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -15,7 +15,7 @@
 
 void CLuaPedDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"createPed", CreatePed},
         {"detonateSatchels", DetonateSatchels},
         {"killPed", KillPed},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -92,8 +92,8 @@ void CLuaPedDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaPedDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPickupDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPickupDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaPickupDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"createPickup", CreatePickup},
 
         {"getPickupType", GetPickupType},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPickupDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPickupDefs.cpp
@@ -25,10 +25,8 @@ void CLuaPickupDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaPickupDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPickupDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPickupDefs.cpp
@@ -25,8 +25,8 @@ void CLuaPickupDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaPickupDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
@@ -50,10 +50,8 @@ void CLuaPlayerDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaPlayerDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
@@ -50,8 +50,8 @@ void CLuaPlayerDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaPlayerDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaPlayerDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Player get funcs
         {"getLocalPlayer", GetLocalPlayer},
         {"getPlayerName", GetPlayerName},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.cpp
@@ -25,10 +25,8 @@ void CLuaPointLightDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaPointLightDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaPointLightDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"createLight", CreateLight},
         {"getLightType", GetLightType},
         {"getLightRadius", GetLightRadius},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.cpp
@@ -25,8 +25,8 @@ void CLuaPointLightDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaPointLightDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaProjectileDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaProjectileDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaProjectileDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"createProjectile", CreateProjectile},
         {"getProjectileType", GetProjectileType},
         {"getProjectileTarget", GetProjectileTarget},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaProjectileDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaProjectileDefs.cpp
@@ -24,10 +24,8 @@ void CLuaProjectileDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaProjectileDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaProjectileDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaProjectileDefs.cpp
@@ -24,8 +24,8 @@ void CLuaProjectileDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaProjectileDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
@@ -26,10 +26,8 @@ void CLuaRadarAreaDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaRadarAreaDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
@@ -14,7 +14,7 @@
 
 void CLuaRadarAreaDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"createRadarArea", CreateRadarArea},
         {"getRadarAreaColor", GetRadarAreaColor},
         {"getRadarAreaSize", GetRadarAreaSize},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
@@ -26,8 +26,8 @@ void CLuaRadarAreaDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaRadarAreaDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
@@ -14,7 +14,7 @@ using std::list;
 
 void CLuaResourceDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"call", Call},
         {"getThisResource", GetThisResource},
         {"getResourceConfig", GetResourceConfig},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
@@ -30,8 +30,8 @@ void CLuaResourceDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaResourceDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
@@ -30,10 +30,8 @@ void CLuaResourceDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaResourceDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaSearchLightDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaSearchLightDefs.cpp
@@ -28,8 +28,8 @@ void CLuaSearchLightDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaSearchLightDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaSearchLightDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaSearchLightDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaSearchLightDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"createSearchLight", CreateSearchLight},
 
         {"getSearchLightStartPosition", GetSearchLightStartPosition},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaSearchLightDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaSearchLightDefs.cpp
@@ -28,10 +28,8 @@ void CLuaSearchLightDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaSearchLightDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaTeamDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaTeamDefs.cpp
@@ -14,7 +14,7 @@ using std::list;
 
 void CLuaTeamDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"getTeamFromName", GetTeamFromName},
         {"getTeamName", GetTeamName},
         {"getTeamColor", GetTeamColor},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaTeamDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaTeamDefs.cpp
@@ -24,8 +24,8 @@ void CLuaTeamDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaTeamDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaTeamDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaTeamDefs.cpp
@@ -24,10 +24,8 @@ void CLuaTeamDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaTeamDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaTimerDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaTimerDefs.cpp
@@ -23,8 +23,8 @@ void CLuaTimerDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaTimerDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaTimerDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaTimerDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaTimerDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"setTimer", SetTimer},
         {"killTimer", KillTimer},
         {"resetTimer", ResetTimer},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaTimerDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaTimerDefs.cpp
@@ -23,10 +23,8 @@ void CLuaTimerDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaTimerDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -14,7 +14,7 @@
 
 void CLuaVehicleDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Vehicle get funcs
         {"getVehicleType", GetVehicleType},
         {"getVehicleModelFromName", GetVehicleModelFromName},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -142,10 +142,8 @@ void CLuaVehicleDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaVehicleDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -142,8 +142,8 @@ void CLuaVehicleDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaVehicleDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
@@ -31,8 +31,8 @@ void CLuaWaterDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaWaterDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
@@ -31,10 +31,8 @@ void CLuaWaterDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaWaterDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaWaterDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"createWater", CreateWater},
         {"testLineAgainstWater", TestLineAgainstWater},
         {"resetWaterColor", ResetWaterColor},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaWeaponDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaWeaponDefs.cpp
@@ -15,7 +15,7 @@
 
 void CLuaWeaponDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"getWeaponNameFromID", GetWeaponNameFromID},
         {"getWeaponIDFromName", GetWeaponIDFromName},
         {"getSlotFromWeapon", GetSlotFromWeapon},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaWeaponDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaWeaponDefs.cpp
@@ -42,8 +42,8 @@ void CLuaWeaponDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaWeaponDefs::AddClass(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaWeaponDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaWeaponDefs.cpp
@@ -42,10 +42,8 @@ void CLuaWeaponDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaWeaponDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -155,7 +155,7 @@ CResource* CLuaManager::GetVirtualMachineResource(lua_State* luaVM)
 
 void CLuaManager::LoadCFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"addEvent", CLuaFunctionDefs::AddEvent},
         {"addEventHandler", CLuaFunctionDefs::AddEventHandler},
         {"removeEventHandler", CLuaFunctionDefs::RemoveEventHandler},

--- a/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -357,10 +357,8 @@ void CLuaManager::LoadCFunctions()
     };
 
     // Add all functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
     
     // Restricted functions
     CLuaCFunctions::AddFunction("setServerConfigSetting", CLuaFunctionDefs::SetServerConfigSetting, true);

--- a/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -357,8 +357,8 @@ void CLuaManager::LoadCFunctions()
     };
 
     // Add all functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
     
     // Restricted functions
     CLuaCFunctions::AddFunction("setServerConfigSetting", CLuaFunctionDefs::SetServerConfigSetting, true);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaACLDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaACLDefs.cpp
@@ -20,7 +20,7 @@ static const char* GetResourceName(lua_State* luaVM)
 
 void CLuaACLDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"aclReload", aclReload},
         {"aclSave", aclSave},
 

--- a/Server/mods/deathmatch/logic/luadefs/CLuaACLDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaACLDefs.cpp
@@ -56,10 +56,8 @@ void CLuaACLDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaACLDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaACLDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaACLDefs.cpp
@@ -56,8 +56,8 @@ void CLuaACLDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaACLDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
@@ -44,10 +44,8 @@ void CLuaAccountDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaAccountDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaAccountDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Log in/out funcs
         {"logIn", LogIn},
         {"logOut", LogOut},

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
@@ -44,8 +44,8 @@ void CLuaAccountDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaAccountDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaBanDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaBanDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaBanDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"addBan", AddBan},
         {"removeBan", RemoveBan},
 

--- a/Server/mods/deathmatch/logic/luadefs/CLuaBanDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaBanDefs.cpp
@@ -37,10 +37,8 @@ void CLuaBanDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaBanDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaBanDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaBanDefs.cpp
@@ -37,8 +37,8 @@ void CLuaBanDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaBanDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
@@ -34,10 +34,8 @@ void CLuaBlipDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaBlipDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaBlipDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Blip create/destroy funcs
         {"createBlip", CreateBlip},
         {"createBlipAttachedTo", CreateBlipAttachedTo},

--- a/Server/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaBlipDefs.cpp
@@ -34,8 +34,8 @@ void CLuaBlipDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaBlipDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
@@ -27,8 +27,8 @@ void CLuaCameraDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 int CLuaCameraDefs::getCameraMatrix(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
@@ -27,10 +27,8 @@ void CLuaCameraDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 int CLuaCameraDefs::getCameraMatrix(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaCameraDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Get functions
         {"getCameraMatrix", getCameraMatrix},
         {"getCameraTarget", getCameraTarget},

--- a/Server/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
@@ -36,10 +36,8 @@ void CLuaColShapeDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaColShapeDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
@@ -36,8 +36,8 @@ void CLuaColShapeDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaColShapeDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaColShapeDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"createColCircle", CreateColCircle},
         {"createColCuboid", CreateColCuboid},
         {"createColSphere", CreateColSphere},

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDatabaseDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDatabaseDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaDatabaseDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"dbConnect", DbConnect},
         {"dbExec", DbExec},
         {"dbQuery", DbQuery},

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDatabaseDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDatabaseDefs.cpp
@@ -32,10 +32,8 @@ void CLuaDatabaseDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaDatabaseDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDatabaseDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDatabaseDefs.cpp
@@ -32,8 +32,8 @@ void CLuaDatabaseDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaDatabaseDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -100,10 +100,8 @@ void CLuaElementDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 // TODO: specials

--- a/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -100,8 +100,8 @@ void CLuaElementDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 // TODO: specials

--- a/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaElementDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Create/destroy
         {"createElement", createElement},
         {"destroyElement", destroyElement},

--- a/Server/mods/deathmatch/logic/luadefs/CLuaHandlingDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaHandlingDefs.cpp
@@ -25,10 +25,8 @@ void CLuaHandlingDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 int CLuaHandlingDefs::SetVehicleHandling(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaHandlingDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaHandlingDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaHandlingDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Set
         {"setVehicleHandling", SetVehicleHandling},
         {"setModelHandling", SetModelHandling},

--- a/Server/mods/deathmatch/logic/luadefs/CLuaHandlingDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaHandlingDefs.cpp
@@ -25,8 +25,8 @@ void CLuaHandlingDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 int CLuaHandlingDefs::SetVehicleHandling(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaMarkerDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaMarkerDefs.cpp
@@ -33,10 +33,8 @@ void CLuaMarkerDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaMarkerDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaMarkerDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaMarkerDefs.cpp
@@ -12,7 +12,7 @@
 
 void CLuaMarkerDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Marker functions
         {"createMarker", CreateMarker},
 

--- a/Server/mods/deathmatch/logic/luadefs/CLuaMarkerDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaMarkerDefs.cpp
@@ -33,8 +33,8 @@ void CLuaMarkerDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaMarkerDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
@@ -29,10 +29,8 @@ void CLuaObjectDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaObjectDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaObjectDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Object create/destroy funcs
         {"createObject", CreateObject},
 

--- a/Server/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
@@ -29,8 +29,8 @@ void CLuaObjectDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaObjectDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaPedDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Ped funcs
         {"createPed", CreatePed},
         {"getValidPedModels", GetValidPedModels},

--- a/Server/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -78,10 +78,8 @@ void CLuaPedDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 // TODO: specials

--- a/Server/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -78,8 +78,8 @@ void CLuaPedDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 // TODO: specials

--- a/Server/mods/deathmatch/logic/luadefs/CLuaPickupDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaPickupDefs.cpp
@@ -32,8 +32,8 @@ void CLuaPickupDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaPickupDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaPickupDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaPickupDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaPickupDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Create/destroy
         {"createPickup", createPickup},
 

--- a/Server/mods/deathmatch/logic/luadefs/CLuaPickupDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaPickupDefs.cpp
@@ -32,10 +32,8 @@ void CLuaPickupDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaPickupDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
@@ -102,8 +102,8 @@ void CLuaPlayerDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaPlayerDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
@@ -102,10 +102,8 @@ void CLuaPlayerDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaPlayerDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaPlayerDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Player get funcs
         {"getPlayerCount", GetPlayerCount},
         {"getPlayerFromNick", GetPlayerFromName},

--- a/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaRadarAreaDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Radar area create/destroy funcs
         {"createRadarArea", CreateRadarArea},
 

--- a/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
@@ -30,10 +30,8 @@ void CLuaRadarAreaDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaRadarAreaDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
@@ -30,8 +30,8 @@ void CLuaRadarAreaDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaRadarAreaDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
@@ -68,8 +68,8 @@ void CLuaResourceDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 
     CLuaCFunctions::AddFunction("updateResourceACLRequest", updateResourceACLRequest, true);
 }

--- a/Server/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
@@ -68,10 +68,8 @@ void CLuaResourceDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 
     CLuaCFunctions::AddFunction("updateResourceACLRequest", updateResourceACLRequest, true);
 }

--- a/Server/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
@@ -16,7 +16,7 @@ extern CNetServer* g_pRealNetServer;
 
 void CLuaResourceDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Create/edit functions
         {"createResource", createResource},
         {"copyResource", copyResource},

--- a/Server/mods/deathmatch/logic/luadefs/CLuaTeamDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaTeamDefs.cpp
@@ -33,8 +33,8 @@ void CLuaTeamDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaTeamDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaTeamDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaTeamDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaTeamDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Team create/destroy functions
         {"createTeam", CreateTeam},
 

--- a/Server/mods/deathmatch/logic/luadefs/CLuaTeamDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaTeamDefs.cpp
@@ -33,10 +33,8 @@ void CLuaTeamDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaTeamDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaTextDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"textCreateDisplay", textCreateDisplay},
         {"textDestroyDisplay", textDestroyDisplay},
         {"textCreateTextItem", textCreateTextItem},

--- a/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.cpp
@@ -39,8 +39,8 @@ void CLuaTextDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaTextDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.cpp
@@ -39,10 +39,8 @@ void CLuaTextDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaTextDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaTimerDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaTimerDefs.cpp
@@ -23,8 +23,8 @@ void CLuaTimerDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaTimerDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaTimerDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaTimerDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaTimerDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"setTimer", SetTimer},
         {"killTimer", KillTimer},
         {"resetTimer", ResetTimer},

--- a/Server/mods/deathmatch/logic/luadefs/CLuaTimerDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaTimerDefs.cpp
@@ -23,10 +23,8 @@ void CLuaTimerDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaTimerDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -120,10 +120,8 @@ void CLuaVehicleDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaVehicleDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaVehicleDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Vehicle create/destroy funcs
         {"createVehicle", CreateVehicle},
 

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -120,8 +120,8 @@ void CLuaVehicleDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaVehicleDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVoiceDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVoiceDefs.cpp
@@ -20,8 +20,8 @@ void CLuaVoiceDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 int CLuaVoiceDefs::IsVoiceEnabled(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVoiceDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVoiceDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaVoiceDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"isVoiceEnabled", IsVoiceEnabled},
         {"setPlayerVoiceBroadcastTo", SetPlayerVoiceBroadcastTo},
         {"setPlayerVoiceIgnoreFrom", setPlayerVoiceIgnoreFrom},

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVoiceDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVoiceDefs.cpp
@@ -20,10 +20,8 @@ void CLuaVoiceDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 int CLuaVoiceDefs::IsVoiceEnabled(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaWaterDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"createWater", CreateWater},
         {"setWaterLevel", SetWaterLevel},
         {"resetWaterLevel", ResetWaterLevel},

--- a/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
@@ -25,10 +25,8 @@ void CLuaWaterDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaWaterDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
@@ -25,8 +25,8 @@ void CLuaWaterDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaWaterDefs::AddClass(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaWorldDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaWorldDefs.cpp
@@ -90,10 +90,8 @@ void CLuaWorldDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 int CLuaWorldDefs::getTime(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaWorldDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaWorldDefs.cpp
@@ -90,8 +90,8 @@ void CLuaWorldDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 int CLuaWorldDefs::getTime(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaWorldDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaWorldDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaWorldDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Get
         {"getTime", getTime},
         {"getWeather", getWeather},

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaBitDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaBitDefs.cpp
@@ -14,7 +14,7 @@
 
 void CLuaBitDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"bitAnd", bitAnd},
         {"bitNot", bitNot},
         {"bitOr", bitOr},

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaBitDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaBitDefs.cpp
@@ -32,8 +32,8 @@ void CLuaBitDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 int CLuaBitDefs::bitAnd(lua_State* luaVM)

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaBitDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaBitDefs.cpp
@@ -32,10 +32,8 @@ void CLuaBitDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 int CLuaBitDefs::bitAnd(lua_State* luaVM)

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
@@ -28,8 +28,8 @@ void CLuaCryptDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 std::string CLuaCryptDefs::Md5(std::string strMd5)

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
@@ -13,7 +13,7 @@
 
 void CLuaCryptDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"md5", ArgumentParserWarn<false, Md5>},
         {"sha256", ArgumentParserWarn<false, Sha256>},
         {"hash", ArgumentParserWarn<false, Hash>},

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
@@ -28,10 +28,8 @@ void CLuaCryptDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 std::string CLuaCryptDefs::Md5(std::string strMd5)

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
@@ -14,7 +14,7 @@
 
 void CLuaFileDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"fileOpen", fileOpen},
         {"fileCreate", fileCreate},
         {"fileExists", fileExists},

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
@@ -36,10 +36,8 @@ void CLuaFileDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaFileDefs::AddClass(lua_State* luaVM)

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
@@ -36,8 +36,8 @@ void CLuaFileDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaFileDefs::AddClass(lua_State* luaVM)

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUTFDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUTFDefs.cpp
@@ -21,10 +21,8 @@ void CLuaUTFDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 int CLuaUTFDefs::UtfLen(lua_State* luaVM)

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUTFDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUTFDefs.cpp
@@ -21,8 +21,8 @@ void CLuaUTFDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 int CLuaUTFDefs::UtfLen(lua_State* luaVM)

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUTFDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUTFDefs.cpp
@@ -12,7 +12,7 @@
 
 void CLuaUTFDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"utfLen", UtfLen},
         {"utfSeek", UtfSeek},
         {"utfSub", UtfSub},

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
@@ -49,10 +49,8 @@ void CLuaUtilDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 int CLuaUtilDefs::DisabledFunction(lua_State* luaVM)

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
@@ -49,8 +49,8 @@ void CLuaUtilDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 int CLuaUtilDefs::DisabledFunction(lua_State* luaVM)

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
@@ -12,7 +12,7 @@
 
 void CLuaUtilDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Util functions to make scripting easier for the end user
         // Some of these are based on standard mIRC script funcs as a lot of people will be used to them
         {"deref", Dereference},

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
@@ -36,10 +36,8 @@ void CLuaXMLDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& pair : functions)
-    {
-        CLuaCFunctions::AddFunction(pair.first, pair.second);
-    }
+    for (const auto& [k, v] : functions)
+        CLuaCFunctions::AddFunction(k, v);
 }
 
 void CLuaXMLDefs::AddClass(lua_State* luaVM)

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
@@ -36,8 +36,8 @@ void CLuaXMLDefs::LoadFunctions()
     };
 
     // Add functions
-    for (const auto& [k, v] : functions)
-        CLuaCFunctions::AddFunction(k, v);
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
 }
 
 void CLuaXMLDefs::AddClass(lua_State* luaVM)

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaXMLDefs.cpp
@@ -12,7 +12,7 @@
 
 void CLuaXMLDefs::LoadFunctions()
 {
-    std::map<const char*, lua_CFunction> functions{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         {"xmlCreateFile", xmlCreateFile},
         {"xmlLoadFile", xmlLoadFile},
         {"xmlLoadString", xmlLoadString},


### PR DESCRIPTION
As the name states it, this PR modifies all 
`std::map<const char*, lua_CFunction> functions` to
`constexpr static const std::pair<const char*, lua_CFunction> functions[]`
so it can be inlined. 
Also the last commit modifies all `idk what it was` to 
```cpp
for (const auto& [name, func] : functions)
    CLuaCFunctions::AddFunction(name, func);
```