### PR TITLE
Add engineRestreamWorld function

### DIFF
--- a/Client/game_sa/CStreamingSA.cpp
+++ b/Client/game_sa/CStreamingSA.cpp
@@ -134,3 +134,11 @@ void CStreamingSA::RequestSpecialModel(DWORD model, const char* szTexture, DWORD
         add     esp, 0xC
     }
 }
+
+void CStreamingSA::ReinitStreaming()
+{
+    typedef int(__cdecl * Function_ReInitStreaming)();
+    Function_ReInitStreaming reinitStreaming = (Function_ReInitStreaming)(0x40E560);
+
+    reinitStreaming();
+}

--- a/Client/game_sa/CStreamingSA.h
+++ b/Client/game_sa/CStreamingSA.h
@@ -27,4 +27,5 @@ public:
     void LoadAllRequestedModels(BOOL bOnlyPriorityModels = 0, const char* szTag = NULL);
     BOOL HasModelLoaded(DWORD dwModelID);
     void RequestSpecialModel(DWORD model, const char* szTexture, DWORD channel);
+    void ReinitStreaming();
 };

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -5841,6 +5841,9 @@ void CClientGame::ResetMapInfo()
             g_pNet->DeallocateNetBitStream(pBitStream);
         }
     }
+
+    // Reload world
+    RestreamWorld();
 }
 
 void CClientGame::SendPedWastedPacket(CClientPed* Ped, ElementID damagerID, unsigned char ucWeapon, unsigned char ucBodyPiece, AssocGroupId animGroup,
@@ -6960,6 +6963,23 @@ void CClientGame::RestreamModel(unsigned short usModel)
         // 'Restream' upgrades after model replacement to propagate visual changes with immediate effect
         if (CClientObjectManager::IsValidModel(usModel) && CVehicleUpgrades::IsUpgrade(usModel))
         m_pManager->GetVehicleManager()->RestreamVehicleUpgrades(usModel);
+}
+
+void CClientGame::RestreamWorld()
+{
+    for (unsigned int uiModelID = 0; uiModelID <= 26316; uiModelID++)
+    {
+        g_pClientGame->GetModelCacheManager()->OnRestreamModel(uiModelID);
+    }
+    m_pManager->GetObjectManager()->RestreamAllObjects();
+    m_pManager->GetVehicleManager()->RestreamAllVehicles();
+    m_pManager->GetPedManager()->RestreamAllPeds();
+    m_pManager->GetPickupManager()->RestreamAllPickups();
+
+    typedef int(__cdecl * Function_ReInitStreaming)();
+    Function_ReInitStreaming reinitStreaming = (Function_ReInitStreaming)(0x40E560);
+
+    reinitStreaming();
 }
 
 void CClientGame::TriggerDiscordJoin(SString strSecret)

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -5842,7 +5842,6 @@ void CClientGame::ResetMapInfo()
         }
     }
 
-    // Reload world
     RestreamWorld();
 }
 

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -6975,10 +6975,7 @@ void CClientGame::RestreamWorld()
     m_pManager->GetPedManager()->RestreamAllPeds();
     m_pManager->GetPickupManager()->RestreamAllPickups();
 
-    typedef int(__cdecl * Function_ReInitStreaming)();
-    Function_ReInitStreaming reinitStreaming = (Function_ReInitStreaming)(0x40E560);
-
-    reinitStreaming();
+    g_pGame->GetStreaming()->ReinitStreaming();
 }
 
 void CClientGame::TriggerDiscordJoin(SString strSecret)

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -442,6 +442,7 @@ public:
 
     bool TriggerBrowserRequestResultEvent(const std::unordered_set<SString>& newPages);
     void RestreamModel(unsigned short usModel);
+    void RestreamWorld();
 
     void TriggerDiscordJoin(SString strSecret);
 

--- a/Client/mods/deathmatch/logic/CClientObjectManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientObjectManager.cpp
@@ -353,9 +353,8 @@ void CClientObjectManager::RestreamObjects(unsigned short usModel)
 
 void CClientObjectManager::RestreamAllObjects()
 {
-    for (uint i = 0; i < m_Objects.size(); i++)
+    for (auto& object : m_Objects)
     {
-        CClientObject* pObject = m_Objects[i];
 
         // Streamed in and same model ID?
         if (pObject->IsStreamedIn())

--- a/Client/mods/deathmatch/logic/CClientObjectManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientObjectManager.cpp
@@ -351,6 +351,22 @@ void CClientObjectManager::RestreamObjects(unsigned short usModel)
     }
 }
 
