### PR TITLE
Add async checksum generation for resource files

### DIFF
--- a/Client/mods/deathmatch/logic/CDownloadableResource.cpp
+++ b/Client/mods/deathmatch/logic/CDownloadableResource.cpp
@@ -10,6 +10,8 @@
  *****************************************************************************/
 
 #include <StdInc.h>
+#include <functional> // std::bind
+#include <future>     // return value from SharedUtil::async
 
 CDownloadableResource::CDownloadableResource(CResource* pResource, eResourceType resourceType, const char* szName, const char* szNameShort, uint uiDownloadSize,
                                              CChecksum serverChecksum, bool bAutoDownload)
@@ -39,6 +41,14 @@ CDownloadableResource::~CDownloadableResource()
 bool CDownloadableResource::DoesClientAndServerChecksumMatch()
 {
     return (m_LastClientChecksum == m_ServerChecksum);
+}
+
+std::future<CChecksum> CDownloadableResource::GenerateClientChecksumAsync()
+{
+    // Force us to use a buffer and not re-read the file twice,
+    // because HDD bandwidth is more important than multi-core speed(we're fast enough already in terms of CPU)
+    return SharedUtil::async([this]() { return GenerateClientChecksum(CBuffer()); });
+    //return SharedUtil::async(std::bind(&CDownloadableResource::GenerateClientChecksum, this), CBuffer());
 }
 
 CChecksum CDownloadableResource::GenerateClientChecksum()

--- a/Client/mods/deathmatch/logic/CDownloadableResource.cpp
+++ b/Client/mods/deathmatch/logic/CDownloadableResource.cpp
@@ -15,21 +15,15 @@
 #define INVALIDATE_OLD_FUTURE if (m_GenerateChecksumFuture.valid()) m_GenerateChecksumFuture = std::future<CChecksum>();
 
 CDownloadableResource::CDownloadableResource(CResource* pResource, eResourceType resourceType, const char* szName, const char* szNameShort, uint uiDownloadSize,
-                                             CChecksum serverChecksum, bool bAutoDownload)
+                                             CChecksum serverChecksum, bool bAutoDownload) :
+    m_pResource(pResource),
+    m_resourceType(resourceType),
+    m_strName(std::string(szName)),
+    m_strNameShort(std::string(szNameShort)),
+    m_ServerChecksum(serverChecksum),
+    m_bAutoDownload(bAutoDownload),
+    m_uiDownloadSize(uiDownloadSize)
 {
-    m_pResource = pResource;
-    m_resourceType = resourceType;
-    m_strName = szName;
-    m_strNameShort = szNameShort;
-    m_ServerChecksum = serverChecksum;
-    m_bAutoDownload = bAutoDownload;
-    m_bInDownloadQueue = false;
-    m_bDownloaded = false;
-    m_uiDownloadSize = uiDownloadSize;
-    m_uiHttpServerIndex = 0;
-    m_bModifedByScript = false;
-
-    GenerateClientChecksum();
     g_pClientGame->GetResourceManager()->OnAddResourceFile(this);
 }
 

--- a/Client/mods/deathmatch/logic/CDownloadableResource.cpp
+++ b/Client/mods/deathmatch/logic/CDownloadableResource.cpp
@@ -97,6 +97,12 @@ CChecksum CDownloadableResource::GetServerChecksum()
     return m_ServerChecksum;
 }
 
