### PR TITLE
Fix stack overflow when attaching elements in maps

### DIFF
--- a/Client/mods/deathmatch/logic/CClientEntity.cpp
+++ b/Client/mods/deathmatch/logic/CClientEntity.cpp
@@ -1070,6 +1070,29 @@ bool CClientEntity::IsEntityAttached(CClientEntity* pEntity)
     return ListContains(m_AttachedEntities, pEntity);
 }
 
+bool CClientEntity::IsAttachedToElement(CClientEntity* pEntity, bool bRecursive)
+{
+    if (bRecursive)
+    {
+        std::set<CClientEntity*> history;
+
+        for (CClientEntity* pCurrent = this; pCurrent; pCurrent = pCurrent->GetAttachedTo())
+        {
+            if (pCurrent == pEntity)
+                return true;
+
+            if (MapContains(history, pCurrent))
+                break; // This should not be possible, but you never know
+
+            MapInsert(history, pCurrent);
+        }
+
+        return false;
+    }
+
+    return m_pAttachedToEntity == pEntity;
+}
+
 void CClientEntity::ReattachEntities()
 {
     // Jax: this should be called on streamIn/creation

--- a/Client/mods/deathmatch/logic/CClientEntity.cpp
+++ b/Client/mods/deathmatch/logic/CClientEntity.cpp
@@ -1081,10 +1081,8 @@ bool CClientEntity::IsAttachedToElement(CClientEntity* pEntity, bool bRecursive)
             if (pCurrent == pEntity)
                 return true;
 
-            if (MapContains(history, pCurrent))
+            if (!std::get<bool>(history.insert(pCurrent)))
                 break; // This should not be possible, but you never know
-
-            MapInsert(history, pCurrent);
         }
 
         return false;

--- a/Client/mods/deathmatch/logic/CClientEntity.h
+++ b/Client/mods/deathmatch/logic/CClientEntity.h
@@ -233,7 +233,7 @@ public:
     virtual void   GetAttachedOffsets(CVector& vecPosition, CVector& vecRotation);
     virtual void   SetAttachedOffsets(CVector& vecPosition, CVector& vecRotation);
     bool           IsEntityAttached(CClientEntity* pEntity);
-    bool           IsAttachedToElement(CClientEntity* pEntity, bool bRecursive = false);
+    bool           IsAttachedToElement(CClientEntity* pEntity, bool bRecursive = true);
     uint           GetAttachedEntityCount() { return m_AttachedEntities.size(); }
     CClientEntity* GetAttachedEntity(uint uiIndex) { return m_AttachedEntities[uiIndex]; }
     void           ReattachEntities();

--- a/Client/mods/deathmatch/logic/CClientEntity.h
+++ b/Client/mods/deathmatch/logic/CClientEntity.h
@@ -233,6 +233,7 @@ public:
     virtual void   GetAttachedOffsets(CVector& vecPosition, CVector& vecRotation);
     virtual void   SetAttachedOffsets(CVector& vecPosition, CVector& vecRotation);
     bool           IsEntityAttached(CClientEntity* pEntity);
