### PR TITLE
Support for passing macros to a shader

### DIFF
--- a/Client/core/Graphics/CRenderItem.EffectCloner.h
+++ b/Client/core/Graphics/CRenderItem.EffectCloner.h
@@ -7,6 +7,37 @@
  *
  *****************************************************************************/
 
+struct SEffectInvariant
+{
+    SString      strFile;
+    EffectMacroList macros;
+
+    bool operator ==(const SEffectInvariant& e) const
+    {
+        return strFile == e.strFile && macros == e.macros;
+    }
+};
+
+template<>
+struct std::hash<SEffectInvariant>
+{
+    size_t operator()(const SEffectInvariant& entry) const
+    {
+        using EffectHash = std::size_t;
+
+        EffectHash uiHash = std::hash<SString>{}(entry.strFile);
+
+        for (const auto& [name, definition] : entry.macros)
+        {
+            // Hash function from boost
+            uiHash ^= std::hash<SString>{}(name)       + 0x9e3779b9 + (uiHash << 6) + (uiHash >> 2);
+            uiHash ^= std::hash<SString>{}(definition) + 0x9e3779b9 + (uiHash << 6) + (uiHash >> 2);
+        }
+
+        return uiHash;
+    }
+};
+
 ////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////
 //
@@ -19,14 +50,13 @@ class CEffectCloner
 public:
     CEffectCloner(CRenderItemManager* pManager);
     void         DoPulse();
-    CEffectWrap* CreateD3DEffect(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus,
-        bool bDebug, const std::vector<std::pair<SString, SString>>& macros);
-    void         ReleaseD3DEffect(CEffectWrap* pD3DEffect);
+    CEffectWrap* CreateD3DEffect(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug, const EffectMacroList& macros);
+    void         ReleaseD3DEffect(CEffectWrap* pD3DEffect);    
+private:
     void         MaybeTidyUp(bool bForceDrasticMeasures = false);
-    std::size_t  CalculateInvariantHash(const SString& strFile, const std::vector<std::pair<SString, SString>>& macros);
 
-    CElapsedTime                            m_TidyupTimer;
-    CRenderItemManager*                     m_pManager;
-    std::map<std::size_t, CEffectTemplate*> m_ValidMap;            // Active and files not changed since first created
-    std::vector<CEffectTemplate*>           m_OldList;             // Active but files changed since first created
+    CElapsedTime                                            m_TidyupTimer;
+    CRenderItemManager*                                     m_pManager;
+    std::unordered_map<SEffectInvariant, CEffectTemplate*>  m_ValidMap;      // Active and files not changed since first created
+    std::vector<CEffectTemplate*>                           m_OldList;       // Active but files changed since first created
 };

--- a/Client/core/Graphics/CRenderItem.EffectCloner.h
+++ b/Client/core/Graphics/CRenderItem.EffectCloner.h
@@ -19,12 +19,14 @@ class CEffectCloner
 public:
     CEffectCloner(CRenderItemManager* pManager);
     void         DoPulse();
-    CEffectWrap* CreateD3DEffect(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug);
+    CEffectWrap* CreateD3DEffect(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus,
+        bool bDebug, const std::vector<std::pair<SString, SString>>& macros);
     void         ReleaseD3DEffect(CEffectWrap* pD3DEffect);
     void         MaybeTidyUp(bool bForceDrasticMeasures = false);
+    std::size_t  CalculateInvariantHash(const SString& strFile, const std::vector<std::pair<SString, SString>>& macros);
 
-    CElapsedTime                        m_TidyupTimer;
-    CRenderItemManager*                 m_pManager;
-    std::map<SString, CEffectTemplate*> m_ValidMap;            // Active and files not changed since first created
-    std::vector<CEffectTemplate*>       m_OldList;             // Active but files changed since first created
+    CElapsedTime                            m_TidyupTimer;
+    CRenderItemManager*                     m_pManager;
+    std::map<std::size_t, CEffectTemplate*> m_ValidMap;            // Active and files not changed since first created
+    std::vector<CEffectTemplate*>           m_OldList;             // Active but files changed since first created
 };

