### PR TITLE
Further xmlLoadString memleak fixes

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -57,11 +57,6 @@ CLuaMain::~CLuaMain()
 
     // Delete the timer manager
     delete m_pLuaTimerManager;
-    
-    for (auto& xmlNode : m_XMLNodes)
-    {
-        delete xmlNode;
-    }
 
     CClientPerfStatLuaMemory::GetSingleton()->OnLuaMainDestroy(this);
     CClientPerfStatLuaTiming::GetSingleton()->OnLuaMainDestroy(this);
@@ -370,10 +365,13 @@ CXMLFile* CLuaMain::CreateXML(const char* szFilename, bool bUseIDs, bool bReadOn
 
 CXMLNode* CLuaMain::ParseString(const char* strXmlContent)
 {
-    CXMLNode* xmlNode = g_pCore->GetXML()->ParseString(strXmlContent);
-    if (xmlNode)
-        m_XMLNodes.push_back(xmlNode);
-    return xmlNode;
+    auto xmlStringNode = g_pCore->GetXML()->ParseString(strXmlContent);
+    if (!xmlStringNode)
+        return nullptr;
+
+    auto node = xmlStringNode->node;
+    m_XMLStringNodes.emplace(std::move(xmlStringNode));
+    return node;
 }
 
 bool CLuaMain::DestroyXML(CXMLFile* pFile)

--- a/Client/mods/deathmatch/logic/lua/CLuaMain.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaMain.h
@@ -95,8 +95,8 @@ private:
 
     class CResource* m_pResource;
 
-    std::list<CXMLFile*> m_XMLFiles;
-    std::list<CXMLNode*> m_XMLNodes;
+    std::list<CXMLFile*>                            m_XMLFiles;
+    std::unordered_set<std::unique_ptr<SXMLString>> m_XMLStringNodes;
     static SString       ms_strExpectedUndumpHash;
 
     bool m_bEnableOOP;

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -77,11 +77,6 @@ CLuaMain::~CLuaMain()
         delete xmlFile;
     }
 
-    for (auto& xmlNode : m_XMLNodes)
-    {
-        delete xmlNode;
-    }
-
     // Eventually delete the text displays the LUA script didn't
     list<CTextDisplay*>::iterator iterDisplays = m_Displays.begin();
     for (; iterDisplays != m_Displays.end(); ++iterDisplays)
@@ -422,10 +417,13 @@ CXMLFile* CLuaMain::CreateXML(const char* szFilename, bool bUseIDs, bool bReadOn
 
 CXMLNode* CLuaMain::ParseString(const char* strXmlContent)
 {
-    CXMLNode* xmlNode = g_pServerInterface->GetXML()->ParseString(strXmlContent);
-    if (xmlNode)
-        m_XMLNodes.push_back(xmlNode);
-    return xmlNode;
+    auto xmlStringNode = g_pServerInterface->GetXML()->ParseString(strXmlContent);
+    if (!xmlStringNode)
+        return nullptr;
+
+    auto node = xmlStringNode->node;
+    m_XMLStringNodes.emplace(std::move(xmlStringNode));
+    return node;
 }
 
 bool CLuaMain::DestroyXML(CXMLFile* pFile)

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.h
@@ -133,10 +133,10 @@ private:
     CVehicleManager*     m_pVehicleManager;
     CMapManager*         m_pMapManager;
 
-    list<CXMLFile*>     m_XMLFiles;
-    list<CXMLNode*>     m_XMLNodes;
-    list<CTextDisplay*> m_Displays;
-    list<CTextItem*>    m_TextItems;
+    list<CXMLFile*>                                 m_XMLFiles;
+    std::unordered_set<std::unique_ptr<SXMLString>> m_XMLStringNodes;
+    list<CTextDisplay*>                             m_Displays;
+    list<CTextItem*>                                m_TextItems;
 
     bool m_bEnableOOP;
 

--- a/Shared/XML/CXMLImpl.cpp
+++ b/Shared/XML/CXMLImpl.cpp
@@ -41,7 +41,7 @@ void CXMLImpl::DeleteXML(CXMLFile* pFile)
     delete pFile;
 }
 
