### PR TITLE
Fix #1671: Can't watch youtube videos due to non working button

### DIFF
--- a/Client/cefweb/CWebCore.cpp
+++ b/Client/cefweb/CWebCore.cpp
@@ -253,7 +253,7 @@ eURLState CWebCore::GetDomainState(const SString& strURL, bool bOutputDebug)
     std::lock_guard<std::recursive_mutex> lock(m_FilterMutex);
 
     // Initialize wildcard whitelist (be careful with modifying) | Todo: Think about the following
-    static SString wildcardWhitelist[] = {"*.googlevideo.com", "*.google.com", "*.youtube.com", "*.ytimg.com", "*.vimeocdn.com"};
+    static SString wildcardWhitelist[] = {"*.googlevideo.com", "*.google.com", "*.youtube.com", "*.ytimg.com", "*.vimeocdn.com", "*.gstatic.com", "*.googleapis.com", "*.ggpht.com"};
 
     for (int i = 0; i < sizeof(wildcardWhitelist) / sizeof(SString); ++i)
     {


### PR DESCRIPTION
PR speaks for itself ([see comment](https://github.com/multitheftauto/mtasa-blue/issues/1671#issuecomment-697443024))

This is the bare minimum to be able to play Youtube video's.. other blocked requests (e.g full list of domains listed in the issue) aren't as critical as these, and can be for later discussion.

Closes #1671 