### PR TITLE
Allow allocating new vehicles models using engineRequestModel 

### DIFF
--- a/Client/game_sa/CBikeHandlingEntrySA.cpp
+++ b/Client/game_sa/CBikeHandlingEntrySA.cpp
@@ -14,25 +14,15 @@
 CBikeHandlingEntrySA::CBikeHandlingEntrySA()
 {
     // Create a new interface and zero it
-    m_pBikeHandlingSA = new tBikeHandlingDataSA;
-    memset(m_pBikeHandlingSA, 0, sizeof(tBikeHandlingDataSA));
-    m_bDeleteInterface = true;
+    m_pBikeHandlingSA = std::make_shared<tBikeHandlingDataSA>();
+    memset(m_pBikeHandlingSA.get(), 0, sizeof(tBikeHandlingDataSA));
 }
 
 CBikeHandlingEntrySA::CBikeHandlingEntrySA(tBikeHandlingDataSA* pOriginal)
 {
     // Store gta's pointer
     m_pBikeHandlingSA = NULL;
-    m_bDeleteInterface = false;
     memcpy(&m_BikeHandling, pOriginal, sizeof(tBikeHandlingDataSA));
-}
-
-CBikeHandlingEntrySA::~CBikeHandlingEntrySA()
-{
-    if (m_bDeleteInterface)
-    {
-        delete m_pBikeHandlingSA;
-    }
 }
 
 // Apply the handlingdata from another data
@@ -49,8 +39,8 @@ void CBikeHandlingEntrySA::Recalculate()
     if (m_pBikeHandlingSA)
     {
         // Copy our stored field to GTA's
-        memcpy(m_pBikeHandlingSA, &m_BikeHandling, sizeof(m_BikeHandling));
+        memcpy(m_pBikeHandlingSA.get(), &m_BikeHandling, sizeof(m_BikeHandling));
 
-       ((void(_stdcall*)(tBikeHandlingDataSA*))FUNC_HandlingDataMgr_ConvertBikeDataToGameUnits)(m_pBikeHandlingSA);
+       ((void(_stdcall*)(tBikeHandlingDataSA*))FUNC_HandlingDataMgr_ConvertBikeDataToGameUnits)(m_pBikeHandlingSA.get());
     }
 }

--- a/Client/game_sa/CBikeHandlingEntrySA.cpp
+++ b/Client/game_sa/CBikeHandlingEntrySA.cpp
@@ -13,34 +13,24 @@
 
 CBikeHandlingEntrySA::CBikeHandlingEntrySA()
 {
-    // Create a new interface and zero it
-    m_pBikeHandlingSA = std::make_shared<tBikeHandlingDataSA>();
-    memset(m_pBikeHandlingSA.get(), 0, sizeof(tBikeHandlingDataSA));
+    memset(&m_pBikeHandlingSA, 0, sizeof(tBikeHandlingDataSA));
 }
 
 CBikeHandlingEntrySA::CBikeHandlingEntrySA(tBikeHandlingDataSA* pOriginal)
 {
-    // Store gta's pointer
-    m_pBikeHandlingSA = NULL;
-    memcpy(&m_BikeHandling, pOriginal, sizeof(tBikeHandlingDataSA));
+    memset(&m_pBikeHandlingSA, 0, sizeof(tBikeHandlingDataSA));
+    m_BikeHandling = *pOriginal;
 }
 
-// Apply the handlingdata from another data
 void CBikeHandlingEntrySA::Assign(const CBikeHandlingEntry* pData)
 {
-    // Copy the data
     const CBikeHandlingEntrySA* pEntrySA = static_cast<const CBikeHandlingEntrySA*>(pData);
     m_BikeHandling = pEntrySA->m_BikeHandling;
 }
 
 void CBikeHandlingEntrySA::Recalculate()
 {
-    // Real GTA class?
-    if (m_pBikeHandlingSA)
-    {
-        // Copy our stored field to GTA's
-        memcpy(m_pBikeHandlingSA.get(), &m_BikeHandling, sizeof(m_BikeHandling));
-
-       ((void(_stdcall*)(tBikeHandlingDataSA*))FUNC_HandlingDataMgr_ConvertBikeDataToGameUnits)(m_pBikeHandlingSA.get());
-    }
+    auto HandlingDataMgr_ConvertBikeDataToGameUnits = (void(_stdcall*)(tBikeHandlingDataSA*))0x6F5290;
+    m_pBikeHandlingSA = m_BikeHandling;
+    HandlingDataMgr_ConvertBikeDataToGameUnits(&m_pBikeHandlingSA);
 }

--- a/Client/game_sa/CBikeHandlingEntrySA.cpp
+++ b/Client/game_sa/CBikeHandlingEntrySA.cpp
@@ -1,0 +1,56 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        game_sa/CHandlingEntrySA.cpp
+ *  PURPOSE:     Vehicle handling data entry
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+
+CBikeHandlingEntrySA::CBikeHandlingEntrySA()
+{
+    // Create a new interface and zero it
+    m_pBikeHandlingSA = new tBikeHandlingDataSA;
+    memset(m_pBikeHandlingSA, 0, sizeof(tBikeHandlingDataSA));
+    m_bDeleteInterface = true;
+}
+
+CBikeHandlingEntrySA::CBikeHandlingEntrySA(tBikeHandlingDataSA* pOriginal)
+{
+    // Store gta's pointer
+    m_pBikeHandlingSA = NULL;
+    m_bDeleteInterface = false;
+    memcpy(&m_BikeHandling, pOriginal, sizeof(tBikeHandlingDataSA));
+}
+
+CBikeHandlingEntrySA::~CBikeHandlingEntrySA()
+{
+    if (m_bDeleteInterface)
+    {
+        delete m_pBikeHandlingSA;
+    }
+}
+
+// Apply the handlingdata from another data
+void CBikeHandlingEntrySA::Assign(const CBikeHandlingEntry* pData)
+{
+    // Copy the data
+    const CBikeHandlingEntrySA* pEntrySA = static_cast<const CBikeHandlingEntrySA*>(pData);
+    m_BikeHandling = pEntrySA->m_BikeHandling;
+}
+
+void CBikeHandlingEntrySA::Recalculate()
+{
+    // Real GTA class?
+    if (m_pBikeHandlingSA)
+    {
+        // Copy our stored field to GTA's
+        memcpy(m_pBikeHandlingSA, &m_BikeHandling, sizeof(m_BikeHandling));
+
+       ((void(_stdcall*)(tBikeHandlingDataSA*))FUNC_HandlingDataMgr_ConvertBikeDataToGameUnits)(m_pBikeHandlingSA);
+    }
+}

--- a/Client/game_sa/CBikeHandlingEntrySA.h
+++ b/Client/game_sa/CBikeHandlingEntrySA.h
@@ -1,0 +1,61 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        game_sa/CHandlingEntrySA.h
+ *  PURPOSE:     Header file for vehicle handling data entry class
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#pragma once
+
+#include <game/CBikeHandlingEntry.h>
+#include "Common.h"
+#define FUNC_HandlingDataMgr_ConvertBikeDataToGameUnits 0x6F5290
+
+struct tBikeHandlingDataSA
+{
+    int iVehicleID;
+    float fLeanFwdCOM;
+    float fLeanFwdForce;
+    float fLeanBackCOM;
+    float fLeanBackForce;
+    float fMaxLean;
+    float fFullAnimLean;
+    float fDesLean;
+    float fSpeedSteer;
+    float fSlipSteer;
+    float fNoPlayerCOMz;
+    float fWheelieAng;
+    float fStoppieAng;
+    float fWheelieSteer;
+    float fWheelieStabMult;
+    float fStoppieStabMult;
+};
+
+class CBikeHandlingEntrySA : public CBikeHandlingEntry
+{
+public:
+    // Constructor for creatable dummy entries
+    CBikeHandlingEntrySA();
+
+    // Constructor for original entries
+    CBikeHandlingEntrySA(tBikeHandlingDataSA* pOriginal);
+
+    virtual ~CBikeHandlingEntrySA();
+
+    // Use this to copy data from an another handling class to this
+    void Assign(const CBikeHandlingEntry* pData);
+
+    void Recalculate();
+
+    tBikeHandlingDataSA* GetInterface() { return m_pBikeHandlingSA; };
+
+private:
+    tBikeHandlingDataSA* m_pBikeHandlingSA;
+    bool                 m_bDeleteInterface;
+
+    tBikeHandlingDataSA m_BikeHandling;
+};

--- a/Client/game_sa/CBikeHandlingEntrySA.h
+++ b/Client/game_sa/CBikeHandlingEntrySA.h
@@ -17,7 +17,7 @@
 
 struct tBikeHandlingDataSA
 {
-    int iVehicleID;
+    int   iVehicleID;
     float fLeanFwdCOM;
     float fLeanFwdForce;
     float fLeanBackCOM;
@@ -44,18 +44,14 @@ public:
     // Constructor for original entries
     CBikeHandlingEntrySA(tBikeHandlingDataSA* pOriginal);
 
-    virtual ~CBikeHandlingEntrySA();
-
     // Use this to copy data from an another handling class to this
     void Assign(const CBikeHandlingEntry* pData);
 
     void Recalculate();
 
-    tBikeHandlingDataSA* GetInterface() { return m_pBikeHandlingSA; };
+    tBikeHandlingDataSA* GetInterface() { return m_pBikeHandlingSA.get(); };
 
 private:
-    tBikeHandlingDataSA* m_pBikeHandlingSA;
-    bool                 m_bDeleteInterface;
-
-    tBikeHandlingDataSA m_BikeHandling;
+    std::shared_ptr<tBikeHandlingDataSA> m_pBikeHandlingSA;
+    tBikeHandlingDataSA                  m_BikeHandling;
 };

--- a/Client/game_sa/CBikeHandlingEntrySA.h
+++ b/Client/game_sa/CBikeHandlingEntrySA.h
@@ -13,7 +13,6 @@
 
 #include <game/CBikeHandlingEntry.h>
 #include "Common.h"
-#define FUNC_HandlingDataMgr_ConvertBikeDataToGameUnits 0x6F5290
 
 struct tBikeHandlingDataSA
 {
@@ -38,20 +37,13 @@ struct tBikeHandlingDataSA
 class CBikeHandlingEntrySA : public CBikeHandlingEntry
 {
 public:
-    // Constructor for creatable dummy entries
     CBikeHandlingEntrySA();
-
-    // Constructor for original entries
     CBikeHandlingEntrySA(tBikeHandlingDataSA* pOriginal);
-
-    // Use this to copy data from an another handling class to this
     void Assign(const CBikeHandlingEntry* pData);
-
     void Recalculate();
-
-    tBikeHandlingDataSA* GetInterface() { return m_pBikeHandlingSA.get(); };
+    tBikeHandlingDataSA* GetInterface() { return &m_pBikeHandlingSA; };
 
 private:
-    std::shared_ptr<tBikeHandlingDataSA> m_pBikeHandlingSA;
-    tBikeHandlingDataSA                  m_BikeHandling;
+    tBikeHandlingDataSA m_pBikeHandlingSA;
+    tBikeHandlingDataSA m_BikeHandling;
 };

--- a/Client/game_sa/CBikeSA.cpp
+++ b/Client/game_sa/CBikeSA.cpp
@@ -38,3 +38,20 @@ CBikeSA::CBikeSA(eVehicleTypes dwModelID, unsigned char ucVariation, unsigned ch
         pGame->GetWorld()->Add((CEntitySA *)this);
     }*/
 }
+
+CBikeHandlingEntry* CBikeSA::GetBikeHandlingData()
+{
+    return m_pBikeHandlingData;
+}
+
+void CBikeSA::SetBikeHandlingData(CBikeHandlingEntry* pBikeHandling)
+{
+    m_pBikeHandlingData = static_cast<CBikeHandlingEntrySA*>(pBikeHandling);
+    GetBikeInterface()->pBikeHandlingData = m_pBikeHandlingData->GetInterface();
+    RecalculateBikeHandling();
+}
+
+void CBikeSA::RecalculateBikeHandling()
+{
+    m_pBikeHandlingData->Recalculate();
+}

--- a/Client/game_sa/CBikeSA.h
+++ b/Client/game_sa/CBikeSA.h
@@ -18,16 +18,75 @@
 
 class CBikeSAInterface : public CVehicleSAInterface
 {
-    // fill this
+public:
+    DOUBLE                      m_apModelNodes[10];
+    unsigned char               bLeanMatrixCalculated;
+    char                        pad0[3];
+    CMatrix                     mLeanMatrix;
+    unsigned char               cDamageFlags;
+    char                        pad1[27];
+    CVector                     unknowVector;
+    tBikeHandlingDataSA*        pBikeHandlingData;
+    //00000640 m_rideAnimData  CRideAnimData ?
+    //0000065C m_anWheelDamageState db 2 dup(?)
+    //0000065E field_65E       db ?
+    //0000065F field_65F       db ?
+    //00000660 m_anWheelColPoint CColPoint 4 dup(?)
+    //00000710 m_wheelsDistancesToGround1 dd 4 dup(?)
+    //00000720 field_720       dd 4 dup(?)
+    //00000730 field_730       dd 4 dup(?)
+    //00000740 field_740       dd ?
+    //00000744 m_anWheelSurfaceType dd 2 dup(?)
+    //0000074C field_74C       db 2 dup(?)
+    //0000074E field_74E       db 2 dup(?)
+    //00000750 m_afWheelRotationX dd 2 dup(?)
+    //00000758 field_758       dd 2 dup(?)
+    //00000760 field_760       dd ?
+    //00000764 field_764       dd ?
+    //00000768 field_768       dd ?
+    //0000076C field_76C       dd ?
+    //00000770 field_770       dd 4 dup(?)
+    //00000780 field_780       dd 4 dup(?)
+    //00000790 m_fHeightAboveRoad dd ?
+    //00000794 m_fCarTraction  dd ?
+    //00000798 field_798       dd ?
+    //0000079C field_79C       dd ?
+    //000007A0 field_7A0       dd ?
+    //000007A4 field_7A4       dd ?
+    //000007A8 field_7A8       dw ?
+    //000007AA field_7AA       db 2 dup(?)
+    //000007AC field_7AC       dd ?
+    //000007B0 field_7B0       dd ?
+    //000007B4 m_bPedLeftHandFixed db ?
+    //000007B5 m_bPedRightHandFixed db ?
+    //000007B6 field_7B6       db 2 dup(?)
+    //000007B8 field_7B8       dd ?
+    //000007BC field_7BC       dd ?
+    //000007C0 m_apWheelCollisionEntity dd 4 dup(?)
+    //000007D0 m_avTouchPointsLocalSpace CVector 4 dup(?)
+    //00000800 damagedEntity   dd ?                    ;
+    //00000804 m_nNumContactWheels db ?
+    //00000805 m_nNumWheelsOnGround db ?
+    //00000806 field_806 db ?
+    //00000807 field_807 db ?
+    //00000808 field_808 dd
+    //0000080C m_anWheelState dd 2 dup(?);
 };
+// Size = 0x814
 
 class CBikeSA : public virtual CBike, public virtual CVehicleSA
 {
+private:
+    CBikeHandlingEntrySA* m_pBikeHandlingData;
 public:
     CBikeSA(){};
-
     CBikeSA(CBikeSAInterface* bike);
     CBikeSA(eVehicleTypes dwModelID, unsigned char ucVariation, unsigned char ucVariation2);
 
-    // void                    PlaceOnRoadProperly ( void );
+    CBikeSAInterface*   GetBikeInterface() { return (CBikeSAInterface*)m_pInterface; };
+
+    CBikeHandlingEntry* GetBikeHandlingData();
+    void                SetBikeHandlingData(CBikeHandlingEntry* pHandling);
+
+    void                RecalculateBikeHandling();
 };

--- a/Client/game_sa/CBoatHandlingEntrySA.cpp
+++ b/Client/game_sa/CBoatHandlingEntrySA.cpp
@@ -14,25 +14,15 @@
 CBoatHandlingEntrySA::CBoatHandlingEntrySA()
 {
     // Create a new interface and zero it
-    m_pBoatHandlingSA = new tBoatHandlingDataSA;
-    memset(m_pBoatHandlingSA, 0, sizeof(tBoatHandlingDataSA));
-    m_bDeleteInterface = true;
+    m_pBoatHandlingSA = std::make_shared<tBoatHandlingDataSA>();
+    memset(m_pBoatHandlingSA.get(), 0, sizeof(tBoatHandlingDataSA));
 }
 
 CBoatHandlingEntrySA::CBoatHandlingEntrySA(tBoatHandlingDataSA* pOriginal)
 {
     // Store gta's pointer
-    m_pBoatHandlingSA = new tBoatHandlingDataSA;
-    m_bDeleteInterface = false;
-    memcpy(m_pBoatHandlingSA, pOriginal, sizeof(tBoatHandlingDataSA));
-}
-
-CBoatHandlingEntrySA::~CBoatHandlingEntrySA()
-{
-    if (m_bDeleteInterface)
-    {
-        delete m_pBoatHandlingSA;
-    }
+    m_pBoatHandlingSA = std::make_shared<tBoatHandlingDataSA>();
+    memcpy(m_pBoatHandlingSA.get(), pOriginal, sizeof(tBoatHandlingDataSA));
 }
 
 // Apply the handlingdata from another data

--- a/Client/game_sa/CBoatHandlingEntrySA.cpp
+++ b/Client/game_sa/CBoatHandlingEntrySA.cpp
@@ -13,22 +13,16 @@
 
 CBoatHandlingEntrySA::CBoatHandlingEntrySA()
 {
-    // Create a new interface and zero it
-    m_pBoatHandlingSA = std::make_shared<tBoatHandlingDataSA>();
-    memset(m_pBoatHandlingSA.get(), 0, sizeof(tBoatHandlingDataSA));
+    memset(&m_pBoatHandlingSA, 0, sizeof(tBoatHandlingDataSA));
 }
 
 CBoatHandlingEntrySA::CBoatHandlingEntrySA(tBoatHandlingDataSA* pOriginal)
 {
-    // Store gta's pointer
-    m_pBoatHandlingSA = std::make_shared<tBoatHandlingDataSA>();
-    memcpy(m_pBoatHandlingSA.get(), pOriginal, sizeof(tBoatHandlingDataSA));
+    m_pBoatHandlingSA = *pOriginal;
 }
 
-// Apply the handlingdata from another data
 void CBoatHandlingEntrySA::Assign(const CBoatHandlingEntry* pData)
 {
-    // Copy the data
     const CBoatHandlingEntrySA* pEntrySA = static_cast<const CBoatHandlingEntrySA*>(pData);
     m_pBoatHandlingSA = pEntrySA->m_pBoatHandlingSA;
 }

--- a/Client/game_sa/CBoatHandlingEntrySA.cpp
+++ b/Client/game_sa/CBoatHandlingEntrySA.cpp
@@ -1,0 +1,44 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        game_sa/CBoatHandlingEntrySA.cpp
+ *  PURPOSE:     Vehicle flying handling data entry
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+
+CBoatHandlingEntrySA::CBoatHandlingEntrySA()
+{
+    // Create a new interface and zero it
+    m_pBoatHandlingSA = new tBoatHandlingDataSA;
+    memset(m_pBoatHandlingSA, 0, sizeof(tBoatHandlingDataSA));
+    m_bDeleteInterface = true;
+}
+
+CBoatHandlingEntrySA::CBoatHandlingEntrySA(tBoatHandlingDataSA* pOriginal)
+{
+    // Store gta's pointer
+    m_pBoatHandlingSA = new tBoatHandlingDataSA;
+    m_bDeleteInterface = false;
+    memcpy(m_pBoatHandlingSA, pOriginal, sizeof(tBoatHandlingDataSA));
+}
+
+CBoatHandlingEntrySA::~CBoatHandlingEntrySA()
+{
+    if (m_bDeleteInterface)
+    {
+        delete m_pBoatHandlingSA;
+    }
+}
+
+// Apply the handlingdata from another data
+void CBoatHandlingEntrySA::Assign(const CBoatHandlingEntry* pData)
+{
+    // Copy the data
+    const CBoatHandlingEntrySA* pEntrySA = static_cast<const CBoatHandlingEntrySA*>(pData);
+    m_pBoatHandlingSA = pEntrySA->m_pBoatHandlingSA;
+}