--- a/Client/core/Graphics/CRenderItem.EffectTemplate.cpp
+++ b/Client/core/Graphics/CRenderItem.EffectTemplate.cpp
@@ -17,7 +17,7 @@
 //
 ///////////////////////////////////////////////////////////////
 CEffectTemplate* NewEffectTemplate(CRenderItemManager* pManager, const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug,
-        const std::vector<std::pair<SString, SString>>& macros, HRESULT& outHResult)
+        const EffectMacroList& macros, HRESULT& outHResult)
 {
     CEffectTemplate* pEffectTemplate = new CEffectTemplate();
     pEffectTemplate->PostConstruct(pManager, strFile, strRootPath, bIsRawData, strOutStatus, bDebug, macros);
@@ -122,7 +122,7 @@ namespace
 //
 ////////////////////////////////////////////////////////////////
 void CEffectTemplate::PostConstruct(CRenderItemManager* pManager, const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus,
-    bool bDebug, const std::vector<std::pair<SString, SString>>& macros)
+    bool bDebug, const EffectMacroList& macros)
 {
     Super::PostConstruct(pManager);
 
@@ -203,7 +203,7 @@ void CEffectTemplate::OnResetDevice()
 //
 ////////////////////////////////////////////////////////////////
 void CEffectTemplate::CreateUnderlyingData(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus,
-    bool bDebug, const std::vector<std::pair<SString, SString>>& macros)
+    bool bDebug, const EffectMacroList& macros)
 {
     assert(!m_pD3DEffect);
 
@@ -216,12 +216,8 @@ void CEffectTemplate::CreateUnderlyingData(const SString& strFile, const SString
     macroList.back().Name = "IS_DEPTHBUFFER_RAWZ";
     macroList.back().Definition = bUsesRAWZ ? "1" : "0";
 
-    for (const auto& entry : macros)
-    {
-        macroList.push_back(D3DXMACRO());
-        macroList.back().Name = entry.first.c_str();
-        macroList.back().Definition = entry.second.c_str();
-    }
+    for (const auto& [name, definition] : macros)
+        macroList.push_back(std::move(D3DXMACRO{ name.c_str(), definition.c_str() }));
 
     macroList.push_back(D3DXMACRO());
     macroList.back().Name = NULL;
@@ -359,9 +355,6 @@ void CEffectTemplate::CreateUnderlyingData(const SString& strFile, const SString
             SAFE_RELEASE(pDisassembly);
         }
     }
-
-    // Copy macros
-    m_Macros = macros;
 
     // Copy MD5s of all loaded files
     m_FileMD5Map = IncludeManager.m_FileMD5Map;

--- a/Client/core/Graphics/CRenderItem.EffectTemplate.cpp
+++ b/Client/core/Graphics/CRenderItem.EffectTemplate.cpp
@@ -17,10 +17,10 @@
 //
 ///////////////////////////////////////////////////////////////
 CEffectTemplate* NewEffectTemplate(CRenderItemManager* pManager, const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug,
-                                   HRESULT& outHResult)
+        const std::vector<std::pair<SString, SString>>& macros, HRESULT& outHResult)
 {
     CEffectTemplate* pEffectTemplate = new CEffectTemplate();
-    pEffectTemplate->PostConstruct(pManager, strFile, strRootPath, bIsRawData, strOutStatus, bDebug);
+    pEffectTemplate->PostConstruct(pManager, strFile, strRootPath, bIsRawData, strOutStatus, bDebug, macros);
 
     outHResult = pEffectTemplate->m_CreateHResult;
     if (!pEffectTemplate->IsValid())
@@ -121,12 +121,13 @@ namespace
 //
 //
 ////////////////////////////////////////////////////////////////
-void CEffectTemplate::PostConstruct(CRenderItemManager* pManager, const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug)
+void CEffectTemplate::PostConstruct(CRenderItemManager* pManager, const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus,
+    bool bDebug, const std::vector<std::pair<SString, SString>>& macros)
 {
     Super::PostConstruct(pManager);
 
     // Initial creation of d3d data
-    CreateUnderlyingData(strFile, strRootPath, bIsRawData, strOutStatus, bDebug);
+    CreateUnderlyingData(strFile, strRootPath, bIsRawData, strOutStatus, bDebug, macros);
 }
 
 ////////////////////////////////////////////////////////////////
@@ -201,7 +202,8 @@ void CEffectTemplate::OnResetDevice()
 //
 //
 ////////////////////////////////////////////////////////////////
-void CEffectTemplate::CreateUnderlyingData(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug)
+void CEffectTemplate::CreateUnderlyingData(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus,
+    bool bDebug, const std::vector<std::pair<SString, SString>>& macros)
 {
     assert(!m_pD3DEffect);
 
@@ -213,6 +215,13 @@ void CEffectTemplate::CreateUnderlyingData(const SString& strFile, const SString
     macroList.push_back(D3DXMACRO());
     macroList.back().Name = "IS_DEPTHBUFFER_RAWZ";
     macroList.back().Definition = bUsesRAWZ ? "1" : "0";
+
+    for (const auto& entry : macros)
+    {
+        macroList.push_back(D3DXMACRO());
+        macroList.back().Name = entry.first.c_str();
+        macroList.back().Definition = entry.second.c_str();
+    }
 
     macroList.push_back(D3DXMACRO());
     macroList.back().Name = NULL;
@@ -350,6 +359,9 @@ void CEffectTemplate::CreateUnderlyingData(const SString& strFile, const SString
             SAFE_RELEASE(pDisassembly);
         }
     }
+
+    // Copy macros
+    m_Macros = macros;
 
     // Copy MD5s of all loaded files
     m_FileMD5Map = IncludeManager.m_FileMD5Map;

--- a/Client/core/Graphics/CRenderItem.EffectTemplate.h
+++ b/Client/core/Graphics/CRenderItem.EffectTemplate.h
@@ -21,7 +21,7 @@ class CEffectTemplate : public CEffectParameters
     DECLARE_CLASS(CEffectTemplate, CEffectParameters)
     CEffectTemplate() : ClassInit(this) {}
     virtual void PostConstruct(CRenderItemManager* pManager, const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus,
-        bool bDebug, const std::vector<std::pair<SString, SString>>& macros);
+        bool bDebug, const EffectMacroList& macros);
     virtual void PreDestruct();
     virtual bool IsValid();
     virtual void OnLostDevice();
@@ -31,7 +31,7 @@ class CEffectTemplate : public CEffectParameters
     CEffectWrap* CloneD3DEffect(SString& strOutStatus);
     void         UnCloneD3DEffect(CEffectWrap* pD3DEffect);
     void         CreateUnderlyingData(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus,
-        bool bDebug, const std::vector<std::pair<SString, SString>>& macros);
+        bool bDebug, const EffectMacroList& macros);
     void         ReleaseUnderlyingData();
     bool         ValidateDepthBufferUsage(D3DXHANDLE hTechnique, SString& strOutErrorExtra);
 
