### PR TITLE
Refactor vehicle blowup

### DIFF
--- a/Client/mods/deathmatch/logic/CClientVehicle.h
+++ b/Client/mods/deathmatch/logic/CClientVehicle.h
@@ -198,7 +198,7 @@ public:
     void  SetHealth(float fHealth);
     void  Fix();
     void  Blow(bool bAllowMovement = false);
-    bool  IsVehicleBlown() { return m_bBlown; };
+    bool  IsVehicleBlown() const noexcept { return m_bBlown; };
 
     CVehicleColor& GetColor();
     void           SetColor(const CVehicleColor& color);

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -2788,11 +2788,6 @@ bool CStaticFunctionDefinitions::BlowVehicle(CClientEntity& Entity)
 
     return false;
 }
-bool CStaticFunctionDefinitions::IsVehicleBlown(CClientVehicle& Vehicle, bool& bBlown)
-{
-    bBlown = Vehicle.IsVehicleBlown();
-    return true;
-}
 
 bool CStaticFunctionDefinitions::GetVehicleVariant(CClientVehicle* pVehicle, unsigned char& ucVariant, unsigned char& ucVariant2)
 {

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -211,7 +211,6 @@ public:
     static bool            GetTrainSpeed(CClientVehicle& Vehicle, float& fSpeed);
     static bool            GetTrainPosition(CClientVehicle& Vehicle, float& fPosition);
     static bool            IsTrainChainEngine(CClientVehicle& Vehicle, bool& bChainEngine);
-    static bool            IsVehicleBlown(CClientVehicle& Vehicle, bool& bBlown);
     static bool            GetVehicleHeadLightColor(CClientVehicle& Vehicle, SColor& outColor);
     static bool            GetVehicleCurrentGear(CClientVehicle& Vehicle, unsigned short& currentGear);
     static bool            GetVehicleVariant(CClientVehicle* pVehicle, unsigned char& ucVariant, unsigned char& ucVariant2);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -61,7 +61,7 @@ void CLuaVehicleDefs::LoadFunctions()
         {"getTrainPosition", GetTrainPosition},
         {"isTrainChainEngine", IsTrainChainEngine},
         {"getVehicleGravity", GetVehicleGravity},
-        {"isVehicleBlown", IsVehicleBlown},
+        {"isVehicleBlown", ArgumentParserWarn<false, IsVehicleBlown>},
         {"isVehicleTaxiLightOn", IsVehicleTaxiLightOn},
         {"getVehicleHeadLightColor", GetVehicleHeadLightColor},
         {"getVehicleCurrentGear", GetVehicleCurrentGear},
@@ -1569,26 +1569,9 @@ int CLuaVehicleDefs::BlowVehicle(lua_State* luaVM)
     return 1;
 }
 
