### PR TITLE
Add get/setVehicleModelWheelSize

### DIFF
--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -474,7 +474,7 @@ void CGameSA::Reset()
         // restore default properties of all CObjectGroupPhysicalPropertiesSA instances
         CObjectGroupPhysicalPropertiesSA::RestoreDefaultValues();
 
-        // Restore model wheel sizes
+        // Restore vehicle model wheel sizes
         CModelInfoSA::ResetAllVehiclesWheelSizes();
     }
 }

--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -473,6 +473,9 @@ void CGameSA::Reset()
         CModelInfoSA::RestoreAllObjectsPropertiesGroups();
         // restore default properties of all CObjectGroupPhysicalPropertiesSA instances
         CObjectGroupPhysicalPropertiesSA::RestoreDefaultValues();
+
+        // Restore model wheel sizes
+        CModelInfoSA::ResetAllVehiclesWheelSizes();
     }
 }
 

--- a/Client/game_sa/CModelInfoSA.h
+++ b/Client/game_sa/CModelInfoSA.h
@@ -357,7 +357,7 @@ public:
     static void  ResetAllVehicleDummies();
     float        GetVehicleWheelSize(eResizableVehicleWheelGroup eWheelGroup) override;
     void         SetVehicleWheelSize(eResizableVehicleWheelGroup eWheelGroup, float fWheelSize) override;
-    void         ResetVehicleWheelSizes(std::pair<float, float>* defaultSizes = NULL) override;
+    void         ResetVehicleWheelSizes(std::pair<float, float>* defaultSizes = nullptr) override;
     static void  ResetAllVehiclesWheelSizes();
 
     // ONLY use for peds

--- a/Client/game_sa/CModelInfoSA.h
+++ b/Client/game_sa/CModelInfoSA.h
@@ -280,6 +280,7 @@ protected:
     static std::map<DWORD, BYTE>                                                 ms_ModelDefaultAlphaTransparencyMap;
     static std::unordered_map<std::uint32_t, std::map<eVehicleDummies, CVector>> ms_ModelDefaultDummiesPosition;
     static std::unordered_map<DWORD, unsigned short>                             ms_OriginalObjectPropertiesGroups;
+    static std::unordered_map<DWORD, std::pair<float, float>>                    ms_VehicleModelDefaultWheelSizes;
     bool                                                                         m_bAddedRefForCollision;
     SVehicleSupportedUpgrades                                                    m_ModelSupportedUpgrades;
 
@@ -354,6 +355,12 @@ public:
     void         SetVehicleDummyPosition(eVehicleDummies eDummy, const CVector& vecPosition) override;
     void         ResetVehicleDummies(bool bRemoveFromDummiesMap);
     static void  ResetAllVehicleDummies();
+    float        GetVehicleWheelSizeFront() override;
+    void         SetVehicleWheelSizeFront(float fWheelSize, bool bStoreDefaultSize = true) override;
+    float        GetVehicleWheelSizeRear() override;
+    void         SetVehicleWheelSizeRear(float fWheelSize, bool bStoreDefaultSize = true) override;
+    void         ResetVehicleWheelSizes() override;
+    static void  ResetAllVehiclesWheelSizes();
 
     // ONLY use for peds
     void GetVoice(short* psVoiceType, short* psVoice);

--- a/Client/game_sa/CModelInfoSA.h
+++ b/Client/game_sa/CModelInfoSA.h
@@ -355,11 +355,9 @@ public:
     void         SetVehicleDummyPosition(eVehicleDummies eDummy, const CVector& vecPosition) override;
     void         ResetVehicleDummies(bool bRemoveFromDummiesMap);
     static void  ResetAllVehicleDummies();
-    float        GetVehicleWheelSizeFront() override;
-    void         SetVehicleWheelSizeFront(float fWheelSize, bool bStoreDefaultSize = true) override;
-    float        GetVehicleWheelSizeRear() override;
-    void         SetVehicleWheelSizeRear(float fWheelSize, bool bStoreDefaultSize = true) override;
-    void         ResetVehicleWheelSizes() override;
+    float        GetVehicleWheelSize(eResizableVehicleWheelGroup eWheelGroup) override;
+    void         SetVehicleWheelSize(eResizableVehicleWheelGroup eWheelGroup, float fWheelSize) override;
+    void         ResetVehicleWheelSizes(std::pair<float, float>* defaultSizes = NULL) override;
     static void  ResetAllVehiclesWheelSizes();
 
     // ONLY use for peds

