### PR TITLE
Add override argument to setAnalogControlState

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPad.cpp
+++ b/Client/mods/deathmatch/logic/CClientPad.cpp
@@ -16,7 +16,7 @@
 #define CS_NAN -32768
 
 SFixedArray<short, MAX_GTA_CONTROLS>       CClientPad::m_sScriptedStates;
-SFixedArray<bool, MAX_GTA_ANALOG_CONTROLS> CClientPad::m_bScriptedStatesOverride;
+SFixedArray<bool, MAX_GTA_ANALOG_CONTROLS> CClientPad::m_bScriptedStatesNextFrameOverride;
 bool                                       CClientPad::m_bFlyWithMouse;
 bool                                       CClientPad::m_bSteerWithMouse;
 
@@ -119,7 +119,7 @@ CClientPad::CClientPad()
     for (unsigned int i = 0; i < MAX_GTA_ANALOG_CONTROLS; i++)
     {
         m_sScriptedStates[i] = CS_NAN;
-        m_bScriptedStatesOverride[i] = false;
+        m_bScriptedStatesNextFrameOverride[i] = false;
     }
 }
 
@@ -602,82 +602,82 @@ bool CClientPad::SetAnalogControlState(const char* szName, float fState, bool bF
             case 0:
                 m_sScriptedStates[uiIndex] = (short)(fState * -128.0f);
                 m_sScriptedStates[1] = 0;
-                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
-                m_bScriptedStatesOverride[1] = false;
+                m_bScriptedStatesNextFrameOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesNextFrameOverride[1] = false;
                 return true;            // Left
             case 1:
                 m_sScriptedStates[uiIndex] = (short)(fState * 128.0f);
                 m_sScriptedStates[0] = 0;
-                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
-                m_bScriptedStatesOverride[0] = false;
+                m_bScriptedStatesNextFrameOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesNextFrameOverride[0] = false;
                 return true;            // Right
             case 2:
                 m_sScriptedStates[uiIndex] = (short)(fState * -128.0f);
                 m_sScriptedStates[3] = 0;
-                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
-                m_bScriptedStatesOverride[3] = false;
+                m_bScriptedStatesNextFrameOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesNextFrameOverride[3] = false;
                 return true;            // Up
             case 3:
                 m_sScriptedStates[uiIndex] = (short)(fState * 128.0f);
                 m_sScriptedStates[2] = 0;
-                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
-                m_bScriptedStatesOverride[2] = false;
+                m_bScriptedStatesNextFrameOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesNextFrameOverride[2] = false;
                 return true;            // Down
             case 4:
                 m_sScriptedStates[uiIndex] = (short)(fState * -128.0f);
                 m_sScriptedStates[5] = 0;
-                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
-                m_bScriptedStatesOverride[5] = false;
+                m_bScriptedStatesNextFrameOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesNextFrameOverride[5] = false;
                 return true;            // Vehicle Left
             case 5:
                 m_sScriptedStates[uiIndex] = (short)(fState * 128.0f);
                 m_sScriptedStates[4] = 0;
-                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
-                m_bScriptedStatesOverride[4] = false;
+                m_bScriptedStatesNextFrameOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesNextFrameOverride[4] = false;
                 return true;            // Vehicle Right
             case 6:
                 m_sScriptedStates[uiIndex] = (short)(fState * -128.0f);
                 m_sScriptedStates[7] = 0;
-                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
-                m_bScriptedStatesOverride[7] = false;
+                m_bScriptedStatesNextFrameOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesNextFrameOverride[7] = false;
                 return true;            // Up
             case 7:
                 m_sScriptedStates[uiIndex] = (short)(fState * 128.0f);
                 m_sScriptedStates[6] = 0;
-                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
-                m_bScriptedStatesOverride[6] = false;
+                m_bScriptedStatesNextFrameOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesNextFrameOverride[6] = false;
                 return true;            // Down
             case 8:
                 m_sScriptedStates[uiIndex] = (short)(fState * 255.0f);
-                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesNextFrameOverride[uiIndex] = bFrameForced;
                 return true;            // Accel
             case 9:
                 m_sScriptedStates[uiIndex] = (short)(fState * 255.0f);
-                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesNextFrameOverride[uiIndex] = bFrameForced;
                 return true;            // Reverse
             case 10:
                 m_sScriptedStates[uiIndex] = (short)(fState * -128.0f);
                 m_sScriptedStates[11] = 0;
-                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
-                m_bScriptedStatesOverride[11] = false;
+                m_bScriptedStatesNextFrameOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesNextFrameOverride[11] = false;
                 return true;            // Special Left
             case 11:
                 m_sScriptedStates[uiIndex] = (short)(fState * 128.0f);
                 m_sScriptedStates[10] = 0;
-                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
-                m_bScriptedStatesOverride[10] = false;
+                m_bScriptedStatesNextFrameOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesNextFrameOverride[10] = false;
                 return true;            // Special Right
             case 12:
                 m_sScriptedStates[uiIndex] = (short)(fState * -128.0f);
                 m_sScriptedStates[13] = 0;
-                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
-                m_bScriptedStatesOverride[13] = false;
+                m_bScriptedStatesNextFrameOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesNextFrameOverride[13] = false;
                 return true;            // Special Up
             case 13:
                 m_sScriptedStates[uiIndex] = (short)(fState * 128.0f);
                 m_sScriptedStates[12] = 0;
-                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
-                m_bScriptedStatesOverride[12] = false;
+                m_bScriptedStatesNextFrameOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesNextFrameOverride[12] = false;
                 return true;            // Special Down
             default:
                 return false;
@@ -742,9 +742,9 @@ void CClientPad::ProcessControl(short& usControlValue, unsigned int uiIndex)
     //          that's why we check unequals != 0
     //          otherwise the values are already in their expected value boundaries
     //
-    // usControlValue               is the updated input value we get from the player
-    // m_sScriptedStates            contains our script value
-    // m_bScriptedStatesOverride    if the player input should be forcefully overriden for the next frame
+    // usControlValue                       is the updated input value we get from the player
+    // m_sScriptedStates                    contains our script value
+    // m_bScriptedStatesNextFrameOverride   if the player input should be forcefully overriden for the next frame
     //
     //
     // old behavior or (override == false)
@@ -760,9 +760,9 @@ void CClientPad::ProcessControl(short& usControlValue, unsigned int uiIndex)
     //
     //
 
-    if (m_bScriptedStatesOverride[uiIndex])
+    if (m_bScriptedStatesNextFrameOverride[uiIndex])
     {
-        m_bScriptedStatesOverride[uiIndex] = false;
+        m_bScriptedStatesNextFrameOverride[uiIndex] = false;
         if (m_sScriptedStates[uiIndex] != CS_NAN)
             std::swap(usControlValue, m_sScriptedStates[uiIndex]);
     }

--- a/Client/mods/deathmatch/logic/CClientPad.cpp
+++ b/Client/mods/deathmatch/logic/CClientPad.cpp
@@ -16,7 +16,7 @@
 #define CS_NAN -32768
 
 SFixedArray<short, MAX_GTA_CONTROLS>       CClientPad::m_sScriptedStates;
-SFixedArray<bool, MAX_GTA_ANALOG_CONTROLS> CClientPad::m_bScriptedReadyToReset;
+SFixedArray<bool, MAX_GTA_ANALOG_CONTROLS> CClientPad::m_bScriptedStatesFrameForced;
 bool                                       CClientPad::m_bFlyWithMouse;
 bool                                       CClientPad::m_bSteerWithMouse;
 
@@ -119,7 +119,7 @@ CClientPad::CClientPad()
     for (unsigned int i = 0; i < MAX_GTA_ANALOG_CONTROLS; i++)
     {
         m_sScriptedStates[i] = CS_NAN;
-        m_bScriptedReadyToReset[i] = false;
+        m_bScriptedStatesFrameForced[i] = false;
     }
 }
 