--- a/Client/game_sa/CBoatHandlingEntrySA.h
+++ b/Client/game_sa/CBoatHandlingEntrySA.h
@@ -32,17 +32,11 @@ struct tBoatHandlingDataSA
 class CBoatHandlingEntrySA : public CBoatHandlingEntry
 {
 public:
-    // Constructor for creatable dummy entries
     CBoatHandlingEntrySA();
-
-    // Constructor for original entries
     CBoatHandlingEntrySA(tBoatHandlingDataSA* pOriginal);
-
-    // Use this to copy data from an another handling class to this
-    void Assign(const CBoatHandlingEntry* pData);
-
-    tBoatHandlingDataSA* GetInterface() { return m_pBoatHandlingSA.get(); };
+    void                 Assign(const CBoatHandlingEntry* pData);
+    tBoatHandlingDataSA* GetInterface() { return &m_pBoatHandlingSA; };
 
 private:
-    std::shared_ptr<tBoatHandlingDataSA> m_pBoatHandlingSA;
+    tBoatHandlingDataSA m_pBoatHandlingSA;
 };

--- a/Client/game_sa/CBoatHandlingEntrySA.h
+++ b/Client/game_sa/CBoatHandlingEntrySA.h
@@ -38,14 +38,11 @@ public:
     // Constructor for original entries
     CBoatHandlingEntrySA(tBoatHandlingDataSA* pOriginal);
 
-    virtual ~CBoatHandlingEntrySA();
-
     // Use this to copy data from an another handling class to this
     void Assign(const CBoatHandlingEntry* pData);
 
-    tBoatHandlingDataSA* GetInterface() { return m_pBoatHandlingSA; };
+    tBoatHandlingDataSA* GetInterface() { return m_pBoatHandlingSA.get(); };
 
 private:
-    tBoatHandlingDataSA* m_pBoatHandlingSA;
-    bool                 m_bDeleteInterface;
+    std::shared_ptr<tBoatHandlingDataSA> m_pBoatHandlingSA;
 };

--- a/Client/game_sa/CBoatHandlingEntrySA.h
+++ b/Client/game_sa/CBoatHandlingEntrySA.h
@@ -1,0 +1,51 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        game_sa/CBoatHandlingEntrySA.h
+ *  PURPOSE:     Header file for vehicle flying handling data entry class
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#pragma once
+
+#include <game/CBoatHandlingEntry.h>
+#include "Common.h"
+
+struct tBoatHandlingDataSA
+{
+    int     iVehicleID;
+    float   fThrustY;
+    float   fThrustZ;
+    float   fThrustAppZ;
+    float   fAqPlaneForce;
+    float   fAqPlaneLimit;
+    float   fAqPlaneOffset;
+    float   fLookLRHeight;
+    float   fWaveAudioMult;
+    CVector vecMoveRes;
+    CVector vecTurnRes;
+};
+
+class CBoatHandlingEntrySA : public CBoatHandlingEntry
+{
+public:
+    // Constructor for creatable dummy entries
+    CBoatHandlingEntrySA();
+
+    // Constructor for original entries
+    CBoatHandlingEntrySA(tBoatHandlingDataSA* pOriginal);
+
+    virtual ~CBoatHandlingEntrySA();
+
+    // Use this to copy data from an another handling class to this
+    void Assign(const CBoatHandlingEntry* pData);
+
+    tBoatHandlingDataSA* GetInterface() { return m_pBoatHandlingSA; };
+
+private:
+    tBoatHandlingDataSA* m_pBoatHandlingSA;
+    bool                 m_bDeleteInterface;
+};

--- a/Client/game_sa/CBoatSA.cpp
+++ b/Client/game_sa/CBoatSA.cpp
@@ -38,3 +38,15 @@ CBoatSA::CBoatSA(eVehicleTypes dwModelID, unsigned char ucVariation, unsigned ch
         pGame->GetWorld()->Add((CEntitySA *)this);
     }   */
 }
+
+CBoatHandlingEntry* CBoatSA::GetBoatHandlingData()
+{
+    return m_pBoatHandlingData;
+}
+
+void CBoatSA::SetBoatHandlingData(CBoatHandlingEntry* pBoatHandling)
+{
+    // Store the handling
+    m_pBoatHandlingData = static_cast<CBoatHandlingEntrySA*>(pBoatHandling);
+    GetBoatInterface()->pBoatHandlingData = m_pBoatHandlingData->GetInterface();
+}

--- a/Client/game_sa/CBoatSA.h
+++ b/Client/game_sa/CBoatSA.h
@@ -16,32 +16,39 @@
 
 class CBoatSAInterface : public CVehicleSAInterface
 {
-    uint32             pad1[3];                                 // 1440
-    uint32             BoatFlags;                               // 1452
-    RwFrame*           pBoatParts[11];                          // 1456 [[ find out correct size
-    uint32             pad2[3];                                 // 1500
-    uint16             pad3;                                    // 1512
-    uint8              pad4[2];                                 // 1514
-    uint32             pad5[3];                                 // 1516
-    void*              pBoatHandlingData;                       // 1528
-    uint32             pad6[5];                                 // 1532
-    CVector            vecUnk1;                                 // 1552
-    CVector            vecUnk2;                                 // 1564
-    class CParticleFx* pBoatPropellerSplashParticle;            // 1576
-    uint32             pad7[4];                                 // 1580
-    uint8              pad8;                                    // 1596
-    uint8              ucPadUsingBoat;                          // 1597  [[ see class CPad
-    uint8              pad9[2];                                 // 1598
-    uint32             pad10[106];                              // 1600
+public:
+    uint32                  pad1[3];                                 // 1440
+    uint32                  BoatFlags;                               // 1452
+    RwFrame*                pBoatParts[11];                          // 1456 [[ find out correct size
+    uint32                  pad2[3];                                 // 1500
+    uint16                  pad3;                                    // 1512
+    uint8                   pad4[2];                                 // 1514
+    uint32                  pad5[3];                                 // 1516
+    tBoatHandlingDataSA*    pBoatHandlingData;                       // 1528
+    uint32                  pad6[5];                                 // 1532
+    CVector                 vecUnk1;                                 // 1552
+    CVector                 vecUnk2;                                 // 1564
+    class CParticleFx*      pBoatPropellerSplashParticle;            // 1576
+    uint32                  pad7[4];                                 // 1580
+    uint8                   pad8;                                    // 1596
+    uint8                   ucPadUsingBoat;                          // 1597  [[ see class CPad
+    uint8                   pad9[2];                                 // 1598
+    uint32                  pad10[106];                              // 1600
 };
 
 class CBoatSA : public virtual CBoat, public virtual CVehicleSA
 {
 private:
+    CBoatHandlingEntrySA* m_pBoatHandlingData;
     //  CBoatSAInterface        * internalInterface;
 public:
     CBoatSA(CBoatSAInterface* boat);
     CBoatSA(eVehicleTypes dwModelID, unsigned char ucVariation, unsigned char ucVariation2);
 
     virtual ~CBoatSA(){};
+
+    CBoatSAInterface*   GetBoatInterface() { return (CBoatSAInterface*)m_pInterface; }
+
+    CBoatHandlingEntry* GetBoatHandlingData();
+    void                SetBoatHandlingData(CBoatHandlingEntry* pHandling);
 };

--- a/Client/game_sa/CFlyingHandlingEntrySA.cpp
+++ b/Client/game_sa/CFlyingHandlingEntrySA.cpp
@@ -13,22 +13,16 @@
 
 CFlyingHandlingEntrySA::CFlyingHandlingEntrySA()
 {
-    // Create a new interface and zero it
-    m_pFlyingHandlingSA = std::make_shared<tFlyingHandlingDataSA>();
-    memset(m_pFlyingHandlingSA.get(), 0, sizeof(tFlyingHandlingDataSA));
+    memset(&m_pFlyingHandlingSA, 0, sizeof(tFlyingHandlingDataSA));
 }
 
 CFlyingHandlingEntrySA::CFlyingHandlingEntrySA(tFlyingHandlingDataSA* pOriginal)
 {
-    // Store gta's pointer
-    m_pFlyingHandlingSA = std::make_shared<tFlyingHandlingDataSA>();
-    memcpy(m_pFlyingHandlingSA.get(), pOriginal, sizeof(tFlyingHandlingDataSA));
+    m_pFlyingHandlingSA = *pOriginal;
 }
 
-// Apply the handlingdata from another data
 void CFlyingHandlingEntrySA::Assign(const CFlyingHandlingEntry* pData)
 {
-    // Copy the data
     const CFlyingHandlingEntrySA* pEntrySA = static_cast<const CFlyingHandlingEntrySA*>(pData);
     m_pFlyingHandlingSA = pEntrySA->m_pFlyingHandlingSA;
 }

--- a/Client/game_sa/CFlyingHandlingEntrySA.cpp
+++ b/Client/game_sa/CFlyingHandlingEntrySA.cpp
@@ -14,25 +14,15 @@
 CFlyingHandlingEntrySA::CFlyingHandlingEntrySA()
 {
     // Create a new interface and zero it
-    m_pFlyingHandlingSA = new tFlyingHandlingDataSA;
-    memset(m_pFlyingHandlingSA, 0, sizeof(tFlyingHandlingDataSA));
-    m_bDeleteInterface = true;
+    m_pFlyingHandlingSA = std::make_shared<tFlyingHandlingDataSA>();
+    memset(m_pFlyingHandlingSA.get(), 0, sizeof(tFlyingHandlingDataSA));
 }
 
 CFlyingHandlingEntrySA::CFlyingHandlingEntrySA(tFlyingHandlingDataSA* pOriginal)
 {
     // Store gta's pointer
-    m_pFlyingHandlingSA = new tFlyingHandlingDataSA;
-    m_bDeleteInterface = false;
-    memcpy(m_pFlyingHandlingSA, pOriginal, sizeof(tFlyingHandlingDataSA));
-}
-
-CFlyingHandlingEntrySA::~CFlyingHandlingEntrySA()
-{
-    if (m_bDeleteInterface)
-    {
-        delete m_pFlyingHandlingSA;
-    }
+    m_pFlyingHandlingSA = std::make_shared<tFlyingHandlingDataSA>();
+    memcpy(m_pFlyingHandlingSA.get(), pOriginal, sizeof(tFlyingHandlingDataSA));
 }
 
 // Apply the handlingdata from another data

--- a/Client/game_sa/CFlyingHandlingEntrySA.cpp
+++ b/Client/game_sa/CFlyingHandlingEntrySA.cpp
@@ -1,0 +1,44 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        game_sa/CFlyingHandlingEntrySA.cpp
+ *  PURPOSE:     Vehicle flying handling data entry
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+
+CFlyingHandlingEntrySA::CFlyingHandlingEntrySA()
+{
+    // Create a new interface and zero it
+    m_pFlyingHandlingSA = new tFlyingHandlingDataSA;
+    memset(m_pFlyingHandlingSA, 0, sizeof(tFlyingHandlingDataSA));
+    m_bDeleteInterface = true;
+}
+
+CFlyingHandlingEntrySA::CFlyingHandlingEntrySA(tFlyingHandlingDataSA* pOriginal)
+{
+    // Store gta's pointer
+    m_pFlyingHandlingSA = new tFlyingHandlingDataSA;
+    m_bDeleteInterface = false;
+    memcpy(m_pFlyingHandlingSA, pOriginal, sizeof(tFlyingHandlingDataSA));
+}
+
+CFlyingHandlingEntrySA::~CFlyingHandlingEntrySA()
+{
+    if (m_bDeleteInterface)
+    {
+        delete m_pFlyingHandlingSA;
+    }
+}
+
+// Apply the handlingdata from another data
+void CFlyingHandlingEntrySA::Assign(const CFlyingHandlingEntry* pData)
+{
+    // Copy the data
+    const CFlyingHandlingEntrySA* pEntrySA = static_cast<const CFlyingHandlingEntrySA*>(pData);
+    m_pFlyingHandlingSA = pEntrySA->m_pFlyingHandlingSA;
+}

--- a/Client/game_sa/CFlyingHandlingEntrySA.h
+++ b/Client/game_sa/CFlyingHandlingEntrySA.h
@@ -14,7 +14,6 @@
 #include <game/CFlyingHandlingEntry.h>
 #include "Common.h"
 
-// sizeof(tFlyingHandlingDataSA) == 0x58
 struct tFlyingHandlingDataSA
 {
     int     iVehicleID;
@@ -40,18 +39,11 @@ struct tFlyingHandlingDataSA
 class CFlyingHandlingEntrySA : public CFlyingHandlingEntry
 {
 public:
-    // Constructor for creatable dummy entries
     CFlyingHandlingEntrySA();
-
-    // Constructor for original entries
     CFlyingHandlingEntrySA(tFlyingHandlingDataSA* pOriginal);
-
-    // Use this to copy data from an another handling class to this
-    void Assign(const CFlyingHandlingEntry* pData);
-
-    tFlyingHandlingDataSA* GetInterface() { return m_pFlyingHandlingSA.get(); };
+    void                   Assign(const CFlyingHandlingEntry* pData);
+    tFlyingHandlingDataSA* GetInterface() { return &m_pFlyingHandlingSA; };
 
 private:
-    std::shared_ptr<tFlyingHandlingDataSA> m_pFlyingHandlingSA;
+    tFlyingHandlingDataSA m_pFlyingHandlingSA;
 };
-

--- a/Client/game_sa/CFlyingHandlingEntrySA.h
+++ b/Client/game_sa/CFlyingHandlingEntrySA.h
@@ -46,15 +46,12 @@ public:
     // Constructor for original entries
     CFlyingHandlingEntrySA(tFlyingHandlingDataSA* pOriginal);
 
-    virtual ~CFlyingHandlingEntrySA();
-
     // Use this to copy data from an another handling class to this
     void Assign(const CFlyingHandlingEntry* pData);
 
-    tFlyingHandlingDataSA* GetInterface() { return m_pFlyingHandlingSA; };
+    tFlyingHandlingDataSA* GetInterface() { return m_pFlyingHandlingSA.get(); };
 
 private:
-    tFlyingHandlingDataSA* m_pFlyingHandlingSA;
-    bool             m_bDeleteInterface;
+    std::shared_ptr<tFlyingHandlingDataSA> m_pFlyingHandlingSA;
 };
 

--- a/Client/game_sa/CFlyingHandlingEntrySA.h
+++ b/Client/game_sa/CFlyingHandlingEntrySA.h
@@ -1,0 +1,60 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        game_sa/CFlyingHandlingEntrySA.h
+ *  PURPOSE:     Header file for vehicle flying handling data entry class
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#pragma once
+
+#include <game/CFlyingHandlingEntry.h>
+#include "Common.h"
+
+// sizeof(tFlyingHandlingDataSA) == 0x58
+struct tFlyingHandlingDataSA
+{
+    int     iVehicleID;
+    float   fThrust;
+    float   fThrustFallOff;
+    float   fYaw;
+    float   fYawStab;
+    float   fSideSlip;
+    float   fRoll;
+    float   fRollStab;
+    float   fPitch;
+    float   fPitchStab;
+    float   fFormLift;
+    float   fAttackLift;
+    float   fGearUpR;
+    float   fGearDownL;
+    float   fWindMult;
+    float   fMoveResistance;
+    CVector vecTurnResistance;
+    CVector vecSpeedResistance;
+};
+
+class CFlyingHandlingEntrySA : public CFlyingHandlingEntry
+{
+public:
+    // Constructor for creatable dummy entries
+    CFlyingHandlingEntrySA();
+
+    // Constructor for original entries
+    CFlyingHandlingEntrySA(tFlyingHandlingDataSA* pOriginal);
+
+    virtual ~CFlyingHandlingEntrySA();
+
+    // Use this to copy data from an another handling class to this
+    void Assign(const CFlyingHandlingEntry* pData);
+
+    tFlyingHandlingDataSA* GetInterface() { return m_pFlyingHandlingSA; };
+
+private:
+    tFlyingHandlingDataSA* m_pFlyingHandlingSA;
+    bool             m_bDeleteInterface;
+};
+

--- a/Client/game_sa/CHandlingEntrySA.cpp
+++ b/Client/game_sa/CHandlingEntrySA.cpp
@@ -65,27 +65,7 @@ void CHandlingEntrySA::Recalculate(unsigned short usModel)
     {
         // Copy our stored field to GTA's
         memcpy(m_pHandlingSA, &m_Handling, sizeof(m_Handling));
-
-        CModelInfo* pModelInfo = pGame->GetModelInfo(usModel);
-        //         bool bIsBike = false;
-        //         if ( pModelInfo )
-        //         {
-        //             bIsBike = ( pModelInfo->IsBike() || pModelInfo->IsBmx() );
-        //         }
-        //         // Bikes and BMX's both use Bike data.
-        //         if ( bIsBike )
-        //         {
-        //             // Call GTA's function that calculates the final values from the read values
-        //             ( (void (_stdcall *)(tHandlingDataSA*))FUNC_HandlingDataMgr_ConvertDataToGameUnits )( m_pHandlingSA );
-        //             // Call GTA's function that calculates the final values from the read values
-        //             ( (void (_stdcall *)(tHandlingDataSA*))FUNC_HandlingDataMgr_ConvertBikeDataToGameUnits )( m_pHandlingSA );
-        //         }
-        //         else
-        // if ( pModelInfo && pModelInfo->IsMonsterTruck() || pModelInfo->IsCar() )
-        {
-            // Call GTA's function that calculates the final values from the read values
-            ((void(_stdcall*)(tHandlingDataSA*))FUNC_HandlingDataMgr_ConvertDataToGameUnits)(m_pHandlingSA);
-        }
+        ((void(_stdcall*)(tHandlingDataSA*))FUNC_HandlingDataMgr_ConvertDataToGameUnits)(m_pHandlingSA);
     }
 }
 

--- a/Client/game_sa/CHandlingEntrySA.h
+++ b/Client/game_sa/CHandlingEntrySA.h
@@ -13,7 +13,6 @@
 
 #include <game/CHandlingEntry.h>
 #include "Common.h"
-#define FUNC_HandlingDataMgr_ConvertBikeDataToGameUnits 0x6F5290
 #define FUNC_HandlingDataMgr_ConvertDataToGameUnits 0x6F5080
 // http://www.gtamodding.com/index.php?title=Handling.cfg#GTA_San_Andreas
 // http://www.gtamodding.com/index.php?title=Memory_Addresses_%28SA%29#Handling
@@ -203,27 +202,4 @@ private:
 
     tHandlingDataSA* m_pOriginalData;
     bool             m_bChanged;
-};
-
-// sizeof(tFlyingHandlingDataSA) == 0x58
-struct tFlyingHandlingDataSA
-{
-    int     iVehicleID;
-    float   fThrust;
-    float   fThrustFallOff;
-    float   fYaw;
-    float   fStab;
-    float   fSideSlip;
-    float   fRoll;
-    float   fRollStab;
-    float   fPitch;
-    float   fPitchStab;
-    float   fFormLift;
-    float   fAttackLift;
-    float   GearUpR;
-    float   GearDownL;
-    float   WindMult;
-    float   MoveResistance;
-    CVector TurnResistance;
-    CVector SpeedResistance;
 };

--- a/Client/game_sa/CHandlingManagerSA.cpp
+++ b/Client/game_sa/CHandlingManagerSA.cpp
@@ -22,6 +22,17 @@ DWORD CHandlingManagerSA::m_dwStore_LoadHandlingCfg = 0;
 tHandlingDataSA   CHandlingManagerSA::m_OriginalHandlingData[HT_MAX];
 CHandlingEntrySA* CHandlingManagerSA::m_pOriginalEntries[HT_MAX];
 
+tFlyingHandlingDataSA   CHandlingManagerSA::m_OriginalFlyingHandlingData[24];
+CFlyingHandlingEntrySA* CHandlingManagerSA::m_pOriginalFlyingEntries[24];
+
+tBoatHandlingDataSA   CHandlingManagerSA::m_OriginalBoatHandlingData[12];
+CBoatHandlingEntrySA* CHandlingManagerSA::m_pOriginalBoatEntries[12];
+
+tBikeHandlingDataSA   CHandlingManagerSA::m_OriginalBikeHandlingData[13];
+CBikeHandlingEntrySA* CHandlingManagerSA::m_pOriginalBikeEntries[13];
+
+// TODO We need install a hook in 0x6F52D0 to make some stuff work corrently
+
 // Use the following code to dump handling data unrecalculated on GTA load.
 // NB: You need to disable the other hook in the constructor of the manager and uncomment the other
 
@@ -112,6 +123,21 @@ CHandlingManagerSA::CHandlingManagerSA()
         m_pOriginalEntries[i] = new CHandlingEntrySA(&m_OriginalHandlingData[i]);
     }
 
