### PR TITLE
Don't pause win-*.bat when run from command line

### DIFF
--- a/win-create-projects.bat
+++ b/win-create-projects.bat
@@ -18,4 +18,4 @@ set SCRIPTFILE="%TEMP%\CreateMyShortcut.vbs"
 cscript //nologo %SCRIPTFILE%
 del /f /q %SCRIPTFILE%
 
-pause
+if %0 == "%~0" pause

--- a/win-install-data.bat
+++ b/win-install-data.bat
@@ -11,4 +11,4 @@ if /I "%ANSWER%"=="y" (
     utils\premake5 install_resources
 )
 
-pause
+if %0 == "%~0" pause


### PR DESCRIPTION
- [x] Checked CI manually to verify that it still works fine (as sometimes script failures don't return a non-zero status code)