### PR TITLE
Update sqlite from 3.34.0 to 3.35.2

### DIFF
--- a/vendor/sqlite/premake5.lua
+++ b/vendor/sqlite/premake5.lua
@@ -15,7 +15,7 @@ project "sqlite"
 		"*.c"
 	}
 
-	defines { "SQLITE_ENABLE_MATH_FUNCTIONS" }
+	defines { "SQLITE_ENABLE_MATH_FUNCTIONS", "SQLITE_ENABLE_JSON1" }
 
 	filter {"system:windows"}
 		disablewarnings { "4996" }

--- a/vendor/sqlite/premake5.lua
+++ b/vendor/sqlite/premake5.lua
@@ -15,5 +15,7 @@ project "sqlite"
 		"*.c"
 	}
 
+	defines { "SQLITE_ENABLE_MATH_FUNCTIONS" }
+
 	filter {"system:windows"}
 		disablewarnings { "4996" }

--- a/vendor/sqlite/sqlite3.h
+++ b/vendor/sqlite/sqlite3.h
@@ -123,9 +123,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.34.0"
-#define SQLITE_VERSION_NUMBER 3034000
-#define SQLITE_SOURCE_ID      "2020-12-01 16:14:00 a26b6597e3ae272231b96f9982c3bcc17ddec2f2b6eb4df06a224b91089fed5b"
+#define SQLITE_VERSION        "3.35.2"
+#define SQLITE_VERSION_NUMBER 3035002
+#define SQLITE_SOURCE_ID      "2021-03-17 19:07:21 ea80f3002f4120f5dcee76e8779dfdc88e1e096c5cdd06904c20fd26d50c3827"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers
@@ -2115,7 +2115,13 @@ struct sqlite3_mem_methods {
 ** The second parameter is a pointer to an integer into which
 ** is written 0 or 1 to indicate whether triggers are disabled or enabled
 ** following this call.  The second parameter may be a NULL pointer, in
-** which case the trigger setting is not reported back. </dd>
+** which case the trigger setting is not reported back.
+**
+** <p>Originally this option disabled all triggers.  ^(However, since
+** SQLite version 3.35.0, TEMP triggers are still allowed even if
+** this option is off.  So, in other words, this option now only disables
+** triggers in the main database schema or in the schemas of ATTACH-ed
+** databases.)^ </dd>
 **
 ** [[SQLITE_DBCONFIG_ENABLE_VIEW]]
 ** <dt>SQLITE_DBCONFIG_ENABLE_VIEW</dt>
@@ -2126,7 +2132,13 @@ struct sqlite3_mem_methods {
 ** The second parameter is a pointer to an integer into which
 ** is written 0 or 1 to indicate whether views are disabled or enabled
 ** following this call.  The second parameter may be a NULL pointer, in
-** which case the view setting is not reported back. </dd>
+** which case the view setting is not reported back.
+**
+** <p>Originally this option disabled all views.  ^(However, since
+** SQLite version 3.35.0, TEMP views are still allowed even if
+** this option is off.  So, in other words, this option now only disables
+** views in the main database schema or in the schemas of ATTACH-ed
+** databases.)^ </dd>
 **
 ** [[SQLITE_DBCONFIG_ENABLE_FTS3_TOKENIZER]]
 ** <dt>SQLITE_DBCONFIG_ENABLE_FTS3_TOKENIZER</dt>
@@ -3499,6 +3511,7 @@ SQLITE_API void sqlite3_progress_handler(sqlite3*, int, int(*)(void*), void*);
 **          that uses dot-files in place of posix advisory locking.
 ** <tr><td> file:data.db?mode=readonly <td>
 **          An error. "readonly" is not a valid option for the "mode" parameter.
+**          Use "ro" instead:  "file:data.db?mode=ro".
 ** </table>
 **
 ** ^URI hexadecimal escape sequences (%HH) are supported within the path and
@@ -3697,7 +3710,7 @@ SQLITE_API sqlite3_file *sqlite3_database_file_object(const char*);
 ** If the Y parameter to sqlite3_free_filename(Y) is anything other
 ** than a NULL pointer or a pointer previously acquired from
 ** sqlite3_create_filename(), then bad things such as heap
-** corruption or segfaults may occur. The value Y should be
+** corruption or segfaults may occur. The value Y should not be
 ** used again after sqlite3_free_filename(Y) has been called.  This means
 ** that if the [sqlite3_vfs.xOpen()] method of a VFS has been called using Y,
 ** then the corresponding [sqlite3_module.xClose() method should also be
@@ -7765,7 +7778,8 @@ SQLITE_API int sqlite3_test_control(int op, ...);
 #define SQLITE_TESTCTRL_PRNG_SEED               28
 #define SQLITE_TESTCTRL_EXTRA_SCHEMA_CHECKS     29
 #define SQLITE_TESTCTRL_SEEK_COUNT              30
-#define SQLITE_TESTCTRL_LAST                    30  /* Largest TESTCTRL */
+#define SQLITE_TESTCTRL_TRACEFLAGS              31
+#define SQLITE_TESTCTRL_LAST                    31  /* Largest TESTCTRL */
 
 /*
 ** CAPI3REF: SQL Keyword Checking
@@ -10439,6 +10453,14 @@ SQLITE_API int sqlite3session_patchset(
 SQLITE_API int sqlite3session_isempty(sqlite3_session *pSession);
 
 /*
+** CAPI3REF: Query for the amount of heap memory used by a session object.
+**
+** This API returns the total amount of heap memory in bytes currently
+** used by the session object passed as the only argument.
+*/
+SQLITE_API sqlite3_int64 sqlite3session_memory_used(sqlite3_session *pSession);
+
+/*
 ** CAPI3REF: Create An Iterator To Traverse A Changeset
 ** CONSTRUCTOR: sqlite3_changeset_iter
 **
@@ -10540,18 +10562,23 @@ SQLITE_API int sqlite3changeset_next(sqlite3_changeset_iter *pIter);
 ** call to [sqlite3changeset_next()] must have returned [SQLITE_ROW]. If this
 ** is not the case, this function returns [SQLITE_MISUSE].
 **
-** If argument pzTab is not NULL, then *pzTab is set to point to a
-** nul-terminated utf-8 encoded string containing the name of the table
-** affected by the current change. The buffer remains valid until either
-** sqlite3changeset_next() is called on the iterator or until the
-** conflict-handler function returns. If pnCol is not NULL, then *pnCol is
-** set to the number of columns in the table affected by the change. If
-** pbIndirect is not NULL, then *pbIndirect is set to true (1) if the change
+** Arguments pOp, pnCol and pzTab may not be NULL. Upon return, three
+** outputs are set through these pointers:
+**
+** *pOp is set to one of [SQLITE_INSERT], [SQLITE_DELETE] or [SQLITE_UPDATE],
+** depending on the type of change that the iterator currently points to;
+**
+** *pnCol is set to the number of columns in the table affected by the change; and
+**
+** *pzTab is set to point to a nul-terminated utf-8 encoded string containing
+** the name of the table affected by the current change. The buffer remains
+** valid until either sqlite3changeset_next() is called on the iterator
+** or until the conflict-handler function returns.
+**
+** If pbIndirect is not NULL, then *pbIndirect is set to true (1) if the change
 ** is an indirect change, or false (0) otherwise. See the documentation for
 ** [sqlite3session_indirect()] for a description of direct and indirect
-** changes. Finally, if pOp is not NULL, then *pOp is set to one of
-** [SQLITE_INSERT], [SQLITE_DELETE] or [SQLITE_UPDATE], depending on the
-** type of change that the iterator currently points to.
+** changes.
 **
 ** If no error occurs, SQLITE_OK is returned. If an error does occur, an
 ** SQLite error code is returned. The values of the output variables may not


### PR DESCRIPTION
## Summary
- Contains various new features and some other minor changes and fixes
- Enable [math functions](https://www.sqlite.org/lang_mathfunc.html) in SQLite
- Enable [json functions](https://www.sqlite.org/json1.html) in SQLite
- Changelogs
  - https://www.sqlite.org/changes.html#version_3_35_2
  - https://www.sqlite.org/changes.html#version_3_35_1
  - https://www.sqlite.org/changes.html#version_3_35_0

## Tests
Tested with [test_sqlite.zip](https://github.com/multitheftauto/mtasa-blue/files/2872064/test_sqlite.zip) (cheers to botder)

## Validation
To help validate the integrity of the update I have created the following bash script that diffs between my PR branch and the official package provided from the [SQLite website](https://www.sqlite.org/download.html).
```bash
#!/bin/bash

SQLITE_UPDATE_VERSION=3.35.2
SQLITE_PATH_NAME=sqlite-$SQLITE_UPDATE_VERSION

GIT_REPO_BRANCH=vendor/sqlite-$SQLITE_UPDATE_VERSION
GIT_REPO_URL=https://github.com/patrikjuvonen/mtasa-blue.git
GIT_REPO_SQLITE_PATH=vendor/sqlite/

echo 1. Download and extract $SQLITE_PATH_NAME...
curl https://www.sqlite.org/2021/sqlite-autoconf-3350200.tar.gz | tar -xz

echo 2. Fetch and checkout the vendor update branch $GIT_REPO_BRANCH from $GIT_REPO_URL...
git fetch $GIT_REPO_URL $GIT_REPO_BRANCH:$GIT_REPO_BRANCH
git checkout $GIT_REPO_BRANCH

echo 3. Start checking integrity...
diff -r --strip-trailing-cr $GIT_REPO_SQLITE_PATH sqlite-*

echo 4. Completed.
exec $SHELL
```

## Past SQLite updates in MTA
| Date | From | To | Link |
| :--- | :--- | :--- | :--- |
| December 2020 | 3.32.3 | 3.34.0 (current) | #1960 |
| July 2020 | 3.31.1 | 3.32.3 | #1561 |
| March 2020 | 3.30.1 | 3.31.1 | #1260 |
| November 2019 | 3.29.0 | 3.30.1 | #1160 |
| August 2019 | 3.28.0 | 3.29.0 | #1028 |
| May 2019 | 3.27.1 | 3.28.0 | #913 |
| February 2019 | 3.24.0 | 3.27.1 | #818 |
| July 2018 | 3.13.0 | 3.24.0 | #245 |
| August 2016 | 3.7.17 | 3.13.0 | 3aa17532867c66818cc3a602c4b1ac2143694066 |
| August 2013 | 3.7.8 | 3.7.17 | fd195b799498f75496fe0c15adac3cab3aecb639 |
| October 2011 | 3.6.14 | 3.7.8 | ca063630631d56d5ba9aba5bf6771fe0299f5a9f |

## Changelog
### 2021-03-17 (3.35.2)
1. Fix a problem in the appendvfs.c extension that was introduced into version 3.35.0.
1. Ensure that date/time functions with no arguments (which generate responses that depend on the current time) are treated as non-deterministic functions. Ticket 2c6c8689fb5f3d2f
1. Fix a problem in the sqldiff utility program having to do with unusual whitespace characters in a virtual table definition.
1. Limit the new UNION ALL optimization described by item 8c in the 3.35.0 release so that it does not try to make too many new subqueries. See forum thread 140a67d3d2 for details.

### 2021-03-15 (3.35.1)
1. Fix a bug in the new DROP COLUMN feature when used on columns that are indexed and that are quoted in the index definition.
1. Improve the built-in documentation for the .dump command in the CLI.

### 2021-03-12 (3.35.0)
1. Added built-in SQL math functions(). (Requires the -DSQLITE_ENABLE_MATH_FUNCTIONS compile-time option.)
1. Added support for ALTER TABLE DROP COLUMN.
1. Generalize UPSERT:
  a. Allow multiple ON CONFLICT clauses that are evaluated in order,
  b. The final ON CONFLICT clause may omit the conflict target and yet still use DO UPDATE.
1. Add support for the RETURNING clause on DELETE, INSERT, and UPDATE statements.
1. Use less memory when running VACUUM on databases containing very large TEXT or BLOB values. It is no longer necessary to hold the entire TEXT or BLOB in memory all at once.
1. Add support for the MATERIALIZED and NOT MATERIALIZED hints when specifying common table expressions. The default behavior was formerly NOT MATERIALIZED, but is now changed to MATERIALIZED for CTEs that are used more than once.
1. The SQLITE_DBCONFIG_ENABLE_TRIGGER and SQLITE_DBCONFIG_ENABLE_VIEW settings are modified so that they only control triggers and views in the main database schema or in attached database schemas and not in the TEMP schema. TEMP triggers and views are always allowed.
1. Query planner/optimizer improvements:
  a. Enhancements to the min/max optimization so that it works better with the IN operator and the OP_SeekScan optimization of the previous release.
  b. Attempt to process EXISTS operators in the WHERE clause as if they were IN operators, in cases where this is a valid transformation and seems likely to improve performance.
  c. Allow UNION ALL sub-queries to be flattened even if the parent query is a join.
  d. Use an index, if appropriate, on IS NOT NULL expressions in the WHERE clause, even if STAT4 is disabled.
  e. Expressions of the form "x IS NULL" or "x IS NOT NULL" might be converted to simply FALSE or TRUE, if "x" is a column that has a "NOT NULL" constraint and is not involved in an outer join.
  f. Avoid checking foreign key constraints on an UPDATE statement if the UPDATE does not modify any columns associated with the foreign key.
  g. Allow WHERE terms to be pushed down into sub-queries that contain window functions, as long as the WHERE term is made up of entirely of constants and copies of expressions found in the PARTITION BY clauses of all window functions in the sub-query.
1. Bug fixes:
  a. Fix a potential NULL pointer dereference when processing a syntactically incorrect SELECT statement with a correlated WHERE clause and a "HAVING 0" clause. (Also fixed in the 3.34.1 patch release.)
  b. Fix a bug in the IN-operator optimization of version 3.33.0 that can cause an incorrect answer.
  c. Fix incorrect answers from the LIKE operator if the pattern ends with "%" and there is an "ESCAPE '_'" clause.