### PR TITLE
Server modules

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -10,11 +10,6 @@
 
 #pragma once
 
-extern "C"
-{
-    #include "lua.h"
-}
-
 #include <net/bitstream.h>
 #include "CLuaArgument.h"
 #include "json.h"

--- a/Server/core/CModManagerImpl.h
+++ b/Server/core/CModManagerImpl.h
@@ -33,6 +33,7 @@ public:
 
     const char*     GetServerPath() { return m_strServerPath; };
     const char*     GetModPath() { return m_strModPath; };
+    const char*     GetModulePath() { return PathJoin(GetServerPath(), SERVER_BIN_PATH_MOD, "modules"); };
     virtual SString GetAbsolutePath(const char* szRelative);
 
     bool         IsModLoaded();

--- a/Server/mods/deathmatch/StdInc.h
+++ b/Server/mods/deathmatch/StdInc.h
@@ -1,5 +1,10 @@
 #ifdef WIN32
 
+extern "C"
+{
+    #include "lua.h"
+}
+
 #include <winsock2.h>
 #include <windows.h>
 #include <mmsystem.h>
@@ -45,6 +50,10 @@ struct SAclRequest;
 #include "CChecksum.h"
 #include "CIdArray.h"
 #include "pcrecpp.h"
+
+#include "../publicsdk/IModule.h";
+#include "../modules/luaModules/include/CLuaModulesModule.h"
+#include "CModuleInterfaceImpl.h"
 
 // Packet includes
 #include "packets/CCameraSyncPacket.h"
@@ -150,7 +159,6 @@ struct SAclRequest;
 
 // Lua includes
 #include "lua/LuaCommon.h"
-#include "lua/CLuaMain.h"
 #include "CEasingCurve.h"
 #include "CBanManager.h"
 #include "lua/CLuaFunctionParseHelpers.h"
@@ -158,7 +166,6 @@ struct SAclRequest;
 #include "lua/CLuaManager.h"
 #include "lua/CLuaTimerManager.h"
 #include "lua/CLuaTimer.h"
-#include "lua/CLuaModuleManager.h"
 #include "lua/CLuaArgument.h"
 #include "lua/CLuaCFunctions.h"
 #include "lua/CLuaArguments.h"
@@ -176,6 +183,8 @@ struct SAclRequest;
 #include "lua/CLuaShared.h"
 
 // Logic includes
+#include "CModule.h"
+#include "CResource.h"
 #include "ASE.h"
 #include "ASEQuerySDK.h"
 #include "CAccessControlList.h"
@@ -257,7 +266,6 @@ struct SAclRequest;
 #include "CRegisteredCommands.h"
 #include "CRegistryManager.h"
 #include "CRegistry.h"
-#include "CResource.h"
 #include "CResourceChecker.h"
 #include "CResourceClientConfigItem.h"
 #include "CResourceClientFileItem.h"

--- a/Server/mods/deathmatch/logic/CConsoleCommands.cpp
+++ b/Server/mods/deathmatch/logic/CConsoleCommands.cpp
@@ -1353,7 +1353,7 @@ bool CConsoleCommands::LoadModule(CConsole* pConsole, const char* szArguments, C
             pEchoClient->SendConsole("loadmodule: Invalid module path");
             return false;
         }
-        SString strFilename = PathJoin(g_pServerInterface->GetModManager()->GetServerPath(), SERVER_BIN_PATH_MOD, "modules", szArguments);
+        SString strFilename = PathJoin(g_pServerInterface->GetModManager()->GetModulePath(), szArguments);
 
         // These modules are late loaded
         int iSuccess = g_pGame->GetModule<CLuaModulesModule>()->LoadModule(szArguments, strFilename, true);
