### PR TITLE
Refactor CClientModelManager

### DIFF
--- a/Client/mods/deathmatch/logic/CClientModel.cpp
+++ b/Client/mods/deathmatch/logic/CClientModel.cpp
@@ -128,3 +128,19 @@ void CClientModel::RestoreEntitiesUsingThisModel()
     // Restore DFF/TXD
     g_pClientGame->GetManager()->GetDFFManager()->RestoreModel(m_iModelID);
 }
+
+unsigned short CClientModel::GetDefaultParentModel(eClientModelType type)
+{
+    switch (type)
+    {
+    case eClientModelType::PED:
+        return 7; // male01
+
+    case eClientModelType::OBJECT:
+        return 1337; // BinNt07_LA (trash can)
+
+    case eClientModelType::VEHICLE:
+        return 400; // VT_LANDSTAL
+    }
+    assert(0); // Shoudn't happen
+}

--- a/Client/mods/deathmatch/logic/CClientModel.cpp
+++ b/Client/mods/deathmatch/logic/CClientModel.cpp
@@ -21,8 +21,11 @@ CClientModel::~CClientModel(void)
     Deallocate();
 }
 
-bool CClientModel::Allocate(ushort usParentID)
+bool CClientModel::Allocate(std::optional<ushort> usParentID)
 {
+    if (!usParentID.has_value())
+        usParentID.emplace(GetDefaultParentModel(m_eModelType));
+
     m_bAllocatedByUs = true;
 
     CModelInfo* pModelInfo = g_pGame->GetModelInfo(m_iModelID, true);
@@ -37,16 +40,16 @@ bool CClientModel::Allocate(ushort usParentID)
             pModelInfo->MakePedModel("PSYCHO");
             break;
         case eClientModelType::OBJECT:
-            if (g_pClientGame->GetObjectManager()->IsValidModel(usParentID))
+            if (g_pClientGame->GetObjectManager()->IsValidModel(usParentID.value()))
             {
-                pModelInfo->MakeObjectModel(usParentID);
+                pModelInfo->MakeObjectModel(usParentID.value());
                 return true;
             }
             break;
         case eClientModelType::VEHICLE:
-            if (g_pClientGame->GetVehicleManager()->IsValidModel(usParentID))
+            if (g_pClientGame->GetVehicleManager()->IsValidModel(usParentID.value()))
             {
-                pModelInfo->MakeVehicleAutomobile(usParentID);
+                pModelInfo->MakeVehicleAutomobile(usParentID.value());
                 return true;
             }
             break;

--- a/Client/mods/deathmatch/logic/CClientModel.cpp
+++ b/Client/mods/deathmatch/logic/CClientModel.cpp
@@ -10,9 +10,8 @@
 
 #include "StdInc.h"
 
-CClientModel::CClientModel(CClientManager* pManager, int iModelID, eClientModelType eModelType)
+CClientModel::CClientModel(int iModelID, eClientModelType eModelType)
 {
-    m_pManager = pManager;
     m_iModelID = iModelID;
     m_eModelType = eModelType;
 }

--- a/Client/mods/deathmatch/logic/CClientModel.h
+++ b/Client/mods/deathmatch/logic/CClientModel.h
@@ -41,6 +41,8 @@ public:
     void             SetParentResource(CResource* pResource) { m_pParentResource = pResource; }
     CResource*       GetParentResource(void) const { return m_pParentResource; }
 
+    static unsigned short GetDefaultParentModel(eClientModelType type);
+
 protected:
     int              m_iModelID;
     eClientModelType m_eModelType;

--- a/Client/mods/deathmatch/logic/CClientModel.h
+++ b/Client/mods/deathmatch/logic/CClientModel.h
@@ -29,7 +29,7 @@ class CClientModel
     friend class CClientModelManager;
 
 public:
-    CClientModel(CClientManager* pManager, int iModelID, eClientModelType eModelType);
+    CClientModel(int iModelID, eClientModelType eModelType);
     ~CClientModel(void);
 
     int              GetModelID(void) const { return m_iModelID; };
@@ -41,10 +41,8 @@ public:
     CResource*       GetParentResource(void) const { return m_pParentResource; }
 
 protected:
-    CClientManager* m_pManager;
-
-    int                             m_iModelID;
-    eClientModelType                m_eModelType;
-    bool                            m_bAllocatedByUs;
-    CResource*                      m_pParentResource; // Resource that allocated model
+    int              m_iModelID;
+    eClientModelType m_eModelType;
+    bool             m_bAllocatedByUs;
+    CResource*       m_pParentResource; // Resource that allocated model
 };

--- a/Client/mods/deathmatch/logic/CClientModel.h
+++ b/Client/mods/deathmatch/logic/CClientModel.h
@@ -28,10 +28,9 @@ class CClientModel
 {
     friend class CClientModelManager;
 
-public:
     CClientModel(int iModelID, eClientModelType eModelType);
     ~CClientModel(void);
-    
+
 public:
     int              GetModelID(void) const { return m_iModelID; };
     eClientModelType GetModelType(void) const { return m_eModelType; };
@@ -47,5 +46,5 @@ protected:
     int              m_iModelID;
     eClientModelType m_eModelType;
     bool             m_bAllocatedByUs;
-    CResource*       m_pParentResource; // Resource that allocated model
+    CResource*       m_pParentResource; // Resource that has allocated us
 };

