### PR TITLE
Add vehicle dependent dummy positions

### DIFF
--- a/Client/game_sa/CAutomobileSA.h
+++ b/Client/game_sa/CAutomobileSA.h
@@ -184,7 +184,7 @@ public:
     char                      field_963;
     float                     field_964;
     int                       m_wheelFrictionState[4];
-    void*                     pNitroParticle[2];
+    CFxSystemSAInterface*     pNitroParticle[2];
     char                      field_980;
     char                      field_981;
     short                     field_982;

--- a/Client/game_sa/CFxSystemSA.cpp
+++ b/Client/game_sa/CFxSystemSA.cpp
@@ -69,13 +69,18 @@ void CFxSystemSA::GetPosition(CVector& vecPos)
 
 void CFxSystemSA::SetPosition(const CVector& vecPos)
 {
-    m_pInterface->matPosition.pos.x = vecPos.fX;
-    m_pInterface->matPosition.pos.y = vecPos.fY;
-    m_pInterface->matPosition.pos.z = vecPos.fZ;
+    SetPosition(m_pInterface, vecPos);
+}
+
+void CFxSystemSA::SetPosition(CFxSystemSAInterface* fxSystem, const CVector& position)
+{
+    fxSystem->matPosition.pos.x = position.fX;
+    fxSystem->matPosition.pos.y = position.fY;
+    fxSystem->matPosition.pos.z = position.fZ;
 
     // Set the update flag(s)
     // this is what RwMatrixUpdate (@0x7F18E0) does
-    m_pInterface->matPosition.flags &= 0xFFFDFFFC;
+    fxSystem->matPosition.flags &= 0xFFFDFFFC;
 }
 
 float CFxSystemSA::GetEffectDensity()

--- a/Client/game_sa/CFxSystemSA.h
+++ b/Client/game_sa/CFxSystemSA.h
@@ -109,6 +109,8 @@ public:
 
     static void StaticSetHooks();
 
+    static void SetPosition(CFxSystemSAInterface* fxSystem, const CVector& position);
+
 protected:
     CFxSystemSAInterface* m_pInterface;
     float                 m_fDrawDistance;

--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -1016,28 +1016,13 @@ void CModelInfoSA::SetVehicleExhaustFumesPosition(const CVector& vecPosition)
     return SetVehicleDummyPosition(eVehicleDummies::EXHAUST, vecPosition);
 }
 
-bool CModelInfoSA::GetVehicleDummyDefaultPositions(std::array<CVector, VEHICLE_DUMMY_COUNT>& positions) const
+bool CModelInfoSA::GetVehicleDummyPositions(std::array<CVector, VEHICLE_DUMMY_COUNT>& positions) const
 {
     if (!IsVehicle())
         return false;
 
     CVector* dummyPositions = reinterpret_cast<CVehicleModelInfoSAInterface*>(m_pInterface)->pVisualInfo->vecDummies;
-
-    for (size_t i = 0; i < positions.size(); ++i)
-    {
-        positions[i] = dummyPositions[i];
-    }
-
-    auto iter = ms_ModelDefaultDummiesPosition.find(m_dwModelID);
-
-    if (iter != ms_ModelDefaultDummiesPosition.end())
-    {
-        for (const auto& dummyDefault : iter->second)
-        {
-            positions[dummyDefault.first] = dummyDefault.second;
-        }
-    }
-
+    std::copy(dummyPositions, dummyPositions + positions.size(), positions.begin());
     return true;
 }
 

--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -25,8 +25,6 @@ std::map<CTimeInfoSAInterface*, CTimeInfoSAInterface*>                CModelInfo
 std::unordered_map<DWORD, unsigned short>                             CModelInfoSA::ms_OriginalObjectPropertiesGroups;
 std::unordered_map<DWORD, std::pair<float, float>>                    CModelInfoSA::ms_VehicleModelDefaultWheelSizes;
 