@@ -1444,7 +1444,7 @@ bool CConsoleCommands::ReloadModule(CConsole* pConsole, const char* szArguments,
         if (pClient->GetNick())
             CLogger::LogPrintf("reloadmodule: Requested by %s\n", pClient->GetNick());
 
-        SString strFilename = PathJoin(g_pServerInterface->GetModManager()->GetServerPath(), SERVER_BIN_PATH_MOD, "modules", szArguments);
+        SString strFilename = PathJoin(g_pServerInterface->GetModManager()->GetModulePath(), szArguments);
 
         int iSuccess = g_pGame->GetModule<CLuaModulesModule>()->ReloadModule(szArguments, strFilename, true);
         switch (iSuccess)
@@ -1504,6 +1504,16 @@ bool CConsoleCommands::ReloadModule(CConsole* pConsole, const char* szArguments,
         pEchoClient->SendConsole("* Syntax: reloadmodule <module-name-with-extension>");
 
     return false;
+}
+
+bool CConsoleCommands::ListModules(CConsole* pConsole, const char* szArguments, CClient* pClient, CClient* pEchoClient)
+{
+    CLuaModulesModule* pLuaModulesModule = g_pGame->GetModule<CLuaModulesModule>();
+    for (auto const& luaModule : pLuaModulesModule->GetAllModules())
+    {
+        pEchoClient->SendConsole(SString("[%s] %s", luaModule.state.c_str(), luaModule.name.c_str()));
+    }
+    return true;
 }
 
 bool CConsoleCommands::Ver(CConsole* pConsole, const char* szArguments, CClient* pClient, CClient* pEchoClient)

--- a/Server/mods/deathmatch/logic/CConsoleCommands.cpp
+++ b/Server/mods/deathmatch/logic/CConsoleCommands.cpp
@@ -1356,7 +1356,7 @@ bool CConsoleCommands::LoadModule(CConsole* pConsole, const char* szArguments, C
         SString strFilename = PathJoin(g_pServerInterface->GetModManager()->GetServerPath(), SERVER_BIN_PATH_MOD, "modules", szArguments);
 
         // These modules are late loaded
-        int iSuccess = g_pGame->GetLuaManager()->GetLuaModuleManager()->LoadModule(szArguments, strFilename, true);
+        int iSuccess = g_pGame->GetModule<CLuaModulesModule>()->LoadModule(szArguments, strFilename, true);
         switch (iSuccess)
         {
             case 1:
@@ -1423,7 +1423,8 @@ bool CConsoleCommands::UnloadModule(CConsole* pConsole, const char* szArguments,
         if (pClient->GetNick())
             CLogger::LogPrintf("unloadmodule: Requested by %s\n", GetAdminNameForLog(pClient).c_str());
 
-        if (g_pGame->GetLuaManager()->GetLuaModuleManager()->UnloadModule(szArguments) != 0)
+        
+        if (g_pGame->GetModule<CLuaModulesModule>()->UnloadModule(szArguments) != 0)
         {
             pEchoClient->SendConsole("unloadmodule: Module failed to unload");
             pEchoClient->SendConsole("unloadmodule: Couldn't find a module by that name");
@@ -1445,7 +1446,7 @@ bool CConsoleCommands::ReloadModule(CConsole* pConsole, const char* szArguments,
 
         SString strFilename = PathJoin(g_pServerInterface->GetModManager()->GetServerPath(), SERVER_BIN_PATH_MOD, "modules", szArguments);
 
-        int iSuccess = g_pGame->GetLuaManager()->GetLuaModuleManager()->ReloadModule(szArguments, strFilename, true);
+        int iSuccess = g_pGame->GetModule<CLuaModulesModule>()->ReloadModule(szArguments, strFilename, true);
         switch (iSuccess)
         {
             case 1:

--- a/Server/mods/deathmatch/logic/CConsoleCommands.h
+++ b/Server/mods/deathmatch/logic/CConsoleCommands.h
@@ -54,6 +54,7 @@ public:
     static bool LoadModule(class CConsole* pConsole, const char* szArguments, CClient* pClient, CClient* pEchoClient);
     static bool UnloadModule(class CConsole* pConsole, const char* szArguments, CClient* pClient, CClient* pEchoClient);
     static bool ReloadModule(class CConsole* pConsole, const char* szArguments, CClient* pClient, CClient* pEchoClient);
+    static bool ListModules(CConsole* pConsole, const char* szArguments, CClient* pClient, CClient* pEchoClient);
 
     static bool Ver(class CConsole* pConsole, const char* szArguments, CClient* pClient, CClient* pEchoClient);
     static bool Ase(class CConsole* pConsole, const char* szArguments, CClient* pClient, CClient* pEchoClient);

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -204,12 +204,13 @@ CGame::CGame() : m_FloodProtect(4, 30000, 30000)            // Max of 4 connecti
 
     memset(&m_bGarageStates[0], 0, sizeof(m_bGarageStates));
 
+    m_vecModules.push_back(new CLuaModulesModule());
     // init our mutex
     pthread_mutex_init(&mutexhttp, NULL);
 }
 
 void CGame::ResetMapInfo()
-{
+    {
     // Add variables to get reset in resetMapInfo here
     m_fGravity = 0.008f;
     m_fGameSpeed = 1.0f;

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -204,7 +204,8 @@ CGame::CGame() : m_FloodProtect(4, 30000, 30000)            // Max of 4 connecti
 
     memset(&m_bGarageStates[0], 0, sizeof(m_bGarageStates));
 
-    m_vecModules.push_back(new CLuaModulesModule());
+    m_pModuleInterface = new CModuleInterfaceImpl(m_pLuaManager, new CModuleLoggerImpl());
+    m_vecModules.push_back(new CLuaModulesModule(m_pModuleInterface));
     // init our mutex
     pthread_mutex_init(&mutexhttp, NULL);
 }
@@ -932,6 +933,10 @@ bool CGame::Start(int iArgumentCount, char* szArguments[])
         }
     }
 
+    for (auto const& module : m_vecModules)
+    {
+        module->Load();
+    }
     // Done
     // If you're ever going to change this message, update the "server ready" determination
     // inside CServer.cpp in deathmatch mod aswell.

--- a/Server/mods/deathmatch/logic/CGame.h
+++ b/Server/mods/deathmatch/logic/CGame.h
@@ -670,5 +670,6 @@ private:
     bool m_DevelopmentModeEnabled;
     bool m_showClientTransferBox = true;
 
+    CModuleInterfaceImpl* m_pModuleInterface;
     std::vector<IModule*> m_vecModules;
 };

--- a/Server/mods/deathmatch/logic/CGame.h
+++ b/Server/mods/deathmatch/logic/CGame.h
@@ -60,6 +60,7 @@ class CGame;
 #include "CBanManager.h"
 
 // Forward declarations
+class CModule;
 class ASE;
 class CAccessControlListManager;
 class CAccountManager;
@@ -462,6 +463,19 @@ public:
     bool IsClientTransferBoxVisible() const { return m_showClientTransferBox; }
     void SetClientTransferBoxVisible(bool visible) { m_showClientTransferBox = visible; }
 
+    template <typename T>
+    T* GetModule()
+    {
+        for (auto const& pModule : m_vecModules)
+        {
+            if (T* p = dynamic_cast<T*>(pModule))
+            {
+                return p;
+            }
+        }
+        return nullptr;
+    }
+
 private:
     void AddBuiltInEvents();
     void RelayPlayerPuresync(class CPacket& Packet);
@@ -655,4 +669,6 @@ private:
 
     bool m_DevelopmentModeEnabled;
     bool m_showClientTransferBox = true;
+
+    std::vector<IModule*> m_vecModules;
 };

--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -785,6 +785,8 @@ bool CMainConfig::LoadExtended()
                     "Usage: unloadmodule <module-filename>\nUnload a module eg: unloadmodule ml_sockets.dll");
     RegisterCommand("reloadmodule", CConsoleCommands::ReloadModule, false,
                     "Usage: reloadmodule <module-filename>\nReload a module eg: reloadmodule ml_sockets.dll");
+    RegisterCommand("modules", CConsoleCommands::ListModules, false,
+                    "Displays list of all modules and its status");
 
     RegisterCommand("ver", CConsoleCommands::Ver, false, "Get the MTA version");
     RegisterCommand("sver", CConsoleCommands::Ver, false, "Get the server MTA version");

--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -642,7 +642,7 @@ bool CMainConfig::LoadExtended()
 
                 if (IsValidFilePath(strBuffer.c_str()))
                 {
-                    g_pGame->GetLuaManager()->GetLuaModuleManager()->LoadModule(strBuffer.c_str(), strFilename, false);
+                    g_pGame->GetModule<CLuaModulesModule>()->LoadModule(strBuffer.c_str(), strFilename, false);
                 }
             }
         }

--- a/Server/mods/deathmatch/logic/CModule.cpp
+++ b/Server/mods/deathmatch/logic/CModule.cpp
@@ -1,0 +1,6 @@
+#include "StdInc.h"
+
+void CModule::DoPulse()
+{
+
+}

--- a/Server/mods/deathmatch/logic/CModule.h
+++ b/Server/mods/deathmatch/logic/CModule.h
@@ -1,0 +1,5 @@
+class CModule : public IModule
+{
+    virtual void DoPulse();
+
+};

--- a/Server/mods/deathmatch/logic/CModuleInterfaceImpl.cpp
+++ b/Server/mods/deathmatch/logic/CModuleInterfaceImpl.cpp
@@ -24,13 +24,13 @@ void CModuleLoggerImpl::LogInformation(lua_State* luaVM, const char* szFormat, .
     va_end(args);
 }
 
-CModuleInterfaceImpl::CModuleInterfaceImpl(CLuaManager* pLuaManager) : m_pLuaManager(pLuaManager)
+CModuleInterfaceImpl::CModuleInterfaceImpl(CLuaManager* pLuaManager, ILogger* pLoggerImpl) : m_pLuaManager(pLuaManager), m_pLogger(pLoggerImpl)
 {
 }
 
 ILogger* CModuleInterfaceImpl::GetLogger()
 {
-    return nullptr; // TODO impelemnt
+    return m_pLogger;
 }
 
 IResource* CModuleInterfaceImpl::GetResourceFromName(const char* name)
