### PR TITLE
Fix for breaking backwards compatibility with oop functions returning vectors

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -1035,9 +1035,24 @@ int CLuaElementDefs::OOP_GetElementBoundingBox(lua_State* luaVM)
         CVector vecMin, vecMax;
         if (CStaticFunctionDefinitions::GetElementBoundingBox(*pEntity, vecMin, vecMax))
         {
-            lua_pushvector(luaVM, vecMin);
-            lua_pushvector(luaVM, vecMax);
-            return 2;
+            // If the caller expects six results, return six floats, otherwise two vectors
+            int iExpected = lua_ncallresult(luaVM);
+            if (iExpected == 6)
+            {
+                lua_pushnumber(luaVM, vecMin.fX);
+                lua_pushnumber(luaVM, vecMin.fY);
+                lua_pushnumber(luaVM, vecMin.fZ);
+                lua_pushnumber(luaVM, vecMax.fX);
+                lua_pushnumber(luaVM, vecMax.fY);
+                lua_pushnumber(luaVM, vecMax.fZ);
+                return 6;
+            }
+            else
+            {
+                lua_pushvector(luaVM, vecMin);
+                lua_pushvector(luaVM, vecMax);
+                return 2;
+            }
         }
     }
     else

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -3236,8 +3236,21 @@ int CLuaVehicleDefs::OOP_GetVehicleComponentPosition(lua_State* luaVM)
         CVector vecPosition;
         if (pVehicle->GetComponentPosition(strComponent, vecPosition, outputBase))
         {
-            lua_pushvector(luaVM, vecPosition);
-            return 1;
+            // If the caller expects three results, return 3 floats, otherwise a vector
+            int iExpected = lua_ncallresult(luaVM);
+            if (iExpected == 3)
+            {
+                lua_pushnumber(luaVM, vecPosition.fX);
+                lua_pushnumber(luaVM, vecPosition.fY);
+                lua_pushnumber(luaVM, vecPosition.fZ);
+                return 3;
+            }
+            else
+            {
+                lua_pushvector(luaVM, vecPosition);
+                return 1;
+            }
+            
         }
     }
     else
@@ -3327,8 +3340,20 @@ int CLuaVehicleDefs::OOP_GetVehicleComponentRotation(lua_State* luaVM)
         {
             // Script uses degrees
             ConvertRadiansToDegrees(vecRotation);
-            lua_pushvector(luaVM, vecRotation);
-            return 1;
+            // If the caller expects three results, return 3 floats, otherwise a vector
+            int iExpected = lua_ncallresult(luaVM);
+            if (iExpected == 3)
+            {
+                lua_pushnumber(luaVM, vecRotation.fX);
+                lua_pushnumber(luaVM, vecRotation.fY);
+                lua_pushnumber(luaVM, vecRotation.fZ);
+                return 3;
+            }
+            else
+            {
+                lua_pushvector(luaVM, vecRotation);
+                return 1;
+            }
         }
     }
     else

--- a/vendor/lua/src/lapi.c
+++ b/vendor/lua/src/lapi.c
@@ -1134,3 +1134,9 @@ LUA_API void lua_addtotalbytes(lua_State *L, int n)
     global_State *g = G(L);
     g->totalbytes += n;
 }
+
+// MTA addition to access expected results
+LUA_API int lua_ncallresult(lua_State *L)
+{
+    return L->nexpectedresults;
+}

--- a/vendor/lua/src/ldo.c
+++ b/vendor/lua/src/ldo.c
@@ -335,6 +335,8 @@ int luaD_precall (lua_State *L, StkId func, int nresults) {
         allowed = pPreCallHook ( *curr_func(L)->c.f, L );
     if ( allowed )
     {
+        // MTA Specific: Store number of expected results for lua_ncallresult
+        L->nexpectedresults = nresults;
         n = (*curr_func(L)->c.f)(L);  /* do the actual call */
         // MTA Specific
         if ( pPostCallHook )

--- a/vendor/lua/src/lstate.h
+++ b/vendor/lua/src/lstate.h
@@ -124,6 +124,8 @@ struct lua_State {
   GCObject *gclist;
   struct lua_longjmp *errorJmp;  /* current error recover point */
   ptrdiff_t errfunc;  /* current error handling function (stack index) */
+  int nexpectedresults; /* MTA specific: Number of expected results from a C call. Only valid inside a function call. 
+						   May no longer be valid if any further Lua calls were made (e.g. via lua_pcall) */
 };
 
 

--- a/vendor/lua/src/lua.h
+++ b/vendor/lua/src/lua.h
@@ -220,7 +220,13 @@ LUA_API int   (lua_load) (lua_State *L, lua_Reader reader, void *dt,
                                         const char *chunkname);
 
 LUA_API int (lua_dump) (lua_State *L, lua_Writer writer, void *data);
-
+// MTA specific: Returns the number of expected results in a C call.
+// Note that this will no longer be reliable if 
+// It will also not be reliable in case of incorrectly called functions
+// e.g. 
+//   local a, b = tostring(3) 
+// will return 2, despite tostring only returning one number
+LUA_API int (lua_ncallresult) (lua_State* L);
 
 /*
 ** coroutine functions


### PR DESCRIPTION
In the resolution to #1240 we've changed oop functions to consistently return vectors, rather than three numbers per vector in `Vehicle.getComponentPosition`, `Vehicle.getComponentRotation` and `Element.getBoundingBox`. It appears that the incorrect variants have been used in some scripts though, which are now broken. 

This PR adds a workaround for the most common use case. Rather than always returning a vector, we conditionally return a vector based on what the caller expected at the callsite (see d3257e4 for the Lua API changes for that). If the caller expected three values, we return three numbers otherwise a vector. This allows both of the following call variants to work
```
local veh = Vehicle(411, 0, 0, 0)
local x, y, z = veh:getCompontentPosition("[...]")
-- x, y, z are now numbers
-- but also:
local vec = veh:getCompontentPosition("[...]")
```

It should be noted that this doesn't fully resolve the backwards incompatible change, as users may have attempted to do one of the following:
```
-- I do not care about the z axis
local x, y = veh:getComponentPosition("[...]") 
-- old: x, y numbers
-- new: x vector y nil

-- Capture it for storage
local compPos = {veh:getComponentPosition("[...]")
-- old: compPos is a table containing three numbers
-- new: compPos is a table containing a single vector
```
But I suspect that those aren't all that commonly found. 
