### PR TITLE
Refactor the database manager to use shared_ptr for CDBResultData

### DIFF
--- a/Server/dbconmy/CDatabaseConnectionMySql.cpp
+++ b/Server/dbconmy/CDatabaseConnectionMySql.cpp
@@ -35,13 +35,13 @@ public:
     virtual uint           GetLastErrorCode();
     virtual void           AddRef();
     virtual void           Release();
-    virtual bool           Query(const SString& strQuery, CRegistryResult& registryResult);
+    virtual bool           Query(const SString& strQuery, CRegistryResultData& registryResult);
     virtual void           Flush();
     virtual int            GetShareCount() { return m_iRefCount; }
 
     // CDatabaseConnectionMySql
     void SetLastError(uint uiCode, const SString& strMessage);
-    bool QueryInternal(const SString& strQuery, CRegistryResult& registryResult);
+    bool QueryInternal(const SString& strQuery, CRegistryResultData& registryResult);
     void BeginAutomaticTransaction();
     void EndAutomaticTransaction();
     int  ConvertToSqliteType(enum_field_types type);
@@ -229,7 +229,7 @@ void CDatabaseConnectionMySql::SetLastError(uint uiCode, const SString& strMessa
 //
 //
 ///////////////////////////////////////////////////////////////
-bool CDatabaseConnectionMySql::Query(const SString& strQuery, CRegistryResult& registryResult)
+bool CDatabaseConnectionMySql::Query(const SString& strQuery, CRegistryResultData& registryResult)
 {
     BeginAutomaticTransaction();
     return QueryInternal(strQuery, registryResult);
@@ -243,9 +243,9 @@ bool CDatabaseConnectionMySql::Query(const SString& strQuery, CRegistryResult& r
 // Return true with datum in registryResult on success
 //
 ///////////////////////////////////////////////////////////////
-bool CDatabaseConnectionMySql::QueryInternal(const SString& strQuery, CRegistryResult& registryResult)
+bool CDatabaseConnectionMySql::QueryInternal(const SString& strQuery, CRegistryResultData& registryResult)
 {
-    CRegistryResultData* pResult = registryResult->GetThis();
+    CRegistryResultData* pResult = &registryResult;
 
     int status = mysql_real_query(m_handle, strQuery, static_cast<unsigned long>(strQuery.length()));
     if (status)
@@ -341,8 +341,8 @@ bool CDatabaseConnectionMySql::QueryInternal(const SString& strQuery, CRegistryR
             return false;
         }
 
-        pResult->pNextResult = new CRegistryResultData();
-        pResult = pResult->pNextResult;
+        pResult->pNextResult = MakeRegistryResultDataRef();
+        pResult = pResult->pNextResult.get();
     }
 
     return true;

--- a/Server/mods/deathmatch/logic/CDatabaseManager.cpp
+++ b/Server/mods/deathmatch/logic/CDatabaseManager.cpp
@@ -388,7 +388,7 @@ CDbJobData* CDatabaseManagerImpl::QueryStartf(SConnectionHandle hConnection, con
 // Start a query and wait for the result
 //
 ///////////////////////////////////////////////////////////////
-bool CDatabaseManagerImpl::QueryWithResultf(SConnectionHandle hConnection, CRegistryResult* pResult, const char* szQuery, ...)
+bool CDatabaseManagerImpl::QueryWithResultf(SConnectionHandle hConnection, CRegistryResultData& result, const char* szQuery, ...)
 {
     va_list vl;
     va_start(vl, szQuery);
@@ -419,14 +419,12 @@ bool CDatabaseManagerImpl::QueryWithResultf(SConnectionHandle hConnection, CRegi
     // Process result
     if (pJobData->result.status == EJobResult::FAIL)
     {
-        if (pResult)
-            *pResult = CRegistryResult();
+        result = {}; // Clear result
         return false;
     }
     else
     {
-        if (pResult)
-            *pResult = pJobData->result.registryResult;
+        result = std::move(pJobData->result.registryResult);
         return true;
     }
 }

--- a/Server/mods/deathmatch/logic/CDatabaseManager.cpp
+++ b/Server/mods/deathmatch/logic/CDatabaseManager.cpp
@@ -45,7 +45,8 @@ public:
     virtual CDbJobData*       GetQueryFromId(SDbJobId id);
     virtual const SString&    GetLastErrorMessage() { return m_strLastErrorMessage; }
     virtual bool              IsLastErrorSuppressed() { return m_bLastErrorSuppressed; }
-    virtual bool              QueryWithResultf(SConnectionHandle hConnection, CRegistryResult* pResult, const char* szQuery, ...);
+    virtual bool              QueryWithResultf(SConnectionHandle hConnection, CRegistryResultData& pResult, const char* szQuery, ...);
+    virtual bool              QueryWithFailedCheckf(SConnectionHandle hConnection, const char* szQuery, ...);
     virtual bool              QueryWithCallback(SConnectionHandle hConnection, PFN_DBRESULT pfnDbResult, void* pCallbackContext, const SString& strQuery,
                                                 CLuaArguments* pArgs = nullptr);
     virtual bool              QueryWithCallbackf(SConnectionHandle hConnection, PFN_DBRESULT pfnDbResult, void* pCallbackContext, const char* szQuery, ...);
@@ -428,6 +429,45 @@ bool CDatabaseManagerImpl::QueryWithResultf(SConnectionHandle hConnection, CRegi
             *pResult = pJobData->result.registryResult;
         return true;
     }
+}
+
+///////////////////////////////////////////////////////////////
+//
+// CDatabaseManagerImpl::QueryWithResultf
+//
+// Start a query and wait for the result, and
+// return whenever it has succeeded or not
+//
+///////////////////////////////////////////////////////////////
+bool CDatabaseManagerImpl::QueryWithFailedCheckf(SConnectionHandle hConnection, const char* szQuery, ...)
+{
+    va_list vl;
+    va_start(vl, szQuery);
+
+    ClearLastErrorMessage();
+
+    // Check connection
+    if (!MapContains(m_ConnectionTypeMap, hConnection))
+    {
+        SetLastErrorMessage("Invalid connection");
+        return false;
+    }
+
+    // Insert arguments with correct escapement
+    SString strEscapedQuery = RestoreQuestionMark(InsertQueryArguments(hConnection, szQuery, vl));
+
+    // Start query
+    CDbJobData* pJobData = m_JobQueue->AddCommand(EJobCommand::QUERY, hConnection, strEscapedQuery);
+    if (!pJobData)
+    {
+        SetLastErrorMessage("Invalid connection");
+        return false;
+    }
+
+    // Wait for result
+    QueryPoll(pJobData, -1);
+
+    return pJobData->result.status == EJobResult::SUCCESS;
 }
 
 ///////////////////////////////////////////////////////////////

--- a/Server/mods/deathmatch/logic/CDatabaseManager.cpp
+++ b/Server/mods/deathmatch/logic/CDatabaseManager.cpp
@@ -162,7 +162,7 @@ SConnectionHandle CDatabaseManagerImpl::Connect(const SString& strType, const SS
 //
 //
 ///////////////////////////////////////////////////////////////
-bool CDatabaseManagerImpl::Disconnect(uint hConnection)
+bool CDatabaseManagerImpl::Disconnect(SConnectionHandle hConnection)
 {
     ClearLastErrorMessage();
 

--- a/Server/mods/deathmatch/logic/CDatabaseManager.h
+++ b/Server/mods/deathmatch/logic/CDatabaseManager.h
@@ -160,7 +160,7 @@ public:
     virtual CDbJobData*       GetQueryFromId(SDbJobId id) = 0;
     virtual const SString&    GetLastErrorMessage() = 0;
     virtual bool              IsLastErrorSuppressed() = 0;
-    virtual bool              QueryWithResultf(SConnectionHandle hConnection, CRegistryResult* pResult, const char* szQuery, ...) = 0;
+    virtual bool              QueryWithResultf(SConnectionHandle hConnection, CRegistryResultData& result, const char* szQuery, ...) = 0;
     virtual bool              QueryWithCallback(SConnectionHandle hConnection, PFN_DBRESULT pfnDbResult, void* pCallbackContext, const SString& strQuery,
                                                 CLuaArguments* pArgs = nullptr) = 0;
     virtual bool              QueryWithCallbackf(SConnectionHandle hConnection, PFN_DBRESULT pfnDbResult, void* pCallbackContext, const char* szQuery, ...) = 0;

--- a/Server/mods/deathmatch/logic/CDatabaseManager.h
+++ b/Server/mods/deathmatch/logic/CDatabaseManager.h
@@ -110,14 +110,14 @@ public:
 
     struct
     {
-        EJobResultType  status;
-        uint            uiErrorCode;
-        SString         strReason;
-        bool            bErrorSuppressed;
-        CRegistryResult registryResult;
-        CTickCount      timeReady;
-        bool            bLoggedWarning;
-        bool            bIgnoreResult;
+        EJobResultType      status;
+        uint                uiErrorCode;
+        SString             strReason;
+        bool                bErrorSuppressed;
+        CRegistryResultData registryResult;
+        CTickCount          timeReady;
+        bool                bLoggedWarning;
+        bool                bIgnoreResult;
     } result;
 
     struct
@@ -161,6 +161,7 @@ public:
     virtual const SString&    GetLastErrorMessage() = 0;
     virtual bool              IsLastErrorSuppressed() = 0;
     virtual bool              QueryWithResultf(SConnectionHandle hConnection, CRegistryResultData& result, const char* szQuery, ...) = 0;
+    virtual bool              QueryWithFailedCheckf(SConnectionHandle hConnection, const char* szQuery, ...) = 0;
     virtual bool              QueryWithCallback(SConnectionHandle hConnection, PFN_DBRESULT pfnDbResult, void* pCallbackContext, const SString& strQuery,
                                                 CLuaArguments* pArgs = nullptr) = 0;
     virtual bool              QueryWithCallbackf(SConnectionHandle hConnection, PFN_DBRESULT pfnDbResult, void* pCallbackContext, const char* szQuery, ...) = 0;

--- a/Server/mods/deathmatch/logic/CDatabaseType.h
+++ b/Server/mods/deathmatch/logic/CDatabaseType.h
@@ -47,7 +47,7 @@ public:
     virtual uint           GetLastErrorCode() = 0;
     virtual void           AddRef() = 0;
     virtual void           Release() = 0;
-    virtual bool           Query(const SString& strQuery, CRegistryResult& registryResult) = 0;
+    virtual bool           Query(const SString& strQuery, CRegistryResultData& registryResult) = 0;
     virtual void           Flush() = 0;
     virtual int            GetShareCount() = 0;
 

--- a/Server/mods/deathmatch/logic/CPerfStat.BandwidthUsage.cpp
+++ b/Server/mods/deathmatch/logic/CPerfStat.BandwidthUsage.cpp
@@ -230,10 +230,10 @@ void CPerfStatBandwidthUsageImpl::LoadStats()
     CDbJobData* pJobData = pDatabaseManager->QueryStartf(
         m_DatabaseConnection, "SELECT `type`,`idx`,`GameRecv`,`GameSent`,`HttpSent`,`GameRecvBlocked`,`GameResent` from " BW_STATS_TABLE_NAME);
     pDatabaseManager->QueryPoll(pJobData, -1);
-    CRegistryResult result = pJobData->result.registryResult;
+    CRegistryResultData& result = pJobData->result.registryResult;
 
     // If data set is empty, try loading old data
-    if (result->nRows == 0)
+    if (result.nRows == 0)
     {
         CDbJobData* pJobData = pDatabaseManager->QueryStartf(
             m_DatabaseConnection, "SELECT `type`,`idx`,`GameRecv`,`GameSent`,`HttpSent`,`GameRecvBlocked` from " BW_STATS_TABLE_NAME);
@@ -242,7 +242,7 @@ void CPerfStatBandwidthUsageImpl::LoadStats()
     }
 
     // If data set is empty, try loading old data
-    if (result->nRows == 0)
+    if (result.nRows == 0)
     {
         pJobData = pDatabaseManager->QueryStartf(m_DatabaseConnection, "SELECT `type`,`idx`,`GameRecv`,`GameSent`,`HttpSent` from " BW_STATS_TABLE_NAME);
         pDatabaseManager->QueryPoll(pJobData, -1);
@@ -250,12 +250,12 @@ void CPerfStatBandwidthUsageImpl::LoadStats()
     }
 
     // If data set is empty, try loading old data
-    if (result->nRows == 0)
-        g_pGame->GetRegistry()->Query(&result, "SELECT `type`,`idx`,`GameRecv`,`GameSent`,`HttpSent` from `_perfstats_bandwidth_usage`");
+    if (result.nRows == 0)
+        g_pGame->GetRegistry()->Query(result, "SELECT `type`,`idx`,`GameRecv`,`GameSent`,`HttpSent` from `_perfstats_bandwidth_usage`");
 
-    if (result->nRows > 0 && result->nColumns >= 5)
+    if (result.nRows > 0 && result.nColumns >= 5)
     {
-        for (CRegistryResultIterator iter = result->begin(); iter != result->end(); ++iter)
+        for (CRegistryResultIterator iter = result.begin(); iter != result.end(); ++iter)
         {
             const CRegistryResultRow& row = *iter;
             SString                   strType = (const char*)row[0].pVal;
@@ -264,10 +264,10 @@ void CPerfStatBandwidthUsageImpl::LoadStats()
             float                     GameSent = std::max(0.f, row[3].fVal);
             float                     HttpSent = std::max(0.f, row[4].fVal);
             float                     GameRecvBlocked = 0;
-            if (result->nColumns >= 6)
+            if (result.nColumns >= 6)
                 GameRecvBlocked = std::max(0.f, row[5].fVal);
             float GameResent = 0;
-            if (result->nColumns >= 7)
+            if (result.nColumns >= 7)
                 GameResent = std::max(0.f, row[6].fVal);
 
             uint uiType = BWStatNameToIndex(strType);

--- a/Server/mods/deathmatch/logic/CRegistry.cpp
+++ b/Server/mods/deathmatch/logic/CRegistry.cpp
@@ -206,24 +206,23 @@ bool CRegistry::QueryInternal(const char* szQuery, CRegistryResult* ppResult)
         return false;
     }
 
-    CRegistryResult& pResult = *ppResult;
     // Get column names
-    pResult->nColumns = sqlite3_column_count(pStmt);
-    pResult->ColNames.clear();
-    for (int i = 0; i < pResult->nColumns; i++)
+    result.nColumns = sqlite3_column_count(pStmt);
+    result.ColNames.clear();
+    for (int i = 0; i < result.nColumns; i++)
     {
-        pResult->ColNames.push_back(sqlite3_column_name(pStmt, i));
+        result.ColNames.push_back(sqlite3_column_name(pStmt, i));
     }
 
     // Fetch the rows
-    pResult->nRows = 0;
-    pResult->Data.clear();
+    result.nRows = 0;
+    result.Data.clear();
     int status;
     while ((status = sqlite3_step(pStmt)) == SQLITE_ROW)
     {
-        pResult->Data.push_back(vector<CRegistryResultCell>(pResult->nColumns));
-        vector<CRegistryResultCell>& row = pResult->Data.back();
-        for (int i = 0; i < pResult->nColumns; i++)
+        result.Data.push_back(vector<CRegistryResultCell>(result.nColumns));
+        vector<CRegistryResultCell>& row = result.Data.back();
+        for (int i = 0; i < result.nColumns; i++)
         {
             CRegistryResultCell& cell = row[i];
             cell.nType = sqlite3_column_type(pStmt, i);
@@ -256,7 +255,7 @@ bool CRegistry::QueryInternal(const char* szQuery, CRegistryResult* ppResult)
                     break;
             }
         }
-        pResult->nRows++;
+        result.nRows++;
     }
 
     // Did we leave the fetching loop because of an error?

--- a/Server/mods/deathmatch/logic/CRegistry.cpp
+++ b/Server/mods/deathmatch/logic/CRegistry.cpp
@@ -273,7 +273,7 @@ bool CRegistry::QueryInternal(const char* szQuery, CRegistryResult* ppResult)
     return true;
 }
 
-bool CRegistry::Query(const std::string& strQuery, CLuaArguments* pArgs, CRegistryResult* pResult)
+bool CRegistry::Query(const std::string& strQuery, CLuaArguments* pArgs, CRegistryResultData& result)
 {
     std::string strParsedQuery = "";
 
@@ -355,7 +355,7 @@ bool CRegistry::Query(const std::string& strQuery, CLuaArguments* pArgs, CRegist
     }
 
     BeginAutomaticTransaction();
-    return QueryInternal(strParsedQuery.c_str(), pResult);
+    return QueryInternal(strParsedQuery.c_str(), result);
 }
 
 bool CRegistry::Select(const std::string& strColumns, const std::string& strTable, const std::string& strWhere, unsigned int uiLimit, CRegistryResult* pResult)
@@ -388,8 +388,8 @@ void CRegistry::BeginAutomaticTransaction()
         }
 
         m_bInAutomaticTransaction = true;
-        CRegistryResult dummy;
-        QueryInternal("BEGIN TRANSACTION", &dummy);
+        CRegistryResultData dummy;
+        QueryInternal("BEGIN TRANSACTION", dummy);
     }
 }
 
@@ -398,8 +398,8 @@ void CRegistry::EndAutomaticTransaction()
     if (m_bInAutomaticTransaction)
     {
         m_bInAutomaticTransaction = false;
-        CRegistryResult dummy;
-        QueryInternal("END TRANSACTION", &dummy);
+        CRegistryResultData dummy;
+        QueryInternal("END TRANSACTION", dummy);
     }
 }
 
@@ -408,21 +408,20 @@ bool CRegistry::Query(const char* szQuery, ...)
     CRegistryResult dummy;
     va_list         vl;
     va_start(vl, szQuery);
-    return Query(&dummy, szQuery, vl);
+    return Query(dummy, szQuery, vl);
 }
 
