### PR TITLE
Disable train track functions

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -57,7 +57,7 @@ void CLuaVehicleDefs::LoadFunctions()
         {"isTrainDerailable", IsTrainDerailable},
         {"getTrainDirection", GetTrainDirection},
         {"getTrainSpeed", GetTrainSpeed},
-        {"getTrainTrack", ArgumentParser<GetTrainTrack>},
+        //{"getTrainTrack", ArgumentParser<GetTrainTrack>},
         {"getTrainPosition", GetTrainPosition},
         {"isTrainChainEngine", IsTrainChainEngine},
         {"getVehicleGravity", GetVehicleGravity},
@@ -118,7 +118,7 @@ void CLuaVehicleDefs::LoadFunctions()
         {"setTrainDerailable", SetTrainDerailable},
         {"setTrainDirection", SetTrainDirection},
         {"setTrainSpeed", SetTrainSpeed},
-        {"setTrainTrack", ArgumentParser<SetTrainTrack>},
+        //{"setTrainTrack", ArgumentParser<SetTrainTrack>},
         {"setTrainPosition", SetTrainPosition},
         {"setVehicleTaxiLightOn", SetVehicleTaxiLightOn},
         {"setVehicleGravity", SetVehicleGravity},
@@ -179,7 +179,7 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getNitroLevel", "getVehicleNitroLevel");
     lua_classfunction(luaVM, "getDirection", "getTrainDirection");
     lua_classfunction(luaVM, "getTrainSpeed", "getTrainSpeed");
-    lua_classfunction(luaVM, "getTrack", "getTrainTrack");
+    //lua_classfunction(luaVM, "getTrack", "getTrainTrack");
     lua_classfunction(luaVM, "getTrainPosition", "getTrainPosition");
     lua_classfunction(luaVM, "getName", "getVehicleName");
     lua_classfunction(luaVM, "getVehicleType", "getVehicleType");
@@ -263,7 +263,7 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setNitroLevel", "setVehicleNitroLevel");
     lua_classfunction(luaVM, "setDirection", "setTrainDirection");
     lua_classfunction(luaVM, "setTrainSpeed", "setTrainSpeed");
-    lua_classfunction(luaVM, "setTrack", "setTrainTrack");
+    //lua_classfunction(luaVM, "setTrack", "setTrainTrack");
     lua_classfunction(luaVM, "setTrainPosition", "setTrainPosition");
     lua_classfunction(luaVM, "setDerailable", "setTrainDerailable");
     lua_classfunction(luaVM, "setDerailed", "setTrainDerailed");
@@ -320,7 +320,7 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "towedByVehicle", NULL, "getVehicleTowedByVehicle");
     lua_classvariable(luaVM, "direction", "setTrainDirection", "getTrainDirection");
     lua_classvariable(luaVM, "trainSpeed", "setTrainSpeed", "getTrainSpeed");
-    lua_classvariable(luaVM, "track", "setTrainTrack", "getTrainTrack");
+    //lua_classvariable(luaVM, "track", "setTrainTrack", "getTrainTrack");
     lua_classvariable(luaVM, "trainPosition", "setTrainPosition", "getTrainPosition");
     lua_classvariable(luaVM, "derailable", "setTrainDerailable", "isTrainDerailable");
     lua_classvariable(luaVM, "derailed", "setTrainDerailed", "isTrainDerailed");

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -57,7 +57,7 @@ void CLuaVehicleDefs::LoadFunctions()
         {"isTrainDerailable", IsTrainDerailable},
         {"getTrainDirection", GetTrainDirection},
         {"getTrainSpeed", GetTrainSpeed},
-        {"getTrainTrack", ArgumentParser<GetTrainTrack>},
+        //{"getTrainTrack", ArgumentParser<GetTrainTrack>},
         {"getTrainPosition", GetTrainPosition},
         {"isVehicleBlown", IsVehicleBlown},
         {"getVehicleHeadLightColor", GetVehicleHeadLightColor},

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -105,7 +105,7 @@ void CLuaVehicleDefs::LoadFunctions()
         {"setTrainDerailable", SetTrainDerailable},
         {"setTrainDirection", SetTrainDirection},
         {"setTrainSpeed", SetTrainSpeed},
-        {"setTrainTrack", ArgumentParser<SetTrainTrack>},
+        //{"setTrainTrack", ArgumentParser<SetTrainTrack>},
         {"setTrainPosition", SetTrainPosition},
         {"setVehicleHeadLightColor", SetVehicleHeadLightColor},
         {"setVehicleTurretPosition", SetVehicleTurretPosition},
