### PR TITLE
Change IDs (file, model and TXD) from 16-bit to 32-bit

### DIFF
--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -2067,7 +2067,7 @@ CModelCacheManager* CCore::GetModelCacheManager()
     return m_pModelCacheManager;
 }
 
-void CCore::AddModelToPersistentCache(ushort usModelId)
+void CCore::AddModelToPersistentCache(uint32 usModelId)
 {
     return GetModelCacheManager()->AddModelToPersistentCache(usModelId);
 }

--- a/Client/core/CCore.h
+++ b/Client/core/CCore.h
@@ -250,7 +250,7 @@ public:
     EDiagnosticDebugType GetDiagnosticDebug();
     void                 SetDiagnosticDebug(EDiagnosticDebugType value);
     CModelCacheManager*  GetModelCacheManager();
-    void                 AddModelToPersistentCache(ushort usModelId);
+    void                 AddModelToPersistentCache(uint32 usModelId);
 
     static void StaticIdleHandler();
     void        IdleHandler();

--- a/Client/core/CModelCacheManager.cpp
+++ b/Client/core/CModelCacheManager.cpp
@@ -38,23 +38,23 @@ public:
     // CModelCacheManager interface
     virtual void DoPulse();
     virtual void GetStats(SModelCacheStats& outStats);
-    virtual bool UnloadModel(ushort usModelId);
-    virtual void OnRestreamModel(ushort usModelId);
+    virtual bool UnloadModel(uint32 usModelId);
+    virtual void OnRestreamModel(uint32 usModelId);
     virtual void OnClientClose();
-    virtual void UpdatePedModelCaching(const std::map<ushort, float>& newNeedCacheList);
-    virtual void UpdateVehicleModelCaching(const std::map<ushort, float>& newNeedCacheList);
-    virtual void AddModelToPersistentCache(ushort usModelId);
+    virtual void UpdatePedModelCaching(const std::map<uint32, float>& newNeedCacheList);
+    virtual void UpdateVehicleModelCaching(const std::map<uint32, float>& newNeedCacheList);
+    virtual void AddModelToPersistentCache(uint32 usModelId);
 
     // CModelCacheManagerImpl methods
     CModelCacheManagerImpl();
     ~CModelCacheManagerImpl();
 
     void PreLoad();
-    void RemoveCacheRefs(std::map<ushort, SModelCacheInfo>& currentCacheInfoMap);
-    void UpdateModelCaching(const std::map<ushort, float>& newNeededList, std::map<ushort, SModelCacheInfo>& currentCacheInfoMap, uint uiMaxCachedAllowed);
-    int  GetModelRefCount(ushort usModelId);
-    void AddModelRefCount(ushort usModelId);
-    void SubModelRefCount(ushort usModelId);
+    void RemoveCacheRefs(std::map<uint32, SModelCacheInfo>& currentCacheInfoMap);
+    void UpdateModelCaching(const std::map<uint32, float>& newNeededList, std::map<uint32, SModelCacheInfo>& currentCacheInfoMap, uint uiMaxCachedAllowed);
+    int  GetModelRefCount(uint32 usModelId);
+    void AddModelRefCount(uint32 usModelId);
+    void SubModelRefCount(uint32 usModelId);
 
 protected:
     CGame*                            m_pGame;
@@ -63,9 +63,9 @@ protected:
     bool                              m_bDonePreLoad;
     uint                              m_uiMaxCachedPedModels;
     uint                              m_uiMaxCachedVehicleModels;
-    std::map<ushort, SModelCacheInfo> m_PedModelCacheInfoMap;
-    std::map<ushort, SModelCacheInfo> m_VehicleModelCacheInfoMap;
-    std::set<ushort>                  m_PermoLoadedModels;
+    std::map<uint32, SModelCacheInfo> m_PedModelCacheInfoMap;
+    std::map<uint32, SModelCacheInfo> m_VehicleModelCacheInfoMap;
+    std::set<uint32>                  m_PermoLoadedModels;
 };
 
 ///////////////////////////////////////////////////////////////
@@ -199,11 +199,11 @@ void CModelCacheManagerImpl::GetStats(SModelCacheStats& outStats)
     outStats.uiNumPedModels = 0;
     outStats.uiNumVehicleModels = 0;
 
-    for (std::map<ushort, SModelCacheInfo>::const_iterator iter = m_PedModelCacheInfoMap.begin(); iter != m_PedModelCacheInfoMap.end(); ++iter)
+    for (std::map<uint32, SModelCacheInfo>::const_iterator iter = m_PedModelCacheInfoMap.begin(); iter != m_PedModelCacheInfoMap.end(); ++iter)
         if (iter->second.bIsModelCachedHere)
             outStats.uiNumPedModels++;
 
-    for (std::map<ushort, SModelCacheInfo>::const_iterator iter = m_VehicleModelCacheInfoMap.begin(); iter != m_VehicleModelCacheInfoMap.end(); ++iter)
+    for (std::map<uint32, SModelCacheInfo>::const_iterator iter = m_VehicleModelCacheInfoMap.begin(); iter != m_VehicleModelCacheInfoMap.end(); ++iter)
         if (iter->second.bIsModelCachedHere)
             outStats.uiNumVehicleModels++;
 }
@@ -242,7 +242,7 @@ void CModelCacheManagerImpl::DoPulse()
 // Keep this model around 4 evar now
 //
 ///////////////////////////////////////////////////////////////
