### PR TITLE
Fix getPedMoveState returns incorrect move states

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -4646,6 +4646,9 @@ bool CClientPed::IsOnGround()
     CVector vecPosition;
     GetPosition(vecPosition);
     float fGroundLevel = static_cast<float>(g_pGame->GetWorld()->FindGroundZFor3DPosition(&vecPosition));
+    // We don't care if the ped is underground
+    if (definitelyLessThan(vecPosition.fZ, fGroundLevel))
+        return false;
     // Check (vecPosition.fZ - fGroundLevel) <= 1.0f
     return definitelyLessThan((vecPosition.fZ - fGroundLevel), 1.0f) || essentiallyEqual((vecPosition.fZ - fGroundLevel), 1.0f);
 }

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -2377,6 +2377,10 @@ eMovementState CClientPed::GetMovementState()
         else if (strcmp(szComplexTaskName, "TASK_COMPLEX_JUMP") == 0)
             return MOVEMENTSTATE_JUMP;
 
+        // Is he entering a vehicle?
+        else if (IsEnteringVehicle())
+            return MOVEMENTSTATE_UNKNOWN;
+
         // Is he falling?
         else if (!IsOnGround() && !GetContactEntity())
             return MOVEMENTSTATE_FALL;
@@ -2416,6 +2420,15 @@ eMovementState CClientPed::GetMovementState()
                 return MOVEMENTSTATE_CRAWL;
         }
     }
+
+    // Do we have a player, and are we in a car?
+    if (m_pPlayerPed && GetRealOccupiedVehicle())
+    {
+        // Is he leaving a vehicle?
+        if (IsLeavingVehicle())
+            return MOVEMENTSTATE_UNKNOWN;
+    }
+
     return MOVEMENTSTATE_UNKNOWN;
 }
 
@@ -4626,7 +4639,7 @@ bool CClientPed::IsOnGround()
     CVector vecPosition;
     GetPosition(vecPosition);
     float fGroundLevel = static_cast<float>(g_pGame->GetWorld()->FindGroundZFor3DPosition(&vecPosition));
-    return (vecPosition.fZ > fGroundLevel && (vecPosition.fZ - fGroundLevel) <= 1.0f);
+    return (vecPosition.fZ > fGroundLevel && (vecPosition.fZ - fGroundLevel) <= 1.01f);
 }
 
 bool CClientPed::IsClimbing()

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -10,6 +10,7 @@
 
 #include "StdInc.h"
 #include "game/CAnimBlendAssocGroup.h"
+#include "Utils.h"
 
 using std::list;
 using std::vector;
@@ -4645,8 +4646,8 @@ bool CClientPed::IsOnGround()
     CVector vecPosition;
     GetPosition(vecPosition);
     float fGroundLevel = static_cast<float>(g_pGame->GetWorld()->FindGroundZFor3DPosition(&vecPosition));
-    return (vecPosition.fZ > fGroundLevel && (vecPosition.fZ - fGroundLevel - 1.0f) <=
-                                                 ((fabs(vecPosition.fZ) < fabs(fGroundLevel) ? fabs(fGroundLevel) : fabs(vecPosition.fZ)) * FLOAT_EPSILON));
+    // Check (vecPosition.fZ - fGroundLevel) <= 1.0f
+    return definitelyLessThan((vecPosition.fZ - fGroundLevel), 1.0f) || essentiallyEqual((vecPosition.fZ - fGroundLevel), 1.0f);
 }
 
 bool CClientPed::IsClimbing()

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -4645,7 +4645,13 @@ bool CClientPed::IsOnGround()
     CVector vecPosition;
     GetPosition(vecPosition);
     float fGroundLevel = static_cast<float>(g_pGame->GetWorld()->FindGroundZFor3DPosition(&vecPosition));
-    return (vecPosition.fZ > fGroundLevel && (vecPosition.fZ - fGroundLevel) <= 1.01f);
+
+    // We don't care if the ped is underground
+    if ((vecPosition.fZ - fGroundLevel) <= FLOAT_EPSILON)
+        return false;
+        
+    // Check that (zPos - groundLevel) <= 1, but also account for epsilon
+    return (vecPosition.fZ - fGroundLevel - 1.0f) <= FLOAT_EPSILON;
 }
 
 bool CClientPed::IsClimbing()

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -4645,13 +4645,8 @@ bool CClientPed::IsOnGround()
     CVector vecPosition;
     GetPosition(vecPosition);
     float fGroundLevel = static_cast<float>(g_pGame->GetWorld()->FindGroundZFor3DPosition(&vecPosition));
