### PR TITLE
Fix arg parser returning tuples rather than values from some functions

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
@@ -816,11 +816,11 @@ int CLuaColShapeDefs::RemoveColPolygonPoint(lua_State* luaVM)
     return luaL_error(luaVM, argStream.GetFullErrorMessage());
 }
 
-std::tuple<float, float> CLuaColShapeDefs::GetColPolygonHeight(CClientColPolygon* pColPolygon)
+CLuaMultiReturn<float, float> CLuaColShapeDefs::GetColPolygonHeight(CClientColPolygon* pColPolygon)
 {
     float fFloor, fCeil;
     pColPolygon->GetHeight(fFloor, fCeil);
-    return std::make_tuple(fFloor, fCeil);
+    return {fFloor, fCeil};
 }
 
 bool CLuaColShapeDefs::SetColPolygonHeight(CClientColPolygon* pColPolygon, std::variant<bool, float> floor, std::variant<bool, float> ceil)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "CLuaDefs.h"
+#include <lua/CLuaMultiReturn.h>
 #include <variant>
 
 class CLuaColShapeDefs : public CLuaDefs
@@ -39,6 +40,6 @@ public:
     LUA_DECLARE(IsInsideColShape);
     LUA_DECLARE(GetColShapeType);
 
-    static std::tuple<float, float> GetColPolygonHeight(CClientColPolygon* pColPolygon);
+    static CLuaMultiReturn<float, float> GetColPolygonHeight(CClientColPolygon* pColPolygon);
     static bool                     SetColPolygonHeight(CClientColPolygon* pColPolygon, std::variant<bool, float> floor, std::variant<bool, float> ceil);
 };

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -1127,7 +1127,7 @@ bool CLuaEngineDefs::EngineSetModelVisibleTime(std::string strModelId, char cHou
     return false;
 }
 
