### PR TITLE
Add onElementWaterInteract event

### DIFF
--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -1549,7 +1549,7 @@ void CGame::AddBuiltInEvents()
     m_Events.AddEvent("onVehicleEnter", "player, seat, jacked", NULL, false);
     m_Events.AddEvent("onVehicleExit", "player, seat, jacker", NULL, false);
     m_Events.AddEvent("onVehicleExplode", "", NULL, false);
-    m_Events.AddEvent("onVehicleDrown", "", nullptr, false);
+    m_Events.AddEvent("onElementWaterInteract", "bWaterInOrOut", nullptr, false);
 
     // Console events
     m_Events.AddEvent("onConsole", "text", NULL, false);

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -1549,7 +1549,7 @@ void CGame::AddBuiltInEvents()
     m_Events.AddEvent("onVehicleEnter", "player, seat, jacked", NULL, false);
     m_Events.AddEvent("onVehicleExit", "player, seat, jacker", NULL, false);
     m_Events.AddEvent("onVehicleExplode", "", NULL, false);
-    m_Events.AddEvent("onVehicleDrown", "", NULL, false);
+    m_Events.AddEvent("onVehicleDrown", "", nullptr, false);
 
     // Console events
     m_Events.AddEvent("onConsole", "text", NULL, false);

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -1549,6 +1549,7 @@ void CGame::AddBuiltInEvents()
     m_Events.AddEvent("onVehicleEnter", "player, seat, jacked", NULL, false);
     m_Events.AddEvent("onVehicleExit", "player, seat, jacker", NULL, false);
     m_Events.AddEvent("onVehicleExplode", "", NULL, false);
+    m_Events.AddEvent("onVehicleDrown", "", NULL, false);
 
     // Console events
     m_Events.AddEvent("onConsole", "text", NULL, false);

--- a/Server/mods/deathmatch/logic/CObject.h
+++ b/Server/mods/deathmatch/logic/CObject.h
@@ -71,6 +71,9 @@ public:
     CPlayer* GetSyncer() { return m_pSyncer; }
     void     SetSyncer(CPlayer* pPlayer);
 
+    float GetLastSyncedIsInWater() { return m_bLastSyncedIsInWater; };
+    void  setLastSyncedIsInWater(bool bIsInWater) { m_bLastSyncedIsInWater = bIsInWater; };
+
     bool     IsLowLod();
     bool     SetLowLodObject(CObject* pLowLodObject);
     CObject* GetLowLodObject();
@@ -103,4 +106,5 @@ protected:
 
 public:
     CPositionRotationAnimation* m_pMoveAnimation;
+    bool                        m_bLastSyncedIsInWater = false;
 };

--- a/Server/mods/deathmatch/logic/CObjectSync.cpp
+++ b/Server/mods/deathmatch/logic/CObjectSync.cpp
@@ -211,6 +211,15 @@ void CObjectSync::Packet_ObjectSync(CObjectSyncPacket& Packet)
                     if (pData->ucFlags & 0x4)
                         pObject->SetHealth(pData->fHealth);
 
+                    bool bInWater = pObject->IsInWater();
+                    if (bInWater != pObject->GetLastSyncedIsInWater())
+                    {
+                        CLuaArguments Arguments;
+                        Arguments.PushBoolean(bInWater);
+                        pPed->CallEvent("onElementWaterInteract", Arguments);
+                    }
+                    pPed->setLastSyncedIsInWater(bInWater);
+
                     // Send this sync
                     pData->bSend = true;
                 }

--- a/Server/mods/deathmatch/logic/CPed.h
+++ b/Server/mods/deathmatch/logic/CPed.h
@@ -257,6 +257,8 @@ public:
 
     bool     IsSyncable() { return m_bSyncable; };
     void     SetSyncable(bool bSynced) { m_bSyncable = bSynced; };
+    float    GetLastSyncedIsInWater() { return m_bLastSyncedIsInWater; };
+    void     setLastSyncedIsInWater(bool bIsInWater) { m_bLastSyncedIsInWater = bIsInWater; };
     CPlayer* m_pSyncer;
 
     bool IsStealthAiming() { return m_bStealthAiming; }
@@ -312,4 +314,5 @@ protected:
 
 private:
     CPedManager* m_pPedManager;
+    bool         m_bLastSyncedIsInWater = false;
 };

--- a/Server/mods/deathmatch/logic/CPedSync.cpp
+++ b/Server/mods/deathmatch/logic/CPedSync.cpp
@@ -251,6 +251,15 @@ void CPedSync::Packet_PedSync(CPedSyncPacket& Packet)
                     if (pData->ucFlags & 0x40 && pPlayer->GetBitStreamVersion() >= 0x55)
                         pPed->SetInWater(pData->bIsInWater);
 
