### PR TITLE
Fix #1594: getPedMoveState returns incorrect move state

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -193,6 +193,8 @@ void CClientPed::Init(CClientManager* pManager, unsigned long ulModelID, bool bI
     m_MovementStateNames[MOVEMENTSTATE_STAND] = "stand";
     m_MovementStateNames[MOVEMENTSTATE_WALK] = "walk";
     m_MovementStateNames[MOVEMENTSTATE_POWERWALK] = "powerwalk";
+    m_MovementStateNames[MOVEMENTSTATE_ENTERINGVEHICLE] = "enteringvehicle";
+    m_MovementStateNames[MOVEMENTSTATE_LEAVINGVEHICLE] = "leavingvehicle";
     m_MovementStateNames[MOVEMENTSTATE_JOG] = "jog";
     m_MovementStateNames[MOVEMENTSTATE_SPRINT] = "sprint";
     m_MovementStateNames[MOVEMENTSTATE_CROUCH] = "crouch";
@@ -2378,7 +2380,7 @@ eMovementState CClientPed::GetMovementState()
             return MOVEMENTSTATE_JUMP;
         // Is he entering a vehicle?
         else if (IsEnteringVehicle())
-            return false;
+            return MOVEMENTSTATE_ENTERINGVEHICLE;
         // Is he falling?
         else if (!IsOnGround() && !GetContactEntity())
             return MOVEMENTSTATE_FALL;
@@ -2424,7 +2426,7 @@ eMovementState CClientPed::GetMovementState()
     {
         // Is he leaving a vehicle?
         if (IsLeavingVehicle())
-            return false;
+            return MOVEMENTSTATE_LEAVINGVEHICLE;
     }
     return MOVEMENTSTATE_UNKNOWN;
 }

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -193,7 +193,7 @@ void CClientPed::Init(CClientManager* pManager, unsigned long ulModelID, bool bI
     m_MovementStateNames[MOVEMENTSTATE_STAND] = "stand";
     m_MovementStateNames[MOVEMENTSTATE_WALK] = "walk";
     m_MovementStateNames[MOVEMENTSTATE_POWERWALK] = "powerwalk";
-	m_MovementStateNames[MOVEMENTSTATE_ENTERINGVEHICLE] = "enteringvehicle";
+    m_MovementStateNames[MOVEMENTSTATE_ENTERINGVEHICLE] = "enteringvehicle";
     m_MovementStateNames[MOVEMENTSTATE_LEAVINGVEHICLE] = "leavingvehicle";
     m_MovementStateNames[MOVEMENTSTATE_JOG] = "jog";
     m_MovementStateNames[MOVEMENTSTATE_SPRINT] = "sprint";
@@ -2380,7 +2380,7 @@ eMovementState CClientPed::GetMovementState()
             return MOVEMENTSTATE_JUMP;
         // Is he entering a vehicle?
         else if (IsEnteringVehicle())
-			return MOVEMENTSTATE_ENTERINGVEHICLE;
+            return MOVEMENTSTATE_ENTERINGVEHICLE;
         // Is he falling?
         else if (!IsOnGround() && !GetContactEntity())
             return MOVEMENTSTATE_FALL;
@@ -2426,7 +2426,7 @@ eMovementState CClientPed::GetMovementState()
     {
         // Is he leaving a vehicle?
         if (IsLeavingVehicle())
-        return MOVEMENTSTATE_LEAVINGVEHICLE;
+            return MOVEMENTSTATE_LEAVINGVEHICLE;
     }
     return MOVEMENTSTATE_UNKNOWN;
 }

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -193,8 +193,6 @@ void CClientPed::Init(CClientManager* pManager, unsigned long ulModelID, bool bI
     m_MovementStateNames[MOVEMENTSTATE_STAND] = "stand";
     m_MovementStateNames[MOVEMENTSTATE_WALK] = "walk";
     m_MovementStateNames[MOVEMENTSTATE_POWERWALK] = "powerwalk";
-    m_MovementStateNames[MOVEMENTSTATE_ENTERINGVEHICLE] = "enteringvehicle";
-    m_MovementStateNames[MOVEMENTSTATE_LEAVINGVEHICLE] = "leavingvehicle";
     m_MovementStateNames[MOVEMENTSTATE_JOG] = "jog";
     m_MovementStateNames[MOVEMENTSTATE_SPRINT] = "sprint";
     m_MovementStateNames[MOVEMENTSTATE_CROUCH] = "crouch";
@@ -2380,7 +2378,7 @@ eMovementState CClientPed::GetMovementState()
             return MOVEMENTSTATE_JUMP;
         // Is he entering a vehicle?
         else if (IsEnteringVehicle())
-            return MOVEMENTSTATE_ENTERINGVEHICLE;
+            return false;
         // Is he falling?
         else if (!IsOnGround() && !GetContactEntity())
             return MOVEMENTSTATE_FALL;
@@ -2426,7 +2424,7 @@ eMovementState CClientPed::GetMovementState()
     {
         // Is he leaving a vehicle?
         if (IsLeavingVehicle())
-            return MOVEMENTSTATE_LEAVINGVEHICLE;
+            return false;
     }
     return MOVEMENTSTATE_UNKNOWN;
 }

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -193,6 +193,8 @@ void CClientPed::Init(CClientManager* pManager, unsigned long ulModelID, bool bI
     m_MovementStateNames[MOVEMENTSTATE_STAND] = "stand";
     m_MovementStateNames[MOVEMENTSTATE_WALK] = "walk";
     m_MovementStateNames[MOVEMENTSTATE_POWERWALK] = "powerwalk";
+	m_MovementStateNames[MOVEMENTSTATE_ENTERINGVEHICLE] = "enteringvehicle";
+    m_MovementStateNames[MOVEMENTSTATE_LEAVINGVEHICLE] = "leavingvehicle";
     m_MovementStateNames[MOVEMENTSTATE_JOG] = "jog";
     m_MovementStateNames[MOVEMENTSTATE_SPRINT] = "sprint";
     m_MovementStateNames[MOVEMENTSTATE_CROUCH] = "crouch";
@@ -2376,7 +2378,9 @@ eMovementState CClientPed::GetMovementState()
         // Is he jumping?
         else if (strcmp(szComplexTaskName, "TASK_COMPLEX_JUMP") == 0)
             return MOVEMENTSTATE_JUMP;
-
+        // Is he entering a vehicle?
+        else if (IsEnteringVehicle())
+			return MOVEMENTSTATE_ENTERINGVEHICLE;
         // Is he falling?
         else if (!IsOnGround() && !GetContactEntity())
             return MOVEMENTSTATE_FALL;
@@ -2415,6 +2419,14 @@ eMovementState CClientPed::GetMovementState()
             else
                 return MOVEMENTSTATE_CRAWL;
         }
