### PR TITLE
Fix disappearance of the collision of the world (#1948)

### DIFF
--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -1273,6 +1273,7 @@ void CModelInfoSA::SetColModel(CColModel* pColModel)
 
         // FUNC_SetColModel resets bDoWeOwnTheColModel
         m_pInterface->bDoWeOwnTheColModel = false;
+        m_pInterface->bCollisionWasStreamedWithModel = false;
 
         // public: static void __cdecl CColAccel::addCacheCol(int, class CColModel const &)
         DWORD func = 0x5B2C20;
@@ -1327,8 +1328,6 @@ void CModelInfoSA::RestoreColModel()
                 push    dwOriginalColModelInterface
                 call    dwFunc
             }
-
-            m_pInterface->bDoWeOwnTheColModel = false;
 
             // public: static void __cdecl CColAccel::addCacheCol(int, class CColModel const &)
             DWORD func = 0x5B2C20;


### PR DESCRIPTION
Revert "Revert "Revert "Fix #927: "Random collisionless objects" still exist (#1818)" (#1847)" (#1930)"

This reverts commit c38a71e3ddbdbd13aa142b7ec50602b7609a86a3.