### PR TITLE
Make `logIn` password argument optional

### DIFF
--- a/Server/mods/deathmatch/logic/CAccountManager.cpp
+++ b/Server/mods/deathmatch/logic/CAccountManager.cpp
@@ -481,7 +481,7 @@ void CAccountManager::RemoveAll()
     DeletePointersAndClearList(m_List);
 }
 
-bool CAccountManager::LogIn(CClient* pClient, CClient* pEchoClient, const char* szAccountName, const char* szPassword)
+bool CAccountManager::LogIn(CClient* pClient, CClient* pEchoClient, const char* szAccountName, const char* szPassword, bool bCheckPassword)
 {
     // Is he already logged in?
     if (pClient->IsRegistered())
@@ -530,7 +530,7 @@ bool CAccountManager::LogIn(CClient* pClient, CClient* pEchoClient, const char* 
             pEchoClient->SendEcho(SString("login: Account for '%s' is already in use", szAccountName).c_str());
         return false;
     }
-    if (!IsValidPassword(szPassword) || !pAccount->IsPassword(szPassword))
+    if (bCheckPassword && (!IsValidPassword(szPassword) || !pAccount->IsPassword(szPassword)))
     {
         if (pEchoClient)
             pEchoClient->SendEcho(SString("login: Invalid password for account '%s'", szAccountName).c_str());

--- a/Server/mods/deathmatch/logic/CAccountManager.h
+++ b/Server/mods/deathmatch/logic/CAccountManager.h
@@ -130,7 +130,7 @@ public:
     CAccount* GetAccountFromScriptID(uint uiScriptID);
     SString   GetActiveCaseVariation(const SString& strName);
 
-    bool LogIn(CClient* pClient, CClient* pEchoClient, const char* szAccountName, const char* szPassword);
+    bool LogIn(CClient* pClient, CClient* pEchoClient, const char* szAccountName, const char* szPassword, bool bCheckPassword = true);
     bool LogOut(CClient* pClient, CClient* pEchoClient);
 
     std::shared_ptr<CLuaArgument> GetAccountData(CAccount* pAccount, const char* szKey);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
@@ -10,12 +10,13 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include <lua/CLuaFunctionParser.h>
 
 void CLuaAccountDefs::LoadFunctions()
 {
     constexpr static const std::pair<const char*, lua_CFunction> functions[]{
         // Log in/out funcs
-        {"logIn", LogIn},
+        {"logIn", ArgumentParserWarn<true, LogIn>},
         {"logOut", LogOut},
 
         // Account get functions
@@ -599,34 +600,10 @@ int CLuaAccountDefs::CopyAccountData(lua_State* luaVM)
     return 1;
 }
 
-int CLuaAccountDefs::LogIn(lua_State* luaVM)
+bool CLuaAccountDefs::LogIn(CPlayer* pPlayer, CAccount* pAccount, std::optional<std::string> password)
 {
-    //  bool logIn ( player thePlayer, account theAccount, string thePassword )
-    CPlayer*  pPlayer;
-    CAccount* pAccount;
-    SString   strPassword;
-
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pPlayer);
-    argStream.ReadUserData(pAccount);
-    argStream.ReadString(strPassword);
-
-    if (!argStream.HasErrors())
-    {
-        // Log him in
-        if (CStaticFunctionDefinitions::LogIn(pPlayer, pAccount, strPassword))
-        {
-            // Success
-            lua_pushboolean(luaVM, true);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    // Failed
-    lua_pushboolean(luaVM, false);
-    return 1;
+    std::string strPassword = password.value_or("");
+    return m_pAccountManager->LogIn(pPlayer, pPlayer, pAccount->GetName().c_str(), strPassword.c_str(), password.has_value());
 }
 
 int CLuaAccountDefs::LogOut(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.h
@@ -19,7 +19,7 @@ public:
     static void AddClass(lua_State* luaVM);
 
     // Log in/out
-    LUA_DECLARE(LogIn);
+    static bool LogIn(CPlayer* pPlayer, CAccount* pAccount, std::optional<std::string> password);
     LUA_DECLARE(LogOut);
 
     // Account get funcs


### PR DESCRIPTION
It would be useful for custom auto-login implementations.