-bool CRegistry::Query(CRegistryResult* pResult, const char* szQuery, ...)
+bool CRegistry::Query(CRegistryResultData& result, const char* szQuery, ...)
 {
     va_list vl;
     va_start(vl, szQuery);
-    return Query(pResult, szQuery, vl);
+    return Query(result, szQuery, vl);
 }
 
-bool CRegistry::Query(CRegistryResult* pResult, const char* szQuery, va_list vl)
+bool CRegistry::Query(CRegistryResultData& result, const char* szQuery, va_list vl)
 {
     // Clear result
-    if (pResult)
-        *pResult = CRegistryResult();
+    result = {};
 
     if (m_bOpened == false)
     {
@@ -495,5 +494,5 @@ bool CRegistry::Query(CRegistryResult* pResult, const char* szQuery, va_list vl)
         EndAutomaticTransaction();
     else
         BeginAutomaticTransaction();
-    return QueryInternal(strParsedQuery.c_str(), pResult);
+    return QueryInternal(strParsedQuery.c_str(), result);
 }

--- a/Server/mods/deathmatch/logic/CRegistry.cpp
+++ b/Server/mods/deathmatch/logic/CRegistry.cpp
@@ -358,7 +358,7 @@ bool CRegistry::Query(const std::string& strQuery, CLuaArguments* pArgs, CRegist
     return QueryInternal(strParsedQuery.c_str(), result);
 }
 
-bool CRegistry::Select(const std::string& strColumns, const std::string& strTable, const std::string& strWhere, unsigned int uiLimit, CRegistryResult* pResult)
+bool CRegistry::Select(const std::string& strColumns, const std::string& strTable, const std::string& strWhere, unsigned int uiLimit, CRegistryResultData& result)
 {
     std::string strQuery = "SELECT " + strColumns + " FROM " + strTable;
     if (!strWhere.empty())
@@ -373,7 +373,7 @@ bool CRegistry::Select(const std::string& strColumns, const std::string& strTabl
     }
 
     // Execute the query
-    return QueryInternal(strQuery.c_str(), pResult);
+    return QueryInternal(strQuery.c_str(), result);
 }
 
 void CRegistry::BeginAutomaticTransaction()

--- a/Server/mods/deathmatch/logic/CRegistry.h
+++ b/Server/mods/deathmatch/logic/CRegistry.h
@@ -149,24 +149,16 @@ typedef std::list<CRegistryResultRow>::const_iterator CRegistryResultIterator;
 
 struct CRegistryResultData
 {
-    CRegistryResultData()
-    {
-        nRows = 0;
-        nColumns = 0;
-        uiNumAffectedRows = 0;
-        ullLastInsertId = 0;
-        pNextResult = nullptr;
-    }
-    ~CRegistryResultData() { SAFE_DELETE(pNextResult); }
-    std::vector<SString>          ColNames;
-    std::list<CRegistryResultRow> Data;
-    int                           nRows;
-    int                           nColumns;
-    uint                          uiNumAffectedRows;
-    uint64                        ullLastInsertId;
-    CRegistryResultData*          pNextResult;
+    CRegistryResultData() = default;
 
-    CRegistryResultData*    GetThis() { return this; }
+    std::vector<SString>          ColNames{};
+    std::list<CRegistryResultRow> Data{};
+    int                           nRows = 0;
+    int                           nColumns = 0;
+    uint                          uiNumAffectedRows = 0;
+    uint64                        ullLastInsertId = 0;
+    CRegistryResultDataRef        pNextResult = nullptr;
+
     CRegistryResultIterator begin() const { return Data.begin(); }
     CRegistryResultIterator end() const { return Data.end(); }
 };

--- a/Server/mods/deathmatch/logic/CRegistry.h
+++ b/Server/mods/deathmatch/logic/CRegistry.h
@@ -44,9 +44,9 @@ public:
     bool Select(const std::string& strColumns, const std::string& strTable, const std::string& strWhere, unsigned int uiLimit, CRegistryResult* pResult);
     bool Update(const std::string& strTable, const std::string& strSet, const std::string& strWhere);
 
-    bool Query(const std::string& strQuery, class CLuaArguments* pArgs, CRegistryResult* pResult);
+    bool Query(const std::string& strQuery, class CLuaArguments* pArgs, CRegistryResultData& result);
     bool Query(const char* szQuery, ...);
-    bool Query(CRegistryResult* pResult, const char* szQuery, ...);
+    bool Query(CRegistryResultData& result, const char* szQuery, ...);
 
     const SString& GetLastError() { return m_strLastErrorMessage; }
 
@@ -54,8 +54,8 @@ protected:
     bool SetLastErrorMessage(const std::string& strLastErrorMessage, const std::string& strQuery);
     bool Exec(const std::string& strQuery);
     bool ExecInternal(const char* szQuery);
-    bool Query(CRegistryResult* pResult, const char* szQuery, va_list vl);
-    bool QueryInternal(const char* szQuery, CRegistryResult* pResult);
+    bool Query(CRegistryResultData& result, const char* szQuery, va_list vl);
+    bool QueryInternal(const char* szQuery, CRegistryResultData& result);
     void BeginAutomaticTransaction();
     void EndAutomaticTransaction();
 
@@ -68,7 +68,11 @@ protected:
     SString   m_strFileName;
 
 private:
-    bool Query(const char* szQuery, CRegistryResult* pResult);            // Not defined to catch incorrect usage
+    // Hack: Since we use a va_list, one might just pass in the result ref
+    // before the query, and expect it to work, but it wont: it'll crash
+    // so declare (but not define!) this function to catch incorrect usage
+    // and avoid headaches
+    bool Query(const char* szQuery, CRegistryResultData& result);
 };
 
 struct CRegistryResultCell

