### PR TITLE
Fix #908: vehicle driver desync after carjacker dies

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -6799,7 +6799,8 @@ void CClientPed::UpdateVehicleInOut()
         else if (m_bIsGettingIntoVehicle)
         {
             // If we aren't working on entering the car (he's either finished or cancelled)
-            if (!IsEnteringVehicle())
+            // Or we are dead (fix for #908)
+            if (!IsEnteringVehicle() || IsDead())
             {
                 // Is he in a vehicle now?
                 CClientVehicle* pVehicle = GetRealOccupiedVehicle();

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -1924,8 +1924,14 @@ void CGame::Packet_PedWasted(CPedWastedPacket& Packet)
     {
         pPed->SetIsDead(true);
         pPed->SetPosition(Packet.m_vecPosition);
+
+        // Reset his vehicle action, but only if not jacking
+        // If jacking we wait for him to reply with VEHICLE_NOTIFY_JACK_ABORT
+        // We don't know if he actually jacked the person at this point, and we need to set the jacked person correctly (fix for #908)
+        if (pPed->GetVehicleAction() != CPed::VEHICLEACTION_JACKING)
+            pPed->SetVehicleAction(CPed::VEHICLEACTION_NONE);
+
         // Remove him from any occupied vehicle
-        pPed->SetVehicleAction(CPlayer::VEHICLEACTION_NONE);
         CVehicle* pVehicle = pPed->GetOccupiedVehicle();
         if (pVehicle)
         {
@@ -1977,8 +1983,13 @@ void CGame::Packet_PlayerWasted(CPlayerWastedPacket& Packet)
         pPlayer->SetArmor(0.0f);
         pPlayer->SetPosition(Packet.m_vecPosition);
 
+        // Reset his vehicle action, but only if not jacking
+        // If jacking we wait for him to reply with VEHICLE_NOTIFY_JACK_ABORT
+        // We don't know if he actually jacked the person at this point, and we need to set the jacked person correctly (fix for #908)
+        if (pPlayer->GetVehicleAction() != CPed::VEHICLEACTION_JACKING)
+            pPlayer->SetVehicleAction(CPed::VEHICLEACTION_NONE);
+
         // Remove him from any occupied vehicle
-        pPlayer->SetVehicleAction(CPlayer::VEHICLEACTION_NONE);
         CVehicle* pVehicle = pPlayer->GetOccupiedVehicle();
         if (pVehicle)
         {
@@ -2814,7 +2825,7 @@ void CGame::Packet_Vehicle_InOut(CVehicleInOutPacket& Packet)
                 }
 
                 // Check we have a valid ped & he is spawned
-                if (bValidPed && pPed->IsSpawned())
+                if (bValidPed)
                 {
                     // Handle it depending on the action
                     switch (ucAction)

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -3615,8 +3615,13 @@ bool CStaticFunctionDefinitions::KillPed(CElement* pElement, CElement* pKiller, 
         // Is the ped alive?
         if (!pPed->IsDead() && pPed->IsSpawned())
         {
+            // Reset his vehicle action, but only if not jacking
+            // If jacking we wait for him to reply with VEHICLE_NOTIFY_JACK_ABORT
+            // We don't know if he actually jacked the person at this point, and we need to set the jacked person correctly (fix for #908)
+            if (pPed->GetVehicleAction() != CPed::VEHICLEACTION_JACKING)
+                pPed->SetVehicleAction(CPed::VEHICLEACTION_NONE);
+
             // Remove him from any occupied vehicle
-            pPed->SetVehicleAction(CPed::VEHICLEACTION_NONE);
             CVehicle* pVehicle = pPed->GetOccupiedVehicle();
             if (pVehicle)
             {


### PR DESCRIPTION
As it is atm, we dont send an abort packet when the jacker dies, because gta doesnt cancel the entering task. And secondly we dont allow in/out packets from dead peds serverside. This has been changed, so the dead jacker can abort properly.

Also fixes the issue described here https://github.com/multitheftauto/mtasa-blue/issues/394#issuecomment-418663188 where you can't exit a vehicle after a jacker dies.