### PR TITLE
Remove CRefCountable from wherever possible

### DIFF
--- a/Client/core/ServerBrowser/CServerBrowser.MasterServerManager.cpp
+++ b/Client/core/ServerBrowser/CServerBrowser.MasterServerManager.cpp
@@ -27,9 +27,11 @@ public:
 
     // CMasterServerManager
 protected:
-    CElapsedTime                               m_ElapsedTime;
-    std::vector<CRemoteMasterServerInterface*> m_MasterServerList;
-    uint                                       m_iActiveAmount;
+    using MasterServerList_t = std::vector<std::unique_ptr<CRemoteMasterServerInterface>>;
+
+    CElapsedTime       m_ElapsedTime;
+    MasterServerList_t m_MasterServerList;
+    uint               m_iActiveAmount;
 };
 
 ///////////////////////////////////////////////////////////////
@@ -65,10 +67,6 @@ CMasterServerManager::CMasterServerManager()
 ///////////////////////////////////////////////////////////////
 CMasterServerManager::~CMasterServerManager()
 {
-    for (uint i = 0; i < m_MasterServerList.size(); i++)
-        SAFE_RELEASE(m_MasterServerList[i]);
-
-    m_MasterServerList.clear();
 }
 
 ///////////////////////////////////////////////////////////////
@@ -87,7 +85,7 @@ void CMasterServerManager::Refresh()
         GetVersionUpdater()->GetAseServerList(resultList);
 
         for (uint i = 0; i < resultList.size(); i++)
-            m_MasterServerList.push_back(NewRemoteMasterServer(resultList[i]));
+            m_MasterServerList.emplace_back(NewRemoteMasterServer(resultList[i]));
     }
 
     // Pass on refresh request to first two servers

--- a/Client/core/ServerBrowser/CServerBrowser.RemoteMasterServer.cpp
+++ b/Client/core/ServerBrowser/CServerBrowser.RemoteMasterServer.cpp
@@ -121,7 +121,6 @@ void CRemoteMasterServer::Refresh()
     // Send new request
     m_strStage = "waitingreply";
     m_llLastRefreshTime = GetTickCount64_();
-    AddRef();            // Keep alive
     SHttpRequestOptions options;
     options.uiConnectionAttempts = 1;
     GetHTTP()->QueueFile(m_strURL, NULL, this, &CRemoteMasterServer::StaticDownloadFinished, options);
@@ -138,7 +137,6 @@ void CRemoteMasterServer::StaticDownloadFinished(const SHttpDownloadResult& resu
 {
     CRemoteMasterServer* pRemoteMasterServer = (CRemoteMasterServer*)result.pObj;
     pRemoteMasterServer->DownloadFinished(result);
-    pRemoteMasterServer->Release();            // Unkeep alive
 }
 
 ///////////////////////////////////////////////////////////////

--- a/Client/core/ServerBrowser/CServerBrowser.RemoteMasterServer.h
+++ b/Client/core/ServerBrowser/CServerBrowser.RemoteMasterServer.h
@@ -6,7 +6,7 @@
 // Communicate with a remote master server and parse the result.
 //
 
-class CRemoteMasterServerInterface : public CRefCountable
+class CRemoteMasterServerInterface
 {
 protected:
     virtual ~CRemoteMasterServerInterface() {}

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -516,7 +516,7 @@ bool CGame::Start(int iArgumentCount, char* szArguments[])
                                     m_pVehicleManager, m_pTeamManager, m_pPedManager, m_pColManager, m_pWaterManager, m_pClock, m_pLuaManager, m_pGroups,
                                     &m_Events, m_pScriptDebugging, &m_ElementDeleter);
     m_pACLManager = new CAccessControlListManager;
-    m_pHqComms = new CHqComms;
+    m_pHqComms = std::make_unique<CHqComms>();
 
     m_pRegisteredCommands = new CRegisteredCommands(m_pACLManager);
     m_pLuaManager = new CLuaManager(m_pObjectManager, m_pPlayerManager, m_pVehicleManager, m_pBlipManager, m_pRadarAreaManager, m_pRegisteredCommands,

--- a/Server/mods/deathmatch/logic/CGame.h
+++ b/Server/mods/deathmatch/logic/CGame.h
@@ -630,9 +630,9 @@ private:
     // Clouds Enabled
     bool m_bCloudsEnabled;
 
-    COpenPortsTester*       m_pOpenPortsTester;
-    CMasterServerAnnouncer* m_pMasterServerAnnouncer;
-    CHqComms*               m_pHqComms;
+    COpenPortsTester*         m_pOpenPortsTester;
+    CMasterServerAnnouncer*   m_pMasterServerAnnouncer;
+    std::unique_ptr<CHqComms> m_pHqComms;
 
     CLightsyncManager m_lightsyncManager;
 

--- a/Server/mods/deathmatch/utils/CHqComms.h
+++ b/Server/mods/deathmatch/utils/CHqComms.h
@@ -20,7 +20,7 @@ enum
 // Check with MTA HQ for status updates
 //
 ////////////////////////////////////////////////////////////////////
-class CHqComms : public CRefCountable
+class CHqComms
 {
 public:
     ZERO_ON_NEW


### PR DESCRIPTION
This PR removes `CRefCountable` where using it doesnt make any sense / can be replaced by `unique_ptr`