### PR TITLE
Revert "Add engineSet/GetModelTime (#752)"

### DIFF
--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -836,11 +836,6 @@ void CGameSA::ResetModelLodDistances()
     CModelInfoSA::StaticResetLodDistances();
 }
 
-void CGameSA::ResetModelTimes()
-{
-    CModelInfoSA::StaticResetModelTimes();
-}
-
 void CGameSA::ResetAlphaTransparencies()
 {
     CModelInfoSA::StaticResetAlphaTransparencies();

--- a/Client/game_sa/CGameSA.h
+++ b/Client/game_sa/CGameSA.h
@@ -417,7 +417,6 @@ public:
     void         ResetModelLodDistances();
     void         ResetAlphaTransparencies();
     void         DisableVSync();
-    void         ResetModelTimes();
 
     void  OnPedContextChange(CPed* pPedContext);
     CPed* GetPedContext();

--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -20,7 +20,6 @@ std::map<unsigned short, int>                                         CModelInfo
 std::map<DWORD, float>                                                CModelInfoSA::ms_ModelDefaultLodDistanceMap;
 std::map<DWORD, BYTE>                                                 CModelInfoSA::ms_ModelDefaultAlphaTransparencyMap;
 std::unordered_map<std::uint32_t, std::map<eVehicleDummies, CVector>> CModelInfoSA::ms_ModelDefaultDummiesPosition;
-std::map<TimeInfo*, TimeInfo*>                                        CModelInfoSA::ms_ModelDefaultModelTimeInfo;
 std::unordered_map<DWORD, unsigned short>                             CModelInfoSA::ms_OriginalObjectPropertiesGroups;
 
 CModelInfoSA::CModelInfoSA()
@@ -561,51 +560,6 @@ float CModelInfoSA::GetLODDistance()
         return m_pInterface->fLodDistanceUnscaled;
 
     return 0.0f;
-}
-
-bool CModelInfoSA::SetTime(char cHourOn, char cHourOff)
-{
-    m_pInterface = ppModelInfo[m_dwModelID];
-    if (!m_pInterface)
-        return false;
-
-    TimeInfo* pTime = ((TimeInfo*(*)(void))m_pInterface->VFTBL->GetTimeInfo)();
-    if (!pTime)
-        return false;
-
-    if (!MapContains(ms_ModelDefaultModelTimeInfo, pTime))
-        MapSet(ms_ModelDefaultModelTimeInfo, pTime, new TimeInfo(pTime->m_nTimeOn, pTime->m_nTimeOff, pTime->m_wOtherTimeModel));
-
-    pTime->m_nTimeOn = cHourOn;
-    pTime->m_nTimeOff = cHourOff;
-    return true;
-}
-
-bool CModelInfoSA::GetTime(char& cHourOn, char& cHourOff)
-{
-    m_pInterface = ppModelInfo[m_dwModelID];
-    if (!m_pInterface)
-        return false;
-
-    TimeInfo* time = ((TimeInfo*(*)(void))m_pInterface->VFTBL->GetTimeInfo)();
-    if (!time)
-        return false;
-
-    cHourOn = time->m_nTimeOn;
-    cHourOff = time->m_nTimeOff;
-    return true;
-}
-
-void CModelInfoSA::StaticResetModelTimes()
-{
-    // Restore default values
-    for (std::map<TimeInfo*, TimeInfo*>::const_iterator iter = ms_ModelDefaultModelTimeInfo.begin(); iter != ms_ModelDefaultModelTimeInfo.end(); ++iter)
-    {
-        iter->first->m_nTimeOn = iter->second->m_nTimeOn;
-        iter->first->m_nTimeOff = iter->second->m_nTimeOff;
-    }
-
-    ms_ModelDefaultModelTimeInfo.clear();
 }
 
 float CModelInfoSA::GetOriginalLODDistance()

--- a/Client/game_sa/CModelInfoSA.h
+++ b/Client/game_sa/CModelInfoSA.h
@@ -268,7 +268,6 @@ protected:
     static std::map<DWORD, float>                                                ms_ModelDefaultLodDistanceMap;
     static std::map<DWORD, BYTE>                                                 ms_ModelDefaultAlphaTransparencyMap;
     static std::unordered_map<std::uint32_t, std::map<eVehicleDummies, CVector>> ms_ModelDefaultDummiesPosition;
-    static std::map<TimeInfo*, TimeInfo*>                                        ms_ModelDefaultModelTimeInfo;
     static std::unordered_map<DWORD, unsigned short>                             ms_OriginalObjectPropertiesGroups;
     bool                                                                         m_bAddedRefForCollision;
     SVehicleSupportedUpgrades                                                    m_ModelSupportedUpgrades;
