### PR TITLE
Better performance profiling

### DIFF
--- a/Client/mods/deathmatch/StdInc.h
+++ b/Client/mods/deathmatch/StdInc.h
@@ -150,6 +150,7 @@
 #include "CLatentTransferManager.h"
 #include "CDebugHookManager.h"
 #include "lua/CLuaShared.h"
+#include "profiler/CPerformanceRecorder.h"
 
 // Deathmatch includes
 #include "ClientCommands.h"

--- a/Client/mods/deathmatch/logic/CClientEntity.cpp
+++ b/Client/mods/deathmatch/logic/CClientEntity.cpp
@@ -732,6 +732,7 @@ bool CClientEntity::AddEvent(CLuaMain* pLuaMain, const char* szName, const CLuaF
 
 bool CClientEntity::CallEvent(const char* szName, const CLuaArguments& Arguments, bool bCallOnChildren)
 {
+    CPerformanceRecorder::EventSample sample(szName);
     if (!g_pClientGame->GetDebugHookManager()->OnPreEvent(szName, Arguments, this, NULL))
         return false;
 

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -733,6 +733,7 @@ void CClientGame::DoPulsePreFrame()
 
 void CClientGame::DoPulsePreHUDRender(bool bDidUnminimize, bool bDidRecreateRenderTargets)
 {
+    CPerformanceRecorder::Sample sample("CClientGame::DoPulsePreHUDRender");
     // Allow scripted dxSetRenderTarget for old scripts
     g_pCore->GetGraphics()->GetRenderItemManager()->EnableSetRenderTargetOldVer(true);
 
@@ -765,6 +766,7 @@ void CClientGame::DoPulsePreHUDRender(bool bDidUnminimize, bool bDidRecreateRend
 
 void CClientGame::DoPulsePostFrame()
 {
+    CPerformanceRecorder::Sample sample("CClientGame::DoPulsePostFrame");
     TIMING_CHECKPOINT("+CClientGame::DoPulsePostFrame");
     #ifdef DEBUG_KEYSTATES
     // Get the controller state
@@ -942,6 +944,7 @@ void CClientGame::DoPulses()
 
     g_pCore->ApplyFrameRateLimit();
 
+    CPerformanceRecorder::Sample sample("CClientGame::DoPulses");
     TIMING_CHECKPOINT("+CClientGame::DoPulses");
 
     m_BuiltCollisionMapThisFrame = false;
@@ -1315,6 +1318,7 @@ void CClientGame::DoPulses()
 // Extrapolation test
 void CClientGame::DoPulses2(bool bCalledFromIdle)
 {
+    CPerformanceRecorder::Sample sample("CClientGame::DoPulses2");
     bool bIsUsingAlternatePulseOrder = IsUsingAlternatePulseOrder(!bCalledFromIdle);
 
     // Figure out which pulses to do
@@ -1345,11 +1349,12 @@ void CClientGame::DoPulses2(bool bCalledFromIdle)
         // be rounded to look more like what is expected
         ChangeFloatPrecision(true);
 
-        // Pulse the network interface
-        TIMING_CHECKPOINT("+NetPulse");
-        g_pNet->DoPulse();
-        TIMING_CHECKPOINT("-NetPulse");
-
+        {
+            // Pulse the network interface
+            TIMING_CHECKPOINT("+NetPulse");
+            g_pNet->DoPulse();
+            TIMING_CHECKPOINT("-NetPulse");
+        }
         // Change precision back, and check we are in low precision mode 4 sure
         ChangeFloatPrecision(false);
         assert(!IsHighFloatPrecision());

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -184,6 +184,7 @@ CClientGame::CClientGame(bool bLocalPlay) : m_ServerInfo(new CServerInfo())
     m_pScriptKeyBinds = new CScriptKeyBinds;
     m_pRemoteCalls = new CRemoteCalls();
     m_pResourceFileDownloadManager = new CResourceFileDownloadManager();
+    m_pPerformanceRecorder = new CPerformanceRecorder();
 
     // Create our net API
     m_pNetAPI = new CNetAPI(m_pManager);
@@ -479,6 +480,7 @@ CClientGame::~CClientGame()
     SAFE_DELETE(m_pLuaManager);
     SAFE_DELETE(m_pLatentTransferManager);
     SAFE_DELETE(m_pResourceFileDownloadManager);
+    SAFE_DELETE(m_pPerformanceRecorder);
 
     SAFE_DELETE(m_pRootEntity);
 

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -184,7 +184,7 @@ CClientGame::CClientGame(bool bLocalPlay) : m_ServerInfo(new CServerInfo())
     m_pScriptKeyBinds = new CScriptKeyBinds;
     m_pRemoteCalls = new CRemoteCalls();
     m_pResourceFileDownloadManager = new CResourceFileDownloadManager();
-    m_pPerformanceRecorder = new CPerformanceRecorder();
+    m_pPerformanceRecorder = std::make_unique<CPerformanceRecorder>();
 
     // Create our net API
     m_pNetAPI = new CNetAPI(m_pManager);
@@ -480,7 +480,6 @@ CClientGame::~CClientGame()
     SAFE_DELETE(m_pLuaManager);
     SAFE_DELETE(m_pLatentTransferManager);
     SAFE_DELETE(m_pResourceFileDownloadManager);
-    SAFE_DELETE(m_pPerformanceRecorder);
 
     SAFE_DELETE(m_pRootEntity);
 

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -299,6 +299,7 @@ public:
     CLatentTransferManager*   GetLatentTransferManager() { return m_pLatentTransferManager; }
     CClientModelCacheManager* GetModelCacheManager() { return m_pModelCacheManager; }
     CDebugHookManager*        GetDebugHookManager() { return m_pDebugHookManager; }
+    CPerformanceRecorder*     GetPerformanceRecorder() const { return m_pPerformanceRecorder; }
 
     CElementDeleter*              GetElementDeleter() { return &m_ElementDeleter; }
     CObjectRespawner*             GetObjectRespawner() { return &m_ObjectRespawner; }
@@ -688,6 +689,7 @@ private:
     CDebugHookManager*            m_pDebugHookManager;
     CRemoteCalls*                 m_pRemoteCalls;
     CResourceFileDownloadManager* m_pResourceFileDownloadManager;
+    CPerformanceRecorder*         m_pPerformanceRecorder;
 
     // Revised facilities
     CServer m_Server;

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -299,7 +299,7 @@ public:
     CLatentTransferManager*   GetLatentTransferManager() { return m_pLatentTransferManager; }
     CClientModelCacheManager* GetModelCacheManager() { return m_pModelCacheManager; }
     CDebugHookManager*        GetDebugHookManager() { return m_pDebugHookManager; }
-    CPerformanceRecorder*     GetPerformanceRecorder() const { return m_pPerformanceRecorder; }
+    CPerformanceRecorder*     GetPerformanceRecorder() const { return m_pPerformanceRecorder.get(); }
 
     CElementDeleter*              GetElementDeleter() { return &m_ElementDeleter; }
     CObjectRespawner*             GetObjectRespawner() { return &m_ObjectRespawner; }
@@ -689,7 +689,6 @@ private:
     CDebugHookManager*            m_pDebugHookManager;
     CRemoteCalls*                 m_pRemoteCalls;
     CResourceFileDownloadManager* m_pResourceFileDownloadManager;
-    CPerformanceRecorder*         m_pPerformanceRecorder;
 
     // Revised facilities
     CServer m_Server;
@@ -705,7 +704,8 @@ private:
     CScriptDebugging*   m_pScriptDebugging;
     CRegisteredCommands m_RegisteredCommands;
 
-    std::unique_ptr<CServerInfo> m_ServerInfo;
+    std::unique_ptr<CServerInfo>          m_ServerInfo;
+    std::unique_ptr<CPerformanceRecorder> m_pPerformanceRecorder;
 
     // Map statuses
     SString m_strCurrentMapName;

--- a/Client/mods/deathmatch/logic/CClientModelCacheManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientModelCacheManager.cpp
@@ -101,6 +101,7 @@ CClientModelCacheManagerImpl::~CClientModelCacheManagerImpl()
 ///////////////////////////////////////////////////////////////
 void CClientModelCacheManagerImpl::DoPulse()
 {
+    CPerformanceRecorder::Sample sample("CClientModelCacheManager::DoPulse");
     m_TickCountNow = CTickCount::Now();
     ClearStats();
 

--- a/Client/mods/deathmatch/logic/CElementDeleter.cpp
+++ b/Client/mods/deathmatch/logic/CElementDeleter.cpp
@@ -88,6 +88,7 @@ void CElementDeleter::DeleteRecursive(class CClientEntity* pElement)
 
 void CElementDeleter::DoDeleteAll()
 {
+    CPerformanceRecorder::Sample sample("CElementDeleter::DoDeleteAll");
     // Make sure elements won't call us back and screw with our list (would crash)
     m_bAllowUnreference = false;
 

--- a/Client/mods/deathmatch/logic/CMovingObjectsManager.cpp
+++ b/Client/mods/deathmatch/logic/CMovingObjectsManager.cpp
@@ -14,6 +14,7 @@
 
 void CMovingObjectsManager::DoPulse()
 {
+    CPerformanceRecorder::Sample sample("CMovingObjectsManager::DoPulse");
     using Iterator = std::list<CDeathmatchObject*>::iterator;
 
     for (Iterator iter = m_List.begin(); iter != m_List.end(); /* manual increment */)

--- a/Client/mods/deathmatch/logic/CPedSync.cpp
+++ b/Client/mods/deathmatch/logic/CPedSync.cpp
@@ -55,6 +55,7 @@ bool CPedSync::ProcessPacket(unsigned char ucPacketID, NetBitStreamInterface& Bi
 
 void CPedSync::DoPulse()
 {
+    CPerformanceRecorder::Sample sample("CPedSync::DoPulse");
     // Got any items?
     if (m_List.size() > 0)
     {

--- a/Client/mods/deathmatch/logic/CUnoccupiedVehicleSync.cpp
+++ b/Client/mods/deathmatch/logic/CUnoccupiedVehicleSync.cpp
@@ -56,6 +56,7 @@ bool CUnoccupiedVehicleSync::ProcessPacket(unsigned char ucPacketID, NetBitStrea
 
 void CUnoccupiedVehicleSync::DoPulse()
 {
+    CPerformanceRecorder::Sample sample("CUnoccupiedVehicleSync::DoPulse");
     // Check all our vehicles for damage
     UpdateDamageModels();
 

--- a/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -508,6 +508,7 @@ const SString& CLuaMain::GetFunctionTag(int iLuaFunction)
 ///////////////////////////////////////////////////////////////
 int CLuaMain::PCall(lua_State* L, int nargs, int nresults, int errfunc)
 {
+    CPerformanceRecorder::Sample sample("CLuaMain::PCall");
     TIMING_CHECKPOINT("+pcall");
     g_pClientGame->ChangeFloatPrecision(true);
     g_pClientGame->GetScriptDebugging()->PushLuaMain(this);

--- a/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -110,6 +110,8 @@ void CLuaManager::ProcessPendingDeleteList()
 
 void CLuaManager::DoPulse()
 {
+    CPerformanceRecorder::Sample sample("CLuaManager::DoPulse");
+    sample.SetArg("Virtual machines count", m_virtualMachines.size());
     list<CLuaMain*>::iterator iter = m_virtualMachines.begin();
     for (; iter != m_virtualMachines.end(); ++iter)
     {

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -1737,7 +1737,7 @@ int CLuaElementDefs::SetElementData(lua_State* luaVM)
                 strKey = strKey.Left(MAX_CUSTOMDATA_NAME_LENGTH);
             }
             sample.SetArg("Key", strKey);
-            sample.SetArg("Synchronized", bSynchronize);
+            sample.SetBool("Synchronized", bSynchronize);
             if (CStaticFunctionDefinitions::SetElementData(*pEntity, strKey, value, bSynchronize))
             {
                 lua_pushboolean(luaVM, true);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -1711,6 +1711,7 @@ int CLuaElementDefs::SetElementID(lua_State* luaVM)
 
 int CLuaElementDefs::SetElementData(lua_State* luaVM)
 {
+    CPerformanceRecorder::FunctionSample sample("SetElementData");
     //  bool setElementData ( element theElement, string key, var value, [bool synchronize = true] )
     CClientEntity* pEntity;
     SString        strKey;
@@ -1735,7 +1736,8 @@ int CLuaElementDefs::SetElementData(lua_State* luaVM)
                                                              *SString("string length reduced to %d characters at argument 2", MAX_CUSTOMDATA_NAME_LENGTH)));
                 strKey = strKey.Left(MAX_CUSTOMDATA_NAME_LENGTH);
             }
-
+            sample.SetArg("Key", strKey);
+            sample.SetArg("Synchronized", bSynchronize);
             if (CStaticFunctionDefinitions::SetElementData(*pEntity, strKey, value, bSynchronize))
             {
                 lua_pushboolean(luaVM, true);

--- a/Client/mods/deathmatch/premake5.lua
+++ b/Client/mods/deathmatch/premake5.lua
@@ -54,6 +54,7 @@ project "Client Deathmatch"
 		"../../../Shared/mods/deathmatch/logic/**.h",
 		"../../../Shared/animation/CEasingCurve.cpp",
 		"../../../Shared/animation/CPositionRotationAnimation.cpp",
+		"../../../Shared/sdk/profiler/CPerformanceRecorder.cpp",
 		-- Todo: Replace these two by using the CryptoPP functions instead
 		"../../../vendor/bochs/bochs_internal/bochs_crc32.cpp"
 	}

--- a/Server/mods/deathmatch/StdInc.h
+++ b/Server/mods/deathmatch/StdInc.h
@@ -177,6 +177,7 @@ struct SAclRequest;
 
 // Logic includes
 #include "ASE.h"
+#include "CPerformanceRecorder.h"
 #include "ASEQuerySDK.h"
 #include "CAccessControlList.h"
 #include "CAccessControlListGroup.h"

--- a/Server/mods/deathmatch/StdInc.h
+++ b/Server/mods/deathmatch/StdInc.h
@@ -177,7 +177,7 @@ struct SAclRequest;
 
 // Logic includes
 #include "ASE.h"
-#include "CPerformanceRecorder.h"
+#include "profiler/CPerformanceRecorder.h"
 #include "ASEQuerySDK.h"
 #include "CAccessControlList.h"
 #include "CAccessControlListGroup.h"

--- a/Server/mods/deathmatch/logic/ASE.cpp
+++ b/Server/mods/deathmatch/logic/ASE.cpp
@@ -134,6 +134,7 @@ bool ASE::SetPortEnabled(bool bInternetEnabled, bool bLanEnabled)
 
 void ASE::DoPulse()
 {
+    CPerformanceRecorder::Sample sample("ASE::DoPulse");
     if (m_SocketList.empty())
         return;
 

--- a/Server/mods/deathmatch/logic/CAccessControlListManager.cpp
+++ b/Server/mods/deathmatch/logic/CAccessControlListManager.cpp
@@ -304,6 +304,7 @@ CAccessControlList* CAccessControlListManager::GetACL(const char* szACLName)
 
 void CAccessControlListManager::DoPulse()
 {
+    CPerformanceRecorder::Sample sample("CAccessControlListManager::DoPulse");
     // Clear cache every 12 hours or if dirty
     if (m_bReadCacheDirty || GetTickCount64_() - m_llLastTimeReadCacheCleared > 1000 * 60 * 60 * 12)
         ClearReadCache();

--- a/Server/mods/deathmatch/logic/CAccountManager.cpp
+++ b/Server/mods/deathmatch/logic/CAccountManager.cpp
@@ -135,6 +135,7 @@ void CAccountManager::DoPulse()
     // Save it only once in a while whenever something has changed
     if (m_bChangedSinceSaved && GetTickCount64_() > m_llLastTimeSaved + 15000)
     {
+        CPerformanceRecorder::Sample sample("CAccountManager::DoPulse");
         // Save it
         Save();
     }

--- a/Server/mods/deathmatch/logic/CBanManager.cpp
+++ b/Server/mods/deathmatch/logic/CBanManager.cpp
@@ -39,6 +39,7 @@ CBanManager::~CBanManager()
 
 void CBanManager::DoPulse()
 {
+    CPerformanceRecorder::Sample sample("CBanManager::DoPulse");
     time_t tTime = time(NULL);
 
     if (tTime > m_tUpdate)

--- a/Server/mods/deathmatch/logic/CBlendedWeather.cpp
+++ b/Server/mods/deathmatch/logic/CBlendedWeather.cpp
@@ -27,6 +27,7 @@ CBlendedWeather::CBlendedWeather(CClock* pClock)
 
 void CBlendedWeather::DoPulse()
 {
+    CPerformanceRecorder::Sample sample("CBlendedWeather::DoPulse");
     Update();
 }
 

--- a/Server/mods/deathmatch/logic/CDatabaseManager.cpp
+++ b/Server/mods/deathmatch/logic/CDatabaseManager.cpp
@@ -119,6 +119,7 @@ CDatabaseManagerImpl::~CDatabaseManagerImpl()
 ///////////////////////////////////////////////////////////////
 void CDatabaseManagerImpl::DoPulse()
 {
+    CPerformanceRecorder::Sample sample("CDatabaseManager::DoPulse");
     m_JobQueue->DoPulse();
 }
 

--- a/Server/mods/deathmatch/logic/CElement.cpp
+++ b/Server/mods/deathmatch/logic/CElement.cpp
@@ -422,6 +422,7 @@ bool CElement::AddEvent(CLuaMain* pLuaMain, const char* szName, const CLuaFuncti
 
 bool CElement::CallEvent(const char* szName, const CLuaArguments& Arguments, CPlayer* pCaller)
 {
+    CPerformanceRecorder::EventSample sample(szName);
     if (!g_pGame->GetDebugHookManager()->OnPreEvent(szName, Arguments, this, pCaller))
         return false;
 

--- a/Server/mods/deathmatch/logic/CElementDeleter.cpp
+++ b/Server/mods/deathmatch/logic/CElementDeleter.cpp
@@ -44,6 +44,8 @@ void CElementDeleter::Delete(class CElement* pElement, bool bUnlink, bool bUpdat
 
 void CElementDeleter::DoDeleteAll()
 {
+    CPerformanceRecorder::Sample sample("CElementDeleter::DoDeleteAll");
+    sample.SetArg("Deleted elements", m_List.size());
     // This depends on CElementDeleter::Unreference() being called in ~CElement()
     while (!m_List.empty())
         delete *m_List.begin();

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -141,6 +141,7 @@ CGame::CGame() : m_FloodProtect(4, 30000, 30000)            // Max of 4 connecti
     m_pBuildingRemovalManager = NULL;
     m_pCustomWeaponManager = NULL;
     m_pFunctionUseLogger = NULL;
+    m_pPerformanceRecorder = nullptr;
 #ifdef WITH_OBJECT_SYNC
     m_pObjectSync = NULL;
 #endif
@@ -320,6 +321,7 @@ CGame::~CGame()
     SAFE_DELETE(m_pSettings);
     SAFE_DELETE(m_pRPCFunctions);
     SAFE_DELETE(m_pWaterManager);
+    SAFE_DELETE(m_pPerformanceRecorder);
     SAFE_DELETE(m_pWeaponStatsManager);
     SAFE_DELETE(m_pBuildingRemovalManager);
     SAFE_DELETE(m_pCustomWeaponManager);
@@ -374,6 +376,13 @@ void CGame::HandleInput(char* szCommand)
 
 void CGame::DoPulse()
 {
+    CPerformanceRecorder::Sample sample("DoPulse");
+    {
+        CPerformanceRecorder::Sample sample("Foo test");
+        for (int i = 0; i < 10000000; i++)
+        {
+        }
+    }
     // Lock the critical section so http server won't interrupt in the middle of our pulse
     Lock();
 
@@ -511,6 +520,7 @@ bool CGame::Start(int iArgumentCount, char* szArguments[])
     m_pTeamManager = new CTeamManager;
     m_pPedManager = new CPedManager;
     m_pWaterManager = new CWaterManager;
+    m_pPerformanceRecorder = new CPerformanceRecorder;
     m_pScriptDebugging = new CScriptDebugging();
     m_pMapManager = new CMapManager(m_pBlipManager, m_pObjectManager, m_pPickupManager, m_pPlayerManager, m_pRadarAreaManager, m_pMarkerManager,
                                     m_pVehicleManager, m_pTeamManager, m_pPedManager, m_pColManager, m_pWaterManager, m_pClock, m_pGroups,

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -420,10 +420,17 @@ void CGame::DoPulse()
         UNCLOCK1("HTTPDownloadManager");
     }
 
-    CLOCK_CALL1(m_pPlayerManager->DoPulse(););
+    {
+        CPerformanceRecorder::Sample sample("CPlayerManager::DoPulse");
+        CLOCK_CALL1(m_pPlayerManager->DoPulse(););
 
-    // Pulse the net interface
-    CLOCK_CALL1(g_pNetServer->DoPulse(););
+    }
+
+    {
+        CPerformanceRecorder::Sample sample("CNetServerBuffer::DoPulse");
+        // Pulse the net interface
+        CLOCK_CALL1(g_pNetServer->DoPulse(););
+    }
 
     if (m_pLanBroadcast)
     {

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -473,10 +473,16 @@ void CGame::DoPulse()
     CLOCK_CALL1(CPerfStatManager::GetSingleton()->DoPulse(););
 
     if (m_pMasterServerAnnouncer)
+    {
+        CPerformanceRecorder::Sample sample("CMasterServerAnnouncer::Pulse");
         m_pMasterServerAnnouncer->Pulse();
+    }
 
     if (m_pHqComms)
+    {
+        CPerformanceRecorder::Sample sample("CHqComms::Pulse");
         m_pHqComms->Pulse();
+    }
 
     CLOCK_CALL1(m_pFunctionUseLogger->Pulse(););
     CLOCK_CALL1(m_lightsyncManager.DoPulse(););

--- a/Server/mods/deathmatch/logic/CGame.h
+++ b/Server/mods/deathmatch/logic/CGame.h
@@ -102,6 +102,7 @@ class CVehicleManager;
 class CZoneNames;
 class CLanBroadcast;
 class CWaterManager;
+class CPerformanceRecorder;
 class CTrainTrackManager;
 class CWeaponStatManager;
 class CBuildingRemovalManager;
@@ -245,6 +246,7 @@ public:
     CZoneNames*                      GetZoneNames() { return m_pZoneNames; }
     CClock*                          GetClock() { return m_pClock; }
     CWaterManager*                   GetWaterManager() { return m_pWaterManager; }
+    CPerformanceRecorder*            GetPerformanceRecorder() { return m_pPerformanceRecorder; }
     CLightsyncManager*               GetLightSyncManager() { return &m_lightsyncManager; }
     CWeaponStatManager*              GetWeaponStatManager() { return m_pWeaponStatsManager; }
     CBuildingRemovalManager*         GetBuildingRemovalManager() { return m_pBuildingRemovalManager; }
@@ -555,6 +557,7 @@ private:
     CRPCFunctions*             m_pRPCFunctions;
     CLanBroadcast*             m_pLanBroadcast;
     CWaterManager*             m_pWaterManager;
+    CPerformanceRecorder*      m_pPerformanceRecorder;
 
     CWeaponStatManager*      m_pWeaponStatsManager;
     CBuildingRemovalManager* m_pBuildingRemovalManager;

--- a/Server/mods/deathmatch/logic/CLightsyncManager.cpp
+++ b/Server/mods/deathmatch/logic/CLightsyncManager.cpp
@@ -76,6 +76,8 @@ void CLightsyncManager::DoPulse()
     // are also storing the delta context in what it happened, so we only consider the health unchanged
     // when we find the marker with the same context value.
 
+    CPerformanceRecorder::Sample sample("CLightsyncManager::DoPulse");
+
     if (g_pBandwidthSettings->bLightSyncEnabled == false)
         return;
 

--- a/Server/mods/deathmatch/logic/CMapManager.cpp
+++ b/Server/mods/deathmatch/logic/CMapManager.cpp
@@ -55,6 +55,7 @@ CMapManager::~CMapManager()
 
 void CMapManager::DoPulse()
 {
+    CPerformanceRecorder::Sample sample("CMapManager::DoPulse");
     // Do the respawning checks
     DoRespawning();
 }

--- a/Server/mods/deathmatch/logic/CPedSync.cpp
+++ b/Server/mods/deathmatch/logic/CPedSync.cpp
@@ -19,6 +19,7 @@ CPedSync::CPedSync(CPlayerManager* pPlayerManager, CPedManager* pPedManager)
 
 void CPedSync::DoPulse()
 {
+    CPerformanceRecorder::Sample sample("CPedSync::DoPulse");
     // Time to check for players that should no longer be syncing a ped or peds that should be synced?
     if (m_UpdateTimer.Get() > 500)
     {

--- a/Server/mods/deathmatch/logic/CPerformanceRecorder.cpp
+++ b/Server/mods/deathmatch/logic/CPerformanceRecorder.cpp
@@ -1,0 +1,74 @@
+#include "StdInc.h"
+
+CPerformanceRecorder::CPerformanceRecorder()
+{
+}
+
+CPerformanceRecorder::~CPerformanceRecorder()
+{
+}
+
+void CPerformanceRecorder::Start()
+{
+    m_bRecordPerformance = true;
+    g_pGame->GetPerformanceRecorder()->m_strStream << '[';
+}
+
+void CPerformanceRecorder::Stop()
+{
+    m_bRecordPerformance = false;
+}
+
+void CPerformanceRecorder::Clear()
+{
+    m_strStream.clear();
+    m_start = GetTimeUs();
+}
+
+std::string CPerformanceRecorder::GetResult()
+{
+    return m_strStream.str() + "]";
+}
+
+CPerformanceRecorder::Sample::Sample(const char* name) : m_szName(name), m_start(GetTimeUs())
+{
+    m_pObject = json_object_new_object();
+}
+//
+//{"name": "aaaaaaaaaaa", "cat": "PERF", "ph": "B", "pid": 22630, "tid": 22630, "ts": 829, "cname": "foo"},
+//{"name": "aaaaaaaaaaa", "cat": "PERF", "ph": "E", "pid": 22630, "tid": 22630, "ts": 2000, "cname": "foo"},
+void CPerformanceRecorder::Sample::Set(const char* szKey, const char* value)
+{
+    if (m_pObject)
+    {
+        json_object_object_add(m_pObject, szKey, json_object_new_string(value));
+    }
+}
+CPerformanceRecorder::Sample::~Sample()
+{
+    if (m_pObject)
+    {
+        json_object* m_pObjectStart = json_object_new_object();
+        json_object_object_add(m_pObjectStart, "name", json_object_new_string(m_szName));
+        json_object_object_add(m_pObjectStart, "cat", json_object_new_string("PERF"));
+        json_object_object_add(m_pObjectStart, "ph", json_object_new_string("B"));
+        json_object_object_add(m_pObjectStart, "ts", json_object_new_int(m_start));
+        json_object_object_add(m_pObjectStart, "pid", json_object_new_int(GetCurrentThreadId()));
+
+
+        Set("name", m_szName);
+        Set("cat", "PERF");
+        Set("ph", "E");
+        json_object_object_add(m_pObject, "ts", json_object_new_int(GetTimeUs()));
+        json_object_object_add(m_pObject, "pid", json_object_new_int(GetCurrentThreadId()));
+
+        int flags = JSON_C_TO_STRING_PLAIN;
+
+        g_pGame->GetPerformanceRecorder()->m_strStream << json_object_to_json_string_ext(m_pObjectStart, flags) << ',';
+        g_pGame->GetPerformanceRecorder()->m_strStream << json_object_to_json_string_ext(m_pObject, flags) << ',';
+        json_object_put(m_pObject);
+        json_object_put(m_pObjectStart);
+    }
+
+    int a = 5;
+}

--- a/Server/mods/deathmatch/logic/CPerformanceRecorder.cpp
+++ b/Server/mods/deathmatch/logic/CPerformanceRecorder.cpp
@@ -30,37 +30,63 @@ std::string CPerformanceRecorder::GetResult()
     return m_strStream.str() + "]";
 }
 
+CPerformanceRecorder::FunctionSample::FunctionSample(const char* name) : Sample("")
+{
+    m_szName = std::string("Native function: ") + name;
+    m_szCategory = "function";
+}
+
+CPerformanceRecorder::EventSample::EventSample(const char* name) : Sample("")
+{
+    m_szName = std::string("Event: ") + name;
+    m_szCategory = "event";
+}
+
 CPerformanceRecorder::Sample::Sample(const char* name) : m_szName(name), m_start(GetTimeUs())
 {
-    m_pObject = json_object_new_object();
+    if (g_pGame->GetPerformanceRecorder() ->m_bRecordPerformance)
+        m_pObject = json_object_new_object();
 }
 //
 //{"name": "aaaaaaaaaaa", "cat": "PERF", "ph": "B", "pid": 22630, "tid": 22630, "ts": 829, "cname": "foo"},
 //{"name": "aaaaaaaaaaa", "cat": "PERF", "ph": "E", "pid": 22630, "tid": 22630, "ts": 2000, "cname": "foo"},
-void CPerformanceRecorder::Sample::Set(const char* szKey, const char* value)
+
+void CPerformanceRecorder::Sample::SetArg(const char* szKey, const char* value)
 {
-    if (m_pObject)
-    {
-        json_object_object_add(m_pObject, szKey, json_object_new_string(value));
-    }
+    if (!m_pObjectArgs)
+        m_pObjectArgs = json_object_new_object();
+
+    json_object_object_add(m_pObjectArgs, szKey, json_object_new_string(value));
 }
+
+void CPerformanceRecorder::Sample::SetArg(const char* szKey, int value)
+{
+    if (!m_pObjectArgs)
+        m_pObjectArgs = json_object_new_object();
+
+    json_object_object_add(m_pObjectArgs, szKey, json_object_new_int(value));
+}
+
 CPerformanceRecorder::Sample::~Sample()
 {
     if (m_pObject)
     {
         json_object* m_pObjectStart = json_object_new_object();
-        json_object_object_add(m_pObjectStart, "name", json_object_new_string(m_szName));
-        json_object_object_add(m_pObjectStart, "cat", json_object_new_string("PERF"));
+        json_object_object_add(m_pObjectStart, "name", json_object_new_string(m_szName.c_str()));
+        json_object_object_add(m_pObjectStart, "cat", json_object_new_string(m_szCategory));
         json_object_object_add(m_pObjectStart, "ph", json_object_new_string("B"));
         json_object_object_add(m_pObjectStart, "ts", json_object_new_int(m_start));
         json_object_object_add(m_pObjectStart, "pid", json_object_new_int(GetCurrentThreadId()));
 
-
-        Set("name", m_szName);
-        Set("cat", "PERF");
-        Set("ph", "E");
+        json_object_object_add(m_pObject, "name", json_object_new_string(m_szName.c_str()));
+        json_object_object_add(m_pObject, "cat", json_object_new_string(m_szCategory));
+        json_object_object_add(m_pObject, "ph", json_object_new_string("E"));
         json_object_object_add(m_pObject, "ts", json_object_new_int(GetTimeUs()));
         json_object_object_add(m_pObject, "pid", json_object_new_int(GetCurrentThreadId()));
+        if (m_pObjectArgs)
+        {
+            json_object_object_add(m_pObjectStart, "args", m_pObjectArgs);
+        }
 
         int flags = JSON_C_TO_STRING_PLAIN;
 
@@ -69,6 +95,4 @@ CPerformanceRecorder::Sample::~Sample()
         json_object_put(m_pObject);
         json_object_put(m_pObjectStart);
     }
-
-    int a = 5;
 }

--- a/Server/mods/deathmatch/logic/CPerformanceRecorder.h
+++ b/Server/mods/deathmatch/logic/CPerformanceRecorder.h
@@ -13,20 +13,35 @@ public:
     bool IsDuringPerformanceRecording() const { return m_bRecordPerformance; }
     std::string GetResult();
 
-    
     class Sample
     {
     public:
         Sample(const char* name);
         ~Sample();
 
-        void Set(const char* szKey, const char* value);
+        void SetArg(const char* szKey, const char* value);
+        void SetArg(const char* szKey, int value);
+
+    protected:
+        std::string  m_szName;
+        const char*  m_szCategory = "default";
     private:
-        const char*  m_szName;
-        TIMEUS       m_start;
+        TIMEUS       m_start = 0;
         json_object* m_pObject = nullptr;
+        json_object* m_pObjectArgs = nullptr;
     };
 
+    class FunctionSample : public Sample
+    {
+    public:
+        FunctionSample(const char* name);
+    };
+    
+    class EventSample : public Sample
+    {
+    public:
+        EventSample(const char* name);
+    };
 
 private:
     bool m_bRecordPerformance = false;

--- a/Server/mods/deathmatch/logic/CPerformanceRecorder.h
+++ b/Server/mods/deathmatch/logic/CPerformanceRecorder.h
@@ -1,0 +1,36 @@
+class CPerformanceRecorder
+{
+    friend class Sample;
+
+public:
+    CPerformanceRecorder();
+    ~CPerformanceRecorder();
+
+    void Start();
+    void Stop();
+    void Clear();
+
+    bool IsDuringPerformanceRecording() const { return m_bRecordPerformance; }
+    std::string GetResult();
+
+    
+    class Sample
+    {
+    public:
+        Sample(const char* name);
+        ~Sample();
+
+        void Set(const char* szKey, const char* value);
+    private:
+        const char*  m_szName;
+        TIMEUS       m_start;
+        json_object* m_pObject = nullptr;
+    };
+
+
+private:
+    bool m_bRecordPerformance = false;
+    TIMEUS m_start;
+
+    std::stringstream m_strStream;
+};

--- a/Server/mods/deathmatch/logic/CPlayerManager.cpp
+++ b/Server/mods/deathmatch/logic/CPlayerManager.cpp
@@ -26,6 +26,7 @@ CPlayerManager::~CPlayerManager()
 
 void CPlayerManager::DoPulse()
 {
+    CPerformanceRecorder::Sample sample("CPlayerManager::DoPulse");
     PulseZombieCheck();
 
     list<CPlayer*>::const_iterator iter = m_Players.begin();
@@ -33,6 +34,7 @@ void CPlayerManager::DoPulse()
     {
         (*iter)->DoPulse();
     }
+    sample.SetArg("Players", m_Players.size());
 }
 
 void CPlayerManager::PulseZombieCheck()

--- a/Server/mods/deathmatch/logic/CRegistryManager.cpp
+++ b/Server/mods/deathmatch/logic/CRegistryManager.cpp
@@ -21,6 +21,7 @@ CRegistryManager::~CRegistryManager()
 
 void CRegistryManager::DoPulse()
 {
+    CPerformanceRecorder::Sample sample("CRegistryManager::DoPulse");
     // End automatic transactions started in the previous pulse
     for (unsigned int i = 0; i < m_RegistryList.size(); i++)
         m_RegistryList[i]->EndAutomaticTransaction();

--- a/Server/mods/deathmatch/logic/CResourceManager.cpp
+++ b/Server/mods/deathmatch/logic/CResourceManager.cpp
@@ -747,6 +747,8 @@ void CResourceManager::QueueResource(CResource* pResource, eResourceQueue eQueue
 
 void CResourceManager::ProcessQueue()
 {
+    CPerformanceRecorder::Sample sample("CResourceManager::ProcessQueue");
+    sample.SetArg("Queue size", m_resourceQueue.size());
     // While we have queuestuff to process
     while (m_resourceQueue.size() > 0)
     {

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -883,12 +883,13 @@ bool CStaticFunctionDefinitions::SetElementData(CElement* pElement, const char* 
     ESyncType     lastSyncType = ESyncType::BROADCAST;
     CLuaArgument* pCurrentVariable = pElement->GetCustomData(szName, false, &lastSyncType);
 
+    sample.SetArg("Sync type", EnumToString(syncType));
+    sample.SetArg("Key", szName);
     if (!pCurrentVariable || *pCurrentVariable != Variable || lastSyncType != syncType)
     {
-        sample.SetArg("Sync type", EnumToString(syncType));
-        sample.SetArg("Key", szName);
         if (syncType != ESyncType::LOCAL)
         {
+            CPerformanceRecorder::Sample sample("Broadcast");
             // Tell our clients to update their data
             unsigned short usNameLength = static_cast<unsigned short>(strlen(szName));
             CBitStream     BitStream;
@@ -896,7 +897,6 @@ bool CStaticFunctionDefinitions::SetElementData(CElement* pElement, const char* 
             BitStream.pBitStream->Write(szName, usNameLength);
             Variable.WriteToBitStream(*BitStream.pBitStream);
 
-            CPerformanceRecorder::Sample sample("Broadcast");
             if (syncType == ESyncType::BROADCAST)
                 m_pPlayerManager->BroadcastOnlyJoined(CElementRPCPacket(pElement, SET_ELEMENT_DATA, *BitStream.pBitStream));
             else

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -878,13 +878,10 @@ bool CStaticFunctionDefinitions::SetElementData(CElement* pElement, const char* 
     assert(pElement);
     assert(szName);
     assert(strlen(szName) <= MAX_CUSTOMDATA_NAME_LENGTH);
-    CPerformanceRecorder::FunctionSample sample("setElementData");
 
     ESyncType     lastSyncType = ESyncType::BROADCAST;
     CLuaArgument* pCurrentVariable = pElement->GetCustomData(szName, false, &lastSyncType);
 
-    sample.SetArg("Sync type", EnumToString(syncType));
-    sample.SetArg("Key", szName);
     if (!pCurrentVariable || *pCurrentVariable != Variable || lastSyncType != syncType)
     {
         if (syncType != ESyncType::LOCAL)

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -878,12 +878,15 @@ bool CStaticFunctionDefinitions::SetElementData(CElement* pElement, const char* 
     assert(pElement);
     assert(szName);
     assert(strlen(szName) <= MAX_CUSTOMDATA_NAME_LENGTH);
+    CPerformanceRecorder::FunctionSample sample("setElementData");
 
     ESyncType     lastSyncType = ESyncType::BROADCAST;
     CLuaArgument* pCurrentVariable = pElement->GetCustomData(szName, false, &lastSyncType);
 
     if (!pCurrentVariable || *pCurrentVariable != Variable || lastSyncType != syncType)
     {
+        sample.SetArg("Sync type", EnumToString(syncType));
+        sample.SetArg("Key", szName);
         if (syncType != ESyncType::LOCAL)
         {
             // Tell our clients to update their data
@@ -893,6 +896,7 @@ bool CStaticFunctionDefinitions::SetElementData(CElement* pElement, const char* 
             BitStream.pBitStream->Write(szName, usNameLength);
             Variable.WriteToBitStream(*BitStream.pBitStream);
 
+            CPerformanceRecorder::Sample sample("Broadcast");
             if (syncType == ESyncType::BROADCAST)
                 m_pPlayerManager->BroadcastOnlyJoined(CElementRPCPacket(pElement, SET_ELEMENT_DATA, *BitStream.pBitStream));
             else

--- a/Server/mods/deathmatch/logic/CUnoccupiedVehicleSync.cpp
+++ b/Server/mods/deathmatch/logic/CUnoccupiedVehicleSync.cpp
@@ -19,6 +19,7 @@ CUnoccupiedVehicleSync::CUnoccupiedVehicleSync(CPlayerManager* pPlayerManager, C
 
 void CUnoccupiedVehicleSync::DoPulse()
 {
+    CPerformanceRecorder::Sample sample("CUnoccupiedVehicleSync::DoPulse");
     // Time to check for players that should no longer be syncing a vehicle or vehicles that should be synced?
     if (m_UpdateTimer.Get() > 500)
     {

--- a/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -104,12 +104,14 @@ void CLuaManager::OnLuaMainCloseVM(CLuaMain* pLuaMain, lua_State* luaVM)
 
 void CLuaManager::DoPulse()
 {
+    CPerformanceRecorder::Sample sample("CLuaManager::DoPulse");
     list<CLuaMain*>::iterator iter;
     for (iter = m_virtualMachines.begin(); iter != m_virtualMachines.end(); ++iter)
     {
         (*iter)->DoPulse();
     }
     m_pLuaModuleManager->DoPulse();
+    sample.SetArg("Virtual machines count", m_virtualMachines.size());
 }
 
 CLuaMain* CLuaManager::GetVirtualMachine(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -1546,6 +1546,7 @@ int CLuaElementDefs::setElementID(lua_State* luaVM)
 
 int CLuaElementDefs::setElementData(lua_State* luaVM)
 {
+    CPerformanceRecorder::FunctionSample sample("setElementData");
     //  bool setElementData ( element theElement, string key, var value, [var syncMode = true] )
     CElement*    pElement;
     SString      strKey;
@@ -1579,6 +1580,8 @@ int CLuaElementDefs::setElementData(lua_State* luaVM)
             strKey = strKey.Left(MAX_CUSTOMDATA_NAME_LENGTH);
         }
 
+        sample.SetArg("Sync type", EnumToString(syncType));
+        sample.SetArg("Key", strKey);
         if (CStaticFunctionDefinitions::SetElementData(pElement, strKey, value, syncType))
         {
             lua_pushboolean(luaVM, true);

--- a/Server/mods/deathmatch/logic/net/CNetBuffer.cpp
+++ b/Server/mods/deathmatch/logic/net/CNetBuffer.cpp
@@ -220,6 +220,7 @@ void CNetServerBuffer::StopNetwork()
 ///////////////////////////////////////////////////////////////////////////
 void CNetServerBuffer::DoPulse()
 {
+    CPerformanceRecorder::Sample sample("CNetServerBuffer::DoPulse");
     // Schedule a net pulse
     SDoPulseArgs* pArgs = new SDoPulseArgs();
     AddCommandAndFree(pArgs);

--- a/Server/mods/deathmatch/premake5.lua
+++ b/Server/mods/deathmatch/premake5.lua
@@ -26,6 +26,7 @@ project "Deathmatch"
 			"../../../Shared/mods/deathmatch/logic",
 			"../../../Shared/animation",
 			"../../../Shared/publicsdk/include",
+			"../../../Shared/sdk/profiler",
 			"../../../vendor/sparsehash/src/",
 			"logic",
 			"utils",
@@ -51,6 +52,7 @@ project "Deathmatch"
 		"../../../Shared/mods/deathmatch/logic/**.h",
 		"../../../Shared/animation/CEasingCurve.cpp",
 		"../../../Shared/animation/CPositionRotationAnimation.cpp",
+		"../../../Shared/sdk/profiler/CPerformanceRecorder.cpp",
 		-- Todo: Replace these two by using the CryptoPP functions instead
 		"../../../vendor/bochs/bochs_internal/bochs_crc32.cpp",
 	}

--- a/Server/mods/deathmatch/utils/CFunctionUseLogger.cpp
+++ b/Server/mods/deathmatch/utils/CFunctionUseLogger.cpp
@@ -32,6 +32,7 @@ CFunctionUseLogger::~CFunctionUseLogger()
 //
 void CFunctionUseLogger::Pulse()
 {
+    CPerformanceRecorder::Sample sample("CFunctionUseLogger::Pulse");
     if (!m_FuncCallRecordMap.empty())
         MaybeFlush();
 }

--- a/Shared/mods/deathmatch/logic/CLatentTransferManager.cpp
+++ b/Shared/mods/deathmatch/logic/CLatentTransferManager.cpp
@@ -42,6 +42,7 @@ CLatentTransferManager::~CLatentTransferManager()
 ///////////////////////////////////////////////////////////////
 void CLatentTransferManager::DoPulse()
 {
+    CPerformanceRecorder::Sample sample("CLatentTransferManager::DoPulse");
     // Update timing info
     CTickCount tickCountNow = CTickCount::Now();
 

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
@@ -46,6 +46,9 @@ void CLuaUtilDefs::LoadFunctions()
         // Utility functions
         {"gettok", GetTok},
         {"tocolor", tocolor},
+        {"startRecordPerformance", ArgumentParser<StartRecordPerformance>},
+        {"stopRecordPerformance", ArgumentParser<StopRecordPerformance>},
+        {"getRecordedPerformance", ArgumentParser<GetRecordedPerformance>},
     };
 
     // Add functions
@@ -710,4 +713,31 @@ int CLuaUtilDefs::tocolor(lua_State* luaVM)
     unsigned long ulColor = COLOR_RGBA(0, 0, 0, 255);
     lua_pushnumber(luaVM, static_cast<lua_Number>(ulColor));
     return 1;
+}
+
+bool CLuaUtilDefs::StartRecordPerformance(std::optional<bool> bClear)
+{
+    if (g_pGame->GetPerformanceRecorder()->IsDuringPerformanceRecording())
+        return false;
+
+    g_pGame->GetPerformanceRecorder()->Start();
+
+    if (bClear.value_or(false))
+        g_pGame->GetPerformanceRecorder()->Clear();
+
+    return true;
+}
+
+bool CLuaUtilDefs::StopRecordPerformance()
+{
+    if (!g_pGame->GetPerformanceRecorder()->IsDuringPerformanceRecording())
+        return false;
+
+    g_pGame->GetPerformanceRecorder()->Stop();
+    return true;
+}
+
+std::string CLuaUtilDefs::GetRecordedPerformance()
+{
+    return g_pGame->GetPerformanceRecorder()->GetResult();
 }

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.h
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.h
@@ -52,4 +52,8 @@ public:
     // Utility functions
     LUA_DECLARE(GetTok);
     LUA_DECLARE(tocolor);
+
+    static bool        StartRecordPerformance(std::optional<bool> bClear);
+    static bool        StopRecordPerformance();
+    static std::string GetRecordedPerformance();
 };

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.h
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.h
@@ -53,7 +53,9 @@ public:
     LUA_DECLARE(GetTok);
     LUA_DECLARE(tocolor);
 
-    static bool        StartRecordPerformance(std::optional<bool> bClear);
+    static bool        StartRecordPerformance();
     static bool        StopRecordPerformance();
-    static std::string GetRecordedPerformance();
+    static bool        ClearPerformanceRecorder();
+    static bool        IsPerformanceRecording();
+    static std::string GetRecordedSamples();
 };

--- a/Shared/premake5.lua
+++ b/Shared/premake5.lua
@@ -10,6 +10,7 @@ project "Shared"
 
 	vpaths {
 		["Headers/*"] = { "**.h", "**.hpp" },
+		["Sources/*"] = "**.cpp",
 		["*"] = "premake5.lua",
 	}
 

--- a/Shared/sdk/profiler/CPerformanceRecorder.cpp
+++ b/Shared/sdk/profiler/CPerformanceRecorder.cpp
@@ -156,7 +156,7 @@ CPerformanceRecorder::Sample::~Sample()
         json_object_object_add(object, "cat", json_object_new_string("default"));
 
     json_object_object_add(object, "ph", json_object_new_string("X"));
-    json_object_object_add(object, "ts", json_object_new_int(m_startTime));
+    json_object_object_add(object, "ts", json_object_new_int64(m_startTime)); // int64 prevents int32 overflowing in this case.
     json_object_object_add(object, "dur", json_object_new_int(GetTimeUs() - m_startTime));
     json_object_object_add(object, "tid", json_object_new_int(getpid()));
 

--- a/Shared/sdk/profiler/CPerformanceRecorder.cpp
+++ b/Shared/sdk/profiler/CPerformanceRecorder.cpp
@@ -82,13 +82,13 @@ CPerformanceRecorder::Sample::~Sample()
         json_object_object_add(m_pObjectStart, "cat", json_object_new_string(m_category.c_str()));
         json_object_object_add(m_pObjectStart, "ph", json_object_new_string("B"));
         json_object_object_add(m_pObjectStart, "ts", json_object_new_int(m_startTime));
-        json_object_object_add(m_pObjectStart, "pid", json_object_new_int(GetCurrentThreadId()));
+        json_object_object_add(m_pObjectStart, "pid", json_object_new_int(0));
 
         json_object_object_add(m_pObject, "name", json_object_new_string(m_name.c_str()));
         json_object_object_add(m_pObject, "cat", json_object_new_string(m_category.c_str()));
         json_object_object_add(m_pObject, "ph", json_object_new_string("E"));
         json_object_object_add(m_pObject, "ts", json_object_new_int(GetTimeUs()));
-        json_object_object_add(m_pObject, "pid", json_object_new_int(GetCurrentThreadId()));
+        json_object_object_add(m_pObject, "pid", json_object_new_int(0));
 
         if (m_pObjectArgs)
         {

--- a/Shared/sdk/profiler/CPerformanceRecorder.cpp
+++ b/Shared/sdk/profiler/CPerformanceRecorder.cpp
@@ -11,7 +11,12 @@ CPerformanceRecorder::~CPerformanceRecorder()
 void CPerformanceRecorder::Start()
 {
     m_bRecordPerformance = true;
-    g_pGame->GetPerformanceRecorder()->m_strStream << '[';
+#ifdef MTA_CLIENT
+    g_pClientGame->GetPerformanceRecorder()->m_strStream
+#else
+    g_pGame->GetPerformanceRecorder()->m_strStream
+#endif
+    << '[';
 }
 
 void CPerformanceRecorder::Stop()
@@ -32,24 +37,25 @@ std::string CPerformanceRecorder::GetResult()
 
 CPerformanceRecorder::FunctionSample::FunctionSample(const char* name) : Sample("")
 {
-    m_szName = std::string("Native function: ") + name;
-    m_szCategory = "function";
+    m_name = std::string("Native function: ") + name;
+    m_category = "function";
 }
 
 CPerformanceRecorder::EventSample::EventSample(const char* name) : Sample("")
 {
-    m_szName = std::string("Event: ") + name;
-    m_szCategory = "event";
+    m_name = std::string("Event: ") + name;
+    m_category = "event";
 }
 
-CPerformanceRecorder::Sample::Sample(const char* name) : m_szName(name), m_start(GetTimeUs())
+CPerformanceRecorder::Sample::Sample(const char* name) : m_name(name), m_startTime(GetTimeUs())
 {
-    if (g_pGame->GetPerformanceRecorder() ->m_bRecordPerformance)
+#ifdef MTA_CLIENT
+    if (g_pClientGame->GetPerformanceRecorder()->m_bRecordPerformance)
+#else
+    if (g_pGame->GetPerformanceRecorder()->m_bRecordPerformance)
+#endif
         m_pObject = json_object_new_object();
 }
-//
-//{"name": "aaaaaaaaaaa", "cat": "PERF", "ph": "B", "pid": 22630, "tid": 22630, "ts": 829, "cname": "foo"},
-//{"name": "aaaaaaaaaaa", "cat": "PERF", "ph": "E", "pid": 22630, "tid": 22630, "ts": 2000, "cname": "foo"},
 
 void CPerformanceRecorder::Sample::SetArg(const char* szKey, const char* value)
 {
@@ -72,17 +78,18 @@ CPerformanceRecorder::Sample::~Sample()
     if (m_pObject)
     {
         json_object* m_pObjectStart = json_object_new_object();
-        json_object_object_add(m_pObjectStart, "name", json_object_new_string(m_szName.c_str()));
-        json_object_object_add(m_pObjectStart, "cat", json_object_new_string(m_szCategory));
+        json_object_object_add(m_pObjectStart, "name", json_object_new_string(m_name.c_str()));
+        json_object_object_add(m_pObjectStart, "cat", json_object_new_string(m_category.c_str()));
         json_object_object_add(m_pObjectStart, "ph", json_object_new_string("B"));
-        json_object_object_add(m_pObjectStart, "ts", json_object_new_int(m_start));
+        json_object_object_add(m_pObjectStart, "ts", json_object_new_int(m_startTime));
         json_object_object_add(m_pObjectStart, "pid", json_object_new_int(GetCurrentThreadId()));
 
-        json_object_object_add(m_pObject, "name", json_object_new_string(m_szName.c_str()));
-        json_object_object_add(m_pObject, "cat", json_object_new_string(m_szCategory));
+        json_object_object_add(m_pObject, "name", json_object_new_string(m_name.c_str()));
+        json_object_object_add(m_pObject, "cat", json_object_new_string(m_category.c_str()));
         json_object_object_add(m_pObject, "ph", json_object_new_string("E"));
         json_object_object_add(m_pObject, "ts", json_object_new_int(GetTimeUs()));
         json_object_object_add(m_pObject, "pid", json_object_new_int(GetCurrentThreadId()));
+
         if (m_pObjectArgs)
         {
             json_object_object_add(m_pObjectStart, "args", m_pObjectArgs);
@@ -90,8 +97,14 @@ CPerformanceRecorder::Sample::~Sample()
 
         int flags = JSON_C_TO_STRING_PLAIN;
 
-        g_pGame->GetPerformanceRecorder()->m_strStream << json_object_to_json_string_ext(m_pObjectStart, flags) << ',';
-        g_pGame->GetPerformanceRecorder()->m_strStream << json_object_to_json_string_ext(m_pObject, flags) << ',';
+#ifdef MTA_CLIENT
+        g_pClientGame->GetPerformanceRecorder()->m_strStream
+#else
+        g_pGame->GetPerformanceRecorder()->m_strStream
+#endif
+                                                       << json_object_to_json_string_ext(m_pObjectStart, flags) << ','
+                                                       << json_object_to_json_string_ext(m_pObject, flags) << ',';
+
         json_object_put(m_pObject);
         json_object_put(m_pObjectStart);
     }

--- a/Shared/sdk/profiler/CPerformanceRecorder.h
+++ b/Shared/sdk/profiler/CPerformanceRecorder.h
@@ -27,15 +27,14 @@ public:
         virtual ~Sample();
 
         void SetArg(const char* szKey, const char* value);
-        void SetArg(const char* szKey, int value);
-        void SetArg(const char* szKey, size_t value);
-        void SetArg(const char* szKey, bool value);
+        void SetArg(const char* szKey, int64_t value);
+        void SetBool(const char* szKey, bool value);
 
         void Exit();
 
     protected:
         std::string m_name;
-        bool        m_enabled;
+        bool        m_enabled = false;
 
     private:
         TIMEUS m_startTime = 0;

--- a/Shared/sdk/profiler/CPerformanceRecorder.h
+++ b/Shared/sdk/profiler/CPerformanceRecorder.h
@@ -28,6 +28,10 @@ public:
 
         void SetArg(const char* szKey, const char* value);
         void SetArg(const char* szKey, int value);
+        void SetArg(const char* szKey, size_t value);
+        void SetArg(const char* szKey, bool value);
+
+        void Exit();
 
     protected:
         std::string m_name;

--- a/Shared/sdk/profiler/CPerformanceRecorder.h
+++ b/Shared/sdk/profiler/CPerformanceRecorder.h
@@ -1,3 +1,5 @@
+#pragma once
+
 class CPerformanceRecorder
 {
     friend class Sample;

--- a/Shared/sdk/profiler/CPerformanceRecorder.h
+++ b/Shared/sdk/profiler/CPerformanceRecorder.h
@@ -23,10 +23,10 @@ public:
         void SetArg(const char* szKey, int value);
 
     protected:
-        std::string  m_szName;
-        const char*  m_szCategory = "default";
+        std::string m_name;
+        std::string m_category = "default";
     private:
-        TIMEUS       m_start = 0;
+        TIMEUS       m_startTime = 0;
         json_object* m_pObject = nullptr;
         json_object* m_pObjectArgs = nullptr;
     };

--- a/Shared/sdk/profiler/CPerformanceRecorder.h
+++ b/Shared/sdk/profiler/CPerformanceRecorder.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stack>
+
 class CPerformanceRecorder
 {
     friend class Sample;
@@ -8,46 +10,51 @@ public:
     CPerformanceRecorder();
     ~CPerformanceRecorder();
 
-    void Start();
-    void Stop();
-    void Clear();
+    void         Start();
+    void         Stop();
+    void         Clear();
+    void         EnterScope();
+    void         ExitScope();
+    json_object* GetSampleObject();
 
-    bool IsDuringPerformanceRecording() const { return m_bRecordPerformance; }
+    bool        IsDuringPerformanceRecording() const { return m_bRecordPerformance; }
     std::string GetResult();
 
     class Sample
     {
     public:
         Sample(const char* name);
-        ~Sample();
+        virtual ~Sample();
 
         void SetArg(const char* szKey, const char* value);
         void SetArg(const char* szKey, int value);
 
     protected:
         std::string m_name;
-        std::string m_category = "default";
+        bool        m_enabled;
+
     private:
-        TIMEUS       m_startTime = 0;
-        json_object* m_pObject = nullptr;
-        json_object* m_pObjectArgs = nullptr;
+        TIMEUS m_startTime = 0;
     };
 
     class FunctionSample : public Sample
     {
     public:
         FunctionSample(const char* name);
+        ~FunctionSample();
     };
-    
+
     class EventSample : public Sample
     {
     public:
         EventSample(const char* name);
+        ~EventSample();
     };
 
 private:
-    bool m_bRecordPerformance = false;
+    bool   m_bRecordPerformance = false;
     TIMEUS m_start;
 
-    std::stringstream m_strStream;
+    std::stack<json_object*> m_stackSamples;
+    json_object*             m_samples;
 };


### PR DESCRIPTION
This idea was in my head for a long time, people uses "rescpu", popular resource to measure performance, but plain numer "10%" next to resource name does not tell the core of the cpu usage. Flag `-g` does not help too much in figuring out what cause server/client to degradate performance. Performance stats can tell you that some part of mta cause high cpu usage, but don't why, what is the excact source of the problem.

Almost everyone have a chrome or other chromium based browser which i used as a tool to display these information.
Idea is simple: make function that let you generate profile data to see them in chrome devtools:

( Based on image below ) With this amount of information, i can tell that "setElementData" in timer ( location can be seen in "summary" when i click on parent box ) cause the most cpu usage due "onElementDataChange" event, not by broadcasting.

It is very easy to use by mta developers, all you have to do is to put `CPerformanceRecorder::Sample sample("name");`, and everything is handled by you in background, you just set the name.  There are also "FunctionSample" - to take a sample of mta native function, and "EventSample" for events. Optionaly you can use `SetArg` over `sample` to add custom content with important informations in "summary" tab.

In initial pr i want to add original timings, timers, events and setElementData function.

Example data you can test yourself by drag and dropping .json file onto "performance" tab in chrome devtools
[result.zip](https://github.com/multitheftauto/mtasa-blue/files/6175700/result.zip)


test code i used

Functions:
`bool startRecordPerformance()` - start performance recording
`bool stopRecordPerformance()` - stopping, pausing performance recording
`bool clearPerformanceRecorder()` - clearing samples buffer
`bool isPerformanceRecording()` - returns true when performance is recording
`string getRecordedSamples()` - returns string json kind with recorded samples

Test code ( 2 hours of running code below, ~300 executions did not cause any crash, memory leak. ):
```lua
assert(stopRecordPerformance() == false)
assert(isPerformanceRecording() == false)
assert(startRecordPerformance() == true)
assert(isPerformanceRecording() == true)
assert(startRecordPerformance() == false)

setTimer(function()
    setElementData(root, "asdf", math.random());
end,0,0)
for i=1,10 do
    setTimer(function()
        
    end,0,0)
end

setTimer(function()
    for i=1,5000000 do

    end
end,5000,1)

setTimer(function()
    assert(isPerformanceRecording() == true)
    assert(stopRecordPerformance() == true)
    assert(isPerformanceRecording() == false)
end,10000,1)

setTimer(function() -- should not be visible in profiler
    for i=1,5000000 do

    end
end,12500,1)

setTimer(function()
    assert(startRecordPerformance() == true)
    assert(isPerformanceRecording() == true)
end,15000,1)

setTimer(function()
    stopRecordPerformance()
    local data = getRecordedSamples()
    clearPerformanceRecorder()
    assert(getRecordedSamples() == "[]")
    local f = fileCreate("result.json");
    fileWrite(f, data)
    fileClose(f)
    setTimer(function()
        restartResource(getThisResource())
    end,500,1)
end, 20000, 1)
```
Memory usage:
![image](https://user-images.githubusercontent.com/22455534/111871624-77e6b580-898b-11eb-90e1-5fbc1450bdaf.png)

Example generated data:
![image](https://user-images.githubusercontent.com/22455534/111871643-89c85880-898b-11eb-8ad9-2e9a8ec544dc.png)
