### PR TITLE
Fix broken dxGetTextWidth caused by 625e86b23eaf

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -33,7 +33,7 @@ void CLuaDrawingDefs::LoadFunctions()
         {"dxDrawMaterialPrimitive", DxDrawMaterialPrimitive},
         {"dxDrawMaterialPrimitive3D", DxDrawMaterialPrimitive3D},
         {"dxDrawWiredSphere", ArgumentParser<DxDrawWiredSphere>},
-        {"dxGetTextWidth", ArgumentParser<DxGetTextWidth>},
+        {"dxGetTextWidth", DxGetTextWidth},
         {"dxGetTextSize", ArgumentParser<DxGetTextSize>},
         {"dxGetFontHeight", DxGetFontHeight},
         {"dxCreateFont", DxCreateFont},


### PR DESCRIPTION
#1481 accidentally adds an ArgumentParser to DxGetTextWidth, which was not updated to the new parser style. This causes `dxGetTextWidth("123455", 1, "Arial")` to always return `1`.

See discussion at https://github.com/multitheftauto/mtasa-blue/commit/625e86b23eafe25b3131b76263ae9465b80d5a8b#r40987158 and https://discordapp.com/channels/278474088903606273/366384007535001612/738140804123459655

