### PR TITLE
Add transfer box customization

### DIFF
--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -351,6 +351,7 @@ void CClientVariables::LoadDefaults()
     DEFAULT("browser_remote_javascript", true);                                       // Execute javascript on remote websites?
     DEFAULT("filter_duplicate_log_lines", true);                                      // Filter duplicate log lines for debug view and clientscript.log
     DEFAULT("discord_rich_presence", true);                                           // Enable Discord Game SDK
+    DEFAULT("always_show_transferbox", false);                                        // Should the transfer box always be visible for downloads? (and ignore scripted control)
     DEFAULT("_beta_qc_rightclick_command", _S("reconnect"));                          // Command to run when right clicking quick connect (beta - can be removed at any time)
 
     if (!Exists("locale"))

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -381,6 +381,11 @@ void CSettings::CreateGUI()
     m_pCheckBoxAllowExternalSounds->GetPosition(vecTemp, false);
     m_pCheckBoxAllowExternalSounds->AutoSize(NULL, 20.0f);
 
+    m_pCheckBoxAlwaysShowTransferBox = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabMultiplayer, _("Always show download window"), false));
+    m_pCheckBoxAlwaysShowTransferBox->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 20.0f));
+    m_pCheckBoxAlwaysShowTransferBox->GetPosition(vecTemp, false);
+    m_pCheckBoxAlwaysShowTransferBox->AutoSize(NULL, 20.0f);
+
     m_pCheckBoxCustomizedSAFiles = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabMultiplayer, _("Use customized GTA:SA files"), true));
     m_pCheckBoxCustomizedSAFiles->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 20.0f));
     m_pCheckBoxCustomizedSAFiles->GetPosition(vecTemp, false);
@@ -1219,6 +1224,7 @@ void CSettings::CreateGUI()
     m_pCheckBoxVolumetricShadows->SetClickHandler(GUI_CALLBACK(&CSettings::OnVolumetricShadowsClick, this));
     m_pCheckBoxAllowScreenUpload->SetClickHandler(GUI_CALLBACK(&CSettings::OnAllowScreenUploadClick, this));
     m_pCheckBoxAllowExternalSounds->SetClickHandler(GUI_CALLBACK(&CSettings::OnAllowExternalSoundsClick, this));
+    m_pCheckBoxAlwaysShowTransferBox->SetClickHandler(GUI_CALLBACK(&CSettings::OnAlwaysShowTransferBoxClick, this));
     m_pCheckBoxCustomizedSAFiles->SetClickHandler(GUI_CALLBACK(&CSettings::OnCustomizedSAFilesClick, this));
     m_pCheckBoxWindowed->SetClickHandler(GUI_CALLBACK(&CSettings::OnWindowedClick, this));
     m_pCheckBoxDPIAware->SetClickHandler(GUI_CALLBACK(&CSettings::OnDPIAwareClick, this));
@@ -1506,20 +1512,6 @@ void CSettings::UpdateVideoTab()
     bool bShowUnsafeResolutions;
     CVARS_GET("show_unsafe_resolutions", bShowUnsafeResolutions);
     m_pCheckBoxShowUnsafeResolutions->SetSelected(bShowUnsafeResolutions);
-
-    // Allow screen upload
-    bool bAllowScreenUploadEnabled;
-    CVARS_GET("allow_screen_upload", bAllowScreenUploadEnabled);
-    m_pCheckBoxAllowScreenUpload->SetSelected(bAllowScreenUploadEnabled);
-
-    // Allow external sounds
-    bool bAllowExternalSoundsEnabled;
-    CVARS_GET("allow_external_sounds", bAllowExternalSoundsEnabled);
-    m_pCheckBoxAllowExternalSounds->SetSelected(bAllowExternalSoundsEnabled);
-
-    // Customized sa files
-    m_pCheckBoxCustomizedSAFiles->SetSelected(GetApplicationSettingInt("customized-sa-files-request") != 0);
-    m_pCheckBoxCustomizedSAFiles->SetVisible(GetApplicationSettingInt("customized-sa-files-show") != 0);
 
     // Grass
     bool bGrassEnabled;
@@ -2931,6 +2923,25 @@ void CSettings::LoadData()
     CVARS_GET("auto_refresh_browser", bVar);
     m_pAutoRefreshBrowser->SetSelected(bVar);
 
+    // Allow screen upload
+    bool bAllowScreenUploadEnabled;
+    CVARS_GET("allow_screen_upload", bAllowScreenUploadEnabled);
+    m_pCheckBoxAllowScreenUpload->SetSelected(bAllowScreenUploadEnabled);
+
+    // Allow external sounds
+    bool bAllowExternalSoundsEnabled;
+    CVARS_GET("allow_external_sounds", bAllowExternalSoundsEnabled);
+    m_pCheckBoxAllowExternalSounds->SetSelected(bAllowExternalSoundsEnabled);
+
+    // Always show transfer box
+    bool alwaysShowTransferBox = false;
+    CVARS_GET("always_show_transferbox", alwaysShowTransferBox);
+    m_pCheckBoxAlwaysShowTransferBox->SetSelected(alwaysShowTransferBox);
+
+    // Customized sa files
+    m_pCheckBoxCustomizedSAFiles->SetSelected(GetApplicationSettingInt("customized-sa-files-request") != 0);
+    m_pCheckBoxCustomizedSAFiles->SetVisible(GetApplicationSettingInt("customized-sa-files-show") != 0);
+
     // Controls
     CVARS_GET("invert_mouse", bVar);
     m_pInvertMouse->SetSelected(bVar);
@@ -3347,6 +3358,9 @@ void CSettings::SaveData()
     // Allow external sounds
     bool bAllowExternalSoundsEnabled = m_pCheckBoxAllowExternalSounds->GetSelected();
     CVARS_SET("allow_external_sounds", bAllowExternalSoundsEnabled);
+
+    // Always show transfer box
+    CVARS_SET("always_show_transferbox", m_pCheckBoxAlwaysShowTransferBox->GetSelected());
 
     // Grass
     bool bGrassEnabled = m_pCheckBoxGrass->GetSelected();
@@ -4366,6 +4380,14 @@ bool CSettings::OnAllowExternalSoundsClick(CGUIElement* pElement)
               "\nbandwidth consumption.\n");
         CCore::GetSingleton().ShowMessageBox(_("EXTERNAL SOUNDS"), strMessage, MB_BUTTON_OK | MB_ICON_INFO);
     }
+    return true;
+}
+
+//
+// Always show transfer box
+//
+bool CSettings::OnAlwaysShowTransferBoxClick(CGUIElement* pElement)
+{
     return true;
 }
 

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -1224,7 +1224,6 @@ void CSettings::CreateGUI()
     m_pCheckBoxVolumetricShadows->SetClickHandler(GUI_CALLBACK(&CSettings::OnVolumetricShadowsClick, this));
     m_pCheckBoxAllowScreenUpload->SetClickHandler(GUI_CALLBACK(&CSettings::OnAllowScreenUploadClick, this));
     m_pCheckBoxAllowExternalSounds->SetClickHandler(GUI_CALLBACK(&CSettings::OnAllowExternalSoundsClick, this));
-    m_pCheckBoxAlwaysShowTransferBox->SetClickHandler(GUI_CALLBACK(&CSettings::OnAlwaysShowTransferBoxClick, this));
     m_pCheckBoxCustomizedSAFiles->SetClickHandler(GUI_CALLBACK(&CSettings::OnCustomizedSAFilesClick, this));
     m_pCheckBoxWindowed->SetClickHandler(GUI_CALLBACK(&CSettings::OnWindowedClick, this));
     m_pCheckBoxDPIAware->SetClickHandler(GUI_CALLBACK(&CSettings::OnDPIAwareClick, this));
