### PR TITLE
Fix #1819: Crash on reconnect 1.5.8-release-20704.0.000

### DIFF
--- a/Client/mods/deathmatch/logic/CClientModelManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientModelManager.cpp
@@ -60,7 +60,7 @@ int CClientModelManager::GetFirstFreeModelID(void)
     for (int i = 0; i < MAX_MODEL_ID; i++)
     {
         CModelInfo* pModelInfo = g_pGame->GetModelInfo(i, true);
-        if (!pModelInfo->IsValid())
+        if (!pModelInfo->IsValid() && (i < 300 || i > 319) )
         {
             return i;
         }

--- a/Client/mods/deathmatch/logic/CClientModelManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientModelManager.cpp
@@ -60,6 +60,7 @@ int CClientModelManager::GetFirstFreeModelID(void)
     for (int i = 0; i < MAX_MODEL_ID; i++)
     {
         CModelInfo* pModelInfo = g_pGame->GetModelInfo(i, true);
+        // GTA can try unload some special ID's in CStreamingSA::ReinitStreaming (Github #1819)
         if (!pModelInfo->IsValid() && (i < 300 || i > 319) )
         {
             return i;


### PR DESCRIPTION
Fix for #1819
Crash reason: MTA try unload some ID's twice