### PR TITLE
Fix #927: "Random collisionless objects" still exist

### DIFF
--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -1243,7 +1243,6 @@ void CModelInfoSA::SetColModel(CColModel* pColModel)
 
         // FUNC_SetColModel resets bDoWeOwnTheColModel
         m_pInterface->bDoWeOwnTheColModel = false;
-        m_pInterface->bCollisionWasStreamedWithModel = false;
 
         // public: static void __cdecl CColAccel::addCacheCol(int, class CColModel const &)
         DWORD func = 0x5B2C20;
@@ -1293,6 +1292,8 @@ void CModelInfoSA::RestoreColModel()
                 push    dwOriginalColModelInterface
                 call    dwFunc
             }
+
+            m_pInterface->bDoWeOwnTheColModel = false;
 
             // public: static void __cdecl CColAccel::addCacheCol(int, class CColModel const &)
             DWORD func = 0x5B2C20;


### PR DESCRIPTION
Thanks @iDannz for good bug description.