### PR TITLE
Fix #1291: getRotation returns incorrect values for ped when set with createPed

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -3614,9 +3614,15 @@ void CClientPed::_CreateModel()
 
         // Restore any settings
         m_pPlayerPed->SetLanding(false);
-        m_pPlayerPed->SetMatrix(&m_Matrix);
+        // update matrix to contain current rotation values - fix github: #1291
+        // as setting it thru the interface(SetCurrent/TargetRotation) doesnt update the matrix 
+        {
+            m_Matrix.SetRotation({ 0, 0, m_fCurrentRotation });
+            SetMatrix(m_Matrix); // also sets the matrix on m_pPlayerPed
+        }
         m_pPlayerPed->SetCurrentRotation(m_fCurrentRotation);
         m_pPlayerPed->SetTargetRotation(m_fTargetRotation);
+
         m_pPlayerPed->SetMoveSpeed(&m_vecMoveSpeed);
         m_pPlayerPed->SetTurnSpeed(&m_vecTurnSpeed);
         Duck(m_bDucked);

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -3614,12 +3614,15 @@ void CClientPed::_CreateModel()
 
         // Restore any settings
         m_pPlayerPed->SetLanding(false);
-        // update matrix to contain current rotation values - fix github: #1291
-        // as setting it thru the interface(SetCurrent/TargetRotation) doesnt update the matrix 
-        {
-            m_Matrix.SetRotation({ 0, 0, m_fCurrentRotation });
-            SetMatrix(m_Matrix); // also sets the matrix on m_pPlayerPed
-        }
+
+        m_pPlayerPed->SetCurrentRotation(m_fCurrentRotation);
+        m_pPlayerPed->SetTargetRotation(m_fTargetRotation);
+
+        // Fix GitHub #1291: also update the matrix to contain the current rotation
+        // as just setting it through the interface above doesn't update our matrix.
+        m_Matrix.SetRotation({0, 0, m_fCurrentRotation});
+        SetMatrix(m_Matrix);            // also sets the matrix on m_pPlayerPed
+
         m_pPlayerPed->SetCurrentRotation(m_fCurrentRotation);
         m_pPlayerPed->SetTargetRotation(m_fTargetRotation);
 


### PR DESCRIPTION
Basically, when you created a ped with `createPed` server side, and set a rotation there, the client side `getElemRot` returned incorrect values, but the ped was visually at the given rot.
This was caused by the matrix not being updated by GTA. We only set current/target rotations in the interface.

This PRr fixes the issue. I dont think it ruins backwards compatibility, since the only case this issue occurs is when the ped is created after setting the rotation values. This probably only occurs when creating the ped with `EntityAdd` packet.