### PR TITLE
Remove unnecessary premake options in lunasvg project

### DIFF
--- a/vendor/lunasvg/premake5.lua
+++ b/vendor/lunasvg/premake5.lua
@@ -4,8 +4,6 @@ project "lunasvg"
 	kind "SharedLib"
 	targetname "lunasvg"
 	targetdir(buildpath("mta"))
-	floatingpoint "Fast"
-	rtti "Off"
 
 	defines { 
 		"LUNASVG_EXPORT", 


### PR DESCRIPTION
Following up from #2378 - another attempt to fix issue `CC31, No such mod installed (deathmatch)` since r20979.

Issue only occurs when using MTA build server... local builds, and GitHub artifacts (debug or release) work fine.