### PR TITLE
Add return value to MapInsert

### DIFF
--- a/Shared/sdk/SharedUtil.FastHashSet.h
+++ b/Shared/sdk/SharedUtil.FastHashSet.h
@@ -45,13 +45,15 @@ namespace SharedUtil
     //
     // CFastHashSet helpers
     //
+
+    // Return true if the insertion took place
     template <class T, class T2>
-    void MapInsert(CFastHashSet<T>& collection, const T2& item)
+    bool MapInsert(CFastHashSet<T>& collection, const T2& item)
     {
-        collection.insert(item);
+        return std::get<bool>(collection.insert(item));
     }
 
-    // Remove key from collection
+    // Return true if the remove took place
     template <class T, class T2>
     bool MapRemove(CFastHashSet<T>& collection, const T2& key)
     {

--- a/Shared/sdk/SharedUtil.Map.h
+++ b/Shared/sdk/SharedUtil.Map.h
@@ -203,11 +203,11 @@ namespace SharedUtil
     // std::set helpers
     //
 
-    // Update or add an item
+    // Return true if the insertion took place
     template <class T, class TR, class T2>
-    void MapInsert(std::set<T, TR>& collection, const T2& item)
+    bool MapInsert(std::set<T, TR>& collection, const T2& item)
     {
-        collection.insert(item);
+        return std::get<bool>(collection.insert(item));
     }
 
 }            // namespace SharedUtil


### PR DESCRIPTION
`MapInsert` will now return true if the insertion took place. Can be used to remove use of `MapContains` before `MapInsert`
