### PR TITLE
Make sure BitStream comparisons still work correctly

### DIFF
--- a/Shared/sdk/net/bitstream.h
+++ b/Shared/sdk/net/bitstream.h
@@ -361,13 +361,14 @@ enum class eBitStreamVersion : unsigned short
 
     // This allows us to automatically increment the BitStreamVersion when things are added to this enum.
     // Make sure you only add things above this comment.
-    Latest,
+    Next,
+    Latest = Next - 1,
 };
 
 // This is a temporary check during the introduction of eBitStreamVersion.
 // We only check it server-side because static_assert is not available for all client projects.
 #ifndef MTA_CLIENT
-static_assert(static_cast<unsigned short>(eBitStreamVersion::Latest) == 0x070);
+static_assert(static_cast<unsigned short>(eBitStreamVersion::Latest) == 0x06F);
 #endif
 
 class NetBitStreamInterface : public NetBitStreamInterfaceNoVersion


### PR DESCRIPTION
This fixes the following issue:

Currently we have this

```cpp
enum class eBitStreamVersion : unsigned short
{
    Unk = 0x06F,
    Latest
};
```

our bitstream version (Latest) is 0x070

If we add a feature, like so:

```cpp
enum class eBitStreamVersion : unsigned short
{
    Unk = 0x06F,
    NewThing,
    Latest
};
```

Latest becomes 0x071. But bitstream checks will compare against NewThing (0x070) which
matches old client/servers whose latest is also 0x070