-// std::array<
-
 CModelInfoSA::CModelInfoSA()
 {
     m_pInterface = NULL;

--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -25,6 +25,8 @@ std::map<CTimeInfoSAInterface*, CTimeInfoSAInterface*>                CModelInfo
 std::unordered_map<DWORD, unsigned short>                             CModelInfoSA::ms_OriginalObjectPropertiesGroups;
 std::unordered_map<DWORD, std::pair<float, float>>                    CModelInfoSA::ms_VehicleModelDefaultWheelSizes;
 
+static constexpr uintptr_t vftable_CVehicleModelInfo = 0x85C5C8u;
+
 CModelInfoSA::CModelInfoSA()
 {
     m_pInterface = NULL;
@@ -249,7 +251,13 @@ BYTE CModelInfoSA::GetVehicleType()
 
 bool CModelInfoSA::IsVehicle() const
 {
-    return m_pInterface != nullptr && reinterpret_cast<intptr_t>(m_pInterface->VFTBL) == 0x85C5C8;
+    // NOTE(botder): This is from CModelInfo::IsVehicleModelType
+    if (m_dwModelID >= 20000)
+        return false;
+
+    // NOTE(botder): m_pInterface might be a nullptr here, we can't use it
+    CBaseModelInfoSAInterface* model = ppModelInfo[m_dwModelID];
+    return model != nullptr && reinterpret_cast<intptr_t>(model->VFTBL) == vftable_CVehicleModelInfo;
 }
 
 bool CModelInfoSA::IsPlayerModel()

--- a/Client/game_sa/CModelInfoSA.h
+++ b/Client/game_sa/CModelInfoSA.h
@@ -335,7 +335,7 @@ public:
     BOOL IsQuadBike();
     BOOL IsBmx();
     BOOL IsTrailer();
-    BOOL IsVehicle();
+    bool IsVehicle() const override;
     BOOL IsUpgrade();
 
     char* GetNameIfVehicle();
@@ -383,6 +383,8 @@ public:
     void*        SetVehicleSuspensionData(void* pSuspensionLines);
     CVector      GetVehicleExhaustFumesPosition() override;
     void         SetVehicleExhaustFumesPosition(const CVector& vecPosition) override;
+    bool         GetVehicleDummyDefaultPositions(std::array<CVector, VEHICLE_DUMMY_COUNT>& positions) const override;
+    CVector      GetVehicleDummyDefaultPosition(eVehicleDummies eDummy) override;
     CVector      GetVehicleDummyPosition(eVehicleDummies eDummy) override;
     void         SetVehicleDummyPosition(eVehicleDummies eDummy, const CVector& vecPosition) override;
     void         ResetVehicleDummies(bool bRemoveFromDummiesMap);

--- a/Client/game_sa/CModelInfoSA.h
+++ b/Client/game_sa/CModelInfoSA.h
@@ -383,9 +383,9 @@ public:
     void*        SetVehicleSuspensionData(void* pSuspensionLines);
     CVector      GetVehicleExhaustFumesPosition() override;
     void         SetVehicleExhaustFumesPosition(const CVector& vecPosition) override;
-    bool         GetVehicleDummyDefaultPositions(std::array<CVector, VEHICLE_DUMMY_COUNT>& positions) const override;
     CVector      GetVehicleDummyDefaultPosition(eVehicleDummies eDummy) override;
     CVector      GetVehicleDummyPosition(eVehicleDummies eDummy) override;
+    bool         GetVehicleDummyPositions(std::array<CVector, VEHICLE_DUMMY_COUNT>& positions) const override;
     void         SetVehicleDummyPosition(eVehicleDummies eDummy, const CVector& vecPosition) override;
     void         ResetVehicleDummies(bool bRemoveFromDummiesMap);
     static void  ResetAllVehicleDummies();

--- a/Client/game_sa/CPoolsSA.cpp
+++ b/Client/game_sa/CPoolsSA.cpp
@@ -97,7 +97,7 @@ CVehicle* CPoolsSA::AddVehicle(CClientVehicle* pClientVehicle, eVehicleTypes eVe
 
     if (m_vehiclePool.ulCount < MAX_VEHICLES)
     {
-        VehicleClass vehicleClass = (VehicleClass)pGame->GetModelInfo(eVehicleType)->GetVehicleType();
+        auto vehicleClass = static_cast<VehicleClass>(pGame->GetModelInfo(eVehicleType)->GetVehicleType());
         
         switch (vehicleClass)
 	    {

--- a/Client/game_sa/CPoolsSA.cpp
+++ b/Client/game_sa/CPoolsSA.cpp
@@ -97,15 +97,15 @@ CVehicle* CPoolsSA::AddVehicle(CClientVehicle* pClientVehicle, eVehicleTypes eVe
 
     if (m_vehiclePool.ulCount < MAX_VEHICLES)
     {
-        eVehicleModelTypes eVehicleModelType = (eVehicleModelTypes)pGame->GetModelInfo(eVehicleType)->GetVehicleType();
+        VehicleClass vehicleClass = (VehicleClass)pGame->GetModelInfo(eVehicleType)->GetVehicleType();
         
-        switch (eVehicleModelType)
+        switch (vehicleClass)
 	    {
-            case eVehicleModelTypes::BOAT:
+            case VehicleClass::BOAT:
                 pVehicle = new CBoatSA(eVehicleType, ucVariation, ucVariation2);
                 break;
-            case eVehicleModelTypes::BMX:
-            case eVehicleModelTypes::BIKE:
+            case VehicleClass::BMX:
+            case VehicleClass::BIKE:
                 pVehicle = new CBikeSA(eVehicleType, ucVariation, ucVariation2);
                 break;
             default:
@@ -147,20 +147,19 @@ CVehicle* CPoolsSA::AddVehicle(CClientVehicle* pClientVehicle, DWORD* pGameInter
             }
             else
             {
-        
-                switch ((eVehicleModelTypes)pInterface->m_type)
-	             {
-                    case eVehicleModelTypes::BOAT:
-                         pVehicle = new CBoatSA(reinterpret_cast<CBoatSAInterface*>(pInterface));
+                switch ((VehicleClass)pInterface->m_vehicleClass)
+                {
+                    case VehicleClass::BOAT:
+                        pVehicle = new CBoatSA(reinterpret_cast<CBoatSAInterface*>(pInterface));
                         break;
-                    case eVehicleModelTypes::BMX:
-                    case eVehicleModelTypes::BIKE:
+                    case VehicleClass::BMX:
+                    case VehicleClass::BIKE:
                         pVehicle = new CBikeSA(reinterpret_cast<CBikeSAInterface*>(pInterface));
                         break;
                     default:
                         pVehicle = new CVehicleSA(pInterface);
                         break;
-	             }
+	            }
 
                 if (!AddVehicleToPool(pClientVehicle, pVehicle))
                 {

--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -212,14 +212,6 @@ void CVehicleSA::Init()
         {
             m_dummyPositions[i] = modelInfo->GetVehicleDummyPosition((eVehicleDummies)i);
         }
-
-        CVector& secondaryExhaust = m_dummyPositions[EXHAUST_SECONDARY];
-
-        if (secondaryExhaust.fX == 0.0f && secondaryExhaust.fY == 0.0f && secondaryExhaust.fZ == 0.0f)
-        {
-            secondaryExhaust = m_dummyPositions[EXHAUST];
-            secondaryExhaust.fX *= -1.0f;
-        }
     }
 
     // Unlock doors as they spawn randomly with locked doors
@@ -2710,7 +2702,7 @@ bool CVehicleSA::SetDummyPosition(eVehicleDummies dummy, const CVector& position
             // NOTE(botder): The following code should be in CAutomobileSA::SetDummyPosition
             //               but we don't use CAutomobileSA yet
             uint8_t vehicleClass = reinterpret_cast<CVehicleSAInterface*>(m_pInterface)->m_vehicleClass;
-            bool isAutomobileClass = static_cast<VehicleClass>(vehicleClass) == VehicleClass::AUTOMOBILE;
+            bool    isAutomobileClass = static_cast<VehicleClass>(vehicleClass) == VehicleClass::AUTOMOBILE;
 
             if (isAutomobileClass)
             {

--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -204,6 +204,17 @@ void CVehicleSA::Init()
     GetVehicleInterface()->m_pVehicle = this;
     g_bVehiclePointerInvalid = false;
 
+    CModelInfo* modelInfo = pGame->GetModelInfo(GetModelIndex());
+
+    if (modelInfo != nullptr)
+    {
+        for (size_t i = 0; i < m_dummyPositions.size(); ++i)
+        {
+            m_dummyPositions[i] = modelInfo->GetVehicleDummyPosition((eVehicleDummies)i);
+            m_dummyPositions[i].fZ += 1.0f;
+        }
+    }
+
     // Unlock doors as they spawn randomly with locked doors
     LockDoors(false);
 
@@ -2667,6 +2678,29 @@ void CVehicleSA::UpdateLandingGearPosition()
         }
     }
 }
+
+bool CVehicleSA::GetDummyPosition(eVehicleDummies dummy, CVector& position) const
+{
+    if (dummy >= 0 && dummy < VEHICLE_DUMMY_COUNT)
+    {
+        position = m_dummyPositions[dummy];
+        return true;
+    }
+
+    return false;
+}
+
+bool CVehicleSA::SetDummyPosition(eVehicleDummies dummy, CVector position)
+{
+    if (dummy >= 0 && dummy < VEHICLE_DUMMY_COUNT)
+    {
+        m_dummyPositions[dummy] = position;
+        return true;
+    }
+
+    return false;
+}
+
 // Change plate text of existing vehicle
 bool CVehicleSA::SetPlateText(const SString& strText)
 {

--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -1950,14 +1950,13 @@ void CVehicleSA::SetBikeWheelStatus(BYTE bWheel, BYTE bStatus)
 bool CVehicleSA::IsWheelCollided(BYTE eWheelPosition)
 {
     auto vehicle = static_cast<CAutomobileSAInterface*>(GetInterface());
-    switch (vehicle->m_type)
+    switch ((VehicleClass)vehicle->m_vehicleClass)
     {
-        case 0:
+        case VehicleClass::AUTOMOBILE:
             if (eWheelPosition < 4)
                 return vehicle->m_wheelCollisionState[eWheelPosition] == 4.f;
             break;
-
-        case 9:
+        case VehicleClass::BIKE:
             if (eWheelPosition < 2)
                 return *(float*)((DWORD)vehicle + 0x730 + eWheelPosition * 8) == 4.f || *(float*)((DWORD)vehicle + 0x734 + eWheelPosition * 8) == 4.f;
             break;

--- a/Client/game_sa/CVehicleSA.h
+++ b/Client/game_sa/CVehicleSA.h
@@ -326,9 +326,6 @@ class CAutoPilot
 
 #define MAX_UPGRADES_ATTACHED 15 // perhaps?
 
-/**
- * \todo GAME RELEASE: Update CVehicleSAInterface
- */
 class CVehicleSAInterface : public CPhysicalSAInterface
 {
 public:
@@ -433,10 +430,12 @@ public:
     BYTE Padding225[4];
 
     // 1424
-    BYTE m_type;            // 0 = car/plane, 5 = boat, 6 = train, 9 = bike
+    uint8_t  m_vehicleClass;
+    uint32_t m_vehicleSubClass;
 
-    // 1425
-    BYTE Padding226[15];
+    int16_t    m_peviousRemapTxd;
+    int16_t    m_remapTxd;
+    RwTexture* m_pRemapTexture;
 };
 static_assert(sizeof(CVehicleSAInterface) == 1440, "Invalid size for CVehicleSAInterface");
 

--- a/Client/game_sa/CVehicleSA.h
+++ b/Client/game_sa/CVehicleSA.h
@@ -326,6 +326,8 @@ class CAutoPilot
 
 #define MAX_UPGRADES_ATTACHED 15 // perhaps?
 
+class CParticleSAInterface;
+
 class CVehicleSAInterface : public CPhysicalSAInterface
 {
 public:
@@ -421,13 +423,18 @@ public:
     unsigned int m_isUsingHornOrSecondarySiren;
 
     // 1304
-    BYTE Padding220[112];
+    uint8_t Padding220[96];
+
+    // 1400
+    CFxSystemSAInterface* m_overheatParticle;
+    CFxSystemSAInterface* m_fireParticle;
+    CFxSystemSAInterface* m_dustParticle;
+    uint32_t m_renderLights;
 
     // 1416
     RwTexture* m_pCustomPlateTexture;
 
-    // 1420
-    BYTE Padding225[4];
+    float m_steeringLeftRight;
 
     // 1424
     uint8_t  m_vehicleClass;
@@ -438,6 +445,8 @@ public:
     RwTexture* m_pRemapTexture;
 };
 static_assert(sizeof(CVehicleSAInterface) == 1440, "Invalid size for CVehicleSAInterface");
+
+class CAutomobileSAInterface;
 
 class CVehicleSA : public virtual CVehicle, public virtual CPhysicalSA
 {
@@ -753,6 +762,8 @@ public:
     const CVector* GetDummyPositions() const override { return m_dummyPositions.data(); }
 
 private:
+    static void SetAutomobileDummyPosition(CAutomobileSAInterface* automobile, eVehicleDummies dummy, const CVector& position);
+
     void           RecalculateSuspensionLines();
     void           CopyGlobalSuspensionLinesToPrivate();
     SVehicleFrame* GetVehicleComponent(const SString& vehicleComponent);

--- a/Client/game_sa/CVehicleSA.h
+++ b/Client/game_sa/CVehicleSA.h
@@ -747,9 +747,10 @@ public:
     CAEVehicleAudioEntitySA* GetVehicleAudioEntity() { return m_pVehicleAudioEntity; };
 
     bool GetDummyPosition(eVehicleDummies dummy, CVector& position) const override;
-    bool SetDummyPosition(eVehicleDummies dummy, CVector position) override;
+    bool SetDummyPosition(eVehicleDummies dummy, const CVector& position) override;
 
-    CVector* GetDummyPositions() { return m_dummyPositions.data(); }
+    CVector*       GetDummyPositions() { return m_dummyPositions.data(); }
+    const CVector* GetDummyPositions() const override { return m_dummyPositions.data(); }
 
 private:
     void           RecalculateSuspensionLines();

--- a/Client/game_sa/CVehicleSA.h
+++ b/Client/game_sa/CVehicleSA.h
@@ -465,6 +465,8 @@ private:
     unsigned char                    m_ucVariantCount;
     bool                             m_doorsUndamageable = false;
 
+    std::array<CVector, VEHICLE_DUMMY_COUNT> m_dummyPositions;
+
 public:
     CVehicleSA();
     CVehicleSA(CVehicleSAInterface* vehicleInterface);
@@ -743,6 +745,11 @@ public:
     void UpdateLandingGearPosition();
 
     CAEVehicleAudioEntitySA* GetVehicleAudioEntity() { return m_pVehicleAudioEntity; };
+
+    bool GetDummyPosition(eVehicleDummies dummy, CVector& position) const override;
+    bool SetDummyPosition(eVehicleDummies dummy, CVector position) override;
+
+    CVector* GetDummyPositions() { return m_dummyPositions.data(); }
 
 private:
     void           RecalculateSuspensionLines();

--- a/Client/game_sa/CVehicleSA.h
+++ b/Client/game_sa/CVehicleSA.h
@@ -326,8 +326,6 @@ class CAutoPilot
 
 #define MAX_UPGRADES_ATTACHED 15 // perhaps?
 
-class CParticleSAInterface;
-
 class CVehicleSAInterface : public CPhysicalSAInterface
 {
 public:

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -5110,6 +5110,40 @@ bool CClientVehicle::SetDummyPosition(eVehicleDummies dummy, const CVector& posi
     return false;
 }
 
+bool CClientVehicle::ResetDummyPositions()
+{
+    if (m_pVehicle)
+    {
+        std::array<CVector, VEHICLE_DUMMY_COUNT> positions;
+
+        if (!m_pModelInfo->GetVehicleDummyDefaultPositions(positions))
+            return false;
+
+        for (size_t i = 0; i < positions.size(); ++i)
+        {
+            SetDummyPosition(static_cast<eVehicleDummies>(i), positions[i]);
+        }
+
+        return true;
+    }
+    else
+    {
+        if (m_copyDummyPositions)
+            return false;
+
+        m_copyDummyPositions = true;
+
+        for (CVector& position : m_dummyPositions)
+        {
+            position.fX = 0.0f;
+            position.fY = 0.0f;
+            position.fZ = 0.0f;
+        }
+
+        return true;
+    }
+}
+
 bool CClientVehicle::DoesNeedToWaitForGroundToLoad()
 {
     if (!g_pGame->IsASyncLoadingEnabled())

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -1130,13 +1130,7 @@ void CClientVehicle::SetModelBlocking(unsigned short usModel, unsigned char ucVa
 
         // Reset stored dummy positions
         m_copyDummyPositions = true;
-
-        for (CVector& position : m_dummyPositions)
-        {
-            position.fX = 0.0f;
-            position.fY = 0.0f;
-            position.fZ = 0.0f;
-        }
+        m_dummyPositions = {};
 
         // Create the vehicle if we're streamed in
         if (IsStreamedIn())
@@ -3022,11 +3016,7 @@ void CClientVehicle::Create()
         if (m_copyDummyPositions)
         {
             const CVector* positions = m_pVehicle->GetDummyPositions();
-
-            for (size_t i = 0; i < VEHICLE_DUMMY_COUNT; ++i)
-            {
-                m_dummyPositions[i] = positions[i];
-            }
+            std::copy(positions, positions + VEHICLE_DUMMY_COUNT, m_dummyPositions.begin());
         }
         else
         {
@@ -5116,7 +5106,7 @@ bool CClientVehicle::ResetDummyPositions()
     {
         std::array<CVector, VEHICLE_DUMMY_COUNT> positions;
 
-        if (!m_pModelInfo->GetVehicleDummyDefaultPositions(positions))
+        if (!m_pModelInfo->GetVehicleDummyPositions(positions))
             return false;
 
         for (size_t i = 0; i < positions.size(); ++i)
@@ -5132,14 +5122,7 @@ bool CClientVehicle::ResetDummyPositions()
             return false;
 
         m_copyDummyPositions = true;
-
-        for (CVector& position : m_dummyPositions)
-        {
-            position.fX = 0.0f;
-            position.fY = 0.0f;
-            position.fZ = 0.0f;
-        }
-
+        m_dummyPositions = {};
         return true;
     }
 }

--- a/Client/mods/deathmatch/logic/CClientVehicle.h
+++ b/Client/mods/deathmatch/logic/CClientVehicle.h
@@ -511,6 +511,9 @@ public:
 
     bool OnVehicleFallThroughMap();
 
+    bool GetDummyPosition(eVehicleDummies dummy, CVector& position) const;
+    bool SetDummyPosition(eVehicleDummies dummy, const CVector& position);
+
 protected:
     void ConvertComponentRotationBase(const SString& vehicleComponent, CVector& vecInOutRotation, EComponentBaseType inputBase, EComponentBaseType outputBase);
     void ConvertComponentPositionBase(const SString& vehicleComponent, CVector& vecInOutPosition, EComponentBaseType inputBase, EComponentBaseType outputBase);
@@ -708,4 +711,7 @@ public:
     SSirenInfo                               m_tSirenBeaconInfo;
     std::map<SString, SVehicleComponentData> m_ComponentData;
     bool                                     m_bAsyncLoadingDisabled;
+
+    std::array<CVector, VEHICLE_DUMMY_COUNT> m_dummyPositions;
+    bool                                     m_copyDummyPositions = true;
 };

--- a/Client/mods/deathmatch/logic/CClientVehicle.h
+++ b/Client/mods/deathmatch/logic/CClientVehicle.h
@@ -513,6 +513,7 @@ public:
 
     bool GetDummyPosition(eVehicleDummies dummy, CVector& position) const;
     bool SetDummyPosition(eVehicleDummies dummy, const CVector& position);
+    bool ResetDummyPositions();
 
 protected:
     void ConvertComponentRotationBase(const SString& vehicleComponent, CVector& vecInOutRotation, EComponentBaseType inputBase, EComponentBaseType outputBase);

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -3605,6 +3605,17 @@ bool CStaticFunctionDefinitions::GetVehicleModelDummyPosition(unsigned short usM
     return false;
 }
 
+bool CStaticFunctionDefinitions::GetVehicleModelDummyDefaultPosition(unsigned short usModel, eVehicleDummies eDummy, CVector& vecPosition)
+{
+    CModelInfo* modelInfo = g_pGame->GetModelInfo(usModel);
+
+    if (modelInfo == nullptr || !modelInfo->IsVehicle())
+        return false;
+
+    vecPosition = modelInfo->GetVehicleDummyDefaultPosition(eDummy);
+    return true;
+}
+
 bool CStaticFunctionDefinitions::SetVehicleModelExhaustFumesPosition(unsigned short usModel, CVector& vecPosition)
 {
     if (CClientVehicleManager::IsValidModel(usModel))

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -225,6 +225,7 @@ public:
     static bool            GetVehicleModelExhaustFumesPosition(unsigned short usModel, CVector& vecPosition);
     static bool            SetVehicleModelDummyPosition(unsigned short usModel, eVehicleDummies eDummy, CVector& vecPosition);
     static bool            GetVehicleModelDummyPosition(unsigned short usModel, eVehicleDummies eDummy, CVector& vecPosition);
+    static bool            GetVehicleModelDummyDefaultPosition(unsigned short usModel, eVehicleDummies eDummy, CVector& vecPosition);
 
     // Vehicle set functions
     static bool FixVehicle(CClientEntity& Entity);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -231,6 +231,8 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getUpgradeOnSlot", "getVehicleUpgradeOnSlot");
     lua_classfunction(luaVM, "getModelExhaustFumesPosition", OOP_GetVehicleModelExhaustFumesPosition);
     lua_classfunction(luaVM, "getVehicleModelDummyPosition", OOP_GetVehicleModelDummyPosition);
+    lua_classfunction(luaVM, "getVehicleModelDummyDefaultPosition", ArgumentParser<OOP_GetVehicleModelDummyDefaultPosition>);
+    lua_classfunction(luaVM, "getDummyPosition", ArgumentParser<OOP_GetVehicleDummyPosition>);
     lua_classfunction(luaVM, "getWheelScale", "getVehicleWheelScale");
     lua_classfunction(luaVM, "getModelWheelSize", "getVehicleModelWheelSize");
     lua_classfunction(luaVM, "getWheelFrictionState", "getVehicleWheelFrictionState");
@@ -277,6 +279,8 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setGravity", "setVehicleGravity");
     lua_classfunction(luaVM, "setModelExhaustFumesPosition", "setVehicleModelExhaustFumesPosition");
     lua_classfunction(luaVM, "setVehicleModelDummyPosition", "setVehicleModelDummyPosition");
+    lua_classfunction(luaVM, "setDummyPosition", "setVehicleDummyPosition");
+    lua_classfunction(luaVM, "resetDummyPositions", "resetVehicleDummyPositions");
     lua_classfunction(luaVM, "setVariant", "setVehicleVariant");
     lua_classfunction(luaVM, "setWheelScale", "setVehicleWheelScale");
     lua_classfunction(luaVM, "setModelWheelSize", "setVehicleModelWheelSize");
@@ -4137,6 +4141,16 @@ std::variant<bool, std::tuple<float, float, float>> CLuaVehicleDefs::GetVehicleM
     return std::tuple(position.fX, position.fY, position.fZ);
 }
 
+std::variant<bool, CVector> CLuaVehicleDefs::OOP_GetVehicleModelDummyDefaultPosition(unsigned short vehicleModel, eVehicleDummies dummy)
+{
+    CVector position;
+
+    if (!CStaticFunctionDefinitions::GetVehicleModelDummyDefaultPosition(vehicleModel, dummy, position))
+        return false;
+
+    return position;
+}
+
 bool CLuaVehicleDefs::SetVehicleDummyPosition(CClientVehicle* vehicle, eVehicleDummies dummy, CVector position)
 {
     return vehicle->SetDummyPosition(dummy, position);
@@ -4150,6 +4164,16 @@ std::variant<bool, std::tuple<float, float, float>> CLuaVehicleDefs::GetVehicleD
         return false;
 
     return std::tuple(position.fX, position.fY, position.fZ);
+}
+
+std::variant<bool, CVector> CLuaVehicleDefs::OOP_GetVehicleDummyPosition(CClientVehicle* vehicle, eVehicleDummies dummy)
+{
+    CVector position;
+
+    if (!vehicle->GetDummyPosition(dummy, position))
+        return false;
+
+    return position;
 }
 
 bool CLuaVehicleDefs::ResetVehicleDummyPositions(CClientVehicle* vehicle)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -83,6 +83,7 @@ void CLuaVehicleDefs::LoadFunctions()
         {"getVehicleComponents", GetVehicleComponents},
         {"getVehicleModelExhaustFumesPosition", GetVehicleModelExhaustFumesPosition},
         {"getVehicleModelDummyPosition", GetVehicleModelDummyPosition},
+        {"getVehicleDummyPosition", ArgumentParser<GetVehicleDummyPosition>},
         {"getVehicleWheelScale", ArgumentParser<GetVehicleWheelScale>},
         {"getVehicleModelWheelSize", ArgumentParser<GetVehicleModelWheelSize>},
         {"getVehicleWheelFrictionState", ArgumentParser<GetVehicleWheelFrictionState>},
@@ -142,6 +143,7 @@ void CLuaVehicleDefs::LoadFunctions()
         {"setVehicleWindowOpen", SetVehicleWindowOpen},
         {"setVehicleModelExhaustFumesPosition", SetVehicleModelExhaustFumesPosition},
         {"setVehicleModelDummyPosition", SetVehicleModelDummyPosition},
+        {"setVehicleDummyPosition", ArgumentParser<SetVehicleDummyPosition>},
         {"setVehicleVariant", ArgumentParser<SetVehicleVariant>},
         {"setVehicleWheelScale", ArgumentParser<SetVehicleWheelScale>},
         {"setVehicleModelWheelSize", ArgumentParser<SetVehicleModelWheelSize>},
@@ -4121,4 +4123,19 @@ int CLuaVehicleDefs::GetVehicleWheelFrictionState(CClientVehicle* pVehicle, unsi
         throw std::invalid_argument("Invalid vehicle type");
 
     return pVehicle->GetWheelFrictionState(wheel);
+}
+
+bool CLuaVehicleDefs::SetVehicleDummyPosition(CClientVehicle* vehicle, eVehicleDummies dummy, CVector position)
+{
+    return vehicle->SetDummyPosition(dummy, position);
+}
+
+std::variant<bool, std::tuple<float, float, float>> CLuaVehicleDefs::GetVehicleDummyPosition(CClientVehicle* vehicle, eVehicleDummies dummy)
+{
+    CVector position;
+
+    if (!vehicle->GetDummyPosition(dummy, position))
+        return false;
+
+    return std::tuple(position.fX, position.fY, position.fZ);
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -83,6 +83,7 @@ void CLuaVehicleDefs::LoadFunctions()
         {"getVehicleComponents", GetVehicleComponents},
         {"getVehicleModelExhaustFumesPosition", GetVehicleModelExhaustFumesPosition},
         {"getVehicleModelDummyPosition", GetVehicleModelDummyPosition},
+        {"getVehicleModelDummyDefaultPosition", ArgumentParser<GetVehicleModelDummyDefaultPosition>},
         {"getVehicleDummyPosition", ArgumentParser<GetVehicleDummyPosition>},
         {"getVehicleWheelScale", ArgumentParser<GetVehicleWheelScale>},
         {"getVehicleModelWheelSize", ArgumentParser<GetVehicleModelWheelSize>},
@@ -143,6 +144,7 @@ void CLuaVehicleDefs::LoadFunctions()
         {"setVehicleWindowOpen", SetVehicleWindowOpen},
         {"setVehicleModelExhaustFumesPosition", SetVehicleModelExhaustFumesPosition},
         {"setVehicleModelDummyPosition", SetVehicleModelDummyPosition},
+        {"resetVehicleDummyPositions", ArgumentParser<ResetVehicleDummyPositions>},
         {"setVehicleDummyPosition", ArgumentParser<SetVehicleDummyPosition>},
         {"setVehicleVariant", ArgumentParser<SetVehicleVariant>},
         {"setVehicleWheelScale", ArgumentParser<SetVehicleWheelScale>},
@@ -4125,6 +4127,16 @@ int CLuaVehicleDefs::GetVehicleWheelFrictionState(CClientVehicle* pVehicle, unsi
     return pVehicle->GetWheelFrictionState(wheel);
 }
 
+std::variant<bool, std::tuple<float, float, float>> CLuaVehicleDefs::GetVehicleModelDummyDefaultPosition(unsigned short vehicleModel, eVehicleDummies dummy)
+{
+    CVector position;
+
+    if (!CStaticFunctionDefinitions::GetVehicleModelDummyDefaultPosition(vehicleModel, dummy, position))
+        return false;
+
+    return std::tuple(position.fX, position.fY, position.fZ);
+}
+
 bool CLuaVehicleDefs::SetVehicleDummyPosition(CClientVehicle* vehicle, eVehicleDummies dummy, CVector position)
 {
     return vehicle->SetDummyPosition(dummy, position);
@@ -4138,4 +4150,9 @@ std::variant<bool, std::tuple<float, float, float>> CLuaVehicleDefs::GetVehicleD
         return false;
 
     return std::tuple(position.fX, position.fY, position.fZ);
+}
+
+bool CLuaVehicleDefs::ResetVehicleDummyPositions(CClientVehicle* vehicle)
+{
+    return vehicle->ResetDummyPositions();
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -140,6 +140,9 @@ public:
     LUA_DECLARE(SetVehicleModelDummyPosition);
     LUA_DECLARE_OOP(GetVehicleModelDummyPosition)
 
+    static bool                                                SetVehicleDummyPosition(CClientVehicle* vehicle, eVehicleDummies dummy, CVector position);
+    static std::variant<bool, std::tuple<float, float, float>> GetVehicleDummyPosition(CClientVehicle* vehicle, eVehicleDummies dummy);
+
     LUA_DECLARE(SetVehicleModelExhaustFumesPosition);
     LUA_DECLARE_OOP(GetVehicleModelExhaustFumesPosition);
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -140,8 +140,11 @@ public:
     LUA_DECLARE(SetVehicleModelDummyPosition);
     LUA_DECLARE_OOP(GetVehicleModelDummyPosition)
 
+    static std::variant<bool, std::tuple<float, float, float>> GetVehicleModelDummyDefaultPosition(unsigned short vehicleModel, eVehicleDummies dummy);
+
     static bool                                                SetVehicleDummyPosition(CClientVehicle* vehicle, eVehicleDummies dummy, CVector position);
     static std::variant<bool, std::tuple<float, float, float>> GetVehicleDummyPosition(CClientVehicle* vehicle, eVehicleDummies dummy);
+    static bool                                                ResetVehicleDummyPositions(CClientVehicle* vehicle);
 
     LUA_DECLARE(SetVehicleModelExhaustFumesPosition);
     LUA_DECLARE_OOP(GetVehicleModelExhaustFumesPosition);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -141,9 +141,11 @@ public:
     LUA_DECLARE_OOP(GetVehicleModelDummyPosition)
 
     static std::variant<bool, std::tuple<float, float, float>> GetVehicleModelDummyDefaultPosition(unsigned short vehicleModel, eVehicleDummies dummy);
+    static std::variant<bool, CVector>                         OOP_GetVehicleModelDummyDefaultPosition(unsigned short vehicleModel, eVehicleDummies dummy);
 
     static bool                                                SetVehicleDummyPosition(CClientVehicle* vehicle, eVehicleDummies dummy, CVector position);
     static std::variant<bool, std::tuple<float, float, float>> GetVehicleDummyPosition(CClientVehicle* vehicle, eVehicleDummies dummy);
+    static std::variant<bool, CVector>                         OOP_GetVehicleDummyPosition(CClientVehicle* vehicle, eVehicleDummies dummy);
     static bool                                                ResetVehicleDummyPositions(CClientVehicle* vehicle);
 
     LUA_DECLARE(SetVehicleModelExhaustFumesPosition);

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -67,6 +67,7 @@ public:
     void                InitHooks_Weapons();
     void                InitHooks_Peds();
     void                InitHooks_VehicleCollision();
+    void                InitHooks_VehicleDummies();
     void                InitHooks_Vehicles();
     void                InitHooks_Rendering();
     void                InitHooks_LicensePlate();

--- a/Client/multiplayer_sa/CMultiplayerSA_1.3.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_1.3.cpp
@@ -201,6 +201,7 @@ void CMultiplayerSA::InitHooks_13()
     InitHooks_Weapons();
     InitHooks_Peds();
     InitHooks_VehicleCollision();
+    InitHooks_VehicleDummies();
     InitHooks_Vehicles();
     InitHooks_Rendering();
 }

--- a/Client/multiplayer_sa/CMultiplayerSA_VehicleDummies.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_VehicleDummies.cpp
@@ -9,7 +9,7 @@
 *****************************************************************************/
 #include "StdInc.h"
 
-static const DWORD CModelInfo__ms_modelInfoPtrs = 0xA9B0C8;
+static const uint32_t CModelInfo__ms_modelInfoPtrs = 0xA9B0C8;
 
 static CVector* vehicleDummiesPositionArray = nullptr;
 
@@ -28,7 +28,7 @@ static void __cdecl UpdateVehicleDummiesPositionArray(CVehicleSAInterface* vehic
 //////////////////////////////////////////////////////////////////////////////////////////
 //     0x6DE2EA | 8B 3C 8D C8 B0 A9 00 | mov edi, CModelInfo::ms_modelInfoPtrs
 // >>> 0x6DE2F1 | 8B 57 5C             | mov edx, [edi+5Ch]
-//     0x6DE2F4 | 83 C2 48             | add edx, 48h
+// >>> 0x6DE2F4 | 83 C2 48             | add edx, 48h
 //     0x6DE2F7 | 8B 02                | mov eax, [edx]
 #define HOOKPOS_CVehicle_AddExhaustParticles               0x6DE2F1
 #define HOOKSIZE_CVehicle_AddExhaustParticles              6
@@ -64,12 +64,12 @@ static void _declspec(naked) HOOK_CVehicle_AddExhaustParticles()
 //
 // CFire::ProcessFire
 //
-// Required for: ???
+// Required for: Update vehicle fire position
 //
 //////////////////////////////////////////////////////////////////////////////////////////
 //     0x53A70D | 8B 04 95 C8 B0 A9 00 | mov eax, CModelInfo::ms_modelInfoPtrs
 // >>> 0x53A714 | 8B 40 5C             | mov eax, [eax+5Ch]
-//     0x53A717 | 8B 10                | mov edx, [eax]
+// >>> 0x53A717 | 8B 10                | mov edx, [eax]
 //     0x53A719 | 89 54 24 18          | mov [esp+3Ch+var_24.x], edx
 #define HOOKPOS_CFire_ProcessFire               0x53A714
 #define HOOKSIZE_CFire_ProcessFire              5
@@ -110,7 +110,7 @@ static void _declspec(naked) HOOK_CFire_ProcessFire()
 //////////////////////////////////////////////////////////////////////////////////////////
 //     0x6A3BDB | 8B 04 85 C8 B0 A9 00 | mov eax, CModelInfo::ms_modelInfoPtrs
 // >>> 0x6A3BE2 | 8B 48 5C             | mov ecx, [eax+5Ch]
-//     0x6A3BE5 | 83 C1 48             | add ecx, 48h
+// >>> 0x6A3BE5 | 83 C1 48             | add ecx, 48h
 //     0x6A3BE8 | 8B 11                | mov edx, [ecx]
 #define HOOKPOS_CAutomobile_DoNitroEffect_1               0x6A3BE2
 #define HOOKSIZE_CAutomobile_DoNitroEffect_1              6
@@ -151,15 +151,15 @@ static void _declspec(naked) HOOK_CAutomobile_DoNitroEffect_1()
 //////////////////////////////////////////////////////////////////////////////////////////
 //     0x6A3C66 | 74 76             | jz   short loc_6A3CDE
 // >>> 0x6A3C68 | 8B 44 24 1C       | mov  eax, [esp+38h+position.z]
-//     0x6A3C6C | D9 44 24 14       | fld  [esp+38h+position.x]
-//     0x6A3C70 | D8 0D 1C 8C 85 00 | fmul -1.0f
-//     0x6A3C76 | 8B 4C 24 14       | mov  ecx, [esp+38h+position.x]
-//     0x6A3C7A | 8B 54 24 18       | mov  edx, [esp+38h+position.y]
-//     0x6A3C7E | 89 44 24 28       | mov  [esp+38h+secondaryNitroPos.z], eax
-//     0x6A3C82 | 85 7E 40          | test [esi+40h], edi
-//     0x6A3C85 | 89 4C 24 20       | mov  [esp+38h+secondaryNitroPos.x], ecx
-//     0x6A3C89 | D9 5C 24 20       | fstp [esp+38h+secondaryNitroPos.x]
-//     0x6A3C8D | 89 54 24 24       | mov  [esp+38h+secondaryNitroPos.y], edx
+// >>> 0x6A3C6C | D9 44 24 14       | fld  [esp+38h+position.x]
+// >>> 0x6A3C70 | D8 0D 1C 8C 85 00 | fmul -1.0f
+// >>> 0x6A3C76 | 8B 4C 24 14       | mov  ecx, [esp+38h+position.x]
+// >>> 0x6A3C7A | 8B 54 24 18       | mov  edx, [esp+38h+position.y]
+// >>> 0x6A3C7E | 89 44 24 28       | mov  [esp+38h+secondaryNitroPos.z], eax
+// >>> 0x6A3C82 | 85 7E 40          | test [esi+40h], edi
+// >>> 0x6A3C85 | 89 4C 24 20       | mov  [esp+38h+secondaryNitroPos.x], ecx
+// >>> 0x6A3C89 | D9 5C 24 20       | fstp [esp+38h+secondaryNitroPos.x]
+// >>> 0x6A3C8D | 89 54 24 24       | mov  [esp+38h+secondaryNitroPos.y], edx
 //     0x6A3C91 | 74 4B             | jz   short loc_6A3CDE
 #define HOOKPOS_CAutomobile_DoNitroEffect_2               0x6A3C68
 #define HOOKSIZE_CAutomobile_DoNitroEffect_2              41
@@ -212,10 +212,10 @@ static void _declspec(naked) HOOK_CAutomobile_DoNitroEffect_2()
 //               The secondary front light only appears if the position is non-zero
 //
 //////////////////////////////////////////////////////////////////////////////////////////
-//     0x6E1F35 | 8B 04 95 C8 B0 A9 00 | mov   eax, CModelInfo::ms_modelInfoPtrs
-// >>> 0x6E1F3C | 8B 40 5C             | mov   eax, [eax+5Ch]
-//     0x6E1F3F | 83 C0 18             | add   eax, 18h
-//     0x6E1F42 | 8B 08                | mov   ecx, [eax]
+//     0x6E1F35 | 8B 04 95 C8 B0 A9 00 | mov eax, CModelInfo::ms_modelInfoPtrs
+// >>> 0x6E1F3C | 8B 40 5C             | mov eax, [eax+5Ch]
+// >>> 0x6E1F3F | 83 C0 18             | add eax, 18h
+//     0x6E1F42 | 8B 08                | mov ecx, [eax]
 #define HOOKPOS_CVehicle_DoVehicleLights               0x6E1F3C
 #define HOOKSIZE_CVehicle_DoVehicleLights              6
 static const DWORD CONTINUE_CVehicle_DoVehicleLights = 0x6E1F42;
@@ -255,7 +255,7 @@ static void _declspec(naked) HOOK_CVehicle_DoVehicleLights()
 //////////////////////////////////////////////////////////////////////////////////////////
 //     0x6A7178 | 8B 04 95 C8 B0 A9 00 | mov eax, CModelInfo::ms_modelInfoPtrs
 // >>> 0x6A717F | 8B 40 5C             | mov eax, [eax+5Ch]
-//     0x6A7182 | 83 C0 54             | add eax, 54h
+// >>> 0x6A7182 | 83 C0 54             | add eax, 54h
 //     0x6A7185 | 8B 08                | mov ecx, [eax]
 #define HOOKPOS_CAutomobile_ProcessCarOnFireAndExplode               0x6A717F
 #define HOOKSIZE_CAutomobile_ProcessCarOnFireAndExplode              6
@@ -296,7 +296,7 @@ static void _declspec(naked) HOOK_CAutomobile_ProcessCarOnFireAndExplode()
 //////////////////////////////////////////////////////////////////////////////////////////
 //     0x6B804C | 8B 04 95 C8 B0 A9 00 | mov eax, CModelInfo::ms_modelInfoPtrs
 // >>> 0x6B8053 | 8B 40 5C             | mov eax, [eax+92]
-//     0x6B8056 | 83 C0 78             | add eax, 78h
+// >>> 0x6B8056 | 83 C0 78             | add eax, 78h
 //     0x6B8059 | 8B 10                | mov edx, [eax]
 #define HOOKPOS_CBike_FixHandsToBars               0x6B8053
 #define HOOKSIZE_CBike_FixHandsToBars              6
@@ -332,16 +332,16 @@ static void _declspec(naked) HOOK_CBike_FixHandsToBars()
 //
 // CPed::SetPedPositionInCar (1 of 4)
 //
-// Required for: Seat position for ped in vehicle (eVehicleDummies::SEAT_FRONT and ::LIGHT_FRONT_MAIN for boats???)
+// Required for: Seat position for ped in vehicle (eVehicleDummies::SEAT_FRONT)
 //
 //////////////////////////////////////////////////////////////////////////////////////////
-//     0x5DF98B | 83 7F 3C 05 | cmp dword ptr [edi+3Ch], 5
+//     0x5DF989 | 75 5B       | jnz short loc_5DF9E6
+// >>> 0x5DF98B | 83 7F 3C 05 | cmp dword ptr [edi+3Ch], 5
 // >>> 0x5DF98F | 8B 7F 5C    | mov edi, [edi+5Ch]
 //     0x5DF992 | 74 03       | jz  short loc_5DF997
-//     0x5DF994 | 83 C7 30    | add edi, 30h
-#define HOOKPOS_CPed_SetPedPositionInCar_1               0x5DF98F
-#define HOOKSIZE_CPed_SetPedPositionInCar_1              5
-static const DWORD CONTINUE_CPed_SetPedPositionInCar_1 = 0x5DF997;
+#define HOOKPOS_CPed_SetPedPositionInCar_1               0x5DF98B
+#define HOOKSIZE_CPed_SetPedPositionInCar_1              7
+static const DWORD CONTINUE_CPed_SetPedPositionInCar_1 = 0x5DF992;
 
 static void _declspec(naked) HOOK_CPed_SetPedPositionInCar_1()
 {
@@ -358,11 +358,13 @@ static void _declspec(naked) HOOK_CPed_SetPedPositionInCar_1()
         jz      continueWithOriginalCode
 
         popad
+        cmp     dword ptr [edi+3Ch], 5
         mov     edi, vehicleDummiesPositionArray
         jmp     CONTINUE_CPed_SetPedPositionInCar_1
 
         continueWithOriginalCode:
         popad
+        cmp     dword ptr [edi+3Ch], 5
         mov     edi, [edi+5Ch]
         jmp     CONTINUE_CPed_SetPedPositionInCar_1
     }
@@ -377,7 +379,7 @@ static void _declspec(naked) HOOK_CPed_SetPedPositionInCar_1()
 //////////////////////////////////////////////////////////////////////////////////////////
 //     0x5DFA54 | 75 22       | jnz short loc_5DFA78
 // >>> 0x5DFA56 | 8B 47 5C    | mov eax, [edi+5Ch]
-//     0x5DFA59 | 83 C0 3C    | add eax, 3Ch
+// >>> 0x5DFA59 | 83 C0 3C    | add eax, 3Ch
 //     0x5DFA5C | 8B 10       | mov edx, [eax]
 #define HOOKPOS_CPed_SetPedPositionInCar_2               0x5DFA56
 #define HOOKSIZE_CPed_SetPedPositionInCar_2              6
@@ -417,13 +419,13 @@ static void _declspec(naked) HOOK_CPed_SetPedPositionInCar_2()
 // Required for: Seat position for ped in vehicle (eVehicleDummies::SEAT_FRONT and ::LIGHT_FRONT_MAIN for boats???)
 //
 //////////////////////////////////////////////////////////////////////////////////////////
-//     0x5DFA04 | 83 7F 3C 05 | cmp dword ptr [edi+3Ch], 5
+//     0x5DFA02 | 74 7C       | jz  short loc_5DFA80
+// >>> 0x5DFA04 | 83 7F 3C 05 | cmp dword ptr [edi+3Ch], 5
 // >>> 0x5DFA08 | 8B 7F 5C    | mov edi, [edi+5Ch]
 //     0x5DFA0B | 74 03       | jz  short loc_5DFA10
-//     0x5DFA0D | 83 C7 30    | add edi, 30h
-#define HOOKPOS_CPed_SetPedPositionInCar_3               0x5DFA08
-#define HOOKSIZE_CPed_SetPedPositionInCar_3              5
-static const DWORD CONTINUE_CPed_SetPedPositionInCar_3 = 0x5DFA10;
+#define HOOKPOS_CPed_SetPedPositionInCar_3               0x5DFA04
+#define HOOKSIZE_CPed_SetPedPositionInCar_3              7
+static const DWORD CONTINUE_CPed_SetPedPositionInCar_3 = 0x5DFA0B;
 
 static void _declspec(naked) HOOK_CPed_SetPedPositionInCar_3()
 {
@@ -440,11 +442,13 @@ static void _declspec(naked) HOOK_CPed_SetPedPositionInCar_3()
         jz      continueWithOriginalCode
 
         popad
+        cmp     dword ptr [edi+3Ch], 5
         mov     edi, vehicleDummiesPositionArray
         jmp     CONTINUE_CPed_SetPedPositionInCar_3
 
         continueWithOriginalCode:
         popad
+        cmp     dword ptr [edi+3Ch], 5
         mov     edi, [edi+5Ch]
         jmp     CONTINUE_CPed_SetPedPositionInCar_3
     }
@@ -459,7 +463,7 @@ static void _declspec(naked) HOOK_CPed_SetPedPositionInCar_3()
 //////////////////////////////////////////////////////////////////////////////////////////
 //     0x5DFA7E | 75 84       | jnz short loc_5DFA04
 // >>> 0x5DFA80 | 8B 57 5C    | mov edx, [edi+5Ch]
-//     0x5DFA83 | 83 C2 3C    | add edx, 3Ch
+// >>> 0x5DFA83 | 83 C2 3C    | add edx, 3Ch
 //     0x5DFA86 | 8B 02       | mov eax, [edx]
 #define HOOKPOS_CPed_SetPedPositionInCar_4               0x5DFA80
 #define HOOKSIZE_CPed_SetPedPositionInCar_4              6
@@ -486,7 +490,7 @@ static void _declspec(naked) HOOK_CPed_SetPedPositionInCar_4()
 
         continueWithOriginalCode:
         popad
-        mov     edx, [eax+5Ch]
+        mov     edx, [edi+5Ch]
         add     edx, 3Ch
         jmp     CONTINUE_CPed_SetPedPositionInCar_4
     }
@@ -501,7 +505,7 @@ static void _declspec(naked) HOOK_CPed_SetPedPositionInCar_4()
 //////////////////////////////////////////////////////////////////////////////////////////
 //     0x6E0A62 | 8B 04 85 C8 B0 A9 00 | mov eax, CModelInfo::ms_modelInfoPtrs
 // >>> 0x6E0A69 | 8B 50 5C             | mov edx, [eax+5Ch]
-//     0x6E0A6C | 8D 0C 5B             | lea ecx, [ebx+ebx*2]
+// >>> 0x6E0A6C | 8D 0C 5B             | lea ecx, [ebx+ebx*2]
 //     0x6E0A6F | 8D 04 CA             | lea eax, [edx+ecx*8]
 #define HOOKPOS_CVehicle_DoHeadLightEffect               0x6E0A69
 #define HOOKSIZE_CVehicle_DoHeadLightEffect              6
@@ -542,8 +546,8 @@ static void _declspec(naked) HOOK_CVehicle_DoHeadLightEffect()
 //////////////////////////////////////////////////////////////////////////////////////////
 //     0x6E17B9 | 8B 04 85 C8 B0 A9 00 | mov  eax, CModelInfo::ms_modelInfoPtrs
 // >>> 0x6E17C0 | 8B 50 5C             | mov  edx, [eax+5Ch]
-//     0x6E17C3 | 53                   | push ebx
-//     0x6E17C4 | 8B 5C 24 34          | mov  ebx, [esp+4+30h]
+// >>> 0x6E17C3 | 53                   | push ebx
+// >>> 0x6E17C4 | 8B 5C 24 34          | mov  ebx, [esp+4+30h]
 //     0x6E17C8 | 83 FB 01             | cmp  ebx, 1
 #define HOOKPOS_CVehicle_DoTailLightEffect               0x6E17C0
 #define HOOKSIZE_CVehicle_DoTailLightEffect              8
@@ -586,7 +590,7 @@ static void _declspec(naked) HOOK_CVehicle_DoTailLightEffect()
 //////////////////////////////////////////////////////////////////////////////////////////
 //     0x6E144B | 8B 04 85 C8 B0 A9 00 | mov  eax, CModelInfo::ms_modelInfoPtrs
 // >>> 0x6E1452 | 8B 50 5C             | mov  edx, [eax+5Ch]
-//     0x6E1455 | 8B 02                | mov  eax, [edx]
+// >>> 0x6E1455 | 8B 02                | mov  eax, [edx]
 //     0x6E1457 | 89 44 24 18          | mov  [esp+24h+var_C], eax
 #define HOOKPOS_CVehicle_DoHeadLightReflectionSingle               0x6E1452
 #define HOOKSIZE_CVehicle_DoHeadLightReflectionSingle              5
@@ -627,7 +631,7 @@ static void _declspec(naked) HOOK_CVehicle_DoHeadLightReflectionSingle()
 //////////////////////////////////////////////////////////////////////////////////////////
 //     0x6E1607 | 8B 04 85 C8 B0 A9 00 | mov eax, CModelInfo::ms_modelInfoPtrs
 // >>> 0x6E160E | 8B 50 5C             | mov edx, [eax+5Ch]
-//     0x6E1611 | 8B 02                | mov eax, [edx]
+// >>> 0x6E1611 | 8B 02                | mov eax, [edx]
 //     0x6E1613 | 89 44 24 10          | mov [esp+1Ch+var_C], eax
 #define HOOKPOS_CVehicle_DoHeadLightReflectionTwin               0x6E160E
 #define HOOKSIZE_CVehicle_DoHeadLightReflectionTwin              5
@@ -668,8 +672,8 @@ static void _declspec(naked) HOOK_CVehicle_DoHeadLightReflectionTwin()
 //////////////////////////////////////////////////////////////////////////////////////////
 //     0x6D4293 | 66 8B 51 22          | mov   dx, [ecx+22h]
 // >>> 0x6D4297 | 0F BF CA             | movsx ecx, dx
-//     0x6D429A | 8B 04 8D C8 B0 A9 00 | mov   eax, CModelInfo::ms_modelInfoPtrs
-//     0x6D42A1 | 8B 40 5C             | mov   eax, [eax+5Ch]
+// >>> 0x6D429A | 8B 04 8D C8 B0 A9 00 | mov   eax, CModelInfo::ms_modelInfoPtrs
+// >>> 0x6D42A1 | 8B 40 5C             | mov   eax, [eax+5Ch]
 //     0x6D42A4 | 05 9C 00 00 00       | add   eax, 9Ch
 #define HOOKPOS_CVehicle_GetPlaneGunsPosition               0x6D4297
 #define HOOKSIZE_CVehicle_GetPlaneGunsPosition              13
@@ -712,7 +716,7 @@ static void _declspec(naked) HOOK_CVehicle_GetPlaneGunsPosition()
 //////////////////////////////////////////////////////////////////////////////////////////
 //     0x6D46E9 | 8B 04 BD C8 B0 A9 00 | mov eax, CModelInfo::ms_modelInfoPtrs
 // >>> 0x6D46F0 | 8B 40 5C             | mov eax, [eax+5Ch]
-//     0x6D46F3 | 05 9C 00 00 00       | add eax, 9Ch
+// >>> 0x6D46F3 | 05 9C 00 00 00       | add eax, 9Ch
 //     0x6D46F8 | 8B 08                | mov ecx, [eax]
 #define HOOKPOS_CVehicle_GetPlaneOrdnancePosition               0x6D46F0
 #define HOOKSIZE_CVehicle_GetPlaneOrdnancePosition              8
@@ -748,12 +752,12 @@ static void _declspec(naked) HOOK_CVehicle_GetPlaneOrdnancePosition()
 //
 // CVehicle::CanBeDriven
 //
-// Required for: Unknown (eVehicleDummies::LIGHT_REAR_SECONDARY ???)
+// Required for: Unknown
 //
 //////////////////////////////////////////////////////////////////////////////////////////
 //     0x6D5431 | 8B 04 85 C8 B0 A9 00 | mov eax, CModelInfo::ms_modelInfoPtrs
 // >>> 0x6D5438 | 83 78 3C 05          | cmp dword ptr [eax+3Ch], 5
-//     0x6D543C | 8B 40 5C             | mov eax, [eax+5Ch]
+// >>> 0x6D543C | 8B 40 5C             | mov eax, [eax+5Ch]
 //     0x6D543F | 74 03                | jz  short loc_6D5444
 #define HOOKPOS_CVehicle_CanBeDriven               0x6D5438
 #define HOOKSIZE_CVehicle_CanBeDriven              7
@@ -789,13 +793,12 @@ static void _declspec(naked) HOOK_CVehicle_CanBeDriven()
 //
 // CPlane::PreRender (1 of 3)
 //
-// Required for: Unknown (eVehicleDummies::EXHAUST_SECONDARY ???)
-//               (CPlane might be using a different enum for dummies)
+// Required for: Unknown (CPlane might be using a different enum for dummies)
 //
 //////////////////////////////////////////////////////////////////////////////////////////
 //     0x6C9716 | E8 95 24 ED FF    | call CMatrix::UpdateRW
 // >>> 0x6C971B | 8B 4D 5C          | mov  ecx, [ebp+5Ch]
-//     0x6C971E | 81 C1 84 00 00 00 | add  ecx, 84h
+// >>> 0x6C971E | 81 C1 84 00 00 00 | add  ecx, 84h
 //     0x6C9724 | 8B 11             | mov  edx, [ecx]
 #define HOOKPOS_CPlane_PreRender_1               0x6C971B
 #define HOOKSIZE_CPlane_PreRender_1              9
@@ -831,13 +834,12 @@ static void _declspec(naked) HOOK_CPlane_PreRender_1()
 //
 // CPlane::PreRender (2 of 3)
 //
-// Required for: Unknown (eVehicleDummies::TRAILER_ATTACH ???)
-//               (CPlane might be using a different enum for dummies)
+// Required for: Unknown (CPlane might be using a different enum for dummies)
 //
 //////////////////////////////////////////////////////////////////////////////////////////
 //     0x6C98C4 | E8 E7 22 ED FF | call CMatrix::UpdateRW
 // >>> 0x6C98C9 | 8B 45 5C       | mov  eax, [ebp+5Ch]
-//     0x6C98CC | 83 C0 6C       | add  eax, 6Ch
+// >>> 0x6C98CC | 83 C0 6C       | add  eax, 6Ch
 //     0x6C98CF | 8B 08          | mov  ecx, [eax]
 #define HOOKPOS_CPlane_PreRender_2               0x6C98C9
 #define HOOKSIZE_CPlane_PreRender_2              6
@@ -873,13 +875,12 @@ static void _declspec(naked) HOOK_CPlane_PreRender_2()
 //
 // CPlane::PreRender (3 of 3)
 //
-// Required for: Unknown (eVehicleDummies::HAND_REST ???)
-//               (CPlane might be using a different enum for dummies)
+// Required for: Unknown (CPlane might be using a different enum for dummies)
 //
 //////////////////////////////////////////////////////////////////////////////////////////
 //     0x6C9B51 | E8 5A 20 ED FF | call CMatrix::UpdateRW
 // >>> 0x6C9B56 | 8B 45 5C       | mov  eax, [ebp+5Ch]
-//     0x6C9B59 | 83 C0 78       | add  eax, 78h
+// >>> 0x6C9B59 | 83 C0 78       | add  eax, 78h
 //     0x6C9B5C | 8B 08          | mov  ecx, [eax]
 #define HOOKPOS_CPlane_PreRender_3               0x6C9B56
 #define HOOKSIZE_CPlane_PreRender_3              6
@@ -920,7 +921,7 @@ static void _declspec(naked) HOOK_CPlane_PreRender_3()
 //////////////////////////////////////////////////////////////////////////////////////////
 //     0x6E0E2D | 8B 0C 85 C8 B0 A9 00 | mov ecx, CModelInfo::ms_modelInfoPtrs
 // >>> 0x6E0E34 | 8B 49 5C             | mov ecx, [ecx+5Ch]
-//     0x6E0E37 | 8B 84 24 9C 00 00 00 | mov eax, [esp+98h+arg_0]
+// >>> 0x6E0E37 | 8B 84 24 9C 00 00 00 | mov eax, [esp+98h+arg_0]
 //     0x6E0E3E | 83 F8 01             | cmp eax, 1
 #define HOOKPOS_CVehicle_DoHeadLightBeam               0x6E0E34
 #define HOOKSIZE_CVehicle_DoHeadLightBeam              10
@@ -979,8 +980,8 @@ void CMultiplayerSA::InitHooks_VehicleDummies()
     // EZHookInstall(CPlane_PreRender_2);
     // EZHookInstall(CPlane_PreRender_3);
     // EZHookInstall(CFire_ProcessFire); // No visible effect
-    // EZHookInstall(CPed_SetPedPositionInCar_1); Player's world and seat position breaks
-    // EZHookInstall(CPed_SetPedPositionInCar_2);
-    // EZHookInstall(CPed_SetPedPositionInCar_3);
-    // EZHookInstall(CPed_SetPedPositionInCar_4);
+    EZHookInstall(CPed_SetPedPositionInCar_1);
+    EZHookInstall(CPed_SetPedPositionInCar_2);
+    EZHookInstall(CPed_SetPedPositionInCar_3);
+    EZHookInstall(CPed_SetPedPositionInCar_4);
 }

--- a/Client/multiplayer_sa/CMultiplayerSA_VehicleDummies.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_VehicleDummies.cpp
@@ -55,9 +55,25 @@ static void __cdecl ApplyExhaustParticlesPosition(CVehicleSAInterface* vehicleIn
     if (vehicleDummiesPositionArray != nullptr)
     {
         *mainPosition = vehicleDummiesPositionArray[EXHAUST];
-        *secondaryPosition  = vehicleDummiesPositionArray[EXHAUST_SECONDARY];
+        *secondaryPosition = vehicleDummiesPositionArray[EXHAUST_SECONDARY];
 
-        if (secondaryPosition->fX == 0.0 && secondaryPosition->fY == 0.0 && secondaryPosition->fZ == 0.0)
+        bool    applyNegativeMainPosition = false;
+        int16_t extras = vehicleInterface->m_upgrades[0];
+
+        if (vehicleInterface->m_nModelIndex == VT_NRG500)
+        {
+            applyNegativeMainPosition = extras != 0 && extras != 1;
+        }
+        else if (vehicleInterface->m_nModelIndex == VT_BF400)
+        {
+            applyNegativeMainPosition = extras != 2;
+        }
+        else if (vehicleInterface->m_nModelIndex == VT_FCR900)
+        {
+            applyNegativeMainPosition = extras != 1;
+        }
+
+        if (applyNegativeMainPosition || secondaryPosition->fX == 0.0 && secondaryPosition->fY == 0.0 && secondaryPosition->fZ == 0.0)
         {
             *secondaryPosition = *mainPosition;
             secondaryPosition->fX *= -1.0f;

--- a/Client/multiplayer_sa/CMultiplayerSA_VehicleDummies.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_VehicleDummies.cpp
@@ -62,6 +62,47 @@ static void _declspec(naked) HOOK_CVehicle_AddExhaustParticles()
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
+// CVehicle::AddDamagedVehicleParticles
+//
+// Required for: Position for vehicle engine damage particles (eVehicleDummies::ENGINE)
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+//     0x6D2B02 | 8B 0C 8D C8 B0 A9 00 | mov  ecx, CModelInfo::ms_modelInfoPtrs
+// >>> 0x6D2B09 | 8B 49 5C             | mov  ecx, [ecx+5Ch]
+// >>> 0x6D2B0C | 83 C1 54             | add  ecx, 54h
+//     0x6D2B0F | 84 D2                | test dl, dl
+#define HOOKPOS_CVehicle_AddDamagedVehicleParticles               0x6D2B09
+#define HOOKSIZE_CVehicle_AddDamagedVehicleParticles              6
+static const DWORD CONTINUE_CVehicle_AddDamagedVehicleParticles = 0x6D2B0F;
+
+static void _declspec(naked) HOOK_CVehicle_AddDamagedVehicleParticles()
+{
+    _asm
+    {
+        pushad
+        push    esi // CVehicleSAInterface*
+        call    UpdateVehicleDummiesPositionArray
+        add     esp, 4
+
+        mov     eax, vehicleDummiesPositionArray
+        test    eax, eax
+        jz      continueWithOriginalCode
+
+        popad
+        mov     ecx, vehicleDummiesPositionArray
+        add     ecx, 54h
+        jmp     CONTINUE_CVehicle_AddDamagedVehicleParticles
+
+        continueWithOriginalCode:
+        popad
+        mov     ecx, [edi+5Ch]
+        add     ecx, 54h
+        jmp     CONTINUE_CVehicle_AddDamagedVehicleParticles
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
 // CFire::ProcessFire
 //
 // Required for: Update vehicle fire position
@@ -972,6 +1013,7 @@ void CMultiplayerSA::InitHooks_VehicleDummies()
     EZHookInstall(CVehicle_GetPlaneOrdnancePosition);
     EZHookInstall(CVehicle_CanBeDriven);
     EZHookInstall(CVehicle_AddExhaustParticles);
+    EZHookInstall(CVehicle_AddDamagedVehicleParticles);
     EZHookInstall(CAutomobile_DoNitroEffect_1);
     EZHookInstall(CAutomobile_DoNitroEffect_2);
     EZHookInstall(CAutomobile_ProcessCarOnFireAndExplode);

--- a/Client/multiplayer_sa/CMultiplayerSA_VehicleDummies.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_VehicleDummies.cpp
@@ -57,6 +57,9 @@ static void __cdecl ApplyExhaustParticlesPosition(CVehicleSAInterface* vehicleIn
         *mainPosition = vehicleDummiesPositionArray[EXHAUST];
         *secondaryPosition = vehicleDummiesPositionArray[EXHAUST_SECONDARY];
 
+        // NOTE(botder): Certain bike models (NRG-500, BF-400, FCR-900) actually use the secondary exhaust position
+        //               and we can't abuse it for these models to position double exhausts here.
+        //               Bikes use the secondary exhaust position in case they have extras (read: exhausts) installed
         bool    applyNegativeMainPosition = false;
         int16_t extras = vehicleInterface->m_upgrades[0];
 

--- a/Client/multiplayer_sa/CMultiplayerSA_VehicleDummies.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_VehicleDummies.cpp
@@ -172,6 +172,12 @@ static void __cdecl ApplySecondaryExhaustNitroPosition(CVehicleSAInterface* vehi
     if (vehicleDummiesPositionArray != nullptr)
     {
         *secondaryExhaustPosition = vehicleDummiesPositionArray[EXHAUST_SECONDARY];
+
+        if (secondaryExhaustPosition->fX == 0.0 && secondaryExhaustPosition->fY == 0.0 && secondaryExhaustPosition->fZ == 0.0)
+        {
+            *secondaryExhaustPosition = vehicleDummiesPositionArray[EXHAUST];
+            secondaryExhaustPosition->fX *= -1.0f;
+        }
     }
     else
     {

--- a/Client/multiplayer_sa/CMultiplayerSA_VehicleDummies.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_VehicleDummies.cpp
@@ -1,0 +1,668 @@
+/*****************************************************************************
+*
+*  PROJECT:     Multi Theft Auto
+*  LICENSE:     See LICENSE in the top level directory
+*  FILE:        multiplayer_sa/CMultiplayerSA_VehicleDummies.cpp
+*
+*  Multi Theft Auto is available from https://multitheftauto.com/
+*
+*****************************************************************************/
+#include "StdInc.h"
+
+static const DWORD CModelInfo__ms_modelInfoPtrs = 0xA9B0C8;
+
+static CVector* vehicleDummiesPositionArray = nullptr;
+
+static void _cdecl UpdateVehicleDummiesPositionArray(CVehicleSAInterface* vehicleInterface)
+{
+    SClientEntity<CVehicleSA>* vehicle = pGameInterface->GetPools()->GetVehicle(reinterpret_cast<DWORD*>(vehicleInterface));
+    vehicleDummiesPositionArray = (vehicle != nullptr) ? vehicle->pEntity->GetDummyPositions() : nullptr;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CVehicle::AddExhaustParticles
+//
+// Required for: Position for vehicle exhaust particles (eVehicleDummies::EXHAUST)
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+//     0x6DE2EA | 8B 3C 8D C8 B0 A9 00 | mov edi, CModelInfo::ms_modelInfoPtrs
+// >>> 0x6DE2F1 | 8B 57 5C             | mov edx, [edi+5Ch]
+//     0x6DE2F4 | 83 C2 48             | add edx, 48h
+//     0x6DE2F7 | 8B 02                | mov eax, [edx]
+#define HOOKPOS_CVehicle_AddExhaustParticles               0x6DE2F1
+#define HOOKSIZE_CVehicle_AddExhaustParticles              6
+static const DWORD CONTINUE_CVehicle_AddExhaustParticles = 0x6DE2F7;
+
+static void _declspec(naked) HOOK_CVehicle_AddExhaustParticles()
+{
+    _asm
+    {
+        pushad
+        push    esi // CVehicleSAInterface*
+        call    UpdateVehicleDummiesPositionArray
+        add     esp, 4
+
+        mov     eax, vehicleDummiesPositionArray
+        test    eax, eax
+        jz      continueWithOriginalCode
+
+        popad
+        mov     edx, vehicleDummiesPositionArray
+        add     edx, 48h
+        jmp     CONTINUE_CVehicle_AddExhaustParticles
+
+        continueWithOriginalCode:
+        popad
+        mov     edx, [edi+5Ch]
+        add     edx, 48h
+        jmp     CONTINUE_CVehicle_AddExhaustParticles
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CFire::ProcessFire
+//
+// Required for: ???
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+//     0x53A70D | 8B 04 95 C8 B0 A9 00 | mov eax, CModelInfo::ms_modelInfoPtrs
+// >>> 0x53A714 | 8B 40 5C             | mov eax, [eax+5Ch]
+//     0x53A717 | 8B 10                | mov edx, [eax]
+//     0x53A719 | 89 54 24 18          | mov [esp+3Ch+var_24.x], edx
+#define HOOKPOS_CFire_ProcessFire               0x53A714
+#define HOOKSIZE_CFire_ProcessFire              5
+static const DWORD CONTINUE_CFire_ProcessFire = 0x53A719;
+
+static void _declspec(naked) HOOK_CFire_ProcessFire()
+{
+    _asm
+    {
+        pushad
+        push    ecx            // CVehicleSAInterface*
+        call    UpdateVehicleDummiesPositionArray
+        add     esp, 4
+
+        mov     eax, vehicleDummiesPositionArray
+        test    eax, eax
+        jz      continueWithOriginalCode
+
+        popad
+        mov     eax, vehicleDummiesPositionArray
+        mov     edx, [eax]
+        jmp     CONTINUE_CFire_ProcessFire
+
+        continueWithOriginalCode:
+        popad
+        mov     eax, [eax+5Ch]
+        mov     edx, [eax]
+        jmp     CONTINUE_CFire_ProcessFire
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CAutomobile::DoNitroEffect
+//
+// Required for: Position for vehicle nitro (+ recharge) effect particles
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+//     0x6A3BDB | 8B 04 85 C8 B0 A9 00 | mov eax, CModelInfo::ms_modelInfoPtrs
+// >>> 0x6A3BE2 | 8B 48 5C             | mov ecx, [eax+5Ch]
+//     0x6A3BE5 | 83 C1 48             | add ecx, 48h
+//     0x6A3BE8 | 8B 11                | mov edx, [ecx]
+#define HOOKPOS_CAutomobile_DoNitroEffect               0x6A3BE2
+#define HOOKSIZE_CAutomobile_DoNitroEffect              6
+static const DWORD CONTINUE_CAutomobile_DoNitroEffect = 0x6A3BE8;
+
+static void _declspec(naked) HOOK_CAutomobile_DoNitroEffect()
+{
+    _asm
+    {
+        pushad
+        push    esi            // CVehicleSAInterface*
+        call    UpdateVehicleDummiesPositionArray
+        add     esp, 4
+
+        mov     eax, vehicleDummiesPositionArray
+        test    eax, eax
+        jz      continueWithOriginalCode
+
+        popad
+        mov     ecx, vehicleDummiesPositionArray
+        add     ecx, 48h
+        jmp     CONTINUE_CAutomobile_DoNitroEffect
+
+        continueWithOriginalCode:
+        popad
+        mov     ecx, [eax+5Ch]
+        add     ecx, 48h
+        jmp     CONTINUE_CAutomobile_DoNitroEffect
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CVehicle::DoVehicleLights
+//
+// Required for: Position for a secondary front light (eVehicleDummies::LIGHT_FRONT_SECONDARY)
+//               The secondary front light only appears if the position is non-zero
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+//     0x6E1F35 | 8B 04 95 C8 B0 A9 00 | mov   eax, CModelInfo::ms_modelInfoPtrs
+// >>> 0x6E1F3C | 8B 40 5C             | mov   eax, [eax+5Ch]
+//     0x6E1F3F | 83 C0 18             | add   eax, 18h
+//     0x6E1F42 | 8B 08                | mov   ecx, [eax]
+#define HOOKPOS_CVehicle_DoVehicleLights               0x6E1F3C
+#define HOOKSIZE_CVehicle_DoVehicleLights              6
+static const DWORD CONTINUE_CVehicle_DoVehicleLights = 0x6E1F42;
+
+static void _declspec(naked) HOOK_CVehicle_DoVehicleLights()
+{
+    _asm
+    {
+        pushad
+        push    esi            // CVehicleSAInterface*
+        call    UpdateVehicleDummiesPositionArray
+        add     esp, 4
+
+        mov     eax, vehicleDummiesPositionArray
+        test    eax, eax
+        jz      continueWithOriginalCode
+
+        popad
+        mov     eax, vehicleDummiesPositionArray
+        add     eax, 18h
+        jmp     CONTINUE_CVehicle_DoVehicleLights
+
+        continueWithOriginalCode:
+        popad
+        mov     eax, [eax+5Ch]
+        add     eax, 18h
+        jmp     CONTINUE_CVehicle_DoVehicleLights
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CAutomobile::ProcessCarOnFireAndExplode
+//
+// Required for: Position for the fire of the burning vehicle engine (eVehicleDummies::ENGINE)
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+//     0x6A7178 | 8B 04 95 C8 B0 A9 00 | mov eax, CModelInfo::ms_modelInfoPtrs
+// >>> 0x6A717F | 8B 40 5C             | mov eax, [eax+5Ch]
+//     0x6A7182 | 83 C0 54             | add eax, 54h
+//     0x6A7185 | 8B 08                | mov ecx, [eax]
+#define HOOKPOS_CAutomobile_ProcessCarOnFireAndExplode               0x6A717F
+#define HOOKSIZE_CAutomobile_ProcessCarOnFireAndExplode              6
+static const DWORD CONTINUE_CAutomobile_ProcessCarOnFireAndExplode = 0x6A7185;
+
+static void _declspec(naked) HOOK_CAutomobile_ProcessCarOnFireAndExplode()
+{
+    _asm
+    {
+        pushad
+        push    esi            // CVehicleSAInterface*
+        call    UpdateVehicleDummiesPositionArray
+        add     esp, 4
+
+        mov     eax, vehicleDummiesPositionArray
+        test    eax, eax
+        jz      continueWithOriginalCode
+
+        popad
+        mov     eax, vehicleDummiesPositionArray
+        add     eax, 54h
+        jmp     CONTINUE_CAutomobile_ProcessCarOnFireAndExplode
+
+        continueWithOriginalCode:
+        popad
+        mov     eax, [eax+5Ch]
+        add     eax, 54h
+        jmp     CONTINUE_CAutomobile_ProcessCarOnFireAndExplode
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CBike::FixHandsToBars
+//
+// Required for: Position for ped hands on a bike (eVehicleDummies::HAND_REST)
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+//     0x6B804C | 8B 04 95 C8 B0 A9 00 | mov eax, CModelInfo::ms_modelInfoPtrs
+// >>> 0x6B8053 | 8B 40 5C             | mov eax, [eax+92]
+//     0x6B8056 | 83 C0 78             | add eax, 78h
+//     0x6B8059 | 8B 10                | mov edx, [eax]
+#define HOOKPOS_CBike_FixHandsToBars               0x6B8053
+#define HOOKSIZE_CBike_FixHandsToBars              6
+static const DWORD CONTINUE_CBike_FixHandsToBars = 0x6B8059;
+
+static void _declspec(naked) HOOK_CBike_FixHandsToBars()
+{
+    _asm
+    {
+        pushad
+        push    ebx            // CVehicleSAInterface*
+        call    UpdateVehicleDummiesPositionArray
+        add     esp, 4
+
+        mov     eax, vehicleDummiesPositionArray
+        test    eax, eax
+        jz      continueWithOriginalCode
+
+        popad
+        mov     eax, vehicleDummiesPositionArray
+        add     eax, 78h
+        jmp     CONTINUE_CBike_FixHandsToBars
+
+        continueWithOriginalCode:
+        popad
+        mov     eax, [eax+5Ch]
+        add     eax, 78h
+        jmp     CONTINUE_CBike_FixHandsToBars
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CPed::SetPedPositionInCar (1 of 4)
+//
+// Required for: Seat position for ped in vehicle (eVehicleDummies::SEAT_FRONT and ::LIGHT_FRONT_MAIN for boats???)
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+//     0x5DF98B | 83 7F 3C 05 | cmp dword ptr [edi+3Ch], 5
+// >>> 0x5DF98F | 8B 7F 5C    | mov edi, [edi+5Ch]
+//     0x5DF992 | 74 03       | jz  short loc_5DF997
+//     0x5DF994 | 83 C7 30    | add edi, 30h
+#define HOOKPOS_CPed_SetPedPositionInCar_1               0x5DF98F
+#define HOOKSIZE_CPed_SetPedPositionInCar_1              5
+static const DWORD CONTINUE_CPed_SetPedPositionInCar_1 = 0x5DF997;
+
+static void _declspec(naked) HOOK_CPed_SetPedPositionInCar_1()
+{
+    _asm
+    {
+        pushad
+        mov     eax, [esi+58Ch]
+        push    eax            // CVehicleSAInterface*
+        call    UpdateVehicleDummiesPositionArray
+        add     esp, 4
+
+        mov     eax, vehicleDummiesPositionArray
+        test    eax, eax
+        jz      continueWithOriginalCode
+
+        popad
+        mov     edi, vehicleDummiesPositionArray
+        jmp     CONTINUE_CPed_SetPedPositionInCar_1
+
+        continueWithOriginalCode:
+        popad
+        mov     edi, [edi+5Ch]
+        jmp     CONTINUE_CPed_SetPedPositionInCar_1
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CPed::SetPedPositionInCar (2 of 4)
+//
+// Required for: Seat position for ped in vehicle (eVehicleDummies::SEAT_REAR)
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+//     0x5DFA54 | 75 22       | jnz short loc_5DFA78
+// >>> 0x5DFA56 | 8B 47 5C    | mov eax, [edi+5Ch]
+//     0x5DFA59 | 83 C0 3C    | add eax, 3Ch
+//     0x5DFA5C | 8B 10       | mov edx, [eax]
+#define HOOKPOS_CPed_SetPedPositionInCar_2               0x5DFA56
+#define HOOKSIZE_CPed_SetPedPositionInCar_2              6
+static const DWORD CONTINUE_CPed_SetPedPositionInCar_2 = 0x5DFA5C;
+
+static void _declspec(naked) HOOK_CPed_SetPedPositionInCar_2()
+{
+    _asm
+    {
+        pushad
+        mov     eax, [esi+58Ch]
+        push    eax            // CVehicleSAInterface*
+        call    UpdateVehicleDummiesPositionArray
+        add     esp, 4
+
+        mov     eax, vehicleDummiesPositionArray
+        test    eax, eax
+        jz      continueWithOriginalCode
+
+        popad
+        mov     eax, vehicleDummiesPositionArray
+        add     eax, 3Ch
+        jmp     CONTINUE_CPed_SetPedPositionInCar_2
+
+        continueWithOriginalCode:
+        popad
+        mov     eax, [edi+5Ch]
+        add     eax, 3Ch
+        jmp     CONTINUE_CPed_SetPedPositionInCar_2
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CPed::SetPedPositionInCar (3 of 4)
+//
+// Required for: Seat position for ped in vehicle (eVehicleDummies::SEAT_FRONT and ::LIGHT_FRONT_MAIN for boats???)
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+//     0x5DFA04 | 83 7F 3C 05 | cmp dword ptr [edi+3Ch], 5
+// >>> 0x5DFA08 | 8B 7F 5C    | mov edi, [edi+5Ch]
+//     0x5DFA0B | 74 03       | jz  short loc_5DFA10
+//     0x5DFA0D | 83 C7 30    | add edi, 30h
+#define HOOKPOS_CPed_SetPedPositionInCar_3               0x5DFA08
+#define HOOKSIZE_CPed_SetPedPositionInCar_3              5
+static const DWORD CONTINUE_CPed_SetPedPositionInCar_3 = 0x5DFA10;
+
+static void _declspec(naked) HOOK_CPed_SetPedPositionInCar_3()
+{
+    _asm
+    {
+        pushad
+        mov     eax, [esi+58Ch]
+        push    eax            // CVehicleSAInterface*
+        call    UpdateVehicleDummiesPositionArray
+        add     esp, 4
+
+        mov     eax, vehicleDummiesPositionArray
+        test    eax, eax
+        jz      continueWithOriginalCode
+
+        popad
+        mov     edi, vehicleDummiesPositionArray
+        jmp     CONTINUE_CPed_SetPedPositionInCar_3
+
+        continueWithOriginalCode:
+        popad
+        mov     edi, [edi+5Ch]
+        jmp     CONTINUE_CPed_SetPedPositionInCar_3
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CPed::SetPedPositionInCar (4 of 4)
+//
+// Required for: Seat position for ped in vehicle (eVehicleDummies::SEAT_REAR)
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+//     0x5DFA7E | 75 84       | jnz short loc_5DFA04
+// >>> 0x5DFA80 | 8B 57 5C    | mov edx, [edi+5Ch]
+//     0x5DFA83 | 83 C2 3C    | add edx, 3Ch
+//     0x5DFA86 | 8B 02       | mov eax, [edx]
+#define HOOKPOS_CPed_SetPedPositionInCar_4               0x5DFA80
+#define HOOKSIZE_CPed_SetPedPositionInCar_4              6
+static const DWORD CONTINUE_CPed_SetPedPositionInCar_4 = 0x5DFA86;
+
+static void _declspec(naked) HOOK_CPed_SetPedPositionInCar_4()
+{
+    _asm
+    {
+        pushad
+        mov     eax, [esi+58Ch]
+        push    eax            // CVehicleSAInterface*
+        call    UpdateVehicleDummiesPositionArray
+        add     esp, 4
+
+        mov     eax, vehicleDummiesPositionArray
+        test    eax, eax
+        jz      continueWithOriginalCode
+
+        popad
+        mov     edx, vehicleDummiesPositionArray
+        add     edx, 3Ch
+        jmp     CONTINUE_CPed_SetPedPositionInCar_4
+
+        continueWithOriginalCode:
+        popad
+        mov     edx, [eax+5Ch]
+        add     edx, 3Ch
+        jmp     CONTINUE_CPed_SetPedPositionInCar_4
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CVehicle::DoHeadLightEffect
+//
+// Required for: Position for vehicle head light coronas (eVehicleDummies::LIGHT_FRONT_MAIN)
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+//     0x6E0A62 | 8B 04 85 C8 B0 A9 00 | mov eax, CModelInfo::ms_modelInfoPtrs
+// >>> 0x6E0A69 | 8B 50 5C             | mov edx, [eax+5Ch]
+//     0x6E0A6C | 8D 0C 5B             | lea ecx, [ebx+ebx*2]
+//     0x6E0A6F | 8D 04 CA             | lea eax, [edx+ecx*8]
+#define HOOKPOS_CVehicle_DoHeadLightEffect               0x6E0A69
+#define HOOKSIZE_CVehicle_DoHeadLightEffect              6
+static const DWORD CONTINUE_CVehicle_DoHeadLightEffect = 0x6E0A6F;
+
+static void _declspec(naked) HOOK_CVehicle_DoHeadLightEffect()
+{
+    _asm
+    {
+        pushad
+        push    ecx            // CVehicleSAInterface*
+        call    UpdateVehicleDummiesPositionArray
+        add     esp, 4
+
+        mov     eax, vehicleDummiesPositionArray
+        test    eax, eax
+        jz      continueWithOriginalCode
+
+        popad
+        mov     edx, vehicleDummiesPositionArray
+        lea     ecx, [ebx+ebx*2]
+        jmp     CONTINUE_CVehicle_DoHeadLightEffect
+
+        continueWithOriginalCode:
+        popad
+        mov     edx, [eax+5Ch]
+        lea     ecx, [ebx+ebx*2]
+        jmp     CONTINUE_CVehicle_DoHeadLightEffect
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CVehicle::DoTailLightEffect
+//
+// Required for: Position for vehicle tail light coronas (eVehicleDummies::LIGHT_REAR_MAIN)
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+//     0x6E17B9 | 8B 04 85 C8 B0 A9 00 | mov  eax, CModelInfo::ms_modelInfoPtrs
+// >>> 0x6E17C0 | 8B 50 5C             | mov  edx, [eax+5Ch]
+//     0x6E17C3 | 53                   | push ebx
+//     0x6E17C4 | 8B 5C 24 34          | mov  ebx, [esp+4+30h]
+//     0x6E17C8 | 83 FB 01             | cmp  ebx, 1
+#define HOOKPOS_CVehicle_DoTailLightEffect               0x6E17C0
+#define HOOKSIZE_CVehicle_DoTailLightEffect              8
+static const DWORD CONTINUE_CVehicle_DoTailLightEffect = 0x6E17C8;
+
+static void _declspec(naked) HOOK_CVehicle_DoTailLightEffect()
+{
+    _asm
+    {
+        pushad
+        push    esi            // CVehicleSAInterface*
+        call    UpdateVehicleDummiesPositionArray
+        add     esp, 4
+
+        mov     eax, vehicleDummiesPositionArray
+        test    eax, eax
+        jz      continueWithOriginalCode
+
+        popad
+        mov     edx, vehicleDummiesPositionArray
+        push    ebx
+        mov     ebx, [esp+4+30h]
+        jmp     CONTINUE_CVehicle_DoTailLightEffect
+
+        continueWithOriginalCode:
+        popad
+        mov     edx, [eax+5Ch]
+        push    ebx
+        mov     ebx, [esp+4+30h]
+        jmp     CONTINUE_CVehicle_DoTailLightEffect
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CVehicle::DoHeadLightReflectionSingle
+//
+// Required for: Position for car light shadow (eVehicleDummies::LIGHT_FRONT_MAIN)
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+//     0x6E144B | 8B 04 85 C8 B0 A9 00 | mov  eax, CModelInfo::ms_modelInfoPtrs
+// >>> 0x6E1452 | 8B 50 5C             | mov  edx, [eax+5Ch]
+//     0x6E1455 | 8B 02                | mov  eax, [edx]
+//     0x6E1457 | 89 44 24 18          | mov  [esp+24h+var_C], eax
+#define HOOKPOS_CVehicle_DoHeadLightReflectionSingle               0x6E1452
+#define HOOKSIZE_CVehicle_DoHeadLightReflectionSingle              5
+static const DWORD CONTINUE_CVehicle_DoHeadLightReflectionSingle = 0x6E1457;
+
+static void _declspec(naked) HOOK_CVehicle_DoHeadLightReflectionSingle()
+{
+    _asm
+    {
+        pushad
+        push    ecx            // CVehicleSAInterface*
+        call    UpdateVehicleDummiesPositionArray
+        add     esp, 4
+
+        mov     eax, vehicleDummiesPositionArray
+        test    eax, eax
+        jz      continueWithOriginalCode
+
+        popad
+        mov     edx, vehicleDummiesPositionArray
+        mov     eax, [edx]
+        jmp     CONTINUE_CVehicle_DoHeadLightReflectionSingle
+
+        continueWithOriginalCode:
+        popad
+        mov     edx, [eax+5Ch]
+        mov     eax, [edx]
+        jmp     CONTINUE_CVehicle_DoHeadLightReflectionSingle
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CVehicle::DoHeadLightReflectionTwin
+//
+// Required for: Position for car light shadow (eVehicleDummies::LIGHT_FRONT_MAIN)
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+//     0x6E1607 | 8B 04 85 C8 B0 A9 00 | mov eax, CModelInfo::ms_modelInfoPtrs
+// >>> 0x6E160E | 8B 50 5C             | mov edx, [eax+5Ch]
+//     0x6E1611 | 8B 02                | mov eax, [edx]
+//     0x6E1613 | 89 44 24 10          | mov [esp+1Ch+var_C], eax
+#define HOOKPOS_CVehicle_DoHeadLightReflectionTwin               0x6E160E
+#define HOOKSIZE_CVehicle_DoHeadLightReflectionTwin              5
+static const DWORD CONTINUE_CVehicle_DoHeadLightReflectionTwin = 0x6E1613;
+
+static void _declspec(naked) HOOK_CVehicle_DoHeadLightReflectionTwin()
+{
+    _asm
+    {
+        pushad
+        push    ecx            // CVehicleSAInterface*
+        call    UpdateVehicleDummiesPositionArray
+        add     esp, 4
+
+        mov     eax, vehicleDummiesPositionArray
+        test    eax, eax
+        jz      continueWithOriginalCode
+
+        popad
+        mov     edx, vehicleDummiesPositionArray
+        mov     eax, [edx]
+        jmp     CONTINUE_CVehicle_DoHeadLightReflectionTwin
+
+        continueWithOriginalCode:
+        popad
+        mov     edx, [eax+5Ch]
+        mov     eax, [edx]
+        jmp     CONTINUE_CVehicle_DoHeadLightReflectionTwin
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CVehicle::GetPlaneGunsPosition
+//
+// Required for: Plane gun position (eVehicleDummies::VEH_GUN)
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+//     0x6D4293 | 66 8B 51 22          | mov   dx, [ecx+22h]
+// >>> 0x6D4297 | 0F BF CA             | movsx ecx, dx
+//     0x6D429A | 8B 04 8D C8 B0 A9 00 | mov   eax, CModelInfo::ms_modelInfoPtrs
+//     0x6D42A1 | 8B 40 5C             | mov   eax, [eax+5Ch]
+//     0x6D42A4 | 05 9C 00 00 00       | add   eax, 9Ch
+#define HOOKPOS_CVehicle_GetPlaneGunsPosition               0x6D4297
+#define HOOKSIZE_CVehicle_GetPlaneGunsPosition              13
+static const DWORD CONTINUE_CVehicle_GetPlaneGunsPosition = 0x6D42A4;
+
+static void _declspec(naked) HOOK_CVehicle_GetPlaneGunsPosition()
+{
+    _asm
+    {
+        pushad
+        push    ecx            // CVehicleSAInterface*
+        call    UpdateVehicleDummiesPositionArray
+        add     esp, 4
+
+        mov     eax, vehicleDummiesPositionArray
+        test    eax, eax
+        jz      continueWithOriginalCode
+
+        popad
+        movsx   ecx, dx
+        mov     eax, CModelInfo__ms_modelInfoPtrs
+        mov     eax, vehicleDummiesPositionArray
+        jmp     CONTINUE_CVehicle_GetPlaneGunsPosition
+
+        continueWithOriginalCode:
+        popad
+        movsx   ecx, dx
+        mov     eax, CModelInfo__ms_modelInfoPtrs
+        mov     eax, [eax+5Ch]
+        jmp     CONTINUE_CVehicle_GetPlaneGunsPosition
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CMultiplayerSA::InitHooks_VehicleDummies
+//
+// Setup hooks
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+void CMultiplayerSA::InitHooks_VehicleDummies()
+{
+    EZHookInstall(CVehicle_AddExhaustParticles);
+    EZHookInstall(CFire_ProcessFire);
+    EZHookInstall(CAutomobile_DoNitroEffect);
+    EZHookInstall(CVehicle_DoVehicleLights);
+    EZHookInstall(CAutomobile_ProcessCarOnFireAndExplode);
+    EZHookInstall(CBike_FixHandsToBars);
+    EZHookInstall(CPed_SetPedPositionInCar_1);
+    EZHookInstall(CPed_SetPedPositionInCar_2);
+    EZHookInstall(CPed_SetPedPositionInCar_3);
+    EZHookInstall(CPed_SetPedPositionInCar_4);
+    EZHookInstall(CVehicle_DoHeadLightEffect);
+    EZHookInstall(CVehicle_DoTailLightEffect);
+    EZHookInstall(CVehicle_DoHeadLightReflectionSingle);
+    EZHookInstall(CVehicle_DoHeadLightReflectionTwin);
+    EZHookInstall(CVehicle_GetPlaneGunsPosition);
+}

--- a/Client/sdk/game/CModelInfo.h
+++ b/Client/sdk/game/CModelInfo.h
@@ -126,7 +126,7 @@ public:
     virtual BOOL  IsQuadBike() = 0;
     virtual BOOL  IsBmx() = 0;
     virtual BOOL  IsTrailer() = 0;
-    virtual BOOL  IsVehicle() = 0;
+    virtual bool  IsVehicle() const = 0;
 
     virtual char* GetNameIfVehicle() = 0;
 
@@ -167,6 +167,8 @@ public:
     virtual void*        SetVehicleSuspensionData(void* pSuspensionLines) = 0;
     virtual CVector      GetVehicleExhaustFumesPosition() = 0;
     virtual void         SetVehicleExhaustFumesPosition(const CVector& position) = 0;
+    virtual bool         GetVehicleDummyDefaultPositions(std::array<CVector, VEHICLE_DUMMY_COUNT>& positions) const = 0;
+    virtual CVector      GetVehicleDummyDefaultPosition(eVehicleDummies eDummy) = 0;
     virtual CVector      GetVehicleDummyPosition(eVehicleDummies eDummy) = 0;
     virtual void         SetVehicleDummyPosition(eVehicleDummies eDummy, const CVector& vecPosition) = 0;
     virtual void         ResetVehicleDummies(bool bRemoveFromDummiesMap) = 0;

--- a/Client/sdk/game/CModelInfo.h
+++ b/Client/sdk/game/CModelInfo.h
@@ -167,9 +167,9 @@ public:
     virtual void*        SetVehicleSuspensionData(void* pSuspensionLines) = 0;
     virtual CVector      GetVehicleExhaustFumesPosition() = 0;
     virtual void         SetVehicleExhaustFumesPosition(const CVector& position) = 0;
-    virtual bool         GetVehicleDummyDefaultPositions(std::array<CVector, VEHICLE_DUMMY_COUNT>& positions) const = 0;
     virtual CVector      GetVehicleDummyDefaultPosition(eVehicleDummies eDummy) = 0;
     virtual CVector      GetVehicleDummyPosition(eVehicleDummies eDummy) = 0;
+    virtual bool         GetVehicleDummyPositions(std::array<CVector, VEHICLE_DUMMY_COUNT>& positions) const = 0;
     virtual void         SetVehicleDummyPosition(eVehicleDummies eDummy, const CVector& vecPosition) = 0;
     virtual void         ResetVehicleDummies(bool bRemoveFromDummiesMap) = 0;
     virtual float        GetVehicleWheelSize(eResizableVehicleWheelGroup eWheelGroup) = 0;

--- a/Client/sdk/game/CVehicle.h
+++ b/Client/sdk/game/CVehicle.h
@@ -336,5 +336,7 @@ public:
     virtual CAEVehicleAudioEntity*            GetVehicleAudioEntity() = 0;
 
     virtual bool GetDummyPosition(eVehicleDummies dummy, CVector& position) const = 0;
-    virtual bool SetDummyPosition(eVehicleDummies dummy, CVector position) = 0;
+    virtual bool SetDummyPosition(eVehicleDummies dummy, const CVector& position) = 0;
+
+    virtual const CVector* GetDummyPositions() const = 0;
 };

--- a/Client/sdk/game/CVehicle.h
+++ b/Client/sdk/game/CVehicle.h
@@ -334,4 +334,7 @@ public:
     virtual float                             GetWheelScale() = 0;
     virtual void                              SetWheelScale(float fWheelScale) = 0;
     virtual CAEVehicleAudioEntity*            GetVehicleAudioEntity() = 0;
+
+    virtual bool GetDummyPosition(eVehicleDummies dummy, CVector& position) const = 0;
+    virtual bool SetDummyPosition(eVehicleDummies dummy, CVector position) = 0;
 };

--- a/Client/sdk/game/Common.h
+++ b/Client/sdk/game/Common.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include <windows.h>
-#include <type_traits>
 #include <stdint.h>
 
 // Limits for MTA

--- a/Client/sdk/game/Common.h
+++ b/Client/sdk/game/Common.h
@@ -12,6 +12,8 @@
 #pragma once
 
 #include <windows.h>
+#include <type_traits>
+#include <stdint.h>
 
 // Limits for MTA
 #define MAX_VEHICLES_MTA                    64          // Real limit is 110
@@ -184,17 +186,17 @@ typedef struct eControlStatesSA
     DWORD dwKeyHeld;
 } eControlStatesSA;
 
-enum class eVehicleModelTypes
+enum class VehicleClass : uint8_t
 {
-    AUTOMOBILE = 0,
-    MONSTERTRUCK,
-    QUADBIKE,
-    HELICOPTER,
+    AUTOMOBILE,
+    MONSTER_TRUCK,
+    QUAD,
+    HELI,
     PLANE,
     BOAT,
     TRAIN,
-    FHELI, // RC ?
-    FPLANE, // RC ?
+    FAKE_HELI,
+    FAKE_PLANE,
     BIKE,
     BMX,
     TRAILER,

--- a/Client/sdk/game/Common.h
+++ b/Client/sdk/game/Common.h
@@ -1552,6 +1552,7 @@ enum eVehicleDummies
     EXHAUST_SECONDARY,
     WING_AIRTRAIL,
     VEH_GUN,
+    VEHICLE_DUMMY_COUNT,
 };
 
 enum class eResizableVehicleWheelGroup


### PR DESCRIPTION
![Bikes with different exhaust fumes positions](https://user-images.githubusercontent.com/38703318/103547483-bd273b00-4ea4-11eb-97b3-f0b898c4a1fd.png)
(The picture above shows the exhaust fumes exception for the NRG-500 with three variations of the bike)

Fixes issue #341 (partially).

This pull request makes every vehicle dummy position vehicle dependent. That means you can change a dummy position for every vehicle independently. In the current state, on creation a vehicle copies the dummy positions from the model info, which can be manipulated with existing functions. After creation, vehicles **DO NOT** copy the model info anymore, even if changed.

Dummy positions from the model will only be copied, if the vehicle dependent dummy positions were not changed prior to (re-)creation or the vehicle model was changed.

If a vehicle has double exhausts, it will try to use the `EXHAUST_SECONDARY` dummy position, if it's not zero. Otherwise, it will use the main exhaust position with the x-position negated (*= -1.0). Certain bike models like NRG-500, BF-400 and FCR-900 will ignore the secondary exhaust dummy position, unless certain upgrades are installed. If these upgrades aren't installed, the bikes will default to the negated primary exhaust position for the second exhaust (if there is one).

Changing the vehicle exhaust positions will also update the exhaust particle positions.
Changing the vehicle engine position will also update the vehicle fire and engine damage particles.

## New client functions
```lua
bool | float,float,float getVehicleDummyPosition(element: vehicle, vehicle-dummy dummy)
bool | float,float,float getVehicleModelDummyDefaultPosition(number model, vehicle-dummy dummy)
bool setVehicleDummyPosition(element: vehicle, vehicle-dummy dummy, float x, float y, float z)
bool resetVehicleDummyPositions(element: vehicle)
```

## New client OOP functions
```lua
bool | Vector3 Vehicle.getVehicleModelDummyDefaultPosition(number model, vehicle-dummy dummy)
bool | Vector3 vehicle:getDummyPosition(vehicle-dummy dummy)
bool vehicle:setDummyPosition(vehicle-dummy dummy, Vector3 position)
bool vehicle:resetDummyPositions()
```

My testing resource: [dummies.zip](https://github.com/multitheftauto/mtasa-blue/files/5765239/dummies.zip)
