### PR TITLE
Add new events onPlayerWeaponGiven and onPlayerWeapon(s)Taken

### DIFF
--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -1582,7 +1582,7 @@ void CGame::AddBuiltInEvents()
     m_Events.AddEvent("onPlayerWeaponFire", "weapon, endX, endY, endZ, hitElement, startX, startY, startZ", NULL, false);
     m_Events.AddEvent("onPlayerWeaponGiven", "weapon", NULL, false);
     m_Events.AddEvent("onPlayerWeaponTaken", "weapon", NULL, false);
-    m_Events.AddEvent("onPlayerWeaponsTaken", "weapon", NULL, false);
+    m_Events.AddEvent("onPlayerWeaponsTaken", "", NULL, false);
 }
 
 void CGame::ProcessTrafficLights(long long llCurrentTime)

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -1580,6 +1580,9 @@ void CGame::AddBuiltInEvents()
     // Weapon events
     m_Events.AddEvent("onWeaponFire", "", NULL, false);
     m_Events.AddEvent("onPlayerWeaponFire", "weapon, endX, endY, endZ, hitElement, startX, startY, startZ", NULL, false);
+    m_Events.AddEvent("onPlayerWeaponGiven", "weapon", NULL, false);
+    m_Events.AddEvent("onPlayerWeaponTaken", "weapon", NULL, false);
+    m_Events.AddEvent("onPlayerWeaponsTaken", "weapon", NULL, false);
 }
 
 void CGame::ProcessTrafficLights(long long llCurrentTime)


### PR DESCRIPTION
When this PR is merged it should fix #2157.

I would like second thoughts on whether I should add these events for peds as well, for e.g:
onPedWeaponGiven, onPedWeaponTaken, onPedWeaponsTaken because events like onPlayerWeaponSwitch and onPedWeaponSwitch are separate but have the same function signature. Maybe they aren't needed because scripts which do ped stuff generally have checks before giveWeapon/takeWeapon anyway whereas player scripts are more impromptu.