@@ -41,8 +41,7 @@ class CEffectTemplate : public CEffectParameters
     CTickCount                 m_TickCountLastUsed;
     uint                       m_uiCloneCount;
     HRESULT                    m_CreateHResult;
-    std::vector<std::pair<SString, SString>> m_Macros;
 };
 
 CEffectTemplate* NewEffectTemplate(CRenderItemManager* pManager, const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug,
-    const std::vector<std::pair<SString, SString>>& macros, HRESULT& outHResult);
+    const EffectMacroList& macros, HRESULT& outHResult);

--- a/Client/core/Graphics/CRenderItem.EffectTemplate.h
+++ b/Client/core/Graphics/CRenderItem.EffectTemplate.h
@@ -20,7 +20,8 @@ class CEffectTemplate : public CEffectParameters
 {
     DECLARE_CLASS(CEffectTemplate, CEffectParameters)
     CEffectTemplate() : ClassInit(this) {}
-    virtual void PostConstruct(CRenderItemManager* pManager, const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug);
+    virtual void PostConstruct(CRenderItemManager* pManager, const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus,
+        bool bDebug, const std::vector<std::pair<SString, SString>>& macros);
     virtual void PreDestruct();
     virtual bool IsValid();
     virtual void OnLostDevice();
@@ -29,7 +30,8 @@ class CEffectTemplate : public CEffectParameters
     int          GetTicksSinceLastUsed();
     CEffectWrap* CloneD3DEffect(SString& strOutStatus);
     void         UnCloneD3DEffect(CEffectWrap* pD3DEffect);
-    void         CreateUnderlyingData(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug);
+    void         CreateUnderlyingData(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus,
+        bool bDebug, const std::vector<std::pair<SString, SString>>& macros);
     void         ReleaseUnderlyingData();
     bool         ValidateDepthBufferUsage(D3DXHANDLE hTechnique, SString& strOutErrorExtra);
 
@@ -39,7 +41,8 @@ class CEffectTemplate : public CEffectParameters
     CTickCount                 m_TickCountLastUsed;
     uint                       m_uiCloneCount;
     HRESULT                    m_CreateHResult;
+    std::vector<std::pair<SString, SString>> m_Macros;
 };
 
 CEffectTemplate* NewEffectTemplate(CRenderItemManager* pManager, const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug,
-                                   HRESULT& outHResult);
+    const std::vector<std::pair<SString, SString>>& macros, HRESULT& outHResult);