+CChecksum CDownloadableResource::GetLastClientChecksum()
+{
+    MakeSureChecksumIsGenerated();
+    return m_LastClientChecksum; 
+}
+
 int CDownloadableResource::GetDownloadPriorityGroup()
 {
     return m_pResource->GetDownloadPriorityGroup();

--- a/Client/mods/deathmatch/logic/CDownloadableResource.h
+++ b/Client/mods/deathmatch/logic/CDownloadableResource.h
@@ -71,19 +71,20 @@ public:
 protected:
     void MakeSureChecksumIsGenerated();
 
+    CResource*    m_pResource = nullptr;
     eResourceType m_resourceType;
 
-    SString m_strName;
-    SString m_strNameShort;
+    SString m_strName = "";
+    SString m_strNameShort = "";
 
     std::future<CChecksum> m_GenerateChecksumFuture;
     CChecksum              m_LastClientChecksum;
     CChecksum              m_ServerChecksum;
 
-    bool m_bAutoDownload;
-    bool m_bInDownloadQueue;            // File in auto download queue
-    bool m_bDownloaded;                 // File has been downloaded and is ready to use
-    uint m_uiDownloadSize;
-    uint m_uiHttpServerIndex;
-    bool m_bModifedByScript;
+    bool m_bAutoDownload = false;
+    bool m_bInDownloadQueue = false;    // File in auto download queue
+    bool m_bDownloaded = false;         // File has been downloaded and is ready to use
+    uint m_uiDownloadSize = 0;
+    uint m_uiHttpServerIndex = 0;
+    bool m_bModifedByScript = false;
 };

