### PR TITLE
Fix detection of some dff's

### DIFF
--- a/Client/mods/deathmatch/logic/CClientDFF.cpp
+++ b/Client/mods/deathmatch/logic/CClientDFF.cpp
@@ -369,5 +369,5 @@ bool CClientDFF::ReplaceVehicleModel(RpClump* pClump, ushort usModel, bool bAlph
 // Return true if data looks like DFF file contents
 bool CClientDFF::IsDFFData(const SString& strData)
 {
-    return strData.length() > 32 && memcmp(strData, "\x10\x00\x00\x00", 4) == 0;
+    return strData.length() > 32 && (memcmp(strData, "\x10\x00\x00\x00", 4) == 0 || memcmp(strData, "\x2B\x00\x00\x00", 4) == 0);
 }


### PR DESCRIPTION
Fix issue #1444 
Some DFF's have UV Animation Dictionary RW Section (0x2B). IsDFFData check only 0x10 section and you can't load DFF's with 0x2B section from buffer using engineLoadDFF.