### PR TITLE
Fix #1659: revert fix for #1317

### DIFF
--- a/Client/mods/deathmatch/logic/CClientColShape.cpp
+++ b/Client/mods/deathmatch/logic/CClientColShape.cpp
@@ -73,19 +73,7 @@ void CClientColShape::SetPosition(const CVector& vecPosition)
         UpdateSpatialData();
         CStaticFunctionDefinitions::RefreshColShapeColliders(this);
     }
-}
-
-void CClientColShape::AttachTo(CClientEntity* pEntity)
-{
-    CClientEntity::AttachTo(pEntity);
-    if (pEntity && m_pAttachedToEntity)
-    {
-        CVector pVector;
-
-        pEntity->GetPosition(pVector);
-        SetPosition(pVector + m_vecAttachedPosition);
-    }
-}
+};
 
 void CClientColShape::CallHitCallback(CClientEntity& Entity)
 {

--- a/Client/mods/deathmatch/logic/CClientColShape.h
+++ b/Client/mods/deathmatch/logic/CClientColShape.h
@@ -48,8 +48,6 @@ public:
     virtual void GetPosition(CVector& vecPosition) const { vecPosition = m_vecPosition; };
     virtual void SetPosition(const CVector& vecPosition);
 
-    void AttachTo(CClientEntity* pEntity) override;
-
     virtual bool DoHitDetection(const CVector& vecNowPosition, float fRadius) = 0;
 
     bool IsEnabled() { return m_bIsEnabled; };

--- a/Client/mods/deathmatch/logic/CClientMarker.cpp
+++ b/Client/mods/deathmatch/logic/CClientMarker.cpp
@@ -89,23 +89,6 @@ void CClientMarker::SetPosition(const CVector& vecPosition)
     UpdateStreamPosition(vecPosition);
 }
 
-void CClientMarker::AttachTo(CClientEntity* pEntity)
-{
-    CClientEntity::AttachTo(pEntity);
-    if (m_pCollision){
-        m_pCollision->AttachTo(pEntity);
-    }
-}
-
-void CClientMarker::SetAttachedOffsets(CVector& vecPosition, CVector& vecRotation)
-{
-    CClientEntity::SetAttachedOffsets(vecPosition, vecRotation);
-    if (m_pCollision)
-    {
-        m_pCollision->SetAttachedOffsets(vecPosition, vecRotation);
-    }
-}
-
 bool CClientMarker::SetMatrix(const CMatrix& matrix)
 {
     if (m_pMarker)

--- a/Client/mods/deathmatch/logic/CClientMarker.h
+++ b/Client/mods/deathmatch/logic/CClientMarker.h
@@ -46,9 +46,6 @@ public:
     void SetPosition(const CVector& vecPosition);
     bool SetMatrix(const CMatrix& matrix);
 
-    void AttachTo(CClientEntity* pEntity) override;
-    void SetAttachedOffsets(CVector& vecPosition, CVector& vecRotation) override;
-
     void DoPulse();
 
     eClientEntityType GetType() const { return CCLIENTMARKER; }

--- a/Server/mods/deathmatch/logic/CColShape.cpp
+++ b/Server/mods/deathmatch/logic/CColShape.cpp
@@ -57,16 +57,6 @@ void CColShape::SetPosition(const CVector& vecPosition)
     CStaticFunctionDefinitions::RefreshColShapeColliders(this);
 }
 
-void CColShape::AttachTo(CElement* pElement)
-{
-    CElement::AttachTo(pElement);
-    if (pElement && m_pAttachedTo)
-    {
-        CVector pVector = pElement->GetPosition();
-        SetPosition(pVector + m_vecAttachedPosition);
-    }
-}
-
 void CColShape::CallHitCallback(CElement& Element)
 {
     // Call the callback with us as the shape if it exists

--- a/Server/mods/deathmatch/logic/CColShape.h
+++ b/Server/mods/deathmatch/logic/CColShape.h
@@ -41,8 +41,6 @@ public:
     const CVector& GetPosition();
     virtual void   SetPosition(const CVector& vecPosition);
 
-    void AttachTo(CElement* pElement);
-
     void                CallHitCallback(CElement& Element);
     void                CallLeaveCallback(CElement& Element);
     class CColCallback* SetCallback(class CColCallback* pCallback) { return (m_pCallback = pCallback); };

--- a/Server/mods/deathmatch/logic/CMarker.cpp
+++ b/Server/mods/deathmatch/logic/CMarker.cpp
@@ -170,21 +170,6 @@ void CMarker::SetPosition(const CVector& vecPosition)
     }
 }
 
-void CMarker::AttachTo(CElement* pElement)
-{
-    CElement::AttachTo(pElement);
-    m_pCollision->AttachTo(pElement);
-}
-
-void CMarker::SetAttachedOffsets(CVector& vecPosition, CVector& vecRotation)
-{
-    CElement::SetAttachedOffsets(vecPosition, vecRotation);
-    if (m_pCollision)
-    {
-        m_pCollision->SetAttachedOffsets(vecPosition, vecRotation);
-    }
-}
-
 void CMarker::SetTarget(const CVector* pTargetVector)
 {
     // Got a target vector?

--- a/Server/mods/deathmatch/logic/CMarker.h
+++ b/Server/mods/deathmatch/logic/CMarker.h
@@ -61,9 +61,6 @@ public:
     void SetSize(float fSize);
     void SetColor(const SColor color);
 
-    void AttachTo(CElement* pElement);
-    void SetAttachedOffsets(CVector& vecPosition, CVector& vecRotation);
-
     void SetIcon(unsigned char ucIcon);
 
     CColShape* GetColShape() { return m_pCollision; }


### PR DESCRIPTION
- Reverts "Fix crash from #1363 (#1364)" (fee420d70112d6d53e75d798643a92b36837fc81).
- Reverts "Update colshape and marker hit detection when attaching (#1327)" (3b95ff48969474c691a8a4f2276f581377111f06).

Reopens #1317 and fixes #1659.