### PR TITLE
Improve export function call performance, and a small refactor to CResource

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPerfStat.LuaTiming.cpp
+++ b/Client/mods/deathmatch/logic/CClientPerfStat.LuaTiming.cpp
@@ -123,7 +123,7 @@ public:
     // CClientPerfStatLuaTiming
     virtual void OnLuaMainCreate(CLuaMain* pLuaMain);
     virtual void OnLuaMainDestroy(CLuaMain* pLuaMain);
-    virtual void UpdateLuaTiming(CLuaMain* pLuaMain, const char* szEventName, TIMEUS timeUs);
+    virtual void UpdateLuaTiming(CLuaMain* pLuaMain, const SString& strEventName, TIMEUS timeUs);
 
     // CClientPerfStatLuaTimingImpl functions
     void GetLuaTimingStats(CClientPerfStatResult* pResult, const std::map<SString, int>& strOptionMap, const SString& strFilter);
@@ -221,7 +221,7 @@ void CClientPerfStatLuaTimingImpl::OnLuaMainDestroy(CLuaMain* pLuaMain)
 //
 //
 ///////////////////////////////////////////////////////////////
-void CClientPerfStatLuaTimingImpl::UpdateLuaTiming(CLuaMain* pLuaMain, const char* szEventName, TIMEUS timeUs)
+void CClientPerfStatLuaTimingImpl::UpdateLuaTiming(CLuaMain* pLuaMain, const SString& strEventName, TIMEUS timeUs)
 {
     CLuaMainTiming* pLuaMainTiming = MapFind(AllLuaTiming.LuaMainTimingMap, pLuaMain);
     if (!pLuaMainTiming)

--- a/Client/mods/deathmatch/logic/CClientPerfStat.LuaTiming.cpp
+++ b/Client/mods/deathmatch/logic/CClientPerfStat.LuaTiming.cpp
@@ -223,27 +223,15 @@ void CClientPerfStatLuaTimingImpl::OnLuaMainDestroy(CLuaMain* pLuaMain)
 ///////////////////////////////////////////////////////////////
 void CClientPerfStatLuaTimingImpl::UpdateLuaTiming(CLuaMain* pLuaMain, const SString& strEventName, TIMEUS timeUs)
 {
-    CLuaMainTiming* pLuaMainTiming = MapFind(AllLuaTiming.LuaMainTimingMap, pLuaMain);
-    if (!pLuaMainTiming)
+    CLuaMainTiming& pLuaMainTiming = AllLuaTiming.LuaMainTimingMap[pLuaMain];
     {
-        MapSet(AllLuaTiming.LuaMainTimingMap, pLuaMain, CLuaMainTiming());
-        pLuaMainTiming = MapFind(AllLuaTiming.LuaMainTimingMap, pLuaMain);
-    }
-
-    {
-        CTiming& acc = pLuaMainTiming->ResourceTiming.s5.acc;
+        CTiming& acc = pLuaMainTiming.ResourceTiming.s5.acc;
         acc.total_us += timeUs;
     }
 
-    CTimingBlock* pEventTiming = MapFind(pLuaMainTiming->EventTimingMap, szEventName);
-    if (!pEventTiming)
+    CTimingBlock& pEventTiming = pLuaMainTiming.EventTimingMap[strEventName];
     {
-        MapSet(pLuaMainTiming->EventTimingMap, szEventName, CTimingBlock());
-        pEventTiming = MapFind(pLuaMainTiming->EventTimingMap, szEventName);
-    }
-
-    {
-        CTiming& acc = pEventTiming->s5.acc;
+        CTiming& acc = pEventTiming.s5.acc;
         acc.calls++;
         acc.total_us += timeUs;
         acc.max_us = std::max(acc.max_us, timeUs);

--- a/Client/mods/deathmatch/logic/CClientPerfStatModule.h
+++ b/Client/mods/deathmatch/logic/CClientPerfStatModule.h
@@ -99,7 +99,7 @@ public:
     // CClientPerfStatLuaTiming
     virtual void OnLuaMainCreate(CLuaMain* pLuaMain) = 0;
     virtual void OnLuaMainDestroy(CLuaMain* pLuaMain) = 0;
-    virtual void UpdateLuaTiming(CLuaMain* pLuaMain, const char* szEventName, TIMEUS timeUs) = 0;
+    virtual void UpdateLuaTiming(CLuaMain* pLuaMain, const SString& strEventName, TIMEUS timeUs) = 0;
 
     static CClientPerfStatLuaTiming* GetSingleton();
 };

--- a/Client/mods/deathmatch/logic/CResource.cpp
+++ b/Client/mods/deathmatch/logic/CResource.cpp
@@ -202,11 +202,10 @@ void CResource::AddExportedFunction(const char* szFunctionName)
     m_ExportedFunctionsSet.insert(szFunctionName); 
 }
 
-bool CResource::CallExportedFunction(const char* szFunctionName, CLuaArguments& args, CLuaArguments& returns, CResource& caller)
+bool CResource::CallExportedFunction(const SString& strFunctionName, CLuaArguments& args, CLuaArguments& returns, CResource& caller)
 {
-    // Check if we actually have this function exported
-    if (m_ExportedFunctionsSet.find(szFunctionName) != m_ExportedFunctionsSet.end())
-        return args.CallGlobal(m_pLuaVM, szFunctionName, &returns);
+    if (m_ExportedFunctionsSet.find(strFunctionName) != m_ExportedFunctionsSet.end()) // Is it actually exported?
+        return args.CallGlobal(m_pLuaVM, strFunctionName, &returns);
     return false;
 }
 

--- a/Client/mods/deathmatch/logic/CResource.cpp
+++ b/Client/mods/deathmatch/logic/CResource.cpp
@@ -466,3 +466,11 @@ void CResource::HandleDownloadedFileTrouble(CResourceFile* pResourceFile, bool b
     g_pClientGame->TellServerSomethingImportant(bScript ? 1002 : 1013, strMessage, 4);
     g_pCore->GetConsole()->Printf("Download error: %s", *strMessage);
 }
+
+CResourceFile* CResource::GetFileFromShortName(const char* szShortName)
+{
+    for (auto* pFile : m_ResourceFiles)
+        if (strcmp(szShortName, pFile->GetShortName()) == 0)
+            return pFile;
+    return nullptr;
+}

--- a/Client/mods/deathmatch/logic/CResource.cpp
+++ b/Client/mods/deathmatch/logic/CResource.cpp
@@ -152,14 +152,6 @@ CResource::~CResource()
         delete (*iterc);
     }
     m_ConfigFiles.clear();
