### PR TITLE
Fix missing return values (#2026)

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaVectorGraphicDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVectorGraphicDefs.cpp
@@ -61,7 +61,7 @@ bool CLuaVectorGraphicDefs::SetDocument(CClientVectorGraphic* pVectorGraphic, CX
     if (!pVectorGraphic || !pXMLNode || !pXMLNode->IsValid())
         return false;
 
-    pVectorGraphic->SetDocument(pXMLNode);
+    return pVectorGraphic->SetDocument(pXMLNode);
 }
 
 bool CLuaVectorGraphicDefs::LoadFromFile(lua_State* luaVM, CClientVectorGraphic* pVectorGraphic, CScriptFile* pFile, std::string strPath,
@@ -94,6 +94,8 @@ bool CLuaVectorGraphicDefs::LoadFromFile(lua_State* luaVM, CClientVectorGraphic*
             return false;
         }
     }
+
+    return true;
 }
 
 bool CLuaVectorGraphicDefs::SetSize(CClientVectorGraphic* pVectorGraphic, CVector2D size)
@@ -276,15 +278,13 @@ CLuaMultiReturn<int, int> CLuaVectorGraphicDefs::SVGGetSize(CClientVectorGraphic
     return {(int)pVectorGraphic->GetRenderItem()->m_uiSizeX, (int)pVectorGraphic->GetRenderItem()->m_uiSizeY};
 }
 
-bool CLuaVectorGraphicDefs::SVGSetSize(CClientVectorGraphic* pVectorGraphic, int width, int height, std::optional<CLuaFunctionRef> luaFunctionRef)
+bool CLuaVectorGraphicDefs::SVGSetSize(CClientVectorGraphic* pVectorGraphic, CVector2D size, std::optional<CLuaFunctionRef> luaFunctionRef)
 {
-    if (width <= 0 || height <= 0)
+    if (size.fX <= 0 || size.fY <= 0)
         throw std::invalid_argument("A vector graphic must be atleast 1x1 in size.");
 
-    if (width > 4096 || height > 4096)
+    if (size.fX > 4096 || size.fY > 4096)
         throw std::invalid_argument("A vector graphic cannot exceed 4096x4096 in size.");
-
-    CVector2D size = CVector2D(width, height);
 
     if (luaFunctionRef.has_value() && VERIFY_FUNCTION(luaFunctionRef.value()))
     {

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVectorGraphicDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVectorGraphicDefs.h
@@ -24,7 +24,7 @@ public:
     static bool      SVGSetDocumentXML(CClientVectorGraphic* pVectorGraphic, CXMLNode* pXMLNode, std::optional<CLuaFunctionRef> luaFunctionRef);
 
     static CLuaMultiReturn<int, int> SVGGetSize(CClientVectorGraphic* pVectorGraphic);
-    static bool                      SVGSetSize(CClientVectorGraphic* pVectorGraphic, int width, int height, std::optional<CLuaFunctionRef> luaFunctionRef);
+    static bool                      SVGSetSize(CClientVectorGraphic* pVectorGraphic, CVector2D size, std::optional<CLuaFunctionRef> luaFunctionRef);
 
 private:
     static bool LoadFromData(lua_State* luaVM, CClientVectorGraphic* pVectorGraphic, std::string strRawData);


### PR DESCRIPTION
Should be the reason for `CC31, No such mod installed (deathmatch)` since r20979.

Also changed SVGSetSize to use a CVector2D instead of two ints.