### PR TITLE
Bugfix (onColShape/onElementColShape)

### DIFF
--- a/Client/mods/deathmatch/logic/CClientColManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientColManager.cpp
@@ -146,7 +146,7 @@ void CClientColManager::HandleHitDetectionResult(bool bHit, CClientColShape* pSh
             pEntity->AddCollision(pShape);
 
             // Can we call the event?
-            if (pShape->GetAutoCallEvent())
+            if (pShape->GetAutoCallEvent() && !pEntity->IsBeingDeleted())
             {
                 // Call the event
                 CLuaArguments Arguments;
@@ -173,16 +173,20 @@ void CClientColManager::HandleHitDetectionResult(bool bHit, CClientColShape* pSh
             pShape->RemoveCollider(pEntity);
             pEntity->RemoveCollision(pShape);
 
-            // Call the event
-            CLuaArguments Arguments;
-            Arguments.PushElement(pEntity);
-            Arguments.PushBoolean((pShape->GetDimension() == pEntity->GetDimension()));
-            pShape->CallEvent("onClientColShapeLeave", Arguments, true);
+            // Can we call the event?
+            if(!pEntity->IsBeingDeleted())
+            {
+                // Call the event
+                CLuaArguments Arguments;
+                Arguments.PushElement(pEntity);
+                Arguments.PushBoolean((pShape->GetDimension() == pEntity->GetDimension()));
+                pShape->CallEvent("onClientColShapeLeave", Arguments, true);
 
-            CLuaArguments Arguments2;
-            Arguments2.PushElement(pShape);
-            Arguments2.PushBoolean((pShape->GetDimension() == pEntity->GetDimension()));
-            pEntity->CallEvent("onClientElementColShapeLeave", Arguments2, true);
+                CLuaArguments Arguments2;
+                Arguments2.PushElement(pShape);
+                Arguments2.PushBoolean((pShape->GetDimension() == pEntity->GetDimension()));
+                pEntity->CallEvent("onClientElementColShapeLeave", Arguments2, true);
+            }
 
             pShape->CallLeaveCallback(*pEntity);
         }

--- a/Server/mods/deathmatch/logic/CColManager.cpp
+++ b/Server/mods/deathmatch/logic/CColManager.cpp
@@ -135,7 +135,7 @@ void CColManager::HandleHitDetectionResult(bool bHit, CColShape* pShape, CElemen
             pEntity->AddCollision(pShape);
 
             // Can we call the event?
-            if (pShape->GetAutoCallEvent())
+            if (pShape->GetAutoCallEvent() && !pEntity->IsBeingDeleted())
             {
                 // Call the event
                 CLuaArguments Arguments;
@@ -162,16 +162,20 @@ void CColManager::HandleHitDetectionResult(bool bHit, CColShape* pShape, CElemen
             pShape->RemoveCollider(pEntity);
             pEntity->RemoveCollision(pShape);
 
-            // Call the event
-            CLuaArguments Arguments;
-            Arguments.PushElement(pEntity);
-            Arguments.PushBoolean((pShape->GetDimension() == pEntity->GetDimension()));
-            pShape->CallEvent("onColShapeLeave", Arguments);
+            // Can we call the event?
+            if(!pEntity->IsBeingDeleted())
+            {
+                // Call the event
+                CLuaArguments Arguments;
+                Arguments.PushElement(pEntity);
+                Arguments.PushBoolean((pShape->GetDimension() == pEntity->GetDimension()));
+                pShape->CallEvent("onColShapeLeave", Arguments);
 
-            CLuaArguments Arguments2;
-            Arguments2.PushElement(pShape);
-            Arguments2.PushBoolean((pShape->GetDimension() == pEntity->GetDimension()));
-            pEntity->CallEvent("onElementColShapeLeave", Arguments2);
+                CLuaArguments Arguments2;
+                Arguments2.PushElement(pShape);
+                Arguments2.PushBoolean((pShape->GetDimension() == pEntity->GetDimension()));
+                pEntity->CallEvent("onElementColShapeLeave", Arguments2);
+            }
 
             pShape->CallLeaveCallback(*pEntity);
         }


### PR DESCRIPTION
Event needs a was-element-destroyed check.

PoC:
```lua
local vehicleModel = 404
local vehiclePos = Vector3(0, 0, 5)
createVehicle(vehicleModel, vehiclePos)
createColSphere(vehiclePos, 10)
addEventHandler("onColShapeLeave", resourceRoot, function( el, md )
    if not getElementType(el) then outputChatBox("invalid element type. gotcha?", root) return end -- returns a warning
    if getElementType(el) ~= "player" then return end
    if not isPedInVehicle(el) then outputChatBox("you should be in vehicle to reproduce that", root) end
    destroyElement( getPedOccupiedVehicle( el ) )
end)
```