### PR TITLE
Refactor teaEncode/teaDecode functions to use std::string_view

### DIFF
--- a/Client/mods/deathmatch/premake5.lua
+++ b/Client/mods/deathmatch/premake5.lua
@@ -7,7 +7,7 @@ project "Client Deathmatch"
 	pchheader "StdInc.h"
 	pchsource "StdInc.cpp"
 
-	defines { "LUA_USE_APICHECK", "SDK_WITH_BCRYPT" }
+	defines { "LUA_USE_APICHECK", "SDK_WITH_BCRYPT", "SDK_WITH_TEA" }
 	links {
 		"Lua_Client", "pcre", "json-c", "ws2_32", "portaudio", "zlib", "cryptopp", "libspeex", "blowfish_bcrypt",
 		"../../../vendor/bass/lib/bass",

--- a/Server/mods/deathmatch/premake5.lua
+++ b/Server/mods/deathmatch/premake5.lua
@@ -30,7 +30,7 @@ project "Deathmatch"
 			"."
 		}
 
-	defines { "SDK_WITH_BCRYPT" }
+	defines { "SDK_WITH_BCRYPT", "SDK_WITH_TEA" }
 	links {
 		"Lua_Server", "sqlite", "ehs", "cryptopp", "pme", "pcre", "json-c", "zip", "zlib", "blowfish_bcrypt",
 	}

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
@@ -291,10 +291,10 @@ int CLuaCryptDefs::EncodeString(lua_State* luaVM)
                     if (pLuaMain)
                     {
                         CLuaShared::GetAsyncTaskScheduler()->PushTask<SString>(
-                            [data, key] {
+                            [toEncode = std::move(data), encodeKey = std::move(key)]{
                                 // Execute time-consuming task
                                 SString result;
-                                SharedUtil::TeaEncode(data, key, &result);
+                                SharedUtil::TeaEncode(toEncode, encodeKey, &result);
                                 return result;
                             },
                             [luaFunctionRef](const SString& result) {
@@ -305,7 +305,8 @@ int CLuaCryptDefs::EncodeString(lua_State* luaVM)
                                     arguments.PushString(result);
                                     arguments.Call(pLuaMain, luaFunctionRef);
                                 }
-                            });
+                            }
+                        );
 
                         lua_pushboolean(luaVM, true);
                     }
