### PR TITLE
Optimize CCustomData 

### DIFF
--- a/Server/mods/deathmatch/logic/CCustomData.cpp
+++ b/Server/mods/deathmatch/logic/CCustomData.cpp
@@ -11,15 +11,6 @@
 
 #include "StdInc.h"
 
-void CCustomData::Copy(CCustomData* pCustomData)
-{
-    map<std::string, SCustomData>::const_iterator iter = pCustomData->IterBegin();
-    for (; iter != pCustomData->IterEnd(); iter++)
-    {
-        Set(iter->first.c_str(), iter->second.Variable);
-    }
-}
-
 SCustomData* CCustomData::Get(const char* szName)
 {
     assert(szName);

--- a/Server/mods/deathmatch/logic/CCustomData.cpp
+++ b/Server/mods/deathmatch/logic/CCustomData.cpp
@@ -13,29 +13,26 @@
 
 CXMLNode* CCustomData::OutputToXML(CXMLNode* pNode)
 {
-    std::map<std::string, SCustomData>::const_iterator iter = m_Data.begin();
-    for (; iter != m_Data.end(); iter++)
+    for (auto& [name, data] : m_Data)
     {
-        CLuaArgument* arg = (CLuaArgument*)&iter->second.Variable;
-
-        switch (arg->GetType())
+        switch (data.Variable.GetType())
         {
             case LUA_TSTRING:
             {
-                CXMLAttribute* attr = pNode->GetAttributes().Create(iter->first.c_str());
-                attr->SetValue(arg->GetString().c_str());
+                CXMLAttribute* attr = pNode->GetAttributes().Create(name.c_str());
+                attr->SetValue(data.Variable.GetString().c_str());
                 break;
             }
             case LUA_TNUMBER:
             {
-                CXMLAttribute* attr = pNode->GetAttributes().Create(iter->first.c_str());
-                attr->SetValue((float)arg->GetNumber());
+                CXMLAttribute* attr = pNode->GetAttributes().Create(name.c_str());
+                attr->SetValue((float)data.Variable.GetNumber());
                 break;
             }
             case LUA_TBOOLEAN:
             {
-                CXMLAttribute* attr = pNode->GetAttributes().Create(iter->first.c_str());
-                attr->SetValue(arg->GetBoolean());
+                CXMLAttribute* attr = pNode->GetAttributes().Create(name.c_str());
+                attr->SetValue(data.Variable.GetBoolean());
                 break;
             }
         }

--- a/Server/mods/deathmatch/logic/CCustomData.cpp
+++ b/Server/mods/deathmatch/logic/CCustomData.cpp
@@ -31,17 +31,6 @@ SCustomData* CCustomData::Get(const char* szName)
     return NULL;
 }
 
-SCustomData* CCustomData::GetSynced(const char* szName)
-{
-    assert(szName);
-
-    std::map<std::string, SCustomData>::const_iterator it = m_SyncedData.find(szName);
-    if (it != m_SyncedData.end())
-        return (SCustomData*)&it->second;
-
-    return NULL;
-}
-
 bool CCustomData::DeleteSynced(const char* szName)
 {
     // Find the item and delete it

--- a/Server/mods/deathmatch/logic/CCustomData.cpp
+++ b/Server/mods/deathmatch/logic/CCustomData.cpp
@@ -31,30 +31,6 @@ SCustomData* CCustomData::Get(const char* szName)
     return NULL;
 }
 
-void CCustomData::UpdateSynced(const char* szName, const CLuaArgument& Variable, ESyncType syncType)
-{
-    if (syncType == ESyncType::BROADCAST)
-    {
-        SCustomData* pDataSynced = GetSynced(szName);
-        if (pDataSynced)
-        {
-            pDataSynced->Variable = Variable;
-            pDataSynced->syncType = syncType;
-        }
-        else
-        {
-            SCustomData newData;
-            newData.Variable = Variable;
-            newData.syncType = syncType;
-            m_SyncedData[szName] = newData;
-        }
-    }
-    else
-    {
-        DeleteSynced(szName);
-    }
-}
-
 void CCustomData::Set(const char* szName, const CLuaArgument& Variable, ESyncType syncType)
 {
     assert(szName);

--- a/Server/mods/deathmatch/logic/CCustomData.cpp
+++ b/Server/mods/deathmatch/logic/CCustomData.cpp
@@ -11,45 +11,6 @@
 
 #include "StdInc.h"
 
-void CCustomData::Set(const std::string& szName, const CLuaArgument& Variable, ESyncType syncType)
-{
-    assert(szName);
-
-    // Grab the item with the given name
-    SCustomData* pData = Get(szName);
-    if (pData)
-    {
-        // Update existing
-        pData->Variable = Variable;
-        pData->syncType = syncType;
-        UpdateSynced(szName, Variable, syncType);
-    }
-    else
-    {
-        // Add new
-        SCustomData newData;
-        newData.Variable = Variable;
-        newData.syncType = syncType;
-        m_Data[szName] = newData;
-        UpdateSynced(szName, Variable, syncType);
-    }
-}
-
-bool CCustomData::Delete(const std::string& szName)
-{
-    // Find the item and delete it
-    std::map<std::string, SCustomData>::iterator it = m_Data.find(szName);
-    if (it != m_Data.end())
-    {
-        DeleteSynced(szName);
-        m_Data.erase(it);
-        return true;
-    }
-
-    // Didn't exist
-    return false;
-}
-
 CXMLNode* CCustomData::OutputToXML(CXMLNode* pNode)
 {
     std::map<std::string, SCustomData>::const_iterator iter = m_Data.begin();

--- a/Server/mods/deathmatch/logic/CCustomData.cpp
+++ b/Server/mods/deathmatch/logic/CCustomData.cpp
@@ -150,8 +150,3 @@ CXMLNode* CCustomData::OutputToXML(CXMLNode* pNode)
     }
     return pNode;
 }
-
-unsigned short CCustomData::CountOnlySynchronized()
-{
-    return static_cast<unsigned short>(m_SyncedData.size());
-}

--- a/Server/mods/deathmatch/logic/CCustomData.cpp
+++ b/Server/mods/deathmatch/logic/CCustomData.cpp
@@ -31,20 +31,6 @@ SCustomData* CCustomData::Get(const char* szName)
     return NULL;
 }
 
-bool CCustomData::DeleteSynced(const char* szName)
-{
-    // Find the item and delete it
-    std::map<std::string, SCustomData>::iterator iter = m_SyncedData.find(szName);
-    if (iter != m_SyncedData.end())
-    {
-        m_SyncedData.erase(iter);
-        return true;
-    }
-
-    // Didn't exist
-    return false;
-}
-
 void CCustomData::UpdateSynced(const char* szName, const CLuaArgument& Variable, ESyncType syncType)
 {
     if (syncType == ESyncType::BROADCAST)

--- a/Server/mods/deathmatch/logic/CCustomData.cpp
+++ b/Server/mods/deathmatch/logic/CCustomData.cpp
@@ -11,17 +11,6 @@
 
 #include "StdInc.h"
 
-SCustomData* CCustomData::Get(const std::string& name)
-{
-    assert(szName);
-
-    std::map<std::string, SCustomData>::const_iterator it = m_Data.find(szName);
-    if (it != m_Data.end())
-        return (SCustomData*)&it->second;
-
-    return NULL;
-}
-
 void CCustomData::Set(const std::string& szName, const CLuaArgument& Variable, ESyncType syncType)
 {
     assert(szName);

--- a/Server/mods/deathmatch/logic/CCustomData.cpp
+++ b/Server/mods/deathmatch/logic/CCustomData.cpp
@@ -11,7 +11,7 @@
 
 #include "StdInc.h"
 
-SCustomData* CCustomData::Get(const char* szName)
+SCustomData* CCustomData::Get(const std::string& name)
 {
     assert(szName);
 
@@ -22,7 +22,7 @@ SCustomData* CCustomData::Get(const char* szName)
     return NULL;
 }
 
-void CCustomData::Set(const char* szName, const CLuaArgument& Variable, ESyncType syncType)
+void CCustomData::Set(const std::string& szName, const CLuaArgument& Variable, ESyncType syncType)
 {
     assert(szName);
 
@@ -46,7 +46,7 @@ void CCustomData::Set(const char* szName, const CLuaArgument& Variable, ESyncTyp
     }
 }
 
-bool CCustomData::Delete(const char* szName)
+bool CCustomData::Delete(const std::string& szName)
 {
     // Find the item and delete it
     std::map<std::string, SCustomData>::iterator it = m_Data.find(szName);

--- a/Server/mods/deathmatch/logic/CCustomData.h
+++ b/Server/mods/deathmatch/logic/CCustomData.h
@@ -50,7 +50,6 @@ public:
     std::map<std::string, SCustomData>::const_iterator SyncedIterEnd() { return m_SyncedData.end(); }
 
 private:
-    bool DeleteSynced(const char* szName);
     void UpdateSynced(const char* szName, const CLuaArgument& Variable, ESyncType syncType);
 
     std::map<std::string, SCustomData> m_Data;

--- a/Server/mods/deathmatch/logic/CCustomData.h
+++ b/Server/mods/deathmatch/logic/CCustomData.h
@@ -36,7 +36,12 @@ class CCustomData
 public:
     SCustomData* Get(const std::string& name) { return MapFind(m_Data, name); }
 
-    bool Delete(const std::string& name);
+    void Set(const std::string& name, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST)
+    {
+        auto& data = m_Data[name];
+        data.Variable = Variable;
+        data.syncType = syncType;
+    }
 
     CXMLNode* OutputToXML(CXMLNode* pNode);
 

--- a/Server/mods/deathmatch/logic/CCustomData.h
+++ b/Server/mods/deathmatch/logic/CCustomData.h
@@ -58,5 +58,5 @@ public:
 
     const auto& GetAll() const noexcept { return m_Data; }
 private:
-    SharedUtil::CFastHashMap<std::string, SCustomData> m_Data;
+    SharedUtil::CFastHashMap<SString, SCustomData> m_Data;
 };

--- a/Server/mods/deathmatch/logic/CCustomData.h
+++ b/Server/mods/deathmatch/logic/CCustomData.h
@@ -34,8 +34,6 @@ struct SCustomData
 class CCustomData
 {
 public:
-    void Copy(CCustomData* pCustomData);
-
     SCustomData* Get(const char* szName);
     void         Set(const char* szName, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST);
 

--- a/Server/mods/deathmatch/logic/CCustomData.h
+++ b/Server/mods/deathmatch/logic/CCustomData.h
@@ -50,8 +50,6 @@ public:
     std::map<std::string, SCustomData>::const_iterator SyncedIterEnd() { return m_SyncedData.end(); }
 
 private:
-    void UpdateSynced(const char* szName, const CLuaArgument& Variable, ESyncType syncType);
-
     std::map<std::string, SCustomData> m_Data;
     std::map<std::string, SCustomData> m_SyncedData;
 };

--- a/Server/mods/deathmatch/logic/CCustomData.h
+++ b/Server/mods/deathmatch/logic/CCustomData.h
@@ -43,11 +43,6 @@ public:
 
     std::map<std::string, SCustomData>::const_iterator IterBegin() { return m_Data.begin(); }
     std::map<std::string, SCustomData>::const_iterator IterEnd() { return m_Data.end(); }
-
-    std::map<std::string, SCustomData>::const_iterator SyncedIterBegin() { return m_SyncedData.begin(); }
-    std::map<std::string, SCustomData>::const_iterator SyncedIterEnd() { return m_SyncedData.end(); }
-
 private:
     std::map<std::string, SCustomData> m_Data;
-    std::map<std::string, SCustomData> m_SyncedData;
 };

--- a/Server/mods/deathmatch/logic/CCustomData.h
+++ b/Server/mods/deathmatch/logic/CCustomData.h
@@ -34,8 +34,7 @@ struct SCustomData
 class CCustomData
 {
 public:
-    SCustomData* Get(const std::string& szName);
-    void         Set(const std::string& szName, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST);
+    SCustomData* Get(const std::string& name) { return MapFind(m_Data, name); }
 
     bool Delete(const std::string& name);
 

--- a/Server/mods/deathmatch/logic/CCustomData.h
+++ b/Server/mods/deathmatch/logic/CCustomData.h
@@ -13,7 +13,7 @@
 
 #include <core/CServerInterface.h>
 #include "lua/CLuaArgument.h"
-#include <map>
+#include "SharedUtil.FastHashMap.h"
 #include <string>
 
 #define MAX_CUSTOMDATA_NAME_LENGTH 128
@@ -41,8 +41,10 @@ public:
 
     CXMLNode* OutputToXML(CXMLNode* pNode);
 
+    /*
     std::map<std::string, SCustomData>::const_iterator IterBegin() { return m_Data.begin(); }
     std::map<std::string, SCustomData>::const_iterator IterEnd() { return m_Data.end(); }
+    */
 private:
-    std::map<std::string, SCustomData> m_Data;
+    SharedUtil::CFastHashMap<std::string, SCustomData> m_Data;
 };

--- a/Server/mods/deathmatch/logic/CCustomData.h
+++ b/Server/mods/deathmatch/logic/CCustomData.h
@@ -47,10 +47,15 @@ public:
 
     CXMLNode* OutputToXML(CXMLNode* pNode);
 
-    /*
-    std::map<std::string, SCustomData>::const_iterator IterBegin() { return m_Data.begin(); }
-    std::map<std::string, SCustomData>::const_iterator IterEnd() { return m_Data.end(); }
-    */
+    const size_t Count() const noexcept { return m_Data.size(); }
+    const size_t CountSynced() const
+    {
+        return std::count_if(m_Data.begin(), m_Data.end(), [](const auto& kvpair) {
+            return kvpair.second.syncType != ESyncType::LOCAL;
+        });
+    }
+    
+
 private:
     SharedUtil::CFastHashMap<std::string, SCustomData> m_Data;
 };

--- a/Server/mods/deathmatch/logic/CCustomData.h
+++ b/Server/mods/deathmatch/logic/CCustomData.h
@@ -37,7 +37,6 @@ public:
     void Copy(CCustomData* pCustomData);
 
     SCustomData* Get(const char* szName);
-    SCustomData* GetSynced(const char* szName);
     void         Set(const char* szName, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST);
 
     bool Delete(const char* szName);

--- a/Server/mods/deathmatch/logic/CCustomData.h
+++ b/Server/mods/deathmatch/logic/CCustomData.h
@@ -43,6 +43,8 @@ public:
         data.syncType = syncType;
     }
 
