### PR TITLE
Fix #322: onClientMarkerHit(Leave) ignores element's interior

### DIFF
--- a/Client/mods/deathmatch/logic/CClientMarker.cpp
+++ b/Client/mods/deathmatch/logic/CClientMarker.cpp
@@ -399,7 +399,7 @@ void CClientMarker::StreamOut()
 
 void CClientMarker::Callback_OnCollision(CClientColShape& Shape, CClientEntity& Entity)
 {
-    if (IS_PLAYER(&Entity))
+    if (IS_PLAYER(&Entity) && GetInterior() == Entity.GetInterior())            // Matching interior?
     {
         // Call the marker hit event
         CLuaArguments Arguments;
@@ -411,7 +411,7 @@ void CClientMarker::Callback_OnCollision(CClientColShape& Shape, CClientEntity& 
 
 void CClientMarker::Callback_OnLeave(CClientColShape& Shape, CClientEntity& Entity)
 {
-    if (IS_PLAYER(&Entity))
+    if (IS_PLAYER(&Entity) && GetInterior() == Entity.GetInterior())            // Matching interior?
     {
         // Call the marker hit event
         CLuaArguments Arguments;


### PR DESCRIPTION
According to #322 Looks like [onClientMarkerHit](https://wiki.multitheftauto.com/wiki/OnClientMarkerHit) doesn't care about element's interior and when I checked MTA's code looks like [onClientMarkerLeave](https://wiki.multitheftauto.com/wiki/OnClientMarkerLeave) does the same thing, and for [onMakerHit](https://wiki.multitheftauto.com/wiki/OnMarkerHit) and [onMakerLeave](https://wiki.multitheftauto.com/wiki/OnMarkerLeave) they do check for interior.
https://github.com/multitheftauto/mtasa-blue/blob/3b95ff48969474c691a8a4f2276f581377111f06/Server/mods/deathmatch/logic/CMarker.cpp#L315