### PR TITLE
Add final where possible - server

### DIFF
--- a/Server/mods/deathmatch/logic/CConsoleClient.h
+++ b/Server/mods/deathmatch/logic/CConsoleClient.h
@@ -16,7 +16,7 @@
 #include "CConsole.h"
 #include "CLogger.h"
 
-class CConsoleClient : public CElement, public CClient
+class CConsoleClient final : public CElement, public CClient
 {
 public:
     CConsoleClient(CConsole* pConsole);

--- a/Server/mods/deathmatch/logic/CDummy.h
+++ b/Server/mods/deathmatch/logic/CDummy.h
@@ -13,7 +13,7 @@
 
 #include "CElement.h"
 
-class CDummy : public CElement
+class CDummy final : public CElement
 {
 public:
     CDummy(class CGroups* pGroups, CElement* pParent);

--- a/Server/mods/deathmatch/logic/CElement.h
+++ b/Server/mods/deathmatch/logic/CElement.h
@@ -44,7 +44,7 @@ typedef CFastList<CElement*> CChildListType;
 typedef CFastList<CElement*> CElementListType;
 
 // List of elements which is auto deleted when the last user calls Release()
-class CElementListSnapshot : public std::vector<CElement*>, public CRefCountableST
+class CElementListSnapshot final : public std::vector<CElement*>, public CRefCountableST
 {
 };
 

--- a/Server/mods/deathmatch/logic/CPickup.h
+++ b/Server/mods/deathmatch/logic/CPickup.h
@@ -19,7 +19,7 @@ class CPickup;
 #include "CElement.h"
 #include "CEvents.h"
 
-class CPickup : public CElement, private CColCallback
+class CPickup final : public CElement, private CColCallback
 {
     friend class CPickupManager;
 

--- a/Server/mods/deathmatch/logic/CPlayer.h
+++ b/Server/mods/deathmatch/logic/CPlayer.h
@@ -65,7 +65,7 @@ struct SScreenShotInfo
     CBuffer   buffer;
 };
 
-class CPlayer : public CPed, public CClient
+class CPlayer final : public CPed, public CClient
 {
     friend class CElement;
     friend class CScriptDebugging;

--- a/Server/mods/deathmatch/logic/CScriptFile.h
+++ b/Server/mods/deathmatch/logic/CScriptFile.h
@@ -15,7 +15,7 @@
 #include <stdio.h>
 #include <string>
 
-class CScriptFile : public CElement
+class CScriptFile final : public CElement
 {
 public:
     enum eMode

--- a/Server/mods/deathmatch/logic/CTeam.h
+++ b/Server/mods/deathmatch/logic/CTeam.h
@@ -19,7 +19,7 @@ class CTeam;
 
 #define MAX_TEAM_NAME 128
 
-class CTeam : public CElement
+class CTeam final : public CElement
 {
     friend class CTeamManager;
 

--- a/Server/mods/deathmatch/logic/CTrainTrack.h
+++ b/Server/mods/deathmatch/logic/CTrainTrack.h
@@ -27,7 +27,7 @@ struct STrackNode
     STrackNode() {}
 };
 
-class CTrainTrack : public CElement
+class CTrainTrack final : public CElement
 {
 public:
     CTrainTrack(CTrainTrackManager* pManager, const std::vector<STrackNode>& nodes, bool linkLastNodes, CElement* pParent, uchar defaultTrackId = 0xFF);

--- a/Server/mods/deathmatch/logic/CVehicle.h
+++ b/Server/mods/deathmatch/logic/CVehicle.h
@@ -138,7 +138,7 @@ struct SSirenInfo
 
 class CTrainTrack;
 
-class CVehicle : public CElement
+class CVehicle final : public CElement
 {
     friend class CPlayer;
 

--- a/Server/mods/deathmatch/logic/CWater.h
+++ b/Server/mods/deathmatch/logic/CWater.h
@@ -13,7 +13,7 @@
 
 class CWaterManager;
 
-class CWater : public CElement
+class CWater final : public CElement
 {
 public:
     enum EWaterType


### PR DESCRIPTION
The previous PR, but separated:

Adding the final keyword allows the compiler to "devirtualize" (virtual) calls, aka inline them.
This will probably blow some hacky code up pretty hard, im sure.