### PR TITLE
Source Map compatibility in CResourceHTMLItem

### DIFF
--- a/Server/mods/deathmatch/logic/CResourceHTMLItem.cpp
+++ b/Server/mods/deathmatch/logic/CResourceHTMLItem.cpp
@@ -337,6 +337,8 @@ void CResourceHTMLItem::GetMimeType(const char* szFilename)
             m_strMime = "image/jpg";
         else if (strcmp(pExtn, "js") == 0)
             m_strMime = "text/javascript";
+        else if (strcmp(pExtn, "map") == 0)
+            m_strMime = "application/json";
         else
             m_strMime = "text/html";
     }


### PR DESCRIPTION
A Source map is used to make minified/compiled and combined JavaScript files easier to debug.