+                    bool bInWater = pPed->IsInWater();
+                    if (bInWater != pPed->GetLastSyncedIsInWater())
+                    {
+                        CLuaArguments Arguments;
+                        Arguments.PushBoolean(bInWater);
+                        pPed->CallEvent("onElementWaterInteract", Arguments);
+                    }
+                    pPed->setLastSyncedIsInWater(bInWater);
+
                     // Send this sync
                     pData->bSend = true;
                 }

--- a/Server/mods/deathmatch/logic/CUnoccupiedVehicleSync.cpp
+++ b/Server/mods/deathmatch/logic/CUnoccupiedVehicleSync.cpp
@@ -417,11 +417,12 @@ void CUnoccupiedVehicleSync::Packet_UnoccupiedVehicleSync(CUnoccupiedVehicleSync
                         bool bDerailed = pVehicle->IsDerailed();
                         bool bInWater = pVehicle->IsInWater();
 
-                        if (bInWater && bInWater != pVehicle->GetLastSyncedIsInWater())
+                        if (bInWater != pVehicle->GetLastSyncedIsInWater())
                         {
                             // Call the event once in water
                             CLuaArguments Arguments;
-                            pVehicle->CallEvent("onVehicleDrown", Arguments);
+                            Arguments.PushBoolean(bInWater);
+                            pVehicle->CallEvent("onElementWaterInteract", Arguments);
                         }
                         pVehicle->setLastSyncedIsInWater(bInWater);
 

--- a/Server/mods/deathmatch/logic/CUnoccupiedVehicleSync.cpp
+++ b/Server/mods/deathmatch/logic/CUnoccupiedVehicleSync.cpp
@@ -417,6 +417,14 @@ void CUnoccupiedVehicleSync::Packet_UnoccupiedVehicleSync(CUnoccupiedVehicleSync
                         bool bDerailed = pVehicle->IsDerailed();
                         bool bInWater = pVehicle->IsInWater();
 
+                        if (bInWater && bInWater != pVehicle->GetLastSyncedIsInWater())
+                        {
+                            // Call the event once in water
+                            CLuaArguments Arguments;
+                            pVehicle->CallEvent("onVehicleDrown", Arguments);
+                        }
+                        pVehicle->setLastSyncedIsInWater(bInWater);
+
                         // Turn the engine on if it's on
                         pVehicle->SetEngineOn(vehicle.data.bEngineOn);
 

--- a/Server/mods/deathmatch/logic/CVehicle.cpp
+++ b/Server/mods/deathmatch/logic/CVehicle.cpp
@@ -28,6 +28,7 @@ CVehicle::CVehicle(CVehicleManager* pVehicleManager, CElement* pParent, unsigned
     m_eVehicleType = CVehicleManager::GetVehicleType(m_usModel);
     m_fHealth = DEFAULT_VEHICLE_HEALTH;
     m_fLastSyncedHealthHealth = DEFAULT_VEHICLE_HEALTH;
+    m_bLastSyncedIsInWater = DEFAULT_IS_IN_WATER;
     m_llIdleTime = CTickCount::Now();
     m_fTurretPositionX = 0;
     m_fTurretPositionY = 0;

--- a/Server/mods/deathmatch/logic/CVehicle.cpp
+++ b/Server/mods/deathmatch/logic/CVehicle.cpp
@@ -28,7 +28,6 @@ CVehicle::CVehicle(CVehicleManager* pVehicleManager, CElement* pParent, unsigned
     m_eVehicleType = CVehicleManager::GetVehicleType(m_usModel);
     m_fHealth = DEFAULT_VEHICLE_HEALTH;
     m_fLastSyncedHealthHealth = DEFAULT_VEHICLE_HEALTH;
-    m_bLastSyncedIsInWater = DEFAULT_IS_IN_WATER;
     m_llIdleTime = CTickCount::Now();
     m_fTurretPositionX = 0;
     m_fTurretPositionY = 0;

--- a/Server/mods/deathmatch/logic/CVehicle.h
+++ b/Server/mods/deathmatch/logic/CVehicle.h
@@ -367,7 +367,7 @@ private:
     CVector        m_vecTurnSpeed;
     float          m_fHealth;
     float          m_fLastSyncedHealthHealth;
-    bool           m_bLastSyncedIsInWater;
+    bool           m_bLastSyncedIsInWater = false;
     CTickCount     m_llBlowTime;
     CTickCount     m_llIdleTime;
 

--- a/Server/mods/deathmatch/logic/CVehicle.h
+++ b/Server/mods/deathmatch/logic/CVehicle.h
@@ -23,6 +23,7 @@ class CVehicle;
 #define MAX_VEHICLE_SEATS 9
 #define DEFAULT_VEHICLE_HEALTH 1000
 #define MAX_VEHICLE_HEALTH 10000
+#define DEFAULT_IS_IN_WATER false
 
 enum eWheelStatus
 {
@@ -188,6 +189,8 @@ public:
     void  SetHealth(float fHealth) { m_fHealth = fHealth; };
     float GetLastSyncedHealth() { return m_fLastSyncedHealthHealth; };
     void  SetLastSyncedHealth(float fHealth) { m_fLastSyncedHealthHealth = fHealth; };
+    float GetLastSyncedIsInWater() { return m_bLastSyncedIsInWater; };
+    void  setLastSyncedIsInWater(bool bIsInWater) { m_bLastSyncedIsInWater = bIsInWater; };
 
     CVehicleColor& RandomizeColor();
 
@@ -364,6 +367,7 @@ private:
     CVector        m_vecTurnSpeed;
     float          m_fHealth;
     float          m_fLastSyncedHealthHealth;
+    bool           m_bLastSyncedIsInWater;
     CTickCount     m_llBlowTime;
     CTickCount     m_llIdleTime;
 

--- a/Server/mods/deathmatch/logic/CVehicle.h
+++ b/Server/mods/deathmatch/logic/CVehicle.h
@@ -23,8 +23,6 @@ class CVehicle;
 #define MAX_VEHICLE_SEATS 9
 #define DEFAULT_VEHICLE_HEALTH 1000
 #define MAX_VEHICLE_HEALTH 10000
-#define DEFAULT_IS_IN_WATER false
-
 enum eWheelStatus
 {
     DT_WHEEL_INTACT = 0,

--- a/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
@@ -263,6 +263,16 @@ bool CPlayerPuresyncPacket::Read(NetBitStreamInterface& BitStream)
             pSourcePlayer->CallEvent("onPlayerDamage", Arguments);
         }
 
+        bool bInWater = pSourcePlayer->IsInWater();
+        if (bInWater != pSourcePlayer->GetLastSyncedIsInWater())
+        {
+            // Call the event once in water
+            CLuaArguments Arguments;
+            Arguments.PushBoolean(bInWater);
+            pSourcePlayer->CallEvent("onElementWaterInteract", Arguments);
+        }
+        pSourcePlayer->setLastSyncedIsInWater(bInWater);
+
         // Success
         return true;
     }

--- a/Server/mods/deathmatch/logic/packets/CVehiclePuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CVehiclePuresyncPacket.cpp
@@ -154,6 +154,15 @@ bool CVehiclePuresyncPacket::Read(NetBitStreamInterface& BitStream)
                 // - Caz
                 pVehicle->SetLastSyncedHealth(fHealth);
 
+                bool bInWater = pVehicle->IsInWater();
+                if (bInWater && bInWater != pVehicle->GetLastSyncedIsInWater())
+                {
+                    // Call the event once in water
+                    CLuaArguments Arguments;
+                    pVehicle->CallEvent("onVehicleDrown", Arguments);
+                }
+                pVehicle->setLastSyncedIsInWater(bInWater);
+
                 // Trailer chain
                 CVehicle* pTowedByVehicle = pVehicle;
                 ElementID TrailerID;

--- a/Server/mods/deathmatch/logic/packets/CVehiclePuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CVehiclePuresyncPacket.cpp
@@ -155,11 +155,12 @@ bool CVehiclePuresyncPacket::Read(NetBitStreamInterface& BitStream)
                 pVehicle->SetLastSyncedHealth(fHealth);
 
                 bool bInWater = pVehicle->IsInWater();
-                if (bInWater && bInWater != pVehicle->GetLastSyncedIsInWater())
+                if (bInWater != pVehicle->GetLastSyncedIsInWater())
                 {
                     // Call the event once in water
                     CLuaArguments Arguments;
-                    pVehicle->CallEvent("onVehicleDrown", Arguments);
+                    Arguments.PushBoolean(bInWater);
+                    pVehicle->CallEvent("onElementWaterInteract", Arguments);
                 }
                 pVehicle->setLastSyncedIsInWater(bInWater);
 


### PR DESCRIPTION
### Why we need It?
Well looks like we have `onVehicleExplode` and many other vehicle events but we don't have this one, also as requested in issue #1426, this PR introduces a new event in MTA since not everyone can use `cols` etc... and It's better than adding a `timer` or calling `onClientRender` or something to check if the element isInWater.
**(Also this event is triggered for unoccupied vehicles too)**
### Functionality
```lua
 function teteVehicle(thep)
 local x, y, z = getElementPosition(thep)
 teteCar = createVehicle(411, x+2, y, z)
 addEventHandler("onVehicleDrown", teteCar, function()
 outputChatBox("rip Tete car")
 end)
 end
 addCommandHandler("tetecar", teteVehicle)
```
This event is triggered when a vehicle drowns.
### Screenshots
![tete](https://user-images.githubusercontent.com/67543158/92388882-e65ed700-f10f-11ea-91b1-08cb57924745.png)
