### PR TITLE
Re-introduce "Random collisionless objects" fix

### DIFF
--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -1273,7 +1273,6 @@ void CModelInfoSA::SetColModel(CColModel* pColModel)
 
         // FUNC_SetColModel resets bDoWeOwnTheColModel
         m_pInterface->bDoWeOwnTheColModel = false;
-        m_pInterface->bCollisionWasStreamedWithModel = false;
 
         // public: static void __cdecl CColAccel::addCacheCol(int, class CColModel const &)
         DWORD func = 0x5B2C20;
@@ -1328,6 +1327,8 @@ void CModelInfoSA::RestoreColModel()
                 push    dwOriginalColModelInterface
                 call    dwFunc
             }
+
+            m_pInterface->bDoWeOwnTheColModel = false;
 
             // public: static void __cdecl CColAccel::addCacheCol(int, class CColModel const &)
             DWORD func = 0x5B2C20;


### PR DESCRIPTION
This reverts commit 04b9dd33ed764fa6966a5571ad89b20067949b03, re-introducing the fix for collisionless objects (issue #927).

It's the right time to put it back, because nightlies are stable again and this fix clearly wasn't at fault for the crashes the revert intended to fix. See below to confirm that:

> 
> 
> Can we revert [b6cf87a](https://github.com/multitheftauto/mtasa-blue/commit/b6cf87a10edc067119508fb263ea612acc46c964) if [de6b51b](https://github.com/multitheftauto/mtasa-blue/commit/de6b51b6c3fa6d02a89f9ccba1d5f54311c7be8a) is not reason for latest crashes?

Not yet, we need to wait for a few days at least.

_Originally posted by @saml1er in https://github.com/multitheftauto/mtasa-blue/issues/927#issuecomment-733739778_