-int CLuaVehicleDefs::IsVehicleBlown(lua_State* luaVM)
+bool CLuaVehicleDefs::IsVehicleBlown(CClientVehicle* vehicle)
 {
-    CClientVehicle*  pVehicle = NULL;
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pVehicle);
-
-    if (!argStream.HasErrors())
-    {
-        bool bBlown;
-        if (CStaticFunctionDefinitions::IsVehicleBlown(*pVehicle, bBlown))
-        {
-            lua_pushboolean(luaVM, bBlown);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vehicle->IsVehicleBlown();
 }
 
 int CLuaVehicleDefs::GetVehicleHeadLightColor(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -67,7 +67,7 @@ public:
     LUA_DECLARE(GetTrainPosition);
     LUA_DECLARE(IsTrainChainEngine);
     LUA_DECLARE_OOP(GetVehicleGravity);
-    LUA_DECLARE(IsVehicleBlown);
+    static bool IsVehicleBlown(CClientVehicle* vehicle);
     LUA_DECLARE(GetVehicleHeadLightColor);
     LUA_DECLARE(GetVehicleCurrentGear);
     LUA_DECLARE(GetVehicleHandling);

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -2627,12 +2627,12 @@ void CGame::Packet_ExplosionSync(CExplosionSyncPacket& Packet)
                                 if (pVehicle->GetIsBlown() == false)
                                 {
                                     pVehicle->SetIsBlown(true);
+                                    pVehicle->SetEngineOn(false);
 
-                                    // Call the onVehicleExplode event
                                     CLuaArguments Arguments;
                                     pVehicle->CallEvent("onVehicleExplode", Arguments);
-                                    // Update our engine State
-                                    pVehicle->SetEngineOn(false);
+
+                                    bBroadcast = pVehicle->GetIsBlown() && !pVehicle->IsBeingDeleted();
                                 }
                                 else
                                 {

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -5270,23 +5270,26 @@ bool CStaticFunctionDefinitions::FixVehicle(CElement* pElement)
     return false;
 }
 
-bool CStaticFunctionDefinitions::BlowVehicle(CElement* pElement, bool bExplode)
+bool CStaticFunctionDefinitions::BlowVehicle(CElement* pElement)
 {
-    assert(pElement);
-    RUN_CHILDREN(BlowVehicle(*iter, bExplode))
-
+    RUN_CHILDREN(BlowVehicle(*iter))
+    
     if (!IS_VEHICLE(pElement))
         return false;
 
     CVehicle* vehicle = static_cast<CVehicle*>(pElement);
 
-    if (vehicle->GetIsBlown())
+    if (vehicle->GetIsBlown() || vehicle->IsBeingDeleted())
         return false;
 
     vehicle->SetIsBlown(true);
 
     CLuaArguments Arguments;
     vehicle->CallEvent("onVehicleExplode", Arguments);
+
+    // Abort if vehicle got fixed or destroyed
+    if (!vehicle->GetIsBlown() || vehicle->IsBeingDeleted())
+        return true;
 
     vehicle->SetHealth(0.0f);
     vehicle->SetEngineOn(false);

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -269,7 +269,6 @@ public:
     static bool  GetTrainDirection(CVehicle* pVehicle, bool& bDirection);
     static bool  GetTrainSpeed(CVehicle* pVehicle, float& fSpeed);
     static bool  GetTrainPosition(CVehicle* pVehicle, float& fPosition);
-    static bool  IsVehicleBlown(CVehicle* pVehicle);
     static bool  GetVehicleHeadLightColor(CVehicle* pVehicle, SColor& outColor);
     static bool  GetVehicleDoorOpenRatio(CVehicle* pVehicle, unsigned char ucDoor, float& fRatio);
 

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -289,7 +289,7 @@ public:
 
     // Vehicle set functions
     static bool FixVehicle(CElement* pElement);
-    static bool BlowVehicle(CElement* pElement, bool bExplode);
+    static bool BlowVehicle(CElement* pElement);
     static bool SetVehicleColor(CElement* pElement, const CVehicleColor& color);
     static bool SetVehicleLandingGearDown(CElement* pElement, bool bLandingGearDown);
     static bool SetVehicleLocked(CElement* pElement, bool bLocked);

--- a/Server/mods/deathmatch/logic/CVehicle.cpp
+++ b/Server/mods/deathmatch/logic/CVehicle.cpp
@@ -898,11 +898,6 @@ void CVehicle::SetIsBlown(bool bBlown)
         m_llBlowTime = CTickCount::Now();
 }
 
-bool CVehicle::GetIsBlown()
-{
-    return m_llBlowTime.ToLongLong() != 0;
-}
-
 bool CVehicle::IsBlowTimerFinished()
 {
     return GetIsBlown() && CTickCount::Now() > m_llBlowTime + CTickCount((long long)m_ulBlowRespawnInterval);

--- a/Server/mods/deathmatch/logic/CVehicle.h
+++ b/Server/mods/deathmatch/logic/CVehicle.h
@@ -338,7 +338,7 @@ public:
     void ResetDoors();
     void ResetDoorsWheelsPanelsLights();
     void SetIsBlown(bool bBlown);
-    bool GetIsBlown();
+    bool GetIsBlown() const noexcept { return m_llBlowTime.ToLongLong() != 0; }
     bool IsBlowTimerFinished();
     void StopIdleTimer();
     void RestartIdleTimer();

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -59,7 +59,7 @@ void CLuaVehicleDefs::LoadFunctions()
         {"getTrainSpeed", GetTrainSpeed},
         //{"getTrainTrack", ArgumentParser<GetTrainTrack>},
         {"getTrainPosition", GetTrainPosition},
-        {"isVehicleBlown", IsVehicleBlown},
+        {"isVehicleBlown", ArgumentParserWarn<false, IsVehicleBlown>},
         {"getVehicleHeadLightColor", GetVehicleHeadLightColor},
         {"getVehicleDoorOpenRatio", GetVehicleDoorOpenRatio},
 
@@ -1751,26 +1751,9 @@ int CLuaVehicleDefs::BlowVehicle(lua_State* luaVM)
     return 1;
 }
 
-int CLuaVehicleDefs::IsVehicleBlown(lua_State* luaVM)
+bool CLuaVehicleDefs::IsVehicleBlown(CVehicle* vehicle)
 {
-    CVehicle* pVehicle;
-
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pVehicle);
-
-    if (!argStream.HasErrors())
-    {
-        if (CStaticFunctionDefinitions::IsVehicleBlown(pVehicle))
-        {
-            lua_pushboolean(luaVM, true);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vehicle->GetIsBlown();
 }
 
 int CLuaVehicleDefs::GetVehicleHeadLightColor(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -65,7 +65,7 @@ void CLuaVehicleDefs::LoadFunctions()
 
         // Vehicle set funcs
         {"fixVehicle", FixVehicle},
-        {"blowVehicle", BlowVehicle},
+        {"blowVehicle", ArgumentParserWarn<false, CStaticFunctionDefinitions::BlowVehicle>},
         {"setVehicleRotation", SetVehicleRotation},
         {"setVehicleTurnVelocity", SetVehicleTurnVelocity},
         {"setVehicleColor", SetVehicleColor},
@@ -1715,30 +1715,6 @@ int CLuaVehicleDefs::FixVehicle(lua_State* luaVM)
     if (!argStream.HasErrors())
     {
         if (CStaticFunctionDefinitions::FixVehicle(pElement))
-        {
-            lua_pushboolean(luaVM, true);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
-}
-
-int CLuaVehicleDefs::BlowVehicle(lua_State* luaVM)
-{
-    CElement* pElement;
-    bool      bExplode;
-
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pElement);
-    argStream.ReadBool(bExplode, true);
-
-    if (!argStream.HasErrors())
-    {
-        if (CStaticFunctionDefinitions::BlowVehicle(pElement, bExplode))
         {
             lua_pushboolean(luaVM, true);
             return 1;

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -70,7 +70,6 @@ public:
 
     // Vehicle set functions
     LUA_DECLARE(FixVehicle);
-    LUA_DECLARE(BlowVehicle);
     LUA_DECLARE(SetVehicleRotation);
     LUA_DECLARE(SetVehicleTurnVelocity);
     LUA_DECLARE(SetVehicleColor);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -64,7 +64,7 @@ public:
     LUA_DECLARE(GetTrainSpeed);
     static std::variant<CTrainTrack*, bool> GetTrainTrack(CVehicle* pVehicle);
     LUA_DECLARE(GetTrainPosition);
-    LUA_DECLARE(IsVehicleBlown);
+    static bool IsVehicleBlown(CVehicle* vehicle);
     LUA_DECLARE(GetVehicleHeadLightColor);
     LUA_DECLARE(GetVehicleDoorOpenRatio);
 


### PR DESCRIPTION
## Summary
- Refactor Lua functions to use new argument parser with warnings
- Remove **explode** parameter for `blowVehicle` (it was never implemented properly and caused onVehicleExplode to trigger twice when a client send the explosion sync for the vehicle blow)
- Fixing or destroying the vehicle in onVehicleExplode avoids broadcasting the blow-up packet

Fixes issue #455 (**onVehicleExplode triggers twice [server-side]**)