### PR TITLE
Use enum classes for BitStream

### DIFF
--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -1067,7 +1067,7 @@ void CClientGame::DoPulses()
             m_bWaitingForLocalConnect = false;
 
             // Assume local server has the same bitstream version
-            g_pNet->SetServerBitStreamVersion(MTA_DM_BITSTREAM_VERSION);
+            g_pNet->SetServerBitStreamVersion(static_cast<unsigned short>(MTA_DM_BITSTREAM_VERSION));
 
             // Run the game normally.
             StartGame(m_strLocalNick, m_Server.GetPassword().c_str(), m_ServerType);

--- a/Client/sdk/net/CNet.h
+++ b/Client/sdk/net/CNet.h
@@ -107,6 +107,7 @@ public:
 
     virtual void           SetServerBitStreamVersion(unsigned short usServerBitStreamVersion) = 0;
     virtual unsigned short GetServerBitStreamVersion() = 0;
+    bool                   CanServerBitStream(eBitStreamVersion query) { return static_cast<eBitStreamVersion>(GetServerBitStreamVersion()) >= query; }
 
     virtual void           GetStatus(char* szStatus, size_t maxLength) = 0;
     virtual unsigned short GetNetRev() = 0;

--- a/Client/version.h
+++ b/Client/version.h
@@ -74,7 +74,9 @@
 #define _NETCODE_VERSION_BRANCH_ID      0x4         // Use 0x1 - 0xF to indicate an incompatible branch is being used (0x0 is reserved, 0x4 is trunk)
 #define _CLIENT_NET_MODULE_VERSION      0x0AB       // (0x000 - 0xfff) Lvl9 wizards only
 #define _NETCODE_VERSION                0x1DA       // (0x000 - 0xfff) Increment when net messages change (pre-release)
-#define MTA_DM_BITSTREAM_VERSION        0x06F       // (0x000 - 0xfff) Increment when net messages change (post-release). (Changing will also require additional backward compatibility code).
+
+// (0x000 - 0xfff) Update bitstream.h when net messages change (post-release). (Changing will also require additional backward compatibility code).
+#define MTA_DM_BITSTREAM_VERSION eBitStreamVersion::Latest
 
 // To avoid user confusion, make sure the ASE version matches only if communication is possible
 #if defined(MTA_DM_CONNECT_TO_PUBLIC)

--- a/Server/mods/deathmatch/logic/CPlayer.h
+++ b/Server/mods/deathmatch/logic/CPlayer.h
@@ -94,6 +94,7 @@ public:
     void               SetMTAVersion(unsigned short usMTAVersion) { m_usMTAVersion = usMTAVersion; };
     unsigned short     GetBitStreamVersion() { return m_usBitStreamVersion; };
     void               SetBitStreamVersion(unsigned short usBitStreamVersion) { m_usBitStreamVersion = usBitStreamVersion; };
+    bool               CanBitStream(eBitStreamVersion query) { return static_cast<eBitStreamVersion>(m_usBitStreamVersion) >= query; }
     void               SetPlayerVersion(const CMtaVersion& strPlayerVersion);
     const CMtaVersion& GetPlayerVersion() { return m_strPlayerVersion; };
     bool               ShouldIgnoreMinClientVersionChecks();

--- a/Server/version.h
+++ b/Server/version.h
@@ -77,7 +77,9 @@
 #define _NETCODE_VERSION_BRANCH_ID      0x4         // Use 0x1 - 0xF to indicate an incompatible branch is being used (0x0 is reserved, 0x4 is trunk)
 #define _SERVER_NET_MODULE_VERSION      0x0AB       // (0x000 - 0xfff) Lvl9 wizards only
 #define _NETCODE_VERSION                0x1DA       // (0x000 - 0xfff) Increment when net messages change (pre-release)
-#define MTA_DM_BITSTREAM_VERSION        0x06F       // (0x000 - 0xfff) Increment when net messages change (post-release). (Changing will also require additional backward compatibility code).
+
+// (0x000 - 0xfff) Update bitstream.h when net messages change (post-release). (Changing will also require additional backward compatibility code).
+#define MTA_DM_BITSTREAM_VERSION eBitStreamVersion::Latest
 
 // To avoid user confusion, make sure the ASE version matches only if communication is possible
 #if defined(MTA_DM_CONNECT_FROM_PUBLIC)

--- a/Shared/sdk/net/bitstream.h
+++ b/Shared/sdk/net/bitstream.h
@@ -348,6 +348,28 @@ public:
     }
 };
 
+// eBitStreamVersion allows us to track what BitStream version is being used without placing magic numbers everywhere.
+// It also helps us know what code branches can be removed when we increment a major version of MTA.
+// Make sure you only add new items to the end of the list, above the "Latest" entry.
+enum class eBitStreamVersion : unsigned short
+{
+    Unk = 0x06F,
+
+    //
+    // 1.5.8 RELEASED - 2020-10-11
+    //
+
+    // This allows us to automatically increment the BitStreamVersion when things are added to this enum.
+    // Make sure you only add things above this comment.
+    Latest,
+};
+
+// This is a temporary check during the introduction of eBitStreamVersion.
+// We only check it server-side because static_assert is not available for all client projects.
+#ifndef MTA_CLIENT
+static_assert(static_cast<unsigned short>(eBitStreamVersion::Latest) == 0x070);
+#endif
+
 class NetBitStreamInterface : public NetBitStreamInterfaceNoVersion
 {
     NetBitStreamInterface(const NetBitStreamInterface&);
@@ -358,8 +380,12 @@ protected:
     virtual ~NetBitStreamInterface() { DEBUG_DESTROY_COUNT("NetBitStreamInterface"); }
 
 public:
-    virtual                operator NetBitStreamInterface&() { return *this; }
+    virtual operator NetBitStreamInterface&() { return *this; }
     virtual unsigned short Version() const = 0;
+
+    bool Can(eBitStreamVersion query) {
+        return static_cast<eBitStreamVersion>(Version()) >= query;
+    }
 };
 
 // Interface for all sync structures


### PR DESCRIPTION
This pull request allows for querying BitStream compatibility by doing (for example) `bitStream.Can(eBitStreamVersion::FakeLagCommand)` instead of getting the number and doing comparisons. You just need to add to the enum list.

I propose that all future code uses this system as much as possible, instead of doing `GetVersion`.

There is [a second pull request](https://github.com/qaisjp/mtasa-blue/compare/qaisjp/bitstream-enum-class...qaisjp:bitstream-apply-enum-classes) ready that applies the use of this feature to every change since the release of 1.5. I'll submit that pull request if/once this one merges. 

**Note**: this pull request also increments the BitStream version. This is harmless, right?