### PR TITLE
Enforce existing username length limit

### DIFF
--- a/Server/mods/deathmatch/Config.h
+++ b/Server/mods/deathmatch/Config.h
@@ -57,6 +57,10 @@ public:
 
 #define MAX_TEAM_NAME_LENGTH 255
 
+// Min and max number of characters in usernames
+#define MIN_USERNAME_LENGTH 1
+#define MAX_USERNAME_LENGTH 64
+
 // Min number of characters in passwords
 #define MIN_PASSWORD_LENGTH 1
 

--- a/Server/mods/deathmatch/Config.h
+++ b/Server/mods/deathmatch/Config.h
@@ -57,10 +57,6 @@ public:
 
 #define MAX_TEAM_NAME_LENGTH 255
 
-// Min and max number of characters in usernames
-#define MIN_USERNAME_LENGTH 1
-#define MAX_USERNAME_LENGTH 64
-
 // Min number of characters in passwords
 #define MIN_PASSWORD_LENGTH 1
 

--- a/Server/mods/deathmatch/logic/CAccount.cpp
+++ b/Server/mods/deathmatch/logic/CAccount.cpp
@@ -20,7 +20,7 @@ CAccount::CAccount(CAccountManager* pManager, EAccountType accountType, const st
     m_bChanged = false;
     m_pManager = pManager;
     m_AccountType = accountType;
-    m_strName = strName.substr(0, MAX_USERNAME_LENGTH);
+    m_strName = strName.substr(0, CAccountManager::MAX_USERNAME_LENGTH);
     m_iUserID = iUserID;
     m_strIP = strIP;
     m_strSerial = strSerial;
@@ -46,7 +46,7 @@ void CAccount::SetName(const std::string& strName)
 {
     if (m_strName != strName)
     {
-        std::string strNewName = strName.substr(0, MAX_USERNAME_LENGTH);
+        std::string strNewName = strName.substr(0, CAccountManager::MAX_USERNAME_LENGTH);
         m_pManager->ChangingName(this, m_strName, strNewName);
         m_strName = strNewName;
         m_pManager->MarkAsChanged(this);

--- a/Server/mods/deathmatch/logic/CAccount.cpp
+++ b/Server/mods/deathmatch/logic/CAccount.cpp
@@ -20,7 +20,7 @@ CAccount::CAccount(CAccountManager* pManager, EAccountType accountType, const st
     m_bChanged = false;
     m_pManager = pManager;
     m_AccountType = accountType;
-    m_strName = strName;
+    m_strName = strName.substr(0, MAX_USERNAME_LENGTH);
     m_iUserID = iUserID;
     m_strIP = strIP;
     m_strSerial = strSerial;
@@ -46,8 +46,9 @@ void CAccount::SetName(const std::string& strName)
 {
     if (m_strName != strName)
     {
-        m_pManager->ChangingName(this, m_strName, strName);
-        m_strName = strName;
+        std::string strNewName = strName.substr(0, MAX_USERNAME_LENGTH);
+        m_pManager->ChangingName(this, m_strName, strNewName);
+        m_strName = strNewName;
         m_pManager->MarkAsChanged(this);
     }
 }

--- a/Server/mods/deathmatch/logic/CAccount.cpp
+++ b/Server/mods/deathmatch/logic/CAccount.cpp
@@ -44,9 +44,9 @@ CAccount::~CAccount()
 
 void CAccount::SetName(const std::string& strName)
 {
-    if (m_strName != strName)
+    std::string strNewName = strName.substr(0, CAccountManager::MAX_USERNAME_LENGTH);
+    if (m_strName != strNewName)
     {
-        std::string strNewName = strName.substr(0, CAccountManager::MAX_USERNAME_LENGTH);
         m_pManager->ChangingName(this, m_strName, strNewName);
         m_strName = std::move(strNewName);
         m_pManager->MarkAsChanged(this);

--- a/Server/mods/deathmatch/logic/CAccount.cpp
+++ b/Server/mods/deathmatch/logic/CAccount.cpp
@@ -48,7 +48,7 @@ void CAccount::SetName(const std::string& strName)
     {
         std::string strNewName = strName.substr(0, CAccountManager::MAX_USERNAME_LENGTH);
         m_pManager->ChangingName(this, m_strName, strNewName);
-        m_strName = strNewName;
+        m_strName = std::move(strNewName);
         m_pManager->MarkAsChanged(this);
     }
 }

--- a/Server/mods/deathmatch/logic/CAccountManager.cpp
+++ b/Server/mods/deathmatch/logic/CAccountManager.cpp
@@ -166,12 +166,12 @@ bool CAccountManager::Load()
         // Check for overlong names and incorrect escapement
         bool bRemoveAccount = false;
         bool bChanged = false;
-        if (strName.length() > 64)
+        if (strName.length() > MAX_USERNAME_LENGTH)
         {
             // Try to repair name
             if (strName.length() <= 256)
             {
-                strName = strName.Replace("\"\"", "\"", true).substr(0, 64);
+                strName = strName.Replace("\"\"", "\"", true).substr(0, MAX_USERNAME_LENGTH);
                 bChanged = true;
             }
 
@@ -481,7 +481,7 @@ void CAccountManager::RemoveAll()
     DeletePointersAndClearList(m_List);
 }
 
-bool CAccountManager::LogIn(CClient* pClient, CClient* pEchoClient, const char* szAccountName, const char* szPassword)
+bool CAccountManager::LogIn(CClient* pClient, CClient* pEchoClient, std::string strAccountName, const char* szPassword)
 {
     // Is he already logged in?
     if (pClient->IsRegistered())
@@ -503,6 +503,21 @@ bool CAccountManager::LogIn(CClient* pClient, CClient* pEchoClient, const char* 
     SString  strPlayerName = pPlayer->GetNick();
     SString  strPlayerIP = pPlayer->GetSourceIP();
     SString  strPlayerSerial = pPlayer->GetSerial();
+
+    if (strAccountName.length() > MAX_USERNAME_LENGTH)
+        strAccountName = strAccountName.substr(0, MAX_USERNAME_LENGTH);
+
+    const char* szAccountName = strAccountName.c_str();
+
+    if (!IsValidAccountName(szAccountName))
+    {
+        if (pEchoClient)
+            pEchoClient->SendEcho("login: Invalid account name provided");
+        CLogger::AuthPrintf("LOGIN: %s tried to log in with an invalid account name (IP: %s  Serial: %s)\n", szAccountName, strPlayerIP.c_str(),
+                            strPlayerSerial.c_str());
+        m_AccountProtect.AddConnect(strPlayerIP.c_str());
+        return false;
+    }
 
     if (m_AccountProtect.IsFlooding(strPlayerIP.c_str()))
     {
@@ -1058,7 +1073,7 @@ void CAccountManager::DbCallback(CDbJobData* pJobData)
 //
 bool CAccountManager::IsValidAccountName(const SString& strName)
 {
-    if (strName.length() < 1)
+    if (strName.length() < MIN_USERNAME_LENGTH)
         return false;
     return true;
 }
@@ -1078,7 +1093,7 @@ bool CAccountManager::IsValidPassword(const SString& strPassword)
 //
 bool CAccountManager::IsValidNewAccountName(const SString& strName)
 {
-    if (!IsValidAccountName(strName))
+    if (!IsValidAccountName(strName) || strName.length() > MAX_USERNAME_LENGTH)
         return false;
 
     // Extra restrictions for new account names

--- a/Server/mods/deathmatch/logic/CAccountManager.cpp
+++ b/Server/mods/deathmatch/logic/CAccountManager.cpp
@@ -481,7 +481,7 @@ void CAccountManager::RemoveAll()
     DeletePointersAndClearList(m_List);
 }
 
-bool CAccountManager::LogIn(CClient* pClient, CClient* pEchoClient, std::string strAccountName, const char* szPassword)
+bool CAccountManager::LogIn(CClient* pClient, CClient* pEchoClient, const std::string& strAccountName, const char* szPassword)
 {
     // Is he already logged in?
     if (pClient->IsRegistered())
@@ -504,10 +504,8 @@ bool CAccountManager::LogIn(CClient* pClient, CClient* pEchoClient, std::string 
     SString  strPlayerIP = pPlayer->GetSourceIP();
     SString  strPlayerSerial = pPlayer->GetSerial();
 
-    if (strAccountName.length() > MAX_USERNAME_LENGTH)
-        strAccountName = strAccountName.substr(0, MAX_USERNAME_LENGTH);
-
-    const char* szAccountName = strAccountName.c_str();
+    std::string strSlicedAccountName = strAccountName.substr(0, MAX_USERNAME_LENGTH);
+    const char* szAccountName = strSlicedAccountName.c_str();
 
     if (!IsValidAccountName(szAccountName))
     {

--- a/Server/mods/deathmatch/logic/CAccountManager.cpp
+++ b/Server/mods/deathmatch/logic/CAccountManager.cpp
@@ -522,7 +522,7 @@ bool CAccountManager::LogIn(CClient* pClient, CClient* pEchoClient, std::string 
     if (m_AccountProtect.IsFlooding(strPlayerIP.c_str()))
     {
         if (pEchoClient)
-            pEchoClient->SendEcho(SString("login: Account locked", szAccountName).c_str());
+            pEchoClient->SendEcho("login: Account locked");
         CLogger::AuthPrintf("LOGIN: Ignoring %s trying to log in as '%s' (IP: %s  Serial: %s)\n", strPlayerName.c_str(), szAccountName, strPlayerIP.c_str(),
                             strPlayerSerial.c_str());
         return false;

--- a/Server/mods/deathmatch/logic/CAccountManager.h
+++ b/Server/mods/deathmatch/logic/CAccountManager.h
@@ -133,7 +133,7 @@ public:
     CAccount* GetAccountFromScriptID(uint uiScriptID);
     SString   GetActiveCaseVariation(const SString& strName);
 
-    bool LogIn(CClient* pClient, CClient* pEchoClient, std::string strAccountName, const char* szPassword);
+    bool LogIn(CClient* pClient, CClient* pEchoClient, const std::string& strAccountName, const char* szPassword);
     bool LogOut(CClient* pClient, CClient* pEchoClient);
 
     std::shared_ptr<CLuaArgument> GetAccountData(CAccount* pAccount, const char* szKey);

--- a/Server/mods/deathmatch/logic/CAccountManager.h
+++ b/Server/mods/deathmatch/logic/CAccountManager.h
@@ -130,7 +130,7 @@ public:
     CAccount* GetAccountFromScriptID(uint uiScriptID);
     SString   GetActiveCaseVariation(const SString& strName);
 
-    bool LogIn(CClient* pClient, CClient* pEchoClient, const char* szAccountName, const char* szPassword);
+    bool LogIn(CClient* pClient, CClient* pEchoClient, std::string strAccountName, const char* szPassword);
     bool LogOut(CClient* pClient, CClient* pEchoClient);
 
     std::shared_ptr<CLuaArgument> GetAccountData(CAccount* pAccount, const char* szKey);

--- a/Server/mods/deathmatch/logic/CAccountManager.h
+++ b/Server/mods/deathmatch/logic/CAccountManager.h
@@ -114,6 +114,9 @@ class CAccountManager
     friend class CAccount;
 
 public:
+    static inline constexpr size_t MIN_USERNAME_LENGTH = 1;
+    static inline constexpr size_t MAX_USERNAME_LENGTH = 64;
+
     CAccountManager(const SString& strDbPathFilename);
     ~CAccountManager();
 


### PR DESCRIPTION
At the moment our database code already limits usernames to 64 characters long, but is not enforced elsewhere in the code, causing potential buffer overflows when handling usernames. To fix this let's limit the usernames to max length.

Note that whether the limit should be changed is out-of-scope for this PR. This PR only wants to get rid of potential issues caused by overlong usernames.

Should be backwards compatible as far as I can see.