### PR TITLE
Add lua_getowner for fast access to owner resource

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -143,7 +143,7 @@ void CLuaMain::InitVM()
     assert(!m_luaVM);
 
     // Create a new VM
-    m_luaVM = lua_open();
+    m_luaVM = lua_open(this);
     m_pLuaManager->OnLuaMainOpenVM(this, m_luaVM);
 
     // Set the instruction count hook

--- a/Client/mods/deathmatch/logic/lua/LuaCommon.cpp
+++ b/Client/mods/deathmatch/logic/lua/LuaCommon.cpp
@@ -192,6 +192,16 @@ void lua_pushmatrix(lua_State* luaVM, const CMatrix& matrix)
     lua_addtotalbytes(luaVM, LUA_GC_EXTRA_BYTES);
 }
 
+CLuaMain* lua_getmtasacluamain(lua_State* L)
+{
+    return static_cast<class CLuaMain*>(lua_getmtasaowner(L));
+}
+
+CResource* lua_getmtasaresource(lua_State* L)
+{
+    return lua_getmtasacluamain(L)->GetResource();
+}
+
 // Just do a type check vs LUA_TNONE before calling this, or bant
 const char* lua_makestring(lua_State* luaVM, int iArgument)
 {

--- a/Client/mods/deathmatch/logic/lua/LuaCommon.cpp
+++ b/Client/mods/deathmatch/logic/lua/LuaCommon.cpp
@@ -192,14 +192,14 @@ void lua_pushmatrix(lua_State* luaVM, const CMatrix& matrix)
     lua_addtotalbytes(luaVM, LUA_GC_EXTRA_BYTES);
 }
 
-CLuaMain* lua_getmtasacluamain(lua_State* L)
+CLuaMain& lua_getownercluamain(lua_State* L)
 {
-    return static_cast<class CLuaMain*>(lua_getmtasaowner(L));
+    return *static_cast<class CLuaMain*>(lua_getmtasaowner(L));
 }
 
-CResource* lua_getmtasaresource(lua_State* L)
+CResource& lua_getownerresource(lua_State* L)
 {
-    return lua_getmtasacluamain(L)->GetResource();
+    return *lua_getownercluamain(L).GetResource();
 }
 
 // Just do a type check vs LUA_TNONE before calling this, or bant

--- a/Client/mods/deathmatch/logic/lua/LuaCommon.h
+++ b/Client/mods/deathmatch/logic/lua/LuaCommon.h
@@ -78,6 +78,9 @@ void lua_classmetamethod(lua_State* luaVM, const char* szName, lua_CFunction fn)
 
 const char* lua_makestring(lua_State* luaVM, int iArgument);
 
+class CLuaMain* lua_getownercluamain(lua_State* L);
+class CResource* lua_getownerresource(lua_State* L);
+
 // Lua debug info for logging
 enum
 {

--- a/Client/mods/deathmatch/logic/lua/LuaCommon.h
+++ b/Client/mods/deathmatch/logic/lua/LuaCommon.h
@@ -78,8 +78,8 @@ void lua_classmetamethod(lua_State* luaVM, const char* szName, lua_CFunction fn)
 
 const char* lua_makestring(lua_State* luaVM, int iArgument);
 
-class CLuaMain* lua_getownercluamain(lua_State* L);
-class CResource* lua_getownerresource(lua_State* L);
+class CLuaMain& lua_getownercluamain(lua_State* L);
+class CResource& lua_getownerresource(lua_State* L);
 
 // Lua debug info for logging
 enum

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -172,7 +172,7 @@ void CLuaMain::InitVM()
     assert(!m_luaVM);
 
     // Create a new VM
-    m_luaVM = lua_open(m_pResource);
+    m_luaVM = lua_open(this);
     m_pLuaManager->OnLuaMainOpenVM(this, m_luaVM);
 
     // Set the instruction count hook

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -172,7 +172,7 @@ void CLuaMain::InitVM()
     assert(!m_luaVM);
 
     // Create a new VM
-    m_luaVM = lua_open();
+    m_luaVM = lua_open(m_pResource);
     m_pLuaManager->OnLuaMainOpenVM(this, m_luaVM);
 
     // Set the instruction count hook

--- a/Server/mods/deathmatch/logic/lua/LuaCommon.cpp
+++ b/Server/mods/deathmatch/logic/lua/LuaCommon.cpp
@@ -274,6 +274,16 @@ void lua_pushmatrix(lua_State* luaVM, const CMatrix& matrix)
     lua_addtotalbytes(luaVM, LUA_GC_EXTRA_BYTES);
 }
 
