### PR TITLE
(Re-)Add second parameter 'withExplosion' for blowVehicle

### DIFF
--- a/Client/mods/deathmatch/logic/CClientExplosionManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientExplosionManager.cpp
@@ -49,7 +49,7 @@ bool CClientExplosionManager::Hook_ExplosionCreation(CEntity* pGameExplodingEnti
     if (!pResponsibleGameEntity)
         return false;
 
-    CClientEntity* const pResponsible = pPools->GetClientEntity(reinterpret_cast<DWORD*>(pResponsibleGameEntity->GetInterface()));;
+    CClientEntity* const pResponsible = pPools->GetClientEntity(reinterpret_cast<DWORD*>(pResponsibleGameEntity->GetInterface()));
 
     if (!pResponsible)
         return false;
@@ -89,13 +89,25 @@ bool CClientExplosionManager::Hook_ExplosionCreation(CEntity* pGameExplodingEnti
 
     if (pResponsible->IsLocalEntity() || (bHasModel && CClientObjectManager::IsBreakableModel(usModel)))
     {
-        CLuaArguments Arguments;
-        Arguments.PushNumber(vecPosition.fX);
-        Arguments.PushNumber(vecPosition.fY);
-        Arguments.PushNumber(vecPosition.fZ);
-        Arguments.PushNumber(explosionWeaponType);
-        const bool bAllowExplosion = pResponsible->CallEvent("onClientExplosion", Arguments, true);
-        return bAllowExplosion;
+        CLuaArguments arguments;
+        arguments.PushNumber(vecPosition.fX);
+        arguments.PushNumber(vecPosition.fY);
+        arguments.PushNumber(vecPosition.fZ);
+        arguments.PushNumber(explosionWeaponType);
+        bool allowExplosion = pResponsible->CallEvent("onClientExplosion", arguments, true);
+
+        // Check if the exploding entity is a client-only vehicle that exploded
+        if (pGameExplodingEntity != nullptr && pResponsible->GetType() == CCLIENTVEHICLE)
+        {
+            auto vehicle = reinterpret_cast<CClientVehicle*>(pResponsible);
+
+            // Create an explosion if the vehicle was intact or awaiting this explosion
+            allowExplosion = allowExplosion && (vehicle->GetBlowState() != VehicleBlowState::BLOWN);
+
+            vehicle->SetBlowState(VehicleBlowState::BLOWN);
+        }
+        
+        return allowExplosion;
     }
 
     // All explosions are handled server side (ATTENTION: always 'return false;' below)

--- a/Client/mods/deathmatch/logic/CClientExplosionManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientExplosionManager.cpp
@@ -129,6 +129,7 @@ bool CClientExplosionManager::Hook_ExplosionCreation(CEntity* pGameExplodingEnti
         auto vehicle = reinterpret_cast<CClientVehicle*>(pResponsible);
         pOriginSource = vehicle;
 
+        // Create an explosion, if the vehicle was not blown by us directly (CClientVehicle::Blow)
         if (vehicle->GetBlowState() == VehicleBlowState::INTACT)
         {
             vehicle->SetBlowState(VehicleBlowState::AWAITING_EXPLOSION_SYNC);

--- a/Client/mods/deathmatch/logic/CClientExplosionManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientExplosionManager.cpp
@@ -124,14 +124,14 @@ bool CClientExplosionManager::Hook_ExplosionCreation(CEntity* pGameExplodingEnti
     CClientEntity* pOriginSource = nullptr;
 
     // Is this an exploding vehicle?
-    if (pGameExplodingEntity && pGameExplodingEntity->GetEntityType() == ENTITY_TYPE_VEHICLE)
+    if (pGameExplodingEntity != nullptr && pResponsible->GetType() == CCLIENTVEHICLE)
     {
-        // Set our origin-source to the vehicle
-        SClientEntity<CVehicleSA>* pVehicleClientEntity = pPools->GetVehicle(reinterpret_cast<DWORD*>(pGameExplodingEntity->GetInterface()));
+        auto vehicle = reinterpret_cast<CClientVehicle*>(pResponsible);
+        pOriginSource = vehicle;
 
-        if (pVehicleClientEntity)
+        if (vehicle->GetBlowState() == VehicleBlowState::INTACT)
         {
-            pOriginSource = pVehicleClientEntity->pClientEntity;
+            vehicle->SetBlowState(VehicleBlowState::AWAITING_EXPLOSION_SYNC);
         }
     }
     // If theres other players, sync it relative to the closest (lag compensation)

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -5079,6 +5079,22 @@ void CClientGame::SendExplosionSync(const CVector& vecPosition, eExplosionType T
             pBitStream->WriteBit(true);
             pBitStream->Write(pOrigin->GetID());
 
+            // Because we use this packet to notify the server of blown vehicles,
+            // we include a bit, whether the vehicle was blown without an explosion
+            if (pBitStream->Can(eBitStreamVersion::VehicleBlowStateSupport))
+            {
+                if (pOrigin->GetType() == CCLIENTVEHICLE)
+                {
+                    auto vehicle = reinterpret_cast<CClientVehicle*>(pOrigin);
+                    pBitStream->WriteBit(1);
+                    pBitStream->WriteBit(vehicle->GetBlowState() == VehicleBlowState::BLOWN);
+                }
+                else
+                {
+                    pBitStream->WriteBit(0);
+                }
+            }
+            
             // Convert position
             CVector vecTemp;
             pOrigin->GetPosition(vecTemp);

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -137,10 +137,9 @@ CClientVehicle::CClientVehicle(CClientManager* pManager, ElementID ID, unsigned 
     m_bJustBlewUp = false;
     m_ucAlpha = 255;
     m_bAlphaChanged = false;
-    m_bBlowNextFrame = false;
+    m_blowAfterStreamIn = false;
     m_bIsOnGround = false;
     m_ulIllegalTowBreakTime = 0;
-    m_bBlown = false;
     m_LastSyncedData = new SLastSyncedVehData;
     m_bIsDerailed = false;
     m_bIsDerailable = true;
@@ -812,10 +811,6 @@ void CClientVehicle::SetDoorsUndamageable(bool bUndamageable)
 
 float CClientVehicle::GetHealth() const
 {
-    // If we're blown, return 0
-    if (m_bBlown)
-        return 0.0f;
-
     if (m_pVehicle)
     {
         return m_pVehicle->GetHealth();
@@ -824,29 +819,29 @@ float CClientVehicle::GetHealth() const
     return m_fHealth;
 }
 
-void CClientVehicle::SetHealth(float fHealth)
+void CClientVehicle::SetHealth(float health)
 {
+    if (health < 0.0f || IsBlown())
+        health = 0.0f;
+
+    m_fHealth = health;
+
     if (m_pVehicle)
     {
-        // Is the car is dead and we want to un-die it?
-        if (fHealth > 0.0f && GetHealth() <= 0.0f)
-        {
-            Destroy();
-            m_fHealth = fHealth;            // NEEDS to be here!
-            Create();
-        }
-        else
-        {
-            m_pVehicle->SetHealth(fHealth);
-        }
+        m_pVehicle->SetHealth(health);
     }
-    m_fHealth = fHealth;
 }
 
 void CClientVehicle::Fix()
 {
-    m_bBlown = false;
-    m_bBlowNextFrame = false;
+    m_blowAfterStreamIn = false;
+
+    if (m_blowState != VehicleBlowState::INTACT)
+    {
+        m_blowState = VehicleBlowState::INTACT;
+        ReCreate();
+    }
+
     if (m_pVehicle)
     {
         m_pVehicle->Fix();
@@ -932,8 +927,14 @@ void CClientVehicle::Fix()
     }
 }
 
-void CClientVehicle::Blow(bool bAllowMovement)
+void CClientVehicle::Blow(VehicleBlowFlags blow)
 {
+    if (m_blowState != VehicleBlowState::INTACT)
+        return;
+
+    m_blowState = (blow.withExplosion ? VehicleBlowState::AWAITING_EXPLOSION_SYNC : VehicleBlowState::BLOWN);
+    m_fHealth = 0.0f;
+
     if (m_pVehicle)
     {
         // Make sure it can be damaged
@@ -952,13 +953,19 @@ void CClientVehicle::Blow(bool bAllowMovement)
 
         m_pVehicle->BlowUp(NULL, 0);
 
+        // Blowing up a vehicle will cause an explosion in the original game code, but we have a hook in place,
+        // which will prevent the explosion and forward the information to the server to relay it to everyone from there.
+        // That hook may call further Lua events, which could result in a fixed vehicle and we have to check for that here.
+        if (m_blowState == VehicleBlowState::INTACT)
+            return;
+
         // And force the wheel states to "burst"
         SetWheelStatus(FRONT_LEFT_WHEEL, DT_WHEEL_BURST);
         SetWheelStatus(FRONT_RIGHT_WHEEL, DT_WHEEL_BURST);
         SetWheelStatus(REAR_LEFT_WHEEL, DT_WHEEL_BURST);
         SetWheelStatus(REAR_RIGHT_WHEEL, DT_WHEEL_BURST);
 
-        if (!bAllowMovement)
+        if (!blow.withMovement)
         {
             // Make sure it doesn't change speeds (slightly cleaner for syncing)
             SetMoveSpeed(vecMoveSpeed);
@@ -968,8 +975,6 @@ void CClientVehicle::Blow(bool bAllowMovement)
         // Restore the old can be damaged state
         CalcAndUpdateCanBeDamagedFlag();
     }
-    m_fHealth = 0.0f;
-    m_bBlown = true;
 }
 
 CVehicleColor& CClientVehicle::GetColor()
@@ -1340,12 +1345,6 @@ bool CClientVehicle::IsUpsideDown() const
 
     // TODO: Figure out this using matrix?
     return false;
-}
-
-bool CClientVehicle::IsBlown() const
-{
-    // Game layer functions aren't reliable
-    return m_bBlown;
 }
 
 bool CClientVehicle::IsSirenOrAlarmActive()
@@ -2304,10 +2303,20 @@ void CClientVehicle::StreamedInPulse()
             m_bJustStreamedIn = false;
         }
 
-        if (m_bBlowNextFrame)
+        if (m_blowAfterStreamIn)
         {
-            Blow(false);
-            m_bBlowNextFrame = false;
+            m_blowAfterStreamIn = false;
+
+            VehicleBlowState previousBlowState = m_blowState;
+            m_blowState = VehicleBlowState::INTACT;
+
+            VehicleBlowFlags blow;
+            blow.withMovement = false;
+            blow.withExplosion = (previousBlowState == VehicleBlowState::AWAITING_EXPLOSION_SYNC);
+            Blow(blow);
+
+            if (m_blowState != VehicleBlowState::INTACT)
+                m_blowState = previousBlowState;
         }
 
         // Handle door ratio auto reallowment
@@ -2328,7 +2337,7 @@ void CClientVehicle::StreamedInPulse()
         }
 
         // Are we an unmanned, invisible, blown-up plane?
-        if (!GetOccupant() && m_eVehicleType == CLIENTVEHICLE_PLANE && m_bBlown && !m_pVehicle->IsVisible())
+        if (!GetOccupant() && m_eVehicleType == CLIENTVEHICLE_PLANE && IsBlown() && !m_pVehicle->IsVisible())
         {
             // Disable our collisions
             m_pVehicle->SetUsesCollision(false);
@@ -2440,20 +2449,6 @@ void CClientVehicle::StreamedInPulse()
                 pCarriage = pCarriage->m_pPreviousLink;
             }
         }
-
-        /*
-        // Are we blown?
-        if ( m_bBlown )
-        {
-            // Has our engine status been reset to on_fire somewhere?
-            CDamageManager* pDamageManager = m_pVehicle->GetDamageManager ();
-            if ( pDamageManager->GetEngineStatus () == DT_ENGINE_ON_FIRE )
-            {
-                // Change it back to fucked
-                pDamageManager->SetEngineStatus ( DT_ENGINE_ENGINE_PIPES_BURST );
-            }
-        }
-        */
 
         // Limit burnout turn speed to ensure smoothness
         if (m_pDriver)
@@ -2766,9 +2761,7 @@ void CClientVehicle::Create()
             m_pVehicle->SetAlpha(m_ucAlpha);
 
         m_pVehicle->SetHealth(m_fHealth);
-
-        if (m_bBlown || m_fHealth == 0.0f)
-            m_bBlowNextFrame = true;
+        m_blowAfterStreamIn = IsBlown();
 
         CalcAndUpdateCanBeDamagedFlag();
 

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -834,19 +834,19 @@ void CClientVehicle::SetHealth(float health)
 
 void CClientVehicle::Fix()
 {
+    if (m_pVehicle)
+    {
+        m_pVehicle->Fix();
+        // Make sure its visible, if its supposed to be
+        m_pVehicle->SetVisible(m_bVisible);
+    }
+
     m_blowAfterStreamIn = false;
 
     if (m_blowState != VehicleBlowState::INTACT)
     {
         m_blowState = VehicleBlowState::INTACT;
         ReCreate();
-    }
-
-    if (m_pVehicle)
-    {
-        m_pVehicle->Fix();
-        // Make sure its visible, if its supposed to be
-        m_pVehicle->SetVisible(m_bVisible);
     }
 
     SetHealth(DEFAULT_VEHICLE_HEALTH);

--- a/Client/mods/deathmatch/logic/CClientVehicle.h
+++ b/Client/mods/deathmatch/logic/CClientVehicle.h
@@ -64,6 +64,21 @@ enum eWindow
     MAX_WINDOWS
 };
 
+enum class VehicleBlowState : unsigned char
+{
+    INTACT,
+    AWAITING_EXPLOSION_SYNC,
+    BLOWN,
+};
+
+struct VehicleBlowFlags
+{
+    bool withMovement : 1;
+    bool withExplosion : 1;
+
+    constexpr VehicleBlowFlags() : withMovement(true), withExplosion(true) {}
+};
+
 namespace EComponentBase
 {
     enum EComponentBaseType
@@ -195,10 +210,13 @@ public:
     void SetDoorsUndamageable(bool bUndamageable);
 
     float GetHealth() const;
-    void  SetHealth(float fHealth);
+    void  SetHealth(float health);
     void  Fix();
-    void  Blow(bool bAllowMovement = false);
-    bool  IsVehicleBlown() const noexcept { return m_bBlown; };
+
+    void             Blow(VehicleBlowFlags blow);
+    bool             IsBlown() const noexcept { return m_blowState != VehicleBlowState::INTACT; }
+    void             SetBlowState(VehicleBlowState state) { m_blowState = state; }
+    VehicleBlowState GetBlowState() const noexcept { return m_blowState; }
 
     CVehicleColor& GetColor();
     void           SetColor(const CVehicleColor& color);
@@ -235,7 +253,6 @@ public:
     bool IsDrowning() const;
     bool IsDriven() const;
     bool IsUpsideDown() const;
-    bool IsBlown() const;
 
     bool IsSirenOrAlarmActive();
     void SetSirenOrAlarmActive(bool bActive);
@@ -619,7 +636,7 @@ protected:
     unsigned char                          m_ucAlpha;
     bool                                   m_bAlphaChanged;
     double                                 m_dLastRotationTime;
-    bool                                   m_bBlowNextFrame;
+    bool                                   m_blowAfterStreamIn;
     bool                                   m_bIsOnGround;
     bool                                   m_bHeliSearchLightVisible;
     float                                  m_fHeliRotorSpeed;
@@ -675,8 +692,9 @@ protected:
 
     unsigned long m_ulIllegalTowBreakTime;
 
-    bool m_bBlown;
     bool m_bHasDamageModel;
+
+    VehicleBlowState m_blowState = VehicleBlowState::INTACT;
 
     bool                          m_bTaxiLightOn;
     std::list<CClientProjectile*> m_Projectiles;

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -2653,6 +2653,7 @@ void CPacketHandler::Packet_EntityAdd(NetBitStreamInterface& bitStream)
         // CMatrix              (48)    - matrix
         // unsigned char        (1)     - vehicle id
         // float                (4)     - health
+        // unsigned char        (1)     - blow state (if supported)
         // unsigned char        (1)     - color 1
         // unsigned char        (1)     - color 2
         // unsigned char        (1)     - color 3
@@ -3202,6 +3203,35 @@ retry:
                         return;
                     }
 
+                    // Read out blow state
+                    VehicleBlowState blowState = VehicleBlowState::INTACT;
+                    unsigned char    rawBlowState = 0;
+
+                    if (bitStream.Can(eBitStreamVersion::VehicleBlowStateSupport))
+                    {
+                        if (!bitStream.ReadBits(&rawBlowState, 2))
+                        {
+                            RaiseEntityAddError(75);
+                            return;
+                        }
+
+                        switch (rawBlowState)
+                        {
+                            case 1:
+                                blowState = VehicleBlowState::AWAITING_EXPLOSION_SYNC;
+                                break;
+                            case 2:
+                                blowState = VehicleBlowState::BLOWN;
+                                break;
+                        }
+                    }
+                    else if (health.data.fValue <= 0.0f)
+                    {
+                        // Blow state is not supported by the server and we are required to blow the vehicle
+                        // if the health is equal to or below zero
+                        blowState = VehicleBlowState::AWAITING_EXPLOSION_SYNC;
+                    }
+
                     // Read out the color
                     CVehicleColor vehColor;
                     uchar         ucNumColors = 0;
@@ -3255,8 +3285,9 @@ retry:
                         return;
                     }
 
-                    // Set the health, color and paintjob
+                    // Set the health, blow state, color and paintjob
                     pVehicle->SetHealth(health.data.fValue);
+                    pVehicle->SetBlowState(blowState);
                     pVehicle->SetPaintjob(paintjob.data.ucPaintjob);
                     pVehicle->SetColor(vehColor);
 
@@ -4398,6 +4429,19 @@ void CPacketHandler::Packet_ExplosionSync(NetBitStreamInterface& bitStream)
     if (bHasOrigin && !bitStream.Read(OriginID))
         return;
 
+    // Explosion sync may include information, whether a vehicle was blown without an explosion
+    bool isVehicleResponsible = false;
+    bool blowVehicleWithoutExplosion = false;
+
+    if (bHasOrigin && bitStream.Can(eBitStreamVersion::VehicleBlowStateSupport))
+    {
+        if (!bitStream.ReadBit(isVehicleResponsible))
+            return;
+
+        if (isVehicleResponsible && !bitStream.ReadBit(blowVehicleWithoutExplosion))
+            return;
+    }
+
     // Read out the position
     SPositionSync position(false);
     if (!bitStream.Read(&position))
@@ -4503,17 +4547,34 @@ void CPacketHandler::Packet_ExplosionSync(NetBitStreamInterface& bitStream)
             case EXP_TYPE_CAR_QUICK:
             case EXP_TYPE_HELI:
             {
-                // Make sure the vehicle's blown
-                CClientVehicle* pExplodingVehicle = static_cast<CClientVehicle*>(pOrigin);
-                pExplodingVehicle->Blow(false);
+                CClientVehicle* vehicle = static_cast<CClientVehicle*>(pOrigin);
+
+                if (blowVehicleWithoutExplosion)
+                    bCancelExplosion = true;
+
+                // Make sure the vehicle is blown (even if fixed before)
+                if (vehicle->GetBlowState() == VehicleBlowState::INTACT)
+                {
+                    VehicleBlowFlags blow;
+                    blow.withMovement = false;
+                    blow.withExplosion = !bCancelExplosion;
+                    vehicle->Blow(blow);
+                }
+
+                // Change the blow state only if the vehicle wasn't fixed
+                if (vehicle->GetBlowState() != VehicleBlowState::INTACT)
+                    vehicle->SetBlowState(VehicleBlowState::BLOWN);
 
                 // Call onClientVehicleExplode
-                CLuaArguments Arguments;
-                pExplodingVehicle->CallEvent("onClientVehicleExplode", Arguments, true);
+                CLuaArguments arguments;
+                arguments.PushBoolean(!bCancelExplosion);            // withExplosion
+                vehicle->CallEvent("onClientVehicleExplode", arguments, true);
 
                 if (!bCancelExplosion)
+                {
                     g_pClientGame->m_pManager->GetExplosionManager()->Create(EXP_TYPE_GRENADE, position.data.vecPosition, pCreator, true, -1.0f, false,
                                                                              WEAPONTYPE_EXPLOSION);
+                }
                 break;
             }
             default:

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -2774,15 +2774,17 @@ bool CStaticFunctionDefinitions::FixVehicle(CClientEntity& Entity)
     return false;
 }
 
-bool CStaticFunctionDefinitions::BlowVehicle(CClientEntity& Entity)
+bool CStaticFunctionDefinitions::BlowVehicle(CClientEntity& Entity, std::optional<bool> withExplosion)
 {
-    RUN_CHILDREN(BlowVehicle(**iter))
-
+    RUN_CHILDREN(BlowVehicle(**iter, withExplosion))
+    
     if (IS_VEHICLE(&Entity))
     {
-        CClientVehicle& Vehicle = static_cast<CClientVehicle&>(Entity);
+        CClientVehicle& vehicle = static_cast<CClientVehicle&>(Entity);
 
-        Vehicle.Blow(true);
+        VehicleBlowFlags blow;
+        blow.withExplosion = withExplosion.value_or(true);
+        vehicle.Blow(blow);
         return true;
     }
 

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -228,7 +228,7 @@ public:
 
     // Vehicle set functions
     static bool FixVehicle(CClientEntity& Entity);
-    static bool BlowVehicle(CClientEntity& Entity);
+    static bool BlowVehicle(CClientEntity& Entity, std::optional<bool> withExplosion);
     static bool SetVehicleColor(CClientEntity& Entity, const CVehicleColor& color);
     static bool SetVehicleLandingGearDown(CClientEntity& Entity, bool bLandingGearDown);
     static bool SetVehicleLocked(CClientEntity& Entity, bool bLocked);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -92,7 +92,7 @@ void CLuaVehicleDefs::LoadFunctions()
         // Vehicle set funcs
         {"createVehicle", CreateVehicle},
         {"fixVehicle", FixVehicle},
-        {"blowVehicle", BlowVehicle},
+        {"blowVehicle", ArgumentParserWarn<false, BlowVehicle>},
         {"setVehicleTurnVelocity", SetVehicleTurnVelocity},
         {"setVehicleColor", SetVehicleColor},
         {"setVehicleLandingGearDown", SetVehicleLandingGearDown},
@@ -1548,30 +1548,9 @@ int CLuaVehicleDefs::FixVehicle(lua_State* luaVM)
     return 1;
 }
 
-int CLuaVehicleDefs::BlowVehicle(lua_State* luaVM)
-{
-    CClientEntity*   pEntity = NULL;
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pEntity);
-
-    if (!argStream.HasErrors())
-    {
-        if (CStaticFunctionDefinitions::BlowVehicle(*pEntity))
-        {
-            lua_pushboolean(luaVM, true);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
-}
-
 bool CLuaVehicleDefs::IsVehicleBlown(CClientVehicle* vehicle)
 {
-    return vehicle->IsVehicleBlown();
+    return vehicle->IsBlown();
 }
 
 int CLuaVehicleDefs::GetVehicleHeadLightColor(lua_State* luaVM)
@@ -4162,4 +4141,9 @@ std::variant<bool, CVector> CLuaVehicleDefs::OOP_GetVehicleDummyPosition(CClient
 bool CLuaVehicleDefs::ResetVehicleDummyPositions(CClientVehicle* vehicle)
 {
     return vehicle->ResetDummyPositions();
+}
+
+bool CLuaVehicleDefs::BlowVehicle(CClientEntity* entity, std::optional<bool> withExplosion)
+{
+    return CStaticFunctionDefinitions::BlowVehicle(*entity, withExplosion);
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -82,7 +82,7 @@ public:
     LUA_DECLARE(IsVehicleWindowOpen);
 
     LUA_DECLARE(FixVehicle);
-    LUA_DECLARE(BlowVehicle);
+    static bool BlowVehicle(CClientEntity* entity, std::optional<bool> withExplosion);
     LUA_DECLARE(SetVehicleRotation);
     LUA_DECLARE(SetVehicleTurnVelocity);
     LUA_DECLARE(SetVehicleColor);

--- a/Client/mods/deathmatch/logic/rpc/CVehicleRPCs.cpp
+++ b/Client/mods/deathmatch/logic/rpc/CVehicleRPCs.cpp
@@ -78,17 +78,25 @@ void CVehicleRPCs::FixVehicle(CClientEntity* pSource, NetBitStreamInterface& bit
 
 void CVehicleRPCs::BlowVehicle(CClientEntity* pSource, NetBitStreamInterface& bitStream)
 {
-    // Read out the vehicle id
-    unsigned char ucTimeContext;
-    if (bitStream.Read(ucTimeContext))
+    unsigned char syncTimeContext;
+    bool          withExplosion = true;
+
+    if (bitStream.Read(syncTimeContext))
     {
-        // Grab the vehicle
-        CClientVehicle* pVehicle = m_pVehicleManager->Get(pSource->GetID());
-        if (pVehicle)
+        if (bitStream.Can(eBitStreamVersion::VehicleBlowStateSupport) && !bitStream.ReadBit(withExplosion))
         {
-            // Blow it and change the time context
-            pVehicle->Blow(true);
-            pVehicle->SetSyncTimeContext(ucTimeContext);
+            return;
+        }
+
+        CClientVehicle* vehicle = m_pVehicleManager->Get(pSource->GetID());
+        
+        if (vehicle)
+        {
+            VehicleBlowFlags blow;
+            blow.withExplosion = withExplosion;
+            vehicle->Blow(blow);
+
+            vehicle->SetSyncTimeContext(syncTimeContext);
         }
     }
 }

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -2623,17 +2623,23 @@ void CGame::Packet_ExplosionSync(CExplosionSyncPacket& Packet)
                             case 7:             // EXP_TYPE_HELI
                             case 12:            // EXP_TYPE_TINY - RC Vehicles
                             {
-                                CVehicle* pVehicle = static_cast<CVehicle*>(pOrigin);
-                                // Is this vehicle not already blown?
-                                if (pVehicle->GetIsBlown() == false)
+                                CVehicle*        vehicle = static_cast<CVehicle*>(pOrigin);
+                                VehicleBlowState previousBlowState = vehicle->GetBlowState();
+
+                                if (previousBlowState != VehicleBlowState::BLOWN)
                                 {
-                                    pVehicle->SetIsBlown(true);
-                                    pVehicle->SetEngineOn(false);
+                                    vehicle->SetBlowState(VehicleBlowState::BLOWN);
+                                    vehicle->SetEngineOn(false);
 
-                                    CLuaArguments Arguments;
-                                    pVehicle->CallEvent("onVehicleExplode", Arguments);
+                                    // NOTE(botder): We only trigger this event if we didn't blow up a vehicle with `blowVehicle`
+                                    if (previousBlowState == VehicleBlowState::INTACT)
+                                    {
+                                        CLuaArguments arguments;
+                                        arguments.PushBoolean(true);            // withExplosion
+                                        vehicle->CallEvent("onVehicleExplode", arguments);
+                                    }
 
-                                    bBroadcast = pVehicle->GetIsBlown() && !pVehicle->IsBeingDeleted();
+                                    bBroadcast = vehicle->GetBlowState() == VehicleBlowState::BLOWN && !vehicle->IsBeingDeleted();
                                 }
                                 else
                                 {

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -2635,7 +2635,7 @@ void CGame::Packet_ExplosionSync(CExplosionSyncPacket& Packet)
                                     if (previousBlowState == VehicleBlowState::INTACT)
                                     {
                                         CLuaArguments arguments;
-                                        arguments.PushBoolean(true);            // withExplosion
+                                        arguments.PushBoolean(!Packet.m_blowVehicleWithoutExplosion);
                                         vehicle->CallEvent("onVehicleExplode", arguments);
                                     }
 

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -5255,9 +5255,9 @@ bool CStaticFunctionDefinitions::FixVehicle(CElement* pElement)
         pVehicle->GenerateSyncTimeContext();
 
         // Repair it
+        pVehicle->SetBlowState(VehicleBlowState::INTACT);
         pVehicle->SetHealth(DEFAULT_VEHICLE_HEALTH);
         pVehicle->ResetDoorsWheelsPanelsLights();
-        pVehicle->SetBlowState(VehicleBlowState::INTACT);
 
         // Tell everyone
         CBitStream BitStream;
@@ -5298,6 +5298,7 @@ bool CStaticFunctionDefinitions::BlowVehicle(CElement* pElement, std::optional<b
 
     CBitStream BitStream;
     BitStream.pBitStream->Write(vehicle->GenerateSyncTimeContext());
+    BitStream.pBitStream->WriteBit(createExplosion);            // only consumed by clients with at least eBitStreamVersion::VehicleBlowStateSupport
     m_pPlayerManager->BroadcastOnlyJoined(CElementRPCPacket(vehicle, BLOW_VEHICLE, *BitStream.pBitStream));
     return true;
 }

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -289,7 +289,7 @@ public:
 
     // Vehicle set functions
     static bool FixVehicle(CElement* pElement);
-    static bool BlowVehicle(CElement* pElement);
+    static bool BlowVehicle(CElement* pElement, std::optional<bool> withExplosion);
     static bool SetVehicleColor(CElement* pElement, const CVehicleColor& color);
     static bool SetVehicleLandingGearDown(CElement* pElement, bool bLandingGearDown);
     static bool SetVehicleLocked(CElement* pElement, bool bLocked);

--- a/Server/mods/deathmatch/logic/CVehicle.cpp
+++ b/Server/mods/deathmatch/logic/CVehicle.cpp
@@ -180,6 +180,7 @@ CElement* CVehicle::Clone(bool* bAddEntity, CResource* pResource)
         CVector vecRotationDegrees;
         GetRotationDegrees(vecRotationDegrees);
         pTemp->SetRotationDegrees(vecRotationDegrees);
+        pTemp->SetBlowState(m_blowState);
         pTemp->SetHealth(GetHealth());
         pTemp->SetColor(GetColor());
         pTemp->SetUpgrades(GetUpgrades());
@@ -515,6 +516,14 @@ void CVehicle::SetVariants(unsigned char ucVariant, unsigned char ucVariant2)
 {
     m_ucVariant = ucVariant;
     m_ucVariant2 = ucVariant2;
+}
+
+void CVehicle::SetHealth(float fHealth)
+{
+    if (fHealth < 0.0f || IsBlown())
+        fHealth = 0.0f;
+
+    m_fHealth = fHealth;
 }
 
 CVehicleColor& CVehicle::RandomizeColor()

--- a/Server/mods/deathmatch/logic/CVehicle.cpp
+++ b/Server/mods/deathmatch/logic/CVehicle.cpp
@@ -741,7 +741,7 @@ bool CVehicle::SetTowedByVehicle(CVehicle* pVehicle)
 void CVehicle::SpawnAt(const CVector& vecPosition, const CVector& vecRotation)
 {
     SetHealth(GetRespawnHealth());
-    SetIsBlown(false);
+    SetBlowState(VehicleBlowState::INTACT);
     StopIdleTimer();
     ResetDoorsWheelsPanelsLights();
     SetLandingGearDown(true);
@@ -889,18 +889,23 @@ void CVehicle::ResetDoorsWheelsPanelsLights()
     memset(&m_ucLightStates[0], 0, sizeof(m_ucLightStates));
 }
 
-// For blow respawn timer
-void CVehicle::SetIsBlown(bool bBlown)
+bool CVehicle::IsBlowTimerFinished()
 {
-    if (!bBlown)
-        m_llBlowTime = CTickCount(0LL);
-    else
+    return (m_blowState == VehicleBlowState::BLOWN) && CTickCount::Now() > m_llBlowTime + CTickCount((long long)m_ulBlowRespawnInterval);
+}
+
+void CVehicle::ResetExplosionTimer()
+{
+    if (m_blowState == VehicleBlowState::BLOWN)
         m_llBlowTime = CTickCount::Now();
 }
 
-bool CVehicle::IsBlowTimerFinished()
+void CVehicle::SetBlowState(VehicleBlowState state)
 {
-    return GetIsBlown() && CTickCount::Now() > m_llBlowTime + CTickCount((long long)m_ulBlowRespawnInterval);
+    m_blowState = state;
+
+    if (state == VehicleBlowState::BLOWN)
+        m_llBlowTime = CTickCount::Now();
 }
 
 void CVehicle::StopIdleTimer()

--- a/Server/mods/deathmatch/logic/CVehicle.h
+++ b/Server/mods/deathmatch/logic/CVehicle.h
@@ -136,6 +136,13 @@ struct SSirenInfo
     SFixedArray<SSirenBeaconInfo, 8> m_tSirenInfo;
 };
 
+enum class VehicleBlowState : unsigned char
+{
+    INTACT,
+    AWAITING_EXPLOSION_SYNC,
+    BLOWN,
+};
+
 class CTrainTrack;
 
 class CVehicle final : public CElement
@@ -337,9 +344,14 @@ public:
 
     void ResetDoors();
     void ResetDoorsWheelsPanelsLights();
-    void SetIsBlown(bool bBlown);
-    bool GetIsBlown() const noexcept { return m_llBlowTime.ToLongLong() != 0; }
+
     bool IsBlowTimerFinished();
+    void ResetExplosionTimer();
+
+    bool             IsBlown() const noexcept { return m_blowState != VehicleBlowState::INTACT; }
+    void             SetBlowState(VehicleBlowState state);
+    VehicleBlowState GetBlowState() const noexcept { return m_blowState; }
+
     void StopIdleTimer();
     void RestartIdleTimer();
     bool IsIdleTimerRunning();
@@ -368,6 +380,8 @@ private:
     float          m_fLastSyncedHealthHealth;
     CTickCount     m_llBlowTime;
     CTickCount     m_llIdleTime;
+
+    VehicleBlowState m_blowState = VehicleBlowState::INTACT;
 
     unsigned char m_ucMaxPassengersOverride;
 

--- a/Server/mods/deathmatch/logic/CVehicle.h
+++ b/Server/mods/deathmatch/logic/CVehicle.h
@@ -194,7 +194,7 @@ public:
     void           SetTurnSpeed(const CVector& vecTurnSpeed) { m_vecTurnSpeed = vecTurnSpeed; };
 
     float GetHealth() { return m_fHealth; };
-    void  SetHealth(float fHealth) { m_fHealth = fHealth; };
+    void  SetHealth(float fHealth);
     float GetLastSyncedHealth() { return m_fLastSyncedHealthHealth; };
     void  SetLastSyncedHealth(float fHealth) { m_fLastSyncedHealthHealth = fHealth; };
 

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -1729,7 +1729,7 @@ int CLuaVehicleDefs::FixVehicle(lua_State* luaVM)
 
 bool CLuaVehicleDefs::IsVehicleBlown(CVehicle* vehicle)
 {
-    return vehicle->GetIsBlown();
+    return vehicle->IsBlown();
 }
 
 int CLuaVehicleDefs::GetVehicleHeadLightColor(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/packets/CEntityAddPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CEntityAddPacket.cpp
@@ -440,6 +440,24 @@ bool CEntityAddPacket::Write(NetBitStreamInterface& BitStream) const
                     health.data.fValue = pVehicle->GetHealth();
                     BitStream.Write(&health);
 
+                    // Blow state
+                    if (BitStream.Can(eBitStreamVersion::VehicleBlowStateSupport))
+                    {
+                        unsigned char blowState = 0;
+
+                        switch (pVehicle->GetBlowState())
+                        {
+                            case VehicleBlowState::AWAITING_EXPLOSION_SYNC:
+                                blowState = 1;
+                                break;
+                            case VehicleBlowState::BLOWN:
+                                blowState = 2;
+                                break;
+                        }
+
+                        BitStream.WriteBits(&blowState, 2);
+                    }
+
                     // Color
                     CVehicleColor& vehColor = pVehicle->GetColor();
                     uchar          ucNumColors = vehColor.GetNumColorsUsed() - 1;

--- a/Server/mods/deathmatch/logic/packets/CExplosionSyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CExplosionSyncPacket.cpp
@@ -34,6 +34,15 @@ bool CExplosionSyncPacket::Read(NetBitStreamInterface& BitStream)
     if (bHasOrigin && !BitStream.Read(m_OriginID))
         return false;
 
+    if (BitStream.Can(eBitStreamVersion::VehicleBlowStateSupport))
+    {
+        if (!BitStream.ReadBit(m_isVehicleResponsible))
+            return false;
+
+        if (m_isVehicleResponsible && !BitStream.ReadBit(m_blowVehicleWithoutExplosion))
+            return false;
+    }
+
     SPositionSync position(false);
     if (BitStream.Read(&position))
     {
@@ -73,6 +82,14 @@ bool CExplosionSyncPacket::Write(NetBitStreamInterface& BitStream) const
     }
     else
         BitStream.WriteBit(false);
+
+    if (BitStream.Can(eBitStreamVersion::VehicleBlowStateSupport))
+    {
+        BitStream.WriteBit(m_isVehicleResponsible);
+
+        if (m_isVehicleResponsible)
+            BitStream.WriteBit(m_blowVehicleWithoutExplosion);
+    }
 
     // Write position and type
     SPositionSync position(false);

--- a/Server/mods/deathmatch/logic/packets/CExplosionSyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CExplosionSyncPacket.cpp
@@ -34,7 +34,7 @@ bool CExplosionSyncPacket::Read(NetBitStreamInterface& BitStream)
     if (bHasOrigin && !BitStream.Read(m_OriginID))
         return false;
 
-    if (BitStream.Can(eBitStreamVersion::VehicleBlowStateSupport))
+    if (bHasOrigin && BitStream.Can(eBitStreamVersion::VehicleBlowStateSupport))
     {
         if (!BitStream.ReadBit(m_isVehicleResponsible))
             return false;
@@ -79,17 +79,17 @@ bool CExplosionSyncPacket::Write(NetBitStreamInterface& BitStream) const
     {
         BitStream.WriteBit(true);
         BitStream.Write(m_OriginID);
+
+        if (BitStream.Can(eBitStreamVersion::VehicleBlowStateSupport))
+        {
+            BitStream.WriteBit(m_isVehicleResponsible);
+
+            if (m_isVehicleResponsible)
+                BitStream.WriteBit(m_blowVehicleWithoutExplosion);
+        }
     }
     else
         BitStream.WriteBit(false);
-
-    if (BitStream.Can(eBitStreamVersion::VehicleBlowStateSupport))
-    {
-        BitStream.WriteBit(m_isVehicleResponsible);
-
-        if (m_isVehicleResponsible)
-            BitStream.WriteBit(m_blowVehicleWithoutExplosion);
-    }
 
     // Write position and type
     SPositionSync position(false);

--- a/Server/mods/deathmatch/logic/packets/CExplosionSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CExplosionSyncPacket.h
@@ -46,4 +46,7 @@ public:
     ElementID     m_OriginID;
     CVector       m_vecPosition;
     unsigned char m_ucType;
+
+    bool m_isVehicleResponsible = false;
+    bool m_blowVehicleWithoutExplosion = false;
 };

--- a/Shared/sdk/net/bitstream.h
+++ b/Shared/sdk/net/bitstream.h
@@ -461,6 +461,10 @@ enum class eBitStreamVersion : unsigned short
     // 2021-01-16 0x72
     SetColPolygonHeight,
 
+    // Support for vehicle blow without explosion and blow state synchronisation
+    // 2021-02-26 0x73
+    VehicleBlowStateSupport,
+
     // This allows us to automatically increment the BitStreamVersion when things are added to this enum.
     // Make sure you only add things above this comment.
     Next,


### PR DESCRIPTION
This pull request reimplements the second parameter for blowVehicle and adds that parameter to the clientside function:

```lua
bool blowVehicle(vehicle [, withExplosion = true ])
```

This pull request also changes bitstreams for explosion synchronisation, entity add for vehicles and the vehicle blow remote procedure call (rpc) to support _vehicle blow state_. Changes to the bitstreams are backwards compatible. Servers, which don't support the new bitstream, will signalise a blown vehicle always with zero (or below) health - the newer client will blow these cars on stream-in. I have tested the synchronisation briefly with @CrosRoad95.

Vehicle blow state has been added to properly synchronise the blown state of vehicles. A vehicle may be
- intact or 
- blown but waiting for explosion sync or 
- completely blown (explosion may or may not have happened).

This pull request most likely also fixes the desync for remotely synchronised vehicles repeatedly blowing up over and over again. A vehicle would blow up, then be re-created by CClientVehicle::SetHealth most likely from pure sync only to blow up again on the next streamed-in pulse ad infinitum.

A blown vehicle will always remain at zero health. A vehicle can only be restored with fixVehicle.

I have prepared a document with the packet flow and changes for vehicle blow state here:
https://github.com/botder/mtasa-documents/blob/d47ee3b9d1808570d4b890ff506bb6c81ea76518/vehicle-blow-state.txt