### PR TITLE
Refactor CVector/2D/4D to use constexpr + noexcept everywhere

### DIFF
--- a/Shared/sdk/CVector.h
+++ b/Shared/sdk/CVector.h
@@ -26,53 +26,63 @@
 class CVector
 {
 public:
-    float fX, fY, fZ;
+    float fX = 0.0f;
+    float fY = 0.0f;
+    float fZ = 0.0f;
 
-    CVector()
-    {
-        this->fX = 0;
-        this->fY = 0;
-        this->fZ = 0;
-    };
+    constexpr CVector() = default;
 
-    CVector(float fX, float fY, float fZ)
+    constexpr CVector(float x, float y, float z) :
+        fX(x),
+        fY(y),
+        fZ(z)
     {
-        this->fX = fX;
-        this->fY = fY;
-        this->fZ = fZ;
     }
 
-    CVector(const CVector4D& vec)
+    constexpr CVector(const CVector4D& vec) noexcept :
+        fX(vec.fX),
+        fY(vec.fY),
+        fZ(vec.fZ)
     {
-        this->fX = vec.fX;
-        this->fY = vec.fY;
-        this->fZ = vec.fZ;
     }
 
+    constexpr CVector& operator=(const CVector4D& vec) noexcept
+    {
+        fX = vec.fX;
+        fY = vec.fY;
+        fZ = vec.fZ;
+        return *this;
+    }
+
+
+    constexpr CVector Clone() const { return *this; }
+
+    // returns the length of the vector and normalizes it
     float Normalize()
     {
-        float t = sqrt(fX * fX + fY * fY + fZ * fZ);
+        const float t = Length();
         if (t > FLOAT_EPSILON)
         {
-            float fRcpt = 1 / t;
-            fX *= fRcpt;
-            fY *= fRcpt;
-            fZ *= fRcpt;
+            fX /= t;
+            fY /= t;
+            fZ /= t;
+
+            return t;
         }
         else
-            t = 0;
-        return t;
+            return 0;
     }
 
-    float Length() const { return sqrt((fX * fX) + (fY * fY) + (fZ * fZ)); }
+    inline float Length() const { return sqrt((fX * fX) + (fY * fY) + (fZ * fZ)); }
 
-    float LengthSquared() const { return (fX * fX) + (fY * fY) + (fZ * fZ); }
+    // returns just the squared length(eg.: x*x* + y*y + z*z)
+    inline float LengthSquared() const { return (fX * fX) + (fY * fY) + (fZ * fZ); }
 
-    float DotProduct(const CVector* param) const { return fX * param->fX + fY * param->fY + fZ * param->fZ; }
+    inline float DotProduct(const CVector* param) const { return fX * param->fX + fY * param->fY + fZ * param->fZ; }
 
     void CrossProduct(const CVector* param)
     {
-        float _fX = fX, _fY = fY, _fZ = fZ;
+        const float _fX = fX, _fY = fY, _fZ = fZ;
         fX = _fY * param->fZ - param->fY * _fZ;
         fY = _fZ * param->fX - param->fZ * _fX;
         fZ = _fX * param->fY - param->fX * _fY;
@@ -83,7 +93,7 @@ public:
     {
         CVector vecRotation;
         vecRotation.fZ = atan2(fY, fX);
-        CVector vecTemp(sqrt(fX * fX + fY * fY), fZ, 0);
+        CVector vecTemp(std::hypotf(fX, fY), fZ, 0);
         vecTemp.Normalize();
         vecRotation.fY = atan2(vecTemp.fX, vecTemp.fY) - PI / 2;
         return vecRotation;
@@ -97,25 +107,16 @@ public:
             vecResult = CVector(fZ, 0, -fX);
         else
             vecResult = CVector(0, -fZ, fY);
+
         vecResult.Normalize();
         return vecResult;
     }
 
-    CVector Clone() const
-    {
-        CVector vecResult;
-        vecResult.fX = fX;
-        vecResult.fY = fY;
-        vecResult.fZ = fZ;
-        return vecResult;
-    }
-
     // Intersections code based on https://github.com/juj/MathGeoLib/blob/master/src/Geometry/Plane.h
-    bool IntesectsLinePlane(const CVector& vecRay, const CVector& vecNormal, const CVector& vecPosition, float* fOutDist) const
+    bool IntesectsLinePlane(const CVector& vecRay, const CVector& vecNormal, const CVector& vecPosition, float* fOutDist) const noexcept
     {
-        bool bIntersects = false;
+        const float fDenom = vecNormal.DotProduct(&vecRay);
 
-        float fDenom = vecNormal.DotProduct(&vecRay);
         if (fabs(fDenom) > 1e-4f)
         {
             *fOutDist = (vecPosition.Length() - vecNormal.DotProduct(this)) / fDenom;
@@ -132,12 +133,13 @@ public:
         return fabs(vecNormal.DotProduct(this) - vecPosition.Length()) < 1e-3f;;
     }
 
-    bool IntersectsSegmentPlane(const CVector& vecSegment, const CVector& vecNormal, const CVector& vecPosition, CVector* outVec) const
+    bool IntersectsSegmentPlane(const CVector& vecSegment, const CVector& vecNormal, const CVector& vecPosition, CVector* outVec) const noexcept
     {
         float fDist;
         CVector vecRay = vecSegment;
         vecRay.Normalize();
         bool bIntersects = IntesectsLinePlane(vecRay, vecNormal, vecPosition, &fDist);
+
         const float fSegLength = vecSegment.Length();
         
         *outVec = *this + vecRay * fDist;
@@ -145,9 +147,9 @@ public:
     }
 
     // https://en.wikipedia.org/wiki/M%C3%B6ller%E2%80%93Trumbore_intersection_algorithm
-    bool IntersectsSegmentTriangle(const CVector& vecSegment, const CVector& vecVert1, const CVector& vecVert2, const CVector& vecVert3, CVector* outVec) const
+    bool IntersectsSegmentTriangle(const CVector& vecSegment, const CVector& vecVert1, const CVector& vecVert2, const CVector& vecVert3, CVector* outVec) const noexcept
     {
-        const float fEpsilon = 1e-6f;
+        constexpr float fEpsilon = 1e-6f;
 
         CVector vecEdge1, vecEdge2, h, s;
         float a, f, u, v;
@@ -192,96 +194,88 @@ public:
         return false;
     }
 
-    CVector operator+(const CVector& vecRight) const { return CVector(fX + vecRight.fX, fY + vecRight.fY, fZ + vecRight.fZ); }
+    constexpr CVector operator+(const CVector& vecRight) const noexcept { return CVector(fX + vecRight.fX, fY + vecRight.fY, fZ + vecRight.fZ); }
 
-    CVector operator-(const CVector& vecRight) const { return CVector(fX - vecRight.fX, fY - vecRight.fY, fZ - vecRight.fZ); }
 
-    CVector operator*(const CVector& vecRight) const { return CVector(fX * vecRight.fX, fY * vecRight.fY, fZ * vecRight.fZ); }
+    constexpr CVector operator-(const CVector& vecRight) const noexcept { return CVector(fX - vecRight.fX, fY - vecRight.fY, fZ - vecRight.fZ); }
 
-    CVector operator*(float fRight) const { return CVector(fX * fRight, fY * fRight, fZ * fRight); }
+    constexpr CVector operator-() const noexcept { return CVector(-fX, -fY, -fZ); }
 
-    CVector operator/(const CVector& vecRight) const { return CVector(fX / vecRight.fX, fY / vecRight.fY, fZ / vecRight.fZ); }
 
-    CVector operator/(float fRight) const
-    {
-        float fRcpValue = 1 / fRight;
-        return CVector(fX * fRcpValue, fY * fRcpValue, fZ * fRcpValue);
-    }
+    constexpr CVector operator*(const CVector& vecRight) const noexcept { return CVector(fX * vecRight.fX, fY * vecRight.fY, fZ * vecRight.fZ); }
 
-    CVector operator-() const { return CVector(-fX, -fY, -fZ); }
+    constexpr CVector operator*(const float fRight) const noexcept { return CVector(fX * fRight, fY * fRight, fZ * fRight); }
 
-    void operator+=(float fRight)
+
+    constexpr CVector operator/(const CVector& vecRight) const noexcept { return CVector(fX / vecRight.fX, fY / vecRight.fY, fZ / vecRight.fZ); }
+
+    constexpr CVector operator/(const float fRight) const noexcept { return CVector(fX / fRight, fY / fRight, fZ / fRight); }
+
+
+    constexpr void operator+=(const float fRight) noexcept
     {
         fX += fRight;
         fY += fRight;
         fZ += fRight;
     }
 
-    void operator+=(const CVector& vecRight)
+    constexpr void operator+=(const CVector& vecRight) noexcept
     {
         fX += vecRight.fX;
         fY += vecRight.fY;
         fZ += vecRight.fZ;
     }
 
-    void operator-=(float fRight)
+
+    constexpr void operator-=(const float fRight) noexcept
     {
         fX -= fRight;
         fY -= fRight;
         fZ -= fRight;
     }
 
-    void operator-=(const CVector& vecRight)
+    constexpr void operator-=(const CVector& vecRight) noexcept
     {
         fX -= vecRight.fX;
         fY -= vecRight.fY;
         fZ -= vecRight.fZ;
     }
 
-    void operator*=(float fRight)
+
+    constexpr void operator*=(const float fRight) noexcept
     {
         fX *= fRight;
         fY *= fRight;
         fZ *= fRight;
     }
 
-    void operator*=(const CVector& vecRight)
+    constexpr void operator*=(const CVector& vecRight) noexcept
     {
         fX *= vecRight.fX;
         fY *= vecRight.fY;
         fZ *= vecRight.fZ;
     }
 
-    void operator/=(float fRight)
+
+    constexpr void operator/=(const float fRight) noexcept
     {
-        float fRcpValue = 1 / fRight;
-        fX *= fRcpValue;
-        fY *= fRcpValue;
-        fZ *= fRcpValue;
+        fX /= fRight;
+        fY /= fRight;
+        fZ /= fRight;
     }
 
-    void operator/=(const CVector& vecRight)
+    constexpr void operator/=(const CVector& vecRight) noexcept
     {
         fX /= vecRight.fX;
         fY /= vecRight.fY;
         fZ /= vecRight.fZ;
     }
 
-    bool operator==(const CVector& param) const
+
+    inline bool operator==(const CVector& param) const noexcept
     {
         return ((fabs(fX - param.fX) < FLOAT_EPSILON) && (fabs(fY - param.fY) < FLOAT_EPSILON) && (fabs(fZ - param.fZ) < FLOAT_EPSILON));
     }
 
-    bool operator!=(const CVector& param) const
-    {
-        return ((fabs(fX - param.fX) >= FLOAT_EPSILON) || (fabs(fY - param.fY) >= FLOAT_EPSILON) || (fabs(fZ - param.fZ) >= FLOAT_EPSILON));
-    }
-
-    CVector& operator=(const CVector4D& vec)
-    {
-        fX = vec.fX;
-        fY = vec.fY;
-        fZ = vec.fZ;
-        return *this;
-    }
+    inline bool operator!=(const CVector& param) const noexcept { return !(*this == param); }
 };

--- a/Shared/sdk/CVector.h
+++ b/Shared/sdk/CVector.h
@@ -75,7 +75,8 @@ public:
 
     inline float Length() const { return sqrt((fX * fX) + (fY * fY) + (fZ * fZ)); }
 
-    // returns just the squared length(eg.: x*x* + y*y + z*z)
+    // LengthSquared returns Length() without sqrt applied (i.e. returns x*x* + y*y + z*z)
+    // For more info see CMaterialLine3DBatcher::Flush()
     inline float LengthSquared() const { return (fX * fX) + (fY * fY) + (fZ * fZ); }
 
     inline float DotProduct(const CVector* param) const { return fX * param->fX + fY * param->fY + fZ * param->fZ; }

--- a/Shared/sdk/CVector.h
+++ b/Shared/sdk/CVector.h
@@ -57,7 +57,7 @@ public:
 
     constexpr CVector Clone() const { return *this; }
 
-    // returns the length of the vector and normalizes it
+    // Normalize returns the normalized length of the vector.
     float Normalize()
     {
         const float t = Length();
@@ -75,8 +75,8 @@ public:
 
     inline float Length() const { return sqrt((fX * fX) + (fY * fY) + (fZ * fZ)); }
 
-    // LengthSquared returns Length() without sqrt applied (i.e. returns x*x* + y*y + z*z)
-    // For more info see CMaterialLine3DBatcher::Flush()
+    // LengthSquared returns Length() without sqrt applied (i.e. returns x*x* + y*y + z*z).
+    // This can be useful if you only want to compare lengths.
     inline float LengthSquared() const { return (fX * fX) + (fY * fY) + (fZ * fZ); }
 
     inline float DotProduct(const CVector* param) const { return fX * param->fX + fY * param->fY + fZ * param->fZ; }
@@ -212,7 +212,6 @@ public:
 
     constexpr CVector operator/(const float fRight) const noexcept { return CVector(fX / fRight, fY / fRight, fZ / fRight); }
 
-
     constexpr void operator+=(const float fRight) noexcept
     {
         fX += fRight;
@@ -226,7 +225,6 @@ public:
         fY += vecRight.fY;
         fZ += vecRight.fZ;
     }
-
 
     constexpr void operator-=(const float fRight) noexcept
     {
@@ -242,7 +240,6 @@ public:
         fZ -= vecRight.fZ;
     }
 
-
     constexpr void operator*=(const float fRight) noexcept
     {
         fX *= fRight;
@@ -256,7 +253,6 @@ public:
         fY *= vecRight.fY;
         fZ *= vecRight.fZ;
     }
-
 
     constexpr void operator/=(const float fRight) noexcept
     {

--- a/Shared/sdk/CVector2D.h
+++ b/Shared/sdk/CVector2D.h
@@ -62,7 +62,8 @@ public:
 
     float Length() const { return std::hypotf(fX, fY); }
 
-    // returns just the squared length(eg.: x*x* + y*y)
+    // LengthSquared returns Length() without sqrt applied (i.e. returns x*x* + y*y)
+    // For more info see CMaterialLine3DBatcher::Flush()
     constexpr float LengthSquared() const noexcept { return (fX * fX) + (fY * fY); }
 
     inline void Normalize() noexcept

--- a/Shared/sdk/CVector2D.h
+++ b/Shared/sdk/CVector2D.h
@@ -20,53 +20,54 @@
 class CVector2D
 {
 public:
-    CVector2D()
+    float fX = 0.0f;
+    float fY = 0.0f;
+
+    constexpr CVector2D() noexcept = default;
+
+    constexpr CVector2D(float x, float y) noexcept :
+        fX(x),
+        fY(y)
     {
-        fX = 0;
-        fY = 0;
     }
 
-    CVector2D(float _fX, float _fY)
+    constexpr CVector2D(const CVector& vec) noexcept :
+        fX(vec.fX),
+        fY(vec.fY)
     {
-        fX = _fX;
-        fY = _fY;
     }
 
-    CVector2D(const CVector& vec)
+    constexpr CVector2D(const CVector4D& vec) noexcept :
+        fX(vec.fX),
+        fY(vec.fY)
     {
-        fX = vec.fX;
-        fY = vec.fY;
     }
 
-    CVector2D(const CVector4D& vec)
-    {
-        fX = vec.fX;
-        fY = vec.fY;
-    }
 
-    CVector2D& operator=(const CVector& vec)
-    {
-        fX = vec.fX;
-        fY = vec.fY;
-        return *this;
-    }
-
-    CVector2D& operator=(const CVector4D& vec)
+    constexpr CVector2D& operator=(const CVector& vec) noexcept
     {
         fX = vec.fX;
         fY = vec.fY;
         return *this;
     }
 
-    float DotProduct(CVector2D& other) const { return fX * other.fX + fY * other.fY; }
-
-    float Length() const { return sqrt(fX * fX + fY * fY); }
-
-    float LengthSquared() const { return (fX * fX) + (fY * fY); }
-
-    void Normalize()
+    constexpr CVector2D& operator=(const CVector4D& vec) noexcept
     {
-        float fLength = Length();
+        fX = vec.fX;
+        fY = vec.fY;
+        return *this;
+    }
+
+    constexpr float DotProduct(CVector2D& other) const { return fX * other.fX + fY * other.fY; }
+
+    float Length() const { return std::hypotf(fX, fY); }
+
+    // returns just the squared length(eg.: x*x* + y*y)
+    constexpr float LengthSquared() const noexcept { return (fX * fX) + (fY * fY); }
+
+    inline void Normalize() noexcept
+    {
+        const float fLength = Length();
         if (fLength > 0.0f)
         {
             fX /= fLength;
@@ -74,74 +75,67 @@ public:
         }
     }
 
-    CVector2D operator*(float fRight) const { return CVector2D(fX * fRight, fY * fRight); }
+    constexpr CVector2D operator*(float fRight) const noexcept { return CVector2D(fX * fRight, fY * fRight); }
 
-    CVector2D operator/(float fRight) const
-    {
-        float fRcpValue = 1 / fRight;
-        return CVector2D(fX * fRcpValue, fY * fRcpValue);
-    }
+    constexpr CVector2D operator/(float fRight) const noexcept { return CVector2D(fX / fRight, fY / fRight); }
 
-    CVector2D operator+(const CVector2D& vecRight) const { return CVector2D(fX + vecRight.fX, fY + vecRight.fY); }
+    constexpr CVector2D operator+(const CVector2D& vecRight) const noexcept { return CVector2D(fX + vecRight.fX, fY + vecRight.fY); }
 
-    CVector2D operator-(const CVector2D& vecRight) const { return CVector2D(fX - vecRight.fX, fY - vecRight.fY); }
+    constexpr CVector2D operator-(const CVector2D& vecRight) const noexcept { return CVector2D(fX - vecRight.fX, fY - vecRight.fY); }
 
-    CVector2D operator*(const CVector2D& vecRight) const { return CVector2D(fX * vecRight.fX, fY * vecRight.fY); }
+    constexpr CVector2D operator*(const CVector2D& vecRight) const noexcept { return CVector2D(fX * vecRight.fX, fY * vecRight.fY); }
 
-    CVector2D operator/(const CVector2D& vecRight) const { return CVector2D(fX / vecRight.fX, fY / vecRight.fY); }
+    constexpr CVector2D operator/(const CVector2D& vecRight) const noexcept { return CVector2D(fX / vecRight.fX, fY / vecRight.fY); }
 
-    void operator+=(float fRight)
+    constexpr void operator+=(float fRight) noexcept
     {
         fX += fRight;
         fY += fRight;
     }
 
-    void operator+=(const CVector2D& vecRight)
+    constexpr void operator+=(const CVector2D& vecRight) noexcept
     {
         fX += vecRight.fX;
         fY += vecRight.fY;
     }
 
-    void operator-=(float fRight)
+    constexpr void operator-=(float fRight) noexcept
     {
         fX -= fRight;
         fY -= fRight;
     }
 
-    void operator-=(const CVector2D& vecRight)
+    constexpr void operator-=(const CVector2D& vecRight) noexcept
     {
         fX -= vecRight.fX;
         fY -= vecRight.fY;
     }
 
-    void operator*=(float fRight)
+    constexpr void operator*=(float fRight) noexcept
     {
         fX *= fRight;
         fY *= fRight;
     }
 
-    void operator*=(const CVector2D& vecRight)
+    constexpr void operator*=(const CVector2D& vecRight) noexcept
     {
         fX *= vecRight.fX;
         fY *= vecRight.fY;
     }
 
-    void operator/=(float fRight)
+    constexpr void operator/=(float fRight) noexcept
     {
         fX /= fRight;
         fY /= fRight;
     }
 
-    void operator/=(const CVector2D& vecRight)
+    constexpr void operator/=(const CVector2D& vecRight) noexcept
     {
         fX /= vecRight.fX;
         fY /= vecRight.fY;
     }
 
-    bool operator==(const CVector2D& param) const { return ((fabs(fX - param.fX) < FLOAT_EPSILON) && (fabs(fY - param.fY) < FLOAT_EPSILON)); }
+    bool operator==(const CVector2D& param) const noexcept { return ((fabs(fX - param.fX) < FLOAT_EPSILON) && (fabs(fY - param.fY) < FLOAT_EPSILON)); }
 
-    bool operator!=(const CVector2D& param) const { return ((fabs(fX - param.fX) >= FLOAT_EPSILON) || (fabs(fY - param.fY) >= FLOAT_EPSILON)); }
-
-    float fX;
-    float fY;
+    bool operator!=(const CVector2D& param) const noexcept { return !(*this == param); }
 };

--- a/Shared/sdk/CVector2D.h
+++ b/Shared/sdk/CVector2D.h
@@ -62,8 +62,8 @@ public:
 
     float Length() const { return std::hypotf(fX, fY); }
 
-    // LengthSquared returns Length() without sqrt applied (i.e. returns x*x* + y*y)
-    // For more info see CMaterialLine3DBatcher::Flush()
+    // LengthSquared returns Length() without sqrt applied (i.e. returns x*x* + y*y).
+    // This can be useful if you only want to compare lengths.
     constexpr float LengthSquared() const noexcept { return (fX * fX) + (fY * fY); }
 
     inline void Normalize() noexcept

--- a/Shared/sdk/CVector4D.h
+++ b/Shared/sdk/CVector4D.h
@@ -20,48 +20,37 @@
 class CVector4D
 {
 public:
-    CVector4D()
+    float fX = 0.0f;
+    float fY = 0.0f;
+    float fZ = 0.0f;
+    float fW = 0.0f;
+
+    constexpr CVector4D() noexcept = default;
+
+    constexpr CVector4D(const CVector4D&) noexcept = default;
+
+    constexpr CVector4D& operator=(const CVector4D&) noexcept = default;
+
+    constexpr CVector4D(float x, float y, float z, float w) noexcept :
+        fX(x),
+        fY(y),
+        fZ(z),
+        fW(w)
     {
-        fX = 0;
-        fY = 0;
-        fZ = 0;
-        fW = 0;
     }
 
-    CVector4D(float _fX, float _fY, float _fZ, float _fW)
+    // Warning, this function is returning the wrong value(fW is missing), its kept because nothing uses it, only
+    // CLuaVector4DDefs.
+    constexpr float DotProduct(const CVector4D& other) const noexcept { return fX * other.fX + fY * other.fY + fZ * other.fZ; }
+
+    float Length() const noexcept { return sqrt(fX * fX + fY * fY + fZ * fZ + fW * fW); }
+
+    // returns just the squared length(eg.: x*x* + y*y + z*z + w*w)
+    constexpr float LengthSquared() const noexcept { return (fX * fX) + (fY * fY) + (fZ * fZ) + (fW * fW); }
+
+    void Normalize() noexcept
     {
-        fX = _fX;
-        fY = _fY;
-        fZ = _fZ;
-        fW = _fW;
-    }
-
-    CVector4D(const CVector4D& vec)
-    {
-        fX = vec.fX;
-        fY = vec.fY;
-        fZ = vec.fZ;
-        fW = vec.fW;
-    }
-
-    CVector4D& operator=(const CVector4D& vec)
-    {
-        fX = vec.fX;
-        fY = vec.fY;
-        fZ = vec.fZ;
-        fW = vec.fW;
-        return *this;
-    }
-
-    float DotProduct(CVector4D& other) const { return fX * other.fX + fY * other.fY + fZ * other.fZ; }
-
-    float Length() const { return sqrt(fX * fX + fY * fY + fZ * fZ + fW * fW); }
-
-    float LengthSquared() const { return (fX * fX) + (fY * fY) + (fZ * fZ) + (fW * fW); }
-
-    void Normalize()
-    {
-        float fLength = Length();
+        const float fLength = Length();
         if (fLength > 0.0f)
         {
             fX /= fLength;
@@ -71,23 +60,22 @@ public:
         }
     }
 
-    CVector4D operator*(float fRight) const { return CVector4D(fX * fRight, fY * fRight, fZ * fRight, fW * fRight); }
+    constexpr CVector4D operator*(const CVector4D& vecRight) const { return CVector4D(fX * vecRight.fX, fY * vecRight.fY, fZ * vecRight.fZ, fW * vecRight.fW); }
 
-    CVector4D operator/(float fRight) const
-    {
-        float fRcpValue = 1 / fRight;
-        return CVector4D(fX * fRcpValue, fY * fRcpValue, fZ * fRcpValue, fW * fRcpValue);
-    }
+    constexpr CVector4D operator*(const float fRight) const noexcept { return CVector4D(fX * fRight, fY * fRight, fZ * fRight, fW * fRight); }
 
-    CVector4D operator+(const CVector4D& vecRight) const { return CVector4D(fX + vecRight.fX, fY + vecRight.fY, fZ + vecRight.fZ, fW + vecRight.fW); }
 
-    CVector4D operator-(const CVector4D& vecRight) const { return CVector4D(fX - vecRight.fX, fY - vecRight.fY, fZ - vecRight.fZ, fW - vecRight.fW); }
+    constexpr CVector4D operator+(const CVector4D& vecRight) const noexcept { return CVector4D(fX + vecRight.fX, fY + vecRight.fY, fZ + vecRight.fZ, fW + vecRight.fW); }
 
-    CVector4D operator*(const CVector4D& vecRight) const { return CVector4D(fX * vecRight.fX, fY * vecRight.fY, fZ * vecRight.fZ, fW * vecRight.fW); }
+    constexpr CVector4D operator-(const CVector4D& vecRight) const noexcept { return CVector4D(fX - vecRight.fX, fY - vecRight.fY, fZ - vecRight.fZ, fW - vecRight.fW); }
 
-    CVector4D operator/(const CVector4D& vecRight) const { return CVector4D(fX / vecRight.fX, fY / vecRight.fY, fZ / vecRight.fZ, fW / vecRight.fW); }
 
-    void operator+=(float fRight)
+    constexpr CVector4D operator/(const CVector4D& vecRight) const noexcept { return CVector4D(fX / vecRight.fX, fY / vecRight.fY, fZ / vecRight.fZ, fW / vecRight.fW); }
+
+    constexpr CVector4D operator/(const float fRight) const noexcept { return CVector4D(fX / fRight, fY / fRight, fZ / fRight, fW / fRight); }
+
+
+    constexpr void operator+=(const float fRight) noexcept
     {
         fX += fRight;
         fY += fRight;
@@ -95,7 +83,7 @@ public:
         fW += fRight;
     }
 
-    void operator+=(const CVector4D& vecRight)
+    constexpr void operator+=(const CVector4D& vecRight) noexcept
     {
         fX += vecRight.fX;
         fY += vecRight.fY;
@@ -103,7 +91,7 @@ public:
         fW += vecRight.fW;
     }
 
-    void operator-=(float fRight)
+    constexpr void operator-=(const float fRight) noexcept
     {
         fX -= fRight;
         fY -= fRight;
@@ -111,7 +99,7 @@ public:
         fW -= fRight;
     }
 
-    void operator-=(const CVector4D& vecRight)
+    constexpr void operator-=(const CVector4D& vecRight) noexcept
     {
         fX -= vecRight.fX;
         fY -= vecRight.fY;
@@ -119,7 +107,7 @@ public:
         fW -= vecRight.fW;
     }
 
-    void operator*=(float fRight)
+    constexpr void operator*=(const float fRight) noexcept
     {
         fX *= fRight;
         fY *= fRight;
@@ -127,15 +115,8 @@ public:
         fW *= fRight;
     }
 
-    void operator*=(const CVector4D& vecRight)
-    {
-        fX *= vecRight.fX;
-        fY *= vecRight.fY;
-        fZ *= vecRight.fZ;
-        fW *= vecRight.fW;
-    }
 
-    void operator/=(float fRight)
+    constexpr void operator/=(const float fRight) noexcept
     {
         fX /= fRight;
         fY /= fRight;
@@ -143,7 +124,7 @@ public:
         fW /= fRight;
     }
 
-    void operator/=(const CVector4D& vecRight)
+    constexpr void operator/=(const CVector4D& vecRight) noexcept
     {
         fX /= vecRight.fX;
         fY /= vecRight.fY;
@@ -151,20 +132,11 @@ public:
         fW /= vecRight.fW;
     }
 
-    bool operator==(const CVector4D& param) const
+    bool operator==(const CVector4D& param) const noexcept
     {
         return ((fabs(fX - param.fX) < FLOAT_EPSILON) && (fabs(fY - param.fY) < FLOAT_EPSILON) && (fabs(fZ - param.fZ) < FLOAT_EPSILON) &&
                 (fabs(fW - param.fW) < FLOAT_EPSILON));
     }
 
-    bool operator!=(const CVector4D& param) const
-    {
-        return ((fabs(fX - param.fX) >= FLOAT_EPSILON) || (fabs(fY - param.fY) >= FLOAT_EPSILON) || (fabs(fZ - param.fZ) >= FLOAT_EPSILON) ||
-                (fabs(fW - param.fW) >= FLOAT_EPSILON));
-    }
-
-    float fX;
-    float fY;
-    float fZ;
-    float fW;
+     bool operator!=(const CVector4D& param) const noexcept { return !(*this == param); }
 };

--- a/Shared/sdk/CVector4D.h
+++ b/Shared/sdk/CVector4D.h
@@ -45,8 +45,8 @@ public:
 
     float Length() const noexcept { return sqrt(fX * fX + fY * fY + fZ * fZ + fW * fW); }
 
-    // LengthSquared returns Length() without sqrt applied (i.e. returns x*x* + y*y + z*z + w*w)
-    // For more info see CMaterialLine3DBatcher::Flush()
+    // LengthSquared returns Length() without sqrt applied (i.e. returns x*x* + y*y + z*z + w*w).
+    // This can be useful if you only want to compare lengths.
     constexpr float LengthSquared() const noexcept { return (fX * fX) + (fY * fY) + (fZ * fZ) + (fW * fW); }
 
     void Normalize() noexcept
@@ -74,7 +74,6 @@ public:
     constexpr CVector4D operator/(const CVector4D& vecRight) const noexcept { return CVector4D(fX / vecRight.fX, fY / vecRight.fY, fZ / vecRight.fZ, fW / vecRight.fW); }
 
     constexpr CVector4D operator/(const float fRight) const noexcept { return CVector4D(fX / fRight, fY / fRight, fZ / fRight, fW / fRight); }
-
 
     constexpr void operator+=(const float fRight) noexcept
     {

--- a/Shared/sdk/CVector4D.h
+++ b/Shared/sdk/CVector4D.h
@@ -45,7 +45,8 @@ public:
 
     float Length() const noexcept { return sqrt(fX * fX + fY * fY + fZ * fZ + fW * fW); }
 
-    // returns just the squared length(eg.: x*x* + y*y + z*z + w*w)
+    // LengthSquared returns Length() without sqrt applied (i.e. returns x*x* + y*y + z*z + w*w)
+    // For more info see CMaterialLine3DBatcher::Flush()
     constexpr float LengthSquared() const noexcept { return (fX * fX) + (fY * fY) + (fZ * fZ) + (fW * fW); }
 
     void Normalize() noexcept


### PR DESCRIPTION
Basically this PR makes the above mentioned classes use constexpr, and noexcept everywhere they can.

All functions other than the constructors were probably inlined before anyways, but declaring the constructors as `constexpr` allows me(or someone else), to declare constexpr variables with vectors. 
Its kinda useful, just gives me that _constifying_ feel. 

These edits are cherry-picked from #1467