### PR TITLE
Fix std::optional popping and error messages in new parser

### DIFF
--- a/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
@@ -385,6 +385,9 @@ struct CLuaFunctionParserBase
                 SetBadArgumentError(L, strExpected, index, strReceived);
             }
 
+            // We didn't call PopUnsafe, so we need to manually increment the index
+            index++;
+
             return std::nullopt;
         }
 

--- a/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
@@ -377,8 +377,15 @@ struct CLuaFunctionParserBase
             using param = typename is_specialization<T, std::optional>::param_t;
             if (TypeMatch<param>(L, index))
                 return PopUnsafe<param>(L, index);
-            else
-                return std::nullopt;
+
+            if (!lua_isnoneornil(L, index))
+            {
+                SString strReceived = ReadParameterAsString(L, index);
+                SString strExpected = TypeToName<param>();
+                SetBadArgumentError(L, strExpected, index, strReceived);
+            }
+
+            return std::nullopt;
         }
 
         else if constexpr (is_2specialization<T, std::vector>::value)            // 2 specialization due to allocator


### PR DESCRIPTION
**Issue 1: Pop Lua argument when invalid optional encountered**

Example:

- Signature: `test(string name, opt<int> bornAt, opt<int> diedAt)`
- Call (1): `test("1", nil, 1000)`
- Call (2): `test("2", 1000, 2000)`

In (1), only `name` will be set. In (2), both `bornAt` and `diedAt` are
set.

Thanks to @Pirulax for identifying the fix.

**Issue 2: Bad types to optionals are ignored (new parser)**

No warning is shown.