@@ -52,6 +52,11 @@ IResource* CModuleInterfaceImpl::GetResourceFromName(const char* name)
 const char* CModuleInterfaceImpl::GetServerPath()
 {
     return g_pServerInterface->GetModManager()->GetServerPath();
+}
+
+const char* CModuleInterfaceImpl::GetModulesPath()
+{
+    return PathJoin(GetServerPath(), SERVER_BIN_PATH_MOD, "modules");
 }
 
 IResource* CModuleInterfaceImpl::GetResourceFromLuaState(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/CModuleInterfaceImpl.cpp
+++ b/Server/mods/deathmatch/logic/CModuleInterfaceImpl.cpp
@@ -103,4 +103,3 @@ void CModuleInterfaceImpl::AddFunction(lua_State* luaVM, const char* szName, lua
     CLuaCFunctions::AddFunction(szName, function);
     lua_register(luaVM, szName, function);
 }
-

--- a/Server/mods/deathmatch/logic/CModuleInterfaceImpl.cpp
+++ b/Server/mods/deathmatch/logic/CModuleInterfaceImpl.cpp
@@ -1,0 +1,101 @@
+#include "StdInc.h"
+
+void CModuleLoggerImpl::Printf(const char* szFormat, ...)
+{
+    va_list args;
+    va_start(args, szFormat);
+    CLogger::LogPrintf(szFormat, va_pass(args));
+    va_end(args);
+}
+
+void CModuleLoggerImpl::ErrorPrintf(const char* szFormat, ...)
+{
+    va_list args;
+    va_start(args, szFormat);
+    CLogger::ErrorPrintf(szFormat, va_pass(args));
+    va_end(args);
+}
+
+void CModuleLoggerImpl::LogInformation(lua_State* luaVM, const char* szFormat, ...)
+{
+    va_list args;
+    va_start(args, szFormat);
+    g_pGame->GetScriptDebugging()->LogInformation(luaVM, szFormat, va_pass(args));
+    va_end(args);
+}
+
+CModuleInterfaceImpl::CModuleInterfaceImpl(CLuaManager* pLuaManager) : m_pLuaManager(pLuaManager)
+{
+}
+
+ILogger* CModuleInterfaceImpl::GetLogger()
+{
+    return nullptr; // TODO impelemnt
+}
+
+IResource* CModuleInterfaceImpl::GetResourceFromName(const char* name)
+{
+    CResource* pResource = g_pGame->GetResourceManager()->GetResource(name);
+
+    if (pResource)
+    {
+        CLuaMain* pLuaMain = pResource->GetVirtualMachine();
+        if (pLuaMain)
+        {
+            return (IResource*)pLuaMain->GetResource();
+        }
+    }
+
+    return nullptr;
+}
+
+const char* CModuleInterfaceImpl::GetServerPath()
+{
+    return g_pServerInterface->GetModManager()->GetServerPath();
+}
+
+IResource* CModuleInterfaceImpl::GetResourceFromLuaState(lua_State* luaVM)
+{
+    CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+    if (pLuaMain)
+    {
+        CResource* pResource = pLuaMain->GetResource();
+        if (pResource)
+        {
+            return pResource;
+        }
+    }
+    return nullptr;
+}
+
+unsigned long CModuleInterfaceImpl::GetVersion()
+{
+    return CStaticFunctionDefinitions::GetVersion();
+}
+
+const char* CModuleInterfaceImpl::GetVersionString()
+{
+    return CStaticFunctionDefinitions::GetVersionString();
+}
+
+const char* CModuleInterfaceImpl::GetVersionName()
+{
+    return CStaticFunctionDefinitions::GetVersionName();
+}
+
+unsigned long CModuleInterfaceImpl::GetNetcodeVersion()
+{
+    return CStaticFunctionDefinitions::GetNetcodeVersion();
+}
+
+const char* CModuleInterfaceImpl::GetOperatingSystemName()
+{
+    return CStaticFunctionDefinitions::GetOperatingSystemName();
+}
+
+void CModuleInterfaceImpl::AddFunction(lua_State* luaVM, const char* szName, lua_CFunction function)
+{
+    CLuaCFunctions::AddFunction(szName, function);
+    lua_register(luaVM, szName, function);
+}
+

--- a/Server/mods/deathmatch/logic/CModuleInterfaceImpl.h
+++ b/Server/mods/deathmatch/logic/CModuleInterfaceImpl.h
@@ -1,0 +1,29 @@
+class CLuaManager;
+
+class CModuleLoggerImpl : ILogger
+{
+    void Printf(const char* szFormat, ...);
+    void ErrorPrintf(const char* szFormat, ...);
+    void LogInformation(lua_State* luaVM, const char* szFormat, ...);
+};
+
+class CModuleInterfaceImpl : public IModuleInterface
+{
+public:
+    CModuleInterfaceImpl(CLuaManager* pLuaManager);
+
+    ILogger*      GetLogger();
+    IResource*    GetResourceFromName(const char* name);
+    const char*   GetServerPath();
+    IResource*    GetResourceFromLuaState(lua_State* luaVM);
+    unsigned long GetVersion();
+    const char*   GetVersionString();
+    const char*   GetVersionName();
+    unsigned long GetNetcodeVersion();
+    const char*   GetOperatingSystemName();
+    void          AddFunction(lua_State* luaVM, const char* szName, lua_CFunction function);
+
+
+private:
+    CLuaManager* m_pLuaManager;
+};

--- a/Server/mods/deathmatch/logic/CModuleInterfaceImpl.h
+++ b/Server/mods/deathmatch/logic/CModuleInterfaceImpl.h
@@ -1,7 +1,8 @@
 class CLuaManager;
 
-class CModuleLoggerImpl : ILogger
+class CModuleLoggerImpl : public ILogger
 {
+public:
     void Printf(const char* szFormat, ...);
     void ErrorPrintf(const char* szFormat, ...);
     void LogInformation(lua_State* luaVM, const char* szFormat, ...);
@@ -10,11 +11,12 @@ class CModuleLoggerImpl : ILogger
 class CModuleInterfaceImpl : public IModuleInterface
 {
 public:
-    CModuleInterfaceImpl(CLuaManager* pLuaManager);
+    CModuleInterfaceImpl(CLuaManager* pLuaManager, ILogger* pLoggerImpl);
 
     ILogger*      GetLogger();
     IResource*    GetResourceFromName(const char* name);
     const char*   GetServerPath();
+    const char*   GetModulesPath();
     IResource*    GetResourceFromLuaState(lua_State* luaVM);
     unsigned long GetVersion();
     const char*   GetVersionString();
@@ -26,4 +28,5 @@ public:
 
 private:
     CLuaManager* m_pLuaManager;
+    ILogger*     m_pLogger;
 };

--- a/Server/mods/deathmatch/logic/CResource.cpp
+++ b/Server/mods/deathmatch/logic/CResource.cpp
@@ -1012,7 +1012,7 @@ bool CResource::Stop(bool bManualStop)
     CLogger::LogPrintf(LOGLEVEL_LOW, "Stopping %s\n", m_strResourceName.c_str());
 
     // Tell the modules we are stopping
-    g_pGame->GetLuaManager()->GetLuaModuleManager()->ResourceStopping(m_pVM->GetVirtualMachine());
+    g_pGame->GetModule<CLuaModulesModule>()->ResourceStopping(this);
 
     // Remove us from the running resources list
     m_StartedResources.remove(this);
@@ -1050,7 +1050,7 @@ bool CResource::Stop(bool bManualStop)
     }
 
     // Tell the module manager we have stopped
-    g_pGame->GetLuaManager()->GetLuaModuleManager()->ResourceStopped(m_pVM->GetVirtualMachine());
+    g_pGame->GetModule<CLuaModulesModule>()->ResourceStopped(this);
 
     // Remove the temporary XML storage node
     if (m_pNodeStorage)
@@ -3358,4 +3358,18 @@ bool CResource::IsFileDbConnectMysqlProtected(const SString& strAbsFilename, boo
     }
 
     return false;
+}
+
+CChecksum CResource::GetFileChecksum(const char* szFile)
+{
+    list<CResourceFile*>::iterator iter = IterBegin();
+    for (; iter != IterEnd(); ++iter)
+    {
+        if (strcmp((*iter)->GetName(), szFile) == 0)
+            return (*iter)->GetLastChecksum();
+    }
+    //     m_pScriptDebugging->LogInformation(luaVM, szFormat, args);
+
+
+    return CChecksum();
 }

--- a/Server/mods/deathmatch/logic/CResource.h
+++ b/Server/mods/deathmatch/logic/CResource.h
@@ -128,22 +128,10 @@ enum class EResourceState : unsigned char
     Stopping,            // the resource is stopping
 };
 
-struct SResourceStartOptions
-{
-    bool bIncludedResources = true;
-    bool bConfigs = true;
-    bool bMaps = true;
-    bool bScripts = true;
-    bool bHTML = true;
-    bool bClientConfigs = true;
-    bool bClientScripts = true;
-    bool bClientFiles = true;
-};
-
 // A resource is either a directory with files or a ZIP file which contains the content of such directory.
 // The directory or ZIP file must contain a meta.xml file, which describes the required content by the resource.
 // It's a process-like environment for scripts, maps, images and other files.
