### PR TITLE
An option to flip UV on material lines

### DIFF
--- a/Client/core/Graphics/CGraphics.cpp
+++ b/Client/core/Graphics/CGraphics.cpp
@@ -844,7 +844,7 @@ void CGraphics::DrawLine3DQueued(const CVector& vecBegin, const CVector& vecEnd,
 }
 
 void CGraphics::DrawMaterialLine3DQueued(const CVector& vecBegin, const CVector& vecEnd, float fWidth, unsigned long ulColor, CMaterialItem* pMaterial,
-                                         float fU, float fV, float fSizeU, float fSizeV, bool bRelativeUV, bool bUseFaceToward, const CVector& vecFaceToward,
+                                         float fU, float fV, float fSizeU, float fSizeV, bool bRelativeUV, bool bFlipUV, bool bUseFaceToward, const CVector& vecFaceToward,
                                          bool bPostGUI)
 {
     if (g_pCore->IsWindowMinimized())
@@ -858,10 +858,10 @@ void CGraphics::DrawMaterialLine3DQueued(const CVector& vecBegin, const CVector&
 
     // Add it to the queue
     if (bPostGUI && !CCore::GetSingleton().IsMenuVisible())
-        m_pMaterialLine3DBatcherPostGUI->AddLine3D(vecBegin, vecEnd, fWidth, ulColor, pMaterial, fU, fV, fSizeU, fSizeV, bRelativeUV, bUseFaceToward,
+        m_pMaterialLine3DBatcherPostGUI->AddLine3D(vecBegin, vecEnd, fWidth, ulColor, pMaterial, fU, fV, fSizeU, fSizeV, bRelativeUV, bFlipUV, bUseFaceToward,
                                                    vecFaceToward);
     else
-        m_pMaterialLine3DBatcherPreGUI->AddLine3D(vecBegin, vecEnd, fWidth, ulColor, pMaterial, fU, fV, fSizeU, fSizeV, bRelativeUV, bUseFaceToward,
+        m_pMaterialLine3DBatcherPreGUI->AddLine3D(vecBegin, vecEnd, fWidth, ulColor, pMaterial, fU, fV, fSizeU, fSizeV, bRelativeUV, bFlipUV, bUseFaceToward,
                                                   vecFaceToward);
 }
 

--- a/Client/core/Graphics/CGraphics.h
+++ b/Client/core/Graphics/CGraphics.h
@@ -138,8 +138,8 @@ public:
     void DrawLine3DQueued(const CVector& vecBegin, const CVector& vecEnd, float fWidth, unsigned long ulColor, bool bPostGUI);
 
     void DrawMaterialLine3DQueued(const CVector& vecBegin, const CVector& vecEnd, float fWidth, unsigned long ulColor, CMaterialItem* pMaterial, float fU = 0,
-                                  float fV = 0, float fSizeU = 1, float fSizeV = 1, bool bRelativeUV = true, bool bUseFaceToward = false,
-                                  const CVector& vecFaceToward = CVector(), bool bPostGUI = false);
+                                  float fV = 0, float fSizeU = 1, float fSizeV = 1, bool bRelativeUV = true, bool bFlipUV = false, bool bUseFaceToward = false,
+                                  const CVector& vecFaceToward = CVector(), bool bPostGUI = false) override;
 
     void DrawRectQueued(float fX, float fY, float fWidth, float fHeight, unsigned long ulColor, bool bPostGUI, bool bSubPixelPositioning = false);
 

--- a/Client/core/Graphics/CMaterialLine3DBatcher.cpp
+++ b/Client/core/Graphics/CMaterialLine3DBatcher.cpp
@@ -235,13 +235,26 @@ void CMaterialLine3DBatcher::DrawBatch(const CVector& vecCameraPos, uint* pBatch
         const CVector vecA1 = item.vecFrom - vecShift;
         const CVector vecB1 = item.vecTo - vecShift;
 
-        WRITE_PDT_VERTEX(pBuffer, vecA1.fX, vecA1.fY, vecA1.fZ, ulColor, item.fU1, item.fV1);
-        WRITE_PDT_VERTEX(pBuffer, vecA2.fX, vecA2.fY, vecA2.fZ, ulColor, item.fU2, item.fV1);
-        WRITE_PDT_VERTEX(pBuffer, vecB1.fX, vecB1.fY, vecB1.fZ, ulColor, item.fU1, item.fV2);
+        if (item.bFlipUV)
+        {
+            WRITE_PDT_VERTEX(pBuffer, vecA1.fX, vecA1.fY, vecA1.fZ, ulColor, item.fU1, item.fV2);
+            WRITE_PDT_VERTEX(pBuffer, vecA2.fX, vecA2.fY, vecA2.fZ, ulColor, item.fU1, item.fV1);
+            WRITE_PDT_VERTEX(pBuffer, vecB1.fX, vecB1.fY, vecB1.fZ, ulColor, item.fU2, item.fV2);
 
-        WRITE_PDT_VERTEX(pBuffer, vecA2.fX, vecA2.fY, vecA2.fZ, ulColor, item.fU2, item.fV1);
-        WRITE_PDT_VERTEX(pBuffer, vecB2.fX, vecB2.fY, vecB2.fZ, ulColor, item.fU2, item.fV2);
-        WRITE_PDT_VERTEX(pBuffer, vecB1.fX, vecB1.fY, vecB1.fZ, ulColor, item.fU1, item.fV2);
+            WRITE_PDT_VERTEX(pBuffer, vecA2.fX, vecA2.fY, vecA2.fZ, ulColor, item.fU1, item.fV1);
+            WRITE_PDT_VERTEX(pBuffer, vecB2.fX, vecB2.fY, vecB2.fZ, ulColor, item.fU2, item.fV1);
+            WRITE_PDT_VERTEX(pBuffer, vecB1.fX, vecB1.fY, vecB1.fZ, ulColor, item.fU2, item.fV2);
+        }
+        else
+        {
+            WRITE_PDT_VERTEX(pBuffer, vecA1.fX, vecA1.fY, vecA1.fZ, ulColor, item.fU1, item.fV1);
+            WRITE_PDT_VERTEX(pBuffer, vecA2.fX, vecA2.fY, vecA2.fZ, ulColor, item.fU2, item.fV1);
+            WRITE_PDT_VERTEX(pBuffer, vecB1.fX, vecB1.fY, vecB1.fZ, ulColor, item.fU1, item.fV2);
+
+            WRITE_PDT_VERTEX(pBuffer, vecA2.fX, vecA2.fY, vecA2.fZ, ulColor, item.fU2, item.fV1);
+            WRITE_PDT_VERTEX(pBuffer, vecB2.fX, vecB2.fY, vecB2.fZ, ulColor, item.fU2, item.fV2);
+            WRITE_PDT_VERTEX(pBuffer, vecB1.fX, vecB1.fY, vecB1.fZ, ulColor, item.fU1, item.fV2);
+        }
     }
 
     // Set vertex stream
@@ -310,7 +323,7 @@ void CMaterialLine3DBatcher::DrawBatch(const CVector& vecCameraPos, uint* pBatch
 //
 ////////////////////////////////////////////////////////////////
 void CMaterialLine3DBatcher::AddLine3D(const CVector& vecFrom, const CVector& vecTo, float fWidth, ulong ulColor, CMaterialItem* pMaterial, float fU, float fV,
-                                       float fSizeU, float fSizeV, bool bRelativeUV, bool bUseFaceToward, const CVector& vecFaceToward)
+                                       float fSizeU, float fSizeV, bool bRelativeUV, bool bFlipUV, bool bUseFaceToward, const CVector& vecFaceToward)
 {
     if (!pMaterial)
         return;
@@ -330,6 +343,7 @@ void CMaterialLine3DBatcher::AddLine3D(const CVector& vecFrom, const CVector& ve
     item.fV1 = fV;
     item.fU2 = fU + fSizeU;
     item.fV2 = fV + fSizeV;
+    item.bFlipUV = bFlipUV;
     if (!bRelativeUV)
     {
         // If UV's are absolute pixels, then scale the range to 0.0f - 1.0f.

--- a/Client/core/Graphics/CMaterialLine3DBatcher.h
+++ b/Client/core/Graphics/CMaterialLine3DBatcher.h
@@ -19,6 +19,7 @@ struct SMaterialLine3DItem
     CMaterialItem* pMaterial;
     float          fU1, fV1;
     float          fU2, fV2;
+    bool           bFlipUV;
     float          fWidth;
     ulong          ulColor;
     bool           bUseFaceToward;
@@ -39,7 +40,7 @@ public:
     void Flush();
     bool HasItems() { return !m_LineList.empty(); }
     void AddLine3D(const CVector& vecFrom, const CVector& vecTo, float fWidth, ulong ulColor, CMaterialItem* pMaterial, float fU, float fV, float fSizeU,
-                   float fSizeV, bool bRelativeUV, bool bUseFaceToward, const CVector& vecFaceToward);
+                   float fSizeV, bool bRelativeUV, bool bFlipUV, bool bUseFaceToward, const CVector& vecFaceToward);
 
 protected:
     void DrawBatch(const CVector& vecCameraPos, uint* pBatchIndices, uint uiNumBatchLines, CMaterialItem* pMaterial);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -214,13 +214,14 @@ int CLuaDrawingDefs::DxDrawLine3D(lua_State* luaVM)
 
 int CLuaDrawingDefs::DxDrawMaterialLine3D(lua_State* luaVM)
 {
-    //  bool dxDrawMaterialLine3D ( float startX, float startY, float startZ, float endX, float endY, float endZ, element material, int width [, int color =
+    //  bool dxDrawMaterialLine3D ( float startX, float startY, float startZ, float endX, float endY, float endZ, [bool flipUV,] element material, int width [, int color =
     //  white,
     //                          float faceX, float faceY, float faceZ ] )
     CVector          vecBegin;
     CVector          vecEnd;
+    bool             bFlipUV;
     CClientMaterial* pMaterial;
-    float            fWidth;
+    float            fWidth;   
     SColor           color;
     bool             bPostGUI;
     CVector          vecFaceToward;
@@ -229,8 +230,9 @@ int CLuaDrawingDefs::DxDrawMaterialLine3D(lua_State* luaVM)
     CScriptArgReader argStream(luaVM);
     argStream.ReadVector3D(vecBegin);
     argStream.ReadVector3D(vecEnd);
+    argStream.ReadIfNextIsBool(bFlipUV, false);
     argStream.ReadUserData(pMaterial);
-    argStream.ReadNumber(fWidth);
+    argStream.ReadNumber(fWidth);    
     argStream.ReadColor(color, 0xFFFFFFFF);
     argStream.ReadIfNextIsBool(bPostGUI, false);
     if (argStream.NextIsVector3D())
@@ -241,7 +243,7 @@ int CLuaDrawingDefs::DxDrawMaterialLine3D(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        g_pCore->GetGraphics()->DrawMaterialLine3DQueued(vecBegin, vecEnd, fWidth, color, pMaterial->GetMaterialItem(), 0, 0, 1, 1, true, bUseFaceToward,
+        g_pCore->GetGraphics()->DrawMaterialLine3DQueued(vecBegin, vecEnd, fWidth, color, pMaterial->GetMaterialItem(), 0, 0, 1, 1, true, bFlipUV, bUseFaceToward,
                                                          vecFaceToward, bPostGUI);
         lua_pushboolean(luaVM, true);
         return 1;
@@ -258,13 +260,14 @@ int CLuaDrawingDefs::DxDrawMaterialSectionLine3D(lua_State* luaVM)
 {
     //  bool dxDrawMaterialSectionLine3D ( float startX, float startY, float startZ, float endX, float endY, float endZ, float u, float v, float usize, float
     //  vsize,
-    //                                  element material, int width, [ int color = white, float faceX, float faceY, float faceZ ] )
+    //                                  [bool flipUV,] element material, int width, [int color = white, float faceX, float faceY, float faceZ ] )
     CVector          vecBegin;
     CVector          vecEnd;
     CVector2D        vecSectionPos;
     CVector2D        vecSectionSize;
+    bool             bFlipUV;
     CClientMaterial* pMaterial;
-    float            fWidth;
+    float            fWidth;    
     SColor           color;
     bool             bPostGUI;
     CVector          vecFaceToward;
@@ -275,8 +278,9 @@ int CLuaDrawingDefs::DxDrawMaterialSectionLine3D(lua_State* luaVM)
     argStream.ReadVector3D(vecEnd);
     argStream.ReadVector2D(vecSectionPos);
     argStream.ReadVector2D(vecSectionSize);
+    argStream.ReadIfNextIsBool(bFlipUV, false);
     argStream.ReadUserData(pMaterial);
-    argStream.ReadNumber(fWidth);
+    argStream.ReadNumber(fWidth);    
     argStream.ReadColor(color, 0xFFFFFFFF);
     argStream.ReadIfNextIsBool(bPostGUI, false);
     if (argStream.NextIsVector3D())
@@ -288,7 +292,7 @@ int CLuaDrawingDefs::DxDrawMaterialSectionLine3D(lua_State* luaVM)
     if (!argStream.HasErrors())
     {
         g_pCore->GetGraphics()->DrawMaterialLine3DQueued(vecBegin, vecEnd, fWidth, color, pMaterial->GetMaterialItem(), vecSectionPos.fX, vecSectionPos.fY,
-                                                         vecSectionSize.fX, vecSectionSize.fY, false, bUseFaceToward, vecFaceToward, bPostGUI);
+                                                         vecSectionSize.fX, vecSectionSize.fY, false, bFlipUV, bUseFaceToward, vecFaceToward, bPostGUI);
         lua_pushboolean(luaVM, true);
         return 1;
     }

--- a/Client/sdk/core/CGraphicsInterface.h
+++ b/Client/sdk/core/CGraphicsInterface.h
@@ -147,7 +147,7 @@ public:
     virtual void DrawLine3DQueued(const CVector& vecBegin, const CVector& vecEnd, float fWidth, unsigned long ulColor, bool bPostGUI) = 0;
 
     virtual void DrawMaterialLine3DQueued(const CVector& vecBegin, const CVector& vecEnd, float fWidth, unsigned long ulColor, CMaterialItem* pMaterial,
-                                          float fU = 0, float fV = 0, float fSizeU = 1, float fSizeV = 1, bool bRelativeUV = true, bool bUseFaceToward = false,
+                                          float fU = 0, float fV = 0, float fSizeU = 1, float fSizeV = 1, bool bRelativeUV = true, bool bFlipUV = false, bool bUseFaceToward = false,
                                           const CVector& vecFaceToward = CVector(), bool bPostGUI = false) = 0;
 
     virtual void DrawRectQueued(float fX, float fY, float fWidth, float fHeight, unsigned long ulColor, bool bPostGUI, bool bSubPixelPositioning = false) = 0;


### PR DESCRIPTION
In my experience there is a lot of circumstances when material line used to draw all kind of ropes, tapes and other rectangular textures. And it tends to be accompanied by difficulties related to a line UV orientation. This PR is indended to simplify this task and brings a new optional argument to flip UV orientation in some cases.

[BEFORE] Instead of writing a shader to rotate a texture:
```Lua
local tapeTex = dxCreateTexture( "tape.png")
local shader = dxCreateShader(
    [[
        texture Tex0;

        float3x3 getTextureTransform()
        {
            return float3x3(0, 1, 0, -1, 0, 0, 0, 0, 1);
        }

        technique simple
        {
            pass P0
            {
                Texture[0] = Tex0;
                TextureTransform[0] = getTextureTransform();
                TextureTransformFlags[0] = Count2;
            }
        }
    ]]
)
dxSetShaderValue( shader, "Tex0", tapeTex )

addEventHandler( "onClientRender", root,
    function()
        local TAPE_LEN = 5
        local x0, y0, z0 = 0, 0, 5
        local x1, y1, z1 = TAPE_LEN, 0, 5

        local tw, th = dxGetMaterialSize( tapeTex )
        local usize = TAPE_LEN / ( 1 * ( tw / th ) )

        dxDrawMaterialSectionLine3D( x0, y0, z0, x1, y1, z1, 0, 0, tw, usize * th, shader, 1 )
    end
)
```

[AFTER] Using this PR you can simply:
```Lua
local tapeTex = dxCreateTexture( "tape.png")

addEventHandler( "onClientRender", root,
	function()
	local TAPE_LEN = 5
        local x0, y0, z0 = TAPE_LEN, 0, 5
        local x1, y1, z1 = 0, 0, 5

        local tw, th = dxGetMaterialSize( tapeTex )
        local usize = TAPE_LEN / ( 1 * ( tw / th ) )

        dxDrawMaterialSectionLine3D( x0, y0, z0, x1, y1, z1, 0, 0, usize * tw, th, true, tapeTex, 1 )
    end
)
```

The syntax:
`bool dxDrawMaterialLine3D ( float startX, float startY, float startZ, float endX, float endY, float endZ, [bool flipUV,] element material, int width [, int color = white, [ bool postGUI = false, ] float faceX, float faceY, float faceZ ] )`

`bool dxDrawMaterialSectionLine3D ( float startX, float startY, float startZ, float endX, float endY, float endZ, float u, float v, float usize, float vsize, [bool flipUV,] element material, int width, [int color = white, [ bool postGUI = false, ] float faceX, float faceY, float faceZ ] )`