--- a/Client/mods/deathmatch/logic/CClientDFF.cpp
+++ b/Client/mods/deathmatch/logic/CClientDFF.cpp
@@ -264,6 +264,7 @@ void CClientDFF::InternalRestoreModel(unsigned short usModel)
     // Restore all the models we replaced.
     CModelInfo* pModelInfo = g_pGame->GetModelInfo(usModel);
     pModelInfo->ResetVehicleDummies(true);
+    pModelInfo->ResetVehicleWheelSizes();
     pModelInfo->RestoreOriginalModel();
     pModelInfo->ResetAlphaTransparency();
 
@@ -351,6 +352,8 @@ bool CClientDFF::ReplaceVehicleModel(RpClump* pClump, ushort usModel, bool bAlph
     // Grab the model info for that model and replace the model
     CModelInfo* pModelInfo = g_pGame->GetModelInfo(usModel);
     pModelInfo->SetCustomModel(pClump);
+
+    pModelInfo->ResetVehicleWheelSizes();
 
     pModelInfo->SetAlphaTransparencyEnabled(bAlphaTransparency);
 

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -3603,32 +3603,17 @@ bool CStaticFunctionDefinitions::SetVehicleWindowOpen(CClientVehicle& Vehicle, u
     return Vehicle.SetWindowOpen(ucWindow, bOpen);
 }
 
-bool CStaticFunctionDefinitions::SetVehicleModelWheelSizeFront(unsigned short usModel, float fWheelSize)
+bool CStaticFunctionDefinitions::SetVehicleModelWheelSize(unsigned short usModel, eResizableVehicleWheelGroup eWheelGroup, float fWheelSize)
 {
     if (CClientVehicleManager::IsValidModel(usModel))
     {
         auto pModelInfo = g_pGame->GetModelInfo(usModel);
         if (pModelInfo)
         {
-            pModelInfo->SetVehicleWheelSizeFront(fWheelSize);
+            pModelInfo->SetVehicleWheelSize(eWheelGroup, fWheelSize);
             // Restream needed to update ride height
             m_pVehicleManager->RestreamVehicles(usModel);
-            return true;
-        }
-    }
-    return false;
-}
 
-bool CStaticFunctionDefinitions::SetVehicleModelWheelSizeRear(unsigned short usModel, float fWheelSize)
-{
-    if (CClientVehicleManager::IsValidModel(usModel))
-    {
-        auto pModelInfo = g_pGame->GetModelInfo(usModel);
-        if (pModelInfo)
-        {
-            pModelInfo->SetVehicleWheelSizeRear(fWheelSize);
-            // Restream needed to update ride height
-            m_pVehicleManager->RestreamVehicles(usModel);
             return true;
         }
     }
@@ -3668,28 +3653,14 @@ bool CStaticFunctionDefinitions::GetVehicleModelDummyPosition(unsigned short usM
     return false;
 }
 
-bool CStaticFunctionDefinitions::GetVehicleModelWheelSizeFront(unsigned short usModel, float& fWheelSize)
+bool CStaticFunctionDefinitions::GetVehicleModelWheelSize(unsigned short usModel, eResizableVehicleWheelGroup eWheelGroup, float& fWheelSize)
 {
-    if (CClientVehicleManager::IsValidModel(usModel))
+    if (CClientVehicleManager::IsValidModel(usModel) && eWheelGroup != eResizableVehicleWheelGroup::ALL_WHEELS)
     {
         auto pModelInfo = g_pGame->GetModelInfo(usModel);
         if (pModelInfo)
         {
-            fWheelSize = pModelInfo->GetVehicleWheelSizeFront();
-            return true;
-        }
-    }
-    return false;
-}
-
-bool CStaticFunctionDefinitions::GetVehicleModelWheelSizeRear(unsigned short usModel, float& fWheelSize)
-{
-    if (CClientVehicleManager::IsValidModel(usModel))
-    {
-        auto pModelInfo = g_pGame->GetModelInfo(usModel);
-        if (pModelInfo)
-        {
-            fWheelSize = pModelInfo->GetVehicleWheelSizeRear();
+            fWheelSize = pModelInfo->GetVehicleWheelSize(eWheelGroup);
             return true;
         }
     }

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -3603,6 +3603,38 @@ bool CStaticFunctionDefinitions::SetVehicleWindowOpen(CClientVehicle& Vehicle, u
     return Vehicle.SetWindowOpen(ucWindow, bOpen);
 }
 
+bool CStaticFunctionDefinitions::SetVehicleModelWheelSizeFront(unsigned short usModel, float fWheelSize)
+{
+    if (CClientVehicleManager::IsValidModel(usModel))
+    {
+        auto pModelInfo = g_pGame->GetModelInfo(usModel);
+        if (pModelInfo)
+        {
+            pModelInfo->SetVehicleWheelSizeFront(fWheelSize);
+            // Restream needed to update ride height
+            m_pVehicleManager->RestreamVehicles(usModel);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CStaticFunctionDefinitions::SetVehicleModelWheelSizeRear(unsigned short usModel, float fWheelSize)
+{
+    if (CClientVehicleManager::IsValidModel(usModel))
+    {
+        auto pModelInfo = g_pGame->GetModelInfo(usModel);
+        if (pModelInfo)
+        {
+            pModelInfo->SetVehicleWheelSizeRear(fWheelSize);
+            // Restream needed to update ride height
+            m_pVehicleManager->RestreamVehicles(usModel);
+            return true;
+        }
+    }
+    return false;
+}
+
 bool CStaticFunctionDefinitions::IsVehicleWindowOpen(CClientVehicle& Vehicle, uchar ucWindow)
 {
     return Vehicle.IsWindowOpen(ucWindow);
@@ -3630,6 +3662,34 @@ bool CStaticFunctionDefinitions::GetVehicleModelDummyPosition(unsigned short usM
         if (pModelInfo)
         {
             vecPosition = pModelInfo->GetVehicleDummyPosition(eDummies);
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CStaticFunctionDefinitions::GetVehicleModelWheelSizeFront(unsigned short usModel, float& fWheelSize)
+{
+    if (CClientVehicleManager::IsValidModel(usModel))
+    {
+        auto pModelInfo = g_pGame->GetModelInfo(usModel);
+        if (pModelInfo)
+        {
+            fWheelSize = pModelInfo->GetVehicleWheelSizeFront();
+            return true;
+        }
+    }
+    return false;
+}
+
+bool CStaticFunctionDefinitions::GetVehicleModelWheelSizeRear(unsigned short usModel, float& fWheelSize)
+{
+    if (CClientVehicleManager::IsValidModel(usModel))
+    {
+        auto pModelInfo = g_pGame->GetModelInfo(usModel);
+        if (pModelInfo)
+        {
+            fWheelSize = pModelInfo->GetVehicleWheelSizeRear();
             return true;
         }
     }

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -226,6 +226,8 @@ public:
     static bool            GetVehicleModelExhaustFumesPosition(unsigned short usModel, CVector& vecPosition);
     static bool            SetVehicleModelDummyPosition(unsigned short usModel, eVehicleDummies eDummy, CVector& vecPosition);
     static bool            GetVehicleModelDummyPosition(unsigned short usModel, eVehicleDummies eDummy, CVector& vecPosition);
+    static bool            GetVehicleModelWheelSizeFront(unsigned short usModel, float& fWheelSize);
+    static bool            GetVehicleModelWheelSizeRear(unsigned short usModel, float& fWheelSize);
 
     // Vehicle set functions
     static bool FixVehicle(CClientEntity& Entity);
@@ -270,6 +272,8 @@ public:
     static bool SetVehiclePlateText(CClientEntity& Entity, const SString& strText);
     static bool SetHeliBladeCollisionsEnabled(CClientVehicle& Vehicle, bool bEnabled);
     static bool SetVehicleWindowOpen(CClientVehicle& Vehicle, uchar ucWindow, bool bOpen);
+    static bool SetVehicleModelWheelSizeFront(unsigned short usModel, float fWheelSize);
+    static bool SetVehicleModelWheelSizeRear(unsigned short usModel, float fWheelSize);
 
     // Object get funcs
     static CClientObject* CreateObject(CResource& Resource, unsigned short usModelID, const CVector& vecPosition, const CVector& vecRotation, bool bLowLod);

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -226,8 +226,7 @@ public:
     static bool            GetVehicleModelExhaustFumesPosition(unsigned short usModel, CVector& vecPosition);
     static bool            SetVehicleModelDummyPosition(unsigned short usModel, eVehicleDummies eDummy, CVector& vecPosition);
     static bool            GetVehicleModelDummyPosition(unsigned short usModel, eVehicleDummies eDummy, CVector& vecPosition);
-    static bool            GetVehicleModelWheelSizeFront(unsigned short usModel, float& fWheelSize);
-    static bool            GetVehicleModelWheelSizeRear(unsigned short usModel, float& fWheelSize);
+    static bool            GetVehicleModelWheelSize(unsigned short usModel, eResizableVehicleWheelGroup eWheelGroup, float& fWheelSize);
 
     // Vehicle set functions
     static bool FixVehicle(CClientEntity& Entity);
@@ -272,8 +271,7 @@ public:
     static bool SetVehiclePlateText(CClientEntity& Entity, const SString& strText);
     static bool SetHeliBladeCollisionsEnabled(CClientVehicle& Vehicle, bool bEnabled);
     static bool SetVehicleWindowOpen(CClientVehicle& Vehicle, uchar ucWindow, bool bOpen);
-    static bool SetVehicleModelWheelSizeFront(unsigned short usModel, float fWheelSize);
-    static bool SetVehicleModelWheelSizeRear(unsigned short usModel, float fWheelSize);
+    static bool SetVehicleModelWheelSize(unsigned short usModel, eResizableVehicleWheelGroup eWheelGroup, float fWheelSize);
 
     // Object get funcs
     static CClientObject* CreateObject(CResource& Resource, unsigned short usModelID, const CVector& vecPosition, const CVector& vecRotation, bool bLowLod);

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
@@ -581,6 +581,12 @@ ADD_ENUM(WING_AIRTRAIL, "wing_airtrail")
 ADD_ENUM(VEH_GUN, "veh_gun")
 IMPLEMENT_ENUM_END("vehicle-dummy")
 
+IMPLEMENT_ENUM_CLASS_BEGIN(eResizableVehicleWheelGroup)
+ADD_ENUM(eResizableVehicleWheelGroup::FRONT_AXLE, "front_axle")
+ADD_ENUM(eResizableVehicleWheelGroup::REAR_AXLE, "rear_axle")
+ADD_ENUM(eResizableVehicleWheelGroup::ALL_WHEELS, "all_wheels")
+IMPLEMENT_ENUM_CLASS_END("resizable-vehicle-wheel-group")
+
 IMPLEMENT_ENUM_BEGIN(eSurfaceProperties)
 ADD_ENUM(SURFACE_PROPERTY_AUDIO, "audio")
 ADD_ENUM(SURFACE_PROPERTY_STEPWATERSPLASH, "stepwatersplash")

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
@@ -57,6 +57,7 @@ DECLARE_ENUM(eCursorType)
 DECLARE_ENUM(eWheelPosition)
 DECLARE_ENUM(D3DPRIMITIVETYPE);
 DECLARE_ENUM(eVehicleDummies);
+DECLARE_ENUM_CLASS(eResizableVehicleWheelGroup);
 DECLARE_ENUM(eSurfaceProperties);
 DECLARE_ENUM(eSurfaceAudio);
 DECLARE_ENUM(eSurfaceBulletEffect);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -83,6 +83,8 @@ void CLuaVehicleDefs::LoadFunctions()
         {"getVehicleComponents", GetVehicleComponents},
         {"getVehicleModelExhaustFumesPosition", GetVehicleModelExhaustFumesPosition},
         {"getVehicleModelDummyPosition", GetVehicleModelDummyPosition},
+        {"getVehicleModelFrontWheelSize", ArgumentParser<GetVehicleModelFrontWheelSize>},
+        {"getVehicleModelRearWheelSize", ArgumentParser<GetVehicleModelRearWheelSize>},
 
         // Vehicle set funcs
         {"createVehicle", CreateVehicle},
@@ -139,6 +141,8 @@ void CLuaVehicleDefs::LoadFunctions()
         {"setVehicleWindowOpen", SetVehicleWindowOpen},
         {"setVehicleModelExhaustFumesPosition", SetVehicleModelExhaustFumesPosition},
         {"setVehicleModelDummyPosition", SetVehicleModelDummyPosition },
+        {"setVehicleModelFrontWheelSize", ArgumentParser<SetVehicleModelFrontWheelSize>},
+        {"setVehicleModelRearWheelSize", ArgumentParser<SetVehicleModelRearWheelSize>},
     };
 
     // Add functions
@@ -221,6 +225,8 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getUpgradeOnSlot", "getVehicleUpgradeOnSlot");
     lua_classfunction(luaVM, "getModelExhaustFumesPosition", OOP_GetVehicleModelExhaustFumesPosition);
     lua_classfunction(luaVM, "getVehicleModelDummyPosition", OOP_GetVehicleModelDummyPosition);
+    lua_classfunction(luaVM, "getModelFrontWheelSize", "getVehicleModelFrontWheelSize");
+    lua_classfunction(luaVM, "getModelRearWheelSize", "getVehicleModelRearWheelSize");
 
     lua_classfunction(luaVM, "setComponentVisible", "setVehicleComponentVisible");
     lua_classfunction(luaVM, "setSirensOn", "setVehicleSirensOn");
@@ -264,6 +270,8 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setGravity", "setVehicleGravity");
     lua_classfunction(luaVM, "setModelExhaustFumesPosition", "setVehicleModelExhaustFumesPosition");
     lua_classfunction(luaVM, "setVehicleModelDummyPosition", "setVehicleModelDummyPosition");
+    lua_classfunction(luaVM, "setModelFrontWheelSize", "setVehicleModelFrontWheelSize");
+    lua_classfunction(luaVM, "setModelRearWheelSize", "setVehicleModelRearWheelSize");
 
     lua_classfunction(luaVM, "resetComponentPosition", "resetVehicleComponentPosition");
     lua_classfunction(luaVM, "resetComponentRotation", "resetVehicleComponentRotation");
@@ -4051,4 +4059,40 @@ int CLuaVehicleDefs::OOP_GetVehicleModelExhaustFumesPosition(lua_State* luaVM)
 
     lua_pushboolean(luaVM, false);
     return 1;
+}
+
+float CLuaVehicleDefs::GetVehicleModelFrontWheelSize(const unsigned short usModel)
+{
+    float fWheelSize;
+
+    if (!CStaticFunctionDefinitions::GetVehicleModelWheelSizeFront(usModel, fWheelSize))
+        throw std::invalid_argument("Invalid model ID");
+
+    return fWheelSize;
+}
+
+bool CLuaVehicleDefs::SetVehicleModelFrontWheelSize(const unsigned short usModel, const float fWheelSize)
+{
+    if (fWheelSize <= 0)
+        throw std::invalid_argument("Invalid wheel size");
+
+    return CStaticFunctionDefinitions::SetVehicleModelWheelSizeFront(usModel, fWheelSize);
+}
+
+float CLuaVehicleDefs::GetVehicleModelRearWheelSize(const unsigned short usModel)
+{
+    float fWheelSize;
+
+    if (!CStaticFunctionDefinitions::GetVehicleModelWheelSizeRear(usModel, fWheelSize))
+        throw std::invalid_argument("Invalid model ID");
+
+    return fWheelSize;
+}
+
+bool CLuaVehicleDefs::SetVehicleModelRearWheelSize(const unsigned short usModel, const float fWheelSize)
+{
+    if (fWheelSize <= 0)
+        throw std::invalid_argument("Invalid wheel size");
+
+    return CStaticFunctionDefinitions::SetVehicleModelWheelSizeRear(usModel, fWheelSize);
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -4057,12 +4057,10 @@ int CLuaVehicleDefs::OOP_GetVehicleModelExhaustFumesPosition(lua_State* luaVM)
     return 1;
 }
 
-std::variant<float, std::unordered_map<std::string, float>> CLuaVehicleDefs::GetVehicleModelWheelSize(
-    const unsigned short usModel, const std::optional<eResizableVehicleWheelGroup> eWheelGroup)
+std::variant<float, std::unordered_map<std::string, float>> CLuaVehicleDefs::GetVehicleModelWheelSize(const unsigned short              usModel,
+                                                                                                      const eResizableVehicleWheelGroup eWheelGroup)
 {
-    eResizableVehicleWheelGroup eActualWheelGroup = eWheelGroup.value_or(eResizableVehicleWheelGroup::ALL_WHEELS);
-
-    if (eActualWheelGroup == eResizableVehicleWheelGroup::ALL_WHEELS)
+    if (eWheelGroup == eResizableVehicleWheelGroup::ALL_WHEELS)
     {
         float fFrontWheelSize;
         if (!CStaticFunctionDefinitions::GetVehicleModelWheelSize(usModel, eResizableVehicleWheelGroup::FRONT_AXLE, fFrontWheelSize))
@@ -4081,7 +4079,7 @@ std::variant<float, std::unordered_map<std::string, float>> CLuaVehicleDefs::Get
     else
     {
         float fWheelSize;
-        if (!CStaticFunctionDefinitions::GetVehicleModelWheelSize(usModel, eActualWheelGroup, fWheelSize))
+        if (!CStaticFunctionDefinitions::GetVehicleModelWheelSize(usModel, eWheelGroup, fWheelSize))
             throw std::invalid_argument("Invalid model ID");
 
         return fWheelSize;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -4057,10 +4057,12 @@ int CLuaVehicleDefs::OOP_GetVehicleModelExhaustFumesPosition(lua_State* luaVM)
     return 1;
 }
 
-std::variant<float, std::unordered_map<std::string, float>> CLuaVehicleDefs::GetVehicleModelWheelSize(const unsigned short              usModel,
-                                                                                                      const eResizableVehicleWheelGroup eWheelGroup)
+std::variant<float, std::unordered_map<std::string, float>> CLuaVehicleDefs::GetVehicleModelWheelSize(
+    const unsigned short usModel, const std::optional<eResizableVehicleWheelGroup> eWheelGroup)
 {
-    if (eWheelGroup == eResizableVehicleWheelGroup::ALL_WHEELS)
+    eResizableVehicleWheelGroup eActualWheelGroup = eWheelGroup.value_or(eResizableVehicleWheelGroup::ALL_WHEELS);
+
+    if (eActualWheelGroup == eResizableVehicleWheelGroup::ALL_WHEELS)
     {
         float fFrontWheelSize;
         if (!CStaticFunctionDefinitions::GetVehicleModelWheelSize(usModel, eResizableVehicleWheelGroup::FRONT_AXLE, fFrontWheelSize))
@@ -4079,18 +4081,17 @@ std::variant<float, std::unordered_map<std::string, float>> CLuaVehicleDefs::Get
     else
     {
         float fWheelSize;
-        if (!CStaticFunctionDefinitions::GetVehicleModelWheelSize(usModel, eWheelGroup, fWheelSize))
+        if (!CStaticFunctionDefinitions::GetVehicleModelWheelSize(usModel, eActualWheelGroup, fWheelSize))
             throw std::invalid_argument("Invalid model ID");
 
         return fWheelSize;
     }
 }
 
-bool CLuaVehicleDefs::SetVehicleModelWheelSize(const unsigned short usModel, const std::optional<eResizableVehicleWheelGroup> eWheelGroup,
-                                               const float fWheelSize)
+bool CLuaVehicleDefs::SetVehicleModelWheelSize(const unsigned short usModel, const eResizableVehicleWheelGroup eWheelGroup, const float fWheelSize)
 {
     if (fWheelSize <= 0)
         throw std::invalid_argument("Invalid wheel size");
 
-    return CStaticFunctionDefinitions::SetVehicleModelWheelSize(usModel, eWheelGroup.value_or(eResizableVehicleWheelGroup::ALL_WHEELS), fWheelSize);
+    return CStaticFunctionDefinitions::SetVehicleModelWheelSize(usModel, eWheelGroup, fWheelSize);
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -143,6 +143,11 @@ public:
     LUA_DECLARE(SetVehicleModelExhaustFumesPosition);
     LUA_DECLARE_OOP(GetVehicleModelExhaustFumesPosition);
 
+    static float GetVehicleModelFrontWheelSize(const unsigned short usModel);
+    static bool  SetVehicleModelFrontWheelSize(const unsigned short usModel, const float fWheelSize);
+    static float GetVehicleModelRearWheelSize(const unsigned short usModel);
+    static bool  SetVehicleModelRearWheelSize(const unsigned short usModel, const float fWheelSize);
+
     // Components
     LUA_DECLARE(SetVehicleComponentPosition);
     LUA_DECLARE_OOP(GetVehicleComponentPosition);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -143,9 +143,9 @@ public:
     LUA_DECLARE(SetVehicleModelExhaustFumesPosition);
     LUA_DECLARE_OOP(GetVehicleModelExhaustFumesPosition);
 
-    static std::variant<float, std::unordered_map<std::string, float>> GetVehicleModelWheelSize(const unsigned short              usModel,
-                                                                                                const eResizableVehicleWheelGroup eWheelGroup);
-    static bool SetVehicleModelWheelSize(const unsigned short usModel, const std::optional<eResizableVehicleWheelGroup> eWheelGroup, const float fWheelSize);
+    static std::variant<float, std::unordered_map<std::string, float>> GetVehicleModelWheelSize(const unsigned short                             usModel,
+                                                                                                const std::optional<eResizableVehicleWheelGroup> eWheelGroup);
+    static bool SetVehicleModelWheelSize(const unsigned short usModel, const eResizableVehicleWheelGroup eWheelGroup, const float fWheelSize);
 
     // Components
     LUA_DECLARE(SetVehicleComponentPosition);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -143,10 +143,9 @@ public:
     LUA_DECLARE(SetVehicleModelExhaustFumesPosition);
     LUA_DECLARE_OOP(GetVehicleModelExhaustFumesPosition);
 
-    static float GetVehicleModelFrontWheelSize(const unsigned short usModel);
-    static bool  SetVehicleModelFrontWheelSize(const unsigned short usModel, const float fWheelSize);
-    static float GetVehicleModelRearWheelSize(const unsigned short usModel);
-    static bool  SetVehicleModelRearWheelSize(const unsigned short usModel, const float fWheelSize);
+    static std::variant<float, std::unordered_map<std::string, float>> GetVehicleModelWheelSize(const unsigned short                             usModel,
+                                                                                                const std::optional<eResizableVehicleWheelGroup> eWheelGroup);
+    static bool SetVehicleModelWheelSize(const unsigned short usModel, const std::optional<eResizableVehicleWheelGroup> eWheelGroup, const float fWheelSize);
 
     // Components
     LUA_DECLARE(SetVehicleComponentPosition);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -143,8 +143,8 @@ public:
     LUA_DECLARE(SetVehicleModelExhaustFumesPosition);
     LUA_DECLARE_OOP(GetVehicleModelExhaustFumesPosition);
 
-    static std::variant<float, std::unordered_map<std::string, float>> GetVehicleModelWheelSize(const unsigned short                             usModel,
-                                                                                                const std::optional<eResizableVehicleWheelGroup> eWheelGroup);
+    static std::variant<float, std::unordered_map<std::string, float>> GetVehicleModelWheelSize(const unsigned short              usModel,
+                                                                                                const eResizableVehicleWheelGroup eWheelGroup);
     static bool SetVehicleModelWheelSize(const unsigned short usModel, const std::optional<eResizableVehicleWheelGroup> eWheelGroup, const float fWheelSize);
 
     // Components

--- a/Client/sdk/game/CModelInfo.h
+++ b/Client/sdk/game/CModelInfo.h
@@ -154,11 +154,9 @@ public:
     virtual CVector      GetVehicleDummyPosition(eVehicleDummies eDummy) = 0;
     virtual void         SetVehicleDummyPosition(eVehicleDummies eDummy, const CVector& vecPosition) = 0;
     virtual void         ResetVehicleDummies(bool bRemoveFromDummiesMap) = 0;
-    virtual float        GetVehicleWheelSizeFront() = 0;
-    virtual void         SetVehicleWheelSizeFront(float fWheelSize, bool bStoreDefaultSize = true) = 0;
-    virtual float        GetVehicleWheelSizeRear() = 0;
-    virtual void         SetVehicleWheelSizeRear(float fWheelSize, bool bStoreDefaultSize = true) = 0;
-    virtual void         ResetVehicleWheelSizes() = 0;
+    virtual float        GetVehicleWheelSize(eResizableVehicleWheelGroup eWheelGroup) = 0;
+    virtual void         SetVehicleWheelSize(eResizableVehicleWheelGroup eWheelGroup, float fWheelSize) = 0;
+    virtual void         ResetVehicleWheelSizes(std::pair<float, float>* defaultSizes = NULL) = 0;
 
     // Init the supported upgrades structure
     virtual void InitialiseSupportedUpgrades(RpClump* pClump) = 0;

--- a/Client/sdk/game/CModelInfo.h
+++ b/Client/sdk/game/CModelInfo.h
@@ -156,7 +156,7 @@ public:
     virtual void         ResetVehicleDummies(bool bRemoveFromDummiesMap) = 0;
     virtual float        GetVehicleWheelSize(eResizableVehicleWheelGroup eWheelGroup) = 0;
     virtual void         SetVehicleWheelSize(eResizableVehicleWheelGroup eWheelGroup, float fWheelSize) = 0;
-    virtual void         ResetVehicleWheelSizes(std::pair<float, float>* defaultSizes = NULL) = 0;
+    virtual void         ResetVehicleWheelSizes(std::pair<float, float>* defaultSizes = nullptr) = 0;
 
     // Init the supported upgrades structure
     virtual void InitialiseSupportedUpgrades(RpClump* pClump) = 0;

--- a/Client/sdk/game/CModelInfo.h
+++ b/Client/sdk/game/CModelInfo.h
@@ -154,6 +154,11 @@ public:
     virtual CVector      GetVehicleDummyPosition(eVehicleDummies eDummy) = 0;
     virtual void         SetVehicleDummyPosition(eVehicleDummies eDummy, const CVector& vecPosition) = 0;
     virtual void         ResetVehicleDummies(bool bRemoveFromDummiesMap) = 0;
+    virtual float        GetVehicleWheelSizeFront() = 0;
+    virtual void         SetVehicleWheelSizeFront(float fWheelSize, bool bStoreDefaultSize = true) = 0;
+    virtual float        GetVehicleWheelSizeRear() = 0;
+    virtual void         SetVehicleWheelSizeRear(float fWheelSize, bool bStoreDefaultSize = true) = 0;
+    virtual void         ResetVehicleWheelSizes() = 0;
 
     // Init the supported upgrades structure
     virtual void InitialiseSupportedUpgrades(RpClump* pClump) = 0;

--- a/Client/sdk/game/Common.h
+++ b/Client/sdk/game/Common.h
@@ -1536,6 +1536,13 @@ enum eVehicleDummies
     VEH_GUN,
 };
 
+enum class eResizableVehicleWheelGroup
+{
+    FRONT_AXLE = 0,
+    REAR_AXLE,
+    ALL_WHEELS = 0xFF,
+};
+
 enum eObjectProperty
 {
     OBJECT_PROPERTY_ALL,

--- a/Shared/mods/deathmatch/logic/lua/LuaBasic.h
+++ b/Shared/mods/deathmatch/logic/lua/LuaBasic.h
@@ -83,7 +83,7 @@ namespace lua
     template <typename... Ts>
     int Push(lua_State* L, const std::variant<Ts...>&& val)
     {
-        return std::visit([L](auto&& value) -> int { return Push(L, value); }, val);
+        return std::visit([L](auto&& value) -> int { return Push(L, std::move(value)); }, val);
     }
 
     template <typename T>


### PR DESCRIPTION
These functions, related to issue #719, allow getting and setting the front and rear wheel size of a vehicle model that GTA: SA reads from the `vehicle.ide` file in clientside Lua scripts. Moreover, in combination with #1641, all the wheels can then be visually scaled per vehicle.

## Considerations
### Why?
#1641 provides functions that allow customizing the draw scale of all the wheels of a vehicle, which should be enough for compensating typical small differences in sizes and allowing some creative usages.

However, this PR provides another solution, which also has a feature that is desired by some people I talked to on Discord: it influences the related physical parameters of the model. These parameters are the ride height (which is also known as "height above ground", and affects handling) and wheel collision (used to check if bullets hit a tyre to burst it, for example). This approach not only allows to compensate for bigger differences, which relieves 3D artists of having to stick to a ride height that is similar to the default one, but also allows for even more model customization. For instance, race servers may use these functions to give a different feel to a same car model for each race.

As the wheel size parameters do not change the visual scale of the wheels, unless they are different for each axle (in which case the wheels are drawn with a different scale for each axle and rotated), the core idea of #1641 is still relevant for further per-vehicle, all-wheel customization, that takes the model wheel scale influenced by these functions as a basis.

### Potential for improvement
I think that this patchset could be improved with the following ideas:

- Expand the vehicle model loading functions to calculate these values automagically (but the ability to set them manually doesn't need to be removed; there might be some use cases based on deliberately setting different values).
- Allow each vehicle to have different wheel sizes, even if they share the same model.
- Make the wheel size different for each wheel, instead of for each axle.

Nevertheless, those ideas are rather complex to implement. I believe that this PR (and maybe its "companion" #1641) offers substantial functionality for server owners that, perhaps most importantly, shouldn't impose a notorious mantainance or backward compability burden, should these improvements be made.

## Acknowledgements
I'd like to thank @saml1er for sharing over Discord the results of his previous experiments with changing these parameters, which included proof of concept code and some helpful pointers. Without his help this PR probably wouldn't exist.

## Functions added
```lua
float/table getVehicleModelWheelSize ( int vehicleModel[, string wheelGroup ] )
```
Returns a decimal number that represents the size of the wheels in the specified wheel group of a vehicle model ID. The possible wheel groups are "front_axle" (for the wheels in the front axle), "rear_axle" (for the wheels in the rear axle) and "all_wheels" (for all the wheel groups). These sizes affect the ride height and wheel collision, but they also may affect visual wheel scale and rotation if they differ. The default values for a model are read by GTA: SA from the `vehicles.ide` file, and must be greater than 0. If the wheel group is "all_wheels" or not specified, a table like `{ ["front_axle"] = 0.7, ["rear_axle"] = 0.8 }` is returned, with the values for each wheel group.
```lua
bool setVehicleModelWheelSize ( int vehicleModel, string wheelGroup, float wheelSize )
```
Sets the wheel size multiplier for the wheels in a wheel group of a vehicle model ID.

## Screenshots
Custom vehicle model, before and after:
![mta-screen_2020-08-29_19-00-21](https://user-images.githubusercontent.com/7822554/91645860-6cf92180-ea49-11ea-9915-638210aa1789.png)
![mta-screen_2020-08-29_19-00-38](https://user-images.githubusercontent.com/7822554/91645865-72ef0280-ea49-11ea-8524-f963da3fcd2e.png)
A funky quad:
![mta-screen_2020-08-29_19-13-52](https://user-images.githubusercontent.com/7822554/91645867-76828980-ea49-11ea-9aa5-795367c4c53a.png)
