### PR TITLE
Remove unused variable from COpenPortsTester.h

### DIFF
--- a/Server/mods/deathmatch/utils/COpenPortsTester.h
+++ b/Server/mods/deathmatch/utils/COpenPortsTester.h
@@ -22,7 +22,6 @@ public:
             return;
 
         // Construct URL
-        SString strServerIP = g_pGame->GetConfig()->GetServerIP();
         ushort  usServerPort = g_pGame->GetConfig()->GetServerPort();
         ushort  usHTTPPort = g_pGame->GetConfig()->GetHTTPPort();
         SString strURL(PORT_TESTER_URL "?simple=1&g=%u", usServerPort);


### PR DESCRIPTION
The `strServerIP` variable is not used in the `Start()` method of the `COpenPortsTester` class, so it can (and probably should) be removed. I don't think that this variable is meant to do anything meaningful anyway, as I couldn't find any commit or issue relating to it.