### PR TITLE
Add getTowHitch/BarPosition

### DIFF
--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -4634,6 +4634,27 @@ void CClientVehicle::RemoveVehicleSirens()
     m_tSirenBeaconInfo.m_ucSirenCount = 0;
 }
 
+std::optional<CVector> CClientVehicle::GetTowHitchPos()
+{
+    if (!m_pVehicle)
+        return std::nullopt;
+
+    CVector out;
+    m_pVehicle->GetTowHitchPos(&out);
+    return out;
+}
+
+std::optional<CVector> CClientVehicle::GetTowBarPos(CClientVehicle* pAttachTo, bool bIgnoreModelType)
+{
+    CVehicle* pAttachToGameVeh = pAttachTo->GetGameVehicle();
+    if (!m_pVehicle || !pAttachToGameVeh)
+        return std::nullopt;
+
+    CVector out;
+    m_pVehicle->GetTowBarPos(&out, pAttachToGameVeh);
+    return out;
+}
+
 bool CClientVehicle::SetComponentPosition(const SString& vehicleComponent, CVector vecPosition, EComponentBaseType inputBase)
 {
     // Ensure position is parent relative

--- a/Client/mods/deathmatch/logic/CClientVehicle.h
+++ b/Client/mods/deathmatch/logic/CClientVehicle.h
@@ -15,6 +15,7 @@ class CClientVehicle;
 
 #include <game/CPlane.h>
 #include <game/CVehicle.h>
+#include <optional>
 
 #include "CClientCommon.h"
 #include "CClientCamera.h"
@@ -481,6 +482,9 @@ public:
     void SetVehicleSirenColour(unsigned char ucSirenID, SColor tVehicleSirenColour);
     void SetVehicleFlags(bool bEnable360, bool bEnableRandomiser, bool bEnableLOSCheck, bool bEnableSilent);
     void RemoveVehicleSirens();
+
+    std::optional<CVector> GetTowHitchPos();
+    std::optional<CVector> GetTowBarPos(CClientVehicle* pAttachTo, bool bIgnoreModelType = false);
 
     bool ResetComponentPosition(const SString& vehicleComponent);
     bool SetComponentPosition(const SString& vehicleComponent, CVector vecPosition, EComponentBaseType base = EComponentBase::PARENT);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -76,6 +76,8 @@ void CLuaVehicleDefs::LoadFunctions()
         {"getVehicleNitroLevel", GetVehicleNitroLevel},
         {"getHeliBladeCollisionsEnabled", GetHeliBladeCollisionsEnabled},
         {"isVehicleWindowOpen", IsVehicleWindowOpen},
+        {"GetVehicleTowHitchPosition", ArgumentParser<GetVehicleTowHitchPosition>},
+        {"GetVehicleTowBarPosition", ArgumentParser<GetVehicleTowBarPosition>},
         {"getVehicleComponentPosition", GetVehicleComponentPosition},
         {"getVehicleComponentRotation", GetVehicleComponentRotation},
         {"getVehicleComponentScale", GetVehicleComponentScale},
@@ -3149,6 +3151,24 @@ int CLuaVehicleDefs::GetVehicleDoorOpenRatio(lua_State* luaVM)
 
     lua_pushboolean(luaVM, false);
     return 1;
+}
+
+std::variant<bool, CVector>
+CLuaVehicleDefs::GetVehicleTowHitchPosition(CClientVehicle* pVeh)
+{
+    const std::optional<CVector> pos = pVeh->GetTowHitchPos();
+    if (pos.has_value())
+        return pos.value();
+    return false;
+}
+
+std::variant<bool, CVector>
+CLuaVehicleDefs::GetVehicleTowBarPosition(CClientVehicle* pVeh, CClientVehicle* pToAttach, std::optional<bool> bIgnoreModelType)
+{
+    const std::optional<CVector> pos = pVeh->GetTowBarPos(pToAttach, bIgnoreModelType.value_or(false));
+    if (pos.has_value())
+        return pos.value();
+    return false;
 }
 
 int CLuaVehicleDefs::SetVehicleComponentPosition(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -76,8 +76,8 @@ void CLuaVehicleDefs::LoadFunctions()
         {"getVehicleNitroLevel", GetVehicleNitroLevel},
         {"getHeliBladeCollisionsEnabled", GetHeliBladeCollisionsEnabled},
         {"isVehicleWindowOpen", IsVehicleWindowOpen},
-        {"GetVehicleTowHitchPosition", ArgumentParser<GetVehicleTowHitchPosition>},
-        {"GetVehicleTowBarPosition", ArgumentParser<GetVehicleTowBarPosition>},
+        {"getVehicleTowHitchPosition", ArgumentParser<GetVehicleTowHitchPosition>},
+        {"getVehicleTowBarPosition", ArgumentParser<GetVehicleTowBarPosition>},
         {"getVehicleComponentPosition", GetVehicleComponentPosition},
         {"getVehicleComponentRotation", GetVehicleComponentRotation},
         {"getVehicleComponentScale", GetVehicleComponentScale},
@@ -219,6 +219,8 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getSirenParams", "getVehicleSirenParams");
     lua_classfunction(luaVM, "getSirens", "getVehicleSirens");
     lua_classfunction(luaVM, "getSirensOn", "getVehicleSirensOn");
+    lua_classfunction(luaVM, "getTowHitchPosition", ArgumentParser<GetVehicleTowHitchPosition_OOP>);
+    lua_classfunction(luaVM, "getTowBarPosition", ArgumentParser<GetVehicleTowBarPosition_OOP>);
     lua_classfunction(luaVM, "getComponentPosition", OOP_GetVehicleComponentPosition);
     lua_classfunction(luaVM, "getComponentVisible", "getVehicleComponentVisible");
     lua_classfunction(luaVM, "getComponentRotation", OOP_GetVehicleComponentRotation);
@@ -317,6 +319,7 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "undamageableDoors", "setVehicleDoorsUndamageable", NULL);
     lua_classvariable(luaVM, "taxiLight", "setVehicleTaxiLightOn", "isVehicleTaxiLightOn");
     lua_classvariable(luaVM, "handling", NULL, "getVehicleHandling");
