### PR TITLE
Use SFixedString in CPlayer & Add string_view support to SFixedString

### DIFF
--- a/Server/mods/deathmatch/logic/CPlayer.cpp
+++ b/Server/mods/deathmatch/logic/CPlayer.cpp
@@ -237,14 +237,14 @@ bool CPlayer::IsSubscribed(CElement* pElement, const std::string& strName) const
 
 const char* CPlayer::GetSourceIP()
 {
-    if (m_strIP.empty())
+    if (m_IP.Empty())
     {
-        char           szIP[22];
+        dassert(m_IP.GetMaxLength() >= 22);
+
         unsigned short usPort;
-        g_pNetServer->GetPlayerIP(m_PlayerSocket, szIP, &usPort);
-        m_strIP = szIP;
+        g_pNetServer->GetPlayerIP(m_PlayerSocket, m_IP.Data(), &usPort);
     }
-    return m_strIP;
+    return m_IP;
 }
 
 uint CPlayer::Send(const CPacket& Packet)

--- a/Server/mods/deathmatch/logic/CPlayer.cpp
+++ b/Server/mods/deathmatch/logic/CPlayer.cpp
@@ -73,7 +73,6 @@ CPlayer::CPlayer(CPlayerManager* pPlayerManager, class CScriptDebugging* pScript
 
     m_bCursorShowing = false;
 
-    m_szNametagText = NULL;
     m_ucNametagR = 0xFF;
     m_ucNametagG = 0xFF;
     m_ucNametagB = 0xFF;
@@ -125,13 +124,6 @@ CPlayer::~CPlayer()
 
     // Delete the player text manager
     delete m_pPlayerTextManager;
-
-    // Destroy our nick
-    if (m_szNametagText)
-    {
-        delete[] m_szNametagText;
-        m_szNametagText = NULL;
-    }
 
     SetTeam(NULL, true);
 
@@ -542,16 +534,9 @@ void CPlayer::Reset()
 
 void CPlayer::SetNametagText(const char* szText)
 {
-    if (m_szNametagText)
-    {
-        delete[] m_szNametagText;
-        m_szNametagText = NULL;
-    }
+    m_nametagText.Clear();
     if (szText)
-    {
-        m_szNametagText = new char[strlen(szText) + 1];
-        strcpy(m_szNametagText, szText);
-    }
+        m_nametagText = szText;
 }
 
 void CPlayer::GetNametagColor(unsigned char& ucR, unsigned char& ucG, unsigned char& ucB)

--- a/Server/mods/deathmatch/logic/CPlayer.cpp
+++ b/Server/mods/deathmatch/logic/CPlayer.cpp
@@ -176,11 +176,6 @@ void CPlayer::DoPulse()
     }
 }
 
-void CPlayer::SetNick(const char* szNick)
-{
-    m_nick = szNick;
-}
-
 // Ignore min client version checks if is a custom build and both player and server have build number of 0
 bool CPlayer::ShouldIgnoreMinClientVersionChecks()
 {

--- a/Server/mods/deathmatch/logic/CPlayer.cpp
+++ b/Server/mods/deathmatch/logic/CPlayer.cpp
@@ -178,7 +178,7 @@ void CPlayer::DoPulse()
 
 void CPlayer::SetNick(const char* szNick)
 {
-    m_strNick.AssignLeft(szNick, MAX_PLAYER_NICK_LENGTH);
+    m_nick = szNick;
 }
 
 // Ignore min client version checks if is a custom build and both player and server have build number of 0
@@ -530,13 +530,6 @@ void CPlayer::Reset()
 
     m_bNametagShowing = true;
     m_usModel = 0;
-}
-
-void CPlayer::SetNametagText(const char* szText)
-{
-    m_nametagText.Clear();
-    if (szText)
-        m_nametagText = szText;
 }
 
 void CPlayer::GetNametagColor(unsigned char& ucR, unsigned char& ucG, unsigned char& ucB)

--- a/Server/mods/deathmatch/logic/CPlayer.h
+++ b/Server/mods/deathmatch/logic/CPlayer.h
@@ -203,7 +203,7 @@ public:
     bool IsCursorShowing() { return m_bCursorShowing; }
     void SetCursorShowing(bool bCursorShowing) { m_bCursorShowing = bCursorShowing; }
 