@@ -164,7 +164,7 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getSirens", "getVehicleSirens");
     lua_classfunction(luaVM, "getDirection", "getTrainDirection");
     lua_classfunction(luaVM, "getTrainSpeed", "getTrainSpeed");
-    lua_classfunction(luaVM, "getTrack", "getTrainTrack");
+    //lua_classfunction(luaVM, "getTrack", "getTrainTrack");
     lua_classfunction(luaVM, "getTrainPosition", "getTrainPosition");
     lua_classfunction(luaVM, "getHeadLightColor", "getVehicleHeadLightColor");
     lua_classfunction(luaVM, "getColor", "getVehicleColor");
@@ -226,7 +226,7 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setDerailable", "setTrainDerailable");
     lua_classfunction(luaVM, "setDerailed", "setTrainDerailed");
     lua_classfunction(luaVM, "setDirection", "setTrainDirection");
-    lua_classfunction(luaVM, "setTrack", "setTrainTrack");
+    //lua_classfunction(luaVM, "setTrack", "setTrainTrack");
     lua_classfunction(luaVM, "setTrainPosition", "setTrainPosition");
     lua_classfunction(luaVM, "setTrainSpeed", "setTrainSpeed");            // Reduce confusion
 
@@ -237,7 +237,7 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "blown", "blowVehicle", "isVehicleBlown");
     lua_classvariable(luaVM, "direction", "setTrainDirection", "getTrainDirection");
     lua_classvariable(luaVM, "trainSpeed", "setTrainSpeed", "getTrainSpeed");
-    lua_classvariable(luaVM, "track", "setTrainTrack", "getTrainTrack");
+    //lua_classvariable(luaVM, "track", "setTrainTrack", "getTrainTrack");
     lua_classvariable(luaVM, "trainPosition", "setTrainPosition", "getTrainPosition");
     lua_classvariable(luaVM, "taxiLightOn", "setVehicleTaxiLightOn", "isVehicleTaxiLightOn");
     lua_classvariable(luaVM, "fuelTankExplodable", "setVehicleFuelTankExplodable", "isVehicleFuelTankExplodable");

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaTrainTrackDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaTrainTrackDefs.cpp
@@ -17,11 +17,11 @@ void CLuaTrainTrackDefs::LoadFunctions()
 
 void CLuaTrainTrackDefs::AddClass(lua_State* luaVM)
 {
-    lua_newclass(luaVM);
+    //lua_newclass(luaVM);
 
-    lua_classfunction(luaVM, "getDefault", "getDefaultTrack");
+    //lua_classfunction(luaVM, "getDefault", "getDefaultTrack");
 
-    lua_registerclass(luaVM, "TrainTrack", "Element");
+    //lua_registerclass(luaVM, "TrainTrack", "Element");
 }
 
 auto CLuaTrainTrackDefs::GetDefaultTrack(uchar trackID) -> CLuaTrainTrackDefs::TrainTrack

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaTrainTrackDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaTrainTrackDefs.cpp
@@ -12,7 +12,7 @@
 
 void CLuaTrainTrackDefs::LoadFunctions()
 {
-    CLuaCFunctions::AddFunction("getDefaultTrack", ArgumentParser<GetDefaultTrack>);
+    //CLuaCFunctions::AddFunction("getDefaultTrack", ArgumentParser<GetDefaultTrack>);
 }
 
 void CLuaTrainTrackDefs::AddClass(lua_State* luaVM)


### PR DESCRIPTION
Custom train tracks is incomplete and requires further iteration before being a full MTA release.

Since I'm no longer working on MTA and cannot continue iterating on this train tracks work, this PR disables some functions that were turned on in https://github.com/multitheftauto/mtasa-blue/pull/1715.

If you want to continue the work, feel free to refer to https://github.com/multitheftauto/mtasa-blue/pull/250

That branch is kinda broken (crashes or freezes when you get in a train, last I checked), but most of the code works. I was aiming to fix that freezing problem by slowly iterating: submitting working PRs to master and adding small features bit by bit.

So if you want to continue the train tracks work, you'll probably have to rewrite most of it (or manually copy chunks bit by bit) from the huge train tracks branch. I used a `git worktree` to keep two branches checked out in the same git repository (instead of cloning twice).