@@ -320,9 +319,6 @@ public:
     void           RestreamIPL();
     static void    StaticFlushPendingRestreamIPL();
     static void    StaticSetHooks();
-    bool           GetTime(char& cHourOn, char& cHourOff);
-    bool           SetTime(char cHourOn, char cHourOff);
-    static void    StaticResetModelTimes();
 
     void        SetAlphaTransparencyEnabled(BOOL bEnabled);
     bool        IsAlphaTransparencyEnabled();

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -3560,7 +3560,6 @@ void CClientGame::Event_OnIngame()
 
     g_pGame->ResetModelLodDistances();
     g_pGame->ResetAlphaTransparencies();
-    g_pGame->ResetModelTimes();
 
     // Make sure we can access all areas
     g_pGame->GetStats()->ModifyStat(CITIES_PASSED, 2.0);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -37,8 +37,6 @@ void CLuaEngineDefs::LoadFunctions()
         {"engineGetModelIDFromName", EngineGetModelIDFromName},
         {"engineGetModelTextureNames", EngineGetModelTextureNames},
         {"engineGetVisibleTextureNames", EngineGetVisibleTextureNames},
-        {"engineSetModelVisibleTime", EngineSetModelVisibleTime},
-        {"engineGetModelVisibleTime", EngineGetModelVisibleTime},
         {"engineGetModelTextures", EngineGetModelTextures},
         {"engineGetSurfaceProperties", EngineGetSurfaceProperties},
         {"engineSetSurfaceProperties", EngineSetSurfaceProperties},
@@ -72,7 +70,6 @@ void CLuaEngineDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setAsynchronousLoading", "engineSetAsynchronousLoading");
     lua_classfunction(luaVM, "setModelLODDistance", "engineSetModelLODDistance");
     lua_classfunction(luaVM, "resetModelLODDistance", "engineResetModelLODDistance");
-    lua_classfunction(luaVM, "setModelVisibleTime", "engineSetModelVisibleTime");
 
     lua_classfunction(luaVM, "getVisibleTextureNames", "engineGetVisibleTextureNames");
     lua_classfunction(luaVM, "getModelLODDistance", "engineGetModelLODDistance");
@@ -80,7 +77,6 @@ void CLuaEngineDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getModelTextures", "engineGetModelTextures");
     lua_classfunction(luaVM, "getModelIDFromName", "engineGetModelIDFromName");
     lua_classfunction(luaVM, "getModelNameFromID", "engineGetModelNameFromID");
-    lua_classfunction(luaVM, "getModelVisibleTime", "engineGetModelVisibleTime");
     lua_classfunction(luaVM, "getModelPhysicalPropertiesGroup", "engineGetModelPhysicalPropertiesGroup");
     lua_classfunction(luaVM, "setModelPhysicalPropertiesGroup", "engineSetModelPhysicalPropertiesGroup");
     lua_classfunction(luaVM, "restoreModelPhysicalPropertiesGroup", "engineRestoreModelPhysicalPropertiesGroup");
@@ -775,7 +771,7 @@ int CLuaEngineDefs::EngineResetModelLODDistance(lua_State* luaVM)
 
     if (argStream.HasErrors())
         return luaL_error(luaVM, argStream.GetFullErrorMessage());
-    
+
     unsigned short usModelID = CModelNames::ResolveModelID(strModel);
     CModelInfo*    pModelInfo = g_pGame->GetModelInfo(usModelID);
     if (pModelInfo)
@@ -1095,74 +1091,6 @@ int CLuaEngineDefs::EngineGetVisibleTextureNames(lua_State* luaVM)
         m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
 
     // We failed