+    bool Delete(const std::string& name) { return (bool)m_Data.erase(name); }
+
     CXMLNode* OutputToXML(CXMLNode* pNode);
 
     /*

--- a/Server/mods/deathmatch/logic/CCustomData.h
+++ b/Server/mods/deathmatch/logic/CCustomData.h
@@ -18,7 +18,7 @@
 
 #define MAX_CUSTOMDATA_NAME_LENGTH 128
 
-enum class ESyncType
+enum class ESyncType : unsigned char
 {
     LOCAL,
     BROADCAST,
@@ -41,8 +41,6 @@ public:
     void         Set(const char* szName, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST);
 
     bool Delete(const char* szName);
-
-    unsigned short CountOnlySynchronized();
 
     CXMLNode* OutputToXML(CXMLNode* pNode);
 

--- a/Server/mods/deathmatch/logic/CCustomData.h
+++ b/Server/mods/deathmatch/logic/CCustomData.h
@@ -34,10 +34,10 @@ struct SCustomData
 class CCustomData
 {
 public:
-    SCustomData* Get(const char* szName);
-    void         Set(const char* szName, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST);
+    SCustomData* Get(const std::string& szName);
+    void         Set(const std::string& szName, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST);
 
-    bool Delete(const char* szName);
+    bool Delete(const std::string& name);
 
     CXMLNode* OutputToXML(CXMLNode* pNode);
 

--- a/Server/mods/deathmatch/logic/CCustomData.h
+++ b/Server/mods/deathmatch/logic/CCustomData.h
@@ -56,6 +56,7 @@ public:
     }
     
 
+    const auto& GetAll() const noexcept { return m_Data; }
 private:
     SharedUtil::CFastHashMap<std::string, SCustomData> m_Data;
 };

--- a/Server/mods/deathmatch/logic/CElement.cpp
+++ b/Server/mods/deathmatch/logic/CElement.cpp
@@ -497,10 +497,8 @@ void CElement::ReadCustomData(CEvents* pEvents, CXMLNode& Node)
 
 CLuaArgument* CElement::GetCustomData(const std::string& name, bool bInheritData, ESyncType* pSyncType)
 {
-    assert(szName);
-
     // Grab it and return a pointer to the variable
-    SCustomData* pData = m_pCustomData->Get(szName);
+    SCustomData* pData = m_pCustomData->Get(name);
     if (pData)
     {
         if (pSyncType)
@@ -511,7 +509,7 @@ CLuaArgument* CElement::GetCustomData(const std::string& name, bool bInheritData
     // If none, try returning parent's custom data
     if (bInheritData && m_pParent)
     {
-        return m_pParent->GetCustomData(szName, true, pSyncType);
+        return m_pParent->GetCustomData(name, true, pSyncType);
     }
 
     // None available

--- a/Server/mods/deathmatch/logic/CElement.cpp
+++ b/Server/mods/deathmatch/logic/CElement.cpp
@@ -495,7 +495,7 @@ void CElement::ReadCustomData(CEvents* pEvents, CXMLNode& Node)
     }
 }
 
-CLuaArgument* CElement::GetCustomData(const char* szName, bool bInheritData, ESyncType* pSyncType)
+CLuaArgument* CElement::GetCustomData(const std::string& name, bool bInheritData, ESyncType* pSyncType)
 {
     assert(szName);
 

--- a/Server/mods/deathmatch/logic/CElement.cpp
+++ b/Server/mods/deathmatch/logic/CElement.cpp
@@ -692,32 +692,31 @@ bool CElement::GetCustomDataBool(const char* szName, bool& bOut, bool bInheritDa
     return false;
 }
 
-void CElement::SetCustomData(const char* szName, const CLuaArgument& Variable, ESyncType syncType, CPlayer* pClient, bool bTriggerEvent)
+void CElement::SetCustomData(const std::string& name, const CLuaArgument& Variable, ESyncType syncType, CPlayer* pClient, bool bTriggerEvent)
 {
-    assert(szName);
-    if (strlen(szName) > MAX_CUSTOMDATA_NAME_LENGTH)
+    if (name.length() > MAX_CUSTOMDATA_NAME_LENGTH)
     {
         // Don't allow it to be set if the name is too long
-        CLogger::ErrorPrintf("Custom data name too long (%s)\n", *SStringX(szName).Left(MAX_CUSTOMDATA_NAME_LENGTH + 1));
+        CLogger::ErrorPrintf("Custom data name too long (%.*s)\n", MAX_CUSTOMDATA_NAME_LENGTH, name.c_str());
         return;
     }
 
     // Grab the old variable
     CLuaArgument       oldVariable;
-    const SCustomData* pData = m_pCustomData->Get(szName);
+    const SCustomData* pData = m_pCustomData->Get(name);
     if (pData)
     {
         oldVariable = pData->Variable;
     }
 
     // Set the new data
-    m_pCustomData->Set(szName, Variable, syncType);
+    m_pCustomData->Set(name, Variable, syncType);
 
     if (bTriggerEvent)
     {
         // Trigger the onElementDataChange event on us
         CLuaArguments Arguments;
-        Arguments.PushString(szName);
+        Arguments.PushString(name);
         Arguments.PushArgument(oldVariable);
         Arguments.PushArgument(Variable);
         CallEvent("onElementDataChange", Arguments, pClient);

--- a/Server/mods/deathmatch/logic/CElement.h
+++ b/Server/mods/deathmatch/logic/CElement.h
@@ -141,7 +141,7 @@ public:
     bool           GetCustomDataInt(const char* szName, int& iOut, bool bInheritData);
     bool           GetCustomDataFloat(const char* szName, float& fOut, bool bInheritData);
     bool           GetCustomDataBool(const char* szName, bool& bOut, bool bInheritData);
-    void SetCustomData(const char* szName, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST, CPlayer* pClient = NULL, bool bTriggerEvent = true);
+    void SetCustomData(const std::string& name, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST, CPlayer* pClient = NULL, bool bTriggerEvent = true);
     void DeleteCustomData(const char* szName);
     void SendAllCustomData(CPlayer* pPlayer);
 

--- a/Server/mods/deathmatch/logic/CElement.h
+++ b/Server/mods/deathmatch/logic/CElement.h
@@ -135,7 +135,7 @@ public:
 
     void           ReadCustomData(CEvents* pEvents, CXMLNode& Node);
     CCustomData*   GetCustomDataPointer() { return m_pCustomData; }
-    CLuaArgument*  GetCustomData(const char* szName, bool bInheritData, ESyncType* pSyncType = NULL);
+    CLuaArgument*  GetCustomData(const std::string& name, bool bInheritData, ESyncType* pSyncType = NULL);
     CLuaArguments* GetAllCustomData(CLuaArguments* table);
     bool           GetCustomDataString(const char* szName, char* pOut, size_t sizeBuffer, bool bInheritData);
     bool           GetCustomDataInt(const char* szName, int& iOut, bool bInheritData);

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -333,7 +333,7 @@ CElement* CStaticFunctionDefinitions::CloneElement(CResource* pResource, CElemen
             vecNewPosition += pElement->GetPosition();
 
         pNewElement->SetPosition(vecNewPosition);
-        pNewElement->GetCustomDataPointer()->Copy(pElement->GetCustomDataPointer());
+        *pNewElement->GetCustomDataPointer() = *pElement->GetCustomDataPointer();
         pNewElement->SetInterior(pElement->GetInterior());
         pNewElement->SetDimension(pElement->GetDimension());
 

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -394,13 +394,12 @@ CElement* CStaticFunctionDefinitions::GetElementByIndex(const char* szType, unsi
     return m_pMapManager->GetRootElement()->FindChildByType(szType, uiIndex, true);
 }
 
-CLuaArgument* CStaticFunctionDefinitions::GetElementData(CElement* pElement, const char* szName, bool bInherit)
+CLuaArgument* CStaticFunctionDefinitions::GetElementData(CElement* pElement, const std::string& name, bool bInherit)
 {
     assert(pElement);
-    assert(szName);
 
     // Return its custom data
-    return pElement->GetCustomData(szName, bInherit);
+    return pElement->GetCustomData(name, bInherit);
 }
 
 CLuaArguments* CStaticFunctionDefinitions::GetAllElementData(CElement* pElement, CLuaArguments* table)
@@ -876,7 +875,7 @@ bool CStaticFunctionDefinitions::SetElementID(CElement* pElement, const char* sz
 bool CStaticFunctionDefinitions::SetElementData(CElement* pElement, const std::string& name, const CLuaArgument& Variable, ESyncType syncType)
 {
     assert(pElement);
-    assert(szName);
+
     assert(name.length() <= MAX_CUSTOMDATA_NAME_LENGTH);
 
     ESyncType     lastSyncType = ESyncType::BROADCAST;

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -886,27 +886,27 @@ bool CStaticFunctionDefinitions::SetElementData(CElement* pElement, const std::s
         if (syncType != ESyncType::LOCAL)
         {
             // Tell our clients to update their data
-            unsigned short usNameLength = static_cast<unsigned short>(strlen(szName));
+            unsigned short usNameLength = static_cast<unsigned short>(name.length());
             CBitStream     BitStream;
             BitStream.pBitStream->WriteCompressed(usNameLength);
-            BitStream.pBitStream->Write(szName, usNameLength);
+            BitStream.pBitStream->Write(name.c_str(), usNameLength);
             Variable.WriteToBitStream(*BitStream.pBitStream);
 
             if (syncType == ESyncType::BROADCAST)
                 m_pPlayerManager->BroadcastOnlyJoined(CElementRPCPacket(pElement, SET_ELEMENT_DATA, *BitStream.pBitStream));
             else
-                m_pPlayerManager->BroadcastOnlySubscribed(CElementRPCPacket(pElement, SET_ELEMENT_DATA, *BitStream.pBitStream), pElement, szName);
+                m_pPlayerManager->BroadcastOnlySubscribed(CElementRPCPacket(pElement, SET_ELEMENT_DATA, *BitStream.pBitStream), pElement, name.c_str());
 
-            CPerfStatEventPacketUsage::GetSingleton()->UpdateElementDataUsageOut(szName, m_pPlayerManager->Count(),
+            CPerfStatEventPacketUsage::GetSingleton()->UpdateElementDataUsageOut(name.c_str(), m_pPlayerManager->Count(),
                                                                                  BitStream.pBitStream->GetNumberOfBytesUsed());
         }
 
         // Unsubscribe all the players
         if (lastSyncType == ESyncType::SUBSCRIBE && syncType != ESyncType::SUBSCRIBE)
-            m_pPlayerManager->ClearElementData(pElement, szName);
+            m_pPlayerManager->ClearElementData(pElement, name.c_str());
 
         // Set its custom data
-        pElement->SetCustomData(szName, Variable, syncType);
+        pElement->SetCustomData(name, Variable, syncType);
         return true;
     }
     return false;

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -879,7 +879,7 @@ bool CStaticFunctionDefinitions::SetElementData(CElement* pElement, const std::s
     assert(name.length() <= MAX_CUSTOMDATA_NAME_LENGTH);
 
     ESyncType     lastSyncType = ESyncType::BROADCAST;
-    CLuaArgument* pCurrentVariable = pElement->GetCustomData(szName, false, &lastSyncType);
+    CLuaArgument* pCurrentVariable = pElement->GetCustomData(name, false, &lastSyncType);
 
     if (!pCurrentVariable || *pCurrentVariable != Variable || lastSyncType != syncType)
     {

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -873,11 +873,11 @@ bool CStaticFunctionDefinitions::SetElementID(CElement* pElement, const char* sz
     return true;
 }
 
-bool CStaticFunctionDefinitions::SetElementData(CElement* pElement, const char* szName, const CLuaArgument& Variable, ESyncType syncType)
+bool CStaticFunctionDefinitions::SetElementData(CElement* pElement, const std::string& name, const CLuaArgument& Variable, ESyncType syncType)
 {
     assert(pElement);
     assert(szName);
-    assert(strlen(szName) <= MAX_CUSTOMDATA_NAME_LENGTH);
+    assert(name.length() <= MAX_CUSTOMDATA_NAME_LENGTH);
 
     ESyncType     lastSyncType = ESyncType::BROADCAST;
     CLuaArgument* pCurrentVariable = pElement->GetCustomData(szName, false, &lastSyncType);

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -75,7 +75,7 @@ public:
     // Element set funcs
     static bool ClearElementVisibleTo(CElement* pElement);
     static bool SetElementID(CElement* pElement, const char* szID);
-    static bool SetElementData(CElement* pElement, const char* szName, const CLuaArgument& Variable, ESyncType syncType);
+    static bool SetElementData(CElement* pElement, const std::string& name, const CLuaArgument& Variable, ESyncType syncType);
     static bool RemoveElementData(CElement* pElement, const char* szName);
     static bool AddElementDataSubscriber(CElement* pElement, const char* szName, CPlayer* pPlayer);
     static bool RemoveElementDataSubscriber(CElement* pElement, const char* szName, CPlayer* pPlayer);

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -43,7 +43,7 @@ public:
     static CElement*      GetElementByIndex(const char* szType, unsigned int uiIndex);
     static CElement*      GetElementChild(CElement* pElement, unsigned int uiIndex);
     static bool           GetElementChildrenCount(CElement* pElement, unsigned int& uiCount);
-    static CLuaArgument*  GetElementData(CElement* pElement, const char* szName, bool bInherit);
+    static CLuaArgument*  GetElementData(CElement* pElement, const std::string& name, bool bInherit);
     static CLuaArguments* GetAllElementData(CElement* pElement, CLuaArguments* table);
     static CElement*      GetElementParent(CElement* pElement);
     static bool           GetElementMatrix(CElement* pElement, CMatrix& matrix);


### PR DESCRIPTION
Changelog:
- Removed redundant `m_SyncedData`
- Changed map type to `CFastHashMap` as we want the absolute maximum performance
- Removed `IterBegin` and `IterSyncedBegin`. Replaced it with `GetAll()` for based range loop
- Changed `const char*` for the name (in function argument list) to `const std::string&` because when searching in the hash map we'll need to use `std::string` anyways (Thats how it works sadly)
- I'll open a separate PR for more changes, because this can be optimized even further

Note:
- This is only the server side. I'll open a separate PR - because I dont want to spam this one with changes, would make it hard to review - which will move all this to `Shared`