@@ -4380,14 +4379,6 @@ bool CSettings::OnAllowExternalSoundsClick(CGUIElement* pElement)
               "\nbandwidth consumption.\n");
         CCore::GetSingleton().ShowMessageBox(_("EXTERNAL SOUNDS"), strMessage, MB_BUTTON_OK | MB_ICON_INFO);
     }
-    return true;
-}
-
-//
-// Always show transfer box
-//
-bool CSettings::OnAlwaysShowTransferBoxClick(CGUIElement* pElement)
-{
     return true;
 }
 

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -384,7 +384,7 @@ void CSettings::CreateGUI()
     m_pCheckBoxAlwaysShowTransferBox = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabMultiplayer, _("Always show download window"), false));
     m_pCheckBoxAlwaysShowTransferBox->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 20.0f));
     m_pCheckBoxAlwaysShowTransferBox->GetPosition(vecTemp, false);
-    m_pCheckBoxAlwaysShowTransferBox->AutoSize(NULL, 20.0f);
+    m_pCheckBoxAlwaysShowTransferBox->AutoSize(nullptr, 20.0f);
 
     m_pCheckBoxCustomizedSAFiles = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabMultiplayer, _("Use customized GTA:SA files"), true));
     m_pCheckBoxCustomizedSAFiles->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 20.0f));

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -380,7 +380,6 @@ protected:
     bool OnVolumetricShadowsClick(CGUIElement* pElement);
     bool OnAllowScreenUploadClick(CGUIElement* pElement);
     bool OnAllowExternalSoundsClick(CGUIElement* pElement);
-    bool OnAlwaysShowTransferBoxClick(CGUIElement* pElement);
     bool OnCustomizedSAFilesClick(CGUIElement* pElement);
     bool ShowUnsafeResolutionsClick(CGUIElement* pElement);
     bool OnWindowedClick(CGUIElement* pElement);

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -154,6 +154,7 @@ protected:
     CGUICheckBox*  m_pCheckBoxAllowScreenUpload;
     CGUICheckBox*  m_pCheckBoxAllowExternalSounds;
     CGUICheckBox*  m_pCheckBoxCustomizedSAFiles;
+    CGUICheckBox*  m_pCheckBoxAlwaysShowTransferBox;
     CGUICheckBox*  m_pCheckBoxGrass;
     CGUICheckBox*  m_pCheckBoxHeatHaze;
     CGUICheckBox*  m_pCheckBoxTyreSmokeParticles;
@@ -379,6 +380,7 @@ protected:
     bool OnVolumetricShadowsClick(CGUIElement* pElement);
     bool OnAllowScreenUploadClick(CGUIElement* pElement);
     bool OnAllowExternalSoundsClick(CGUIElement* pElement);
+    bool OnAlwaysShowTransferBoxClick(CGUIElement* pElement);
     bool OnCustomizedSAFilesClick(CGUIElement* pElement);
     bool ShowUnsafeResolutionsClick(CGUIElement* pElement);
     bool OnWindowedClick(CGUIElement* pElement);

--- a/Client/gui/CGUI_Impl.cpp
+++ b/Client/gui/CGUI_Impl.cpp
@@ -148,9 +148,6 @@ void CGUI_Impl::SetSkin(const char* szName)
 
     // Disallow input routing to the GUI unless edit box has focus
     m_eInputMode = INPUTMODE_NO_BINDS_ON_EDIT;
-
-    // The transfer box is not visible by default
-    m_bTransferBoxVisible = false;
 }
 
 void CGUI_Impl::SetBidiEnabled(bool bEnabled)

--- a/Client/gui/CGUI_Impl.h
+++ b/Client/gui/CGUI_Impl.h
@@ -255,9 +255,6 @@ public:
     void ClearInputHandlers(eInputChannel channel);
     void ClearSystemKeys();
 
-    bool IsTransferBoxVisible() { return m_bTransferBoxVisible; };
-    void SetTransferBoxVisible(bool bVisible) { m_bTransferBoxVisible = bVisible; };
-
     bool Event_CharacterKey(const CEGUI::EventArgs& e);
     bool Event_KeyDown(const CEGUI::EventArgs& e);
     bool Event_MouseClick(const CEGUI::EventArgs& e);
@@ -348,8 +345,6 @@ private:
     eInputChannel m_Channel;
 
     std::list<SString> m_GuiWorkingDirectoryStack;
-
-    bool m_bTransferBoxVisible;
 
     bool         m_HasSchemeLoaded;
     SString      m_CurrentSchemeName;

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -212,8 +212,8 @@ CClientGame::CClientGame(bool bLocalPlay) : m_ServerInfo(new CServerInfo())
     */
 
     // Create the transfer boxes (GUI)
-    m_pTransferBox = new CTransferBox();
-    m_pBigPacketTransferBox = new CTransferBox();
+    m_pTransferBox = new CTransferBox(TransferBoxType::RESOURCE_DOWNLOAD);
+    m_pBigPacketTransferBox = new CTransferBox(TransferBoxType::MAP_DOWNLOAD);
 
     // Store the time we started on
     if (bLocalPlay)
@@ -2614,6 +2614,10 @@ void CClientGame::AddBuiltInEvents()
 
     // Misc events
     m_Events.AddEvent("onClientFileDownloadComplete", "fileName, success", NULL, false);
+
+    m_Events.AddEvent("onClientResourceFileDownload", "resource, fileName, fileSize, state", nullptr, false);
+    m_Events.AddEvent("onClientTransferBoxProgressChange", "downloadedBytes, downloadTotalBytes", nullptr, false);
+    m_Events.AddEvent("onClientTransferBoxVisibilityChange", "isVisible", nullptr, false);
 
     m_Events.AddEvent("onClientWeaponFire", "ped, x, y, z", NULL, false);
 
@@ -5808,12 +5812,12 @@ void CClientGame::NotifyBigPacketProgress(unsigned long ulBytesReceived, unsigne
         m_bReceivingBigPacket = true;
         m_ulBigPacketSize = ulTotalSize;
         m_pBigPacketTransferBox->Hide();
-        m_pBigPacketTransferBox->AddToTotalSize(ulTotalSize);
+        m_pBigPacketTransferBox->AddToDownloadTotalSize(ulTotalSize);
         m_pBigPacketTransferBox->Show();
     }
 
     m_pBigPacketTransferBox->DoPulse();
-    m_pBigPacketTransferBox->SetInfo(std::min(ulTotalSize, ulBytesReceived), CTransferBox::PACKET);
+    m_pBigPacketTransferBox->SetDownloadProgress(std::min(ulTotalSize, ulBytesReceived));
 }
 
 bool CClientGame::SetGlitchEnabled(unsigned char ucGlitch, bool bEnabled)

--- a/Client/mods/deathmatch/logic/CResourceFileDownloadManager.cpp
+++ b/Client/mods/deathmatch/logic/CResourceFileDownloadManager.cpp
@@ -125,13 +125,13 @@ void CResourceFileDownloadManager::DoPulse()
         return;
 
     // Pulse the http downloads
-    uint uiDownloadSizeTotal = 0;
+    uint uiDownloadedSizeTotal = 0;
 
     for (auto serverInfo : m_HttpServerList)
     {
         CNetHTTPDownloadManagerInterface* pHTTP = g_pNet->GetHTTPDownloadManager(serverInfo.downloadChannel);
         pHTTP->ProcessQueuedFiles();
-        uiDownloadSizeTotal += pHTTP->GetDownloadSizeNow();
+        uiDownloadedSizeTotal += pHTTP->GetDownloadSizeNow();
     }
 
     // Handle fatal error