+    bool           IsAttachedToElement(CClientEntity* pEntity, bool bRecursive = false);
     uint           GetAttachedEntityCount() { return m_AttachedEntities.size(); }
     CClientEntity* GetAttachedEntity(uint uiIndex) { return m_AttachedEntities[uiIndex]; }
     void           ReattachEntities();

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1314,19 +1314,8 @@ bool CStaticFunctionDefinitions::AttachElements(CClientEntity& Entity, CClientEn
 {
     RUN_CHILDREN(AttachElements(**iter, AttachedToEntity, vecPosition, vecRotation))
 
-    // Check the elements we are attaching are not already connected
-    std::set<CClientEntity*> history;
-    for (CClientEntity* pCurrent = &AttachedToEntity; pCurrent; pCurrent = pCurrent->GetAttachedTo())
-    {
-        if (pCurrent == &Entity)
-            return false;
-        if (MapContains(history, pCurrent))
-            break;            // This should not be possible, but you never know
-        MapInsert(history, pCurrent);
-    }
-
     // Can these elements be attached?
-    if (Entity.IsAttachToable() && AttachedToEntity.IsAttachable() && Entity.GetDimension() == AttachedToEntity.GetDimension())
+    if (Entity.IsAttachToable() && AttachedToEntity.IsAttachable() && !AttachedToEntity.IsAttachedToElement(&Entity) && Entity.GetDimension() == AttachedToEntity.GetDimension())
     {
         ConvertDegreesToRadians(vecRotation);
 

--- a/Server/mods/deathmatch/logic/CElement.cpp
+++ b/Server/mods/deathmatch/logic/CElement.cpp
@@ -1126,6 +1126,29 @@ bool CElement::IsElementAttached(CElement* pElement)
     return false;
 }
 
+bool CElement::IsAttachedToElement(CElement* pElement, bool bRecursive)
+{
+    if (bRecursive)
+    {
+        std::set<CElement*> history;
+
+        for (CElement* pCurrent = this; pCurrent; pCurrent = pCurrent->GetAttachedToElement())
+        {
+            if (pCurrent == pElement)
+                return true;
+
+            if (MapContains(history, pCurrent))
+                break; // This should not be possible, but you never know
+
+            MapInsert(history, pCurrent);
+        }
+
+        return false;
+    }
+
+    return m_pAttachedTo == pElement;
+}
+
 bool CElement::IsAttachable()
 {
     switch (GetType())

--- a/Server/mods/deathmatch/logic/CElement.cpp
+++ b/Server/mods/deathmatch/logic/CElement.cpp
@@ -1137,10 +1137,8 @@ bool CElement::IsAttachedToElement(CElement* pElement, bool bRecursive)
             if (pCurrent == pElement)
                 return true;
 
-            if (MapContains(history, pCurrent))
+            if (!std::get<bool>(history.insert(pCurrent)))
                 break; // This should not be possible, but you never know
-
-            MapInsert(history, pCurrent);
         }
 
         return false;

--- a/Server/mods/deathmatch/logic/CElement.h
+++ b/Server/mods/deathmatch/logic/CElement.h
@@ -197,7 +197,7 @@ public:
     bool                                 IsElementAttached(CElement* pElement);
     bool                                 IsAttachedToElement(CElement* pElement, bool bRecursive = true);
     virtual bool                         IsAttachable();
-    virtual bool                         IsAttachToable();    
+    virtual bool                         IsAttachToable();
     void                                 GetAttachedPosition(CVector& vecPosition);
     void                                 GetAttachedRotation(CVector& vecRotation);
 

--- a/Server/mods/deathmatch/logic/CElement.h
+++ b/Server/mods/deathmatch/logic/CElement.h
@@ -195,8 +195,9 @@ public:
     std::list<CElement*>::const_iterator AttachedElementsEnd() { return m_AttachedElements.end(); }
     const char*                          GetAttachToID() { return m_strAttachToID; }
     bool                                 IsElementAttached(CElement* pElement);
+    bool                                 IsAttachedToElement(CElement* pElement, bool bRecursive = false);
     virtual bool                         IsAttachable();
-    virtual bool                         IsAttachToable();
+    virtual bool                         IsAttachToable();    
     void                                 GetAttachedPosition(CVector& vecPosition);
     void                                 GetAttachedRotation(CVector& vecRotation);
 

--- a/Server/mods/deathmatch/logic/CElement.h
+++ b/Server/mods/deathmatch/logic/CElement.h
@@ -195,7 +195,7 @@ public:
     std::list<CElement*>::const_iterator AttachedElementsEnd() { return m_AttachedElements.end(); }
     const char*                          GetAttachToID() { return m_strAttachToID; }
     bool                                 IsElementAttached(CElement* pElement);
-    bool                                 IsAttachedToElement(CElement* pElement, bool bRecursive = false);
+    bool                                 IsAttachedToElement(CElement* pElement, bool bRecursive = true);
     virtual bool                         IsAttachable();
     virtual bool                         IsAttachToable();    
     void                                 GetAttachedPosition(CVector& vecPosition);

--- a/Server/mods/deathmatch/logic/CMapManager.cpp
+++ b/Server/mods/deathmatch/logic/CMapManager.cpp
@@ -954,7 +954,7 @@ void CMapManager::LinkupElements()
         {
             CElement* pElement = g_pGame->GetMapManager()->GetRootElement()->FindChild(szAttachToID, 0, true);
 
-            if (pElement)
+            if (pElement && !pElement->IsAttachedToElement(vehicle))
                 vehicle->AttachTo(pElement);
         }
     }
@@ -968,7 +968,7 @@ void CMapManager::LinkupElements()
         if (szAttachToID[0])
         {
             CElement* pElement = g_pGame->GetMapManager()->GetRootElement()->FindChild(szAttachToID, 0, true);
-            if (pElement)
+            if (pElement && !pElement->IsAttachedToElement(pPlayer))
                 pPlayer->AttachTo(pElement);
         }
     }