+CLuaMain* lua_getownercluamain(lua_State* L)
+{
+    return static_cast<class CLuaMain*>(lua_getmtasaowner(L));
+}
+
+CResource* lua_getownerresource(lua_State* L)
+{
+    return lua_getownercluamain(L)->GetResource();
+}
+
 // Just do a type check vs LUA_TNONE before calling this, or bant
 const char* lua_makestring(lua_State* luaVM, int iArgument)
 {

--- a/Server/mods/deathmatch/logic/lua/LuaCommon.cpp
+++ b/Server/mods/deathmatch/logic/lua/LuaCommon.cpp
@@ -274,14 +274,14 @@ void lua_pushmatrix(lua_State* luaVM, const CMatrix& matrix)
     lua_addtotalbytes(luaVM, LUA_GC_EXTRA_BYTES);
 }
 
-CLuaMain* lua_getownercluamain(lua_State* L)
+CLuaMain& lua_getownercluamain(lua_State* L)
 {
-    return static_cast<class CLuaMain*>(lua_getmtasaowner(L));
+    return *static_cast<class CLuaMain*>(lua_getmtasaowner(L));
 }
 
-CResource* lua_getownerresource(lua_State* L)
+CResource& lua_getownerresource(lua_State* L)
 {
-    return lua_getownercluamain(L)->GetResource();
+    return *lua_getownercluamain(L).GetResource();
 }
 
 // Just do a type check vs LUA_TNONE before calling this, or bant

--- a/Server/mods/deathmatch/logic/lua/LuaCommon.h
+++ b/Server/mods/deathmatch/logic/lua/LuaCommon.h
@@ -45,6 +45,9 @@ void lua_pushvector(lua_State* luaVM, const CVector& vector);
 void lua_pushvector(lua_State* luaVM, const CVector4D& vector);
 void lua_pushmatrix(lua_State* luaVM, const CMatrix& matrix);
 
+class CLuaMain* lua_getownercluamain(lua_State* L);
+class CResource* lua_getownerresource(lua_State* L);
+
 // Converts any type to string
 const char* lua_makestring(lua_State* luaVM, int iArgument);
 

--- a/Server/mods/deathmatch/logic/lua/LuaCommon.h
+++ b/Server/mods/deathmatch/logic/lua/LuaCommon.h
@@ -45,8 +45,8 @@ void lua_pushvector(lua_State* luaVM, const CVector& vector);
 void lua_pushvector(lua_State* luaVM, const CVector4D& vector);
 void lua_pushmatrix(lua_State* luaVM, const CMatrix& matrix);
 
-class CLuaMain* lua_getownercluamain(lua_State* L);
-class CResource* lua_getownerresource(lua_State* L);
+class CLuaMain& lua_getownercluamain(lua_State* L);
+class CResource& lua_getownerresource(lua_State* L);
 
 // Converts any type to string
 const char* lua_makestring(lua_State* luaVM, int iArgument);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDefs.cpp
@@ -10,6 +10,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include <lua/LuaCommon.h>
 extern uint g_uiNetSentByteCounter;
 
 namespace
@@ -115,8 +116,7 @@ int CLuaDefs::CanUseFunction(lua_CFunction f, lua_State* luaVM)
     }
     
     // Get associated resource
-    auto pLuaMain{ static_cast<CLuaMain*>(lua_getmtasaowner(luaVM)) };
-    auto pResource{ pLuaMain->GetResource() };
+    auto pResource{ lua_getownerresource(luaVM) };
 
     // Update execution time check
     pResource->GetVirtualMachine()->CheckExecutionTime();

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDefs.cpp
@@ -10,7 +10,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
-#include <lua/LuaCommon.h>
+#include "lua/LuaCommon.h"
 extern uint g_uiNetSentByteCounter;
 
 namespace

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDefs.cpp
@@ -113,9 +113,10 @@ int CLuaDefs::CanUseFunction(lua_CFunction f, lua_State* luaVM)
     {
         return true;
     }
