### PR TITLE
Fix all objects in a specific ide will lose their collisions after restoring collisions

### DIFF
--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -1299,6 +1299,8 @@ void CModelInfoSA::SetColModel(CColModel* pColModel)
         // Call SetColModel
         DWORD dwFunc = FUNC_SetColModel;
         DWORD ModelID = m_dwModelID;
+        // Don't force the isLod argument to prevent collisionless problem
+        bool  isLOD = m_pInterface->bIsLod;
         _asm
         {
             mov     ecx, ModelID
@@ -1308,7 +1310,7 @@ void CModelInfoSA::SetColModel(CColModel* pColModel)
             mov     ecx, dword ptr[eax + ecx*4]
             pop     eax
 
-            push    1
+            push    isLOD
             push    pColModelInterface
             call    dwFunc
         }
@@ -1357,6 +1359,8 @@ void CModelInfoSA::RestoreColModel()
             DWORD dwFunc = FUNC_SetColModel;
             DWORD dwOriginalColModelInterface = (DWORD)m_pOriginalColModelInterface;
             DWORD ModelID = m_dwModelID;
+            // Don't force the isLod argument to prevent collisionless problem
+            bool  isLOD = m_pInterface->bIsLod;
             _asm
             {
                 mov     ecx, ModelID
@@ -1366,7 +1370,7 @@ void CModelInfoSA::RestoreColModel()
                 mov     ecx, dword ptr[eax + ecx*4]
                 pop     eax
 
-                push    1
+                push    isLOD
                 push    dwOriginalColModelInterface
                 call    dwFunc
             }

--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -1299,8 +1299,6 @@ void CModelInfoSA::SetColModel(CColModel* pColModel)
         // Call SetColModel
         DWORD dwFunc = FUNC_SetColModel;
         DWORD ModelID = m_dwModelID;
-        // Don't force the isLod argument to prevent collisionless problem
-        bool  isLOD = m_pInterface->bIsLod;
         _asm
         {
             mov     ecx, ModelID
@@ -1310,7 +1308,7 @@ void CModelInfoSA::SetColModel(CColModel* pColModel)
             mov     ecx, dword ptr[eax + ecx*4]
             pop     eax
 
-            push    isLOD
+            push    1
             push    pColModelInterface
             call    dwFunc
         }
@@ -1359,8 +1357,6 @@ void CModelInfoSA::RestoreColModel()
             DWORD dwFunc = FUNC_SetColModel;
             DWORD dwOriginalColModelInterface = (DWORD)m_pOriginalColModelInterface;
             DWORD ModelID = m_dwModelID;
-            // Don't force the isLod argument to prevent collisionless problem
-            bool  isLOD = m_pInterface->bIsLod;
             _asm
             {
                 mov     ecx, ModelID
@@ -1370,7 +1366,7 @@ void CModelInfoSA::RestoreColModel()
                 mov     ecx, dword ptr[eax + ecx*4]
                 pop     eax
 
-                push    isLOD
+                push    1
                 push    dwOriginalColModelInterface
                 call    dwFunc
             }
@@ -1479,7 +1475,7 @@ void CModelInfoSA::MakeObjectModel(ushort usBaseID)
     MemCpyFast(m_pInterface, pBaseObjectInfo, sizeof(CBaseModelInfoSAInterface));
     m_pInterface->usNumberOfRefs = 0;
     m_pInterface->pRwObject = nullptr;
-    m_pInterface->uObjectInfoIndex = 65535;
+    m_pInterface->usUnknown = 65535;
     m_pInterface->usDynamicIndex = 65535;
 
     ppModelInfo[m_dwModelID] = m_pInterface;
@@ -1497,7 +1493,7 @@ void CModelInfoSA::MakeVehicleAutomobile(ushort usBaseID)
     m_pInterface->usNumberOfRefs = 0;
     m_pInterface->pRwObject = nullptr;
     m_pInterface->pVisualInfo = nullptr;
-    m_pInterface->uObjectInfoIndex = 65535;
+    m_pInterface->usUnknown = 65535;
     m_pInterface->usDynamicIndex = 65535;
 
     ppModelInfo[m_dwModelID] = m_pInterface;

--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -1299,6 +1299,8 @@ void CModelInfoSA::SetColModel(CColModel* pColModel)
         // Call SetColModel
         DWORD dwFunc = FUNC_SetColModel;
         DWORD ModelID = m_dwModelID;
+        // Don't force the isLod argument to prevent collisionless problem
+        bool  isLOD = m_pInterface->bIsLod;
         _asm
         {
             mov     ecx, ModelID
@@ -1308,7 +1310,7 @@ void CModelInfoSA::SetColModel(CColModel* pColModel)
             mov     ecx, dword ptr[eax + ecx*4]
             pop     eax
 
-            push    1
+            push    isLOD
             push    pColModelInterface
             call    dwFunc
         }
@@ -1357,6 +1359,8 @@ void CModelInfoSA::RestoreColModel()
             DWORD dwFunc = FUNC_SetColModel;
             DWORD dwOriginalColModelInterface = (DWORD)m_pOriginalColModelInterface;
             DWORD ModelID = m_dwModelID;
+            // Don't force the isLod argument to prevent collisionless problem
+            bool  isLOD = m_pInterface->bIsLod;
             _asm
             {
                 mov     ecx, ModelID
@@ -1366,7 +1370,7 @@ void CModelInfoSA::RestoreColModel()
                 mov     ecx, dword ptr[eax + ecx*4]
                 pop     eax
 
-                push    1
+                push    isLOD
                 push    dwOriginalColModelInterface
                 call    dwFunc
             }
@@ -1475,7 +1479,7 @@ void CModelInfoSA::MakeObjectModel(ushort usBaseID)
     MemCpyFast(m_pInterface, pBaseObjectInfo, sizeof(CBaseModelInfoSAInterface));
     m_pInterface->usNumberOfRefs = 0;
     m_pInterface->pRwObject = nullptr;
-    m_pInterface->usUnknown = 65535;
+    m_pInterface->uObjectInfoIndex = 65535;
     m_pInterface->usDynamicIndex = 65535;
 
     ppModelInfo[m_dwModelID] = m_pInterface;
@@ -1493,7 +1497,7 @@ void CModelInfoSA::MakeVehicleAutomobile(ushort usBaseID)
     m_pInterface->usNumberOfRefs = 0;
     m_pInterface->pRwObject = nullptr;
     m_pInterface->pVisualInfo = nullptr;
-    m_pInterface->usUnknown = 65535;
+    m_pInterface->uObjectInfoIndex = 65535;
     m_pInterface->usDynamicIndex = 65535;
 
     ppModelInfo[m_dwModelID] = m_pInterface;


### PR DESCRIPTION
The 2nd argument of setColModel, "isLod", is set wrongly. In our case, what we need is just the original value, but the code forces this argument to "true".

I can't reproduce the collisionless issue after with this.
Need more tests to find whether this will cause other issues.

Resolves #927