### PR TITLE
Fix #2183: Tweak bind queue logic

### DIFF
--- a/Client/core/CKeyBinds.cpp
+++ b/Client/core/CKeyBinds.cpp
@@ -483,7 +483,7 @@ bool CKeyBinds::ProcessKeyStroke(const SBindableKey* pKey, bool bState)
                                                 // don't add if its already added to queue
                                                 if (!bAlreadyProcessed)
                                                 {
-                                                    if (processedList.empty())
+                                                    if (pCommandBind->bScriptCreated || processedList.empty())
                                                         Call(pCommandBind);
                                                     else
                                                         m_vecBindQueue.push_back(pCommandBind);

--- a/Client/core/CKeyBinds.cpp
+++ b/Client/core/CKeyBinds.cpp
@@ -2094,9 +2094,12 @@ void CKeyBinds::DoPreFramePulse()
         m_pChatBoxBind = NULL;
     }
 
-    if (!m_vecBindQueue.empty())
+    // Execute two binds from queue
+    for (auto i = 0; i < 2; i++)
     {
         auto it = m_vecBindQueue.begin();
+        if (it == m_vecBindQueue.end())
+            break;
         Call(*it);
         m_vecBindQueue.erase(it);
     }


### PR DESCRIPTION
## Summary
- Fixes #2183
- Execute script created binds same frame
- Execute up to 2 binds in same frame