### PR TITLE
Fix #1443 - trim teaEncode trailing zeroes

### DIFF
--- a/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
@@ -63,7 +63,7 @@ std::string CLuaCryptDefs::TeaDecode(std::string str, std::string key)
 {
     SString result = SharedUtil::Base64decode(str);
     SString strOutResult;
-    SharedUtil::TeaDecode(result, key, &strOutResult);
+    SharedUtil::TeaDecode(result, key, &strOutResult, true);
     return strOutResult;
 }
 
@@ -373,7 +373,7 @@ int CLuaCryptDefs::DecodeString(lua_State* luaVM)
                             [data, key] {
                                 // Execute time-consuming task
                                 SString result;
-                                SharedUtil::TeaDecode(data, key, &result);
+                                SharedUtil::TeaDecode(data, key, &result, true);
                                 return result;
                             },
                             [luaFunctionRef](const SString& result) {
@@ -392,7 +392,7 @@ int CLuaCryptDefs::DecodeString(lua_State* luaVM)
                 else            // Sync
                 {
                     SString result;
-                    SharedUtil::TeaDecode(data, key, &result);
+                    SharedUtil::TeaDecode(data, key, &result, true);
                     lua_pushlstring(luaVM, result, result.length());
                 }
                 return 1;

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
@@ -63,7 +63,7 @@ std::string CLuaCryptDefs::TeaDecode(std::string str, std::string key)
 {
     SString result = SharedUtil::Base64decode(str);
     SString strOutResult;
-    SharedUtil::TeaDecode(result, key, &strOutResult, true);
+    SharedUtil::TeaDecode(result, key, &strOutResult);
     return strOutResult;
 }
 
@@ -373,7 +373,7 @@ int CLuaCryptDefs::DecodeString(lua_State* luaVM)
                             [data, key] {
                                 // Execute time-consuming task
                                 SString result;
-                                SharedUtil::TeaDecode(data, key, &result, true);
+                                SharedUtil::TeaDecode(data, key, &result);
                                 return result;
                             },
                             [luaFunctionRef](const SString& result) {
@@ -392,7 +392,7 @@ int CLuaCryptDefs::DecodeString(lua_State* luaVM)
                 else            // Sync
                 {
                     SString result;
-                    SharedUtil::TeaDecode(data, key, &result, true);
+                    SharedUtil::TeaDecode(data, key, &result);
                     lua_pushlstring(luaVM, result, result.length());
                 }
                 return 1;

--- a/Shared/sdk/SharedUtil.Hash.h
+++ b/Shared/sdk/SharedUtil.Hash.h
@@ -84,7 +84,7 @@ namespace SharedUtil
     void decodeXTea(unsigned int* v, unsigned int* w, unsigned int* k);
 
     void TeaEncode(const SString& str, const SString& key, SString* out);
-    void TeaDecode(const SString& str, const SString& key, SString* out);
+    void TeaDecode(const SString& str, const SString& key, SString* out, const bool trimPaddingAtEnd = false);
 
     unsigned int HashString(const char* szString);
     unsigned int HashString(const char* szString, unsigned int length);

--- a/Shared/sdk/SharedUtil.Hash.h
+++ b/Shared/sdk/SharedUtil.Hash.h
@@ -80,11 +80,8 @@ namespace SharedUtil
         unsigned char m_digest[16];
     };
 
-    void encodeXtea(unsigned int* v, unsigned int* w, unsigned int* k);
-    void decodeXTea(unsigned int* v, unsigned int* w, unsigned int* k);
-
     void TeaEncode(const SString& str, const SString& key, SString* out);
-    void TeaDecode(const SString& str, const SString& key, SString* out, const bool trimPaddingAtEnd = false);
+    void TeaDecode(const SString& str, const SString& key, SString* out);
 
     unsigned int HashString(const char* szString);
     unsigned int HashString(const char* szString, unsigned int length);

--- a/Shared/sdk/SharedUtil.Hash.hpp
+++ b/Shared/sdk/SharedUtil.Hash.hpp
@@ -772,7 +772,7 @@ namespace SharedUtil
         delete[] strbuf;
     }
 
-    void TeaDecode(const SString& str, const SString& key, SString* out)
+    void TeaDecode(const SString& str, const SString& key, SString* out, const bool trimPaddingAtEnd)
     {
         unsigned int v[2];
         unsigned int w[2];
@@ -818,5 +818,22 @@ namespace SharedUtil
 
         out->assign((char*)buffer, numPasses * 4);
         delete[] buffer;
+
+        if (trimPaddingAtEnd)
+        {
+            // Check last block for 0 padding, and delete
+
+            auto iter = out->end() - 1;
+            if (*iter != 0)
+                return;
+
+            const auto blockEnd = out->end() - 4;
+            while (iter > blockEnd && *--iter == 0);
+
+            // Loop goes past the non-0 char, so make sure we only delete 0
+            iter++;
+
+            out->erase(iter, out->end()); // At this point its 100% theres a 0 padding, so we can delete that
+        }
     }
 }            // namespace SharedUtil

