### PR TITLE
Make 3118 and 3553 usable

### DIFF
--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -494,6 +494,7 @@ void CGameSA::Initialize()
     // Initialize garages
     m_pGarages->Initialize();
     SetupSpecialCharacters();
+    SetupBrokenModels();
     m_pRenderWare->Initialize();
 
     // *Sebas* Hide the GTA:SA Main menu.
@@ -812,6 +813,12 @@ void CGameSA::SetupSpecialCharacters()
     ModelInfo[316].MakePedModel ( "COPGRL2" );
     ModelInfo[317].MakePedModel ( "NURGRL2" );
     */
+}
+
+void CGameSA::SetupBrokenModels()
+{
+    ModelInfo[3118].GetInterface()->pColModel = ModelInfo[3059].GetInterface()->pColModel;
+    ModelInfo[3553].GetInterface()->pColModel = ModelInfo[3554].GetInterface()->pColModel;
 }
 
 // Well, has it?

--- a/Client/game_sa/CGameSA.h
+++ b/Client/game_sa/CGameSA.h
@@ -409,6 +409,7 @@ public:
     bool HasCreditScreenFadedOut();
 
     void         SetupSpecialCharacters();
+    void         SetupBrokenModels();
     CWeapon*     CreateWeapon();
     CWeaponStat* CreateWeaponStat(eWeaponType weaponType, eWeaponSkill weaponSkill);
     void         FlushPendingRestreamIPL();


### PR DESCRIPTION
Fixes #1869

This PR add collision for 3118 and 3553. Model 3118 is broken itself, but still usable with custom DFF and COL.
