### PR TITLE
Add getProcessMemory function

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Util.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Util.cpp
@@ -9,6 +9,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include <Psapi.h>
 
 int CLuaFunctionDefs::GetValidPedModels(lua_State* luaVM)
 {
@@ -307,6 +308,18 @@ int CLuaFunctionDefs::GetPerformanceStats(lua_State* luaVM)
     else
         m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
 
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaFunctionDefs::GetProcessMemory(lua_State* luaVM)
+{
+    PROCESS_MEMORY_COUNTERS psmemCounters;
+    if (GetProcessMemoryInfo(GetCurrentProcess(), &psmemCounters, sizeof(psmemCounters)))
+    {
+        lua_pushnumber(luaVM, psmemCounters.WorkingSetSize / 1024LL);
+        return 1;
+    }
     lua_pushboolean(luaVM, false);
     return 1;
 }

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.h
@@ -105,6 +105,7 @@ public:
     LUA_DECLARE(GetNetworkUsageData);
     LUA_DECLARE(GetNetworkStats);
     LUA_DECLARE(GetPerformanceStats);
+    LUA_DECLARE(GetProcessMemory);
     LUA_DECLARE(AddDebugHook);
     LUA_DECLARE(RemoveDebugHook);
     LUA_DECLARE(GetVersion);

--- a/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -223,6 +223,7 @@ void CLuaManager::LoadCFunctions()
         {"getNetworkUsageData", CLuaFunctionDefs::GetNetworkUsageData},
         {"getNetworkStats", CLuaFunctionDefs::GetNetworkStats},
         {"getPerformanceStats", CLuaFunctionDefs::GetPerformanceStats},
+        {"getProcessMemory", CLuaFunctionDefs::GetProcessMemory},
         {"setDevelopmentMode", CLuaFunctionDefs::SetDevelopmentMode},
         {"getDevelopmentMode", CLuaFunctionDefs::GetDevelopmentMode},
         {"addDebugHook", CLuaFunctionDefs::AddDebugHook},


### PR DESCRIPTION
Solves #1563

Adds `getProcessMemory()`

This function returns the current memory usage of **gta_sa.exe** process. Essentially copied from [CMemStats.cpp](https://github.com/multitheftauto/mtasa-blue/blob/c58c3678f263d810f61eb5aecba48e6c4b4dce0c/Client/core/CMemStats.cpp#L461-L463) (win api call)
Returned value in KB is equal to the one displayed in memory stats ("showmemstat" command)

It will be useful for big servers that push memory boundaries to the limit (about 3.3 GB) to avoid crashing the client.
It's not a secret that when you disconnect from one server and connect to another the current memory usage increases and increases (i personally saw values up to 1.6 GB usage after disconnect).
So if you add let's say 1 GB of models to this and some other things the usage will get dangerously close to the limit right after the loading.

This function should allow servers to determine if current memory usage is not too high for their resources. And in this case server could use alternative (more optimized) loading mode or notify the user and ask to restart MTA.
Also it could be used to monitor the memory during gameplay and notify the user if it's getting too high (so user could restart MTA before it unexpectedly crashes in a bad moment).
