### PR TITLE
Store bindable key states to fix getKeyState

### DIFF
--- a/Client/core/CKeyBinds.cpp
+++ b/Client/core/CKeyBinds.cpp
@@ -255,8 +255,24 @@ const SDefaultCommandBind g_dcbDefaultCommands[] = {{"g", true, "enter_passenger
 
                                                     {"", false, NULL, NULL}};
 
+static bool bindableKeyStates[std::size(g_bkKeys)];
+
 // HACK: our current shift key states
 bool bPreLeftShift = false, bPreRightShift = false;
+
+enum eBindableKeys
+{
+    BK_MOUSE_WHEEL_UP = 5,
+    BK_MOUSE_WHEEL_DOWN = 6,
+};
+
+static bool& GetBindableKeyState(const SBindableKey* key)
+{
+    intptr_t base = reinterpret_cast<intptr_t>(&g_bkKeys[0]);
+    intptr_t offset = reinterpret_cast<intptr_t>(key);
+    size_t index = (offset - base) / sizeof(SBindableKey);
+    return bindableKeyStates[index];
+}
 
 // Ensure zero length strings are NULL
 static void NullEmptyStrings(const char*& a, const char*& b = *(const char**)NULL, const char*& c = *(const char**)NULL, const char*& d = *(const char**)NULL,
@@ -319,6 +335,18 @@ bool CKeyBinds::ProcessMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPara
     return false;
 }
 
+void CKeyBinds::OnLoseFocus()
+{
+    for (size_t i = 0; i < std::size(bindableKeyStates); ++i)
+    {
+        if (bindableKeyStates[i] == true)
+        {
+            const SBindableKey* key = &g_bkKeys[i];
+            ProcessKeyStroke(key, false);
+        }
+    }
+}
+
 bool CKeyBinds::ProcessCharacter(WPARAM wChar)
 {
     if (m_CharacterKeyHandler && m_CharacterKeyHandler(wChar))
@@ -349,7 +377,7 @@ bool CKeyBinds::ProcessKeyStroke(const SBindableKey* pKey, bool bState)
     if (m_pCore->IsCursorForcedVisible())
     {
         if (!bIsCursorForced)
-        {
+        {   
             if (m_pCore->IsCursorControlsToggled())
             {
                 SetAllControls(false);
@@ -368,7 +396,15 @@ bool CKeyBinds::ProcessKeyStroke(const SBindableKey* pKey, bool bState)
     if ((pKey->ulCode >= VK_F1 && pKey->ulCode <= VK_F12) || (pKey->ulCode <= VK_MBUTTON))
         bIsConsoleInputKey = false;
 
+    bool& keyState = GetBindableKeyState(pKey);
+
+    if (!bState || bState && !bInputGoesToGUI)
+        keyState = bState;
+
     bool bAllowed = TriggerKeyStrokeHandler(pKey->szKey, bState, bIsConsoleInputKey);
+
+    if (bState && !bAllowed)
+        keyState = false;
 
     // Search through binds
     bool                            bFound = false;
@@ -1781,18 +1817,19 @@ bool CKeyBinds::ControlFunctionExists(SBindableGTAControl* pControl, ControlFunc
     return false;
 }
 
-const SBindableKey* CKeyBinds::GetBindableFromKey(const char* szKey)
+const SBindableKey* CKeyBinds::GetBindableFromKey(const char* szKey) const
 {
-    for (int i = 0; *g_bkKeys[i].szKey != NULL; i++)
+    for (int i = 0; *g_bkKeys[i].szKey != 0; i++)
     {
         const SBindableKey* temp = &g_bkKeys[i];
+
         if (!stricmp(temp->szKey, szKey))
         {
             return temp;
         }
     }
 
-    return NULL;
+    return nullptr;
 }
 
 SBindableGTAControl* CKeyBinds::GetBindableFromAction(eControllerAction action)
@@ -1913,6 +1950,17 @@ const SBindableKey* CKeyBinds::GetBindableFromMessage(UINT uMsg, WPARAM wParam, 
         }
     }
     return NULL;
+}
+
+bool CKeyBinds::GetKeyStateByName(const char* keyName, bool& state) const
+{
+    if (const SBindableKey* key = GetBindableFromKey(keyName); key != nullptr)
+    {
+        state = GetBindableKeyState(key);
+        return true;
+    }
+    
+    return false;
 }
 
 SBindableGTAControl* CKeyBinds::GetBindableFromControl(const char* szControl)
@@ -2299,6 +2347,10 @@ void CKeyBinds::DoPostFramePulse()
                 }
             }
         }
+
+        bindableKeyStates[BK_MOUSE_WHEEL_UP] = false;
+        bindableKeyStates[BK_MOUSE_WHEEL_DOWN] = false;
+        
         m_bMouseWheel = false;
     }
 }