-
-    // Delete the exported functions
-    list<CExportedFunction*>::iterator iterExportedFunction = m_exportedFunctions.begin();
-    for (; iterExportedFunction != m_exportedFunctions.end(); ++iterExportedFunction)
-    {
-        delete (*iterExportedFunction);
-    }
-    m_exportedFunctions.clear();
 }
 
 CDownloadableResource* CResource::AddResourceFile(CDownloadableResource::eResourceType resourceType, const char* szFileName, uint uiDownloadSize,
@@ -207,22 +199,14 @@ CDownloadableResource* CResource::AddConfigFile(const char* szFileName, uint uiD
 
 void CResource::AddExportedFunction(const char* szFunctionName)
 {
-    m_exportedFunctions.push_back(new CExportedFunction(szFunctionName));
+    m_ExportedFunctionsSet.insert(szFunctionName); 
 }
 
 bool CResource::CallExportedFunction(const char* szFunctionName, CLuaArguments& args, CLuaArguments& returns, CResource& caller)
 {
-    list<CExportedFunction*>::iterator iter = m_exportedFunctions.begin();
-    for (; iter != m_exportedFunctions.end(); ++iter)
-    {
-        if (strcmp((*iter)->GetFunctionName(), szFunctionName) == 0)
-        {
-            if (args.CallGlobal(m_pLuaVM, szFunctionName, &returns))
-            {
-                return true;
-            }
-        }
-    }
+    // Check if we actually have this function exported
+    if (m_ExportedFunctionsSet.find(szFunctionName) != m_ExportedFunctionsSet.end())
+        return args.CallGlobal(m_pLuaVM, szFunctionName, &returns);
     return false;
 }
 

--- a/Client/mods/deathmatch/logic/CResource.h
+++ b/Client/mods/deathmatch/logic/CResource.h
@@ -16,6 +16,7 @@
 #include "CResourceConfigItem.h"
 #include "CResourceFile.h"
 #include "CElementGroup.h"
+#include "SharedUtil.FastHashSet.h"
 #include <list>
 
 #define MAX_RESOURCE_NAME_LENGTH    255
@@ -94,8 +95,7 @@ public:
     // Use this for cursor showing/hiding
     void ShowCursor(bool bShow, bool bToggleControls = true);
 
-    std::list<CExportedFunction*>::iterator IterBeginExportedFunctions() { return m_exportedFunctions.begin(); }
-    std::list<CExportedFunction*>::iterator IterEndExportedFunctions() { return m_exportedFunctions.end(); }
+    const auto& GetExportedFunctionNames() const { return m_ExportedFunctionsSet; }
 
     std::list<CResourceFile*>::iterator IterBeginResourceFiles() { return m_ResourceFiles.begin(); }
     std::list<CResourceFile*>::iterator IterEndResourceFiles() { return m_ResourceFiles.end(); }
@@ -144,7 +144,7 @@ private:
 
     std::list<class CResourceFile*>       m_ResourceFiles;
     std::list<class CResourceConfigItem*> m_ConfigFiles;
-    std::list<CExportedFunction*>         m_exportedFunctions;
+    std::set<std::string, std::less<>>    m_ExportedFunctionsSet;            // std::less<> for transparent lookup: https://stackoverflow.com/questions/20317413/what-are-transparent-comparators
     CElementGroup*                        m_pDefaultElementGroup;            // stores elements created by scripts in this resource
     std::list<SNoClientCacheScript>       m_NoClientCacheScriptList;
 };

--- a/Client/mods/deathmatch/logic/CResource.h
+++ b/Client/mods/deathmatch/logic/CResource.h
@@ -141,7 +141,7 @@ private:
 
     std::list<class CResourceFile*>       m_ResourceFiles;
     std::list<class CResourceConfigItem*> m_ConfigFiles;
-    std::set<std::string, std::less<>>    m_ExportedFunctionsSet;            // std::less<> for transparent lookup: https://stackoverflow.com/questions/20317413/what-are-transparent-comparators
+    CFastHashSet<SString>                 m_ExportedFunctionsSet;
     CElementGroup*                        m_pDefaultElementGroup;            // stores elements created by scripts in this resource
     std::list<SNoClientCacheScript>       m_NoClientCacheScriptList;
 };