-CXMLNode* CXMLImpl::ParseString(const char* strXmlContent)
+std::unique_ptr<SXMLString> CXMLImpl::ParseString(const char* strXmlContent)
 {
     TiXmlDocument* xmlDoc = new TiXmlDocument();
     if (xmlDoc)
@@ -52,7 +52,7 @@ CXMLNode* CXMLImpl::ParseString(const char* strXmlContent)
             TiXmlElement* xmlDocumentRoot = xmlDoc->RootElement();
             CXMLNodeImpl* xmlBaseNode = new CXMLNodeImpl(nullptr, nullptr, *xmlDocumentRoot);
             xmlBaseNode->BuildFromDocument();
-            return xmlBaseNode;
+            return std::unique_ptr<SXMLString>(new SXMLStringImpl(xmlDoc, xmlBaseNode));
         }
     }
     return nullptr;

--- a/Shared/XML/CXMLImpl.cpp
+++ b/Shared/XML/CXMLImpl.cpp
@@ -51,14 +51,14 @@ CXMLNode* CXMLImpl::ParseString(const char* strXmlContent)
         {
             TiXmlElement* xmlDocumentRoot = xmlDoc->RootElement();
             CXMLNodeImpl* xmlBaseNode = new CXMLNodeImpl(nullptr, nullptr, *xmlDocumentRoot);
-            CXMLNode*     xmlRootNode = CXMLImpl::BuildNode(xmlBaseNode, xmlDocumentRoot);
-            return xmlRootNode;
+            CXMLImpl::BuildNode(xmlBaseNode, xmlDocumentRoot);
+            return xmlBaseNode;
         }
     }
     return nullptr;
 }
 
-CXMLNode* CXMLImpl::BuildNode(CXMLNodeImpl* xmlParent, TiXmlNode* xmlNode)
+void CXMLImpl::BuildNode(CXMLNodeImpl* xmlParent, TiXmlNode* xmlNode)
 {
     TiXmlNode*    xmlChild = nullptr;
     TiXmlElement* xmlChildElement;
@@ -72,7 +72,6 @@ CXMLNode* CXMLImpl::BuildNode(CXMLNodeImpl* xmlParent, TiXmlNode* xmlNode)
             CXMLImpl::BuildNode(xmlChildNode, xmlChildElement);
         }
     }
-    return xmlParent;
 }
 
 CXMLNode* CXMLImpl::CreateDummyNode()

--- a/Shared/XML/CXMLImpl.cpp
+++ b/Shared/XML/CXMLImpl.cpp
@@ -51,28 +51,13 @@ CXMLNode* CXMLImpl::ParseString(const char* strXmlContent)
         {
             TiXmlElement* xmlDocumentRoot = xmlDoc->RootElement();
             CXMLNodeImpl* xmlBaseNode = new CXMLNodeImpl(nullptr, nullptr, *xmlDocumentRoot);
-            CXMLImpl::BuildNode(xmlBaseNode, xmlDocumentRoot);
+            xmlBaseNode->BuildFromDocument();
             return xmlBaseNode;
         }
     }
     return nullptr;
 }
 
