### PR TITLE
Fix some SVG issues

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPerfStat.LuaMemory.cpp
+++ b/Client/mods/deathmatch/logic/CClientPerfStat.LuaMemory.cpp
@@ -253,6 +253,7 @@ void CClientPerfStatLuaMemoryImpl::GetLuaMemoryStats(CClientPerfStatResult* pRes
     pResult->AddColumn("RenderTargets");
     pResult->AddColumn("ScreenSources");
     pResult->AddColumn("WebBrowsers");
+    pResult->AddColumn("VectorGraphics");
 
     // Calc totals
     if (strFilter == "")

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
@@ -486,7 +486,7 @@ inline SString GetClassTypeName(eSoundEffectParams::Reverb*)
     return "soundeffect-params-reverb";
 }
 
-inline SString GetClassByTypeName(CClientVectorGraphic*)
+inline SString GetClassTypeName(CClientVectorGraphic*)
 {
     return "svg";
 }


### PR DESCRIPTION
This PR:
1) Adds missing column. Currently the game crashes when trying to view player performance information (performancebrowser: client >"Lua memory" / `getPerformanceStats("Lua memory")`).
2) Fixes incorrect function name (`GetClassByTypeName` -> `GetClassTypeName`).
