### PR TITLE
Fix default floor of ColPolygons being zero, rather than max negative

### DIFF
--- a/Client/mods/deathmatch/logic/CClientColPolygon.h
+++ b/Client/mods/deathmatch/logic/CClientColPolygon.h
@@ -45,7 +45,7 @@ protected:
     void CalculateRadius();
     void CalculateRadius(const CVector2D& vecPoint);
 
-    float m_fRadius;
-    float m_fFloor = std::numeric_limits<float>::min();
+    float m_fRadius = 0.0f;
+    float m_fFloor = std::numeric_limits<float>::lowest();
     float m_fCeil = std::numeric_limits<float>::max();
 };

--- a/Client/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
@@ -829,7 +829,7 @@ bool CLuaColShapeDefs::SetColPolygonHeight(CClientColPolygon* pColPolygon, std::
     float fFloor, fCeil;
 
     if (std::holds_alternative<bool>(floor))
-        fFloor = std::numeric_limits<float>::min();
+        fFloor = std::numeric_limits<float>::lowest();
     else
         fFloor = std::get<float>(floor);
 

--- a/Server/mods/deathmatch/logic/CColPolygon.h
+++ b/Server/mods/deathmatch/logic/CColPolygon.h
@@ -50,7 +50,7 @@ protected:
     void CalculateRadius();
     void CalculateRadius(const CVector2D& vecPoint);
 
-    float m_fRadius;
-    float m_fFloor = std::numeric_limits<float>::min();
+    float m_fRadius = 0.0f;
+    float m_fFloor = std::numeric_limits<float>::lowest();
     float m_fCeil = std::numeric_limits<float>::max();
 };

--- a/Server/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaColShapeDefs.cpp
@@ -809,7 +809,7 @@ bool CLuaColShapeDefs::SetColPolygonHeight(CColPolygon* pColPolygon, std::varian
     float fFloor, fCeil;
 
     if (std::holds_alternative<bool>(floor))
-        fFloor = std::numeric_limits<float>::min();
+        fFloor = std::numeric_limits<float>::lowest();
     else
         fFloor = std::get<float>(floor);
 


### PR DESCRIPTION
Fixes #2140.

> The default is std::numeric_limits<float>::min(), which is the minimum representable positive value for a float (hence a value just above zero). This should be std::numeric_limits<float>::lowest() instead (the minimum negative) value.
