### PR TITLE
Remove amx from installer

### DIFF
--- a/Shared/installer/nightly.nsi
+++ b/Shared/installer/nightly.nsi
@@ -929,12 +929,6 @@ SectionGroup /e "$(INST_SEC_SERVER)" SECGSERVER
 
     !ifndef LIGHTBUILD
         SectionGroup "$(INST_SEC_OPTIONAL_RESOURCES)" SEC07
-            Section "AMX Emulation package"
-            SectionIn 1 2
-                SetOutPath "$INSTDIR\server\mods\deathmatch\resources\[gamemodes]\[amx]"
-                SetOverwrite ifnewer
-                File /r "${SERVER_FILES_ROOT}\mods\deathmatch\resources\[gamemodes]\[amx]\amx"
-            SectionEnd
             Section "Assault Gamemode"
             SectionIn 1 2
                 SetOutPath "$INSTDIR\server\mods\deathmatch\resources\[gamemodes]\[assault]"


### PR DESCRIPTION
amx was removed from the official mtasa-resources package in the
following commit:
https://github.com/multitheftauto/mtasa-resources/commit/aa3b8015a13740fdf4b3953f4d5fe85a4888bb85

It is now in its own repository at https://github.com/multitheftauto/amx.

This PR fixes problems with not being able to build the installer.