### PR TITLE
Improve server console input handling

### DIFF
--- a/Server/core/CServerImpl.cpp
+++ b/Server/core/CServerImpl.cpp
@@ -133,8 +133,8 @@ void CServerImpl::Printf(const char* szFormat, ...)
 
 bool CServerImpl::IsRequestingExit()
 {
-#ifdef WIN32
     bool quit = m_bRequestedQuit.load();
+#ifdef WIN32
     m_pThreadCommandQueue->Process(quit, NULL);
 #endif
     return quit;

--- a/Server/core/CServerImpl.h
+++ b/Server/core/CServerImpl.h
@@ -93,8 +93,8 @@ private:
     SString m_strServerPath;
     SString m_strServerModPath;
 
-    bool m_bRequestedQuit;
-    bool m_bRequestedReset;
+    mutable std::atomic<bool> m_bRequestedQuit;
+    bool                      m_bRequestedReset;
 
     wchar_t m_szInputBuffer[255];
     uint    m_uiInputCount;
@@ -107,6 +107,7 @@ private:
     std::vector<std::vector<SString>> m_vecCommandHistory = {{"", ""}};
     uint                              m_uiSelectedCommandHistoryEntry = 0;
 
+    std::thread m_threadConsoleInput;
 #ifdef WIN32
     HANDLE    m_hConsole;
     HANDLE    m_hConsoleInput;


### PR DESCRIPTION
This improvment makes server fps does not affect console typing speed. If you make by accident resource that cause server to hang, you can easier type command to restart/stop resource that cause the problem.

Here's how it works in action:
https://www.youtube.com/watch?v=uJ5BSSbjtjc&feature=youtu.be