### PR TITLE
Fix #1973: Nested tuples not working in argument parser return values

### DIFF
--- a/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
@@ -664,7 +664,8 @@ struct CLuaFunctionParser<ErrorOnFailure, ReturnOnFailure, Func> : CLuaFunctionP
     template <typename T>
     inline int PushResult(lua_State* L, const T& value)
     {
-        return lua::Push(L, value);
+        lua::Push(L, value);
+        return 1;
     }
 
     inline int operator()(lua_State* L, CScriptDebugging* pScriptDebugging)

--- a/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
@@ -18,6 +18,21 @@ class CLuaArgument;
 #include "lua/CLuaStackChecker.h"
 #include "lua/LuaBasic.h"
 
+// Wrapper around std::tuple to indicate that multiple values should be pushed to
+// the Lua stack
+template<typename... Ts>
+struct LuaMultiReturn
+{
+    // Note: We use a separate template for the constructor arguments
+    // to allow type conversions. For example: return { "hello", 42 };
+    // is a valid statement to construct a LuaMuliReturn<std::string, int>
+    template <typename... Args>
+    LuaMultiReturn(Args... args) : values{args...} {}
+
+    std::tuple<Ts...> values;
+};
+
+
 struct CLuaFunctionParserBase
 {
     // iIndex is passed around by reference
@@ -653,10 +668,10 @@ struct CLuaFunctionParser<ErrorOnFailure, ReturnOnFailure, Func> : CLuaFunctionP
 
     // Tuples can be used to return multiple results
     template <typename... Ts>
-    inline int PushResult(lua_State* L, const std::tuple<Ts...>& tuple)
+    inline int PushResult(lua_State* L, const LuaMultiReturn<Ts...>& result)
     {
         // Call Push on each element of the tuple
-        std::apply([L](const auto&... value) { (lua::Push(L, value), ...); }, tuple);
+        std::apply([L](const auto&... value) { (lua::Push(L, value), ...); }, result.values);
         return sizeof...(Ts);
     }
 

--- a/Shared/mods/deathmatch/logic/lua/LuaBasic.h
+++ b/Shared/mods/deathmatch/logic/lua/LuaBasic.h
@@ -13,7 +13,7 @@
 
 /*
     Basic Lua operations:
-        int Push(L, T value)
+        void Push(L, T value)
         T PopPrimitive(L, std::size_t stackIndex)
 */
 
@@ -28,117 +28,103 @@ namespace lua
     template <typename T>
     inline T PopPrimitive(lua_State* L, std::size_t& index);
 
-
     // Push should push a value of type T to the Lua Stack
-    // The return value must be the net amount of items pushed to the stack, which should
-    // be 1 for most types (e.g. Push<int>) but may be any number for special cases
-    // like tuples, in order to allow returning multiple values from a function
-    inline int Push(lua_State* L, int value)
+    // This will always increase the stack size by 1
+    inline void Push(lua_State* L, int value)
     {
         lua_pushnumber(L, value);
-        return 1;
     }
-    inline int Push(lua_State* L, unsigned int value)
+    inline void Push(lua_State* L, unsigned int value)
     {
         lua_pushnumber(L, value);
-        return 1;
     }
-    inline int Push(lua_State* L, float value)
+    inline void Push(lua_State* L, float value)
     {
         lua_pushnumber(L, value);
-        return 1;
     }
-    inline int Push(lua_State* L, double value)
+    inline void Push(lua_State* L, double value)
     {
         lua_pushnumber(L, value);
-        return 1;
     }
 
-    inline int Push(lua_State* L, bool value)
+    inline void Push(lua_State* L, bool value)
     {
         lua_pushboolean(L, value);
-        return 1;
     }
 
-    inline int Push(lua_State* L, nullptr_t)
+    inline void Push(lua_State* L, nullptr_t)
     {
         lua_pushnil(L);
-        return 1;
     }
 
-    inline int Push(lua_State* L, const std::string& value)
+    inline void Push(lua_State* L, const std::string& value)
     {
         lua_pushlstring(L, value.data(), value.length());
-        return 1;
     }
 
-    inline int Push(lua_State* L, const CLuaArgument& arg)
+    inline void Push(lua_State* L, const CLuaArgument& arg)
     {
         if (arg.GetType() == LUA_TNONE)
-            return 0;
-
+        {
+            // Calling lua::Push with a LUA_TNONE type value is not allowed, since this is rather error-prone
+            // as many callers would not check the stack position after pushing.
+            // Hence throw & abort here and let developers fix it.
+            throw std::logic_error("lua::Push");
+        }
+        
         arg.Push(L);
-        return 1;
     }
 
-    inline int Push(lua_State* L, const CLuaArguments& args)
+    inline void Push(lua_State* L, const CLuaArguments& args)
     {
         args.PushAsTable(L);
-        return 1;
     }
 
-    inline int Push(lua_State* L, const CVector2D& value)
+    inline void Push(lua_State* L, const CVector2D& value)
     {
         lua_pushvector(L, value);
-        return 1;
     }
 
-    inline int Push(lua_State* L, const CVector& value)
+    inline void Push(lua_State* L, const CVector& value)
     {
         lua_pushvector(L, value);
-        return 1;
     }
 
-    inline int Push(lua_State* L, const CVector4D& value)
+    inline void  Push(lua_State* L, const CVector4D& value)
     {
         lua_pushvector(L, value);
-        return 1;
     }
 
-    inline int Push(lua_State* L, const CMatrix& value)
+    inline void Push(lua_State* L, const CMatrix& value)
     {
         lua_pushmatrix(L, value);
-        return 1;
     }
 
     // Overload for enum types only
     template <typename T>
-    typename std::enable_if_t<std::is_enum_v<T>, int> Push(lua_State* L, const T& val)
+    typename std::enable_if_t<std::is_enum_v<T>> Push(lua_State* L, const T& val)
     {
         // Push<string> must be defined before this function, otherwise it wont compile
-        return Push(L, EnumToString(val));
+        Push(L, EnumToString(val));
     }
 
     // Overload for pointers to classes. We boldly assume that these are script entities
     template <typename T>
-    std::enable_if_t<std::is_class_v<T>, int> Push(lua_State* L, T* val)
+    std::enable_if_t<std::is_class_v<T>> Push(lua_State* L, T* val)
     {
         lua_pushelement(L, val);
-        return 1;
     }
 
     template <typename T>
-    int Push(lua_State* L, const std::shared_ptr<T>& ptr)
+    void Push(lua_State* L, const std::shared_ptr<T>& ptr)
     {
         lua_pushelement(L, ptr.get());
-        return 1;
     }
 
     template <typename T>
-    int Push(lua_State* L, const std::unique_ptr<T>& ptr)
+    void Push(lua_State* L, const std::unique_ptr<T>& ptr)
     {
         lua_pushelement(L, ptr.get());
-        return 1;
     }
 
     /*****************************************************************\
@@ -148,42 +134,42 @@ namespace lua
     \*****************************************************************/
 
     template <typename... Ts>
-    int Push(lua_State* L, const std::variant<Ts...>& val);
+    void Push(lua_State* L, const std::variant<Ts...>& val);
 
     template <typename T>
-    int Push(lua_State* L, const std::optional<T>& val);
+    void Push(lua_State* L, const std::optional<T>& val);
 
     template <typename T, size_t N>
-    int Push(lua_State* L, const std::array<T, N>& val);
+    void Push(lua_State* L, const std::array<T, N>& val);
 
     template <typename T>
-    int Push(lua_State* L, const std::vector<T>& val);
+    void Push(lua_State* L, const std::vector<T>& val);
 
     template <typename K, typename V>
-    int Push(lua_State* L, const std::unordered_map<K, V>& val);
+    void Push(lua_State* L, const std::unordered_map<K, V>& val);
 
     template<typename... Ts>
-    int Push(lua_State* L, const std::tuple<Ts...>& tuple);
+    void Push(lua_State* L, const std::tuple<Ts...>& tuple);
 
     // Define after this line, declare above.
 
     template <typename... Ts>
-    int Push(lua_State* L, const std::variant<Ts...>& val)
+    void Push(lua_State* L, const std::variant<Ts...>& val)
     {
-        return std::visit([L](const auto& value) -> int { return Push(L, value); }, val);
+        std::visit([L](const auto& value) { Push(L, value); }, val);
     }
 
     template <typename T>
-    int Push(lua_State* L, const std::optional<T>& val)
+    void Push(lua_State* L, const std::optional<T>& val)
     {
         if (val.has_value())
-            return Push(L, val.value());
+            Push(L, val.value());
         else
-            return Push(L, nullptr);
+            Push(L, nullptr);
     }
 
     template <typename T, size_t N>
-    int Push(lua_State* L, const std::array<T, N>& val)
+    void Push(lua_State* L, const std::array<T, N>& val)
     {
         lua_createtable(L, N, 0);
         lua_Number i = 1;
@@ -192,13 +178,10 @@ namespace lua
             Push(L, v);
             lua_rawseti(L, -2, i++);
         }
-
-        // Only the table remains on the stack
-        return 1;
     }
 
     template <typename T>