-    char* GetNametagText() { return m_szNametagText; }
+    char* GetNametagText() { return m_nametagText; }
     void  SetNametagText(const char* szText);
     void  GetNametagColor(unsigned char& ucR, unsigned char& ucG, unsigned char& ucB);
     void  SetNametagOverrideColor(unsigned char ucR, unsigned char ucG, unsigned char ucB);
@@ -409,7 +409,7 @@ private:
 
     bool m_bCursorShowing;
 
-    char*         m_szNametagText;
+    SFixedString<MAX_PLAYER_NAMETAG_LENGTH> m_nametagText;
     unsigned char m_ucNametagR;
     unsigned char m_ucNametagG;
     unsigned char m_ucNametagB;

--- a/Server/mods/deathmatch/logic/CPlayer.h
+++ b/Server/mods/deathmatch/logic/CPlayer.h
@@ -86,7 +86,7 @@ public:
     unsigned long long GetTimeSinceConnected() { return m_ConnectedTimer.Get(); }
 
     const char* GetNick() { return m_nick; };
-    void        SetNick(const char* szNick);
+    void        SetNick(std::string_view nick) { m_nick.AssignAtMost(nick); }
 
     int                GetGameVersion() { return m_iGameVersion; };
     void               SetGameVersion(int iGameVersion) { m_iGameVersion = iGameVersion; };
@@ -204,7 +204,7 @@ public:
     void SetCursorShowing(bool bCursorShowing) { m_bCursorShowing = bCursorShowing; }
 
     std::string_view GetNametagText() { return m_nametagText; }
-    void  SetNametagText(std::string_view text) { m_nametagText = text; }
+    void  SetNametagText(std::string_view text) { m_nametagText.AssignAtMost(text); }
     void  GetNametagColor(unsigned char& ucR, unsigned char& ucG, unsigned char& ucB);
     void  SetNametagOverrideColor(unsigned char ucR, unsigned char ucG, unsigned char ucB);
     void  RemoveNametagOverrideColor();

--- a/Server/mods/deathmatch/logic/CPlayer.h
+++ b/Server/mods/deathmatch/logic/CPlayer.h
@@ -85,7 +85,7 @@ public:
     int                GetClientType() { return CClient::CLIENT_PLAYER; };
     unsigned long long GetTimeSinceConnected() { return m_ConnectedTimer.Get(); }
 
-    const char* GetNick() { return m_strNick; };
+    const char* GetNick() { return m_nick; };
     void        SetNick(const char* szNick);
 
     int                GetGameVersion() { return m_iGameVersion; };
@@ -203,8 +203,8 @@ public:
     bool IsCursorShowing() { return m_bCursorShowing; }
     void SetCursorShowing(bool bCursorShowing) { m_bCursorShowing = bCursorShowing; }
 
-    char* GetNametagText() { return m_nametagText; }
-    void  SetNametagText(const char* szText);
+    std::string_view GetNametagText() { return m_nametagText; }
+    void  SetNametagText(std::string_view text) { m_nametagText = text; }
     void  GetNametagColor(unsigned char& ucR, unsigned char& ucG, unsigned char& ucB);
     void  SetNametagOverrideColor(unsigned char ucR, unsigned char ucG, unsigned char ucB);
     void  RemoveNametagOverrideColor();
@@ -353,7 +353,7 @@ private:
 
     CPlayerTextManager* m_pPlayerTextManager;
 
-    SString        m_strNick;
+    SFixedString<MAX_PLAYER_NICK_LENGTH> m_nick;
     bool           m_bDoNotSendEntities;
     int            m_iGameVersion;
     unsigned short m_usMTAVersion;

--- a/Server/mods/deathmatch/logic/CPlayer.h
+++ b/Server/mods/deathmatch/logic/CPlayer.h
@@ -450,7 +450,7 @@ private:
     int     m_iLastPuresyncZoneDebug;
 
     long long m_llLastPositionHasChanged;