-
+    
     // Get associated resource
-    auto pResource{static_cast<CResource*>(lua_getowner(luaVM))};
+    auto pLuaMain{ static_cast<CLuaMain*>(lua_getowner(luaVM)) };
+    auto pResource{ pLuaMain->GetResource() };
 
     // Update execution time check
     pResource->GetVirtualMachine()->CheckExecutionTime();

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDefs.cpp
@@ -116,16 +116,16 @@ int CLuaDefs::CanUseFunction(lua_CFunction f, lua_State* luaVM)
     }
     
     // Get associated resource
-    auto pResource{ lua_getownerresource(luaVM) };
+    CResource& resource{ lua_getownerresource(luaVM) };
 
     // Update execution time check
-    pResource->GetVirtualMachine()->CheckExecutionTime();
+    resource.GetVirtualMachine()->CheckExecutionTime();
 
     // Check function right cache in resource
     bool bAllowed;
 
     // Check cached ACL rights
-    if (pResource->CheckFunctionRightCache(f, &bAllowed))
+    if (resource.CheckFunctionRightCache(f, &bAllowed))
     {
         // If in cache, and not allowed, do warning here
         if (!bAllowed)
@@ -167,7 +167,7 @@ int CLuaDefs::CanUseFunction(lua_CFunction f, lua_State* luaVM)
             }
         }
         // Update cache in resource
-        pResource->UpdateFunctionRightCache(f, bAllowed);
+        resource.UpdateFunctionRightCache(f, bAllowed);
     }
 
     if (!g_pGame->GetDebugHookManager()->OnPreFunction(f, luaVM, bAllowed))

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDefs.cpp
@@ -115,9 +115,7 @@ int CLuaDefs::CanUseFunction(lua_CFunction f, lua_State* luaVM)
     }
 
     // Get associated resource
-    CResource* pResource = m_pResourceManager->GetResourceFromLuaState(luaVM);
-    if (!pResource)
-        return true;
+    auto pResource{static_cast<CResource*>(lua_getowner(luaVM))};
 
     // Update execution time check
     pResource->GetVirtualMachine()->CheckExecutionTime();

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDefs.cpp
@@ -115,7 +115,7 @@ int CLuaDefs::CanUseFunction(lua_CFunction f, lua_State* luaVM)
     }
     
     // Get associated resource
-    auto pLuaMain{ static_cast<CLuaMain*>(lua_getowner(luaVM)) };
+    auto pLuaMain{ static_cast<CLuaMain*>(lua_getmtasaowner(luaVM)) };
     auto pResource{ pLuaMain->GetResource() };
 
     // Update execution time check

--- a/vendor/lua/src/lapi.c
+++ b/vendor/lua/src/lapi.c
@@ -1140,3 +1140,9 @@ LUA_API int lua_ncallresult(lua_State *L)
 {
     return L->nexpectedresults;
 }
+
+// MTA Addition to access `owner` value
+LUA_API void *lua_getowner(lua_State* L)
+{
+    return G(L)->owner;
+}

--- a/vendor/lua/src/lapi.c
+++ b/vendor/lua/src/lapi.c
@@ -1142,7 +1142,7 @@ LUA_API int lua_ncallresult(lua_State *L)
 }
 
 // MTA Addition to access `owner` value
-LUA_API void *lua_getowner(lua_State* L)
+LUA_API void *lua_getmtasaowner(lua_State* L)
 {
-    return G(L)->owner;
+    return G(L)->mtasaowner;
 }

--- a/vendor/lua/src/lauxlib.c
+++ b/vendor/lua/src/lauxlib.c
@@ -644,8 +644,8 @@ static int panic (lua_State *L) {
 }
 
 
