### PR TITLE
Remove client entity check from setPedArmor

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -2188,9 +2188,6 @@ int CLuaPedDefs::SetPedMoveAnim(lua_State* luaVM)
 
 bool CLuaPedDefs::SetPedArmor(CClientPed* const ped, const float armor)
 {
-    if (!ped->IsLocalEntity())
-        return false;
-
     ped->SetArmor(armor);
     return true;
 }


### PR DESCRIPTION
## Summary

This removes the client entity check, allowing `setPedArmor` to be run for any kind of ped, client side.

## Motivation

Fixes #1636. [I have been thinking about removing it for a while.](https://discordapp.com/channels/278474088903606273/366384007535001612/716893734125436971) #1636 was a good reminder.

That thread says:

> armor may be puresynced

It is! https://github.com/multitheftauto/mtasa-blue/blob/1c253bc509489547a7991953369088dc75b291a1/Client/mods/deathmatch/logic/CNetAPI.cpp#L1151-L1154

This means that localPlayer armor updates on the client will sync to the server.

This entity client check is being removed as the **only** ped related operations that won't work for server-side peds are:

- killPed
- setPedStat
- setPedFightingStyle ([my request!](https://discordapp.com/channels/278474088903606273/366384007535001612/716954404871471144) - probably not even necessary)
- setPedArmor (seems odd that this would be blocked, but not setElementHealth, so this PR removes this restriction)
- anything vehicle related (all vehicle operations only work for client vehicles/peds)

There are lots of other operations (setElementHealth, setElementPosition, setElementRotation) that work, so there's little reason to block setPedArmor.