### PR TITLE
Save server row index instead of finding it

### DIFF
--- a/Client/core/ServerBrowser/CServerBrowser.cpp
+++ b/Client/core/ServerBrowser/CServerBrowser.cpp
@@ -833,7 +833,7 @@ void CServerBrowser::UpdateServerList(ServerBrowserType Type, bool bClearServerL
         m_pServerPlayerList[Type]->Clear();
     }
 
-    bool didUpdateRowIndexes = false;
+    bool didUpdateRowIndices = false;
 
     // Loop the server list
     for (CServerListIterator it = pList->IteratorBegin(); it != pList->IteratorEnd(); it++)
@@ -850,10 +850,10 @@ void CServerBrowser::UpdateServerList(ServerBrowserType Type, bool bClearServerL
         // Add/update/remove the item to the list
         if (pServer->revisionInList[Type] != pServer->uiRevision || bClearServerList)
         {
-            if (!didUpdateRowIndexes)
+            if (!didUpdateRowIndices)
             {
                 UpdateRowIndexMembers(Type);
-                didUpdateRowIndexes = true;
+                didUpdateRowIndices = true;
             }
 
             pServer->revisionInList[Type] = pServer->uiRevision;

--- a/Client/core/ServerBrowser/CServerBrowser.cpp
+++ b/Client/core/ServerBrowser/CServerBrowser.cpp
@@ -821,7 +821,8 @@ void CServerBrowser::UpdateServerList(ServerBrowserType Type, bool bClearServerL
     // Get the appropriate server list
     CServerList* pList = GetServerList(Type);
 
-    if (pList->GetRevision() != m_pServerListRevision[Type] || bClearServerList)
+    bool bGetListsCleared = pList->GetRevision() != m_pServerListRevision[Type] || bClearServerList;
+    if (bGetListsCleared)
     {
         m_pServerListRevision[Type] = pList->GetRevision();
 
@@ -832,10 +833,15 @@ void CServerBrowser::UpdateServerList(ServerBrowserType Type, bool bClearServerL
         m_pServerPlayerList[Type]->Clear();
     }
 
+    bool didUpdateRowIndexes = false;
+
     // Loop the server list
     for (CServerListIterator it = pList->IteratorBegin(); it != pList->IteratorEnd(); it++)
     {
         CServerListItem* pServer = *it;
+
+        if (bGetListsCleared)
+            pServer->iRowIndex = -1;
 
         // Find info from server cache for favourites and recent
         if (Type == ServerBrowserType::FAVOURITES || Type == ServerBrowserType::RECENTLY_PLAYED)
@@ -844,6 +850,12 @@ void CServerBrowser::UpdateServerList(ServerBrowserType Type, bool bClearServerL
         // Add/update/remove the item to the list
         if (pServer->revisionInList[Type] != pServer->uiRevision || bClearServerList)
         {
+            if (!didUpdateRowIndexes)
+            {
+                UpdateRowIndexMembers(Type);
+                didUpdateRowIndexes = true;
+            }
+
             pServer->revisionInList[Type] = pServer->uiRevision;
             AddServerToList(pServer, Type);
         }
@@ -950,7 +962,7 @@ void CServerBrowser::UpdateHistoryList()
     }
 }
 
-void CServerBrowser::AddServerToList(const CServerListItem* pServer, const ServerBrowserType Type)
+void CServerBrowser::AddServerToList(CServerListItem* pServer, const ServerBrowserType Type)
 {
     bool bIncludeEmpty = m_pIncludeEmpty[Type]->GetSelected();
     bool bIncludeFull = m_pIncludeFull[Type]->GetSelected();
@@ -1023,11 +1035,12 @@ void CServerBrowser::AddServerToList(const CServerListItem* pServer, const Serve
         //
         // Remove server from list
         //
-
-        int iIndex = FindRowFromServer(Type, pServer);
+        int iIndex = pServer->iRowIndex;
         if (iIndex != -1)
         {
             m_pServerList[Type]->RemoveRow(iIndex);
+            pServer->iRowIndex = -1;
+            UpdateRowIndexMembers(Type);
         }
     }
     else
@@ -1037,9 +1050,12 @@ void CServerBrowser::AddServerToList(const CServerListItem* pServer, const Serve
         //
 
         // Get existing row or create a new row if not found
-        int iIndex = FindRowFromServer(Type, pServer);
+        int iIndex = pServer->iRowIndex;
         if (iIndex == -1)
+        {
             iIndex = m_pServerList[Type]->AddRow(true);
+            pServer->iRowIndex = iIndex;
+        }
 
         const SString strVersion = !bIncludeOtherVersions ? "" : pServer->strVersion;
         const SString strVersionSortKey = pServer->strVersionSortKey + pServer->strTieBreakSortKey;
@@ -1087,6 +1103,10 @@ void CServerBrowser::AddServerToList(const CServerListItem* pServer, const Serve
         m_pServerList[Type]->SetItemColor(iIndex, m_hPlayers[Type], color.R, color.G, color.B, color.A);
         m_pServerList[Type]->SetItemColor(iIndex, m_hPing[Type], color.R, color.G, color.B, color.A);
         m_pServerList[Type]->SetItemColor(iIndex, m_hGame[Type], color.R, color.G, color.B, color.A);
+
+        // If the index was modified from the original, then update all indexes because it means there was some sort
+        if (pServer->iRowIndex != iIndex)
+            UpdateRowIndexMembers(Type);
     }
 }
 
@@ -2073,23 +2093,21 @@ unsigned short CServerBrowser::FindServerHttpPort(const std::string& strHost, un
 
 /////////////////////////////////////////////////////////////////
 //
-// CServerBrowser::FindRowFromServer
+// CServerBrowser::UpdateRowIndexMembers
 //
-//
+// Update row index property of each CServerListItem on the server list
 //
 /////////////////////////////////////////////////////////////////
-int CServerBrowser::FindRowFromServer(ServerBrowserType Type, const CServerListItem* pServer)
+void CServerBrowser::UpdateRowIndexMembers(ServerBrowserType Type)
 {
     CGUIGridList* pServerList = m_pServerList[Type];
     int           iRowCount = pServerList->GetRowCount();
-    for (int i = 0; i < iRowCount; i++)
+
+    for (int iRowIndex = 0; iRowIndex < iRowCount; iRowIndex++)
     {
-        if (pServer == (CServerListItem*)pServerList->GetItemData(i, DATA_PSERVER))
-        {
-            return i;
-        }
+        CServerListItem* pServer = (CServerListItem*)pServerList->GetItemData(iRowIndex, DATA_PSERVER);
+        pServer->iRowIndex = iRowIndex;
     }
-    return -1;
 }
 
 /////////////////////////////////////////////////////////////////

--- a/Client/core/ServerBrowser/CServerBrowser.h
+++ b/Client/core/ServerBrowser/CServerBrowser.h
@@ -95,7 +95,7 @@ public:
     CServerListItem* FindServerFromRow(ServerBrowserType Type, int iRow);
     CServerListItem* FindServer(const std::string& strHost, unsigned short usPort);
     unsigned short   FindServerHttpPort(const std::string& strHost, unsigned short usPort);
-    int              FindRowFromServer(ServerBrowserType Type, const CServerListItem* pServer);
+    void             UpdateRowIndexMembers(ServerBrowserType Type);
     void             UpdateSelectedServerPlayerList(ServerBrowserType Type);
     void             GetVisibleEndPointList(std::vector<SAddressPort>& outEndpointList);
 
@@ -207,7 +207,7 @@ private:
     void         UpdateServerList(ServerBrowserType Type, bool bClearServerList = false);
     void         UpdateHistoryList();
     CServerList* GetServerList(ServerBrowserType Type);
-    void         AddServerToList(const CServerListItem* pServer, const ServerBrowserType Type);
+    void         AddServerToList(CServerListItem* pServer, const ServerBrowserType Type);
     bool         RemoveSelectedServerFromRecentlyPlayedList();
 
     bool OnClick(CGUIElement* pElement);

--- a/Client/core/ServerBrowser/CServerList.h
+++ b/Client/core/ServerBrowser/CServerList.h
@@ -141,6 +141,8 @@ public:
         bSerials = false;
         bPassworded = false;
         bKeepFlag = false;
+        iRowIndex = -1;
+
         nPlayers = 0;
         nMaxPlayers = 0;
         nPing = 9999;
@@ -192,6 +194,7 @@ public:
     uint           uiQueryRetryCount;
     uint           uiRevision;
     bool           bKeepFlag;
+    int            iRowIndex;
 
     SString strGameName;                  // Game name. Always 'mta'
     SString strVersion;                   // Game version


### PR DESCRIPTION
Saving/Caching the row index of each server in server list allow us to avoid making unnecesary for-loop (for each server) to find if the row already exists. For example on the first load, where the first action is just to add (not update nor remove), avoiding this will increase the performance a lot and it won't get so much time to load.