### PR TITLE
dxGetTextSize: accept one float or Vector2 as scale

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -864,7 +864,7 @@ int CLuaDrawingDefs::OOP_DxGetTextWidth(lua_State* luaVM)
 }
 
 CVector2D CLuaDrawingDefs::OOP_DxGetTextSize(std::variant<CClientDxFont*, eFontType> variantFont, const std::string text, const std::optional<float> optWidth,
-                                             std::optional<std::variant<CVector2D, float>> optScaleXY, const std::optional<bool> optWordBreak,
+                                             const std::optional<std::variant<CVector2D, float>> optScaleXY, const std::optional<bool> optWordBreak,
                                              const std::optional<bool> optColorCoded)
 {
     // float, float dxGetTextSize ( string text, [float width=0, float scaleXY=1.0, float=scaleY=1.0, mixed font="default",

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -864,19 +864,27 @@ int CLuaDrawingDefs::OOP_DxGetTextWidth(lua_State* luaVM)
 }
 
 CVector2D CLuaDrawingDefs::OOP_DxGetTextSize(std::variant<CClientDxFont*, eFontType> variantFont, const std::string text, const std::optional<float> optWidth,
-                                             const std::optional<float> optScaleXY, const std::optional<float> optScaleY,
-                                             const std::optional<bool> optWordBreak, const std::optional<bool> optColorCoded)
+                                             std::optional<std::variant<CVector2D, float>> optScaleXY, const std::optional<bool> optWordBreak,
+                                             const std::optional<bool> optColorCoded)
 {
-    // float dxGetTextHeight ( string text, [float width, float scaleXY=1.0, float=scaleY=1.0, mixed font="default", bool wordBreak=false, bool
-    // colorCoded=false] )
+    // float, float dxGetTextSize ( string text, [float width=0, float scaleXY=1.0, float=scaleY=1.0, mixed font="default",
+    // bool wordBreak=false, bool colorCoded=false] )
     CGraphicsInterface* const graphics = g_pCore->GetGraphics();
 
     // resolve scale (use X as Y value, if optScaleY is empty)
     CVector2D scale(1.0f, 1.0f);
     if (optScaleXY.has_value())
     {
-        scale.fX = optScaleXY.value();
-        scale.fY = optScaleY.has_value() ? optScaleY.value() : scale.fX;
+        std::variant<CVector2D, float> scaleXY = optScaleXY.value();
+        if (std::holds_alternative<float>(scaleXY))
+        {
+            scale.fX = std::get<float>(scaleXY);
+            scale.fY = scale.fX;
+        }
+        else
+        {
+            scale = std::get<CVector2D>(scaleXY);
+        }
     }
 
     CVector2D vecSize;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.h
@@ -37,15 +37,16 @@ public:
 
     static CVector2D OOP_DxGetTextSize(
         // font can be called with a std::nullopt to grab the FONT_DEFAULT, see DxGetTextSize
-        std::variant<CClientDxFont*, eFontType> font, const std::string text, const std::optional<float> optWidth, const std::optional<float> optScaleXY,
-        const std::optional<float> optScaleY, const std::optional<bool> optWordBreak, const std::optional<bool> optColorCoded);
+        std::variant<CClientDxFont*, eFontType> font, const std::string text, const std::optional<float> optWidth,
+        const std::optional<std::variant<CVector2D, float>> optScaleXY, const std::optional<bool> optWordBreak, const std::optional<bool> optColorCoded);
 
-     static inline std::tuple<float, float> DxGetTextSize(std::string text, std::optional<float> optWidth, std::optional<float> optScaleXY,
-                                                         std::optional<float> optScaleY, std::optional<std::variant<CClientDxFont*, eFontType>> optFont,
-                                                         std::optional<bool> optWordBreak, std::optional<bool> optColorCoded)
+    static inline std::tuple<float, float> DxGetTextSize(std::string text, std::optional<float> optWidth,
+                                                         std::optional<std::variant<CVector2D, float>>          optScaleXY,
+                                                         std::optional<std::variant<CClientDxFont*, eFontType>> optFont, std::optional<bool> optWordBreak,
+                                                         std::optional<bool> optColorCoded)
     {
         const auto size = OOP_DxGetTextSize(std::move(optFont.value_or(FONT_DEFAULT)), std::move(text), std::move(optWidth), std::move(optScaleXY),
-                                            std::move(optScaleY), std::move(optWordBreak), std::move(optColorCoded));
+                                            std::move(optWordBreak), std::move(optColorCoded));
 
         return {size.fX, size.fY};
     };


### PR DESCRIPTION
```lua
dxGetTextSize("Hello", 0) -- x, y: 1
dxGetTextSize("Hello", 0, 0.5) -- x, y: 0.5
dxGetTextSize("Hello", 0, 1, 2)
dxGetTextSize("Hello", 0, Vector2(3, 5))
```