### PR TITLE
Partial fix (part 3) #2277, fix #2034: Fix sync door opening, fix sync of vehicle parts (doors, lights, panels and wheels) states on custom allocated vehicle model IDs

### DIFF
--- a/Client/mods/deathmatch/logic/CNetAPI.cpp
+++ b/Client/mods/deathmatch/logic/CNetAPI.cpp
@@ -1910,7 +1910,7 @@ void CNetAPI::ReadFullVehicleSpecific(CClientVehicle* pVehicle, NetBitStreamInte
     }
 
     // Read door angles.
-    if (CClientVehicleManager::HasDoors(iRemoteModelID))
+    if (CClientVehicleManager::HasDoors(iRemoteModelID) || !CClientVehicleManager::IsStandardModel(iRemoteModelID))
     {
         SDoorOpenRatioSync door;
         for (unsigned char i = 2; i < 6; ++i)
@@ -1944,7 +1944,7 @@ void CNetAPI::WriteFullVehicleSpecific(CClientVehicle* pVehicle, NetBitStreamInt
     }
 
     // Sync door angles.
-    if (CClientVehicleManager::HasDoors(iModelID))
+    if (CClientVehicleManager::HasDoors(iModelID) || !CClientVehicleManager::IsStandardModel(iModelID))
     {
         SDoorOpenRatioSync door;
         for (unsigned char i = 2; i < 6; ++i)

--- a/Server/mods/deathmatch/logic/CVehicleManager.cpp
+++ b/Server/mods/deathmatch/logic/CVehicleManager.cpp
@@ -544,6 +544,7 @@ bool CVehicleManager::HasDamageModel(eVehicleType Type)
         case VEHICLE_HELI:
         case VEHICLE_PLANE:
         case VEHICLE_CAR:
+        case VEHICLE_NONE:
             return true;
         default:
             return false;


### PR DESCRIPTION
This pull makes the server treat vehicle IDs outside the range 400-611 (VEHICLE_NONE) as having doors, thus enables sync, which the client expected and was misinterpreting wrong data as door open ratio sync, which had a knock-on effect on door, lights, panels and wheel states sync.

Because to the client the vehicle copies the type of its parent, if it's a doorless type (i.e. boat, bike, bmx, etc.) it wouldn't normally send door sync. This pull forces this data to be sent for all custom vehicle IDs, the sever always reads this data for non-standard models, always sends it off to other clients, and all clients (with this patch) will read this data and apply it only if it makes sense (i.e. the vehicle has doors on the client)