@@ -148,12 +148,12 @@ void CResourceFileDownloadManager::DoPulse()
     }
 
     // Update progress box
-    GetTransferBox()->SetDownloadProgress(uiDownloadSizeTotal);
+    GetTransferBox()->SetDownloadProgress(uiDownloadedSizeTotal);
     GetTransferBox()->DoPulse();
 
     // Call Lua event 'onClientTransferBoxProgressChange'
     CLuaArguments arguments;
-    arguments.PushNumber(uiDownloadSizeTotal);
+    arguments.PushNumber(uiDownloadedSizeTotal);
     arguments.PushNumber(GetTransferBox()->GetDownloadTotalSize());
 
     g_pClientGame->GetRootEntity()->CallEvent("onClientTransferBoxProgressChange", arguments, false);

--- a/Client/mods/deathmatch/logic/CResourceFileDownloadManager.cpp
+++ b/Client/mods/deathmatch/logic/CResourceFileDownloadManager.cpp
@@ -82,6 +82,16 @@ void CResourceFileDownloadManager::UpdatePendingDownloads()
             ListRemove(m_PendingFileDownloadList, pResourceFile);
             m_ActiveFileDownloadList.push_back(pResourceFile);
             BeginResourceFileDownload(pResourceFile, 0);
+
+            // Call Lua event 'onClientResourceFileDownload'
+            CLuaArguments arguments;
+            arguments.PushResource(pResourceFile->GetResource());
+            arguments.PushString(pResourceFile->GetShortName());
+            arguments.PushNumber(pResourceFile->GetDownloadSize());
+            arguments.PushString("queued");
+
+            CClientEntity* resourceEntity = pResourceFile->GetResource()->GetResourceEntity();
+            resourceEntity->CallEvent("onClientResourceFileDownload", arguments, false);
         }
     }
 }
@@ -116,6 +126,7 @@ void CResourceFileDownloadManager::DoPulse()
 
     // Pulse the http downloads
     uint uiDownloadSizeTotal = 0;
+
     for (auto serverInfo : m_HttpServerList)
     {
         CNetHTTPDownloadManagerInterface* pHTTP = g_pNet->GetHTTPDownloadManager(serverInfo.downloadChannel);
@@ -137,8 +148,15 @@ void CResourceFileDownloadManager::DoPulse()
     }
 
     // Update progress box
-    GetTransferBox()->SetInfo(uiDownloadSizeTotal);
+    GetTransferBox()->SetDownloadProgress(uiDownloadSizeTotal);
     GetTransferBox()->DoPulse();
+
+    // Call Lua event 'onClientTransferBoxProgressChange'
+    CLuaArguments arguments;
+    arguments.PushNumber(uiDownloadSizeTotal);
+    arguments.PushNumber(GetTransferBox()->GetDownloadTotalSize());
+
+    g_pClientGame->GetRootEntity()->CallEvent("onClientTransferBoxProgressChange", arguments, false);
 
     // Check if completed downloading current group
     if (m_ActiveFileDownloadList.empty())
@@ -148,6 +166,12 @@ void CResourceFileDownloadManager::DoPulse()
         {
             m_bIsTransferingFiles = false;
             GetTransferBox()->Hide();
+
+            // Call Lua event 'onClientTransferBoxVisibilityChange'
+            CLuaArguments arguments;
+            arguments.PushBoolean(false);
+
+            g_pClientGame->GetRootEntity()->CallEvent("onClientTransferBoxVisibilityChange", arguments, false);
         }
 
         // Load our newly ready resources
@@ -174,8 +198,15 @@ void CResourceFileDownloadManager::AddDownloadSize(int iSize)
             CNetHTTPDownloadManagerInterface* pHTTP = g_pNet->GetHTTPDownloadManager(serverInfo.downloadChannel);
             pHTTP->ResetDownloadSize();
         }
+
+        // Call Lua event 'onClientTransferBoxVisibilityChange'
+        CLuaArguments arguments;
+        arguments.PushBoolean(true);
+
+        g_pClientGame->GetRootEntity()->CallEvent("onClientTransferBoxVisibilityChange", arguments, false);
     }
-    GetTransferBox()->AddToTotalSize(iSize);
+
+    GetTransferBox()->AddToDownloadTotalSize(iSize);
 }
 
 ///////////////////////////////////////////////////////////////
@@ -226,14 +257,15 @@ bool CResourceFileDownloadManager::BeginResourceFileDownload(CDownloadableResour
     options.uiConnectTimeoutMs = serverInfo.uiConnectTimeoutMs;
     options.bCheckContents = true;
     options.bIsLocal = g_pClientGame->IsLocalGame();
-    SString* pstrContext = MakeDownloadContextString(pResourceFile);
-    SString  strFilename = pResourceFile->GetName();
-    bool bUniqueDownload = pHTTP->QueueFile(strHTTPDownloadURLFull, strFilename, pstrContext, StaticDownloadFinished, options);
+
+    bool bUniqueDownload = pHTTP->QueueFile(strHTTPDownloadURLFull, pResourceFile->GetName(), pResourceFile, StaticDownloadFinished, options);
+
     if (!bUniqueDownload)
     {
         // TODO - If piggybacking on another matching download, then adjust progress bar
         OutputDebugLine(SString("[ResourceFileDownload] Using existing download for %s", *strHTTPDownloadURLFull));
     }
+
     return true;
 }
 
