### PR TITLE
Fix #2280: onClientElementInteriorChange is triggered even if the element has not changed its interior

### DIFF
--- a/Client/mods/deathmatch/logic/CClientEntity.cpp
+++ b/Client/mods/deathmatch/logic/CClientEntity.cpp
@@ -1307,10 +1307,13 @@ void CClientEntity::SetInterior(unsigned char ucInterior)
     unsigned char ucOldInterior = m_ucInterior;
     m_ucInterior = ucInterior;
 
-    CLuaArguments Arguments;
-    Arguments.PushNumber(ucOldInterior);
-    Arguments.PushNumber(ucInterior);
-    CallEvent("onClientElementInteriorChange", Arguments, true);
+    if (ucOldInterior != ucInterior)
+    {
+        CLuaArguments Arguments;
+        Arguments.PushNumber(ucOldInterior);
+        Arguments.PushNumber(ucInterior);
+        CallEvent("onClientElementInteriorChange", Arguments, true);
+    }
 }
 
 bool CClientEntity::IsOnScreen()


### PR DESCRIPTION
Issue #2280 again :)

#2309, of course, this doesn't fix the source of the problem, I assume something is messed up with the synchronization if dd27ea8 broke it, just because of that is-equals check.