### PR TITLE
Revert "Allow to use peds and vehicles as a camera target (#1398)"

### DIFF
--- a/Client/mods/deathmatch/logic/CNetAPI.cpp
+++ b/Client/mods/deathmatch/logic/CNetAPI.cpp
@@ -1981,11 +1981,11 @@ void CNetAPI::WriteCameraSync(NetBitStreamInterface& BitStream)
     {
         // Write our target
         ElementID      ID = INVALID_ELEMENT_ID;
-        CClientEntity* pTarget = pCamera->GetTargetEntity();
-        if (!pTarget)
-            pTarget = g_pClientGame->GetLocalPlayer();
-        if (!pTarget->IsLocalEntity())
-            ID = pTarget->GetID();
+        CClientPlayer* pPlayer = pCamera->GetFocusedPlayer();
+        if (!pPlayer)
+            pPlayer = g_pClientGame->GetLocalPlayer();
+        if (!pPlayer->IsLocalEntity())
+            ID = pPlayer->GetID();
 
         BitStream.Write(ID);
     }

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -4826,6 +4826,9 @@ bool CStaticFunctionDefinitions::SetCameraTarget(CClientEntity* pEntity)
 {
     assert(pEntity);
 
+    // Save our current target for later
+    CClientEntity* pPreviousTarget = m_pCamera->GetTargetEntity();
+
     switch (pEntity->GetType())
     {
         case CCLIENTPLAYER:
@@ -4843,12 +4846,6 @@ bool CStaticFunctionDefinitions::SetCameraTarget(CClientEntity* pEntity)
                 // Put the focus on that player
                 m_pCamera->SetFocus(pPlayer, MODE_CAM_ON_A_STRING, false);
             }
-            break;
-        }
-        case CCLIENTPED:
-        case CCLIENTVEHICLE:
-        {
-            m_pCamera->SetFocus(pEntity, MODE_CAM_ON_A_STRING, false);
             break;
         }
         default:

--- a/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
@@ -12,8 +12,6 @@
 
 #include "StdInc.h"
 
-#define MIN_CLIENT_REQ_SETCAMERATARGET_USE_ANY_ELEMENTS "1.5.8-9.20677"
-
 void CLuaCameraDefs::LoadFunctions()
 {
     constexpr static const std::pair<const char*, lua_CFunction> functions[]{
@@ -333,9 +331,6 @@ int CLuaCameraDefs::SetCameraTarget(lua_State* luaVM)
     {
         CClientEntity* pTarget;
         argStream.ReadUserData(pTarget);
-
-        if (pTarget->GetType() != CCLIENTPLAYER)
-            MinClientReqCheck(argStream, MIN_CLIENT_REQ_SETCAMERATARGET_USE_ANY_ELEMENTS, "target is not a player");
 
         if (!argStream.HasErrors())
         {

--- a/Client/mods/deathmatch/logic/rpc/CCameraRPCs.cpp
+++ b/Client/mods/deathmatch/logic/rpc/CCameraRPCs.cpp
@@ -63,6 +63,9 @@ void CCameraRPCs::SetCameraTarget(NetBitStreamInterface& bitStream)
         CClientEntity* pEntity = CElementIDs::GetElement(targetID);
         if (pEntity)
         {
+            // Save our current target for later
+            CClientEntity* pPreviousTarget = m_pCamera->GetTargetEntity();
+
             switch (pEntity->GetType())
             {
                 case CCLIENTPLAYER:
@@ -78,12 +81,6 @@ void CCameraRPCs::SetCameraTarget(NetBitStreamInterface& bitStream)
                         // Put the focus on that player
                         m_pCamera->SetFocus(pPlayer, MODE_CAM_ON_A_STRING, false);
                     }
-                    break;
-                }
-                case CCLIENTPED:
-                case CCLIENTVEHICLE:
-                {
-                    m_pCamera->SetFocus(pEntity, MODE_CAM_ON_A_STRING, false);
                     break;
                 }
                 default:

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -3677,7 +3677,7 @@ void CGame::Packet_CameraSync(CCameraSyncPacket& Packet)
         }
         else
         {
-            CElement* pTarget = GetElementFromId<CElement>(Packet.m_TargetID);
+            CPlayer* pTarget = GetElementFromId<CPlayer>(Packet.m_TargetID);
             if (!pTarget)
                 pTarget = pPlayer;
 

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -4490,27 +4490,20 @@ bool CStaticFunctionDefinitions::SetCameraTarget(CElement* pElement, CElement* p
         if (!pTarget)
             pTarget = pPlayer;
 
-        // Make sure our target is supported
-        switch (pTarget->GetType())
+        // Make sure our target is a player element
+        if (pTarget->GetType() == CElement::PLAYER)
         {
-            case CElement::PLAYER:
-            case CElement::PED:
-            case CElement::VEHICLE:
-            {
-                pCamera->SetMode(CAMERAMODE_PLAYER);
-                pCamera->SetTarget(pTarget);
-                pCamera->SetRoll(0.0f);
-                pCamera->SetFOV(70.0f);
+            pCamera->SetMode(CAMERAMODE_PLAYER);
+            pCamera->SetTarget(pTarget);
+            pCamera->SetRoll(0.0f);
+            pCamera->SetFOV(70.0f);
 
-                CBitStream BitStream;
-                if (pPlayer->GetBitStreamVersion() >= 0x5E)
-                    BitStream.pBitStream->Write(pCamera->GenerateSyncTimeContext());
-                BitStream.pBitStream->Write(pTarget->GetID());
-                pPlayer->Send(CLuaPacket(SET_CAMERA_TARGET, *BitStream.pBitStream));
-                return true;
-            }
-            default:
-                return false;
+            CBitStream BitStream;
+            if (pPlayer->GetBitStreamVersion() >= 0x5E)
+                BitStream.pBitStream->Write(pCamera->GenerateSyncTimeContext());
+            BitStream.pBitStream->Write(pTarget->GetID());
+            pPlayer->Send(CLuaPacket(SET_CAMERA_TARGET, *BitStream.pBitStream));
+            return true;
         }
     }
 

--- a/Server/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
@@ -11,8 +11,6 @@
 
 #include "StdInc.h"
 
-#define MIN_SERVER_REQ_SETCAMERATARGET_USE_ANY_ELEMENTS "1.5.8-9.20677"
-
 void CLuaCameraDefs::LoadFunctions()
 {
     constexpr static const std::pair<const char*, lua_CFunction> functions[]{
@@ -194,9 +192,6 @@ int CLuaCameraDefs::setCameraTarget(lua_State* luaVM)
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pPlayer);
     argStream.ReadUserData(pTarget, NULL);
-
-    if (pTarget && pTarget->GetType() != CElement::PLAYER)
-        MinServerReqCheck(argStream, MIN_SERVER_REQ_SETCAMERATARGET_USE_ANY_ELEMENTS, "target is not a player");
 
     if (!argStream.HasErrors())
     {


### PR DESCRIPTION
Causes weird camera focusing desync issues that look like this

https://cdn.discordapp.com/attachments/588804725802270773/767816132030758982/2020-10-19_11-26-18.mp4

and 

https://cdn.discordapp.com/attachments/588804725802270773/767849210694336555/MTA__San_Andreas_2020-10-19_21-37-52.mp4
