### PR TITLE
Revert "setWaterLevel: add option to change water level outside world…

### DIFF
--- a/Client/game_sa/CWaterManagerSA.cpp
+++ b/Client/game_sa/CWaterManagerSA.cpp
@@ -742,25 +742,17 @@ bool CWaterManagerSA::SetPositionWaterLevel(const CVector& vecPosition, float fL
     return SetPolyWaterLevel(pPoly, fLevel, pChangeSource);
 }
 
-bool CWaterManagerSA::SetWorldWaterLevel(float fLevel, void* pChangeSource, bool bIncludeWorldNonSeaLevel, bool bIncludeWorldSeaLevel, bool bIncludeOutsideWorldLevel)
+bool CWaterManagerSA::SetWorldWaterLevel(float fLevel, void* pChangeSource, bool bIncludeWorldNonSeaLevel)
 {
     assert(m_bInitializedVertices);
     CVector vecVertexPos;
-
-    if (bIncludeWorldSeaLevel || bIncludeWorldNonSeaLevel)
+    for (DWORD i = 0; i < NUM_DefWaterVertices; i++)
     {
-        for (DWORD i = 0; i < NUM_DefWaterVertices; i++)
-        {
-            m_Vertices[i].GetPosition(vecVertexPos);
-            if ((bIncludeWorldNonSeaLevel && m_Vertices[i].IsWorldNonSeaLevel()) || (bIncludeWorldSeaLevel && !m_Vertices[i].IsWorldNonSeaLevel())) 
-                vecVertexPos.fZ = fLevel;
-            m_Vertices[i].SetPosition(vecVertexPos, pChangeSource);
-        }        
+        m_Vertices[i].GetPosition(vecVertexPos);
+        if (bIncludeWorldNonSeaLevel || !m_Vertices[i].IsWorldNonSeaLevel())
+            vecVertexPos.fZ = fLevel;
+        m_Vertices[i].SetPosition(vecVertexPos, pChangeSource);
     }
-
-    if (bIncludeOutsideWorldLevel)
-        SetOutsideWorldWaterLevel(fLevel);
-
     return true;
 }
 
@@ -774,17 +766,6 @@ bool CWaterManagerSA::SetPolyWaterLevel(CWaterPoly* pPoly, float fLevel, void* p
         pPoly->GetVertex(i)->SetPosition(vecVertexPos, pChangeSource);
     }
     return true;
-}
-
-void CWaterManagerSA::SetOutsideWorldWaterLevel(float fLevel)
-{
-    // Outside world vertices
-    MemPut<float>(0x6EFECC, fLevel);
-    MemPut<float>(0x6EFF0C, fLevel);
-    MemPut<float>(0x6EFF4A, fLevel);
-    MemPut<float>(0x6EFFA6, fLevel);
-    // Collision
-    MemPut<float>(0x6E873F, fLevel);
 }
 
 float CWaterManagerSA::GetWaveLevel()
@@ -976,16 +957,12 @@ void CWaterManagerSA::ResetWorldWaterLevel()
     if (m_bInitializedVertices)
         for (DWORD i = 0; i < NUM_DefWaterVertices; i++)
             m_Vertices[i].Reset();
