### PR TITLE
Improve checksum error messages for internal HTTP servers

### DIFF
--- a/Client/mods/deathmatch/logic/CDownloadableResource.cpp
+++ b/Client/mods/deathmatch/logic/CDownloadableResource.cpp
@@ -43,7 +43,7 @@ bool CDownloadableResource::DoesClientAndServerChecksumMatch()
 
 CChecksum CDownloadableResource::GenerateClientChecksum()
 {
-    m_LastClientChecksum = CChecksum::GenerateChecksumFromFile(m_strName);
+    m_LastClientChecksum = CChecksum::GenerateChecksumFromFileUnsafe(m_strName);
     return m_LastClientChecksum;
 }
 

--- a/Client/mods/deathmatch/logic/CResource.cpp
+++ b/Client/mods/deathmatch/logic/CResource.cpp
@@ -470,13 +470,24 @@ void CResource::AddToElementGroup(CClientEntity* pElement)
 //
 void CResource::HandleDownloadedFileTrouble(CResourceFile* pResourceFile, bool bScript)
 {
-    // Compose message
-    uint    uiGotFileSize = (uint)FileSize(pResourceFile->GetName());
-    SString strGotMd5 = ConvertDataToHexString(CChecksum::GenerateChecksumFromFile(pResourceFile->GetName()).md5.data, sizeof(MD5));
-    SString strWantedMd5 = ConvertDataToHexString(pResourceFile->GetServerChecksum().md5.data, sizeof(MD5));
+    auto checksumResult = CChecksum::GenerateChecksumFromFile(pResourceFile->GetName());
+
+    SString errorMessage;
+    if (std::holds_alternative<std::string>(checksumResult))
+        errorMessage = std::get<std::string>(checksumResult);
+    else
+    {
+        CChecksum checksum = std::get<CChecksum>(checksumResult);
+
+        // Compose message
+        uint    uiGotFileSize = (uint)FileSize(pResourceFile->GetName());
+        SString strGotMd5 = ConvertDataToHexString(checksum.md5.data, sizeof(MD5));
+        SString strWantedMd5 = ConvertDataToHexString(pResourceFile->GetServerChecksum().md5.data, sizeof(MD5));
+        errorMessage = SString("Got size:%d MD5:%s, wanted MD5:%s", uiGotFileSize, *strGotMd5, *strWantedMd5);
+    }
+
     SString strFilename = ExtractFilename(PathConform(pResourceFile->GetShortName()));
-    SString strMessage =
-        SString("HTTP server file mismatch (%s) %s [Got size:%d MD5:%s, wanted MD5:%s]", GetName(), *strFilename, uiGotFileSize, *strGotMd5, *strWantedMd5);
+    SString strMessage = SString("HTTP server file mismatch! (%s) %s [%s]", GetName(), *strFilename, *errorMessage);
 
     // Log to the server & client console
     g_pClientGame->TellServerSomethingImportant(bScript ? 1002 : 1013, strMessage, 4);

--- a/Client/mods/deathmatch/logic/CResource.cpp
+++ b/Client/mods/deathmatch/logic/CResource.cpp
@@ -322,7 +322,7 @@ void CResource::Load()
         else if (pResourceFile->IsAutoDownload())
         {
             // Check the file contents
-            if (CChecksum::GenerateChecksumFromFile(pResourceFile->GetName()) == pResourceFile->GetServerChecksum())
+            if (CChecksum::GenerateChecksumFromFileUnsafe(pResourceFile->GetName()) == pResourceFile->GetServerChecksum())
             {
             }
             else

--- a/Client/mods/deathmatch/logic/CResourceFileDownloadManager.cpp
+++ b/Client/mods/deathmatch/logic/CResourceFileDownloadManager.cpp
@@ -265,7 +265,7 @@ void CResourceFileDownloadManager::DownloadFinished(const SHttpDownloadResult& r
     assert(ListContains(m_ActiveFileDownloadList, pResourceFile));
     if (result.bSuccess)
     {
-        CChecksum checksum = CChecksum::GenerateChecksumFromFile(pResourceFile->GetName());
+        CChecksum checksum = CChecksum::GenerateChecksumFromFileUnsafe(pResourceFile->GetName());
         if (checksum != pResourceFile->GetServerChecksum())
         {
             // Checksum failed - Try download on next server

--- a/Client/mods/deathmatch/logic/CResourceManager.cpp
+++ b/Client/mods/deathmatch/logic/CResourceManager.cpp
@@ -265,7 +265,7 @@ void CResourceManager::ValidateResourceFile(const SString& strInFilename, const 
             if (buffer)
                 checksum = CChecksum::GenerateChecksumFromBuffer(buffer, bufferSize);
             else
-                checksum = CChecksum::GenerateChecksumFromFile(strInFilename);
+                checksum = CChecksum::GenerateChecksumFromFileUnsafe(strInFilename);
             if (checksum != pResourceFile->GetServerChecksum())
             {
                 char szMd5[33];

--- a/Client/mods/deathmatch/logic/CSingularFileDownload.cpp
+++ b/Client/mods/deathmatch/logic/CSingularFileDownload.cpp
@@ -96,6 +96,6 @@ bool CSingularFileDownload::DoesClientAndServerChecksumMatch()
 
 CChecksum CSingularFileDownload::GenerateClientChecksum()
 {
-    m_LastClientChecksum = CChecksum::GenerateChecksumFromFile(m_strName);
+    m_LastClientChecksum = CChecksum::GenerateChecksumFromFileUnsafe(m_strName);
     return m_LastClientChecksum;
 }

--- a/Server/mods/deathmatch/logic/CResource.cpp
+++ b/Server/mods/deathmatch/logic/CResource.cpp
@@ -509,7 +509,7 @@ std::future<SString> CResource::GenerateChecksumForFile(CResourceFile* pResource
                     return SString("ERROR: Resource '%s' client filename '%s' not allowed\n", GetName().c_str(), *ExtractFilename(strCachedFilePath));
                 }
 
-                CChecksum cachedChecksum = CChecksum::GenerateChecksumFromFile(strCachedFilePath);
+                CChecksum cachedChecksum = CChecksum::GenerateChecksumFromFileUnsafe(strCachedFilePath);
 
                 if (pResourceFile->GetLastChecksum() != cachedChecksum)
                 {
@@ -559,7 +559,7 @@ bool CResource::GenerateChecksums()
     SString strPath;
 
     if (GetFilePath("meta.xml", strPath))
-        m_metaChecksum = CChecksum::GenerateChecksumFromFile(strPath);
+        m_metaChecksum = CChecksum::GenerateChecksumFromFileUnsafe(strPath);
     else
         m_metaChecksum = CChecksum();
 
@@ -572,7 +572,7 @@ bool CResource::HasResourceChanged()
     if (IsResourceZip())
     {
         // Zip file might have changed
-        CChecksum checksum = CChecksum::GenerateChecksumFromFile(m_strResourceZip);
+        CChecksum checksum = CChecksum::GenerateChecksumFromFileUnsafe(m_strResourceZip);
         if (checksum != m_zipHash)
             return true;
     }
@@ -581,7 +581,7 @@ bool CResource::HasResourceChanged()
     {
         if (GetFilePath(pResourceFile->GetName(), strPath))
         {
-            CChecksum checksum = CChecksum::GenerateChecksumFromFile(strPath);
+            CChecksum checksum = CChecksum::GenerateChecksumFromFileUnsafe(strPath);
 
             if (pResourceFile->GetLastChecksum() != checksum)
                 return true;
@@ -594,7 +594,7 @@ bool CResource::HasResourceChanged()
                 case CResourceFile::RESOURCE_FILE_TYPE_CLIENT_FILE:
                 {
                     string    strCachedFilePath = pResourceFile->GetCachedPathFilename();
-                    CChecksum cachedChecksum = CChecksum::GenerateChecksumFromFile(strCachedFilePath);
+                    CChecksum cachedChecksum = CChecksum::GenerateChecksumFromFileUnsafe(strCachedFilePath);
 
                     if (cachedChecksum != checksum)
                         return true;
@@ -609,7 +609,7 @@ bool CResource::HasResourceChanged()
 
     if (GetFilePath("meta.xml", strPath))
     {
-        CChecksum checksum = CChecksum::GenerateChecksumFromFile(strPath);
+        CChecksum checksum = CChecksum::GenerateChecksumFromFileUnsafe(strPath);
         if (checksum != m_metaChecksum)
             return true;
     }
@@ -2956,7 +2956,7 @@ bool CResource::UnzipResource()
     m_zipfile = nullptr;
 
     // Store the hash so we can figure out whether it has changed later
-    m_zipHash = CChecksum::GenerateChecksumFromFile(m_strResourceZip);
+    m_zipHash = CChecksum::GenerateChecksumFromFileUnsafe(m_strResourceZip);
     return true;
 }
 

--- a/Shared/sdk/CChecksum.h
+++ b/Shared/sdk/CChecksum.h
@@ -18,7 +18,6 @@
 class CChecksum
 {
 public:
-
     // Initialize to zeros
     CChecksum()
     {

--- a/Shared/sdk/CChecksum.h
+++ b/Shared/sdk/CChecksum.h
@@ -47,6 +47,7 @@ public:
     }
 
     // GenerateChecksumFromFileUnsafe should never ever be used unless you are a bad person. Or unless you really know what you're doing.
+    // If it's the latter, please leave a code comment somewhere explaining why. Otherwise we'll think it's just code that hasn't been migrated yet.
     static CChecksum GenerateChecksumFromFileUnsafe(const SString& strFilename)
     {
         auto result = GenerateChecksumFromFile(strFilename);

--- a/Shared/sdk/CChecksum.h
+++ b/Shared/sdk/CChecksum.h
@@ -47,6 +47,18 @@ public:
         return result;
     }
 
+    // GenerateChecksumFromFileUnsafe should never ever be used unless you are a bad person. Or unless you really know what you're doing.
+    static CChecksum GenerateChecksumFromFileUnsafe(const SString& strFilename)
+    {
+        auto result = GenerateChecksumFromFile(strFilename);
+
+        // If it holds an error message, just return a default CChecksum
+        if (std::holds_alternative<std::string>(result))
+            return CChecksum();
+
+        return std::get<CChecksum>(result);
+    }
+
     static CChecksum GenerateChecksumFromBuffer(const char* cpBuffer, unsigned long ulLength)
     {
         CChecksum result;


### PR DESCRIPTION
**Reviewable commit by commit**

Context is available at https://github.com/multitheftauto/mtasa-blue/issues/1340#issuecomment-719888637

This only works for internal HTTP servers right now, with the possibility to extend it for other servers later, in a future PR.

Try turning off whitespace diffs when reviewing the first commit.

**Before**

![image](https://user-images.githubusercontent.com/923242/97772179-6f0c5900-1b3c-11eb-8960-9d6463eb6de2.png)

**After**

![image](https://user-images.githubusercontent.com/923242/97772181-759ad080-1b3c-11eb-8abe-5105773f4b2f.png)
