### PR TITLE
Revert "Fix #1443 - trim teaEncode trailing zeroes"

### DIFF
--- a/Shared/sdk/SharedUtil.Hash.h
+++ b/Shared/sdk/SharedUtil.Hash.h
@@ -80,6 +80,9 @@ namespace SharedUtil
         unsigned char m_digest[16];
     };
 
+    void encodeXtea(unsigned int* v, unsigned int* w, unsigned int* k);
+    void decodeXTea(unsigned int* v, unsigned int* w, unsigned int* k);
+
     void TeaEncode(const SString& str, const SString& key, SString* out);
     void TeaDecode(const SString& str, const SString& key, SString* out);
 

--- a/Shared/sdk/SharedUtil.Hash.hpp
+++ b/Shared/sdk/SharedUtil.Hash.hpp
@@ -696,7 +696,7 @@ namespace SharedUtil
             return GenerateHashHexString(hashFunction, NULL, 0);
     }
 
-    inline void encodeXtea(unsigned int* v, unsigned int* w, unsigned int* k)
+    void encodeXtea(unsigned int* v, unsigned int* w, unsigned int* k)
     {
         unsigned int v0 = v[0], v1 = v[1], i, sum = 0;
         unsigned int delta = 0x9E3779B9;
@@ -710,7 +710,7 @@ namespace SharedUtil
         w[1] = v1;
     }
 
-    inline void decodeXtea(unsigned int* v, unsigned int* w, unsigned int* k)
+    void decodeXtea(unsigned int* v, unsigned int* w, unsigned int* k)
     {
         unsigned int v0 = v[0], v1 = v[1], i, sum = 0xC6EF3720;
         unsigned int delta = 0x9E3779B9;
@@ -818,26 +818,5 @@ namespace SharedUtil
 
         out->assign((char*)buffer, numPasses * 4);
         delete[] buffer;
-
-
-        // Delete all 0's from the end
-        // As of now, even if the user passed it in
-        // We'll delete it, because there's no way
-        // We can know if the user added the padding or not.
-
-        // Note: If we get there, there's at least 1 block(4 chars)
-        //       before out->end()
-        {
-            // Traverse the string until the beginning, or until the fist non-0 char
-            auto iter = out->end();
-            for (; iter != out->begin(); iter--)
-            {
-                if (*std::prev(iter) != 0)
-                    break;
-            }
-
-            if (iter != out->end())
-                out->erase(iter, out->end()); // Erase all 0s
-        }
     }
 }            // namespace SharedUtil


### PR DESCRIPTION
#1534 trims all trailing zeroes including those that should be there.
```lua
local str = encodeString("tea", "Hel\0lo\0", {key = "1234"})
iprint(decodeString("tea", str, {key = "1234"}) -- "Hel\0lo"
```
We need to find another solution for #1443.
Reverts multitheftauto/mtasa-blue#1534