### PR TITLE
Add minimum version check for resetBlurLevel

### DIFF
--- a/Server/mods/deathmatch/logic/CResourceChecker.Data.h
+++ b/Server/mods/deathmatch/logic/CResourceChecker.Data.h
@@ -229,6 +229,7 @@ namespace
         {"engineGetModelTextures", "1.5.7-9.20416"},
         {"dxGetTextSize", "1.5.7-9.20447"},
         {"hasElementData", "1.5.7-9.20447"},
+        {"resetBlurLevel", "1.5.7-9.20450"},
         {"setVehicleModelWheelSize", "1.5.7-9.20642"},
         {"getVehicleModelWheelSize", "1.5.7-9.20642"},
         {"setVehicleWheelScale", "1.5.7-9.20642"},


### PR DESCRIPTION
We missed this function in #1706 