### PR TITLE
Fix crash when deleting a chatbox bind too early

### DIFF
--- a/Client/core/CKeyBinds.cpp
+++ b/Client/core/CKeyBinds.cpp
@@ -505,6 +505,11 @@ void CKeyBinds::Add(CKeyBind* pKeyBind)
 
 void CKeyBinds::Remove(CKeyBind* pKeyBind)
 {
+    // If this is an active chatbox bind, delete it
+    // so it won't be called on next frame
+    if (m_pChatBoxBind == pKeyBind)
+        m_pChatBoxBind = nullptr;
+
     if (m_bProcessingKeyStroke)
         pKeyBind->beingDeleted = true;
     else


### PR DESCRIPTION
In 062aa3fe92242a9e30e3177871a9467a1293ea6d (PR #1615) binds were set to be removed when calling `unbindKey`. This usually works fine, with the exception of chatbox commands (e.g. `/me`), which open a chatbox with a specific prefix. As one does not want the bound key itself to appear in the chatbox as input, the bind execution is delayed by one frame. As we now properly delete binds, a chatbox command bind may be deleted *before* it gets executed, causing a crash. 

This simply removes the dangling pointer to the chatbox bind if it gets removed, which cancels the execution for the next frame as well.