+    }
+
+    // Do we have a player, and are we in a car?
+    if (m_pPlayerPed && GetRealOccupiedVehicle())
+    {
+        // Is he leaving a vehicle?
+        if (IsLeavingVehicle())
+        return MOVEMENTSTATE_LEAVINGVEHICLE;
     }
     return MOVEMENTSTATE_UNKNOWN;
 }

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -71,8 +71,6 @@ enum eMovementState
     MOVEMENTSTATE_JUMP,                       // Jumping
     MOVEMENTSTATE_FALL,                       // Falling
     MOVEMENTSTATE_CLIMB,                      // Climbing
-    MOVEMENTSTATE_ENTERINGVEHICLE,            // Entering vehicle
-    MOVEMENTSTATE_LEAVINGVEHICLE,             // Leaving vehicle
 };
 
 enum eDeathAnims

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -71,6 +71,8 @@ enum eMovementState
     MOVEMENTSTATE_JUMP,                       // Jumping
     MOVEMENTSTATE_FALL,                       // Falling
     MOVEMENTSTATE_CLIMB,                      // Climbing
+    MOVEMENTSTATE_ENTERINGVEHICLE,            // Entering vehicle
+    MOVEMENTSTATE_LEAVINGVEHICLE,             // Leaving vehicle
 };
 
 enum eDeathAnims

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -60,19 +60,19 @@ enum eBodyPart
 enum eMovementState
 {
     MOVEMENTSTATE_UNKNOWN,
-    MOVEMENTSTATE_STAND,                // Standing still
-    MOVEMENTSTATE_WALK,                 // Walking
-    MOVEMENTSTATE_POWERWALK,            // Walking quickly
-    MOVEMENTSTATE_JOG,                  // Jogging
-    MOVEMENTSTATE_SPRINT,               // Sprinting
-    MOVEMENTSTATE_CROUCH,               // Crouching still
-    MOVEMENTSTATE_CRAWL,                // Crouch-moving
-    MOVEMENTSTATE_ROLL,                 // Crouch-rolling (Needs adding)
-    MOVEMENTSTATE_JUMP,                 // Jumping
-    MOVEMENTSTATE_FALL,                 // Falling
-    MOVEMENTSTATE_CLIMB,                // Climbing
-	MOVEMENTSTATE_ENTERINGVEHICLE,      // Entering vehicle
-    MOVEMENTSTATE_LEAVINGVEHICLE,       // Leaving vehicle
+    MOVEMENTSTATE_STAND,                      // Standing still
+    MOVEMENTSTATE_WALK,                       // Walking
+    MOVEMENTSTATE_POWERWALK,                  // Walking quickly
+    MOVEMENTSTATE_JOG,                        // Jogging
+    MOVEMENTSTATE_SPRINT,                     // Sprinting
+    MOVEMENTSTATE_CROUCH,                     // Crouching still
+    MOVEMENTSTATE_CRAWL,                      // Crouch-moving
+    MOVEMENTSTATE_ROLL,                       // Crouch-rolling (Needs adding)
+    MOVEMENTSTATE_JUMP,                       // Jumping
+    MOVEMENTSTATE_FALL,                       // Falling
+    MOVEMENTSTATE_CLIMB,                      // Climbing
+    MOVEMENTSTATE_ENTERINGVEHICLE,            // Entering vehicle
+    MOVEMENTSTATE_LEAVINGVEHICLE,             // Leaving vehicle
 };
 
 enum eDeathAnims

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -70,7 +70,9 @@ enum eMovementState
     MOVEMENTSTATE_ROLL,                 // Crouch-rolling (Needs adding)
     MOVEMENTSTATE_JUMP,                 // Jumping
     MOVEMENTSTATE_FALL,                 // Falling
