### PR TITLE
Fix camera logic after warpPedIntoVehicle

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -1424,6 +1424,7 @@ void CClientPed::WarpIntoVehicle(CClientVehicle* pVehicle, unsigned int uiSeat)
         }
     }
 
+    CClientVehicle* pPrevVehicle = GetRealOccupiedVehicle();
     // Eventually remove us from a previous vehicle
     RemoveFromVehicle();
     // m_uiOccupyingSeat = uiSeat;
@@ -1460,6 +1461,9 @@ void CClientPed::WarpIntoVehicle(CClientVehicle* pVehicle, unsigned int uiSeat)
                 pGameVehicle->GetVehicleAudioEntity()->JustGotInVehicleAsDriver();
             }
 
+            // Make sure our camera is fixed on the new vehicle
+            if (m_bIsLocalPlayer && pPrevVehicle && m_pManager->GetCamera()->GetTargetEntity() == pPrevVehicle)
+                m_pManager->GetCamera()->SetTargetEntity(pVehicle);
         }
 
         // Update the vehicle and us so we know we've occupied it
@@ -1503,6 +1507,9 @@ void CClientPed::WarpIntoVehicle(CClientVehicle* pVehicle, unsigned int uiSeat)
                         pGameVehicle->GetVehicleAudioEntity()->JustGotInVehicleAsDriver();
                     }
 
+                    // Make sure our camera is fixed on the new vehicle
+                    if (m_bIsLocalPlayer && pPrevVehicle && m_pManager->GetCamera()->GetTargetEntity() == pPrevVehicle)
+                        m_pManager->GetCamera()->SetTargetEntity(pVehicle);
                 }
             }
 


### PR DESCRIPTION
This PR restores camera autofocus on new car after `warpPedIntoVehicle` , if camera was focused on previous car

Fixes #2402