### PR TITLE
Fix #2335: Don't allow dead peds to enter vehicles

### DIFF
--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -2834,7 +2834,7 @@ void CGame::Packet_Vehicle_InOut(CVehicleInOutPacket& Packet)
                     }
                 }
 
-                // Check we have a valid ped & he is spawned
+                // Check we have a valid ped
                 if (bValidPed)
                 {
                     // Handle it depending on the action
@@ -2856,6 +2856,13 @@ void CGame::Packet_Vehicle_InOut(CVehicleInOutPacket& Packet)
                                 FAIL_ACTION,
                                 FAIL_TRAILER,
                             } failReason = FAIL_INVALID;
+
+                            // Is he spawned? (Fix for #2335)
+                            if (!pPed->IsSpawned()) {
+                                CVehicleInOutPacket Reply(PedID, VehicleID, 0, VEHICLE_ATTEMPT_FAILED);
+                                pPlayer->Send(Reply);
+                                break;
+                            }
 
                             // Is this vehicle enterable? (not a trailer)
                             unsigned short usVehicleModel = pVehicle->GetModel();


### PR DESCRIPTION
#1907 allowed dead peds to send entry/exit packets, because this is necessary to fix #908 
This PR fixes #2335 by not allowing a dead ped to enter a vehicle (serverside).

But why is this clientside check in `CClientPed::EnterVehicle` not preventing a dead ped from sending a packet?

https://github.com/multitheftauto/mtasa-blue/blob/2aa3c38ea24c373e6a7d0050613ea41b7dc14510/Client/mods/deathmatch/logic/CClientPed.cpp#L6456-L6459

Because in `CClientPed::IsDead` when the ped is streamed it queries gta for TASK_SIMPLE_DEAD instead of returning m_bDead, and the task probably isn't initiated yet before the next frame (and it processed the player wasted packet from `killPed` and entity destroy packet from `destroyElement` in the same frame, so when `CClientGame::DoVehicleInKeyCheck()` is pulsed afterwards the player appears to be alive and outside a vehicle for that 1 frame).
