### PR TITLE
Add finalizers to classes wherever possible

### DIFF
--- a/Client/mods/deathmatch/logic/CClientCamera.h
+++ b/Client/mods/deathmatch/logic/CClientCamera.h
@@ -29,7 +29,7 @@ namespace EFixedCameraMode
 }
 using EFixedCameraMode::EFixedCameraModeType;
 
-class CClientCamera : public CClientEntity
+class CClientCamera final : public CClientEntity
 {
     DECLARE_CLASS(CClientCamera, CClientEntity)
     friend class CClientManager;

--- a/Client/mods/deathmatch/logic/CClientCivilian.h
+++ b/Client/mods/deathmatch/logic/CClientCivilian.h
@@ -19,7 +19,7 @@ class CClientCivilian;
 #include "CClientCommon.h"
 #include "CClientEntity.h"
 
-class CClientCivilian : public CClientEntity
+class CClientCivilian final : public CClientEntity
 {
     DECLARE_CLASS(CClientCivilian, CClientEntity)
     friend class CClientCivilianManager;

--- a/Client/mods/deathmatch/logic/CClientColCircle.h
+++ b/Client/mods/deathmatch/logic/CClientColCircle.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-class CClientColCircle : public CClientColShape
+class CClientColCircle final : public CClientColShape
 {
     DECLARE_CLASS(CClientColCircle, CClientColShape)
 public:

--- a/Client/mods/deathmatch/logic/CClientColCuboid.h
+++ b/Client/mods/deathmatch/logic/CClientColCuboid.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-class CClientColCuboid : public CClientColShape
+class CClientColCuboid final : public CClientColShape
 {
     DECLARE_CLASS(CClientColCuboid, CClientColShape)
 public:

--- a/Client/mods/deathmatch/logic/CClientColModel.h
+++ b/Client/mods/deathmatch/logic/CClientColModel.h
@@ -13,7 +13,7 @@
 #include <list>
 #include "CClientEntity.h"
 
-class CClientColModel : public CClientEntity
+class CClientColModel final : public CClientEntity
 {
     DECLARE_CLASS(CClientColModel, CClientEntity)
 public:

--- a/Client/mods/deathmatch/logic/CClientColPolygon.h
+++ b/Client/mods/deathmatch/logic/CClientColPolygon.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-class CClientColPolygon : public CClientColShape
+class CClientColPolygon final : public CClientColShape
 {
     DECLARE_CLASS(CClientColPolygon, CClientColShape)
 public:

--- a/Client/mods/deathmatch/logic/CClientColRectangle.h
+++ b/Client/mods/deathmatch/logic/CClientColRectangle.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-class CClientColRectangle : public CClientColShape
+class CClientColRectangle final : public CClientColShape
 {
     DECLARE_CLASS(CClientColRectangle, CClientColShape)
 public:

--- a/Client/mods/deathmatch/logic/CClientColSphere.h
+++ b/Client/mods/deathmatch/logic/CClientColSphere.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-class CClientColSphere : public CClientColShape
+class CClientColSphere final : public CClientColShape
 {
     DECLARE_CLASS(CClientColSphere, CClientColShape)
 public:

--- a/Client/mods/deathmatch/logic/CClientColTube.h
+++ b/Client/mods/deathmatch/logic/CClientColTube.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-class CClientColTube : public CClientColShape
+class CClientColTube final : public CClientColShape
 {
     DECLARE_CLASS(CClientColTube, CClientColShape)
 public:

--- a/Client/mods/deathmatch/logic/CClientDFF.h
+++ b/Client/mods/deathmatch/logic/CClientDFF.h
@@ -22,7 +22,7 @@ struct SLoadedClumpInfo
     RpClump* pClump;
 };
 
-class CClientDFF : public CClientEntity
+class CClientDFF final : public CClientEntity
 {
     DECLARE_CLASS(CClientDFF, CClientEntity)
     friend class CClientDFFManager;

--- a/Client/mods/deathmatch/logic/CClientDummy.h
+++ b/Client/mods/deathmatch/logic/CClientDummy.h
@@ -12,7 +12,7 @@
 
 #include "CClientEntity.h"
 
-class CClientDummy : public CClientEntity
+class CClientDummy final : public CClientEntity
 {
     DECLARE_CLASS(CClientDummy, CClientEntity)
 public:

--- a/Client/mods/deathmatch/logic/CClientEffect.h
+++ b/Client/mods/deathmatch/logic/CClientEffect.h
@@ -15,7 +15,7 @@
 
 class CClientManager;
 
-class CClientEffect : public CClientEntity
+class CClientEffect final : public CClientEntity
 {
     DECLARE_CLASS(CClientEffect, CClientEntity)
 public:

--- a/Client/mods/deathmatch/logic/CClientIFP.h
+++ b/Client/mods/deathmatch/logic/CClientIFP.h
@@ -14,7 +14,7 @@
 #include "CFileReader.h"
 #include "CIFPAnimations.h"
 
-class CClientIFP : public CClientEntity, CFileReader
+class CClientIFP final : public CClientEntity, CFileReader
 {
 public:
     typedef CIFPAnimations::SAnimation                           SAnimation;

--- a/Client/mods/deathmatch/logic/CClientMarker.h
+++ b/Client/mods/deathmatch/logic/CClientMarker.h
@@ -20,7 +20,7 @@
 
 class CClientMarkerManager;
 
-class CClientMarker : public CClientStreamElement, private CClientColCallback
+class CClientMarker final : public CClientStreamElement, private CClientColCallback
 {
     DECLARE_CLASS(CClientMarker, CClientStreamElement)
     friend class CClientMarkerManager;

--- a/Client/mods/deathmatch/logic/CClientPathNode.h
+++ b/Client/mods/deathmatch/logic/CClientPathNode.h
@@ -14,7 +14,7 @@ class CClientPathNode;
 
 #include "CClientManager.h"
 
-class CClientPathNode : public CClientEntity
+class CClientPathNode final : public CClientEntity
 {
     DECLARE_CLASS(CClientPathNode, CClientEntity)
     friend class CClientPathManager;

--- a/Client/mods/deathmatch/logic/CClientPickup.h
+++ b/Client/mods/deathmatch/logic/CClientPickup.h
@@ -17,7 +17,7 @@ class CClientPickup;
 #include "CClientColShape.h"
 #include "CClientColCallback.h"
 
-class CClientPickup : public CClientStreamElement, private CClientColCallback
+class CClientPickup final : public CClientStreamElement, private CClientColCallback
 {
     DECLARE_CLASS(CClientPickup, CClientStreamElement)
     friend class CClientColShape;

--- a/Client/mods/deathmatch/logic/CClientPlayer.h
+++ b/Client/mods/deathmatch/logic/CClientPlayer.h
@@ -28,7 +28,8 @@ enum ePuresyncType
     PURESYNC_TYPE_LIGHTSYNC,
     PURESYNC_TYPE_PURESYNC,
 };
-class CClientPlayer : public CClientPed
+
+class CClientPlayer final : public CClientPed
 {
     DECLARE_CLASS(CClientPlayer, CClientPed)
     friend class CClientPlayerManager;

--- a/Client/mods/deathmatch/logic/CClientPointLights.h
+++ b/Client/mods/deathmatch/logic/CClientPointLights.h
@@ -14,7 +14,7 @@
 
 class CClientPointLightsManager;
 
-class CClientPointLights : public CClientEntity
+class CClientPointLights final : public CClientEntity
 {
     DECLARE_CLASS(CClientPointLights, CClientEntity)
     friend class CClientPointLightsManager;

--- a/Client/mods/deathmatch/logic/CClientProjectile.h
+++ b/Client/mods/deathmatch/logic/CClientProjectile.h
@@ -49,7 +49,7 @@ public:
     unsigned short usModel;
 };
 
-class CClientProjectile : public CClientEntity
+class CClientProjectile final : public CClientEntity
 {
     DECLARE_CLASS(CClientProjectile, CClientEntity)
     friend class CClientProjectileManager;

--- a/Client/mods/deathmatch/logic/CClientRadarArea.h
+++ b/Client/mods/deathmatch/logic/CClientRadarArea.h
@@ -15,7 +15,7 @@
 
 class CClientRadarAreaManager;
 
-class CClientRadarArea : public CClientEntity
+class CClientRadarArea final : public CClientEntity
 {
     DECLARE_CLASS(CClientRadarArea, CClientEntity)
     friend class CClientRadarAreaManager;

--- a/Client/mods/deathmatch/logic/CClientRadarMarker.h
+++ b/Client/mods/deathmatch/logic/CClientRadarMarker.h
@@ -21,7 +21,7 @@ class CClientRadarMarker;
 
 #define RADAR_MARKER_LIMIT 63
 
-class CClientRadarMarker : public CClientEntity
+class CClientRadarMarker final : public CClientEntity
 {
     DECLARE_CLASS(CClientRadarMarker, CClientEntity)
     friend class CClientRadarMarkerManager;

--- a/Client/mods/deathmatch/logic/CClientSearchLight.h
+++ b/Client/mods/deathmatch/logic/CClientSearchLight.h
@@ -12,7 +12,7 @@
 
 class CClientPointLightsManager;
 
-class CClientSearchLight : public CClientStreamElement
+class CClientSearchLight final : public CClientStreamElement
 {
     DECLARE_CLASS(CClientSearchLight, CClientEntity);
     friend class CClientPointLightsManager;

--- a/Client/mods/deathmatch/logic/CClientSound.h
+++ b/Client/mods/deathmatch/logic/CClientSound.h
@@ -17,7 +17,7 @@ class CBassAudio;
 #include "CClientEntity.h"
 #include "CSimulatedPlayPosition.h"
 
-class CClientSound : public CClientEntity
+class CClientSound final : public CClientEntity
 {
     DECLARE_CLASS(CClientSound, CClientEntity)
     friend class CClientSoundManager;

--- a/Client/mods/deathmatch/logic/CClientTXD.h
+++ b/Client/mods/deathmatch/logic/CClientTXD.h
@@ -13,7 +13,7 @@
 
 #include "CClientEntity.h"
 
-class CClientTXD : public CClientEntity
+class CClientTXD final : public CClientEntity
 {
     DECLARE_CLASS(CClientTXD, CClientEntity)
 public:

--- a/Client/mods/deathmatch/logic/CClientTeam.h
+++ b/Client/mods/deathmatch/logic/CClientTeam.h
@@ -16,7 +16,7 @@ class CClientTeam;
 #include "CClientPlayer.h"
 #include "CClientTeamManager.h"
 
-class CClientTeam : public CClientEntity
+class CClientTeam final : public CClientEntity
 {
     DECLARE_CLASS(CClientTeam, CClientEntity)
     friend class CClientTeamManager;

--- a/Client/mods/deathmatch/logic/CClientVehicle.h
+++ b/Client/mods/deathmatch/logic/CClientVehicle.h
@@ -125,7 +125,7 @@ struct SVehicleComponentData
 };
 class CClientProjectile;
 
-class CClientVehicle final : public CClientStreamElement
+class CClientVehicle : public CClientStreamElement
 {
     DECLARE_CLASS(CClientVehicle, CClientStreamElement)
     friend class CClientCamera;

--- a/Client/mods/deathmatch/logic/CClientVehicle.h
+++ b/Client/mods/deathmatch/logic/CClientVehicle.h
@@ -125,7 +125,7 @@ struct SVehicleComponentData
 };
 class CClientProjectile;
 
-class CClientVehicle : public CClientStreamElement
+class CClientVehicle final : public CClientStreamElement
 {
     DECLARE_CLASS(CClientVehicle, CClientStreamElement)
     friend class CClientCamera;

--- a/Client/mods/deathmatch/logic/CClientWater.h
+++ b/Client/mods/deathmatch/logic/CClientWater.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-class CClientWater : public CClientEntity
+class CClientWater final : public CClientEntity
 {
     DECLARE_CLASS(CClientWater, CClientEntity)
 public:

--- a/Client/mods/deathmatch/logic/CClientWeapon.h
+++ b/Client/mods/deathmatch/logic/CClientWeapon.h
@@ -40,7 +40,7 @@ enum eWeaponFlags
     WEAPONFLAGS_DISABLE_MODEL,
     WEAPONFLAGS_INSTANT_RELOAD,
 };
-class CClientWeapon : public CClientObject
+class CClientWeapon final : public CClientObject
 {
     DECLARE_CLASS(CClientWeapon, CClientObject)
 public:

--- a/Client/mods/deathmatch/logic/CDeathmatchObject.h
+++ b/Client/mods/deathmatch/logic/CDeathmatchObject.h
@@ -13,7 +13,7 @@
 
 #include "CClientObject.h"
 
-class CDeathmatchObject : public CClientObject
+class CDeathmatchObject final : public CClientObject
 {
     DECLARE_CLASS(CDeathmatchObject, CClientObject)
 public:

--- a/Client/mods/deathmatch/logic/CDeathmatchVehicle.h
+++ b/Client/mods/deathmatch/logic/CDeathmatchVehicle.h
@@ -13,7 +13,7 @@
 
 #include "CClientVehicle.h"
 
-class CDeathmatchVehicle : public CClientVehicle
+class CDeathmatchVehicle final : public CClientVehicle
 {
     DECLARE_CLASS(CDeathmatchVehicle, CClientVehicle)
 public:

--- a/Client/mods/deathmatch/logic/CScriptFile.h
+++ b/Client/mods/deathmatch/logic/CScriptFile.h
@@ -14,7 +14,7 @@
 #include <stdio.h>
 #include <string>
 
-class CScriptFile : public CClientEntity
+class CScriptFile final : public CClientEntity
 {
     DECLARE_CLASS(CScriptFile, CClientEntity)
 public:

--- a/Server/mods/deathmatch/logic/CConsoleClient.h
+++ b/Server/mods/deathmatch/logic/CConsoleClient.h
@@ -16,7 +16,7 @@
 #include "CConsole.h"
 #include "CLogger.h"
 
-class CConsoleClient : public CElement, public CClient
+class CConsoleClient final : public CElement, public CClient
 {
 public:
     CConsoleClient(CConsole* pConsole);

--- a/Server/mods/deathmatch/logic/CCustomWeapon.h
+++ b/Server/mods/deathmatch/logic/CCustomWeapon.h
@@ -54,7 +54,7 @@ struct SWeaponConfiguration
     SLineOfSightFlags flags;
 };
 
-class CCustomWeapon : public CObject
+class CCustomWeapon final : public CObject
 {
 public:
     CCustomWeapon(CElement* pParent, CObjectManager* pObjectManager, CCustomWeaponManager* pWeaponManager, eWeaponType weaponType);

--- a/Server/mods/deathmatch/logic/CDatabaseManager.h
+++ b/Server/mods/deathmatch/logic/CDatabaseManager.h
@@ -177,7 +177,7 @@ CDatabaseManager* NewDatabaseManager();
 // TODO - Check it does not get synced to the client
 //
 ///////////////////////////////////////////////////////////////
-class CDatabaseConnectionElement : public CElement
+class CDatabaseConnectionElement final : public CElement
 {
 public:
     CDatabaseConnectionElement(CElement* pParent, SConnectionHandle connection) : CElement(pParent), m_Connection(connection)

--- a/Server/mods/deathmatch/logic/CDummy.h
+++ b/Server/mods/deathmatch/logic/CDummy.h
@@ -13,7 +13,7 @@
 
 #include "CElement.h"
 
-class CDummy : public CElement
+class CDummy final : public CElement
 {
 public:
     CDummy(class CGroups* pGroups, CElement* pParent);

--- a/Server/mods/deathmatch/logic/CElement.h
+++ b/Server/mods/deathmatch/logic/CElement.h
@@ -44,7 +44,7 @@ typedef CFastList<CElement*> CChildListType;
 typedef CFastList<CElement*> CElementListType;
 
 // List of elements which is auto deleted when the last user calls Release()
-class CElementListSnapshot : public std::vector<CElement*>, public CRefCountableST
+class CElementListSnapshot final : public std::vector<CElement*>, public CRefCountableST
 {
 };
 

--- a/Server/mods/deathmatch/logic/CObject.h
+++ b/Server/mods/deathmatch/logic/CObject.h
@@ -19,7 +19,7 @@
 #include "TInterpolation.h"
 #include "CPositionRotationAnimation.h"
 
-class CObject : public CElement
+class CObject final : public CElement
 {
     friend class CPlayer;
 

--- a/Server/mods/deathmatch/logic/CObject.h
+++ b/Server/mods/deathmatch/logic/CObject.h
@@ -19,7 +19,7 @@
 #include "TInterpolation.h"
 #include "CPositionRotationAnimation.h"
 
-class CObject final : public CElement
+class CObject : public CElement
 {
     friend class CPlayer;
 

--- a/Server/mods/deathmatch/logic/CPickup.h
+++ b/Server/mods/deathmatch/logic/CPickup.h
@@ -19,7 +19,7 @@ class CPickup;
 #include "CElement.h"
 #include "CEvents.h"
 
-class CPickup : public CElement, private CColCallback
+class CPickup final : public CElement, private CColCallback
 {
     friend class CPickupManager;
 

--- a/Server/mods/deathmatch/logic/CPlayer.h
+++ b/Server/mods/deathmatch/logic/CPlayer.h
@@ -65,7 +65,7 @@ struct SScreenShotInfo
     CBuffer   buffer;
 };
 
-class CPlayer : public CPed, public CClient
+class CPlayer final : public CPed, public CClient
 {
     friend class CElement;
     friend class CScriptDebugging;

--- a/Server/mods/deathmatch/logic/CScriptFile.h
+++ b/Server/mods/deathmatch/logic/CScriptFile.h
@@ -15,7 +15,7 @@
 #include <stdio.h>
 #include <string>
 
-class CScriptFile : public CElement
+class CScriptFile final : public CElement
 {
 public:
     enum eMode

--- a/Server/mods/deathmatch/logic/CTeam.h
+++ b/Server/mods/deathmatch/logic/CTeam.h
@@ -19,7 +19,7 @@ class CTeam;
 
 #define MAX_TEAM_NAME 128
 
-class CTeam : public CElement
+class CTeam final : public CElement
 {
     friend class CTeamManager;
 

--- a/Server/mods/deathmatch/logic/CTrainTrack.h
+++ b/Server/mods/deathmatch/logic/CTrainTrack.h
@@ -27,7 +27,7 @@ struct STrackNode
     STrackNode() {}
 };
 
-class CTrainTrack : public CElement
+class CTrainTrack final : public CElement
 {
 public:
     CTrainTrack(CTrainTrackManager* pManager, const std::vector<STrackNode>& nodes, bool linkLastNodes, CElement* pParent, uchar defaultTrackId = 0xFF);

--- a/Server/mods/deathmatch/logic/CVehicle.h
+++ b/Server/mods/deathmatch/logic/CVehicle.h
@@ -138,7 +138,7 @@ struct SSirenInfo
 
 class CTrainTrack;
 
-class CVehicle : public CElement
+class CVehicle final : public CElement
 {
     friend class CPlayer;
 

--- a/Server/mods/deathmatch/logic/CWater.h
+++ b/Server/mods/deathmatch/logic/CWater.h
@@ -13,7 +13,7 @@
 
 class CWaterManager;
 
-class CWater : public CElement
+class CWater final : public CElement
 {
 public:
     enum EWaterType


### PR DESCRIPTION
Adding the `final` keyword allows the compiler to "devirtualize" (virtual) calls, aka inline them. 

This will probably blow some hacky code up pretty hard, im sure.