+    lua_classvariable(luaVM, "towHitchPosition", NULL, ArgumentParser<GetVehicleTowHitchPosition_OOP>);
     lua_classvariable(luaVM, "components", NULL, "getVehicleComponents");
     lua_classvariable(luaVM, "towingVehicle", NULL, "getVehicleTowingVehicle");
     lua_classvariable(luaVM, "towedByVehicle", NULL, "getVehicleTowedByVehicle");
@@ -3154,7 +3157,7 @@ int CLuaVehicleDefs::GetVehicleDoorOpenRatio(lua_State* luaVM)
 }
 
 std::variant<bool, CVector>
-CLuaVehicleDefs::GetVehicleTowHitchPosition(CClientVehicle* pVeh)
+CLuaVehicleDefs::GetVehicleTowHitchPosition_OOP(CClientVehicle* pVeh)
 {
     const std::optional<CVector> pos = pVeh->GetTowHitchPos();
     if (pos.has_value())
@@ -3162,12 +3165,36 @@ CLuaVehicleDefs::GetVehicleTowHitchPosition(CClientVehicle* pVeh)
     return false;
 }
 
+std::variant<bool, std::tuple<float, float, float>>
+CLuaVehicleDefs::GetVehicleTowHitchPosition(CClientVehicle* pVeh)
+{
+    const std::optional<CVector> pos = pVeh->GetTowHitchPos();
+    if (pos.has_value())
+    {
+        const CVector value = pos.value();
+        return std::make_tuple(value.fX, value.fY, value.fZ);
+    }
+    return false;
+}
+
 std::variant<bool, CVector>