+void CClientObjectManager::RestreamAllObjects()
+{
+    for (uint i = 0; i < m_Objects.size(); i++)
+    {
+        CClientObject* pObject = m_Objects[i];
+
+        // Streamed in and same model ID?
+        if (pObject->IsStreamedIn())
+        {
+            // Stream it out for a while until streamed decides to stream it
+            // back in eventually
+            pObject->StreamOutForABit();
+        }
+    }
+}
+
 void CClientObjectManager::RemoveFromLists(CClientObject* pObject)
 {
     if (m_bCanRemoveFromList)

--- a/Client/mods/deathmatch/logic/CClientObjectManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientObjectManager.cpp
@@ -353,7 +353,7 @@ void CClientObjectManager::RestreamObjects(unsigned short usModel)
 
 void CClientObjectManager::RestreamAllObjects()
 {
-    for (auto& object : m_Objects)
+    for (auto& pObject: m_Objects)
     {
 
         // Streamed in and same model ID?

--- a/Client/mods/deathmatch/logic/CClientObjectManager.h
+++ b/Client/mods/deathmatch/logic/CClientObjectManager.h
@@ -41,6 +41,7 @@ public:
     bool        IsHardObjectLimitReached();
 
     void RestreamObjects(unsigned short usModel);
+    void RestreamAllObjects();
 
     void AddToList(CClientObject* pObject) { m_Objects.push_back(pObject); }
     void RemoveFromLists(CClientObject* pObject);

--- a/Client/mods/deathmatch/logic/CClientPedManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientPedManager.cpp
@@ -129,7 +129,7 @@ void CClientPedManager::RestreamPeds(unsigned short usModel)
 
 void CClientPedManager::RestreamAllPeds()
 {
-    for (auto& ped: m_List)
+    for (auto& pPed: m_List)
     {
 
         // Streamed in and same vehicle ID?

--- a/Client/mods/deathmatch/logic/CClientPedManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientPedManager.cpp
@@ -129,12 +129,8 @@ void CClientPedManager::RestreamPeds(unsigned short usModel)
 
 void CClientPedManager::RestreamAllPeds()
 {
-    // Store the affected vehicles
-    CClientPed*                              pPed;
-    std::vector<CClientPed*>::const_iterator iter = IterBegin();
-    for (; iter != IterEnd(); iter++)
+    for (auto& ped: m_List)
     {
-        pPed = *iter;
 
         // Streamed in and same vehicle ID?
         if (pPed->IsStreamedIn())

--- a/Client/mods/deathmatch/logic/CClientPedManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientPedManager.cpp
@@ -126,6 +126,31 @@ void CClientPedManager::RestreamPeds(unsigned short usModel)
         }
     }
 }
+
+void CClientPedManager::RestreamAllPeds()
+{
+    // Store the affected vehicles
+    CClientPed*                              pPed;
+    std::vector<CClientPed*>::const_iterator iter = IterBegin();
+    for (; iter != IterEnd(); iter++)
+    {
+        pPed = *iter;
+
+        // Streamed in and same vehicle ID?
+        if (pPed->IsStreamedIn())
+        {
+            // Stream it out for a while until streamed decides to stream it
+            // back in eventually
+            pPed->StreamOutForABit();
+            // Hack fix for Players not unloading.
+            if (IS_PLAYER(pPed))
+            {
+                pPed->SetModel(0, true);
+            }
+        }
+    }
+}
+
 void CClientPedManager::RestreamWeapon(unsigned short usModel)
 {
     eWeaponSlot eSlot = (eWeaponSlot)GetWeaponSlotFromModel(usModel);

--- a/Client/mods/deathmatch/logic/CClientPedManager.h
+++ b/Client/mods/deathmatch/logic/CClientPedManager.h
@@ -39,6 +39,7 @@ public:
     static bool           IsValidWeaponModel(DWORD dwModelID);
 
     void RestreamPeds(unsigned short usModel);
+    void RestreamAllPeds();
     void RestreamWeapon(unsigned short usModel);
 
 protected:

--- a/Client/mods/deathmatch/logic/CClientPickupManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientPickupManager.cpp
@@ -134,7 +134,7 @@ void CClientPickupManager::RestreamPickups(unsigned short usModel)
 
 void CClientPickupManager::RestreamAllPickups()
 {
-    for (auto& pickup : m_List)
+    for (auto& pPickup: m_List)
     {
 
         if (pPickup->IsStreamedIn())

--- a/Client/mods/deathmatch/logic/CClientPickupManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientPickupManager.cpp
@@ -134,9 +134,8 @@ void CClientPickupManager::RestreamPickups(unsigned short usModel)
 
 void CClientPickupManager::RestreamAllPickups()
 {
-    for (std::list<CClientPickup*>::const_iterator iter = IterBegin(); iter != IterEnd(); iter++)
+    for (auto& pickup : m_List)
     {
-        CClientPickup* pPickup = *iter;
 
         if (pPickup->IsStreamedIn())
         {

--- a/Client/mods/deathmatch/logic/CClientPickupManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientPickupManager.cpp
@@ -131,3 +131,16 @@ void CClientPickupManager::RestreamPickups(unsigned short usModel)
         }
     }
 }
+
+void CClientPickupManager::RestreamAllPickups()
+{
+    for (std::list<CClientPickup*>::const_iterator iter = IterBegin(); iter != IterEnd(); iter++)
+    {
+        CClientPickup* pPickup = *iter;
+
+        if (pPickup->IsStreamedIn())
+        {
+            pPickup->StreamOutForABit();
+        }
+    }
+}

--- a/Client/mods/deathmatch/logic/CClientPickupManager.h
+++ b/Client/mods/deathmatch/logic/CClientPickupManager.h
@@ -43,6 +43,7 @@ public:
 
     static bool IsPickupLimitReached();
     void        RestreamPickups(unsigned short usModel);
+    void        RestreamAllPickups();
 
 private:
     CClientPickupManager(CClientManager* pManager);

--- a/Client/mods/deathmatch/logic/CClientVehicleManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicleManager.cpp
@@ -752,6 +752,26 @@ void CClientVehicleManager::RestreamVehicles(unsigned short usModel)
     }
 }
 
+void CClientVehicleManager::RestreamAllVehicles()
+{
+    // This can speed up initial connect
+    if (m_StreamedIn.empty())
+        return;
+
+    for (uint i = 0; i < m_List.size(); i++)
+    {
+        CClientVehicle* pVehicle = m_List[i];
+
+        // Streamed in and same vehicle ID?
+        if (pVehicle->IsStreamedIn())
+        {
+            // Stream it out for a while until streamed decides to stream it
+            // back in eventually
+            pVehicle->StreamOutForABit();
+        }
+    }
+}
+
 void CClientVehicleManager::RestreamVehicleUpgrades(unsigned short usModel)
 {
     for (uint i = 0; i < m_List.size(); i++)

--- a/Client/mods/deathmatch/logic/CClientVehicleManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicleManager.cpp
@@ -758,7 +758,7 @@ void CClientVehicleManager::RestreamAllVehicles()
     if (m_StreamedIn.empty())
         return;
 
-    for (auto& vehicle : m_List)
+    for (auto& pVehicle: m_List)
     {
         // Streamed in and same vehicle ID?
         if (pVehicle->IsStreamedIn())

--- a/Client/mods/deathmatch/logic/CClientVehicleManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicleManager.cpp
@@ -758,10 +758,8 @@ void CClientVehicleManager::RestreamAllVehicles()
     if (m_StreamedIn.empty())
         return;
 
-    for (uint i = 0; i < m_List.size(); i++)
+    for (auto& vehicle : m_List)
     {
-        CClientVehicle* pVehicle = m_List[i];
-
         // Streamed in and same vehicle ID?
         if (pVehicle->IsStreamedIn())
         {

--- a/Client/mods/deathmatch/logic/CClientVehicleManager.h
+++ b/Client/mods/deathmatch/logic/CClientVehicleManager.h
@@ -55,6 +55,7 @@ public:
     static bool IsVehicleLimitReached();
 
     void RestreamVehicles(unsigned short usModel);
+    void RestreamAllVehicles();
     void RestreamVehicleUpgrades(unsigned short usModel);
 
     std::vector<CClientVehicle*>::const_iterator IterBegin() { return m_List.begin(); };

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -1980,18 +1980,7 @@ int CLuaEngineDefs::EngineRestoreObjectGroupPhysicalProperties(lua_State* luaVM)
 
 int CLuaEngineDefs::EngineRestreamWorld(lua_State* luaVM)
 {
-    for (unsigned int uiModelID = 0; uiModelID <= 26316; uiModelID++)
-    {
-        g_pClientGame->GetModelCacheManager()->OnRestreamModel(uiModelID);
-    }
-    m_pManager->GetObjectManager()->RestreamAllObjects();
-    m_pManager->GetVehicleManager()->RestreamAllVehicles();
-    m_pManager->GetPedManager()->RestreamAllPeds();
-
-    typedef int(__cdecl * Function_ReInitStreaming)();
-    Function_ReInitStreaming reinitStreaming = (Function_ReInitStreaming)(0x40E560);
-
-    reinitStreaming();
+    g_pClientGame->RestreamWorld();
 
     lua_pushnil(luaVM);
     return 1;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -1978,10 +1978,8 @@ int CLuaEngineDefs::EngineRestoreObjectGroupPhysicalProperties(lua_State* luaVM)
     return 1;
 }
 
-int CLuaEngineDefs::EngineRestreamWorld(lua_State* luaVM)
+bool CLuaEngineDefs::EngineRestreamWorld(lua_State* const luaVM)
 {
     g_pClientGame->RestreamWorld();
-
-    lua_pushnil(luaVM);
-    return 1;
+    return true;
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -46,7 +46,8 @@ void CLuaEngineDefs::LoadFunctions()
         {"engineRestoreModelPhysicalPropertiesGroup", EngineRestoreModelPhysicalPropertiesGroup},
         {"engineSetObjectGroupPhysicalProperty", EngineSetObjectGroupPhysicalProperty},
         {"engineGetObjectGroupPhysicalProperty", EngineGetObjectGroupPhysicalProperty},
-        {"engineRestoreObjectGroupPhysicalProperties", EngineRestoreObjectGroupPhysicalProperties}
+        {"engineRestoreObjectGroupPhysicalProperties", EngineRestoreObjectGroupPhysicalProperties},
+        {"engineRestreamWorld", EngineRestreamWorld},
 
         // CLuaCFunctions::AddFunction ( "engineReplaceMatchingAtomics", EngineReplaceMatchingAtomics );
         // CLuaCFunctions::AddFunction ( "engineReplaceWheelAtomics", EngineReplaceWheelAtomics );
@@ -1974,5 +1975,24 @@ int CLuaEngineDefs::EngineRestoreObjectGroupPhysicalProperties(lua_State* luaVM)
 
     pGroup->RestoreDefault();
     lua_pushboolean(luaVM, true);
+    return 1;
+}
+
+int CLuaEngineDefs::EngineRestreamWorld(lua_State* luaVM)
+{
+    for (unsigned int uiModelID = 0; uiModelID <= 26316; uiModelID++)
+    {
+        g_pClientGame->GetModelCacheManager()->OnRestreamModel(uiModelID);
+    }
+    m_pManager->GetObjectManager()->RestreamAllObjects();
+    m_pManager->GetVehicleManager()->RestreamAllVehicles();
+    m_pManager->GetPedManager()->RestreamAllPeds();
+
+    typedef int(__cdecl * Function_ReInitStreaming)();
+    Function_ReInitStreaming reinitStreaming = (Function_ReInitStreaming)(0x40E560);
+
+    reinitStreaming();
+
+    lua_pushnil(luaVM);
     return 1;
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -10,6 +10,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include <lua/CLuaFunctionParser.h>
 
 void CLuaEngineDefs::LoadFunctions()
 {

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -47,7 +47,7 @@ void CLuaEngineDefs::LoadFunctions()
         {"engineSetObjectGroupPhysicalProperty", EngineSetObjectGroupPhysicalProperty},
         {"engineGetObjectGroupPhysicalProperty", EngineGetObjectGroupPhysicalProperty},
         {"engineRestoreObjectGroupPhysicalProperties", EngineRestoreObjectGroupPhysicalProperties},
-        {"engineRestreamWorld", EngineRestreamWorld},
+        {"engineRestreamWorld", ArgumentParser<EngineRestreamWorld>},
 
         // CLuaCFunctions::AddFunction ( "engineReplaceMatchingAtomics", EngineReplaceMatchingAtomics );
         // CLuaCFunctions::AddFunction ( "engineReplaceWheelAtomics", EngineReplaceWheelAtomics );

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
@@ -57,6 +57,7 @@ public:
     LUA_DECLARE(EngineSetObjectGroupPhysicalProperty)
     LUA_DECLARE(EngineGetObjectGroupPhysicalProperty)
     LUA_DECLARE(EngineRestoreObjectGroupPhysicalProperties)
+    LUA_DECLARE(EngineRestreamWorld)
 
 private:
     static void AddEngineColClass(lua_State* luaVM);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
@@ -57,8 +57,7 @@ public:
     LUA_DECLARE(EngineSetObjectGroupPhysicalProperty)
     LUA_DECLARE(EngineGetObjectGroupPhysicalProperty)
     LUA_DECLARE(EngineRestoreObjectGroupPhysicalProperties)
-    LUA_DECLARE(EngineRestreamWorld)
-
+    static bool CLuaEngineDefs::EngineRestreamWorld(lua_State* const luaVM);
 private:
     static void AddEngineColClass(lua_State* luaVM);
     static void AddEngineTxdClass(lua_State* luaVM);

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1503,6 +1503,8 @@ void CMultiplayerSA::InitHooks()
     InitHooks_VehicleDamage();
     InitHooks_VehicleLights();
     InitHooks_VehicleWeapons();
+
+    InitHooks_Streaming();
 }
 
 // Used to store copied pointers for explosions in the FxSystem

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -75,6 +75,7 @@ public:
     void                InitHooks_VehicleWeapons();
     void                InitHooks_Direct3D();
     void                InitHooks_FixLineOfSightArgs();
+    void                InitHooks_Streaming();
     CRemoteDataStorage* CreateRemoteDataStorage();
     void                DestroyRemoteDataStorage(CRemoteDataStorage* pData);
     void                AddRemoteDataStorage(CPlayerPed* pPed, CRemoteDataStorage* pData);

--- a/Client/multiplayer_sa/CMultiplayerSA_Streaming.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Streaming.cpp
@@ -25,7 +25,6 @@ void OnModelLoaded(unsigned int uiModelID)
 //////////////////////////////////////////////////////////////////////////////////////////
 #define HOOKPOS_CStreaming__ConvertBufferToObject  0x40CB88
 #define HOOKSIZE_CStreaming__ConvertBufferToObject 9
-static DWORD CONTINUE_CStreaming__ConvertBufferToObject = 0x40CB91;
 
 static void _declspec(naked) HOOK_CStreaming__ConvertBufferToObject()
 {

--- a/Client/multiplayer_sa/CMultiplayerSA_Streaming.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Streaming.cpp
@@ -1,0 +1,57 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        multiplayer_sa/CMultiplayerSA_Streaming.cpp
+ *
+ *  Multi Theft Auto is available from https://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+
+void OnModelLoaded(unsigned int uiModelID)
+{
+    if (uiModelID < 20000)
+        pGameInterface->GetModelInfo(uiModelID)->MakeCustomModel();
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CStreaming::ConvertBufferToObject
+//
+// This hook load custom models
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+#define HOOKPOS_CStreaming__ConvertBufferToObject  0x40CB88
+#define HOOKSIZE_CStreaming__ConvertBufferToObject 9
+static DWORD CONTINUE_CStreaming__ConvertBufferToObject = 0x40CB91;
+
+static void _declspec(naked) HOOK_CStreaming__ConvertBufferToObject()
+{
+    _asm {
+        push    esi
+        call    OnModelLoaded
+        pop esi
+
+        pop     edi
+        pop     esi
+        pop     ebp
+        mov     al, 1
+        pop     ebx
+        add     esp, 20h
+        retn
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CMultiplayerSA::InitHooks_Streaming
+//
+// Setup hooks
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+void CMultiplayerSA::InitHooks_Streaming()
+{
+    EZHookInstall(CStreaming__ConvertBufferToObject);
+}

--- a/Client/sdk/game/CStreaming.h
+++ b/Client/sdk/game/CStreaming.h
@@ -18,4 +18,5 @@ public:
     virtual void LoadAllRequestedModels(BOOL bOnlyPriorityModels = 0, const char* szTag = NULL) = 0;
     virtual BOOL HasModelLoaded(DWORD dwModelID) = 0;
     virtual void RequestSpecialModel(DWORD model, const char* szTexture, DWORD channel) = 0;
+    virtual void ReinitStreaming() = 0;
 };


### PR DESCRIPTION
Fixes #1394
Fixes #550

This function will force unload all models(). This can be useful if you try to replace buildings in SA world. You can avoid some hacks from [this page](https://wiki.multitheftauto.com/wiki/EngineReplaceModel_notes)

**API:**
```lua
engineRestreamWorld()
```

**TEST:**
Just use resources from #1394

For custom IMG's ( #1677 ):
Use any resource from #1677. Replace model when it loaded and run `crun engineRestreamWorld()`. Model should be reloaded.