### PR TITLE
Fix #2048: Player is not able to leave Vehicle, which is about to explode with 0 health 

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -6640,12 +6640,6 @@ bool CClientPed::ExitVehicle()
         return false;
     }
 
-    // Dead vehicle?
-    if (pOccupiedVehicle->GetHealth() <= 0.0f)
-    {
-        return false;
-    }
-
     // Check the server is compatible if we are a ped
     if (!IsLocalPlayer() && !g_pNet->CanServerBitStream(eBitStreamVersion::PedEnterExit))
     {


### PR DESCRIPTION
The check for dead vehicle was added in https://github.com/multitheftauto/mtasa-blue/commit/94c6aba300460199690b66a38b6db36f4fe63a20 but is unnecessary when exiting.