-LUALIB_API lua_State *luaL_newstate (void* owner) {
-  lua_State *L = lua_newstate(l_alloc, NULL, owner);
+LUALIB_API lua_State *luaL_newstate (void* mtasaowner) {
+  lua_State *L = lua_newstate(l_alloc, NULL, mtasaowner);
   if (L) lua_atpanic(L, &panic);
   return L;
 }

--- a/vendor/lua/src/lauxlib.c
+++ b/vendor/lua/src/lauxlib.c
@@ -644,8 +644,8 @@ static int panic (lua_State *L) {
 }
 
 
-LUALIB_API lua_State *luaL_newstate (void) {
-  lua_State *L = lua_newstate(l_alloc, NULL);
+LUALIB_API lua_State *luaL_newstate (void* owner) {
+  lua_State *L = lua_newstate(l_alloc, NULL, owner);
   if (L) lua_atpanic(L, &panic);
   return L;
 }

--- a/vendor/lua/src/lauxlib.h
+++ b/vendor/lua/src/lauxlib.h
@@ -79,7 +79,7 @@ LUALIB_API int (luaL_loadbuffer) (lua_State *L, const char *buff, size_t sz,
                                   const char *name);
 LUALIB_API int (luaL_loadstring) (lua_State *L, const char *s);
 
-LUALIB_API lua_State *(luaL_newstate) (void *owner);
+LUALIB_API lua_State *(luaL_newstate) (void *mtasaowner);
 
 
 LUALIB_API const char *(luaL_gsub) (lua_State *L, const char *s, const char *p,

--- a/vendor/lua/src/lauxlib.h
+++ b/vendor/lua/src/lauxlib.h
@@ -79,7 +79,7 @@ LUALIB_API int (luaL_loadbuffer) (lua_State *L, const char *buff, size_t sz,
                                   const char *name);
 LUALIB_API int (luaL_loadstring) (lua_State *L, const char *s);
 
-LUALIB_API lua_State *(luaL_newstate) (void);
+LUALIB_API lua_State *(luaL_newstate) (void *owner);
 
 
 LUALIB_API const char *(luaL_gsub) (lua_State *L, const char *s, const char *p,

--- a/vendor/lua/src/lstate.c
+++ b/vendor/lua/src/lstate.c
@@ -140,7 +140,7 @@ void luaE_freethread (lua_State *L, lua_State *L1) {
 }
 
 
-LUA_API lua_State *lua_newstate (lua_Alloc f, void *ud) {
+LUA_API lua_State *lua_newstate (lua_Alloc f, void *ud, void *owner) {
   int i;
   lua_State *L;
   global_State *g;
@@ -156,6 +156,7 @@ LUA_API lua_State *lua_newstate (lua_Alloc f, void *ud) {
   preinit_state(L, g);
   g->frealloc = f;
   g->ud = ud;
+  g->owner = owner;
   g->mainthread = L;
   g->uvhead.u.l.prev = &g->uvhead;
   g->uvhead.u.l.next = &g->uvhead;
@@ -222,4 +223,3 @@ LUA_API lua_State* lua_getmainstate (lua_State *L) {
     }
     return L;
 }
-

--- a/vendor/lua/src/lstate.c
+++ b/vendor/lua/src/lstate.c
@@ -140,7 +140,7 @@ void luaE_freethread (lua_State *L, lua_State *L1) {
 }
 
 
-LUA_API lua_State *lua_newstate (lua_Alloc f, void *ud, void *owner) {
+LUA_API lua_State *lua_newstate (lua_Alloc f, void *ud, void *mtasaowner) {
   int i;
   lua_State *L;
   global_State *g;
@@ -156,7 +156,7 @@ LUA_API lua_State *lua_newstate (lua_Alloc f, void *ud, void *owner) {
   preinit_state(L, g);
   g->frealloc = f;
   g->ud = ud;
-  g->owner = owner;
+  g->mtasaowner = mtasaowner;
   g->mainthread = L;
   g->uvhead.u.l.prev = &g->uvhead;
   g->uvhead.u.l.next = &g->uvhead;

--- a/vendor/lua/src/lstate.h
+++ b/vendor/lua/src/lstate.h
@@ -93,7 +93,7 @@ typedef struct global_State {
   TString *tmname[TM_N];  /* array with tag-method names */
 
   /* MTA Specific stuff */
-  void *owner;  /* pointer to this VM's CLuaMain */
+  void *mtasaowner;  /* pointer to this state's CLuaMain */
 } global_State;
 
 

--- a/vendor/lua/src/lstate.h
+++ b/vendor/lua/src/lstate.h
@@ -91,6 +91,9 @@ typedef struct global_State {
   UpVal uvhead;  /* head of double-linked list of all open upvalues */
   struct Table *mt[NUM_TAGS];  /* metatables for basic types */
   TString *tmname[TM_N];  /* array with tag-method names */
+
+  /* MTA Specific stuff */
+  void *owner;  /* pointer to owner CResource */
 } global_State;
 
 

--- a/vendor/lua/src/lstate.h
+++ b/vendor/lua/src/lstate.h
@@ -93,7 +93,7 @@ typedef struct global_State {
   TString *tmname[TM_N];  /* array with tag-method names */
 
   /* MTA Specific stuff */
-  void *owner;  /* pointer to owner CResource */
+  void *owner;  /* pointer to this VM's CLuaMain */
 } global_State;
 
 

--- a/vendor/lua/src/lua.h
+++ b/vendor/lua/src/lua.h
@@ -119,7 +119,7 @@ typedef LUA_INTEGER lua_Integer;
 /*
 ** state manipulation
 */
-LUA_API lua_State *(lua_newstate) (lua_Alloc f, void *ud, void *owner);
+LUA_API lua_State *(lua_newstate) (lua_Alloc f, void *ud, void *mtasaowner);
 LUA_API void       (lua_close) (lua_State *L);
 LUA_API lua_State *(lua_newthread) (lua_State *L);
 
@@ -128,7 +128,7 @@ LUA_API lua_CFunction (lua_atpanic) (lua_State *L, lua_CFunction panicf);
 // MTA Specific functions.
 // ChrML: Added function to get the main state from a lua state that is a coroutine
 LUA_API lua_State* (lua_getmainstate) (lua_State* L);
-LUA_API void *lua_getowner(lua_State* L);
+LUA_API void *lua_getmtasaowner(lua_State* L);
 
 /*
 ** basic stack manipulation
@@ -308,7 +308,7 @@ LUA_API void lua_setallocf (lua_State *L, lua_Alloc f, void *ud);
 ** compatibility macros and functions
 */
 
-#define lua_open(owner)	    luaL_newstate(owner)
+#define lua_open(mtasaowner)	    luaL_newstate(mtasaowner)
 
 #define lua_getregistry(L)	lua_pushvalue(L, LUA_REGISTRYINDEX)
 

--- a/vendor/lua/src/lua.h
+++ b/vendor/lua/src/lua.h
@@ -56,6 +56,7 @@ typedef int (*lua_CFunction) (lua_State *L);
 */
 typedef int (*lua_PreCallHook) ( lua_CFunction f, lua_State* L );
 LUA_API void lua_registerPreCallHook ( lua_PreCallHook f );
+
 typedef void (*lua_PostCallHook) ( lua_CFunction f, lua_State* L );
 LUA_API void lua_registerPostCallHook ( lua_PostCallHook f );
 
@@ -118,7 +119,7 @@ typedef LUA_INTEGER lua_Integer;
 /*
 ** state manipulation
 */
-LUA_API lua_State *(lua_newstate) (lua_Alloc f, void *ud);
+LUA_API lua_State *(lua_newstate) (lua_Alloc f, void *ud, void *owner);
 LUA_API void       (lua_close) (lua_State *L);
 LUA_API lua_State *(lua_newthread) (lua_State *L);
 
@@ -127,6 +128,7 @@ LUA_API lua_CFunction (lua_atpanic) (lua_State *L, lua_CFunction panicf);
 // MTA Specific functions.
 // ChrML: Added function to get the main state from a lua state that is a coroutine
 LUA_API lua_State* (lua_getmainstate) (lua_State* L);
+LUA_API void *lua_getowner(lua_State* L);
 
 /*
 ** basic stack manipulation
@@ -306,7 +308,7 @@ LUA_API void lua_setallocf (lua_State *L, lua_Alloc f, void *ud);
 ** compatibility macros and functions
 */
 
-#define lua_open()	luaL_newstate()
+#define lua_open(owner)	    luaL_newstate(owner)
 
 #define lua_getregistry(L)	lua_pushvalue(L, LUA_REGISTRYINDEX)
 


### PR DESCRIPTION
I dont like modifying vendor libraries, but we 've already modified Lua here and there, so this small addition won't hurt anyone.
This small change speeds up the API by at least 5%.
Ultimately we could refactor all the old code to use this function.