### PR TITLE
Fix serverside key binds not working since #1978

### DIFF
--- a/Server/mods/deathmatch/logic/CKeyBinds.cpp
+++ b/Server/mods/deathmatch/logic/CKeyBinds.cpp
@@ -654,7 +654,7 @@ void CKeyBinds::CheckAndUpdatePlayerRPC()
     }
     else if (m_bIsRPCEnabled && listSize == 0)
     {
-        disabledServerRPCFunctions[eServerRPCFunctions::CURSOR_EVENT] = false;
+        disabledServerRPCFunctions[eServerRPCFunctions::CURSOR_EVENT] = true;
         m_pPlayer->Send(CServerRPCControlPacket(disabledServerRPCFunctions));
         m_bIsRPCEnabled = false;
     }

--- a/Server/mods/deathmatch/logic/CKeyBinds.h
+++ b/Server/mods/deathmatch/logic/CKeyBinds.h
@@ -122,7 +122,10 @@ public:
 protected:
     bool Remove(CKeyBind* pKeyBind);
 
+    void CheckAndUpdatePlayerRPC();
+
     CPlayer*             m_pPlayer;
     std::list<CKeyBind*> m_List;
     bool                 m_bProcessingKey;
+    bool                 m_bIsRPCEnabled;
 };


### PR DESCRIPTION
Resolves #2217 

Keybind processing on the client relies on the CURSOR_EVENT RPC which was disabled by default after #1978

(for more info read the code around here, which is calling CClientGame::ProcessMessageForCursorEvents)
https://github.com/multitheftauto/mtasa-blue/blob/17a2f84d733da99db8aa6414c09ee1bdeebe5893/Client/core/CMessageLoopHook.cpp#L443

This PR fixes that, by leaving the RPC disabled by default, but checking everytime a bind is added or removed, whether the RPC needs enabling (or disabling again).