--- a/Client/core/Graphics/CRenderItem.Shader.cpp
+++ b/Client/core/Graphics/CRenderItem.Shader.cpp
@@ -21,8 +21,7 @@ uint CShaderItem::ms_uiCreateTimeCounter = 0;
 //
 ////////////////////////////////////////////////////////////////
 void CShaderItem::PostConstruct(CRenderItemManager* pManager, const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority,
-                                float fMaxDistance, bool bLayered, bool bDebug, int iTypeMask,
-                                const std::vector<std::pair<SString, SString>>& macros)
+                                float fMaxDistance, bool bLayered, bool bDebug, int iTypeMask, const EffectMacroList& macros)
 {
     m_fPriority = fPriority;
     m_uiCreateTime = ms_uiCreateTimeCounter++;            // Priority tie breaker
@@ -93,7 +92,7 @@ void CShaderItem::OnResetDevice()
 //
 ////////////////////////////////////////////////////////////////
 void CShaderItem::CreateUnderlyingData(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus,
-    bool bDebug, const std::vector<std::pair<SString, SString>>& macros)
+    bool bDebug, const EffectMacroList& macros)
 {
     assert(!m_pEffectWrap);
     assert(!m_pShaderInstance);

--- a/Client/core/Graphics/CRenderItem.Shader.cpp
+++ b/Client/core/Graphics/CRenderItem.Shader.cpp
@@ -21,7 +21,8 @@ uint CShaderItem::ms_uiCreateTimeCounter = 0;
 //
 ////////////////////////////////////////////////////////////////
 void CShaderItem::PostConstruct(CRenderItemManager* pManager, const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority,
-                                float fMaxDistance, bool bLayered, bool bDebug, int iTypeMask)
+                                float fMaxDistance, bool bLayered, bool bDebug, int iTypeMask,
+                                const std::vector<std::pair<SString, SString>>& macros)
 {
     m_fPriority = fPriority;
     m_uiCreateTime = ms_uiCreateTimeCounter++;            // Priority tie breaker
@@ -32,7 +33,7 @@ void CShaderItem::PostConstruct(CRenderItemManager* pManager, const SString& str
     Super::PostConstruct(pManager);
 
     // Initial creation of d3d data
-    CreateUnderlyingData(strFile, strRootPath, bIsRawData, strOutStatus, bDebug);
+    CreateUnderlyingData(strFile, strRootPath, bIsRawData, strOutStatus, bDebug, macros);
 }
 
 ////////////////////////////////////////////////////////////////
@@ -91,12 +92,13 @@ void CShaderItem::OnResetDevice()
 //
 //
 ////////////////////////////////////////////////////////////////
-void CShaderItem::CreateUnderlyingData(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug)
+void CShaderItem::CreateUnderlyingData(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus,
+    bool bDebug, const std::vector<std::pair<SString, SString>>& macros)
 {
     assert(!m_pEffectWrap);
     assert(!m_pShaderInstance);
 
-    m_pEffectWrap = m_pManager->GetEffectCloner()->CreateD3DEffect(strFile, strRootPath, bIsRawData, strOutStatus, bDebug);
+    m_pEffectWrap = m_pManager->GetEffectCloner()->CreateD3DEffect(strFile, strRootPath, bIsRawData, strOutStatus, bDebug, macros);
     if (!m_pEffectWrap)
         return;
 

--- a/Client/core/Graphics/CRenderItemManager.cpp
+++ b/Client/core/Graphics/CRenderItemManager.cpp
@@ -232,7 +232,7 @@ CWebBrowserItem* CRenderItemManager::CreateWebBrowser(uint uiSizeX, uint uiSizeY
 //
 ////////////////////////////////////////////////////////////////
 CShaderItem* CRenderItemManager::CreateShader(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority,
-                                              float fMaxDistance, bool bLayered, bool bDebug, int iTypeMask, const std::vector<std::pair<SString, SString>>& macros)
+                                              float fMaxDistance, bool bLayered, bool bDebug, int iTypeMask, const EffectMacroList& macros)
 {
     if (!CanCreateRenderItem(CShaderItem::GetClassId()))
         return NULL;

--- a/Client/core/Graphics/CRenderItemManager.cpp
+++ b/Client/core/Graphics/CRenderItemManager.cpp
@@ -232,7 +232,7 @@ CWebBrowserItem* CRenderItemManager::CreateWebBrowser(uint uiSizeX, uint uiSizeY
 //
 ////////////////////////////////////////////////////////////////
 CShaderItem* CRenderItemManager::CreateShader(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority,
-                                              float fMaxDistance, bool bLayered, bool bDebug, int iTypeMask)
+                                              float fMaxDistance, bool bLayered, bool bDebug, int iTypeMask, const std::vector<std::pair<SString, SString>>& macros)
 {
     if (!CanCreateRenderItem(CShaderItem::GetClassId()))
         return NULL;
@@ -240,7 +240,7 @@ CShaderItem* CRenderItemManager::CreateShader(const SString& strFile, const SStr
     strOutStatus = "";
 
     CShaderItem* pShaderItem = new CShaderItem();
-    pShaderItem->PostConstruct(this, strFile, strRootPath, bIsRawData, strOutStatus, fPriority, fMaxDistance, bLayered, bDebug, iTypeMask);
+    pShaderItem->PostConstruct(this, strFile, strRootPath, bIsRawData, strOutStatus, fPriority, fMaxDistance, bLayered, bDebug, iTypeMask, macros);
 
     if (!pShaderItem->IsValid())
     {

--- a/Client/core/Graphics/CRenderItemManager.h
+++ b/Client/core/Graphics/CRenderItemManager.h
@@ -29,7 +29,7 @@ public:
                                         uint uiSizeY = RDEFAULT, ERenderFormat format = RFORMAT_UNKNOWN, ETextureAddress textureAddress = TADDRESS_WRAP,
                                         ETextureType textureType = TTYPE_TEXTURE, uint uiVolumeDepth = 1);
     virtual CShaderItem*  CreateShader(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority, float fMaxDistance,
-                                       bool bLayered, bool bDebug, int iTypeMask, const std::vector<std::pair<SString, SString>>& macros);
+                                       bool bLayered, bool bDebug, int iTypeMask, const EffectMacroList& macros);
     virtual CRenderTargetItem* CreateRenderTarget(uint uiSizeX, uint uiSizeY, bool bWithAlphaChannel, bool bForce = false);
     virtual CScreenSourceItem* CreateScreenSource(uint uiSizeX, uint uiSizeY);
     virtual CWebBrowserItem*   CreateWebBrowser(uint uiSizeX, uint uiSizeY);

--- a/Client/core/Graphics/CRenderItemManager.h
+++ b/Client/core/Graphics/CRenderItemManager.h
@@ -29,7 +29,7 @@ public:
                                         uint uiSizeY = RDEFAULT, ERenderFormat format = RFORMAT_UNKNOWN, ETextureAddress textureAddress = TADDRESS_WRAP,
                                         ETextureType textureType = TTYPE_TEXTURE, uint uiVolumeDepth = 1);
     virtual CShaderItem*  CreateShader(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority, float fMaxDistance,
-                                       bool bLayered, bool bDebug, int iTypeMask);
+                                       bool bLayered, bool bDebug, int iTypeMask, const std::vector<std::pair<SString, SString>>& macros);
     virtual CRenderTargetItem* CreateRenderTarget(uint uiSizeX, uint uiSizeY, bool bWithAlphaChannel, bool bForce = false);
     virtual CScreenSourceItem* CreateScreenSource(uint uiSizeX, uint uiSizeY);
     virtual CWebBrowserItem*   CreateWebBrowser(uint uiSizeX, uint uiSizeY);

--- a/Client/mods/deathmatch/logic/CClientRenderElementManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientRenderElementManager.cpp
@@ -136,11 +136,11 @@ CClientTexture* CClientRenderElementManager::CreateTexture(const SString& strFul
 //
 ////////////////////////////////////////////////////////////////
 CClientShader* CClientRenderElementManager::CreateShader(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority,
-                                                         float fMaxDistance, bool bLayered, bool bDebug, int iTypeMask)
+                                                         float fMaxDistance, bool bLayered, bool bDebug, int iTypeMask, const std::vector<std::pair<SString, SString>>& macros)
 {
     // Create the item
     CShaderItem* pShaderItem =
-        m_pRenderItemManager->CreateShader(strFile, strRootPath, bIsRawData, strOutStatus, fPriority, fMaxDistance, bLayered, bDebug, iTypeMask);
+        m_pRenderItemManager->CreateShader(strFile, strRootPath, bIsRawData, strOutStatus, fPriority, fMaxDistance, bLayered, bDebug, iTypeMask, macros);
 
     // Check create worked
     if (!pShaderItem)

--- a/Client/mods/deathmatch/logic/CClientRenderElementManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientRenderElementManager.cpp
@@ -136,7 +136,7 @@ CClientTexture* CClientRenderElementManager::CreateTexture(const SString& strFul
 //
 ////////////////////////////////////////////////////////////////
 CClientShader* CClientRenderElementManager::CreateShader(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority,
-                                                         float fMaxDistance, bool bLayered, bool bDebug, int iTypeMask, const std::vector<std::pair<SString, SString>>& macros)
+                                                         float fMaxDistance, bool bLayered, bool bDebug, int iTypeMask, const EffectMacroList& macros)
 {
     // Create the item
     CShaderItem* pShaderItem =

--- a/Client/mods/deathmatch/logic/CClientRenderElementManager.h
+++ b/Client/mods/deathmatch/logic/CClientRenderElementManager.h
@@ -30,7 +30,7 @@ public:
                                        uint uiSizeY = RDEFAULT, ERenderFormat format = RFORMAT_UNKNOWN, ETextureAddress textureAddress = TADDRESS_WRAP,
                                        ETextureType textureType = TTYPE_TEXTURE, uint uiVolumeDepth = 1);
     CClientShader*       CreateShader(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority, float fMaxDistance,
-                                      bool bLayered, bool bDebug, int iTypeMask);
+                                      bool bLayered, bool bDebug, int iTypeMask, const std::vector<std::pair<SString, SString>>& macros);
     CClientRenderTarget* CreateRenderTarget(uint uiSizeX, uint uiSizeY, bool bWithAlphaChannel);
     CClientScreenSource* CreateScreenSource(uint uiSizeX, uint uiSizeY);
     CClientWebBrowser*   CreateWebBrowser(uint uiSizeX, uint uiSizeY, bool bIsLocal, bool bTransparent);

--- a/Client/mods/deathmatch/logic/CClientRenderElementManager.h
+++ b/Client/mods/deathmatch/logic/CClientRenderElementManager.h
@@ -30,7 +30,7 @@ public:
                                        uint uiSizeY = RDEFAULT, ERenderFormat format = RFORMAT_UNKNOWN, ETextureAddress textureAddress = TADDRESS_WRAP,
                                        ETextureType textureType = TTYPE_TEXTURE, uint uiVolumeDepth = 1);
     CClientShader*       CreateShader(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority, float fMaxDistance,
-                                      bool bLayered, bool bDebug, int iTypeMask, const std::vector<std::pair<SString, SString>>& macros);
+                                      bool bLayered, bool bDebug, int iTypeMask, const EffectMacroList& macros);
     CClientRenderTarget* CreateRenderTarget(uint uiSizeX, uint uiSizeY, bool bWithAlphaChannel);
     CClientScreenSource* CreateScreenSource(uint uiSizeX, uint uiSizeY);
     CClientWebBrowser*   CreateWebBrowser(uint uiSizeX, uint uiSizeY, bool bIsLocal, bool bTransparent);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -1126,7 +1126,7 @@ int CLuaDrawingDefs::DxCreateShader(lua_State* luaVM)
     //  element dxCreateShader( string filepath / string raw_data [, float priority = 0, float maxdistance = 0, bool layered = false, string elementTypes =
     //  "world,vehicle,object,other" ] )
     SString                      strFile;