--- a/Server/mods/deathmatch/logic/CRegistry.h
+++ b/Server/mods/deathmatch/logic/CRegistry.h
@@ -9,7 +9,10 @@
  *
  *****************************************************************************/
 
-typedef CAutoRefedPointer<struct CRegistryResultData> CRegistryResult;
+struct CRegistryResultData;
+
+typedef std::shared_ptr<CRegistryResultData> CRegistryResultDataRef;
+constexpr static auto MakeRegistryResultDataRef = std::make_shared<CRegistryResultData>;
 
 #pragma once
 

--- a/Server/mods/deathmatch/logic/CRegistry.h
+++ b/Server/mods/deathmatch/logic/CRegistry.h
@@ -41,7 +41,7 @@ public:
 
     bool Delete(const std::string& strTable, const std::string& strWhere);
     bool Insert(const std::string& strTable, const std::string& strValues, const std::string& strColumns);
-    bool Select(const std::string& strColumns, const std::string& strTable, const std::string& strWhere, unsigned int uiLimit, CRegistryResult* pResult);
+    bool Select(const std::string& strColumns, const std::string& strTable, const std::string& strWhere, unsigned int uiLimit, CRegistryResultData& result);
     bool Update(const std::string& strTable, const std::string& strSet, const std::string& strWhere);
 
     bool Query(const std::string& strQuery, class CLuaArguments* pArgs, CRegistryResultData& result);

