### PR TITLE
Add extra checks in CXMLImpl::ParseString to avoid crash when invalid XML data supplied

### DIFF
--- a/Shared/XML/CXMLImpl.cpp
+++ b/Shared/XML/CXMLImpl.cpp
@@ -46,13 +46,21 @@ std::unique_ptr<SXMLString> CXMLImpl::ParseString(const char* strXmlContent)
     TiXmlDocument* xmlDoc = new TiXmlDocument();
     if (xmlDoc)
     {
-        xmlDoc->Parse(strXmlContent, 0, TIXML_DEFAULT_ENCODING);
+        xmlDoc->Parse(strXmlContent, 0, TIXML_ENCODING_UTF8);
         if (!xmlDoc->Error())
         {
             TiXmlElement* xmlDocumentRoot = xmlDoc->RootElement();
-            CXMLNodeImpl* xmlBaseNode = new CXMLNodeImpl(nullptr, nullptr, *xmlDocumentRoot);
-            xmlBaseNode->BuildFromDocument();
-            return std::unique_ptr<SXMLString>(new SXMLStringImpl(xmlDoc, xmlBaseNode));
+
+            if (xmlDocumentRoot)
+            {
+                CXMLNodeImpl* xmlBaseNode = new CXMLNodeImpl(nullptr, nullptr, *xmlDocumentRoot);
+
+                if (xmlBaseNode && xmlBaseNode->IsValid())
+                {
+                    xmlBaseNode->BuildFromDocument();
+                    return std::unique_ptr<SXMLString>(new SXMLStringImpl(xmlDoc, xmlBaseNode));
+                }
+            }
         }
     }
     return nullptr;

--- a/Shared/XML/CXMLImpl.cpp
+++ b/Shared/XML/CXMLImpl.cpp
@@ -46,7 +46,7 @@ std::unique_ptr<SXMLString> CXMLImpl::ParseString(const char* strXmlContent)
     TiXmlDocument* xmlDoc = new TiXmlDocument();
     if (xmlDoc)
     {
-        xmlDoc->Parse(strXmlContent, 0, TIXML_ENCODING_UTF8);
+        xmlDoc->Parse(strXmlContent, 0, TIXML_DEFAULT_ENCODING);
         if (!xmlDoc->Error())
         {
             TiXmlElement* xmlDocumentRoot = xmlDoc->RootElement();


### PR DESCRIPTION
As above, doing something like `xmlLoadString("<>asd")` would crash the client or server.