-
-    // We don't care if the ped is underground
-    if ((vecPosition.fZ - fGroundLevel) <= FLOAT_EPSILON)
-        return false;
-        
-    // Check that (zPos - groundLevel) <= 1, but also account for epsilon
-    return (vecPosition.fZ - fGroundLevel - 1.0f) <= FLOAT_EPSILON;
+    return (vecPosition.fZ > fGroundLevel && (vecPosition.fZ - fGroundLevel - 1.0f) <=
+                                                 ((fabs(vecPosition.fZ) < fabs(fGroundLevel) ? fabs(fGroundLevel) : fabs(vecPosition.fZ)) * FLOAT_EPSILON));
 }
 
 bool CClientPed::IsClimbing()

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -2416,15 +2416,9 @@ eMovementState CClientPed::GetMovementState()
         {
             // Is he moving the contoller at all?
             if (cs.LeftStickX == 0 && cs.LeftStickY == 0)
-            {
                 return MOVEMENTSTATE_CROUCH;
-            }
             else
-            {
-                if ((cs.LeftStickX == -128 || cs.LeftStickX == 128) && cs.RightShoulder1)
-                    return MOVEMENTSTATE_ROLL;
                 return MOVEMENTSTATE_CRAWL;
-            }
         }
     }
 

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -2415,9 +2415,15 @@ eMovementState CClientPed::GetMovementState()
         {
             // Is he moving the contoller at all?
             if (cs.LeftStickX == 0 && cs.LeftStickY == 0)
+            {
                 return MOVEMENTSTATE_CROUCH;
+            }
             else
+            {
+                if ((cs.LeftStickX == -128 || cs.LeftStickX == 128) && cs.RightShoulder1)
+                    return MOVEMENTSTATE_ROLL;
                 return MOVEMENTSTATE_CRAWL;
+            }
         }
     }
 

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -2378,7 +2378,6 @@ eMovementState CClientPed::GetMovementState()
         else if (strcmp(szComplexTaskName, "TASK_COMPLEX_JUMP") == 0)
             return MOVEMENTSTATE_JUMP;
 
-        // Is he entering a vehicle?
         else if (IsEnteringVehicle())
             return MOVEMENTSTATE_UNKNOWN;
 
@@ -2422,10 +2421,8 @@ eMovementState CClientPed::GetMovementState()
         }
     }
 
-    // Do we have a player, and are we in a car?
     if (m_pPlayerPed && GetRealOccupiedVehicle())
     {
-        // Is he leaving a vehicle?
         if (IsLeavingVehicle())
             return MOVEMENTSTATE_UNKNOWN;
     }

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -67,7 +67,7 @@ enum eMovementState
     MOVEMENTSTATE_SPRINT,               // Sprinting
     MOVEMENTSTATE_CROUCH,               // Crouching still
     MOVEMENTSTATE_CRAWL,                // Crouch-moving
-    MOVEMENTSTATE_ROLL,                 // Crouch-rolling && Crawl-rolling
+    MOVEMENTSTATE_ROLL,                 // Crouch-rolling (Needs adding)
     MOVEMENTSTATE_JUMP,                 // Jumping
     MOVEMENTSTATE_FALL,                 // Falling
     MOVEMENTSTATE_CLIMB                 // Climbing

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -67,7 +67,7 @@ enum eMovementState
     MOVEMENTSTATE_SPRINT,               // Sprinting
     MOVEMENTSTATE_CROUCH,               // Crouching still
     MOVEMENTSTATE_CRAWL,                // Crouch-moving
-    MOVEMENTSTATE_ROLL,                 // Crouch-rolling (Needs adding)
+    MOVEMENTSTATE_ROLL,                 // Crouch-rolling && Crawl-rolling
     MOVEMENTSTATE_JUMP,                 // Jumping
     MOVEMENTSTATE_FALL,                 // Falling
     MOVEMENTSTATE_CLIMB                 // Climbing

--- a/Shared/mods/deathmatch/logic/Utils.cpp
+++ b/Shared/mods/deathmatch/logic/Utils.cpp
@@ -1134,3 +1134,23 @@ CVector ConvertEulerRotationOrder(const CVector& a_vRotation, eEulerRotationOrde
         return a_vRotation;
     }
 }
+
+bool approximatelyEqual(float a, float b, float epsilon)
+{
+    return fabs(a - b) <= ((fabs(a) < fabs(b) ? fabs(b) : fabs(a)) * FLOAT_EPSILON);
+}
+
+bool essentiallyEqual(float a, float b, float epsilon)
+{
+    return fabs(a - b) <= ((fabs(a) > fabs(b) ? fabs(b) : fabs(a)) * FLOAT_EPSILON);
+}
+
+bool definitelyGreaterThan(float a, float b, float epsilon)
+{
+    return (a - b) > ((fabs(a) < fabs(b) ? fabs(b) : fabs(a)) * FLOAT_EPSILON);
+}
+
+bool definitelyLessThan(float a, float b, float epsilon)
+{
+    return (b - a) > ((fabs(a) < fabs(b) ? fabs(b) : fabs(a)) * FLOAT_EPSILON);
+}

--- a/Shared/mods/deathmatch/logic/Utils.h
+++ b/Shared/mods/deathmatch/logic/Utils.h
@@ -327,3 +327,9 @@ void DeletePointersAndClearList(T& elementList)
 #if defined(MTA_DEBUG) && defined(MTA_CLIENT)
 HMODULE RemoteLoadLibrary(HANDLE hProcess, const char* szLibPath);
 #endif
+
+// Comparing floating point numbers
+bool approximatelyEqual(float a, float b, float epsilon = FLOAT_EPSILON);
+bool essentiallyEqual(float a, float b, float epsilon = FLOAT_EPSILON);
+bool definitelyGreaterThan(float a, float b, float epsilon = FLOAT_EPSILON);
+bool definitelyLessThan(float a, float b, float epsilon = FLOAT_EPSILON);


### PR DESCRIPTION
This should fix the following issues:
#1598 
#1594 
#1590 