-class CResource : public EHS
+class CResource : public EHS, public IResource
 {
     using KeyValueMap = CFastHashMap<SString, SString>;
 
@@ -236,6 +224,7 @@ public:
 
     const SString& GetName() const noexcept { return m_strResourceName; }
 
+    lua_State*      GetLuaState() { return m_pVM->GetVirtualMachine(); }
     CLuaMain*       GetVirtualMachine() { return m_pVM; }
     const CLuaMain* GetVirtualMachine() const { return m_pVM; }
 
@@ -327,6 +316,7 @@ public:
     void SetUsingDbConnectMysql(bool bUsingDbConnectMysql) { m_bUsingDbConnectMysql = bUsingDbConnectMysql; }
     bool IsUsingDbConnectMysql();
     bool IsFileDbConnectMysqlProtected(const SString& strFilename, bool bReadOnly);
+    CChecksum GetFileChecksum(const char* szFile);
 
 public:
     static std::list<CResource*> m_StartedResources;

--- a/Server/mods/deathmatch/logic/CResourceManager.h
+++ b/Server/mods/deathmatch/logic/CResourceManager.h
@@ -14,12 +14,24 @@
 
 #pragma once
 
-#include "CResource.h"
 #include "CElement.h"
 #include "ehs/ehs.h"
 #include <list>
 
 class CResource;
+
+struct SResourceStartOptions
+{
+    bool bIncludedResources = true;
+    bool bConfigs = true;
+    bool bMaps = true;
+    bool bScripts = true;
+    bool bHTML = true;
+    bool bClientConfigs = true;
+    bool bClientScripts = true;
+    bool bClientFiles = true;
+};
+
 #define INVALID_RESOURCE_NET_ID     0xFFFF
 
 class CResourceManager

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -210,7 +210,9 @@ void CLuaMain::LoadEmbeddedScripts()
 
 void CLuaMain::RegisterModuleFunctions()
 {
-    m_pLuaManager->GetLuaModuleManager()->RegisterFunctions(m_luaVM);
+
+    // TODO
+ //   m_pLuaManager->GetLuaModuleManager()->RegisterFunctions(m_luaVM);
 }
 
 // Special function(s) that are only visible to HTMLD scripts
@@ -381,6 +383,11 @@ void CLuaMain::UnloadScript()
 void CLuaMain::DoPulse()
 {
     m_pLuaTimerManager->DoPulse(this);
+}
+
+unsigned long CLuaMain::GetElementCount() const
+{
+    return m_pResource && m_pResource->GetElementGroup() ? m_pResource->GetElementGroup()->GetCount() : 0;
 }
 
 // Keep count of the number of open files in this resource and issue a warning if too high

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.h
@@ -17,7 +17,6 @@ class CLuaMain;
 #include "lua/CLuaVector3.h"
 #include "lua/CLuaVector4.h"
 #include "lua/CLuaMatrix.h"
-#include "CLuaModuleManager.h"
 #include "../CTextDisplay.h"
 
 #define MAX_SCRIPTNAME_LENGTH 64
@@ -73,7 +72,7 @@ public:
     unsigned long GetXMLFileCount() const { return m_XMLFiles.size(); };
     unsigned long GetOpenFileCount() const { return m_OpenFilenameList.size(); };
     unsigned long GetTimerCount() const { return m_pLuaTimerManager ? m_pLuaTimerManager->GetTimerCount() : 0; };
-    unsigned long GetElementCount() const { return m_pResource && m_pResource->GetElementGroup() ? m_pResource->GetElementGroup()->GetCount() : 0; };
+    unsigned long GetElementCount() const;
     unsigned long GetTextDisplayCount() const { return m_Displays.size(); };
     unsigned long GetTextItemCount() const { return m_TextItems.size(); };
     void          OnOpenFile(const SString& strFilename);

--- a/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -27,10 +27,6 @@ CLuaManager::CLuaManager(CObjectManager* pObjectManager, CPlayerManager* pPlayer
     m_pMapManager = pMapManager;
     m_pEvents = pEvents;
 
-    // Create our lua dynamic module manager
-    m_pLuaModuleManager = new CLuaModuleManager(this);
-    m_pLuaModuleManager->SetScriptDebugging(g_pGame->GetScriptDebugging());
-
     // Load our C Functions into Lua and hook callback
     LoadCFunctions();
     lua_registerPreCallHook(CLuaDefs::CanUseFunction);
@@ -53,9 +49,6 @@ CLuaManager::~CLuaManager()
     {
         delete (*iter);
     }
-
-    // Destroy the module manager
-    delete m_pLuaModuleManager;
 }
 
 CLuaMain* CLuaManager::CreateVirtualMachine(CResource* pResourceOwner, bool bEnableOOP)
@@ -108,7 +101,8 @@ void CLuaManager::DoPulse()
     {
         (*iter)->DoPulse();
     }
-    m_pLuaModuleManager->DoPulse();
+    // TODO impelemnt
+    //m_pLuaModuleManager->DoPulse();
 }
 
 CLuaMain* CLuaManager::GetVirtualMachine(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/lua/CLuaManager.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaManager.h
@@ -43,8 +43,6 @@ public:
     void       OnLuaMainOpenVM(CLuaMain* pLuaMain, lua_State* luaVM);
     void       OnLuaMainCloseVM(CLuaMain* pLuaMain, lua_State* luaVM);
 
-    CLuaModuleManager* GetLuaModuleManager() const { return m_pLuaModuleManager; }
-
     list<CLuaMain*>::const_iterator IterBegin() { return m_virtualMachines.begin(); };
     list<CLuaMain*>::const_iterator IterEnd() { return m_virtualMachines.end(); };
 
@@ -61,7 +59,6 @@ private:
     CVehicleManager*           m_pVehicleManager;
     CMapManager*               m_pMapManager;
     CEvents*                   m_pEvents;
-    CLuaModuleManager*         m_pLuaModuleManager;
 
     CFastHashMap<lua_State*, CLuaMain*> m_VirtualMachineMap;
     list<CLuaMain*>                     m_virtualMachines;

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDefs.cpp
@@ -72,7 +72,6 @@ void CLuaDefs::Initialize(CGame* pGame)
     m_pResourceManager = pGame->GetResourceManager();
     m_pACLManager = pGame->GetACLManager();
     m_pMainConfig = pGame->GetConfig();
-    m_pLuaModuleManager = m_pLuaManager->GetLuaModuleManager();
 }
 
 bool CLuaDefs::CanUseFunction(const char* szFunction, lua_State* luaVM, bool bRestricted)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDefs.h
@@ -85,7 +85,6 @@ protected:
     static CResourceManager*          m_pResourceManager;
     static CAccessControlListManager* m_pACLManager;
     static CMainConfig*               m_pMainConfig;
-    static inline CLuaModuleManager*  m_pLuaModuleManager = nullptr;
 
 protected:
     // Old style: Only warn on failure. This should

