### PR TITLE
 Refactor LogIn function 

### DIFF
--- a/Server/mods/deathmatch/logic/CAccountManager.cpp
+++ b/Server/mods/deathmatch/logic/CAccountManager.cpp
@@ -481,7 +481,7 @@ void CAccountManager::RemoveAll()
     DeletePointersAndClearList(m_List);
 }
 
-bool CAccountManager::LogIn(CClient* pClient, CClient* pEchoClient, const char* szAccountName, const char* szPassword, bool bCheckPassword)
+bool CAccountManager::LogIn(CClient* pClient, CClient* pEchoClient, const char* szAccountName, std::optional<SString> password)
 {
     // Is he already logged in?
     if (pClient->IsRegistered())
@@ -530,7 +530,8 @@ bool CAccountManager::LogIn(CClient* pClient, CClient* pEchoClient, const char* 
             pEchoClient->SendEcho(SString("login: Account for '%s' is already in use", szAccountName).c_str());
         return false;
     }
-    if (bCheckPassword && (!IsValidPassword(szPassword) || !pAccount->IsPassword(szPassword)))
+
+    if (password.has_value() && !pAccount->IsPassword(password.value()))
     {
         if (pEchoClient)
             pEchoClient->SendEcho(SString("login: Invalid password for account '%s'", szAccountName).c_str());

--- a/Server/mods/deathmatch/logic/CAccountManager.cpp
+++ b/Server/mods/deathmatch/logic/CAccountManager.cpp
@@ -531,7 +531,7 @@ bool CAccountManager::LogIn(CClient* pClient, CClient* pEchoClient, const char* 
         return false;
     }
 
-    if (password.has_value() && !pAccount->IsPassword(password.value()))
+    if (password.has_value() && (!IsValidPassword(password.value()) || !pAccount->IsPassword(password.value())))
     {
         if (pEchoClient)
             pEchoClient->SendEcho(SString("login: Invalid password for account '%s'", szAccountName).c_str());

--- a/Server/mods/deathmatch/logic/CAccountManager.h
+++ b/Server/mods/deathmatch/logic/CAccountManager.h
@@ -14,6 +14,8 @@ class CAccountManager;
 #pragma once
 
 #include "CAccount.h"
+#include <optional>
+
 typedef uint SDbConnectionId;
 
 #define GUEST_ACCOUNT_NAME          "guest"
@@ -130,7 +132,7 @@ public:
     CAccount* GetAccountFromScriptID(uint uiScriptID);
     SString   GetActiveCaseVariation(const SString& strName);
 
-    bool LogIn(CClient* pClient, CClient* pEchoClient, const char* szAccountName, const char* szPassword, bool bCheckPassword = true);
+    bool LogIn(CClient* pClient, CClient* pEchoClient, const char* szAccountName, std::optional<SString> password);
     bool LogOut(CClient* pClient, CClient* pEchoClient);
 
     std::shared_ptr<CLuaArgument> GetAccountData(CAccount* pAccount, const char* szKey);

--- a/Server/mods/deathmatch/logic/CConsoleCommands.cpp
+++ b/Server/mods/deathmatch/logic/CConsoleCommands.cpp
@@ -836,7 +836,7 @@ bool CConsoleCommands::LogIn(CConsole* pConsole, const char* szArguments, CClien
 
         if (CAccountManager::IsValidAccountName(szNick) && CAccountManager::IsValidPassword(szPassword))
         {
-            return g_pGame->GetAccountManager()->LogIn(pClient, pEchoClient, szNick, szPassword);
+            return g_pGame->GetAccountManager()->LogIn(pClient, pEchoClient, szNick, std::string(szPassword));
         }
         else
         {

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -11347,11 +11347,6 @@ bool CStaticFunctionDefinitions::CopyAccountData(CAccount* pAccount, CAccount* p
     return true;
 }
 
-bool CStaticFunctionDefinitions::LogIn(CPlayer* pPlayer, CAccount* pAccount, const char* szPassword)
-{
-    return m_pAccountManager->LogIn(pPlayer, pPlayer, pAccount->GetName().c_str(), szPassword);
-}
-
 bool CStaticFunctionDefinitions::LogOut(CPlayer* pPlayer)
 {
     return m_pAccountManager->LogOut(pPlayer, pPlayer);

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -692,7 +692,6 @@ public:
     static bool      CopyAccountData(CAccount* pAccount, CAccount* pFromAccount);
 
     // Log in/out funcs
-    static bool LogIn(CPlayer* pPlayer, CAccount* pAccount, const char* szPassword);
     static bool LogOut(CPlayer* pPlayer);
 
     // Admin funcs

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
@@ -602,8 +602,7 @@ int CLuaAccountDefs::CopyAccountData(lua_State* luaVM)
 
 bool CLuaAccountDefs::LogIn(CPlayer* pPlayer, CAccount* pAccount, std::optional<std::string> password)
 {
-    std::string strPassword = password.value_or("");
-    return m_pAccountManager->LogIn(pPlayer, pPlayer, pAccount->GetName().c_str(), strPassword.c_str(), password.has_value());
+    return m_pAccountManager->LogIn(pPlayer, pPlayer, pAccount->GetName().c_str(), std::move(password));
 }
 
 int CLuaAccountDefs::LogOut(lua_State* luaVM)


### PR DESCRIPTION
Reopening as the previous branch was here, instead on my fork. Sorry about that. Need to get used to commit access

Use std::optional for password in CAccountManager as well.
Remove dead code CStaticFnDefs::LogIn