### PR TITLE
Typo fix in remotely

### DIFF
--- a/Client/loader/Utils.cpp
+++ b/Client/loader/Utils.cpp
@@ -60,7 +60,7 @@ bool CallRemoteFunction(HANDLE hProcess, const SString& strFunctionName, const W
         }
 
         /* Start a remote thread executing LoadLibraryA exported from Kernel32. Passing the
-           remotly allocated path buffer as an argument to that thread (and also to LoadLibraryA)
+           remotely allocated path buffer as an argument to that thread (and also to LoadLibraryA)
            will make the remote process load the DLL into it's userspace (giving the DLL full
            access to the game executable).*/
         LPTHREAD_START_ROUTINE pFunc = reinterpret_cast<LPTHREAD_START_ROUTINE>(GetProcAddress(hKernel32, strFunctionName));

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -3051,7 +3051,7 @@ void CClientPed::ApplyControllerStateFixes(CControllerState& Current)
     }
 
     // If we started crouching less than some time ago, make sure we can't jump or sprint.
-    // This fixes the exploit both locally and remotly that enables players to abort
+    // This fixes the exploit both locally and remotely that enables players to abort
     // the crouching animation and shoot quickly with slow shooting weapons. Also fixes
     // the exploit making you able to get crouched without being able to move and shoot
     // with infinite ammo for remote players.
@@ -3124,7 +3124,7 @@ void CClientPed::ApplyControllerStateFixes(CControllerState& Current)
         {
             // Don't allow the aiming key (RightShoulder1)
             // This fixes bug allowing you to run around in aim mode while
-            // entering a vehicle both locally and remotly.
+            // entering a vehicle both locally and remotely.
             Current.RightShoulder1 = 0;
         }
     }

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -4880,7 +4880,7 @@ void CPacketHandler::Packet_LuaEvent(NetBitStreamInterface& bitStream)
             // Read out the arguments aswell
             CLuaArguments Arguments(bitStream);
 
-            // Grab the event. Does it exist and is it remotly triggerable?
+            // Grab the event. Does it exist and is it remotely triggerable?
             SEvent* pEvent = g_pClientGame->m_Events.Get(szName);
             if (pEvent)
             {
@@ -4894,7 +4894,7 @@ void CPacketHandler::Packet_LuaEvent(NetBitStreamInterface& bitStream)
                     }
                 }
                 else
-                    g_pClientGame->m_pScriptDebugging->LogError(NULL, "Server triggered clientside event %s, but event is not marked as remotly triggerable",
+                    g_pClientGame->m_pScriptDebugging->LogError(NULL, "Server triggered clientside event %s, but event is not marked as remotely triggerable",
                                                                 szName);
             }
             else

--- a/Client/multiplayer_sa/multiplayer_keysync.cpp
+++ b/Client/multiplayer_sa/multiplayer_keysync.cpp
@@ -94,7 +94,7 @@ void         PostContextSwitch()
     MemPutFast<BYTE>(0x50BFB1, 0x8B);
     MemPutFast<BYTE>(0x50BFB2, 0x44);
 
-    // This is so weapon clicks and similar don't play for us when done remotly
+    // This is so weapon clicks and similar don't play for us when done remotely
     MemPutFast<BYTE>(0x60F273, 0x75);
     MemPutFast<BYTE>(0x60F260, 0x74);
     MemPutFast<BYTE>(0x60F261, 0x13);
@@ -346,7 +346,7 @@ void SwitchContext(CPed* thePed)
                     //*(BYTE *)0x73811C = 0x90;
                     //*(BYTE *)0x73811D = 0xE9;
 
-                    // This is so weapon clicks and similar don't play for us when done remotly
+                    // This is so weapon clicks and similar don't play for us when done remotely
                     MemPutFast<BYTE>(0x60F273, 0xEB);
                     MemPutFast<BYTE>(0x60F260, 0x90);
                     MemPutFast<BYTE>(0x60F261, 0x90);

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -2491,7 +2491,7 @@ void CGame::Packet_LuaEvent(CLuaEventPacket& Packet)
                 pElement->CallEvent(szName, *pArguments, pCaller);
             }
             else
-                m_pScriptDebugging->LogError(NULL, "Client (%s) triggered serverside event %s, but event is not marked as remotly triggerable",
+                m_pScriptDebugging->LogError(NULL, "Client (%s) triggered serverside event %s, but event is not marked as remotely triggerable",
                                              pCaller->GetNick(), szName);
         }
         else

--- a/Shared/mods/deathmatch/logic/Utils.cpp
+++ b/Shared/mods/deathmatch/logic/Utils.cpp
@@ -460,7 +460,7 @@ HMODULE RemoteLoadLibrary(HANDLE hProcess, const char* szLibPath)
         }
 
         /* Start a remote thread executing LoadLibraryA exported from Kernel32. Passing the
-           remotly allocated path buffer as an argument to that thread (and also to LoadLibraryA)
+           remotely allocated path buffer as an argument to that thread (and also to LoadLibraryA)
            will make the remote process load the DLL into it's userspace (giving the DLL full
            access to the game executable).*/
         hThread =


### PR DESCRIPTION
Fixes a typo in the word "remotely" in 9 places. Majority of these are in comments, two notable exceptions are the server sided and client sided error messages when triggering an event remotely while it is not marked as remotely triggerable.