### PR TITLE
Fix isPlayerHudComponentVisible incompatible with command `showhud`

### DIFF
--- a/Client/game_sa/CHudSA.cpp
+++ b/Client/game_sa/CHudSA.cpp
@@ -276,6 +276,8 @@ bool CHudSA::IsComponentVisible(eHudComponent component)
     SHudComponent* pComponent = MapFind(m_HudComponentMap, component);
     if (pComponent)
     {
+        if (g_pCore->GetGame()->GetHud()->IsDisabled())
+            return false;
         // Determine if invisible by matching data with disabled values
         uchar* pSrc = (uchar*)(&pComponent->disabledData);
         uchar* pDest = (uchar*)(pComponent->uiDataAddr);

--- a/Client/game_sa/CHudSA.cpp
+++ b/Client/game_sa/CHudSA.cpp
@@ -271,13 +271,16 @@ void CHudSA::SetComponentVisible(eHudComponent component, bool bVisible)
 //
 // CHudSA::IsComponentVisible
 //
-bool CHudSA::IsComponentVisible(eHudComponent component)
+bool CHudSA::IsComponentVisible(eHudComponent component, bool bOutIsEnabled)
 {
     SHudComponent* pComponent = MapFind(m_HudComponentMap, component);
     if (pComponent)
     {
-        if (g_pCore->GetGame()->GetHud()->IsDisabled())
-            return false;
+        if (bOutIsEnabled)
+        {
+            if (g_pCore->GetGame()->GetHud()->IsDisabled())
+                return false;
+        }
         // Determine if invisible by matching data with disabled values
         uchar* pSrc = (uchar*)(&pComponent->disabledData);
         uchar* pDest = (uchar*)(pComponent->uiDataAddr);

--- a/Client/game_sa/CHudSA.h
+++ b/Client/game_sa/CHudSA.h
@@ -77,7 +77,7 @@ public:
     bool CalcScreenCoors(CVector* vecPosition1, CVector* vecPosition2, float* fX, float* fY, bool bSetting1, bool bSetting2);
     void Draw2DPolygon(float fX1, float fY1, float fX2, float fY2, float fX3, float fY3, float fX4, float fY4, DWORD dwColor);
     void SetComponentVisible(eHudComponent component, bool bVisible);
-    bool IsComponentVisible(eHudComponent component);
+    bool IsComponentVisible(eHudComponent component, bool bOutIsEnabled);
     void AdjustComponents(float fAspectRatio);
     void ResetComponentAdjustment();
 

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1951,9 +1951,9 @@ bool CStaticFunctionDefinitions::ShowPlayerHudComponent(eHudComponent component,
     return true;
 }
 
-bool CStaticFunctionDefinitions::IsPlayerHudComponentVisible(eHudComponent component, bool& bOutIsVisible)
+bool CStaticFunctionDefinitions::IsPlayerHudComponentVisible(eHudComponent component, bool bOutIsEnabled, bool& bOutIsVisible)
 {
-    bOutIsVisible = g_pGame->GetHud()->IsComponentVisible(component);
+    bOutIsVisible = g_pGame->GetHud()->IsComponentVisible(component, bOutIsEnabled);
     return true;
 }
 

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -119,7 +119,7 @@ public:
 
     // Player set funcs
     static bool ShowPlayerHudComponent(eHudComponent component, bool bShow);
-    static bool IsPlayerHudComponentVisible(eHudComponent component, bool& bOutIsVisible);
+    static bool IsPlayerHudComponentVisible(eHudComponent component, bool bOutIsEnabled, bool& bOutIsVisible);
     static bool SetPlayerMoney(long lMoney, bool bInstant);
     static bool GivePlayerMoney(long lMoney);
     static bool TakePlayerMoney(long lMoney);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
@@ -334,16 +334,18 @@ int CLuaPlayerDefs::ShowPlayerHudComponent(lua_State* luaVM)
 
 int CLuaPlayerDefs::IsPlayerHudComponentVisible(lua_State* luaVM)
 {
-    //  bool isPlayerHudComponentVisible ( string componen )
+    //  bool isPlayerHudComponentVisible ( string component, checkEnabled = true )
     eHudComponent component;
+    bool          bIsEnabled;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadEnumString(component);
+    argStream.ReadBool(bIsEnabled, true);
 
     if (!argStream.HasErrors())
     {
         bool bIsVisible;
-        if (CStaticFunctionDefinitions::IsPlayerHudComponentVisible(component, bIsVisible))
+        if (CStaticFunctionDefinitions::IsPlayerHudComponentVisible(component, bIsEnabled, bIsVisible))
         {
             lua_pushboolean(luaVM, bIsVisible);
             return 1;

--- a/Client/sdk/game/CHud.h
+++ b/Client/sdk/game/CHud.h
@@ -50,7 +50,7 @@ public:
     //  virtual VOID                SetVehicleName( char * szName )=0;
     // virtual VOID              SetZoneName( char * szName )=0;
     virtual void SetComponentVisible(eHudComponent component, bool bVisible) = 0;
-    virtual bool IsComponentVisible(eHudComponent component) = 0;
+    virtual bool IsComponentVisible(eHudComponent component, bool bOutIsEnabled) = 0;
     virtual void AdjustComponents(float fAspectRatio) = 0;
     virtual void ResetComponentAdjustment() = 0;
 };


### PR DESCRIPTION
this should Fix #547 since the command `showhud` disables the hud and `isPlayerHudComponentVisible` only checks if the component is visible so It makes no sense. 
This should be enough but feel free to say anything.