-    lua_pushboolean(luaVM, false);
-    return 1;
-}
-
-int CLuaEngineDefs::EngineSetModelVisibleTime(lua_State* luaVM)
-{
-    // bool engineSetModelVisibleTime ( int/string modelID, int hourOn, int hourOff )
-    SString strModelId;
-    char cHourOn,cHourOff;
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadString(strModelId);
-    argStream.ReadNumber(cHourOn);
-    argStream.ReadNumber(cHourOff);
-
-    if (!argStream.HasErrors())
-    {
-        ushort      usModelID = CModelNames::ResolveModelID(strModelId);
-        CModelInfo* pModelInfo = g_pGame->GetModelInfo(usModelID);
-        if (pModelInfo)
-        {
-            if (cHourOn >= 0 && cHourOn <= 24 && cHourOff >= 0 && cHourOff <= 24)
-            {
-                lua_pushboolean(luaVM, pModelInfo->SetTime(cHourOn, cHourOff));
-                return 1;
-            }
-        }
-    }
-    else
-        luaL_error(luaVM, argStream.GetFullErrorMessage());
-
-    // Failed
-    lua_pushboolean(luaVM, false);
-    return 1;
-}
-
-int CLuaEngineDefs::EngineGetModelVisibleTime(lua_State* luaVM)
-{
-    // int, int engineGetModelVisibleTime ( int/string modelID )
-    SString strModelId;
-
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadString(strModelId);
-
-    if (!argStream.HasErrors())
-    {
-        ushort      usModelID = CModelNames::ResolveModelID(strModelId);
-        CModelInfo* pModelInfo = g_pGame->GetModelInfo(usModelID);
-        if (pModelInfo)
-        {
-            char cHourOn, cHourOff;
-            if (pModelInfo->GetTime(cHourOn, cHourOff))
-            {
-                lua_pushnumber(luaVM, cHourOn);
-                lua_pushnumber(luaVM, cHourOff);
-                return 2;
-            }
-            else // Model is incompatible, don't let confuse user.
-            {
-                lua_pushnumber(luaVM, 0);
-                lua_pushnumber(luaVM, 24);
-                return 2;
-            }
-        }
-    }
-    else
-        luaL_error(luaVM, argStream.GetFullErrorMessage());
-
-    // Failed
     lua_pushboolean(luaVM, false);
     return 1;
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
@@ -47,8 +47,6 @@ public:
     LUA_DECLARE(EngineGetModelIDFromName);
     LUA_DECLARE(EngineGetModelTextureNames);
     LUA_DECLARE(EngineGetVisibleTextureNames);
-    LUA_DECLARE(EngineSetModelVisibleTime);
-    LUA_DECLARE(EngineGetModelVisibleTime);
     LUA_DECLARE(EngineGetModelTextures);
     LUA_DECLARE(EngineSetSurfaceProperties);
     LUA_DECLARE(EngineGetSurfaceProperties);

--- a/Client/sdk/game/CGame.h
+++ b/Client/sdk/game/CGame.h
@@ -239,7 +239,6 @@ public:
     virtual void ResetModelLodDistances() = 0;
     virtual void ResetAlphaTransparencies() = 0;
     virtual void DisableVSync() = 0;
-    virtual void ResetModelTimes() = 0;
 
     virtual void  OnPedContextChange(CPed* pPedContext) = 0;
     virtual CPed* GetPedContext() = 0;

--- a/Client/sdk/game/CModelInfo.h
+++ b/Client/sdk/game/CModelInfo.h
@@ -129,8 +129,6 @@ public:
     virtual float          GetOriginalLODDistance() = 0;
     virtual void           SetLODDistance(float fDistance, bool bOverrideMaxDistance = false) = 0;
     virtual void           RestreamIPL() = 0;
-    virtual bool           GetTime(char& hourOn, char& hourOff) = 0;
-    virtual bool           SetTime(char hourOn, char hourOff) = 0;
 
     virtual void ModelAddRef(EModelRequestType requestType, const char* szTag /* = NULL*/) = 0;
     virtual void RemoveRef(bool bRemoveExtraGTARef = false) = 0;

--- a/Client/sdk/game/RenderWare.h
+++ b/Client/sdk/game/RenderWare.h
@@ -424,10 +424,3 @@ struct RwError
 {
     int err1, err2;
 };
-
-struct TimeInfo {
-    TimeInfo(char timeOn, char timeOff, short OtherTimeModel) : m_nTimeOn(timeOn), m_nTimeOff(timeOff), m_wOtherTimeModel(OtherTimeModel) {};
-    char m_nTimeOn;
-    char m_nTimeOff;
-    short m_wOtherTimeModel;
-};


### PR DESCRIPTION
**Summary**

Revert #752 which introduces `engineSetModelTime` and `engineGetModelTime`. This feature does not work in Release builds, only Debug builds!

**Motivation**

This pull request fixes #1543. I believe it's broken because of this particular line: 

https://github.com/multitheftauto/mtasa-blue/blob/429c0b783c537253125d37ac45fc06bc446ab2f7/Client/game_sa/CModelInfoSA.cpp#L572-L574

Which accesses this field, which does not seem to be suitable for consumption:

https://github.com/multitheftauto/mtasa-blue/blob/c5ebd7f30bc3f19f46b8ea202288780e845b58f6/Client/game_sa/CModelInfoSA.h#L129-L132

And line 79 here:

https://github.com/multitheftauto/mtasa-blue/blob/c5ebd7f30bc3f19f46b8ea202288780e845b58f6/Client/game_sa/CModelInfoSA.h#L71-L89

To bring back this feature, someone needs to make `CBaseModelInfoSAInterface ` and the surrounding code in `game_sa` suitable for consumption.