### PR TITLE
Update curl from 7.79.0 to 7.79.1

### DIFF
--- a/vendor/curl/CHANGES
+++ b/vendor/curl/CHANGES
@@ -6,6 +6,171 @@
 
                                   Changelog
 
+Version 7.79.1 (22 Sep 2021)
+
+Daniel Stenberg (22 Sep 2021)
+- RELEASE-NOTES: synced
+  
+  curl 7.79.1 release
+
+- THANKS: added names from the 7.79.1 release
+
+- test897: verify delivery of IMAP post-body header content
+  
+  The "content" is delivered as "body" by curl, but the envelope continues
+  after the body and the rest of it should be delivered as header.
+  
+  The IMAP server can now get 'POSTFETCH' set to include more data to
+  include after the body and test 897 is done to verify that such "extra"
+  header data is in fact delivered by curl as header.
+  
+  Ref: #7284 but fails to reproduce the issue
+  
+  Closes #7748
+
+- KNOWN_BUGS: connection migration doesn't work
+  
+  Closes #7695
+
+- RELEASE-NOTES: synced
+
+- http: fix the broken >3 digit response code detection
+  
+  When the "reason phrase" in the HTTP status line starts with a digit,
+  that was treated as the forth response code digit and curl would claim
+  the response to be non-compliant.
+  
+  Added test 1466 to verify this case.
+  
+  Regression brought by 5dc594e44f73b17
+  Reported-by: Glenn de boer
+  Fixes #7738
+  Closes #7739
+
+Jay Satiro (17 Sep 2021)
+- strerror: use sys_errlist instead of strerror on Windows
+  
+  - Change Curl_strerror to use sys_errlist[errnum] instead of strerror to
+    retrieve the error message on Windows.
+  
+  Windows' strerror writes to a static buffer and is not thread-safe.
+  
+  Follow-up to 2f0bb86 which removed most instances of strerror in favor
+  of calling Curl_strerror (which calls strerror_r for other platforms).
+  
+  Ref: https://github.com/curl/curl/pull/7685
+  Ref: https://github.com/curl/curl/commit/2f0bb86
+  
+  Closes https://github.com/curl/curl/pull/7735
+
+Daniel Stenberg (16 Sep 2021)
+- dist: provide lib/.checksrc in the tarball
+  
+  So that debug builds work (checksrc really)
+  
+  Reported-by: Marcel Raad
+  Reported-by: tawmoto on github
+  Fixes #7733
+  Closes #7734
+
+- TODO: Improve documentation about fork safety
+  
+  Closes #6968
+
+- hsts: CURLSTS_FAIL from hsts read callback should fail transfer
+  
+  ... and have CURLE_ABORTED_BY_CALLBACK returned.
+  
+  Extended test 1915 to verify.
+  
+  Reported-by: Jonathan Cardoso
+  Fixes #7726
+  Closes #7729
+
+- test1184: disable
+  
+  The test should be fine and it works for me repeated when run manually,
+  but clearly it causes CI failures and it needs more research.
+  
+  Reported-by: RiderALT on github
+  Fixes #7725
+  Closes #7732
+
+- Curl_http2_setup: don't change connection data on repeat invokes
+  
+  Regression from 3cb8a748670ab88c (releasde in 7.79.0). That change moved
+  transfer oriented inits to before the check but also erroneously moved a
+  few connection oriented ones, which causes problems.
+  
+  Reported-by: Evangelos Foutras
+  Fixes #7730
+  Closes #7731
+
+- RELEASE-NOTES: synced
+  
+  and bump to 7.79.1
+
+Kamil Dudka (16 Sep 2021)
+- tests/sshserver.pl: make it work with openssh-8.7p1
+  
+  ... by not using options with no argument where an argument is required:
+  
+  === Start of file tests/log/ssh_server.log
+  curl_sshd_config line 6: no argument after keyword "DenyGroups"
+  curl_sshd_config line 7: no argument after keyword "AllowGroups"
+  curl_sshd_config line 10: Deprecated option AuthorizedKeysFile2
+  curl_sshd_config line 29: Deprecated option KeyRegenerationInterval
+  curl_sshd_config line 39: Deprecated option RhostsRSAAuthentication
+  curl_sshd_config line 40: Deprecated option RSAAuthentication
+  curl_sshd_config line 41: Deprecated option ServerKeyBits
+  curl_sshd_config line 45: Deprecated option UseLogin
+  curl_sshd_config line 56: no argument after keyword "AcceptEnv"
+  curl_sshd_config: terminating, 3 bad configuration options
+  === End of file tests/log/ssh_server.log
+  
+  === Start of file log/sftp_server.log
+  curl_sftp_config line 33: Unsupported option "rhostsrsaauthentication"
+  curl_sftp_config line 34: Unsupported option "rsaauthentication"
+  curl_sftp_config line 52: no argument after keyword "sendenv"
+  curl_sftp_config: terminating, 1 bad configuration options
+  Connection closed.
+  Connection closed
+  === End of file log/sftp_server.log
+  
+  Closes #7724
+
+Daniel Stenberg (15 Sep 2021)
+- hsts: handle unlimited expiry
+  
+  When setting a blank expire string, meaning unlimited, curl would pass
+  TIME_T_MAX to getime_r() when creating the output, while on 64 bit
+  systems such a large value cannot be convetered to a tm struct making
+  curl to exit the loop with an error instead. It can't be converted
+  because the year it would represent doesn't fit in the 'int tm_year'
+  field!
+  
+  Starting now, unlimited expiry is instead handled differently by using a
+  human readable expiry date spelled out as "unlimited" instead of trying
+  to use a distant actual date.
+  
+  Test 1660 and 1915 have been updated to help verify this change.
+  
+  Reported-by: Jonathan Cardoso
+  Fixes #7720
+  Closes #7721
+
+- curl_multi_fdset: make FD_SET() not operate on sockets out of range
+  
+  The VALID_SOCK() macro was made to only check for FD_SETSIZE if curl was
+  built to use select(), even though the curl_multi_fdset() function
+  always and unconditionally uses FD_SET and needs the check.
+  
+  Reported-by: 0xee on github
+  Fixes #7718
+  Closes #7719
+
+- FAQ: add GOPHERS + curl works on data, not files
+
 Version 7.79.0 (14 Sep 2021)
 
 Daniel Stenberg (14 Sep 2021)