+    for (int i = 0; i < 24; i++)
+    {
+        m_pOriginalFlyingEntries[i] = new CFlyingHandlingEntrySA(&m_OriginalFlyingHandlingData[i]);
+    }
+
+    for (int i = 0; i < 12; i++)
+    {
+        m_pOriginalBoatEntries[i] = new CBoatHandlingEntrySA(&m_OriginalBoatHandlingData[i]);
+    }
+
+    for (int i = 0; i < 13; i++)
+    {
+        m_pOriginalBikeEntries[i] = new CBikeHandlingEntrySA(&m_OriginalBikeHandlingData[i]);
+    }
+
     // Uncomment this to dump
     // HookInstall ( Func_Calculate, (DWORD) Hook_Calculate, 11 );
     m_HandlingNames["mass"] = HANDLING_MASS;                                                             // works (mass > 0)
@@ -158,6 +184,12 @@ CHandlingManagerSA::~CHandlingManagerSA()
     {
         delete m_pOriginalEntries[i];
     }
+
+    for (int i = 0; i < 24; i++)
+    {
+        delete m_pOriginalFlyingEntries[i];
+    }
+
 }
 
 eHandlingProperty CHandlingManagerSA::GetPropertyEnumFromName(std::string strName)
@@ -178,6 +210,24 @@ CHandlingEntry* CHandlingManagerSA::CreateHandlingData()
     return pHandlingEntry;
 }
 
