### PR TITLE
Downgrade CEF to 81.3.10+gb223419+chromium-81.0.4044.138

### DIFF
--- a/utils/buildactions/install_cef.lua
+++ b/utils/buildactions/install_cef.lua
@@ -8,8 +8,8 @@ local CEF_URL_PREFIX = "http://opensource.spotify.com/cefbuilds/cef_binary_"
 local CEF_URL_SUFFIX = "_windows32_minimal.tar.bz2"
 
 -- Change here to update CEF version
-local CEF_VERSION = "83.3.11+g1fac1e5+chromium-83.0.4103.61"
-local CEF_HASH = "cb8fbb5fd54eb0f686a177333d481355fb34cea184888835ea39fbd0d5181e8d"
+local CEF_VERSION = "81.3.10+gb223419+chromium-81.0.4044.138"
+local CEF_HASH = "27d698c45cc2c0b15972589c32243fff15aca8d3fc1638c8a05ba54db0b63f05"
 
 function make_cef_download_url()
 	return CEF_URL_PREFIX..http.escapeUrlParam(CEF_VERSION)..CEF_URL_SUFFIX


### PR DESCRIPTION
Downgrading from 83.3.11+g1fac1e5+chromium-83.0.4103.61.

This fixes #1493 and essentially reverts 42cb6691357a.

This PR supersedes #1494 and is a replacement for #1496.