@@ -8109,174 +8274,3 @@ Daniel Stenberg (20 Jan 2021)
   Closes #6473
 
 - gopher: remove accidental conn->data leftover
-
-- libssh: avoid plain free() of libssh-memory
-  
-  Since curl's own memory debugging system redefines free() calls to track
-  and fiddle with memory, it cannot be used on memory allocated by 3rd
-  party libraries.
-  
-  Third party libraries SHOULD NOT require free() to release allocated
-  resources for this reason - and libs can use separate healp allocators
-  on some systems (like Windows) so free() doesn't necessarily work
-  anyway.
-  
-  Filed as an issue with libssh: https://bugs.libssh.org/T268
-  
-  Closes #6481
-
-- send: assert that Curl_write_plain() has a ->conn when called
-  
-  To help catch bad invokes.
-  
-  Closes #6476
-
-- test410: verify HTTPS GET with a 49K request header
-  
-  skip test 410 for mesalink in the CI as it otherwise hangs "forever"
-
-- lib: pass in 'struct Curl_easy *' to most functions
-  
-  ... in most cases instead of 'struct connectdata *' but in some cases in
-  addition to.
-  
-  - We mostly operate on transfers and not connections.
-  
-  - We need the transfer handle to log, store data and more. Everything in
-    libcurl is driven by a transfer (the CURL * in the public API).
-  
-  - This work clarifies and separates the transfers from the connections
-    better.
-  
-  - We should avoid "conn->data". Since individual connections can be used
-    by many transfers when multiplexing, making sure that conn->data
-    points to the current and correct transfer at all times is difficult
-    and has been notoriously error-prone over the years. The goal is to
-    ultimately remove the conn->data pointer for this reason.
-  
-  Closes #6425
-
-Emil Engler (17 Jan 2021)
-- docs: fix typos in NEW-PROTOCOL.md
-  
-  This fixes a misspelled "it" and a grammatically wrong "-ing" suffix.
-  
-  Closes #6471
-
-Daniel Stenberg (16 Jan 2021)
-- RELEASE-NOTES: synced
-
-Jay Satiro (16 Jan 2021)
-- [Razvan Cojocaru brought this change]
-
-  cmake: expose CURL_DISABLE_OPENSSL_AUTO_LOAD_CONFIG
-  
-  This does for cmake builds what --disable-openssl-auto-load-config
-  does for autoconf builds.
-  
-  Closes https://github.com/curl/curl/pull/6435
-
-Daniel Stenberg (15 Jan 2021)
-- test1918: verify curl_easy_option_by_name() and curl_easy_option_by_id()
-  
-  ... and as a practical side-effect, make sure that the
-  Curl_easyopts_check() function is asserted in debug builds, which we
-  want to detect mismatches between the options list in easyoptions.c and
-  the options in curl.h
-  
-  Found-by: Gisle Vanem
-  Bug: https://github.com/curl/curl/commit/08e8455dddc5e48e58a12ade3815c01ae3da3b64#commitcomment-45991815
-  
-  Closes #6461
-
-- [Gisle Vanem brought this change]
-
-  easyoptions: add the missing AWS_SIGV4
-  
-  Follow-up from AWS_SIGV4
-
-- schannel_verify: fix safefree call typo
-  
-  Follow-up from e87ad71d1ba00519
-  
-  Closes #6459
-
-- mime: make sure setting MIMEPOST to NULL resets properly
-  
-  ... so that a function can first use MIMEPOST and then set it to NULL to
-  reset it back to a blank POST.
-  
-  Added test 584 to verify the fix.
-  
-  Reported-by: Christoph M. Becker
-  
-  Fixes #6455
-  Closes #6456
-
-- multi: set the PRETRANSFER time-stamp when we switch to PERFORM
-  
-  ... instead of at end of the DO state. This makes the timer more
-  accurate for the protocols that use the DOING state (such as FTP), and
-  simplifies how the function (now called init_perform) is called.
-  
-  The timer will then include the entire procedure up to PERFORM -
-  including all instructions for getting the transfer started.
-  
-  Closes #6454
-
-- CURLINFO_PRETRANSFER_TIME.3: clarify
-  
-  ... the timer *does* include the instructions for getting the remote
-  file.
-  
-  Ref: #6452
-  Closes #6453
-
-- [Gisle Vanem brought this change]
-
-  schannel: plug a memory-leak
-  
-  ... when built without -DUNICODE.
-  
-  Closes #6457
-
-Jay Satiro (14 Jan 2021)
-- gitattributes: Set batch files to CRLF line endings on checkout
-  
-  If a batch file is run without CRLF line endings (ie LF-only) then
-  arbitrary behavior may occur. I consider that a bug in Windows, however
-  the effects can be serious enough (eg unintended code executed) that
-  we're fixing it in the repo by requiring CRLF line endings for batch
-  files on checkout.
-  
-  Prior to this change the checked-out line endings of batch files were
-  dependent on a user's git preferences. On Windows it is common for git
-  users to have automatic CRLF conversion enabled (core.autocrlf true),
-  but those users that don't would run into this behavior.
-  
-  For example a user has reported running the Visual Studio project
-  generator batch file (projects/generate.bat) and it looped forever.
-  Output showed that the Windows OS interpreter was occasionally jumping
-  to arbitrary points in the batch file and executing commands. This
-  resulted in unintended files being removed (a removal sequence called)
-  and looping forever.
-  
-  Ref: https://serverfault.com/q/429594
-  Ref: https://stackoverflow.com/q/232651
-  Ref: https://www.dostips.com/forum/viewtopic.php?t=8988
-  Ref: https://git-scm.com/docs/gitattributes#_checking_out_and_checking_in
-  Ref: https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_core_autocrlf
-  
-  Bug: https://github.com/curl/curl/discussions/6427
-  Reported-by: Ganesh Kamath
-  
-  Closes https://github.com/curl/curl/pull/6442
-
-Daniel Stenberg (14 Jan 2021)
-- tool_operate: spellfix a comment
-
-- ROADMAP: refreshed
-  
-  o removed HSTS - already implemented
-  o added HTTPS RR records
-  o mention HTTP/3 completion