@@ -258,11 +290,24 @@ void CResourceFileDownloadManager::StaticDownloadFinished(const SHttpDownloadRes
 ///////////////////////////////////////////////////////////////
 void CResourceFileDownloadManager::DownloadFinished(const SHttpDownloadResult& result)
 {
-    CDownloadableResource* pResourceFile = ResolveDownloadContextString((SString*)result.pObj);
-    if (!pResourceFile)
+    auto iter = std::find(std::begin(m_ActiveFileDownloadList), std::end(m_ActiveFileDownloadList),
+                          reinterpret_cast<CDownloadableResource*>(result.pObj));
+
+    if (iter == std::end(m_ActiveFileDownloadList))
         return;
 
-    assert(ListContains(m_ActiveFileDownloadList, pResourceFile));
+    CDownloadableResource* pResourceFile = *iter;
+
+    // Call Lua event 'onClientResourceFileDownload'
+    CLuaArguments arguments;
+    arguments.PushResource(pResourceFile->GetResource());
+    arguments.PushString(pResourceFile->GetShortName());
+    arguments.PushNumber(pResourceFile->GetDownloadSize());
+    arguments.PushString(result.bSuccess ? "finished" : "failed");
+
+    CClientEntity* resourceEntity = pResourceFile->GetResource()->GetResourceEntity();
+    resourceEntity->CallEvent("onClientResourceFileDownload", arguments, false);
+
     if (result.bSuccess)
     {
         CChecksum checksum = CChecksum::GenerateChecksumFromFileUnsafe(pResourceFile->GetName());
@@ -279,8 +324,7 @@ void CResourceFileDownloadManager::DownloadFinished(const SHttpDownloadResult& r
             }
         }
     }
-    else
-    if (result.iErrorCode == 1007)
+    else if (result.iErrorCode == 1007)
     {
         // Download failed due to being unable to create file
         // Ignore here so it will be processed at CResource::HandleDownloadedFileTrouble
@@ -308,47 +352,6 @@ void CResourceFileDownloadManager::DownloadFinished(const SHttpDownloadResult& r
     }
 
     // File now done (or failed)
-    ListRemove(m_ActiveFileDownloadList, pResourceFile);
+    m_ActiveFileDownloadList.erase(iter);
     pResourceFile->SetIsWaitingForDownload(false);
-}
-
-///////////////////////////////////////////////////////////////
-//
-// CResourceFileDownloadManager::MakeDownloadContextString
-//
-// For passing to HTTP->QueueFile
-//
-///////////////////////////////////////////////////////////////
-SString* CResourceFileDownloadManager::MakeDownloadContextString(CDownloadableResource* pDownloadableResource)
-{
-    return new SString("%d:%s", pDownloadableResource->GetResource()->GetScriptID(), pDownloadableResource->GetShortName());
-}
-
-///////////////////////////////////////////////////////////////
-//
-// CResourceFileDownloadManager::ResolveDownloadContextString
-//
-// Decode previously generated context string.
-// Automatically deletes the string
-//
-///////////////////////////////////////////////////////////////
-CDownloadableResource* CResourceFileDownloadManager::ResolveDownloadContextString(SString* pString)
-{
-    SString strFilename;
-    uint    uiScriptId = atoi(pString->SplitLeft(":", &strFilename));
-    delete pString;
-
-    CResource* pResource = g_pClientGame->GetResourceManager()->GetResourceFromScriptID(uiScriptId);
-    if (!pResource)
-        return NULL;
-
-    // Find match in active downloads
-    for (auto pDownloadableResource : m_ActiveFileDownloadList)
-    {
-        if (pDownloadableResource->GetResource() == pResource && pDownloadableResource->GetShortName() == strFilename)
-        {
-            return pDownloadableResource;
-        }
-    }
-    return NULL;
 }

--- a/Client/mods/deathmatch/logic/CResourceFileDownloadManager.h
+++ b/Client/mods/deathmatch/logic/CResourceFileDownloadManager.h
@@ -36,8 +36,6 @@ protected:
     bool                   BeginResourceFileDownload(CDownloadableResource* pDownloadableResource, uint uiHttpServerIndex);
     static void            StaticDownloadFinished(const SHttpDownloadResult& result);
     void                   DownloadFinished(const SHttpDownloadResult& result);
-    SString*               MakeDownloadContextString(CDownloadableResource* pDownloadableResource);
-    CDownloadableResource* ResolveDownloadContextString(SString* pString);
 
     std::vector<CDownloadableResource*> m_PendingFileDownloadList;
     std::vector<CDownloadableResource*> m_ActiveFileDownloadList;

--- a/Client/mods/deathmatch/logic/CTransferBox.cpp
+++ b/Client/mods/deathmatch/logic/CTransferBox.cpp
@@ -144,16 +144,6 @@ bool CTransferBox::SetServerVisibility(bool visible)
     return true;
 }
 
-bool CTransferBox::SetAlwaysVisible(bool visible)
-{
-    if (m_alwaysVisible == visible)
-        return false;
-
-    m_alwaysVisible = visible;
-    UpdateWindowVisibility();
-    return true;
-}
-
 void CTransferBox::UpdateWindowVisibility() const
 {
     bool visible = m_visible.all() || (m_visible[TB_VISIBILITY_MTA] && m_alwaysVisible);

--- a/Client/mods/deathmatch/logic/CTransferBox.cpp
+++ b/Client/mods/deathmatch/logic/CTransferBox.cpp
@@ -96,13 +96,13 @@ void CTransferBox::Hide()
     m_downloadTotalSize = 0;
 }
 
-void CTransferBox::SetDownloadProgress(uint64_t downloadBytesCurrent)
+void CTransferBox::SetDownloadProgress(uint64_t downloadedSizeTotal)
 {
-    SString current = GetDataUnit(downloadBytesCurrent);
+    SString current = GetDataUnit(downloadedSizeTotal);
     SString total = GetDataUnit(m_downloadTotalSize);
     SString progress = m_titleProgressPrefix + " " + SString(_("%s of %s"), current.c_str(), total.c_str());
     m_window->SetText(progress.c_str());
-    m_progressBar->SetProgress(static_cast<float>(static_cast<double>(downloadBytesCurrent) / m_downloadTotalSize));
+    m_progressBar->SetProgress(static_cast<float>(static_cast<double>(downloadedSizeTotal) / m_downloadTotalSize));
 }
 
 void CTransferBox::DoPulse()

--- a/Client/mods/deathmatch/logic/CTransferBox.cpp
+++ b/Client/mods/deathmatch/logic/CTransferBox.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
  *
- *  PROJECT:     Multi Theft Auto v1.0
+ *  PROJECT:     Multi Theft Auto
  *  LICENSE:     See LICENSE in the top level directory
  *  FILE:        mods/deathmatch/logic/CTransferBox.cpp
  *  PURPOSE:     Transfer box GUI
@@ -11,126 +11,151 @@
 
 #include <StdInc.h>
 
-#define TRANSFERBOX_HEIGHT      58
-#define TRANSFERBOX_ICONSIZE    20
-#define TRANSFERBOX_PROGRESSHEIGHT  28
-#define TRANSFERBOX_YSTART      20
-#define TRANSFERBOX_SPACER      11
+#define TRANSFERBOX_HEIGHT         58
+#define TRANSFERBOX_ICONSIZE       20
+#define TRANSFERBOX_PROGRESSHEIGHT 28
+#define TRANSFERBOX_YSTART         20
+#define TRANSFERBOX_SPACER         11
 
