### PR TITLE
Fix all objects in a specific ide will lose their collisions after restoring collisions

### DIFF
--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -1299,7 +1299,8 @@ void CModelInfoSA::SetColModel(CColModel* pColModel)
         // Call SetColModel
         DWORD dwFunc = FUNC_SetColModel;
         DWORD ModelID = m_dwModelID;
-
+        // Don't force the isLod argument to prevent collisionless problem
+        bool  isLOD = m_pInterface->bIsLod;
         _asm
         {
             mov     ecx, ModelID
@@ -1309,7 +1310,7 @@ void CModelInfoSA::SetColModel(CColModel* pColModel)
             mov     ecx, dword ptr[eax + ecx*4]
             pop     eax
 
-            push    1
+            push    isLOD
             push    pColModelInterface
             call    dwFunc
         }
@@ -1358,7 +1359,8 @@ void CModelInfoSA::RestoreColModel()
             DWORD dwFunc = FUNC_SetColModel;
             DWORD dwOriginalColModelInterface = (DWORD)m_pOriginalColModelInterface;
             DWORD ModelID = m_dwModelID;
-
+            // Don't force the isLod argument to prevent collisionless problem
+            bool  isLOD = m_pInterface->bIsLod;
             _asm
             {
                 mov     ecx, ModelID
@@ -1368,7 +1370,7 @@ void CModelInfoSA::RestoreColModel()
                 mov     ecx, dword ptr[eax + ecx*4]
                 pop     eax
 
-                push    1
+                push    isLOD
                 push    dwOriginalColModelInterface
                 call    dwFunc
             }

--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -1292,6 +1292,7 @@ void CModelInfoSA::SetColModel(CColModel* pColModel)
         // If no collision model has been set before, store the original in case we want to restore it
         if (!m_pOriginalColModelInterface)
             m_pOriginalColModelInterface = m_pInterface->pColModel;
+            m_pInterface->bAlphaTransparency = false;
 
         // Apply some low-level hacks
         pColModelInterface->level = 0xA9;
@@ -1299,6 +1300,8 @@ void CModelInfoSA::SetColModel(CColModel* pColModel)
         // Call SetColModel
         DWORD dwFunc = FUNC_SetColModel;
         DWORD ModelID = m_dwModelID;
+        // Don't force the isLod argument to prevent collisionless problem
+        bool  isLOD = m_pInterface->bIsLod;
         _asm
         {
             mov     ecx, ModelID
@@ -1308,7 +1311,7 @@ void CModelInfoSA::SetColModel(CColModel* pColModel)
             mov     ecx, dword ptr[eax + ecx*4]
             pop     eax
 
-            push    1
+            push    isLOD
             push    pColModelInterface
             call    dwFunc
         }
@@ -1357,6 +1360,8 @@ void CModelInfoSA::RestoreColModel()
             DWORD dwFunc = FUNC_SetColModel;
             DWORD dwOriginalColModelInterface = (DWORD)m_pOriginalColModelInterface;
             DWORD ModelID = m_dwModelID;
+            // Don't force the isLod argument to prevent collisionless problem
+            bool  isLOD = m_pInterface->bIsLod;
             _asm
             {
                 mov     ecx, ModelID
@@ -1366,7 +1371,7 @@ void CModelInfoSA::RestoreColModel()
                 mov     ecx, dword ptr[eax + ecx*4]
                 pop     eax
 
-                push    1
+                push    isLOD
                 push    dwOriginalColModelInterface
                 call    dwFunc
             }
@@ -1475,7 +1480,7 @@ void CModelInfoSA::MakeObjectModel(ushort usBaseID)
     MemCpyFast(m_pInterface, pBaseObjectInfo, sizeof(CBaseModelInfoSAInterface));
     m_pInterface->usNumberOfRefs = 0;
     m_pInterface->pRwObject = nullptr;
-    m_pInterface->usUnknown = 65535;
+    m_pInterface->uObjectInfoIndex = 65535;
     m_pInterface->usDynamicIndex = 65535;
 
     ppModelInfo[m_dwModelID] = m_pInterface;
@@ -1493,7 +1498,7 @@ void CModelInfoSA::MakeVehicleAutomobile(ushort usBaseID)
     m_pInterface->usNumberOfRefs = 0;
     m_pInterface->pRwObject = nullptr;
     m_pInterface->pVisualInfo = nullptr;
-    m_pInterface->usUnknown = 65535;
+    m_pInterface->uObjectInfoIndex = 65535;
     m_pInterface->usDynamicIndex = 65535;
 
     ppModelInfo[m_dwModelID] = m_pInterface;

--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -1299,8 +1299,7 @@ void CModelInfoSA::SetColModel(CColModel* pColModel)
         // Call SetColModel
         DWORD dwFunc = FUNC_SetColModel;
         DWORD ModelID = m_dwModelID;
-        // Don't force the isLod argument to prevent collisionless problem
-        bool  isLOD = m_pInterface->bIsLod;
+
         _asm
         {
             mov     ecx, ModelID
@@ -1310,7 +1309,7 @@ void CModelInfoSA::SetColModel(CColModel* pColModel)
             mov     ecx, dword ptr[eax + ecx*4]
             pop     eax
 
-            push    isLOD
+            push    1
             push    pColModelInterface
             call    dwFunc
         }
@@ -1359,8 +1358,7 @@ void CModelInfoSA::RestoreColModel()
             DWORD dwFunc = FUNC_SetColModel;
             DWORD dwOriginalColModelInterface = (DWORD)m_pOriginalColModelInterface;
             DWORD ModelID = m_dwModelID;
