### PR TITLE
Improve addEvent when sharing events over multiple resources

### DIFF
--- a/Client/mods/deathmatch/logic/CEvents.cpp
+++ b/Client/mods/deathmatch/logic/CEvents.cpp
@@ -91,7 +91,7 @@ void CEvents::RemoveAllEvents(class CLuaMain* pMain)
     while (iter != m_EventHashMap.end())
     {
         SEvent* pEvent = (*iter).second;
-        
+
         // If they match, remove pMain from the set and check for deletion
         if (pEvent->pLuaMainSet.find(pMain) != pEvent->pLuaMainSet.end())
         {
@@ -104,11 +104,11 @@ void CEvents::RemoveAllEvents(class CLuaMain* pMain)
                 delete pEvent;
 
                 // Remove from list
-                m_EventHashMap.erase(iter++);
+                m_EventHashMap.erase(iter);
             }
         }
-        else
-            ++iter;
+
+        ++iter;
     }
 }
 

--- a/Client/mods/deathmatch/logic/CEvents.cpp
+++ b/Client/mods/deathmatch/logic/CEvents.cpp
@@ -38,7 +38,7 @@ bool CEvents::AddEvent(const char* szName, const char* szArguments, CLuaMain* pL
             return false;
         
         // Add pLuaMain to the vector, in case it's not already there
-        if (std::find(pEvent->pLuaMainVector.begin(), pEvent->pLuaMainVector.end(), pLuaMain) == pEvent->pLuaMainVector.end())
+        if (!ListContains(pEvent->pLuaMainVector, pLuaMain))
             pEvent->pLuaMainVector.push_back(pLuaMain);
     }
     else
