### PR TITLE
Fix info command displaying two statuses of a running resource

### DIFF
--- a/Server/mods/deathmatch/logic/CResource.cpp
+++ b/Server/mods/deathmatch/logic/CResource.cpp
@@ -1157,6 +1157,8 @@ void CResource::DisplayInfo()            // duplicated for HTML
 
             for (CResource* pDependent : m_Dependents)
                 CLogger::LogPrintf("  %s\n", pDependent->GetName().c_str());
+
+            break;
         }
         case EResourceState::Stopping:
         {


### PR DESCRIPTION
The `info` command displays 2 statuses (running and stopping) if the resource is running.
This PR fixes that.