-std::variant<bool, std::tuple<char, char>> CLuaEngineDefs::EngineGetModelVisibleTime(std::string strModelId)
+std::variant<bool, CLuaMultiReturn<char, char>> CLuaEngineDefs::EngineGetModelVisibleTime(std::string strModelId)
 {
     ushort      usModelID = CModelNames::ResolveModelID(strModelId);
     CModelInfo* pModelInfo = g_pGame->GetModelInfo(usModelID);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
@@ -11,7 +11,7 @@
 
 #pragma once
 #include "CLuaDefs.h"
-#include "CLuaMultiReturn.h"
+#include <lua/CLuaMultiReturn.h>
 
 class CLuaEngineDefs : public CLuaDefs
 {

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "CLuaDefs.h"
+#include "CLuaMultiReturn.h"
 
 class CLuaEngineDefs : public CLuaDefs
 {
@@ -57,9 +58,9 @@ public:
     LUA_DECLARE(EngineSetObjectGroupPhysicalProperty)
     LUA_DECLARE(EngineGetObjectGroupPhysicalProperty)
     LUA_DECLARE(EngineRestoreObjectGroupPhysicalProperties)
-    static bool CLuaEngineDefs::EngineRestreamWorld(lua_State* const luaVM);
+    static bool EngineRestreamWorld(lua_State* const luaVM);
     static bool EngineSetModelVisibleTime(std::string strModelId, char cHourOn, char cHourOff);
-    static std::variant<bool, std::tuple<char, char>> EngineGetModelVisibleTime(std::string strModelId);
+    static std::variant<bool, CLuaMultiReturn<char, char>> EngineGetModelVisibleTime(std::string strModelId);
 
 private:
     static void AddEngineColClass(lua_State* luaVM);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -993,7 +993,7 @@ bool CLuaPedDefs::SetElementBoneRotation(lua_State* const luaVM, CClientPed* ent
     return theEntity ? theEntity->SetBoneRotation(static_cast<eBone>(boneId), yaw, pitch, roll) : false;
 }
 
-std::variant<bool, std::tuple<float, float, float>> CLuaPedDefs::GetElementBonePosition(lua_State* const luaVM, CClientPed* entity, std::int32_t boneId)
+std::variant<bool, CLuaMultiReturn<float, float, float>> CLuaPedDefs::GetElementBonePosition(lua_State* const luaVM, CClientPed* entity, std::int32_t boneId)
 {
     CEntity* theEntity = entity->GetGameEntity();
     CVector  position;
@@ -1002,7 +1002,7 @@ std::variant<bool, std::tuple<float, float, float>> CLuaPedDefs::GetElementBoneP
     return false;
 }
 
-std::variant<bool, std::tuple<float, float, float>> CLuaPedDefs::GetElementBoneRotation(lua_State* const luaVM, CClientPed* entity, std::int32_t boneId)
+std::variant<bool, CLuaMultiReturn<float, float, float>> CLuaPedDefs::GetElementBoneRotation(lua_State* const luaVM, CClientPed* entity, std::int32_t boneId)
 {
     float    yaw = 0.0f, pitch = 0.0f, roll = 0.0f;
     CEntity* theEntity = entity->GetGameEntity();

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "CLuaDefs.h"
 #include "CVector.h"
+#include <lua/CLuaMultiReturn.h>
 
 class CLuaPedDefs : public CLuaDefs
 {
@@ -50,10 +51,10 @@ public:
     LUA_DECLARE(CanPedBeKnockedOffBike);
     static bool SetElementBonePosition(lua_State* const luaVM, CClientPed* entity, std::int32_t boneId, CVector position);
     static bool SetElementBoneRotation(lua_State* const luaVM, CClientPed* entity, std::int32_t boneId, float yaw, float pitch, float roll);
-    static std::variant<bool, std::tuple<float, float, float>>
+    static std::variant<bool, CLuaMultiReturn<float, float, float>>
     GetElementBonePosition(lua_State* const luaVM, CClientPed* entity, std::int32_t boneId);
 
-    static std::variant<bool, std::tuple<float, float, float>>
+    static std::variant<bool, CLuaMultiReturn<float, float, float>>
     GetElementBoneRotation(lua_State* const luaVM, CClientPed* entity, std::int32_t boneId);
 
     static bool

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -4114,7 +4114,7 @@ int CLuaVehicleDefs::GetVehicleWheelFrictionState(CClientVehicle* pVehicle, unsi
     return pVehicle->GetWheelFrictionState(wheel);
 }
 
-std::variant<bool, std::tuple<float, float, float>> CLuaVehicleDefs::GetVehicleModelDummyDefaultPosition(unsigned short vehicleModel, eVehicleDummies dummy)
+std::variant<bool, CLuaMultiReturn<float, float, float>> CLuaVehicleDefs::GetVehicleModelDummyDefaultPosition(unsigned short vehicleModel, eVehicleDummies dummy)
 {
     CVector position;
 
@@ -4139,7 +4139,7 @@ bool CLuaVehicleDefs::SetVehicleDummyPosition(CClientVehicle* vehicle, eVehicleD
     return vehicle->SetDummyPosition(dummy, position);
 }
 
-std::variant<bool, std::tuple<float, float, float>> CLuaVehicleDefs::GetVehicleDummyPosition(CClientVehicle* vehicle, eVehicleDummies dummy)
+std::variant<bool, CLuaMultiReturn<float, float, float>> CLuaVehicleDefs::GetVehicleDummyPosition(CClientVehicle* vehicle, eVehicleDummies dummy)
 {
     CVector position;
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "CLuaDefs.h"
+#include <lua/CLuaMultiReturn.h>
 
 class CLuaVehicleDefs : public CLuaDefs
 {
@@ -140,11 +141,11 @@ public:
     LUA_DECLARE(SetVehicleModelDummyPosition);
     LUA_DECLARE_OOP(GetVehicleModelDummyPosition)
 
-    static std::variant<bool, std::tuple<float, float, float>> GetVehicleModelDummyDefaultPosition(unsigned short vehicleModel, eVehicleDummies dummy);
+    static std::variant<bool, CLuaMultiReturn<float, float, float>> GetVehicleModelDummyDefaultPosition(unsigned short vehicleModel, eVehicleDummies dummy);
     static std::variant<bool, CVector>                         OOP_GetVehicleModelDummyDefaultPosition(unsigned short vehicleModel, eVehicleDummies dummy);
 
     static bool                                                SetVehicleDummyPosition(CClientVehicle* vehicle, eVehicleDummies dummy, CVector position);
-    static std::variant<bool, std::tuple<float, float, float>> GetVehicleDummyPosition(CClientVehicle* vehicle, eVehicleDummies dummy);
+    static std::variant<bool, CLuaMultiReturn<float, float, float>> GetVehicleDummyPosition(CClientVehicle* vehicle, eVehicleDummies dummy);
     static std::variant<bool, CVector>                         OOP_GetVehicleDummyPosition(CClientVehicle* vehicle, eVehicleDummies dummy);
     static bool                                                ResetVehicleDummyPositions(CClientVehicle* vehicle);
 

--- a/Shared/mods/deathmatch/logic/lua/CLuaMultiReturn.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaMultiReturn.h
@@ -1,0 +1,26 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+#pragma once
+
+#include <tuple>
+// Wrapper around std::tuple to indicate that multiple values should be pushed to
+// the Lua stack
+template <typename... Ts>
+struct CLuaMultiReturn
+{
+    // Note: We use a separate template for the constructor arguments
+    // to allow type conversions. For example: return { "hello", 42 };
+    // is a valid statement to construct a LuaMuliReturn<std::string, int>
+    template <typename... Args>
+    CLuaMultiReturn(Args... args) : values{args...}
+    {
+    }
+
+    std::tuple<Ts...> values;
+};


### PR DESCRIPTION
In #1981 I missed the fact that we already had some functions returning tuples for multiple return values. Those now incorrectly return tuples. This PR reverts to the correct functionality and also adds a `std::variant` overload so that `std::variant<bool, CLuaMultiReturn<int, int>>` works.

Affected functions (thanks @Zangomangu):
```
getElementBoneRotation
getElementBonePosition
engineGetModelVisibleTime
getVehicleDummyPosition
getVehicleModelDummyDefaultPosition
getColPolygonHeight
```