--- a/Server/mods/deathmatch/logic/luadefs/CLuaFunctionDefs.Server.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaFunctionDefs.Server.cpp
@@ -688,28 +688,23 @@ int CLuaFunctionDefs::GetModuleInfo(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        std::list<CLuaModule*> modules = m_pLuaModuleManager->GetLoadedModules();
-        for (const auto mod : modules)
+        ILuaModule* pLuaModule = g_pGame->GetModule<CLuaModulesModule>()->GetModuleByName(strModuleName);
+        if (pLuaModule)
         {
-            if (mod->_GetName() == strModuleName)
-            {
-                lua_newtable(luaVM);
+            lua_newtable(luaVM);
 
-                lua_pushstring(luaVM, "name");
-                lua_pushstring(luaVM, mod->_GetFunctions().szModuleName);
-                lua_settable(luaVM, -3);
+            lua_pushstring(luaVM, "name");
+            lua_pushstring(luaVM, pLuaModule->GetName());
+            lua_settable(luaVM, -3);
 
-                lua_pushstring(luaVM, "author");
-                lua_pushstring(luaVM, mod->_GetFunctions().szAuthor);
-                lua_settable(luaVM, -3);
+            lua_pushstring(luaVM, "author");
+            lua_pushstring(luaVM, pLuaModule->GetAuthor());
+            lua_settable(luaVM, -3);
 
-                lua_pushstring(luaVM, "version");
-                SString strVersion("%.2f", mod->_GetFunctions().fVersion);
-                lua_pushstring(luaVM, strVersion);
-                lua_settable(luaVM, -3);
-
-                return 1;
-            }
+            lua_pushstring(luaVM, "version");
+            SString strVersion("%.2f", pLuaModule->GetVersion());
+            lua_pushstring(luaVM, strVersion);
+            lua_settable(luaVM, -3);
         }
     }
     else
@@ -721,14 +716,13 @@ int CLuaFunctionDefs::GetModuleInfo(lua_State* luaVM)
 
 int CLuaFunctionDefs::GetModules(lua_State* luaVM)
 {
+    std::vector<ILuaModule*> modules = g_pGame->GetModule<CLuaModulesModule>()->GetModules();
     lua_newtable(luaVM);
-    list<CLuaModule*>           lua_LoadedModules = m_pLuaModuleManager->GetLoadedModules();
-    list<CLuaModule*>::iterator iter = lua_LoadedModules.begin();
-    unsigned int                uiIndex = 1;
-    for (; iter != lua_LoadedModules.end(); ++iter)
+    unsigned int uiIndex = 1;
+    for (auto const& module : modules)
     {
         lua_pushnumber(luaVM, uiIndex++);
-        lua_pushstring(luaVM, (*iter)->_GetFunctions().szFileName);
+        lua_pushstring(luaVM, module->GetFileName());
         lua_settable(luaVM, -3);
     }
     return 1;

--- a/Server/mods/deathmatch/logic/packets/CPlayerClothesPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerClothesPacket.cpp
@@ -77,3 +77,8 @@ void CPlayerClothesPacket::Add(CPlayerClothes* pClothes)
         }
     }
 }
+
+unsigned int CPlayerClothesPacket::Count()
+{
+    return static_cast<unsigned int>(m_List.size());
+}

--- a/Server/mods/deathmatch/logic/packets/CPlayerClothesPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerClothesPacket.h
@@ -33,8 +33,8 @@ public:
 
     void         Add(const char* szTexture, const char* szModel, unsigned char ucType);
     void         Add(CPlayerClothes* pClothes);
-    unsigned int Count() { return static_cast<unsigned int>(m_List.size()); }
+    unsigned int Count();
 
 private:
-    vector<SPlayerClothes*> m_List;
+    std::vector<SPlayerClothes*> m_List;
 };

--- a/Server/mods/deathmatch/logic/packets/CResourceClientScriptsPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CResourceClientScriptsPacket.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include <vector>
-#include "CResource.h"
 #include "CResourceClientScriptItem.h"
 
 class CResourceClientScriptsPacket final : public CPacket

--- a/Server/mods/deathmatch/logic/packets/CResourceStartPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CResourceStartPacket.h
@@ -13,7 +13,6 @@
 
 #include <list>
 #include "../packets/CPacket.h"
