### PR TITLE
Fix crash related to texture loading

### DIFF
--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -776,7 +776,7 @@ void CModelInfoSA::StaticFlushPendingRestreamIPL()
     for (it = removedModels.begin(); it != removedModels.end(); it++)
     {
         ((void(__cdecl*)(unsigned short))FUNC_RemoveModel)(*it);
-        MemPut<BYTE>((char*)CStreaming__ms_aInfoForModel + 20 * (*it), 0);
+        pGame->GetStreaming()->GetStreamingInfoFromModelId(*it)->loadState = 0;
     }
 }
 


### PR DESCRIPTION
Related to `engineLoadTXD` and `createObject` at server