### PR TITLE
Add option to set allowed events from cef

### DIFF
--- a/Client/mods/deathmatch/logic/CClientWebBrowser.cpp
+++ b/Client/mods/deathmatch/logic/CClientWebBrowser.cpp
@@ -227,6 +227,10 @@ void CClientWebBrowser::Events_OnChangeCursor(unsigned char ucCursor)
 
 void CClientWebBrowser::Events_OnTriggerEvent(const SString& strEventName, const std::vector<std::string>& arguments)
 {
+    if (m_allowedEvents.size() > 0)
+        if (m_allowedEvents.find(strEventName) == m_allowedEvents.end())
+            return;
+
     CLuaArguments Arguments;
     for (std::vector<std::string>::const_iterator iter = arguments.begin(); iter != arguments.end(); ++iter)
     {
@@ -327,12 +331,18 @@ bool CClientWebBrowser::ToggleDevTools(bool visible)
     return m_pWebView->ToggleDevTools(visible);
 }
 
+void CClientWebBrowser::SetAllowedEvents(std::vector<SString> vecAllowedEvents)
+{
+    m_allowedEvents = std::set(vecAllowedEvents.begin(), vecAllowedEvents.end());
+}
+
 CClientGUIWebBrowser::CClientGUIWebBrowser(bool isLocal, bool isTransparent, uint width, uint height, CClientManager* pManager, CLuaMain* pLuaMain,
-                                           CGUIElement* pCGUIElement, ElementID ID)
+                                           CGUIElement* pCGUIElement, std::vector<SString> vecAllowedEvents, ElementID ID)
     : CClientGUIElement(pManager, pLuaMain, pCGUIElement, ID)
 {
     m_pManager = pManager;
     m_pBrowser = g_pClientGame->GetManager()->GetRenderElementManager()->CreateWebBrowser(width, height, isLocal, isTransparent);
+    m_pBrowser->SetAllowedEvents(vecAllowedEvents);
 
     if (m_pBrowser)
     {

--- a/Client/mods/deathmatch/logic/CClientWebBrowser.h
+++ b/Client/mods/deathmatch/logic/CClientWebBrowser.h
@@ -85,17 +85,20 @@ public:
     void Events_OnResourceBlocked(const SString& strURL, const SString& strDomain, unsigned char reason) override;
     void Events_OnAjaxRequest(CAjaxResourceHandlerInterface* pHandler, const SString& strURL) override;
 
+    void SetAllowedEvents(std::vector<SString> vecAllowedEvents);
+
 private:
     CWebViewInterface*                 m_pWebView;
     CResource*                         m_pResource;
     std::map<SString, ajax_callback_t> m_mapAjaxCallback;
+    std::set<SString>                  m_allowedEvents;
 };
 
 class CClientGUIWebBrowser : public CClientGUIElement
 {
 public:
     CClientGUIWebBrowser(bool isLocal, bool isTransparent, uint width, uint height, CClientManager* pManager, CLuaMain* pLuaMain, CGUIElement* pCGUIElement,
-                         ElementID ID = INVALID_ELEMENT_ID);
+                         std::vector<SString> vecAllowedEvents, ElementID ID = INVALID_ELEMENT_ID);
 
     CClientWebBrowser* GetBrowser() { return m_pBrowser; }
 

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -5564,7 +5564,8 @@ bool CStaticFunctionDefinitions::GUIComboBoxIsOpen(CClientEntity& Entity)
 }
 
 CClientGUIElement* CStaticFunctionDefinitions::GUICreateBrowser(CLuaMain& LuaMain, const CVector2D& position, const CVector2D& size, bool bIsLocal,
-                                                                bool bIsTransparent, bool bRelative, CClientGUIElement* pParent)
+                                                                bool bIsTransparent, bool bRelative, CClientGUIElement* pParent,
+                                                                std::vector<SString> vecAllowedEvents)
 {
     CGUIWebBrowser* pElement = m_pGUI->CreateWebBrowser(pParent ? pParent->GetCGUIElement() : nullptr);
     pElement->SetPosition(position, bRelative);
@@ -5573,7 +5574,7 @@ CClientGUIElement* CStaticFunctionDefinitions::GUICreateBrowser(CLuaMain& LuaMai
     // Register to the gui manager
     CVector2D absoluteSize;
     pElement->GetSize(absoluteSize, false);
-    auto pGUIElement = new CClientGUIWebBrowser(bIsLocal, bIsTransparent, (uint)absoluteSize.fX, (uint)absoluteSize.fY, m_pManager, &LuaMain, pElement);
+    auto pGUIElement = new CClientGUIWebBrowser(bIsLocal, bIsTransparent, (uint)absoluteSize.fX, (uint)absoluteSize.fY, m_pManager, &LuaMain, pElement, vecAllowedEvents);
 
     if (!pGUIElement->GetBrowser())
     {

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -441,7 +441,7 @@ public:
     static CClientGUIElement* GUICreateComboBox(CLuaMain& LuaMain, const CVector2D& position, const CVector2D& size, const char* szCaption, bool bRelative,
                                                 CClientGUIElement* pParent);
     static CClientGUIElement* GUICreateBrowser(CLuaMain& LuaMain, const CVector2D& position, const CVector2D& size, bool bIsLocal, bool bIsTransparent,
-                                               bool bRelative, CClientGUIElement* pParent);
+                                               bool bRelative, CClientGUIElement* pParent, std::vector<SString> vecAllowedEvents);
 
     static bool GUIStaticImageLoadImage(CClientEntity& Element, const SString& strDir);
     static bool GUIStaticImageGetNativeSize(CClientEntity& Entity, CVector2D& vecSize);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.cpp
@@ -109,15 +109,18 @@ void CLuaBrowserDefs::AddClass(lua_State* luaVM)
 
 int CLuaBrowserDefs::CreateBrowser(lua_State* luaVM)
 {
-    //  texture createBrowser ( int width, int height, bool isLocal [, bool transparent = false] )
-    CVector2D vecSize;
-    bool      bIsLocal;
-    bool      bTransparent;
+    //  texture createBrowser ( int width, int height, bool isLocal [, bool transparent = false [, table allowedEvents = nil ] )
+    CVector2D            vecSize;
+    bool                 bIsLocal;
+    bool                 bTransparent;
+    std::vector<SString> vecAllowedEvents;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadVector2D(vecSize);
     argStream.ReadBool(bIsLocal);
     argStream.ReadBool(bTransparent, false);
+    if (argStream.NextIsTable())
+        argStream.ReadStringTable(vecAllowedEvents);
 
     if (!argStream.HasErrors())
     {
@@ -157,6 +160,8 @@ int CLuaBrowserDefs::CreateBrowser(lua_State* luaVM)
 
                 // Set our owner resource
                 pBrowserTexture->SetResource(pParentResource);
+
+                pBrowserTexture->SetAllowedEvents(vecAllowedEvents);
             }
             lua_pushelement(luaVM, pBrowserTexture);
             return 1;
@@ -889,13 +894,14 @@ int CLuaBrowserDefs::ReloadBrowserPage(lua_State* luaVM)
 
 int CLuaBrowserDefs::GUICreateBrowser(lua_State* luaVM)
 {
-    //  element guiCreateBrowser ( float x, float y, float width, float height, bool isLocal, bool isTransparent, bool relative, [element parent = nil] )
-    CVector2D          position;
-    CVector2D          size;
-    bool               bIsLocal;
-    bool               bIsTransparent;
-    bool               bIsRelative;
-    CClientGUIElement* parent;
+    //  element guiCreateBrowser ( float x, float y, float width, float height, bool isLocal, bool isTransparent, bool relative, [element parent = nil [, table allowedEvents = nil ] ] )
+    CVector2D            position;
+    CVector2D            size;
+    bool                 bIsLocal;
+    bool                 bIsTransparent;
+    bool                 bIsRelative;
+    CClientGUIElement*   parent;
+    std::vector<SString> vecAllowedEvents;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadVector2D(position);
@@ -904,6 +910,8 @@ int CLuaBrowserDefs::GUICreateBrowser(lua_State* luaVM)
     argStream.ReadBool(bIsTransparent);
     argStream.ReadBool(bIsRelative);
     argStream.ReadUserData(parent, nullptr);
+    if (argStream.NextIsTable())
+        argStream.ReadStringTable(vecAllowedEvents);
 
     if (!argStream.HasErrors())
     {
@@ -933,7 +941,7 @@ int CLuaBrowserDefs::GUICreateBrowser(lua_State* luaVM)
         if (pLuaMain)
         {
             CClientGUIElement* pGUIElement =
-                CStaticFunctionDefinitions::GUICreateBrowser(*pLuaMain, position, size, bIsLocal, bIsTransparent, bIsRelative, parent);
+                CStaticFunctionDefinitions::GUICreateBrowser(*pLuaMain, position, size, bIsLocal, bIsTransparent, bIsRelative, parent, vecAllowedEvents);
 
             if (pGUIElement)
             {


### PR DESCRIPTION
Add option to specify what events should be allowed to call from CEF.
You can not change it after browser get created. This change is to improve security, now one misused "innerHTML" can compromise the whole server and you can do nothing.
If table is empty, every event is allowed, this is by default to provide backward compatiblity.

example code, "hackme" will not triggered:

```lua
local screenWidth, screenHeight = 800, 600

local window = guiCreateWindow( 600, 100, screenWidth, screenHeight, "Web Browser", false )
local browser = guiCreateBrowser( 0, 28, screenWidth, screenHeight, true, false, false, window, { "foo", "bar" } )
local theBrowser = guiGetBrowser( browser )

setDevelopmentMode(true, true)

addEvent("foo", true)
addEventHandler("foo", root, function(message)
    outputChatBox(message)
end)

addEvent("bar", true)
addEventHandler("bar", root, function(message)
    outputChatBox(message)
end)

addEvent("hackme", true)
addEventHandler("hackme", root, function(message)
    outputChatBox(message)
end)

addEventHandler("onClientBrowserCreated", browser,
    function ()
        loadBrowserURL(source, "http://mta/local/example.html")
    end)

addEventHandler( "onClientBrowserDocumentReady", theBrowser, 
	function( )
        executeBrowserJavascript(source, [[
mta.triggerEvent("foo", "foo triggered")
mta.triggerEvent("hackme", "you has been backed")
mta.triggerEvent("foo", "foo triggered again")
mta.triggerEvent("bar", "bar triggered")
]])
	end
)

```