--- a/Shared/sdk/SharedUtil.Hash.hpp
+++ b/Shared/sdk/SharedUtil.Hash.hpp
@@ -820,18 +820,23 @@ namespace SharedUtil
         delete[] buffer;
 
 
-        // Check last block for 0 padding, and erase if there's any
+        // Delete all 0's from the end
+        // As of now, even if the user passed it in
+        // We'll delete it, because there's no way
+        // We can know if the user added the padding or not.
         {
             auto iter = out->end() - 1;
             if (*iter != 0)
                 return;
 
-            const auto blockEnd = out->end() - 4;
-            while (iter > blockEnd && *--iter == 0);
+            // Traverse string until the beginning,
+            // Stop at the first non-zero char
+            while (iter > out->begin() && *--iter == 0);
 
-            // Loop goes past the non-0 char, so make sure we only delete 0
+            // Go back to the zero char
             iter++;
 
+            // Erase 0s
             out->erase(iter, out->end());
         }
     }

--- a/Shared/sdk/SharedUtil.Hash.hpp
+++ b/Shared/sdk/SharedUtil.Hash.hpp
@@ -824,20 +824,20 @@ namespace SharedUtil
         // As of now, even if the user passed it in
         // We'll delete it, because there's no way
         // We can know if the user added the padding or not.
+
+        // Note: If we get there, there's at least 1 block(4 chars)
+        //       before out->end()
         {
-            auto iter = out->end() - 1;
-            if (*iter != 0)
-                return;
+            // Traverse the string until the beginning, or until the fist non-0 char
+            auto iter = out->end();
+            for (; iter != out->begin(); iter--)
+            {
+                if (*std::prev(iter) != 0)
+                    break;
+            }
 
-            // Traverse string until the beginning,
-            // Stop at the first non-zero char
-            while (iter > out->begin() && *--iter == 0);
-
-            // Go back to the zero char
-            iter++;
-
-            // Erase 0s
-            out->erase(iter, out->end());
+            if (iter != out->end()) 
+                out->erase(iter, out->end()); // Erase all 0s
         }
     }
 }            // namespace SharedUtil

--- a/Shared/sdk/SharedUtil.Hash.hpp
+++ b/Shared/sdk/SharedUtil.Hash.hpp
@@ -836,7 +836,7 @@ namespace SharedUtil
                     break;
             }
 
-            if (iter != out->end()) 
+            if (iter != out->end())
                 out->erase(iter, out->end()); // Erase all 0s
         }
     }

--- a/Shared/sdk/SharedUtil.Hash.hpp
+++ b/Shared/sdk/SharedUtil.Hash.hpp
@@ -696,7 +696,7 @@ namespace SharedUtil
             return GenerateHashHexString(hashFunction, NULL, 0);
     }
 
-    void encodeXtea(unsigned int* v, unsigned int* w, unsigned int* k)
+    inline void encodeXtea(unsigned int* v, unsigned int* w, unsigned int* k)
     {
         unsigned int v0 = v[0], v1 = v[1], i, sum = 0;
         unsigned int delta = 0x9E3779B9;
@@ -710,7 +710,7 @@ namespace SharedUtil
         w[1] = v1;
     }
 
-    void decodeXtea(unsigned int* v, unsigned int* w, unsigned int* k)
+    inline void decodeXtea(unsigned int* v, unsigned int* w, unsigned int* k)
     {
         unsigned int v0 = v[0], v1 = v[1], i, sum = 0xC6EF3720;
         unsigned int delta = 0x9E3779B9;
@@ -772,7 +772,7 @@ namespace SharedUtil
         delete[] strbuf;
     }
 
-    void TeaDecode(const SString& str, const SString& key, SString* out, const bool trimPaddingAtEnd)
+    void TeaDecode(const SString& str, const SString& key, SString* out)
     {
         unsigned int v[2];
         unsigned int w[2];
@@ -819,10 +819,9 @@ namespace SharedUtil
         out->assign((char*)buffer, numPasses * 4);
         delete[] buffer;
 
-        if (trimPaddingAtEnd)
-        {
-            // Check last block for 0 padding, and delete
 
+        // Check last block for 0 padding, and erase if there's any
+        {
             auto iter = out->end() - 1;
             if (*iter != 0)
                 return;
@@ -833,7 +832,7 @@ namespace SharedUtil
             // Loop goes past the non-0 char, so make sure we only delete 0
             iter++;
 
-            out->erase(iter, out->end()); // At this point its 100% theres a 0 padding, so we can delete that
+            out->erase(iter, out->end());
         }
     }
 }            // namespace SharedUtil


### PR DESCRIPTION
So basically, with the introduction of sbx's new parser, we started returning strings with `lua_pushlstring`, which takes a length as an argument, thus pushes the whole string along with padding. The old method used `lua_pushstring` which used `strlen`, thus god rid of the padding.
This PR fixes #1443 .

Edit: test resource: [utf1443.zip](https://github.com/multitheftauto/mtasa-blue/files/4813800/utf1443.zip)


