### PR TITLE
Add missing CLuaNetworkDefs::LoadFunctions on client-side

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -315,6 +315,7 @@ void CLuaManager::LoadCFunctions()
     CLuaFireDefs::LoadFunctions();
     CLuaGUIDefs::LoadFunctions();
     CLuaMarkerDefs::LoadFunctions();
+    CLuaNetworkDefs::LoadFunctions();
     CLuaObjectDefs::LoadFunctions();
     CLuaPedDefs::LoadFunctions();
     CLuaPickupDefs::LoadFunctions();


### PR DESCRIPTION
Forgot this. Fixes a typo in #1731
r20683 doesn't have these functions.