-    std::vector<std::pair<SString, SString>>                   macros;
+    EffectMacroList              macros;
     float                        fPriority;
     float                        fMaxDistance;
     bool                         bLayered;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -1126,6 +1126,7 @@ int CLuaDrawingDefs::DxCreateShader(lua_State* luaVM)
     //  element dxCreateShader( string filepath / string raw_data [, float priority = 0, float maxdistance = 0, bool layered = false, string elementTypes =
     //  "world,vehicle,object,other" ] )
     SString                      strFile;
+    std::vector<std::pair<SString, SString>>                   macros;
     float                        fPriority;
     float                        fMaxDistance;
     bool                         bLayered;
@@ -1133,6 +1134,8 @@ int CLuaDrawingDefs::DxCreateShader(lua_State* luaVM)
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadString(strFile);
+    if (argStream.NextIsTable())
+        argStream.ReadPairTable(macros);
     argStream.ReadNumber(fPriority, 0.0f);
     argStream.ReadNumber(fMaxDistance, 0.0f);
     argStream.ReadBool(bLayered, false);
@@ -1207,7 +1210,7 @@ int CLuaDrawingDefs::DxCreateShader(lua_State* luaVM)
 
     SString        strStatus;
     CClientShader* pShader = g_pClientGame->GetManager()->GetRenderElementManager()->CreateShader(strPath, strRootPath, bIsRawData, strStatus, fPriority,
-                                                                                                  fMaxDistance, bLayered, false, iEntityTypeMaskResult);
+                                                                                                  fMaxDistance, bLayered, false, iEntityTypeMaskResult, macros);
 
     if (pShader)
     {

--- a/Client/sdk/core/CRenderItemManagerInterface.h
+++ b/Client/sdk/core/CRenderItemManagerInterface.h
@@ -150,7 +150,7 @@ public:
                                         uint uiSizeY = RDEFAULT, ERenderFormat format = RFORMAT_UNKNOWN, ETextureAddress textureAddress = TADDRESS_WRAP,
                                         ETextureType textureType = TTYPE_TEXTURE, uint uiVolumeDepth = 1) = 0;
     virtual CShaderItem*  CreateShader(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority, float fMaxDistance,
-                                       bool bLayered, bool bDebug, int iTypeMask) = 0;
+                                       bool bLayered, bool bDebug, int iTypeMask, const std::vector<std::pair<SString, SString>>& macros) = 0;
     virtual CRenderTargetItem* CreateRenderTarget(uint uiSizeX, uint uiSizeY, bool bWithAlphaChannel, bool bForce = false) = 0;
     virtual CScreenSourceItem* CreateScreenSource(uint uiSizeX, uint uiSizeY) = 0;
     virtual CWebBrowserItem*   CreateWebBrowser(uint uiSizeX, uint uiSizeY) = 0;
