### PR TITLE
Add missing getType method for camera element

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
@@ -63,7 +63,7 @@ void CLuaCameraDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getClip", "getCameraClip");
     lua_classfunction(luaVM, "getFarClipDistance", "getFarClipDistance");
     lua_classfunction(luaVM, "getNearClipDistance", "getNearClipDistance");
-    lua_classfunction(luaVM, "getType", GetElementType);
+    lua_classfunction(luaVM, "getType", ArgumentParser<GetElementType>);
 
     lua_classfunction(luaVM, "setPosition", OOP_SetCameraPosition);
     lua_classfunction(luaVM, "setRotation", OOP_SetCameraRotation);
@@ -87,7 +87,7 @@ void CLuaCameraDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "position", OOP_SetCameraPosition, OOP_GetCameraPosition);
     lua_classvariable(luaVM, "rotation", OOP_SetCameraRotation, OOP_GetCameraRotation);
     lua_classvariable(luaVM, "matrix", NULL, OOP_GetCameraMatrix);
-    lua_classvariable(luaVM, "type", NULL, GetElementType);
+    lua_classvariable(luaVM, "type", NULL, ArgumentParser<GetElementType>);
 
     lua_registerstaticclass(luaVM, "Camera");
 }
@@ -593,9 +593,7 @@ int CLuaCameraDefs::OOP_SetCameraRotation(lua_State* luaVM)
     return 1;
 }
 
-int CLuaCameraDefs::GetElementType(lua_State* luaVM)
+std::string CLuaCameraDefs::GetElementType()
 {
-    const char* szTypeName = m_pManager->GetCamera()->GetTypeName();
-    lua_pushstring(luaVM, szTypeName);
-    return 1;
+    return std::string(m_pManager->GetCamera()->GetTypeName());
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
@@ -593,7 +593,7 @@ int CLuaCameraDefs::OOP_SetCameraRotation(lua_State* luaVM)
     return 1;
 }
 
-std::string CLuaCameraDefs::GetElementType()
+SString CLuaCameraDefs::GetElementType()
 {
-    return std::string(m_pManager->GetCamera()->GetTypeName());
+    return m_pManager->GetCamera()->GetTypeName();
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
@@ -63,6 +63,7 @@ void CLuaCameraDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getClip", "getCameraClip");
     lua_classfunction(luaVM, "getFarClipDistance", "getFarClipDistance");
     lua_classfunction(luaVM, "getNearClipDistance", "getNearClipDistance");
+    lua_classfunction(luaVM, "getType", GetElementType);
 
     lua_classfunction(luaVM, "setPosition", OOP_SetCameraPosition);
     lua_classfunction(luaVM, "setRotation", OOP_SetCameraRotation);
@@ -86,6 +87,7 @@ void CLuaCameraDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "position", OOP_SetCameraPosition, OOP_GetCameraPosition);
     lua_classvariable(luaVM, "rotation", OOP_SetCameraRotation, OOP_GetCameraRotation);
     lua_classvariable(luaVM, "matrix", NULL, OOP_GetCameraMatrix);
+    lua_classvariable(luaVM, "type", NULL, GetElementType);
 
     lua_registerstaticclass(luaVM, "Camera");
 }
@@ -588,5 +590,12 @@ int CLuaCameraDefs::OOP_SetCameraRotation(lua_State* luaVM)
         return 1;
     }
     lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaCameraDefs::GetElementType(lua_State* luaVM)
+{
+    const char* szTypeName = m_pManager->GetCamera()->GetTypeName();
+    lua_pushstring(luaVM, szTypeName);
     return 1;
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
@@ -87,7 +87,7 @@ void CLuaCameraDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "position", OOP_SetCameraPosition, OOP_GetCameraPosition);
     lua_classvariable(luaVM, "rotation", OOP_SetCameraRotation, OOP_GetCameraRotation);
     lua_classvariable(luaVM, "matrix", NULL, OOP_GetCameraMatrix);
-    lua_classvariable(luaVM, "type", NULL, ArgumentParser<GetElementType>);
+    lua_classvariable(luaVM, "type", nullptr, ArgumentParser<GetElementType>);
 
     lua_registerstaticclass(luaVM, "Camera");
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
@@ -593,7 +593,7 @@ int CLuaCameraDefs::OOP_SetCameraRotation(lua_State* luaVM)
     return 1;
 }
 
-SString CLuaCameraDefs::GetElementType()
+const SString& CLuaCameraDefs::GetElementType()
 {
     return m_pManager->GetCamera()->GetTypeName();
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.h
@@ -48,5 +48,5 @@ public:
     LUA_DECLARE(OOP_GetCameraRotation);
     LUA_DECLARE(OOP_SetCameraRotation);
 
-    static SString GetElementType();
+    static const SString& GetElementType();
 };

--- a/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.h
@@ -48,5 +48,5 @@ public:
     LUA_DECLARE(OOP_GetCameraRotation);
     LUA_DECLARE(OOP_SetCameraRotation);
 
-    static std::string GetElementType();
+    static SString GetElementType();
 };

--- a/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.h
@@ -30,6 +30,7 @@ public:
     LUA_DECLARE(GetCameraGoggleEffect);
     LUA_DECLARE(GetCameraShakeLevel);
     LUA_DECLARE(GetCameraFieldOfView);
+    LUA_DECLARE(GetElementType);
 
     // Cam set funcs
     LUA_DECLARE(SetCameraMatrix);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.h
@@ -30,7 +30,6 @@ public:
     LUA_DECLARE(GetCameraGoggleEffect);
     LUA_DECLARE(GetCameraShakeLevel);
     LUA_DECLARE(GetCameraFieldOfView);
-    LUA_DECLARE(GetElementType);
 
     // Cam set funcs
     LUA_DECLARE(SetCameraMatrix);
@@ -48,4 +47,6 @@ public:
     LUA_DECLARE(OOP_SetCameraPosition);
     LUA_DECLARE(OOP_GetCameraRotation);
     LUA_DECLARE(OOP_SetCameraRotation);
+
+    static std::string GetElementType();
 };


### PR DESCRIPTION
Added missing getType method for camera element
```lua
local camera = getCamera()
print( camera.type ) -- >> "camera"
print( camera:getType() ) -- >> "camera"
```