-CLuaVehicleDefs::GetVehicleTowBarPosition(CClientVehicle* pVeh, CClientVehicle* pToAttach, std::optional<bool> bIgnoreModelType)
+CLuaVehicleDefs::GetVehicleTowBarPosition_OOP(CClientVehicle* pVeh, CClientVehicle* pToAttach, std::optional<bool> bIgnoreModelType)
 {
     const std::optional<CVector> pos = pVeh->GetTowBarPos(pToAttach, bIgnoreModelType.value_or(false));
     if (pos.has_value())
         return pos.value();
+    return false;
+}
+
+std::variant<bool, std::tuple<float, float, float>>
+CLuaVehicleDefs::GetVehicleTowBarPosition(CClientVehicle* pVeh, CClientVehicle* pToAttach, std::optional<bool> bIgnoreModelType)
+{
+    const std::optional<CVector> pos = pVeh->GetTowBarPos(pToAttach, bIgnoreModelType.value_or(false));
+    if (pos.has_value())
+    {
+        const CVector value = pos.value();
+        return std::make_tuple(value.fX, value.fY, value.fZ);
+    }
     return false;
 }
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -151,6 +151,9 @@ public:
     static bool SetVehicleModelWheelSize(const unsigned short usModel, const eResizableVehicleWheelGroup eWheelGroup, const float fWheelSize);
     static int  GetVehicleWheelFrictionState(CClientVehicle* pVehicle, unsigned char wheel);
 
+    static std::variant<bool, CVector> GetVehicleTowHitchPosition(CClientVehicle* pVeh);
+    static std::variant<bool, CVector> GetVehicleTowBarPosition(CClientVehicle* pVeh, CClientVehicle* pToAttach, std::optional<bool> bIgnoreModelType);
+
     // Components
     LUA_DECLARE(SetVehicleComponentPosition);
     LUA_DECLARE_OOP(GetVehicleComponentPosition);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "CLuaDefs.h"
+#include <tuple>
 
 class CLuaVehicleDefs : public CLuaDefs
 {
@@ -151,8 +152,11 @@ public:
     static bool SetVehicleModelWheelSize(const unsigned short usModel, const eResizableVehicleWheelGroup eWheelGroup, const float fWheelSize);
     static int  GetVehicleWheelFrictionState(CClientVehicle* pVehicle, unsigned char wheel);
 
-    static std::variant<bool, CVector> GetVehicleTowHitchPosition(CClientVehicle* pVeh);
-    static std::variant<bool, CVector> GetVehicleTowBarPosition(CClientVehicle* pVeh, CClientVehicle* pToAttach, std::optional<bool> bIgnoreModelType);
+    static std::variant<bool, CVector> GetVehicleTowHitchPosition_OOP(CClientVehicle* pVeh);
+    static std::variant<bool, std::tuple<float, float, float>> GetVehicleTowHitchPosition(CClientVehicle* pVeh);
+
+    static std::variant<bool, CVector> GetVehicleTowBarPosition_OOP(CClientVehicle* pVeh, CClientVehicle* pToAttach, std::optional<bool> bIgnoreModelType);
+    static std::variant<bool, std::tuple<float, float, float>> GetVehicleTowBarPosition(CClientVehicle* pVeh, CClientVehicle* pToAttach, std::optional<bool> bIgnoreModelType);
 
     // Components
     LUA_DECLARE(SetVehicleComponentPosition);


### PR DESCRIPTION
This PR adds 2 functions that can be pretty useful. And since they're already in the game, why not expose them, right? :D
[towthingtest.zip](https://github.com/multitheftauto/mtasa-blue/files/5629160/towthingtest.zip)
Teleport to `2042.39624, 1449.91211, 10.67180` (use `setpos 2042.39624, 1449.91211, 10.67180`)
The green line is the tow hitch position, red one is the tow bar.
Only applicable vehicles have their tow bar accurately calculated(using the `misc_a` component), other's have it behind the vehicle, in the air.
Also, while regular vehicles obviously dont have a properly calculated `tow hitch` position (its in the engine deck) I left it in, since I think it might be useful for someone.
Here's how it looks like:
![image](https://user-images.githubusercontent.com/12902714/100871772-16184380-34a1-11eb-8017-9ab09cacb86a.png)
