### PR TITLE
Fix #2166 and #2167: Use parent model ID of non-standard vehicle model

### DIFF
--- a/Client/mods/deathmatch/logic/CClientVehicleManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicleManager.cpp
@@ -470,6 +470,10 @@ eClientVehicleType CClientVehicleManager::GetVehicleType(unsigned long ulModel)
 
 unsigned char CClientVehicleManager::GetMaxPassengerCount(unsigned long ulModel)
 {
+    // Use parent model ID for non-standard vehicle model IDs.
+    if ((ulModel < 400 || ulModel > 611) && IsValidModel(ulModel))
+        ulModel = g_pGame->GetModelInfo(ulModel)->GetParentID();
+
     // Valid model?
     if (IsStandardModel(ulModel))
     {

--- a/Client/mods/deathmatch/logic/CVehicleNames.cpp
+++ b/Client/mods/deathmatch/logic/CVehicleNames.cpp
@@ -287,6 +287,10 @@ unsigned int CVehicleNames::GetVehicleModel(const char* szName)
 
 const char* CVehicleNames::GetVehicleTypeName(unsigned long ulModel)
 {
+    // Use parent model ID for non-standard vehicle model IDs.
+    if ((ulModel < 400 || ulModel > 611) && CClientVehicleManager::IsValidModel(ulModel))
+        ulModel = g_pGame->GetModelInfo(ulModel)->GetParentID();
+
     // Check whether the model is valid
     if ((IsValidModel(ulModel) || IsModelTrailer(ulModel)) && ((ulModel - 400) < NUMELMS(ucVehicleTypes)))
     {


### PR DESCRIPTION
Make CClientVehicleManager::GetMaxPassengerCount() and CVehicleNames::GetVehicleTypeName() use parent model ID if used on a vehicle added with engineRequestModel().

- I think making functions like these inherit from the parent model is a good default. It shouldn't cause issues if functions to change this are added in the future.

Example of fix working:
![unknown](https://user-images.githubusercontent.com/11845049/120102462-8850a480-c121-11eb-94e9-d4b3216319b1.png)

Test resource:
[erm_fix1test.zip](https://github.com/multitheftauto/mtasa-blue/files/6566948/erm_fix1test.zip)