@@ -92,22 +92,16 @@ void CEvents::RemoveAllEvents(class CLuaMain* pMain)
     while (iter != m_EventHashMap.end())
     {
         SEvent* pEvent = (*iter).second;
+        ListRemoveFirst(pEvent->pLuaMainVector, pMain);
 
-        // If they match, remove pMain from the vector and check for deletion
-        std::vector<class CLuaMain*>::const_iterator pLuaMainIter = std::find(pEvent->pLuaMainVector.begin(), pEvent->pLuaMainVector.end(), pMain);
-        if (pLuaMainIter != pEvent->pLuaMainVector.end())
+        // If no pMain is left, delete it null it and set the bool
+        if (pEvent->pLuaMainVector.empty())
         {
-            pEvent->pLuaMainVector.erase(pLuaMainIter);
+            // Delete the object
+            delete pEvent;
 
-            // If no pMain is left, delete it null it and set the bool
-            if (pEvent->pLuaMainVector.empty())
-            {
-                // Delete the object
-                delete pEvent;
-
-                // Remove from list
-                m_EventHashMap.erase(iter);
-            }
+            // Remove from list
+            m_EventHashMap.erase(iter);
         }
 
         ++iter;

--- a/Client/mods/deathmatch/logic/CEvents.cpp
+++ b/Client/mods/deathmatch/logic/CEvents.cpp
@@ -37,8 +37,9 @@ bool CEvents::AddEvent(const char* szName, const char* szArguments, CLuaMain* pL
         if (pEvent->bAllowRemoteTrigger != bAllowRemoteTrigger)
             return false;
         
-        // Add pLuaMain to the set, std::unordered_set guarantees unique elements
-        pEvent->pLuaMainSet.insert(pLuaMain);
+        // Add pLuaMain to the vector, in case it's not already there
+        if (std::find(pEvent->pLuaMainVector.begin(), pEvent->pLuaMainVector.end(), pLuaMain) == pEvent->pLuaMainVector.end())
+            pEvent->pLuaMainVector.push_back(pLuaMain);
     }
     else
     {
@@ -46,7 +47,7 @@ bool CEvents::AddEvent(const char* szName, const char* szArguments, CLuaMain* pL
         pEvent = new SEvent;
         pEvent->strName = szName;
         pEvent->strArguments = szArguments;
-        pEvent->pLuaMainSet.insert(pLuaMain);
+        pEvent->pLuaMainVector.push_back(pLuaMain);
         pEvent->bAllowRemoteTrigger = bAllowRemoteTrigger;
     }
 
@@ -92,13 +93,14 @@ void CEvents::RemoveAllEvents(class CLuaMain* pMain)
     {
         SEvent* pEvent = (*iter).second;
 
-        // If they match, remove pMain from the set and check for deletion
-        if (pEvent->pLuaMainSet.find(pMain) != pEvent->pLuaMainSet.end())
+        // If they match, remove pMain from the vector and check for deletion
+        std::vector<class CLuaMain*>::const_iterator pLuaMainIter = std::find(pEvent->pLuaMainVector.begin(), pEvent->pLuaMainVector.end(), pMain);
+        if (pLuaMainIter != pEvent->pLuaMainVector.end())
         {
-            pEvent->pLuaMainSet.erase(pMain);
+            pEvent->pLuaMainVector.erase(pLuaMainIter);
 
             // If no pMain is left, delete it null it and set the bool
-            if (pEvent->pLuaMainSet.empty())
+            if (pEvent->pLuaMainVector.empty())
             {
                 // Delete the object
                 delete pEvent;

--- a/Client/mods/deathmatch/logic/CEvents.cpp
+++ b/Client/mods/deathmatch/logic/CEvents.cpp
@@ -37,7 +37,7 @@ bool CEvents::AddEvent(const char* szName, const char* szArguments, CLuaMain* pL
         if (pEvent->bAllowRemoteTrigger != bAllowRemoteTrigger)
             return false;
         
-        // Add pLuaMain to the set, std::set guarantees unique elements
+        // Add pLuaMain to the set, std::unordered_set guarantees unique elements
         pEvent->pLuaMainSet.insert(pLuaMain);
     }
     else
@@ -98,7 +98,7 @@ void CEvents::RemoveAllEvents(class CLuaMain* pMain)
             pEvent->pLuaMainSet.erase(pMain);
 
             // If no pMain is left, delete it null it and set the bool
-            if (pEvent->pLuaMainSet.size() == 0)
+            if (pEvent->pLuaMainSet.empty())
             {
                 // Delete the object
                 delete pEvent;

--- a/Client/mods/deathmatch/logic/CEvents.h
+++ b/Client/mods/deathmatch/logic/CEvents.h
@@ -16,10 +16,10 @@
 
 struct SEvent
 {
-    class CLuaMain* pLuaMain;
-    std::string     strName;
-    std::string     strArguments;
-    bool            bAllowRemoteTrigger;
+    std::set<class CLuaMain*> pLuaMainSet;
+    std::string               strName;
+    std::string               strArguments;
+    bool                      bAllowRemoteTrigger;
 };
 
 class CEvents

--- a/Client/mods/deathmatch/logic/CEvents.h
+++ b/Client/mods/deathmatch/logic/CEvents.h
@@ -16,10 +16,10 @@
 
 struct SEvent
 {
-    std::unordered_set<class CLuaMain*> pLuaMainSet;
-    std::string                         strName;
-    std::string                         strArguments;
-    bool                                bAllowRemoteTrigger;
+    std::vector<class CLuaMain*> pLuaMainVector;
+    std::string                  strName;
+    std::string                  strArguments;
+    bool                         bAllowRemoteTrigger;
 };
 
 class CEvents

--- a/Client/mods/deathmatch/logic/CEvents.h
+++ b/Client/mods/deathmatch/logic/CEvents.h
@@ -16,10 +16,10 @@
 
 struct SEvent
 {
-    std::set<class CLuaMain*> pLuaMainSet;
-    std::string               strName;
-    std::string               strArguments;
-    bool                      bAllowRemoteTrigger;
+    std::unordered_set<class CLuaMain*> pLuaMainSet;
+    std::string                         strName;
+    std::string                         strArguments;
+    bool                                bAllowRemoteTrigger;
 };
 
 class CEvents

--- a/Server/mods/deathmatch/logic/CEvents.cpp
+++ b/Server/mods/deathmatch/logic/CEvents.cpp
@@ -32,7 +32,7 @@ bool CEvents::AddEvent(const char* szName, const char* szArguments, CLuaMain* pL
             return false;
         
         // Add pLuaMain to the vector, in case it's not already there
-        if (std::find(pEvent->pLuaMainVector.begin(), pEvent->pLuaMainVector.end(), pLuaMain) == pEvent->pLuaMainVector.end())
+        if (!ListContains(pEvent->pLuaMainVector, pLuaMain))
             pEvent->pLuaMainVector.push_back(pLuaMain);
     }
     else
@@ -80,22 +80,16 @@ void CEvents::RemoveAllEvents(class CLuaMain* pMain)
     while (iter != m_EventHashMap.end())
     {
         SEvent* pEvent = (*iter).second;
+        ListRemoveFirst(pEvent->pLuaMainVector, pMain);
 
-        // If they match, remove pMain from the vector and check for deletion
-        std::vector<class CLuaMain*>::const_iterator pLuaMainIter = std::find(pEvent->pLuaMainVector.begin(), pEvent->pLuaMainVector.end(), pMain);
-        if (pLuaMainIter != pEvent->pLuaMainVector.end())
+        // If no pMain is left, delete it null it and set the bool
+        if (pEvent->pLuaMainVector.empty())
         {
-            pEvent->pLuaMainVector.erase(pLuaMainIter);
+            // Delete the object
+            delete pEvent;
 
-            // If no pMain is left, delete it null it and set the bool
-            if (pEvent->pLuaMainVector.empty())
-            {
-                // Delete the object
-                delete pEvent;
-
-                // Remove from list
-                m_EventHashMap.erase(iter);
-            }
+            // Remove from list
+            m_EventHashMap.erase(iter);
         }
 
         ++iter;

--- a/Server/mods/deathmatch/logic/CEvents.cpp
+++ b/Server/mods/deathmatch/logic/CEvents.cpp
@@ -31,7 +31,7 @@ bool CEvents::AddEvent(const char* szName, const char* szArguments, CLuaMain* pL
         if (pEvent->bAllowRemoteTrigger != bAllowRemoteTrigger)
             return false;
         
-        // Add pLuaMain to the set, std::set guarantees unique elements
+        // Add pLuaMain to the set, std::unordered_set guarantees unique elements
         pEvent->pLuaMainSet.insert(pLuaMain);
     }
     else
@@ -86,7 +86,7 @@ void CEvents::RemoveAllEvents(class CLuaMain* pMain)
             pEvent->pLuaMainSet.erase(pMain);
 
             // If no pMain is left, delete it null it and set the bool
-            if (pEvent->pLuaMainSet.size() == 0)
+            if (pEvent->pLuaMainSet.empty())
             {
                 // Delete the object
                 delete pEvent;

--- a/Server/mods/deathmatch/logic/CEvents.cpp
+++ b/Server/mods/deathmatch/logic/CEvents.cpp
@@ -31,8 +31,9 @@ bool CEvents::AddEvent(const char* szName, const char* szArguments, CLuaMain* pL
         if (pEvent->bAllowRemoteTrigger != bAllowRemoteTrigger)
             return false;
         
-        // Add pLuaMain to the set, std::unordered_set guarantees unique elements
-        pEvent->pLuaMainSet.insert(pLuaMain);
+        // Add pLuaMain to the vector, in case it's not already there
+        if (std::find(pEvent->pLuaMainVector.begin(), pEvent->pLuaMainVector.end(), pLuaMain) == pEvent->pLuaMainVector.end())
+            pEvent->pLuaMainVector.push_back(pLuaMain);
     }
     else
     {
@@ -40,7 +41,7 @@ bool CEvents::AddEvent(const char* szName, const char* szArguments, CLuaMain* pL
         pEvent = new SEvent;
         pEvent->strName = szName;
         pEvent->strArguments = szArguments;
-        pEvent->pLuaMainSet.insert(pLuaMain);
+        pEvent->pLuaMainVector.push_back(pLuaMain);
         pEvent->bAllowRemoteTrigger = bAllowRemoteTrigger;
     }
 
@@ -80,13 +81,14 @@ void CEvents::RemoveAllEvents(class CLuaMain* pMain)
     {
         SEvent* pEvent = (*iter).second;
 
-        // If they match, remove pMain from the set and check for deletion
-        if (pEvent->pLuaMainSet.find(pMain) != pEvent->pLuaMainSet.end())
+        // If they match, remove pMain from the vector and check for deletion
+        std::vector<class CLuaMain*>::const_iterator pLuaMainIter = std::find(pEvent->pLuaMainVector.begin(), pEvent->pLuaMainVector.end(), pMain);
+        if (pLuaMainIter != pEvent->pLuaMainVector.end())
         {
-            pEvent->pLuaMainSet.erase(pMain);
+            pEvent->pLuaMainVector.erase(pLuaMainIter);
 
             // If no pMain is left, delete it null it and set the bool
-            if (pEvent->pLuaMainSet.empty())
+            if (pEvent->pLuaMainVector.empty())
             {
                 // Delete the object
                 delete pEvent;

--- a/Server/mods/deathmatch/logic/CEvents.cpp
+++ b/Server/mods/deathmatch/logic/CEvents.cpp
@@ -92,11 +92,11 @@ void CEvents::RemoveAllEvents(class CLuaMain* pMain)
                 delete pEvent;
 
                 // Remove from list
-                m_EventHashMap.erase(iter++);
+                m_EventHashMap.erase(iter);
             }
         }
-        else
-            ++iter;
+
+        ++iter;
     }
 }
 

--- a/Server/mods/deathmatch/logic/CEvents.cpp
+++ b/Server/mods/deathmatch/logic/CEvents.cpp
@@ -22,16 +22,27 @@ bool CEvents::AddEvent(const char* szName, const char* szArguments, CLuaMain* pL
     assert(szName);
     assert(szArguments);
 
-    // If it already exists, return
-    if (Get(szName))
-        return false;
+    // Get the event if it already exists
+    SEvent* pEvent = Get(szName);
 
-    // Create and add the event
-    SEvent* pEvent = new SEvent;
-    pEvent->strName = szName;
-    pEvent->strArguments = szArguments;
-    pEvent->pLuaMain = pLuaMain;
-    pEvent->bAllowRemoteTrigger = bAllowRemoteTrigger;
+    if (pEvent)
+    {
+        // If bAllowRemoteTrigger has been altered, return
+        if (pEvent->bAllowRemoteTrigger != bAllowRemoteTrigger)
+            return false;
+        
+        // Add pLuaMain to the set, std::set guarantees unique elements
+        pEvent->pLuaMainSet.insert(pLuaMain);
+    }
+    else
+    {
+        // Create and add the event
+        pEvent = new SEvent;
+        pEvent->strName = szName;
+        pEvent->strArguments = szArguments;
+        pEvent->pLuaMainSet.insert(pLuaMain);
+        pEvent->bAllowRemoteTrigger = bAllowRemoteTrigger;
+    }
 
     m_EventHashMap[szName] = pEvent;
 
@@ -68,14 +79,21 @@ void CEvents::RemoveAllEvents(class CLuaMain* pMain)
     while (iter != m_EventHashMap.end())
     {
         SEvent* pEvent = (*iter).second;
-        // If they match, delete it null it and set the bool
-        if (pEvent->pLuaMain == pMain)
-        {
-            // Delete the object
-            delete pEvent;
 
-            // Remove from list
-            m_EventHashMap.erase(iter++);
+        // If they match, remove pMain from the set and check for deletion
+        if (pEvent->pLuaMainSet.find(pMain) != pEvent->pLuaMainSet.end())
+        {
+            pEvent->pLuaMainSet.erase(pMain);
+
+            // If no pMain is left, delete it null it and set the bool
+            if (pEvent->pLuaMainSet.size() == 0)
+            {
+                // Delete the object
+                delete pEvent;
+
+                // Remove from list
+                m_EventHashMap.erase(iter++);
+            }
         }
         else
             ++iter;

--- a/Server/mods/deathmatch/logic/CEvents.h
+++ b/Server/mods/deathmatch/logic/CEvents.h
@@ -17,10 +17,10 @@
 
 struct SEvent
 {
-    std::set<class CLuaMain*> pLuaMainSet;
-    std::string               strName;
-    std::string               strArguments;
-    bool                      bAllowRemoteTrigger;
+    std::unordered_set<class CLuaMain*> pLuaMainSet;
+    std::string                         strName;
+    std::string                         strArguments;
+    bool                                bAllowRemoteTrigger;
 };
 
 class CEvents

--- a/Server/mods/deathmatch/logic/CEvents.h
+++ b/Server/mods/deathmatch/logic/CEvents.h
@@ -17,10 +17,10 @@
 
 struct SEvent
 {
-    class CLuaMain* pLuaMain;
-    std::string     strName;
-    std::string     strArguments;
-    bool            bAllowRemoteTrigger;
+    std::set<class CLuaMain*> pLuaMainSet;
+    std::string               strName;
+    std::string               strArguments;
+    bool                      bAllowRemoteTrigger;
 };
 
 class CEvents

--- a/Server/mods/deathmatch/logic/CEvents.h
+++ b/Server/mods/deathmatch/logic/CEvents.h
@@ -17,10 +17,10 @@
 
 struct SEvent
 {
-    std::unordered_set<class CLuaMain*> pLuaMainSet;
-    std::string                         strName;
-    std::string                         strArguments;
-    bool                                bAllowRemoteTrigger;
+    std::vector<class CLuaMain*> pLuaMainVector;
+    std::string                  strName;
+    std::string                  strArguments;
+    bool                         bAllowRemoteTrigger;
 };
 
 class CEvents


### PR DESCRIPTION
Fixes #2448

When adding event handlers for a custom event in multiple resources, you have to use addEvent to make sure the event is already registered when adding the handler. The problem with the existing system happens in a situation where the first resource that used addEvent, is stopped. It is still possible that other resources had handlers for that specific event (and also used addEvent, for that matter), but still the event will never get triggered again. The reason is that the addEvent calls that came after the initial one, immediately returned false and didn't actually do anything.

This PR changes that behaviour, keeping a list of all resources that added a certain event and only removing an event when all resources that used addEvent are stopped. For security reasons, addEvent will return false and not do anything in case the allowRemoteTrigger argument would have been altered between different calls to the function.

Small note: I noticed that the strArguments member of SEvent is never used for anything, perhaps it could be an idea to clean this and remove the unused member?