--- a/Client/mods/deathmatch/logic/CDownloadableResource.h
+++ b/Client/mods/deathmatch/logic/CDownloadableResource.h
@@ -25,7 +25,7 @@
 class CDownloadableResource
 {
 public:
-    enum eResourceType
+    enum eResourceType : unsigned char // Must be unsigned char, so in CClientGame::Packet_StartResource it's read properly from the packet.
     {
         RESOURCE_FILE_TYPE_MAP,
         RESOURCE_FILE_TYPE_SCRIPT,

--- a/Client/mods/deathmatch/logic/CDownloadableResource.h
+++ b/Client/mods/deathmatch/logic/CDownloadableResource.h
@@ -51,9 +51,10 @@ public:
     uint          GetHttpServerIndex() { return m_uiHttpServerIndex; }
     void          SetHttpServerIndex(uint uiHttpServerIndex) { m_uiHttpServerIndex = uiHttpServerIndex; }
 
-    CChecksum GenerateClientChecksum();
-    CChecksum GenerateClientChecksum(CBuffer& outFileData);
-    CChecksum GetServerChecksum();
+    CChecksum              GenerateClientChecksum();
+    CChecksum              GenerateClientChecksum(CBuffer& outFileData);
+    std::future<CChecksum> GenerateClientChecksumAsync();
+    CChecksum              GetServerChecksum();
 
     bool IsAutoDownload() { return m_bAutoDownload; };
     void SetDownloaded() { m_bDownloaded = true; };

--- a/Client/mods/deathmatch/logic/CDownloadableResource.h
+++ b/Client/mods/deathmatch/logic/CDownloadableResource.h
@@ -20,6 +20,7 @@
 
 #include <bochs_internal/crc32.h>
 #include "CChecksum.h"
+#include <future>
 
 class CDownloadableResource
 {
@@ -51,10 +52,11 @@ public:
     uint          GetHttpServerIndex() { return m_uiHttpServerIndex; }
     void          SetHttpServerIndex(uint uiHttpServerIndex) { m_uiHttpServerIndex = uiHttpServerIndex; }
 
-    CChecksum              GenerateClientChecksum();
-    CChecksum              GenerateClientChecksum(CBuffer& outFileData);
-    std::future<CChecksum> GenerateClientChecksumAsync();
-    CChecksum              GetServerChecksum();
+    CChecksum GenerateClientChecksum();
+    CChecksum GenerateClientChecksum(CBuffer& outFileData);
+    void      GenerateClientChecksumAsync();
+    CChecksum GetServerChecksum();
+    CChecksum GetLastClientChecksum();
 
     bool IsAutoDownload() { return m_bAutoDownload; };
     void SetDownloaded() { m_bDownloaded = true; };
@@ -64,15 +66,19 @@ public:
     void SetModifedByScript(bool bModifedByScript) { m_bModifedByScript = bModifedByScript; };
     bool IsModifedByScript() { return m_bModifedByScript; };
 
+    bool HasClientChecksumGenerated();
+
 protected:
-    CResource*    m_pResource;
+    void MakeSureChecksumIsGenerated();
+
     eResourceType m_resourceType;
 
     SString m_strName;
     SString m_strNameShort;
 
-    CChecksum m_LastClientChecksum;
-    CChecksum m_ServerChecksum;
+    std::future<CChecksum> m_GenerateChecksumFuture;
+    CChecksum              m_LastClientChecksum;
+    CChecksum              m_ServerChecksum;
 
     bool m_bAutoDownload;
     bool m_bInDownloadQueue;            // File in auto download queue

--- a/Client/mods/deathmatch/logic/CResource.cpp
+++ b/Client/mods/deathmatch/logic/CResource.cpp
@@ -321,14 +321,14 @@ bool CResource::CanBeLoaded()
 
 bool CResource::IsWaitingForInitialDownloads()
 {
-    for (std::list<CResourceConfigItem*>::iterator iter = m_ConfigFiles.begin(); iter != m_ConfigFiles.end(); ++iter)
-        if ((*iter)->IsWaitingForDownload())
+    for (auto* pFile : m_ResourceFiles)
+        if (pFile->IsWaitingForDownload())
             return true;
 
-    for (std::list<CResourceFile*>::iterator iter = m_ResourceFiles.begin(); iter != m_ResourceFiles.end(); ++iter)
-        if ((*iter)->IsAutoDownload())
-            if ((*iter)->IsWaitingForDownload())
-                return true;
+    for (auto* pFile : m_ResourceFiles)
+        if (pFile->IsAutoDownload() && pFile->IsWaitingForDownload())
+            return true;
+
     return false;
 }
 

--- a/Client/mods/deathmatch/logic/CResource.cpp
+++ b/Client/mods/deathmatch/logic/CResource.cpp
@@ -402,17 +402,6 @@ bool CResource::Load(const bool bCanDownload)
 
             DECLARE_PROFILER_SECTION(OnPostLoadScript)
         }
-        else if (pResourceFile->IsAutoDownload())
-        {
-            // Check the file contents
-            if (CChecksum::GenerateChecksumFromFile(pResourceFile->GetName()) == pResourceFile->GetServerChecksum())
-            {
-            }
-            else
-            {
-                HandleDownloadedFileTrouble(pResourceFile, false);
-            }
-        }
     }
 
     // Set active flag

--- a/Client/mods/deathmatch/logic/CResource.cpp
+++ b/Client/mods/deathmatch/logic/CResource.cpp
@@ -468,15 +468,18 @@ void CResource::AddToElementGroup(CClientEntity* pElement)
 //
 // Handle when things go wrong
 //
-void CResource::HandleDownloadedFileTrouble(CResourceFile* pResourceFile, bool bScript)
+void CResource::HandleDownloadedFileTrouble(CResourceFile* pResourceFile)
 {
+    const bool bScript = pResourceFile->GetResourceType() == CDownloadableResource::RESOURCE_FILE_TYPE_CLIENT_SCRIPT;
+
     // Compose message
-    uint    uiGotFileSize = (uint)FileSize(pResourceFile->GetName());
-    SString strGotMd5 = ConvertDataToHexString(CChecksum::GenerateChecksumFromFile(pResourceFile->GetName()).md5.data, sizeof(MD5));
+    SString strGotMd5 = ConvertDataToHexString(pResourceFile->GetLastClientChecksum().md5.data, sizeof(MD5));
     SString strWantedMd5 = ConvertDataToHexString(pResourceFile->GetServerChecksum().md5.data, sizeof(MD5));
+
+    uint    uiGotFileSize = (uint)FileSize(pResourceFile->GetName());
     SString strFilename = ExtractFilename(PathConform(pResourceFile->GetShortName()));
-    SString strMessage =
-        SString("HTTP server file mismatch (%s) %s [Got size:%d MD5:%s, wanted MD5:%s]", GetName(), *strFilename, uiGotFileSize, *strGotMd5, *strWantedMd5);
+
+    SString strMessage("HTTP server file mismatch (%s) %s [Got size:%d MD5:%s, wanted MD5:%s]", GetName(), *strFilename, uiGotFileSize, *strGotMd5, *strWantedMd5);
 
     // Log to the server & client console
     g_pClientGame->TellServerSomethingImportant(bScript ? 1002 : 1013, strMessage, 4);

--- a/Client/mods/deathmatch/logic/CResource.h
+++ b/Client/mods/deathmatch/logic/CResource.h
@@ -59,7 +59,7 @@ public:
     bool           IsActive() { return m_bActive; };
     bool           CanBeLoaded();
 
-    void    Load();
+    bool    Load(const bool bCanDownload);
     void    Stop();
     SString GetState();
 
@@ -109,6 +109,14 @@ public:
     bool           IsWaitingForInitialDownloads();
     int            GetDownloadPriorityGroup() { return m_iDownloadPriorityGroup; }
     void           SetDownloadPriorityGroup(int iDownloadPriorityGroup) { m_iDownloadPriorityGroup = iDownloadPriorityGroup; }
+
+private:
+    // Returns if there are any files that yet need to be transferred
+    bool MakeSureAllFilesAreDownloaded();
+
+    // Check all file's(except script, as its checked directly before loading) checksums,
+    // And re-downloads them if they're incorrect
+    bool CheckAllFilesAndReDownloadIfNeeded(const bool bCanDownload);
 
 private:
     unsigned short       m_usNetID;

--- a/Client/mods/deathmatch/logic/CResource.h
+++ b/Client/mods/deathmatch/logic/CResource.h
@@ -105,7 +105,7 @@ public:
     const CMtaVersion& GetMinServerReq() const { return m_strMinServerReq; }
     const CMtaVersion& GetMinClientReq() const { return m_strMinClientReq; }
     bool           IsOOPEnabled() { return m_bOOPEnabled; }
-    void           HandleDownloadedFileTrouble(CResourceFile* pResourceFile, bool bScript);
+    void           HandleDownloadedFileTrouble(CResourceFile* pResourceFile);
     bool           IsWaitingForInitialDownloads();
     int            GetDownloadPriorityGroup() { return m_iDownloadPriorityGroup; }
     void           SetDownloadPriorityGroup(int iDownloadPriorityGroup) { m_iDownloadPriorityGroup = iDownloadPriorityGroup; }

--- a/Client/mods/deathmatch/logic/CResourceFileDownloadManager.cpp
+++ b/Client/mods/deathmatch/logic/CResourceFileDownloadManager.cpp
@@ -116,7 +116,7 @@ void CResourceFileDownloadManager::DoPulse()
 
     // Pulse the http downloads
     uint uiDownloadSizeTotal = 0;
-    for (auto serverInfo : m_HttpServerList)
+    for (auto& serverInfo : m_HttpServerList)
     {
         CNetHTTPDownloadManagerInterface* pHTTP = g_pNet->GetHTTPDownloadManager(serverInfo.downloadChannel);
         pHTTP->ProcessQueuedFiles();

--- a/Client/mods/deathmatch/logic/CResourceFileDownloadManager.h
+++ b/Client/mods/deathmatch/logic/CResourceFileDownloadManager.h
@@ -22,6 +22,9 @@ class CResourceFileDownloadManager
 {
 public:
     ZERO_ON_NEW
+
+    CResourceFileDownloadManager();
+
     void AddServer(const SString& strUrl, int iMaxConnectionsPerClient, EDownloadModeType downloadChannel, uint uiConnectionAttempts, uint uiConnectTimeoutMs);
     void AddPendingFileDownload(CDownloadableResource* pDownloadableResource);
     void UpdatePendingDownloads();
@@ -38,6 +41,8 @@ protected:
     void                   DownloadFinished(const SHttpDownloadResult& result);
     SString*               MakeDownloadContextString(CDownloadableResource* pDownloadableResource);
     CDownloadableResource* ResolveDownloadContextString(SString* pString);
+
+    CAsyncTaskScheduler    m_asyncFileChecksumTaskSched;
 
     std::vector<CDownloadableResource*> m_PendingFileDownloadList;
     std::vector<CDownloadableResource*> m_ActiveFileDownloadList;

--- a/Client/mods/deathmatch/logic/CResourceManager.cpp
+++ b/Client/mods/deathmatch/logic/CResourceManager.cpp
@@ -96,16 +96,14 @@ CResource* CResourceManager::GetResource(const char* szResourceName)
 
 void CResourceManager::OnDownloadGroupFinished()
 {
-    // Try to load newly ready resources
-    for (std::list<CResource*>::const_iterator iter = m_resources.begin(); iter != m_resources.end(); ++iter)
+    for (auto* pResource : m_resources)
     {
-        CResource* pResource = *iter;
         if (!pResource->IsActive())
         {
             // Stop as soon as we hit a resource which hasn't downloaded yet (as per previous behaviour)
             if (pResource->IsWaitingForInitialDownloads())
                 break;
-            pResource->Load();
+            pResource->Load(false);
         }
     }
 }

--- a/Shared/sdk/CChecksum.h
+++ b/Shared/sdk/CChecksum.h
@@ -17,17 +17,14 @@
 class CChecksum
 {
 public:
-    // Initialize to zeros
-    CChecksum()
-    {
-        ulCRC = 0;
-        memset(md5.data, 0, sizeof(md5.data));
-    }
+    CChecksum() noexcept = default;
 
     // Comparison operators
     bool operator==(const CChecksum& other) const { return ulCRC == other.ulCRC && memcmp(md5.data, other.md5.data, sizeof(md5.data)) == 0; }
 
     bool operator!=(const CChecksum& other) const { return !operator==(other); }
+
+    operator bool() const { return bIsValid; }
 
     // static generators
     static CChecksum GenerateChecksumFromFile(const SString& strFilename)
@@ -35,6 +32,8 @@ public:
         CChecksum result;
         result.ulCRC = CRCGenerator::GetCRCFromFile(strFilename);
         CMD5Hasher().Calculate(strFilename, result.md5);
+        result.bIsValid = true;
+
         return result;
     }
 
@@ -43,11 +42,14 @@ public:
         CChecksum result;
         result.ulCRC = CRCGenerator::GetCRCFromBuffer(cpBuffer, ulLength);
         CMD5Hasher().Calculate(cpBuffer, ulLength, result.md5);
+        result.bIsValid = true;
+
         return result;
     }
 
-    unsigned long ulCRC;
-    MD5           md5;
+    unsigned long ulCRC = 0;
+    MD5           md5 = { 0 };
+    bool          bIsValid = false;
 };
 
 #endif

--- a/Shared/sdk/SString.h
+++ b/Shared/sdk/SString.h
@@ -45,6 +45,7 @@ public:
     }
 
     SString(const std::string& strText) : std::string(strText) {}
+    SString(std::string&& strText) : std::string(strText) {}
 
     SString& Format(const char* szFormat, ...)
     {


### PR DESCRIPTION
Basically, resource file checksums were checked on the main thread(problem one), also, they were checked, in worst case scenario, 3 times(on the first load), and best case scenario 2.

This PR adds async checksum generation, as well as removes redundant checks. It works perfectly for me, I had no issues whatsoever with it. 

Some notes to who ever tests this PR:
- `Packet_StartResource` is called every time a resources needs to be started. No matter whenever its started with a command / is in `mtaconfig`

- After a resource is stopped all its associated `CResourceFiles` are deleted, which means, after restarting the resource their checksums are rechecked

- Adding the additional `const bool bCanDownload` was necessary to avoid a 'download loop' [as i call it], which occurs when i dont know how / when, but if it does, the resource is stuck in a loop, and tries to download the file over and over again

- `bIsSehrGut` is serious, and without it the code would explode

- Im sorry for the 'addendums', but I just totally forgot about a few things, but I wanted to keep the commits as clean as possible. 

- A rebase will be needed to remove debug stuff


Edit:
Bugs discovered:
- Seems like after updating a resource file, it doesnt re-download it. Needs further investigation
- Make sure there's enough RAM to load the whole file into memory, if not use the fallback, old method(65 kb stack buffer)