--- a/vendor/curl/RELEASE-NOTES
+++ b/vendor/curl/RELEASE-NOTES
@@ -1,147 +1,23 @@
-curl and libcurl 7.79.0
+curl and libcurl 7.79.1
 
- Public curl releases:         202
+ Public curl releases:         203
  Command line options:         242
  curl_easy_setopt() options:   290
  Public functions in libcurl:  85
- Contributors:                 2484
-
-This release includes the following changes:
-
- o bearssl: support CURLOPT_CAINFO_BLOB [3]
- o http: consider cookies over localhost to be secure [24]
- o secure transport: support CURLINFO_CERTINFO [63]
+ Contributors:                 2489
 
 This release includes the following bugfixes:
 
- o CVE-2021-22945: clear the leftovers pointer when sending succeeds [112]
- o CVE-2021-22946: do not ignore --ssl-reqd [111]
- o CVE-2021-22947: reject STARTTLS server response pipelining [110]
- o ares: use ares_getaddrinfo() [51]
- o asyn-ares.c: move all version number checks to the top
- o auth: do not append zero-terminator to authorisation id in kerberos [32]
- o auth: properly handle byte order in kerberos security message [36]
- o auth: use sasl authzid option in kerberos [34]
- o auth: we do not support a security layer after kerberos authentication [35]
- o BINDINGS.md: update links to use https where available [50]
- o build: fix compiler warnings [39]
- o c-hyper: deal with Expect: 100-continue combined with POSTFIELDS [66]
- o c-hyper: fix header value passed to debug callback [46]
- o c-hyper: handle HTTP/1.1 => HTTP/1.0 downgrade on reused connection [65]
- o c-hyper: initial step for 100-continue support [43]
- o c-hyper: initial support for "dumping" 1xx HTTP responses [40]
- o c-hyper: remove the hyper_executor_poll() loop from Curl_http [13]
- o CI/cirrus: reduce compile time with increased parallism [19]
- o CI: use GitHub Container Registry instead of Docker Hub [47]
- o cirrus: Add FreeBSD 13.0 job and disable sanitizer build [128]
- o cmake: avoid poll() on macOS [59]
- o cmake: sync CURL_DISABLE options [55]
- o codeql: fix error "Resource not accessible by integration" [61]
- o compressed.d: it's a request, not an order [21]
- o config.d: escape the backslash properly [81]
- o config.d: note that curlrc is used even when --config [107]
- o config: get rid of the unused HAVE_SIG_ATOMIC_T et. al.
- o configure.ac: revert bad nghttp2 library detection improvements [9]
- o configure: error out if both ngtcp2 and quiche are specified [30]
- o configure: make --disable-hsts work [106]
- o configure: set classic mingw minimum OS version to XP [83]
- o configure: tweak nghttp2 library name fix [2]
- o connect: get local port + ip also when reusing connections [95]
- o connect: remove superfluous conditional [23]
- o curl-openssl.m4: check lib64 for the pkg-config file [14]
- o curl-openssl.m4: show correct output for OpenSSL v3 [75]
- o curl.1: mention "global" flags [7]
- o curl.1: provide examples for each option [99]
- o curl: add warning for ignored data after quoted form parameter [60]
- o curl: add warning for incompatible parameters usage [102]
- o curl: better error message when -O fails to get a good name [88]
- o curl: stop retry if Retry-After: is longer than allowed [104]
- o curl_easy_setopt.3: improve the string copy wording [89]
- o Curl_hsts_loadcb: don't attempt to load if hsts wasn't inited [116]
- o curl_setup.h: sync values for HTTP_ONLY [82]
- o curl_url_get.3: clarify about path and query [45]
- o CURLMOPT_TIMERFUNCTION.3: remove misplaced "time" [5]
- o CURLOPT_DOH_URL.3: CURLOPT_OPENSOCKETFUNCTION is not inherited [8]
- o CURLOPT_SSL_CTX_*.3: tidy up the example [15]
- o CURLOPT_UNIX_SOCKET_PATH.3: remove nginx reference, add see also [90]
- o docs/MQTT: update state of username/password support [4]
- o docs: remove experimental mentions from HSTS and MQTT [93]
- o docs: the security list is reached at security at curl.se now [124]
- o easy: use a custom implementation of wcsdup on Windows [31]
- o examples/*hiperfifo.c: fix calloc arguments to match function proto [103]
- o examples/cookie_interface: avoid printfing time_t directly [18]
- o examples/cookie_interface: fix scan-build printf warning [16]
- o examples/ephiperfifo.c: simplify signal handler [42]
- o FAQ: add two dev related questions [108]
- o getparameter: fix the --local-port number parser [58]
- o happy-eyeballs-timeout-ms.d: polish the wording [10]
- o hostip: Make Curl_ipv6works function independent of getaddrinfo [26]
- o http2: Curl_http2_setup needs to init stream data in all invokes [119]
- o http2: revert a change that broke upgrade to h2c [57]
- o http2: revert call the handle-closed function correctly on closed stream [25]
- o http: disallow >3-digit response codes [80]
- o http: ignore content-length if any transfer-encoding is used [101]
- o http_proxy: clear 'sending' when the outgoing request is sent [6]
- o http_proxy: fix the User-Agent inclusion in CONNECT [115]
- o http_proxy: fix user-agent and custom headers for CONNECT with hyper [38]
- o http_proxy: only wait for writable socket while sending request [78]
- o INTERNALS: bump c-ares requirement to 1.16.0
- o INTERNALS: c-ares has a new home: c-ares.org
- o lib: don't use strerror() [127]
- o libcurl-errors.3: clarify two CURLUcode errors [72]
- o limit-rate.d: clarify base unit [17]
- o mailing lists: move from cool.haxx.se to lists.haxx.se
- o mbedtls: avoid using a large buffer on the stack [105]
- o mbedTLS: initial 3.0.0 support [33]
- o mbedtls_threadlock: fix unused variable warning [11]
- o mksymbolsmanpage.pl: Fix showing symbol's last used version [76]
- o mksymbolsmanpage.pl: match symbols case insenitively [77]
- o multi: fix compiler warning with `CURL_DISABLE_WAKEUP` [96]
- o ngtcp2: compile with the latest ngtcp2 and nghttp3 [12]
- o ngtcp2: fix build with ngtcp2 and nghttp3 [117]
- o ngtcp2: remove the acked_crypto_offset struct field init [64]
- o ngtcp2: replace deprecated functions with nghttp3_conn_shutdown_stream_read [28]
- o ngtcp2: reset the oustanding send buffer again when drained [53]
- o ngtcp2: rework the return value handling of ngtcp2_conn_writev_stream [29]
- o ngtcp2: stop buffering crypto data [85]
- o ngtcp2: utilize crypto API functions to simplify [52]
- o openssl: annotate SSL3_MT_SUPPLEMENTAL_DATA [98]
- o openssl: when creating a new context, there cannot be an old one [48]
- o opt-docs: make sure all man pages have examples [92]
- o opt-docs: verify man page sections + order [91]
- o opts docs: unify phrasing in NAME header [126]
- o output.d: add method to suppress response bodies [49]
- o page-header: add GOPHERS, simplify wording in the 1st para [94]
- o progress: fix a compile warning on some systems [54]
- o progress: make trspeed avoid floats [100]
- o runtests: add option -u to error on server unexpectedly alive [125]
- o schannel: Work around typo in classic mingw macro [84]
- o scripts: invoke interpreters through /usr/bin/env [68]
- o setopt: enable CURLOPT_IGNORE_CONTENT_LENGTH for hyper [70]
- o strerror.h: remove the #include from files not using it
- o symbols-in-versions: fix CURLSSLBACKEND_QSOSSL last used version [73]
- o test1138: remove trailing space to make work with hyper [71]
- o test1173: check references to libcurl options [69]
- o test1280: CRLFify the response to please hyper [86]
- o test1565: fix windows build errors [27]
- o test365: verify response with chunked AND Content-Length headers
- o tests/*server.pl: flush output before executing subprocess [41]
- o tests/*server.py: remove pidfile on server termination [1]
- o tests/runtests.pl: cleanup copy&paste mistakes and unused code
- o tests/server/*.c: align handling of portfile argument and file [56]
- o tests: adjust the tftpd output to work with hyper mode [97]
- o tests: be explicit about using 'python3' instead of 'python' [67]
- o tests: enable test 1129 for hyper builds [87]
- o tests: make three tests pass until 2037 [22]
- o tool/tests: fix potential year 2038 issues [20]
- o tool_operate: Fix --fail-early with parallel transfers [62]
- o url: fix compiler warning in no-verbose builds [120]
- o urlapi.c:seturl: assert URL instead of using if-check [74]
- o vtls: fix typo in schannel_verify.c [44]
- o winbuild/README.md: clarify GEN_PDB option
- o wolfssl: clean up wolfcrypt error queue [79]
- o write-out.d: clarify size_download/upload [118]
- o x509asn1: fix heap over-read when parsing x509 certificates [37]
+ o Curl_http2_setup: don't change connection data on repeat invokes [10]
+ o curl_multi_fdset: make FD_SET() not operate on sockets out of range [4]
+ o dist: provide lib/.checksrc in the tarball [6]
+ o FAQ: add GOPHERS + curl works on data, not files
+ o hsts: CURLSTS_FAIL from hsts read callback should fail transfer [8]
+ o hsts: handle unlimited expiry [3]
+ o http: fix the broken >3 digit response code detection [1]
+ o strerror: use sys_errlist instead of strerror on Windows [5]
+ o test1184: disable [9]
+ o tests/sshserver.pl: make it work with openssh-8.7p1 [2]
 
 This release includes the following known bugs:
 
@@ -150,144 +26,19 @@ This release includes the following known bugs:
 This release would not have looked like this without help, code, reports and
 advice from friends like these:
 
-  a1346054 on github, Aleksandr Krotov, Alex Crichton, April King,
-  Artur Sinila, Barry Pollard, Bastian Krause, Benau on github,
-  Bernhard M. Wiedemann, Bin Lan, Brian Carpenter, Bylon2 on github,
-  Cao ZhenXiang, Carlo Marcelo Arenas Belón, Christian Weisgerber,
-  Colin O'Dell, Dan Fandrich, Daniel Gustafsson, Daniel Stenberg,
-  Daniel Woelfel, Dan Jacobson, David Cook, Don J Olmstead, Ehren Bendler,
-  Emil Engler, Gambit Communications, Gergely Nagy, Gisle Vanem,
-  git-bruh on github, Gleb Ivanovsky, Ikko Ashimine, Inho Oh, Jan Schaumann,
-  Jan Verbeek, Jeff Mears, Jeremy Falcon, Jonathan Cardoso Machado, Josh Soref,
-  Kari Pahula, Marcel Raad, Marc Hörsken, Max Dymond, Michael Kaufmann,
-  Michał Antoniak, modbw on github, Oleg Pudeyev, Oleguer Llopart,
-  Patrick Monnerat, Paul Johnson, Randall S. Becker, Ray Satiro, Rui Pinheiro,
-  Sergey Markelov, T200proX7 on github, Tatsuhiro Tsujikawa, Tk Xiong,
-  Viktor Szakats, Vincent Grande, Yaobin Wen, z2-2z on github,
-  z2_ on hackerone, zloi-user on github,
-  (62 contributors)
+  0xee on github, Daniel Stenberg, Evangelos Foutras, Glenn de boer,
+  Jonathan Cardoso Machado, Kamil Dudka, Marcel Raad, Ray Satiro,
+  RiderALT on github, tawmoto on github, Viktor Szakats,
+  (11 contributors)
 
 References to bug reports and discussions on issues:
 
- [1] = https://curl.se/bug/?i=7506
- [2] = https://curl.se/bug/?i=7485
- [3] = https://curl.se/bug/?i=7468
- [4] = https://curl.se/bug/?i=7474
- [5] = https://curl.se/bug/?i=7470
- [6] = https://curl.se/bug/?i=7155
- [7] = https://curl.se/bug/?i=7457
- [8] = https://curl.se/bug/?i=7441
- [9] = https://curl.se/bug/?i=7514
- [10] = https://curl.se/bug/?i=7433
- [11] = https://curl.se/bug/?i=7393
- [12] = https://curl.se/bug/?i=7541
- [13] = https://curl.se/bug/?i=7499
- [14] = https://curl.se/bug/?i=7503
- [15] = https://curl.se/bug/?i=7500
- [16] = https://curl.se/bug/?i=7497
- [17] = https://curl.se/bug/?i=7439
- [18] = https://curl.se/bug/?i=7490
- [19] = https://curl.se/bug/?i=7505
- [20] = https://curl.se/bug/?i=7466
- [21] = https://curl.se/bug/?i=7516
- [22] = https://curl.se/bug/?i=7512
- [23] = https://curl.se/bug/?i=7511
- [24] = https://curl.se/bug/?i=6733
- [25] = https://curl.se/bug/?i=7400
- [26] = https://curl.se/bug/?i=7529
- [27] = https://curl.se/bug/?i=7527
- [28] = https://curl.se/bug/?i=7546
- [29] = https://curl.se/bug/?i=7546
- [30] = https://curl.se/bug/?i=7545
- [31] = https://curl.se/bug/?i=7540
- [32] = https://curl.se/bug/?i=7008
- [33] = https://curl.se/bug/?i=7428
- [34] = https://curl.se/bug/?i=7008
- [35] = https://curl.se/bug/?i=7008
- [36] = https://curl.se/bug/?i=7008
- [37] = https://curl.se/bug/?i=7536
- [38] = https://curl.se/bug/?i=7598
- [39] = https://curl.se/bug/?i=7528
- [40] = https://curl.se/bug/?i=7597
- [41] = https://curl.se/bug/?i=7530
- [42] = https://curl.se/bug/?i=7310
- [43] = https://curl.se/bug/?i=7568
- [44] = https://curl.se/bug/?i=7566
- [45] = https://curl.se/bug/?i=7563
- [46] = https://curl.se/bug/?i=7567
- [47] = https://curl.se/bug/?i=7587
- [48] = https://curl.se/bug/?i=7585
- [49] = https://curl.se/bug/?i=7560
- [50] = https://curl.se/bug/?i=7558
- [51] = https://curl.se/bug/?i=7364
- [52] = https://curl.se/bug/?i=7551
- [53] = https://curl.se/bug/?i=7538
- [54] = https://curl.se/bug/?i=7549
- [55] = https://curl.se/bug/?i=7624
- [56] = https://curl.se/bug/?i=7574
- [57] = https://curl.se/bug/?i=7633
- [58] = https://curl.se/bug/?i=7582
- [59] = https://curl.se/bug/?i=7595
- [60] = https://curl.se/bug/?i=7394
- [61] = https://curl.se/bug/?i=7575
- [62] = https://curl.se/bug/?i=6939
- [63] = https://curl.se/bug/?i=4130
- [64] = https://curl.se/bug/?i=7578
- [65] = https://curl.se/bug/?i=7617
- [66] = https://curl.se/bug/?i=7616
- [67] = https://curl.se/bug/?i=7602
- [68] = https://curl.se/bug/?i=7602
- [69] = https://curl.se/bug/?i=7656
- [70] = https://curl.se/bug/?i=7614
- [71] = https://curl.se/bug/?i=7613
- [72] = https://curl.se/bug/?i=7611
- [73] = https://curl.se/bug/?i=7609
- [74] = https://curl.se/bug/?i=7610
- [75] = https://curl.se/bug/?i=7606
- [76] = https://github.com/curl/curl/commit/4e53b94#commitcomment-55239509
- [77] = https://github.com/curl/curl/commit/4e53b9430c7504de8984796e2a2091ec16f27136#commitcomment-55239253
- [78] = https://curl.se/bug/?i=7589
- [79] = https://curl.se/bug/?i=7594
- [80] = https://curl.se/bug/?i=7641
- [81] = https://curl.se/bug/?i=7603
- [82] = https://curl.se/bug/?i=7601
- [83] = https://curl.se/bug/?i=7581
- [84] = https://curl.se/bug/?i=7580
- [85] = https://curl.se/bug/?i=7637
- [86] = https://curl.se/bug/?i=7639
- [87] = https://curl.se/bug/?i=7638
- [88] = https://curl.se/bug/?i=7628
- [89] = https://curl.se/bug/?i=7632
- [90] = https://curl.se/bug/?i=7656
- [91] = https://curl.se/bug/?i=7656
- [92] = https://curl.se/bug/?i=7656
- [93] = https://github.com/curl/curl/pull/6700#issuecomment-913792863
- [94] = https://curl.se/bug/?i=7665
- [95] = https://curl.se/bug/?i=7660
- [96] = https://curl.se/bug/?i=7661
- [97] = https://curl.se/bug/?i=7658
- [98] = https://curl.se/bug/?i=7652
- [99] = https://curl.se/bug/?i=7654
- [100] = https://curl.se/bug/?i=7645
- [101] = https://curl.se/bug/?i=7643
- [102] = https://curl.se/bug/?i=7674
- [103] = https://curl.se/bug/?i=7678
- [104] = https://curl.se/bug/?i=7675
- [105] = https://curl.se/bug/?i=7586
- [106] = https://curl.se/bug/?i=7669
- [107] = https://github.com/curl/curl/pull/7666#issuecomment-912214751
- [108] = https://curl.se/bug/?i=7715
- [110] = https://curl.se/docs/CVE-2021-22947.html
- [111] = https://curl.se/docs/CVE-2021-22946.html
- [112] = https://curl.se/docs/CVE-2021-22945.html
- [115] = https://curl.se/bug/?i=7705
- [116] = https://curl.se/bug/?i=7710
- [117] = https://curl.se/bug/?i=7709
- [118] = https://curl.se/bug/?i=7702
- [119] = https://curl.se/bug/?i=7630
- [120] = https://curl.se/bug/?i=7700
- [124] = https://curl.se/bug/?i=7689
- [125] = https://curl.se/bug/?i=7180
- [126] = https://curl.se/bug/?i=7688
- [127] = https://curl.se/bug/?i=7685
- [128] = https://curl.se/bug/?i=7592
+ [1] = https://curl.se/bug/?i=7738
+ [2] = https://curl.se/bug/?i=7724
+ [3] = https://curl.se/bug/?i=7720
+ [4] = https://curl.se/bug/?i=7718
+ [5] = https://curl.se/bug/?i=7735
+ [6] = https://curl.se/bug/?i=7733
+ [8] = https://curl.se/bug/?i=7726
+ [9] = https://curl.se/bug/?i=7725
+ [10] = https://curl.se/bug/?i=7730

--- a/vendor/curl/include/curl/curlver.h
+++ b/vendor/curl/include/curl/curlver.h
@@ -30,13 +30,13 @@
 
 /* This is the version number of the libcurl package from which this header
    file origins: */
