### PR TITLE
Remove forced TADDRESS_CLAMP for VectorGraphic render item

### DIFF
--- a/Client/core/Graphics/CRenderItem.VectorGraphic.cpp
+++ b/Client/core/Graphics/CRenderItem.VectorGraphic.cpp
@@ -25,8 +25,6 @@ void CVectorGraphicItem::PostConstruct(CRenderItemManager* pManager, uint width,
     m_uiSurfaceSizeX = width;
     m_uiSurfaceSizeY = height;
 
-    m_TextureAddress = TADDRESS_CLAMP;
-
     CreateUnderlyingData();
 }
 


### PR DESCRIPTION
Resolves #2397 

Removes forced `TADDRESS_CLAMP` (should default to `TADDRESS_WRAP` - the same as **dxCreateTexture**).

It may introduce edge artifacts when rotating the svg directly via dxDrawImage - in this case they can use **dxCreateTexture** like the workaround in #2397 but instead set `textureEdge` to `clamp`.