### PR TITLE
Refactor CBanManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -416,3 +416,4 @@ utils/DXFiles/
 !*.dll
 !*.exe
 utils/vswhere.exe
+refactor/

--- a/Server/mods/deathmatch/logic/CBan.cpp
+++ b/Server/mods/deathmatch/logic/CBan.cpp
@@ -26,7 +26,7 @@ CBan::~CBan()
     CBanManager::SetBansModified();
 }
 
-time_t CBan::GetBanTimeRemaining()
+time_t CBan::GetBanTimeRemaining() const noexcept
 {
     time_t End = GetTimeOfUnban();
     if (End > 0)
@@ -36,7 +36,7 @@ time_t CBan::GetBanTimeRemaining()
     return 0;
 }
 
-SString CBan::GetDurationDesc()
+SString CBan::GetDurationDesc() const noexcept
 {
     time_t Start = GetTimeOfBan();
     time_t End = GetTimeOfUnban();

--- a/Server/mods/deathmatch/logic/CBan.cpp
+++ b/Server/mods/deathmatch/logic/CBan.cpp
@@ -11,21 +11,6 @@
 
 #include "StdInc.h"
 
-CBan::CBan()
-{
-    m_uiScriptID = CIdArray::PopUniqueId(this, EIdClass::BAN);
-    m_tTimeOfBan = 0;
-    m_tTimeOfUnban = 0;
-    m_bBeingDeleted = false;
-    CBanManager::SetBansModified();
-}
-
-CBan::~CBan()
-{
-    CIdArray::PushUniqueId(this, EIdClass::BAN, m_uiScriptID);
-    CBanManager::SetBansModified();
-}
-
 time_t CBan::GetBanTimeRemaining() const noexcept
 {
     time_t End = GetTimeOfUnban();

--- a/Server/mods/deathmatch/logic/CBan.h
+++ b/Server/mods/deathmatch/logic/CBan.h
@@ -17,6 +17,28 @@
 class CBan
 {
     friend class CBanManager;
+
+    CBan() :
+        m_uiScriptID(CIdArray::PopUniqueId(this, EIdClass::BAN))
+    {
+        CBanManager::SetBansModified();
+    }
+
+    // I'm lazy to implement these, but feel free to do so if it's needed
+    // Tip: Use the copy-swap idiom:
+    // https://stackoverflow.com/questions/3279543/what-is-the-copy-and-swap-idiom
+    CBan(const CBan&) = delete;
+    CBan(CBan&&) = delete;
+    
+    ~CBan()
+    {
+        CIdArray::PushUniqueId(this, EIdClass::BAN, m_uiScriptID);
+        CBanManager::SetBansModified();
+    }
+
+    // Same as above
+    CBan& operator=(const CBan&) = delete;
+    CBan& operator=(CBan&&) = delete;
 public:
     const std::string& GetIP() const noexcept { return m_strIP; };
     void               SetIP(std::string strIP) noexcept
@@ -82,14 +104,14 @@ public:
     void    SetBeingDeleted() noexcept { m_bBeingDeleted = true; }
 
 private:
-    std::string m_strIP;
-    std::string m_strNick;
-    std::string m_strBanner;
-    std::string m_strReason;
-    std::string m_strSerial;
-    std::string m_strAccount;
-    time_t      m_tTimeOfBan;
-    time_t      m_tTimeOfUnban;
-    uint        m_uiScriptID;
-    bool        m_bBeingDeleted;
+    std::string m_strIP{};
+    std::string m_strNick{};
+    std::string m_strBanner{};
+    std::string m_strReason{};
+    std::string m_strSerial{};
+    std::string m_strAccount{};
+    time_t      m_tTimeOfBan = 0;
+    time_t      m_tTimeOfUnban = 0;
+    uint        m_uiScriptID = INVALID_ARRAY_ID;
+    bool        m_bBeingDeleted = false;
 };

--- a/Server/mods/deathmatch/logic/CBan.h
+++ b/Server/mods/deathmatch/logic/CBan.h
@@ -20,68 +20,68 @@ public:
     CBan();
     ~CBan();
 
-    const std::string& GetIP() { return m_strIP; };
-    void               SetIP(const std::string& strIP)
+    const std::string& GetIP() const noexcept { return m_strIP; };
+    void               SetIP(std::string strIP) noexcept
     {
         CBanManager::SetBansModified();
-        m_strIP = strIP;
+        m_strIP = std::move(strIP);
     };
 
-    const std::string& GetNick() { return m_strNick; };
-    void               SetNick(const std::string& strNick)
+    const std::string& GetNick() const noexcept { return m_strNick; };
+    void               SetNick(std::string strNick) noexcept
     {
         CBanManager::SetBansModified();
-        m_strNick = strNick;
+        m_strNick = std::move(strNick);
     };
 
-    const std::string& GetBanner() { return m_strBanner; };
-    void               SetBanner(const std::string& strBanner)
+    const std::string& GetBanner() const noexcept { return m_strBanner; };
+    void               SetBanner(std::string strBanner) noexcept
     {
         CBanManager::SetBansModified();
-        m_strBanner = strBanner;
+        m_strBanner = std::move(strBanner);
     };
 
-    const std::string& GetReason() { return m_strReason; };
-    void               SetReason(const std::string& strReason)
+    const std::string& GetReason() const noexcept { return m_strReason; };
+    void               SetReason(std::string strReason) noexcept
     {
         CBanManager::SetBansModified();
-        m_strReason = strReason;
+        m_strReason = std::move(strReason);
     };
 
-    const time_t GetTimeOfBan() { return m_tTimeOfBan; };
-    void         SetTimeOfBan(time_t tTimeOfBan)
+    const time_t GetTimeOfBan() const noexcept { return m_tTimeOfBan; };
+    void         SetTimeOfBan(time_t tTimeOfBan) noexcept
     {
         CBanManager::SetBansModified();
         m_tTimeOfBan = tTimeOfBan;
     };
 
-    time_t GetTimeOfUnban() { return m_tTimeOfUnban; };
-    void   SetTimeOfUnban(time_t tTimeOfUnban)
+    time_t GetTimeOfUnban() const noexcept { return m_tTimeOfUnban; };
+    void   SetTimeOfUnban(time_t tTimeOfUnban) noexcept
     {
         CBanManager::SetBansModified();
         m_tTimeOfUnban = tTimeOfUnban;
     };
 
-    const std::string& GetSerial() { return m_strSerial; };
-    void               SetSerial(const std::string& strSerial)
+    const std::string& GetSerial() const noexcept { return m_strSerial; };
+    void               SetSerial(std::string strSerial) noexcept
     {
         CBanManager::SetBansModified();
-        m_strSerial = strSerial;
+        m_strSerial = std::move(strSerial);
     };
 
-    const std::string& GetAccount() { return m_strAccount; };
-    void               SetAccount(const std::string& strAccount)
+    const std::string& GetAccount() const noexcept { return m_strAccount; };
+    void               SetAccount(std::string strAccount) noexcept
     {
         CBanManager::SetBansModified();
-        m_strAccount = strAccount;
+        m_strAccount = std::move(strAccount);
     };
 
-    time_t  GetBanTimeRemaining();
-    SString GetDurationDesc();
-    SString GetReasonText() const;
-    uint    GetScriptID() const { return m_uiScriptID; }
-    bool    IsBeingDeleted() const { return m_bBeingDeleted; }
-    void    SetBeingDeleted() { m_bBeingDeleted = true; }
+    time_t  GetBanTimeRemaining() const noexcept;
+    SString GetDurationDesc() const noexcept;
+    SString GetReasonText() const noexcept;
+    uint    GetScriptID() const noexcept { return m_uiScriptID; }
+    bool    IsBeingDeleted() const noexcept { return m_bBeingDeleted; }
+    void    SetBeingDeleted() noexcept { m_bBeingDeleted = true; }
 
 private:
     std::string m_strIP;

--- a/Server/mods/deathmatch/logic/CBan.h
+++ b/Server/mods/deathmatch/logic/CBan.h
@@ -16,10 +16,8 @@
 
 class CBan
 {
+    friend class CBanManager;
 public:
-    CBan();
-    ~CBan();
-
     const std::string& GetIP() const noexcept { return m_strIP; };
     void               SetIP(std::string strIP) noexcept
     {

--- a/Server/mods/deathmatch/logic/CBanManager.cpp
+++ b/Server/mods/deathmatch/logic/CBanManager.cpp
@@ -22,12 +22,12 @@ CBanManager::CBanManager() :
 CBanManager::~CBanManager()
 {
     SaveBanList();
-    list<CBan*>::const_iterator iter = m_BanManager.begin();
-    for (; iter != m_BanManager.end(); iter++)
+    list<CBan*>::const_iterator iter = m_Bans.begin();
+    for (; iter != m_Bans.end(); iter++)
     {
         delete *iter;
     }
-    m_BanManager.clear();
+    m_Bans.clear();
 
     // Cleanup queued deletions
     for (std::set<CBan*>::iterator iter = m_BansBeingDeleted.begin(); iter != m_BansBeingDeleted.end(); iter++)
@@ -43,8 +43,8 @@ void CBanManager::DoPulse()
 
     if (tTime > m_NextUpdateTime)
     {
-        list<CBan*>::const_iterator iter = m_BanManager.begin();
-        while (iter != m_BanManager.end())
+        list<CBan*>::const_iterator iter = m_Bans.begin();
+        while (iter != m_Bans.end())
         {
             if ((*iter)->GetTimeOfUnban() > 0)
             {
@@ -56,7 +56,7 @@ void CBanManager::DoPulse()
                     g_pGame->GetMapManager()->GetRootElement()->CallEvent("onUnban", Arguments);
 
                     RemoveBan(*iter);
-                    iter = m_BanManager.begin();
+                    iter = m_Bans.begin();
                     continue;
                 }
             }
@@ -176,7 +176,7 @@ CBan* CBanManager::AddBan(const SString& strBanner, const SString& strReason, ti
         pBan->SetBanner(strBanner);
 
     // Add it to the back of our banned list, add it to net server's ban list
-    m_BanManager.push_back(pBan);
+    m_Bans.push_back(pBan);
 
     return pBan;
 }
@@ -184,14 +184,14 @@ CBan* CBanManager::AddBan(const SString& strBanner, const SString& strReason, ti
 CBan* CBanManager::GetBanFromScriptID(uint uiScriptID)
 {
     CBan* pBan = (CBan*)CIdArray::FindEntry(uiScriptID, EIdClass::BAN);
-    dassert(!pBan || ListContains(m_BanManager, pBan));
+    dassert(!pBan || ListContains(m_Bans, pBan));
     return pBan;
 }
 
 bool CBanManager::IsSpecificallyBanned(const char* szIP)
 {
-    list<CBan*>::const_iterator iter = m_BanManager.begin();
-    for (; iter != m_BanManager.end(); iter++)
+    list<CBan*>::const_iterator iter = m_Bans.begin();
+    for (; iter != m_Bans.end(); iter++)
     {
         if ((*iter)->GetIP() == szIP)
         {
@@ -204,8 +204,8 @@ bool CBanManager::IsSpecificallyBanned(const char* szIP)
 
 bool CBanManager::IsSerialBanned(const char* szSerial)
 {
-    list<CBan*>::const_iterator iter = m_BanManager.begin();
-    for (; iter != m_BanManager.end(); iter++)
+    list<CBan*>::const_iterator iter = m_Bans.begin();
+    for (; iter != m_Bans.end(); iter++)
     {
         if ((*iter)->GetSerial() == szSerial)
         {
@@ -218,8 +218,8 @@ bool CBanManager::IsSerialBanned(const char* szSerial)
 
 bool CBanManager::IsAccountBanned(const char* szAccount)
 {
-    list<CBan*>::const_iterator iter = m_BanManager.begin();
-    for (; iter != m_BanManager.end(); iter++)
+    list<CBan*>::const_iterator iter = m_Bans.begin();
+    for (; iter != m_Bans.end(); iter++)
     {
         if ((*iter)->GetAccount() == szAccount)
         {
@@ -232,8 +232,8 @@ bool CBanManager::IsAccountBanned(const char* szAccount)
 
 CBan* CBanManager::GetBanFromAccount(const char* szAccount)
 {
-    list<CBan*>::const_iterator iter = m_BanManager.begin();
-    for (; iter != m_BanManager.end(); iter++)
+    list<CBan*>::const_iterator iter = m_Bans.begin();
+    for (; iter != m_Bans.end(); iter++)
     {
         if ((*iter)->GetAccount() == szAccount)
         {
@@ -246,9 +246,9 @@ CBan* CBanManager::GetBanFromAccount(const char* szAccount)
 
 void CBanManager::RemoveBan(CBan* pBan)
 {
-    if (m_BanManager.Contains(pBan))
+    if (m_Bans.Contains(pBan))
     {
-        m_BanManager.remove(pBan);
+        m_Bans.remove(pBan);
         MapInsert(m_BansBeingDeleted, pBan);
         pBan->SetBeingDeleted();
     }
@@ -259,8 +259,8 @@ CBan* CBanManager::GetBanFromIP(const char* szIP)
 {
     CBan* pBanWildcardMatch = NULL;
 
-    list<CBan*>::const_iterator iter = m_BanManager.begin();
-    for (; iter != m_BanManager.end(); iter++)
+    list<CBan*>::const_iterator iter = m_Bans.begin();
+    for (; iter != m_Bans.end(); iter++)
     {
         const SString& strIP = (*iter)->GetIP().c_str();
 
@@ -295,8 +295,8 @@ CBan* CBanManager::GetBanFromIP(const char* szIP)
 
 CBan* CBanManager::GetBanFromSerial(const char* szSerial)
 {
-    list<CBan*>::const_iterator iter = m_BanManager.begin();
-    for (; iter != m_BanManager.end(); iter++)
+    list<CBan*>::const_iterator iter = m_Bans.begin();
+    for (; iter != m_Bans.end(); iter++)
     {
         if ((*iter)->GetSerial() == szSerial)
             return *iter;
@@ -307,8 +307,8 @@ CBan* CBanManager::GetBanFromSerial(const char* szSerial)
 unsigned int CBanManager::GetBansWithNick(const char* szNick)
 {
     unsigned int                uiOccurrances = 0;
-    list<CBan*>::const_iterator iter = m_BanManager.begin();
-    for (; iter != m_BanManager.end(); iter++)
+    list<CBan*>::const_iterator iter = m_Bans.begin();
+    for (; iter != m_Bans.end(); iter++)
     {
         if ((*iter)->GetNick() == szNick)
         {
@@ -322,8 +322,8 @@ unsigned int CBanManager::GetBansWithNick(const char* szNick)
 unsigned int CBanManager::GetBansWithBanner(const char* szBanner)
 {
     unsigned int                uiOccurrances = 0;
-    list<CBan*>::const_iterator iter = m_BanManager.begin();
-    for (; iter != m_BanManager.end(); iter++)
+    list<CBan*>::const_iterator iter = m_Bans.begin();
+    for (; iter != m_Bans.end(); iter++)
     {
         if ((*iter)->GetBanner(), szBanner)
         {
@@ -419,14 +419,14 @@ bool CBanManager::ReloadBanList()
     if (ms_bSaveRequired)
         SaveBanList();
 
-    list<CBan*>::const_iterator iter = m_BanManager.begin();
-    for (; iter != m_BanManager.end(); iter++)
+    list<CBan*>::const_iterator iter = m_Bans.begin();
+    for (; iter != m_Bans.end(); iter++)
     {
         CBan* pBan = *iter;
         MapInsert(m_BansBeingDeleted, pBan);
         pBan->SetBeingDeleted();
     }
-    m_BanManager.clear();
+    m_Bans.clear();
 
     return LoadBanList();
 }
@@ -449,8 +449,8 @@ void CBanManager::SaveBanList()
         {
             // Iterate the ban list adding it to the XML tree
             CXMLNode*                   pNode;
-            list<CBan*>::const_iterator iter = m_BanManager.begin();
-            for (; iter != m_BanManager.end(); iter++)
+            list<CBan*>::const_iterator iter = m_Bans.begin();
+            for (; iter != m_Bans.end(); iter++)
             {
                 pNode = pRootNode->CreateSubNode("ban");
 

--- a/Server/mods/deathmatch/logic/CBanManager.cpp
+++ b/Server/mods/deathmatch/logic/CBanManager.cpp
@@ -15,7 +15,7 @@ bool CBanManager::ms_bSaveRequired = false;
 CBanManager::CBanManager()
 {
     m_strBanListXMLPath = g_pServerInterface->GetModManager()->GetAbsolutePath(FILENAME_BANLIST);
-    m_tUpdate = 0;
+    m_NextUpdateTime = 0;
     m_bAllowSave = false;
 }
 
@@ -41,7 +41,7 @@ void CBanManager::DoPulse()
 {
     time_t tTime = time(NULL);
 
-    if (tTime > m_tUpdate)
+    if (tTime > m_NextUpdateTime)
     {
         list<CBan*>::const_iterator iter = m_BanManager.begin();
         while (iter != m_BanManager.end())
@@ -62,7 +62,7 @@ void CBanManager::DoPulse()
             }
             iter++;
         }
-        m_tUpdate = tTime + 1;
+        m_NextUpdateTime = tTime + 1;
     }
 
     if (ms_bSaveRequired)

--- a/Server/mods/deathmatch/logic/CBanManager.cpp
+++ b/Server/mods/deathmatch/logic/CBanManager.cpp
@@ -160,24 +160,24 @@ CBan* CBanManager::AddBan(const SString& strBanner, const SString& strReason, ti
     return &ban;
 }
 
-bool CBanManager::IsSerialBanned(std::string_view serial)
+bool CBanManager::IsSerialBanned(std::string_view serial) const noexcept
 {
     return (bool)GetBanFromSerial(serial);
 }
 
-bool CBanManager::IsAccountBanned(std::string_view account)
+bool CBanManager::IsAccountBanned(std::string_view account) const noexcept
 {
     return (bool)GetBanFromAccount(account);
 }
 
-bool CBanManager::IsSpecificallyBanned(std::string_view IP)
+bool CBanManager::IsSpecificallyBanned(std::string_view IP) const noexcept
 {
     return FindIf([=](const CBan& ban) {
         return ban.GetIP() == IP; });
 }
 
 // Include wildcard checks
-CBan* CBanManager::GetBanFromIP(std::string_view ip)
+CBan* CBanManager::GetBanFromIP(std::string_view ip) const noexcept
 {
     return FindIf([=](const CBan& ban) {
         const auto& bannedIP = ban.GetIP();
@@ -202,32 +202,32 @@ CBan* CBanManager::GetBanFromIP(std::string_view ip)
     });
 }
 
-CBan* CBanManager::GetBanFromScriptID(uint uiScriptID)
+CBan* CBanManager::GetBanFromScriptID(uint uiScriptID) const noexcept
 {
     CBan* pBan = (CBan*)CIdArray::FindEntry(uiScriptID, EIdClass::BAN);
     dassert(!pBan || ListContains(m_Bans, pBan));
     return pBan;
 }
 
-CBan* CBanManager::GetBanFromAccount(std::string_view account)
+CBan* CBanManager::GetBanFromAccount(std::string_view account) const noexcept
 {
     return FindIf([=](const CBan& ban) {
         return ban.GetAccount() == account; });
 }
 
-CBan* CBanManager::GetBanFromSerial(std::string_view serial)
+CBan* CBanManager::GetBanFromSerial(std::string_view serial) const noexcept
 {
     return FindIf([=](const CBan& ban) {
         return ban.GetSerial() == serial; });
 }
 
-unsigned int CBanManager::GetBansWithNick(std::string_view nick)
+unsigned int CBanManager::GetBansWithNick(std::string_view nick) const noexcept
 {
     return CountIf([=](const CBan& ban) {
         return ban.GetNick() == nick; });
 }
 
-unsigned int CBanManager::GetBansWithBanner(std::string_view banner)
+unsigned int CBanManager::GetBansWithBanner(std::string_view banner) const noexcept
 {
     return CountIf([=](const CBan& ban) {
         return ban.GetBanner() == banner; });

--- a/Server/mods/deathmatch/logic/CBanManager.cpp
+++ b/Server/mods/deathmatch/logic/CBanManager.cpp
@@ -14,7 +14,7 @@ bool CBanManager::ms_bSaveRequired = false;
 
 CBanManager::CBanManager()
 {
-    m_strPath = g_pServerInterface->GetModManager()->GetAbsolutePath(FILENAME_BANLIST);
+    m_strBanListXMLPath = g_pServerInterface->GetModManager()->GetAbsolutePath(FILENAME_BANLIST);
     m_tUpdate = 0;
     m_bAllowSave = false;
 }
@@ -339,7 +339,7 @@ bool CBanManager::LoadBanList()
     m_bAllowSave = true;
 
     // Create the XML
-    CXMLFile* pFile = g_pServerInterface->GetXML()->CreateXML(m_strPath);
+    CXMLFile* pFile = g_pServerInterface->GetXML()->CreateXML(m_strBanListXMLPath);
     if (!pFile)
     {
         return false;
@@ -349,7 +349,7 @@ bool CBanManager::LoadBanList()
     if (!pFile->Parse())
     {
         delete pFile;
-        if (FileExists(m_strPath))
+        if (FileExists(m_strBanListXMLPath))
             CLogger::ErrorPrintf("Error parsing banlist\n");
         return false;
     }
@@ -438,7 +438,7 @@ void CBanManager::SaveBanList()
         return;
 
     // Create the XML file
-    CXMLFile* pFile = g_pServerInterface->GetXML()->CreateXML(m_strPath);
+    CXMLFile* pFile = g_pServerInterface->GetXML()->CreateXML(m_strBanListXMLPath);
     if (pFile)
     {
         // create the root node again as you are outputting all the bans again not just new ones

--- a/Server/mods/deathmatch/logic/CBanManager.cpp
+++ b/Server/mods/deathmatch/logic/CBanManager.cpp
@@ -12,11 +12,11 @@
 #include "StdInc.h"
 bool CBanManager::ms_bSaveRequired = false;
 
-CBanManager::CBanManager()
+CBanManager::CBanManager() :
+    m_strBanListXMLPath(g_pServerInterface->GetModManager()->GetAbsolutePath(FILENAME_BANLIST)),
+    m_NextUpdateTime(0),
+    m_bAllowSave(false)
 {
-    m_strBanListXMLPath = g_pServerInterface->GetModManager()->GetAbsolutePath(FILENAME_BANLIST);
-    m_NextUpdateTime = 0;
-    m_bAllowSave = false;
 }
 
 CBanManager::~CBanManager()

--- a/Server/mods/deathmatch/logic/CBanManager.cpp
+++ b/Server/mods/deathmatch/logic/CBanManager.cpp
@@ -410,23 +410,19 @@ bool CBanManager::IsValidIP(const char* szIP)
 
     if (szIP1 && szIP2 && szIP3 && szIP4)
     {
-        if (IsValidIPPart(szIP1) && IsValidIPPart(szIP2) && IsValidIPPart(szIP3) && IsValidIPPart(szIP4))
-            return true;
+        auto IsValidIPPart = [](const char* part) {
+            if (IsNumericString(part))
+            {
+                int iIP = atoi(part);
+                if (iIP >= 0 && iIP < 256)
+                    return true;
+            }
+            else if (strcmp(part, "*") == 0)
+                return true;
+
+            return false;
+        };
+        return IsValidIPPart(szIP1) && IsValidIPPart(szIP2) && IsValidIPPart(szIP3) && IsValidIPPart(szIP4);
     }
-
-    return false;
-}
-
-bool CBanManager::IsValidIPPart(const char* szIP)
-{
-    if (IsNumericString(szIP))
-    {
-        int iIP = atoi(szIP);
-        if (iIP >= 0 && iIP < 256)
-            return true;
-    }
-    else if (strcmp(szIP, "*") == 0)
-        return true;
-
     return false;
 }

--- a/Server/mods/deathmatch/logic/CBanManager.h
+++ b/Server/mods/deathmatch/logic/CBanManager.h
@@ -38,18 +38,19 @@ public:
 
     CBan* AddBan(const SString& strBanner = "Console", const SString& strReason = "", time_t tTimeOfUnban = 0);
 
-    bool  IsSpecificallyBanned(std::string_view ip);
-    bool  IsSerialBanned(std::string_view serial);
-    bool  IsAccountBanned(std::string_view account);
+    bool  IsSpecificallyBanned(std::string_view ip) const noexcept;
+    bool  IsSerialBanned(std::string_view serial) const noexcept;
+    bool  IsAccountBanned(std::string_view account) const noexcept;
+
+    CBan* GetBanFromIP(std::string_view ip) const noexcept;
+    CBan* GetBanFromScriptID(uint uiScriptID) const noexcept;
+    CBan* GetBanFromAccount(std::string_view account) const noexcept;
+    CBan* GetBanFromSerial(std::string_view serial) const noexcept;
+
+    unsigned int GetBansWithNick(std::string_view szNick) const noexcept;
+    unsigned int GetBansWithBanner(std::string_view szBanner) const noexcept;
+
     void  RemoveBan(CBan* pBan);
-
-    CBan* GetBanFromIP(std::string_view ip);
-    CBan* GetBanFromScriptID(uint uiScriptID);
-    CBan* GetBanFromAccount(std::string_view account);
-    CBan* GetBanFromSerial(std::string_view serial);
-
-    unsigned int GetBansWithNick(std::string_view szNick);
-    unsigned int GetBansWithBanner(std::string_view szBanner);
 
     bool        LoadBanList();
     bool        ReloadBanList();

--- a/Server/mods/deathmatch/logic/CBanManager.h
+++ b/Server/mods/deathmatch/logic/CBanManager.h
@@ -58,12 +58,14 @@ public:
     static bool IsValidIP(const char* szIP);
     static void SetBansModified() { ms_bSaveRequired = true; }
 
+    size_t GetCount() const noexcept { return m_Bans.size(); }
+
     // Iterate thru bans that aren't currently being deleted
     // Even in the class itself use this, not a range based for loop!
     template<class Functor_t>
     void IterBans(const Functor_t& f) const noexcept
     {
-        for (const CBan& ban : m_Bans)
+        for (CBan& ban : m_Bans)
             if (!ban.IsBeingDeleted())
                 f(ban);
     }

--- a/Server/mods/deathmatch/logic/CBanManager.h
+++ b/Server/mods/deathmatch/logic/CBanManager.h
@@ -14,6 +14,11 @@
 #include "CClient.h"
 #include "CPlayerManager.h"
 
+#include <unordered_set>
+#include <vector>
+#include <memory>
+
+
 class CBanManager
 {
 public:
@@ -56,14 +61,14 @@ public:
     bool        IsValidIP(const char* szIP);
     static void SetBansModified() { ms_bSaveRequired = true; }
 
-    list<CBan*>::const_iterator IterBegin() { return m_BanManager.begin(); };
-    list<CBan*>::const_iterator IterEnd() { return m_BanManager.end(); };
+    list<CBan*>::const_iterator IterBegin() { return m_Bans.begin(); };
+    list<CBan*>::const_iterator IterEnd() { return m_Bans.end(); };
 
 private:
     SString m_strBanListXMLPath;
 
-    CMappedList<CBan*> m_BanManager;
-    std::set<CBan*>    m_BansBeingDeleted;
+    CMappedList<CBan*> m_Bans;
+    std::unordered_set<CBan*>    m_BansBeingDeleted;
 
     time_t m_NextUpdateTime;
 

--- a/Server/mods/deathmatch/logic/CBanManager.h
+++ b/Server/mods/deathmatch/logic/CBanManager.h
@@ -54,7 +54,7 @@ public:
     bool        LoadBanList();
     bool        ReloadBanList();
     void        SaveBanList();
-    bool        IsValidIP(const char* szIP);
+    static bool IsValidIP(const char* szIP);
     static void SetBansModified() { ms_bSaveRequired = true; }
 
     // Iterate thru bans that aren't currently being deleted
@@ -97,7 +97,6 @@ private:
 
     time_t m_NextUpdateTime;
 
-    bool        IsValidIPPart(const char* szIP);
     bool        m_bAllowSave;
     static bool ms_bSaveRequired;
 };

--- a/Server/mods/deathmatch/logic/CBanManager.h
+++ b/Server/mods/deathmatch/logic/CBanManager.h
@@ -60,12 +60,12 @@ public:
     list<CBan*>::const_iterator IterEnd() { return m_BanManager.end(); };
 
 private:
-    SString m_strPath;
+    SString m_strBanListXMLPath;
 
     CMappedList<CBan*> m_BanManager;
     std::set<CBan*>    m_BansBeingDeleted;
 
-    time_t m_tUpdate;
+    time_t m_NextUpdateTime;
 
     bool        IsValidIPPart(const char* szIP);
     bool        m_bAllowSave;

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -11710,17 +11710,14 @@ bool CStaticFunctionDefinitions::RemoveBan(CBan* pBan, CPlayer* pResponsible)
     return true;
 }
 
-bool CStaticFunctionDefinitions::GetBans(lua_State* pLua)
+bool CStaticFunctionDefinitions::GetBans(lua_State* luaVM)
 {
-    list<CBan*>::const_iterator iter = m_pBanManager->IterBegin();
-    unsigned int                uiIndex = 0;
-
-    for (; iter != m_pBanManager->IterEnd(); iter++)
-    {
-        lua_pushnumber(pLua, ++uiIndex);
-        lua_pushban(pLua, *iter);
-        lua_settable(pLua, -3);
-    }
+    lua_Number index = 1;
+    m_pBanManager->IterBans([&index, luaVM](CBan& ban) {
+        lua_pushnumber(luaVM, index++);
+        lua_pushban(luaVM, &ban);
+        lua_settable(luaVM, -3);
+    });
     return true;
 }
 


### PR DESCRIPTION
I still think our implementation is horrible.
But nothing I can do about it. We can't use a database, because all calls are blocking, so it would be too slow I presume.
What do others think? Because I feel like this XML magic isn't optimal at all.

Currently, all changes to the ban list are written to the disk at the end of the frame.
So, even if you change a ban / frame, it'll rewrite the whole xml, which isn't fast at all.

This PR:
- todo...