### PR TITLE
Fix off-by-one in off-by-one in error messages fix (31e90bb)

### DIFF
--- a/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
@@ -363,10 +363,10 @@ struct CLuaFunctionParserBase
                 return eValue;
             else
             {
-                SString strReceived = ReadParameterAsString(L, index);
-                SString strExpected = GetEnumTypeName((T)0);
                 // Subtract one from the index, as the call to lua::PopPrimitive above increments the index, even if the
                 // underlying element is of a wrong type
+                SString strReceived = ReadParameterAsString(L, index - 1);
+                SString strExpected = GetEnumTypeName((T)0);
                 SetBadArgumentError(L, strExpected, index - 1, strReceived);
                 return static_cast<T>(0);
             }


### PR DESCRIPTION
UNTESTED. In the "Files changed" tab, make sure to see more context below the diff, specifically [line 370](https://github.com/multitheftauto/mtasa-blue/pull/1477/files#diff-eedaee2413b2da265460ed09b1abe646R370)

See https://github.com/multitheftauto/mtasa-blue/commit/31e90bb34fd2e4f0a32991029db67beac7cd369c#r39546561