### PR TITLE
std::monostate support in new parser

### DIFF
--- a/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
@@ -87,6 +87,8 @@ struct CLuaFunctionParserBase
             return GetClassTypeName((T)0);
         else if constexpr (std::is_same_v<T, dummy_type>)
             return "";
+        else if constexpr (std::is_same_v<T, std::monostate>)
+            return "";
     }
 
     // Reads the parameter type (& value in some cases) at a given index
@@ -278,6 +280,10 @@ struct CLuaFunctionParserBase
         // dummy type is used as overload extension if one overload has fewer arguments
         // thus it is only allowed if there are no further args on the Lua side
         if constexpr (std::is_same_v<T, dummy_type>)
+            return iArgument == LUA_TNONE;
+
+        // no value
+        if constexpr (std::is_same_v<T, std::monostate>)
             return iArgument == LUA_TNONE;
     }
 
@@ -614,6 +620,10 @@ struct CLuaFunctionParserBase
             CLuaArgument argument;
             argument.Read(L, index++);
             return argument;
+        }
+        else if constexpr (std::is_same_v<T, std::monostate>)
+        {
+            return T{};
         }
     }
 };


### PR DESCRIPTION
it let you use std::monostate as an equivalent of no value. Useful for std::optional<std::variant<>> combo.

```cpp
bool CYourDefs::MonoTest(std::variant<std::monostate, float, bool> var)
{
    return var.index() > 0;
}
```
with definition like above, following syntax will valid:
```lua
monoTest()
monoTest(12.3)
monoTest(true)
```
returns true if value is given

https://en.cppreference.com/w/cpp/utility/variant/monostate