--- a/Server/mods/deathmatch/logic/CResourceManager.cpp
+++ b/Server/mods/deathmatch/logic/CResourceManager.cpp
@@ -1316,10 +1316,10 @@ void CResourceManager::LoadBlockedFileReasons()
     pDatabaseManager->QueryPoll(pJobData, -1);
     CRegistryResult& result = pJobData->result.registryResult;
 
-    if (result->nRows > 0 && result->nColumns >= 2)
+    if (result.nRows > 0 && result.nColumns >= 2)
     {
         m_BlockedFileReasonMap.clear();
-        for (CRegistryResultIterator iter = result->begin(); iter != result->end(); ++iter)
+        for (CRegistryResultIterator iter = result.begin(); iter != result.end(); ++iter)
         {
             const CRegistryResultRow& row = *iter;
             SString                   strFileHash = (const char*)row[0].pVal;

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -11071,9 +11071,9 @@ void CStaticFunctionDefinitions::ExecuteSQLCreateTable(const std::string& strTab
     m_pRegistry->CreateTable(strTable, strDefinition);
 }
 
-bool CStaticFunctionDefinitions::ExecuteSQLQuery(const std::string& strQuery, CLuaArguments* pArgs, CRegistryResult* pResult)
+bool CStaticFunctionDefinitions::ExecuteSQLQuery(const std::string& strQuery, CLuaArguments* pArgs, CRegistryResultData& result)
 {
-    return m_pRegistry->Query(strQuery, pArgs, pResult);
+    return m_pRegistry->Query(strQuery, pArgs, result);
 }
 
 const std::string& CStaticFunctionDefinitions::SQLGetLastError()

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -11097,9 +11097,9 @@ bool CStaticFunctionDefinitions::ExecuteSQLInsert(const std::string& strTable, c
 }
 
 bool CStaticFunctionDefinitions::ExecuteSQLSelect(const std::string& strTable, const std::string& strColumns, const std::string& strWhere, unsigned int uiLimit,
-                                                  CRegistryResult* pResult)
+                                                  CRegistryResultData& result)
 {
-    return m_pRegistry->Select(strColumns, strTable, strWhere, uiLimit, pResult);
+    return m_pRegistry->Select(strColumns, strTable, strWhere, uiLimit, result);
 }
 
 bool CStaticFunctionDefinitions::ExecuteSQLUpdate(const std::string& strTable, const std::string& strSet, const std::string& strWhere)

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -666,7 +666,7 @@ public:
     static bool               ExecuteSQLSelect(const std::string& strTable, const std::string& strColumns, const std::string& strWhere, unsigned int uiLimit,
                                                CRegistryResultData& pResult);
     static bool               ExecuteSQLUpdate(const std::string& strTable, const std::string& strSet, const std::string& strWhere);
-    static bool               ExecuteSQLQuery(const std::string& str, CLuaArguments* pArgs, CRegistryResult* pResult);
+    static bool               ExecuteSQLQuery(const std::string& str, CLuaArguments* pArgs, CRegistryResultData& result);
 
     // Account get funcs
     static CAccount*                     GetAccount(const char* szName, const char* szPassword, bool bCaseSensitive = true);

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -664,7 +664,7 @@ public:
     static bool               ExecuteSQLDelete(const std::string& strTable, const std::string& strWhere);
     static bool               ExecuteSQLInsert(const std::string& strTable, const std::string& strValues, const std::string& strColumns);
     static bool               ExecuteSQLSelect(const std::string& strTable, const std::string& strColumns, const std::string& strWhere, unsigned int uiLimit,
-                                               CRegistryResult* pResult);
+                                               CRegistryResultData& pResult);
     static bool               ExecuteSQLUpdate(const std::string& strTable, const std::string& strSet, const std::string& strWhere);
     static bool               ExecuteSQLQuery(const std::string& str, CLuaArguments* pArgs, CRegistryResult* pResult);
 

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDatabaseDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDatabaseDefs.cpp
@@ -673,11 +673,11 @@ int CLuaDatabaseDefs::ExecuteSQLQuery(lua_State* luaVM)
         Args.ReadArguments(luaVM, 2);
 
         CPerfStatSqliteTiming::GetSingleton()->SetCurrentResource(luaVM);