-#define LIBCURL_VERSION "7.79.0"
+#define LIBCURL_VERSION "7.79.1"
 
 /* The numeric version number is also available "in parts" by using these
    defines: */
 #define LIBCURL_VERSION_MAJOR 7
 #define LIBCURL_VERSION_MINOR 79
-#define LIBCURL_VERSION_PATCH 0
+#define LIBCURL_VERSION_PATCH 1
 
 /* This is the numeric version of the libcurl version number, meant for easier
    parsing and comparisons by programs. The LIBCURL_VERSION_NUM define will
@@ -57,7 +57,7 @@
    CURL_VERSION_BITS() macro since curl's own configure script greps for it
    and needs it to contain the full number.
 */
-#define LIBCURL_VERSION_NUM 0x074f00
+#define LIBCURL_VERSION_NUM 0x074f01
 
 /*
  * This is the date and time when the full source package was created. The
@@ -68,7 +68,7 @@
  *
  * "2007-11-23"
  */
-#define LIBCURL_TIMESTAMP "2021-09-15"
+#define LIBCURL_TIMESTAMP "2021-09-22"
 
 #define CURL_VERSION_BITS(x,y,z) ((x)<<16|(y)<<8|(z))
 #define CURL_AT_LEAST_VERSION(x,y,z) \