-CTransferBox::CTransferBox()
+CTransferBox::CTransferBox(TransferBoxType transferType) : m_GUI(g_pCore->GetGUI())
 {
-    CGUI* pGUI = g_pCore->GetGUI();
-    // Create our text for each transfer type
-    m_strTransferText[Type::NORMAL] = _("Download Progress:");
-    m_strTransferText[Type::PACKET] = _("Map download progress:");
+    switch (transferType)
+    {
+        case TransferBoxType::MAP_DOWNLOAD:
+            m_titleProgressPrefix = _("Map download progress:");
+            break;
+        default:
+            m_titleProgressPrefix = _("Download Progress:");
+    }
 
+    m_visible.set(TB_VISIBILITY_CLIENT_SCRIPT);
+    m_visible.set(TB_VISIBILITY_SERVER_SCRIPT);
+
+    CreateTransferWindow();
+}
+
+void CTransferBox::CreateTransferWindow()
+{
     // Find our largest piece of text, so we can size accordingly
-    float fTransferBoxWidth = 0;
-    for (int i = 0; i < Type::MAX_TYPES; i++)
-        fTransferBoxWidth = std::max<float>(
-            fTransferBoxWidth, pGUI->GetTextExtent(m_strTransferText[i] + " " + SString(_("%s of %s"), "999.99 kB", "999.99 kB"), "default-bold-small"));
-    fTransferBoxWidth = std::max<float>(fTransferBoxWidth, pGUI->GetTextExtent(_("Disconnect to cancel download"), "default-normal"));
+    std::string largeTextSample = m_titleProgressPrefix + " " + SString(_("%s of %s"), "999.99 kB", "999.99 kB");
+    float fTransferBoxWidth = m_GUI->GetTextExtent(largeTextSample.c_str(), "default-bold-small");
+    fTransferBoxWidth = std::max<float>(fTransferBoxWidth, m_GUI->GetTextExtent(_("Disconnect to cancel download"), "default-normal"));
 
     // Add some padding to our text for the size of the window
     fTransferBoxWidth += 80;
 
-    // Begin creating our GUI
-    CVector2D ScreenSize = pGUI->GetResolution();
-    float     fFontHeight = pGUI->GetDefaultFont()->GetFontHeight();
+    CVector2D screenSize = m_GUI->GetResolution();
 
-    // create the window
-    m_pWindow = pGUI->CreateWnd();
-    m_pWindow->SetText("");
-    m_pWindow->SetAlpha(0.7f);
-    m_pWindow->SetVisible(false);
-    m_pWindow->SetAlwaysOnTop(true);
-    m_pWindow->SetCloseButtonEnabled(false);
-    m_pWindow->SetSizingEnabled(false);
-    m_pWindow->SetPosition(CVector2D(ScreenSize.fX * 0.5f - fTransferBoxWidth * 0.5f, ScreenSize.fY * 0.85f - TRANSFERBOX_HEIGHT * 0.5f));
-    m_pWindow->SetSize(CVector2D(fTransferBoxWidth, TRANSFERBOX_HEIGHT));            // relative 0.35, 0.225
+    m_window.reset(m_GUI->CreateWnd());
+    m_window->SetText("");
+    m_window->SetAlpha(0.7f);
+    m_window->SetVisible(false);
+    m_window->SetAlwaysOnTop(true);
+    m_window->SetCloseButtonEnabled(false);
+    m_window->SetSizingEnabled(false);
+    m_window->SetPosition(CVector2D(screenSize.fX * 0.5f - fTransferBoxWidth * 0.5f, screenSize.fY * 0.85f - TRANSFERBOX_HEIGHT * 0.5f));
+    m_window->SetSize(CVector2D(fTransferBoxWidth, TRANSFERBOX_HEIGHT));            // relative 0.35, 0.225
 
-    // create the progress bar
-    m_pProgress = pGUI->CreateProgressBar(m_pWindow);
-    m_pProgress->SetPosition(CVector2D(0, TRANSFERBOX_YSTART));
-    m_pProgress->SetSize(CVector2D(fTransferBoxWidth, TRANSFERBOX_HEIGHT - TRANSFERBOX_YSTART - TRANSFERBOX_SPACER));
+    m_progressBar.reset(m_GUI->CreateProgressBar(m_window.get()));
+    m_progressBar->SetPosition(CVector2D(0, TRANSFERBOX_YSTART));
+    m_progressBar->SetSize(CVector2D(fTransferBoxWidth, TRANSFERBOX_HEIGHT - TRANSFERBOX_YSTART - TRANSFERBOX_SPACER));
 
-    // stats label
-    m_pInfo = pGUI->CreateLabel(m_pProgress, _("Disconnect to cancel download"));
-    float fTempX = (m_pProgress->GetSize().fX - pGUI->GetTextExtent(m_pInfo->GetText().c_str()) - TRANSFERBOX_ICONSIZE - 4) * 0.5f;
-    m_pInfo->SetPosition(CVector2D(fTempX + TRANSFERBOX_ICONSIZE + 4, 0));
-    m_pInfo->SetSize(CVector2D(fTransferBoxWidth, TRANSFERBOX_PROGRESSHEIGHT));
-    m_pInfo->SetTextColor(0, 0, 0);
-    m_pInfo->SetVerticalAlign(CGUI_ALIGN_VERTICALCENTER);
+    m_infoLabel.reset(m_GUI->CreateLabel(m_progressBar.get(), _("Disconnect to cancel download")));
+    float fTempX = (m_progressBar->GetSize().fX - m_GUI->GetTextExtent(m_infoLabel->GetText().c_str()) - TRANSFERBOX_ICONSIZE - 4) * 0.5f;
+    m_infoLabel->SetPosition(CVector2D(fTempX + TRANSFERBOX_ICONSIZE + 4, 0));
+    m_infoLabel->SetSize(CVector2D(fTransferBoxWidth, TRANSFERBOX_PROGRESSHEIGHT));
+    m_infoLabel->SetTextColor(0, 0, 0);
+    m_infoLabel->SetVerticalAlign(CGUI_ALIGN_VERTICALCENTER);
 
-    // create the icons
-    for (unsigned int i = 0; i < TRANSFERBOX_FRAMES; i++)
+    for (size_t i = 0; i < m_iconImages.size(); ++i)
     {
-        SString strIcon("cgui\\images\\transferset\\%u.png", i + 1);
-        m_pIcon[i] = pGUI->CreateStaticImage(m_pProgress);
-        m_pIcon[i]->SetFrameEnabled(false);
-        m_pIcon[i]->SetPosition(CVector2D(fTempX, ((TRANSFERBOX_PROGRESSHEIGHT) / 2) - (TRANSFERBOX_ICONSIZE / 2)));
-        m_pIcon[i]->SetSize(CVector2D(TRANSFERBOX_ICONSIZE, TRANSFERBOX_ICONSIZE));
-        m_pIcon[i]->LoadFromFile(strIcon);
-        m_pIcon[i]->SetVisible(false);
-    }
-    m_pIcon[0]->SetVisible(true);
-
-    // set animation counters
-    m_uiVisible = 0;
-    m_dTotalSize = 0;
-}
-
-CTransferBox::~CTransferBox()
-{
-    for (unsigned int i = 0; i < TRANSFERBOX_FRAMES; i++)
-    {
-        delete m_pIcon[i];
+        SString filePath("cgui\\images\\transferset\\%u.png", i + 1);
+        m_iconImages[i].reset(m_GUI->CreateStaticImage(m_progressBar.get()));
+        m_iconImages[i]->SetFrameEnabled(false);
+        m_iconImages[i]->SetPosition(CVector2D(fTempX, ((TRANSFERBOX_PROGRESSHEIGHT) / 2) - (TRANSFERBOX_ICONSIZE / 2)));
+        m_iconImages[i]->SetSize(CVector2D(TRANSFERBOX_ICONSIZE, TRANSFERBOX_ICONSIZE));
+        m_iconImages[i]->LoadFromFile(filePath);
+        m_iconImages[i]->SetVisible(false);
     }
 
-    if (m_pWindow != NULL)
-        delete m_pWindow;
-    if (m_pInfo != NULL)
-        delete m_pInfo;
-    if (m_pProgress != NULL)
-        delete m_pProgress;
+    m_iconIndex = 0;
+    m_iconImages[m_iconIndex]->SetVisible(true);
 }
 
 void CTransferBox::Show()
 {
-    m_pWindow->SetVisible(true);
-    g_pCore->GetGUI()->SetTransferBoxVisible(true);
+    m_visible.set(TB_VISIBILITY_MTA);
+    UpdateWindowVisibility();
 }
 
 void CTransferBox::Hide()
 {
-    m_pWindow->SetVisible(false);
-    g_pCore->GetGUI()->SetTransferBoxVisible(false);
+    m_visible.reset(TB_VISIBILITY_MTA);
+    UpdateWindowVisibility();
 
-    m_dTotalSize = 0;
+    m_downloadTotalSize = 0;
 }
 
