### PR TITLE
Security Fix: SMods can perform escalation attack

### DIFF
--- a/Server/mods/deathmatch/acl.xml
+++ b/Server/mods/deathmatch/acl.xml
@@ -180,7 +180,7 @@
       <right name="command.delaccount" access="true" />
       <right name="command.chgpass" access="true" />
       <right name="function.addAccount" access="true" />
-      <right name="function.removeAccount" access="true" />
+      <right name="function.removeAccount" access="false" />
       <right name="function.setAccountName" access="true" />
       <right name="function.setAccountPassword" access="true" />
    </acl>

--- a/Server/mods/deathmatch/acl.xml
+++ b/Server/mods/deathmatch/acl.xml
@@ -177,7 +177,6 @@
       <right name="command.unloadmodule" access="true" />
       <right name="command.reloadmodule" access="true" />
       <right name="command.addaccount" access="true" />
-      <right name="command.chgpass" access="true" />
       <right name="function.addAccount" access="true" />
       <right name="function.setAccountName" access="true" />
       <right name="function.setAccountPassword" access="true" />
@@ -198,6 +197,7 @@
       <right name="command.reloadacl" access="true" />
       <right name="command.stopall" access="true" />
       <right name="command.delaccount" access="true" />
+      <right name="command.chgpass" access="true" />
       <right name="function.addBan" access="true" />
       <right name="function.setUnbanTime" access="true" />
       <right name="function.setBanAdmin" access="true" />

--- a/Server/mods/deathmatch/acl.xml
+++ b/Server/mods/deathmatch/acl.xml
@@ -177,10 +177,8 @@
       <right name="command.unloadmodule" access="true" />
       <right name="command.reloadmodule" access="true" />
       <right name="command.addaccount" access="true" />
-      <right name="command.delaccount" access="true" />
       <right name="command.chgpass" access="true" />
       <right name="function.addAccount" access="true" />
-      <right name="function.removeAccount" access="false" />
       <right name="function.setAccountName" access="true" />
       <right name="function.setAccountPassword" access="true" />
    </acl>
@@ -199,6 +197,7 @@
       <right name="command.authserial" access="true" />
       <right name="command.reloadacl" access="true" />
       <right name="command.stopall" access="true" />
+      <right name="command.delaccount" access="true" />
       <right name="function.addBan" access="true" />
       <right name="function.setUnbanTime" access="true" />
       <right name="function.setBanAdmin" access="true" />
@@ -233,6 +232,7 @@
       <right name="function.updateResourceACLRequest" access="true" />
       <right name="function.shutdown" access="true" />
       <right name="function.setPlayerScriptDebugLevel" access="true" />
+      <right name="function.removeAccount" access="true" />
    </acl>
    <acl name="RPC">
       <right name="function.callRemote" access="true" />


### PR DESCRIPTION
Fixes a vulnerability where a supermoderator can delete a admin account an re-register it, gaining admin access in a server.

Reported by LosFaul#4799 in discord private channel