### PR TITLE
Update sqlite from 3.35.2 to 3.35.5

### DIFF
--- a/vendor/sqlite/sqlite3.h
+++ b/vendor/sqlite/sqlite3.h
@@ -123,9 +123,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.35.2"
-#define SQLITE_VERSION_NUMBER 3035002
-#define SQLITE_SOURCE_ID      "2021-03-17 19:07:21 ea80f3002f4120f5dcee76e8779dfdc88e1e096c5cdd06904c20fd26d50c3827"
+#define SQLITE_VERSION        "3.35.5"
+#define SQLITE_VERSION_NUMBER 3035005
+#define SQLITE_SOURCE_ID      "2021-04-19 18:32:05 1b256d97b553a9611efca188a3d995a2fff712759044ba480f9a0c9e98fae886"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
## Summary
- Contains various fixes
- Changelogs
  - https://www.sqlite.org/changes.html#version_3_35_5
  - https://www.sqlite.org/changes.html#version_3_35_4
  - https://www.sqlite.org/changes.html#version_3_35_3

## Tests
Tested with [test_sqlite.zip](https://github.com/multitheftauto/mtasa-blue/files/2872064/test_sqlite.zip) (cheers to botder)

## Validation
To help validate the integrity of the update I have created the following bash script that diffs between my PR branch and the official package provided from the [SQLite website](https://www.sqlite.org/download.html).
```bash
#!/bin/bash

SQLITE_UPDATE_VERSION=3.35.5
SQLITE_PATH_NAME=sqlite-$SQLITE_UPDATE_VERSION

GIT_REPO_BRANCH=vendor/sqlite-$SQLITE_UPDATE_VERSION
GIT_REPO_URL=https://github.com/patrikjuvonen/mtasa-blue.git
GIT_REPO_SQLITE_PATH=vendor/sqlite/

echo 1. Download and extract $SQLITE_PATH_NAME...
curl https://www.sqlite.org/2021/sqlite-autoconf-3350500.tar.gz | tar -xz

echo 2. Fetch and checkout the vendor update branch $GIT_REPO_BRANCH from $GIT_REPO_URL...
git fetch $GIT_REPO_URL $GIT_REPO_BRANCH:$GIT_REPO_BRANCH
git checkout $GIT_REPO_BRANCH

echo 3. Start checking integrity...
diff -r --strip-trailing-cr $GIT_REPO_SQLITE_PATH sqlite-*

echo 4. Completed.
exec $SHELL
```

## Past SQLite updates in MTA
| Date | From | To | Link |
| :--- | :--- | :--- | :--- |
| March 2021 | 3.34.0 | 3.35.2 (current) | #2142 |
| December 2020 | 3.32.3 | 3.34.0 | #1960 |
| July 2020 | 3.31.1 | 3.32.3 | #1561 |
| March 2020 | 3.30.1 | 3.31.1 | #1260 |
| November 2019 | 3.29.0 | 3.30.1 | #1160 |
| August 2019 | 3.28.0 | 3.29.0 | #1028 |
| May 2019 | 3.27.1 | 3.28.0 | #913 |
| February 2019 | 3.24.0 | 3.27.1 | #818 |
| July 2018 | 3.13.0 | 3.24.0 | #245 |
| August 2016 | 3.7.17 | 3.13.0 | 3aa17532867c66818cc3a602c4b1ac2143694066 |
| August 2013 | 3.7.8 | 3.7.17 | fd195b799498f75496fe0c15adac3cab3aecb639 |
| October 2011 | 3.6.14 | 3.7.8 | ca063630631d56d5ba9aba5bf6771fe0299f5a9f |

## Changelog
### 2021-04-19 (3.35.5)
1. Fix defects in the new ALTER TABLE DROP COLUMN feature that could corrupt the database file.
1. Fix an obscure query optimizer problem that might cause an incorrect query result.

### 2021-04-02 (3.35.4)
1. Fix a defect in the query planner optimization identified by item 8b above. Ticket de7db14784a08053.
1. Fix a defect in the new RETURNING syntax. Ticket 132994c8b1063bfb.
1. Fix the new RETURNING feature so that it raises an error if one of the terms in the RETURNING clause references a unknown table, instead of silently ignoring that error.
1. Fix an assertion associated with aggregate function processing that was incorrectly triggered by the push-down optimization.

### 2021-03-26 (3.35.3)
1. Enhance the OP_OpenDup opcode of the bytecode engine so that it works even if the cursor being duplicated itself came from OP_OpenDup. Fix for ticket bb8a9fd4a9b7fce5. This problem only came to light due to the recent MATERIALIZED hint enhancement.
1. When materializing correlated common table expressions, do so separately for each use case, as that is required for correctness. This fixes a problem that was introduced by the MATERIALIZED hint enhancement.
1. Fix a problem in the filename normalizer of the unix VFS.
1. Fix the "box" output mode in the CLI so that it works with statements that returns one or more rows of zero columns (such as PRAGMA incremental_vacuum). Forum post afbbcb5b72.
1. Improvements to error messages generated by faulty common table expressions. Forum post aa5a0431c99e.
1. Fix some incorrect assert() statements.
1. Fix to the SELECT statement syntax diagram so that the FROM clause syntax is shown correctly. Forum post 9ed02582fe.
1. Fix the EBCDIC character classifier so that it understands newlines as whitespace. Forum post 58540ce22dcd.
1. Improvements the xBestIndex method in the implementation of the (unsupported) wholenumber virtual table extension so that it does a better job of convincing the query planner to avoid trying to materialize a table with an infinite number of rows. Forum post b52a020ce4.