### PR TITLE
Fix #2127: Attached players desync after reconnect

### DIFF
--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -4122,7 +4122,7 @@ retry:
             pTempEntity->SetParent(pParent);
         }
 
-        if (TempAttachedToID != INVALID_ELEMENT_ID && pTempEntity->GetType() != CCLIENTPLAYER)
+        if (TempAttachedToID != INVALID_ELEMENT_ID)
         {
             CClientEntity* pAttachedToEntity = CElementIDs::GetElement(TempAttachedToID);
             if (pAttachedToEntity)


### PR DESCRIPTION
Removed a check that caused old players from being attached to elements for new players.
Fixes #2127