@@ -354,12 +354,12 @@ class CShaderItem : public CMaterialItem
     DECLARE_CLASS(CShaderItem, CMaterialItem)
     CShaderItem() : ClassInit(this) {}
     virtual void PostConstruct(CRenderItemManager* pManager, const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority,
-                               float fMaxDistance, bool bLayered, bool bDebug, int iTypeMask);
+                               float fMaxDistance, bool bLayered, bool bDebug, int iTypeMask, const std::vector<std::pair<SString, SString>>& macros);
     virtual void PreDestruct();
     virtual bool IsValid();
     virtual void OnLostDevice();
     virtual void OnResetDevice();
-    void         CreateUnderlyingData(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug);
+    void         CreateUnderlyingData(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug, const std::vector<std::pair<SString, SString>>& macros);
     void         ReleaseUnderlyingData();
     virtual bool SetValue(const SString& strName, CTextureItem* pTextureItem);
     virtual bool SetValue(const SString& strName, bool bValue);

--- a/Client/sdk/core/CRenderItemManagerInterface.h
+++ b/Client/sdk/core/CRenderItemManagerInterface.h
@@ -130,6 +130,8 @@ struct SDxStatus
     } settings;
 };
 
+using EffectMacroList = std::vector<std::pair<SString, SString>>;
+
 ////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////
 //