-void CXMLImpl::BuildNode(CXMLNodeImpl* xmlParent, TiXmlNode* xmlNode)
-{
-    TiXmlNode*    xmlChild = nullptr;
-    TiXmlElement* xmlChildElement;
-    CXMLNodeImpl* xmlChildNode;
-    while (xmlChild = xmlNode->IterateChildren(xmlChild))
-    {
-        xmlChildElement = xmlChild->ToElement();
-        if (xmlChildElement)
-        {
-            xmlChildNode = new CXMLNodeImpl(nullptr, xmlParent, *xmlChildElement);
-            CXMLImpl::BuildNode(xmlChildNode, xmlChildElement);
-        }
-    }
-}
 
 CXMLNode* CXMLImpl::CreateDummyNode()
 {

--- a/Shared/XML/CXMLImpl.h
+++ b/Shared/XML/CXMLImpl.h
@@ -21,7 +21,6 @@ public:
 
     CXMLFile* CreateXML(const char* szFilename, bool bUseIDs, bool bReadOnly);
     CXMLNode* ParseString(const char* strXmlContent);
-    void      BuildNode(CXMLNodeImpl* xmlParent, TiXmlNode* xmlNode);
     void      DeleteXML(CXMLFile* pFile);
 
     CXMLNode* CreateDummyNode();

--- a/Shared/XML/CXMLImpl.h
+++ b/Shared/XML/CXMLImpl.h
@@ -20,6 +20,7 @@ typedef struct SXMLStringImpl : SXMLString
     SXMLStringImpl(TiXmlDocument* d, CXMLNode* n) : doc(d) { node = n; };
     ~SXMLStringImpl()
     {
+        delete node;
         delete doc;
         std::cout << "delete doc;\n";
     };

--- a/Shared/XML/CXMLImpl.h
+++ b/Shared/XML/CXMLImpl.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include <xml/CXML.h>
-#include <iostream>
 
 typedef struct SXMLStringImpl : SXMLString
 {
@@ -22,7 +21,6 @@ typedef struct SXMLStringImpl : SXMLString
     {
         delete node;
         delete doc;
-        std::cout << "delete doc;\n";
     };
 } SXMLStringImpl;
 

--- a/Shared/XML/CXMLImpl.h
+++ b/Shared/XML/CXMLImpl.h
@@ -13,15 +13,22 @@
 
 #include <xml/CXML.h>
 
+typedef struct SXMLStringImpl : SXMLString
+{
+    TiXmlDocument* doc;
+    SXMLStringImpl(TiXmlDocument* d, CXMLNode* n) : doc(d) { node = n; };
+    ~SXMLStringImpl() { delete doc; };
+} SXMLStringImpl;
+
 class CXMLImpl : public CXML
 {
 public:
     CXMLImpl();
     virtual ~CXMLImpl();
 
-    CXMLFile* CreateXML(const char* szFilename, bool bUseIDs, bool bReadOnly);
-    CXMLNode* ParseString(const char* strXmlContent);
-    void      DeleteXML(CXMLFile* pFile);
+    CXMLFile*                   CreateXML(const char* szFilename, bool bUseIDs, bool bReadOnly);
+    std::unique_ptr<SXMLString> ParseString(const char* strXmlContent);
+    void                        DeleteXML(CXMLFile* pFile);
 
     CXMLNode* CreateDummyNode();
 

--- a/Shared/XML/CXMLImpl.h
+++ b/Shared/XML/CXMLImpl.h
@@ -21,7 +21,7 @@ public:
 
     CXMLFile* CreateXML(const char* szFilename, bool bUseIDs, bool bReadOnly);
     CXMLNode* ParseString(const char* strXmlContent);
-    CXMLNode* BuildNode(CXMLNodeImpl* xmlParent, TiXmlNode* xmlNode);
+    void      BuildNode(CXMLNodeImpl* xmlParent, TiXmlNode* xmlNode);
     void      DeleteXML(CXMLFile* pFile);
 
     CXMLNode* CreateDummyNode();

--- a/Shared/XML/CXMLImpl.h
+++ b/Shared/XML/CXMLImpl.h
@@ -12,12 +12,17 @@
 #pragma once
 
 #include <xml/CXML.h>
+#include <iostream>
 
 typedef struct SXMLStringImpl : SXMLString
 {
     TiXmlDocument* doc;
     SXMLStringImpl(TiXmlDocument* d, CXMLNode* n) : doc(d) { node = n; };
-    ~SXMLStringImpl() { delete doc; };
+    ~SXMLStringImpl()
+    {
+        delete doc;
+        std::cout << "delete doc;\n";
+    };
 } SXMLStringImpl;
 
 class CXMLImpl : public CXML

--- a/Shared/XML/CXMLNodeImpl.cpp
+++ b/Shared/XML/CXMLNodeImpl.cpp
@@ -74,6 +74,20 @@ CXMLNodeImpl::~CXMLNodeImpl()
     }
 }
 
