### PR TITLE
Fix #868, #1662 and #1740: Fix sync of light states (damage) and wheel states

### DIFF
--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -2331,9 +2331,6 @@ void CGame::Packet_VehiclePuresync(CVehiclePuresyncPacket& Packet)
             // Increment counter to spread out damage info sends
             pVehicle->m_uiDamageInfoSendPhase++;
 
-            // Increment counter to spread out damage info sends
-            pVehicle->m_uiDamageInfoSendPhase++;
-
             CLOCK("VehiclePuresync", "RelayPlayerPuresync");
             // Relay to other players
             RelayPlayerPuresync(Packet);


### PR DESCRIPTION
Fixes #868 
Fixes #1662 
Fixes #1740

Essentially reverts d51aee516f20ae17c8b96af01d220bfd089f982e from 7 years ago (originally implemented 9bb96e5c421aecb339717b804b6c8b19f0b3c156)
This commit caused the phase to always be an even number (last bit always 0), which prevented wheel and light states to sync in the following code https://github.com/multitheftauto/mtasa-blue/blob/ca3b0b778e9695ce7da6391eda14429aa055d1f2/Server/mods/deathmatch/logic/net/CSimVehiclePuresyncPacket.cpp#L401-L416 https://github.com/multitheftauto/mtasa-blue/blob/16769b8d1c94e2b9fe6323dcba46d1305f87a190/Shared/sdk/net/SyncStructures.h#L1594-L1609 as the phase takes the last two bits (bitwise AND with 3, 0b11) and sequences sync packets between them.

A side effect of this pull is that door states and panel states will be synced half as frequently, with light and wheel syncs taking place instead at half those times.