### PR TITLE
Add openBrowserURL function

### DIFF
--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -227,6 +227,16 @@ bool CStaticFunctionDefinitions::DownloadFile(CResource* pResource, const char* 
     return false;
 }
 
+bool CStaticFunctionDefinitions::OpenBrowserURL(const SString& strUrl)
+{
+    if (strUrl.BeginsWithI("http://") || strUrl.BeginsWithI("https://"))
+    {
+        return ShellExecuteNonBlocking("open", strUrl.c_str());
+    }
+
+    return false;
+}
+
 bool CStaticFunctionDefinitions::OutputConsole(const char* szText)
 {
     m_pCore->GetConsole()->Print(szText);

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -36,6 +36,7 @@ public:
 
     // Misc funcs
     static bool DownloadFile(CResource* pResource, const char* szFile, CResource* pRequestResource, CChecksum checksum = CChecksum());
+    static bool OpenBrowserURL(const SString& strUrl);
 
     // Output funcs
     static bool OutputConsole(const char* szText);

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Util.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Util.cpp
@@ -396,6 +396,29 @@ int CLuaFunctionDefs::DownloadFile(lua_State* luaVM)
     return 1;
 }
 
+int CLuaFunctionDefs::OpenBrowserURL(lua_State* luaVM)
+{
+    SString         strURL;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadString(strURL);
+
+    if (!argStream.HasErrors())
+    {
+        if (CStaticFunctionDefinitions::OpenBrowserURL(strURL))
+        {
+            lua_pushboolean(luaVM, true);
+            return 1;
+        }
+    }
+    else
+    {
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+    }
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
 int CLuaFunctionDefs::AddDebugHook(lua_State* luaVM)
 {
     //  bool AddDebugHook ( string hookType, function callback[, table allowedNames ] )

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.h
@@ -43,6 +43,7 @@ public:
 
     // Misc functions
     LUA_DECLARE(DownloadFile);
+    LUA_DECLARE(OpenBrowserURL);
 
     // Output functions
     LUA_DECLARE(OutputConsole);

--- a/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -197,6 +197,7 @@ void CLuaManager::LoadCFunctions()
         // Util functions
         {"getValidPedModels", CLuaFunctionDefs::GetValidPedModels},
         {"downloadFile", CLuaFunctionDefs::DownloadFile},
+        {"openBrowserURL", CLuaFunctionDefs::OpenBrowserURL},
 
         // Input functions
         {"bindKey", CLuaFunctionDefs::BindKey},


### PR DESCRIPTION
This pull request adding **openBrowserURL** function **client-side only**.
Function opens the url in the client default system browser.


# openBrowserURL
```lua
bool openBrowserURL(string url)
```
Variable `url` must starts with **`http://`** or **`https://`** otherwise will returns false also if failed to open url returns false.

---------------------------------------
This functions can be used for example to open oauth2 url.
Thank you.