-
-    SetOutsideWorldWaterLevel(DEFAULT_WATER_LEVEL);
 }
 
 void CWaterManagerSA::Reset()
 {
     // Resets all water to the original single player configuration
     UndoChanges();
-
-    SetOutsideWorldWaterLevel(DEFAULT_WATER_LEVEL);
 
     MemSetFast(m_QuadPool, 0, sizeof(m_QuadPool));
     MemSetFast(m_TrianglePool, 0, sizeof(m_TrianglePool));

--- a/Client/game_sa/CWaterManagerSA.h
+++ b/Client/game_sa/CWaterManagerSA.h
@@ -13,7 +13,6 @@
 
 #include "CWaterSA.h"
 
-#define DEFAULT_WATER_LEVEL                0.0f
 #define DEFAULT_WAVE_LEVEL                 0.0f
 
 #define FUNC_ReadWaterConfiguration        0x6EAE80         // ()
@@ -155,10 +154,9 @@ public:
 
     bool GetWaterLevel(const CVector& vecPosition, float* pfLevel, bool bCheckWaves, CVector* pvecUnknown);
 
-    bool SetWorldWaterLevel(float fLevel, void* pChangeSource, bool bIncludeWorldNonSeaLevel, bool bIncludeWorldSeaLevel, bool bIncludeOutsideWorldLevel);
+    bool SetWorldWaterLevel(float fLevel, void* pChangeSource, bool bIncludeWorldNonSeaLevel);
     bool SetPositionWaterLevel(const CVector& vecPosition, float fLevel, void* pChangeSource);
     bool SetPolyWaterLevel(CWaterPoly* pPoly, float fLevel, void* pChangeSource);
-    void SetOutsideWorldWaterLevel(float fLevel);
     void ResetWorldWaterLevel();
 
     float GetWaveLevel();

--- a/Client/mods/deathmatch/logic/CClientWaterManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientWaterManager.cpp
@@ -88,9 +88,9 @@ bool CClientWaterManager::SetPositionWaterLevel(const CVector& vecPosition, floa
     return g_pGame->GetWaterManager()->SetPositionWaterLevel(vecPosition, fLevel, pChangeSource);
 }
 
-bool CClientWaterManager::SetWorldWaterLevel(float fLevel, void* pChangeSource, bool bIncludeWorldNonSeaLevel, bool bIncludeWorldSeaLevel, bool bIncludeOutsideWorldLevel)
+bool CClientWaterManager::SetWorldWaterLevel(float fLevel, void* pChangeSource, bool bIncludeWorldNonSeaLevel)
 {
-    return g_pGame->GetWaterManager()->SetWorldWaterLevel(fLevel, pChangeSource, bIncludeWorldNonSeaLevel, bIncludeWorldSeaLevel, bIncludeOutsideWorldLevel);
+    return g_pGame->GetWaterManager()->SetWorldWaterLevel(fLevel, pChangeSource, bIncludeWorldNonSeaLevel);
 }
 
 bool CClientWaterManager::SetAllElementWaterLevel(float fLevel, void* pChangeSource)

--- a/Client/mods/deathmatch/logic/CClientWaterManager.h
+++ b/Client/mods/deathmatch/logic/CClientWaterManager.h
@@ -29,7 +29,7 @@ public:
 
     bool GetWaterLevel(CVector& vecPosition, float* pfLevel, bool bCheckWaves, CVector* pvecUnknown);
     bool SetPositionWaterLevel(const CVector& vecPosition, float fLevel, void* pChangeSource);
-    bool SetWorldWaterLevel(float fLevel, void* pChangeSource, bool bIncludeWorldNonSeaLevel, bool bIncludeWorldSeaLevel, bool bIncludeOutsideWorldLevel);
+    bool SetWorldWaterLevel(float fLevel, void* pChangeSource, bool bIncludeWorldNonSeaLevel);
     bool SetAllElementWaterLevel(float fLevel, void* pChangeSource);
     void ResetWorldWaterLevel();
 

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -2230,32 +2230,18 @@ void CPacketHandler::Packet_MapInfo(NetBitStreamInterface& bitStream)
     float fSeaLevel = 0.0f;
     bool  bHasNonSeaLevel = false;
     float fNonSeaLevel = 0.0f;
-    bool  bHasOutsideLevel = false;
-    float fOutsideLevel = 0.0f;
     bitStream.Read(fSeaLevel);
     bitStream.ReadBit(bHasNonSeaLevel);
     if (bHasNonSeaLevel)
-    {
         bitStream.Read(fNonSeaLevel);
-    }
-    if (bitStream.Can(eBitStreamVersion::SetWaterLevel_ChangeOutsideWorldLevel))
-    {
-        bitStream.ReadBit(bHasOutsideLevel);
-        if (bHasOutsideLevel)
-        {
-            bitStream.Read(fOutsideLevel);
-        }
-    }
+
     // Reset world water level to GTA default
     g_pClientGame->GetManager()->GetWaterManager()->ResetWorldWaterLevel();
     // Apply world non-sea level (to all world water)
     if (bHasNonSeaLevel)
-        g_pClientGame->GetManager()->GetWaterManager()->SetWorldWaterLevel(fNonSeaLevel, nullptr, true, false, false);
-     // Apply outside world level (before -3000 and after 3000)
-    if (bHasOutsideLevel)
-        g_pClientGame->GetManager()->GetWaterManager()->SetWorldWaterLevel(fOutsideLevel, nullptr, false, false, true);
+        g_pClientGame->GetManager()->GetWaterManager()->SetWorldWaterLevel(fNonSeaLevel, NULL, true);
     // Apply world sea level (to world sea level water only)
-    g_pClientGame->GetManager()->GetWaterManager()->SetWorldWaterLevel(fSeaLevel, nullptr, false, true, false);
+    g_pClientGame->GetManager()->GetWaterManager()->SetWorldWaterLevel(fSeaLevel, NULL, false);
 
     unsigned short usFPSLimit = 36;
     bitStream.ReadCompressed(usFPSLimit);

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -6307,9 +6307,9 @@ bool CStaticFunctionDefinitions::GetWaterVertexPosition(CClientWater* pWater, in
     return pWater->GetVertexPosition(iVertexIndex - 1, vecPosition);
 }
 
-bool CStaticFunctionDefinitions::SetWorldWaterLevel(float fLevel, void* pChangeSource, bool bIncludeWorldNonSeaLevel, bool bIncludeWorldSeaLevel, bool bIncludeOutsideWorldLevel)
+bool CStaticFunctionDefinitions::SetWorldWaterLevel(float fLevel, void* pChangeSource, bool bIncludeWorldNonSeaLevel)
 {
-    return g_pClientGame->GetManager()->GetWaterManager()->SetWorldWaterLevel(fLevel, pChangeSource, bIncludeWorldNonSeaLevel, bIncludeWorldSeaLevel, bIncludeOutsideWorldLevel);
+    return g_pClientGame->GetManager()->GetWaterManager()->SetWorldWaterLevel(fLevel, pChangeSource, bIncludeWorldNonSeaLevel);
 }
 
 bool CStaticFunctionDefinitions::SetPositionWaterLevel(const CVector& vecPosition, float fLevel, void* pChangeSource)

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -571,7 +571,7 @@ public:
     static bool          GetWaterLevel(CVector& vecPosition, float& fLevel, bool bCheckWaves, CVector& vecUnknown);
     static bool          GetWaterLevel(CClientWater* pWater, float& fLevel);
     static bool          GetWaterVertexPosition(CClientWater* pWater, int iVertexIndex, CVector& vecPosition);
-    static bool          SetWorldWaterLevel(float fLevel, void* pChangeSource, bool bIncludeWorldNonSeaLevel, bool bIncludeWorldSeaLevel, bool bIncludeOutsideWorldLevel);
+    static bool          SetWorldWaterLevel(float fLevel, void* pChangeSource, bool bIncludeWorldNonSeaLevel);
     static bool          SetPositionWaterLevel(const CVector& vecPosition, float fLevel, void* pChangeSource);
     static bool          SetAllElementWaterLevel(float fLevel, void* pChangeSource);
     static bool          ResetWorldWaterLevel();

--- a/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
@@ -240,24 +240,20 @@ int CLuaWaterDefs::SetWaterLevel(lua_State* luaVM)
     else
     {
         // Call type 3
-        //  bool setWaterLevel ( float level, bool bIncludeWorldNonSeaLevel, bool bIncludeAllWaterElements, bool bIncludeWorldSeaLevel, bool bIncludeOutsideWorldLevel )
+        //  bool setWaterLevel ( float level, bool bIncludeWorldNonSeaLevel, bool bIncludeAllWaterElements )
         float fLevel;
         bool  bIncludeWorldNonSeaLevel;
         bool  bIncludeAllWaterElements;
-        bool  bIncludeWorldSeaLevel;
-        bool  bIncludeOutsideWorldLevel;
 
         argStream.ReadNumber(fLevel);
         argStream.ReadBool(bIncludeWorldNonSeaLevel, true);
         argStream.ReadBool(bIncludeAllWaterElements, true);
-        argStream.ReadBool(bIncludeWorldSeaLevel, true);
-        argStream.ReadBool(bIncludeOutsideWorldLevel, false);
 
         if (!argStream.HasErrors())
         {
             if (bIncludeAllWaterElements)
                 CStaticFunctionDefinitions::SetAllElementWaterLevel(fLevel, pResource);
-            if (CStaticFunctionDefinitions::SetWorldWaterLevel(fLevel, pResource, bIncludeWorldNonSeaLevel, bIncludeWorldSeaLevel, bIncludeOutsideWorldLevel))
+            if (CStaticFunctionDefinitions::SetWorldWaterLevel(fLevel, pResource, bIncludeWorldNonSeaLevel))
             {
                 lua_pushboolean(luaVM, true);
                 return 1;

--- a/Client/mods/deathmatch/logic/rpc/CWaterRPCs.cpp
+++ b/Client/mods/deathmatch/logic/rpc/CWaterRPCs.cpp
@@ -26,18 +26,11 @@ void CWaterRPCs::LoadFunctions()
 void CWaterRPCs::SetWorldWaterLevel(NetBitStreamInterface& bitStream)
 {
     float fLevel;
-    bool  bIncludeWorldNonSeaLevel = true;
-    bool  bIncludeWorldSeaLevel = true;
-    bool  bIncludeOutsideWorldLevel = false;
+    bool  bIncludeWorldNonSeaLevel;
 
     if (bitStream.Read(fLevel) && bitStream.ReadBit(bIncludeWorldNonSeaLevel))
     {
-        if (bitStream.Can(eBitStreamVersion::SetWaterLevel_ChangeOutsideWorldLevel))
-        {
-            bitStream.ReadBit(bIncludeWorldSeaLevel);
-            bitStream.ReadBit(bIncludeOutsideWorldLevel);
-        }
-        m_pWaterManager->SetWorldWaterLevel(fLevel, nullptr, bIncludeWorldNonSeaLevel, bIncludeWorldSeaLevel, bIncludeOutsideWorldLevel);
+        m_pWaterManager->SetWorldWaterLevel(fLevel, NULL, bIncludeWorldNonSeaLevel);
     }
 }
 

--- a/Client/sdk/game/CWaterManager.h
+++ b/Client/sdk/game/CWaterManager.h
@@ -21,7 +21,7 @@ public:
     virtual bool        DeletePoly(CWaterPoly* pPoly) = 0;
 
     virtual bool GetWaterLevel(const CVector& vecPosition, float* pfLevel, bool bCheckWaves, CVector* pvecUnknown) = 0;
-    virtual bool SetWorldWaterLevel(float fLevel, void* pChangeSource, bool bIncludeWorldNonSeaLevel, bool bIncludeWorldSeaLevel, bool bIncludeOutsideWorldLevel) = 0;
+    virtual bool SetWorldWaterLevel(float fLevel, void* pChangeSource, bool bIncludeWorldNonSeaLevel) = 0;
     virtual bool SetPositionWaterLevel(const CVector& vecPosition, float fLevel, void* pChangeSource) = 0;
     virtual bool SetPolyWaterLevel(CWaterPoly* pPoly, float fLevel, void* pChangeSource) = 0;
     virtual void ResetWorldWaterLevel() = 0;

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -9161,15 +9161,13 @@ bool CStaticFunctionDefinitions::SetAllElementWaterLevel(float fLevel)
     return true;
 }
 
-bool CStaticFunctionDefinitions::SetWorldWaterLevel(float fLevel, bool bIncludeWorldNonSeaLevel, bool bIncludeWorldSeaLevel, bool bIncludeOutsideWorldLevel)
+bool CStaticFunctionDefinitions::SetWorldWaterLevel(float fLevel, bool bIncludeWorldNonSeaLevel)
 {
-    g_pGame->GetWaterManager()->SetWorldWaterLevel(fLevel, bIncludeWorldNonSeaLevel, bIncludeWorldSeaLevel, bIncludeOutsideWorldLevel);
+    g_pGame->GetWaterManager()->SetWorldWaterLevel(fLevel, bIncludeWorldNonSeaLevel);
 
     CBitStream BitStream;
     BitStream.pBitStream->Write(fLevel);
     BitStream.pBitStream->WriteBit(bIncludeWorldNonSeaLevel);
-    BitStream.pBitStream->WriteBit(bIncludeWorldSeaLevel);
-    BitStream.pBitStream->WriteBit(bIncludeOutsideWorldLevel);
     m_pPlayerManager->BroadcastOnlyJoined(CLuaPacket(SET_WORLD_WATER_LEVEL, *BitStream.pBitStream));
     return true;
 }

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -547,7 +547,7 @@ public:
     static CWater* CreateWater(CResource* pResource, CVector* pV1, CVector* pV2, CVector* pV3, CVector* pV4, bool bShallow);
     static bool    SetElementWaterLevel(CWater* pWater, float fLevel);
     static bool    SetAllElementWaterLevel(float fLevel);
-    static bool    SetWorldWaterLevel(float fLevel, bool bIncludeWorldNonSeaLevel, bool bIncludeWorldSeaLevel, bool bIncludeOutsideWorldLevel);
+    static bool    SetWorldWaterLevel(float fLevel, bool bIncludeWorldNonSeaLevel);
     static bool    ResetWorldWaterLevel();
     static bool    GetWaterVertexPosition(CWater* pWater, int iVertexIndex, CVector& vecPosition);
     static bool    SetWaterVertexPosition(CWater* pWater, int iVertexIndex, CVector& vecPosition);

--- a/Server/mods/deathmatch/logic/CWaterManager.cpp
+++ b/Server/mods/deathmatch/logic/CWaterManager.cpp
@@ -14,10 +14,8 @@
 CWaterManager::CWaterManager()
 {
     m_WorldWaterLevelInfo.bNonSeaLevelSet = false;
-    m_WorldWaterLevelInfo.bOutsideLevelSet = false;
     m_WorldWaterLevelInfo.fSeaLevel = 0;
     m_WorldWaterLevelInfo.fNonSeaLevel = 0;
-    m_WorldWaterLevelInfo.fOutsideLevel = 0;
     m_fGlobalWaveHeight = 0.0f;
 }
 
@@ -66,31 +64,21 @@ void CWaterManager::SetAllElementWaterLevel(float fLevel)
     }
 }
 
-void CWaterManager::SetWorldWaterLevel(float fLevel, bool bIncludeWorldNonSeaLevel, bool bIncludeWorldSeaLevel, bool bIncludeOutsideWorldLevel)
+void CWaterManager::SetWorldWaterLevel(float fLevel, bool bIncludeWorldNonSeaLevel)
 {
-    if (bIncludeWorldSeaLevel)
-    {
-        m_WorldWaterLevelInfo.fSeaLevel = fLevel;
-    }
+    m_WorldWaterLevelInfo.fSeaLevel = fLevel;
     if (bIncludeWorldNonSeaLevel)
     {
         m_WorldWaterLevelInfo.bNonSeaLevelSet = true;
         m_WorldWaterLevelInfo.fNonSeaLevel = fLevel;
-    }
-    if (bIncludeOutsideWorldLevel)
-    {
-        m_WorldWaterLevelInfo.bOutsideLevelSet = true;
-        m_WorldWaterLevelInfo.fOutsideLevel = fLevel;
     }
 }
 
 void CWaterManager::ResetWorldWaterLevel()
 {
     m_WorldWaterLevelInfo.bNonSeaLevelSet = false;
-    m_WorldWaterLevelInfo.bOutsideLevelSet = false;
     m_WorldWaterLevelInfo.fSeaLevel = 0;
     m_WorldWaterLevelInfo.fNonSeaLevel = 0;
-    m_WorldWaterLevelInfo.fOutsideLevel = 0;
 }
 
 void CWaterManager::DeleteAll()

--- a/Server/mods/deathmatch/logic/CWaterManager.h
+++ b/Server/mods/deathmatch/logic/CWaterManager.h
@@ -32,7 +32,7 @@ public:
     void  SetGlobalWaveHeight(float fHeight) { m_fGlobalWaveHeight = fHeight; }
 
     const SWorldWaterLevelInfo& GetWorldWaterLevelInfo() const { return m_WorldWaterLevelInfo; }
-    void                        SetWorldWaterLevel(float fLevel, bool bIncludeWorldNonSeaLevel, bool bIncludeWorldSeaLevel, bool bIncludeOutsideWorldLevel);
+    void                        SetWorldWaterLevel(float fLevel, bool bIncludeWorldNonSeaLevel);
     void                        ResetWorldWaterLevel();
     void                        SetElementWaterLevel(CWater* pWater, float fLevel);
     void                        SetAllElementWaterLevel(float fLevel);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
@@ -130,24 +130,20 @@ int CLuaWaterDefs::SetWaterLevel(lua_State* luaVM)
     else
     {
         // Call type 2
-        //  bool setWaterLevel ( float level, bool bIncludeWorldNonSeaLevel, bool bIncludeAllWaterElements, bool bIncludeWorldSeaLevel, bool bIncludeOutsideWorldLevel )
+        //  bool setWaterLevel ( float level, bool bIncludeWorldNonSeaLevel, bool bIncludeAllWaterElements )
         float fLevel;
         bool  bIncludeWorldNonSeaLevel;
         bool  bIncludeAllWaterElements;
-        bool  bIncludeWorldSeaLevel;
-        bool  bIncludeOutsideWorldLevel;
 
         argStream.ReadNumber(fLevel);
         argStream.ReadBool(bIncludeWorldNonSeaLevel, true);
         argStream.ReadBool(bIncludeAllWaterElements, true);
-        argStream.ReadBool(bIncludeWorldSeaLevel, true);
-        argStream.ReadBool(bIncludeOutsideWorldLevel, false);
 
         if (!argStream.HasErrors())
         {
             if (bIncludeAllWaterElements)
                 CStaticFunctionDefinitions::SetAllElementWaterLevel(fLevel);
-            if (CStaticFunctionDefinitions::SetWorldWaterLevel(fLevel, bIncludeWorldNonSeaLevel, bIncludeWorldSeaLevel, bIncludeOutsideWorldLevel))
+            if (CStaticFunctionDefinitions::SetWorldWaterLevel(fLevel, bIncludeWorldNonSeaLevel))
             {
                 lua_pushboolean(luaVM, true);
                 return 1;

--- a/Server/mods/deathmatch/logic/packets/CMapInfoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CMapInfoPacket.cpp
@@ -133,17 +133,8 @@ bool CMapInfoPacket::Write(NetBitStreamInterface& BitStream) const
     BitStream.Write(m_WorldWaterLevelInfo.fSeaLevel);
     BitStream.WriteBit(m_WorldWaterLevelInfo.bNonSeaLevelSet);
     if (m_WorldWaterLevelInfo.bNonSeaLevelSet)
-    {
         BitStream.Write(m_WorldWaterLevelInfo.fNonSeaLevel);
-    }
-    if (BitStream.Can(eBitStreamVersion::SetWaterLevel_ChangeOutsideWorldLevel))
-    {
-        BitStream.WriteBit(m_WorldWaterLevelInfo.bOutsideLevelSet);
-        if (m_WorldWaterLevelInfo.bOutsideLevelSet)
-        {
-            BitStream.Write(m_WorldWaterLevelInfo.fOutsideLevel);
-        }
-    }
+
     BitStream.WriteCompressed(m_usFPSLimit);
 
     // Write the garage states

--- a/Server/mods/deathmatch/logic/packets/CMapInfoPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CMapInfoPacket.h
@@ -16,10 +16,8 @@
 struct SWorldWaterLevelInfo
 {
     bool  bNonSeaLevelSet;
-    bool  bOutsideLevelSet;
     float fSeaLevel;
     float fNonSeaLevel;
-    float fOutsideLevel;
 };
 
 class CMapInfoPacket final : public CPacket

--- a/Shared/sdk/net/bitstream.h
+++ b/Shared/sdk/net/bitstream.h
@@ -444,10 +444,6 @@ enum class eBitStreamVersion : unsigned short
     // 1.5.8 RELEASED - 2020-10-11
     //
 
-    // setWaterLevel: add bIncludeWorldSeaLevel and bIncludeOutsideWorldLevel
-    // 2020-11-03 0x70
-    SetWaterLevel_ChangeOutsideWorldLevel,
-
     // This allows us to automatically increment the BitStreamVersion when things are added to this enum.
     // Make sure you only add things above this comment.
     Next,


### PR DESCRIPTION
According to our research over at [#development](https://discordapp.com/channels/278474088903606273/366384007535001612/782640347288174594), and thanks to [Dutchman's help](https://pastebin.com/ssyaeH8z) the issue seems to be caused by this commit. (Since it modifies the MapInfo packet, and even after reverting bd895707df2204393e2c0586c63a46065a7d2150 it still exists I presume this is the commit causing the issue).

As of my knowledge the client bitstream version reflects the one the stream was written with.
Eg.: Server is at 0x10, client at 0x20, the bitstream (that is, `bitStream.getVersion()` on the client) will at most be 0x10.
If not, then [this line](https://github.com/multitheftauto/mtasa-blue/commit/483c4d0b84f6791f67e73f9a4e45d69bcdc5eaae#diff-ca2b02caf256208d2211a21b062c3202b7334801dffa4106bbf052ab3c85a12fR2241-R2248) causes the issue, since a `bit` might be `true` at the point when `ReadBit` is called, which in turn reads 4 bytes (the float), and hence the whole packet is corrupted. 