### PR TITLE
Fix crash in CModelInfoSA::GetVehicleWheelSize if model info is not l…

### DIFF
--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -1020,6 +1020,10 @@ float CModelInfoSA::GetVehicleWheelSize(eResizableVehicleWheelGroup eWheelGroup)
     if (!IsVehicle())
         return 0.0f;
 
+    // Request model load right now if not loaded yet
+    if (!IsLoaded())
+        Request(BLOCKING, "GetVehicleWheelSize");
+
     auto pVehicleModel = reinterpret_cast<CVehicleModelInfoSAInterface*>(m_pInterface);
     switch (eWheelGroup)
     {
@@ -1036,6 +1040,10 @@ void CModelInfoSA::SetVehicleWheelSize(eResizableVehicleWheelGroup eWheelGroup, 
 {
     if (!IsVehicle())
         return;
+
+    // Request model load right now if not loaded yet
+    if (!IsLoaded())
+        Request(BLOCKING, "SetVehicleWheelSize");
 
     auto pVehicleModel = reinterpret_cast<CVehicleModelInfoSAInterface*>(m_pInterface);
 


### PR DESCRIPTION
This fixes a crash introduced with the recent addition of wheel scale functionality. Since `CClientVehicle::ResetWheelScale` may be called even if the vehicle is not streamed in, the model info for the vehicle may not be loaded. As a result, accessing the model info may fail, when trying to call `CClientVehicle::ResetWheelScale`, causing a crash. 

To fix, we make `CModelInfo::GetVehicleWheelSize` load the model if required. I also applied this to `SetVehicleWheelSize` as I suspect we might run into similar issues.

--- 

Generally the way we handle `CModelInfo` seems a bit confusing and unreliable. Might be better to wrap it to request models automatically when attempting to use them via a RAII wrapper.