### PR TITLE
Allow hourOn to be greater than hourOff for engineSetModelVisibleTime

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -1120,9 +1120,6 @@ int CLuaEngineDefs::EngineSetModelVisibleTime(lua_State* luaVM)
         CModelInfo* pModelInfo = g_pGame->GetModelInfo(usModelID);
         if (pModelInfo)
         {
-            if (cHourOn > cHourOff)
-                std::swap(cHourOn, cHourOff);
-
             if (cHourOn >= 0 && cHourOn <= 24 && cHourOff >= 0 && cHourOff <= 24)
             {
                 lua_pushboolean(luaVM, pModelInfo->SetTime(cHourOn, cHourOff));


### PR DESCRIPTION
Some San Andreas night objects appear at 23 and disappear "next morning". It was impossible to set similar behavior.
```lua
engineSetModelVisibleTime(9934, 23, 6) -- Before: visible from 6 to 23. After: visible from 23 to 6.
```