+CFlyingHandlingEntry* CHandlingManagerSA::CreateFlyingHandlingData()
+{
+    CFlyingHandlingEntrySA* pFlyingHandlingEntry = new CFlyingHandlingEntrySA();
+    return pFlyingHandlingEntry;
+}
+
+CBoatHandlingEntry* CHandlingManagerSA::CreateBoatHandlingData()
+{
+    CBoatHandlingEntrySA* pBoatHandlingEntry = new CBoatHandlingEntrySA();
+    return pBoatHandlingEntry;
+}
+
+CBikeHandlingEntry* CHandlingManagerSA::CreateBikeHandlingData()
+{
+    CBikeHandlingEntrySA* pBikeHandlingEntry = new CBikeHandlingEntrySA();
+    return pBikeHandlingEntry;
+}
+
 const CHandlingEntry* CHandlingManagerSA::GetOriginalHandlingData(eVehicleTypes eModel)
 {
     // Within range?
@@ -187,6 +237,54 @@ const CHandlingEntry* CHandlingManagerSA::GetOriginalHandlingData(eVehicleTypes 
         eHandlingTypes eHandling = GetHandlingID(eModel);
         // Return it
         return m_pOriginalEntries[eHandling];
+    }
+
+    return NULL;
+}
+
+const CFlyingHandlingEntry* CHandlingManagerSA::GetOriginalFlyingHandlingData(eVehicleTypes eModel)
+{
+    // Within range?
+    if (eModel >= 400 && eModel < VT_MAX)
+    {
+        // Get our Handling ID
+        eHandlingTypes eHandling = GetHandlingID(eModel);
+        // Original GTA:SA behavior
+        if (eHandling < 186 || eHandling > 209)
+            return m_pOriginalFlyingEntries[0];
+        else
+            return m_pOriginalFlyingEntries[eHandling - 186];
+    }
+
+    return NULL;
+}
+
+const CBoatHandlingEntry* CHandlingManagerSA::GetOriginalBoatHandlingData(eVehicleTypes eModel)
+{
+    // Within range?
+    if (eModel >= 400 && eModel < VT_MAX)
+    {
+        // Get our Handling ID
+        eHandlingTypes eHandling = GetHandlingID(eModel);
+        // Original GTA:SA behavior
+        if (eHandling < 175 || eHandling > 186)
+            return m_pOriginalBoatEntries[0];
+        else
+            return m_pOriginalBoatEntries[eHandling - 175];
+    }
+
+    return NULL;
+}
+
+const CBikeHandlingEntry* CHandlingManagerSA::GetOriginalBikeHandlingData(eVehicleTypes eModel)
+{
+    // Within range?
+    if (eModel >= 400 && eModel < VT_MAX)
+    {
+        // Get our Handling ID
+        eHandlingTypes eHandling = GetHandlingID(eModel);
+        if (eHandling >= HT_BIKE || eHandling <= HT_FREEWAY)
+            return m_pOriginalBikeEntries[eHandling - HT_BIKE];
     }
 
     return NULL;
@@ -8215,6 +8313,833 @@ void CHandlingManagerSA::InitializeDefaultHandlings()
 
     m_OriginalHandlingData[217] = m_OriginalHandlingData[126];  // HT_FREIBOX = HT_FREIFLAT
     m_OriginalHandlingData[217].iVehicleID = 217;
+
+    // Aircrafts handling
+
+    m_OriginalFlyingHandlingData[0].iVehicleID = 186;
+    m_OriginalFlyingHandlingData[0].fThrust = 0.5f;
+    m_OriginalFlyingHandlingData[0].fThrustFallOff = 0.40f;
+    m_OriginalFlyingHandlingData[0].fYaw = -0.00006f;
+    m_OriginalFlyingHandlingData[0].fYawStab = 0.002f;
+    m_OriginalFlyingHandlingData[0].fSideSlip = 0.10f;
+    m_OriginalFlyingHandlingData[0].fRoll = 0.002f;
+    m_OriginalFlyingHandlingData[0].fRollStab = -0.002f;
+    m_OriginalFlyingHandlingData[0].fPitch = 0.0002f;
+    m_OriginalFlyingHandlingData[0].fPitchStab = 0.0020f;
+    m_OriginalFlyingHandlingData[0].fFormLift = 0.020f;
+    m_OriginalFlyingHandlingData[0].fAttackLift = 0.15f;
+    m_OriginalFlyingHandlingData[0].fGearUpR = 1.0f;
+    m_OriginalFlyingHandlingData[0].fGearDownL = 1.0f;
+    m_OriginalFlyingHandlingData[0].fWindMult = 0.2f;
+    m_OriginalFlyingHandlingData[0].fMoveResistance = 1.0f;
+    m_OriginalFlyingHandlingData[0].vecTurnResistance = CVector(0.998f, 0.998, 0.995);
+    m_OriginalFlyingHandlingData[0].vecSpeedResistance = CVector(20.0f, 50.0f, 20.0f);
+
+    m_OriginalFlyingHandlingData[1].iVehicleID = 187;
+    m_OriginalFlyingHandlingData[1].fThrust = 0.4f;
+    m_OriginalFlyingHandlingData[1].fThrustFallOff = 0.30f;
+    m_OriginalFlyingHandlingData[1].fYaw = -0.0025f;
+    m_OriginalFlyingHandlingData[1].fYawStab = 0.02f;
+    m_OriginalFlyingHandlingData[1].fSideSlip = 0.10f;
+    m_OriginalFlyingHandlingData[1].fRoll = 0.001f;
+    m_OriginalFlyingHandlingData[1].fRollStab = -0.002f;
+    m_OriginalFlyingHandlingData[1].fPitch = 0.0003f;
+    m_OriginalFlyingHandlingData[1].fPitchStab = 0.0020f;
+    m_OriginalFlyingHandlingData[1].fFormLift = 0.000f;
+    m_OriginalFlyingHandlingData[1].fAttackLift = 0.10f;
+    m_OriginalFlyingHandlingData[1].fGearUpR = 1.0f;
+    m_OriginalFlyingHandlingData[1].fGearDownL = 1.0f;
+    m_OriginalFlyingHandlingData[1].fWindMult = 0.2f;
+    m_OriginalFlyingHandlingData[1].fMoveResistance = 0.995f;
+    m_OriginalFlyingHandlingData[1].vecTurnResistance = CVector(1.000f, 1.000, 0.998);
+    m_OriginalFlyingHandlingData[1].vecSpeedResistance = CVector(0.0f, 0.0f, 10.0f);
+
+    m_OriginalFlyingHandlingData[2].iVehicleID = 188;
+    m_OriginalFlyingHandlingData[2].fThrust = 0.5f;
+    m_OriginalFlyingHandlingData[2].fThrustFallOff = 0.30f;
+    m_OriginalFlyingHandlingData[2].fYaw = -0.00010f;
+    m_OriginalFlyingHandlingData[2].fYawStab = 0.004f;
+    m_OriginalFlyingHandlingData[2].fSideSlip = 0.10f;
+    m_OriginalFlyingHandlingData[2].fRoll = 0.002f;
+    m_OriginalFlyingHandlingData[2].fRollStab = -0.002f;
+    m_OriginalFlyingHandlingData[2].fPitch = 0.0002f;
+    m_OriginalFlyingHandlingData[2].fPitchStab = 0.0020f;
+    m_OriginalFlyingHandlingData[2].fFormLift = 0.008f;
+    m_OriginalFlyingHandlingData[2].fAttackLift = 0.10f;
+    m_OriginalFlyingHandlingData[2].fGearUpR = 0.2f;
+    m_OriginalFlyingHandlingData[2].fGearDownL = 1.2f;
+    m_OriginalFlyingHandlingData[2].fWindMult = 0.2f;
+    m_OriginalFlyingHandlingData[2].fMoveResistance = 1.0f;
+    m_OriginalFlyingHandlingData[2].vecTurnResistance = CVector(0.998f, 0.998, 0.990);
+    m_OriginalFlyingHandlingData[2].vecSpeedResistance = CVector(10.0f, 20.0f, 0.0f);
+
+    m_OriginalFlyingHandlingData[3].iVehicleID = 189;
+    m_OriginalFlyingHandlingData[3].fThrust = 0.65f;
+    m_OriginalFlyingHandlingData[3].fThrustFallOff = 0.10f;
+    m_OriginalFlyingHandlingData[3].fYaw = -0.00010f;
+    m_OriginalFlyingHandlingData[3].fYawStab = 0.002f;
+    m_OriginalFlyingHandlingData[3].fSideSlip = 0.10f;
+    m_OriginalFlyingHandlingData[3].fRoll = 0.002f;
+    m_OriginalFlyingHandlingData[3].fRollStab = -0.002f;
+    m_OriginalFlyingHandlingData[3].fPitch = 0.0002f;
+    m_OriginalFlyingHandlingData[3].fPitchStab = 0.0020f;
+    m_OriginalFlyingHandlingData[3].fFormLift = 0.018f;
+    m_OriginalFlyingHandlingData[3].fAttackLift = 0.15f;
+    m_OriginalFlyingHandlingData[3].fGearUpR = 1.0f;
+    m_OriginalFlyingHandlingData[3].fGearDownL = 1.0f;
+    m_OriginalFlyingHandlingData[3].fWindMult = 0.2f;
+    m_OriginalFlyingHandlingData[3].fMoveResistance = 1.0f;
+    m_OriginalFlyingHandlingData[3].vecTurnResistance = CVector(0.998f, 0.998, 0.990);
+    m_OriginalFlyingHandlingData[3].vecSpeedResistance = CVector(20.0f, 50.0f, 20.0f);
+
+    m_OriginalFlyingHandlingData[4].iVehicleID = 190;
+    m_OriginalFlyingHandlingData[4].fThrust = 0.6f;
+    m_OriginalFlyingHandlingData[4].fThrustFallOff = 0.10f;
+    m_OriginalFlyingHandlingData[4].fYaw = -0.00015f;
+    m_OriginalFlyingHandlingData[4].fYawStab = 0.002f;
+    m_OriginalFlyingHandlingData[4].fSideSlip = 0.10f;
+    m_OriginalFlyingHandlingData[4].fRoll = 0.002f;
+    m_OriginalFlyingHandlingData[4].fRollStab = -0.002f;
+    m_OriginalFlyingHandlingData[4].fPitch = 0.0003f;
+    m_OriginalFlyingHandlingData[4].fPitchStab = 0.0020f;
+    m_OriginalFlyingHandlingData[4].fFormLift = 0.030f;
+    m_OriginalFlyingHandlingData[4].fAttackLift = 0.20f;
+    m_OriginalFlyingHandlingData[4].fGearUpR = 1.0f;
+    m_OriginalFlyingHandlingData[4].fGearDownL = 1.0f;
+    m_OriginalFlyingHandlingData[4].fWindMult = 0.2f;
+    m_OriginalFlyingHandlingData[4].fMoveResistance = 1.0f;
+    m_OriginalFlyingHandlingData[4].vecTurnResistance = CVector(0.9985f, 0.997, 0.995);
+    m_OriginalFlyingHandlingData[4].vecSpeedResistance = CVector(20.0f, 30.0f, 20.0f);
+
+    m_OriginalFlyingHandlingData[5].iVehicleID = 191;
+    m_OriginalFlyingHandlingData[5].fThrust = 0.8f;
+    m_OriginalFlyingHandlingData[5].fThrustFallOff = 0.30f;
+    m_OriginalFlyingHandlingData[5].fYaw = -0.00020f;
+    m_OriginalFlyingHandlingData[5].fYawStab = 0.002f;
+    m_OriginalFlyingHandlingData[5].fSideSlip = 0.010f;
+    m_OriginalFlyingHandlingData[5].fRoll = 0.004f;
+    m_OriginalFlyingHandlingData[5].fRollStab = -0.001f;
+    m_OriginalFlyingHandlingData[5].fPitch = 0.0005f;
+    m_OriginalFlyingHandlingData[5].fPitchStab = 0.0015f;
+    m_OriginalFlyingHandlingData[5].fFormLift = 0.014f;
+    m_OriginalFlyingHandlingData[5].fAttackLift = 0.14f;
+    m_OriginalFlyingHandlingData[5].fGearUpR = 1.0f;
+    m_OriginalFlyingHandlingData[5].fGearDownL = 1.0f;
+    m_OriginalFlyingHandlingData[5].fWindMult = 0.2f;
+    m_OriginalFlyingHandlingData[5].fMoveResistance = 1.0f;
+    m_OriginalFlyingHandlingData[5].vecTurnResistance = CVector(0.997f, 0.997, 0.997);
+    m_OriginalFlyingHandlingData[5].vecSpeedResistance = CVector(10.0f, 5.0f, 5.0f);
+
+    m_OriginalFlyingHandlingData[6].iVehicleID = 192;
+    m_OriginalFlyingHandlingData[6].fThrust = 0.5f;
+    m_OriginalFlyingHandlingData[6].fThrustFallOff = 1.00f;
+    m_OriginalFlyingHandlingData[6].fYaw = -0.00003f;
+    m_OriginalFlyingHandlingData[6].fYawStab = 0.001f;
+    m_OriginalFlyingHandlingData[6].fSideSlip = 0.10f;
+    m_OriginalFlyingHandlingData[6].fRoll = 0.002f;
+    m_OriginalFlyingHandlingData[6].fRollStab = -0.002f;
+    m_OriginalFlyingHandlingData[6].fPitch = 0.00006f;
+    m_OriginalFlyingHandlingData[6].fPitchStab = 0.0015f;
+    m_OriginalFlyingHandlingData[6].fFormLift = 0.006f;
+    m_OriginalFlyingHandlingData[6].fAttackLift = 0.10f;
+    m_OriginalFlyingHandlingData[6].fGearUpR = 0.3f;
+    m_OriginalFlyingHandlingData[6].fGearDownL = 1.7f;
+    m_OriginalFlyingHandlingData[6].fWindMult = 0.2f;
+    m_OriginalFlyingHandlingData[6].fMoveResistance = 1.0f;
+    m_OriginalFlyingHandlingData[6].vecTurnResistance = CVector(0.998f, 0.996, 0.995);
+    m_OriginalFlyingHandlingData[6].vecSpeedResistance = CVector(20.0f, 50.0f, 20.0f);
+
+    m_OriginalFlyingHandlingData[7].iVehicleID = 193;
+    m_OriginalFlyingHandlingData[7].fThrust = 1.1f;
+    m_OriginalFlyingHandlingData[7].fThrustFallOff = 1.00f;
+    m_OriginalFlyingHandlingData[7].fYaw = -0.00010f;
+    m_OriginalFlyingHandlingData[7].fYawStab = 0.004f;
+    m_OriginalFlyingHandlingData[7].fSideSlip = 0.10f;
+    m_OriginalFlyingHandlingData[7].fRoll = 0.002f;
+    m_OriginalFlyingHandlingData[7].fRollStab = -0.002f;
+    m_OriginalFlyingHandlingData[7].fPitch = 0.0001f;
+    m_OriginalFlyingHandlingData[7].fPitchStab = 0.0020f;
+    m_OriginalFlyingHandlingData[7].fFormLift = 0.006f;
+    m_OriginalFlyingHandlingData[7].fAttackLift = 0.10f;
+    m_OriginalFlyingHandlingData[7].fGearUpR = 0.1f;
+    m_OriginalFlyingHandlingData[7].fGearDownL = 1.3f;
+    m_OriginalFlyingHandlingData[7].fWindMult = 0.2f;
+    m_OriginalFlyingHandlingData[7].fMoveResistance = 1.0f;
+    m_OriginalFlyingHandlingData[7].vecTurnResistance = CVector(0.998f, 0.997, 0.995);
+    m_OriginalFlyingHandlingData[7].vecSpeedResistance = CVector(10.0f, 10.0f, 40.0f);
+
+    m_OriginalFlyingHandlingData[8].iVehicleID = 194;
+    m_OriginalFlyingHandlingData[8].fThrust = 0.4f;
+    m_OriginalFlyingHandlingData[8].fThrustFallOff = 0.30f;
+    m_OriginalFlyingHandlingData[8].fYaw = -0.00001f;
+    m_OriginalFlyingHandlingData[8].fYawStab = 0.005f;
+    m_OriginalFlyingHandlingData[8].fSideSlip = 0.10f;
+    m_OriginalFlyingHandlingData[8].fRoll = 0.001f;
+    m_OriginalFlyingHandlingData[8].fRollStab = -0.003f;
+    m_OriginalFlyingHandlingData[8].fPitch = 0.00003f;
+    m_OriginalFlyingHandlingData[8].fPitchStab = 0.0030f;
+    m_OriginalFlyingHandlingData[8].fFormLift = 0.012f;
+    m_OriginalFlyingHandlingData[8].fAttackLift = 0.20f;
+    m_OriginalFlyingHandlingData[8].fGearUpR = 0.3f;
+    m_OriginalFlyingHandlingData[8].fGearDownL = 1.3f;
+    m_OriginalFlyingHandlingData[8].fWindMult = 0.1f;
+    m_OriginalFlyingHandlingData[8].fMoveResistance = 1.0f;
+    m_OriginalFlyingHandlingData[8].vecTurnResistance = CVector(0.998f, 0.997, 0.995);
+    m_OriginalFlyingHandlingData[8].vecSpeedResistance = CVector(20.0f, 100.0f, 20.0f);
+
+    m_OriginalFlyingHandlingData[9].iVehicleID = 195;
+    m_OriginalFlyingHandlingData[9].fThrust = 0.35f;
+    m_OriginalFlyingHandlingData[9].fThrustFallOff = 1.00f;
+    m_OriginalFlyingHandlingData[9].fYaw = -0.000005f;
+    m_OriginalFlyingHandlingData[9].fYawStab = 0.0002f;
+    m_OriginalFlyingHandlingData[9].fSideSlip = 0.10f;
+    m_OriginalFlyingHandlingData[9].fRoll = 0.0003f;
+    m_OriginalFlyingHandlingData[9].fRollStab = -0.0001f;
+    m_OriginalFlyingHandlingData[9].fPitch = 0.00001f;
+    m_OriginalFlyingHandlingData[9].fPitchStab = 0.00005f;
+    m_OriginalFlyingHandlingData[9].fFormLift = 0.008f;
+    m_OriginalFlyingHandlingData[9].fAttackLift = 0.10f;
+    m_OriginalFlyingHandlingData[9].fGearUpR = 0.5f;
+    m_OriginalFlyingHandlingData[9].fGearDownL = 1.5f;
+    m_OriginalFlyingHandlingData[9].fWindMult = 0.1f;
+    m_OriginalFlyingHandlingData[9].fMoveResistance = 1.0f;
+    m_OriginalFlyingHandlingData[9].vecTurnResistance = CVector(0.998f, 0.997, 0.995);
+    m_OriginalFlyingHandlingData[9].vecSpeedResistance = CVector(20.0f, 100.0f, 20.0f);
+
+    m_OriginalFlyingHandlingData[10].iVehicleID = 196;
+    m_OriginalFlyingHandlingData[10].fThrust = 0.35f;
+    m_OriginalFlyingHandlingData[10].fThrustFallOff = 1.00f;
+    m_OriginalFlyingHandlingData[10].fYaw = -0.000005f;
+    m_OriginalFlyingHandlingData[10].fYawStab = 0.0002f;
+    m_OriginalFlyingHandlingData[10].fSideSlip = 0.10f;
+    m_OriginalFlyingHandlingData[10].fRoll = 0.0003f;
+    m_OriginalFlyingHandlingData[10].fRollStab = -0.0001f;
+    m_OriginalFlyingHandlingData[10].fPitch = 0.00001f;
+    m_OriginalFlyingHandlingData[10].fPitchStab = 0.00005f;
+    m_OriginalFlyingHandlingData[10].fFormLift = 0.008f;
+    m_OriginalFlyingHandlingData[10].fAttackLift = 0.10f;
+    m_OriginalFlyingHandlingData[10].fGearUpR = 0.5f;
+    m_OriginalFlyingHandlingData[10].fGearDownL = 1.5f;
+    m_OriginalFlyingHandlingData[10].fWindMult = 0.1f;
+    m_OriginalFlyingHandlingData[10].fMoveResistance = 1.0f;
+    m_OriginalFlyingHandlingData[10].vecTurnResistance = CVector(0.998f, 0.997, 0.995);
+    m_OriginalFlyingHandlingData[10].vecSpeedResistance = CVector(20.0f, 100.0f, 20.0f);
+
+    m_OriginalFlyingHandlingData[11].iVehicleID = 197;
+    m_OriginalFlyingHandlingData[11].fThrust = 0.5f;
+    m_OriginalFlyingHandlingData[11].fThrustFallOff = 0.40f;
+    m_OriginalFlyingHandlingData[11].fYaw = -0.00015f;
+    m_OriginalFlyingHandlingData[11].fYawStab = 0.002f;
+    m_OriginalFlyingHandlingData[11].fSideSlip = 0.10f;
+    m_OriginalFlyingHandlingData[11].fRoll = 0.003f;
+    m_OriginalFlyingHandlingData[11].fRollStab = -0.002f;
+    m_OriginalFlyingHandlingData[11].fPitch = 0.0003f;
+    m_OriginalFlyingHandlingData[11].fPitchStab = 0.0020f;
+    m_OriginalFlyingHandlingData[11].fFormLift = 0.020f;
+    m_OriginalFlyingHandlingData[11].fAttackLift = 0.15f;
+    m_OriginalFlyingHandlingData[11].fGearUpR = 1.0f;
+    m_OriginalFlyingHandlingData[11].fGearDownL = 1.0f;
+    m_OriginalFlyingHandlingData[11].fWindMult = 0.2f;
+    m_OriginalFlyingHandlingData[11].fMoveResistance = 1.0f;
+    m_OriginalFlyingHandlingData[11].vecTurnResistance = CVector(0.998f, 0.998, 0.995);
+    m_OriginalFlyingHandlingData[11].vecSpeedResistance = CVector(20.0f, 50.0f, 20.0f);
+
+    m_OriginalFlyingHandlingData[12].iVehicleID = 198;
+    m_OriginalFlyingHandlingData[12].fThrust = 0.40f;
+    m_OriginalFlyingHandlingData[12].fThrustFallOff = 0.95f;
+    m_OriginalFlyingHandlingData[12].fYaw = -0.001f;
+    m_OriginalFlyingHandlingData[12].fYawStab = 0.01f;
+    m_OriginalFlyingHandlingData[12].fSideSlip = 0.05f;
+    m_OriginalFlyingHandlingData[12].fRoll = 0.0020f;
+    m_OriginalFlyingHandlingData[12].fRollStab = 2.0f;
+    m_OriginalFlyingHandlingData[12].fPitch = 0.0020f;
+    m_OriginalFlyingHandlingData[12].fPitchStab = 2.0f;
+    m_OriginalFlyingHandlingData[12].fFormLift = 0.7f;
+    m_OriginalFlyingHandlingData[12].fAttackLift = 0.004f;
+    m_OriginalFlyingHandlingData[12].fGearUpR = 0.2f;
+    m_OriginalFlyingHandlingData[12].fGearDownL = 1.0f;
+    m_OriginalFlyingHandlingData[12].fWindMult = 0.2f;
+    m_OriginalFlyingHandlingData[12].fMoveResistance = 0.998f;
+    m_OriginalFlyingHandlingData[12].vecTurnResistance = CVector(0.980f, 0.980, 0.990);
+    m_OriginalFlyingHandlingData[12].vecSpeedResistance = CVector(1.0f, 1.0f, 10.0f);
+
+    m_OriginalFlyingHandlingData[13].iVehicleID = 199;
+    m_OriginalFlyingHandlingData[13].fThrust = 0.50f;
+    m_OriginalFlyingHandlingData[13].fThrustFallOff = 0.95f;
+    m_OriginalFlyingHandlingData[13].fYaw = -0.001f;
+    m_OriginalFlyingHandlingData[13].fYawStab = 0.01f;
+    m_OriginalFlyingHandlingData[13].fSideSlip = 0.05f;
+    m_OriginalFlyingHandlingData[13].fRoll = 0.0020f;
+    m_OriginalFlyingHandlingData[13].fRollStab = 2.0f;
+    m_OriginalFlyingHandlingData[13].fPitch = 0.0020f;
+    m_OriginalFlyingHandlingData[13].fPitchStab = 2.0f;
+    m_OriginalFlyingHandlingData[13].fFormLift = 0.7f;
+    m_OriginalFlyingHandlingData[13].fAttackLift = 0.003f;
+    m_OriginalFlyingHandlingData[13].fGearUpR = 0.2f;
+    m_OriginalFlyingHandlingData[13].fGearDownL = 1.0f;
+    m_OriginalFlyingHandlingData[13].fWindMult = 0.2f;
+    m_OriginalFlyingHandlingData[13].fMoveResistance = 0.998f;
+    m_OriginalFlyingHandlingData[13].vecTurnResistance = CVector(0.980f, 0.980, 0.990);
+    m_OriginalFlyingHandlingData[13].vecSpeedResistance = CVector(1.0f, 1.0f, 10.0f);
+
+    m_OriginalFlyingHandlingData[14].iVehicleID = 200;
+    m_OriginalFlyingHandlingData[14].fThrust = 0.60f;
+    m_OriginalFlyingHandlingData[14].fThrustFallOff = 0.85f;
+    m_OriginalFlyingHandlingData[14].fYaw = -0.0005f;
+    m_OriginalFlyingHandlingData[14].fYawStab = 0.005f;
+    m_OriginalFlyingHandlingData[14].fSideSlip = 0.03f;
+    m_OriginalFlyingHandlingData[14].fRoll = 0.0010f;
+    m_OriginalFlyingHandlingData[14].fRollStab = 1.5f;
+    m_OriginalFlyingHandlingData[14].fPitch = 0.0010f;
+    m_OriginalFlyingHandlingData[14].fPitchStab = 1.5f;
+    m_OriginalFlyingHandlingData[14].fFormLift = 0.6f;
+    m_OriginalFlyingHandlingData[14].fAttackLift = 0.002f;
+    m_OriginalFlyingHandlingData[14].fGearUpR = 0.2f;
+    m_OriginalFlyingHandlingData[14].fGearDownL = 1.0f;
+    m_OriginalFlyingHandlingData[14].fWindMult = 0.2f;
+    m_OriginalFlyingHandlingData[14].fMoveResistance = 0.9985f;
+    m_OriginalFlyingHandlingData[14].vecTurnResistance = CVector(0.992f, 0.992, 0.996);
+    m_OriginalFlyingHandlingData[14].vecSpeedResistance = CVector(0.5f, 0.5f, 10.0f);
+
+    m_OriginalFlyingHandlingData[15].iVehicleID = 201;
+    m_OriginalFlyingHandlingData[15].fThrust = 0.60f;
+    m_OriginalFlyingHandlingData[15].fThrustFallOff = 0.95f;
+    m_OriginalFlyingHandlingData[15].fYaw = -0.0005f;
+    m_OriginalFlyingHandlingData[15].fYawStab = 0.005f;
+    m_OriginalFlyingHandlingData[15].fSideSlip = 0.03f;
+    m_OriginalFlyingHandlingData[15].fRoll = 0.0012f;
+    m_OriginalFlyingHandlingData[15].fRollStab = 1.0f;
+    m_OriginalFlyingHandlingData[15].fPitch = 0.0015f;
+    m_OriginalFlyingHandlingData[15].fPitchStab = 1.0f;
+    m_OriginalFlyingHandlingData[15].fFormLift = 0.6f;
+    m_OriginalFlyingHandlingData[15].fAttackLift = 0.002f;
+    m_OriginalFlyingHandlingData[15].fGearUpR = 0.2f;
+    m_OriginalFlyingHandlingData[15].fGearDownL = 1.0f;
+    m_OriginalFlyingHandlingData[15].fWindMult = 0.2f;
+    m_OriginalFlyingHandlingData[15].fMoveResistance = 0.9985f;
+    m_OriginalFlyingHandlingData[15].vecTurnResistance = CVector(0.992f, 0.992, 0.996);
+    m_OriginalFlyingHandlingData[15].vecSpeedResistance = CVector(1.5f, 1.5f, 10.0f);
+
+    m_OriginalFlyingHandlingData[16].iVehicleID = 202;
+    m_OriginalFlyingHandlingData[16].fThrust = 0.60f;
+    m_OriginalFlyingHandlingData[16].fThrustFallOff = 0.75f;
+    m_OriginalFlyingHandlingData[16].fYaw = -0.0005f;
+    m_OriginalFlyingHandlingData[16].fYawStab = 0.005f;
+    m_OriginalFlyingHandlingData[16].fSideSlip = 0.03f;
+    m_OriginalFlyingHandlingData[16].fRoll = 0.0010f;
+    m_OriginalFlyingHandlingData[16].fRollStab = 1.5f;
+    m_OriginalFlyingHandlingData[16].fPitch = 0.0010f;
+    m_OriginalFlyingHandlingData[16].fPitchStab = 1.5f;
+    m_OriginalFlyingHandlingData[16].fFormLift = 0.6f;
+    m_OriginalFlyingHandlingData[16].fAttackLift = 0.002f;
+    m_OriginalFlyingHandlingData[16].fGearUpR = 0.2f;
+    m_OriginalFlyingHandlingData[16].fGearDownL = 1.0f;
+    m_OriginalFlyingHandlingData[16].fWindMult = 0.2f;
+    m_OriginalFlyingHandlingData[16].fMoveResistance = 0.9985f;
+    m_OriginalFlyingHandlingData[16].vecTurnResistance = CVector(0.992f, 0.992, 0.996);
+    m_OriginalFlyingHandlingData[16].vecSpeedResistance = CVector(0.5f, 0.5f, 10.0f);
+
+    m_OriginalFlyingHandlingData[17].iVehicleID = 203;
+    m_OriginalFlyingHandlingData[17].fThrust = 0.55f;
+    m_OriginalFlyingHandlingData[17].fThrustFallOff = 0.50f;
+    m_OriginalFlyingHandlingData[17].fYaw = -0.0005f;
+    m_OriginalFlyingHandlingData[17].fYawStab = 0.005f;
+    m_OriginalFlyingHandlingData[17].fSideSlip = 0.01f;
+    m_OriginalFlyingHandlingData[17].fRoll = 0.001f;
+    m_OriginalFlyingHandlingData[17].fRollStab = 1.0f;
+    m_OriginalFlyingHandlingData[17].fPitch = 0.001f;
+    m_OriginalFlyingHandlingData[17].fPitchStab = 1.0f;
+    m_OriginalFlyingHandlingData[17].fFormLift = 0.5f;
+    m_OriginalFlyingHandlingData[17].fAttackLift = 0.001f;
+    m_OriginalFlyingHandlingData[17].fGearUpR = 0.2f;
+    m_OriginalFlyingHandlingData[17].fGearDownL = 1.0f;
+    m_OriginalFlyingHandlingData[17].fWindMult = 0.2f;
+    m_OriginalFlyingHandlingData[17].fMoveResistance = 0.9985f;
+    m_OriginalFlyingHandlingData[17].vecTurnResistance = CVector(0.992f, 0.992, 0.992);
+    m_OriginalFlyingHandlingData[17].vecSpeedResistance = CVector(2.0f, 2.0f, 7.0f);
+
+    m_OriginalFlyingHandlingData[18].iVehicleID = 204;
+    m_OriginalFlyingHandlingData[18].fThrust = 0.3f;
+    m_OriginalFlyingHandlingData[18].fThrustFallOff = 0.85f;
+    m_OriginalFlyingHandlingData[18].fYaw = -0.0003f;
+    m_OriginalFlyingHandlingData[18].fYawStab = 0.005f;
+    m_OriginalFlyingHandlingData[18].fSideSlip = 0.02f;
+    m_OriginalFlyingHandlingData[18].fRoll = 0.0007f;
+    m_OriginalFlyingHandlingData[18].fRollStab = 1.0f;
+    m_OriginalFlyingHandlingData[18].fPitch = 0.0007f;
+    m_OriginalFlyingHandlingData[18].fPitchStab = 1.0f;
+    m_OriginalFlyingHandlingData[18].fFormLift = 0.5f;
+    m_OriginalFlyingHandlingData[18].fAttackLift = 0.001f;
+    m_OriginalFlyingHandlingData[18].fGearUpR = 0.2f;
+    m_OriginalFlyingHandlingData[18].fGearDownL = 1.0f;
+    m_OriginalFlyingHandlingData[18].fWindMult = 0.1f;
+    m_OriginalFlyingHandlingData[18].fMoveResistance = 0.9985f;
+    m_OriginalFlyingHandlingData[18].vecTurnResistance = CVector(0.992f, 0.992, 0.995);
+    m_OriginalFlyingHandlingData[18].vecSpeedResistance = CVector(2.0f, 2.0f, 10.0f);
+
+    m_OriginalFlyingHandlingData[19].iVehicleID = 205;
+    m_OriginalFlyingHandlingData[19].fThrust = 0.4f;
+    m_OriginalFlyingHandlingData[19].fThrustFallOff = 0.85f;
+    m_OriginalFlyingHandlingData[19].fYaw = -0.0003f;
+    m_OriginalFlyingHandlingData[19].fYawStab = 0.005f;
+    m_OriginalFlyingHandlingData[19].fSideSlip = 0.02f;
+    m_OriginalFlyingHandlingData[19].fRoll = 0.0007f;
+    m_OriginalFlyingHandlingData[19].fRollStab = 1.0f;
+    m_OriginalFlyingHandlingData[19].fPitch = 0.0007f;
+    m_OriginalFlyingHandlingData[19].fPitchStab = 1.0f;
+    m_OriginalFlyingHandlingData[19].fFormLift = 0.5f;
+    m_OriginalFlyingHandlingData[19].fAttackLift = 0.001f;
+    m_OriginalFlyingHandlingData[19].fGearUpR = 0.2f;
+    m_OriginalFlyingHandlingData[19].fGearDownL = 1.0f;
+    m_OriginalFlyingHandlingData[19].fWindMult = 0.1f;
+    m_OriginalFlyingHandlingData[19].fMoveResistance = 0.9985f;
+    m_OriginalFlyingHandlingData[19].vecTurnResistance = CVector(0.992f, 0.992, 0.995);
+    m_OriginalFlyingHandlingData[19].vecSpeedResistance = CVector(2.0f, 2.0f, 10.0f);
+
+    m_OriginalFlyingHandlingData[20].iVehicleID = 206;
+    m_OriginalFlyingHandlingData[20].fThrust = 0.4f;
+    m_OriginalFlyingHandlingData[20].fThrustFallOff = 0.85f;
+    m_OriginalFlyingHandlingData[20].fYaw = -0.0003f;
+    m_OriginalFlyingHandlingData[20].fYawStab = 0.005f;
+    m_OriginalFlyingHandlingData[20].fSideSlip = 0.02f;
+    m_OriginalFlyingHandlingData[20].fRoll = 0.0007f;
+    m_OriginalFlyingHandlingData[20].fRollStab = 1.0f;
+    m_OriginalFlyingHandlingData[20].fPitch = 0.0007f;
+    m_OriginalFlyingHandlingData[20].fPitchStab = 1.0f;
+    m_OriginalFlyingHandlingData[20].fFormLift = 0.5f;
+    m_OriginalFlyingHandlingData[20].fAttackLift = 0.001f;
+    m_OriginalFlyingHandlingData[20].fGearUpR = 0.2f;
+    m_OriginalFlyingHandlingData[20].fGearDownL = 1.0f;
+    m_OriginalFlyingHandlingData[20].fWindMult = 0.1f;
+    m_OriginalFlyingHandlingData[20].fMoveResistance = 0.9985f;
+    m_OriginalFlyingHandlingData[20].vecTurnResistance = CVector(0.992f, 0.992, 0.995);
+    m_OriginalFlyingHandlingData[20].vecSpeedResistance = CVector(2.0f, 2.0f, 10.0f);
+
+    m_OriginalFlyingHandlingData[21].iVehicleID = 207;
+    m_OriginalFlyingHandlingData[21].fThrust = 0.5f;
+    m_OriginalFlyingHandlingData[21].fThrustFallOff = -0.05f;
+    m_OriginalFlyingHandlingData[21].fYaw = -0.006f;
+    m_OriginalFlyingHandlingData[21].fYawStab = 0.6f;
+    m_OriginalFlyingHandlingData[21].fSideSlip = 0.30f;
+    m_OriginalFlyingHandlingData[21].fRoll = 0.015f;
+    m_OriginalFlyingHandlingData[21].fRollStab = -0.005f;
+    m_OriginalFlyingHandlingData[21].fPitch = 0.005f;
+    m_OriginalFlyingHandlingData[21].fPitchStab = 0.2f;
+    m_OriginalFlyingHandlingData[21].fFormLift = 0.10f;
+    m_OriginalFlyingHandlingData[21].fAttackLift = 0.30f;
+    m_OriginalFlyingHandlingData[21].fGearUpR = 0.2f;
+    m_OriginalFlyingHandlingData[21].fGearDownL = 1.0f;
+    m_OriginalFlyingHandlingData[21].fWindMult = 0.1f;
+    m_OriginalFlyingHandlingData[21].fMoveResistance = 1.0f;
+    m_OriginalFlyingHandlingData[21].vecTurnResistance = CVector(0.998f, 0.996, 0.990);
+    m_OriginalFlyingHandlingData[21].vecSpeedResistance = CVector(10.0f, 40.0f, 10.0f);
+
+    m_OriginalFlyingHandlingData[22].iVehicleID = 208;
+    m_OriginalFlyingHandlingData[22].fThrust = 0.20f;
+    m_OriginalFlyingHandlingData[22].fThrustFallOff = 0.75f;
+    m_OriginalFlyingHandlingData[22].fYaw = -0.001f;
+    m_OriginalFlyingHandlingData[22].fYawStab = 0.05f;
+    m_OriginalFlyingHandlingData[22].fSideSlip = 0.10f;
+    m_OriginalFlyingHandlingData[22].fRoll = 0.006f;
+    m_OriginalFlyingHandlingData[22].fRollStab = 6.0f;
+    m_OriginalFlyingHandlingData[22].fPitch = 0.006f;
+    m_OriginalFlyingHandlingData[22].fPitchStab = 6.0f;
+    m_OriginalFlyingHandlingData[22].fFormLift = 0.7f;
+    m_OriginalFlyingHandlingData[22].fAttackLift = 0.015f;
+    m_OriginalFlyingHandlingData[22].fGearUpR = 0.2f;
+    m_OriginalFlyingHandlingData[22].fGearDownL = 1.0f;
+    m_OriginalFlyingHandlingData[22].fWindMult = 0.1f;
+    m_OriginalFlyingHandlingData[22].fMoveResistance = 0.989f;
+    m_OriginalFlyingHandlingData[22].vecTurnResistance = CVector(0.850f, 0.860, 0.992);
+    m_OriginalFlyingHandlingData[22].vecSpeedResistance = CVector(0.0f, 0.0f, 7.0f);
+
+    m_OriginalFlyingHandlingData[23].iVehicleID = 209;
+    m_OriginalFlyingHandlingData[23].fThrust = 0.25f;
+    m_OriginalFlyingHandlingData[23].fThrustFallOff = 0.6f;
+    m_OriginalFlyingHandlingData[23].fYaw = -0.002f;
+    m_OriginalFlyingHandlingData[23].fYawStab = 0.05f;
+    m_OriginalFlyingHandlingData[23].fSideSlip = 0.10f;
+    m_OriginalFlyingHandlingData[23].fRoll = 0.009f;
+    m_OriginalFlyingHandlingData[23].fRollStab = 5.0f;
+    m_OriginalFlyingHandlingData[23].fPitch = 0.009f;
+    m_OriginalFlyingHandlingData[23].fPitchStab = 5.0f;
+    m_OriginalFlyingHandlingData[23].fFormLift = 0.4f;
+    m_OriginalFlyingHandlingData[23].fAttackLift = 0.008f;
+    m_OriginalFlyingHandlingData[23].fGearUpR = 0.2f;
+    m_OriginalFlyingHandlingData[23].fGearDownL = 1.0f;
+    m_OriginalFlyingHandlingData[23].fWindMult = 0.1f;
+    m_OriginalFlyingHandlingData[23].fMoveResistance = 0.989f;
+    m_OriginalFlyingHandlingData[23].vecTurnResistance = CVector(0.880f, 0.880, 0.998);
+    m_OriginalFlyingHandlingData[23].vecSpeedResistance = CVector(0.0f, 0.0f, 5.0f);
+
+    // Boats handling
+
+    m_OriginalBoatHandlingData[0].iVehicleID = 175;
+    m_OriginalBoatHandlingData[0].fThrustY = 0.79f;
+    m_OriginalBoatHandlingData[0].fThrustZ= 0.5f;
+    m_OriginalBoatHandlingData[0].fThrustAppZ = 0.6f;
+    m_OriginalBoatHandlingData[0].fAqPlaneForce = 7.0f;
+    m_OriginalBoatHandlingData[0].fAqPlaneLimit = 0.60f;
+    m_OriginalBoatHandlingData[0].fAqPlaneOffset = -1.9f;
+    m_OriginalBoatHandlingData[0].fWaveAudioMult = 4.0f;
+    m_OriginalBoatHandlingData[0].vecMoveRes = CVector(0.8f, 0.998f, 0.998f);
+    m_OriginalBoatHandlingData[0].vecTurnRes = CVector(0.85f, 0.98f, 0.97f);
+    m_OriginalBoatHandlingData[0].fLookLRHeight = 4.0f;
+
+    m_OriginalBoatHandlingData[1].iVehicleID = 176;
+    m_OriginalBoatHandlingData[1].fThrustY = 0.65f;
+    m_OriginalBoatHandlingData[1].fThrustZ= 0.5f;
+    m_OriginalBoatHandlingData[1].fThrustAppZ = 0.5f;
+    m_OriginalBoatHandlingData[1].fAqPlaneForce = 8.0f;
+    m_OriginalBoatHandlingData[1].fAqPlaneLimit = 0.70f;
+    m_OriginalBoatHandlingData[1].fAqPlaneOffset = -0.5f;
+    m_OriginalBoatHandlingData[1].fWaveAudioMult = 3.0f;
+    m_OriginalBoatHandlingData[1].vecMoveRes = CVector(0.7f, 0.998f, 0.999f);
+    m_OriginalBoatHandlingData[1].vecTurnRes = CVector(0.85f, 0.98f, 0.96f);
+    m_OriginalBoatHandlingData[1].fLookLRHeight = 4.0f;
+
+    m_OriginalBoatHandlingData[2].iVehicleID = 177;
+    m_OriginalBoatHandlingData[2].fThrustY = 0.35f;
+    m_OriginalBoatHandlingData[2].fThrustZ= 0.6f;
+    m_OriginalBoatHandlingData[2].fThrustAppZ = 0.0f;
+    m_OriginalBoatHandlingData[2].fAqPlaneForce = 3.0f;
+    m_OriginalBoatHandlingData[2].fAqPlaneLimit = 0.20f;
+    m_OriginalBoatHandlingData[2].fAqPlaneOffset = -0.9f;
+    m_OriginalBoatHandlingData[2].fWaveAudioMult = 3.5f;
+    m_OriginalBoatHandlingData[2].vecMoveRes = CVector(0.8f, 0.998f, 0.995f);
+    m_OriginalBoatHandlingData[2].vecTurnRes = CVector(0.85f, 0.98f, 0.96f);
+    m_OriginalBoatHandlingData[2].fLookLRHeight = 4.0f;
+
+    m_OriginalBoatHandlingData[3].iVehicleID = 178;
+    m_OriginalBoatHandlingData[3].fThrustY = 0.75f;
+    m_OriginalBoatHandlingData[3].fThrustZ= 0.7f;
+    m_OriginalBoatHandlingData[3].fThrustAppZ = 0.0f;
+    m_OriginalBoatHandlingData[3].fAqPlaneForce = 3.0f;
+    m_OriginalBoatHandlingData[3].fAqPlaneLimit = 0.20f;
+    m_OriginalBoatHandlingData[3].fAqPlaneOffset = 0.0f;
+    m_OriginalBoatHandlingData[3].fWaveAudioMult = 10.0f;
+    m_OriginalBoatHandlingData[3].vecMoveRes = CVector(0.7f, 0.998f, 0.999f);
+    m_OriginalBoatHandlingData[3].vecTurnRes = CVector(0.85f, 0.96f, 0.96f);
+    m_OriginalBoatHandlingData[3].fLookLRHeight = 4.0f;
+
+    m_OriginalBoatHandlingData[4].iVehicleID = 179;
+    m_OriginalBoatHandlingData[4].fThrustY = 0.50f;
+    m_OriginalBoatHandlingData[4].fThrustZ= 1.1f;
+    m_OriginalBoatHandlingData[4].fThrustAppZ = 0.2f;
+    m_OriginalBoatHandlingData[4].fAqPlaneForce = 9.0f;
+    m_OriginalBoatHandlingData[4].fAqPlaneLimit = 0.80f;
+    m_OriginalBoatHandlingData[4].fAqPlaneOffset = 1.2f;
+    m_OriginalBoatHandlingData[4].fWaveAudioMult = 4.0f;
+    m_OriginalBoatHandlingData[4].vecMoveRes = CVector(0.90f, 0.998f, 0.999f);
+    m_OriginalBoatHandlingData[4].vecTurnRes = CVector(0.89f, 0.975f, 0.97f);
+    m_OriginalBoatHandlingData[4].fLookLRHeight = 4.0f;
+
+    m_OriginalBoatHandlingData[5].iVehicleID = 180;
+    m_OriginalBoatHandlingData[5].fThrustY = 0.35f;
+    m_OriginalBoatHandlingData[5].fThrustZ= 0.6f;
+    m_OriginalBoatHandlingData[5].fThrustAppZ = 0.5f;
+    m_OriginalBoatHandlingData[5].fAqPlaneForce = 4.0f;
+    m_OriginalBoatHandlingData[5].fAqPlaneLimit = 0.35f;
+    m_OriginalBoatHandlingData[5].fAqPlaneOffset = -1.0f;
+    m_OriginalBoatHandlingData[5].fWaveAudioMult = 6.0f;
+    m_OriginalBoatHandlingData[5].vecMoveRes = CVector(0.7f, 0.998f, 0.995f);
+    m_OriginalBoatHandlingData[5].vecTurnRes = CVector(0.78f, 0.985f, 0.96f);
+    m_OriginalBoatHandlingData[5].fLookLRHeight = 5.0f;
+
+    m_OriginalBoatHandlingData[6].iVehicleID = 181;
+    m_OriginalBoatHandlingData[6].fThrustY = 0.50f;
+    m_OriginalBoatHandlingData[6].fThrustZ= 0.65f;
+    m_OriginalBoatHandlingData[6].fThrustAppZ = 0.5f;
+    m_OriginalBoatHandlingData[6].fAqPlaneForce = 8.0f;
+    m_OriginalBoatHandlingData[6].fAqPlaneLimit = 0.60f;
+    m_OriginalBoatHandlingData[6].fAqPlaneOffset = -0.3f;
+    m_OriginalBoatHandlingData[6].fWaveAudioMult = 3.0f;
+    m_OriginalBoatHandlingData[6].vecMoveRes = CVector(0.7f, 0.996f, 0.998f);
+    m_OriginalBoatHandlingData[6].vecTurnRes = CVector(0.85f, 0.96f, 0.96f);
+    m_OriginalBoatHandlingData[6].fLookLRHeight = 3.0f;
+
+    m_OriginalBoatHandlingData[7].iVehicleID = 182;
+    m_OriginalBoatHandlingData[7].fThrustY = 0.70f;
+    m_OriginalBoatHandlingData[7].fThrustZ= 0.6f;
+    m_OriginalBoatHandlingData[7].fThrustAppZ = 0.4f;
+    m_OriginalBoatHandlingData[7].fAqPlaneForce = 5.0f;
+    m_OriginalBoatHandlingData[7].fAqPlaneLimit = 0.30f;
+    m_OriginalBoatHandlingData[7].fAqPlaneOffset = -0.8f;
+    m_OriginalBoatHandlingData[7].fWaveAudioMult = 3.0f;
+    m_OriginalBoatHandlingData[7].vecMoveRes = CVector(0.94f, 0.993f, 0.997f);
+    m_OriginalBoatHandlingData[7].vecTurnRes = CVector(0.85f, 0.94f, 0.94f);
+    m_OriginalBoatHandlingData[7].fLookLRHeight = 3.0f;
+
+    m_OriginalBoatHandlingData[8].iVehicleID = 183;
+    m_OriginalBoatHandlingData[8].fThrustY = 0.95f;
+    m_OriginalBoatHandlingData[8].fThrustZ= 0.7f;
+    m_OriginalBoatHandlingData[8].fThrustAppZ = 0.0f;
+    m_OriginalBoatHandlingData[8].fAqPlaneForce = 1.5f;
+    m_OriginalBoatHandlingData[8].fAqPlaneLimit = 0.10f;
+    m_OriginalBoatHandlingData[8].fAqPlaneOffset = 0.0f;
+    m_OriginalBoatHandlingData[8].fWaveAudioMult = 3.5f;
+    m_OriginalBoatHandlingData[8].vecMoveRes = CVector(0.8f, 0.998f, 0.970f);
+    m_OriginalBoatHandlingData[8].vecTurnRes = CVector(0.84f, 0.99f, 0.94f);
+    m_OriginalBoatHandlingData[8].fLookLRHeight = 5.0f;
+
+    m_OriginalBoatHandlingData[9].iVehicleID = 184;
+    m_OriginalBoatHandlingData[9].fThrustY = 0.50f;
+    m_OriginalBoatHandlingData[9].fThrustZ= 0.6f;
+    m_OriginalBoatHandlingData[9].fThrustAppZ = 0.9f;
+    m_OriginalBoatHandlingData[9].fAqPlaneForce = 9.0f;
+    m_OriginalBoatHandlingData[9].fAqPlaneLimit = 0.80f;
+    m_OriginalBoatHandlingData[9].fAqPlaneOffset = -1.0f;
+    m_OriginalBoatHandlingData[9].fWaveAudioMult = 4.0f;
+    m_OriginalBoatHandlingData[9].vecMoveRes = CVector(0.92f, 0.998f, 0.998f);
+    m_OriginalBoatHandlingData[9].vecTurnRes = CVector(0.87f, 0.96f, 0.97f);
+    m_OriginalBoatHandlingData[9].fLookLRHeight = 4.0f;
+
+    m_OriginalBoatHandlingData[10].iVehicleID = 185;
+    m_OriginalBoatHandlingData[10].fThrustY = 0.50f;
+    m_OriginalBoatHandlingData[10].fThrustZ= 0.9f;
+    m_OriginalBoatHandlingData[10].fThrustAppZ = 0.5f;
+    m_OriginalBoatHandlingData[10].fAqPlaneForce = 6.0f;
+    m_OriginalBoatHandlingData[10].fAqPlaneLimit = 0.50f;
+    m_OriginalBoatHandlingData[10].fAqPlaneOffset = -0.5f;
+    m_OriginalBoatHandlingData[10].fWaveAudioMult = 3.0f;
+    m_OriginalBoatHandlingData[10].vecMoveRes = CVector(0.7f, 0.998f, 0.999f);
+    m_OriginalBoatHandlingData[10].vecTurnRes = CVector(0.85f, 0.98f, 0.96f);
+    m_OriginalBoatHandlingData[10].fLookLRHeight = 4.0f;
+
+    m_OriginalBoatHandlingData[11].iVehicleID = 186;
+    m_OriginalBoatHandlingData[11].fThrustY = 0.50f;
+    m_OriginalBoatHandlingData[11].fThrustZ= 1.2f;
+    m_OriginalBoatHandlingData[11].fThrustAppZ = 1.2f;
+    m_OriginalBoatHandlingData[11].fAqPlaneForce = 50.0f;
+    m_OriginalBoatHandlingData[11].fAqPlaneLimit = 0.85f;
+    m_OriginalBoatHandlingData[11].fAqPlaneOffset = -0.4f;
+    m_OriginalBoatHandlingData[11].fWaveAudioMult = 20.0f;
+    m_OriginalBoatHandlingData[11].vecMoveRes = CVector(0.93f, 0.998f, 0.999f);
+    m_OriginalBoatHandlingData[11].vecTurnRes = CVector(0.95f, 0.96f, 0.96f);
+    m_OriginalBoatHandlingData[11].fLookLRHeight = 4.5f;
+
+    // Bike handlings
+
+    m_OriginalBikeHandlingData[0].iVehicleID = 162;
+    m_OriginalBikeHandlingData[0].fLeanFwdCOM = 0.35f;
+    m_OriginalBikeHandlingData[0].fLeanFwdForce = 0.15f;
+    m_OriginalBikeHandlingData[0].fLeanBackCOM = 0.34f;
+    m_OriginalBikeHandlingData[0].fLeanBackForce = 0.10f;
+    m_OriginalBikeHandlingData[0].fMaxLean = 45.0f;
+    m_OriginalBikeHandlingData[0].fFullAnimLean = 38.0f;
+    m_OriginalBikeHandlingData[0].fDesLean = 0.93f;
+    m_OriginalBikeHandlingData[0].fSpeedSteer = 0.70f;
+    m_OriginalBikeHandlingData[0].fSlipSteer = 0.5f;
+    m_OriginalBikeHandlingData[0].fNoPlayerCOMz = 0.1f;
+    m_OriginalBikeHandlingData[0].fWheelieAng = 35.0f;
+    m_OriginalBikeHandlingData[0].fStoppieAng = -40.0f;
+    m_OriginalBikeHandlingData[0].fWheelieSteer = -0.009f;
+    m_OriginalBikeHandlingData[0].fWheelieStabMult = 0.7f;
+    m_OriginalBikeHandlingData[0].fStoppieStabMult = 0.6f;
+
+    m_OriginalBikeHandlingData[1].iVehicleID = 163;
+    m_OriginalBikeHandlingData[1].fLeanFwdCOM = 0.35f;
+    m_OriginalBikeHandlingData[1].fLeanFwdForce = 0.25f;
+    m_OriginalBikeHandlingData[1].fLeanBackCOM = 0.25f;
+    m_OriginalBikeHandlingData[1].fLeanBackForce = 0.04f;
+    m_OriginalBikeHandlingData[1].fMaxLean = 35.0f;
+    m_OriginalBikeHandlingData[1].fFullAnimLean = 25.0f;
+    m_OriginalBikeHandlingData[1].fDesLean = 0.90f;
+    m_OriginalBikeHandlingData[1].fSpeedSteer = 0.75f;
+    m_OriginalBikeHandlingData[1].fSlipSteer = 0.8f;
+    m_OriginalBikeHandlingData[1].fNoPlayerCOMz = 0.1f;
+    m_OriginalBikeHandlingData[1].fWheelieAng = 35.0f;
+    m_OriginalBikeHandlingData[1].fStoppieAng = -45.0f;
+    m_OriginalBikeHandlingData[1].fWheelieSteer = -0.010f;
+    m_OriginalBikeHandlingData[1].fWheelieStabMult = 0.7f;
+    m_OriginalBikeHandlingData[1].fStoppieStabMult = 0.5f;
+
+    m_OriginalBikeHandlingData[2].iVehicleID = 164;
+    m_OriginalBikeHandlingData[2].fLeanFwdCOM = 0.40f;
+    m_OriginalBikeHandlingData[2].fLeanFwdForce = 0.40f;
+    m_OriginalBikeHandlingData[2].fLeanBackCOM = 0.30f;
+    m_OriginalBikeHandlingData[2].fLeanBackForce = 0.08f;
+    m_OriginalBikeHandlingData[2].fMaxLean = 48.0f;
+    m_OriginalBikeHandlingData[2].fFullAnimLean = 43.0f;
+    m_OriginalBikeHandlingData[2].fDesLean = 0.92f;
+    m_OriginalBikeHandlingData[2].fSpeedSteer = 0.60f;
+    m_OriginalBikeHandlingData[2].fSlipSteer = 1.0f;
+    m_OriginalBikeHandlingData[2].fNoPlayerCOMz = 0.1f;
+    m_OriginalBikeHandlingData[2].fWheelieAng = 45.0f;
+    m_OriginalBikeHandlingData[2].fStoppieAng = -35.0f;
+    m_OriginalBikeHandlingData[2].fWheelieSteer = -0.010f;
+    m_OriginalBikeHandlingData[2].fWheelieStabMult = 0.5f;
+    m_OriginalBikeHandlingData[2].fStoppieStabMult = 0.5f;
+
+    m_OriginalBikeHandlingData[3].iVehicleID = 165;
+    m_OriginalBikeHandlingData[3].fLeanFwdCOM = 0.33f;
+    m_OriginalBikeHandlingData[3].fLeanFwdForce = 0.15f;
+    m_OriginalBikeHandlingData[3].fLeanBackCOM = 0.28f;
+    m_OriginalBikeHandlingData[3].fLeanBackForce = 0.15f;
+    m_OriginalBikeHandlingData[3].fMaxLean = 45.0f;
+    m_OriginalBikeHandlingData[3].fFullAnimLean = 38.0f;
+    m_OriginalBikeHandlingData[3].fDesLean = 0.93f;
+    m_OriginalBikeHandlingData[3].fSpeedSteer = 0.70f;
+    m_OriginalBikeHandlingData[3].fSlipSteer = 0.5f;
+    m_OriginalBikeHandlingData[3].fNoPlayerCOMz = 0.1f;
+    m_OriginalBikeHandlingData[3].fWheelieAng = 35.0f;
+    m_OriginalBikeHandlingData[3].fStoppieAng = -40.0f;
+    m_OriginalBikeHandlingData[3].fWheelieSteer = -0.009f;
+    m_OriginalBikeHandlingData[3].fWheelieStabMult = 0.7f;
+    m_OriginalBikeHandlingData[3].fStoppieStabMult = 0.6f;
+
+    m_OriginalBikeHandlingData[4].iVehicleID = 166;
+    m_OriginalBikeHandlingData[4].fLeanFwdCOM = 0.25f;
+    m_OriginalBikeHandlingData[4].fLeanFwdForce = 0.10f;
+    m_OriginalBikeHandlingData[4].fLeanBackCOM = 0.30f;
+    m_OriginalBikeHandlingData[4].fLeanBackForce = 0.10f;
+    m_OriginalBikeHandlingData[4].fMaxLean = 55.0f;
+    m_OriginalBikeHandlingData[4].fFullAnimLean = 38.0f;
+    m_OriginalBikeHandlingData[4].fDesLean = 0.95f;
+    m_OriginalBikeHandlingData[4].fSpeedSteer = 0.60f;
+    m_OriginalBikeHandlingData[4].fSlipSteer = 0.5f;
+    m_OriginalBikeHandlingData[4].fNoPlayerCOMz = 0.1f;
+    m_OriginalBikeHandlingData[4].fWheelieAng = 30.0f;
+    m_OriginalBikeHandlingData[4].fStoppieAng = -35.0f;
+    m_OriginalBikeHandlingData[4].fWheelieSteer = -0.012f;
+    m_OriginalBikeHandlingData[4].fWheelieStabMult = 0.7f;
+    m_OriginalBikeHandlingData[4].fStoppieStabMult = 0.6f;
+
+    m_OriginalBikeHandlingData[5].iVehicleID = 167;
+    m_OriginalBikeHandlingData[5].fLeanFwdCOM = 0.25f;
+    m_OriginalBikeHandlingData[5].fLeanFwdForce = 0.08f;
+    m_OriginalBikeHandlingData[5].fLeanBackCOM = 0.25f;
+    m_OriginalBikeHandlingData[5].fLeanBackForce = 0.08f;
+    m_OriginalBikeHandlingData[5].fMaxLean = 40.0f;
+    m_OriginalBikeHandlingData[5].fFullAnimLean = 30.0f;
+    m_OriginalBikeHandlingData[5].fDesLean = 0.93f;
+    m_OriginalBikeHandlingData[5].fSpeedSteer = 0.65f;
+    m_OriginalBikeHandlingData[5].fSlipSteer = 0.5f;
+    m_OriginalBikeHandlingData[5].fNoPlayerCOMz = 0.1f;
+    m_OriginalBikeHandlingData[5].fWheelieAng = 35.0f;
+    m_OriginalBikeHandlingData[5].fStoppieAng = -40.0f;
+    m_OriginalBikeHandlingData[5].fWheelieSteer = -0.009f;
+    m_OriginalBikeHandlingData[5].fWheelieStabMult = 0.5f;
+    m_OriginalBikeHandlingData[5].fStoppieStabMult = 0.5f;
+
+    m_OriginalBikeHandlingData[6].iVehicleID = 168;
+    m_OriginalBikeHandlingData[6].fLeanFwdCOM = 0.35f;
+    m_OriginalBikeHandlingData[6].fLeanFwdForce = 0.10f;
+    m_OriginalBikeHandlingData[6].fLeanBackCOM = 0.35f;
+    m_OriginalBikeHandlingData[6].fLeanBackForce = 0.10f;
+    m_OriginalBikeHandlingData[6].fMaxLean = 40.0f;
+    m_OriginalBikeHandlingData[6].fFullAnimLean = 30.0f;
+    m_OriginalBikeHandlingData[6].fDesLean = 0.92f;
+    m_OriginalBikeHandlingData[6].fSpeedSteer = 0.65f;
+    m_OriginalBikeHandlingData[6].fSlipSteer = 0.6f;
+    m_OriginalBikeHandlingData[6].fNoPlayerCOMz = 0.1f;
+    m_OriginalBikeHandlingData[6].fWheelieAng = 40.0f;
+    m_OriginalBikeHandlingData[6].fStoppieAng = -40.0f;
+    m_OriginalBikeHandlingData[6].fWheelieSteer = -0.013f;
+    m_OriginalBikeHandlingData[6].fWheelieStabMult = 0.6f;
+    m_OriginalBikeHandlingData[6].fStoppieStabMult = 0.5f;
+
+    m_OriginalBikeHandlingData[7].iVehicleID = 169;
+    m_OriginalBikeHandlingData[7].fLeanFwdCOM = 0.10f;
+    m_OriginalBikeHandlingData[7].fLeanFwdForce = 0.05f;
+    m_OriginalBikeHandlingData[7].fLeanBackCOM = 0.20f;
+    m_OriginalBikeHandlingData[7].fLeanBackForce = 0.05f;
+    m_OriginalBikeHandlingData[7].fMaxLean = 30.0f;
+    m_OriginalBikeHandlingData[7].fFullAnimLean = 25.0f;
+    m_OriginalBikeHandlingData[7].fDesLean = 0.945f;
+    m_OriginalBikeHandlingData[7].fSpeedSteer = 1.20f;
+    m_OriginalBikeHandlingData[7].fSlipSteer = 0.7f;
+    m_OriginalBikeHandlingData[7].fNoPlayerCOMz = 0.1f;
+    m_OriginalBikeHandlingData[7].fWheelieAng = 33.0f;
+    m_OriginalBikeHandlingData[7].fStoppieAng = -55.0f;
+    m_OriginalBikeHandlingData[7].fWheelieSteer = -0.006f;
+    m_OriginalBikeHandlingData[7].fWheelieStabMult = 0.4f;
+    m_OriginalBikeHandlingData[7].fStoppieStabMult = 0.3f;
+
+    m_OriginalBikeHandlingData[8].iVehicleID = 170;
+    m_OriginalBikeHandlingData[8].fLeanFwdCOM = 0.14f;
+    m_OriginalBikeHandlingData[8].fLeanFwdForce = 0.04f;
+    m_OriginalBikeHandlingData[8].fLeanBackCOM = 0.14f;
+    m_OriginalBikeHandlingData[8].fLeanBackForce = 0.08f;
+    m_OriginalBikeHandlingData[8].fMaxLean = 48.0f;
+    m_OriginalBikeHandlingData[8].fFullAnimLean = 43.0f;
+    m_OriginalBikeHandlingData[8].fDesLean = 0.88f;
+    m_OriginalBikeHandlingData[8].fSpeedSteer = 0.60f;
+    m_OriginalBikeHandlingData[8].fSlipSteer = 1.0f;
+    m_OriginalBikeHandlingData[8].fNoPlayerCOMz = 0.1f;
+    m_OriginalBikeHandlingData[8].fWheelieAng = 45.0f;
+    m_OriginalBikeHandlingData[8].fStoppieAng = -35.0f;
+    m_OriginalBikeHandlingData[8].fWheelieSteer = -0.007f;
+    m_OriginalBikeHandlingData[8].fWheelieStabMult = 1.0f;
+    m_OriginalBikeHandlingData[8].fStoppieStabMult = 0.5f;
+
+    m_OriginalBikeHandlingData[9].iVehicleID = 171;
+    m_OriginalBikeHandlingData[9].fLeanFwdCOM = 0.35f;
+    m_OriginalBikeHandlingData[9].fLeanFwdForce = 0.50f;
+    m_OriginalBikeHandlingData[9].fLeanBackCOM = 0.30f;
+    m_OriginalBikeHandlingData[9].fLeanBackForce = 0.09f;
+    m_OriginalBikeHandlingData[9].fMaxLean = 48.0f;
+    m_OriginalBikeHandlingData[9].fFullAnimLean = 43.0f;
+    m_OriginalBikeHandlingData[9].fDesLean = 0.92f;
+    m_OriginalBikeHandlingData[9].fSpeedSteer = 0.60f;
+    m_OriginalBikeHandlingData[9].fSlipSteer = 1.0f;
+    m_OriginalBikeHandlingData[9].fNoPlayerCOMz = 0.1f;
+    m_OriginalBikeHandlingData[9].fWheelieAng = 45.0f;
+    m_OriginalBikeHandlingData[9].fStoppieAng = -35.0f;
+    m_OriginalBikeHandlingData[9].fWheelieSteer = -0.007f;
+    m_OriginalBikeHandlingData[9].fWheelieStabMult = 1.0f;
+    m_OriginalBikeHandlingData[9].fStoppieStabMult = 0.5f;
+
+    m_OriginalBikeHandlingData[10].iVehicleID = 172;
+    m_OriginalBikeHandlingData[10].fLeanFwdCOM = 0.35f;
+    m_OriginalBikeHandlingData[10].fLeanFwdForce = 0.50f;
+    m_OriginalBikeHandlingData[10].fLeanBackCOM = 0.30f;
+    m_OriginalBikeHandlingData[10].fLeanBackForce = 0.09f;
+    m_OriginalBikeHandlingData[10].fMaxLean = 40.0f;
+    m_OriginalBikeHandlingData[10].fFullAnimLean = 30.0f;
+    m_OriginalBikeHandlingData[10].fDesLean = 0.92f;
+    m_OriginalBikeHandlingData[10].fSpeedSteer = 0.60f;
+    m_OriginalBikeHandlingData[10].fSlipSteer = 1.0f;
+    m_OriginalBikeHandlingData[10].fNoPlayerCOMz = 0.1f;
+    m_OriginalBikeHandlingData[10].fWheelieAng = 45.0f;
+    m_OriginalBikeHandlingData[10].fStoppieAng = -35.0f;
+    m_OriginalBikeHandlingData[10].fWheelieSteer = -0.007f;
+    m_OriginalBikeHandlingData[10].fWheelieStabMult = 0.6f;
+    m_OriginalBikeHandlingData[10].fStoppieStabMult = 0.5f;
+
+    m_OriginalBikeHandlingData[11].iVehicleID = 173;
+    m_OriginalBikeHandlingData[11].fLeanFwdCOM = 0.35f;
+    m_OriginalBikeHandlingData[11].fLeanFwdForce = 0.30f;
+    m_OriginalBikeHandlingData[11].fLeanBackCOM = 0.25f;
+    m_OriginalBikeHandlingData[11].fLeanBackForce = 0.08f;
+    m_OriginalBikeHandlingData[11].fMaxLean = 48.0f;
+    m_OriginalBikeHandlingData[11].fFullAnimLean = 43.0f;
+    m_OriginalBikeHandlingData[11].fDesLean = 0.92f;
+    m_OriginalBikeHandlingData[11].fSpeedSteer = 0.60f;
+    m_OriginalBikeHandlingData[11].fSlipSteer = 1.0f;
+    m_OriginalBikeHandlingData[11].fNoPlayerCOMz = 0.1f;
+    m_OriginalBikeHandlingData[11].fWheelieAng = 35.0f;
+    m_OriginalBikeHandlingData[11].fStoppieAng = -35.0f;
+    m_OriginalBikeHandlingData[11].fWheelieSteer = -0.015f;
+    m_OriginalBikeHandlingData[11].fWheelieStabMult = 0.6f;
+    m_OriginalBikeHandlingData[11].fStoppieStabMult = 0.5f;
+
+    m_OriginalBikeHandlingData[12].iVehicleID = 174;
+    m_OriginalBikeHandlingData[12].fLeanFwdCOM = 0.10f;
+    m_OriginalBikeHandlingData[12].fLeanFwdForce = 0.05f;
+    m_OriginalBikeHandlingData[12].fLeanBackCOM = 0.30f;
+    m_OriginalBikeHandlingData[12].fLeanBackForce = 0.062f;
+    m_OriginalBikeHandlingData[12].fMaxLean = 30.0f;
+    m_OriginalBikeHandlingData[12].fFullAnimLean = 25.0f;
+    m_OriginalBikeHandlingData[12].fDesLean = 0.945f;
+    m_OriginalBikeHandlingData[12].fSpeedSteer = 1.20f;
+    m_OriginalBikeHandlingData[12].fSlipSteer = 0.7f;
+    m_OriginalBikeHandlingData[12].fNoPlayerCOMz = 0.1f;
+    m_OriginalBikeHandlingData[12].fWheelieAng = 33.0f;
+    m_OriginalBikeHandlingData[12].fStoppieAng = -55.0f;
+    m_OriginalBikeHandlingData[12].fWheelieSteer = -0.006f;
+    m_OriginalBikeHandlingData[12].fWheelieStabMult = 0.5f;
+    m_OriginalBikeHandlingData[12].fStoppieStabMult = 0.3f;
 }
 
 void CHandlingManagerSA::CheckSuspensionChanges(CHandlingEntry* pEntry)