--- a/Client/mods/deathmatch/logic/CResource.h
+++ b/Client/mods/deathmatch/logic/CResource.h
@@ -74,7 +74,7 @@ public:
     void           AddToElementGroup(CClientEntity* pElement);
 
     void AddExportedFunction(const char* szFunctionName);
-    bool CallExportedFunction(const char* szFunctionName, CLuaArguments& args, CLuaArguments& returns, CResource& caller);
+    bool CallExportedFunction(const SString& strFunctionName, CLuaArguments& args, CLuaArguments& returns, CResource& caller);
 
     class CClientEntity* GetResourceEntity() { return m_pResourceEntity; }
     void                 SetResourceEntity(CClientEntity* pEntity) { m_pResourceEntity = pEntity; }

--- a/Client/mods/deathmatch/logic/CResource.h
+++ b/Client/mods/deathmatch/logic/CResource.h
@@ -97,9 +97,6 @@ public:
 
     const auto& GetExportedFunctionNames() const { return m_ExportedFunctionsSet; }
 
-    std::list<CResourceFile*>::iterator IterBeginResourceFiles() { return m_ResourceFiles.begin(); }
-    std::list<CResourceFile*>::iterator IterEndResourceFiles() { return m_ResourceFiles.end(); }
-
     void           SetRemainingNoClientCacheScripts(unsigned short usRemaining) { m_usRemainingNoClientCacheScripts = usRemaining; }
     void           LoadNoClientCacheScript(const char* chunk, unsigned int length, const SString& strFilename);
     const CMtaVersion& GetMinServerReq() const { return m_strMinServerReq; }