--- a/Client/mods/deathmatch/logic/CClientModel.h
+++ b/Client/mods/deathmatch/logic/CClientModel.h
@@ -12,7 +12,7 @@ class CClientModel;
 
 #pragma once
 
-#include <list>
+#include <optional>
 
 enum class eClientModelType
 {
@@ -31,10 +31,11 @@ class CClientModel
 public:
     CClientModel(int iModelID, eClientModelType eModelType);
     ~CClientModel(void);
-
+    
+public:
     int              GetModelID(void) const { return m_iModelID; };
     eClientModelType GetModelType(void) const { return m_eModelType; };
-    bool             Allocate(ushort usParentID);
+    bool             Allocate(std::optional<ushort> usParentID);
     bool             Deallocate(void);
     void             RestoreEntitiesUsingThisModel();
     void             SetParentResource(CResource* pResource) { m_pParentResource = pResource; }

--- a/Client/mods/deathmatch/logic/CClientModelManager.h
+++ b/Client/mods/deathmatch/logic/CClientModelManager.h
@@ -12,7 +12,7 @@ class CClientModelManager;
 
 #pragma once
 
-#include <list>
+#include <optional>
 #include <vector>
 #include <memory>
 #include "CClientModel.h"
@@ -21,26 +21,24 @@ class CClientModelManager;
 
 class CClientModelManager
 {
-    friend class CClientModel;
-
 public:
     CClientModelManager() = default;
-    ~CClientModelManager(void);
+    ~CClientModelManager() = default;
 
-    void RemoveAll(void);
+    ushort GetFirstFreeModelID() const noexcept;
+    ushort Request(CResource* pParentResource, eClientModelType type, std::optional<ushort> parentModelID);
 
-    void Add(const std::shared_ptr<CClientModel>& pModel);
-    bool Remove(const std::shared_ptr<CClientModel>& pModel);
-
-    int GetFirstFreeModelID(void);
-
-    std::shared_ptr<CClientModel> FindModelByID(int iModelID);
-
-    std::vector<std::shared_ptr<CClientModel>> GetModelsByType(eClientModelType type, const unsigned int minModelID = 0);
-
+    bool Free(ushort id);
     void DeallocateModelsAllocatedByResource(CResource* pResource);
+
+    std::shared_ptr<CClientModel> FindModelByID(ushort iModelID)  const noexcept;
+    std::vector<std::shared_ptr<CClientModel>> GetModelsByType(eClientModelType type, const unsigned int minModelID = 0) const;
+
+    // Check if the ID is < MAX_MODEL_ID
+    // Logical validity means that the model might be in our model array
+    static bool IsLogicallyValidID(ushort id) { return id < MAX_MODEL_ID; }
 
 private:
     std::shared_ptr<CClientModel> m_Models[MAX_MODEL_ID];
-    unsigned int                  m_modelCount = 0;
+    size_t                        m_modelCount = 0;
 };

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
@@ -27,8 +27,8 @@ public:
     LUA_DECLARE(EngineRestoreCOL);
     LUA_DECLARE(EngineReplaceModel);
     LUA_DECLARE(EngineRestoreModel);
-    LUA_DECLARE(EngineRequestModel);
-    LUA_DECLARE(EngineFreeModel);
+
+    static std::variant<bool, ushort> EngineRequestModel(lua_State* luaVM, eClientModelType modelType, std::optional<ushort> parentModel);
     LUA_DECLARE(EngineReplaceAnimation);
     LUA_DECLARE(EngineRestoreAnimation);
     LUA_DECLARE(EngineReplaceMatchingAtomics);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
@@ -29,6 +29,8 @@ public:
     LUA_DECLARE(EngineRestoreModel);
 
     static std::variant<bool, ushort> EngineRequestModel(lua_State* luaVM, eClientModelType modelType, std::optional<ushort> parentModel);
+    static bool                       EngineFreeModel(ushort id);
+
     LUA_DECLARE(EngineReplaceAnimation);
     LUA_DECLARE(EngineRestoreAnimation);
     LUA_DECLARE(EngineReplaceMatchingAtomics);


### PR DESCRIPTION
Sorry for the `Refactor CClientModelManager` commit not being more atomic, so just ignore the diff, because I've refactored every function in there.

This PR:
- Fixes the flipped relationship between the `model` and `manager. Now only the manager can construct a `model`.
- - This removes `CClientModelManager* m_pManager` from `CClientModel` 
- Moves model creation code into the manager (which for some odd reason was in the Lua API `EngineRequestModel` function)
- Improve `CClientModel::Allocate` by automatically choosing a default parent id if none given 
- Improve error checking in `EngineFreeModel`