### PR TITLE
Keep console position and size when changing locale

### DIFF
--- a/Client/core/CGUI.cpp
+++ b/Client/core/CGUI.cpp
@@ -249,7 +249,7 @@ void CLocalGUI::DoPulse()
                 m_LastSettingsRevision = cvars->GetRevision() - 1;
 
                 if (m_LocaleChangeCounter == 2)
-                    CCore::GetSingleton().ShowMessageBox(_E("CC99"), ("PLEASE WAIT...................."), MB_ICON_INFO);
+                    CCore::GetSingleton().ShowMessageBox(_E("CC99"), ("Changing Language, please wait..."), MB_ICON_INFO);
             }
             else
             {

--- a/Client/core/CGUI.cpp
+++ b/Client/core/CGUI.cpp
@@ -249,7 +249,7 @@ void CLocalGUI::DoPulse()
                 m_LastSettingsRevision = cvars->GetRevision() - 1;
 
                 if (m_LocaleChangeCounter == 2)
-                    CCore::GetSingleton().ShowMessageBox(_E("CC99"), ("Changing Language, please wait..."), MB_ICON_INFO);
+                    CCore::GetSingleton().ShowMessageBox(_E("CC99"), ("Changing language, please wait..."), MB_ICON_INFO);
             }
             else
             {

--- a/Client/core/CGUI.cpp
+++ b/Client/core/CGUI.cpp
@@ -102,6 +102,10 @@ void CLocalGUI::ChangeLocale(const char* szName)
 {
     bool guiWasLoaded = m_pMainMenu != NULL;
     assert(guiWasLoaded);
+
+    CVector2D vPos = m_pConsole->GetPosition();
+    CVector2D vSize = m_pConsole->GetSize();
+
     if (guiWasLoaded)
         DestroyWindows();
 
@@ -112,7 +116,15 @@ void CLocalGUI::ChangeLocale(const char* szName)
     m_LastLocaleName = szName;
 
     if (guiWasLoaded)
+    {
         CreateWindows(guiWasLoaded);
+
+        if (m_pConsole != nullptr)
+        {
+            m_pConsole->SetPosition(vPos);
+            m_pConsole->SetSize(vSize);
+        }
+    }
 }
 
 void CLocalGUI::CreateWindows(bool bGameIsAlreadyLoaded)


### PR DESCRIPTION
This PR fixes #1969 by re-applying position and size when language is changed.