@@ -109,7 +106,8 @@ public:
     bool           IsWaitingForInitialDownloads();
     int            GetDownloadPriorityGroup() { return m_iDownloadPriorityGroup; }
     void           SetDownloadPriorityGroup(int iDownloadPriorityGroup) { m_iDownloadPriorityGroup = iDownloadPriorityGroup; }
-
+    CResourceFile* GetFileFromShortName(const char* szShortName);
+    
 private:
     unsigned short       m_usNetID;
     uint                 m_uiScriptID;

--- a/Client/mods/deathmatch/logic/CResource.h
+++ b/Client/mods/deathmatch/logic/CResource.h
@@ -16,7 +16,6 @@
 #include "CResourceConfigItem.h"
 #include "CResourceFile.h"
 #include "CElementGroup.h"
-#include "SharedUtil.FastHashSet.h"
 #include <list>
 
 #define MAX_RESOURCE_NAME_LENGTH    255

--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
@@ -250,10 +250,9 @@ bool CLuaArguments::Call(CLuaMain* pLuaMain, const CLuaFunctionRef& iLuaFunction
     return true;
 }
 
-bool CLuaArguments::CallGlobal(CLuaMain* pLuaMain, const char* szFunction, CLuaArguments* returnValues) const
+bool CLuaArguments::CallGlobal(CLuaMain* pLuaMain, const SString& strFunctionName, CLuaArguments* returnValues) const
 {
     assert(pLuaMain);
-    assert(szFunction);
     TIMEUS startTime = GetTimeUs();
 
     // Add the function name to the stack and get the event from the table
@@ -261,7 +260,7 @@ bool CLuaArguments::CallGlobal(CLuaMain* pLuaMain, const char* szFunction, CLuaA
     assert(luaVM);
     LUA_CHECKSTACK(luaVM, 1);
     int luaStackPointer = lua_gettop(luaVM);
-    lua_pushstring(luaVM, szFunction);
+    lua_pushlstring(luaVM, strFunctionName.data(), strFunctionName.length());
     lua_gettable(luaVM, LUA_GLOBALSINDEX);
 
     // If that function doesn't exist, return false
@@ -310,7 +309,7 @@ bool CLuaArguments::CallGlobal(CLuaMain* pLuaMain, const char* szFunction, CLuaA
             lua_pop(luaVM, 1);
     }
 
-    CClientPerfStatLuaTiming::GetSingleton()->UpdateLuaTiming(pLuaMain, szFunction, GetTimeUs() - startTime);
+    CClientPerfStatLuaTiming::GetSingleton()->UpdateLuaTiming(pLuaMain, strFunctionName, GetTimeUs() - startTime);
     return true;
 }
 

--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -47,7 +47,7 @@ public:
     void PushArguments(lua_State* luaVM) const;
     void PushArguments(const CLuaArguments& Arguments);
     bool Call(class CLuaMain* pLuaMain, const CLuaFunctionRef& iLuaFunction, CLuaArguments* returnValues = NULL) const;
-    bool CallGlobal(class CLuaMain* pLuaMain, const char* szFunction, CLuaArguments* returnValues = NULL) const;
+    bool CallGlobal(class CLuaMain* pLuaMain, const SString& strFunctionName, CLuaArguments* returnValues = NULL) const;
 
     void ReadTable(lua_State* luaVM, int iIndexBegin, CFastHashMap<const void*, CLuaArguments*>* pKnownTables = NULL);
     void PushAsTable(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKnownTables = NULL);

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Util.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Util.cpp
@@ -361,26 +361,18 @@ int CLuaFunctionDefs::DownloadFile(lua_State* luaVM)
             // Resolve other resource from name
             if (CResourceManager::ParseResourcePathInput(strFileInput, pOtherResource, NULL, &strMetaPath))
             {
-                std::list<CResourceFile*>::const_iterator iter = pOtherResource->IterBeginResourceFiles();
-                for (; iter != pOtherResource->IterEndResourceFiles(); iter++)
-                {
-                    if (strcmp(strMetaPath, (*iter)->GetShortName()) == 0)
-                    {
-                        if (CStaticFunctionDefinitions::DownloadFile(pOtherResource, strMetaPath, pThisResource, (*iter)->GetServerChecksum()))
-                        {
-                            lua_pushboolean(luaVM, true);
-                            return 1;
-                        }
-                    }
-                }
-                m_pScriptDebugging->LogCustom(luaVM, SString("%s: File doesn't exist", lua_tostring(luaVM, lua_upvalueindex(1))));
+                if (CResourceFile* pFile = pOtherResource->GetFileFromShortName(strMetaPath.c_str()))
+                    lua_pushboolean(luaVM, CStaticFunctionDefinitions::DownloadFile(pOtherResource, strMetaPath, pThisResource, pFile->GetServerChecksum()));
+                else
+                    m_pScriptDebugging->LogWarning(luaVM, "%s: File %s doesn't exist", lua_tostring(luaVM, lua_upvalueindex(1)), strMetaPath.c_str());
             }
             else
             {
-                m_pScriptDebugging->LogCustom(luaVM, 255, 255, 255, "%s: Invalid path", lua_tostring(luaVM, lua_upvalueindex(1)));
+                m_pScriptDebugging->LogCustom(luaVM, 255, 255, 255, "%s: Invalid path (%s)", lua_tostring(luaVM, lua_upvalueindex(1)), strFileInput.c_str());
             }
         }
     }
