### PR TITLE
Refactor of CPlayerManager::IsValidPlayerModel() based on issue #2244

### DIFF
--- a/Server/mods/deathmatch/logic/CPlayerManager.cpp
+++ b/Server/mods/deathmatch/logic/CPlayerManager.cpp
@@ -320,12 +320,15 @@ void CPlayerManager::Broadcast(const CPacket& Packet, const std::multimap<ushort
     DoBroadcast(Packet, groupMap);
 }
 
+const bool CPlayerManager::ValidPlayerModels[313] = {1,1,1,0,0,0,0,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1};
+
 bool CPlayerManager::IsValidPlayerModel(unsigned short usPlayerModel)
 {
-    return (usPlayerModel == 0 || usPlayerModel == 1 || usPlayerModel == 2 || usPlayerModel == 7 ||
-            (usPlayerModel >= 9 && usPlayerModel != 208 && usPlayerModel != 149 && usPlayerModel != 119 && usPlayerModel != 86 && usPlayerModel != 74 &&
-             usPlayerModel != 65 && usPlayerModel != 42 && usPlayerModel <= 272) ||
-            (usPlayerModel >= 274 && usPlayerModel <= 288) || (usPlayerModel >= 290 && usPlayerModel <= 312));
+    if (usPlayerModel < 0 || usPlayerModel > 312)
+    {
+        return false;
+    }
+    return (ValidPlayerModels[usPlayerModel]);
 }
 
 void CPlayerManager::ClearElementData(CElement* pElement, const std::string& name)

--- a/Server/mods/deathmatch/logic/CPlayerManager.cpp
+++ b/Server/mods/deathmatch/logic/CPlayerManager.cpp
@@ -320,15 +320,31 @@ void CPlayerManager::Broadcast(const CPacket& Packet, const std::multimap<ushort
     DoBroadcast(Packet, groupMap);
 }
 
-const bool CPlayerManager::ValidPlayerModels[313] = {1,1,1,0,0,0,0,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1};
-
-bool CPlayerManager::IsValidPlayerModel(unsigned short usPlayerModel)
+bool CPlayerManager::IsValidPlayerModel(unsigned short model)
 {
-    if (usPlayerModel < 0 || usPlayerModel > 312)
+    if (model > 312)
+        return false; // TODO: On client side maybe check if a model was allocated with engineRequestModel and it is a ped
+        
+    switch (model)
     {
-        return false;
+        case 3:
+        case 4:
+        case 5:
+        case 6:
+        case 8:
+        case 42:
+        case 65:
+        case 74:
+        case 86:
+        case 119:
+        case 149:
+        case 208:
+        case 273:
+        case 289:
+            return false;
+        default:
+            return true;
     }
-    return (ValidPlayerModels[usPlayerModel]);
 }
 
 void CPlayerManager::ClearElementData(CElement* pElement, const std::string& name)

--- a/Server/mods/deathmatch/logic/CPlayerManager.h
+++ b/Server/mods/deathmatch/logic/CPlayerManager.h
@@ -53,7 +53,7 @@ public:
     static void Broadcast(const CPacket& Packet, const std::vector<CPlayer*>& sendList);
     static void Broadcast(const CPacket& Packet, const std::multimap<ushort, CPlayer*>& groupMap);
 
-    static bool IsValidPlayerModel(unsigned short usPlayerModel);
+    static bool IsValidPlayerModel(unsigned short model);
 
     void ClearElementData(CElement* pElement, const std::string& name);
     void ClearElementData(CElement* pElement);
@@ -65,8 +65,6 @@ public:
 private:
     void AddToList(CPlayer* pPlayer);
     void RemoveFromList(CPlayer* pPlayer);
-
-    const static bool ValidPlayerModels[];
 
     class CScriptDebugging* m_pScriptDebugging;
 

--- a/Server/mods/deathmatch/logic/CPlayerManager.h
+++ b/Server/mods/deathmatch/logic/CPlayerManager.h
@@ -66,6 +66,8 @@ private:
     void AddToList(CPlayer* pPlayer);
     void RemoveFromList(CPlayer* pPlayer);
 
+    const static bool ValidPlayerModels[];
+
     class CScriptDebugging* m_pScriptDebugging;
 
     CMappedList<CPlayer*>                 m_Players;


### PR DESCRIPTION
Fixes #2244
Hey, you meant this way of using static array? Let me know if this way of doing it works for you aesthetically, otherwise it behaves exactly the same as original IsValidPlayerModel based on the test I run.