### PR TITLE
Refactor CConsoleCommands::Debugscript

### DIFF
--- a/Client/game_sa/CAEAudioHardwareSA.cpp
+++ b/Client/game_sa/CAEAudioHardwareSA.cpp
@@ -18,33 +18,10 @@ CAEAudioHardwareSA::CAEAudioHardwareSA(CAEAudioHardwareSAInterface* pInterface)
 
 bool CAEAudioHardwareSA::IsSoundBankLoaded(short wSoundBankID, short wSoundBankSlotID)
 {
-    DWORD dwSoundBankID = wSoundBankID;
-    DWORD dwSoundBankSlotID = wSoundBankSlotID;
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAEAudioHardware__IsSoundBankLoaded;
-    bool  bReturn = false;
-    _asm
-    {
-        push    dwSoundBankSlotID
-        push    dwSoundBankID
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    return ((bool(__thiscall*)(void*, short, short))FUNC_CAEAudioHardware__IsSoundBankLoaded)((void*)m_pInterface, wSoundBankID, wSoundBankSlotID);
 }
 
-void CAEAudioHardwareSA::LoadSoundBank(short wSoundBankID, short wSoundBankSlotID)
+bool CAEAudioHardwareSA::LoadSoundBank(short wSoundBankID, short wSoundBankSlotID)
 {
-    DWORD dwSoundBankID = wSoundBankID;
-    DWORD dwSoundBankSlotID = wSoundBankSlotID;
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAEAudioHardware__LoadSoundBank;
-    _asm
-    {
-        push    dwSoundBankSlotID
-        push    dwSoundBankID
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    return ((bool(__thiscall*)(void*, short, short))FUNC_CAEAudioHardware__LoadSoundBank)((void*)m_pInterface, wSoundBankID, wSoundBankSlotID);
 }

--- a/Client/game_sa/CAEAudioHardwareSA.h
+++ b/Client/game_sa/CAEAudioHardwareSA.h
@@ -19,8 +19,10 @@
 
 #define CLASS_CAEAudioHardware                                              0xB5F8B8
 
-class CAEAudioHardwareSAInterface
+struct CAEAudioHardwareSAInterface
 {
+    BYTE field_0;
+    char m_bDisableEffectsLoading;
 };
 
 class CAEAudioHardwareSA : public CAEAudioHardware
@@ -28,7 +30,8 @@ class CAEAudioHardwareSA : public CAEAudioHardware
 public:
     CAEAudioHardwareSA(CAEAudioHardwareSAInterface* pInterface);
     bool IsSoundBankLoaded(short wSoundBankID, short wSoundBankSlotID);
-    void LoadSoundBank(short wSoundBankID, short wSoundBankSlotID);
+    bool LoadSoundBank(short wSoundBankID, short wSoundBankSlotID);
+    bool IsEffectsLoadingDisabled() const { return m_pInterface->m_bDisableEffectsLoading; }
 
 private:
     CAEAudioHardwareSAInterface* m_pInterface;

--- a/Client/game_sa/CAEVehicleAudioEntitySA.cpp
+++ b/Client/game_sa/CAEVehicleAudioEntitySA.cpp
@@ -11,6 +11,8 @@
 
 #include "StdInc.h"
 
+//static auto s_aEngineDummySlots = (CAEVehicleAudioEntitySA::DummyEngineSlot*)(VAR_CAEVehicleAudioEntity__s_aDummyEngineSlots);
+
 CAEVehicleAudioEntitySA::CAEVehicleAudioEntitySA(CAEVehicleAudioEntitySAInterface* pInterface)
 {
     m_pInterface = pInterface;
@@ -53,15 +55,80 @@ void CAEVehicleAudioEntitySA::TurnOnRadioForVehicle()
 
 void CAEVehicleAudioEntitySA::StopVehicleEngineSound(unsigned char ucSlot)
 {
-    DWORD          dwFunc = FUNC_CAESound__Stop;
     tVehicleSound* pVehicleSound = &m_pInterface->m_aEngineSounds[ucSlot];
     if (pVehicleSound->m_pSound)
+        ((void(__cdecl*)(CAESound*))FUNC_CAESound__Stop)(pVehicleSound->m_pSound);
+}
+
+int CAEVehicleAudioEntitySA::StoppedUsingBankSlot(int bankId)
+{
+    return ((int(__cdecl*)(int))FUNC_CAEVehicleAudioEntity__StoppedUsingBankSlot)(bankId);
+}
+
+short CAEVehicleAudioEntitySA::RequestBankSlot(unsigned short bankId)
+{
+    return ((short(__cdecl*)(short))FUNC_CAEVehicleAudioEntity__RequestBankSlot)(bankId);
+}
+
+short CAEVehicleAudioEntitySA::DemandBankSlot(unsigned short bankId)
+{
+    return ((short(__cdecl*)(short))FUNC_CAEVehicleAudioEntity__DemandBankSlot)(bankId);
+}
+
+void CAEVehicleAudioEntitySA::CancelVehicleEngineSound(short engineSoundStateID)
+{
+    return ((void(__thiscall*)(void*, short))FUNC_CAEVehicleAudioEntity__CancelVehicleEngineSound)((void*)m_pInterface, engineSoundStateID);
+}
+
+void CAEVehicleAudioEntitySA::MakeSureEngineSoundsAreLoaded()
+{
+    // TODO: Check if this is the right way to do this
+    //       (aka should we write a function to load the sound bank, and all that, or this hack is just fine)
+    ((void(__thiscall*)(void*))FUNC_CAEVehicleAudioEntity__JustGotInVehicleAsDriver)((void*)m_pInterface);
+}
+
+unsigned int CAEVehicleAudioEntitySA::SetEngineAccelerationSoundBank(unsigned int bankId) // Seems to crash with id 83
+{
+    if (bankId == m_pInterface->m_wEngineOnSoundBankId)
+        return m_pInterface->m_wEngineOnSoundBankId;
+
+    // TODO: Add check for bankid (maybe use CAEAudioHardware or something)
+    auto oldValue = m_pInterface->m_wEngineOnSoundBankId;
+    m_pInterface->m_wEngineOnSoundBankId = bankId;
+    m_pInterface->m_nSettings.m_wEngineOnSoundBankId = bankId;
+
+    MakeSureEngineSoundsAreLoaded();
+
+    return oldValue;
+}
+
+unsigned int CAEVehicleAudioEntitySA::SetEngineDeaccelerationSoundBank(unsigned int bankId)
+{
+    if (bankId == m_pInterface->m_wEngineOffSoundBankId)
+        return m_pInterface->m_wEngineOffSoundBankId;
+
+    // TODO: Add check for bankid (maybe use CAEAudioHardware or something)
+    const short previousBank = m_pInterface->m_wEngineOffSoundBankId;
+    const short previousSlot = m_pInterface->m_wEngineSlotInBank;
+
+    m_pInterface->m_wEngineOffSoundBankId = bankId;
+    m_pInterface->m_nSettings.m_wEngineOffSoundBankId = bankId;
+
+    StoppedUsingBankSlot(m_pInterface->m_wEngineSlotInBank);
+    m_pInterface->m_wEngineSlotInBank = RequestBankSlot(bankId); // Loads the sound bank (if it wasnt)
+
+    if (m_pInterface->m_wEngineSlotInBank == -1) // failed to load, revert to the previous one
     {
-        DWORD dwThis = (DWORD)pVehicleSound->m_pSound;
-        _asm
-        {
-            mov     ecx, dwThis
-            call    dwFunc
-        }
+        m_pInterface->m_wEngineOffSoundBankId = previousBank;
+        m_pInterface->m_nSettings.m_wEngineOffSoundBankId = previousBank;
+        m_pInterface->m_wEngineSlotInBank = previousSlot;
     }
+    else
+    {
+        if (!pGame->GetAEAudioHardware()->IsSoundBankLoaded(bankId, m_pInterface->m_wEngineSlotInBank))
+            if (!pGame->GetAEAudioHardware()->LoadSoundBank(bankId, m_pInterface->m_wEngineSlotInBank))
+                throw std::invalid_argument("sound bank didnt get loaded");
+    }
+
+    return previousBank;
 }

--- a/Client/game_sa/CAudioEngineSA.h
+++ b/Client/game_sa/CAudioEngineSA.h
@@ -100,7 +100,7 @@ public:
     };
     unsigned short m_wIsUsed;                         // +88
     short          unk4;                              // +90 = 1005
-    short          m_wCurrentPlayPosition;            // +92
+    short          m_wCurrentPlayPositionPercent;     // +92
     short          unk5;                              // +94 = 0
     float          m_fFinalVolume;                    // +96
     float          m_fFrequency;                      // +100

--- a/Client/game_sa/CVehicleSA.h
+++ b/Client/game_sa/CVehicleSA.h
@@ -364,10 +364,10 @@ public:
 
     CAutoPilot    AutoPilot;                   // +1008
     CVehicleFlags m_nVehicleFlags;             // +1064?
-    unsigned int  m_TimeOfCreation;            // GetTimeInMilliseconds when this vehicle was created.
+    unsigned int  m_TimeOfCreation;            // 1072 - GetTimeInMilliseconds when this vehicle was created. 
 
-    unsigned char m_colour1, m_colour2, m_colour3, m_colour4;
-    char          m_comp1, m_comp2;
+    unsigned char m_colour1, m_colour2, m_colour3, m_colour4;   // 1076, 1077, 1078, 1079
+    char          m_comp1, m_comp2;                             // 1080, 1081
     short         m_upgrades[MAX_UPGRADES_ATTACHED];            // 1082
     float         m_wheelScale;                                 // 1112
 

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -40,6 +40,7 @@ CClientVehicle::CClientVehicle(CClientManager* pManager, ElementID ID, unsigned 
     m_pVehicle = NULL;
     m_pUpgrades = new CVehicleUpgrades(this);
     m_pClump = NULL;
+
     m_pOriginalHandlingEntry = g_pGame->GetHandlingManager()->GetOriginalHandlingData(static_cast<eVehicleTypes>(usModel));
     m_pHandlingEntry = g_pGame->GetHandlingManager()->CreateHandlingData();
     m_pHandlingEntry->Assign(m_pOriginalHandlingEntry);

--- a/Client/mods/deathmatch/logic/CClientVehicle.h
+++ b/Client/mods/deathmatch/logic/CClientVehicle.h
@@ -496,6 +496,8 @@ public:
 
     bool OnVehicleFallThroughMap();
 
+    auto GetVehicle() const { return m_pVehicle; }
+
 protected:
     void ConvertComponentRotationBase(const SString& vehicleComponent, CVector& vecInOutRotation, EComponentBaseType inputBase, EComponentBaseType outputBase);
     void ConvertComponentPositionBase(const SString& vehicleComponent, CVector& vecInOutPosition, EComponentBaseType inputBase, EComponentBaseType outputBase);

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -8869,6 +8869,20 @@ bool CStaticFunctionDefinitions::SetVehicleHandling(CClientVehicle* pVehicle, eH
     return false;
 }
 
+template<typename T>
+bool CStaticFunctionDefinitions::SetVehicleSoundProperty(CClientVehicle* pVehicle, eVehicleSoundProperty property, T value)
+{
+    /*
+    * TODO: uncomment
+    if (!pVehicle->IsLocalEntity())
+        return false;
+    */
+
+    if (CVehicleAudioSettings* settings = pVehicle->GetSoundSettings())
+        return settings->SetPropertyValue(property, value);
+    return false;
+}
+
 bool CStaticFunctionDefinitions::ResetVehicleHandling(CClientVehicle* pVehicle)
 {
     assert(pVehicle);

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -810,6 +810,9 @@ public:
     static bool              SetEntryHandling(CHandlingEntry* pEntry, eHandlingProperty eProperty, unsigned int uiValue);
     static bool              SetEntryHandling(CHandlingEntry* pEntry, eHandlingProperty eProperty, unsigned char ucValue);
 
+    template<typename T>
+    bool SetVehicleSoundProperty(CClientVehicle* pVehicle, eVehicleSoundProperty property, T value);
+
     // Version funcs
     static unsigned long GetVersion();
     static const char*   GetVersionString();

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
@@ -654,6 +654,19 @@ ADD_ENUM(SURFACE_ADHESION_GROUP_SAND, "sand")
 ADD_ENUM(SURFACE_ADHESION_GROUP_WET, "wet")
 IMPLEMENT_ENUM_END("surface-adhesion-group")
 
+IMPLEMENT_ENUM_CLASS_BEGIN(eVehicleSoundProperty)
+ADD_ENUM(eVehicleSoundProperty::ENGINE_ON_SBANK, "engineOnSoundBankId")
+ADD_ENUM(eVehicleSoundProperty::ENGINE_OFF_SBANK, "engineOffSoundBankId")
+ADD_ENUM(eVehicleSoundProperty::ENGINE_SBANK_SLOT, "engineSoundBankSlot")
+ADD_ENUM(eVehicleSoundProperty::ENGINE_ACCELERATE_SBANK, "engineAccelerateSoundBankId")
+ADD_ENUM(eVehicleSoundProperty::ENGINE_DEACCELERATE_SBANK, "engineDeaccelerateSoundBankId")
+ADD_ENUM(eVehicleSoundProperty::HORN_SFX_ID, "hornSfxId")
+ADD_ENUM(eVehicleSoundProperty::HORN_HIGH_VOLUME, "hornHighVolume")
+ADD_ENUM(eVehicleSoundProperty::HORN_VOLUME_DELTA, "hornVolumeDelta")
+ADD_ENUM(eVehicleSoundProperty::DOOR_SOUND_ID, "doorSoundId")
+ADD_ENUM(eVehicleSoundProperty::GENERAL_VOLUME, "generalVolume")
+IMPLEMENT_ENUM_CLASS_END("vehicle-sound-property")
+
 //
 // Get best guess at name of userdata type
 //

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
@@ -103,6 +103,27 @@ enum eJSONPrettyType
 };
 DECLARE_ENUM(eJSONPrettyType);
 
+enum class eVehicleSoundProperty
+{
+    VEHICLE_SOUND_TYPE,
+
+    HORN_SFX_ID,
+    HORN_HIGH_VOLUME,
+    HORN_VOLUME_DELTA,
+
+    DOOR_SOUND_ID,
+
+    GENERAL_VOLUME,
+
+    ENGINE_ON_SBANK,
+    ENGINE_OFF_SBANK,
+
+    ENGINE_SBANK_SLOT,
+    ENGINE_ACCELERATE_SBANK,
+    ENGINE_DEACCELERATE_SBANK,
+};
+DECLARE_ENUM_CLASS(eVehicleSoundProperty);
+
 // class -> class type
 inline eCGUIType GetClassType(CGUIButton*)
 {

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -83,6 +83,7 @@ void CLuaVehicleDefs::LoadFunctions()
         {"getVehicleComponents", GetVehicleComponents},
         {"getVehicleModelExhaustFumesPosition", GetVehicleModelExhaustFumesPosition},
         {"getVehicleModelDummyPosition", GetVehicleModelDummyPosition},
+        {"getVehicleSoundProperty", ArgumentParser<GetVehicleSoundProperty>},
 
         // Vehicle set funcs
         {"createVehicle", CreateVehicle},
@@ -139,6 +140,7 @@ void CLuaVehicleDefs::LoadFunctions()
         {"setVehicleWindowOpen", SetVehicleWindowOpen},
         {"setVehicleModelExhaustFumesPosition", SetVehicleModelExhaustFumesPosition},
         {"setVehicleModelDummyPosition", SetVehicleModelDummyPosition },
+        {"setVehicleSoundProperty", ArgumentParser<SetVehicleSoundProperty>}
     };
 
     // Add functions
@@ -2954,6 +2956,39 @@ int CLuaVehicleDefs::GetOriginalHandling(lua_State* luaVM)
 
     lua_pushboolean(luaVM, false);
     return 1;
+}
+
+std::variant<bool, unsigned int> CLuaVehicleDefs::SetVehicleSoundProperty(CClientVehicle* vehicle, eVehicleSoundProperty property, unsigned int value)
+{
+    switch (property)
+    {
+    case eVehicleSoundProperty::ENGINE_ACCELERATE_SBANK:
+        return vehicle->GetVehicle()->GetVehicleAudioEntity()->SetEngineAccelerationSoundBank(value);
+
+    case eVehicleSoundProperty::ENGINE_DEACCELERATE_SBANK:
+        return vehicle->GetVehicle()->GetVehicleAudioEntity()->SetEngineDeaccelerationSoundBank(value);
+
+    default:
+        throw std::invalid_argument("Unsupported property");
+    }
+}
+
+std::variant<unsigned int, bool, float, std::string> CLuaVehicleDefs::GetVehicleSoundProperty(CClientVehicle* vehicle, eVehicleSoundProperty property)
+{
+    if (!vehicle->GetVehicle())
+        throw std::invalid_argument("vehicle->GetVehicle() is nullptr");
+
+    if (!vehicle->GetVehicle()->GetVehicleAudioEntity())
+        throw std::invalid_argument("vehicle->GetVehicle()->GetVehicleAudioEntity() is nullptr");
+
+    switch (property)
+    {
+    case eVehicleSoundProperty::ENGINE_ACCELERATE_SBANK:
+        return vehicle->GetVehicle()->GetVehicleAudioEntity()->GetEngineAccelerationSoundBank();
+
+    default:
+        throw std::invalid_argument("Unsupported property");
+    }
 }
 
 int CLuaVehicleDefs::SetVehicleDoorOpenRatio(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -156,4 +156,9 @@ public:
     LUA_DECLARE(SetVehicleComponentVisible);
     LUA_DECLARE(GetVehicleComponentVisible);
     LUA_DECLARE(GetVehicleComponents);
+
+    // Vehicle sound modifying things
+    static std::variant<bool, unsigned int> SetVehicleSoundProperty(CClientVehicle* vehicle, eVehicleSoundProperty property, unsigned int value);
+    static std::variant<unsigned int, bool, float, std::string> GetVehicleSoundProperty(CClientVehicle* vehicle, eVehicleSoundProperty property);
+    static std::unordered_map<std::string_view, CLuaArgument> GetVehicleOriginalAudioSettings();
 };

--- a/Client/sdk/game/CAEAudioHardware.h
+++ b/Client/sdk/game/CAEAudioHardware.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-enum eBankSlot : short
+enum eBankSlot : short // World sounds?
 {
     BANKSLOT_FRONTEND_GAME = 0,
     BANKSLOT_FRONTEND_MENU = 1,
@@ -64,5 +64,5 @@ class CAEAudioHardware
 {
 public:
     virtual bool IsSoundBankLoaded(short wSoundBankID, short wSoundBankSlotID) = 0;
-    virtual void LoadSoundBank(short wSoundBankID, short wSoundBankSlotID) = 0;
+    virtual bool LoadSoundBank(short wSoundBankID, short wSoundBankSlotID) = 0;
 };

--- a/Client/sdk/game/CAEVehicleAudioEntity.h
+++ b/Client/sdk/game/CAEVehicleAudioEntity.h
@@ -2,7 +2,7 @@
  *
  *  PROJECT:        Multi Theft Auto v1.0
  *  LICENSE:        See LICENSE in the top level directory
- *  FILE:        sdk/game/CAEVehicleAudioEntity.h
+ *  FILE:           sdk/game/CAEVehicleAudioEntity.h
  *  PURPOSE:        Vehicle audio interface
  *
  *  Multi Theft Auto is available from http://www.multitheftauto.com/
@@ -11,25 +11,17 @@
 
 #pragma once
 
-enum eVehicleAudioType
-{
-    VEHICLE_AUDIO_CAR = 0,
-    VEHICLE_AUDIO_BIKE,
-    VEHICLE_AUDIO_BICYCLE,
-    VEHICLE_AUDIO_BOAT,
-    VEHICLE_AUDIO_HELI,
-    VEHICLE_AUDIO_PLANE,
-    VEHICLE_AUDIO_SEAPLANE,            // unused?
-
-    VEHICLE_AUDIO_TRAIN = 8,
-    VEHICLE_AUDIO_SPECIAL,            // RC vehicles, vortex, caddy, few trailers
-    VEHICLE_AUDIO_SILENT
-};
-
 class CAEVehicleAudioEntity
 {
 public:
     virtual void JustGotInVehicleAsDriver() = 0;
     virtual void JustGotOutOfVehicleAsDriver() = 0;
     virtual void TurnOnRadioForVehicle() = 0;
+
+    virtual void SetVehicleSoundType(enum eVehicleAudioType type) = 0;
+
+    virtual unsigned int SetEngineAccelerationSoundBank(unsigned int val) = 0;
+    virtual unsigned int GetEngineAccelerationSoundBank() const = 0;
+
+    virtual unsigned int SetEngineDeaccelerationSoundBank(unsigned int val) = 0;
 };


### PR DESCRIPTION
In a previous commit ( 8f25c22 ) the `debugscript` command got fixed, but I think it needs a refactor as well, so here we are.
I didnt want to be consistent with the existing style, because I think this is more readable, but correct me if im wrong.