### PR TITLE
Trim keybind whitespace to avoid duplicates

### DIFF
--- a/Client/core/CKeyBinds.cpp
+++ b/Client/core/CKeyBinds.cpp
@@ -928,6 +928,7 @@ CCommandBind* CKeyBinds::FindCommandMatch(const char* szKey, const char* szComma
     if (szCompArguments)
         szCompArguments = SharedUtil::Trim(szCompArguments);
 
+    CKeyBind* pResult = nullptr;
     list<CKeyBind*>::const_iterator iter = m_pList->begin();
     for (; iter != m_pList->end(); iter++)
     {
@@ -948,8 +949,8 @@ CCommandBind* CKeyBinds::FindCommandMatch(const char* szKey, const char* szComma
                                 {
                                     if (!szOriginalScriptKey || (pBind->strOriginalScriptKey == szOriginalScriptKey))
                                     {
-                                        free(szCompArguments);
-                                        return pBind;
+                                        pResult = pBind;
+                                        break;
                                     }
                                 }
                             }
@@ -960,7 +961,7 @@ CCommandBind* CKeyBinds::FindCommandMatch(const char* szKey, const char* szComma
         }
     }
     free(szCompArguments);
-    return NULL;
+    return pResult;
 }
 
 //

--- a/Client/core/CKeyBinds.cpp
+++ b/Client/core/CKeyBinds.cpp
@@ -948,6 +948,7 @@ CCommandBind* CKeyBinds::FindCommandMatch(const char* szKey, const char* szComma
                                 {
                                     if (!szOriginalScriptKey || (pBind->strOriginalScriptKey == szOriginalScriptKey))
                                     {
+                                        free(szCompArguments);
                                         return pBind;
                                     }
                                 }
@@ -958,6 +959,7 @@ CCommandBind* CKeyBinds::FindCommandMatch(const char* szKey, const char* szComma
             }
         }
     }
+    free(szCompArguments);
     return NULL;
 }
 

--- a/Client/core/CKeyBinds.cpp
+++ b/Client/core/CKeyBinds.cpp
@@ -928,7 +928,7 @@ CCommandBind* CKeyBinds::FindCommandMatch(const char* szKey, const char* szComma
     if (szCompArguments)
         szCompArguments = SharedUtil::Trim(szCompArguments);
 
-    CKeyBind* pResult = nullptr;
+    CCommandBind*                   pResult = nullptr;
     list<CKeyBind*>::const_iterator iter = m_pList->begin();
     for (; iter != m_pList->end(); iter++)
     {

--- a/Client/core/CKeyBinds.cpp
+++ b/Client/core/CKeyBinds.cpp
@@ -922,6 +922,10 @@ CCommandBind* CKeyBinds::FindCommandMatch(const char* szKey, const char* szComma
 {
     NullEmptyStrings(szKey, szArguments, szResource, szOriginalScriptKey);
 
+    char* szCompArguments = strdup(szArguments);
+    if (szArguments)
+        szCompArguments = SharedUtil::Trim(szCompArguments);
+
     list<CKeyBind*>::const_iterator iter = m_pList->begin();
     for (; iter != m_pList->end(); iter++)
     {
@@ -934,7 +938,7 @@ CCommandBind* CKeyBinds::FindCommandMatch(const char* szKey, const char* szComma
                 {
                     if (!bCheckState || (pBind->bHitState == bState))
                     {
-                        if (!szArguments || (pBind->szArguments && strcmp(pBind->szArguments, szArguments) == 0))
+                        if (!szCompArguments || (pBind->szArguments && strcmp(pBind->szArguments, szCompArguments) == 0))
                         {
                             if (!szResource || (pBind->szResource && strcmp(pBind->szResource, szResource) == 0))
                             {
@@ -2692,7 +2696,12 @@ void CKeyBinds::BindCommand(const char* szCmdLine)
 
                 if (szCommand)
                 {
-                    char*   szArguments = strtok(NULL, "\0");
+                    char* szArguments = strtok(NULL, "\0");
+                    if (szArguments)
+                        szArguments = SharedUtil::Trim(szArguments);
+                    if (szArguments != nullptr && szArguments[0] == '\0')
+                        szArguments = nullptr;
+
                     SString strKeyState("%s", bState ? "down" : "up");
                     SString strCommandAndArguments("%s%s%s", szCommand, szArguments ? " " : "", szArguments ? szArguments : "");
 

--- a/Client/core/CKeyBinds.cpp
+++ b/Client/core/CKeyBinds.cpp
@@ -922,8 +922,10 @@ CCommandBind* CKeyBinds::FindCommandMatch(const char* szKey, const char* szComma
 {
     NullEmptyStrings(szKey, szArguments, szResource, szOriginalScriptKey);
 
-    char* szCompArguments = strdup(szArguments);
+    char* szCompArguments = nullptr;
     if (szArguments)
+        szCompArguments = strdup(szArguments);
+    if (szCompArguments)
         szCompArguments = SharedUtil::Trim(szCompArguments);
 
     list<CKeyBind*>::const_iterator iter = m_pList->begin();

--- a/Shared/sdk/SharedUtil.Misc.h
+++ b/Shared/sdk/SharedUtil.Misc.h
@@ -246,6 +246,10 @@ namespace SharedUtil
     bool IsLuaCompiledScript(const void* pData, uint uiLength);
     bool IsLuaObfuscatedScript(const void* pData, uint uiLength);
 
+    // Return a pointer to the (shifted) trimmed string
+    // @ref https://stackoverflow.com/a/26984026
+    char* Trim(char* szText);
+
     //
     // Some templates
     //

--- a/Shared/sdk/SharedUtil.Misc.hpp
+++ b/Shared/sdk/SharedUtil.Misc.hpp
@@ -1466,6 +1466,31 @@ bool SharedUtil::IsColorCodeW(const wchar_t* wszColorCode)
     return true;
 }
 
+char* SharedUtil::Trim(char* szText)
+{
+    char*  szOriginal = szText;
+    size_t uiLen = 0;
+
+    while (isspace((unsigned char)*szText))
+        szText++;
+
+    if (*szText)
+    {
+        char* p = szText;
+        while (*p)
+            p++;
+        while (isspace((unsigned char)*(--p)))
+            ;
+        p[1] = '\0';
+        uiLen = (size_t)(p - szText + 1);
+    }
+
+    if (szText == szOriginal)
+        return szText;
+
+    return static_cast<char*>(memmove(szOriginal, szText, uiLen + 1));
+}
+
 // Convert a standard multibyte UTF-8 std::string into a UTF-16 std::wstring
 std::wstring SharedUtil::MbUTF8ToUTF16(const SString& input)
 {


### PR DESCRIPTION
## Summary
- Trim keybind whitespace to avoid accidental duplicates