### PR TITLE
Remove dead code in CClientVehicle::SetEngineBroken

### DIFF
--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -1167,12 +1167,6 @@ void CClientVehicle::SetEngineBroken(bool bEngineBroken)
     {
         m_pVehicle->SetEngineBroken(bEngineBroken);
         m_pVehicle->SetEngineOn(!bEngineBroken);
-
-        // We need to recreate the vehicle if we're going from broken to unbroken
-        if (!bEngineBroken && m_pVehicle->IsEngineBroken())
-        {
-            ReCreate();
-        }
     }
     m_bEngineBroken = bEngineBroken;
 }


### PR DESCRIPTION
So this one is a bit weird. The code we have right now does the following:
```
        m_pVehicle->SetEngineBroken(bEngineBroken);
        m_pVehicle->SetEngineOn(!bEngineBroken);

        // We need to recreate the vehicle if we're going from broken to unbroken
        if (!bEngineBroken && m_pVehicle->IsEngineBroken())
        {
            ReCreate();
        }
```
The `if` is never actually taken, since `IsEngineBroken() == bEngineBroken` due to previously setting `SetEngineBroken(bEngineBroken);`. Usually I'd just fix the issue, however after looking into `git blame` we've had that issue (at least) since the initial open sourcing of MTA back in 2008. As I'm not aware of us having any issues with broken engines, I'd suggest we just remove the unused part of the code.