-void CTransferBox::SetInfo(double dDownloadSizeNow, CTransferBox::Type eTransferType)
+void CTransferBox::SetDownloadProgress(uint64_t downloadBytesCurrent)
 {
-    // Convert to reasonable units
-    SString strDownloadSizeNow = GetDataUnit(static_cast<unsigned long long>(dDownloadSizeNow));
-    SString strDownloadSizeTotal = GetDataUnit(static_cast<unsigned long long>(m_dTotalSize));
-
-    SString strBuffer = m_strTransferText[eTransferType] + " " +
-                        SString(_("%s of %s"), strDownloadSizeNow.c_str(),
-                                strDownloadSizeTotal.c_str());            // TRANSLATORS: This represents the download progress. E.g. "500 kB of 800 kB"
-    m_pWindow->SetText(strBuffer);
-
-    m_pProgress->SetProgress(static_cast<float>(dDownloadSizeNow / m_dTotalSize));
+    SString current = GetDataUnit(downloadBytesCurrent);
+    SString total = GetDataUnit(m_downloadTotalSize);
+    SString progress = m_titleProgressPrefix + " " + SString(_("%s of %s"), current.c_str(), total.c_str());
+    m_window->SetText(progress.c_str());
+    m_progressBar->SetProgress(static_cast<float>(static_cast<double>(downloadBytesCurrent) / m_downloadTotalSize));
 }
 
 void CTransferBox::DoPulse()
 {
-    // animated icon mechanism
-    if (m_AnimTimer.Get() > TRANSFERBOX_DELAY)
+    if (m_iconTimer.Get() >= 50)
     {
-        m_AnimTimer.Reset();
-        m_pIcon[m_uiVisible]->SetVisible(false);
-        m_uiVisible = (m_uiVisible + 1) % TRANSFERBOX_FRAMES;
-        m_pIcon[m_uiVisible]->SetVisible(true);
+        m_iconTimer.Reset();
+        m_iconImages[m_iconIndex]->SetVisible(false);
+        m_iconIndex = (m_iconIndex + 1) % m_iconImages.size();
+        m_iconImages[m_iconIndex]->SetVisible(true);
+
+        bool alwaysShowTransferBox = false;
+
+        if (g_pCore->GetCVars()->Get("always_show_transferbox", alwaysShowTransferBox); m_alwaysVisible != alwaysShowTransferBox)
+        {
+            m_alwaysVisible = alwaysShowTransferBox;
+            UpdateWindowVisibility();
+        }
     }
+}
+
+bool CTransferBox::SetClientVisibility(bool visible)
+{
+    if (m_visible[TB_VISIBILITY_CLIENT_SCRIPT] == visible)
+        return false;
+
+    m_visible.set(TB_VISIBILITY_CLIENT_SCRIPT, visible);
+    UpdateWindowVisibility();
+    return true;
+}
+
+bool CTransferBox::SetServerVisibility(bool visible)
+{
+    if (m_visible[TB_VISIBILITY_SERVER_SCRIPT] == visible)
+        return false;
+
+    m_visible.set(TB_VISIBILITY_SERVER_SCRIPT, visible);
+    UpdateWindowVisibility();
+    return true;
+}
+
+bool CTransferBox::SetAlwaysVisible(bool visible)
+{
+    if (m_alwaysVisible == visible)
+        return false;
+
+    m_alwaysVisible = visible;
+    UpdateWindowVisibility();
+    return true;
+}
+
+void CTransferBox::UpdateWindowVisibility() const
+{
+    bool visible = m_visible.all() || (m_visible[TB_VISIBILITY_MTA] && m_alwaysVisible);
+    m_window->SetVisible(visible);
 }

--- a/Client/mods/deathmatch/logic/CTransferBox.h
+++ b/Client/mods/deathmatch/logic/CTransferBox.h
@@ -42,7 +42,6 @@ public:
     bool SetClientVisibility(bool visible);
     bool SetServerVisibility(bool visible);
 
-    bool SetAlwaysVisible(bool visible);
     bool IsAlwaysVisible() const { return m_alwaysVisible; }
 
 private:

--- a/Client/mods/deathmatch/logic/CTransferBox.h
+++ b/Client/mods/deathmatch/logic/CTransferBox.h
@@ -11,8 +11,6 @@
 
 #pragma once
 
-// #include "CClientCommon.h"
-// #include <gui/CGUI.h>
 #include <memory>
 #include <bitset>
 
@@ -34,7 +32,7 @@ public:
 
     bool IsVisible() const { return m_visible[TB_VISIBILITY_MTA]; }
 
-    void SetDownloadProgress(uint64_t downloadBytesCurrent);
+    void SetDownloadProgress(uint64_t downloadedSizeTotal);
 
     void     AddToDownloadTotalSize(uint64 bytes) { m_downloadTotalSize += bytes; }
     uint64_t GetDownloadTotalSize() const { return m_downloadTotalSize; }

--- a/Client/mods/deathmatch/logic/CTransferBox.h
+++ b/Client/mods/deathmatch/logic/CTransferBox.h
@@ -1,59 +1,74 @@
 /*****************************************************************************
  *
- *  PROJECT:     Multi Theft Auto v1.0
+ *  PROJECT:     Multi Theft Auto
  *  LICENSE:     See LICENSE in the top level directory
  *  FILE:        mods/deathmatch/logic/CTransferBox.h
  *  PURPOSE:     Header for transfer box class
  *
- *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *  Multi Theft Auto is available from https://multitheftauto.com/
  *
  *****************************************************************************/
 
 #pragma once
 
-#define TRANSFERBOX_FRAMES  10
-#define TRANSFERBOX_DELAY   50
+// #include "CClientCommon.h"
+// #include <gui/CGUI.h>
+#include <memory>
+#include <bitset>
 
-#include "CClientCommon.h"
-#include <gui/CGUI.h>
+enum class TransferBoxType : uint8_t
+{
+    RESOURCE_DOWNLOAD,
+    MAP_DOWNLOAD,
+};
 
 class CTransferBox
 {
 public:
-    enum Type
-    {
-        NORMAL,
-        PACKET,
-        MAX_TYPES
-    };
-
-    CTransferBox();
-    virtual ~CTransferBox();
+    explicit CTransferBox(TransferBoxType transferType);
 
     void Show();
     void Hide();
 
-    void SetInfo(double dDownloadSizeNow, CTransferBox::Type eTransferType = CTransferBox::NORMAL);
-
     void DoPulse();
 
-    bool OnCancelClick(CGUIElement* pElement);
+    bool IsVisible() const { return m_visible[TB_VISIBILITY_MTA]; }
 
-    bool IsVisible() { return m_pWindow->IsVisible(); };
+    void SetDownloadProgress(uint64_t downloadBytesCurrent);
 
-    void AddToTotalSize(double dSize) { m_dTotalSize += dSize; };
+    void     AddToDownloadTotalSize(uint64 bytes) { m_downloadTotalSize += bytes; }
+    uint64_t GetDownloadTotalSize() const { return m_downloadTotalSize; }
+
+    bool SetClientVisibility(bool visible);
+    bool SetServerVisibility(bool visible);
+
+    bool SetAlwaysVisible(bool visible);
+    bool IsAlwaysVisible() const { return m_alwaysVisible; }
 
 private:
-    CGUIWindow*                                       m_pWindow;
-    SFixedArray<CGUIStaticImage*, TRANSFERBOX_FRAMES> m_pIcon;
-    CGUILabel*                                        m_pInfo;
-    CGUIProgressBar*                                  m_pProgress;
+    void CreateTransferWindow();
 
-    bool m_bMultipleDownloads;
+    void UpdateWindowVisibility() const;
 
-    unsigned int m_uiVisible;
-    CElapsedTime m_AnimTimer;
-    double       m_dTotalSize;
+    std::string m_titleProgressPrefix;
+    uint64_t    m_downloadTotalSize = 0;
 
-    SString m_strTransferText[Type::MAX_TYPES];
+    CGUI*                                            m_GUI;
+    std::unique_ptr<CGUIWindow>                      m_window;
+    std::unique_ptr<CGUIProgressBar>                 m_progressBar;
+    std::unique_ptr<CGUILabel>                       m_infoLabel;
+    std::array<std::unique_ptr<CGUIStaticImage>, 10> m_iconImages;
+    size_t                                           m_iconIndex;
+    CElapsedTime                                     m_iconTimer;
+
+    enum VisibilitySource
+    {
+        TB_VISIBILITY_MTA,
+        TB_VISIBILITY_CLIENT_SCRIPT,
+        TB_VISIBILITY_SERVER_SCRIPT,
+        TB_VISIBILITY_SOURCES_SIZE,
+    };
+
+    std::bitset<TB_VISIBILITY_SOURCES_SIZE> m_visible;
+    bool                                    m_alwaysVisible = true;
 };

