### PR TITLE
Fix #1724: setPedAnimation breaks setChoking and setWearingJetpack in the same frame

### DIFF
--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -4228,10 +4228,6 @@ bool CStaticFunctionDefinitions::SetPedAnimation(CElement* pElement, const SStri
         CPed* pPed = static_cast<CPed*>(pElement);
         if (pPed->IsSpawned())
         {
-            // Remove jetpack now so it doesn't stay on (#9522#c25612)
-            if (pPed->HasJetPack())
-                pPed->SetHasJetPack(false);
-
             // Remove choking state
             if (pPed->IsChoking())
                 pPed->SetChoking(false);
@@ -4242,6 +4238,10 @@ bool CStaticFunctionDefinitions::SetPedAnimation(CElement* pElement, const SStri
             CBitStream BitStream;
             if (!blockName.empty() && !animName.empty())
             {
+                // Remove jetpack now so it doesn't stay on (#9522#c25612)
+                if (pPed->HasJetPack())
+                    pPed->SetHasJetPack(false);
+
                 BitStream.pBitStream->WriteString<unsigned char>(blockName);
                 BitStream.pBitStream->WriteString<unsigned char>(animName);
                 BitStream.pBitStream->Write(iTime);

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -4228,10 +4228,6 @@ bool CStaticFunctionDefinitions::SetPedAnimation(CElement* pElement, const SStri
         CPed* pPed = static_cast<CPed*>(pElement);
         if (pPed->IsSpawned())
         {
-            // Remove choking state
-            if (pPed->IsChoking())
-                pPed->SetChoking(false);
-
             // TODO: save their animation?
 
             // Tell the players
@@ -4241,6 +4237,10 @@ bool CStaticFunctionDefinitions::SetPedAnimation(CElement* pElement, const SStri
                 // Remove jetpack now so it doesn't stay on (#9522#c25612)
                 if (pPed->HasJetPack())
                     pPed->SetHasJetPack(false);
+
+                // Remove choking state
+                if (pPed->IsChoking())
+                    pPed->SetChoking(false);
 
                 BitStream.pBitStream->WriteString<unsigned char>(blockName);
                 BitStream.pBitStream->WriteString<unsigned char>(animName);


### PR DESCRIPTION
Tested fully as follows:

### Test 1
1. Give ped a jetpack.
1. Set their position to something with warp enabled.
1. Expectation: jetpack should be removed.
```lua
setPedWearingJetpack(me, true) setElementPosition(me, me.position+Vector3(0, 5, 5), true)
```
**Test succeeded**

### Test 2
1. Give ped a jetpack.
1. Set their position to something with warp disabled.
1. Expectation: jetpack should not be removed.
```lua
setPedWearingJetpack(me, true) setElementPosition(me, me.position+Vector3(0, 5, 5), false)
```
**Test succeeded**

### Test 3
1. Give ped a jetpack.
1. Freeze them.
1. Expectation: jetpack should not be removed.
```lua
setPedWearingJetpack(me, true) setElementFrozen(me, true)
```
**Test succeeded**

### Test 4
1. Give ped a jetpack.
1. Set their animation.
1. Expectation: jetpack should be removed.
```lua
setPedWearingJetpack(me, true) setPedAnimation(me, "muscular", "muscleidle", 500, false, false, false, false, 0, true)
```
**Test succeeded**

### Test 5
1. Give ped a jetpack.
1. Set their animation.
1. Give them a jetpack.
1. Expectation: they should now be on a jetpack.
```lua
setPedWearingJetpack(me, true) setPedAnimation(me, "muscular", "muscleidle", 500, false, false, false, false, 0, true) setPedWearingJetpack(me, true)
setPedWearingJetpack(me, true) setPedAnimation(me, "muscular", "muscleidle", 500, false, false, false, false, 0, true) setTimer(setPedWearingJetpack, 501, 1, me, true)
```
**Test succeeded**

### Test 6
1. Give ped a jetpack.
1. Set their animation.
1. Give them a jetpack.
1. Remove their jetpack.
1. Set their model to something else.
1. Expectation: they should not be doing the animation you set them in step 2.
```lua
setPedWearingJetpack(me, true) setPedAnimation(me, "flame", "flame_fire", 2000, true, true, true, false, 0, true) setPedWearingJetpack(me, true) setPedWearingJetpack(me, false) setElementModel(me, math.random(0,2))
```
**Test succeeded**

### Test 7
1. Give ped a jetpack.
1. Set them choking.
1. Expectation: jetpack should be removed.
```lua
setPedWearingJetpack(me, true) setPedChoking(me, true)
```
**Test succeeded**

### Test 8
1. Give ped a jetpack.
1. Set them choking.
1. Give them a jetpack.
1. Expectation: they should now be on a jetpack.
```lua
setPedWearingJetpack(me, true) setPedChoking(me, true) setPedWearingJetpack(me, true)
```
**Test succeeded**