@@ -982,7 +982,7 @@ void CMapManager::LinkupElements()
         if (szAttachToID[0])
         {
             CElement* pElement = g_pGame->GetMapManager()->GetRootElement()->FindChild(szAttachToID, 0, true);
-            if (pElement)
+            if (pElement && !pElement->IsAttachedToElement(pObject))
                 pObject->AttachTo(pElement);
         }
     }
@@ -996,7 +996,7 @@ void CMapManager::LinkupElements()
         if (szAttachToID[0])
         {
             CElement* pElement = g_pGame->GetMapManager()->GetRootElement()->FindChild(szAttachToID, 0, true);
-            if (pElement)
+            if (pElement && !pElement->IsAttachedToElement(pBlip))
                 pBlip->AttachTo(pElement);
         }
     }

--- a/Server/mods/deathmatch/logic/CResourceMapItem.cpp
+++ b/Server/mods/deathmatch/logic/CResourceMapItem.cpp
@@ -207,7 +207,7 @@ void CResourceMapItem::LinkupElements()
         {
             CElement* const pElement = pRootElement->FindChild(szAttachToID, 0, true);
 
-            if (pElement)
+            if (pElement && !pElement->IsAttachedToElement(vehicle))
                 vehicle->AttachTo(pElement);
         }
     }
@@ -221,7 +221,7 @@ void CResourceMapItem::LinkupElements()
         {
             CElement* const pElement = pRootElement->FindChild(szAttachToID, 0, true);
 
-            if (pElement)
+            if (pElement && !pElement->IsAttachedToElement(pPlayer))
                 pPlayer->AttachTo(pElement);
         }
     }
@@ -235,7 +235,7 @@ void CResourceMapItem::LinkupElements()
         {
             CElement* const pElement = pRootElement->FindChild(szAttachToID, 0, true);
 
-            if (pElement)
+            if (pElement && !pElement->IsAttachedToElement(pObject))
                 pObject->AttachTo(pElement);
         }
     }
@@ -249,7 +249,7 @@ void CResourceMapItem::LinkupElements()
         {
             CElement* const pElement = pRootElement->FindChild(szAttachToID, 0, true);
 
-            if (pElement)
+            if (pElement && !pElement->IsAttachedToElement(pBlip))
                 pBlip->AttachTo(pElement);
         }
     }

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1450,18 +1450,7 @@ bool CStaticFunctionDefinitions::AttachElements(CElement* pElement, CElement* pA
     assert(pElement);
     assert(pAttachedToElement);
 
-    // Check the elements we are attaching are not already connected
-    std::set<CElement*> history;
-    for (CElement* pCurrent = pAttachedToElement; pCurrent; pCurrent = pCurrent->GetAttachedToElement())
-    {
-        if (pCurrent == pElement)
-            return false;
-        if (MapContains(history, pCurrent))
-            break;            // This should not be possible, but you never know
-        MapInsert(history, pCurrent);
-    }
-
-    if (pElement->IsAttachToable() && pAttachedToElement->IsAttachable() && pElement->GetDimension() == pAttachedToElement->GetDimension())
+    if (pElement->IsAttachToable() && pAttachedToElement->IsAttachable() && !pAttachedToElement->IsAttachedToElement(pElement) && pElement->GetDimension() == pAttachedToElement->GetDimension())
     {
         pElement->SetAttachedOffsets(vecPosition, vecRotation);
         ConvertDegreesToRadians(vecRotation);


### PR DESCRIPTION
When storing elements in maps sometimes we are attaching elements. In that case cross referencing may lead to 
an endless cycle and finally to a stack overflow error. The PR is intended to fix it.

The resource for crashing your own server:
[test.zip](https://github.com/multitheftauto/mtasa-blue/files/5212644/test.zip)