-#include "../CResource.h"
 
 class CResourceStartPacket final : public CPacket
 {

--- a/Server/mods/deathmatch/premake5.lua
+++ b/Server/mods/deathmatch/premake5.lua
@@ -35,6 +35,7 @@ project "Deathmatch"
 	defines { "SDK_WITH_BCRYPT" }
 	links {
 		"Lua_Server", "sqlite", "ehs", "cryptopp", "pme", "pcre", "json-c", "zip", "zlib", "blowfish_bcrypt",
+		"luaModules"
 	}
 
 	vpaths {

--- a/Server/modules/luaModules/StdInc.cpp
+++ b/Server/modules/luaModules/StdInc.cpp
@@ -1,0 +1,1 @@
+#include "StdInc.h"

--- a/Server/modules/luaModules/StdInc.h
+++ b/Server/modules/luaModules/StdInc.h
@@ -1,0 +1,35 @@
+//#include "../../../../Shared/publicsdk/include/ILuaModuleManager.h"
+
+class CLuaModuleManager;
+
+#define MAX_INFO_LENGTH 128
+
+class CChecksum
+{
+public:
+    unsigned long ulCRC;
+    unsigned char mD5[16];
+};
+
+
+extern "C"
+{
+    #include <lua.h>
+    #include <lualib.h>
+    #include <lauxlib.h>
+}
+
+#ifdef WIN32
+    #include <windows.h>
+#endif
+
+#include "string"
+#include "vector"
+
+//#include "sdk/SharedUtil.File.hpp"
+//#include "sdk/std::string.hpp"
+#include "publicsdk/IModule.h"
+#include "publicsdk/include/ILuaModuleManager.h"
+#include "CLuaModule.h"
+#include "CLuaModuleManager.h"
+#include "CLuaModulesModule.h"

--- a/Server/modules/luaModules/StdInc.h
+++ b/Server/modules/luaModules/StdInc.h
@@ -1,5 +1,3 @@
-//#include "../../../../Shared/publicsdk/include/ILuaModuleManager.h"
-
 class CLuaModuleManager;
 
 #define MAX_INFO_LENGTH 128

--- a/Server/modules/luaModules/include/CLuaModule.h
+++ b/Server/modules/luaModules/include/CLuaModule.h
@@ -19,7 +19,7 @@ typedef void* HMODULE;
 
 typedef bool (*DefaultModuleFunc)();
 typedef void (*RegisterModuleFunc)(lua_State*);
-typedef bool (*InitModuleFunc)(ILuaModuleManager*, char*, char*, float*);
+typedef bool (*InitModuleFunc)(ILuaModuleManager*, char*, char*, float*, int version, int revision);
 
 struct FunctionInfo
 {
@@ -38,7 +38,7 @@ struct FunctionInfo
     RegisterModuleFunc ResourceStopped;
 };
 
-class CLuaModule : public ILuaModuleManager10, public ILuaModule
+class CLuaModule : public ILuaModuleManager20, public ILuaModule
 {
 public:
     CLuaModule(CLuaModuleManager* pLuaModuleManager, IModuleInterface* pModuleInterface, const char* szFileName, const char* szShortFileName);
@@ -49,8 +49,7 @@ public:
     void      ErrorPrintf(const char* szFormat, ...);
     void      DebugPrintf(lua_State* luaVM, const char* szFormat, ...);
     bool      RegisterFunction(lua_State* luaVM, const char* szFunctionName, lua_CFunction Func);
-    bool      GetResourceName(lua_State*   luaVM,
-                              std::string& strName);            // This function might not work if module and MTA were compiled with different compiler versions
+    bool      GetResourceName(lua_State* luaVM, std::string& strName);            // This function might not work if module and MTA were compiled with different compiler versions
     CChecksum GetResourceMetaChecksum(lua_State* luaVM);
     CChecksum GetResourceFileChecksum(lua_State* luaVM, const char* szFile);
 
@@ -83,6 +82,9 @@ public:
     const char* GetAuthor() const { return m_FunctionInfo.szAuthor; };
     float       GetVersion() const { return m_FunctionInfo.fVersion; };
     const char* GetFileName() const { return m_FunctionInfo.szFileName.c_str(); };
+
+    IResource*              GetResourceFromNameV2(const char* szResourceName);
+    IResource*              GetResourceFromLuaState(lua_State* luaVM);
 
 private:
     std::string              m_szFileName;

--- a/Server/modules/luaModules/include/CLuaModuleManager.h
+++ b/Server/modules/luaModules/include/CLuaModuleManager.h
@@ -9,42 +9,26 @@
  *
  *****************************************************************************/
 
-// IMPLEMENTATION of Lua dynamic modules
-
-class CLuaModuleManager;
-
-#pragma once
-
-#include "CLuaMain.h"
-#include "ILuaModuleManager.h"
-#include "CLuaManager.h"
-#include "../CLogger.h"
-#include "../CResource.h"
-#include "CLuaModule.h"
-
 class CScriptDebugging;
 
 class CLuaModuleManager
 {
 public:
-    CLuaModuleManager(CLuaManager* pLuaManager);
+    CLuaModuleManager(IModuleInterface* pModuleInterface);
     ~CLuaModuleManager();
 
     // functions for deathmatch
     void DoPulse();
     int  LoadModule(const char* szShortFileName, const char* szFileName, bool bLateLoad);
-    void SetScriptDebugging(CScriptDebugging* pScriptDebugging);
-    void RegisterFunctions(lua_State* luaVM);
+    void RegisterFunctions(IResource* resource);
     int  UnloadModule(const char* szShortFileName);
     int  ReloadModule(const char* szShortFileName, const char* szFileName, bool bLateLoad);
-    void ResourceStopping(lua_State* luaVM);
-    void ResourceStopped(lua_State* luaVM);
+    void ResourceStopping(IResource* resource);
+    void ResourceStopped(IResource* resource);
 
-    CLuaManager*      GetLuaManager() { return m_pLuaManager; };
-    list<CLuaModule*> GetLoadedModules() { return m_Modules; };
+    std::vector<CLuaModule*> GetLoadedModules() { return m_vecModules; };
 
 private:
-    CScriptDebugging* m_pScriptDebugging;
-    CLuaManager*      m_pLuaManager;
-    list<CLuaModule*> m_Modules;
+    IModuleInterface*        m_pModuleInterface;
+    std::vector<CLuaModule*> m_vecModules;
 };

--- a/Server/modules/luaModules/include/CLuaModulesModule.h
+++ b/Server/modules/luaModules/include/CLuaModulesModule.h
@@ -5,18 +5,23 @@ class CLuaModuleManager;
 class CLuaModulesModule : public IModule
 {
 public:
-    void                     Load(IModuleInterface* pModuleInterface);
-    void                     UnLoad();
-    void                     DoPulse();
-    void                     ResourceStarted(IResource* pResource);
-    void                     ResourceStopped(IResource* pResource);
-    void                     ResourceStopping(IResource* pResource);
-    int                      LoadModule(const char* szShortFileName, const char* szFileName, bool bLateLoad);
-    int                      UnloadModule(const char* szShortFileName);
-    int                      ReloadModule(const char* szShortFileName, const char* szFileName, bool bLateLoad);
-    ILuaModule*              GetModuleByName(const char* szName);
-    std::vector<ILuaModule*> GetModules();
+    CLuaModulesModule(IModuleInterface* pModuleInterface) : m_pModuleInterface(pModuleInterface) {}
+
+    void                      Load();
+    void                      UnLoad();
+    void                      DoPulse();
+    void                      ResourceStarted(IResource* pResource);
+    void                      ResourceStopped(IResource* pResource);
+    void                      ResourceStopping(IResource* pResource);
+    int                       LoadModule(const char* szShortFileName, const char* szFileName, bool bLateLoad);
+    int                       UnloadModule(const char* szShortFileName);
+    int                       ReloadModule(const char* szShortFileName, const char* szFileName, bool bLateLoad);
+    ILuaModule*               GetModuleByName(const char* szName);
+    std::vector<ILuaModule*>  GetModules();
+    std::vector<SFoundModule> GetAllModules();
+    bool                      IsModuleRunning(std::string moduleName);
 
 private:
+    IModuleInterface*  m_pModuleInterface;
     CLuaModuleManager* m_pLuaModuleManager;
 };

--- a/Server/modules/luaModules/include/CLuaModulesModule.h
+++ b/Server/modules/luaModules/include/CLuaModulesModule.h
@@ -1,0 +1,22 @@
+#include "interfaces/ILuaModule.h"
+
+class CLuaModuleManager;
+
+class CLuaModulesModule : public IModule
+{
+public:
+    void                     Load(IModuleInterface* pModuleInterface);
+    void                     UnLoad();
+    void                     DoPulse();
+    void                     ResourceStarted(IResource* pResource);
+    void                     ResourceStopped(IResource* pResource);
+    void                     ResourceStopping(IResource* pResource);
+    int                      LoadModule(const char* szShortFileName, const char* szFileName, bool bLateLoad);
+    int                      UnloadModule(const char* szShortFileName);
+    int                      ReloadModule(const char* szShortFileName, const char* szFileName, bool bLateLoad);
+    ILuaModule*              GetModuleByName(const char* szName);
+    std::vector<ILuaModule*> GetModules();
+
+private:
+    CLuaModuleManager* m_pLuaModuleManager;
+};

--- a/Server/modules/luaModules/include/interfaces/ILuaModule.h
+++ b/Server/modules/luaModules/include/interfaces/ILuaModule.h
@@ -1,0 +1,10 @@
+#pragma once
+
+class ILuaModule
+{
+public:
+    virtual const char* GetName() const = 0;
+    virtual const char* GetAuthor() const = 0;
+    virtual float       GetVersion() const = 0;
+    virtual const char* GetFileName() const = 0;
+};

--- a/Server/modules/luaModules/include/interfaces/ILuaModule.h
+++ b/Server/modules/luaModules/include/interfaces/ILuaModule.h
@@ -1,5 +1,11 @@
 #pragma once
 
+struct SFoundModule
+{
+    std::string name;
+    std::string state;
+};
+
 class ILuaModule
 {
 public:

--- a/Server/modules/luaModules/premake5.lua
+++ b/Server/modules/luaModules/premake5.lua
@@ -1,0 +1,31 @@
+project "LuaModules"
+	language "C++"
+	targetname "LuaModules"
+	kind "StaticLib"
+	
+	pchheader "StdInc.h"
+	pchsource "StdInc.cpp"
+
+	includedirs {
+		".",
+		"include",
+		"../../../Shared/",
+		"../../../vendor/lua/src",
+	}
+
+	vpaths { 
+		["Headers"] = "**.h",
+		["Interfaces"] = "include/interfaces/**.h",
+		["Sources"] = "**.cpp",
+		["*"] = "premake5.lua"
+	}
+
+	files {
+		"premake5.lua",
+		"**.h",
+		"**.cpp"
+	}
+
+	links {
+		"Lua_Server"
+	}

--- a/Server/modules/luaModules/src/CLuaModule.cpp
+++ b/Server/modules/luaModules/src/CLuaModule.cpp
@@ -13,6 +13,9 @@
 #include <sdk/SharedUtil.File.h>
 #include <sdk/SharedUtil.Defines.h>
 
+#define MTA_API_VERSION 2
+#define MTA_API_REVISION 0
+
 CLuaModule::CLuaModule(CLuaModuleManager* pLuaModuleManager, IModuleInterface* pModuleInterface, const char* szFileName, const char* szShortFileName)
 {
     // Set module manager
@@ -390,4 +393,14 @@ bool CLuaModule::GetResourceFilePath(lua_State* luaVM, const char* fileName, cha
 
     std::strncpy(path, p.c_str(), length);
     return true;
+}
+
+IResource* CLuaModule::GetResourceFromNameV2(const char* szResourceName)
+{
+    return m_pModuleInterface->GetResourceFromName(szResourceName);
+}
+
+IResource* CLuaModule::GetResourceFromLuaState(lua_State* luaVM)
+{
+    return m_pModuleInterface->GetResourceFromLuaState(luaVM);
 }

--- a/Server/modules/luaModules/src/CLuaModule.cpp
+++ b/Server/modules/luaModules/src/CLuaModule.cpp
@@ -21,7 +21,7 @@ CLuaModule::CLuaModule(CLuaModuleManager* pLuaModuleManager, IModuleInterface* p
     m_pModuleInterface = pModuleInterface;
     // set module path
     m_szFileName = szFileName;
-    m_szShortFileName = szFileName;
+    m_szShortFileName = szShortFileName;
     // set as uninitialised
     m_bInitialised = false;
 }

--- a/Server/modules/luaModules/src/CLuaModulesModule.cpp
+++ b/Server/modules/luaModules/src/CLuaModulesModule.cpp
@@ -1,0 +1,69 @@
+#include "StdInc.h"
+
+void CLuaModulesModule::Load(IModuleInterface* pModuleInterface)
+{
+    m_pLuaModuleManager = new CLuaModuleManager(pModuleInterface);
+    
+}
+
+void CLuaModulesModule::UnLoad()
+{
+}
+
+void CLuaModulesModule::DoPulse()
+{
+    m_pLuaModuleManager->DoPulse();
+}
+
+void CLuaModulesModule::ResourceStarted(IResource* pResource)
+{
+}
+
+void CLuaModulesModule::ResourceStopped(IResource* pResource)
+{
+    m_pLuaModuleManager->ResourceStopped(pResource);
+}
+
+void CLuaModulesModule::ResourceStopping(IResource* pResource)
+{
+    m_pLuaModuleManager->ResourceStopping(pResource);
+}
+
+int CLuaModulesModule::LoadModule(const char* szShortFileName, const char* szFileName, bool bLateLoad)
+{
+    return m_pLuaModuleManager->LoadModule(szShortFileName, szFileName, bLateLoad);
+}
+
+int CLuaModulesModule::UnloadModule(const char* szShortFileName)
+{
+    return m_pLuaModuleManager->UnloadModule(szShortFileName);
+}
+
+int CLuaModulesModule::ReloadModule(const char* szShortFileName, const char* szFileName, bool bLateLoad)
+{
+    return m_pLuaModuleManager->ReloadModule(szShortFileName, szFileName, bLateLoad);
+}
+
+ILuaModule* CLuaModulesModule::GetModuleByName(const char* szName)
+{
+    std::vector<CLuaModule*> luaModules = m_pLuaModuleManager->GetLoadedModules();
+    for (const auto luaModule : luaModules)
+    {
+        if (luaModule->_GetName() == szName)
+        {
+            return luaModule;
+        }
+    }
+    return nullptr;
+}
+
+std::vector<ILuaModule*> CLuaModulesModule::GetModules()
+{
+    std::vector<CLuaModule*> luaModules = m_pLuaModuleManager->GetLoadedModules();
+    std::vector<ILuaModule*> modules(luaModules.size());
+    for (const auto luaModule : luaModules)
+    {
+        modules.push_back(luaModule);
+    }
+    return modules;
+}

--- a/Server/modules/luaModules/src/CLuaModulesModule.cpp
+++ b/Server/modules/luaModules/src/CLuaModulesModule.cpp
@@ -1,8 +1,9 @@
 #include "StdInc.h"
+#include <sdk/SharedUtil.File.h>
 
-void CLuaModulesModule::Load(IModuleInterface* pModuleInterface)
+void CLuaModulesModule::Load()
 {
-    m_pLuaModuleManager = new CLuaModuleManager(pModuleInterface);
+    m_pLuaModuleManager = new CLuaModuleManager(m_pModuleInterface);
     
 }
 
@@ -66,4 +67,38 @@ std::vector<ILuaModule*> CLuaModulesModule::GetModules()
         modules.push_back(luaModule);
     }
     return modules;
+}
+
+bool CLuaModulesModule::IsModuleRunning(std::string moduleName)
+{
+    std::vector<CLuaModule*> luaModules = m_pLuaModuleManager->GetLoadedModules();
+    for (const auto luaModule : luaModules)
+    {
+        if (luaModule->_GetName() == moduleName)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+std::vector<SFoundModule> CLuaModulesModule::GetAllModules()
+{
+    std::vector<SFoundModule> foundModules;
+    std::vector<SString>      itemList = SharedUtil::FindFiles(SharedUtil::PathJoin(m_pModuleInterface->GetModulesPath(), "*"), true, false);
+    for (auto const& file : itemList)
+    {
+        SFoundModule foundModule;
+        foundModule.name = file;
+        if (IsModuleRunning(file))
+        {
+            foundModule.state = "running";
+        }
+        else
+        {
+            foundModule.state = "loaded";
+        }
+        foundModules.push_back(foundModule);
+    }
+    return foundModules;
 }

--- a/Server/sdk/core/CModManager.h
+++ b/Server/sdk/core/CModManager.h
@@ -19,6 +19,7 @@ public:
     virtual const char* GetServerPath() = 0;
     virtual const char* GetModPath() = 0;
     virtual SString     GetAbsolutePath(const char* szRelative) = 0;
+    virtual const char* GetModulePath() = 0;
 
     virtual void SetExitCode(int exitCode) = 0;
     virtual int  GetExitCode() const = 0;

--- a/Shared/publicsdk/IModule.h
+++ b/Shared/publicsdk/IModule.h
@@ -1,44 +1,4 @@
-class lua_State;
-
-class ILogger
-{
-public:
-    virtual void Printf(const char* szFormat, ...) = 0;
-    virtual void ErrorPrintf(const char* szFormat, ...) = 0;
-    virtual void LogInformation(lua_State* luaVM, const char* szFormat, ...) = 0;
-};
-
-class IElement
-{
-public:
-};
-
-class IResource : public IElement
-{
-public:
-    virtual lua_State*         GetLuaState() = 0;
-    virtual const CChecksum&   GetLastMetaChecksum() = 0;
-    virtual CChecksum          GetFileChecksum(const char* szFile) = 0;
-    virtual const std::string& GetName() const = 0;
-    virtual bool               GetFilePath(const char* szFilename, std::string& strPath) = 0;
-};
-
-class IModuleInterface
-{
-public:
-    virtual ILogger*    GetLogger() = 0;
-    virtual IResource*  GetResourceFromName(const char* name) = 0;
-    virtual const char* GetServerPath() = 0;
-    virtual const char* GetModulesPath() = 0;
-    virtual IResource*  GetResourceFromLuaState(lua_State* luaVM) = 0;
-
-    virtual unsigned long GetVersion() = 0;
-    virtual const char*   GetVersionString() = 0;
-    virtual const char*   GetVersionName() = 0;
-    virtual unsigned long GetNetcodeVersion() = 0;
-    virtual const char*   GetOperatingSystemName() = 0;
-    virtual void          AddFunction(lua_State* luaVM, const char* szName, lua_CFunction function) = 0;
-};
+#include "IModuleInterfaces.h"
 
 class IModule
 {

--- a/Shared/publicsdk/IModule.h
+++ b/Shared/publicsdk/IModule.h
@@ -1,0 +1,51 @@
+class lua_State;
+
+class ILogger
+{
+public:
+    virtual void Printf(const char* szFormat, ...) = 0;
+    virtual void ErrorPrintf(const char* szFormat, ...) = 0;
+    virtual void LogInformation(lua_State* luaVM, const char* szFormat, ...) = 0;
+};
+
+class IElement
+{
+public:
+};
+
+class IResource : public IElement
+{
+public:
+    virtual lua_State*         GetLuaState() = 0;
+    virtual const CChecksum&   GetLastMetaChecksum() = 0;
+    virtual CChecksum          GetFileChecksum(const char* szFile) = 0;
+    virtual const std::string& GetName() const = 0;
+    virtual bool               GetFilePath(const char* szFilename, std::string& strPath) = 0;
+};
+
+class IModuleInterface
+{
+public:
+    virtual ILogger*    GetLogger() = 0;
+    virtual IResource*  GetResourceFromName(const char* name) = 0;
+    virtual const char* GetServerPath() = 0;
+    virtual IResource*  GetResourceFromLuaState(lua_State* luaVM) = 0;
+
+    virtual unsigned long GetVersion() = 0;
+    virtual const char*   GetVersionString() = 0;
+    virtual const char*   GetVersionName() = 0;
+    virtual unsigned long GetNetcodeVersion() = 0;
+    virtual const char*   GetOperatingSystemName() = 0;
+    virtual void          AddFunction(lua_State* luaVM, const char* szName, lua_CFunction function) = 0;
+};
+
+class IModule
+{
+public:
+    virtual void Load(IModuleInterface* moduleInterface) = 0;
+    virtual void UnLoad() = 0;
+    virtual void DoPulse() = 0;
+    virtual void ResourceStarted(IResource* resource) = 0;
+    virtual void ResourceStopped(IResource* resource) = 0;
+    virtual void ResourceStopping(IResource* resource) = 0;
+};

--- a/Shared/publicsdk/IModule.h
+++ b/Shared/publicsdk/IModule.h
@@ -29,6 +29,7 @@ public:
     virtual ILogger*    GetLogger() = 0;
     virtual IResource*  GetResourceFromName(const char* name) = 0;
     virtual const char* GetServerPath() = 0;
+    virtual const char* GetModulesPath() = 0;
     virtual IResource*  GetResourceFromLuaState(lua_State* luaVM) = 0;
 
     virtual unsigned long GetVersion() = 0;
@@ -42,7 +43,7 @@ public:
 class IModule
 {
 public:
-    virtual void Load(IModuleInterface* moduleInterface) = 0;
+    virtual void Load() = 0;
     virtual void UnLoad() = 0;
     virtual void DoPulse() = 0;
     virtual void ResourceStarted(IResource* resource) = 0;

--- a/Shared/publicsdk/IModuleInterfaces.h
+++ b/Shared/publicsdk/IModuleInterfaces.h
@@ -1,0 +1,42 @@
+class ILogger
+{
+public:
+    virtual void Printf(const char* szFormat, ...) = 0;
+    virtual void ErrorPrintf(const char* szFormat, ...) = 0;
+    virtual void LogInformation(lua_State* luaVM, const char* szFormat, ...) = 0;
+};
+
+class IElement
+{
+public:
+    // Add new methods always at the end
+};
+
+class IResource
+{
+public:
+    // Add new methods always at the end
+    virtual lua_State*         GetLuaState() = 0;
+    virtual const CChecksum&   GetLastMetaChecksum() = 0;
+    virtual CChecksum          GetFileChecksum(const char* szFile) = 0;
+    virtual const std::string& GetName() const = 0;
+    virtual bool               GetFilePath(const char* szFilename, std::string& strPath) = 0;
+};
+
+class IModuleInterface
+{
+public:
+    // Add new methods always at the end
+    virtual ILogger*        GetLogger() = 0;
+    virtual IResource*      GetResourceFromName(const char* name) = 0;
+    virtual const char*     GetServerPath() = 0;
+    virtual const char*     GetModulesPath() = 0;
+    virtual IResource*      GetResourceFromLuaState(lua_State* luaVM) = 0;
+
+    virtual unsigned long GetVersion() = 0;
+    virtual const char*   GetVersionString() = 0;
+    virtual const char*   GetVersionName() = 0;
+    virtual unsigned long GetNetcodeVersion() = 0;
+    virtual const char*   GetOperatingSystemName() = 0;
+    virtual void          AddFunction(lua_State* luaVM, const char* szName, lua_CFunction function) = 0;
+};

--- a/Shared/publicsdk/include/ILuaModuleManager.h
+++ b/Shared/publicsdk/include/ILuaModuleManager.h
@@ -11,27 +11,6 @@
 
 // INTERFACE for Lua dynamic modules
 
-#pragma once
-
-#define MAX_INFO_LENGTH 128
-
-extern "C"
-{
-    #include <lua.h>
-    #include <lualib.h>
-    #include <lauxlib.h>
-}
-#include <string>
-
-#ifndef __CChecksum_H
-class CChecksum
-{
-public:
-    unsigned long ulCRC;
-    unsigned char mD5[16];
-};
-#endif
-
 /* Interface for modules until DP2.3 */
 class ILuaModuleManager
 {

--- a/Shared/publicsdk/include/ILuaModuleManager.h
+++ b/Shared/publicsdk/include/ILuaModuleManager.h
@@ -42,3 +42,15 @@ public:
     virtual bool GetResourceName(lua_State* luaVM, char* szName, size_t length) = 0;
     virtual bool GetResourceFilePath(lua_State* luaVM, const char* fileName, char* path, size_t length) = 0;
 };
+
+class ILuaModuleManager20 : public ILuaModuleManager10
+{
+public:
+    virtual IResource* GetResourceFromNameV2(const char* szResourceName) = 0;
+    virtual IResource* GetResourceFromLuaState(lua_State* luaVM) = 0;
+};
+
+// Wants to add new methods? create new class that inherits from ILuaModuleManager20, call it eg: ILuaModuleManager21
+// Add your methods and update version in MTA_API_VERSION and MTA_API_REVISION in CLuaModule.cpp
+// where 21 - 2 version, 1 - revision. Remember to update CLuaModule to inherit from new class you created
+// Wants to update existing function? Bump version and add method with `VX` where X is next version

--- a/premake5.lua
+++ b/premake5.lua
@@ -147,6 +147,8 @@ workspace "MTASA"
 		include "Server/launcher"
 		include "Server/mods/deathmatch"
 		include "Server/sdk"
+		group "Server/Modules"
+			include "Server/modules/luaModules"
 
 		group "Shared"
 		include "Shared"


### PR DESCRIPTION
Because of modules in mta are almost dead feature ( except ml_socket ), i spent a few days of improving it and adding some new small features.
I changed architecture of mta a little, new folder called "server/modules" contains all extra features, for example lua modules as they are called in code base. This approach let offload main project ( deathmatch ) by removing few headers but added few to communicate between main project and modules.
![image](https://user-images.githubusercontent.com/22455534/137933125-a8fa3905-23c7-4649-9372-e0c22a8cd29c.png)
No more waiting few minutes to compile, LuaModules project compiles in seconds what improve productivity.

Inside that project you can see first "module" called "LuaModules" - This project has only one job: manage lua modules, nothing else while main project don't know what are lua modules.

New lua manager, 2.0 has been added right now with only two functions to get `IResource` - a new interface class used to expose functionality to different projects, lua modules.

New command "modules" will tell you current status of modules and list of availiable ones:
![image](https://user-images.githubusercontent.com/22455534/137934161-c6edd4bd-e982-4c08-8304-36bee712489b.png)

The main goal is to make module be able to do everything. Right now they let you add custom functions and events, nothing more. 

This pr is mainly a refactor and preparing a base for further updates.