### PR TITLE
Use long long as Lua integer formatting type

### DIFF
--- a/vendor/lua/src/luaconf.h
+++ b/vendor/lua/src/luaconf.h
@@ -747,18 +747,8 @@ union luai_Cast { double l_d; long l_l; };
 ** CHANGE them if your system supports long long or does not support long.
 */
 
-#if defined(LUA_USELONGLONG)
-
 #define LUA_INTFRMLEN		"ll"
 #define LUA_INTFRM_T		long long
-
-#else
-
-#define LUA_INTFRMLEN		"l"
-#define LUA_INTFRM_T		long
-
-#endif
-
 
 
 /* =================================================================== */


### PR DESCRIPTION
This changes the integer type Lua uses for formatting to `long long`, rather than just `long` before. Since we have C++11 conforming compilers, all our supported platforms have `long long` anyway. 

Fixes #1667 