+
     lua_pushboolean(luaVM, false);
     return 1;
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
@@ -393,17 +393,19 @@ int CLuaResourceDefs::GetResourceExportedFunctions(lua_State* luaVM)
         }
     }
 
+    // Push all functions into a key-value pair table
     if (pResource)
     {
         lua_newtable(luaVM);
-        unsigned int                       uiIndex = 0;
-        list<CExportedFunction*>::iterator iterd = pResource->IterBeginExportedFunctions();
-        for (; iterd != pResource->IterEndExportedFunctions(); iterd++)
+        unsigned int uiIndex = 0;
+
+        for (const auto& strName : pResource->GetExportedFunctionNames())
         {
             lua_pushnumber(luaVM, ++uiIndex);
-            lua_pushstring(luaVM, (*iterd)->GetFunctionName());
-            lua_settable(luaVM, -3);
+            lua_pushstring(luaVM, strName.c_str());
+            lua_settable(luaVM, -3); // Pack it into a key-value pair
         }
+
         return 1;
     }
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
@@ -403,7 +403,7 @@ int CLuaResourceDefs::GetResourceExportedFunctions(lua_State* luaVM)
         {
             lua_pushnumber(luaVM, ++uiIndex);
             lua_pushstring(luaVM, strName.c_str());
-            lua_settable(luaVM, -3); // Pack it into a key-value pair
+            lua_settable(luaVM, -3);            // Pack it into a key-value pair
         }
 
         return 1;


### PR DESCRIPTION
As we all know(or at least me xd), exported function calls are pretty slow. 

Currently, we use an std::list with a heap allocated object(not even Terry A. Davis knows why). This PR aims to improve its performance by using a hash set. 

I think the benefits are obvious: **no cache misses, log(n)** VS **cache misses(a lot) and O(n)**