-    SString   m_strIP;
+    SFixedString<32> m_IP;
 
     SScreenShotInfo m_ScreenShotInfo;
 

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -138,7 +138,7 @@ public:
     static bool SetPlayerScriptDebugLevel(CElement* pElement, unsigned int uiLevel);
     static bool SetPlayerWantedLevel(CElement* pElement, unsigned int iLevel);
     static bool ForcePlayerMap(CElement* pElement, bool bVisible);
-    static bool SetPlayerNametagText(CElement* pElement, const char* szText);
+    static bool SetPlayerNametagText(CElement* pElement, const std::string& szText);
     static bool SetPlayerNametagColor(CElement* pElement, bool bRemoveOverride, unsigned char ucR, unsigned char ucG, unsigned char ucB);
     static bool SetPlayerNametagShowing(CElement* pElement, bool bShowing);
     static bool SpawnPlayer(CPlayer* pPlayer, const CVector& vecPosition, float fRotation, unsigned long ulModel, unsigned char ucInterior,

--- a/Server/mods/deathmatch/logic/packets/CPlayerListPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerListPacket.cpp
@@ -131,10 +131,8 @@ bool CPlayerListPacket::Write(NetBitStreamInterface& BitStream) const
         BitStream.WriteBit(pPlayer->IsFrozen());
 
         // Nametag stuff
-        unsigned char    ucNametagTextLength = 0u;
         std::string_view nametagText = pPlayer->GetNametagText();
-
-        ucNametagTextLength = (unsigned char)nametagText.length();
+        unsigned char    ucNametagTextLength = static_cast<unsigned char>(nametagText.length());
 
         if (!BitStream.Can(eBitStreamVersion::UnicodeNametags))
         {

--- a/Server/mods/deathmatch/logic/packets/CPlayerListPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerListPacket.cpp
@@ -131,20 +131,20 @@ bool CPlayerListPacket::Write(NetBitStreamInterface& BitStream) const
         BitStream.WriteBit(pPlayer->IsFrozen());
 
         // Nametag stuff
-        unsigned char ucNametagTextLength = 0;
-        char*         szNametagText = pPlayer->GetNametagText();
-        if (szNametagText)
-            ucNametagTextLength = static_cast<unsigned char>(strlen(szNametagText));
+        unsigned char    ucNametagTextLength = 0u;
+        std::string_view nametagText = pPlayer->GetNametagText();
+
+        ucNametagTextLength = (unsigned char)nametagText.length();
 
         if (!BitStream.Can(eBitStreamVersion::UnicodeNametags))
         {
             // Old client version has a fixed buffer of 22 characters
-            ucNametagTextLength = std::min<uchar>(ucNametagTextLength, 22);
+            ucNametagTextLength = std::min<unsigned char>(ucNametagTextLength, 22u);
         }
 
         BitStream.Write(ucNametagTextLength);
-        if (ucNametagTextLength > 0)
-            BitStream.Write(szNametagText, ucNametagTextLength);
+        if (ucNametagTextLength)
+            BitStream.Write(nametagText.data(), ucNametagTextLength);
 
         // Write nametag color if it's overridden
         if (pPlayer->IsNametagColorOverridden())

--- a/Shared/mods/deathmatch/logic/Utils.cpp
+++ b/Shared/mods/deathmatch/logic/Utils.cpp
@@ -924,28 +924,17 @@ void ReadCameraOrientation(const CVector& vecBasePosition, NetBitStreamInterface
         vecOutCamPosition = vecBasePosition - vecUsePosition;
 }
 
-bool IsNametagValid(const char* szNick)
+bool IsNametagValid(const std::string& nick)
 {
     // Grab the size of the nick. Check that it's not to long or short
-    size_t sizeNick = MbUTF8ToUTF16(szNick).size();
+    size_t sizeNick = MbUTF8ToUTF16(nick).size();
     if (sizeNick < MIN_PLAYER_NAMETAG_LENGTH || sizeNick > MAX_PLAYER_NAMETAG_LENGTH)
     {
         return false;
     }
 
     // Check that each character is valid (visible characters exluding space)
-    unsigned char ucTemp;
-    for (size_t i = 0; i < sizeNick; i++)
-    {
-        ucTemp = szNick[i];
-        if (ucTemp < 32)
-        {
-            return false;
-        }
-    }
-
-    // nametag is valid, return true
-    return true;
+    return std::find_if(nick.begin(), nick.end(), [](char c) { return c < 32; }) == nick.end();
 }
 
 bool IsNickValid(const char* szNick)

--- a/Shared/mods/deathmatch/logic/Utils.h
+++ b/Shared/mods/deathmatch/logic/Utils.h
@@ -275,7 +275,7 @@ void ReadCameraOrientation(const CVector& vecBasePosition, NetBitStreamInterface
 
 // Validation funcs
 bool IsNickValid(const char* szNick);
-bool IsNametagValid(const char* szNick);
+bool IsNametagValid(const std::string& szNick);
 
 // Network funcs
 SString LongToDottedIP(unsigned long ulIP);

--- a/Shared/sdk/SharedUtil.Misc.h
+++ b/Shared/sdk/SharedUtil.Misc.h
@@ -660,26 +660,49 @@ namespace SharedUtil
     //
     // Fixed sized string buffer
     //
-    template <int MAX_LENGTH>
+    template <size_t MAX_LENGTH>
     class SFixedString
     {
         char szData[MAX_LENGTH + 1];
 
     public:
-        SFixedString() { szData[0] = 0; }
+        constexpr SFixedString() { szData[0] = 0; }
+
 
         // In
-        SFixedString& operator=(const char* szOther)
+        constexpr SFixedString& Assign(const char* szOther, size_t len)
         {
-            STRNCPY(szData, szOther, MAX_LENGTH + 1);
+            STRNCPY(szData, szOther, len + 1);
             return *this;
         }
 
+        constexpr SFixedString& operator=(const char* szOther)
+        {
+            Assign(szOther, MAX_LENGTH + 1);
+            return *this;
+        }
+#ifdef __cpp_lib_string_view
+        constexpr SFixedString& operator=(std::string_view other)
+        {
+            Assign(other.data(), other.length() + 1);
+            return *this;
+        }
+#endif
+
+#ifdef __cpp_lib_string_view
         // Out
-        operator const char*() const { return szData; }
+        constexpr operator std::string_view() const { return { szData }; }
+#endif
+        constexpr operator const char*() const { return szData; }
+        constexpr char*           Data() { return &szData[0]; }
+
+        constexpr size_t GetMaxLength() const { return MAX_LENGTH; }
+        size_t GetLength() const { return strlen(szData); }
 
         // Shake it all about
         void Encrypt();
+        constexpr bool Empty() { return szData[0] == 0; }
+        constexpr void Clear() const { szData[0] = 0; }
     };
 
     ///////////////////////////////////////////////////////////////

--- a/Shared/sdk/SharedUtil.Misc.h
+++ b/Shared/sdk/SharedUtil.Misc.h
@@ -692,7 +692,7 @@ namespace SharedUtil
         {
             if (m > MAX_LENGTH)
                 throw std::length_error{"m > MAX_LENGTH"};
-            Assign(other, strlen(other)); // Might be slow with if other is very long.
+            Assign(other, std::min<size_t>(strlen(other), m)); // Might be slow with if `other` is very long
             return *this;
         }
 

--- a/Shared/sdk/SharedUtil.Misc.h
+++ b/Shared/sdk/SharedUtil.Misc.h
@@ -701,8 +701,8 @@ namespace SharedUtil
 
         // Shake it all about
         void Encrypt();
-        constexpr bool Empty() { return szData[0] == 0; }
-        constexpr void Clear() const { szData[0] = 0; }
+        constexpr bool Empty() const { return !szData[0]; }
+        constexpr void Clear() { szData[0] = 0; }
     };
 
     ///////////////////////////////////////////////////////////////


### PR DESCRIPTION
Use SFixedString instead of `std::string`, because we are limiting the max length anyways.
I'm not quite sure whenever this is a good idea from a maintainability standpoint tho.

Briefly tested, works fine. Needs a unit test, which I'll do later. In the meantime feel free to review.