-        if (CStaticFunctionDefinitions::ExecuteSQLQuery(strQuery, &Args, &Result))
+        if (CStaticFunctionDefinitions::ExecuteSQLQuery(strQuery, &Args, Result))
         {
             lua_newtable(luaVM);
             int i = 0;
-            for (CRegistryResultIterator iter = Result->begin(); iter != Result->end(); ++iter, ++i)
+            for (CRegistryResultIterator iter = Result.begin(); iter != Result.end(); ++iter, ++i)
             {
                 const CRegistryResultRow& row = *iter;
                 // for ( int i = 0; i < Result.nRows; i++ ) {
@@ -685,14 +685,14 @@ int CLuaDatabaseDefs::ExecuteSQLQuery(lua_State* luaVM)
                 lua_pushnumber(luaVM, i + 1);            // row index number (starting at 1, not 0)
                 lua_pushvalue(luaVM, -2);                // value
                 lua_settable(luaVM, -4);                 // refer to the top level table
-                for (int j = 0; j < Result->nColumns; j++)
+                for (int j = 0; j < Result.nColumns; j++)
                 {
                     const CRegistryResultCell& cell = row[j];
                     if (cell.nType == SQLITE_NULL)
                         continue;
 
                     // Push the column name
-                    lua_pushlstring(luaVM, Result->ColNames[j].c_str(), Result->ColNames[j].size());
+                    lua_pushlstring(luaVM, Result.ColNames[j].c_str(), Result.ColNames[j].size());
                     switch (cell.nType)            // push the value with the right type
                     {
                         case SQLITE_INTEGER:

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDatabaseDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDatabaseDefs.cpp
@@ -751,11 +751,11 @@ int CLuaDatabaseDefs::ExecuteSQLSelect(lua_State* luaVM)
     {
         CRegistryResult Result;
         CPerfStatSqliteTiming::GetSingleton()->SetCurrentResource(luaVM);
-        if (CStaticFunctionDefinitions::ExecuteSQLSelect(strTable, strColumns, strWhere, uiLimit, &Result))
+        if (CStaticFunctionDefinitions::ExecuteSQLSelect(strTable, strColumns, strWhere, uiLimit, Result))
         {
             lua_newtable(luaVM);
             int i = 0;
-            for (CRegistryResultIterator iter = Result->begin(); iter != Result->end(); ++iter, ++i)
+            for (CRegistryResultIterator iter = Result.begin(); iter != Result.end(); ++iter, ++i)
             {
                 const CRegistryResultRow& row = *iter;
                 //            for ( int i = 0; i < Result.nRows; i++ ) {
@@ -763,14 +763,14 @@ int CLuaDatabaseDefs::ExecuteSQLSelect(lua_State* luaVM)
                 lua_pushnumber(luaVM, i + 1);            // row index number (starting at 1, not 0)
                 lua_pushvalue(luaVM, -2);                // value
                 lua_settable(luaVM, -4);                 // refer to the top level table
-                for (int j = 0; j < Result->nColumns; j++)
+                for (int j = 0; j < Result.nColumns; j++)
                 {
                     const CRegistryResultCell& cell = row[j];
                     if (cell.nType == SQLITE_NULL)
                         continue;
 
                     // Push the column name
-                    lua_pushlstring(luaVM, Result->ColNames[j].c_str(), Result->ColNames[j].size());
+                    lua_pushlstring(luaVM, Result.ColNames[j].c_str(), Result.ColNames[j].size());
                     switch (cell.nType)            // push the value with the right type
                     {
                         case SQLITE_INTEGER:


### PR DESCRIPTION
This PR removes `CAutoRefedPointer` usage from the database manager, because its useless. The struct is small enough to fit on the stack without any issues.
This is a preparation to remove `CAutoRefedPointer`