@@ -590,7 +590,7 @@ bool CClientPad::GetAnalogControlState(const char* szName, CControllerState& cs,
     return false;
 }
 // Set the analog control state and store them temporarilly before they are actually applied.  Used for players.
-bool CClientPad::SetAnalogControlState(const char* szName, float fState)
+bool CClientPad::SetAnalogControlState(const char* szName, float fState, bool bFrameForced)
 {
     // Ensure values are between 0 and 1
     fState = Clamp<float>(0, fState, 1);
@@ -602,56 +602,82 @@ bool CClientPad::SetAnalogControlState(const char* szName, float fState)
             case 0:
                 m_sScriptedStates[uiIndex] = (short)(fState * -128.0f);
                 m_sScriptedStates[1] = 0;
+                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
+                m_bScriptedStatesFrameForced[1] = false;
                 return true;            // Left
             case 1:
                 m_sScriptedStates[uiIndex] = (short)(fState * 128.0f);
                 m_sScriptedStates[0] = 0;
+                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
+                m_bScriptedStatesFrameForced[0] = false;
                 return true;            // Right
             case 2:
                 m_sScriptedStates[uiIndex] = (short)(fState * -128.0f);
                 m_sScriptedStates[3] = 0;
+                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
+                m_bScriptedStatesFrameForced[3] = false;
                 return true;            // Up
             case 3:
                 m_sScriptedStates[uiIndex] = (short)(fState * 128.0f);
                 m_sScriptedStates[2] = 0;
+                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
+                m_bScriptedStatesFrameForced[2] = false;
                 return true;            // Down
             case 4:
                 m_sScriptedStates[uiIndex] = (short)(fState * -128.0f);
                 m_sScriptedStates[5] = 0;
+                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
+                m_bScriptedStatesFrameForced[5] = false;
                 return true;            // Vehicle Left
             case 5:
                 m_sScriptedStates[uiIndex] = (short)(fState * 128.0f);
                 m_sScriptedStates[4] = 0;
+                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
+                m_bScriptedStatesFrameForced[4] = false;
                 return true;            // Vehicle Right
             case 6:
                 m_sScriptedStates[uiIndex] = (short)(fState * -128.0f);
                 m_sScriptedStates[7] = 0;
+                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
+                m_bScriptedStatesFrameForced[7] = false;
                 return true;            // Up
             case 7:
                 m_sScriptedStates[uiIndex] = (short)(fState * 128.0f);
                 m_sScriptedStates[6] = 0;
+                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
+                m_bScriptedStatesFrameForced[6] = false;
                 return true;            // Down
             case 8:
                 m_sScriptedStates[uiIndex] = (short)(fState * 255.0f);
+                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
                 return true;            // Accel
             case 9:
                 m_sScriptedStates[uiIndex] = (short)(fState * 255.0f);
+                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
                 return true;            // Reverse
             case 10:
                 m_sScriptedStates[uiIndex] = (short)(fState * -128.0f);
                 m_sScriptedStates[11] = 0;
+                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
+                m_bScriptedStatesFrameForced[11] = false;
                 return true;            // Special Left
             case 11:
                 m_sScriptedStates[uiIndex] = (short)(fState * 128.0f);
                 m_sScriptedStates[10] = 0;
+                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
+                m_bScriptedStatesFrameForced[10] = false;
                 return true;            // Special Right
             case 12:
                 m_sScriptedStates[uiIndex] = (short)(fState * -128.0f);
                 m_sScriptedStates[13] = 0;
+                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
+                m_bScriptedStatesFrameForced[13] = false;
                 return true;            // Special Up
             case 13:
                 m_sScriptedStates[uiIndex] = (short)(fState * 128.0f);
                 m_sScriptedStates[12] = 0;
+                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
+                m_bScriptedStatesFrameForced[12] = false;
                 return true;            // Special Down
             default:
                 return false;
@@ -672,59 +698,85 @@ void CClientPad::ProcessSetAnalogControlState(CControllerState& cs, bool bOnFoot
 {
     // We forcefully apply the control state until we find that the user isnt pressing that button anymore.
     // When that happens, we wait for new input and then stop setting the control state and remove it.
+    // false negative
+    // true positive
+    // true/false as third argument was actually redundant
     if (bOnFoot)
     {
         unsigned int uiIndex = 0;
 
-        ProcessControl(cs.LeftStickX, uiIndex, false);
+        ProcessControl(cs.LeftStickX, uiIndex); //, false
         uiIndex++;            // Left
-        ProcessControl(cs.LeftStickX, uiIndex, true);
+        ProcessControl(cs.LeftStickX, uiIndex); //, true
         uiIndex++;            // Right
-        ProcessControl(cs.LeftStickY, uiIndex, false);
+        ProcessControl(cs.LeftStickY, uiIndex); //, false
         uiIndex++;            // Up
-        ProcessControl(cs.LeftStickY, uiIndex, true);
+        ProcessControl(cs.LeftStickY, uiIndex); //, true
         uiIndex++;            // Down
     }
     else
     {
         unsigned int uiIndex = 4;
 
-        ProcessControl(cs.LeftStickX, uiIndex, false);
+        ProcessControl(cs.LeftStickX, uiIndex); //, false
         uiIndex++;            // Left
-        ProcessControl(cs.LeftStickX, uiIndex, true);
+        ProcessControl(cs.LeftStickX, uiIndex); //, true
         uiIndex++;            // Right
-        ProcessControl(cs.LeftStickY, uiIndex, false);
+        ProcessControl(cs.LeftStickY, uiIndex); //, false
         uiIndex++;            // Up
-        ProcessControl(cs.LeftStickY, uiIndex, true);
+        ProcessControl(cs.LeftStickY, uiIndex); //, true
         uiIndex++;            // Down
-        ProcessControl(cs.ButtonCross, uiIndex, true);
+        ProcessControl(cs.ButtonCross, uiIndex); //, true
         uiIndex++;            // Accel
-        ProcessControl(cs.ButtonSquare, uiIndex, true);
+        ProcessControl(cs.ButtonSquare, uiIndex); //, true
         uiIndex++;            // Brake
-        ProcessControl(cs.RightStickX, uiIndex, false);
+        ProcessControl(cs.RightStickX, uiIndex); //, false
         uiIndex++;            // Special Left
-        ProcessControl(cs.RightStickX, uiIndex, true);
+        ProcessControl(cs.RightStickX, uiIndex); //, true
         uiIndex++;            // Special Right
-        ProcessControl(cs.RightStickY, uiIndex, false);
+        ProcessControl(cs.RightStickY, uiIndex); //, false
         uiIndex++;            // Special Up
-        ProcessControl(cs.RightStickY, uiIndex, true);
+        ProcessControl(cs.RightStickY, uiIndex); //, true
         uiIndex++;            // Special Down
     }
 }
 
-void CClientPad::ProcessControl(short& usControlValue, unsigned int uiIndex, bool bPositive)
+void CClientPad::ProcessControl(short& usControlValue, unsigned int uiIndex)
 {
-    bool bResetCmp = bPositive ? (usControlValue > 0) : (usControlValue < 0);
-    if (!m_bScriptedReadyToReset[uiIndex])            // If we havent marked as ready to reset the control, find out if we are
-        m_bScriptedReadyToReset[uiIndex] = ((m_sScriptedStates[uiIndex] != CS_NAN) && (usControlValue == 0));
+    // Note:    control values can be 0, negative or positive
+    //          that's why we check unequals != 0
+    //          otherwise the values are already in their expected value boundaries
+    //
+    // usControlValue           is the updated input value we get from the player
+    // m_sScriptedStates        contains our script value
+    //
+    //
+    // old behavior or (frameForced == false)
+    //      - player input will not be overwitten if it's unequals to 0*
+    //      - otherwise it will use the last set value after player input went 0*
+    //        and will keep this behavior for comming frames
+    //
+    // behavior with (frameForced == true)
+    //      - will overwrite the player input even if not 0*
+    //        only for the next frame
+    //
+    // 0* = no key pressed or analog hardware controll touched
+    //
+    //
 
-    if (m_bScriptedReadyToReset[uiIndex] && bResetCmp)            // If we're ready to reset, and our reset comparision is passed
-        m_sScriptedStates[uiIndex] = CS_NAN;                      // Remove our scripted control state
-    else
-        // Only apply the control state of we're actually a number, and that we're positive when we want it to be and vice versa
+    if (m_bScriptedStatesFrameForced[uiIndex])
+    {
+        m_bScriptedStatesFrameForced[uiIndex] = false;
         if (m_sScriptedStates[uiIndex] != CS_NAN)
-        if ((bPositive && m_sScriptedStates[uiIndex] > 0) || (!bPositive && m_sScriptedStates[uiIndex] < 0))
-            usControlValue = m_sScriptedStates[uiIndex];            // Otherwise force the scripted control state
+            std::swap(usControlValue, m_sScriptedStates[uiIndex]);
+    }
+    else
+    {
+        if (usControlValue != 0)
+            m_sScriptedStates[uiIndex] = CS_NAN;
+        else if (m_sScriptedStates[uiIndex] != CS_NAN && m_sScriptedStates[uiIndex] != 0)
+            usControlValue = m_sScriptedStates[uiIndex];
+    }
 }
 
 // Process toggled controls and apply them directly to the pad state.  Used for players when keyboard input blocking is insufficient.

--- a/Client/mods/deathmatch/logic/CClientPad.cpp
+++ b/Client/mods/deathmatch/logic/CClientPad.cpp
@@ -16,7 +16,7 @@
 #define CS_NAN -32768
 
 SFixedArray<short, MAX_GTA_CONTROLS>       CClientPad::m_sScriptedStates;
-SFixedArray<bool, MAX_GTA_ANALOG_CONTROLS> CClientPad::m_bScriptedStatesFrameForced;
+SFixedArray<bool, MAX_GTA_ANALOG_CONTROLS> CClientPad::m_bScriptedStatesOverride;
 bool                                       CClientPad::m_bFlyWithMouse;
 bool                                       CClientPad::m_bSteerWithMouse;
 
@@ -119,7 +119,7 @@ CClientPad::CClientPad()
     for (unsigned int i = 0; i < MAX_GTA_ANALOG_CONTROLS; i++)
     {
         m_sScriptedStates[i] = CS_NAN;
-        m_bScriptedStatesFrameForced[i] = false;
+        m_bScriptedStatesOverride[i] = false;
     }
 }
 
@@ -602,82 +602,82 @@ bool CClientPad::SetAnalogControlState(const char* szName, float fState, bool bF
             case 0:
                 m_sScriptedStates[uiIndex] = (short)(fState * -128.0f);
                 m_sScriptedStates[1] = 0;
-                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
-                m_bScriptedStatesFrameForced[1] = false;
+                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesOverride[1] = false;
                 return true;            // Left
             case 1:
                 m_sScriptedStates[uiIndex] = (short)(fState * 128.0f);
                 m_sScriptedStates[0] = 0;
-                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
-                m_bScriptedStatesFrameForced[0] = false;
+                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesOverride[0] = false;
                 return true;            // Right
             case 2:
                 m_sScriptedStates[uiIndex] = (short)(fState * -128.0f);
                 m_sScriptedStates[3] = 0;
-                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
-                m_bScriptedStatesFrameForced[3] = false;
+                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesOverride[3] = false;
                 return true;            // Up
             case 3:
                 m_sScriptedStates[uiIndex] = (short)(fState * 128.0f);
                 m_sScriptedStates[2] = 0;
-                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
-                m_bScriptedStatesFrameForced[2] = false;
+                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesOverride[2] = false;
                 return true;            // Down
             case 4:
                 m_sScriptedStates[uiIndex] = (short)(fState * -128.0f);
                 m_sScriptedStates[5] = 0;
-                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
-                m_bScriptedStatesFrameForced[5] = false;
+                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesOverride[5] = false;
                 return true;            // Vehicle Left
             case 5:
                 m_sScriptedStates[uiIndex] = (short)(fState * 128.0f);
                 m_sScriptedStates[4] = 0;
-                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
-                m_bScriptedStatesFrameForced[4] = false;
+                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesOverride[4] = false;
                 return true;            // Vehicle Right
             case 6:
                 m_sScriptedStates[uiIndex] = (short)(fState * -128.0f);
                 m_sScriptedStates[7] = 0;
-                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
-                m_bScriptedStatesFrameForced[7] = false;
+                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesOverride[7] = false;
                 return true;            // Up
             case 7:
                 m_sScriptedStates[uiIndex] = (short)(fState * 128.0f);
                 m_sScriptedStates[6] = 0;
-                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
-                m_bScriptedStatesFrameForced[6] = false;
+                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesOverride[6] = false;
                 return true;            // Down
             case 8:
                 m_sScriptedStates[uiIndex] = (short)(fState * 255.0f);
-                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
+                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
                 return true;            // Accel
             case 9:
                 m_sScriptedStates[uiIndex] = (short)(fState * 255.0f);
-                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
+                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
                 return true;            // Reverse
             case 10:
                 m_sScriptedStates[uiIndex] = (short)(fState * -128.0f);
                 m_sScriptedStates[11] = 0;
-                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
-                m_bScriptedStatesFrameForced[11] = false;
+                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesOverride[11] = false;
                 return true;            // Special Left
             case 11:
                 m_sScriptedStates[uiIndex] = (short)(fState * 128.0f);
                 m_sScriptedStates[10] = 0;
-                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
-                m_bScriptedStatesFrameForced[10] = false;
+                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesOverride[10] = false;
                 return true;            // Special Right
             case 12:
                 m_sScriptedStates[uiIndex] = (short)(fState * -128.0f);
                 m_sScriptedStates[13] = 0;
-                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
-                m_bScriptedStatesFrameForced[13] = false;
+                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesOverride[13] = false;
                 return true;            // Special Up
             case 13:
                 m_sScriptedStates[uiIndex] = (short)(fState * 128.0f);
                 m_sScriptedStates[12] = 0;
-                m_bScriptedStatesFrameForced[uiIndex] = bFrameForced;
-                m_bScriptedStatesFrameForced[12] = false;
+                m_bScriptedStatesOverride[uiIndex] = bFrameForced;
+                m_bScriptedStatesOverride[12] = false;
                 return true;            // Special Down
             default:
                 return false;
@@ -698,46 +698,41 @@ void CClientPad::ProcessSetAnalogControlState(CControllerState& cs, bool bOnFoot
 {
     // We forcefully apply the control state until we find that the user isnt pressing that button anymore.
     // When that happens, we wait for new input and then stop setting the control state and remove it.
-    // false negative
-    // true positive
-    // true/false as third argument was actually redundant
     if (bOnFoot)
     {
         unsigned int uiIndex = 0;
 
-        ProcessControl(cs.LeftStickX, uiIndex); //, false
-        uiIndex++;            // Left
-        ProcessControl(cs.LeftStickX, uiIndex); //, true
-        uiIndex++;            // Right
-        ProcessControl(cs.LeftStickY, uiIndex); //, false
-        uiIndex++;            // Up
-        ProcessControl(cs.LeftStickY, uiIndex); //, true
-        uiIndex++;            // Down
+        ProcessControl(cs.LeftStickX, uiIndex); // Left
+        uiIndex++;            
+        ProcessControl(cs.LeftStickX, uiIndex); // Right
+        uiIndex++;            
+        ProcessControl(cs.LeftStickY, uiIndex); // Up
+        uiIndex++;            
+        ProcessControl(cs.LeftStickY, uiIndex); // Down
     }
     else
     {
         unsigned int uiIndex = 4;
 
-        ProcessControl(cs.LeftStickX, uiIndex); //, false
-        uiIndex++;            // Left
-        ProcessControl(cs.LeftStickX, uiIndex); //, true
-        uiIndex++;            // Right
-        ProcessControl(cs.LeftStickY, uiIndex); //, false
-        uiIndex++;            // Up
-        ProcessControl(cs.LeftStickY, uiIndex); //, true
-        uiIndex++;            // Down
-        ProcessControl(cs.ButtonCross, uiIndex); //, true
-        uiIndex++;            // Accel
-        ProcessControl(cs.ButtonSquare, uiIndex); //, true
-        uiIndex++;            // Brake
-        ProcessControl(cs.RightStickX, uiIndex); //, false
-        uiIndex++;            // Special Left
-        ProcessControl(cs.RightStickX, uiIndex); //, true
-        uiIndex++;            // Special Right
-        ProcessControl(cs.RightStickY, uiIndex); //, false
-        uiIndex++;            // Special Up
-        ProcessControl(cs.RightStickY, uiIndex); //, true
-        uiIndex++;            // Special Down
+        ProcessControl(cs.LeftStickX, uiIndex); // Left
+        uiIndex++;            
+        ProcessControl(cs.LeftStickX, uiIndex); // Right
+        uiIndex++;            
+        ProcessControl(cs.LeftStickY, uiIndex); // Up
+        uiIndex++;            
+        ProcessControl(cs.LeftStickY, uiIndex); // Down
+        uiIndex++;            
+        ProcessControl(cs.ButtonCross, uiIndex); // Accel
+        uiIndex++;            
+        ProcessControl(cs.ButtonSquare, uiIndex); // Brake
+        uiIndex++;            
+        ProcessControl(cs.RightStickX, uiIndex); // Special Left
+        uiIndex++;            
+        ProcessControl(cs.RightStickX, uiIndex); // Special Right
+        uiIndex++;            
+        ProcessControl(cs.RightStickY, uiIndex); // Special Up
+        uiIndex++;            
+        ProcessControl(cs.RightStickY, uiIndex); // Special Down
     }
 }
 
@@ -747,16 +742,17 @@ void CClientPad::ProcessControl(short& usControlValue, unsigned int uiIndex)
     //          that's why we check unequals != 0
     //          otherwise the values are already in their expected value boundaries
     //
-    // usControlValue           is the updated input value we get from the player
-    // m_sScriptedStates        contains our script value
+    // usControlValue               is the updated input value we get from the player
+    // m_sScriptedStates            contains our script value
+    // m_bScriptedStatesOverride    if the player input should be forcefully overriden for the next frame
     //
     //
-    // old behavior or (frameForced == false)
-    //      - player input will not be overwitten if it's unequals to 0*
+    // old behavior or (override == false)
+    //      - player input will not be overwitten if it's unequals to 0* and script input is set 0
     //      - otherwise it will use the last set value after player input went 0*
     //        and will keep this behavior for comming frames
     //
-    // behavior with (frameForced == true)
+    // behavior with (override == true)
     //      - will overwrite the player input even if not 0*
     //        only for the next frame
     //
@@ -764,9 +760,9 @@ void CClientPad::ProcessControl(short& usControlValue, unsigned int uiIndex)
     //
     //
 
-    if (m_bScriptedStatesFrameForced[uiIndex])
+    if (m_bScriptedStatesOverride[uiIndex])
     {
-        m_bScriptedStatesFrameForced[uiIndex] = false;
+        m_bScriptedStatesOverride[uiIndex] = false;
         if (m_sScriptedStates[uiIndex] != CS_NAN)
             std::swap(usControlValue, m_sScriptedStates[uiIndex]);
     }

--- a/Client/mods/deathmatch/logic/CClientPad.h
+++ b/Client/mods/deathmatch/logic/CClientPad.h
@@ -39,14 +39,14 @@ public:
     static void RemoveSetAnalogControlState(const char* szName);
 
     static void ProcessSetAnalogControlState(CControllerState& cs, bool bOnFoot);
-    static void ProcessControl(short& usControlValue, unsigned int uiIndex); //, bool bPositive
+    static void ProcessControl(short& usControlValue, unsigned int uiIndex);
 
     static void ProcessAllToggledControls(CControllerState& cs, bool bOnFoot);
     static bool ProcessToggledControl(const char* szName, CControllerState& cs, bool bOnFoot, bool bEnabled);
     static bool GetControlState(const char* szName, CControllerState& State, bool bOnFoot);
 
     static SFixedArray<short, MAX_GTA_CONTROLS>       m_sScriptedStates;
-    static SFixedArray<bool, MAX_GTA_ANALOG_CONTROLS> m_bScriptedStatesOverride;
+    static SFixedArray<bool, MAX_GTA_ANALOG_CONTROLS> m_bScriptedStatesNextFrameOverride;
     static bool                                       m_bFlyWithMouse;
     static bool                                       m_bSteerWithMouse;
 

--- a/Client/mods/deathmatch/logic/CClientPad.h
+++ b/Client/mods/deathmatch/logic/CClientPad.h
@@ -35,18 +35,18 @@ public:
     void DoPulse(CClientPed* pPed);
 
     static bool GetAnalogControlState(const char* szName, CControllerState& cs, bool bOnFoot, float& fState, bool bIgnoreOverrides);
-    static bool SetAnalogControlState(const char* szName, float fState);
+    static bool SetAnalogControlState(const char* szName, float fState, bool bFrameForced);
     static void RemoveSetAnalogControlState(const char* szName);
 
     static void ProcessSetAnalogControlState(CControllerState& cs, bool bOnFoot);
-    static void ProcessControl(short& usControlValue, unsigned int uiIndex, bool bResetCmp);
+    static void ProcessControl(short& usControlValue, unsigned int uiIndex); //, bool bPositive
 
     static void ProcessAllToggledControls(CControllerState& cs, bool bOnFoot);
     static bool ProcessToggledControl(const char* szName, CControllerState& cs, bool bOnFoot, bool bEnabled);
     static bool GetControlState(const char* szName, CControllerState& State, bool bOnFoot);
 
     static SFixedArray<short, MAX_GTA_CONTROLS>       m_sScriptedStates;
-    static SFixedArray<bool, MAX_GTA_ANALOG_CONTROLS> m_bScriptedReadyToReset;
+    static SFixedArray<bool, MAX_GTA_ANALOG_CONTROLS> m_bScriptedStatesFrameForced;
     static bool                                       m_bFlyWithMouse;
     static bool                                       m_bSteerWithMouse;
 

--- a/Client/mods/deathmatch/logic/CClientPad.h
+++ b/Client/mods/deathmatch/logic/CClientPad.h
@@ -46,7 +46,7 @@ public:
     static bool GetControlState(const char* szName, CControllerState& State, bool bOnFoot);
 
     static SFixedArray<short, MAX_GTA_CONTROLS>       m_sScriptedStates;
-    static SFixedArray<bool, MAX_GTA_ANALOG_CONTROLS> m_bScriptedStatesFrameForced;
+    static SFixedArray<bool, MAX_GTA_ANALOG_CONTROLS> m_bScriptedStatesOverride;
     static bool                                       m_bFlyWithMouse;
     static bool                                       m_bSteerWithMouse;
 

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -7084,7 +7084,7 @@ bool CStaticFunctionDefinitions::SetControlState(const char* szControl, bool bSt
     {
         if (CClientPad::GetAnalogControlIndex(szControl, uiIndex))
         {
-            if (CClientPad::SetAnalogControlState(szControl, 1.0))
+            if (CClientPad::SetAnalogControlState(szControl, 1.0, false))
             {
                 return true;
             }

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Input.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Input.cpp
@@ -301,9 +301,10 @@ int CLuaFunctionDefs::GetAnalogControlState(lua_State* luaVM)
 
 int CLuaFunctionDefs::SetAnalogControlState(lua_State* luaVM)
 {
-    //  bool setAnalogControlState ( string controlName [, float state] )
+    //  bool setAnalogControlState ( string controlName [, float state][, bFrameForced] )
     SString          strControlState = "";
     float            fState = 0.0f;
+    bool             bFrameForced = false;
     CScriptArgReader argStream(luaVM);
     argStream.ReadString(strControlState);
 
@@ -312,7 +313,10 @@ int CLuaFunctionDefs::SetAnalogControlState(lua_State* luaVM)
         if (argStream.NextIsNumber())
         {
             argStream.ReadNumber(fState);
-            if (CClientPad::SetAnalogControlState(strControlState, fState))
+            if (argStream.NextIsBool())
+                argStream.ReadBool(bFrameForced, false);
+
+            if (CClientPad::SetAnalogControlState(strControlState, fState, bFrameForced))
             {
                 lua_pushboolean(luaVM, true);
                 return 1;

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Input.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Input.cpp
@@ -304,7 +304,7 @@ int CLuaFunctionDefs::SetAnalogControlState(lua_State* luaVM)
     //  bool setAnalogControlState ( string controlName [, float state][, bFrameForced] )
     SString          strControlState = "";
     float            fState = 0.0f;
-    bool             bFrameForced = false;
+    bool             bOverrideUserInput = false;
     CScriptArgReader argStream(luaVM);
     argStream.ReadString(strControlState);
 
@@ -314,9 +314,9 @@ int CLuaFunctionDefs::SetAnalogControlState(lua_State* luaVM)
         {
             argStream.ReadNumber(fState);
             if (argStream.NextIsBool())
-                argStream.ReadBool(bFrameForced, false);
+                argStream.ReadBool(bOverrideUserInput, false);
 
-            if (CClientPad::SetAnalogControlState(strControlState, fState, bFrameForced))
+            if (CClientPad::SetAnalogControlState(strControlState, fState, bOverrideUserInput))
             {
                 lua_pushboolean(luaVM, true);
                 return 1;

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Input.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Input.cpp
@@ -304,7 +304,7 @@ int CLuaFunctionDefs::SetAnalogControlState(lua_State* luaVM)
     //  bool setAnalogControlState ( string controlName [, float state][, bFrameForced] )
     SString          strControlState = "";
     float            fState = 0.0f;
-    bool             bOverrideUserInput = false;
+    bool             bForceOverrideNextFrame = false; //if user input effect should be forcefully overriden for the next frame
     CScriptArgReader argStream(luaVM);
     argStream.ReadString(strControlState);
 
@@ -314,9 +314,9 @@ int CLuaFunctionDefs::SetAnalogControlState(lua_State* luaVM)
         {
             argStream.ReadNumber(fState);
             if (argStream.NextIsBool())
-                argStream.ReadBool(bOverrideUserInput, false);
+                argStream.ReadBool(bForceOverrideNextFrame, false);
 
-            if (CClientPad::SetAnalogControlState(strControlState, fState, bOverrideUserInput))
+            if (CClientPad::SetAnalogControlState(strControlState, fState, bForceOverrideNextFrame))
             {
                 lua_pushboolean(luaVM, true);
                 return 1;


### PR DESCRIPTION
This PR adds a frameForced argument to setAnalogControlState
this allows me to solve my issues i had here: https://github.com/multitheftauto/mtasa-blue/issues/567
Fixes #567

```lua
setAnalogControlState(string state[, float state ][, bool forceOverrideNextFrame = false])
```

old behavior (override = false)
      - player input will not be overwitten if it's unequals to 0
      - otherwise it will use the last set value after player input went 0 every following frame

behavior with (override = true)
      - will overwrite the player input even if it's not 0, but only for the next frame


example edge case:
todo the way setAnalogControlState works
you can in case of a script were you want to invert player controlls only get the player value
with getAnalogControlState if you use set the raw value to true
this is because the opposite control value is always set to 0 except for accelerate and brake


some code examples:

Allows to perfectly switch left right steering of the player
can be usefull for fun race maps with item pickup scripts :)
```lua
addEventHandler("onClientPreRender", root,
    function()
        local right = getAnalogControlState("vehicle_right", true)
        local left = getAnalogControlState("vehicle_left", true)
        
        if right > left then
            setAnalogControlState("vehicle_left", right, true)
        else
            setAnalogControlState("vehicle_right", left, true)
        end
    end
)
```

Allows to make traction control for custom handlings with very aggressive acceleration
for example: take bullet and use this code with runcode
srun setVehicleHandling(me.vehicle, "engineAcceleration", 50) setVehicleHandling(me.vehicle, "maxVelocity", 400)
then try to drive with and with out traction controll script
```lua
addEventHandler("onClientPreRender", root,
    function()
        local vehicle = getPedOccupiedVehicle(localPlayer)
        if vehicle then

            local rearLeft = getVehicleWheelFrictionState(vehicle, 1)
            local rearRight = getVehicleWheelFrictionState(vehicle, 3)
            local rl = tostring(isVehicleWheelOnGround(vehicle, 1))
            local rr = tostring(isVehicleWheelOnGround(vehicle, 3))

            local input = getAnalogControlState("accelerate")
            local tC = 1
            if rl and rr and rearLeft == 1 and rearRight == 1 then
                tC = 0.3
            end
            setAnalogControlState("accelerate", input * tC, true)
        end
    end
)
```

there is also a lot more use stuff where this can be usefull
but the most important is:
- first it doesn't require weird script hacks anymore for keyboard
- second it works for gamepad players too