--- a/Client/game_sa/CHandlingManagerSA.h
+++ b/Client/game_sa/CHandlingManagerSA.h
@@ -13,6 +13,9 @@
 
 #include <game/CHandlingManager.h>
 #include "CHandlingEntrySA.h"
+#include "CFlyingHandlingEntrySA.h"
+#include "CBoatHandlingEntrySA.h"
+#include "CBikeHandlingEntrySA.h"
 
 class CHandlingManagerSA : public CHandlingManager
 {
@@ -21,8 +24,14 @@ public:
     ~CHandlingManagerSA();
 
     CHandlingEntry* CreateHandlingData();
+    CFlyingHandlingEntry* CreateFlyingHandlingData();
+    CBoatHandlingEntry* CreateBoatHandlingData();
+    CBikeHandlingEntry*   CreateBikeHandlingData();
 
     const CHandlingEntry* GetOriginalHandlingData(eVehicleTypes eModel);
+    const CFlyingHandlingEntry* GetOriginalFlyingHandlingData(eVehicleTypes eModel);
+    const CBoatHandlingEntry* GetOriginalBoatHandlingData(eVehicleTypes eModel);
+    const CBikeHandlingEntry*   GetOriginalBikeHandlingData(eVehicleTypes eModel);
 
     eHandlingTypes GetHandlingID(eVehicleTypes eModel);
 
@@ -39,6 +48,15 @@ private:
     // Original handling data unaffected by handling.cfg changes
     static tHandlingDataSA   m_OriginalHandlingData[HT_MAX];
     static CHandlingEntrySA* m_pOriginalEntries[HT_MAX];
+
+    static tFlyingHandlingDataSA   m_OriginalFlyingHandlingData[24];
+    static CFlyingHandlingEntrySA* m_pOriginalFlyingEntries[24];
+
+    static tBoatHandlingDataSA   m_OriginalBoatHandlingData[12];
+    static CBoatHandlingEntrySA* m_pOriginalBoatEntries[12];
+
+    static tBikeHandlingDataSA   m_OriginalBikeHandlingData[13];
+    static CBikeHandlingEntrySA* m_pOriginalBikeEntries[13];
 
     std::map<std::string, eHandlingProperty> m_HandlingNames;
     int                                      iChangedVehicles;

--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -230,13 +230,13 @@ BOOL CModelInfoSA::IsTrailer()
     return (BOOL)bReturn;
 }
 
