### PR TITLE
Enable GPU for CEF

### DIFF
--- a/Client/cefweb/CWebApp.cpp
+++ b/Client/cefweb/CWebApp.cpp
@@ -27,8 +27,6 @@ void CWebApp::OnRegisterCustomSchemes(CefRawPtr<CefSchemeRegistrar> registrar)
 
 void CWebApp::OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefCommandLine> command_line)
 {
-    command_line->AppendSwitch("disable-gpu-compositing");
-    command_line->AppendSwitch("disable-gpu");
     // command_line->AppendSwitch("disable-d3d11");
     command_line->AppendSwitch("enable-begin-frame-scheduling");
 


### PR DESCRIPTION
This removes `--disable-gpu`. I haven't checked performance, though. How 2 check performance @Jusonex?

-----

Fix #1493 'browser transparency does not work' (tested fix)

Upstream issue:
https://bitbucket.org/chromiumembedded/cef/issues/2938/osr-transparent-background-broken-since
/
https://bitbucket.org/chromiumembedded/cef/issues/2944/osr-no-transparency-when-gpu-disabled

Partially reverts 2b3998456b3180c2f40da6055bf307e470e6f457 "Tweak CEF
rendering performance"