### PR TITLE
Use vector length method instead of manual distance calculation

### DIFF
--- a/Server/mods/deathmatch/logic/CBuildingRemovalManager.cpp
+++ b/Server/mods/deathmatch/logic/CBuildingRemovalManager.cpp
@@ -73,13 +73,7 @@ void CBuildingRemovalManager::RestoreWorldModel(unsigned short usModel, float fR
         if (pFind)
         {
             const CVector& vecRemovalPos = pFind->GetPosition();
-            // Grab distances across each axis
-            float fDistanceX = vecPos.fX - vecRemovalPos.fX;
-            float fDistanceY = vecPos.fY - vecRemovalPos.fY;
-            float fDistanceZ = vecPos.fZ - vecRemovalPos.fZ;
-
-            // Square root 'em
-            float fDistance = sqrt(fDistanceX * fDistanceX + fDistanceY * fDistanceY + fDistanceZ * fDistanceZ);
+            float fDistance = (vecPos - vecRemovalPos).Length();
 
             if (fDistance <= pFind->GetRadius() && (cInterior == -1 || pFind->GetInterior() == cInterior))
             {


### PR DESCRIPTION
Simplifies distance calculation by using `.Length()` method on the `CVector` class
