### PR TITLE
Fix setCameraTarget minimum required server version

### DIFF
--- a/Server/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
@@ -11,7 +11,7 @@
 
 #include "StdInc.h"
 
-#define MIN_SERVER_REQ_SETCAMERATARGET_USE_ANY_ELEMENTS "1.5.8-0.00000"
+#define MIN_SERVER_REQ_SETCAMERATARGET_USE_ANY_ELEMENTS "1.5.8-9.20677"
 
 void CLuaCameraDefs::LoadFunctions()
 {


### PR DESCRIPTION
 #1398 and #1726 related issue. This one is server.