### PR TITLE
Fix onClientElementInteriorChange is triggered even if the element already in the same interior

### DIFF
--- a/Client/mods/deathmatch/logic/CClientEntity.cpp
+++ b/Client/mods/deathmatch/logic/CClientEntity.cpp
@@ -1298,6 +1298,9 @@ unsigned char CClientEntity::GetInterior()
 
 void CClientEntity::SetInterior(unsigned char ucInterior)
 {
+    if (m_ucInterior == ucInterior)
+        return;
+
     CEntity* pEntity = GetGameEntity();
     if (pEntity)
     {


### PR DESCRIPTION
Issue #2280 