@@ -370,10 +371,10 @@ int CLuaCryptDefs::DecodeString(lua_State* luaVM)
                     if (pLuaMain)
                     {
                         CLuaShared::GetAsyncTaskScheduler()->PushTask<SString>(
-                            [data, key] {
+                            [toEncode = std::move(data), encodeKey = std::move(key)]{
                                 // Execute time-consuming task
                                 SString result;
-                                SharedUtil::TeaDecode(data, key, &result);
+                                SharedUtil::TeaDecode(toEncode, encodeKey, &result);
                                 return result;
                             },
                             [luaFunctionRef](const SString& result) {
@@ -384,7 +385,8 @@ int CLuaCryptDefs::DecodeString(lua_State* luaVM)
                                     arguments.PushString(result);
                                     arguments.Call(pLuaMain, luaFunctionRef);
                                 }
-                            });
+                            }
+                        );
 
                         lua_pushboolean(luaVM, true);
                     }

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
@@ -257,7 +257,7 @@ int CLuaCryptDefs::PasswordVerify(lua_State* luaVM)
 int CLuaCryptDefs::EncodeString(lua_State* luaVM)
 {
     StringEncryptFunction algorithm;
-    SString               data;
+    std::string_view      data;
     CStringMap            options;
     CLuaFunctionRef       luaFunctionRef;
 
@@ -291,8 +291,7 @@ int CLuaCryptDefs::EncodeString(lua_State* luaVM)
                     if (pLuaMain)
                     {
                         CLuaShared::GetAsyncTaskScheduler()->PushTask<SString>(
-                            [toEncode = std::move(data), encodeKey = std::move(key)]{
-                                // Execute time-consuming task
+                            [toEncode = std::string(data), encodeKey = std::move(key)]{ // Must copy data into std::string, because value might get GC'd
                                 SString result;
                                 SharedUtil::TeaEncode(toEncode, encodeKey, &result);
                                 return result;
@@ -337,7 +336,7 @@ int CLuaCryptDefs::EncodeString(lua_State* luaVM)
 int CLuaCryptDefs::DecodeString(lua_State* luaVM)
 {
     StringEncryptFunction algorithm;
-    SString               data;
+    std::string_view      data;
     CStringMap            options;
     CLuaFunctionRef       luaFunctionRef;
 
@@ -371,7 +370,7 @@ int CLuaCryptDefs::DecodeString(lua_State* luaVM)
                     if (pLuaMain)
                     {
                         CLuaShared::GetAsyncTaskScheduler()->PushTask<SString>(
-                            [toEncode = std::move(data), encodeKey = std::move(key)]{
+                            [toEncode = std::string(data), encodeKey = std::move(key)]{ // Must copy data into std::string, because value might get GC'd
                                 // Execute time-consuming task
                                 SString result;
                                 SharedUtil::TeaDecode(toEncode, encodeKey, &result);

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
@@ -52,16 +52,16 @@ std::string CLuaCryptDefs::Hash(EHashFunctionType hashFunction, std::string strS
     return GenerateHashHexString(hashFunction, strSourceData).ToLower();
 }
 
-std::string CLuaCryptDefs::TeaEncode(std::string str, std::string key)
+std::string CLuaCryptDefs::TeaEncode(std::string_view str, std::string_view key)
 {
     SString result;
     SharedUtil::TeaEncode(str, key, &result);
     return SharedUtil::Base64encode(result);
 }
 
-std::string CLuaCryptDefs::TeaDecode(std::string str, std::string key)
+std::string CLuaCryptDefs::TeaDecode(std::string_view str, std::string_view key)
 {
-    SString result = SharedUtil::Base64decode(str);
+    SString result = SharedUtil::Base64decode(std::string{ str.data(), str.length() });
     SString strOutResult;
     SharedUtil::TeaDecode(result, key, &strOutResult);
     return strOutResult;

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.h
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.h
@@ -22,8 +22,8 @@ public:
 
     static std::string Hash(EHashFunctionType hashFunction, std::string strSourceData);
 
-    static std::string TeaEncode(std::string str, std::string key);
-    static std::string TeaDecode(std::string str, std::string key);
+    static std::string TeaEncode(std::string_view str, std::string_view key);
+    static std::string TeaDecode(std::string_view str, std::string_view key);
     static std::string Base64encode(std::string str);
     static std::string Base64decode(std::string str);
     LUA_DECLARE(PasswordHash);

--- a/Shared/sdk/CScriptArgReader.h
+++ b/Shared/sdk/CScriptArgReader.h
@@ -593,21 +593,21 @@ public:
     {
         switch (lua_type(m_luaVM, m_iIndex))
         {
-        case LUA_TNUMBER:
-        case LUA_TSTRING:
-        {
-            outValue = {
-                lua_tostring(m_luaVM, m_iIndex),
-                lua_strlen(m_luaVM, m_iIndex)
-            };
+            case LUA_TNUMBER:
+            case LUA_TSTRING:
+            {
+                outValue = {
+                    lua_tostring(m_luaVM, m_iIndex),
+                    lua_strlen(m_luaVM, m_iIndex)
+                };
 
-            break;
-        }
-        default:
-        {
-            outValue = { nullptr, 0 };
-            SetTypeError("string");
-        }
+                break;
+            }
+            default:
+            {
+                outValue = { nullptr, 0 };
+                SetTypeError("string");
+            }
         }
 
         m_iIndex++;

--- a/Shared/sdk/CScriptArgReader.h
+++ b/Shared/sdk/CScriptArgReader.h
@@ -587,7 +587,7 @@ public:
     }
 
     //
-    // Read next string, using default if needed
+    // Read next string
     //
     void ReadString(std::string_view& outValue)
     {

--- a/Shared/sdk/CScriptArgReader.h
+++ b/Shared/sdk/CScriptArgReader.h
@@ -587,6 +587,33 @@ public:
     }
 
     //
+    // Read next string, using default if needed
+    //
+    void ReadString(std::string_view& outValue)
+    {
+        switch (lua_type(m_luaVM, m_iIndex))
+        {
+        case LUA_TNUMBER:
+        case LUA_TSTRING:
+        {
+            outValue = {
+                lua_tostring(m_luaVM, m_iIndex),
+                lua_strlen(m_luaVM, m_iIndex)
+            };
+
+            break;
+        }
+        default:
+        {
+            outValue = { nullptr, 0 };
+            SetTypeError("string");
+        }
+        }
+
+        m_iIndex++;
+    }
+
+    //
     // Force-reads next argument as string
     //
     void ReadAnyAsString(SString& outValue)

--- a/Shared/sdk/SharedUtil.Hash.h
+++ b/Shared/sdk/SharedUtil.Hash.h
@@ -9,6 +9,10 @@
  *
  *****************************************************************************/
 
+#ifdef SDK_WITH_TEA
+#include <string_view>
+#endif
+
 namespace EHashFunction
 {
     enum EHashFunctionType
@@ -80,11 +84,13 @@ namespace SharedUtil
         unsigned char m_digest[16];
     };
 
+#ifdef SDK_WITH_TEA
     void encodeXtea(unsigned int* v, unsigned int* w, unsigned int* k);
-    void decodeXTea(unsigned int* v, unsigned int* w, unsigned int* k);
+    void decodeXtea(unsigned int* v, unsigned int* w, unsigned int* k);
 
-    void TeaEncode(const SString& str, const SString& key, SString* out);
-    void TeaDecode(const SString& str, const SString& key, SString* out);
+    void TeaEncode(const std::string_view str, const std::string_view key, SString* out);
+    void TeaDecode(const std::string_view str, const std::string_view key, SString* out);
+#endif
 
     unsigned int HashString(const char* szString);
     unsigned int HashString(const char* szString, unsigned int length);

--- a/Shared/sdk/SharedUtil.Hash.hpp
+++ b/Shared/sdk/SharedUtil.Hash.hpp
@@ -696,6 +696,7 @@ namespace SharedUtil
             return GenerateHashHexString(hashFunction, NULL, 0);
     }
 
+#ifdef SDK_WITH_TEA
     void encodeXtea(unsigned int* v, unsigned int* w, unsigned int* k)
     {
         unsigned int v0 = v[0], v1 = v[1], i, sum = 0;
@@ -819,4 +820,5 @@ namespace SharedUtil
         out->assign((char*)buffer, numPasses * 4);
         delete[] buffer;
     }
+#endif // SDK_WITH_TEA
 }            // namespace SharedUtil

--- a/Shared/sdk/SharedUtil.Hash.hpp
+++ b/Shared/sdk/SharedUtil.Hash.hpp
@@ -724,7 +724,7 @@ namespace SharedUtil
         w[1] = v1;
     }
 
-    void TeaEncode(const SString& str, const SString& key, SString* out)
+    void TeaEncode(const std::string_view str, const std::string_view key, SString* out)
     {
         unsigned int v[2];
         unsigned int w[2];
@@ -742,7 +742,7 @@ namespace SharedUtil
         int len = key.length();
         if (len > 16)
             len = 16;
-        memcpy(keybuffer, key.c_str(), len);
+        memcpy(keybuffer, key.data(), len);
         for (int i = 0; i < 4; ++i)
             k[i] = keybuffer[i];
 
@@ -754,7 +754,7 @@ namespace SharedUtil
             strbuflen += 4 - (strbuflen % 4);
         unsigned char* strbuf = new unsigned char[strbuflen];
         memset(strbuf, 0, strbuflen);
-        memcpy(strbuf, str.c_str(), str.length());
+        memcpy(strbuf, str.data(), str.length());
 
         // Encode it!
         v[1] = 0;
@@ -772,7 +772,7 @@ namespace SharedUtil
         delete[] strbuf;
     }
 
-    void TeaDecode(const SString& str, const SString& key, SString* out)
+    void TeaDecode(const std::string_view str, const std::string_view key, SString* out)
     {
         unsigned int v[2];
         unsigned int w[2];
@@ -797,7 +797,7 @@ namespace SharedUtil
         int len = key.length();
         if (len > 16)
             len = 16;
-        memcpy(keybuffer, key.c_str(), len);
+        memcpy(keybuffer, key.data(), len);
         for (int i = 0; i < 4; ++i)
             k[i] = keybuffer[i];
 
@@ -806,7 +806,7 @@ namespace SharedUtil
         memset(buffer, 0, numPasses * 4 + 4);
 
         // Decode it!
-        const char* p = str.c_str();
+        const char* p = str.data();
         v[1] = *(unsigned int*)&p[numPasses * 4];
         for (int i = 0; i < numPasses; ++i)
         {

--- a/Shared/sdk/SharedUtil.Tests.hpp
+++ b/Shared/sdk/SharedUtil.Tests.hpp
@@ -760,10 +760,11 @@ void SharedUtil_Hash_Tests()
         TEST_END
     }
 
+#ifdef SDK_WITH_TEA
     // TeaEncode/TeaDecode
     {
         TEST_FUNCTION
-        SString strEncoded;
+            SString strEncoded;
         TeaEncode(a, b, &strEncoded);
         if (!result.empty())
             assert(strEncoded == result);
@@ -771,7 +772,7 @@ void SharedUtil_Hash_Tests()
         TeaDecode(strEncoded, b, &strDecoded);
         assert(a == *strDecoded);
         TEST_VARS
-        const SString a;
+            const SString a;
         const SString b;
         const SString result;
         TEST_DATA = {
@@ -781,7 +782,7 @@ void SharedUtil_Hash_Tests()
         };
         TEST_END
     }
-
+#endif // SDK_WITH_TEA
     #define szTempFilename "hash_""\xD0""\x98""_test"
 
     // MD5


### PR DESCRIPTION
This PR replaces teaEncode/teaDecode input from `std::string` to `std::string_view`. Also adds a new macro `SDK_WITH_TEA`, for compatibility reasons (Game and multiplayer SA still use c++14, and `string_view` is c++17).

Also, now it uses `std::move` in the lambda capture list for `en/decodeString` for improved performance.