### PR TITLE
Move Linux CI image to multitheftauto namespace 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -121,7 +121,7 @@ jobs:
     name: linux-release
     runs-on: ubuntu-16.04
     container:
-      image: docker://sbx320/mtasa-blue-azure:latest
+      image: docker://ghcr.io/multitheftauto/mtasa-blue-build:latest
     steps:
       - uses: actions/checkout@v2
       - name: Run Build
@@ -131,7 +131,7 @@ jobs:
     name: linux-debug
     runs-on: ubuntu-16.04
     container:
-      image: docker://sbx320/mtasa-blue-azure:latest
+      image: docker://ghcr.io/multitheftauto/mtasa-blue-build:latest
     steps:
       - uses: actions/checkout@v2
       - name: Run Build

--- a/.github/workflows/dockerimage.yaml
+++ b/.github/workflows/dockerimage.yaml
@@ -1,0 +1,26 @@
+name: Docker Image
+
+on: 
+  push:
+    branches:
+    - master
+    paths: 
+    - '.github/**'
+    - 'Dockerfile'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: docker/setup-buildx-action@v1
+    - uses: docker/login-action@v1 
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.CI_PAT }}
+    - uses: docker/build-push-action@v2.2.1
+      with:
+        push: true
+        file: ./Dockerfile
+        tags: ghcr.io/multitheftauto/mtasa-blue-build:latest

--- a/.github/workflows/dockerimage.yaml
+++ b/.github/workflows/dockerimage.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - master
-    - feature/ci-actions
     paths: 
     - '.github/**'
     - 'Dockerfile'

--- a/.github/workflows/dockerimage.yaml
+++ b/.github/workflows/dockerimage.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - feature/ci-actions
     paths: 
     - '.github/**'
     - 'Dockerfile'

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,16 +10,12 @@ ENV BUILD_BITS 64
 # This is important for using apt-get
 USER root
 
-# Install dependencies to install the latest gcc
-RUN apt-get update && \
-    apt-get install -y software-properties-common wget && \
-    add-apt-repository ppa:ubuntu-toolchain-r/test
-
 # Install latest gcc and libs
 RUN dpkg --add-architecture i386 && apt-get update && \
-    apt-get install -y ca-certificates git build-essential gcc-multilib g++-multilib gcc-8-multilib g++-8-multilib curl subversion ncftp \
+    apt-get install -y software-properties-common wget ca-certificates git build-essential \
+        gcc-multilib g++-multilib gcc-10-multilib g++-10-multilib curl subversion ncftp \
         libncursesw5-dev libmysqlclient-dev \
-        lib32ncursesw5-dev libncursesw5-dev:i386
+        lib32ncursesw5-dev libncursesw5-dev:i386 
 
 # Set build directory
 VOLUME /build

--- a/vendor/curl/lib/config-linux.h
+++ b/vendor/curl/lib/config-linux.h
@@ -689,7 +689,7 @@
 /* #undef HAVE_STRNICMP */
 
 /* Define to 1 if you have the <stropts.h> header file. */
-#define HAVE_STROPTS_H 1
+/* #undef HAVE_STROPTS_H */
 
 /* Define to 1 if you have the strstr function. */
 #define HAVE_STRSTR 1


### PR DESCRIPTION
Previously we relied on the CI docker image in sbx320/mtasa-blue-azure hosted on Dockerhub. To make this a bit more maintainable, we should have this on the multitheftauto namespace. As Github also has a container registry now, we can simply use that one.

This PR adds a new CI action, which triggers only for `Dockerfile` (and actions changes). The Linux CI action then uses the https://github.com/orgs/multitheftauto/packages/container/package/mtasa-blue-build build image. It also upgrades the base image to Ubuntu 20.04 and gcc-10.