### PR TITLE
Change CStreaming::GetStreamingInfoFromModelId to accept uint32, remove an unneccessary limit

### DIFF
--- a/Client/game_sa/CStreamingSA.cpp
+++ b/Client/game_sa/CStreamingSA.cpp
@@ -140,7 +140,7 @@ void CStreamingSA::RequestSpecialModel(DWORD model, const char* szTexture, DWORD
     }
 }
 
-CStreamingInfo* CStreamingSA::GetStreamingInfoFromModelId(ushort id)
+CStreamingInfo* CStreamingSA::GetStreamingInfoFromModelId(uint32 id)
 {
     return &ms_aInfoForModel[id];
 }

--- a/Client/game_sa/CStreamingSA.h
+++ b/Client/game_sa/CStreamingSA.h
@@ -28,7 +28,8 @@ public:
     BOOL HasModelLoaded(DWORD dwModelID);
     void RequestSpecialModel(DWORD model, const char* szTexture, DWORD channel);
     void ReinitStreaming();
-    CStreamingInfo* GetStreamingInfoFromModelId(ushort id);
+    CStreamingInfo* GetStreamingInfoFromModelId(uint32 id);
+
 private:
     static CStreamingInfo* ms_aInfoForModel; // count: 26316 in unmodified game
 };

--- a/Client/sdk/game/CStreaming.h
+++ b/Client/sdk/game/CStreaming.h
@@ -46,6 +46,6 @@ public:
     virtual void LoadAllRequestedModels(BOOL bOnlyPriorityModels = 0, const char* szTag = NULL) = 0;
     virtual BOOL HasModelLoaded(DWORD dwModelID) = 0;
     virtual void RequestSpecialModel(DWORD model, const char* szTexture, DWORD channel) = 0;
-    virtual CStreamingInfo* GetStreamingInfoFromModelId(unsigned short id) = 0;
+    virtual CStreamingInfo* GetStreamingInfoFromModelId(uint32 id) = 0;
     virtual void ReinitStreaming() = 0;
 };


### PR DESCRIPTION
Changes argument for CStreaming::GetStreamingInfoFromModelId from ushort (which makes a limit of 65536 IDs) to uint32, which is just good enough.

Simple change, reviewing this should take 10 seconds.