-BOOL CModelInfoSA::IsVehicle()
+BYTE CModelInfoSA::GetVehicleType()
 {
-    /*
     DEBUG_TRACE("BOOL CModelInfoSA::IsVehicle ( )");
+    // This function will return a vehicle type for vehicles or 0xFF on failure
     DWORD dwFunction = FUNC_IsVehicleModelType;
     DWORD ModelID = m_dwModelID;
-    BYTE bReturn = 0;
+    BYTE bReturn = -1;
     _asm
     {
         push    ModelID
@@ -244,11 +244,12 @@ BOOL CModelInfoSA::IsVehicle()
         mov     bReturn, al
         add     esp, 4
     }
-    return (BOOL)bReturn;
-    */
+    return bReturn;
+}
 
-    // Above doesn't seem to work
-    return m_dwModelID >= 400 && m_dwModelID <= 611;
+BOOL CModelInfoSA::IsVehicle()
+{
+    return GetVehicleType() != 0xFF;
 }
 
 bool CModelInfoSA::IsPlayerModel()
@@ -322,12 +323,6 @@ VOID CModelInfoSA::Request(EModelRequestType requestType, const char* szTag)
     if (IsLoaded())
         return;
 
-    if (m_dwModelID <= 288 && m_dwModelID != 7 && !pGame->GetModelInfo(7)->IsLoaded())
-    {
-        // Skin 7 must be loaded in order for other skins to work. No, really. (#4010)
-        pGame->GetModelInfo(7)->Request(requestType, "Model 7");
-    }
-
     // Bikes can sometimes get stuck when loading unless the anim file is handled like what is does here
     // Don't change the code below unless you can test it (by recreating the problem it solves)
     if (IsVehicle())
@@ -348,6 +343,11 @@ VOID CModelInfoSA::Request(EModelRequestType requestType, const char* szTag)
                 pAnim->Request(requestType, szTag);
             }
         }
+    }
+    else if (m_dwModelID <= 288 && m_dwModelID != 7 && !pGame->GetModelInfo(7)->IsLoaded())
+    {
+        // Skin 7 must be loaded in order for other skins to work. No, really. (#4010)
+        pGame->GetModelInfo(7)->Request(requestType, "Model 7");
     }
 
     if (requestType == BLOCKING)
@@ -1386,7 +1386,6 @@ void CModelInfoSA::MakePedModel(char* szTexture)
     // Create a new CPedModelInfo
     CPedModelInfoSA pedModelInfo;
     ppModelInfo[m_dwModelID] = (CBaseModelInfoSAInterface*)pedModelInfo.GetPedModelInfoInterface();
-
     // Load our texture
     pGame->GetStreaming()->RequestSpecialModel(m_dwModelID, szTexture, 0);
 }
@@ -1404,6 +1403,25 @@ void CModelInfoSA::MakeObjectModel(ushort usBaseID)
 
     ppModelInfo[m_dwModelID] = m_pInterface;
 
+    m_dwParentID = usBaseID;
+    CopyStreamingInfoFromModel(usBaseID);
+}
+
+void CModelInfoSA::MakeVehicleAutomobile(ushort usBaseID)
+{
+    CVehicleModelInfoSAInterface* m_pInterface = new CVehicleModelInfoSAInterface();
+
+    CBaseModelInfoSAInterface* pBaseObjectInfo = (CBaseModelInfoSAInterface*)ppModelInfo[usBaseID];
+    MemCpyFast(m_pInterface, pBaseObjectInfo, sizeof(CVehicleModelInfoSAInterface));
+    m_pInterface->usNumberOfRefs = 0;
+    m_pInterface->pRwObject = nullptr;
+    m_pInterface->pVisualInfo = nullptr;
+    m_pInterface->usUnknown = 65535;
+    m_pInterface->usDynamicIndex = 65535;
+
+    ppModelInfo[m_dwModelID] = m_pInterface;
+
+    m_dwParentID = usBaseID;
     CopyStreamingInfoFromModel(usBaseID);
 }
 

--- a/Client/game_sa/CModelInfoSA.h
+++ b/Client/game_sa/CModelInfoSA.h
@@ -237,6 +237,8 @@ class CVehicleModelVisualInfoSAInterface            // Not sure about this name.
 {
 public:
     CVector vecDummies[15];
+    char m_sUpgrade[18];
+
 };
 
 class CVehicleModelInfoSAInterface : public CBaseModelInfoSAInterface
@@ -262,6 +264,23 @@ public:
     unsigned int                        uiComponentRules;
     float                               fSteeringAngle;
     CVehicleModelVisualInfoSAInterface* pVisualInfo;            // +92
