### PR TITLE
Optimize split: Use string_view, and don't buffer if delimiter is a char

### DIFF
--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
@@ -183,11 +183,11 @@ int CLuaUtilDefs::Split(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        if (strDelimeter.length() == 1) // Fast way(doesn't need a separate buffer)
+        if (strDelimeter.length() == 1) // Fast way (doesn't need a separate buffer)
         {
             const char delimeter = strDelimeter[0];
 
-            size_t start = 0;               // Beginning of the token
+            size_t start = 0; // Beginning of the token
             size_t end = std::string::npos; // End of the token
 
             lua_Number tblindex = 1;
@@ -198,16 +198,16 @@ int CLuaUtilDefs::Split(lua_State* luaVM)
                 if (start != end) // Make sure this token isn't empty(it may be)
                 {
                     const auto token = input.substr(start, end - start);
-                    lua_pushnumber(luaVM, tblindex++);                      // Push table index
-                    lua_pushlstring(luaVM, token.data(), token.length());   // Push string value
-                    lua_settable(luaVM, -3);                                // Push it into the table   
+                    lua_pushnumber(luaVM, tblindex++); // Push table index
+                    lua_pushlstring(luaVM, token.data(), token.length()); // Push string value
+                    lua_settable(luaVM, -3); // Push it into the table   
                 }
 
                 if (end == std::string::npos) // No more delimeter chars
                     break;
 
-                start = end + 1;                // Move caret after this delimeter
-                if (start >= input.length())    // Make sure we still are in the string
+                start = end + 1; // Move caret after this delimeter
+                if (start >= input.length()) // Make sure we still are in the string
                     break;
             }
         }
@@ -224,9 +224,9 @@ int CLuaUtilDefs::Split(lua_State* luaVM)
             lua_Number tblindex = 1;
             while (szToken)
             {
-                lua_pushnumber(luaVM, tblindex++);  // Push table index
-                lua_pushstring(luaVM, szToken);     // Push string value
-                lua_settable(luaVM, -3);            // Push it into the table
+                lua_pushnumber(luaVM, tblindex++); // Push table index
+                lua_pushstring(luaVM, szToken); // Push string value
+                lua_settable(luaVM, -3); // Push it into the table
 
                 szToken = strtok(NULL, strDelimeter.c_str());
             }

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
@@ -9,7 +9,6 @@
  *****************************************************************************/
 
 #include "StdInc.h"
-#include <string.h>
 
 void CLuaUtilDefs::LoadFunctions()
 {
@@ -215,7 +214,7 @@ int CLuaUtilDefs::Split(lua_State* luaVM)
         {
             // Copy the string
             auto szInputCopy = std::make_unique<char[]>(input.length() + 1);
-            strcpy_s(szInputCopy.get(), input.length(), input.data());
+            strcpy(szInputCopy.get(), input.data());
 
             unsigned int uiCount = 0;
             char* szToken = strtok(szInputCopy.get(), strDelimeter.c_str());

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
@@ -9,7 +9,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
-#include <cstring>
+#include <string.h>
 
 void CLuaUtilDefs::LoadFunctions()
 {

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
@@ -9,6 +9,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include <cstring>
 
 void CLuaUtilDefs::LoadFunctions()
 {

--- a/Shared/sdk/CScriptArgReader.h
+++ b/Shared/sdk/CScriptArgReader.h
@@ -586,6 +586,34 @@ public:
         m_iIndex++;
     }
 
+
+    //
+    // Read next string
+    //
+    void ReadString(std::string_view& outValue)
+    {
+        switch (lua_type(m_luaVM, m_iIndex))
+        {
+        case LUA_TNUMBER:
+        case LUA_TSTRING:
+        {
+            outValue = {
+                lua_tostring(m_luaVM, m_iIndex),
+                lua_strlen(m_luaVM, m_iIndex)
+            };
+
+            break;
+        }
+        default:
+        {
+            outValue = { nullptr, 0 };
+            SetTypeError("string");
+        }
+        }
+
+        m_iIndex++;
+    }
+
     //
     // Force-reads next argument as string
     //


### PR DESCRIPTION
This PR removes the redundant buffer(`SString`, and then `new char[]`).
Now it only buffers `if delimenter.length() > 1`
Now it uses std::make_unique(for `char[]` buffer)

Unit tests [here](https://repl.it/@JohnLugo/SimpleTinyOpengroup#main.cpp) for the no-buffer case