--- a/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -11,6 +11,7 @@
 
 #include "StdInc.h"
 #include "../luadefs/CLuaFireDefs.h"
+#include "../luadefs/CLuaClientDefs.h"
 
 using std::list;
 
@@ -277,4 +278,5 @@ void CLuaManager::LoadCFunctions()
     CLuaWeaponDefs::LoadFunctions();
     CLuaWorldDefs::LoadFunctions();
     CLuaXMLDefs::LoadFunctions();
+    CLuaClientDefs::LoadFunctions();
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaClientDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaClientDefs.cpp
@@ -1,0 +1,41 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        mods/deathmatch/logic/luadefs/CLuaClientDefs.cpp
+ *  PURPOSE:     Lua client definitions class
+ *
+ *  Multi Theft Auto is available from https://multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+#include "CLuaClientDefs.h"
+#include "lua/CLuaFunctionParser.h"
+
+void CLuaClientDefs::LoadFunctions()
+{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
+        {"setTransferBoxVisible", ArgumentParser<SetTransferBoxVisible>},
+        {"isTransferBoxVisible", ArgumentParser<IsTransferBoxVisible>},
+        {"isTransferBoxAlwaysVisible", ArgumentParser<IsTransferBoxAlwaysVisible>},
+    };
+
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
+}
+
+bool CLuaClientDefs::SetTransferBoxVisible(bool visible)
+{
+    return g_pClientGame->GetTransferBox()->SetClientVisibility(visible);
+}
+
+bool CLuaClientDefs::IsTransferBoxVisible()
+{
+    return g_pClientGame->GetTransferBox()->IsVisible();
+}
+
+bool CLuaClientDefs::IsTransferBoxAlwaysVisible()
+{
+    return g_pClientGame->GetTransferBox()->IsAlwaysVisible();
+}

--- a/Client/mods/deathmatch/logic/luadefs/CLuaClientDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaClientDefs.h
@@ -1,0 +1,25 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        mods/deathmatch/logic/luadefs/CLuaClientDefs.h
+ *  PURPOSE:     Lua client definitions class
+ *
+ *  Multi Theft Auto is available from https://multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#pragma once
+
+#include "CLuaDefs.h"
+
+class CLuaClientDefs : public CLuaDefs
+{
+public:
+    static void LoadFunctions();
+
+private:
+    static bool SetTransferBoxVisible(bool visible);
+    static bool IsTransferBoxVisible();
+    static bool IsTransferBoxAlwaysVisible();
+};

--- a/Client/mods/deathmatch/logic/rpc/COutputRPCs.cpp
+++ b/Client/mods/deathmatch/logic/rpc/COutputRPCs.cpp
@@ -15,6 +15,7 @@
 void COutputRPCs::LoadFunctions()
 {
     AddHandler(TOGGLE_DEBUGGER, ToggleDebugger, "ToggleDebugger");
+    AddHandler(SET_TRANSFER_BOX_VISIBILITY, SetTransferBoxVisibility, "SetTransferBoxVisibility");
 }
 
 void COutputRPCs::ToggleDebugger(NetBitStreamInterface& bitStream)
@@ -23,4 +24,9 @@ void COutputRPCs::ToggleDebugger(NetBitStreamInterface& bitStream)
     bitStream.Read(ucEnable);
 
     g_pCore->SetDebugVisible((ucEnable == 1));
+}
+
+void COutputRPCs::SetTransferBoxVisibility(NetBitStreamInterface& bitStream)
+{
+    g_pClientGame->GetTransferBox()->SetServerVisibility(bitStream.ReadBit());
 }

--- a/Client/mods/deathmatch/logic/rpc/COutputRPCs.h
+++ b/Client/mods/deathmatch/logic/rpc/COutputRPCs.h
@@ -19,4 +19,5 @@ public:
     static void LoadFunctions();
 
     DECLARE_RPC(ToggleDebugger);
+    DECLARE_RPC(SetTransferBoxVisibility);
 };

--- a/Client/sdk/gui/CGUI.h
+++ b/Client/sdk/gui/CGUI.h
@@ -164,9 +164,6 @@ public:
     virtual void ClearInputHandlers(eInputChannel channel) = 0;
     virtual void ClearSystemKeys() = 0;
 
-    virtual bool IsTransferBoxVisible() = 0;
-    virtual void SetTransferBoxVisible(bool bVisible) = 0;
-
     virtual void CleanDeadPool() = 0;
 
     virtual CGUIWindow* LoadLayout(CGUIElement* pParent, const SString& strFilename) = 0;

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -1273,6 +1273,9 @@ void CGame::InitialDataStream(CPlayer& Player)
     // Tell him current sync rates
     CStaticFunctionDefinitions::SendSyncIntervals(&Player);
 
+    // Tell client the transfer box visibility
+    CStaticFunctionDefinitions::SendClientTransferBoxVisibility(&Player);
+
     // Tell him current bullet sync enabled weapons and vehicle extrapolation settings
     SendSyncSettings(&Player);
 

--- a/Server/mods/deathmatch/logic/CGame.h
+++ b/Server/mods/deathmatch/logic/CGame.h
@@ -459,6 +459,9 @@ public:
     void SetDevelopmentMode(bool enabled) { m_DevelopmentModeEnabled = enabled; }
     bool GetDevelopmentMode() { return m_DevelopmentModeEnabled; }
 
+    bool IsClientTransferBoxVisible() const { return m_showClientTransferBox; }
+    void SetClientTransferBoxVisible(bool visible) { m_showClientTransferBox = visible; }
+
 private:
     void AddBuiltInEvents();
     void RelayPlayerPuresync(class CPacket& Packet);
@@ -650,4 +653,5 @@ private:
     SharedUtil::CAsyncTaskScheduler* m_pAsyncTaskScheduler;
 
     bool m_DevelopmentModeEnabled;
+    bool m_showClientTransferBox = true;
 };

--- a/Server/mods/deathmatch/logic/CResourceChecker.Data.h
+++ b/Server/mods/deathmatch/logic/CResourceChecker.Data.h
@@ -234,6 +234,14 @@ namespace
         {"getVehicleModelWheelSize", "1.5.7-9.20642"},
         {"setVehicleWheelScale", "1.5.7-9.20642"},
         {"getVehicleWheelScale", "1.5.7-9.20642"},