+    char                                pad3[464];
+    char                                pDirtMaterial[64]; // *RwMaterial
+    char                                pad4[64];
+    char                                primColors[8];
+    char                                secondColors[8];
+    char                                treeColors[8];
+    char                                fourColors[8];
+    unsigned char                       ucNumOfColorVariations;
+    unsigned char                       ucLastColorVariation;
+    unsigned char                       ucPrimColor;
+    unsigned char                       ucSecColor;
+    unsigned char                       ucTertColor;
+    unsigned char                       ucQuatColor;
+    char                                upgrades[36];
+    char                                anRemapTXDs[8];
+    char                                pad5[2];
+    char                                pAnimBlock[4];
 };
 
 /**
@@ -273,6 +292,7 @@ class CModelInfoSA : public CModelInfo
 protected:
     CBaseModelInfoSAInterface*                                                   m_pInterface;
     DWORD                                                                        m_dwModelID;
+    DWORD                                                                        m_dwParentID;
     DWORD                                                                        m_dwReferences;
     DWORD                                                                        m_dwPendingInterfaceRef;
     CColModel*                                                                   m_pCustomColModel;
@@ -317,6 +337,7 @@ public:
 
     char* GetNameIfVehicle();
 
+    BYTE           GetVehicleType();
     VOID           Request(EModelRequestType requestType, const char* szTag);
     VOID           Remove();
     BYTE           GetLevelFromPosition(CVector* vecPosition);
@@ -385,10 +406,11 @@ public:
     RwObject* GetRwObject() { return m_pInterface ? m_pInterface->pRwObject : NULL; }
 
     // CModelInfoSA methods
-    void CopyStreamingInfoFromModel(ushort usBaseModelID);
     void MakePedModel(char* szTexture);
     void MakeObjectModel(ushort usBaseModelID);
+    void MakeVehicleAutomobile(ushort usBaseModelID);
     void DeallocateModel(void);
+    unsigned int GetParentID() { return m_dwParentID; };
 
     SVehicleSupportedUpgrades GetVehicleSupportedUpgrades() { return m_ModelSupportedUpgrades; }
 
@@ -404,5 +426,6 @@ public:
     bool IsTowableBy(CModelInfo* towingModel) override;
 
 private:
+    void CopyStreamingInfoFromModel(ushort usCopyFromModelID);
     void RwSetSupportedUpgrades(RwFrame* parent, DWORD dwModel);
 };

--- a/Client/game_sa/CPoolsSA.cpp
+++ b/Client/game_sa/CPoolsSA.cpp
@@ -97,7 +97,22 @@ CVehicle* CPoolsSA::AddVehicle(CClientVehicle* pClientVehicle, eVehicleTypes eVe
 
     if (m_vehiclePool.ulCount < MAX_VEHICLES)
     {
-        pVehicle = new CVehicleSA(eVehicleType, ucVariation, ucVariation2);
+        eVehicleModelTypes eVehicleModelType = (eVehicleModelTypes)pGame->GetModelInfo(eVehicleType)->GetVehicleType();
+        
+        switch (eVehicleModelType)
+	    {
+            case eVehicleModelTypes::BOAT:
+                pVehicle = new CBoatSA(eVehicleType, ucVariation, ucVariation2);
+                break;
+            case eVehicleModelTypes::BMX:
+            case eVehicleModelTypes::BIKE:
+                pVehicle = new CBikeSA(eVehicleType, ucVariation, ucVariation2);
+                break;
+            default:
+                pVehicle = new CVehicleSA(eVehicleType, ucVariation, ucVariation2);
+                break;
+	    }
+
         if (!AddVehicleToPool(pClientVehicle, pVehicle))
         {
             delete pVehicle;
@@ -132,8 +147,21 @@ CVehicle* CPoolsSA::AddVehicle(CClientVehicle* pClientVehicle, DWORD* pGameInter
             }
             else
             {
-                // Create it
-                pVehicle = new CVehicleSA(pInterface);
+        
+                switch ((eVehicleModelTypes)pInterface->m_type)
+	             {
+                    case eVehicleModelTypes::BOAT:
+                         pVehicle = new CBoatSA(reinterpret_cast<CBoatSAInterface*>(pInterface));
+                        break;
+                    case eVehicleModelTypes::BMX:
+                    case eVehicleModelTypes::BIKE:
+                        pVehicle = new CBikeSA(reinterpret_cast<CBikeSAInterface*>(pInterface));
+                        break;
+                    default:
+                        pVehicle = new CVehicleSA(pInterface);
+                        break;
+	             }
+
                 if (!AddVehicleToPool(pClientVehicle, pVehicle))
                 {
                     delete pVehicle;

--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -96,6 +96,7 @@ CVehicleSA::CVehicleSA(eVehicleTypes dwModelID, unsigned char ucVariation, unsig
     //                              ModelID, Position, IsMissionVehicle
 
     m_pHandlingData = NULL;
+    m_pFlyingHandlingData = NULL;
     m_pSuspensionLines = NULL;
 
     DWORD dwReturn = 0;
@@ -1827,12 +1828,24 @@ CHandlingEntry* CVehicleSA::GetHandlingData()
     return m_pHandlingData;
 }
 
+CFlyingHandlingEntry* CVehicleSA::GetFlyingHandlingData()
+{
+    return m_pFlyingHandlingData;
+}
+
 void CVehicleSA::SetHandlingData(CHandlingEntry* pHandling)
 {
     // Store the handling and recalculate it
     m_pHandlingData = static_cast<CHandlingEntrySA*>(pHandling);
     GetVehicleInterface()->pHandlingData = m_pHandlingData->GetInterface();
     RecalculateHandling();
+}
+
+void CVehicleSA::SetFlyingHandlingData(CFlyingHandlingEntry* pFlyingHandling)
+{
+    // Store the handling
+    m_pFlyingHandlingData = static_cast<CFlyingHandlingEntrySA*>(pFlyingHandling);
+    GetVehicleInterface()->pFlyingHandlingData = m_pFlyingHandlingData->GetInterface();
 }
 
 void CVehicleSA::RecalculateHandling()
@@ -2643,7 +2656,7 @@ void CVehicleSA::UpdateLandingGearPosition()
             // Update Air Resistance
             float fDragCoeff = GetHandlingData()->GetDragCoeff();
 
-            const float& fFlyingHandlingGearUpR = pVehicle->pFlyingHandlingData->GearUpR;
+            const float& fFlyingHandlingGearUpR = pVehicle->pFlyingHandlingData->fGearUpR;
             pVehicle->m_fAirResistance = fDragCoeff / 1000.0f * 0.5f * fFlyingHandlingGearUpR;
         }
     }

--- a/Client/game_sa/CVehicleSA.h
+++ b/Client/game_sa/CVehicleSA.h
@@ -448,6 +448,7 @@ private:
     CDamageManagerSA*                m_pDamageManager;
     CAEVehicleAudioEntitySA*         m_pVehicleAudioEntity;
     CHandlingEntrySA*                m_pHandlingData;
+    CFlyingHandlingEntrySA*          m_pFlyingHandlingData;
     void*                            m_pSuspensionLines;
     bool                             m_bIsDerailable;
     unsigned char                    m_ucAlpha;
@@ -658,6 +659,9 @@ public:
 
     CHandlingEntry* GetHandlingData();
     void            SetHandlingData(CHandlingEntry* pHandling);
+
+    CFlyingHandlingEntry* GetFlyingHandlingData();
+    void                  SetFlyingHandlingData(CFlyingHandlingEntry* pHandling);
 
     void BurstTyre(BYTE bTyre);
 

--- a/Client/mods/deathmatch/logic/CClientModel.h
+++ b/Client/mods/deathmatch/logic/CClientModel.h
@@ -19,6 +19,7 @@ enum class eClientModelType
 {
     PED,
     OBJECT,
+    VEHICLE,
 };
 
 class CClientModel
@@ -31,7 +32,7 @@ public:
 
     int                             GetModelID(void) const { return m_iModelID; };
     eClientModelType                GetModelType(void) const { return m_eModelType; };
-    bool                            Allocate(void);
+    bool                            Allocate(ushort usParentID);
     bool                            Deallocate(void);
     void                            SetParentResource(CResource* pResource) { m_pParentResource = pResource; }
     CResource*                      GetParentResource(void) const { return m_pParentResource; }

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -4408,7 +4408,7 @@ CFlyingHandlingEntry* CClientVehicle::GetFlyingHandlingData()
     {
         return m_pFlyingHandlingEntry;
     }
-    return NULL;
+    return nullptr;
 }
 
 CBoatHandlingEntry* CClientVehicle::GetBoatHandlingData()

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -40,14 +40,39 @@ CClientVehicle::CClientVehicle(CClientManager* pManager, ElementID ID, unsigned 
     m_pVehicle = NULL;
     m_pUpgrades = new CVehicleUpgrades(this);
     m_pClump = NULL;
-    m_pOriginalHandlingEntry = g_pGame->GetHandlingManager()->GetOriginalHandlingData(static_cast<eVehicleTypes>(usModel));
+
+    // Grab the model info
+    m_pModelInfo = g_pGame->GetModelInfo(usModel);
+
+    // Apply handling
+    ushort usHandlingModelID = m_usModel;
+    if (m_usModel < 400 || m_usModel > 611)
+        usHandlingModelID = m_pModelInfo->GetParentID();
+
+    m_pOriginalHandlingEntry = g_pGame->GetHandlingManager()->GetOriginalHandlingData(static_cast<eVehicleTypes>(usHandlingModelID));
     m_pHandlingEntry = g_pGame->GetHandlingManager()->CreateHandlingData();
     m_pHandlingEntry->Assign(m_pOriginalHandlingEntry);
 
+    m_pOriginalFlyingHandlingEntry = g_pGame->GetHandlingManager()->GetOriginalFlyingHandlingData(static_cast<eVehicleTypes>(usHandlingModelID));
+    m_pFlyingHandlingEntry = g_pGame->GetHandlingManager()->CreateFlyingHandlingData();
+    m_pFlyingHandlingEntry->Assign(m_pOriginalFlyingHandlingEntry);
+
+    m_pOriginalBoatHandlingEntry = g_pGame->GetHandlingManager()->GetOriginalBoatHandlingData(static_cast<eVehicleTypes>(usHandlingModelID));
+    if (m_pOriginalBoatHandlingEntry)
+    {
+        m_pBoatHandlingEntry = g_pGame->GetHandlingManager()->CreateBoatHandlingData();
+        m_pBoatHandlingEntry->Assign(m_pOriginalBoatHandlingEntry);
+    }
+
+    m_pOriginalBikeHandlingEntry = g_pGame->GetHandlingManager()->GetOriginalBikeHandlingData(static_cast<eVehicleTypes>(usHandlingModelID));
+    if (m_pOriginalBikeHandlingEntry)
+    {
+        m_pBikeHandlingEntry = g_pGame->GetHandlingManager()->CreateBikeHandlingData();
+        m_pBikeHandlingEntry->Assign(m_pOriginalBikeHandlingEntry);
+    }
+
     SetTypeName("vehicle");
 
-    // Grab the model info and the bounding box
-    m_pModelInfo = g_pGame->GetModelInfo(usModel);
     m_ucMaxPassengers = CClientVehicleManager::GetMaxPassengerCount(usModel);
 
     // Set our default properties
@@ -243,6 +268,9 @@ CClientVehicle::~CClientVehicle()
 
     delete m_pUpgrades;
     delete m_pHandlingEntry;
+    delete m_pFlyingHandlingEntry;
+    delete m_pBoatHandlingEntry;
+    delete m_pBikeHandlingEntry;
     delete m_LastSyncedData;
     CClientEntityRefManager::RemoveEntityRefs(0, &m_pDriver, &m_pOccupyingDriver, &m_pPreviousLink, &m_pNextLink, &m_pTowedVehicle, &m_pTowedByVehicle,
                                               &m_pPickedUpWinchEntity, NULL);
@@ -1061,8 +1089,34 @@ void CClientVehicle::SetModelBlocking(unsigned short usModel, unsigned char ucVa
         m_ucMaxPassengers = CClientVehicleManager::GetMaxPassengerCount(usModel);
 
         // Reset handling to fit the vehicle
-        m_pOriginalHandlingEntry = g_pGame->GetHandlingManager()->GetOriginalHandlingData((eVehicleTypes)usModel);
+        ushort usHandlingModelID = usModel;
+        if (usHandlingModelID < 400 || usHandlingModelID > 611)
+            usHandlingModelID = m_pModelInfo->GetParentID();
+
+        m_pOriginalHandlingEntry = g_pGame->GetHandlingManager()->GetOriginalHandlingData((eVehicleTypes)usHandlingModelID);
         m_pHandlingEntry->Assign(m_pOriginalHandlingEntry);
+
+        m_pOriginalFlyingHandlingEntry = g_pGame->GetHandlingManager()->GetOriginalFlyingHandlingData((eVehicleTypes)usHandlingModelID);
+        m_pFlyingHandlingEntry->Assign(m_pOriginalFlyingHandlingEntry);
+
+        m_pOriginalBoatHandlingEntry = g_pGame->GetHandlingManager()->GetOriginalBoatHandlingData((eVehicleTypes)usHandlingModelID);
+        if (m_pOriginalBoatHandlingEntry)
+        {
+            if (!m_pBoatHandlingEntry)
+                m_pBoatHandlingEntry = g_pGame->GetHandlingManager()->CreateBoatHandlingData();
+
+             m_pBoatHandlingEntry->Assign(m_pOriginalBoatHandlingEntry);
+        }
+
+        m_pOriginalBikeHandlingEntry = g_pGame->GetHandlingManager()->GetOriginalBikeHandlingData((eVehicleTypes)usHandlingModelID);
+        if (m_pOriginalBikeHandlingEntry)
+        {
+            if (!m_pBikeHandlingEntry)
+                m_pBikeHandlingEntry = g_pGame->GetHandlingManager()->CreateBikeHandlingData();
+
+            m_pBikeHandlingEntry->Assign(m_pOriginalBikeHandlingEntry);
+        }
+
         ApplyHandling();
 
         SetSirenOrAlarmActive(false);
@@ -2823,6 +2877,19 @@ void CClientVehicle::Create()
         if (m_pHandlingEntry)
         {
             m_pVehicle->SetHandlingData(m_pHandlingEntry);
+            m_pVehicle->SetFlyingHandlingData(m_pFlyingHandlingEntry);
+
+            switch (m_eVehicleType)
+            {
+                case CLIENTVEHICLE_BOAT:
+                    dynamic_cast<CBoat*>(m_pVehicle)->SetBoatHandlingData(m_pBoatHandlingEntry);
+                    break;
+                case CLIENTVEHICLE_BIKE:
+                case CLIENTVEHICLE_BMX:
+                    dynamic_cast<CBike*>(m_pVehicle)->SetBikeHandlingData(m_pBikeHandlingEntry);
+                default:
+                    break;
+            }
 
             if (m_bHasCustomHandling)
                 ApplyHandling();
@@ -2972,6 +3039,21 @@ void CClientVehicle::Destroy()
         m_fHeliRotorSpeed = GetHeliRotorSpeed();
         m_bHeliSearchLightVisible = IsHeliSearchLightVisible();
         m_pHandlingEntry = m_pVehicle->GetHandlingData();
+        m_pFlyingHandlingEntry = m_pVehicle->GetFlyingHandlingData();
+
+        switch (m_eVehicleType)
+        {
+            case CLIENTVEHICLE_BOAT:
+                m_pBoatHandlingEntry = dynamic_cast<CBoat*>(m_pVehicle)->GetBoatHandlingData();
+                break;
+            case CLIENTVEHICLE_BIKE:
+            case CLIENTVEHICLE_BMX:
+                m_pBikeHandlingEntry = dynamic_cast<CBike*>(m_pVehicle)->GetBikeHandlingData();
+                break;
+            default:
+                break;
+        }            
+
         if (m_eVehicleType == CLIENTVEHICLE_CAR || m_eVehicleType == CLIENTVEHICLE_PLANE || m_eVehicleType == CLIENTVEHICLE_QUADBIKE)
         {
             m_pVehicle->GetTurretRotation(&m_fTurretHorizontal, &m_fTurretVertical);
@@ -4292,10 +4374,15 @@ void CClientVehicle::UnpairPedAndVehicle(CClientPed* pClientPed)
 
 void CClientVehicle::ApplyHandling()
 {
-    if (m_pVehicle)
-        m_pVehicle->RecalculateHandling();
-
     m_bHasCustomHandling = true;
+
+    if (!m_pVehicle)
+        return;
+
+    m_pVehicle->RecalculateHandling();
+
+    if (m_eVehicleType == CLIENTVEHICLE_BMX || m_eVehicleType == CLIENTVEHICLE_BIKE)
+        dynamic_cast<CBike*>(m_pVehicle)->RecalculateBikeHandling();
 }
 
 CHandlingEntry* CClientVehicle::GetHandlingData()
@@ -4307,6 +4394,51 @@ CHandlingEntry* CClientVehicle::GetHandlingData()
     else if (m_pHandlingEntry)
     {
         return m_pHandlingEntry;
+    }
+    return NULL;
+}
+
+CFlyingHandlingEntry* CClientVehicle::GetFlyingHandlingData()
+{
+    if (m_pVehicle)
+    {
+        return m_pVehicle->GetFlyingHandlingData();
+    }
+    else if (m_pFlyingHandlingEntry)
+    {
+        return m_pFlyingHandlingEntry;
+    }
+    return NULL;
+}
+
+CBoatHandlingEntry* CClientVehicle::GetBoatHandlingData()
+{
+    if (m_eVehicleType != CLIENTVEHICLE_BOAT)
+        return NULL;
+
+    if (m_pVehicle)
+    {
+        return dynamic_cast<CBoat*>(m_pVehicle)->GetBoatHandlingData();
+    }
+    else if (m_pBoatHandlingEntry)
+    {
+        return m_pBoatHandlingEntry;
+    }
+    return NULL;
+}
+
+CBikeHandlingEntry* CClientVehicle::GetBikeHandlingData()
+{
+    if (m_eVehicleType != CLIENTVEHICLE_BIKE && m_eVehicleType != CLIENTVEHICLE_BMX)
+        return NULL;
+
+    if (m_pVehicle)
+    {
+        return dynamic_cast<CBike*>(m_pVehicle)->GetBikeHandlingData();
+    }
+    else if (m_pBikeHandlingEntry)
+    {
+        return m_pBikeHandlingEntry;
     }
     return NULL;
 }

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -4430,7 +4430,7 @@ CBoatHandlingEntry* CClientVehicle::GetBoatHandlingData()
 CBikeHandlingEntry* CClientVehicle::GetBikeHandlingData()
 {
     if (m_eVehicleType != CLIENTVEHICLE_BIKE && m_eVehicleType != CLIENTVEHICLE_BMX)
-        return NULL;
+        return nullptr;
 
     if (m_pVehicle)
     {

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -4418,13 +4418,13 @@ CBoatHandlingEntry* CClientVehicle::GetBoatHandlingData()
 
     if (m_pVehicle)
     {
-        return dynamic_cast<CBoat*>(m_pVehicle)->GetBoatHandlingData();
+        return reinterpret_cast<CBoat*>(m_pVehicle)->GetBoatHandlingData();
     }
     else if (m_pBoatHandlingEntry)
     {
         return m_pBoatHandlingEntry;
     }
-    return NULL;
+    return nullptr;
 }
 
 CBikeHandlingEntry* CClientVehicle::GetBikeHandlingData()

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -4434,13 +4434,13 @@ CBikeHandlingEntry* CClientVehicle::GetBikeHandlingData()
 
     if (m_pVehicle)
     {
-        return dynamic_cast<CBike*>(m_pVehicle)->GetBikeHandlingData();
+        return reinterpret_cast<CBike*>(m_pVehicle)->GetBikeHandlingData();
     }
     else if (m_pBikeHandlingEntry)
     {
         return m_pBikeHandlingEntry;
     }
-    return NULL;
+    return nullptr;
 }
 
 CSphere CClientVehicle::GetWorldBoundingSphere()

--- a/Client/mods/deathmatch/logic/CClientVehicle.h
+++ b/Client/mods/deathmatch/logic/CClientVehicle.h
@@ -457,7 +457,16 @@ public:
 
     void                  ApplyHandling();
     CHandlingEntry*       GetHandlingData();
-    const CHandlingEntry* GetOriginalHandlingData() { return m_pOriginalHandlingEntry; }
+    const CHandlingEntry* GetOriginalHandlingData() { return m_pOriginalHandlingEntry; };
+
+    CFlyingHandlingEntry*       GetFlyingHandlingData();
+    const CFlyingHandlingEntry* GetOriginalFlyingHandlingData() { return m_pOriginalFlyingHandlingEntry; };
+
+    CBoatHandlingEntry*       GetBoatHandlingData();
+    const CBoatHandlingEntry* GetOriginalBoatHandlingData() { return m_pOriginalBoatHandlingEntry; };
+
+    CBikeHandlingEntry*       GetBikeHandlingData();
+    const CBikeHandlingEntry* GetOriginalBikeHandlingData() { return m_pOriginalBikeHandlingEntry; };
 
     uint GetTimeSinceLastPush() { return (uint)(CTickCount::Now() - m_LastPushedTime).ToLongLong(); }
     void ResetLastPushTime() { m_LastPushedTime = CTickCount::Now(); }
@@ -610,6 +619,12 @@ protected:
     float                                  m_fHeliRotorSpeed;
     const CHandlingEntry*                  m_pOriginalHandlingEntry;
     CHandlingEntry*                        m_pHandlingEntry;
+    const CFlyingHandlingEntry*            m_pOriginalFlyingHandlingEntry;
+    CFlyingHandlingEntry*                  m_pFlyingHandlingEntry;
+    const CBoatHandlingEntry*              m_pOriginalBoatHandlingEntry;
+    CBoatHandlingEntry*                    m_pBoatHandlingEntry;
+    const CBikeHandlingEntry*              m_pOriginalBikeHandlingEntry;
+    CBikeHandlingEntry*                    m_pBikeHandlingEntry;
     float                                  m_fNitroLevel;
     char                                   m_cNitroCount;
     float                                  m_fWheelScale;

--- a/Client/mods/deathmatch/logic/CClientVehicleManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicleManager.cpp
@@ -422,6 +422,12 @@ bool CClientVehicleManager::IsTrainModel(unsigned long ulModel)
 
 bool CClientVehicleManager::IsValidModel(unsigned long ulModel)
 {
+    CModelInfo* pModelInfo = g_pGame->GetModelInfo(ulModel);
+    return pModelInfo && pModelInfo->IsVehicle();
+}
+
+bool CClientVehicleManager::IsStandardModel(unsigned long ulModel)
+{
     return ulModel >= 400 && ulModel <= 611;
 }
 
@@ -465,7 +471,7 @@ eClientVehicleType CClientVehicleManager::GetVehicleType(unsigned long ulModel)
 unsigned char CClientVehicleManager::GetMaxPassengerCount(unsigned long ulModel)
 {
     // Valid model?
-    if (IsValidModel(ulModel))
+    if (IsStandardModel(ulModel))
     {
         return g_ucMaxPassengers[ulModel - 400];
     }
@@ -480,7 +486,7 @@ void CClientVehicleManager::GetRandomVariation(unsigned short usModel, unsigned 
     ucVariant = 255;
     ucVariant2 = 255;
     // Valid model?
-    if (IsValidModel(usModel) && g_ucVariants[usModel - 400] != 255)
+    if (IsStandardModel(usModel) && g_ucVariants[usModel - 400] != 255)
     {
         // caddy || cropduster
         if (usModel == 457 || usModel == 512)
@@ -614,37 +620,37 @@ unsigned char CClientVehicleManager::ConvertIndexToGameSeat(unsigned long ulMode
 
 bool CClientVehicleManager::HasTurret(unsigned long ulModel)
 {
-    return (IsValidModel(ulModel) && (g_ulVehicleAttributes[ulModel - 400] & VEHICLE_HAS_TURRENT));
+    return (IsStandardModel(ulModel) && (g_ulVehicleAttributes[ulModel - 400] & VEHICLE_HAS_TURRENT));
 }
 
 bool CClientVehicleManager::HasSirens(unsigned long ulModel)
 {
-    return (IsValidModel(ulModel) && (g_ulVehicleAttributes[ulModel - 400] & VEHICLE_HAS_SIRENS));
+    return (IsStandardModel(ulModel) && (g_ulVehicleAttributes[ulModel - 400] & VEHICLE_HAS_SIRENS));
 }
 
 bool CClientVehicleManager::HasTaxiLight(unsigned long ulModel)
 {
-    return (IsValidModel(ulModel) && (g_ulVehicleAttributes[ulModel - 400] & VEHICLE_HAS_TAXI_LIGHTS));
+    return (IsStandardModel(ulModel) && (g_ulVehicleAttributes[ulModel - 400] & VEHICLE_HAS_TAXI_LIGHTS));
 }
 
 bool CClientVehicleManager::HasSearchLight(unsigned long ulModel)
 {
-    return (IsValidModel(ulModel) && (g_ulVehicleAttributes[ulModel - 400] & VEHICLE_HAS_SEARCH_LIGHT));
+    return (IsStandardModel(ulModel) && (g_ulVehicleAttributes[ulModel - 400] & VEHICLE_HAS_SEARCH_LIGHT));
 }
 
 bool CClientVehicleManager::HasLandingGears(unsigned long ulModel)
 {
-    return (IsValidModel(ulModel) && (g_ulVehicleAttributes[ulModel - 400] & VEHICLE_HAS_LANDING_GEARS));
+    return (IsStandardModel(ulModel) && (g_ulVehicleAttributes[ulModel - 400] & VEHICLE_HAS_LANDING_GEARS));
 }
 
 bool CClientVehicleManager::HasAdjustableProperty(unsigned long ulModel)
 {
-    return (IsValidModel(ulModel) && (g_ulVehicleAttributes[ulModel - 400] & VEHICLE_HAS_ADJUSTABLE_PROPERTY));
+    return (IsStandardModel(ulModel) && (g_ulVehicleAttributes[ulModel - 400] & VEHICLE_HAS_ADJUSTABLE_PROPERTY));
 }
 
 bool CClientVehicleManager::HasSmokeTrail(unsigned long ulModel)
 {
-    return (IsValidModel(ulModel) && (g_ulVehicleAttributes[ulModel - 400] & VEHICLE_HAS_SMOKE_TRAIL));
+    return (IsStandardModel(ulModel) && (g_ulVehicleAttributes[ulModel - 400] & VEHICLE_HAS_SMOKE_TRAIL));
 }
 
 bool CClientVehicleManager::HasDamageModel(unsigned long ulModel)

--- a/Client/mods/deathmatch/logic/CClientVehicleManager.h
+++ b/Client/mods/deathmatch/logic/CClientVehicleManager.h
@@ -34,6 +34,7 @@ public:
 
     static bool               IsTrainModel(unsigned long ulModel);
     static bool               IsValidModel(unsigned long ulModel);
+    static bool               IsStandardModel(unsigned long ulModel);
     static eClientVehicleType GetVehicleType(unsigned long ulModel);
     static unsigned char      GetMaxPassengerCount(unsigned long ulModel);
     static unsigned char      ConvertIndexToGameSeat(unsigned long ulModel, unsigned char ucIndex);

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
@@ -663,6 +663,7 @@ IMPLEMENT_ENUM_END("surface-adhesion-group")
 IMPLEMENT_ENUM_CLASS_BEGIN(eClientModelType)
 ADD_ENUM(eClientModelType::PED, "ped")
 ADD_ENUM(eClientModelType::OBJECT, "object")
+ADD_ENUM(eClientModelType::VEHICLE, "vehicle")
 IMPLEMENT_ENUM_CLASS_END("client-model-type")
 
 //

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -595,13 +595,13 @@ int CLuaEngineDefs::EngineRequestModel(lua_State* luaVM)
                         switch (eModelType)
                         {
                             case eClientModelType::PED:
-                                usParentID = 7;
+                                usParentID = 7; // male01
                                 break;
                             case eClientModelType::OBJECT:
-                                usParentID = 1337;
+                                usParentID = 1337; // BinNt07_LA (trash can)
                                 break;
                             case eClientModelType::VEHICLE:
-                                usParentID = 400;
+                                usParentID = VT_LANDSTAL;
                                 break;
                             default:
                                 break;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -585,7 +585,29 @@ int CLuaEngineDefs::EngineRequestModel(lua_State* luaVM)
                     CClientModel* pModel = m_pManager->GetModelManager()->FindModelByID(iModelID);
                     if (pModel == nullptr)
                         pModel = new CClientModel(m_pManager, iModelID, eModelType);
-                    pModel->Allocate();
+
+                    ushort usParentID = -1;
+
+                    if (argStream.NextIsNumber())
+                        argStream.ReadNumber(usParentID);
+                    else
+                    {
+                        switch (eModelType)
+                        {
+                            case eClientModelType::PED:
+                                usParentID = 7;
+                                break;
+                            case eClientModelType::OBJECT:
+                                usParentID = 1337;
+                                break;
+                            case eClientModelType::VEHICLE:
+                                usParentID = 400;
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                    pModel->Allocate(usParentID);
                     pModel->SetParentResource(pResource);
 
                     lua_pushinteger(luaVM, iModelID);

--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -82,7 +82,7 @@ static tVehicleAudioSettings* __fastcall getVehicleSoundSettings()
     // Check if it is a custom model
     if (usModel < VT_LANDSTAL || usModel >= VT_MAX)
         usModel = pGameInterface->GetModelInfo(usModel)->GetParentID();
-    return (tVehicleAudioSettings*)0x860AF0 + (usModel - 400);
+    return (tVehicleAudioSettings*)0x860AF0 + (usModel - VT_LANDSTAL);
 }
 
 #define HOOKPOS_CAEVehicleAudioEntity__Initialise  0x4F77C1

--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -60,6 +60,56 @@ static void _declspec(naked) HOOK_CDamageManager__ProgressDoorDamage()
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
+// CAEVehicleAudioEntity::Initialise
+//
+// This hook setup a audio interfeace for custom vehicles
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+//     0x4F77C1 | 8D 34 C0              | lea esi, [eax + eax * 8]
+//     0x4F77C4 | 8D BD 80 00 00 00     | lea edi, [ebp + 80h]
+//     0x4F77CA | 8D 34 B5 F0 0A 86 00  | lea esi, _VehicleAudioProperties.m_eVehicleSoundType[esi * 4]
+//     0x4F77D1 | B9 09 00 00 00        | mov ecx,9
+//     0x4F77D6 | F3 A5                 | rep movsd
+//     0x4F77D8 | 8B CA                 | mov ecx, edx;
+
+
+static CVehicleSAInterface* pRequestSoundSettingsVehicle = 0;
+tVehicleAudioSettings*      pVehicleAudioSettings = nullptr;
+
+static tVehicleAudioSettings* __fastcall getVehicleSoundSettings()
+{
+    ushort usModel = pRequestSoundSettingsVehicle->m_nModelIndex;
+    // Check if it is a custom model
+    if (usModel < 400 || usModel > 611)
+        usModel = pGameInterface->GetModelInfo(usModel)->GetParentID();
+    return (tVehicleAudioSettings*)0x860AF0 + (usModel - 400);
+}
+
+#define HOOKPOS_CAEVehicleAudioEntity__Initialise  0x4F77C1
+#define HOOKSIZE_CAEVehicleAudioEntity__Initialise 0x10
+static DWORD CONTINUE_CAEVehicleAudioEntity__Initialise = 0x4F77D1;
+
+static void _declspec(naked) HOOK_CAEVehicleAudioEntity__Initialise()
+{
+    _asm
+    {
+        pushad
+        mov     pRequestSoundSettingsVehicle, edx
+    }
+
+    pVehicleAudioSettings = getVehicleSoundSettings();
+
+    _asm
+    {
+        popad
+        lea    edi, [ebp + 80h]
+        mov    esi, pVehicleAudioSettings
+        jmp CONTINUE_CAEVehicleAudioEntity__Initialise
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
 // CMultiplayerSA::InitHooks_Vehicles
 //
 // Setup hooks
@@ -68,4 +118,5 @@ static void _declspec(naked) HOOK_CDamageManager__ProgressDoorDamage()
 void CMultiplayerSA::InitHooks_Vehicles()
 {
     EZHookInstall(CDamageManager__ProgressDoorDamage);
+    EZHookInstall(CAEVehicleAudioEntity__Initialise);
 }

--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -80,7 +80,7 @@ static tVehicleAudioSettings* __fastcall getVehicleSoundSettings()
 {
     ushort usModel = pRequestSoundSettingsVehicle->m_nModelIndex;
     // Check if it is a custom model
-    if (usModel < 400 || usModel > 611)
+    if (usModel < VT_LANDSTAL || usModel >= VT_MAX)
         usModel = pGameInterface->GetModelInfo(usModel)->GetParentID();
     return (tVehicleAudioSettings*)0x860AF0 + (usModel - 400);
 }

--- a/Client/sdk/game/CBike.h
+++ b/Client/sdk/game/CBike.h
@@ -18,5 +18,7 @@ class CBike : public virtual CVehicle
 public:
     virtual ~CBike(){};
 
-    // virtual void PlaceOnRoadProperly ( void )=0;
+    virtual CBikeHandlingEntry* GetBikeHandlingData() = 0;
+    virtual void                SetBikeHandlingData(CBikeHandlingEntry* pHandling) = 0;
+    virtual void                RecalculateBikeHandling() = 0;
 };

--- a/Client/sdk/game/CBikeHandlingEntry.h
+++ b/Client/sdk/game/CBikeHandlingEntry.h
@@ -1,0 +1,26 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        sdk/game/CHandlingEntry.h
+ *  PURPOSE:     Vehicle handling entry interface
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#pragma once
+
+class CBikeHandlingEntry
+{
+public:
+    // Destructor
+    virtual ~CBikeHandlingEntry(){};
+
+    // Use this to copy data from an another handling class to this
+    virtual void Assign(const CBikeHandlingEntry* pData) = 0;
+
+    // Call this every time you're done changing something. This will recalculate
+    // all transmission/handling values according to the new values.
+    virtual void Recalculate() = 0;
+};

--- a/Client/sdk/game/CBoat.h
+++ b/Client/sdk/game/CBoat.h
@@ -17,4 +17,7 @@ class CBoat : public virtual CVehicle
 {
 public:
     virtual ~CBoat(){};
+
+    virtual CBoatHandlingEntry* GetBoatHandlingData() = 0;
+    virtual void                SetBoatHandlingData(CBoatHandlingEntry* pHandling) = 0;
 };

--- a/Client/sdk/game/CBoatHandlingEntry.h
+++ b/Client/sdk/game/CBoatHandlingEntry.h
@@ -2,8 +2,8 @@
  *
  *  PROJECT:     Multi Theft Auto v1.0
  *  LICENSE:     See LICENSE in the top level directory
- *  FILE:        sdk/game/CBmx.h
- *  PURPOSE:     BMX vehicle entity interface
+ *  FILE:        sdk/game/CBoatHandlingEntry.h
+ *  PURPOSE:     Vehicle handling entry interface
  *
  *  Multi Theft Auto is available from http://www.multitheftauto.com/
  *
@@ -11,10 +11,12 @@
 
 #pragma once
 
-#include "CBike.h"
-
-class CBmx : public virtual CBike
+class CBoatHandlingEntry
 {
 public:
-    virtual ~CBmx(){};
+    // Destructor
+    virtual ~CBoatHandlingEntry(){};
+
+    // Use this to copy data from an another handling class to this
+    virtual void Assign(const CBoatHandlingEntry* pData) = 0;
 };

--- a/Client/sdk/game/CFlyingHandlingEntry.h
+++ b/Client/sdk/game/CFlyingHandlingEntry.h
@@ -2,8 +2,8 @@
  *
  *  PROJECT:     Multi Theft Auto v1.0
  *  LICENSE:     See LICENSE in the top level directory
- *  FILE:        sdk/game/CBmx.h
- *  PURPOSE:     BMX vehicle entity interface
+ *  FILE:        sdk/game/CFlyingHandlingEntry.h
+ *  PURPOSE:     Vehicle handling entry interface
  *
  *  Multi Theft Auto is available from http://www.multitheftauto.com/
  *
@@ -11,10 +11,13 @@
 
 #pragma once
 
-#include "CBike.h"
-
-class CBmx : public virtual CBike
+class CFlyingHandlingEntry
 {
 public:
-    virtual ~CBmx(){};
+
+    // Destructor
+    virtual ~CFlyingHandlingEntry(){};
+
+    // Use this to copy data from an another handling class to this
+    virtual void Assign(const CFlyingHandlingEntry* pData) = 0;
 };

--- a/Client/sdk/game/CHandlingManager.h
+++ b/Client/sdk/game/CHandlingManager.h
@@ -12,14 +12,24 @@
 #pragma once
 
 #include "CHandlingEntry.h"
+#include "CFlyingHandlingEntry.h"
+#include "CBoatHandlingEntry.h"
+#include "CBikeHandlingEntry.h"
 
 class CHandlingManager
 {
 public:
-    virtual CHandlingEntry* CreateHandlingData() = 0;
+    virtual CHandlingEntry*             CreateHandlingData() = 0;
+    virtual CFlyingHandlingEntry*       CreateFlyingHandlingData() = 0;
+    virtual CBoatHandlingEntry*         CreateBoatHandlingData() = 0;
+    virtual CBikeHandlingEntry*         CreateBikeHandlingData() = 0;
 
-    virtual const CHandlingEntry* GetOriginalHandlingData(enum eVehicleTypes eModel) = 0;
-    virtual eHandlingProperty     GetPropertyEnumFromName(std::string strName) = 0;
-    virtual void                  RemoveChangedVehicle() = 0;
-    virtual void                  CheckSuspensionChanges(CHandlingEntry* pEntry) = 0;
+    virtual const CHandlingEntry*       GetOriginalHandlingData(enum eVehicleTypes eModel) = 0;
+    virtual const CFlyingHandlingEntry* GetOriginalFlyingHandlingData(enum eVehicleTypes eModel) = 0;
+    virtual const CBoatHandlingEntry*   GetOriginalBoatHandlingData(enum eVehicleTypes eModel) = 0;
+    virtual const CBikeHandlingEntry*   GetOriginalBikeHandlingData(enum eVehicleTypes eModel) = 0;
+
+    virtual eHandlingProperty           GetPropertyEnumFromName(std::string strName) = 0;
+    virtual void                        RemoveChangedVehicle() = 0;
+    virtual void                        CheckSuspensionChanges(CHandlingEntry* pEntry) = 0;
 };

--- a/Client/sdk/game/CModelInfo.h
+++ b/Client/sdk/game/CModelInfo.h
@@ -130,6 +130,7 @@ public:
 
     virtual char* GetNameIfVehicle() = 0;
 
+    virtual BYTE           GetVehicleType() = 0;
     virtual VOID           Request(EModelRequestType requestType, const char* szTag /* = NULL*/) = 0;
     virtual BYTE           GetLevelFromPosition(CVector* vecPosition) = 0;
     virtual BOOL           IsLoaded() = 0;
