### PR TITLE
Tweak wheel scaling behavior to be more consistent

### DIFF
--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -5024,7 +5024,7 @@ void CClientVehicle::ResetWheelScale()
 {
     // The calculation of the default wheel scale is based on original GTA code at functions
     // 0x6E3290 (CVehicle::AddVehicleUpgrade) and 0x6DF930 (CVehicle::RemoveVehicleUpgrade)
-    if (m_pUpgrades && m_pUpgrades->GetSlotState(12) != 0)
+    if (m_pUpgrades->GetSlotState(12) != 0)
         m_fWheelScale = m_pModelInfo->GetVehicleWheelSize(eResizableVehicleWheelGroup::FRONT_AXLE);
     else
         m_fWheelScale = 1.0f;

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -2828,14 +2828,16 @@ void CClientVehicle::Create()
                 ApplyHandling();
         }
 
-        // Re-add all the upgrades - Has to be applied after handling *shrugs*
-        bool bPreviousWheelScaleChanged = m_bWheelScaleChanged;
+        // Applying wheel upgrades can change these values.
+        // We should keep track of the original values to restore them
+        bool  bPreviousWheelScaleChanged = m_bWheelScaleChanged;
         float fPreviousWheelScale = m_fWheelScale;
+
+        // Re-add all the upgrades - Has to be applied after handling *shrugs*
         if (m_pUpgrades)
             m_pUpgrades->ReAddAll();
 
-        // Set wheel scale after wheel upgrades have been added.
-        // They change it and reset m_bWheelScaleChanged
+        // Restore custom wheel scale
         if (bPreviousWheelScaleChanged)
         {
             m_pVehicle->SetWheelScale(fPreviousWheelScale);

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -5022,6 +5022,8 @@ float CClientVehicle::GetWheelScale()
 // (i.e. after installing a wheel upgrade)
 void CClientVehicle::ResetWheelScale()
 {
+    assert(m_pUpgrades);
+
     // The calculation of the default wheel scale is based on original GTA code at functions
     // 0x6E3290 (CVehicle::AddVehicleUpgrade) and 0x6DF930 (CVehicle::RemoveVehicleUpgrade)
     if (m_pUpgrades->GetSlotState(12) != 0)

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -5024,7 +5024,7 @@ void CClientVehicle::ResetWheelScale()
 {
     // The calculation of the default wheel scale is based on original GTA code at functions
     // 0x6E3290 (CVehicle::AddVehicleUpgrade) and 0x6DF930 (CVehicle::RemoveVehicleUpgrade)
-    if (m_pUpgrades->GetSlotState(12) != 0)
+    if (m_pUpgrades && m_pUpgrades->GetSlotState(12) != 0)
         m_fWheelScale = m_pModelInfo->GetVehicleWheelSize(eResizableVehicleWheelGroup::FRONT_AXLE);
     else
         m_fWheelScale = 1.0f;

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -2841,6 +2841,7 @@ void CClientVehicle::Create()
         if (bPreviousWheelScaleChanged)
         {
             m_pVehicle->SetWheelScale(fPreviousWheelScale);
+            m_fWheelScale = fPreviousWheelScale;
             m_bWheelScaleChanged = true;
         }
 

--- a/Client/mods/deathmatch/logic/CClientVehicle.h
+++ b/Client/mods/deathmatch/logic/CClientVehicle.h
@@ -496,6 +496,7 @@ public:
 
     float GetWheelScale();
     void  SetWheelScale(float fWheelScale);
+    void  ResetWheelScale();
 
     bool OnVehicleFallThroughMap();
 
@@ -621,6 +622,7 @@ protected:
     float m_fTrainPosition;
     uchar m_ucTrackID;
     bool  m_bJustStreamedIn;
+    bool  m_bWheelScaleChanged;
 
     // Time dependent error compensation interpolation
     struct

--- a/Client/mods/deathmatch/logic/CVehicleUpgrades.cpp
+++ b/Client/mods/deathmatch/logic/CVehicleUpgrades.cpp
@@ -611,6 +611,10 @@ void CVehicleUpgrades::ForceAddUpgrade(unsigned short usUpgrade)
 
         // Add it to the slot
         m_SlotStates[ucSlot] = usUpgrade;
+
+        // Reset wheel scale if it is a wheel upgrade
+        if (ucSlot == 12)
+            m_pVehicle->ResetWheelScale();
     }
 }
 
@@ -655,6 +659,10 @@ bool CVehicleUpgrades::RemoveUpgrade(unsigned short usUpgrade)
             {
                 m_SlotStates[ucSlot] = 0;
             }
+
+            // Reset wheel scale if it is a wheel upgrade
+            if (ucSlot == 12)
+                m_pVehicle->ResetWheelScale();
 
             return true;
         }
@@ -710,6 +718,10 @@ void CVehicleUpgrades::RemoveAll(bool bRipFromVehicle)
                 }
             }
             m_SlotStates[ucSlot] = 0;
+
+            // Reset wheel scale for wheel upgrades
+            if (ucSlot == 12 && m_pVehicle)
+                m_pVehicle->ResetWheelScale();
         }
     }
 }


### PR DESCRIPTION
#1641, which introduced `setVehicleWheelScale`, doesn't account for GTA: SA changing the wheel scale as a result of wheel upgrades being added or removed, and using different default scales for vehicles with upgraded wheels. Although this does not pose a serious issue, I have just found that it leads to inconsistent behavior, like the one that is shown in the following flow of events:


> - Wheel upgrade is removed from streamed in vehicle
> - Wheel scale is reset by GTA to the default, which is returned by getVehicleWheelScale
> - Vehicle is streamed out and back in
> - The wheel scale is set back to the last value set by a script or 1 (not the same scale that it was streamed out with)


This PR tweaks that behavior by adding logic to synchronize the default wheel scale calculated by GTA with the one present in `CClientVehicle` attributes, for which functionality added in #1644 is used. This way, the previous event flow, for example, becomes:


> - Wheel upgrade is removed from streamed in vehicle
> - Wheel scale is reset by GTA
> - Vehicle is streamed out and back in
> - The wheel scale set by GTA is preserved


Also, as expected, the scale set by a script is now always honored, until it is reset by GTA during a script-initiated wheel upgrade installation or removal.

All in all, I believe that the new behavior is more consistent with the expectations that script developers may have, and as the function was introduced only days ago, it's not too late to fix this. Moreover, I think that GTA resetting the wheel size makes sense because, as upgraded wheel models are reused accross different vehicles, they need different scales to accomodate each vehicle, so it should be changed anyway. Finally, as a side bonus, the new behavior works better for streamed out vehicles.