-void CModelCacheManagerImpl::AddModelToPersistentCache(ushort usModelId)
+void CModelCacheManagerImpl::AddModelToPersistentCache(uint32 usModelId)
 {
     if (!MapContains(m_PermoLoadedModels, usModelId))
     {
@@ -258,7 +258,7 @@ void CModelCacheManagerImpl::AddModelToPersistentCache(ushort usModelId)
 //
 //
 ///////////////////////////////////////////////////////////////
-void CModelCacheManagerImpl::UpdatePedModelCaching(const std::map<ushort, float>& newNeedCacheList)
+void CModelCacheManagerImpl::UpdatePedModelCaching(const std::map<uint32, float>& newNeedCacheList)
 {
     DoPulse();
     UpdateModelCaching(newNeedCacheList, m_PedModelCacheInfoMap, m_uiMaxCachedPedModels);
@@ -271,7 +271,7 @@ void CModelCacheManagerImpl::UpdatePedModelCaching(const std::map<ushort, float>
 //
 //
 ///////////////////////////////////////////////////////////////
-void CModelCacheManagerImpl::UpdateVehicleModelCaching(const std::map<ushort, float>& newNeedCacheList)
+void CModelCacheManagerImpl::UpdateVehicleModelCaching(const std::map<uint32, float>& newNeedCacheList)
 {
     DoPulse();
     UpdateModelCaching(newNeedCacheList, m_VehicleModelCacheInfoMap, m_uiMaxCachedVehicleModels);
@@ -282,11 +282,11 @@ void CModelCacheManagerImpl::UpdateVehicleModelCaching(const std::map<ushort, fl
 // CModelCacheManagerImpl::RemoveCacheRefs
 //
 ///////////////////////////////////////////////////////////////
-void CModelCacheManagerImpl::RemoveCacheRefs(std::map<ushort, SModelCacheInfo>& currentCacheInfoMap)
+void CModelCacheManagerImpl::RemoveCacheRefs(std::map<uint32, SModelCacheInfo>& currentCacheInfoMap)
 {
-    for (std::map<ushort, SModelCacheInfo>::iterator iter = currentCacheInfoMap.begin(); iter != currentCacheInfoMap.end(); ++iter)
+    for (std::map<uint32, SModelCacheInfo>::iterator iter = currentCacheInfoMap.begin(); iter != currentCacheInfoMap.end(); ++iter)
     {
-        const ushort     usModelId = iter->first;
+        const uint32     usModelId = iter->first;
         SModelCacheInfo& info = iter->second;
 
         if (info.bIsModelCachedHere)
@@ -302,13 +302,13 @@ void CModelCacheManagerImpl::RemoveCacheRefs(std::map<ushort, SModelCacheInfo>& 
 // CModelCacheManagerImpl::UpdateModelCaching
 //
 ///////////////////////////////////////////////////////////////
-void CModelCacheManagerImpl::UpdateModelCaching(const std::map<ushort, float>& newNeedCacheList, std::map<ushort, SModelCacheInfo>& currentCacheInfoMap,
+void CModelCacheManagerImpl::UpdateModelCaching(const std::map<uint32, float>& newNeedCacheList, std::map<uint32, SModelCacheInfo>& currentCacheInfoMap,
                                                 uint uiMaxCachedAllowed)
 {
     // Update some flags and remove info for uncached and unneeded
-    for (std::map<ushort, SModelCacheInfo>::iterator iter = currentCacheInfoMap.begin(); iter != currentCacheInfoMap.end();)
+    for (std::map<uint32, SModelCacheInfo>::iterator iter = currentCacheInfoMap.begin(); iter != currentCacheInfoMap.end();)
     {
-        const ushort     usModelId = iter->first;
+        const uint32     usModelId = iter->first;
         SModelCacheInfo& info = iter->second;
 
         info.bIsModelLoadedByGame = GetModelRefCount(usModelId) > (info.bIsModelCachedHere ? 1 : 0);
@@ -326,7 +326,7 @@ void CModelCacheManagerImpl::UpdateModelCaching(const std::map<ushort, float>& n
     }
 
     // Update current from new needed
-    for (std::map<ushort, float>::const_iterator iter = newNeedCacheList.begin(); iter != newNeedCacheList.end(); ++iter)
+    for (std::map<uint32, float>::const_iterator iter = newNeedCacheList.begin(); iter != newNeedCacheList.end(); ++iter)
     {
         SModelCacheInfo& info = MapGet(currentCacheInfoMap, iter->first);
         info.fClosestDistSq = iter->second;
@@ -337,14 +337,14 @@ void CModelCacheManagerImpl::UpdateModelCaching(const std::map<ushort, float>& n
 
     uint uiNumModelsCachedHereOnly = 0;
 
-    std::map<uint, ushort> maybeUncacheUnneededList;
-    std::map<uint, ushort> maybeUncacheNeededList;
-    std::map<uint, ushort> maybeCacheList;
+    std::map<uint, uint32> maybeUncacheUnneededList;
+    std::map<uint, uint32> maybeUncacheNeededList;
+    std::map<uint, uint32> maybeCacheList;
 
     // Update active
-    for (std::map<ushort, SModelCacheInfo>::iterator iter = currentCacheInfoMap.begin(); iter != currentCacheInfoMap.end(); ++iter)
+    for (std::map<uint32, SModelCacheInfo>::iterator iter = currentCacheInfoMap.begin(); iter != currentCacheInfoMap.end(); ++iter)
     {
-        const ushort     usModelId = iter->first;
+        const uint32     usModelId = iter->first;
         SModelCacheInfo& info = iter->second;
 
         if (info.bIsModelLoadedByGame)
@@ -385,7 +385,7 @@ void CModelCacheManagerImpl::UpdateModelCaching(const std::map<ushort, float>& n
     // If at or above cache limit, try to uncache unneeded first
     if (uiNumModelsCachedHereOnly >= uiMaxCachedAllowed && !maybeUncacheUnneededList.empty())
     {
-        const ushort     usModelId = maybeUncacheUnneededList.rbegin()->second;
+        const uint32     usModelId = maybeUncacheUnneededList.rbegin()->second;
         SModelCacheInfo* pInfo = MapFind(currentCacheInfoMap, usModelId);
         assert(pInfo);
         assert(pInfo->bIsModelCachedHere);
@@ -399,7 +399,7 @@ void CModelCacheManagerImpl::UpdateModelCaching(const std::map<ushort, float>& n
         // Only uncache from the needed list if above limit
 
         // Uncache furthest away model
-        const ushort     usModelId = maybeUncacheNeededList.rbegin()->second;
+        const uint32     usModelId = maybeUncacheNeededList.rbegin()->second;
         SModelCacheInfo* pInfo = MapFind(currentCacheInfoMap, usModelId);
         assert(pInfo);
         assert(pInfo->bIsModelCachedHere);
@@ -413,7 +413,7 @@ void CModelCacheManagerImpl::UpdateModelCaching(const std::map<ushort, float>& n
     if (!maybeCacheList.empty() && uiNumModelsCachedHereOnly < uiMaxCachedAllowed)
     {
         // Cache one which has been waiting the longest
-        const ushort     usModelId = maybeCacheList.rbegin()->second;
+        const uint32     usModelId = maybeCacheList.rbegin()->second;
         SModelCacheInfo* pInfo = MapFind(currentCacheInfoMap, usModelId);
         assert(pInfo);
         assert(!pInfo->bIsModelCachedHere);
@@ -428,7 +428,7 @@ void CModelCacheManagerImpl::UpdateModelCaching(const std::map<ushort, float>& n
 // CModelCacheManagerImpl::GetModelRefCount
 //
 ///////////////////////////////////////////////////////////////
-int CModelCacheManagerImpl::GetModelRefCount(ushort usModelId)
+int CModelCacheManagerImpl::GetModelRefCount(uint32 usModelId)
 {
     CModelInfo* pModelInfo = m_pGame->GetModelInfo(usModelId);
     if (pModelInfo)
@@ -441,7 +441,7 @@ int CModelCacheManagerImpl::GetModelRefCount(ushort usModelId)
 // CModelCacheManagerImpl::AddModelRefCount
 //
 ///////////////////////////////////////////////////////////////
-void CModelCacheManagerImpl::AddModelRefCount(ushort usModelId)
+void CModelCacheManagerImpl::AddModelRefCount(uint32 usModelId)
 {
     CModelInfo* pModelInfo = m_pGame->GetModelInfo(usModelId);
     if (pModelInfo)
@@ -453,7 +453,7 @@ void CModelCacheManagerImpl::AddModelRefCount(ushort usModelId)
 // CModelCacheManagerImpl::SubModelRefCount
 //
 ///////////////////////////////////////////////////////////////
-void CModelCacheManagerImpl::SubModelRefCount(ushort usModelId)
+void CModelCacheManagerImpl::SubModelRefCount(uint32 usModelId)
 {
     CModelInfo* pModelInfo = m_pGame->GetModelInfo(usModelId);
     if (pModelInfo)
@@ -467,7 +467,7 @@ void CModelCacheManagerImpl::SubModelRefCount(ushort usModelId)
 // Remove model and associated txd from memory
 //
 ///////////////////////////////////////////////////////////////
-bool CModelCacheManagerImpl::UnloadModel(ushort usModelId)
+bool CModelCacheManagerImpl::UnloadModel(uint32 usModelId)
 {
     // Stream out usages in the client module
     CClientBase* pClientBase = CModManager::GetSingleton().GetCurrentMod();
@@ -492,13 +492,13 @@ bool CModelCacheManagerImpl::UnloadModel(ushort usModelId)
 // Uncache here, now.
 //
 ///////////////////////////////////////////////////////////////
-void CModelCacheManagerImpl::OnRestreamModel(ushort usModelId)
+void CModelCacheManagerImpl::OnRestreamModel(uint32 usModelId)
 {
-    std::map<ushort, SModelCacheInfo>* mapList[] = {&m_PedModelCacheInfoMap, &m_VehicleModelCacheInfoMap};
+    std::map<uint32, SModelCacheInfo>* mapList[] = {&m_PedModelCacheInfoMap, &m_VehicleModelCacheInfoMap};
 
     for (uint i = 0; i < NUMELMS(mapList); i++)
     {
-        std::map<ushort, SModelCacheInfo>& cacheInfoMap = *mapList[i];
+        std::map<uint32, SModelCacheInfo>& cacheInfoMap = *mapList[i];
 
         SModelCacheInfo* pInfo = MapFind(cacheInfoMap, usModelId);
         if (pInfo)

--- a/Client/core/CModelCacheManager.h
+++ b/Client/core/CModelCacheManager.h
@@ -17,12 +17,12 @@ public:
     // CModelCacheManager interface
     virtual void DoPulse() = 0;
     virtual void GetStats(SModelCacheStats& outStats) = 0;
-    virtual bool UnloadModel(ushort usModelId) = 0;
-    virtual void OnRestreamModel(ushort usModelId) = 0;
+    virtual bool UnloadModel(uint32 usModelId) = 0;
+    virtual void OnRestreamModel(uint32 usModelId) = 0;
     virtual void OnClientClose() = 0;
-    virtual void UpdatePedModelCaching(const std::map<ushort, float>& newNeedCacheList) = 0;
-    virtual void UpdateVehicleModelCaching(const std::map<ushort, float>& newNeedCacheList) = 0;
-    virtual void AddModelToPersistentCache(ushort usModelId) = 0;
+    virtual void UpdatePedModelCaching(const std::map<uint32, float>& newNeedCacheList) = 0;
+    virtual void UpdateVehicleModelCaching(const std::map<uint32, float>& newNeedCacheList) = 0;
+    virtual void AddModelToPersistentCache(uint32 usModelId) = 0;
 };
 
 CModelCacheManager* NewModelCacheManager();

--- a/Client/core/Graphics/CRenderItemManager.TextureReplace.cpp
+++ b/Client/core/Graphics/CRenderItemManager.TextureReplace.cpp
@@ -16,7 +16,7 @@
 // Get the names of all streamed in world textures, filtered by name and/or model
 //
 ////////////////////////////////////////////////////////////////
-void CRenderItemManager::GetVisibleTextureNames(std::vector<SString>& outNameList, const SString& strTextureNameMatch, ushort usModelID)
+void CRenderItemManager::GetVisibleTextureNames(std::vector<SString>& outNameList, const SString& strTextureNameMatch, uint32 usModelID)
 {
     // If modelid supplied, get the model texture names into a map
     std::set<SString> modelTextureNameMap;

--- a/Client/core/Graphics/CRenderItemManager.h
+++ b/Client/core/Graphics/CRenderItemManager.h
@@ -44,7 +44,7 @@ public:
                                                              bool bAppendLayers);
     virtual bool               RemoveShaderItemFromWorldTexture(CShaderItem* pShaderItem, const SString& strTextureNameMatch, CClientEntityBase* pClientEntity);
     virtual void               RemoveClientEntityRefs(CClientEntityBase* pClientEntity);
-    virtual void               GetVisibleTextureNames(std::vector<SString>& outNameList, const SString& strTextureNameMatch, ushort usModelID);
+    virtual void               GetVisibleTextureNames(std::vector<SString>& outNameList, const SString& strTextureNameMatch, uint32 usModelID);
     virtual eDxTestMode        GetTestMode() { return m_TestMode; }
     virtual void               SetTestMode(eDxTestMode testMode);
     virtual void               GetDxStatus(SDxStatus& outStatus);

--- a/Client/game_sa/CHandlingEntrySA.cpp
+++ b/Client/game_sa/CHandlingEntrySA.cpp
@@ -58,7 +58,7 @@ void CHandlingEntrySA::Assign(const CHandlingEntry* pData)
     pGame->GetHandlingManager()->CheckSuspensionChanges(this);
 }
 
-void CHandlingEntrySA::Recalculate(unsigned short usModel)
+void CHandlingEntrySA::Recalculate(uint32 usModel)
 {
     // Real GTA class?
     if (m_pHandlingSA)

--- a/Client/game_sa/CHandlingEntrySA.h
+++ b/Client/game_sa/CHandlingEntrySA.h
@@ -188,7 +188,7 @@ public:
     void SetTailLight(eLightType Style) { m_Handling.ucTailLight = Style; };
     void SetAnimGroup(unsigned char ucGroup) { m_Handling.ucAnimGroup = ucGroup; };
 
-    void Recalculate(unsigned short usModel);
+    void Recalculate(uint32 usModel);
 
     tHandlingDataSA* GetInterface() { return m_pHandlingSA; };
 

--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -553,7 +553,7 @@ skip:
     return fReturn;
 }
 
-unsigned short CModelInfoSA::GetTextureDictionaryID()
+uint32 CModelInfoSA::GetTextureDictionaryID()
 {
     m_pInterface = ppModelInfo[m_dwModelID];
     if (m_pInterface)
@@ -562,7 +562,7 @@ unsigned short CModelInfoSA::GetTextureDictionaryID()
     return 0;
 }
 
-void CModelInfoSA::SetTextureDictionaryID(unsigned short usID)
+void CModelInfoSA::SetTextureDictionaryID(uint32 usID)
 {
     m_pInterface = ppModelInfo[m_dwModelID];
     if (m_pInterface)
@@ -1405,7 +1405,7 @@ void CModelInfoSA::SetVoice(const char* szVoiceType, const char* szVoice)
     SetVoice(sVoiceType, sVoiceID);
 }
 
-void CModelInfoSA::CopyStreamingInfoFromModel(ushort usBaseModelID)
+void CModelInfoSA::CopyStreamingInfoFromModel(uint32 usBaseModelID)
 {
     CStreamingInfo* pBaseModelStreamingInfo = pGame->GetStreaming()->GetStreamingInfoFromModelId(usBaseModelID);
     CStreamingInfo* pTargetModelStreamingInfo = pGame->GetStreaming()->GetStreamingInfoFromModelId(m_dwModelID);
@@ -1425,7 +1425,7 @@ void CModelInfoSA::MakePedModel(char* szTexture)
     pGame->GetStreaming()->RequestSpecialModel(m_dwModelID, szTexture, 0);
 }
 
-void CModelInfoSA::MakeObjectModel(ushort usBaseID)
+void CModelInfoSA::MakeObjectModel(uint32 usBaseID)
 {
     CBaseModelInfoSAInterface* m_pInterface = new CBaseModelInfoSAInterface();
 
@@ -1442,7 +1442,7 @@ void CModelInfoSA::MakeObjectModel(ushort usBaseID)
     CopyStreamingInfoFromModel(usBaseID);
 }
 
-void CModelInfoSA::MakeVehicleAutomobile(ushort usBaseID)
+void CModelInfoSA::MakeVehicleAutomobile(uint32 usBaseID)
 {
     CVehicleModelInfoSAInterface* m_pInterface = new CVehicleModelInfoSAInterface();
 
@@ -1744,7 +1744,7 @@ bool CModelInfoSA::ForceUnload()
         return false;
 
     // If success, then remove txd
-    ushort usTxdId = GetTextureDictionaryID();
+    uint32 usTxdId = GetTextureDictionaryID();
     if (usTxdId)
         pGame->GetRenderWare()->TxdForceUnload(usTxdId, true);
 

--- a/Client/game_sa/CModelInfoSA.h
+++ b/Client/game_sa/CModelInfoSA.h
@@ -351,8 +351,8 @@ public:
     bool           IsValid();
     bool           IsAllocatedInArchive();
     float          GetDistanceFromCentreOfMassToBaseOfModel();
-    unsigned short GetTextureDictionaryID();
-    void           SetTextureDictionaryID(unsigned short usID);
+    uint32         GetTextureDictionaryID();
+    void           SetTextureDictionaryID(uint32 usID);
     float          GetLODDistance();
     float          GetOriginalLODDistance();
     void           SetLODDistance(float fDistance, bool bOverrideMaxDistance = false);
@@ -411,8 +411,8 @@ public:
 
     // CModelInfoSA methods
     void MakePedModel(char* szTexture);
-    void MakeObjectModel(ushort usBaseModelID);
-    void MakeVehicleAutomobile(ushort usBaseModelID);
+    void MakeObjectModel(uint32 usBaseModelID);
+    void MakeVehicleAutomobile(uint32 usBaseModelID);
     void DeallocateModel(void);
     unsigned int GetParentID() { return m_dwParentID; };
 
@@ -430,6 +430,6 @@ public:
     bool IsTowableBy(CModelInfo* towingModel) override;
 
 private:
-    void CopyStreamingInfoFromModel(ushort usCopyFromModelID);
+    void CopyStreamingInfoFromModel(uint32 usCopyFromModelID);
     void RwSetSupportedUpgrades(RwFrame* parent, DWORD dwModel);
 };

--- a/Client/game_sa/CRenderWareSA.ClothesReplacing.cpp
+++ b/Client/game_sa/CRenderWareSA.ClothesReplacing.cpp
@@ -54,7 +54,7 @@ namespace
 // Add replacement txd for a clothing component
 //
 ////////////////////////////////////////////////////////////////
-void CRenderWareSA::ClothesAddReplacementTxd(char* pFileData, ushort usFileId)
+void CRenderWareSA::ClothesAddReplacementTxd(char* pFileData, uint32 usFileId)
 {
     if (!pFileData)
         return;

--- a/Client/game_sa/CRenderWareSA.ShaderSupport.cpp
+++ b/Client/game_sa/CRenderWareSA.ShaderSupport.cpp
@@ -51,7 +51,7 @@ DWORD RETURN_CTxdStore_RemoveTxd = 0x731E96;
 //
 struct STxdStreamEvent
 {
-    STxdStreamEvent(bool bAdded, ushort usTxdId) : bAdded(bAdded), usTxdId(usTxdId) {}
+    STxdStreamEvent(bool bAdded, uint32 usTxdId) : bAdded(bAdded), usTxdId(usTxdId) {}
 
     bool operator<(const STxdStreamEvent& other) const
     {
@@ -60,7 +60,7 @@ struct STxdStreamEvent
     bool operator==(const STxdStreamEvent& other) const { return usTxdId == other.usTxdId && bAdded == other.bAdded; }
 
     bool   bAdded;
-    ushort usTxdId;
+    uint32 usTxdId;
 };
 
 static CMappedArray<STxdStreamEvent> ms_txdStreamEventList;
@@ -70,7 +70,7 @@ static CMappedArray<STxdStreamEvent> ms_txdStreamEventList;
 ////////////////////////////////////////////////////////////////
 __declspec(noinline) void _cdecl OnStreamingAddedTxd(DWORD dwTxdId)
 {
-    ushort usTxdId = (ushort)dwTxdId;
+    uint32 usTxdId = (uint32)dwTxdId;
     // Ensure there are no previous events for this txd
     ms_txdStreamEventList.remove(STxdStreamEvent(false, usTxdId));
     ms_txdStreamEventList.remove(STxdStreamEvent(true, usTxdId));
@@ -103,7 +103,7 @@ void _declspec(naked) HOOK_CTxdStore_SetupTxdParent()
 ////////////////////////////////////////////////////////////////
 __declspec(noinline) void _cdecl OnStreamingRemoveTxd(DWORD dwTxdId)
 {
-    ushort usTxdId = (ushort)dwTxdId - pGame->GetBaseIDforTXD();
+    uint32 usTxdId = (uint32)dwTxdId - pGame->GetBaseIDforTXD();
     // Ensure there are no previous events for this txd
     ms_txdStreamEventList.remove(STxdStreamEvent(true, usTxdId));
     ms_txdStreamEventList.remove(STxdStreamEvent(false, usTxdId));
@@ -212,7 +212,7 @@ void CRenderWareSA::PulseWorldTextureWatch()
 // Create a texinfo for the texture
 //
 ////////////////////////////////////////////////////////////////
-void CRenderWareSA::StreamingAddedTexture(ushort usTxdId, const SString& strTextureName, CD3DDUMMY* pD3DData)
+void CRenderWareSA::StreamingAddedTexture(uint32 usTxdId, const SString& strTextureName, CD3DDUMMY* pD3DData)
 {
     STexInfo* pTexInfo = CreateTexInfo(usTxdId, strTextureName, pD3DData);
     OnTextureStreamIn(pTexInfo);
@@ -226,11 +226,11 @@ void CRenderWareSA::StreamingAddedTexture(ushort usTxdId, const SString& strText
 // Delete texinfos which came from that TXD
 //
 ////////////////////////////////////////////////////////////////
-void CRenderWareSA::StreamingRemovedTxd(ushort usTxdId)
+void CRenderWareSA::StreamingRemovedTxd(uint32 usTxdId)
 {
     TIMING_CHECKPOINT("+StreamingRemovedTxd");
 
-    typedef std::multimap<ushort, STexInfo*>::const_iterator ConstIterType;
+    typedef std::multimap<uint32, STexInfo*>::const_iterator ConstIterType;
     std::pair<ConstIterType, ConstIterType>                  range = m_TexInfoMap.equal_range(usTxdId);
     for (ConstIterType iter = range.first; iter != range.second;)
     {
@@ -286,7 +286,7 @@ void CRenderWareSA::ScriptRemovedTexture(RwTexture* pTex)
 {
     TIMING_CHECKPOINT("+ScriptRemovedTexture");
     // Find TexInfo for this script added texture
-    for (std::multimap<ushort, STexInfo*>::iterator iter = m_TexInfoMap.begin(); iter != m_TexInfoMap.end();)
+    for (std::multimap<uint32, STexInfo*>::iterator iter = m_TexInfoMap.begin(); iter != m_TexInfoMap.end();)
     {
         STexInfo* pTexInfo = iter->second;
         if (pTexInfo->texTag == pTex)
@@ -341,7 +341,7 @@ void CRenderWareSA::SpecialRemovedTexture(RwTexture* pTex)
     MapRemove(m_SpecialTextures, pTex);
 
     // Find TexInfo for this special texture
-    for (std::multimap<ushort, STexInfo*>::iterator iter = m_TexInfoMap.begin(); iter != m_TexInfoMap.end();)
+    for (std::multimap<uint32, STexInfo*>::iterator iter = m_TexInfoMap.begin(); iter != m_TexInfoMap.end();)
     {
         STexInfo* pTexInfo = iter->second;
         if (pTexInfo->texTag == pTex)
@@ -407,7 +407,7 @@ void CRenderWareSA::DestroyTexInfo(STexInfo* pTexInfo)
 //
 //
 ////////////////////////////////////////////////////////////////
-void CRenderWareSA::SetRenderingClientEntity(CClientEntityBase* pClientEntity, ushort usModelId, int iTypeMask)
+void CRenderWareSA::SetRenderingClientEntity(CClientEntityBase* pClientEntity, uint32 usModelId, int iTypeMask)
 {
     m_pRenderingClientEntity = pClientEntity;
     m_usRenderingEntityModelId = usModelId;

--- a/Client/game_sa/CRenderWareSA.ShaderSupport.h
+++ b/Client/game_sa/CRenderWareSA.ShaderSupport.h
@@ -31,16 +31,16 @@ struct STexNameInfo;
 //
 struct STexTag
 {
-    STexTag(ushort usTxdId) : m_bUsingTxdId(true), m_usTxdId(usTxdId), m_pTex(NULL) {}
+    STexTag(uint32 usTxdId) : m_bUsingTxdId(true), m_usTxdId(usTxdId), m_pTex(NULL) {}
 
     STexTag(RwTexture* pTex) : m_bUsingTxdId(false), m_usTxdId(0), m_pTex(pTex) {}
 
-    bool operator==(ushort usTxdId) const { return m_bUsingTxdId && usTxdId == m_usTxdId; }
+    bool operator==(uint32 usTxdId) const { return m_bUsingTxdId && usTxdId == m_usTxdId; }
 
     bool operator==(RwTexture* pTex) const { return !m_bUsingTxdId && pTex == m_pTex; }
 
     const bool       m_bUsingTxdId;
-    const ushort     m_usTxdId;            // Streamed textures are identified using the TXD id
+    const uint32     m_usTxdId;            // Streamed textures are identified using the TXD id
     const RwTexture* m_pTex;               // Custom textures are identified using the RwTexture pointer
 };
 

--- a/Client/game_sa/CRenderWareSA.TextureReplacing.cpp
+++ b/Client/game_sa/CRenderWareSA.TextureReplacing.cpp
@@ -17,11 +17,11 @@ class CModelTexturesInfo
 public:
     std::vector<RwTexture*>            originalTextures;
     std::vector<SReplacementTextures*> usedByReplacements;
-    ushort                             usTxdId;
+    uint32                             usTxdId;
     RwTexDictionary*                   pTxd;
 };
 
-std::map<ushort, CModelTexturesInfo> ms_ModelTexturesInfoMap;
+std::map<uint32, CModelTexturesInfo> ms_ModelTexturesInfoMap;
 
 ////////////////////////////////////////////////////////////////
 //
@@ -30,13 +30,13 @@ std::map<ushort, CModelTexturesInfo> ms_ModelTexturesInfoMap;
 // Find/create texture info for a modelid
 //
 ////////////////////////////////////////////////////////////////
-CModelTexturesInfo* CRenderWareSA::GetModelTexturesInfo(ushort usModelId)
+CModelTexturesInfo* CRenderWareSA::GetModelTexturesInfo(uint32 usModelId)
 {
     CModelInfoSA* pModelInfo = dynamic_cast<CModelInfoSA*>(pGame->GetModelInfo(usModelId));
     if (!pModelInfo)
         return NULL;
 
-    ushort usTxdId = pModelInfo->GetTextureDictionaryID();
+    uint32 usTxdId = pModelInfo->GetTextureDictionaryID();
 
     CModelTexturesInfo* pInfo = MapFind(ms_ModelTexturesInfoMap, usTxdId);
     if (!pInfo)
@@ -127,7 +127,7 @@ bool CRenderWareSA::ModelInfoTXDLoadTextures(SReplacementTextures* pReplacementT
 // Returns true if model was affected.
 //
 ////////////////////////////////////////////////////////////////
-bool CRenderWareSA::ModelInfoTXDAddTextures(SReplacementTextures* pReplacementTextures, ushort usModelId)
+bool CRenderWareSA::ModelInfoTXDAddTextures(SReplacementTextures* pReplacementTextures, uint32 usModelId)
 {
     // Already done for this modelid?
     if (ListContains(pReplacementTextures->usedInModelIds, usModelId))
@@ -216,7 +216,7 @@ void CRenderWareSA::ModelInfoTXDRemoveTextures(SReplacementTextures* pReplacemen
         SReplacementTextures::SPerTxd& perTxdInfo = pReplacementTextures->perTxdList[i];
 
         // Get textures info
-        ushort              usTxdId = perTxdInfo.usTxdId;
+        uint32              usTxdId = perTxdInfo.usTxdId;
         CModelTexturesInfo* pInfo = MapFind(ms_ModelTexturesInfoMap, usTxdId);
 
         // Validate

--- a/Client/game_sa/CRenderWareSA.cpp
+++ b/Client/game_sa/CRenderWareSA.cpp
@@ -242,12 +242,12 @@ RwTexDictionary* CRenderWareSA::ReadTXD(const SString& strFilename, const SStrin
 // Reads and parses a DFF file specified by a path (szDFF) into a CModelInfo identified by the object id (usModelID)
 // bLoadEmbeddedCollisions should be true for vehicles
 // Any custom TXD should be imported before this call
-RpClump* CRenderWareSA::ReadDFF(const SString& strFilename, const SString& buffer, unsigned short usModelID, bool bLoadEmbeddedCollisions)
+RpClump* CRenderWareSA::ReadDFF(const SString& strFilename, const SString& buffer, uint32 usModelID, bool bLoadEmbeddedCollisions)
 {
     // Set correct TXD as materials are processed at the same time
     if (usModelID != 0)
     {
-        unsigned short usTxdId = ((CBaseModelInfoSAInterface**)ARRAY_ModelInfo)[usModelID]->usTextureDictionary;
+        uint32 usTxdId = ((CBaseModelInfoSAInterface**)ARRAY_ModelInfo)[usModelID]->usTextureDictionary;
         SetTextureDict(usTxdId);
     }
 
@@ -350,7 +350,7 @@ bool CRenderWareSA::DoContainTheSameGeometry(RpClump* pClumpA, RpClump* pClumpB,
 }
 
 // Replaces a vehicle/weapon/ped model
-void CRenderWareSA::ReplaceModel(RpClump* pNew, unsigned short usModelID, DWORD dwSetClumpFunction)
+void CRenderWareSA::ReplaceModel(RpClump* pNew, uint32 usModelID, DWORD dwSetClumpFunction)
 {
     auto CVehicleModelInfo_CVehicleStructure_Destructor = (void(__thiscall*) (CVehicleModelVisualInfoSAInterface * pThis))0x4C7410;
     auto CVehicleModelInfo_CVehicleStructure_release = (void(__cdecl*) (CVehicleModelVisualInfoSAInterface * pThis))0x4C9580;
@@ -395,19 +395,19 @@ void CRenderWareSA::ReplaceModel(RpClump* pNew, unsigned short usModelID, DWORD 
 }
 
 // Replaces a vehicle model
-void CRenderWareSA::ReplaceVehicleModel(RpClump* pNew, unsigned short usModelID)
+void CRenderWareSA::ReplaceVehicleModel(RpClump* pNew, uint32 usModelID)
 {
     ReplaceModel(pNew, usModelID, FUNC_LoadVehicleModel);
 }
 
 // Replaces a weapon model
-void CRenderWareSA::ReplaceWeaponModel(RpClump* pNew, unsigned short usModelID)
+void CRenderWareSA::ReplaceWeaponModel(RpClump* pNew, uint32 usModelID)
 {
     ReplaceModel(pNew, usModelID, FUNC_LoadWeaponModel);
 }
 
 // Replaces a ped model
-void CRenderWareSA::ReplacePedModel(RpClump* pNew, unsigned short usModelID)
+void CRenderWareSA::ReplacePedModel(RpClump* pNew, uint32 usModelID)
 {
     ReplaceModel(pNew, usModelID, FUNC_LoadPedModel);
 }
@@ -463,7 +463,7 @@ unsigned int CRenderWareSA::LoadAtomics(RpClump* pClump, RpAtomicContainer* pAto
 // Replaces all atomics for a specific model
 typedef struct
 {
-    unsigned short usTxdID;
+    uint32   usTxdID;
     RpClump*       pClump;
 } SAtomicsReplacer;
 bool AtomicsReplacer(RpAtomic* pAtomic, void* data)
@@ -480,7 +480,7 @@ bool AtomicsReplacer(RpAtomic* pAtomic, void* data)
     return true;
 }
 
-void CRenderWareSA::ReplaceAllAtomicsInModel(RpClump* pNew, unsigned short usModelID)
+void CRenderWareSA::ReplaceAllAtomicsInModel(RpClump* pNew, uint32 usModelID)
 {
     CModelInfo* pModelInfo = pGame->GetModelInfo(usModelID);
     if (pModelInfo)
@@ -570,7 +570,7 @@ bool CRenderWareSA::ReplacePartModels(RpClump* pClump, RpAtomicContainer* pAtomi
 }
 
 // Replaces a CColModel for a specific object identified by the object id (usModelID)
-void CRenderWareSA::ReplaceCollisions(CColModel* pCol, unsigned short usModelID)
+void CRenderWareSA::ReplaceCollisions(CColModel* pCol, uint32 usModelID)
 {
     DWORD*        pPool = (DWORD*)ARRAY_ModelInfo;
     CColModelSA*  pColModel = (CColModelSA*)pCol;
@@ -621,7 +621,7 @@ void CRenderWareSA::RwTexDictionaryRemoveTexture(RwTexDictionary* pTXD, RwTextur
     pTex->txd = NULL;
 }
 
-short CRenderWareSA::CTxdStore_GetTxdRefcount(unsigned short usTxdID)
+short CRenderWareSA::CTxdStore_GetTxdRefcount(uint32 usTxdID)
 {
     return *(short*)(*(*(DWORD**)0xC8800C) + 0xC * usTxdID + 4);
 }
@@ -645,7 +645,7 @@ bool CRenderWareSA::RwTexDictionaryContainsTexture(RwTexDictionary* pTXD, RwText
 // No idea what will happen if there is a custom txd replacement
 //
 ////////////////////////////////////////////////////////////////
-void CRenderWareSA::TxdForceUnload(ushort usTxdId, bool bDestroyTextures)
+void CRenderWareSA::TxdForceUnload(uint32 usTxdId, bool bDestroyTextures)
 {
     RwTexDictionary* pTxd = CTxdStore_GetTxd(usTxdId);
     if (!pTxd)
@@ -685,7 +685,7 @@ void CRenderWareSA::TxdForceUnload(ushort usTxdId, bool bDestroyTextures)
 // Get a TXD ID associated with the model ID
 //
 ////////////////////////////////////////////////////////////////
-ushort CRenderWareSA::GetTXDIDForModelID(ushort usModelID)
+uint32 CRenderWareSA::GetTXDIDForModelID(uint32 usModelID)
 {
     if (usModelID >= pGame->GetBaseIDforTXD() && usModelID < pGame->GetBaseIDforCOL())
     {
@@ -712,7 +712,7 @@ ushort CRenderWareSA::GetTXDIDForModelID(ushort usModelID)
 // Will try to load the model if needed
 //
 ////////////////////////////////////////////////////////////////
-void CRenderWareSA::GetModelTextureNames(std::vector<SString>& outNameList, ushort usModelId)
+void CRenderWareSA::GetModelTextureNames(std::vector<SString>& outNameList, uint32 usModelId)
 {
     outNameList.clear();
 
@@ -723,7 +723,7 @@ void CRenderWareSA::GetModelTextureNames(std::vector<SString>& outNameList, usho
         return;
     }
 
-    ushort usTxdId = GetTXDIDForModelID(usModelId);
+    uint32 usTxdId = GetTXDIDForModelID(usModelId);
 
     if (usTxdId == 0)
         return;
@@ -760,11 +760,11 @@ void CRenderWareSA::GetModelTextureNames(std::vector<SString>& outNameList, usho
 // Will try to load the model if needed
 //
 ////////////////////////////////////////////////////////////////
-bool CRenderWareSA::GetModelTextures(std::vector<std::tuple<std::string, CPixels>>& outTextureList, ushort usModelId, std::vector<SString> vTextureNames)
+bool CRenderWareSA::GetModelTextures(std::vector<std::tuple<std::string, CPixels>>& outTextureList, uint32 usModelId, std::vector<SString> vTextureNames)
 {
     outTextureList.clear();
 
-    ushort usTxdId = GetTXDIDForModelID(usModelId);
+    uint32 usTxdId = GetTXDIDForModelID(usModelId);
 
     if (usTxdId == 0)
         return false;
@@ -830,7 +830,7 @@ bool CRenderWareSA::GetModelTextures(std::vector<std::tuple<std::string, CPixels
 // If TXD must already be loaded
 //
 ////////////////////////////////////////////////////////////////
-void CRenderWareSA::GetTxdTextures(std::vector<RwTexture*>& outTextureList, ushort usTxdId)
+void CRenderWareSA::GetTxdTextures(std::vector<RwTexture*>& outTextureList, uint32 usTxdId)
 {
     if (usTxdId == 0)
         return;

--- a/Client/game_sa/CRenderWareSA.h
+++ b/Client/game_sa/CRenderWareSA.h
@@ -32,9 +32,9 @@ public:
     ~CRenderWareSA();
     void Initialize();
     bool ModelInfoTXDLoadTextures(SReplacementTextures* pReplacementTextures, const SString& strFilename, const SString& buffer, bool bFilteringEnabled);
-    bool ModelInfoTXDAddTextures(SReplacementTextures* pReplacementTextures, ushort usModelId);
+    bool ModelInfoTXDAddTextures(SReplacementTextures* pReplacementTextures, uint32 usModelId);
     void ModelInfoTXDRemoveTextures(SReplacementTextures* pReplacementTextures);
-    void ClothesAddReplacementTxd(char* pFileData, ushort usFileId);
+    void ClothesAddReplacementTxd(char* pFileData, uint32 usFileId);
     void ClothesRemoveReplacementTxd(char* pFileData);
     bool HasClothesReplacementChanged();
 
@@ -42,7 +42,7 @@ public:
     RwTexDictionary* ReadTXD(const SString& strFilename, const SString& buffer);
 
     // Reads and parses a DFF file specified by a path (szDFF) into a CModelInfo identified by the object id (usModelID)
-    RpClump* ReadDFF(const SString& strFilename, const SString& buffer, unsigned short usModelID, bool bLoadEmbeddedCollisions);
+    RpClump* ReadDFF(const SString& strFilename, const SString& buffer, uint32 usModelID, bool bLoadEmbeddedCollisions);
 
     // Destroys a DFF instance
     void DestroyDFF(RpClump* pClump);
@@ -57,13 +57,13 @@ public:
     CColModel* ReadCOL(const SString& buffer);
 
     // Replaces a CColModel for a specific object identified by the object id (usModelID)
-    void ReplaceCollisions(CColModel* pColModel, unsigned short usModelID);
+    void ReplaceCollisions(CColModel* pColModel, uint32 usModelID);
 
     // Loads all atomics from a clump into a container struct and returns the number of atomics it loaded
     unsigned int LoadAtomics(RpClump* pClump, RpAtomicContainer* pAtomics);
 
     // Replaces all atomics for a specific model
-    void ReplaceAllAtomicsInModel(RpClump* pSrc, unsigned short usModelID);
+    void ReplaceAllAtomicsInModel(RpClump* pSrc, uint32 usModelID);
 
     // Replaces all atomics in a clump
     void ReplaceAllAtomicsInClump(RpClump* pDst, RpAtomicContainer* pAtomics, unsigned int uiAtomics);
@@ -78,27 +78,27 @@ public:
     void AddAllAtomics(RpClump* pDst, RpClump* pSrc);
 
     // Replaces a CClumpModelInfo (or CVehicleModelInfo, since its just for vehicles) clump with a new clump
-    void ReplaceVehicleModel(RpClump* pNew, unsigned short usModelID);
+    void ReplaceVehicleModel(RpClump* pNew, uint32 usModelID);
 
     // Replaces a CClumpModelInfo clump with a new clump
-    void ReplaceWeaponModel(RpClump* pNew, unsigned short usModelID);
+    void ReplaceWeaponModel(RpClump* pNew, uint32 usModelID);
 
-    void ReplacePedModel(RpClump* pNew, unsigned short usModelID);
+    void ReplacePedModel(RpClump* pNew, uint32 usModelID);
 
-    void ReplaceModel(RpClump* pNew, unsigned short usModelID, DWORD dwSetClumpFunction);
+    void ReplaceModel(RpClump* pNew, uint32 usModelID, DWORD dwSetClumpFunction);
 
     // Replaces dynamic parts of the vehicle (models that have two different versions: 'ok' and 'dam'), such as doors
     // szName should be without the part suffix (e.g. 'door_lf' or 'door_rf', and not 'door_lf_dummy')
     bool ReplacePartModels(RpClump* pClump, RpAtomicContainer* pAtomics, unsigned int uiAtomics, const char* szName);
 
-    ushort             GetTXDIDForModelID(ushort usModelID);
+    uint32             GetTXDIDForModelID(uint32 usModelID);
     void               PulseWorldTextureWatch();
-    void               GetModelTextureNames(std::vector<SString>& outNameList, ushort usModelID);
-    bool               GetModelTextures(std::vector<std::tuple<std::string, CPixels>>& outTextureList, ushort usModelID, std::vector<SString> vTextureNames);
-    void               GetTxdTextures(std::vector<RwTexture*>& outTextureList, ushort usTxdId);
+    void               GetModelTextureNames(std::vector<SString>& outNameList, uint32 usModelID);
+    bool               GetModelTextures(std::vector<std::tuple<std::string, CPixels>>& outTextureList, uint32 usModelID, std::vector<SString> vTextureNames);
+    void               GetTxdTextures(std::vector<RwTexture*>& outTextureList, uint32 usTxdId);
     static void        GetTxdTextures(std::vector<RwTexture*>& outTextureList, RwTexDictionary* pTXD);
     const char*        GetTextureName(CD3DDUMMY* pD3DData);
-    void               SetRenderingClientEntity(CClientEntityBase* pClientEntity, ushort usModelId, int iTypeMask);
+    void               SetRenderingClientEntity(CClientEntityBase* pClientEntity, uint32 usModelId, int iTypeMask);
     SShaderItemLayers* GetAppliedShaderForD3DData(CD3DDUMMY* pD3DData);
     void               AppendAdditiveMatch(CSHADERDUMMY* pShaderData, CClientEntityBase* pClientEntity, const char* strTextureNameMatch, float fShaderPriority,
                                            bool bShaderLayered, int iTypeMask, uint uiShaderCreateTime, bool bShaderUsesVertexShader, bool bAppendLayers);
@@ -106,7 +106,7 @@ public:
     void               RemoveClientEntityRefs(CClientEntityBase* pClientEntity);
     void               RemoveShaderRefs(CSHADERDUMMY* pShaderItem);
     bool               RightSizeTxd(const SString& strInTxdFilename, const SString& strOutTxdFilename, uint uiSizeLimit);
-    void               TxdForceUnload(ushort usTxdId, bool bDestroyTextures);
+    void               TxdForceUnload(uint32 usTxdId, bool bDestroyTextures);
 
     void CMatrixToRwMatrix(const CMatrix& mat, RwMatrix& rwOutMatrix);
     void RwMatrixToCMatrix(const RwMatrix& rwMatrix, CMatrix& matOut);
@@ -121,7 +121,7 @@ public:
     RwTexture*          RightSizeTexture(RwTexture* pTexture, uint uiSizeLimit, SString& strError);
     void                ResetStats();
     void                GetShaderReplacementStats(SShaderReplacementStats& outStats);
-    CModelTexturesInfo* GetModelTexturesInfo(ushort usModelId);
+    CModelTexturesInfo* GetModelTexturesInfo(uint32 usModelId);
 
     RwFrame* GetFrameFromName(RpClump* pRoot, SString strName);
 
@@ -129,12 +129,12 @@ public:
     static void  StaticSetClothesReplacingHooks();
     static void  RwTexDictionaryRemoveTexture(RwTexDictionary* pTXD, RwTexture* pTex);
     static bool  RwTexDictionaryContainsTexture(RwTexDictionary* pTXD, RwTexture* pTex);
-    static short CTxdStore_GetTxdRefcount(unsigned short usTxdID);
+    static short CTxdStore_GetTxdRefcount(uint32 usTxdID);
     static bool  StaticGetTextureCB(RwTexture* texture, std::vector<RwTexture*>* pTextureList);
 
     void      InitTextureWatchHooks();
-    void      StreamingAddedTexture(ushort usTxdId, const SString& strTextureName, CD3DDUMMY* pD3DData);
-    void      StreamingRemovedTxd(ushort usTxdId);
+    void      StreamingAddedTexture(uint32 usTxdId, const SString& strTextureName, CD3DDUMMY* pD3DData);
+    void      StreamingRemovedTxd(uint32 usTxdId);
     void      ScriptAddedTxd(RwTexDictionary* pTxd);
     void      ScriptRemovedTexture(RwTexture* pTex);
     void      SpecialAddedTexture(RwTexture* texture, const char* szTextureName = NULL);
@@ -152,10 +152,10 @@ public:
     void SetGTAVertexShadersEnabled(bool bEnable);
 
     // Watched world textures
-    std::multimap<ushort, STexInfo*>    m_TexInfoMap;
+    std::multimap<uint32, STexInfo*>    m_TexInfoMap;
     CFastHashMap<CD3DDUMMY*, STexInfo*> m_D3DDataTexInfoMap;
     CClientEntityBase*                  m_pRenderingClientEntity;
-    ushort                              m_usRenderingEntityModelId;
+    uint32                              m_usRenderingEntityModelId;
     int                                 m_iRenderingEntityType;
     CMatchChannelManager*               m_pMatchChannelManager;
     int                                 m_uiReplacementRequestCounter;

--- a/Client/game_sa/CWorldSA.cpp
+++ b/Client/game_sa/CWorldSA.cpp
@@ -20,9 +20,9 @@ namespace
 
 CWorldSA::CWorldSA()
 {
-    m_pBuildingRemovals = new std::multimap<unsigned short, SBuildingRemoval*>;
-    m_pDataBuildings = new std::multimap<unsigned short, sDataBuildingRemovalItem*>;
-    m_pBinaryBuildings = new std::multimap<unsigned short, sBuildingRemovalItem*>;
+    m_pBuildingRemovals = new std::multimap<uint32, SBuildingRemoval*>;
+    m_pDataBuildings = new std::multimap<uint32, sDataBuildingRemovalItem*>;
+    m_pBinaryBuildings = new std::multimap<uint32, sBuildingRemovalItem*>;
 
     m_pSurfaceInfo = reinterpret_cast<CSurfaceType*>(ARRAY_SurfaceInfos);
 
@@ -651,7 +651,7 @@ int CWorldSA::FindClosestRailTrackNode(const CVector& vecPosition, uchar& ucOutT
     return iNodeId;
 }
 
-void CWorldSA::RemoveBuilding(unsigned short usModelToRemove, float fRange, float fX, float fY, float fZ, char cInterior, uint* pOutAmount)
+void CWorldSA::RemoveBuilding(uint32 usModelToRemove, float fRange, float fX, float fY, float fZ, char cInterior, uint* pOutAmount)
 {
     // New building Removal
     SBuildingRemoval* pRemoval = new SBuildingRemoval();
@@ -662,14 +662,14 @@ void CWorldSA::RemoveBuilding(unsigned short usModelToRemove, float fRange, floa
     pRemoval->m_fRadius = fRange;
     pRemoval->m_cInterior = cInterior;
     // Push it to the back of the removal list
-    m_pBuildingRemovals->insert(std::pair<unsigned short, SBuildingRemoval*>(usModelToRemove, pRemoval));
+    m_pBuildingRemovals->insert(std::pair<uint32, SBuildingRemoval*>(usModelToRemove, pRemoval));
 
     bool bFound = false;
     uint uiAmount = 0;
     // Init loop variables
-    std::pair<std::multimap<unsigned short, sDataBuildingRemovalItem*>::iterator, std::multimap<unsigned short, sDataBuildingRemovalItem*>::iterator>
+    std::pair<std::multimap<uint32, sDataBuildingRemovalItem*>::iterator, std::multimap<uint32, sDataBuildingRemovalItem*>::iterator>
                                                                              iterators = m_pDataBuildings->equal_range(usModelToRemove);
-    std::multimap<unsigned short, sDataBuildingRemovalItem*>::const_iterator iter = iterators.first;
+    std::multimap<uint32, sDataBuildingRemovalItem*>::const_iterator iter = iterators.first;
     for (; iter != iterators.second; ++iter)
     {
         sDataBuildingRemovalItem* pFind = (*iter).second;
@@ -726,9 +726,9 @@ void CWorldSA::RemoveBuilding(unsigned short usModelToRemove, float fRange, floa
         }
     }
 
-    std::pair<std::multimap<unsigned short, sBuildingRemovalItem*>::iterator, std::multimap<unsigned short, sBuildingRemovalItem*>::iterator> iteratorsBinary =
+    std::pair<std::multimap<uint32, sBuildingRemovalItem*>::iterator, std::multimap<uint32, sBuildingRemovalItem*>::iterator> iteratorsBinary =
         m_pBinaryBuildings->equal_range(usModelToRemove);
-    std::multimap<unsigned short, sBuildingRemovalItem*>::const_iterator iterBinary = iteratorsBinary.first;
+    std::multimap<uint32, sBuildingRemovalItem*>::const_iterator iterBinary = iteratorsBinary.first;
     for (; iterBinary != iteratorsBinary.second; ++iterBinary)
     {
         sBuildingRemovalItem* pFindBinary = (*iterBinary).second;
@@ -792,15 +792,15 @@ void CWorldSA::RemoveBuilding(unsigned short usModelToRemove, float fRange, floa
         *pOutAmount = uiAmount;
 }
 
-bool CWorldSA::RestoreBuilding(unsigned short usModelToRestore, float fRange, float fX, float fY, float fZ, char cInterior, uint* pOutAmount)
+bool CWorldSA::RestoreBuilding(uint32 usModelToRestore, float fRange, float fX, float fY, float fZ, char cInterior, uint* pOutAmount)
 {
     bool bSuccess = false;
     uint uiAmount = 0;
 
     // Init some variables
-    std::pair<std::multimap<unsigned short, SBuildingRemoval*>::iterator, std::multimap<unsigned short, SBuildingRemoval*>::iterator> iterators =
+    std::pair<std::multimap<uint32, SBuildingRemoval*>::iterator, std::multimap<uint32, SBuildingRemoval*>::iterator> iterators =
         m_pBuildingRemovals->equal_range(usModelToRestore);
-    std::multimap<unsigned short, SBuildingRemoval*>::const_iterator iter = iterators.first;
+    std::multimap<uint32, SBuildingRemoval*>::const_iterator iter = iterators.first;
     // Loop through the buildings list
     for (; iter != iterators.second;)
     {
@@ -894,9 +894,9 @@ bool CWorldSA::RestoreBuilding(unsigned short usModelToRestore, float fRange, fl
         else
             iter++;
     }
-    std::pair<std::multimap<unsigned short, sDataBuildingRemovalItem*>::iterator, std::multimap<unsigned short, sDataBuildingRemovalItem*>::iterator>
+    std::pair<std::multimap<uint32, sDataBuildingRemovalItem*>::iterator, std::multimap<uint32, sDataBuildingRemovalItem*>::iterator>
                                                                              dataBuildingIterators = m_pDataBuildings->equal_range(usModelToRestore);
-    std::multimap<unsigned short, sDataBuildingRemovalItem*>::const_iterator iterator = dataBuildingIterators.first;
+    std::multimap<uint32, sDataBuildingRemovalItem*>::const_iterator iterator = dataBuildingIterators.first;
     for (; iterator != dataBuildingIterators.second; ++iterator)
     {
         sDataBuildingRemovalItem* pFound = (*iterator).second;
@@ -926,9 +926,9 @@ bool CWorldSA::RestoreBuilding(unsigned short usModelToRestore, float fRange, fl
         }
     }
 
-    std::pair<std::multimap<unsigned short, sBuildingRemovalItem*>::iterator, std::multimap<unsigned short, sBuildingRemovalItem*>::iterator>
+    std::pair<std::multimap<uint32, sBuildingRemovalItem*>::iterator, std::multimap<uint32, sBuildingRemovalItem*>::iterator>
                                                                          binaryBuildingIterators = m_pBinaryBuildings->equal_range(usModelToRestore);
-    std::multimap<unsigned short, sBuildingRemovalItem*>::const_iterator iteratorBinary = binaryBuildingIterators.first;
+    std::multimap<uint32, sBuildingRemovalItem*>::const_iterator iteratorBinary = binaryBuildingIterators.first;
     for (; iteratorBinary != binaryBuildingIterators.second; ++iteratorBinary)
     {
         sBuildingRemovalItem* pFoundBinary = (*iteratorBinary).second;
@@ -968,9 +968,9 @@ bool CWorldSA::RestoreBuilding(unsigned short usModelToRestore, float fRange, fl
 bool CWorldSA::IsRemovedModelInRadius(SIPLInst* pInst)
 {
     // Init some variables
-    std::pair<std::multimap<unsigned short, SBuildingRemoval*>::iterator, std::multimap<unsigned short, SBuildingRemoval*>::iterator> iterators =
+    std::pair<std::multimap<uint32, SBuildingRemoval*>::iterator, std::multimap<uint32, SBuildingRemoval*>::iterator> iterators =
         m_pBuildingRemovals->equal_range(pInst->m_nModelIndex);
-    std::multimap<unsigned short, SBuildingRemoval*>::const_iterator iter = iterators.first;
+    std::multimap<uint32, SBuildingRemoval*>::const_iterator iter = iterators.first;
     // Loop through the buildings list
     for (; iter != iterators.second; ++iter)
     {
@@ -998,9 +998,9 @@ bool CWorldSA::IsRemovedModelInRadius(SIPLInst* pInst)
 bool CWorldSA::IsObjectRemoved(CEntitySAInterface* pInterface)
 {
     // Init some variables
-    std::pair<std::multimap<unsigned short, SBuildingRemoval*>::iterator, std::multimap<unsigned short, SBuildingRemoval*>::iterator> iterators =
+    std::pair<std::multimap<uint32, SBuildingRemoval*>::iterator, std::multimap<uint32, SBuildingRemoval*>::iterator> iterators =
         m_pBuildingRemovals->equal_range(pInterface->m_nModelIndex);
-    std::multimap<unsigned short, SBuildingRemoval*>::const_iterator iter = iterators.first;
+    std::multimap<uint32, SBuildingRemoval*>::const_iterator iter = iterators.first;
     // Loop through the buildings list
     for (; iter != iterators.second; ++iter)
     {
@@ -1036,13 +1036,13 @@ bool CWorldSA::IsObjectRemoved(CEntitySAInterface* pInterface)
 }
 
 // Check if a given model is replaced
-bool CWorldSA::IsModelRemoved(unsigned short usModelID)
+bool CWorldSA::IsModelRemoved(uint32 usModelID)
 {
     return m_pBuildingRemovals->count(usModelID) > 0;
 }
 
 // Check if a given model is replaced
-bool CWorldSA::IsDataModelRemoved(unsigned short usModelID)
+bool CWorldSA::IsDataModelRemoved(uint32 usModelID)
 {
     return m_pBuildingRemovals->count(usModelID) > 0;
 }
@@ -1058,7 +1058,7 @@ void CWorldSA::ClearRemovedBuildingLists(uint* pOutAmount)
 {
     // Ensure no memory leaks by deleting items.
     uint                                                             uiAmount = 0;
-    std::multimap<unsigned short, SBuildingRemoval*>::const_iterator iter = m_pBuildingRemovals->begin();
+    std::multimap<uint32, SBuildingRemoval*>::const_iterator iter = m_pBuildingRemovals->begin();
 
     for (; iter != m_pBuildingRemovals->end();)
     {
@@ -1124,7 +1124,7 @@ void CWorldSA::ClearRemovedBuildingLists(uint* pOutAmount)
             iter++;
     }
     // Init some variables
-    std::multimap<unsigned short, sDataBuildingRemovalItem*>::const_iterator iterator = m_pDataBuildings->begin();
+    std::multimap<uint32, sDataBuildingRemovalItem*>::const_iterator iterator = m_pDataBuildings->begin();
     // Loop through the data building list
     for (; iterator != m_pDataBuildings->end(); ++iterator)
     {
@@ -1136,7 +1136,7 @@ void CWorldSA::ClearRemovedBuildingLists(uint* pOutAmount)
         }
     }
     // Init some variables
-    std::multimap<unsigned short, sBuildingRemovalItem*>::const_iterator iteratorBinary = m_pBinaryBuildings->begin();
+    std::multimap<uint32, sBuildingRemovalItem*>::const_iterator iteratorBinary = m_pBinaryBuildings->begin();
     // Loop through the data building list
     for (; iteratorBinary != m_pBinaryBuildings->end(); ++iteratorBinary)
     {
@@ -1150,7 +1150,7 @@ void CWorldSA::ClearRemovedBuildingLists(uint* pOutAmount)
     // Delete old building lists
     delete m_pBuildingRemovals;
     // Create new
-    m_pBuildingRemovals = new std::multimap<unsigned short, SBuildingRemoval*>;
+    m_pBuildingRemovals = new std::multimap<uint32, SBuildingRemoval*>;
     m_pRemovedEntities.clear();
 
     if (pOutAmount)
@@ -1161,9 +1161,9 @@ void CWorldSA::ClearRemovedBuildingLists(uint* pOutAmount)
 SBuildingRemoval* CWorldSA::GetBuildingRemoval(CEntitySAInterface* pInterface)
 {
     // Init some variables
-    std::pair<std::multimap<unsigned short, SBuildingRemoval*>::iterator, std::multimap<unsigned short, SBuildingRemoval*>::iterator> iterators =
+    std::pair<std::multimap<uint32, SBuildingRemoval*>::iterator, std::multimap<uint32, SBuildingRemoval*>::iterator> iterators =
         m_pBuildingRemovals->equal_range(pInterface->m_nModelIndex);
-    std::multimap<unsigned short, SBuildingRemoval*>::const_iterator iter = iterators.first;
+    std::multimap<uint32, SBuildingRemoval*>::const_iterator iter = iterators.first;
     // Loop through the buildings list
     for (; iter != iterators.second; ++iter)
     {
@@ -1201,7 +1201,7 @@ void CWorldSA::AddDataBuilding(CEntitySAInterface* pInterface)
         // Create a new building removal
         sDataBuildingRemovalItem* pBuildingRemoval = new sDataBuildingRemovalItem(pInterface, true);
         // Insert it with the model index so we can fast lookup
-        m_pDataBuildings->insert(std::pair<unsigned short, sDataBuildingRemovalItem*>((unsigned short)pInterface->m_nModelIndex, pBuildingRemoval));
+        m_pDataBuildings->insert(std::pair<uint32, sDataBuildingRemovalItem*>((uint32)pInterface->m_nModelIndex, pBuildingRemoval));
         m_pAddedEntities[(DWORD)pInterface] = true;
         m_pRemovedEntities[(DWORD)pInterface] = false;
     }
@@ -1214,7 +1214,7 @@ void CWorldSA::AddBinaryBuilding(CEntitySAInterface* pInterface)
         // Create a new building removal
         sBuildingRemovalItem* pBuildingRemoval = new sBuildingRemovalItem(pInterface, false);
         // Insert it with the model index so we can fast lookup
-        m_pBinaryBuildings->insert(std::pair<unsigned short, sBuildingRemovalItem*>((unsigned short)pInterface->m_nModelIndex, pBuildingRemoval));
+        m_pBinaryBuildings->insert(std::pair<uint32, sBuildingRemovalItem*>((uint32)pInterface->m_nModelIndex, pBuildingRemoval));
         m_pAddedEntities[(DWORD)pInterface] = true;
         m_pRemovedEntities[(DWORD)pInterface] = false;
     }
@@ -1222,9 +1222,9 @@ void CWorldSA::AddBinaryBuilding(CEntitySAInterface* pInterface)
 
 void CWorldSA::RemoveWorldBuildingFromLists(CEntitySAInterface* pInterface)
 {
-    std::pair<std::multimap<unsigned short, SBuildingRemoval*>::iterator, std::multimap<unsigned short, SBuildingRemoval*>::iterator> iterators =
+    std::pair<std::multimap<uint32, SBuildingRemoval*>::iterator, std::multimap<uint32, SBuildingRemoval*>::iterator> iterators =
         m_pBuildingRemovals->equal_range(pInterface->m_nModelIndex);
-    std::multimap<unsigned short, SBuildingRemoval*>::const_iterator iter = iterators.first;
+    std::multimap<uint32, SBuildingRemoval*>::const_iterator iter = iterators.first;
 
     // Loop through the buildings list
     for (; iter != iterators.second; ++iter)
@@ -1275,9 +1275,9 @@ void CWorldSA::RemoveWorldBuildingFromLists(CEntitySAInterface* pInterface)
     }
     {
         // Init some variables
-        std::pair<std::multimap<unsigned short, sDataBuildingRemovalItem*>::iterator, std::multimap<unsigned short, sDataBuildingRemovalItem*>::iterator>
+        std::pair<std::multimap<uint32, sDataBuildingRemovalItem*>::iterator, std::multimap<uint32, sDataBuildingRemovalItem*>::iterator>
                                                                                  dataIterators = m_pDataBuildings->equal_range(pInterface->m_nModelIndex);
-        std::multimap<unsigned short, sDataBuildingRemovalItem*>::const_iterator iterator = dataIterators.first;
+        std::multimap<uint32, sDataBuildingRemovalItem*>::const_iterator iterator = dataIterators.first;
         for (; iterator != dataIterators.second;)
         {
             sDataBuildingRemovalItem* pFound = (*iterator).second;
@@ -1298,9 +1298,9 @@ void CWorldSA::RemoveWorldBuildingFromLists(CEntitySAInterface* pInterface)
     }
     {
         // Init some variables
-        std::pair<std::multimap<unsigned short, sBuildingRemovalItem*>::iterator, std::multimap<unsigned short, sBuildingRemovalItem*>::iterator>
+        std::pair<std::multimap<uint32, sBuildingRemovalItem*>::iterator, std::multimap<uint32, sBuildingRemovalItem*>::iterator>
                                                                              binaryIterators = m_pBinaryBuildings->equal_range(pInterface->m_nModelIndex);
-        std::multimap<unsigned short, sBuildingRemovalItem*>::const_iterator iteratorBinary = binaryIterators.first;
+        std::multimap<uint32, sBuildingRemovalItem*>::const_iterator iteratorBinary = binaryIterators.first;
         for (; iteratorBinary != binaryIterators.second;)
         {
             sBuildingRemovalItem* pFound = (*iteratorBinary).second;

--- a/Client/game_sa/CWorldSA.h
+++ b/Client/game_sa/CWorldSA.h
@@ -104,17 +104,17 @@ public:
      * StopAllLawEnforcersInTheirTracks
 
      */
-    void              RemoveBuilding(unsigned short usModelToRemove, float fDistance, float fX, float fY, float fZ, char cInterior, uint* pOutAmount = NULL);
+    void              RemoveBuilding(uint32 usModelToRemove, float fDistance, float fX, float fY, float fZ, char cInterior, uint* pOutAmount = NULL);
     bool              IsRemovedModelInRadius(SIPLInst* pInst);
-    bool              IsModelRemoved(unsigned short modelID);
+    bool              IsModelRemoved(uint32 modelID);
     void              ClearRemovedBuildingLists(uint* pOutAmount = NULL);
-    bool              RestoreBuilding(unsigned short usModelToRestore, float fDistance, float fX, float fY, float fZ, char cInterior, uint* pOutAmount = NULL);
+    bool              RestoreBuilding(uint32 usModelToRestore, float fDistance, float fX, float fY, float fZ, char cInterior, uint* pOutAmount = NULL);
     SBuildingRemoval* GetBuildingRemoval(CEntitySAInterface* pInterface);
     void              AddDataBuilding(CEntitySAInterface* pInterface);
     void              RemoveWorldBuildingFromLists(CEntitySAInterface* pInterface);
     void              AddBinaryBuilding(CEntitySAInterface* pInterface);
     bool              IsObjectRemoved(CEntitySAInterface* pInterface);
-    bool              IsDataModelRemoved(unsigned short usModelID);
+    bool              IsDataModelRemoved(uint32 usModelID);
     bool              IsEntityRemoved(CEntitySAInterface* pInterface);
     bool              CalculateImpactPosition(const CVector& vecInputStart, CVector& vecInputEnd);
 
@@ -122,10 +122,10 @@ public:
     void              ResetAllSurfaceInfo() override;
     bool              ResetSurfaceInfo(short sSurfaceID) override;
 private:
-    std::multimap<unsigned short, SBuildingRemoval*>*         m_pBuildingRemovals;
-    std::multimap<unsigned short, sDataBuildingRemovalItem*>* m_pDataBuildings;
-    std::multimap<unsigned short, sBuildingRemovalItem*>*     m_pBinaryBuildings;
-    std::map<unsigned short, unsigned short>*                 m_pRemovedObjects;
+    std::multimap<uint32, SBuildingRemoval*>*                 m_pBuildingRemovals;
+    std::multimap<uint32, sDataBuildingRemovalItem*>*         m_pDataBuildings;
+    std::multimap<uint32, sBuildingRemovalItem*>*             m_pBinaryBuildings;
+    std::map<uint32, unsigned short>*                         m_pRemovedObjects;
     std::map<DWORD, bool>                                     m_pRemovedEntities;
     std::map<DWORD, bool>                                     m_pAddedEntities;
     float                                                     m_fAircraftMaxHeight;

--- a/Client/game_sa/gamesa_renderware.h
+++ b/Client/game_sa/gamesa_renderware.h
@@ -198,7 +198,7 @@ RWFUNC(RtQuatRotate_t RtQuatRotate, (RtQuatRotate_t)0xDEAD)
 /** GTA function definitions and mappings                                   **/
 /*****************************************************************************/
 
-typedef bool(__cdecl* SetTextureDict_t)(unsigned short id);
+typedef bool(__cdecl* SetTextureDict_t)(unsigned int id);
 typedef bool(__cdecl* LoadClumpFile_t)(RwStream* stream, unsigned int id);            // (stream, model id)
 typedef bool(__cdecl* LoadModel_t)(RwBuffer* filename, unsigned int id);              // (memory chunk, model id)
 typedef void(__cdecl* LoadCollisionModel_t)(unsigned char*, CColModelSAInterface*, const char*);

--- a/Client/mods/deathmatch/CClient.cpp
+++ b/Client/mods/deathmatch/CClient.cpp
@@ -256,7 +256,7 @@ bool CClient::ProcessCommand(const char* szCommandLine)
     return false;
 }
 
-void CClient::RestreamModel(unsigned short usModel)
+void CClient::RestreamModel(uint32_t usModel)
 {
     if (g_pClientGame)
     {

--- a/Client/mods/deathmatch/CClient.h
+++ b/Client/mods/deathmatch/CClient.h
@@ -23,7 +23,7 @@ public:
     void PreHUDRenderExecutionHandler(bool bDidUnminimize, bool bDidRecreateRenderTargets);
     void PostFrameExecutionHandler();
     void IdleHandler();
-    void RestreamModel(unsigned short usModel);
+    void RestreamModel(uint32 usModel);
 
     bool WebsiteRequestResultHandler(const std::unordered_set<SString>& newPages);
 

--- a/Client/mods/deathmatch/logic/CClientCivilian.h
+++ b/Client/mods/deathmatch/logic/CClientCivilian.h
@@ -40,7 +40,7 @@ public:
     int  GetRotation();
     void SetRotation(int iRotation);
 
-    void ModelRequestCallback(unsigned short usModelID){};
+    void ModelRequestCallback(uint32 usModelID){};
 
     float GetDistanceFromCentreOfMassToBaseOfModel();
 

--- a/Client/mods/deathmatch/logic/CClientColModel.cpp
+++ b/Client/mods/deathmatch/logic/CClientColModel.cpp
@@ -77,7 +77,7 @@ bool CClientColModel::LoadFromBuffer(SString buffer)
     return m_pColModel != nullptr;
 }
 
-bool CClientColModel::Replace(unsigned short usModel)
+bool CClientColModel::Replace(uint32 usModel)
 {
     // We have a model loaded?
     if (m_pColModel)
@@ -105,7 +105,7 @@ bool CClientColModel::Replace(unsigned short usModel)
     return false;
 }
 
-void CClientColModel::Restore(unsigned short usModel)
+void CClientColModel::Restore(uint32 usModel)
 {
     // Restore it
     InternalRestore(usModel);
@@ -117,7 +117,7 @@ void CClientColModel::Restore(unsigned short usModel)
 void CClientColModel::RestoreAll()
 {
     // Loop through our replaced ids
-    std::list<unsigned short>::iterator iter = m_Replaced.begin();
+    std::list<uint32>::iterator iter = m_Replaced.begin();
     for (; iter != m_Replaced.end(); iter++)
     {
         // Restore this model
@@ -128,10 +128,10 @@ void CClientColModel::RestoreAll()
     m_Replaced.clear();
 }
 
-bool CClientColModel::HasReplaced(unsigned short usModel)
+bool CClientColModel::HasReplaced(uint32 usModel)
 {
     // Loop through our replaced ids
-    std::list<unsigned short>::iterator iter = m_Replaced.begin();
+    std::list<uint32>::iterator iter = m_Replaced.begin();
     for (; iter != m_Replaced.end(); iter++)
     {
         // Is this the given ID
@@ -146,7 +146,7 @@ bool CClientColModel::HasReplaced(unsigned short usModel)
     return false;
 }
 
-void CClientColModel::InternalRestore(unsigned short usModel)
+void CClientColModel::InternalRestore(uint32 usModel)
 {
     // Grab the model info and restore it
     CModelInfo* pModel = g_pGame->GetModelInfo(usModel);

--- a/Client/mods/deathmatch/logic/CClientColModel.h
+++ b/Client/mods/deathmatch/logic/CClientColModel.h
@@ -27,11 +27,11 @@ public:
 
     bool IsLoaded() { return m_pColModel != NULL; };
 
-    bool Replace(unsigned short usModel);
-    void Restore(unsigned short usModel);
+    bool Replace(uint32 usModel);
+    void Restore(uint32 usModel);
     void RestoreAll();
 
-    bool        HasReplaced(unsigned short usModel);
+    bool        HasReplaced(uint32 usModel);
     static bool IsCOLData(const SString& strData);
 
     // Sorta a hack that these are required by CClientEntity...
@@ -43,10 +43,10 @@ private:
     bool LoadFromFile(SString filePath);
     bool LoadFromBuffer(SString buffer);
 
-    void InternalRestore(unsigned short usModel);
+    void InternalRestore(uint32 usModel);
 
     class CClientColModelManager* m_pColModelManager;
 
     CColModel*                m_pColModel;
-    std::list<unsigned short> m_Replaced;
+    std::list<uint32> m_Replaced;
 };

--- a/Client/mods/deathmatch/logic/CClientColModelManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientColModelManager.cpp
@@ -60,7 +60,7 @@ bool CClientColModelManager::Exists(CClientColModel* pCol)
     return false;
 }
 
-CClientColModel* CClientColModelManager::GetElementThatReplaced(unsigned short usModel, CClientColModel* pDontSearch)
+CClientColModel* CClientColModelManager::GetElementThatReplaced(uint32 usModel, CClientColModel* pDontSearch)
 {
     // Item exists in list?
     std::list<CClientColModel*>::iterator iter = m_List.begin();
@@ -78,13 +78,13 @@ CClientColModel* CClientColModelManager::GetElementThatReplaced(unsigned short u
     return NULL;
 }
 
-bool CClientColModelManager::IsReplacableModel(unsigned short usModel)
+bool CClientColModelManager::IsReplacableModel(uint32 usModel)
 {
     // We can only replace object collisions atm
     return CClientObjectManager::IsValidModel(usModel);
 }
 
-bool CClientColModelManager::RestoreModel(unsigned short usModel)
+bool CClientColModelManager::RestoreModel(uint32 usModel)
 {
     // Grab the item that replaced that model
     CClientColModel* pCol = GetElementThatReplaced(usModel);

--- a/Client/mods/deathmatch/logic/CClientColModelManager.h
+++ b/Client/mods/deathmatch/logic/CClientColModelManager.h
@@ -24,10 +24,10 @@ public:
     void RemoveAll();
     bool Exists(CClientColModel* pCol);
 
-    CClientColModel* GetElementThatReplaced(unsigned short usModel, CClientColModel* pDontSearch = NULL);
+    CClientColModel* GetElementThatReplaced(uint32 usModel, CClientColModel* pDontSearch = NULL);
 
-    static bool IsReplacableModel(unsigned short usModel);
-    bool        RestoreModel(unsigned short usModel);
+    static bool IsReplacableModel(uint32 usModel);
+    bool        RestoreModel(uint32 usModel);
 
     std::list<CClientColModel*>::const_iterator IterBegin() { return m_List.begin(); }
     std::list<CClientColModel*>::const_iterator IterEnd() { return m_List.end(); }

--- a/Client/mods/deathmatch/logic/CClientDFF.cpp
+++ b/Client/mods/deathmatch/logic/CClientDFF.cpp
@@ -188,7 +188,7 @@ bool CClientDFF::DoReplaceModel(uint32 usModel, bool bAlphaTransparency)
 bool CClientDFF::HasReplaced(uint32 usModel)
 {
     // See if we have a match in our list
-    std::list<unsigned short>::iterator iter = m_Replaced.begin();
+    std::list<uint32>::iterator iter = m_Replaced.begin();
     for (; iter != m_Replaced.end(); iter++)
     {
         // Compare the models
@@ -212,7 +212,7 @@ void CClientDFF::RestoreModel(uint32 usModel)
 void CClientDFF::RestoreModels()
 {
     // Loop through our list over replaced models
-    std::list<unsigned short>::iterator iter = m_Replaced.begin();
+    std::list<uint32>::iterator iter = m_Replaced.begin();
     for (; iter != m_Replaced.end(); iter++)
     {
         // Restore this model

--- a/Client/mods/deathmatch/logic/CClientDFF.cpp
+++ b/Client/mods/deathmatch/logic/CClientDFF.cpp
@@ -35,7 +35,7 @@ CClientDFF::~CClientDFF()
 }
 
 // Get a clump which has been loaded to replace the specified model id
-RpClump* CClientDFF::GetLoadedClump(ushort usModelId)
+RpClump* CClientDFF::GetLoadedClump(uint32 usModelId)
 {
     if (usModelId == 0)
         return NULL;
@@ -89,7 +89,7 @@ bool CClientDFF::Load(bool isRaw, SString input)
 
 void CClientDFF::UnloadDFF()
 {
-    for (std::map<ushort, SLoadedClumpInfo>::iterator iter = m_LoadedClumpInfoMap.begin(); iter != m_LoadedClumpInfoMap.end(); ++iter)
+    for (std::map<uint32, SLoadedClumpInfo>::iterator iter = m_LoadedClumpInfoMap.begin(); iter != m_LoadedClumpInfoMap.end(); ++iter)
     {
         SLoadedClumpInfo& info = iter->second;
         if (info.pClump)
@@ -99,7 +99,7 @@ void CClientDFF::UnloadDFF()
     m_LoadedClumpInfoMap.clear();
 }
 
-bool CClientDFF::ReplaceModel(unsigned short usModel, bool bAlphaTransparency)
+bool CClientDFF::ReplaceModel(uint32 usModel, bool bAlphaTransparency)
 {
     // Record attempt in case it all goes wrong
     CArgMap argMap;
@@ -134,7 +134,7 @@ bool CClientDFF::LoadFromBuffer(SString buffer)
     return true;
 }
 
-bool CClientDFF::DoReplaceModel(unsigned short usModel, bool bAlphaTransparency)
+bool CClientDFF::DoReplaceModel(uint32 usModel, bool bAlphaTransparency)
 {
     if (!CClientDFFManager::IsReplacableModel(usModel))
         return false;
@@ -185,7 +185,7 @@ bool CClientDFF::DoReplaceModel(unsigned short usModel, bool bAlphaTransparency)
     return false;
 }
 
-bool CClientDFF::HasReplaced(unsigned short usModel)
+bool CClientDFF::HasReplaced(uint32 usModel)
 {
     // See if we have a match in our list
     std::list<unsigned short>::iterator iter = m_Replaced.begin();
@@ -202,7 +202,7 @@ bool CClientDFF::HasReplaced(unsigned short usModel)
     return false;
 }
 
-void CClientDFF::RestoreModel(unsigned short usModel)
+void CClientDFF::RestoreModel(uint32 usModel)
 {
     // Restore the model and remove it from the list
     InternalRestoreModel(usModel);
@@ -223,7 +223,7 @@ void CClientDFF::RestoreModels()
     m_Replaced.clear();
 }
 
-void CClientDFF::InternalRestoreModel(unsigned short usModel)
+void CClientDFF::InternalRestoreModel(uint32 usModel)
 {
     // Is this a vehicle ID?
     if (CClientVehicleManager::IsValidModel(usModel))
@@ -282,7 +282,7 @@ void CClientDFF::InternalRestoreModel(unsigned short usModel)
     }
 }
 
-bool CClientDFF::ReplaceObjectModel(RpClump* pClump, ushort usModel, bool bAlphaTransparency)
+bool CClientDFF::ReplaceObjectModel(RpClump* pClump, uint32 usModel, bool bAlphaTransparency)
 {
     // Stream out all the object models with matching ID.
     // Streamer will stream them back in async after a frame
@@ -303,7 +303,7 @@ bool CClientDFF::ReplaceObjectModel(RpClump* pClump, ushort usModel, bool bAlpha
     return true;
 }
 
-bool CClientDFF::ReplaceWeaponModel(RpClump* pClump, ushort usModel, bool bAlphaTransparency)
+bool CClientDFF::ReplaceWeaponModel(RpClump* pClump, uint32 usModel, bool bAlphaTransparency)
 {
     // Stream out all the weapon models with matching ID.
     // Streamer will stream them back in async after a frame
@@ -324,7 +324,7 @@ bool CClientDFF::ReplaceWeaponModel(RpClump* pClump, ushort usModel, bool bAlpha
     return true;
 }
 
-bool CClientDFF::ReplacePedModel(RpClump* pClump, ushort usModel, bool bAlphaTransparency)
+bool CClientDFF::ReplacePedModel(RpClump* pClump, uint32 usModel, bool bAlphaTransparency)
 {
     // Stream out all the weapon models with matching ID.
     // Streamer will stream them back in async after a frame
@@ -344,7 +344,7 @@ bool CClientDFF::ReplacePedModel(RpClump* pClump, ushort usModel, bool bAlphaTra
     return true;
 }
 
-bool CClientDFF::ReplaceVehicleModel(RpClump* pClump, ushort usModel, bool bAlphaTransparency)
+bool CClientDFF::ReplaceVehicleModel(RpClump* pClump, uint32 usModel, bool bAlphaTransparency)
 {
     // Make sure previous model+collision is loaded
     m_pManager->GetModelRequestManager()->RequestBlocking(usModel, "CClientDFF::ReplaceVehicleModel");

--- a/Client/mods/deathmatch/logic/CClientDFF.h
+++ b/Client/mods/deathmatch/logic/CClientDFF.h
@@ -71,5 +71,5 @@ private:
     bool                               m_bIsRawData = false;
     std::map<uint32, SLoadedClumpInfo> m_LoadedClumpInfoMap;
 
-    std::list<unsigned short> m_Replaced;
+    std::list<uint32> m_Replaced;
 };

--- a/Client/mods/deathmatch/logic/CClientDFF.h
+++ b/Client/mods/deathmatch/logic/CClientDFF.h
@@ -35,11 +35,11 @@ public:
 
     bool Load(bool isRaw, SString input);
 
-    bool ReplaceModel(unsigned short usModel, bool bAlphaTransparency);
+    bool ReplaceModel(uint32 usModel, bool bAlphaTransparency);
 
-    bool HasReplaced(unsigned short usModel);
+    bool HasReplaced(uint32 usModel);
 
-    void RestoreModel(unsigned short usModel);
+    void RestoreModel(uint32 usModel);
     void RestoreModels();
 
     static bool IsDFFData(const SString& strData);
@@ -53,23 +53,23 @@ private:
     bool LoadFromFile(SString filePath);
     bool LoadFromBuffer(SString buffer);
 
-    bool DoReplaceModel(unsigned short usModel, bool bAlphaTransparency);
+    bool DoReplaceModel(uint32 usModel, bool bAlphaTransparency);
     void UnloadDFF();
-    void InternalRestoreModel(unsigned short usModel);
+    void InternalRestoreModel(uint32 usModel);
 
-    bool ReplaceObjectModel(RpClump* pClump, ushort usModel, bool bAlphaTransparency);
-    bool ReplaceVehicleModel(RpClump* pClump, ushort usModel, bool bAlphaTransparency);
-    bool ReplaceWeaponModel(RpClump* pClump, ushort usModel, bool bAlphaTransparency);
-    bool ReplacePedModel(RpClump* pClump, ushort usModel, bool bAlphaTransparency);
+    bool ReplaceObjectModel(RpClump* pClump, uint32 usModel, bool bAlphaTransparency);
+    bool ReplaceVehicleModel(RpClump* pClump, uint32 usModel, bool bAlphaTransparency);
+    bool ReplaceWeaponModel(RpClump* pClump, uint32 usModel, bool bAlphaTransparency);
+    bool ReplacePedModel(RpClump* pClump, uint32 usModel, bool bAlphaTransparency);
 
-    RpClump* GetLoadedClump(ushort usModelId);
+    RpClump* GetLoadedClump(uint32 usModelId);
 
     class CClientDFFManager* m_pDFFManager;
 
     SString                            m_strDffFilename;
     SString                            m_RawDataBuffer;
     bool                               m_bIsRawData = false;
-    std::map<ushort, SLoadedClumpInfo> m_LoadedClumpInfoMap;
+    std::map<uint32, SLoadedClumpInfo> m_LoadedClumpInfoMap;
 
     std::list<unsigned short> m_Replaced;
 };

--- a/Client/mods/deathmatch/logic/CClientDFFManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientDFFManager.cpp
@@ -58,7 +58,7 @@ bool CClientDFFManager::Exists(CClientDFF* pDFF)
     return false;
 }
 
-CClientDFF* CClientDFFManager::GetElementThatReplaced(unsigned short usModel, CClientDFF* pDontSearch)
+CClientDFF* CClientDFFManager::GetElementThatReplaced(uint32 usModel, CClientDFF* pDontSearch)
 {
     // Matches given DFF?
     std::list<CClientDFF*>::iterator iter = m_List.begin();
@@ -76,13 +76,13 @@ CClientDFF* CClientDFFManager::GetElementThatReplaced(unsigned short usModel, CC
     return NULL;
 }
 
-bool CClientDFFManager::IsReplacableModel(unsigned short usModel)
+bool CClientDFFManager::IsReplacableModel(uint32 usModel)
 {
     // Either a vehicle model or an object model
     return CClientObjectManager::IsValidModel(usModel) || CClientVehicleManager::IsValidModel(usModel) || CClientPlayerManager::IsValidModel(usModel);
 }
 
-bool CClientDFFManager::RestoreModel(unsigned short usModel)
+bool CClientDFFManager::RestoreModel(uint32 usModel)
 {
     // Get the DFF file that replaced it
     CClientDFF* pDFF = GetElementThatReplaced(usModel);

--- a/Client/mods/deathmatch/logic/CClientDFFManager.h
+++ b/Client/mods/deathmatch/logic/CClientDFFManager.h
@@ -26,10 +26,10 @@ public:
     void RemoveAll();
     bool Exists(CClientDFF* pDFF);
 
-    CClientDFF* GetElementThatReplaced(unsigned short usModel, CClientDFF* pDontSearch = NULL);
+    CClientDFF* GetElementThatReplaced(uint32 usModel, CClientDFF* pDontSearch = NULL);
 
-    static bool IsReplacableModel(unsigned short usModel);
-    bool        RestoreModel(unsigned short usModel);
+    static bool IsReplacableModel(uint32 usModel);
+    bool        RestoreModel(uint32 usModel);
 
     std::list<CClientDFF*>::const_iterator IterBegin() { return m_List.begin(); }
     std::list<CClientDFF*>::const_iterator IterEnd() { return m_List.end(); }

--- a/Client/mods/deathmatch/logic/CClientExplosionManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientExplosionManager.cpp
@@ -84,7 +84,7 @@ bool CClientExplosionManager::Hook_ExplosionCreation(CEntity* pGameExplodingEnti
     }
 
     // Handle this explosion client side only if entity is local or breakable (i.e. barrel)
-    unsigned short usModel;
+    uint32     usModel;
     const bool     bHasModel = CStaticFunctionDefinitions::GetElementModel(*pResponsible, usModel);
 
     if (pResponsible->IsLocalEntity() || (bHasModel && CClientObjectManager::IsBreakableModel(usModel)))

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -3499,7 +3499,7 @@ void CClientGame::StaticGameProjectileDestructHandler(CEntitySAInterface* pProje
     g_pClientGame->GameProjectileDestructHandler(pProjectile);
 }
 
-void CClientGame::StaticGameModelRemoveHandler(ushort usModelId)
+void CClientGame::StaticGameModelRemoveHandler(uint32 usModelId)
 {
     g_pClientGame->GameModelRemoveHandler(usModelId);
 }
@@ -3519,13 +3519,13 @@ void CClientGame::StaticGameEntityRenderHandler(CEntitySAInterface* pGameEntity)
         if (pClientEntity)
         {
             int    iTypeMask;
-            ushort usModelId = 0xFFFF;
+            uint32 usModelId = 0xFFFFFFFF;
             switch (pClientEntity->GetType())
             {
                 case CCLIENTPED:
                 case CCLIENTPLAYER:
                     iTypeMask = TYPE_MASK_PED;
-                    usModelId = (ushort) static_cast<CClientPed*>(pClientEntity)->GetModel();
+                    usModelId = (uint32) static_cast<CClientPed*>(pClientEntity)->GetModel();
                     break;
                 case CCLIENTVEHICLE:
                     iTypeMask = TYPE_MASK_VEHICLE;
@@ -3542,7 +3542,7 @@ void CClientGame::StaticGameEntityRenderHandler(CEntitySAInterface* pGameEntity)
         }
     }
 
-    g_pGame->GetRenderWare()->SetRenderingClientEntity(NULL, 0xFFFF, TYPE_MASK_WORLD);
+    g_pGame->GetRenderWare()->SetRenderingClientEntity(NULL, 0xFFFFFFFF, TYPE_MASK_WORLD);
 }
 
 void CClientGame::StaticTaskSimpleBeHitHandler(CPedSAInterface* pPedAttacker, ePedPieceTypes hitBodyPart, int hitBodySide, int weaponId)
@@ -4725,7 +4725,7 @@ void CClientGame::GameProjectileDestructHandler(CEntitySAInterface* pProjectile)
         CStaticFunctionDefinitions::DestroyElement(*pClientProjectile);
 }
 
-void CClientGame::GameModelRemoveHandler(ushort usModelId)
+void CClientGame::GameModelRemoveHandler(uint32 usModelId)
 {
     // m_pGameEntityXRefManager->OnGameModelRemove(usModelId);
 }
@@ -6443,7 +6443,7 @@ bool CClientGame::TriggerBrowserRequestResultEvent(const std::unordered_set<SStr
     return GetRootEntity()->CallEvent("onClientBrowserWhitelistChange", Arguments, false);
 }
 
-void CClientGame::RestreamModel(unsigned short usModel)
+void CClientGame::RestreamModel(uint32 usModel)
 {
     // Is this a vehicle ID?
     if (CClientVehicleManager::IsValidModel(usModel))

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -5138,7 +5138,7 @@ void CClientGame::SendProjectileSync(CClientProjectile* pProjectile)
         // Write the projectile's model
         if (pBitStream->Version() >= 0x4F)
             if (pBitStream->Version() >= 0x52 || pOriginSource)            // Fix possible error for 0x51 server
-                pBitStream->Write(pProjectile->GetModel());
+                pBitStream->Write((uint16)pProjectile->GetModel());
 
         switch (weaponType)
         {

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -435,7 +435,7 @@ public:
     bool    IsHighFloatPrecision() const;
 
     bool TriggerBrowserRequestResultEvent(const std::unordered_set<SString>& newPages);
-    void RestreamModel(unsigned short usModel);
+    void RestreamModel(uint32 usModel);
     void RestreamWorld();
 
     void TriggerDiscordJoin(SString strSecret);
@@ -527,7 +527,7 @@ private:
     static void StaticGameVehicleDestructHandler(CEntitySAInterface* pVehicle);
     static void StaticGamePlayerDestructHandler(CEntitySAInterface* pPlayer);
     static void StaticGameProjectileDestructHandler(CEntitySAInterface* pProjectile);
-    static void StaticGameModelRemoveHandler(ushort usModelId);
+    static void StaticGameModelRemoveHandler(uint32 usModelId);
     static void StaticGameRunNamedAnimDestructorHandler(class CTaskSimpleRunNamedAnimSAInterface* pTask);
     static bool StaticWorldSoundHandler(const SWorldSoundEvent& event);
     static void StaticGameEntityRenderHandler(CEntitySAInterface* pEntity);
@@ -571,7 +571,7 @@ private:
     void        GameVehicleDestructHandler(CEntitySAInterface* pVehicle);
     void        GamePlayerDestructHandler(CEntitySAInterface* pPlayer);
     void        GameProjectileDestructHandler(CEntitySAInterface* pProjectile);
-    void        GameModelRemoveHandler(ushort usModelId);
+    void        GameModelRemoveHandler(uint32 usModelId);
     void        GameRunNamedAnimDestructorHandler(class CTaskSimpleRunNamedAnimSAInterface* pTask);
     bool        WorldSoundHandler(const SWorldSoundEvent& event);
     void        TaskSimpleBeHitHandler(CPedSAInterface* pPedAttacker, ePedPieceTypes hitBodyPart, int hitBodySide, int weaponId);

--- a/Client/mods/deathmatch/logic/CClientModel.cpp
+++ b/Client/mods/deathmatch/logic/CClientModel.cpp
@@ -22,7 +22,7 @@ CClientModel::~CClientModel(void)
     Deallocate();
 }
 
-bool CClientModel::Allocate(ushort usParentID)
+bool CClientModel::Allocate(uint32 usParentID)
 {
     m_bAllocatedByUs = true;
 

--- a/Client/mods/deathmatch/logic/CClientModel.h
+++ b/Client/mods/deathmatch/logic/CClientModel.h
@@ -34,7 +34,7 @@ public:
 
     int              GetModelID(void) const { return m_iModelID; };
     eClientModelType GetModelType(void) const { return m_eModelType; };
-    bool             Allocate(ushort usParentID);
+    bool             Allocate(uint32 usParentID);
     bool             Deallocate(void);
     void             RestoreEntitiesUsingThisModel();
     void             SetParentResource(CResource* pResource) { m_pParentResource = pResource; }

--- a/Client/mods/deathmatch/logic/CClientModelCacheManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientModelCacheManager.cpp
@@ -37,7 +37,7 @@ public:
 
     // CClientModelCacheManager interface
     virtual void DoPulse();
-    virtual void OnRestreamModel(ushort usModelId);
+    virtual void OnRestreamModel(uint32 usModelId);
 
     // CClientModelCacheManagerImpl methods
     CClientModelCacheManagerImpl();
@@ -45,12 +45,12 @@ public:
 
     void DoPulsePedModels();
     void DoPulseVehicleModels();
-    void ProcessPlayerList(std::map<ushort, float>& outNeedCacheList, const std::vector<CClientPlayer*>& playerList, float fMaxStreamDistanceSq);
-    void ProcessPedList(std::map<ushort, float>& outNeedCacheList, const std::vector<CClientPed*>& pedList, float fMaxStreamDistanceSq);
-    void ProcessVehicleList(std::map<ushort, float>& outNeedCacheList, const std::vector<CClientVehicle*>& vehicleList, float fMaxStreamDistanceSq);
-    void InsertIntoNeedCacheList(std::map<ushort, float>& outNeedCacheList, ushort usModelId, float fDistSq);
+    void ProcessPlayerList(std::map<uint32, float>& outNeedCacheList, const std::vector<CClientPlayer*>& playerList, float fMaxStreamDistanceSq);
+    void ProcessPedList(std::map<uint32, float>& outNeedCacheList, const std::vector<CClientPed*>& pedList, float fMaxStreamDistanceSq);
+    void ProcessVehicleList(std::map<uint32, float>& outNeedCacheList, const std::vector<CClientVehicle*>& vehicleList, float fMaxStreamDistanceSq);
+    void InsertIntoNeedCacheList(std::map<uint32, float>& outNeedCacheList, uint32 usModelId, float fDistSq);
     void ClearStats();
-    void AddProcessStat(const char* szTag, bool bCache, ePuresyncType syncType, ushort usModelId, const CVector& vecStartPos, const CVector& vecEndPos);
+    void AddProcessStat(const char* szTag, bool bCache, ePuresyncType syncType, uint32 usModelId, const CVector& vecStartPos, const CVector& vecEndPos);
 
 protected:
     int                 m_iFrameCounter;
@@ -187,7 +187,7 @@ void CClientModelCacheManagerImpl::DoPulsePedModels()
     }
 
     // Compile a list of ped models which should be cached
-    std::map<ushort, float> newNeedCacheList;
+    std::map<uint32, float> newNeedCacheList;
     ProcessPlayerList(newNeedCacheList, playerList, Square(PED_STREAM_IN_DISTANCE + STREAMER_STREAM_OUT_EXTRA_DISTANCE + m_fSmoothCameraSpeed * 2));
     ProcessPedList(newNeedCacheList, pedList, Square(PED_STREAM_IN_DISTANCE + STREAMER_STREAM_OUT_EXTRA_DISTANCE + m_fSmoothCameraSpeed * 2));
 
@@ -225,7 +225,7 @@ void CClientModelCacheManagerImpl::DoPulseVehicleModels()
     }
 
     // Compile a list of vehicle models which should be cached
-    std::map<ushort, float> newNeedCacheList;
+    std::map<uint32, float> newNeedCacheList;
     ProcessVehicleList(newNeedCacheList, vehicleList, Square(VEHICLE_STREAM_IN_DISTANCE + STREAMER_STREAM_OUT_EXTRA_DISTANCE + m_fSmoothCameraSpeed * 2));
 
     // Apply desired caching
@@ -237,7 +237,7 @@ void CClientModelCacheManagerImpl::DoPulseVehicleModels()
 // CClientModelCacheManagerImpl::ProcessPlayerList
 //
 ///////////////////////////////////////////////////////////////
-void CClientModelCacheManagerImpl::ProcessPlayerList(std::map<ushort, float>& outNeedCacheList, const std::vector<CClientPlayer*>& playerList,
+void CClientModelCacheManagerImpl::ProcessPlayerList(std::map<uint32, float>& outNeedCacheList, const std::vector<CClientPlayer*>& playerList,
                                                      float fMaxStreamDistanceSq)
 {
     const ulong ulTimeNow = CClientTime::GetTime();
@@ -314,14 +314,14 @@ void CClientModelCacheManagerImpl::ProcessPlayerList(std::map<ushort, float>& ou
 // CClientModelCacheManagerImpl::ProcessPedList
 //
 ///////////////////////////////////////////////////////////////
-void CClientModelCacheManagerImpl::ProcessPedList(std::map<ushort, float>& outNeedCacheList, const std::vector<CClientPed*>& pedList,
+void CClientModelCacheManagerImpl::ProcessPedList(std::map<uint32, float>& outNeedCacheList, const std::vector<CClientPed*>& pedList,
                                                   float fMaxStreamDistanceSq)
 {
     const ulong ulTimeNow = CClientTime::GetTime();
     for (std::vector<CClientPed*>::const_iterator iter = pedList.begin(); iter != pedList.end(); ++iter)
     {
         CClientPed*  pPed = *iter;
-        const ushort usModelId = (ushort)pPed->GetModel();
+        const uint32 usModelId = (uint32)pPed->GetModel();
 
         if (usModelId < 7 || usModelId > 312)
             continue;
@@ -379,14 +379,14 @@ void CClientModelCacheManagerImpl::ProcessPedList(std::map<ushort, float>& outNe
 // CClientModelCacheManagerImpl::ProcessVehicleList
 //
 ///////////////////////////////////////////////////////////////
-void CClientModelCacheManagerImpl::ProcessVehicleList(std::map<ushort, float>& outNeedCacheList, const std::vector<CClientVehicle*>& vehicleList,
+void CClientModelCacheManagerImpl::ProcessVehicleList(std::map<uint32, float>& outNeedCacheList, const std::vector<CClientVehicle*>& vehicleList,
                                                       float fMaxStreamDistanceSq)
 {
     const ulong ulTimeNow = CClientTime::GetTime();
     for (std::vector<CClientVehicle*>::const_iterator iter = vehicleList.begin(); iter != vehicleList.end(); ++iter)
     {
         CClientVehicle* pVehicle = *iter;
-        const ushort    usModelId = pVehicle->GetModel();
+        const uint32    usModelId = pVehicle->GetModel();
 
         if (usModelId < 400 || usModelId > 611)
             continue;
@@ -456,7 +456,7 @@ void CClientModelCacheManagerImpl::ProcessVehicleList(std::map<ushort, float>& o
 // Update model id closest distance
 //
 ///////////////////////////////////////////////////////////////
-void CClientModelCacheManagerImpl::InsertIntoNeedCacheList(std::map<ushort, float>& outNeedCacheList, ushort usModelId, float fDistSq)
+void CClientModelCacheManagerImpl::InsertIntoNeedCacheList(std::map<uint32, float>& outNeedCacheList, uint32 usModelId, float fDistSq)
 {
     float* pfDistSqCurrent = MapFind(outNeedCacheList, usModelId);
     if (!pfDistSqCurrent)
@@ -492,7 +492,7 @@ void CClientModelCacheManagerImpl::ClearStats()
 // CClientModelCacheManagerImpl::AddProcessStat
 //
 ///////////////////////////////////////////////////////////////
-void CClientModelCacheManagerImpl::AddProcessStat(const char* szTag, bool bCache, ePuresyncType syncType, ushort usModelId, const CVector& vecStartPos,
+void CClientModelCacheManagerImpl::AddProcessStat(const char* szTag, bool bCache, ePuresyncType syncType, uint32 usModelId, const CVector& vecStartPos,
                                                   const CVector& vecEndPos)
 {
 #ifdef WITH_MODEL_CACHE_STATS
@@ -514,7 +514,7 @@ void CClientModelCacheManagerImpl::AddProcessStat(const char* szTag, bool bCache
 // Uncache here, now.
 //
 ///////////////////////////////////////////////////////////////
-void CClientModelCacheManagerImpl::OnRestreamModel(ushort usModelId)
+void CClientModelCacheManagerImpl::OnRestreamModel(uint32 usModelId)
 {
     m_pCoreModelCacheManager->OnRestreamModel(usModelId);
 }

--- a/Client/mods/deathmatch/logic/CClientModelCacheManager.h
+++ b/Client/mods/deathmatch/logic/CClientModelCacheManager.h
@@ -14,7 +14,7 @@ public:
 
     // CClientModelCacheManager interface
     virtual void DoPulse() = 0;
-    virtual void OnRestreamModel(ushort usModelId) = 0;
+    virtual void OnRestreamModel(uint32 usModelId) = 0;
 };
 
 CClientModelCacheManager* NewClientModelCacheManager();

--- a/Client/mods/deathmatch/logic/CClientModelRequestManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientModelRequestManager.cpp
@@ -29,7 +29,7 @@ CClientModelRequestManager::~CClientModelRequestManager()
     m_Requests.clear();
 }
 
-bool CClientModelRequestManager::IsLoaded(unsigned short usModelID)
+bool CClientModelRequestManager::IsLoaded(uint32 usModelID)
 {
     // Grab the model info
     CModelInfo* pInfo = g_pGame->GetModelInfo(usModelID);
@@ -97,7 +97,7 @@ CModelInfo* CClientModelRequestManager::GetRequestedModelInfo(CClientEntity* pRe
     return NULL;
 }
 
-bool CClientModelRequestManager::RequestBlocking(unsigned short usModelID, const char* szTag)
+bool CClientModelRequestManager::RequestBlocking(uint32 usModelID, const char* szTag)
 {
     // Grab the model info
     CModelInfo* pInfo = g_pGame->GetModelInfo(usModelID);
@@ -116,7 +116,7 @@ bool CClientModelRequestManager::RequestBlocking(unsigned short usModelID, const
     return false;
 }
 
-bool CClientModelRequestManager::Request(unsigned short usModelID, CClientEntity* pRequester)
+bool CClientModelRequestManager::Request(uint32 usModelID, CClientEntity* pRequester)
 {
     assert(pRequester);
     SClientModelRequest* pEntry;

--- a/Client/mods/deathmatch/logic/CClientModelRequestManager.h
+++ b/Client/mods/deathmatch/logic/CClientModelRequestManager.h
@@ -31,14 +31,14 @@ public:
     CClientModelRequestManager();
     ~CClientModelRequestManager();
 
-    bool        IsLoaded(unsigned short usModelID);
+    bool        IsLoaded(uint32 usModelID);
     bool        IsRequested(CModelInfo* pModelInfo);
     bool        HasRequested(CClientEntity* pRequester);
     CModelInfo* GetRequestedModelInfo(CClientEntity* pRequester);
 
-    bool RequestBlocking(unsigned short usModelID, const char* szTag);
+    bool RequestBlocking(uint32 usModelID, const char* szTag);
 
-    bool Request(unsigned short usModelID, CClientEntity* pRequester);
+    bool Request(uint32 usModelID, CClientEntity* pRequester);
     void Cancel(CClientEntity* pRequester, bool bAllowQueue);
 
 private:

--- a/Client/mods/deathmatch/logic/CClientObject.cpp
+++ b/Client/mods/deathmatch/logic/CClientObject.cpp
@@ -17,7 +17,7 @@
 #define M_PI 3.14159265358979323846
 #endif
 
-CClientObject::CClientObject(CClientManager* pManager, ElementID ID, unsigned short usModel, bool bLowLod)
+CClientObject::CClientObject(CClientManager* pManager, ElementID ID, uint32 usModel, bool bLowLod)
     : ClassInit(this), CClientStreamElement(bLowLod ? pManager->GetObjectLodStreamer() : pManager->GetObjectStreamer(), ID), m_bIsLowLod(bLowLod)
 {
     // Init
@@ -253,7 +253,7 @@ void CClientObject::UpdateVisibility()
     }
 }
 
-void CClientObject::SetModel(unsigned short usModel)
+void CClientObject::SetModel(uint32 usModel)
 {
     // Valid model ID?
     if (CClientObjectManager::IsValidModel(usModel))

--- a/Client/mods/deathmatch/logic/CClientObject.h
+++ b/Client/mods/deathmatch/logic/CClientObject.h
@@ -29,7 +29,7 @@ class CClientObject : public CClientStreamElement
     friend class CClientPed;
 
 public:
-    CClientObject(class CClientManager* pManager, ElementID ID, unsigned short usModel, bool bLowLod);
+    CClientObject(class CClientManager* pManager, ElementID ID, uint32 usModel, bool bLowLod);
     ~CClientObject();
 
     void Unlink();
@@ -67,8 +67,8 @@ public:
     bool IsVisible() { return m_bIsVisible; };
     void SetVisible(bool bVisible);
 
-    unsigned short GetModel() const { return m_usModel; };
-    void           SetModel(unsigned short usModel);
+    uint32 GetModel() const { return m_usModel; };
+    void           SetModel(uint32 usModel);
 
     bool           IsLowLod();
     bool           SetLowLodObject(CClientObject* pLowLodObject);
@@ -133,7 +133,7 @@ protected:
     class CClientObjectManager*       m_pObjectManager;
     class CClientModelRequestManager* m_pModelRequester;
 
-    unsigned short m_usModel;
+   uint32 m_usModel;
 
     CVector       m_vecPosition;
     CVector       m_vecRotation;

--- a/Client/mods/deathmatch/logic/CClientObjectManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientObjectManager.cpp
@@ -288,7 +288,7 @@ bool CClientObjectManager::IsHardObjectLimitReached()
     return g_pGame->GetPools()->GetObjectCount() >= MAX_OBJECTS_MTA;
 }
 
-void CClientObjectManager::RestreamObjects(unsigned short usModel)
+void CClientObjectManager::RestreamObjects(uint32 usModel)
 {
     for (uint i = 0; i < m_Objects.size(); i++)
     {

--- a/Client/mods/deathmatch/logic/CClientObjectManager.h
+++ b/Client/mods/deathmatch/logic/CClientObjectManager.h
@@ -41,7 +41,7 @@ public:
     bool        IsLowLodObjectLimitReached();
     bool        IsHardObjectLimitReached();
 
-    void RestreamObjects(unsigned short usModel);
+    void RestreamObjects(uint32 usModel);
     void RestreamAllObjects();
 
     void AddToList(CClientObject* pObject) { m_Objects.push_back(pObject); }

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -701,7 +701,7 @@ void CClientPed::SetCurrentRotationNew(float fRotation)
     SetRotationRadiansNew(CVector(0, 0, fRotation));
 }
 
-void CClientPed::Spawn(const CVector& vecPosition, float fRotation, unsigned short usModel, unsigned char ucInterior)
+void CClientPed::Spawn(const CVector& vecPosition, float fRotation, uint32 usModel, unsigned char ucInterior)
 {
     // Remove us from our car
     RemoveFromVehicle();

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -229,7 +229,7 @@ public:
     int  GetVehicleInOutState() { return m_iVehicleInOutState; };
     void SetVehicleInOutState(int iState) { m_iVehicleInOutState = iState; };
 
-    unsigned long GetModel() { return m_ulModel; };
+    uint32 GetModel() { return m_ulModel; };
     bool          SetModel(unsigned long ulModel, bool bTemp = false);
 
     bool GetCanBeKnockedOffBike();
@@ -589,7 +589,7 @@ public:
     CPad*                       m_pPad;
     bool                        m_bIsLocalPlayer;
     int                         m_pRespawnState;
-    unsigned long               m_ulModel;
+    uint32                      m_ulModel;
     CMatrix                     m_matFrozen;
     bool                        m_bRadioOn;
     unsigned char               m_ucRadioChannel;

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -198,7 +198,7 @@ public:
     // This function spawns/respawns this ped in any location. This will force a recreation
     // and restoration of initial state. This will also remove all weapons, unfreeze,
     // remove jetpack, etc...
-    void Spawn(const CVector& vecPosition, float fRotation, unsigned short usModel, unsigned char ucInterior);
+    void Spawn(const CVector& vecPosition, float fRotation, uint32 usModel, unsigned char ucInterior);
 
     void ResetInterpolation();
 

--- a/Client/mods/deathmatch/logic/CClientPedManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientPedManager.cpp
@@ -98,7 +98,7 @@ void CClientPedManager::OnDestruction(CClientPed* pPed)
     ListRemove(m_StreamedIn, pPed);
 }
 
-void CClientPedManager::RestreamPeds(unsigned short usModel)
+void CClientPedManager::RestreamPeds(uint32 usModel)
 {
     g_pClientGame->GetModelCacheManager()->OnRestreamModel(usModel);
 
@@ -147,7 +147,7 @@ void CClientPedManager::RestreamAllPeds()
     }
 }
 
-void CClientPedManager::RestreamWeapon(unsigned short usModel)
+void CClientPedManager::RestreamWeapon(uint32 usModel)
 {
     eWeaponSlot eSlot = (eWeaponSlot)GetWeaponSlotFromModel(usModel);
     // Store the affected vehicles

--- a/Client/mods/deathmatch/logic/CClientPedManager.h
+++ b/Client/mods/deathmatch/logic/CClientPedManager.h
@@ -38,9 +38,9 @@ public:
     static unsigned short GetWeaponSlotFromModel(DWORD dwModelID);
     static bool           IsValidWeaponModel(DWORD dwModelID);
 
-    void RestreamPeds(unsigned short usModel);
+    void RestreamPeds(uint32 usModel);
     void RestreamAllPeds();
-    void RestreamWeapon(unsigned short usModel);
+    void RestreamWeapon(uint32 usModel);
 
 protected:
     CClientPedManager(class CClientManager* pManager);

--- a/Client/mods/deathmatch/logic/CClientPickup.cpp
+++ b/Client/mods/deathmatch/logic/CClientPickup.cpp
@@ -12,7 +12,7 @@
 
 extern CClientGame* g_pClientGame;
 
-CClientPickup::CClientPickup(CClientManager* pManager, ElementID ID, unsigned short usModel, CVector vecPosition)
+CClientPickup::CClientPickup(CClientManager* pManager, ElementID ID, uint32 usModel, CVector vecPosition)
     : ClassInit(this), CClientStreamElement(pManager->GetPickupStreamer(), ID)
 {
     // Initialize
@@ -80,7 +80,7 @@ void CClientPickup::SetPosition(const CVector& vecPosition)
     }
 }
 
-void CClientPickup::SetModel(unsigned short usModel)
+void CClientPickup::SetModel(uint32 usModel)
 {
     // Different from our current id?
     if (m_usModel != usModel)

--- a/Client/mods/deathmatch/logic/CClientPickup.h
+++ b/Client/mods/deathmatch/logic/CClientPickup.h
@@ -127,7 +127,7 @@ private:
 
     CClientPickupManager* m_pPickupManager;
 
-    unsigned short m_usModel;
+    uint32 m_usModel;
     CPickup*       m_pPickup;
     CObject*       m_pObject;
     CVector        m_vecPosition;

--- a/Client/mods/deathmatch/logic/CClientPickup.h
+++ b/Client/mods/deathmatch/logic/CClientPickup.h
@@ -88,7 +88,7 @@ public:
         WEAPON_INVALID = 0xFF,
     };
 
-    CClientPickup(class CClientManager* pManager, ElementID ID, unsigned short usModel, CVector vecPosition = CVector(0, 0, 0));
+    CClientPickup(class CClientManager* pManager, ElementID ID, uint32 usModel, CVector vecPosition = CVector(0, 0, 0));
     ~CClientPickup();
 
     void Unlink();
@@ -104,7 +104,7 @@ public:
 
     void           GetPosition(CVector& vecPosition) const override;
     void           SetPosition(const CVector& vecPosition);
-    void           SetModel(unsigned short usModel);
+    void           SetModel(uint32 usModel);
 
     void AttachTo(CClientEntity* pEntity) override;
 

--- a/Client/mods/deathmatch/logic/CClientPickupManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientPickupManager.cpp
@@ -119,7 +119,7 @@ void CClientPickupManager::RemoveFromList(CClientPickup* pPickup)
     }
 }
 
-void CClientPickupManager::RestreamPickups(unsigned short usModel)
+void CClientPickupManager::RestreamPickups(uint32 usModel)
 {
     for (std::list<CClientPickup*>::const_iterator iter = IterBegin(); iter != IterEnd(); iter++)
     {

--- a/Client/mods/deathmatch/logic/CClientPickupManager.h
+++ b/Client/mods/deathmatch/logic/CClientPickupManager.h
@@ -42,7 +42,7 @@ public:
     static unsigned short GetArmorModel() { return 1242; };
 
     static bool IsPickupLimitReached();
-    void        RestreamPickups(unsigned short usModel);
+    void        RestreamPickups(uint32 usModel);
     void        RestreamAllPickups();
 
 private:

--- a/Client/mods/deathmatch/logic/CClientProjectile.cpp
+++ b/Client/mods/deathmatch/logic/CClientProjectile.cpp
@@ -156,7 +156,7 @@ void CClientProjectile::DoPulse()
     }
 }
 
-void CClientProjectile::Initiate(CVector& vecPosition, CVector& vecRotation, CVector& vecVelocity, unsigned short usModel)
+void CClientProjectile::Initiate(CVector& vecPosition, CVector& vecRotation, CVector& vecVelocity, uint32 usModel)
 {
     dassert(!m_pInitiateData);
 
@@ -291,14 +291,14 @@ void CClientProjectile::SetVelocity(CVector& vecVelocity)
         m_pProjectile->SetMoveSpeed(&vecVelocity);
 }
 
-unsigned short CClientProjectile::GetModel()
+uint32 CClientProjectile::GetModel()
 {
     if (m_pProjectile)
         return m_pProjectile->GetModelIndex();
     return 0;
 }
 
-void CClientProjectile::SetModel(unsigned short usModel)
+void CClientProjectile::SetModel(uint32 usModel)
 {
     if (m_pProjectile)
         m_pProjectile->SetModelIndex(usModel);

--- a/Client/mods/deathmatch/logic/CClientProjectile.h
+++ b/Client/mods/deathmatch/logic/CClientProjectile.h
@@ -46,7 +46,7 @@ public:
     CVector*       pvecPosition;
     CVector*       pvecRotation;
     CVector*       pvecVelocity;
-    unsigned short usModel;
+    uint32         usModel;
 };
 
 class CClientProjectile : public CClientEntity
@@ -67,7 +67,7 @@ public:
     void              Unlink();
 
     void DoPulse();
-    void Initiate(CVector& vecPosition, CVector& vecRotation, CVector& vecVelocity, unsigned short usModel);
+    void Initiate(CVector& vecPosition, CVector& vecRotation, CVector& vecVelocity, uint32 usModel);
     void Destroy(bool bBlow = true);
 
     bool           IsActive();
@@ -81,8 +81,8 @@ public:
     void           SetRotationDegrees(const CVector& vecRotation);
     void           GetVelocity(CVector& vecVelocity);
     void           SetVelocity(CVector& vecVelocity);
-    unsigned short GetModel();
-    void           SetModel(unsigned short usModel);
+    uint32         GetModel();
+    void           SetModel(uint32 usModel);
     void           SetCounter(DWORD dwCounter);
     DWORD          GetCounter();
     CClientEntity* GetCreator() { return m_pCreator; }

--- a/Client/mods/deathmatch/logic/CClientTXD.cpp
+++ b/Client/mods/deathmatch/logic/CClientTXD.cpp
@@ -50,7 +50,7 @@ bool CClientTXD::Load(bool isRaw, SString input, bool enableFiltering)
     }
 }
 
-bool CClientTXD::Import(unsigned short usModelID)
+bool CClientTXD::Import(uint32 usModelID)
 {
     if (usModelID >= CLOTHES_TEX_ID_FIRST && usModelID <= CLOTHES_TEX_ID_LAST)
     {
@@ -119,7 +119,7 @@ bool CClientTXD::Import(unsigned short usModelID)
     return false;
 }
 
-bool CClientTXD::IsImportableModel(unsigned short usModelID)
+bool CClientTXD::IsImportableModel(uint32 usModelID)
 {
     // Currently we work on vehicles and objects
     return CClientObjectManager::IsValidModel(usModelID) || CClientVehicleManager::IsValidModel(usModelID) || CClientPlayerManager::IsValidModel(usModelID) ||
@@ -148,7 +148,7 @@ bool CClientTXD::LoadFromBuffer(SString buffer)
     return g_pGame->GetRenderWare()->ModelInfoTXDLoadTextures(&m_ReplacementTextures, NULL, m_FileData, m_bFilteringEnabled);
 }
 
-void CClientTXD::Restream(unsigned short usModelID)
+void CClientTXD::Restream(uint32 usModelID)
 {
     if (CClientVehicleManager::IsValidModel(usModelID))
     {

--- a/Client/mods/deathmatch/logic/CClientTXD.h
+++ b/Client/mods/deathmatch/logic/CClientTXD.h
@@ -26,15 +26,15 @@ public:
 
     eClientEntityType GetType() const { return CCLIENTTXD; }
     bool              Load(bool isRaw, SString input, bool enableFiltering);
-    bool              Import(unsigned short usModelID);
-    static bool       IsImportableModel(unsigned short usModelID);
+    bool              Import(uint32 usModelID);
+    static bool       IsImportableModel(uint32 usModelID);
     static bool       IsTXDData(const SString& strData);
 
 private:
     bool LoadFromFile(SString filePath);
     bool LoadFromBuffer(SString buffer);
 
-    void Restream(unsigned short usModel);
+    void Restream(uint32 usModel);
     bool GetFilenameToUse(SString& strOutFilename);
 
     SString              m_strFilename;

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -23,7 +23,7 @@ std::set<const CClientEntity*> ms_AttachedVehiclesToIgnore;
 #define VEHICLE_INTERPOLATION_WARP_THRESHOLD            15
 #define VEHICLE_INTERPOLATION_WARP_THRESHOLD_FOR_SPEED  10
 
-CClientVehicle::CClientVehicle(CClientManager* pManager, ElementID ID, unsigned short usModel, unsigned char ucVariation, unsigned char ucVariation2)
+CClientVehicle::CClientVehicle(CClientManager* pManager, ElementID ID, uint32 usModel, unsigned char ucVariation, unsigned char ucVariation2)
     : ClassInit(this), CClientStreamElement(pManager->GetVehicleStreamer(), ID)
 {
     CClientEntityRefManager::AddEntityRefs(ENTITY_REF_DEBUG(this, "CClientVehicle"), &m_pDriver, &m_pOccupyingDriver, &m_pPreviousLink, &m_pNextLink,
@@ -45,7 +45,7 @@ CClientVehicle::CClientVehicle(CClientManager* pManager, ElementID ID, unsigned 
     m_pModelInfo = g_pGame->GetModelInfo(usModel);
 
     // Apply handling
-    ushort usHandlingModelID = m_usModel;
+    uint32 usHandlingModelID = m_usModel;
     if (m_usModel < 400 || m_usModel > 611)
         usHandlingModelID = m_pModelInfo->GetParentID();
 
@@ -1029,7 +1029,7 @@ void CClientVehicle::SetTurretRotation(float fHorizontal, float fVertical)
     m_fTurretVertical = fVertical;
 }
 
-void CClientVehicle::SetModelBlocking(unsigned short usModel, unsigned char ucVariant, unsigned char ucVariant2)
+void CClientVehicle::SetModelBlocking(uint32 usModel, unsigned char ucVariant, unsigned char ucVariant2)
 {
     // Different vehicle ID than we have now?
     if (m_usModel != usModel)

--- a/Client/mods/deathmatch/logic/CClientVehicle.h
+++ b/Client/mods/deathmatch/logic/CClientVehicle.h
@@ -136,7 +136,7 @@ class CClientVehicle : public CClientStreamElement
 
 protected:            // Use CDeathmatchVehicle constructor for now. Will get removed later when this class is
                       // cleaned up.
-    CClientVehicle(CClientManager* pManager, ElementID ID, unsigned short usModel, unsigned char ucVariation, unsigned char ucVariation2);
+    CClientVehicle(CClientManager* pManager, ElementID ID, uint32 usModel, unsigned char ucVariation, unsigned char ucVariation2);
 
 public:
     ~CClientVehicle();
@@ -206,8 +206,8 @@ public:
     void GetTurretRotation(float& fHorizontal, float& fVertical);
     void SetTurretRotation(float fHorizontal, float fVertical);
 
-    unsigned short GetModel() { return m_usModel; };
-    void           SetModelBlocking(unsigned short usModel, unsigned char ucVariant, unsigned char ucVariant2);
+    uint32 GetModel() { return m_usModel; };
+    void           SetModelBlocking(uint32 usModel, unsigned char ucVariant, unsigned char ucVariant2);
 
     unsigned char GetVariant() { return m_ucVariation; };
     unsigned char GetVariant2() { return m_ucVariation2; };
@@ -533,7 +533,7 @@ protected:
     class CClientObjectManager* m_pObjectManager;
     CClientVehicleManager*      m_pVehicleManager;
     CClientModelRequestManager* m_pModelRequester;
-    unsigned short              m_usModel;
+    uint32              m_usModel;
     bool                        m_bHasLandingGear;
     eClientVehicleType          m_eVehicleType;
     unsigned char               m_ucMaxPassengers;

--- a/Client/mods/deathmatch/logic/CClientVehicle.h
+++ b/Client/mods/deathmatch/logic/CClientVehicle.h
@@ -533,7 +533,7 @@ protected:
     class CClientObjectManager* m_pObjectManager;
     CClientVehicleManager*      m_pVehicleManager;
     CClientModelRequestManager* m_pModelRequester;
-    uint32              m_usModel;
+    uint32                      m_usModel;
     bool                        m_bHasLandingGear;
     eClientVehicleType          m_eVehicleType;
     unsigned char               m_ucMaxPassengers;

--- a/Client/mods/deathmatch/logic/CClientVehicleManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicleManager.cpp
@@ -480,7 +480,7 @@ unsigned char CClientVehicleManager::GetMaxPassengerCount(unsigned long ulModel)
     return 0xFF;
 }
 
-void CClientVehicleManager::GetRandomVariation(unsigned short usModel, unsigned char& ucVariant, unsigned char& ucVariant2)
+void CClientVehicleManager::GetRandomVariation(uint32 usModel, unsigned char& ucVariant, unsigned char& ucVariant2)
 {
     RandomizeRandomSeed();
     ucVariant = 255;
@@ -736,7 +736,7 @@ void CClientVehicleManager::OnDestruction(CClientVehicle* pVehicle)
     ListRemove(m_StreamedIn, pVehicle);
 }
 
-void CClientVehicleManager::RestreamVehicles(unsigned short usModel)
+void CClientVehicleManager::RestreamVehicles(uint32 usModel)
 {
     g_pClientGame->GetModelCacheManager()->OnRestreamModel(usModel);
 
@@ -776,7 +776,7 @@ void CClientVehicleManager::RestreamAllVehicles()
     }
 }
 
-void CClientVehicleManager::RestreamVehicleUpgrades(unsigned short usModel)
+void CClientVehicleManager::RestreamVehicleUpgrades(uint32 usModel)
 {
     for (uint i = 0; i < m_List.size(); i++)
     {

--- a/Client/mods/deathmatch/logic/CClientVehicleManager.h
+++ b/Client/mods/deathmatch/logic/CClientVehicleManager.h
@@ -38,7 +38,7 @@ public:
     static eClientVehicleType GetVehicleType(unsigned long ulModel);
     static unsigned char      GetMaxPassengerCount(unsigned long ulModel);
     static unsigned char      ConvertIndexToGameSeat(unsigned long ulModel, unsigned char ucIndex);
-    static void               GetRandomVariation(unsigned short usModel, unsigned char& ucVariant, unsigned char& ucVariant2);
+    static void               GetRandomVariation(uint32 usModel, unsigned char& ucVariant, unsigned char& ucVariant2);
 
     static bool HasTurret(unsigned long ulModel);
     static bool HasSirens(unsigned long ulModel);
@@ -55,9 +55,9 @@ public:
 
     static bool IsVehicleLimitReached();
 
-    void RestreamVehicles(unsigned short usModel);
+    void RestreamVehicles(uint32 usModel);
     void RestreamAllVehicles();
-    void RestreamVehicleUpgrades(unsigned short usModel);
+    void RestreamVehicleUpgrades(uint32 usModel);
 
     std::vector<CClientVehicle*>::const_iterator IterBegin() { return m_List.begin(); };
     std::vector<CClientVehicle*>::const_iterator IterEnd() { return m_List.end(); };

--- a/Client/mods/deathmatch/logic/CDeathmatchObject.cpp
+++ b/Client/mods/deathmatch/logic/CDeathmatchObject.cpp
@@ -17,7 +17,7 @@ extern CClientGame* g_pClientGame;
 
 #ifdef WITH_OBJECT_SYNC
 CDeathmatchObject::CDeathmatchObject(CClientManager* pManager, CMovingObjectsManager* pMovingObjectsManager, CObjectSync* pObjectSync, ElementID ID,
-                                     unsigned short usModel)
+                                     uint32 usModel)
     : ClassInit(this), CClientObject(pManager, ID, usModel)
 {
     m_pMovingObjectsManager = pMovingObjectsManager;
@@ -37,7 +37,7 @@ CDeathmatchObject::~CDeathmatchObject()
 
 #else
 
-CDeathmatchObject::CDeathmatchObject(CClientManager* pManager, CMovingObjectsManager* pMovingObjectsManager, ElementID ID, unsigned short usModel, bool bLowLod)
+CDeathmatchObject::CDeathmatchObject(CClientManager* pManager, CMovingObjectsManager* pMovingObjectsManager, ElementID ID, uint32 usModel, bool bLowLod)
     : ClassInit(this), CClientObject(pManager, ID, usModel, bLowLod)
 {
     m_pMovingObjectsManager = pMovingObjectsManager;

--- a/Client/mods/deathmatch/logic/CDeathmatchObject.h
+++ b/Client/mods/deathmatch/logic/CDeathmatchObject.h
@@ -19,9 +19,9 @@ class CDeathmatchObject : public CClientObject
 public:
 #ifdef WITH_OBJECT_SYNC
     CDeathmatchObject(CClientManager* pManager, class CMovingObjectsManager* pMovingObjectsManager, class CObjectSync* pObjectSync, ElementID ID,
-                      unsigned short usModel);
+                      uint32 usModel);
 #else
-    CDeathmatchObject(CClientManager* pManager, class CMovingObjectsManager* pMovingObjectsManager, ElementID ID, unsigned short usModel, bool bLowLod);
+    CDeathmatchObject(CClientManager* pManager, class CMovingObjectsManager* pMovingObjectsManager, ElementID ID, uint32 usModel, bool bLowLod);
 #endif
     ~CDeathmatchObject();
 

--- a/Client/mods/deathmatch/logic/CDeathmatchVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CDeathmatchVehicle.cpp
@@ -12,7 +12,7 @@
 #include "StdInc.h"
 #include "net/SyncStructures.h"
 
-CDeathmatchVehicle::CDeathmatchVehicle(CClientManager* pManager, CUnoccupiedVehicleSync* pUnoccupiedVehicleSync, ElementID ID, unsigned short usVehicleModel,
+CDeathmatchVehicle::CDeathmatchVehicle(CClientManager* pManager, CUnoccupiedVehicleSync* pUnoccupiedVehicleSync, ElementID ID, uint32 usVehicleModel,
                                        unsigned char ucVariant, unsigned char ucVariant2)
     : ClassInit(this), CClientVehicle(pManager, ID, usVehicleModel, ucVariant, ucVariant2)
 {

--- a/Client/mods/deathmatch/logic/CDeathmatchVehicle.h
+++ b/Client/mods/deathmatch/logic/CDeathmatchVehicle.h
@@ -17,7 +17,7 @@ class CDeathmatchVehicle : public CClientVehicle
 {
     DECLARE_CLASS(CDeathmatchVehicle, CClientVehicle)
 public:
-    CDeathmatchVehicle(CClientManager* pManager, class CUnoccupiedVehicleSync* pUnoccupiedVehicleSync, ElementID ID, unsigned short usVehicleModel,
+    CDeathmatchVehicle(CClientManager* pManager, class CUnoccupiedVehicleSync* pUnoccupiedVehicleSync, ElementID ID, uint32 usVehicleModel,
                        unsigned char ucVariant, unsigned char ucVariant2);
     ~CDeathmatchVehicle();
 

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1449,7 +1449,7 @@ bool CStaticFunctionDefinitions::SetElementModel(CClientEntity& Entity, uint32 u
         {
             // Grab the model
             CClientPed&          Ped = static_cast<CClientPed&>(Entity);
-            const unsigned short usCurrentModel = static_cast<ushort>(Ped.GetModel());
+            const uint32 usCurrentModel = static_cast<ushort>(Ped.GetModel());
 
             if (usCurrentModel == usModel)
                 return false;
@@ -1466,7 +1466,7 @@ bool CStaticFunctionDefinitions::SetElementModel(CClientEntity& Entity, uint32 u
         case CCLIENTVEHICLE:
         {
             CClientVehicle&      Vehicle = static_cast<CClientVehicle&>(Entity);
-            const unsigned short usCurrentModel = Vehicle.GetModel();
+            const uint32    usCurrentModel = Vehicle.GetModel();
 
             if (usCurrentModel == usModel)
                 return false;
@@ -1486,7 +1486,7 @@ bool CStaticFunctionDefinitions::SetElementModel(CClientEntity& Entity, uint32 u
         case CCLIENTWEAPON:
         {
             CClientObject&       Object = static_cast<CClientObject&>(Entity);
-            const unsigned short usCurrentModel = Object.GetModel();
+            const uint32   usCurrentModel = Object.GetModel();
 
             if (usCurrentModel == usModel)
                 return false;
@@ -1505,7 +1505,7 @@ bool CStaticFunctionDefinitions::SetElementModel(CClientEntity& Entity, uint32 u
         case CCLIENTPROJECTILE:
         {
             CClientProjectile&   Projectile = static_cast<CClientProjectile&>(Entity);
-            const unsigned short usCurrentModel = Projectile.GetModel();
+            const uint32       usCurrentModel = Projectile.GetModel();
 
             if (usCurrentModel == usModel)
                 return false;

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -722,7 +722,7 @@ bool CStaticFunctionDefinitions::GetElementHealth(CClientEntity& Entity, float& 
     return true;
 }
 
-bool CStaticFunctionDefinitions::GetElementModel(CClientEntity& Entity, unsigned short& usModel)
+bool CStaticFunctionDefinitions::GetElementModel(CClientEntity& Entity, uint32& usModel)
 {
     switch (Entity.GetType())
     {
@@ -1438,7 +1438,7 @@ bool CStaticFunctionDefinitions::SetElementHealth(CClientEntity& Entity, float f
     return true;
 }
 
-bool CStaticFunctionDefinitions::SetElementModel(CClientEntity& Entity, unsigned short usModel)
+bool CStaticFunctionDefinitions::SetElementModel(CClientEntity& Entity, uint32 usModel)
 {
     RUN_CHILDREN(SetElementModel(**iter, usModel))
 
@@ -2621,7 +2621,7 @@ CClientPed* CStaticFunctionDefinitions::CreatePed(CResource& Resource, unsigned 
     return NULL;
 }
 
-bool CStaticFunctionDefinitions::GetVehicleModelFromName(const char* szName, unsigned short& usID)
+bool CStaticFunctionDefinitions::GetVehicleModelFromName(const char* szName, uint32& usID)
 {
     assert(szName);
 
@@ -2653,7 +2653,7 @@ bool CStaticFunctionDefinitions::GetVehicleUpgradeSlotName(unsigned short usUpgr
     return false;
 }
 
-bool CStaticFunctionDefinitions::GetVehicleNameFromModel(unsigned short usModel, SString& strOutName)
+bool CStaticFunctionDefinitions::GetVehicleNameFromModel(uint32 usModel, SString& strOutName)
 {
     strOutName = CVehicleNames::GetVehicleName(usModel);
     return !strOutName.empty();
@@ -2733,7 +2733,7 @@ bool CStaticFunctionDefinitions::IsTrainChainEngine(CClientVehicle& Vehicle, boo
     return true;
 }
 
-CClientVehicle* CStaticFunctionDefinitions::CreateVehicle(CResource& Resource, unsigned short usModel, const CVector& vecPosition, const CVector& vecRotation,
+CClientVehicle* CStaticFunctionDefinitions::CreateVehicle(CResource& Resource, uint32 usModel, const CVector& vecPosition, const CVector& vecRotation,
                                                           const char* szRegPlate, unsigned char ucVariant, unsigned char ucVariant2)
 {
     if (CClientVehicleManager::IsValidModel(usModel) && (ucVariant <= 5 || ucVariant == 255) && (ucVariant2 <= 5 || ucVariant2 == 255))
@@ -3577,7 +3577,7 @@ bool CStaticFunctionDefinitions::IsVehicleWindowOpen(CClientVehicle& Vehicle, uc
     return Vehicle.IsWindowOpen(ucWindow);
 }
 
-bool CStaticFunctionDefinitions::SetVehicleModelDummyPosition(unsigned short usModel, eVehicleDummies eDummies, CVector& vecPosition)
+bool CStaticFunctionDefinitions::SetVehicleModelDummyPosition(uint32 usModel, eVehicleDummies eDummies, CVector& vecPosition)
 {
     if (CClientVehicleManager::IsValidModel(usModel))
     {
@@ -3591,7 +3591,7 @@ bool CStaticFunctionDefinitions::SetVehicleModelDummyPosition(unsigned short usM
     return false;
 }
 
-bool CStaticFunctionDefinitions::GetVehicleModelDummyPosition(unsigned short usModel, eVehicleDummies eDummies, CVector& vecPosition)
+bool CStaticFunctionDefinitions::GetVehicleModelDummyPosition(uint32 usModel, eVehicleDummies eDummies, CVector& vecPosition)
 {
     if (CClientVehicleManager::IsValidModel(usModel))
     {
@@ -3605,7 +3605,7 @@ bool CStaticFunctionDefinitions::GetVehicleModelDummyPosition(unsigned short usM
     return false;
 }
 
-bool CStaticFunctionDefinitions::SetVehicleModelExhaustFumesPosition(unsigned short usModel, CVector& vecPosition)
+bool CStaticFunctionDefinitions::SetVehicleModelExhaustFumesPosition(uint32 usModel, CVector& vecPosition)
 {
     if (CClientVehicleManager::IsValidModel(usModel))
     {
@@ -3619,7 +3619,7 @@ bool CStaticFunctionDefinitions::SetVehicleModelExhaustFumesPosition(unsigned sh
     return false;
 }
 
-bool CStaticFunctionDefinitions::GetVehicleModelExhaustFumesPosition(unsigned short usModel, CVector& vecPosition)
+bool CStaticFunctionDefinitions::GetVehicleModelExhaustFumesPosition(uint32 usModel, CVector& vecPosition)
 {
     if (CClientVehicleManager::IsValidModel(usModel))
     {
@@ -3826,7 +3826,7 @@ bool CStaticFunctionDefinitions::IsElementFrozenWaitingForGroundToLoad(CClientEn
     return false;
 }
 
-CClientObject* CStaticFunctionDefinitions::CreateObject(CResource& Resource, unsigned short usModelID, const CVector& vecPosition, const CVector& vecRotation,
+CClientObject* CStaticFunctionDefinitions::CreateObject(CResource& Resource, uint32 usModelID, const CVector& vecPosition, const CVector& vecRotation,
                                                         bool bLowLod)
 {
     if (CClientObjectManager::IsValidModel(usModelID))
@@ -4263,7 +4263,7 @@ CClientPickup* CStaticFunctionDefinitions::CreatePickup(CResource& Resource, con
                                                         unsigned long ulRespawnInterval, double dSix)
 {
     CClientPickup* pPickup = NULL;
-    unsigned short usModel = 0;
+    uint32         usModel = 0;
     switch (ucType)
     {
         case CClientPickup::ARMOR:
@@ -4371,7 +4371,7 @@ bool CStaticFunctionDefinitions::SetPickupType(CClientEntity& Entity, unsigned c
         else if (ucType == CClientPickup::CUSTOM)
         {
             // Get the weapon id
-            unsigned short usModel = static_cast<unsigned short>(dThree);
+            uint32 usModel = static_cast<uint32>(dThree);
             if (CClientObjectManager::IsValidModel(usModel))
             {
                 Pickup.SetModel(usModel);
@@ -6574,7 +6574,7 @@ bool CStaticFunctionDefinitions::AreTrafficLightsLocked(bool& bLocked)
     return true;
 }
 
-bool CStaticFunctionDefinitions::RemoveWorldBuilding(unsigned short usModelToRemove, float fRadius, float fX, float fY, float fZ, char cInterior,
+bool CStaticFunctionDefinitions::RemoveWorldBuilding(uint32 usModelToRemove, float fRadius, float fX, float fY, float fZ, char cInterior,
                                                      uint& uiOutAmount)
 {
     g_pGame->GetWorld()->RemoveBuilding(usModelToRemove, fRadius, fX, fY, fZ, cInterior, &uiOutAmount);
@@ -6587,7 +6587,7 @@ bool CStaticFunctionDefinitions::RestoreWorldBuildings(uint& uiOutAmount)
     return true;
 }
 
-bool CStaticFunctionDefinitions::RestoreWorldBuilding(unsigned short usModelToRestore, float fRadius, float fX, float fY, float fZ, char cInterior,
+bool CStaticFunctionDefinitions::RestoreWorldBuilding(uint32 usModelToRestore, float fRadius, float fX, float fY, float fZ, char cInterior,
                                                       uint& uiOutAmount)
 {
     return g_pGame->GetWorld()->RestoreBuilding(usModelToRestore, fRadius, fX, fY, fZ, cInterior, &uiOutAmount);
@@ -7143,7 +7143,7 @@ bool CStaticFunctionDefinitions::ToggleAllControls(bool bGTAControls, bool bMTAC
 
 CClientProjectile* CStaticFunctionDefinitions::CreateProjectile(CResource& Resource, CClientEntity& Creator, unsigned char ucWeaponType, CVector& vecOrigin,
                                                                 float fForce, CClientEntity* pTarget, CVector& vecRotation, CVector& vecVelocity,
-                                                                unsigned short usModel)
+                                                                uint32 usModel)
 {
     ConvertDegreesToRadians(vecRotation);
 

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -68,7 +68,7 @@ public:
     static bool           GetElementAlpha(CClientEntity& Entity, unsigned char& ucAlpha);
     static bool           IsElementOnScreen(CClientEntity& Entity, bool& bOnScreen);
     static bool           GetElementHealth(CClientEntity& Entity, float& fHealth);
-    static bool           GetElementModel(CClientEntity& Entity, unsigned short& usModel);
+    static bool           GetElementModel(CClientEntity& Entity, uint32& usModel);
     static bool           IsElementInWater(CClientEntity& Entity, bool& bInWater);
     static bool           IsElementSyncer(CClientEntity& Entity, bool& bIsSyncer);
     static bool           IsElementCollidableWith(CClientEntity& Entity, CClientEntity& ThisEntity, bool& bCanCollide);
@@ -97,7 +97,7 @@ public:
     static bool          SetElementAttachedOffsets(CClientEntity& Entity, CVector& vecPosition, CVector& vecRotation);
     static bool          SetElementAlpha(CClientEntity& Entity, unsigned char ucAlpha);
     static bool          SetElementHealth(CClientEntity& Entity, float fHealth);
-    static bool          SetElementModel(CClientEntity& Entity, unsigned short usModel);
+    static bool          SetElementModel(CClientEntity& Entity, uint32 usModel);
     static bool          SetElementCollisionsEnabled(CClientEntity& Entity, bool bEnabled);
     static bool          SetElementCollidableWith(CClientEntity& Entity, CClientEntity& ThisEntity, bool bCanCollide);
     static bool          SetElementFrozen(CClientEntity& Entity, bool bFrozen);
@@ -196,12 +196,12 @@ public:
     static bool GetClothesTypeName(unsigned char ucType, SString& strOutName);
 
     // Vehicle get funcs
-    static CClientVehicle* CreateVehicle(CResource& Resource, unsigned short usModel, const CVector& vecPosition, const CVector& vecRotation,
+    static CClientVehicle* CreateVehicle(CResource& Resource, uint32 usModel, const CVector& vecPosition, const CVector& vecRotation,
                                          const char* szRegPlate = NULL, unsigned char ucVariant = 5, unsigned char ucVariant2 = 5);
-    static bool            GetVehicleModelFromName(const char* szName, unsigned short& usModel);
+    static bool            GetVehicleModelFromName(const char* szName, uint32& usModel);
     static bool            GetVehicleUpgradeSlotName(unsigned char ucSlot, SString& strOutName);
     static bool            GetVehicleUpgradeSlotName(unsigned short usUpgrade, SString& strOutName);
-    static bool            GetVehicleNameFromModel(unsigned short usModel, SString& strOutName);
+    static bool            GetVehicleNameFromModel(uint32 usModel, SString& strOutName);
     static bool            GetHelicopterRotorSpeed(CClientVehicle& Vehicle, float& fSpeed);
     static bool            GetVehicleEngineState(CClientVehicle& Vehicle, bool& bState);
     static bool            IsVehicleDamageProof(CClientVehicle& Vehicle, bool& bDamageProof);
@@ -221,10 +221,10 @@ public:
     static bool            GetVehicleNitroLevel(CClientVehicle& Vehicle, float& fLevel);
     static bool            GetHeliBladeCollisionsEnabled(CClientVehicle& Vehicle);
     static bool            IsVehicleWindowOpen(CClientVehicle& Vehicle, uchar ucWindow);
-    static bool            SetVehicleModelExhaustFumesPosition(unsigned short usModel, CVector& vecPosition);
-    static bool            GetVehicleModelExhaustFumesPosition(unsigned short usModel, CVector& vecPosition);
-    static bool            SetVehicleModelDummyPosition(unsigned short usModel, eVehicleDummies eDummy, CVector& vecPosition);
-    static bool            GetVehicleModelDummyPosition(unsigned short usModel, eVehicleDummies eDummy, CVector& vecPosition);
+    static bool            SetVehicleModelExhaustFumesPosition(uint32 usModel, CVector& vecPosition);
+    static bool            GetVehicleModelExhaustFumesPosition(uint32 usModel, CVector& vecPosition);
+    static bool            SetVehicleModelDummyPosition(uint32 usModel, eVehicleDummies eDummy, CVector& vecPosition);
+    static bool            GetVehicleModelDummyPosition(uint32 usModel, eVehicleDummies eDummy, CVector& vecPosition);
 
     // Vehicle set functions
     static bool FixVehicle(CClientEntity& Entity);
@@ -270,7 +270,7 @@ public:
     static bool SetVehicleWindowOpen(CClientVehicle& Vehicle, uchar ucWindow, bool bOpen);
 
     // Object get funcs
-    static CClientObject* CreateObject(CResource& Resource, unsigned short usModelID, const CVector& vecPosition, const CVector& vecRotation, bool bLowLod);
+    static CClientObject* CreateObject(CResource& Resource, uint32 usModelID, const CVector& vecPosition, const CVector& vecRotation, bool bLowLod);
     static bool           GetObjectScale(CClientObject& Object, CVector& vecScale);
     static bool           IsObjectBreakable(CClientObject& Object, bool& bBreakable);
     static bool           GetObjectMass(CClientObject& Object, float& fMass);
@@ -595,9 +595,9 @@ public:
     static bool          GetCloudsEnabled();
     static bool          GetTrafficLightState(unsigned char& ucState);
     static bool          AreTrafficLightsLocked(bool& bLocked);
-    static bool          RemoveWorldBuilding(unsigned short usModelToRemove, float fDistance, float fX, float fY, float fZ, char cInterior, uint& uiOutAmount);
+    static bool          RemoveWorldBuilding(uint32 usModelToRemove, float fDistance, float fX, float fY, float fZ, char cInterior, uint& uiOutAmount);
     static bool          RestoreWorldBuildings(uint& uiOutAmount);
-    static bool RestoreWorldBuilding(unsigned short usModelToRestore, float fDistance, float fX, float fY, float fZ, char cInterior, uint& uiOutAmount);
+    static bool          RestoreWorldBuilding(uint32 usModelToRestore, float fDistance, float fX, float fY, float fZ, char cInterior, uint& uiOutAmount);
 
     static bool SetTime(unsigned char ucHour, unsigned char ucMin);
     static bool GetSkyGradient(unsigned char& ucTopRed, unsigned char& ucTopGreen, unsigned char& ucTopBlue, unsigned char& ucBottomRed,
@@ -655,7 +655,7 @@ public:
 
     // Projectile functions
     static CClientProjectile* CreateProjectile(CResource& Resource, CClientEntity& Creator, unsigned char ucWeaponType, CVector& vecOrigin, float fForce,
-                                               CClientEntity* pTarget, CVector& vecRotation, CVector& vecVelocity, unsigned short usModel = 0);
+                                               CClientEntity* pTarget, CVector& vecRotation, CVector& vecVelocity, uint32 usModel = 0);
 
     // Shape create funcs
     static CClientColCircle*    CreateColCircle(CResource& Resource, const CVector2D& vecPosition, float fRadius);

--- a/Client/mods/deathmatch/logic/CVehicleUpgrades.cpp
+++ b/Client/mods/deathmatch/logic/CVehicleUpgrades.cpp
@@ -42,7 +42,7 @@ CVehicleUpgrades::CVehicleUpgrades(CClientVehicle* pVehicle)
     m_usLastLocalAddNitroType = 0;
 }
 
-bool CVehicleUpgrades::IsUpgrade(unsigned short usModel)
+bool CVehicleUpgrades::IsUpgrade(uint32 usModel)
 {
     return (usModel >= 1000 && usModel <= 1193);
 }
@@ -63,7 +63,7 @@ bool CVehicleUpgrades::IsUpgradeCompatible(unsigned short usUpgrade)
     if (vehicleType == CLIENTVEHICLE_BIKE || vehicleType == CLIENTVEHICLE_BMX || vehicleType == CLIENTVEHICLE_HELI)
         return false;
 
-    unsigned short usModel = m_pVehicle->GetModel();
+    uint32 usModel = m_pVehicle->GetModel();
     // Wheels should be compatible with any vehicle which have wheels, except
     // bike/bmx (they're buggy). Vortex is technically a car, but it has no
     // wheels.

--- a/Client/mods/deathmatch/logic/CVehicleUpgrades.h
+++ b/Client/mods/deathmatch/logic/CVehicleUpgrades.h
@@ -29,7 +29,7 @@ class CVehicleUpgrades
 public:
     CVehicleUpgrades(CClientVehicle* pVehicle);
 
-    static bool IsUpgrade(unsigned short usModel);
+    static bool IsUpgrade(uint32 usModel);
     bool        IsUpgradeCompatible(unsigned short usUpgrade);
     static bool GetSlotFromUpgrade(unsigned short usUpgrade, unsigned char& ucSlot);
 
@@ -45,7 +45,7 @@ public:
     void ReAddAll();
     void RemoveAll(bool bRipFromVehicle);
 
-    void RestreamVehicleUpgrades(unsigned short usModel);
+    void RestreamVehicleUpgrades(unsigned short usUpgrade);
 
 protected:
     SSlotStates     m_SlotStates;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -1350,7 +1350,7 @@ int CLuaElementDefs::GetElementModel(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        unsigned short usModel;
+        uint32 usModel;
         if (CStaticFunctionDefinitions::GetElementModel(*pEntity, usModel))
         {
             lua_pushnumber(luaVM, usModel);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -451,7 +451,7 @@ int CLuaEngineDefs::EngineRestoreCOL(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        unsigned short usModelID = CModelNames::ResolveModelID(strModelName);
+        uint32 usModelID = CModelNames::ResolveModelID(strModelName);
 
         if (m_pColModelManager->RestoreModel(usModelID))
         {
@@ -479,7 +479,7 @@ int CLuaEngineDefs::EngineImportTXD(lua_State* luaVM)
     if (!argStream.HasErrors())
     {
         // Valid importable model?
-        ushort usModelID = CModelNames::ResolveModelID(strModelName);
+        uint32 usModelID = CModelNames::ResolveModelID(strModelName);
         if (usModelID == INVALID_MODEL_ID)
             usModelID = CModelNames::ResolveClothesTexID(strModelName);
         if (CClientTXD::IsImportableModel(usModelID))
@@ -516,7 +516,7 @@ int CLuaEngineDefs::EngineReplaceModel(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        ushort usModelID = CModelNames::ResolveModelID(strModelName);
+        uint32 usModelID = CModelNames::ResolveModelID(strModelName);
         if (usModelID != INVALID_MODEL_ID)
         {
             // Fixes vehicle dff leak problem with engineReplaceModel
@@ -542,7 +542,7 @@ int CLuaEngineDefs::EngineReplaceModel(lua_State* luaVM)
 int CLuaEngineDefs::EngineRestoreModel(lua_State* luaVM)
 {
     // Grab the model ID
-    unsigned short usModelID = CModelNames::ResolveModelID(lua_tostring(luaVM, 1));
+    uint32 usModelID = CModelNames::ResolveModelID(lua_tostring(luaVM, 1));
 
     // Valid client DFF and model?
     if (CClientDFFManager::IsReplacableModel(usModelID))
@@ -586,7 +586,7 @@ int CLuaEngineDefs::EngineRequestModel(lua_State* luaVM)
                     if (pModel == nullptr)
                         pModel = std::make_shared<CClientModel>(m_pManager, iModelID, eModelType);
                     m_pManager->GetModelManager()->Add(pModel);
-                    ushort usParentID = -1;
+                    uint32 usParentID = -1;
 
                     if (argStream.NextIsNumber())
                         argStream.ReadNumber(usParentID);
@@ -726,7 +726,7 @@ int CLuaEngineDefs::EngineGetModelLODDistance(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        ushort usModelID = CModelNames::ResolveModelID(strModelId);
+        uint32 usModelID = CModelNames::ResolveModelID(strModelId);
         // Ensure we have a good model (GitHub #446)
         if (usModelID < g_pGame->GetBaseIDforTXD())
         {
@@ -759,7 +759,7 @@ int CLuaEngineDefs::EngineSetModelLODDistance(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        ushort usModelID = CModelNames::ResolveModelID(strModelId);
+        uint32 usModelID = CModelNames::ResolveModelID(strModelId);
         // Ensure we have a good model (GitHub #446)
         if (usModelID < g_pGame->GetBaseIDforTXD())
         {
@@ -790,7 +790,7 @@ int CLuaEngineDefs::EngineResetModelLODDistance(lua_State* luaVM)
     if (argStream.HasErrors())
         return luaL_error(luaVM, argStream.GetFullErrorMessage());
 
-    unsigned short usModelID = CModelNames::ResolveModelID(strModel);
+    uint32      usModelID = CModelNames::ResolveModelID(strModel);
     CModelInfo*    pModelInfo = g_pGame->GetModelInfo(usModelID);
     if (pModelInfo)
     {
@@ -1051,7 +1051,7 @@ int CLuaEngineDefs::EngineGetModelTextureNames(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        ushort usModelID = CModelNames::ResolveModelID(strModelName);
+        uint32 usModelID = CModelNames::ResolveModelID(strModelName);
         if (usModelID != INVALID_MODEL_ID)
         {
             std::vector<SString> nameList;
@@ -1088,7 +1088,7 @@ int CLuaEngineDefs::EngineGetVisibleTextureNames(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        ushort usModelID = CModelNames::ResolveModelID(strModelName);
+        uint32 usModelID = CModelNames::ResolveModelID(strModelName);
         if (usModelID != INVALID_MODEL_ID || strModelName == "")
         {
             std::vector<SString> nameList;
@@ -1115,7 +1115,7 @@ int CLuaEngineDefs::EngineGetVisibleTextureNames(lua_State* luaVM)
 
 bool CLuaEngineDefs::EngineSetModelVisibleTime(std::string strModelId, char cHourOn, char cHourOff)
 {
-    ushort      usModelID = CModelNames::ResolveModelID(strModelId);
+    uint32      usModelID = CModelNames::ResolveModelID(strModelId);
     CModelInfo* pModelInfo = g_pGame->GetModelInfo(usModelID);
     if (pModelInfo)
     {
@@ -1129,7 +1129,7 @@ bool CLuaEngineDefs::EngineSetModelVisibleTime(std::string strModelId, char cHou
 
 std::variant<bool, std::tuple<char, char>> CLuaEngineDefs::EngineGetModelVisibleTime(std::string strModelId)
 {
-    ushort      usModelID = CModelNames::ResolveModelID(strModelId);
+    uint32      usModelID = CModelNames::ResolveModelID(strModelId);
     CModelInfo* pModelInfo = g_pGame->GetModelInfo(usModelID);
     if (pModelInfo)
     {
@@ -1166,7 +1166,7 @@ int CLuaEngineDefs::EngineGetModelTextures(lua_State* luaVM)
     else if (argStream.NextIsTable())
         argStream.ReadStringTable(vTextureNames);
 
-    ushort usModelID = CModelNames::ResolveModelID(strModelName);
+    uint32 usModelID = CModelNames::ResolveModelID(strModelName);
 
     if (usModelID == INVALID_MODEL_ID || !g_pGame->GetRenderWare()->GetModelTextures(textureList, usModelID, vTextureNames))
     {

--- a/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
@@ -78,7 +78,7 @@ void CLuaObjectDefs::AddClass(lua_State* luaVM)
 int CLuaObjectDefs::CreateObject(lua_State* luaVM)
 {
     //  object createObject ( int modelid, float x, float y, float z, [float rx, float ry, float rz, bool lowLOD] )
-    ushort  usModelID;
+    uint32  usModelID;
     CVector vecPosition;
     CVector vecRotation;
     bool    bLowLod;
@@ -182,7 +182,7 @@ int CLuaObjectDefs::IsObjectBreakable(lua_State* luaVM)
 
     if (argStream.NextIsNumber())
     {
-        unsigned short usModel;
+        uint32 usModel;
         argStream.ReadNumber(usModel);
 
         lua_pushboolean(luaVM, CClientObjectManager::IsBreakableModel(usModel));

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -492,7 +492,7 @@ int CLuaVehicleDefs::GetVehicleModelFromName(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        unsigned short usModel;
+        uint32 usModel;
         if (CStaticFunctionDefinitions::GetVehicleModelFromName(strName, usModel))
         {
             lua_pushnumber(luaVM, static_cast<lua_Number>(usModel));
@@ -3969,7 +3969,7 @@ int CLuaVehicleDefs::OOP_GetVehicleModelDummyPosition(lua_State* luaVM)
 int CLuaVehicleDefs::SetVehicleModelExhaustFumesPosition(lua_State* luaVM)
 {
     // bool setVehicleModelExhaustPosition ( int modelID, float x, float y, float z )
-    unsigned short usModel;
+    uint32  usModel;
     CVector        vecPosition;
 
     CScriptArgReader argStream(luaVM);
@@ -3994,7 +3994,7 @@ int CLuaVehicleDefs::SetVehicleModelExhaustFumesPosition(lua_State* luaVM)
 int CLuaVehicleDefs::GetVehicleModelExhaustFumesPosition(lua_State* luaVM)
 {
     // float, float, float getVehicleModelExhaustPosition ( int modelID )
-    unsigned short usModel;
+    uint32 usModel;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadNumber(usModel);
@@ -4021,7 +4021,7 @@ int CLuaVehicleDefs::GetVehicleModelExhaustFumesPosition(lua_State* luaVM)
 int CLuaVehicleDefs::OOP_GetVehicleModelExhaustFumesPosition(lua_State* luaVM)
 {
     // float, float, float getVehicleModelExhaustPosition ( int modelID )
-    unsigned short usModel;
+    uint32 usModel;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadNumber(usModel);
@@ -4071,7 +4071,7 @@ bool CLuaVehicleDefs::SetVehicleWheelScale(CClientVehicle* const pVehicle, const
 }
 
 std::variant<float, std::unordered_map<std::string, float>> CLuaVehicleDefs::GetVehicleModelWheelSize(
-    const unsigned short usModel, const std::optional<eResizableVehicleWheelGroup> eWheelGroup)
+    const uint32 usModel, const std::optional<eResizableVehicleWheelGroup> eWheelGroup)
 {
     CModelInfo* pModelInfo = nullptr;
     if (CClientVehicleManager::IsValidModel(usModel))
@@ -4092,7 +4092,7 @@ std::variant<float, std::unordered_map<std::string, float>> CLuaVehicleDefs::Get
     return pModelInfo->GetVehicleWheelSize(eActualWheelGroup);
 }
 
-bool CLuaVehicleDefs::SetVehicleModelWheelSize(const unsigned short usModel, const eResizableVehicleWheelGroup eWheelGroup, const float fWheelSize)
+bool CLuaVehicleDefs::SetVehicleModelWheelSize(const uint32 usModel, const eResizableVehicleWheelGroup eWheelGroup, const float fWheelSize)
 {
     CModelInfo* pModelInfo = nullptr;
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -146,9 +146,9 @@ public:
     static bool  SetVehicleVariant(CClientVehicle* pVehicle, std::optional<unsigned char> optVariant1, std::optional<unsigned char> optVariant2);
     static float GetVehicleWheelScale(CClientVehicle* const pVehicle);
     static bool  SetVehicleWheelScale(CClientVehicle* const pVehicle, const float fWheelScale);
-    static std::variant<float, std::unordered_map<std::string, float>> GetVehicleModelWheelSize(const unsigned short                             usModel,
+    static std::variant<float, std::unordered_map<std::string, float>> GetVehicleModelWheelSize(const uint32                                     usModel,
                                                                                                 const std::optional<eResizableVehicleWheelGroup> eWheelGroup);
-    static bool SetVehicleModelWheelSize(const unsigned short usModel, const eResizableVehicleWheelGroup eWheelGroup, const float fWheelSize);
+    static bool SetVehicleModelWheelSize(const uint32 usModel, const eResizableVehicleWheelGroup eWheelGroup, const float fWheelSize);
     static int  GetVehicleWheelFrictionState(CClientVehicle* pVehicle, unsigned char wheel);
 
     // Components

--- a/Client/multiplayer_sa/CMultiplayerSA_ClothesMemFix.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_ClothesMemFix.cpp
@@ -84,7 +84,7 @@ void _declspec(naked) HOOK_CClothesDeleteRwObject()
 //////////////////////////////////////////////////////////////////////////////////////////
 void OnMy_PostCPedDress()
 {
-    ushort                     usModelID = 0;
+    uint32                     usModelID = 0;
     CBaseModelInfoSAInterface* pModelInfo = ((CBaseModelInfoSAInterface**)ARRAY_ModelInfo)[usModelID];
     if (pSavedModel0RwObject)
     {

--- a/Client/multiplayer_sa/CMultiplayerSA_HookDestructors.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_HookDestructors.cpp
@@ -486,7 +486,7 @@ inner:
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
 //
-void _cdecl OnCStreamingRemoveModel(DWORD calledFrom, ushort usModelId)
+void _cdecl OnCStreamingRemoveModel(DWORD calledFrom, uint32 usModelId)
 {
     // Tell client to check for things going away
     if (pGameModelRemoveHandler)

--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -78,7 +78,7 @@ tVehicleAudioSettings*      pVehicleAudioSettings = nullptr;
 
 static tVehicleAudioSettings* __fastcall getVehicleSoundSettings()
 {
-    ushort usModel = pRequestSoundSettingsVehicle->m_nModelIndex;
+    uint32 usModel = pRequestSoundSettingsVehicle->m_nModelIndex;
     // Check if it is a custom model
     if (usModel < VT_LANDSTAL || usModel >= VT_MAX)
         usModel = pGameInterface->GetModelInfo(usModel)->GetParentID();

--- a/Client/sdk/core/CClientBase.h
+++ b/Client/sdk/core/CClientBase.h
@@ -24,7 +24,7 @@ public:
     virtual void PreHUDRenderExecutionHandler(bool bDidUnminimize, bool bDidRecreateRenderTargets) = 0;
     virtual void PostFrameExecutionHandler() = 0;
     virtual void IdleHandler() = 0;
-    virtual void RestreamModel(unsigned short usModel) = 0;
+    virtual void RestreamModel(uint32 usModel) = 0;
 
     virtual bool WebsiteRequestResultHandler(const std::unordered_set<SString>& newPages) = 0;
 

--- a/Client/sdk/core/CCoreInterface.h
+++ b/Client/sdk/core/CCoreInterface.h
@@ -157,7 +157,7 @@ public:
     virtual EDiagnosticDebugType GetDiagnosticDebug() = 0;
     virtual void                 SetDiagnosticDebug(EDiagnosticDebugType value) = 0;
     virtual CModelCacheManager*  GetModelCacheManager() = 0;
-    virtual void                 AddModelToPersistentCache(ushort usModelId) = 0;
+    virtual void                 AddModelToPersistentCache(uint32 usModelId) = 0;
     virtual void                 UpdateDummyProgress(int iValue = -1, const char* szType = "") = 0;
     virtual void                 SetDummyProgressUpdateAlways(bool bAlways) = 0;
 

--- a/Client/sdk/core/CRenderItemManagerInterface.h
+++ b/Client/sdk/core/CRenderItemManagerInterface.h
@@ -167,7 +167,7 @@ public:
                                                              bool bAppendLayers) = 0;
     virtual bool           RemoveShaderItemFromWorldTexture(CShaderItem* pShaderItem, const SString& strTextureNameMatch, CClientEntityBase* pClientEntity) = 0;
     virtual void           RemoveClientEntityRefs(CClientEntityBase* pClientEntity) = 0;
-    virtual void           GetVisibleTextureNames(std::vector<SString>& outNameList, const SString& strTextureNameMatch, ushort usModelID) = 0;
+    virtual void           GetVisibleTextureNames(std::vector<SString>& outNameList, const SString& strTextureNameMatch, uint32 usModelID) = 0;
     virtual eDxTestMode    GetTestMode() = 0;
     virtual void           SetTestMode(eDxTestMode testMode) = 0;
     virtual void           GetDxStatus(SDxStatus& outStatus) = 0;

--- a/Client/sdk/game/CHandlingEntry.h
+++ b/Client/sdk/game/CHandlingEntry.h
@@ -188,5 +188,5 @@ public:
 
     // Call this every time you're done changing something. This will recalculate
     // all transmission/handling values according to the new values.
-    virtual void Recalculate(unsigned short usModel) = 0;
+    virtual void Recalculate(uint32 usModel) = 0;
 };

--- a/Client/sdk/game/CModelInfo.h
+++ b/Client/sdk/game/CModelInfo.h
@@ -138,7 +138,7 @@ public:
     virtual CBoundingBox*  GetBoundingBox() = 0;
     virtual bool           IsValid() = 0;
     virtual bool           IsAllocatedInArchive() = 0;
-    virtual unsigned short GetTextureDictionaryID() = 0;
+    virtual uint32         GetTextureDictionaryID() = 0;
     virtual float          GetLODDistance() = 0;
     virtual float          GetOriginalLODDistance() = 0;
     virtual void           SetLODDistance(float fDistance, bool bOverrideMaxDistance = false) = 0;
@@ -193,8 +193,8 @@ public:
     virtual void      MakeCustomModel() = 0;
     virtual RwObject* GetRwObject() = 0;
     virtual void      MakePedModel(char* szTexture) = 0;
-    virtual void      MakeObjectModel(unsigned short usBaseID) = 0;
-    virtual void      MakeVehicleAutomobile(unsigned short usBaseID) = 0;
+    virtual void      MakeObjectModel(uint32 usBaseID) = 0;
+    virtual void      MakeVehicleAutomobile(uint32 usBaseID) = 0;
 
     virtual SVehicleSupportedUpgrades GetVehicleSupportedUpgrades() = 0;
     virtual void                      ResetSupportedUpgrades() = 0;

--- a/Client/sdk/game/CRenderWare.h
+++ b/Client/sdk/game/CRenderWare.h
@@ -26,14 +26,14 @@ struct SReplacementTextures
     struct SPerTxd
     {
         std::vector<RwTexture*> usingTextures;
-        ushort                  usTxdId;
+        uint32                  usTxdId;
         bool                    bTexturesAreCopies;
     };
 
     std::vector<RwTexture*> textures;              // List of textures we want to inject into TXD's
     std::vector<SPerTxd>    perTxdList;            // TXD's which have been modified
-    std::vector<ushort>     usedInTxdIds;
-    std::vector<ushort>     usedInModelIds;
+    std::vector<uint32>     usedInTxdIds;
+    std::vector<uint32>     usedInModelIds;
 };
 
 // Shader layers to render
@@ -65,34 +65,34 @@ class CRenderWare
 public:
     virtual bool             ModelInfoTXDLoadTextures(SReplacementTextures* pReplacementTextures, const SString& strFilename, const SString& buffer,
                                                       bool bFilteringEnabled) = 0;
-    virtual bool             ModelInfoTXDAddTextures(SReplacementTextures* pReplacementTextures, ushort usModelId) = 0;
+    virtual bool             ModelInfoTXDAddTextures(SReplacementTextures* pReplacementTextures, uint32 usModelId) = 0;
     virtual void             ModelInfoTXDRemoveTextures(SReplacementTextures* pReplacementTextures) = 0;
-    virtual void             ClothesAddReplacementTxd(char* pFileData, ushort usFileId) = 0;
+    virtual void             ClothesAddReplacementTxd(char* pFileData, uint32 usFileId) = 0;
     virtual void             ClothesRemoveReplacementTxd(char* pFileData) = 0;
     virtual bool             HasClothesReplacementChanged() = 0;
     virtual RwTexDictionary* ReadTXD(const SString& strFilename, const SString& buffer) = 0;
-    virtual RpClump*         ReadDFF(const SString& strFilename, const SString& buffer, unsigned short usModelID, bool bLoadEmbeddedCollisions) = 0;
+    virtual RpClump*         ReadDFF(const SString& strFilename, const SString& buffer, uint32 usModelID, bool bLoadEmbeddedCollisions) = 0;
     virtual CColModel*       ReadCOL(const SString& buffer) = 0;
     virtual void             DestroyDFF(RpClump* pClump) = 0;
     virtual void             DestroyTXD(RwTexDictionary* pTXD) = 0;
     virtual void             DestroyTexture(RwTexture* pTex) = 0;
-    virtual void             ReplaceCollisions(CColModel* pColModel, unsigned short usModelID) = 0;
+    virtual void             ReplaceCollisions(CColModel* pColModel, uint32 usModelID) = 0;
     virtual unsigned int     LoadAtomics(RpClump* pClump, RpAtomicContainer* pAtomics) = 0;
-    virtual void             ReplaceAllAtomicsInModel(RpClump* pSrc, unsigned short usModelID) = 0;
+    virtual void             ReplaceAllAtomicsInModel(RpClump* pSrc, uint32 usModelID) = 0;
     virtual void             ReplaceAllAtomicsInClump(RpClump* pDst, RpAtomicContainer* pAtomics, unsigned int uiAtomics) = 0;
     virtual void             ReplaceWheels(RpClump* pClump, RpAtomicContainer* pAtomics, unsigned int uiAtomics, const char* szWheel) = 0;
     virtual void             RepositionAtomic(RpClump* pDst, RpClump* pSrc, const char* szName) = 0;
     virtual void             AddAllAtomics(RpClump* pDst, RpClump* pSrc) = 0;
-    virtual void             ReplaceVehicleModel(RpClump* pNew, unsigned short usModelID) = 0;
-    virtual void             ReplaceWeaponModel(RpClump* pNew, unsigned short usModelID) = 0;
-    virtual void             ReplacePedModel(RpClump* pNew, unsigned short usModelID) = 0;
+    virtual void             ReplaceVehicleModel(RpClump* pNew, uint32 usModelID) = 0;
+    virtual void             ReplaceWeaponModel(RpClump* pNew, uint32 usModelID) = 0;
+    virtual void             ReplacePedModel(RpClump* pNew, uint32 usModelID) = 0;
     virtual bool             ReplacePartModels(RpClump* pClump, RpAtomicContainer* pAtomics, unsigned int uiAtomics, const char* szName) = 0;
     virtual void             PulseWorldTextureWatch() = 0;
-    virtual void             GetModelTextureNames(std::vector<SString>& outNameList, ushort usModelID) = 0;
-    virtual bool             GetModelTextures(std::vector<std::tuple<std::string, CPixels>>& outTextureList, ushort usModelID, std::vector<SString> vTextureNames) = 0;
+    virtual void             GetModelTextureNames(std::vector<SString>& outNameList, uint32 usModelID) = 0;
+    virtual bool             GetModelTextures(std::vector<std::tuple<std::string, CPixels>>& outTextureList, uint32 usModelID, std::vector<SString> vTextureNames) = 0;
     virtual const char*      GetTextureName(CD3DDUMMY* pD3DData) = 0;
 
-    virtual void               SetRenderingClientEntity(CClientEntityBase* pClientEntity, ushort usModelId, int iTypeMask) = 0;
+    virtual void               SetRenderingClientEntity(CClientEntityBase* pClientEntity, uint32 usModelId, int iTypeMask) = 0;
     virtual SShaderItemLayers* GetAppliedShaderForD3DData(CD3DDUMMY* pD3DData) = 0;
     virtual void     AppendAdditiveMatch(CSHADERDUMMY* pShaderData, CClientEntityBase* pClientEntity, const char* strTextureNameMatch, float fShaderPriority,
                                          bool bShaderLayered, int iTypeMask, uint uiShaderCreateTime, bool bShaderUsesVertexShader, bool bAppendLayers) = 0;
@@ -101,7 +101,7 @@ public:
     virtual void     RemoveShaderRefs(CSHADERDUMMY* pShaderItem) = 0;
     virtual RwFrame* GetFrameFromName(RpClump* pRoot, SString strName) = 0;
     virtual bool     RightSizeTxd(const SString& strInTxdFilename, const SString& strOutTxdFilename, uint uiSizeLimit) = 0;
-    virtual void     TxdForceUnload(ushort usTxdId, bool bDestroyTextures) = 0;
+    virtual void     TxdForceUnload(uint32 usTxdId, bool bDestroyTextures) = 0;
 
     virtual void CMatrixToRwMatrix(const CMatrix& mat, RwMatrix& rwOutMatrix) = 0;
     virtual void RwMatrixToCMatrix(const RwMatrix& rwMatrix, CMatrix& matOut) = 0;

--- a/Client/sdk/game/CWorld.h
+++ b/Client/sdk/game/CWorld.h
@@ -43,8 +43,8 @@ struct SLineOfSightBuildingResult
 {
     SLineOfSightBuildingResult() : bValid(false) {}
     bool                bValid;
-    ushort              usModelID;
-    ushort              usLODModelID;
+    uint32              usModelID;
+    uint32              usLODModelID;
     CVector             vecPosition;
     CVector             vecRotation;
     CEntitySAInterface* pInterface;
@@ -79,7 +79,7 @@ struct SBuildingRemoval
         m_pDataRemoveList->push_back(pInterface);
     }
 
-    unsigned short                  m_usModel;
+    uint32                          m_usModel;
     CVector                         m_vecPos;
     float                           m_fRadius;
     char                            m_cInterior;
@@ -332,17 +332,17 @@ public:
     virtual void  FindWorldPositionForRailTrackPosition(float fRailTrackPosition, int iTrackId, CVector* pOutVecPosition) = 0;
     virtual int   FindClosestRailTrackNode(const CVector& vecPosition, uchar& ucOutTrackId, float& fOutRailDistance) = 0;
 
-    virtual void RemoveBuilding(unsigned short usModelToRemove, float fDistance, float fX, float fY, float fZ, char cInterior, uint* pOutAmount = NULL) = 0;
+    virtual void RemoveBuilding(uint32 usModelToRemove, float fDistance, float fX, float fY, float fZ, char cInterior, uint* pOutAmount = NULL) = 0;
     virtual bool IsRemovedModelInRadius(SIPLInst* pInst) = 0;
-    virtual bool IsModelRemoved(unsigned short usModelID) = 0;
+    virtual bool IsModelRemoved(uint32 usModelID) = 0;
     virtual void ClearRemovedBuildingLists(uint* pOutAmount = NULL) = 0;
-    virtual bool RestoreBuilding(unsigned short usModelToRestore, float fDistance, float fX, float fY, float fZ, char cInterior, uint* pOutAmount = NULL) = 0;
+    virtual bool RestoreBuilding(uint32 usModelToRestore, float fDistance, float fX, float fY, float fZ, char cInterior, uint* pOutAmount = NULL) = 0;
     virtual SBuildingRemoval* GetBuildingRemoval(CEntitySAInterface* pInterface) = 0;
     virtual void              AddDataBuilding(CEntitySAInterface* pInterface) = 0;
     virtual void              AddBinaryBuilding(CEntitySAInterface* pInterface) = 0;
     virtual void              RemoveWorldBuildingFromLists(CEntitySAInterface* pInterface) = 0;
     virtual bool              IsObjectRemoved(CEntitySAInterface* pInterface) = 0;
-    virtual bool              IsDataModelRemoved(unsigned short usModelID) = 0;
+    virtual bool              IsDataModelRemoved(uint32 usModelID) = 0;
     virtual bool              IsEntityRemoved(CEntitySAInterface* pInterface) = 0;
     virtual bool              CalculateImpactPosition(const CVector& vecInputStart, CVector& vecInputEnd) = 0;
 

--- a/Client/sdk/multiplayer/CMultiplayer.h
+++ b/Client/sdk/multiplayer/CMultiplayer.h
@@ -115,7 +115,7 @@ typedef void(GameObjectDestructHandler)(CEntitySAInterface* pObject);
 typedef void(GameVehicleDestructHandler)(CEntitySAInterface* pVehicle);
 typedef void(GamePlayerDestructHandler)(CEntitySAInterface* pPlayer);
 typedef void(GameProjectileDestructHandler)(CEntitySAInterface* pProjectile);
-typedef void(GameModelRemoveHandler)(ushort usModelId);
+typedef void(GameModelRemoveHandler)(uint32 usModelId);
 typedef void(GameRunNamedAnimDestructorHandler)(class CTaskSimpleRunNamedAnimSAInterface* pTask);
 typedef void(GameEntityRenderHandler)(CEntitySAInterface* pEntity);
 typedef void(FxSystemDestructionHandler)(void* pFxSA);

--- a/Server/mods/deathmatch/logic/CBuildingRemoval.cpp
+++ b/Server/mods/deathmatch/logic/CBuildingRemoval.cpp
@@ -10,7 +10,7 @@
 
 #include "StdInc.h"
 
-CBuildingRemoval::CBuildingRemoval(unsigned short usModel, float fRadius, const CVector& vecPos, char cInterior)
+CBuildingRemoval::CBuildingRemoval(uint32 usModel, float fRadius, const CVector& vecPos, char cInterior)
 {
     m_usModel = usModel;
     m_fRadius = fRadius;

--- a/Server/mods/deathmatch/logic/CBuildingRemoval.h
+++ b/Server/mods/deathmatch/logic/CBuildingRemoval.h
@@ -18,7 +18,7 @@ public:
 
     float          GetRadius() { return m_fRadius; }
     const CVector& GetPosition() { return m_vecPos; }
-    unsigned short GetModel() { return m_usModel; }
+    uint32 GetModel() { return m_usModel; }
     char           GetInterior() { return m_cInterior; }
 
 private:

--- a/Server/mods/deathmatch/logic/CBuildingRemoval.h
+++ b/Server/mods/deathmatch/logic/CBuildingRemoval.h
@@ -13,7 +13,7 @@
 class CBuildingRemoval
 {
 public:
-    CBuildingRemoval(unsigned short usModel, float fRadius, const CVector& vecPos, char cInterior);
+    CBuildingRemoval(uint32 usModel, float fRadius, const CVector& vecPos, char cInterior);
     ~CBuildingRemoval();
 
     float          GetRadius() { return m_fRadius; }
@@ -22,7 +22,7 @@ public:
     char           GetInterior() { return m_cInterior; }
 
 private:
-    unsigned short m_usModel;
+    uint32 m_usModel;
     CVector        m_vecPos;
     float          m_fRadius;
     char           m_cInterior;

--- a/Server/mods/deathmatch/logic/CBuildingRemovalManager.cpp
+++ b/Server/mods/deathmatch/logic/CBuildingRemovalManager.cpp
@@ -15,19 +15,19 @@ CBuildingRemovalManager::CBuildingRemovalManager()
 
 CBuildingRemovalManager::~CBuildingRemovalManager()
 {
-    for (std::multimap<unsigned short, CBuildingRemoval*>::const_iterator iter = m_BuildingRemovals.begin(); iter != m_BuildingRemovals.end(); iter++)
+    for (std::multimap<uint32, CBuildingRemoval*>::const_iterator iter = m_BuildingRemovals.begin(); iter != m_BuildingRemovals.end(); iter++)
     {
         if ((*iter).second)
             delete (*iter).second;
     }
 }
 
-void CBuildingRemovalManager::CreateBuildingRemoval(unsigned short usModel, float fRadius, const CVector& vecPos, char cInterior)
+void CBuildingRemovalManager::CreateBuildingRemoval(uint32 usModel, float fRadius, const CVector& vecPos, char cInterior)
 {
     // Check if this removal has already been covered
-    std::pair<std::multimap<unsigned short, CBuildingRemoval*>::iterator, std::multimap<unsigned short, CBuildingRemoval*>::iterator> iterators =
+    std::pair<std::multimap<uint32, CBuildingRemoval*>::iterator, std::multimap<uint32, CBuildingRemoval*>::iterator> iterators =
         m_BuildingRemovals.equal_range(usModel);
-    std::multimap<unsigned short, CBuildingRemoval*>::iterator iter = iterators.first;
+    std::multimap<uint32, CBuildingRemoval*>::iterator iter = iterators.first;
     for (; iter != iterators.second; ++iter)
     {
         CBuildingRemoval* pFind = iter->second;
@@ -48,12 +48,12 @@ void CBuildingRemovalManager::CreateBuildingRemoval(unsigned short usModel, floa
     }
 
     CBuildingRemoval* pBuildingRemoval = new CBuildingRemoval(usModel, fRadius, vecPos, cInterior);
-    m_BuildingRemovals.insert(std::pair<unsigned short, CBuildingRemoval*>(usModel, pBuildingRemoval));
+    m_BuildingRemovals.insert(std::pair<uint32, CBuildingRemoval*>(usModel, pBuildingRemoval));
 }
 
 void CBuildingRemovalManager::ClearBuildingRemovals()
 {
-    for (std::multimap<unsigned short, CBuildingRemoval*>::const_iterator iter = m_BuildingRemovals.begin(); iter != m_BuildingRemovals.end(); iter++)
+    for (std::multimap<uint32, CBuildingRemoval*>::const_iterator iter = m_BuildingRemovals.begin(); iter != m_BuildingRemovals.end(); iter++)
     {
         if ((*iter).second)
             delete (*iter).second;
@@ -61,12 +61,12 @@ void CBuildingRemovalManager::ClearBuildingRemovals()
     m_BuildingRemovals.clear();
 }
 
-void CBuildingRemovalManager::RestoreWorldModel(unsigned short usModel, float fRadius, const CVector& vecPos, char cInterior)
+void CBuildingRemovalManager::RestoreWorldModel(uint32 usModel, float fRadius, const CVector& vecPos, char cInterior)
 {
     CBuildingRemoval*                                                                                                                 pFind = NULL;
-    std::pair<std::multimap<unsigned short, CBuildingRemoval*>::iterator, std::multimap<unsigned short, CBuildingRemoval*>::iterator> iterators =
+    std::pair<std::multimap<uint32, CBuildingRemoval*>::iterator, std::multimap<uint32, CBuildingRemoval*>::iterator> iterators =
         m_BuildingRemovals.equal_range(usModel);
-    std::multimap<unsigned short, CBuildingRemoval*>::iterator iter = iterators.first;
+    std::multimap<uint32, CBuildingRemoval*>::iterator iter = iterators.first;
     for (; iter != iterators.second;)
     {
         pFind = (*iter).second;

--- a/Server/mods/deathmatch/logic/CBuildingRemovalManager.h
+++ b/Server/mods/deathmatch/logic/CBuildingRemovalManager.h
@@ -17,12 +17,12 @@ class CBuildingRemovalManager
 public:
     CBuildingRemovalManager();
     ~CBuildingRemovalManager();
-    void CreateBuildingRemoval(unsigned short usModel, float fRadius, const CVector& vecPos, char cInterior);
+    void CreateBuildingRemoval(uint32 usModel, float fRadius, const CVector& vecPos, char cInterior);
     void ClearBuildingRemovals();
-    void RestoreWorldModel(unsigned short usModel, float fRadius, const CVector& vecPos, char cInterior);
-    multimap<unsigned short, CBuildingRemoval*>::const_iterator IterBegin() { return m_BuildingRemovals.begin(); };
-    multimap<unsigned short, CBuildingRemoval*>::const_iterator IterEnd() { return m_BuildingRemovals.end(); };
+    void RestoreWorldModel(uint32 usModel, float fRadius, const CVector& vecPos, char cInterior);
+    multimap<uint32, CBuildingRemoval*>::const_iterator         IterBegin() { return m_BuildingRemovals.begin(); };
+    multimap<uint32, CBuildingRemoval*>::const_iterator IterEnd() { return m_BuildingRemovals.end(); };
 
 private:
-    std::multimap<unsigned short, CBuildingRemoval*> m_BuildingRemovals;
+    std::multimap<uint32, CBuildingRemoval*> m_BuildingRemovals;
 };

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -2848,7 +2848,7 @@ void CGame::Packet_Vehicle_InOut(CVehicleInOutPacket& Packet)
                             } failReason = FAIL_INVALID;
 
                             // Is this vehicle enterable? (not a trailer)
-                            unsigned short usVehicleModel = pVehicle->GetModel();
+                            uint32 usVehicleModel = pVehicle->GetModel();
                             if (!CVehicleManager::IsTrailer(usVehicleModel))
                             {
                                 // He musn't already be doing something

--- a/Server/mods/deathmatch/logic/CMapManager.cpp
+++ b/Server/mods/deathmatch/logic/CMapManager.cpp
@@ -529,7 +529,7 @@ void CMapManager::OnPlayerQuit(CPlayer& Player)
 {
 }
 
-void CMapManager::SpawnPlayer(CPlayer& Player, const CVector& vecPosition, float fRotation, unsigned short usModel, unsigned char ucInterior,
+void CMapManager::SpawnPlayer(CPlayer& Player, const CVector& vecPosition, float fRotation, uint32 usModel, unsigned char ucInterior,
                               unsigned short usDimension, CTeam* pTeam)
 {
     // Don't force them off their team if the spawnpoint doesn't have one

--- a/Server/mods/deathmatch/logic/CMapManager.h
+++ b/Server/mods/deathmatch/logic/CMapManager.h
@@ -60,7 +60,7 @@ public:
     CClock* GetServerClock() { return m_pServerClock; }
 
     void SpawnPlayers();
-    void SpawnPlayer(CPlayer& Player, const CVector& vecPosition, float fRotation, unsigned short usModel, unsigned char ucInterior = 0,
+    void SpawnPlayer(CPlayer& Player, const CVector& vecPosition, float fRotation, uint32 usModel, unsigned char ucInterior = 0,
                      unsigned short usDimension = 0, CTeam* pTeam = NULL);
 
     void DoRespawning();

--- a/Server/mods/deathmatch/logic/CObject.cpp
+++ b/Server/mods/deathmatch/logic/CObject.cpp
@@ -20,7 +20,7 @@ CObject::CObject(CElement* pParent, CObjectManager* pObjectManager, bool bIsLowL
     SetTypeName("object");
 
     m_pObjectManager = pObjectManager;
-    m_usModel = 0xFFFF;
+    m_usModel = 0xFFFFFFFF;
     m_pMoveAnimation = NULL;
     m_ucAlpha = 255;
     m_vecScale = CVector(1.0f, 1.0f, 1.0f);

--- a/Server/mods/deathmatch/logic/CObject.h
+++ b/Server/mods/deathmatch/logic/CObject.h
@@ -50,7 +50,7 @@ public:
     unsigned char GetAlpha() { return m_ucAlpha; }
     void          SetAlpha(unsigned char ucAlpha) { m_ucAlpha = ucAlpha; }
 
-    unsigned short GetModel() { return m_usModel; }
+    uint32 GetModel() { return m_usModel; }
     void           SetModel(uint32 usModel) { m_usModel = usModel; }
 
     const CVector& GetScale() { return m_vecScale; }
@@ -85,7 +85,7 @@ private:
     CObjectManager* m_pObjectManager;
     CVector         m_vecRotation;
     unsigned char   m_ucAlpha;
-    unsigned short  m_usModel;
+    uint32          m_usModel;
     CVector         m_vecScale;
     bool            m_bIsFrozen;
     float           m_fHealth;

--- a/Server/mods/deathmatch/logic/CObject.h
+++ b/Server/mods/deathmatch/logic/CObject.h
@@ -51,7 +51,7 @@ public:
     void          SetAlpha(unsigned char ucAlpha) { m_ucAlpha = ucAlpha; }
 
     unsigned short GetModel() { return m_usModel; }
-    void           SetModel(unsigned short usModel) { m_usModel = usModel; }
+    void           SetModel(uint32 usModel) { m_usModel = usModel; }
 
     const CVector& GetScale() { return m_vecScale; }
     void           SetScale(const CVector& vecScale) { m_vecScale = vecScale; }

--- a/Server/mods/deathmatch/logic/CPed.cpp
+++ b/Server/mods/deathmatch/logic/CPed.cpp
@@ -19,7 +19,7 @@ struct SBodyPartName
 SBodyPartName BodyPartNames[10] = {{"Unknown"},  {"Unknown"},   {"Unknown"},  {"Torso"},     {"Ass"},
                                    {"Left Arm"}, {"Right Arm"}, {"Left Leg"}, {"Right Leg"}, {"Head"}};
 
-CPed::CPed(CPedManager* pPedManager, CElement* pParent, unsigned short usModel) : CElement(pParent)
+CPed::CPed(CPedManager* pPedManager, CElement* pParent, uint32 usModel) : CElement(pParent)
 {
     // Init
     m_pPedManager = pPedManager;
@@ -201,7 +201,7 @@ bool CPed::ReadSpecialData(const int iLine)
     if (GetCustomDataInt("model", iTemp, true))
     {
         // Is it valid?
-        unsigned short usModel = static_cast<unsigned short>(iTemp);
+        uint32 usModel = static_cast<uint32>(iTemp);
         if (CPedManager::IsValidModel(usModel))
         {
             // Remember it and generate a new random color

--- a/Server/mods/deathmatch/logic/CPed.h
+++ b/Server/mods/deathmatch/logic/CPed.h
@@ -131,7 +131,7 @@ public:
         VEHICLEACTION_JACKED,
     };
 
-    CPed(class CPedManager* pPedManager, CElement* pParent, unsigned short usModel);
+    CPed(class CPedManager* pPedManager, CElement* pParent, uint32 usModel);
     ~CPed();
     CElement* Clone(bool* bAddEntity, CResource* pResource) override;
 
@@ -142,8 +142,8 @@ public:
     bool HasValidModel();
 
     bool           IsPlayer() { return m_bIsPlayer; }
-    unsigned short GetModel() { return m_usModel; };
-    void           SetModel(unsigned short usModel) { m_usModel = usModel; };
+    uint32   GetModel() { return m_usModel; };
+    void           SetModel(uint32 usModel) { m_usModel = usModel; };
 
     bool IsDucked() { return m_bDucked; };
     void SetDucked(bool bDucked) { m_bDucked = bDucked; };
@@ -272,7 +272,7 @@ protected:
     bool ReadSpecialData(const int iLine) override;
 
 protected:
-    unsigned short                       m_usModel;
+    uint32_t                             m_usModel;
     CMatrix                              m_Matrix;
     bool                                 m_bDucked;
     bool                                 m_bIsChoking;

--- a/Server/mods/deathmatch/logic/CPedManager.cpp
+++ b/Server/mods/deathmatch/logic/CPedManager.cpp
@@ -20,7 +20,7 @@ CPedManager::~CPedManager()
     DeleteAll();
 }
 
-CPed* CPedManager::Create(unsigned short usModel, CElement* pParent)
+CPed* CPedManager::Create(uint32 usModel, CElement* pParent)
 {
     CPed* const pPed = new CPed(this, pParent, usModel);
 
@@ -69,7 +69,7 @@ bool CPedManager::Exists(CPed* pPed)
     return ListContains(m_List, pPed);
 }
 
-bool CPedManager::IsValidModel(unsigned short usModel)
+bool CPedManager::IsValidModel(uint32 usModel)
 {
     return true;
 }

--- a/Server/mods/deathmatch/logic/CPedManager.h
+++ b/Server/mods/deathmatch/logic/CPedManager.h
@@ -13,6 +13,8 @@ class CPedManager;
 
 #pragma once
 
+#include <SharedUtil.h>
+
 class CPedManager
 {
     friend class CPed;
@@ -21,7 +23,7 @@ public:
     CPedManager();
     ~CPedManager();
 
-    class CPed* Create(unsigned short usModel, CElement* pParent);
+    class CPed* Create(uint32_t usModel, CElement* pParent);
     class CPed* CreateFromXML(CElement* pParent, CXMLNode& Node, CEvents* pEvents);
     void        DeleteAll();
 
@@ -31,7 +33,7 @@ public:
     list<class CPed*>::const_iterator IterBegin() { return m_List.begin(); }
     list<class CPed*>::const_iterator IterEnd() { return m_List.end(); }
 
-    static bool IsValidModel(unsigned short usModel);
+    static bool IsValidModel(uint32_t usModel);
 
 protected:
     void AddToList(class CPed* pPed) { m_List.push_back(pPed); }

--- a/Server/mods/deathmatch/logic/CPickup.h
+++ b/Server/mods/deathmatch/logic/CPickup.h
@@ -120,8 +120,8 @@ public:
     CTickCount GetLastUsedTime() { return m_LastUsedTime; }
     CTickCount GetCreationTime() { return m_CreationTime; }
 
-    unsigned short GetModel() { return m_usModel; };
-    void           SetModel(unsigned short usModel) { m_usModel = usModel; };
+    uint32_t GetModel() { return m_usModel; };
+    void           SetModel(uint32_t usModel) { m_usModel = usModel; };
 
     bool IsVisible() { return m_bVisible; };
     void SetVisible(bool bVisible);

--- a/Server/mods/deathmatch/logic/CPlayerManager.cpp
+++ b/Server/mods/deathmatch/logic/CPlayerManager.cpp
@@ -320,7 +320,7 @@ void CPlayerManager::Broadcast(const CPacket& Packet, const std::multimap<ushort
     DoBroadcast(Packet, groupMap);
 }
 
-bool CPlayerManager::IsValidPlayerModel(unsigned short usPlayerModel)
+bool CPlayerManager::IsValidPlayerModel(uint32 usPlayerModel)
 {
     return (usPlayerModel == 0 || usPlayerModel == 1 || usPlayerModel == 2 || usPlayerModel == 7 ||
             (usPlayerModel >= 9 && usPlayerModel != 208 && usPlayerModel != 149 && usPlayerModel != 119 && usPlayerModel != 86 && usPlayerModel != 74 &&

--- a/Server/mods/deathmatch/logic/CPlayerManager.h
+++ b/Server/mods/deathmatch/logic/CPlayerManager.h
@@ -53,7 +53,7 @@ public:
     static void Broadcast(const CPacket& Packet, const std::vector<CPlayer*>& sendList);
     static void Broadcast(const CPacket& Packet, const std::multimap<ushort, CPlayer*>& groupMap);
 
-    static bool IsValidPlayerModel(unsigned short usPlayerModel);
+    static bool IsValidPlayerModel(uint32 usPlayerModel);
 
     void ClearElementData(CElement* pElement, const std::string& name);
     void ClearElementData(CElement* pElement);

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -595,7 +595,7 @@ bool CStaticFunctionDefinitions::GetElementHealth(CElement* pElement, float& fHe
     return true;
 }
 
-bool CStaticFunctionDefinitions::GetElementModel(CElement* pElement, unsigned short& usModel)
+bool CStaticFunctionDefinitions::GetElementModel(CElement* pElement, uint32& usModel)
 {
     assert(pElement);
 
@@ -1618,7 +1618,7 @@ bool CStaticFunctionDefinitions::SetElementHealth(CElement* pElement, float fHea
     return true;
 }
 
-bool CStaticFunctionDefinitions::SetElementModel(CElement* pElement, unsigned short usModel)
+bool CStaticFunctionDefinitions::SetElementModel(CElement* pElement, uint32 usModel)
 {
     assert(pElement);
     RUN_CHILDREN(SetElementModel(*iter, usModel))
@@ -1991,7 +1991,7 @@ bool CStaticFunctionDefinitions::DetonateSatchels(CElement* pElement)
     return false;
 }
 
-CPed* CStaticFunctionDefinitions::CreatePed(CResource* pResource, unsigned short usModel, const CVector& vecPosition, float fRotation, bool bSynced)
+CPed* CStaticFunctionDefinitions::CreatePed(CResource* pResource, uint32 usModel, const CVector& vecPosition, float fRotation, bool bSynced)
 {
     if (CPlayerManager::IsValidPlayerModel(usModel))
     {
@@ -4765,7 +4765,7 @@ bool CStaticFunctionDefinitions::SetWeaponAmmo(CElement* pElement, unsigned char
     return false;
 }
 
-CVehicle* CStaticFunctionDefinitions::CreateVehicle(CResource* pResource, unsigned short usModel, const CVector& vecPosition, const CVector& vecRotation,
+CVehicle* CStaticFunctionDefinitions::CreateVehicle(CResource* pResource, uint32 usModel, const CVector& vecPosition, const CVector& vecRotation,
                                                     const char* szRegPlate, unsigned char ucVariant, unsigned char ucVariant2)
 {
     unsigned char ucVariation = ucVariant;
@@ -4925,14 +4925,14 @@ bool CStaticFunctionDefinitions::GetVehicleColor(CVehicle* pVehicle, CVehicleCol
     return true;
 }
 
-bool CStaticFunctionDefinitions::GetVehicleModelFromName(const char* szName, unsigned short& usID)
+bool CStaticFunctionDefinitions::GetVehicleModelFromName(const char* szName, uint32& usID)
 {
     assert(szName);
 
     unsigned long ulID = CVehicleNames::GetVehicleModel(szName);
     if (ulID != 0)
     {
-        usID = static_cast<unsigned short>(ulID);
+        usID = static_cast<uint32>(ulID);
         return true;
     }
 
@@ -4955,7 +4955,7 @@ bool CStaticFunctionDefinitions::GetVehicleName(CVehicle* pVehicle, SString& str
     return true;
 }
 
-bool CStaticFunctionDefinitions::GetVehicleNameFromModel(unsigned short usModel, SString& strOutName)
+bool CStaticFunctionDefinitions::GetVehicleNameFromModel(uint32 usModel, SString& strOutName)
 {
     strOutName = CVehicleNames::GetVehicleName(usModel);
     return !strOutName.empty();
@@ -7993,7 +7993,7 @@ bool CStaticFunctionDefinitions::SetBlipVisibleDistance(CElement* pElement, unsi
     return true;
 }
 
-CObject* CStaticFunctionDefinitions::CreateObject(CResource* pResource, unsigned short usModelID, const CVector& vecPosition, const CVector& vecRotation,
+CObject* CStaticFunctionDefinitions::CreateObject(CResource* pResource, uint32 usModelID, const CVector& vecPosition, const CVector& vecRotation,
                                                   bool bIsLowLod)
 {
     CObject* const pObject = m_pObjectManager->Create(pResource->GetDynamicElementRoot(), bIsLowLod);
@@ -8353,7 +8353,7 @@ CPickup* CStaticFunctionDefinitions::CreatePickup(CResource* pResource, const CV
     else if (ucType == CPickup::CUSTOM)
     {
         // Get the model id
-        unsigned short usModel = static_cast<unsigned short>(dFive);
+        uint32 usModel = static_cast<unsigned short>(dFive);
         if (CObjectManager::IsValidModel(usModel))
         {
             // Create the pickup
@@ -8488,7 +8488,7 @@ bool CStaticFunctionDefinitions::SetPickupType(CElement* pElement, unsigned char
         else if (ucType == CPickup::CUSTOM)
         {
             // Get the weapon id
-            unsigned short usModel = static_cast<unsigned short>(dThree);
+            uint32 usModel = static_cast<unsigned short>(dThree);
             if (CObjectManager::IsValidModel(usModel))
             {
                 // Set the type, weapon type and ammo
@@ -10570,7 +10570,7 @@ bool CStaticFunctionDefinitions::ResetFogDistance()
     return true;
 }
 
-bool CStaticFunctionDefinitions::RemoveWorldModel(unsigned short usModel, float fRadius, const CVector& vecPosition, char cInterior)
+bool CStaticFunctionDefinitions::RemoveWorldModel(uint32 usModel, float fRadius, const CVector& vecPosition, char cInterior)
 {
     g_pGame->GetBuildingRemovalManager()->CreateBuildingRemoval(usModel, fRadius, vecPosition, cInterior);
 
@@ -10586,7 +10586,7 @@ bool CStaticFunctionDefinitions::RemoveWorldModel(unsigned short usModel, float 
     return true;
 }
 
-bool CStaticFunctionDefinitions::RestoreWorldModel(unsigned short usModel, float fRadius, const CVector& vecPosition, char cInterior)
+bool CStaticFunctionDefinitions::RestoreWorldModel(uint32 usModel, float fRadius, const CVector& vecPosition, char cInterior)
 {
     g_pGame->GetBuildingRemovalManager()->RestoreWorldModel(usModel, fRadius, vecPosition, cInterior);
 

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -62,7 +62,7 @@ public:
     static bool           GetElementAlpha(CElement* pElement, unsigned char& ucAlpha);
     static bool           IsElementDoubleSided(CElement* pElement, bool& bDoubleSided);
     static bool           GetElementHealth(CElement* pElement, float& fHealth);
-    static bool           GetElementModel(CElement* pElement, unsigned short& usModel);
+    static bool           GetElementModel(CElement* pElement, uint32& usModel);
     static bool           IsElementInWater(CElement* pElement, bool& bInWater);
     static bool           GetElementAttachedOffsets(CElement* pElement, CVector& vecPosition, CVector& vecRotation);
     static CElement*      GetElementSyncer(CElement* pElement);
@@ -94,7 +94,7 @@ public:
     static bool SetElementAlpha(CElement* pElement, unsigned char ucAlpha);
     static bool SetElementDoubleSided(CElement* pElement, bool bDoubleSided);
     static bool SetElementHealth(CElement* pElement, float fHealth);
-    static bool SetElementModel(CElement* pElement, unsigned short usModel);
+    static bool SetElementModel(CElement* pElement, uint32 usModel);
     static bool SetElementAttachedOffsets(CElement* pElement, CVector& vecPosition, CVector& vecRotation);
     static bool SetElementSyncer(CElement* pElement, CPlayer* pPlayer, bool bEnable = true);
     static bool SetElementCollisionsEnabled(CElement* pElement, bool bEnable);
@@ -153,7 +153,7 @@ public:
                                      uint uiMaxPacketSize, CResource* pResource);
 
     // Ped get funcs
-    static CPed*     CreatePed(CResource* pResource, unsigned short usModel, const CVector& vecPosition, float fRotation = 0.0f, bool bSynced = true);
+    static CPed*     CreatePed(CResource* pResource, uint32 usModel, const CVector& vecPosition, float fRotation = 0.0f, bool bSynced = true);
     static bool      GetPedArmor(CPed* pPed, float& fArmor);
     static bool      GetPedRotation(CPed* pPed, float& fRotation);
     static bool      IsPedDead(CPed* pPed, bool& bDead);
@@ -232,16 +232,16 @@ public:
     static bool SetWeaponAmmo(CElement* pElement, unsigned char ucWeaponID, unsigned short usAmmo, unsigned short usAmmoInClip);
 
     // Vehicle create/destroy functions
-    static CVehicle* CreateVehicle(CResource* pResource, unsigned short usModel, const CVector& vecPosition, const CVector& vecRotation, const char* szRegPlate,
+    static CVehicle* CreateVehicle(CResource* pResource, uint32 usModel, const CVector& vecPosition, const CVector& vecRotation, const char* szRegPlate,
                                    unsigned char ucVariant, unsigned char ucVariant2);
 
     // Vehicle get functions
     static bool  GetVehicleVariant(CVehicle* pVehicle, unsigned char& ucVariant, unsigned char& ucVariant2);
     static bool  GetVehicleColor(CVehicle* pVehicle, CVehicleColor& color);
-    static bool  GetVehicleModelFromName(const char* szName, unsigned short& usID);
+    static bool  GetVehicleModelFromName(const char* szName, uint32& usID);
     static bool  GetVehicleMaxPassengers(CVehicle* pVehicle, unsigned char& ucMaxPassengers);
     static bool  GetVehicleName(CVehicle* pVehicle, SString& strOutName);
-    static bool  GetVehicleNameFromModel(unsigned short usModel, SString& strOutName);
+    static bool  GetVehicleNameFromModel(uint32 usModel, SString& strOutName);
     static CPed* GetVehicleOccupant(CVehicle* pVehicle, unsigned int uiSeat);
     static CPed* GetVehicleController(CVehicle* pVehicle);
     static bool  GetVehicleRotation(CVehicle* pVehicle, CVector& vecRotation);
@@ -400,7 +400,7 @@ public:
     static bool SetBlipVisibleDistance(CElement* pElement, unsigned short usVisibleDistance);
 
     // Object create/destroy functions
-    static CObject* CreateObject(CResource* pResource, unsigned short usModelID, const CVector& vecPosition, const CVector& vecRotation, bool bIsLowLod);
+    static CObject* CreateObject(CResource* pResource, uint32 usModelID, const CVector& vecPosition, const CVector& vecRotation, bool bIsLowLod);
 
     // Object get functions
     static bool GetObjectRotation(CObject* pObject, CVector& vecRotation);
@@ -636,8 +636,8 @@ public:
     static bool ResetWindVelocity();
     static bool ResetFarClipDistance();
     static bool ResetFogDistance();
-    static bool RemoveWorldModel(unsigned short usModel, float fRadius, const CVector& vecPosition, char cInterior);
-    static bool RestoreWorldModel(unsigned short usModel, float fRadius, const CVector& vecPosition, char cInterior);
+    static bool RemoveWorldModel(uint32 usModel, float fRadius, const CVector& vecPosition, char cInterior);
+    static bool RestoreWorldModel(uint32 usModel, float fRadius, const CVector& vecPosition, char cInterior);
     static bool RestoreAllWorldModels();
     static bool SendSyncIntervals(CPlayer* pPlayer = NULL);
     static bool SetMoonSize(int iMoonSize);

--- a/Server/mods/deathmatch/logic/CVehicle.cpp
+++ b/Server/mods/deathmatch/logic/CVehicle.cpp
@@ -13,7 +13,7 @@
 
 extern CGame* g_pGame;
 
-CVehicle::CVehicle(CVehicleManager* pVehicleManager, CElement* pParent, unsigned short usModel, unsigned char ucVariant, unsigned char ucVariant2)
+CVehicle::CVehicle(CVehicleManager* pVehicleManager, CElement* pParent, uint32 usModel, unsigned char ucVariant, unsigned char ucVariant2)
     : CElement(pParent)
 {
     CElementRefManager::AddElementRefs(ELEMENT_REF_DEBUG(this, "CVehicle"), &m_pTowedVehicle, &m_pTowedByVehicle, &m_pSyncer, &m_pJackingPed, NULL);
@@ -491,7 +491,7 @@ void CVehicle::SetRotationDegrees(const CVector& vecRotation)
     m_vecRotationDegrees = vecRotation;
 }
 
-void CVehicle::SetModel(unsigned short usModel)
+void CVehicle::SetModel(uint32 usModel)
 {
     if (usModel != m_usModel)
     {

--- a/Server/mods/deathmatch/logic/CVehicle.h
+++ b/Server/mods/deathmatch/logic/CVehicle.h
@@ -144,7 +144,7 @@ class CVehicle final : public CElement
 
 public:
     ZERO_ON_NEW
-    CVehicle(class CVehicleManager* pVehicleManager, CElement* pParent, unsigned short usModel, unsigned char ucVariant, unsigned char ucVariant2);
+    CVehicle(class CVehicleManager* pVehicleManager, CElement* pParent, uint32_t usModel, unsigned char ucVariant, unsigned char ucVariant2);
     ~CVehicle();
     CElement* Clone(bool* bAddEntity, CResource* pResource) override;
 
@@ -154,8 +154,8 @@ public:
 
     void DoPulse();
 
-    unsigned short GetModel() { return m_usModel; };
-    void           SetModel(unsigned short usModel);
+    uint32_t       GetModel() { return m_usModel; };
+    void           SetModel(uint32_t usModel);
     bool           HasValidModel();
 
     unsigned char GetVariant() { return m_ucVariant; };
@@ -357,7 +357,7 @@ private:
     CPlayer*                              m_pSyncer;
     SFixedArray<CPed*, MAX_VEHICLE_SEATS> m_pOccupants;
 
-    unsigned short m_usModel;
+    uint32_t       m_usModel;
     eVehicleType   m_eVehicleType;
     CVector        m_vecPosition;
     CVector        m_vecRotationDegrees;

--- a/Server/mods/deathmatch/logic/CVehicleColorManager.cpp
+++ b/Server/mods/deathmatch/logic/CVehicleColorManager.cpp
@@ -65,14 +65,14 @@ bool CVehicleColorManager::Load(const char* szFilename)
                 char* szColor4 = strtok(NULL, " ");
 
                 // Set the colors that exist
-                unsigned short usModel = 0;
+                uint32         usModel = 0;
                 unsigned char  ucColor1 = 0;
                 unsigned char  ucColor2 = 0;
                 unsigned char  ucColor3 = 0;
                 unsigned char  ucColor4 = 0;
                 if (szModel)
                 {
-                    usModel = static_cast<unsigned short>(atol(szModel));
+                    usModel = static_cast<uint32>(atol(szModel));
 
                     if (szColor1)
                     {
@@ -138,7 +138,7 @@ void CVehicleColorManager::Reset()
     }
 }
 
-void CVehicleColorManager::AddColor(unsigned short usModel, const CVehicleColor& colVehicle)
+void CVehicleColorManager::AddColor(uint32_t usModel, const CVehicleColor& colVehicle)
 {
     if (usModel >= 400 && usModel <= 611)
     {
@@ -146,7 +146,7 @@ void CVehicleColorManager::AddColor(unsigned short usModel, const CVehicleColor&
     }
 }
 
-CVehicleColor CVehicleColorManager::GetRandomColor(unsigned short usModel)
+CVehicleColor CVehicleColorManager::GetRandomColor(uint32_t usModel)
 {
     if (usModel >= 400 && usModel <= 611)
     {

--- a/Server/mods/deathmatch/logic/CVehicleColorManager.h
+++ b/Server/mods/deathmatch/logic/CVehicleColorManager.h
@@ -33,8 +33,8 @@ public:
     bool Generate(const char* szFilename);
     void Reset();
 
-    void          AddColor(unsigned short usModel, const CVehicleColor& colVehicle);
-    CVehicleColor GetRandomColor(unsigned short usModel);
+    void          AddColor(uint32_t usModel, const CVehicleColor& colVehicle);
+    CVehicleColor GetRandomColor(uint32_t usModel);
 
 private:
     SFixedArray<CVehicleColors, 212> m_Colors;

--- a/Server/mods/deathmatch/logic/CVehicleManager.cpp
+++ b/Server/mods/deathmatch/logic/CVehicleManager.cpp
@@ -375,7 +375,7 @@ CVehicleManager::~CVehicleManager()
     DeleteAll();
 }
 
-CVehicle* CVehicleManager::Create(CElement* pParent, unsigned short usModel, unsigned char ucVariant, unsigned char ucVariant2)
+CVehicle* CVehicleManager::Create(CElement* pParent, uint32_t usModel, unsigned char ucVariant, unsigned char ucVariant2)
 {
     CVehicle* const pVehicle = new CVehicle(this, pParent, usModel, ucVariant, ucVariant2);
 
@@ -423,7 +423,7 @@ bool CVehicleManager::IsValidModel(unsigned int ulVehicleModel)
     return ulVehicleModel >= 400 && ulVehicleModel <= 611;
 }
 
-eVehicleType CVehicleManager::GetVehicleType(unsigned short usModel)
+eVehicleType CVehicleManager::GetVehicleType(uint32_t usModel)
 {
     if (!IsValidModel(usModel))
         return VEHICLE_NONE;
@@ -446,7 +446,7 @@ unsigned int CVehicleManager::GetMaxPassengers(unsigned int uiVehicleModel)
     return 0xFF;
 }
 
-void CVehicleManager::GetRandomVariation(unsigned short usModel, unsigned char& ucVariant, unsigned char& ucVariant2)
+void CVehicleManager::GetRandomVariation(uint32_t usModel, unsigned char& ucVariant, unsigned char& ucVariant2)
 {
     RandomizeRandomSeed();
     ucVariant = 255;
@@ -529,7 +529,7 @@ bool CVehicleManager::IsTrailer(unsigned int uiVehicleModel)
     return (IsValidModel(uiVehicleModel) && (gs_vehicleTypes[uiVehicleModel - 400] == VEHICLE_TRAILER));
 }
 
-bool CVehicleManager::HasDamageModel(unsigned short usModel)
+bool CVehicleManager::HasDamageModel(uint32_t usModel)
 {
     return HasDamageModel(GetVehicleType(usModel));
 }
@@ -550,7 +550,7 @@ bool CVehicleManager::HasDamageModel(eVehicleType Type)
     }
 }
 
-bool CVehicleManager::HasDoors(unsigned short usModel)
+bool CVehicleManager::HasDoors(uint32_t usModel)
 {
     bool bHasDoors = false;
 
@@ -581,7 +581,7 @@ bool CVehicleManager::HasDoors(unsigned short usModel)
     return bHasDoors;
 }
 
-CVehicleColor CVehicleManager::GetRandomColor(unsigned short usModel)
+CVehicleColor CVehicleManager::GetRandomColor(uint32_t usModel)
 {
     return m_ColorManager.GetRandomColor(usModel);
 }

--- a/Server/mods/deathmatch/logic/CVehicleManager.h
+++ b/Server/mods/deathmatch/logic/CVehicleManager.h
@@ -30,14 +30,14 @@ public:
     CVehicleManager();
     ~CVehicleManager();
 
-    CVehicle* Create(CElement* pParent, unsigned short usModel, unsigned char ucVariant, unsigned char ucVariant2);
+    CVehicle* Create(CElement* pParent, uint32_t usModel, unsigned char ucVariant, unsigned char ucVariant2);
     CVehicle* CreateFromXML(CElement* pParent, CXMLNode& Node, CEvents* pEvents);
     void      DeleteAll();
 
     bool Exists(CVehicle* pVehicle);
 
     static bool         IsValidModel(unsigned int uiVehicleModel);
-    static eVehicleType GetVehicleType(unsigned short usModel);
+    static eVehicleType GetVehicleType(uint32_t usModel);
     static bool         IsValidUpgrade(unsigned short usUpgrade);
     static unsigned int GetMaxPassengers(unsigned int uiVehicleModel);
     static bool         HasTurret(unsigned int uiVehicleModel);
@@ -47,13 +47,13 @@ public:
     static bool         HasAdjustableProperty(unsigned int uiVehicleModel);
     static bool         HasSmokeTrail(unsigned int uiVehicleModel);
     static bool         IsTrailer(unsigned int uiVehicleModel);
-    static bool         HasDamageModel(unsigned short usModel);
+    static bool         HasDamageModel(uint32_t usModel);
     static bool         HasDamageModel(eVehicleType Type);
-    static bool         HasDoors(unsigned short usModel);
-    static void         GetRandomVariation(unsigned short usModel, unsigned char& ucVariant, unsigned char& ucVariant2);
+    static bool         HasDoors(uint32_t usModel);
+    static void         GetRandomVariation(uint32_t usModel, unsigned char& ucVariant, unsigned char& ucVariant2);
 
     CVehicleColorManager* GetColorManager() { return &m_ColorManager; }
-    CVehicleColor         GetRandomColor(unsigned short usModel);
+    CVehicleColor         GetRandomColor(uint32_t usModel);
 
     void GetVehiclesOfType(unsigned int uiModel, lua_State* luaVM);
 

--- a/Server/mods/deathmatch/logic/CVehicleUpgrades.cpp
+++ b/Server/mods/deathmatch/logic/CVehicleUpgrades.cpp
@@ -68,7 +68,7 @@ bool CVehicleUpgrades::IsUpgradeCompatible(unsigned short usUpgrade)
     if (vehicleType == VEHICLE_BIKE || vehicleType == VEHICLE_BMX || vehicleType == VEHICLE_HELI)
         return false;
 
-    unsigned short usModel = m_pVehicle->GetModel();
+    uint32 usModel = m_pVehicle->GetModel();
     // Wheels should be compatible with any vehicle which have wheels, except
     // bike/bmx (they're buggy). Vortex is technically a car, but it has no
     // wheels.

--- a/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -1364,7 +1364,7 @@ int CLuaElementDefs::getElementModel(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        unsigned short usModel;
+        uint32 usModel;
         if (CStaticFunctionDefinitions::GetElementModel(pElement, usModel))
         {
             lua_pushnumber(luaVM, usModel);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaHandlingDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaHandlingDefs.cpp
@@ -210,7 +210,7 @@ int CLuaHandlingDefs::SetVehicleHandling(lua_State* luaVM)
 int CLuaHandlingDefs::SetModelHandling(lua_State* luaVM)
 {
     //  bool setModelHandling ( int modelId, [ string property, var value ] )
-    unsigned short usModel;
+    uint32 usModel;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadNumber(usModel);
@@ -552,7 +552,7 @@ int CLuaHandlingDefs::GetVehicleHandling(lua_State* luaVM)
 int CLuaHandlingDefs::GetModelHandling(lua_State* luaVM)
 {
     //  table getModelHandling ( int modelId )
-    unsigned short usModel;
+    uint32 usModel;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadNumber(usModel);
@@ -725,7 +725,7 @@ int CLuaHandlingDefs::GetModelHandling(lua_State* luaVM)
 int CLuaHandlingDefs::GetOriginalHandling(lua_State* luaVM)
 {
     //  table getOriginalHandling ( int modelID )
-    unsigned short usModel;
+    uint32 usModel;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadNumber(usModel);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
@@ -52,7 +52,7 @@ void CLuaObjectDefs::AddClass(lua_State* luaVM)
 int CLuaObjectDefs::CreateObject(lua_State* luaVM)
 {
     //  object createObject ( int modelid, float x, float y, float z, [float rx, float ry, float rz, bool lowLOD] )
-    ushort  usModelID;
+    uint32  usModelID;
     CVector vecPosition;
     CVector vecRotation;
     bool    bIsLowLod;

--- a/Server/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -191,7 +191,7 @@ int CLuaPedDefs::GetValidPedModels(lua_State* luaVM)
 
 int CLuaPedDefs::CreatePed(lua_State* luaVM)
 {
-    unsigned short usModel;
+    uint32         usModel;
     CVector        vecPosition;
     float          fRotation;
     bool           bSynced;

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -466,7 +466,7 @@ int CLuaVehicleDefs::GetVehicleModelFromName(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        unsigned short usModel;
+        uint32 usModel;
         if (CStaticFunctionDefinitions::GetVehicleModelFromName(strName, usModel))
         {
             lua_pushnumber(luaVM, static_cast<lua_Number>(usModel));
@@ -823,7 +823,7 @@ int CLuaVehicleDefs::GetVehicleName(lua_State* luaVM)
 
 int CLuaVehicleDefs::GetVehicleNameFromModel(lua_State* luaVM)
 {
-    unsigned short usModel;
+    uint32 usModel;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadNumber(usModel);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaWorldDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaWorldDefs.cpp
@@ -1061,7 +1061,7 @@ int CLuaWorldDefs::RemoveWorldModel(lua_State* luaVM)
 {
     CScriptArgReader argStream(luaVM);
 
-    unsigned short usModel = 0;
+    uint32         usModel = 0;
     float          fRadius = 0.0f;
     char           cInterior = -1;
     CVector        vecPosition;
@@ -1088,7 +1088,7 @@ int CLuaWorldDefs::RestoreWorldModel(lua_State* luaVM)
 {
     CScriptArgReader argStream(luaVM);
 
-    unsigned short usModel = 0;
+    uint32         usModel = 0;
     float          fRadius = 0.0f;
     char           cInterior = -1;
     CVector        vecPosition;

--- a/Server/mods/deathmatch/logic/packets/CEntityAddPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CEntityAddPacket.cpp
@@ -472,7 +472,7 @@ bool CEntityAddPacket::Write(NetBitStreamInterface& BitStream) const
                     BitStream.Write(ucVariant2);
 
                     // If the vehicle has a turret, send its position too
-                    unsigned short usModel = pVehicle->GetModel();
+                    uint32 usModel = pVehicle->GetModel();
                     if (CVehicleManager::HasTurret(usModel))
                     {
                         SVehicleTurretSync specific;

--- a/Server/mods/deathmatch/logic/packets/CEntityAddPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CEntityAddPacket.cpp
@@ -206,7 +206,7 @@ bool CEntityAddPacket::Write(NetBitStreamInterface& BitStream) const
                     BitStream.Write(&rotationRadians);
 
                     // Object id
-                    BitStream.WriteCompressed(pObject->GetModel());
+                    BitStream.WriteCompressed((uint16_t)pObject->GetModel());
 
                     // Alpha
                     SEntityAlphaSync alpha;

--- a/Server/mods/deathmatch/logic/packets/CKeysyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CKeysyncPacket.cpp
@@ -252,7 +252,7 @@ bool CKeysyncPacket::Write(NetBitStreamInterface& BitStream) const
 void CKeysyncPacket::ReadVehicleSpecific(CVehicle* pVehicle, NetBitStreamInterface& BitStream)
 {
     // Turret states
-    unsigned short usModel = pVehicle->GetModel();
+    uint32 usModel = pVehicle->GetModel();
     if (CVehicleManager::HasTurret(usModel))
     {
         // Read out the turret position
@@ -267,7 +267,7 @@ void CKeysyncPacket::ReadVehicleSpecific(CVehicle* pVehicle, NetBitStreamInterfa
 void CKeysyncPacket::WriteVehicleSpecific(CVehicle* pVehicle, NetBitStreamInterface& BitStream) const
 {
     // Turret states
-    unsigned short usModel = pVehicle->GetModel();
+    uint32 usModel = pVehicle->GetModel();
     if (CVehicleManager::HasTurret(usModel))
     {
         // Grab the turret position

--- a/Server/mods/deathmatch/logic/packets/CMapInfoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CMapInfoPacket.cpp
@@ -325,12 +325,15 @@ bool CMapInfoPacket::Write(NetBitStreamInterface& BitStream) const
         }
     }
 
-    multimap<unsigned short, CBuildingRemoval*>::const_iterator iter = g_pGame->GetBuildingRemovalManager()->IterBegin();
+    multimap<uint32, CBuildingRemoval*>::const_iterator iter = g_pGame->GetBuildingRemovalManager()->IterBegin();
     for (; iter != g_pGame->GetBuildingRemovalManager()->IterEnd(); ++iter)
     {
         CBuildingRemoval* pBuildingRemoval = (*iter).second;
         BitStream.WriteBit(true);
-        BitStream.Write(pBuildingRemoval->GetModel());
+
+        uint16 usModelId = pBuildingRemoval->GetModel();
+        BitStream.Write(usModelId);
+
         BitStream.Write(pBuildingRemoval->GetRadius());
         BitStream.Write(pBuildingRemoval->GetPosition().fX);
         BitStream.Write(pBuildingRemoval->GetPosition().fY);

--- a/Server/mods/deathmatch/logic/packets/CMapInfoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CMapInfoPacket.cpp
@@ -331,8 +331,8 @@ bool CMapInfoPacket::Write(NetBitStreamInterface& BitStream) const
         CBuildingRemoval* pBuildingRemoval = (*iter).second;
         BitStream.WriteBit(true);
 
-        uint16 usModelId = pBuildingRemoval->GetModel();
-        BitStream.Write(usModelId);
+        uint32 usModelId = pBuildingRemoval->GetModel();
+        BitStream.Write((uint16)usModelId);
 
         BitStream.Write(pBuildingRemoval->GetRadius());
         BitStream.Write(pBuildingRemoval->GetPosition().fX);

--- a/Server/mods/deathmatch/logic/packets/CPlayerListPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerListPacket.cpp
@@ -167,7 +167,7 @@ bool CPlayerListPacket::Write(NetBitStreamInterface& BitStream) const
         if (true)
         {
             // Player model ID
-            BitStream.WriteCompressed(pPlayer->GetModel());
+            BitStream.WriteCompressed((uint16)pPlayer->GetModel());
 
             // Team id
             CTeam* pTeam = pPlayer->GetTeam();

--- a/Server/mods/deathmatch/logic/packets/CProjectileSyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CProjectileSyncPacket.cpp
@@ -38,8 +38,12 @@ bool CProjectileSyncPacket::Read(NetBitStreamInterface& BitStream)
 
     if (BitStream.Version() >= 0x4F)
     {
-        if (!BitStream.Read(m_usModel))
+        uint16 usModel;
+
+        if (!BitStream.Read(usModel))
             return false;
+
+        m_usModel = usModel;
     }
 
     switch (m_ucWeaponType)
@@ -126,7 +130,7 @@ bool CProjectileSyncPacket::Write(NetBitStreamInterface& BitStream) const
 
     if (BitStream.Version() >= 0x4F)
     {
-        BitStream.Write(m_usModel);
+        BitStream.Write((uint16_t)m_usModel);
     }
 
     switch (m_ucWeaponType)

--- a/Server/mods/deathmatch/logic/packets/CProjectileSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CProjectileSyncPacket.h
@@ -34,5 +34,5 @@ public:
     CVector        m_vecTarget;
     CVector        m_vecRotation;
     CVector        m_vecMoveSpeed;
-    unsigned short m_usModel;
+    uint32         m_usModel;
 };

--- a/Server/mods/deathmatch/logic/packets/CVehiclePuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CVehiclePuresyncPacket.cpp
@@ -679,7 +679,7 @@ bool CVehiclePuresyncPacket::Write(NetBitStreamInterface& BitStream) const
 void CVehiclePuresyncPacket::ReadVehicleSpecific(CVehicle* pVehicle, NetBitStreamInterface& BitStream, int iRemoteModel)
 {
     // Turret data
-    unsigned short usModel = pVehicle->GetModel();
+    uint32 usModel = pVehicle->GetModel();
     if (CVehicleManager::HasTurret(iRemoteModel))
     {
         // Read out the turret position
@@ -721,7 +721,7 @@ void CVehiclePuresyncPacket::ReadVehicleSpecific(CVehicle* pVehicle, NetBitStrea
 void CVehiclePuresyncPacket::WriteVehicleSpecific(CVehicle* pVehicle, NetBitStreamInterface& BitStream) const
 {
     // Turret states
-    unsigned short usModel = pVehicle->GetModel();
+    uint32 usModel = pVehicle->GetModel();
     if (CVehicleManager::HasTurret(usModel))
     {
         SVehicleTurretSync vehicle;


### PR DESCRIPTION
This changes file IDs, model IDs and TXD IDs inside the MTA code from 16-bit to 32-bit.
Prepares the MTA for the future to handle the game, which may be heavily modified.

Net protocol (BitStream related) is still kept unchanged. 16-bit IDs in the net protocol still stay 16-bit for the time being.
Altering the net functionality would require more planning and that's something to leave for the future.

Everything done properly and accurately with an understanding of existing code.