@@ -191,7 +192,8 @@ public:
     virtual void      MakeCustomModel() = 0;
     virtual RwObject* GetRwObject() = 0;
     virtual void      MakePedModel(char* szTexture) = 0;
-    virtual void      MakeObjectModel(ushort usBaseID) = 0;
+    virtual void      MakeObjectModel(unsigned short usBaseID) = 0;
+    virtual void      MakeVehicleAutomobile(unsigned short usBaseID) = 0;
 
     virtual SVehicleSupportedUpgrades GetVehicleSupportedUpgrades() = 0;
     virtual void                      ResetSupportedUpgrades() = 0;
@@ -202,4 +204,6 @@ public:
 
     // Vehicle towing functions
     virtual bool IsTowableBy(CModelInfo* towingModel) = 0;
+
+    virtual unsigned int GetParentID() = 0;
 };

--- a/Client/sdk/game/CStreaming.h
+++ b/Client/sdk/game/CStreaming.h
@@ -43,8 +43,6 @@ public:
     virtual void LoadAllRequestedModels(BOOL bOnlyPriorityModels = 0, const char* szTag = NULL) = 0;
     virtual BOOL HasModelLoaded(DWORD dwModelID) = 0;
     virtual void RequestSpecialModel(DWORD model, const char* szTexture, DWORD channel) = 0;
-
     virtual CStreamingInfo* GetStreamingInfoFromModelId(unsigned short id) = 0;
-
     virtual void ReinitStreaming() = 0;
 };

--- a/Client/sdk/game/CVehicle.h
+++ b/Client/sdk/game/CVehicle.h
@@ -242,6 +242,9 @@ public:
     virtual CHandlingEntry* GetHandlingData() = 0;
     virtual void            SetHandlingData(CHandlingEntry* pHandling) = 0;
 
+    virtual CFlyingHandlingEntry* GetFlyingHandlingData() = 0;
+    virtual void                  SetFlyingHandlingData(CFlyingHandlingEntry* pHandling) = 0;
+
     virtual void BurstTyre(BYTE bTyre) = 0;
 
     virtual BYTE GetBikeWheelStatus(BYTE bWheel) = 0;

--- a/Client/sdk/game/Common.h
+++ b/Client/sdk/game/Common.h
@@ -184,6 +184,22 @@ typedef struct eControlStatesSA
     DWORD dwKeyHeld;
 } eControlStatesSA;
 
+enum class eVehicleModelTypes
+{
+    AUTOMOBILE = 0,
+    MONSTERTRUCK,
+    QUADBIKE,
+    HELICOPTER,
+    PLANE,
+    BOAT,
+    TRAIN,
+    FHELI, // RC ?
+    FPLANE, // RC ?
+    BIKE,
+    BMX,
+    TRAILER,
+};
+
 enum eVehicleTypes
 {
     VT_LANDSTAL = 400,

--- a/Server/mods/deathmatch/logic/CVehicle.h
+++ b/Server/mods/deathmatch/logic/CVehicle.h
@@ -324,7 +324,6 @@ public:
 
     void                  GenerateHandlingData();
     CHandlingEntry*       GetHandlingData() { return m_pHandlingEntry; };
-    //CFlyingHandlingEntry* GetFlyingHandlingData() { return m_pFlyingHandlingEntry; };
 
     uint GetTimeSinceLastPush() { return (uint)(CTickCount::Now(true) - m_LastPushedTime).ToLongLong(); }
     void ResetLastPushTime() { m_LastPushedTime = CTickCount::Now(true); }

--- a/Server/mods/deathmatch/logic/CVehicle.h
+++ b/Server/mods/deathmatch/logic/CVehicle.h
@@ -322,8 +322,9 @@ public:
     void SpawnAt(const CVector& vecPosition, const CVector& vecRotation);
     void Respawn();
 
-    void            GenerateHandlingData();
-    CHandlingEntry* GetHandlingData() { return m_pHandlingEntry; }
+    void                  GenerateHandlingData();
+    CHandlingEntry*       GetHandlingData() { return m_pHandlingEntry; };
+    //CFlyingHandlingEntry* GetFlyingHandlingData() { return m_pFlyingHandlingEntry; };
 
     uint GetTimeSinceLastPush() { return (uint)(CTickCount::Now(true) - m_LastPushedTime).ToLongLong(); }
     void ResetLastPushTime() { m_LastPushedTime = CTickCount::Now(true); }


### PR DESCRIPTION
New API:
```lua
     interger iModelID = engineRequestModel( "vehicle", integer parentID ) 
```

From vehicle with  `parentID` model new vehicle model will have:
* Model (DFF and TXD)
* Vehicle type.
* Sounds. This will include engine sounds, door sounds, slip sounds,, etc.
* Handling. Specific flying/boat/bike handling values also.
* Anim group.
* Default colors.

Does not work:
* Сhassis
* Turrets
* ZR-350 opening headlights
* Rhino, Hydra, Skimmer, Seasparrow
* Some specific effects like a dust effect from some helicopters, smoke effects from bikes.
* Another hardcoded stuff