@@ -150,7 +152,7 @@ public:
                                         uint uiSizeY = RDEFAULT, ERenderFormat format = RFORMAT_UNKNOWN, ETextureAddress textureAddress = TADDRESS_WRAP,
                                         ETextureType textureType = TTYPE_TEXTURE, uint uiVolumeDepth = 1) = 0;
     virtual CShaderItem*  CreateShader(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority, float fMaxDistance,
-                                       bool bLayered, bool bDebug, int iTypeMask, const std::vector<std::pair<SString, SString>>& macros) = 0;
+                                       bool bLayered, bool bDebug, int iTypeMask, const EffectMacroList& macros) = 0;
     virtual CRenderTargetItem* CreateRenderTarget(uint uiSizeX, uint uiSizeY, bool bWithAlphaChannel, bool bForce = false) = 0;
     virtual CScreenSourceItem* CreateScreenSource(uint uiSizeX, uint uiSizeY) = 0;
     virtual CWebBrowserItem*   CreateWebBrowser(uint uiSizeX, uint uiSizeY) = 0;
@@ -354,12 +356,12 @@ class CShaderItem : public CMaterialItem
     DECLARE_CLASS(CShaderItem, CMaterialItem)
     CShaderItem() : ClassInit(this) {}
     virtual void PostConstruct(CRenderItemManager* pManager, const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, float fPriority,
-                               float fMaxDistance, bool bLayered, bool bDebug, int iTypeMask, const std::vector<std::pair<SString, SString>>& macros);
+                               float fMaxDistance, bool bLayered, bool bDebug, int iTypeMask, const EffectMacroList& macros);
     virtual void PreDestruct();
     virtual bool IsValid();
     virtual void OnLostDevice();
     virtual void OnResetDevice();
-    void         CreateUnderlyingData(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug, const std::vector<std::pair<SString, SString>>& macros);
+    void         CreateUnderlyingData(const SString& strFile, const SString& strRootPath, bool bIsRawData, SString& strOutStatus, bool bDebug, const EffectMacroList& macros);
     void         ReleaseUnderlyingData();
     virtual bool SetValue(const SString& strName, CTextureItem* pTextureItem);
     virtual bool SetValue(const SString& strName, bool bValue);


### PR DESCRIPTION
An implementation of idea suggested in the issue #1220

**Syntax:**
`element, string dxCreateShader( string filepath / string raw_data [, table macros = {}, float priority = 0, float maxDistance = 0, bool layered = false, string elementTypes = "world,vehicle,object,other" ] )`
where the **macros** is an optional parameter. For sake of backward compatibility it can be omitted.

Sample resource:
[shader_macro.zip](https://github.com/multitheftauto/mtasa-blue/files/4958577/shader_macro.zip)