+
+        // Features added in 1.5.8
+        {"onClientResourceFileDownload", "1.5.8-9.20788"},
+        {"onClientTransferBoxProgressChange", "1.5.8-9.20788"},
+        {"onClientTransferBoxVisibilityChange", "1.5.8-9.20788"},
+        {"setTransferBoxVisible", "1.5.8-9.20788"},
+        {"isTransferBoxVisible", "1.5.8-9.20788"},
+        {"isTransferBoxAlwaysVisible", "1.5.8-9.20788"},
     };
 
     SVersionItem serverFunctionInitList[] = {
@@ -336,6 +344,10 @@ namespace
         {"addElementDataSubscriber", "1.5.7-9.20477"},
         {"hasElementDataSubscriber", "1.5.7-9.20477"},
         {"removeElementDataSubscriber", "1.5.7-9.20477"},
+
+        // Features added in 1.5.8
+        {"setTransferBoxVisible", "1.5.8-9.20788"},
+        {"isTransferBoxVisible", "1.5.8-9.20788"},
     };
 
     //

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -10640,6 +10640,27 @@ bool CStaticFunctionDefinitions::SendSyncIntervals(CPlayer* pPlayer)
     return true;
 }
 
+void CStaticFunctionDefinitions::SendClientTransferBoxVisibility(CPlayer* player)
+{
+    CBitStream BitStream;
+    BitStream->WriteBit(g_pGame->IsClientTransferBoxVisible());
+
+    if (player)
+        player->Send(CLuaPacket(SET_TRANSFER_BOX_VISIBILITY, *BitStream.pBitStream));
+    else
+        m_pPlayerManager->BroadcastOnlyJoined(CLuaPacket(SET_TRANSFER_BOX_VISIBILITY, *BitStream.pBitStream));
+}
+
+bool CStaticFunctionDefinitions::SetClientTransferBoxVisible(bool visible)
+{
+    if (g_pGame->IsClientTransferBoxVisible() == visible)
+        return false;
+
+    g_pGame->SetClientTransferBoxVisible(visible);
+    SendClientTransferBoxVisibility();
+    return true;
+}
+
 bool CStaticFunctionDefinitions::SetWeather(unsigned char ucWeather)
 {
     // Verify it's within the max valid weather id

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -732,6 +732,8 @@ public:
 
     // Misc funcs
     static bool ResetMapInfo(CElement* pElement);
+    static void SendClientTransferBoxVisibility(CPlayer* player = nullptr);
+    static bool SetClientTransferBoxVisible(bool visible);
 
     // Resource funcs
     static CElement* GetResourceMapRootElement(CResource* pResource, const char* szMap);

--- a/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -10,6 +10,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include "../luadefs/CLuaGenericDefs.h"
 
 extern CGame* g_pGame;
 
@@ -319,6 +320,7 @@ void CLuaManager::LoadCFunctions()
     CLuaWaterDefs::LoadFunctions();
     CLuaWorldDefs::LoadFunctions();
     CLuaXMLDefs::LoadFunctions();
+    CLuaGenericDefs::LoadFunctions();
     // Backward compatibility functions at the end, so the new function name is used in ACL
     CLuaCompatibilityDefs::LoadFunctions();
 }

--- a/Server/mods/deathmatch/logic/luadefs/CLuaGenericDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaGenericDefs.cpp
@@ -1,0 +1,33 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        mods/deathmatch/logic/luadefs/CLuaGenericDefs.cpp
+ *
+ *  Multi Theft Auto is available from https://multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+#include "CLuaGenericDefs.h"
+
+void CLuaGenericDefs::LoadFunctions()
+{
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
+        {"setTransferBoxVisible", ArgumentParser<SetTransferBoxVisible>},
+        {"isTransferBoxVisible", ArgumentParser<IsTransferBoxVisible>},
+    };
+
+    for (const auto& [name, func] : functions)
+        CLuaCFunctions::AddFunction(name, func);
+}
+
+bool CLuaGenericDefs::SetTransferBoxVisible(bool visible)
+{
+    return CStaticFunctionDefinitions::SetClientTransferBoxVisible(visible);
+}
+
+bool CLuaGenericDefs::IsTransferBoxVisible()
+{
+    return g_pGame->IsClientTransferBoxVisible();
+}

--- a/Server/mods/deathmatch/logic/luadefs/CLuaGenericDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaGenericDefs.cpp
@@ -14,17 +14,12 @@
 void CLuaGenericDefs::LoadFunctions()
 {
     constexpr static const std::pair<const char*, lua_CFunction> functions[]{
-        {"setTransferBoxVisible", ArgumentParser<SetTransferBoxVisible>},
+        {"setTransferBoxVisible", ArgumentParser<CStaticFunctionDefinitions::SetClientTransferBoxVisible>},
         {"isTransferBoxVisible", ArgumentParser<IsTransferBoxVisible>},
     };
 
     for (const auto& [name, func] : functions)
         CLuaCFunctions::AddFunction(name, func);
-}
-
-bool CLuaGenericDefs::SetTransferBoxVisible(bool visible)
-{
-    return CStaticFunctionDefinitions::SetClientTransferBoxVisible(visible);
 }
 
 bool CLuaGenericDefs::IsTransferBoxVisible()

--- a/Server/mods/deathmatch/logic/luadefs/CLuaGenericDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaGenericDefs.h
@@ -19,6 +19,5 @@ public:
     static void LoadFunctions();
 
 private:
-    static bool SetTransferBoxVisible(bool visible);
     static bool IsTransferBoxVisible();
 };

--- a/Server/mods/deathmatch/logic/luadefs/CLuaGenericDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaGenericDefs.h
@@ -1,0 +1,24 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        mods/deathmatch/logic/luadefs/CLuaGenericDefs.h
+ *  PURPOSE:     Lua function definitions class
+ *
+ *  Multi Theft Auto is available from https://multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#pragma once
+
+#include "CLuaDefs.h"
+
+class CLuaGenericDefs : public CLuaDefs
+{
+public:
+    static void LoadFunctions();
+
+private:
+    static bool SetTransferBoxVisible(bool visible);
+    static bool IsTransferBoxVisible();
+};

--- a/Shared/sdk/net/rpc_enums.h
+++ b/Shared/sdk/net/rpc_enums.h
@@ -270,6 +270,7 @@ enum eElementRPCFunctions
     UPDATE_COLPOLYGON_POINT,
   
     SET_DISCORD_JOIN_PARAMETERS,
+    SET_TRANSFER_BOX_VISIBILITY,
 
     NUM_RPC_FUNCS // Add above this line
 };


### PR DESCRIPTION
# Transfer box customization
This work is based on the work by @CrosRoad95 in pull request #171 

![grafik](https://user-images.githubusercontent.com/38703318/103296277-16e7bb00-49f6-11eb-9c74-b0d07a416a9c.png)
You are able to hide and show the transfer box on clients.
You can hide the transfer box from server-side before the client starts resources to not show the download window at all.
You are supposed to use a resource with higher download priority to show a custom transfer box.
You will only receive events for the resource download transfer box.
The map download transfer box does not emit these events and **can not** be hidden with the scripting functions.
Players can force the download window to always appear regardless of the script provided setting through settings.

## New server functions
These functions are global. That means they apply for every player.
```lua
bool setTransferBoxVisible(bool visible)
bool isTransferBoxVisible() -- returns false only if the server wants the transfer box hidden for players
```

## New client functions
```lua
bool setTransferBoxVisible(bool visible)
bool isTransferBoxVisible() -- returns true if transfer box should be visible (if a download is running), it does not represent the value set by setTransferBoxVisible
bool isTransferBoxAlwaysVisible() -- returns true if the user enabled the main menu setting to always display it (cvar)
```

## New client events
```lua
onClientResourceFileDownload(resource-pointer resource, string fileName, number fileSize, string state)
-- state can be "queued" or "finished" or "failed"

onClientTransferBoxProgressChange(number downloadedBytes, number downloadTotalBytes)
onClientTransferBoxVisibilityChange(bool isVisible)
```