--- a/vendor/curl/lib/hsts.c
+++ b/vendor/curl/lib/hsts.c
@@ -49,6 +49,7 @@
 #define MAX_HSTS_HOSTLENSTR "256"
 #define MAX_HSTS_DATELEN 64
 #define MAX_HSTS_DATELENSTR "64"
+#define UNLIMITED "unlimited"
 
 #ifdef DEBUGBUILD
 /* to play well with debug builds, we can *set* a fixed time this will
@@ -283,13 +284,17 @@ static CURLcode hsts_push(struct Curl_easy *data,
   e.namelen = strlen(sts->host);
   e.includeSubDomains = sts->includeSubDomains;
 
-  result = Curl_gmtime((time_t)sts->expires, &stamp);
-  if(result)
-    return result;
+  if(sts->expires != TIME_T_MAX) {
+    result = Curl_gmtime((time_t)sts->expires, &stamp);
+    if(result)
+      return result;
 
-  msnprintf(e.expire, sizeof(e.expire), "%d%02d%02d %02d:%02d:%02d",
-            stamp.tm_year + 1900, stamp.tm_mon + 1, stamp.tm_mday,
-            stamp.tm_hour, stamp.tm_min, stamp.tm_sec);
+    msnprintf(e.expire, sizeof(e.expire), "%d%02d%02d %02d:%02d:%02d",
+              stamp.tm_year + 1900, stamp.tm_mon + 1, stamp.tm_mday,
+              stamp.tm_hour, stamp.tm_min, stamp.tm_sec);
+  }
+  else
+    strcpy(e.expire, UNLIMITED);
 
   sc = data->set.hsts_write(data, &e, i,
                             data->set.hsts_write_userp);
@@ -303,14 +308,18 @@ static CURLcode hsts_push(struct Curl_easy *data,
 static CURLcode hsts_out(struct stsentry *sts, FILE *fp)
 {
   struct tm stamp;
-  CURLcode result = Curl_gmtime((time_t)sts->expires, &stamp);
-  if(result)
-    return result;
-
-  fprintf(fp, "%s%s \"%d%02d%02d %02d:%02d:%02d\"\n",
-          sts->includeSubDomains ? ".": "", sts->host,
-          stamp.tm_year + 1900, stamp.tm_mon + 1, stamp.tm_mday,
-          stamp.tm_hour, stamp.tm_min, stamp.tm_sec);
+  if(sts->expires != TIME_T_MAX) {
+    CURLcode result = Curl_gmtime((time_t)sts->expires, &stamp);
+    if(result)
+      return result;
+    fprintf(fp, "%s%s \"%d%02d%02d %02d:%02d:%02d\"\n",
+            sts->includeSubDomains ? ".": "", sts->host,
+            stamp.tm_year + 1900, stamp.tm_mon + 1, stamp.tm_mday,
+            stamp.tm_hour, stamp.tm_min, stamp.tm_sec);
+  }
+  else
+    fprintf(fp, "%s%s \"%s\"\n",
+            sts->includeSubDomains ? ".": "", sts->host, UNLIMITED);
   return CURLE_OK;
 }
 
@@ -403,7 +412,8 @@ static CURLcode hsts_add(struct hsts *h, char *line)
               "%" MAX_HSTS_HOSTLENSTR "s \"%" MAX_HSTS_DATELENSTR "[^\"]\"",
               host, date);
   if(2 == rc) {
-    time_t expires = Curl_getdate_capped(date);
+    time_t expires = strcmp(date, UNLIMITED) ? Curl_getdate_capped(date) :
+      TIME_T_MAX;
     CURLcode result;
     char *p = host;
     bool subdomain = FALSE;
@@ -456,7 +466,7 @@ static CURLcode hsts_pull(struct Curl_easy *data, struct hsts *h)
           return result;
       }
       else if(sc == CURLSTS_FAIL)
-        return CURLE_BAD_FUNCTION_ARGUMENT;
+        return CURLE_ABORTED_BY_CALLBACK;
     } while(sc == CURLSTS_OK);
   }
   return CURLE_OK;

--- a/vendor/curl/lib/hsts.h
+++ b/vendor/curl/lib/hsts.h
@@ -59,7 +59,7 @@ CURLcode Curl_hsts_loadcb(struct Curl_easy *data,
                           struct hsts *h);
 #else
 #define Curl_hsts_cleanup(x)
-#define Curl_hsts_loadcb(x,y)
+#define Curl_hsts_loadcb(x,y) CURLE_OK
 #define Curl_hsts_save(x,y,z)
 #endif /* CURL_DISABLE_HTTP || CURL_DISABLE_HSTS */
 #endif /* HEADER_CURL_HSTS_H */

