### PR TITLE
Revert login behavior changes

### DIFF
--- a/Server/mods/deathmatch/logic/CAccountManager.cpp
+++ b/Server/mods/deathmatch/logic/CAccountManager.cpp
@@ -481,7 +481,7 @@ void CAccountManager::RemoveAll()
     DeletePointersAndClearList(m_List);
 }
 
-bool CAccountManager::LogIn(CClient* pClient, CClient* pEchoClient, const char* szAccountName, const char* szPassword, bool bCheckPassword)
+bool CAccountManager::LogIn(CClient* pClient, CClient* pEchoClient, const char* szAccountName, const char* szPassword)
 {
     // Is he already logged in?
     if (pClient->IsRegistered())
@@ -530,7 +530,7 @@ bool CAccountManager::LogIn(CClient* pClient, CClient* pEchoClient, const char* 
             pEchoClient->SendEcho(SString("login: Account for '%s' is already in use", szAccountName).c_str());
         return false;
     }
-    if (bCheckPassword && (!IsValidPassword(szPassword) || !pAccount->IsPassword(szPassword)))
+    if (!IsValidPassword(szPassword) || !pAccount->IsPassword(szPassword))
     {
         if (pEchoClient)
             pEchoClient->SendEcho(SString("login: Invalid password for account '%s'", szAccountName).c_str());

--- a/Server/mods/deathmatch/logic/CAccountManager.cpp
+++ b/Server/mods/deathmatch/logic/CAccountManager.cpp
@@ -481,7 +481,7 @@ void CAccountManager::RemoveAll()
     DeletePointersAndClearList(m_List);
 }
 
-bool CAccountManager::LogIn(CClient* pClient, CClient* pEchoClient, const char* szAccountName, std::optional<SString> password)
+bool CAccountManager::LogIn(CClient* pClient, CClient* pEchoClient, const char* szAccountName, const char* szPassword, bool bCheckPassword)
 {
     // Is he already logged in?
     if (pClient->IsRegistered())
@@ -530,8 +530,7 @@ bool CAccountManager::LogIn(CClient* pClient, CClient* pEchoClient, const char* 
             pEchoClient->SendEcho(SString("login: Account for '%s' is already in use", szAccountName).c_str());
         return false;
     }
-
-    if (password.has_value() && (!IsValidPassword(password.value()) || !pAccount->IsPassword(password.value())))
+    if (bCheckPassword && (!IsValidPassword(szPassword) || !pAccount->IsPassword(szPassword)))
     {
         if (pEchoClient)
             pEchoClient->SendEcho(SString("login: Invalid password for account '%s'", szAccountName).c_str());

--- a/Server/mods/deathmatch/logic/CAccountManager.h
+++ b/Server/mods/deathmatch/logic/CAccountManager.h
@@ -130,7 +130,7 @@ public:
     CAccount* GetAccountFromScriptID(uint uiScriptID);
     SString   GetActiveCaseVariation(const SString& strName);
 
-    bool LogIn(CClient* pClient, CClient* pEchoClient, const char* szAccountName, const char* szPassword, bool bCheckPassword = true);
+    bool LogIn(CClient* pClient, CClient* pEchoClient, const char* szAccountName, const char* szPassword);
     bool LogOut(CClient* pClient, CClient* pEchoClient);
 
     std::shared_ptr<CLuaArgument> GetAccountData(CAccount* pAccount, const char* szKey);

--- a/Server/mods/deathmatch/logic/CAccountManager.h
+++ b/Server/mods/deathmatch/logic/CAccountManager.h
@@ -14,8 +14,6 @@ class CAccountManager;
 #pragma once
 
 #include "CAccount.h"
-#include <optional>
-
 typedef uint SDbConnectionId;
 
 #define GUEST_ACCOUNT_NAME          "guest"
@@ -132,7 +130,7 @@ public:
     CAccount* GetAccountFromScriptID(uint uiScriptID);
     SString   GetActiveCaseVariation(const SString& strName);
 
-    bool LogIn(CClient* pClient, CClient* pEchoClient, const char* szAccountName, std::optional<SString> password);
+    bool LogIn(CClient* pClient, CClient* pEchoClient, const char* szAccountName, const char* szPassword, bool bCheckPassword = true);
     bool LogOut(CClient* pClient, CClient* pEchoClient);
 
     std::shared_ptr<CLuaArgument> GetAccountData(CAccount* pAccount, const char* szKey);

--- a/Server/mods/deathmatch/logic/CConsoleCommands.cpp
+++ b/Server/mods/deathmatch/logic/CConsoleCommands.cpp
@@ -836,7 +836,7 @@ bool CConsoleCommands::LogIn(CConsole* pConsole, const char* szArguments, CClien
 
         if (CAccountManager::IsValidAccountName(szNick) && CAccountManager::IsValidPassword(szPassword))
         {
-            return g_pGame->GetAccountManager()->LogIn(pClient, pEchoClient, szNick, std::string(szPassword));
+            return g_pGame->GetAccountManager()->LogIn(pClient, pEchoClient, szNick, szPassword);
         }
         else
         {

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -11355,6 +11355,11 @@ bool CStaticFunctionDefinitions::CopyAccountData(CAccount* pAccount, CAccount* p
     return true;
 }
 
+bool CStaticFunctionDefinitions::LogIn(CPlayer* pPlayer, CAccount* pAccount, const char* szPassword)
+{
+    return m_pAccountManager->LogIn(pPlayer, pPlayer, pAccount->GetName().c_str(), szPassword);
+}
+
 bool CStaticFunctionDefinitions::LogOut(CPlayer* pPlayer)
 {
     return m_pAccountManager->LogOut(pPlayer, pPlayer);

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -692,6 +692,7 @@ public:
     static bool      CopyAccountData(CAccount* pAccount, CAccount* pFromAccount);
 
     // Log in/out funcs
+    static bool LogIn(CPlayer* pPlayer, CAccount* pAccount, const char* szPassword);
     static bool LogOut(CPlayer* pPlayer);
 
     // Admin funcs

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.cpp
@@ -602,7 +602,8 @@ int CLuaAccountDefs::CopyAccountData(lua_State* luaVM)
 
 bool CLuaAccountDefs::LogIn(CPlayer* pPlayer, CAccount* pAccount, std::optional<std::string> password)
 {
-    return m_pAccountManager->LogIn(pPlayer, pPlayer, pAccount->GetName().c_str(), std::move(password));
+    std::string strPassword = password.value_or("");
+    return m_pAccountManager->LogIn(pPlayer, pPlayer, pAccount->GetName().c_str(), strPassword.c_str(), password.has_value());
 }
 
 int CLuaAccountDefs::LogOut(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaAccountDefs.h
@@ -19,7 +19,7 @@ public:
     static void AddClass(lua_State* luaVM);
 
     // Log in/out
-    static bool LogIn(CPlayer* pPlayer, CAccount* pAccount, std::optional<std::string> password);
+    LUA_DECLARE(LogIn);
     LUA_DECLARE(LogOut);
 
     // Account get funcs


### PR DESCRIPTION
The changes were not audited properly and must be reverted until a full solution can be provided to the security aspect.

Reverts #1855 and #1848

Related to #1965 