-            // Don't force the isLod argument to prevent collisionless problem
-            bool  isLOD = m_pInterface->bIsLod;
+
             _asm
             {
                 mov     ecx, ModelID
@@ -1370,7 +1368,7 @@ void CModelInfoSA::RestoreColModel()
                 mov     ecx, dword ptr[eax + ecx*4]
                 pop     eax
 
-                push    isLOD
+                push    1
                 push    dwOriginalColModelInterface
                 call    dwFunc
             }

--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -1292,7 +1292,6 @@ void CModelInfoSA::SetColModel(CColModel* pColModel)
         // If no collision model has been set before, store the original in case we want to restore it
         if (!m_pOriginalColModelInterface)
             m_pOriginalColModelInterface = m_pInterface->pColModel;
-            m_pInterface->bAlphaTransparency = false;
 
         // Apply some low-level hacks
         pColModelInterface->level = 0xA9;

--- a/Client/game_sa/CModelInfoSA.h
+++ b/Client/game_sa/CModelInfoSA.h
@@ -165,7 +165,7 @@ public:
     unsigned char bDrawLast : 1;
     unsigned char bDoWeOwnTheColModel : 1;
 
-    unsigned char dwUnknownFlag25 : 1;            // +19
+    unsigned char bHasAnimation : 1;            // +19
     unsigned char dwUnknownFlag26 : 1;
     unsigned char dwUnknownFlag27 : 1;
     unsigned char bSwaysInWind : 1;

--- a/Client/game_sa/CModelInfoSA.h
+++ b/Client/game_sa/CModelInfoSA.h
@@ -151,34 +151,53 @@ public:
     unsigned char  ucAlpha : 8;                         // +12
 
     unsigned char  ucNumOf2DEffects : 8;            // +13
-    unsigned short usUnknown : 16;                  // +14     Something with 2d effects
+    unsigned short uObjectInfoIndex : 16;            // +14
 
     unsigned short usDynamicIndex : 16;            // +16
 
     // Flags used by CBaseModelInfo
-    unsigned char bHasBeenPreRendered : 1;            // +18
-    unsigned char bAlphaTransparency : 1;
-    unsigned char bIsLod : 1;
-    unsigned char bDontWriteZBuffer : 1;
-    unsigned char bDontCastShadowsOn : 1;
+    unsigned char bHasBeenPreRendered : 1;  // Confirmed: Has Pre-Rendered          // +18
+    unsigned char bDrawLast : 1;            // Confirmed: Drawn Last
     unsigned char bDrawAdditive : 1;
-    unsigned char bDrawLast : 1;
+    unsigned char bDontWriteZBuffer : 1;    // Confirmed: Don't Write Z Buffer
+    unsigned char bDontCastShadowsOn : 1;   // Confirmed: Don't Cast Shadow On
+    unsigned char bIsLod : 1;               // Confirmed: is LOD
+    unsigned char bAlphaTransparency : 1;
     unsigned char bDoWeOwnTheColModel : 1;
-
-    unsigned char bHasAnimation : 1;            // +19
-    unsigned char dwUnknownFlag26 : 1;
-    unsigned char dwUnknownFlag27 : 1;
-    unsigned char bSwaysInWind : 1;
-    unsigned char bCollisionWasStreamedWithModel : 1;            // CClumpModelInfo::SetCollisionWasStreamedWithModel(unsigned int)
-    unsigned char bDontCollideWithFlyer : 1;                     // CAtomicModelInfo::SetDontCollideWithFlyer(unsigned int)
-    unsigned char bHasComplexHierarchy : 1;                      // CClumpModelInfo::SetHasComplexHierarchy(unsigned int)
-    unsigned char bWetRoadReflection : 1;                        // CAtomicModelInfo::SetWetRoadReflection(unsigned int)
-
+    union
+    {
+        struct
+        {            // Atomic flags
+            unsigned char bIsRoad : 1;
+            unsigned char : 1;
+            unsigned char bDontCollideWithFlyer : 1;            // CAtomicModelInfo::SetDontCollideWithFlyer(unsigned int)
+            unsigned char nSpecialType : 4;
+            unsigned char bWetRoadReflection : 1;               // CAtomicModelInfo::SetWetRoadReflection(unsigned int)
+        };
+        struct
+        {            // Vehicle flags
+            unsigned char bUsesVehDummy : 1;
+            unsigned char : 1;
+            unsigned char nCarmodId : 5;
+            unsigned char bUseCommonVehicleDictionary : 1;
+        };
+        struct
+        {            // Clump flags
+            unsigned char bHasAnimBlend : 1;                    // Confirmed: has animation
+            unsigned char bHasComplexHierarchy : 1;             // CClumpModelInfo::SetHasComplexHierarchy(unsigned int)
+            unsigned char bUnknown1 : 1;
+            unsigned char bSwaysInWind : 1;                     // Confirmed: Sways in wind
+            unsigned char bCollisionWasStreamedWithModel : 1;   // CClumpModelInfo::SetCollisionWasStreamedWithModel(unsigned int)
+            unsigned char bOwnsCollisionModel : 1;
+            unsigned char bUnknown2 : 1;
+            unsigned char bTagDisabled : 1;
+        };
+    };
+   
     CColModelSAInterface* pColModel;            // +20      CColModel: public CBoundingBox
 
     float     fLodDistanceUnscaled;            // +24      Scaled is this value multiplied with flt_B6F118
     RwObject* pRwObject;                       // +28
-
     // CWeaponModelInfo:
     // +36 = Weapon info as int
 


### PR DESCRIPTION
The 2nd argument of setColModel, "isLod", is set wrongly. In our case, what we need is just the original value, but the code forces this argument to "true".
And I fixed the name/order of some flags of class "CBaseModelInfoSAInterface".
I can't reproduce the collisionless issue after with this.
Need more tests to find whether this will cause other issues.

#927 can be fixed by this PR.