-    int Push(lua_State* L, const std::vector<T>& val)
+    void Push(lua_State* L, const std::vector<T>& val)
     {
         lua_newtable(L);
         int i = 1;
@@ -208,13 +191,10 @@ namespace lua
             Push(L, v);
             lua_settable(L, -3);
         }
-
-        // Only the table remains on the stack
-        return 1;
     }
 
     template <typename K, typename V>
-    int Push(lua_State* L, const std::unordered_map<K, V>& val)
+    void Push(lua_State* L, const std::unordered_map<K, V>& val)
     {
         lua_newtable(L);
         for (const auto& [k, v] : val)
@@ -223,30 +203,24 @@ namespace lua
             Push(L, v);
             lua_settable(L, -3);
         }
-
-        // Only the table remains on the stack
-        return 1;
     }
 
-    // Tuples can be used to build fixed-size tables
+    // Tuples can be used to push fixed-size tables
     // e.g. `std::tuple<float, int, bool>` will be pushed as { float, int, bool }
     template<typename... Ts>
-    int Push(lua_State* L, const std::tuple<Ts...>& tuple)
+    void Push(lua_State* L, const std::tuple<Ts...>& tuple)
     {
         // Call Push on each element of the tuple
         lua_createtable(L, sizeof...(Ts), 0);
-        
         std::apply([L](const auto&... values) {
             int  key = 1;
             auto PushTable = [](lua_State* L, int& key, const auto& value)
             {
-                Push(L, key++);
                 Push(L, value);
-                lua_settable(L, -3);
+                lua_rawseti(L, -2, key++);
             };
 
             (PushTable(L, key, values), ...);
         }, tuple);
-        return 1;
     }
 }


### PR DESCRIPTION
Rather than directly handling tuples in `Push` for multiple return values, I changed it to act on return values from `CLuaFunctionParser` only. Tuples used for `Push` are now pushed as a simple table. This should also make `lua::Push` more usable for other purposes. 