### PR TITLE
Refactor all post 1.5.7 funcs to use the new parser

### DIFF
--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -7323,17 +7323,6 @@ bool CStaticFunctionDefinitions::SetColShapeSize(CClientColShape* pColShape, CVe
     return true;
 }
 
-bool CStaticFunctionDefinitions::GetColPolygonPointPosition(CClientColPolygon* pColPolygon, uint uiPointIndex, CVector2D& vecPoint)
-{
-    if (uiPointIndex < pColPolygon->CountPoints())
-    {
-        vecPoint = *(pColPolygon->IterBegin() + uiPointIndex);
-        return true;
-    }
-
-    return false;
-}
-
 bool CStaticFunctionDefinitions::SetColPolygonPointPosition(CClientColPolygon* pColPolygon, uint uiPointIndex, const CVector2D& vecPoint)
 {
     if (pColPolygon->SetPointPosition(uiPointIndex, vecPoint))

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -2306,18 +2306,18 @@ bool CStaticFunctionDefinitions::SetPedDoingGangDriveby(CClientEntity& Entity, b
 
 bool CStaticFunctionDefinitions::SetPedFightingStyle(CClientEntity& Entity, unsigned char ucStyle)
 {
+    // Is valid style?
+    if (ucStyle < 4 || ucStyle > 16)
+        return false;
+
     RUN_CHILDREN(SetPedFightingStyle(**iter, ucStyle))
     if (IS_PED(&Entity) && Entity.IsLocalEntity())
     {
         CClientPed& Ped = static_cast<CClientPed&>(Entity);
         if (Ped.GetFightingStyle() != ucStyle)
         {
-            // Is valid style
-            if (ucStyle >= 4 && ucStyle <= 16)
-            {
-                Ped.SetFightingStyle(static_cast<eFightingStyle>(ucStyle));
-                return true;
-            }
+            Ped.SetFightingStyle(static_cast<eFightingStyle>(ucStyle));
+            return true;
         }
     }
     return false;
@@ -2504,17 +2504,6 @@ bool CStaticFunctionDefinitions::SetPedOnFire(CClientEntity& Entity, bool bOnFir
         Ped.SetOnFire(bOnFire);
         return true;
     }
-    return false;
-}
-
-bool CStaticFunctionDefinitions::SetPedArmor(CClientPed& Ped, float fArmor)
-{
-    if (Ped.IsLocalEntity())
-    {
-        Ped.SetArmor(fArmor);
-        return true;
-    }
-
     return false;
 }
 

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -4967,15 +4967,6 @@ bool CStaticFunctionDefinitions::GetCursorPosition(CVector2D& vecCursor, CVector
     return false;
 }
 
-// Find custom font from an element, or a standard font from a name.
-ID3DXFont* CStaticFunctionDefinitions::ResolveD3DXFont(eFontType fontType, CClientDxFont* pDxFontElement)
-{
-    if (pDxFontElement)
-        return pDxFontElement->GetD3DXFont();
-
-    return g_pCore->GetGraphics()->GetFont(fontType);
-}
-
 bool CStaticFunctionDefinitions::IsCursorShowing(bool& bShowing)
 {
     bShowing = m_pClientGame->AreCursorEventsEnabled() || m_pCore->IsCursorForcedVisible();

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -635,6 +635,13 @@ public:
     static bool ResetAllSurfaceInfo();
     static bool ResetSurfaceInfo(short sSurfaceID);
 
+    static inline unsigned short ResolveModelID(const std::variant<std::string, unsigned short>& variant)
+    {
+        if (std::holds_alternative<unsigned short>(variant))
+            return std::get<unsigned short>(variant);
+        return CModelNames::ResolveModelID(std::get<std::string>(variant));
+    }
+
     // Input functions
     static bool BindKey(const char* szKey, const char* szHitState, CLuaMain* pLuaMain, const CLuaFunctionRef& iLuaFunction, CLuaArguments& Arguments);
     static bool BindKey(const char* szKey, const char* szHitState, const char* szCommandName, const char* szArguments, const char* szResource);

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -402,7 +402,21 @@ public:
     static bool SetCursorAlpha(float fAlpha);
 
     // Drawing funcs
-    static ID3DXFont* ResolveD3DXFont(eFontType fontType, CClientDxFont* pDxFontElement);
+    static inline ID3DXFont* CStaticFunctionDefinitions::ResolveD3DXFont(const std::variant<CClientDxFont*, eFontType>& variant)
+    {
+        if (std::holds_alternative<eFontType>(variant))
+            return g_pCore->GetGraphics()->GetFont(std::get<eFontType>(variant));
+
+        return std::get<CClientDxFont*>(variant)->GetD3DXFont();
+    }
+
+    static inline  ID3DXFont* CStaticFunctionDefinitions::ResolveD3DXFont(eFontType fontType, CClientDxFont* pDxFontElement)
+    {
+        if (pDxFontElement)
+            return pDxFontElement->GetD3DXFont();
+
+        return g_pCore->GetGraphics()->GetFont(fontType);
+    }
 
     // GUI funcs
     static bool        GUIGetInputEnabled();

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -409,7 +409,7 @@ public:
         return std::get<CClientDxFont*>(variant)->GetD3DXFont();
     }
 
-    static inline  ID3DXFont* CStaticFunctionDefinitions::ResolveD3DXFont(eFontType fontType, CClientDxFont* pDxFontElement)
+    static inline ID3DXFont* CStaticFunctionDefinitions::ResolveD3DXFont(eFontType fontType, CClientDxFont* pDxFontElement)
     {
         if (pDxFontElement)
             return pDxFontElement->GetD3DXFont();
@@ -686,13 +686,11 @@ public:
 
     // Shape get functions
     static bool GetColShapeRadius(CClientColShape* pColShape, float& fRadius);
-    static bool GetColPolygonPointPosition(CClientColPolygon* pColPolygon, uint uiPointIndex, CVector2D& vecPoint);
 
     // Shape set functions
     static bool SetColShapeRadius(CClientColShape* pColShape, float fRadius);
     static bool SetColShapeSize(CClientColShape* pColShape, CVector& vecSize);
     static bool SetColPolygonPointPosition(CClientColPolygon* pColPolygon, uint uiPointIndex, const CVector2D& vecPoint);
-
     static bool AddColPolygonPoint(CClientColPolygon* pColPolygon, const CVector2D& vecPoint);
     static bool AddColPolygonPoint(CClientColPolygon* pColPolygon, uint uiPointIndex, const CVector2D& vecPoint);
     static bool RemoveColPolygonPoint(CClientColPolygon* pColPolygon, uint uiPointIndex);

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -188,7 +188,6 @@ public:
     static bool RemovePedFromVehicle(CClientPed* pPed);
     static bool WarpPedIntoVehicle(CClientPed* pPed, CClientVehicle* pVehicle, unsigned int uiSeat);
     static bool SetPedOxygenLevel(CClientEntity& Entity, float fOxygen);
-    static bool SetPedArmor(CClientPed& Ped, float fArmor);
 
     // Extra Clothes functions
     static bool GetBodyPartName(unsigned char ucID, SString& strOutName);

--- a/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -8,6 +8,8 @@
  *  Multi Theft Auto is available from http://www.multitheftauto.com/
  *
  *****************************************************************************/
+#include "../logic/lua/CLuaFunctionParser.h"
+#include "../logic/luadefs/CLuaDefs.h"
 
 #include "StdInc.h"
 #include "../luadefs/CLuaFireDefs.h"

--- a/Client/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.h
@@ -11,6 +11,8 @@
 
 #pragma once
 #include "CLuaDefs.h"
+#include <optional>
+#include <variant>
 
 class CLuaColShapeDefs : public CLuaDefs
 {
@@ -25,16 +27,26 @@ public:
     LUA_DECLARE(CreateColPolygon);
     LUA_DECLARE(CreateColTube);
 
-    LUA_DECLARE(GetColShapeRadius);
-    LUA_DECLARE(SetColShapeRadius);
-    LUA_DECLARE(GetColShapeSize);
-    LUA_DECLARE(SetColShapeSize);
-    LUA_DECLARE(GetColPolygonPoints);
-    LUA_DECLARE(GetColPolygonPointPosition);
-    LUA_DECLARE(SetColPolygonPointPosition);
-    LUA_DECLARE(AddColPolygonPoint);
-    LUA_DECLARE(RemoveColPolygonPoint);
-
-    LUA_DECLARE(IsInsideColShape);
     LUA_DECLARE(GetColShapeType);
+    LUA_DECLARE(IsInsideColShape);
+
+    static float GetColShapeRadius(CClientColShape* const colShape);
+    static bool  SetColShapeRadius(CClientColShape* const colShape, const float radius);
+
+    static std::variant<CVector, CVector2D, float> GetColShapeSize_OOP(CClientColShape* const colShape);
+    static std::variant<std::tuple<float>, std::tuple<float, float>, std::tuple<float, float, float>> GetColShapeSize(CClientColShape* const colShape);
+
+    LUA_DECLARE(SetColShapeSize);
+    LUA_DECLARE(GetColPolygonPoints)
+
+    static const CVector2D& GetColPolygonPointPosition_OOP(CClientColShape* const colShape, unsigned int pointIndex);
+    static inline std::tuple<float, float> GetColPolygonPointPosition(CClientColShape* const colShape, unsigned int pointIndex)
+    {
+        const auto& vector = GetColPolygonPointPosition_OOP(colShape, pointIndex);
+        return { vector.fX, vector.fY };
+    }
+
+    static bool SetColPolygonPointPosition(CClientColShape* const colShape, unsigned int pointIndex, const CVector2D point);
+    static bool AddColPolygonPoint(CClientColShape* const colShape, const CVector2D point, const std::optional<unsigned int> optPointIndex);
+    static bool RemoveColPolygonPoint(CClientColShape* const colShape, unsigned int pointIndex);
 };

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -29,7 +29,7 @@ void CLuaDrawingDefs::LoadFunctions()
         {"dxDrawPrimitive3D", DxDrawPrimitive3D},
         {"dxDrawMaterialPrimitive", DxDrawMaterialPrimitive},
         {"dxDrawMaterialPrimitive3D", DxDrawMaterialPrimitive3D},
-        {"dxDrawWiredSphere", DxDrawWiredSphere},
+        {"dxDrawWiredSphere", ArgumentParser<DxDrawWiredSphere>},
         {"dxGetTextWidth", DxGetTextWidth},
         {"dxGetTextSize", DxGetTextSize},
         {"dxGetFontHeight", DxGetFontHeight},
@@ -2071,41 +2071,12 @@ int CLuaDrawingDefs::DxSetTextureEdge(lua_State* luaVM)
     return 1;
 }
 
-int CLuaDrawingDefs::DxDrawWiredSphere(lua_State* luaVM)
+bool CLuaDrawingDefs::DxDrawWiredSphere(lua_State* const luaVM, const CVector position, const float radius, const std::optional<SColorARGB> color, const std::optional<float> lineWidth, const std::optional<unsigned int> iterations)
 {
-    //  bool dxDrawWiredSphere( float x, float y, float z, float radius, color theColor, float fLineWidth, uint iterations )
-    CVector          vecPosition;
-    float            fRadius;
-    SColorARGB       color(64, 255, 0, 0);
-    float            fLineWidth = 1;
-    uint             uiIterations = 1;
-    CScriptArgReader argStream(luaVM);
+    // Greater than 4, crash the game
+    if (iterations == 0 || iterations > 4)
+        throw std::invalid_argument("argument 'iterations' must be between 1 and 4");
 
-    CGraphicsInterface* pGraphics = g_pCore->GetGraphics();
-
-    argStream.ReadVector3D(vecPosition);
-    argStream.ReadNumber(fRadius);
-    argStream.ReadColor(color, SColorARGB(64, 255, 0, 0));
-    argStream.ReadNumber(fLineWidth, 1);
-    argStream.ReadNumber(uiIterations, 1);
-
-    if (!argStream.HasErrors())
-    {
-        // Greater than 4, crash the game
-        if (uiIterations >= 1 && uiIterations <= 4)
-        {
-            pGraphics->DrawWiredSphere(vecPosition, fRadius, color, fLineWidth, uiIterations);
-            lua_pushboolean(luaVM, true);
-            return 1;
-        }
-
-        argStream.SetCustomError("Iterations must be between 1 and 4");
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    // Failed
-    lua_pushboolean(luaVM, false);
-    return 1;
+    g_pCore->GetGraphics()->DrawWiredSphere(position, radius, color.value_or(SColorARGB(64, 255, 0, 0)), lineWidth.value_or(1), iterations.value_or(1));
+    return true;
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -2019,7 +2019,7 @@ bool CLuaDrawingDefs::DxDrawWiredSphere(lua_State* const luaVM, const CVector po
 {
     // Greater than 4, crash the game
     if (iterations == 0 || iterations > 4)
-        throw std::invalid_argument("argument 'iterations' must be between 1 and 4");
+        throw std::invalid_argument("Iterations must be between 1 and 4");
 
     g_pCore->GetGraphics()->DrawWiredSphere(position, radius, color.value_or(SColorARGB(64, 255, 0, 0)), lineWidth.value_or(1), iterations.value_or(1));
     return true;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -10,6 +10,9 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include "lua/CLuaFunctionParser.h"
+#include "CLuaDefs.h"
+
 #define MIN_CLIENT_REQ_DXSETRENDERTARGET_CALL_RESTRICTIONS "1.3.0-9.04431"
 extern bool g_bAllowAspectRatioAdjustment;
 
@@ -31,7 +34,7 @@ void CLuaDrawingDefs::LoadFunctions()
         {"dxDrawMaterialPrimitive3D", DxDrawMaterialPrimitive3D},
         {"dxDrawWiredSphere", ArgumentParser<DxDrawWiredSphere>},
         {"dxGetTextWidth", DxGetTextWidth},
-        {"dxGetTextSize", DxGetTextSize},
+        {"dxGetTextSize", ArgumentParser<DxGetTextSize>},
         {"dxGetFontHeight", DxGetFontHeight},
         {"dxCreateFont", DxCreateFont},
         {"dxCreateTexture", DxCreateTexture},
@@ -106,7 +109,7 @@ void CLuaDrawingDefs::AddDxFontClass(lua_State* luaVM)
 
     lua_classfunction(luaVM, "getHeight", OOP_DxGetFontHeight);
     lua_classfunction(luaVM, "getTextWidth", OOP_DxGetTextWidth);
-    lua_classfunction(luaVM, "getTextSize", OOP_DxGetTextSize);
+    lua_classfunction(luaVM, "getTextSize", ArgumentParser<OOP_DxGetTextSize>);
 
     // lua_classvariable ( luaVM, "height", NULL, "dxGetFontHeight"); // swap arguments, .height[scale] = int(height);
 
@@ -854,98 +857,39 @@ int CLuaDrawingDefs::OOP_DxGetTextWidth(lua_State* luaVM)
     return 1;
 }
 
-int CLuaDrawingDefs::DxGetTextSize(lua_State* luaVM)
+CVector2D CLuaDrawingDefs::OOP_DxGetTextSize(
+    std::variant<CClientDxFont*, eFontType> variantFont, // note, that thtis function is called from DxGetTextSize, thats why theres a variant for eFontType.
+    const std::string text,
+    const std::optional<float> optWidth,
+    const std::optional<float> optScaleXY,
+    const std::optional<float> optScaleY,
+    const std::optional<bool> optWordBreak,
+    const std::optional<bool> optColorCoded)
 {
-    //  float, float dxGetTextSize ( string text, [float width=0, float scaleXY=1.0, float=scaleY=1.0, mixed font="default",
-    //      bool wordBreak=false, bool colorCoded=false] )
-    SString        strText;
-    float          fWidth;
-    float          fScaleX;
-    float          fScaleY;
-    eFontType      fontType;
-    CClientDxFont* pDxFontElement;
-    bool           bWordBreak;
-    bool           bColorCoded;
+    // float dxGetTextHeight ( string text, [float width, float scaleXY=1.0, float=scaleY=1.0, mixed font="default", bool wordBreak=false, bool colorCoded=false] )
+    CGraphicsInterface* const graphics = g_pCore->GetGraphics();
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadString(strText);
-    argStream.ReadNumber(fWidth, 0);
-    if (argStream.NextIsUserDataOfType<CLuaVector2D>())
+    // resolve scale(use X as Y value, if optScaleY is empty)
+    CVector2D scale(1.0f, 1.0f);
+    if (optScaleXY.has_value())
     {
-        CVector2D vecScale;
-        argStream.ReadVector2D(vecScale);
-        fScaleX = vecScale.fX;
-        fScaleY = vecScale.fY;
+        scale.fX = optScaleXY.value();
+        scale.fY = optScaleY.has_value() ? optScaleY.value() : scale.fX;
     }
-    else
-    {
-        argStream.ReadNumber(fScaleX, 1);
-        if (argStream.NextIsNumber())
-            argStream.ReadNumber(fScaleY);
-        else
-            fScaleY = fScaleX;
-    }
-    MixedReadDxFontString(argStream, fontType, FONT_DEFAULT, pDxFontElement);
-    argStream.ReadBool(bWordBreak, false);
-    argStream.ReadBool(bColorCoded, false);
-
-    if (argStream.HasErrors())
-        return luaL_error(luaVM, argStream.GetFullErrorMessage());
-
-    // Get DX font
-    ID3DXFont* pD3DXFont = CStaticFunctionDefinitions::ResolveD3DXFont(fontType, pDxFontElement);
 
     CVector2D vecSize;
-    g_pCore->GetGraphics()->GetDXTextSize(vecSize, strText.c_str(), fWidth, fScaleX, fScaleY, pD3DXFont, bWordBreak, bColorCoded);
-    lua_pushnumber(luaVM, vecSize.fX);
-    lua_pushnumber(luaVM, vecSize.fY);
-    return 2;
-}
+    graphics->GetDXTextSize(
+        vecSize,
+        text.c_str(),
+        optWidth.value_or(0.0f),
+        scale.fX,
+        scale.fY,
+        CStaticFunctionDefinitions::ResolveD3DXFont(variantFont),
+        optWordBreak.value_or(false),
+        optColorCoded.value_or(false)
+    );
 
-int CLuaDrawingDefs::OOP_DxGetTextSize(lua_State* luaVM)
-{
-    //  vector2 DxFont:getTextSize ( string text, [float width=0, float scaleXY=1.0, float=scaleY=1.0,
-    //      bool wordBreak=false, bool colorCoded=false] )
-    SString        strText;
-    float          fWidth;
-    float          fScaleX;
-    float          fScaleY;
-    CClientDxFont* pDxFontElement;
-    bool           bWordBreak;
-    bool           bColorCoded;
-
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pDxFontElement);
-    argStream.ReadString(strText);
-    argStream.ReadNumber(fWidth, 0);
-    if (argStream.NextIsUserDataOfType<CLuaVector2D>())
-    {
-        CVector2D vecScale;
-        argStream.ReadVector2D(vecScale);
-        fScaleX = vecScale.fX;
-        fScaleY = vecScale.fY;
-    }
-    else
-    {
-        argStream.ReadNumber(fScaleX, 1);
-        if (argStream.NextIsNumber())
-            argStream.ReadNumber(fScaleY);
-        else
-            fScaleY = fScaleX;
-    }
-    argStream.ReadBool(bWordBreak, false);
-    argStream.ReadBool(bColorCoded, false);
-
-    if (argStream.HasErrors())
-        return luaL_error(luaVM, argStream.GetFullErrorMessage());
-
-    // Get DX font
-    ID3DXFont* pD3DXFont = CStaticFunctionDefinitions::ResolveD3DXFont(FONT_DEFAULT, pDxFontElement);
-
-    CVector2D  vecSize;
-    g_pCore->GetGraphics()->GetDXTextSize(vecSize, strText.c_str(), fWidth, fScaleX, fScaleY, pD3DXFont, bWordBreak, bColorCoded);
-    lua_pushvector(luaVM, vecSize);
-    return 1;
+    return vecSize;
 }
 
 int CLuaDrawingDefs::DxGetFontHeight(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.h
@@ -10,7 +10,9 @@
  *****************************************************************************/
 
 #pragma once
-#include "CLuaDefs.h"
+#include <optional>
+#include <variant>
+#include <utility>
 
 class CLuaDrawingDefs : public CLuaDefs
 {
@@ -31,7 +33,39 @@ public:
     LUA_DECLARE(DxDrawMaterialPrimitive);
     LUA_DECLARE(DxDrawPrimitive3D);
     LUA_DECLARE(DxDrawMaterialPrimitive3D);
-    LUA_DECLARE_OOP(DxGetTextSize);
+
+    static CVector2D OOP_DxGetTextSize(
+        std::variant<CClientDxFont*, eFontType> font, // is optional, so we can call it from DxGetTextSize with a std::nullopt, and we just grab the FONT_DEFAULT.
+        const std::string text,
+        const std::optional<float> optWidth,
+        const std::optional<float> optScaleXY,
+        const std::optional<float> optScaleY,
+        const std::optional<bool> optWordBreak,
+        const std::optional<bool> optColorCoded
+    );
+
+     static inline std::tuple<float, float> DxGetTextSize(
+        std::string text,
+        std::optional<float> optWidth,
+        std::optional<float> optScaleXY,
+        std::optional<float> optScaleY,
+        std::optional<std::variant<CClientDxFont*, eFontType>> optFont,
+        std::optional<bool> optWordBreak,
+        std::optional<bool> optColorCoded
+    )
+    {
+        const auto size = OOP_DxGetTextSize(
+            optFont.has_value() ? std::move(optFont.value()) : FONT_DEFAULT,
+            std::move(text),
+            std::move(optWidth),
+            std::move(optScaleXY),
+            std::move(optScaleY),
+            std::move(optWordBreak),
+            std::move(optColorCoded)
+        );
+
+        return { size.fX, size.fY };
+    }
     LUA_DECLARE_OOP(DxGetTextWidth);
     LUA_DECLARE_OOP(DxGetFontHeight);
     LUA_DECLARE(DxCreateFont);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.h
@@ -32,7 +32,6 @@ public:
     LUA_DECLARE(DxDrawPrimitive3D);
     LUA_DECLARE(DxDrawMaterialPrimitive3D);
     LUA_DECLARE_OOP(DxGetTextSize);
-    LUA_DECLARE(DxDrawWiredSphere);
     LUA_DECLARE_OOP(DxGetTextWidth);
     LUA_DECLARE_OOP(DxGetFontHeight);
     LUA_DECLARE(DxCreateFont);
@@ -61,6 +60,7 @@ public:
     LUA_DECLARE(DxIsAspectRatioAdjustmentEnabled);
     LUA_DECLARE(DxSetTextureEdge);
 
+    static bool DxDrawWiredSphere(lua_State* const luaVM, const CVector position, const float radius, const std::optional<SColorARGB> color, const std::optional<float> lineWidth, const std::optional<unsigned int> iterations);
 private:
     static void AddDxMaterialClass(lua_State* luaVM);
     static void AddDxTextureClass(lua_State* luaVM);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -38,7 +38,7 @@ void CLuaEngineDefs::LoadFunctions()
         {"engineGetModelTextureNames", EngineGetModelTextureNames},
         {"engineGetVisibleTextureNames", EngineGetVisibleTextureNames},
         {"engineSetModelVisibleTime", ArgumentParser<EngineSetModelVisibleTime>},
-        {"engineGetModelVisibleTime", EngineGetModelVisibleTime},
+        {"engineGetModelVisibleTime", ArgumentParser<EngineGetModelVisibleTime>},
         {"engineGetModelTextures", EngineGetModelTextures},
         {"engineGetSurfaceProperties", EngineGetSurfaceProperties},
         {"engineSetSurfaceProperties", EngineSetSurfaceProperties},
@@ -1112,41 +1112,16 @@ bool CLuaEngineDefs::EngineSetModelVisibleTime(const std::variant<std::string, u
     return modelInfo->SetTime(hourOn, hourOff);
 }
 
-int CLuaEngineDefs::EngineGetModelVisibleTime(lua_State* luaVM)
+std::tuple<char, char> CLuaEngineDefs::EngineGetModelVisibleTime(const std::variant<std::string, unsigned short> variantModelID)
 {
-    // int, int engineGetModelVisibleTime ( int/string modelID )
-    SString strModelId;
+    const unsigned short modelID = CStaticFunctionDefinitions::ResolveModelID(variantModelID);
+    CModelInfo* const modelInfo = g_pGame->GetModelInfo(modelID);
+    if (!modelInfo)
+        throw std::invalid_argument(SString("Invalid model id %u", modelID));
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadString(strModelId);
-
-    if (!argStream.HasErrors())
-    {
-        ushort      usModelID = CModelNames::ResolveModelID(strModelId);
-        CModelInfo* pModelInfo = g_pGame->GetModelInfo(usModelID);
-        if (pModelInfo)
-        {
-            char cHourOn, cHourOff;
-            if (pModelInfo->GetTime(cHourOn, cHourOff))
-            {
-                lua_pushnumber(luaVM, cHourOn);
-                lua_pushnumber(luaVM, cHourOff);
-                return 2;
-            }
-            else // Model is incompatible, don't let confuse user.
-            {
-                lua_pushnumber(luaVM, 0);
-                lua_pushnumber(luaVM, 24);
-                return 2;
-            }
-        }
-    }
-    else
-        luaL_error(luaVM, argStream.GetFullErrorMessage());
-
-    // Failed
-    lua_pushboolean(luaVM, false);
-    return 1;
+    char hourOn = 0, hourOff = 24; // If model is incompatible it returns these numbers(in order: 0, 24) so we dont confuse the user
+    modelInfo->GetTime(hourOn, hourOff); 
+    return { hourOn, hourOff };
 }
 
 int CLuaEngineDefs::EngineGetModelTextures(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -29,7 +29,7 @@ void CLuaEngineDefs::LoadFunctions()
         {"engineRequestModel", EngineRequestModel},
         {"engineGetModelLODDistance", EngineGetModelLODDistance},
         {"engineSetModelLODDistance", EngineSetModelLODDistance},
-        {"engineResetModelLODDistance", EngineResetModelLODDistance},
+        {"engineResetModelLODDistance", ArgumentParser<EngineResetModelLODDistance>},
         {"engineSetAsynchronousLoading", EngineSetAsynchronousLoading},
         {"engineApplyShaderToWorldTexture", EngineApplyShaderToWorldTexture},
         {"engineRemoveShaderFromWorldTexture", EngineRemoveShaderFromWorldTexture},
@@ -772,7 +772,8 @@ int CLuaEngineDefs::EngineSetModelLODDistance(lua_State* luaVM)
     return 1;
 }
 
-int CLuaEngineDefs::EngineResetModelLODDistance(lua_State* luaVM)
+//  bool engineResetModelLODDistance(int / string modelID)
+bool CLuaEngineDefs::EngineResetModelLODDistance(const std::variant<std::string, unsigned short> variantModelID)
 {
     const unsigned short modelID = CStaticFunctionDefinitions::ResolveModelID(variantModelID);
     CModelInfo* const modelInfo = g_pGame->GetModelInfo(modelID);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -774,29 +774,18 @@ int CLuaEngineDefs::EngineSetModelLODDistance(lua_State* luaVM)
 
 int CLuaEngineDefs::EngineResetModelLODDistance(lua_State* luaVM)
 {
-    SString          strModel = "";
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadString(strModel);
+    const unsigned short modelID = CStaticFunctionDefinitions::ResolveModelID(variantModelID);
+    CModelInfo* const modelInfo = g_pGame->GetModelInfo(modelID);
+    if (!modelInfo)
+        throw std::invalid_argument(SString("Invalid model id %u", modelID));
 
-    if (argStream.HasErrors())
-        return luaL_error(luaVM, argStream.GetFullErrorMessage());
-    
-    unsigned short usModelID = CModelNames::ResolveModelID(strModel);
-    CModelInfo*    pModelInfo = g_pGame->GetModelInfo(usModelID);
-    if (pModelInfo)
-    {
-        float fCurrentDistance = pModelInfo->GetLODDistance();
-        float fOriginalDistance = pModelInfo->GetOriginalLODDistance();
-        //Make sure we're dealing with a valid LOD distance, and not setting the same LOD distance
-        if (fOriginalDistance > 0.0f && fOriginalDistance != fCurrentDistance) {
-            pModelInfo->SetLODDistance(fOriginalDistance, true);
-            lua_pushboolean(luaVM, true);
-            return 1;
-        }
-    }
+    //Make sure we're dealing with a valid LOD distance, and not setting the same LOD distance
+    const float originalDistance = modelInfo->GetOriginalLODDistance();
+    if (originalDistance == 0.0f || originalDistance == modelInfo->GetLODDistance())
+        return false;
 
-    lua_pushboolean(luaVM, false);
-    return 1;
+    modelInfo->SetLODDistance(originalDistance, true);
+    return true;
 }
 
 int CLuaEngineDefs::EngineSetAsynchronousLoading(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
@@ -11,6 +11,8 @@
 
 #pragma once
 #include "CLuaDefs.h"
+#include <optional>
+#include <variant>
 
 class CLuaEngineDefs : public CLuaDefs
 {
@@ -49,7 +51,7 @@ public:
     LUA_DECLARE(EngineGetVisibleTextureNames);
 
     static bool EngineSetModelVisibleTime(const std::variant<std::string, unsigned short> variantModelID, char hourOn, char hourOff);
-    static std::tuple<char, char> EngineGetModelVisibleTime(const std::variant<std::string, unsigned int> variantModelID);
+    static std::tuple<char, char> EngineGetModelVisibleTime(const std::variant<std::string, unsigned short> variantModelID);
 
     LUA_DECLARE(EngineGetModelTextures);
     LUA_DECLARE(EngineSetSurfaceProperties);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
@@ -47,8 +47,10 @@ public:
     LUA_DECLARE(EngineGetModelIDFromName);
     LUA_DECLARE(EngineGetModelTextureNames);
     LUA_DECLARE(EngineGetVisibleTextureNames);
-    LUA_DECLARE(EngineSetModelVisibleTime);
-    LUA_DECLARE(EngineGetModelVisibleTime);
+
+    static bool EngineSetModelVisibleTime(const std::variant<std::string, unsigned short> variantModelID, char hourOn, char hourOff);
+    static std::tuple<char, char> EngineGetModelVisibleTime(const std::variant<std::string, unsigned int> variantModelID);
+
     LUA_DECLARE(EngineGetModelTextures);
     LUA_DECLARE(EngineSetSurfaceProperties);
     LUA_DECLARE(EngineGetSurfaceProperties);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
@@ -41,7 +41,7 @@ public:
     LUA_DECLARE(EngineReplaceVehiclePart);
     LUA_DECLARE(EngineGetModelLODDistance);
     LUA_DECLARE(EngineSetModelLODDistance);
-    LUA_DECLARE(EngineResetModelLODDistance);
+    static bool EngineResetModelLODDistance(const std::variant<std::string, unsigned short> variantModelID);
     LUA_DECLARE(EngineSetAsynchronousLoading);
     LUA_DECLARE(EngineApplyShaderToWorldTexture);
     LUA_DECLARE(EngineRemoveShaderFromWorldTexture);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -75,7 +75,7 @@ void CLuaPedDefs::LoadFunctions()
         {"setPedControlState", SetPedControlState},
         {"setPedAnalogControlState", SetPedAnalogControlState},
         {"setPedDoingGangDriveby", SetPedDoingGangDriveby},
-        {"setPedFightingStyle", SetPedFightingStyle},
+        {"setPedFightingStyle", ArgumentParser<SetPedFightingStyle>},
         {"setPedLookAt", SetPedLookAt},
         {"setPedHeadless", SetPedHeadless},
         {"setPedFrozen", SetPedFrozen},
@@ -1762,19 +1762,13 @@ int CLuaPedDefs::SetPedDoingGangDriveby(lua_State* luaVM)
     return 1;
 }
 
-int CLuaPedDefs::SetPedFightingStyle(lua_State* luaVM)
+bool CLuaPedDefs::SetPedFightingStyle(CClientEntity* const entity, const unsigned char style)
 {
-    CClientEntity*   pEntity;
-    unsigned char    ucStyle;
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pEntity);
-    argStream.ReadNumber(ucStyle);
+    // Is valid style?
+    if (style < 4 || style > 16)
+        throw std::invalid_argument("Style can only be between 4 and 16");
 
-    if (argStream.HasErrors())
-        return luaL_error(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, CStaticFunctionDefinitions::SetPedFightingStyle(*pEntity, ucStyle));
-    return 1;
+    return  CStaticFunctionDefinitions::SetPedFightingStyle(*entity, style);
 }
 
 int CLuaPedDefs::SetPedLookAt(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -86,7 +86,7 @@ void CLuaPedDefs::LoadFunctions()
         {"warpPedIntoVehicle", WarpPedIntoVehicle},
         {"removePedFromVehicle", RemovePedFromVehicle},
         {"setPedOxygenLevel", SetPedOxygenLevel},
-        {"setPedArmor", SetPedArmor},
+        {"setPedArmor", ArgumentParser<SetPedArmor>},
         {"givePedWeapon", GivePedWeapon},
         {"isPedReloadingWeapon", IsPedReloadingWeapon},
     };
@@ -2198,21 +2198,17 @@ int CLuaPedDefs::SetPedMoveAnim(lua_State* luaVM)
     return 1;
 }
 
-int CLuaPedDefs::SetPedArmor(lua_State* luaVM)
+
+
+
+bool CLuaPedDefs::SetPedArmor(CClientPed* const ped, const float armor)
 {
-    CClientPed*      pPed;
-    float            fArmor;
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pPed);
-    argStream.ReadNumber(fArmor);
-
-    if (argStream.HasErrors())
+    if (ped->IsLocalEntity())
     {
-        return luaL_error(luaVM, argStream.GetFullErrorMessage());
+        ped->SetArmor(armor);
+        return true;
     }
-
-    lua_pushboolean(luaVM, CStaticFunctionDefinitions::SetPedArmor(*pPed, fArmor));
-    return 1;
+    return false;
 }
 
 int CLuaPedDefs::SetPedOxygenLevel(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
@@ -71,7 +71,7 @@ public:
     LUA_DECLARE(SetPedAnimationProgress);
     LUA_DECLARE(SetPedAnimationSpeed);
     LUA_DECLARE(SetPedMoveAnim);
-    LUA_DECLARE(SetPedArmor);
+    static bool SetPedArmor(CClientPed* const ped, const float armor);
     LUA_DECLARE(SetPedWeaponSlot);
     LUA_DECLARE(GivePedWeapon);
     LUA_DECLARE(IsPedReloadingWeapon);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
@@ -80,7 +80,7 @@ public:
     LUA_DECLARE(SetPedControlState);
     LUA_DECLARE(SetPedAnalogControlState);
     LUA_DECLARE(SetPedDoingGangDriveby);
-    LUA_DECLARE(SetPedFightingStyle);
+    static bool SetPedFightingStyle(CClientEntity* const entity, const unsigned char style);
     LUA_DECLARE(SetPedLookAt);
     LUA_DECLARE(SetPedHeadless);
     LUA_DECLARE(SetPedFrozen);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -36,7 +36,7 @@ void CLuaVehicleDefs::LoadFunctions()
         {"getVehicleDoorState", GetVehicleDoorState},
         {"getVehicleLightState", GetVehicleLightState},
         {"getVehiclePanelState", GetVehiclePanelState},
-        {"areVehicleLightsOn", AreVehicleLightsOn},
+        {"areVehicleLightsOn", ArgumentParser<AreVehicleLightsOn>},
         {"getVehicleOverrideLights", GetVehicleOverrideLights},
         {"getVehicleTowedByVehicle", GetVehicleTowedByVehicle},
         {"getVehicleTowingVehicle", GetVehicleTowingVehicle},
@@ -1009,18 +1009,9 @@ int CLuaVehicleDefs::GetVehiclePanelState(lua_State* luaVM)
     return 1;
 }
 
-int CLuaVehicleDefs::AreVehicleLightsOn(lua_State* luaVM)
+bool CLuaVehicleDefs::AreVehicleLightsOn(CClientVehicle* const pVehicle)
 {
-    CClientVehicle*  pVehicle;
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pVehicle);
-
-    if (argStream.HasErrors())
-        return luaL_error(luaVM, argStream.GetFullErrorMessage());
-
-    bool bLightsOn = (pVehicle->AreLightsOn() || pVehicle->GetOverrideLights() == 2);
-    lua_pushboolean(luaVM, bLightsOn);
-    return 1;
+    return pVehicle->AreLightsOn() || pVehicle->GetOverrideLights() == 2;
 }
 
 int CLuaVehicleDefs::GetVehicleOverrideLights(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -44,7 +44,7 @@ public:
     LUA_DECLARE(GetVehicleDoorState);
     LUA_DECLARE(GetVehicleLightState);
     LUA_DECLARE(GetVehiclePanelState);
-    LUA_DECLARE(AreVehicleLightsOn);
+    static bool AreVehicleLightsOn(CClientVehicle* const pVehicle);
     LUA_DECLARE(GetVehicleOverrideLights);
     LUA_DECLARE(GetVehicleTowedByVehicle);
     LUA_DECLARE(GetVehicleTowingVehicle);

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1925,14 +1925,6 @@ const CMtaVersion& CStaticFunctionDefinitions::GetPlayerVersion(CPlayer* pPlayer
     return pPlayer->GetPlayerVersion();
 }
 
-bool CStaticFunctionDefinitions::GetPlayerScriptDebugLevel(CPlayer* pPlayer, unsigned int& uiLevel)
-{
-    assert(pPlayer);
-
-    uiLevel = pPlayer->GetScriptDebugLevel();
-    return true;
-}
-
 bool CStaticFunctionDefinitions::SetPlayerName(CElement* pElement, const char* szName)
 {
     assert(pElement);

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -127,7 +127,6 @@ public:
     static bool               GetPlayerIP(CElement* pElement, SString& strOutIP);
     static CAccount*          GetPlayerAccount(CElement* pElement);
     static const CMtaVersion& GetPlayerVersion(CPlayer* pPlayer);
-    static bool               GetPlayerScriptDebugLevel(CPlayer* pPlayer, unsigned int& uiLevel);
 
     // Player set functions
     static bool SetPlayerMoney(CElement* pElement, long lMoney, bool bInstant);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
@@ -43,7 +43,7 @@ void CLuaPlayerDefs::LoadFunctions()
         {"getPlayerACInfo", GetPlayerACInfo},
         {"resendPlayerModInfo", ResendPlayerModInfo},
         {"resendPlayerACInfo", ResendPlayerACInfo},
-        {"getPlayerScriptDebugLevel", GetPlayerScriptDebugLevel},
+        {"getPlayerScriptDebugLevel", ArgumentParser<GetPlayerScriptDebugLevel>},
 
         // Player set funcs
         {"setPlayerMoney", SetPlayerMoney},
@@ -1511,31 +1511,9 @@ int CLuaPlayerDefs::ResendPlayerACInfo(lua_State* luaVM)
     return 1;
 }
 
-int CLuaPlayerDefs::GetPlayerScriptDebugLevel(lua_State* luaVM)
+unsigned int CLuaPlayerDefs::GetPlayerScriptDebugLevel(CPlayer* const player)
 {
-    // int getPlayerScriptDebugLevel ( player thePlayer )
-    CPlayer* pPlayer;
-
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pPlayer);
-
-    if (argStream.HasErrors())
-    {
-        return luaL_error(luaVM, argStream.GetFullErrorMessage());
-    }
-
-    unsigned int uiLevel;
-
-    if (CStaticFunctionDefinitions::GetPlayerScriptDebugLevel(pPlayer, uiLevel))
-    {
-        lua_pushnumber(luaVM, uiLevel);
-        return 1;
-    }
-    else
-    {
-        lua_pushboolean(luaVM, false);
-        return 1;
-    }
+    return player->GetScriptDebugLevel();
 }
 
 int CLuaPlayerDefs::BindKey(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.h
@@ -46,7 +46,7 @@ public:
     LUA_DECLARE(GetPlayerAccount);
     LUA_DECLARE(GetPlayerVersion);
     LUA_DECLARE(GetPlayerACInfo);
-    static unsigned int CLuaPlayerDefs::GetPlayerScriptDebugLevel(CPlayer* const player);
+    static unsigned int GetPlayerScriptDebugLevel(CPlayer* const player);
 
     // Player set functions
     LUA_DECLARE(SetPlayerMoney);
@@ -66,7 +66,7 @@ public:
     LUA_DECLARE(SetPlayerName);
     LUA_DECLARE(DetonateSatchels);
     LUA_DECLARE(TakePlayerScreenShot);
-    LUA_DECLARE(SetPlayerScriptDebugLevel);
+    static bool SetPlayerScriptDebugLevel(CElement* const element, const std::variant<unsigned int, bool> variant);
 
     // All seeing eye
     LUA_DECLARE(GetPlayerAnnounceValue);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.h
@@ -46,7 +46,7 @@ public:
     LUA_DECLARE(GetPlayerAccount);
     LUA_DECLARE(GetPlayerVersion);
     LUA_DECLARE(GetPlayerACInfo);
-    LUA_DECLARE(GetPlayerScriptDebugLevel);
+    static unsigned int CLuaPlayerDefs::GetPlayerScriptDebugLevel(CPlayer* const player);
 
     // Player set functions
     LUA_DECLARE(SetPlayerMoney);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
@@ -53,7 +53,7 @@ void CLuaResourceDefs::LoadFunctions()
         {"getResourceExportedFunctions", getResourceExportedFunctions},
         {"getResourceOrganizationalPath", getResourceOrganizationalPath},
         {"isResourceArchived", isResourceArchived},
-        {"isResourceProtected", isResourceProtected},
+        {"isResourceProtected", ArgumentParser<isResourceProtected>},
 
         // Set stuff
         {"setResourceInfo", setResourceInfo},
@@ -1464,17 +1464,7 @@ int CLuaResourceDefs::isResourceArchived(lua_State* luaVM)
     return 1;
 }
 
-int CLuaResourceDefs::isResourceProtected(lua_State* luaVM)
+bool CLuaResourceDefs::isResourceProtected(CResource* const resource)
 {
-    //  bool isResourceProtected ( resource theResource )
-    CResource* pResource;
-
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pResource);
-
-    if (argStream.HasErrors())
-        return luaL_error(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, pResource->IsProtected());
-    return 1;
+    return resource->IsProtected();
 }

--- a/Server/mods/deathmatch/logic/luadefs/CLuaResourceDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaResourceDefs.h
@@ -54,7 +54,7 @@ public:
     LUA_DECLARE(getResourceExportedFunctions);
     LUA_DECLARE(getResourceOrganizationalPath);
     LUA_DECLARE(isResourceArchived);
-    LUA_DECLARE(isResourceProtected);
+    static bool isResourceProtected(CResource* const resource);
 
     // Set stuff
     LUA_DECLARE(setResourceInfo);


### PR DESCRIPTION
I've talked with Qais, and he said it would be a big help to refactor all these new functions.

Also, the *not done list*:

- dxDrawPrimitive3D  / dxDrawMaterialPrimitive3D - hard to read table structure. Its pretty specific, so i wont bother trying it with the new parser, will just add a big overhead.
- engineGetModelTextures  - performance issue(returning std::unordred_map, with possibly a lot of strings: a lot of HEAP allocs, which would kill the performance. I suggest to implement `std::vector<std::pair<const char*, Type*>>, or with string_view.`
- SetColShapeSize - argument types depends on colshape type - impossible to do with the new parser(well, not impossible, but im not sure what would be the best way, ill leave it up to you)
- GetColPolygonPoints - modifying it would kill the performance because of std::vector heap allocation on return
- [Add possibility of modifying dynamic objects behavior  (#784)](https://github.com/multitheftauto/mtasa-blue/commit/)

Also, maybe its not the best place to discuss: I think adding the ability to return `std::optional` to the new parser would be dope. Theres a function in the col shape file, where I've left a `TODO` comment, because its ugly and we need a refactor.