### PR TITLE
Fix #817 (clearChatBox() returns false serverside if the player is root)

### DIFF
--- a/Server/mods/deathmatch/logic/lua/CLuaFunctionDefs.Server.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaFunctionDefs.Server.cpp
@@ -166,7 +166,7 @@ int CLuaFunctionDefs::ClearChatBox(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        if (CStaticFunctionDefinitions::ClearChatBox(pElement))
+        if (CStaticFunctionDefinitions::ClearChatBox(pElement) || pElement == m_pRootElement)
         {
             lua_pushboolean(luaVM, true);
             return 1;


### PR DESCRIPTION
Resolves #817 by adding a simple check if the passed element is equal to the root element.

It's also noted in #817 that other functions have the same issue. Do we want to submit separate PRs for each function affected by this, or bundle it all into this PR?