-    MOVEMENTSTATE_CLIMB                 // Climbing
+    MOVEMENTSTATE_CLIMB,                // Climbing
+	MOVEMENTSTATE_ENTERINGVEHICLE,      // Entering vehicle
+    MOVEMENTSTATE_LEAVINGVEHICLE,       // Leaving vehicle
 };
 
 enum eDeathAnims

--- a/Server/mods/deathmatch/logic/CConsoleCommands.cpp
+++ b/Server/mods/deathmatch/logic/CConsoleCommands.cpp
@@ -1232,34 +1232,42 @@ bool CConsoleCommands::DebugScript(CConsole* pConsole, const char* szArguments, 
         {
             CPlayer* pPlayer = static_cast<CPlayer*>(pClient);
 
-            // Convert to number
-            int iLevel = atoi(szArguments);
-            if (iLevel != (int)pPlayer->GetScriptDebugLevel())
+            // To prevent characters before we convert
+            if (strcmp(szArguments, "0") == 0 || strcmp(szArguments, "1") == 0 || strcmp(szArguments, "2") == 0 || strcmp(szArguments, "3") == 0)
             {
-                // Between 0 and 3?
-                if (iLevel >= 0 && iLevel <= 3)
+                // Convert to number
+                int iLevel = atoi(szArguments);
+                if (iLevel != (int)pPlayer->GetScriptDebugLevel())
                 {
-                    // Set the new level
-                    pPlayer->SetScriptDebugLevel(iLevel);
+                    // Between 0 and 3?
+                    if (iLevel >= 0 && iLevel <= 3)
+                    {
+                        // Set the new level
+                        pPlayer->SetScriptDebugLevel(iLevel);
 
-                    // Tell the player and the console
-                    pEchoClient->SendEcho(SString("debugscript: Your debug mode was set to %i", iLevel));
-                    CLogger::LogPrintf("SCRIPT: %s set their script debug mode to %i\n", GetAdminNameForLog(pClient).c_str(), iLevel);
+                        // Tell the player and the console
+                        pEchoClient->SendEcho(SString("debugscript: Your debug mode was set to %i", iLevel));
+                        CLogger::LogPrintf("SCRIPT: %s set their script debug mode to %i\n", GetAdminNameForLog(pClient).c_str(), iLevel);
 
-                    // Enable/Disable their debugger
-                    if (iLevel == 0)
-                        CStaticFunctionDefinitions::SetPlayerDebuggerVisible(pPlayer, false);
+                        // Enable/Disable their debugger
+                        if (iLevel == 0)
+                            CStaticFunctionDefinitions::SetPlayerDebuggerVisible(pPlayer, false);
+                        else
+                            CStaticFunctionDefinitions::SetPlayerDebuggerVisible(pPlayer, true);
+                    }
                     else
-                        CStaticFunctionDefinitions::SetPlayerDebuggerVisible(pPlayer, true);
+                    {
+                        pEchoClient->SendEcho("debugscript: Modes available are 0 (None), 1 (Errors), 2 (Errors + Warnings), 3 (All)");
+                    }
                 }
                 else
                 {
-                    pEchoClient->SendEcho("debugscript: Modes available are 0 (None), 1 (Errors), 2 (Errors + Warnings), 3 (All)");
+                    pEchoClient->SendEcho("debugscript: Your debug mode is already that");
                 }
             }
             else
             {
-                pEchoClient->SendEcho("debugscript: Your debug mode is already that");
+                pEchoClient->SendEcho("debugscript: Syntax is 'debugscript <mode>'");
             }
         }
         else

--- a/Server/mods/deathmatch/logic/CConsoleCommands.cpp
+++ b/Server/mods/deathmatch/logic/CConsoleCommands.cpp
@@ -1232,42 +1232,34 @@ bool CConsoleCommands::DebugScript(CConsole* pConsole, const char* szArguments, 
         {
             CPlayer* pPlayer = static_cast<CPlayer*>(pClient);
 
-            // To prevent characters before we convert
-            if (strcmp(szArguments, "0") == 0 || strcmp(szArguments, "1") == 0 || strcmp(szArguments, "2") == 0 || strcmp(szArguments, "3") == 0)
+            // Convert to number
+            int iLevel = atoi(szArguments);
+            if (iLevel != (int)pPlayer->GetScriptDebugLevel())
             {
-                // Convert to number
-                int iLevel = atoi(szArguments);
-                if (iLevel != (int)pPlayer->GetScriptDebugLevel())
+                // Between 0 and 3?
+                if (iLevel >= 0 && iLevel <= 3)
                 {
-                    // Between 0 and 3?
-                    if (iLevel >= 0 && iLevel <= 3)
-                    {
-                        // Set the new level
-                        pPlayer->SetScriptDebugLevel(iLevel);
+                    // Set the new level
+                    pPlayer->SetScriptDebugLevel(iLevel);
 
-                        // Tell the player and the console
-                        pEchoClient->SendEcho(SString("debugscript: Your debug mode was set to %i", iLevel));
-                        CLogger::LogPrintf("SCRIPT: %s set their script debug mode to %i\n", GetAdminNameForLog(pClient).c_str(), iLevel);
+                    // Tell the player and the console
+                    pEchoClient->SendEcho(SString("debugscript: Your debug mode was set to %i", iLevel));
+                    CLogger::LogPrintf("SCRIPT: %s set their script debug mode to %i\n", GetAdminNameForLog(pClient).c_str(), iLevel);
 
-                        // Enable/Disable their debugger
-                        if (iLevel == 0)
-                            CStaticFunctionDefinitions::SetPlayerDebuggerVisible(pPlayer, false);
-                        else
-                            CStaticFunctionDefinitions::SetPlayerDebuggerVisible(pPlayer, true);
-                    }
+                    // Enable/Disable their debugger
+                    if (iLevel == 0)
+                        CStaticFunctionDefinitions::SetPlayerDebuggerVisible(pPlayer, false);
                     else
-                    {
-                        pEchoClient->SendEcho("debugscript: Modes available are 0 (None), 1 (Errors), 2 (Errors + Warnings), 3 (All)");
-                    }
+                        CStaticFunctionDefinitions::SetPlayerDebuggerVisible(pPlayer, true);
                 }
                 else
                 {
-                    pEchoClient->SendEcho("debugscript: Your debug mode is already that");
+                    pEchoClient->SendEcho("debugscript: Modes available are 0 (None), 1 (Errors), 2 (Errors + Warnings), 3 (All)");
                 }
             }
             else
             {
-                pEchoClient->SendEcho("debugscript: Syntax is 'debugscript <mode>'");
+                pEchoClient->SendEcho("debugscript: Your debug mode is already that");
             }
         }
         else


### PR DESCRIPTION
Fixed getPedMoveState while entering a vehicle and added when leaving a vehicle.