--- a/vendor/curl/lib/http.c
+++ b/vendor/curl/lib/http.c
@@ -4232,9 +4232,9 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
         char separator;
         char twoorthree[2];
         int httpversion = 0;
-        int digit4 = -1; /* should remain untouched to be good */
+        char digit4 = 0;
         nc = sscanf(HEADER1,
-                    " HTTP/%1d.%1d%c%3d%1d",
+                    " HTTP/%1d.%1d%c%3d%c",
                     &httpversion_major,
                     &httpversion,
                     &separator,
@@ -4250,13 +4250,13 @@ CURLcode Curl_http_readwrite_headers(struct Curl_easy *data,
 
         /* There can only be a 4th response code digit stored in 'digit4' if
            all the other fields were parsed and stored first, so nc is 5 when
-           digit4 is not -1 */
-        else if(digit4 != -1) {
+           digit4 a digit */
+        else if(ISDIGIT(digit4)) {
           failf(data, "Unsupported response code in HTTP response");
           return CURLE_UNSUPPORTED_PROTOCOL;
         }
 
-        if((nc == 4) && (' ' == separator)) {
+        if((nc >= 4) && (' ' == separator)) {
           httpversion += 10 * httpversion_major;
           switch(httpversion) {
           case 10:

--- a/vendor/curl/lib/http2.c
+++ b/vendor/curl/lib/http2.c
@@ -2221,12 +2221,6 @@ CURLcode Curl_http2_setup(struct Curl_easy *data,
   stream->mem = data->state.buffer;
   stream->len = data->set.buffer_size;
 
-  httpc->inbuflen = 0;
-  httpc->nread_inbuf = 0;
-
-  httpc->pause_stream_id = 0;
-  httpc->drain_total = 0;
-
   multi_connchanged(data->multi);
   /* below this point only connection related inits are done, which only needs
      to be done once per connection */
@@ -2251,6 +2245,12 @@ CURLcode Curl_http2_setup(struct Curl_easy *data,
   conn->bits.multiplex = TRUE; /* at least potentially multiplexed */
   conn->httpversion = 20;
   conn->bundle->multiuse = BUNDLE_MULTIPLEX;
+
+  httpc->inbuflen = 0;
+  httpc->nread_inbuf = 0;
+
+  httpc->pause_stream_id = 0;
+  httpc->drain_total = 0;
 
   infof(data, "Connection state changed (HTTP/2 confirmed)");
 

--- a/vendor/curl/lib/multi.c
+++ b/vendor/curl/lib/multi.c
@@ -1052,11 +1052,17 @@ CURLMcode curl_multi_fdset(struct Curl_multi *multi,
     for(i = 0; i< MAX_SOCKSPEREASYHANDLE; i++) {
       curl_socket_t s = CURL_SOCKET_BAD;
 
-      if((bitmap & GETSOCK_READSOCK(i)) && VALID_SOCK((sockbunch[i]))) {
+      if((bitmap & GETSOCK_READSOCK(i)) && VALID_SOCK(sockbunch[i])) {
+        if(!FDSET_SOCK(sockbunch[i]))
+          /* pretend it doesn't exist */
+          continue;
         FD_SET(sockbunch[i], read_fd_set);
         s = sockbunch[i];
       }
-      if((bitmap & GETSOCK_WRITESOCK(i)) && VALID_SOCK((sockbunch[i]))) {
+      if((bitmap & GETSOCK_WRITESOCK(i)) && VALID_SOCK(sockbunch[i])) {
+        if(!FDSET_SOCK(sockbunch[i]))
+          /* pretend it doesn't exist */
+          continue;
         FD_SET(sockbunch[i], write_fd_set);
         s = sockbunch[i];
       }

--- a/vendor/curl/lib/strerror.c
+++ b/vendor/curl/lib/strerror.c
@@ -731,12 +731,11 @@ const char *Curl_strerror(int err, char *buf, size_t buflen)
   max = buflen - 1;
   *buf = '\0';
 
-  /* !checksrc! disable STRERROR 2 */
 #if defined(WIN32) || defined(_WIN32_WCE)
 #if defined(WIN32)
   /* 'sys_nerr' is the maximum errno number, it is not widely portable */
   if(err >= 0 && err < sys_nerr)
-    strncpy(buf, strerror(err), max);
+    strncpy(buf, sys_errlist[err], max);
   else
 #endif
   {
@@ -787,6 +786,7 @@ const char *Curl_strerror(int err, char *buf, size_t buflen)
   }
 #else
   {
+    /* !checksrc! disable STRERROR 1 */
     const char *msg = strerror(err);
     if(msg)
       strncpy(buf, msg, max);

--- a/vendor/curl/lib/transfer.c
+++ b/vendor/curl/lib/transfer.c
@@ -1503,7 +1503,7 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
     }
 #endif
     Curl_http2_init_state(&data->state);
-    Curl_hsts_loadcb(data, data->hsts);
+    result = Curl_hsts_loadcb(data, data->hsts);
   }
 
   /*


### PR DESCRIPTION
## Summary
- Contains stability and security related fixes
- 7.79.1: [curl-users mailing list archive](https://curl.se/mail/archive-2021-09/0010.html), [maintainer's blog post](https://daniel.haxx.se/blog/2021/09/22/curl-7-79-1-patched-up-and-ready/), [changelog](https://curl.se/changes.html#7_79_1)

## Tests
- [fetchRemote](https://wiki.multitheftauto.com/wiki/FetchRemote)
  - Download test script (v1.0.1): [test_fetchRemote.zip](https://github.com/multitheftauto/mtasa-blue/files/2873053/test_fetchRemote.zip)
    - Preferable not to run client and server simultaneously
  - URL for unauthenticated requests: https://ptsv2.com/t/mtasa-test-fetchRemote
  - URL for authenticated requests: https://ptsv2.com/t/mtasa-test-fetchRemote-auth
- [callRemote](https://wiki.multitheftauto.com/wiki/CallRemote)
  - Download test script (v1.0.2): [test_callRemote.zip](https://github.com/multitheftauto/mtasa-blue/files/2873055/test_callRemote.zip)
  - URL for unauthenticated requests: https://ptsv2.com/t/mtasa-test-callRemote
  - URL for authenticated requests: https://ptsv2.com/t/mtasa-test-callRemote-auth
- **Please flush all your requests from ptsv2.com after testing!**

## Validation
To help validate the integrity of the update I have created the following bash script that diffs between my PR branch and the official package provided from the [curl website](https://curl.se/download.html).
```bash
#!/bin/bash

CURL_UPDATE_VERSION=7.79.1
CURL_PATH_NAME=curl-$CURL_UPDATE_VERSION

GIT_REPO_BRANCH=vendor/curl-7.79.1
GIT_REPO_URL=https://github.com/multitheftauto/mtasa-blue.git
GIT_REPO_CURL_PATH=vendor/curl/

echo 1. Download and extract $CURL_PATH_NAME...
curl https://curl.se/download/$CURL_PATH_NAME.tar.xz | tar -xJ

echo 2. Fetch and checkout the vendor update branch $GIT_REPO_BRANCH from $GIT_REPO_URL...
git fetch $GIT_REPO_URL $GIT_REPO_BRANCH:$GIT_REPO_BRANCH
git checkout $GIT_REPO_BRANCH

echo 3. Start checking integrity...
diff -r --strip-trailing-cr $GIT_REPO_CURL_PATH $CURL_PATH_NAME

echo 4. Completed.
exec $SHELL
```

## Past curl updates in MTA
| Date | From | To | Link |
| :--- | :--- | :--- | :--- |
| September 2021 | 7.78.0 | 7.79.0 (current) | #2357 |
| August 2021 | 7.77.0 | 7.78.0 | #2285 |
| June 2021 | 7.76.1 | 7.77.0 | #2243 |
| April 2021 | 7.75.0 | 7.76.1 | #2182 |
| March 2021 | 7.74.0 | 7.75.0 | #2081 |
| December 2020 | 7.72.0 | 7.74.0 | #1959 |
| October 2020 | 7.69.1 | 7.72.0 | #1562 |
| March 2020 | 7.68.0 | 7.69.1 | #1302 |
| January 2020 | 7.67.0 | 7.68.0 | #1216 |
| November 2019 | 7.66.0 | 7.67.0 | #1161 |
| September 2019 | 7.65.3 | 7.66.0 | #1099 |
| July 2019 | 7.65.1 | 7.65.3 | #1027 |
| July 2019 | 7.64.1 | 7.65.1 | #1018 |
| April 2019 | 7.64.0 | 7.64.1 | #898 |
| February 2019 | 7.63.0 | 7.64.0 | #819 |
| January 2019 | 7.61.1 | 7.63.0 | #744 |
| September 2018 | 7.61.0 | 7.61.1 | #428 |
| August 2018 | 7.59.0 | 7.61.0 | #271 |
| March 2018 | 7.54.0 | 7.59.0 | b99e343db34e27954fcc6dea5909fafcb06cf695 |
| June 2017 | 7.32.0 | 7.54.0 | c15d999d15ecfedf3e0ad5c9916b1886c489bff5 |
| August 2013 | 7.19.4 | 7.32.0 | aaf3e21de2b35d924463874b8d2af3a094dfa1f2 |

## Copy of curl changelogs
### Fixed in 7.79.1 - September 22 2021
```
Bugfixes:

Curl_http2_setup: don't change connection data on repeat invokes
curl_multi_fdset: make FD_SET() not operate on sockets out of range
dist: provide lib/.checksrc in the tarball
FAQ: add GOPHERS + curl works on data, not files
hsts: CURLSTS_FAIL from hsts read callback should fail transfer
hsts: handle unlimited expiry
http: fix the broken >3 digit response code detection
strerror: use sys_errlist instead of strerror on Windows
test1184: disable
tests/sshserver.pl: make it work with openssh-8.7p1
```