+void CXMLNodeImpl::BuildFromDocument()
+{
+    TiXmlNode*    xmlChild = nullptr;
+    while (xmlChild = m_pNode->IterateChildren(xmlChild))
+    {
+        auto xmlChildElement = xmlChild->ToElement();
+        if (xmlChildElement)
+        {
+            auto xmlChildNode = new CXMLNodeImpl(nullptr, this, *xmlChildElement);
+            xmlChildNode->BuildFromDocument();
+        }
+    }
+}
+
 CXMLNode* CXMLNodeImpl::CreateSubNode(const char* szTagName, CXMLNode* pInsertAfter)
 {
     TiXmlElement* pNewNode;

--- a/Shared/XML/CXMLNodeImpl.h
+++ b/Shared/XML/CXMLNodeImpl.h
@@ -24,6 +24,12 @@ public:
     CXMLNodeImpl(class CXMLFileImpl* pFile, CXMLNodeImpl* pParent, TiXmlElement& Node);
     ~CXMLNodeImpl();
 
+    // BuildFromDocument recursively builds child CXMLNodeImpl from the underlying TiXmlElement.
+    //
+    // This is **only** used for xmlLoadString right now.
+    // Look elsewhere if you're thinking about XML files. It does things a different way.
+    void BuildFromDocument();
+
     CXMLNode* CreateSubNode(const char* szTagName, CXMLNode* pInsertBefore = nullptr);
     void      DeleteSubNode(CXMLNode* pNode) { delete pNode; };
     void      DeleteAllSubNodes();

--- a/Shared/sdk/xml/CXML.h
+++ b/Shared/sdk/xml/CXML.h
@@ -10,7 +10,6 @@
  *****************************************************************************/
 
 #pragma once
-#include <iostream>
 
 class CXMLNode;
 class CXMLFile;
@@ -18,11 +17,7 @@ class CXMLAttribute;
 typedef struct SXMLString
 {
     CXMLNode* node;
-    ~SXMLString()
-    {
-        delete node;
-        std::cout << "delete node;\n";
-    }
+    virtual ~SXMLString(){};
 } SXMLString;
 
 class CXML

--- a/Shared/sdk/xml/CXML.h
+++ b/Shared/sdk/xml/CXML.h
@@ -15,13 +15,19 @@ class CXMLNode;
 class CXMLFile;
 class CXMLAttribute;
 
+typedef struct SXMLString
+{
+    CXMLNode* node;
+    ~SXMLString() { delete node; }
+} SXMLString;
+
 class CXML
 {
 public:
-    virtual CXMLFile* CreateXML(const char* szFilename, bool bUseIDs = false, bool bReadOnly = false) = 0;
-    virtual CXMLNode* ParseString(const char* strXmlContent) = 0;
-    virtual void      DeleteXML(CXMLFile* pFile) = 0;
-    virtual CXMLNode* CreateDummyNode() = 0;
+    virtual CXMLFile*                   CreateXML(const char* szFilename, bool bUseIDs = false, bool bReadOnly = false) = 0;
+    virtual std::unique_ptr<SXMLString> ParseString(const char* strXmlContent) = 0;
+    virtual void                        DeleteXML(CXMLFile* pFile) = 0;
+    virtual CXMLNode*                   CreateDummyNode() = 0;
 
     virtual CXMLAttribute* GetAttrFromID(unsigned long ulID) = 0;
     virtual CXMLFile*      GetFileFromID(unsigned long ulID) = 0;

--- a/Shared/sdk/xml/CXML.h
+++ b/Shared/sdk/xml/CXML.h
@@ -10,15 +10,19 @@
  *****************************************************************************/
 
 #pragma once
+#include <iostream>
 
 class CXMLNode;
 class CXMLFile;
 class CXMLAttribute;
-
 typedef struct SXMLString
 {
     CXMLNode* node;
-    ~SXMLString() { delete node; }
+    ~SXMLString()
+    {
+        delete node;
+        std::cout << "delete node;\n";
+    }
 } SXMLString;
 
 class CXML


### PR DESCRIPTION
I recommend that the reviewer reads commit by commit.

~~Assistance needed - see fffadce "test destructors" - please can someone explain why it only says `delete node;` and not `delete doc;` too?~~

~~When a resource is stopped, `CLuaMain` is deleted, and that automatically deletes this unordered set:~~

```cpp
std::unordered_set<std::unique_ptr<SXMLString>> m_XMLStringNodes;
```

~~And we have destructors defined `SXMLString` and `SXMLStringImpl`.~~

Only tested serverside on windows.