--- a/Client/core/CKeyBinds.h
+++ b/Client/core/CKeyBinds.h
@@ -35,6 +35,7 @@ public:
     ~CKeyBinds();
 
     bool ProcessMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+    void OnLoseFocus() override;
 
 protected:
     bool ProcessCharacter(WPARAM wChar);
@@ -116,12 +117,14 @@ public:
     bool ControlFunctionExists(SBindableGTAControl* pControl, ControlFunctionBindHandler Handler, bool bCheckState = false, bool bState = true);
 
     // Key/code funcs
-    const SBindableKey* GetBindableFromKey(const char* szKey);
+    const SBindableKey* GetBindableFromKey(const char* szKey) override { return reinterpret_cast<const CKeyBinds*>(this)->GetBindableFromKey(szKey); }
+    const SBindableKey* GetBindableFromKey(const char* szKey) const override;
     const SBindableKey* GetBindableFromGTARelative(int iGTAKey);
     bool                IsKey(const char* szKey);
     const SBindableKey* GetBindableFromMessage(UINT uMsg, WPARAM wParam, LPARAM lParam, bool& bState);
     void                SetKeyStrokeHandler(KeyStrokeHandler Handler) { m_KeyStrokeHandler = Handler; }
     void                SetCharacterKeyHandler(CharacterKeyHandler Handler) { m_CharacterKeyHandler = Handler; }
+    bool                GetKeyStateByName(const char* keyName, bool& state) const override;
 
     // Control/action funcs
     SBindableGTAControl* GetBindableFromControl(const char* szControl);

--- a/Client/core/CMessageLoopHook.cpp
+++ b/Client/core/CMessageLoopHook.cpp
@@ -131,6 +131,7 @@ LRESULT CALLBACK CMessageLoopHook::ProcessMessage(HWND hwnd, UINT uMsg, WPARAM w
         if (uMsg == WM_ACTIVATE && LOWORD(wParam) == WA_INACTIVE)
         {
             GetVideoModeManager()->OnLoseFocus();
+            g_pCore->GetKeyBinds()->OnLoseFocus();
         }
         if (uMsg == WM_PAINT)
         {

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -6999,21 +6999,10 @@ bool CStaticFunctionDefinitions::UnbindKey(const char* szKey, const char* szHitS
 
 bool CStaticFunctionDefinitions::GetKeyState(const char* szKey, bool& bState)
 {
-    assert(szKey);
+    if (szKey == nullptr || !g_pCore->IsFocused())
+        return false;
 
-    CKeyBindsInterface* pKeyBinds = g_pCore->GetKeyBinds();
-    const SBindableKey* pKey = pKeyBinds->GetBindableFromKey(szKey);
-    if (pKey)
-    {
-        if (g_pCore->IsFocused())
-        {
-            bState = (::GetKeyState(pKey->ulCode) & 0x8000) ? true : false;
-
-            return true;
-        }
-    }
-
-    return false;
+    return g_pCore->GetKeyBinds()->GetKeyStateByName(szKey, bState);
 }
 
 bool CStaticFunctionDefinitions::GetControlState(const char* szControl, bool& bState)

--- a/Client/sdk/core/CKeyBindsInterface.h
+++ b/Client/sdk/core/CKeyBindsInterface.h
@@ -147,6 +147,7 @@ class CKeyBindsInterface
 {
 public:
     virtual bool ProcessMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) = 0;
+    virtual void OnLoseFocus() = 0;
 
     // Basic funcs
     virtual void Add(CKeyBind* pKeyBind) = 0;
@@ -213,11 +214,13 @@ public:
 
     // Key/code funcs
     virtual const SBindableKey* GetBindableFromKey(const char* szKey) = 0;
+    virtual const SBindableKey* GetBindableFromKey(const char* szKey) const = 0;
     virtual const SBindableKey* GetBindableFromGTARelative(int iGTAKey) = 0;
     virtual bool                IsKey(const char* szKey) = 0;
     virtual const SBindableKey* GetBindableFromMessage(UINT uMsg, WPARAM wParam, LPARAM lParam, bool& bState) = 0;
     virtual void                SetKeyStrokeHandler(KeyStrokeHandler Handler) = 0;
     virtual void                SetCharacterKeyHandler(CharacterKeyHandler Handler) = 0;
+    virtual bool                GetKeyStateByName(const char* keyName, bool& state) const = 0;
 
     // Control/action funcs
     virtual SBindableGTAControl* GetBindableFromControl(const char* szControl) = 0;


### PR DESCRIPTION
Fixes issue #1940 **getKeyState not working for gamepad buttons**

Key state is not stored if any other GUI element or similiar has focus (like main menu, chatbox).

This pull request also resets key state on window-focus loss (ALT-TAB or minimized) - for example, if you hold **mouse1** then you will also receive the **onClientKey** event for key release on ALT-TAB.
This *might* break clientside resource scripts.