### PR TITLE
Fix #1487 - dxDrawMaterialPrimitve crash

### DIFF
--- a/Client/core/Graphics/CGraphics.cpp
+++ b/Client/core/Graphics/CGraphics.cpp
@@ -1517,6 +1517,7 @@ void CGraphics::OnDeviceCreate(IDirect3DDevice9* pDevice)
     m_pMaterialLine3DBatcherPreGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pMaterialLine3DBatcherPostGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pPrimitiveBatcher->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
+    m_pPrimitiveMaterialBatcher->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pPrimitive3DBatcherPreGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pPrimitive3DBatcherPostGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pMaterialPrimitive3DBatcherPreGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());


### PR DESCRIPTION
fixes #1487

This function is useless - you cant adjust the line width, and it just makes no sense to me. I cant even see the lines, even tho it for sure is drawn(checked using the debugger, the d3d function gets called) but there are no visible lines