### PR TITLE
Fix CEF crashing (#2446)

### DIFF
--- a/Client/ceflauncher_DLL/CCefApp.h
+++ b/Client/ceflauncher_DLL/CCefApp.h
@@ -116,7 +116,16 @@ public:
             return;
 
         CefRefPtr<CefProcessMessage> message = V8Helpers::SerialiseV8Arguments("TriggerLuaEvent", arguments);
-        frame.get()->GetBrowser()->GetMainFrame()->SendProcessMessage(PID_BROWSER, message);
+
+        auto browser = frame.get()->GetBrowser();
+
+        if (!browser)
+            return;
+
+        auto mainFrame = browser->GetMainFrame();
+
+        if (mainFrame)
+            mainFrame.get()->SendProcessMessage(PID_BROWSER, message);
     }
 
 public:

--- a/Client/cefweb/CAjaxResourceHandler.cpp
+++ b/Client/cefweb/CAjaxResourceHandler.cpp
@@ -64,7 +64,10 @@ bool CAjaxResourceHandler::ReadResponse(void* data_out, int bytes_to_read, int& 
     {
         bytes_read = 0;
         m_callback = callback;
-        callback.get()->Continue();
+
+        if (callback.get())
+            callback.get()->Continue();
+
         return true;
     }
 

--- a/Client/cefweb/CAjaxResourceHandler.cpp
+++ b/Client/cefweb/CAjaxResourceHandler.cpp
@@ -63,8 +63,8 @@ bool CAjaxResourceHandler::ReadResponse(void* data_out, int bytes_to_read, int& 
     if (!m_bHasData)
     {
         bytes_read = 0;
-        m_callback = callback.get();
-        callback->Continue();
+        m_callback = callback;
+        callback.get()->Continue();
         return true;
     }
 

--- a/Client/cefweb/CAjaxResourceHandler.cpp
+++ b/Client/cefweb/CAjaxResourceHandler.cpp
@@ -44,15 +44,22 @@ void CAjaxResourceHandler::Cancel()
 
 void CAjaxResourceHandler::GetResponseHeaders(CefRefPtr<CefResponse> response, int64& response_length, CefString& redirectUrl)
 {
+    if (!response)
+        return;
+
     CefResponse* pResponse = response.get();
     pResponse->SetStatus(200);
     pResponse->SetStatusText("OK");
     pResponse->SetMimeType(m_strMime);
+
     response_length = -1;
 }
 
 bool CAjaxResourceHandler::ProcessRequest(CefRefPtr<CefRequest> request, CefRefPtr<CefCallback> callback)
 {
+    if (!callback)
+        return false;
+
     // Since we have nothing to process yet, continue
     callback.get()->Continue();
     return true;

--- a/Client/cefweb/CAjaxResourceHandler.cpp
+++ b/Client/cefweb/CAjaxResourceHandler.cpp
@@ -33,8 +33,8 @@ void CAjaxResourceHandler::SetResponse(const SString& data)
     m_strResponse = data;
     m_bHasData = true;
 
-    if (m_callback)
-        m_callback->Continue();
+    if (m_callback && m_callback.get())
+        m_callback.get()->Continue();
 }
 
 // CefResourceHandler implementation

--- a/Client/cefweb/CAjaxResourceHandler.cpp
+++ b/Client/cefweb/CAjaxResourceHandler.cpp
@@ -63,7 +63,7 @@ bool CAjaxResourceHandler::ReadResponse(void* data_out, int bytes_to_read, int& 
     if (!m_bHasData)
     {
         bytes_read = 0;
-        m_callback = callback;
+        m_callback = callback.get();
         callback->Continue();
         return true;
     }

--- a/Client/cefweb/CAjaxResourceHandler.cpp
+++ b/Client/cefweb/CAjaxResourceHandler.cpp
@@ -33,7 +33,7 @@ void CAjaxResourceHandler::SetResponse(const SString& data)
     m_strResponse = data;
     m_bHasData = true;
 
-    if (m_callback && m_callback.get())
+    if (m_callback)
         m_callback.get()->Continue();
 }
 
@@ -44,16 +44,17 @@ void CAjaxResourceHandler::Cancel()
 
 void CAjaxResourceHandler::GetResponseHeaders(CefRefPtr<CefResponse> response, int64& response_length, CefString& redirectUrl)
 {
-    response->SetStatus(200);
-    response->SetStatusText("OK");
-    response->SetMimeType(m_strMime);
+    CefResponse* pResponse = response.get();
+    pResponse->SetStatus(200);
+    pResponse->SetStatusText("OK");
+    pResponse->SetMimeType(m_strMime);
     response_length = -1;
 }
 
 bool CAjaxResourceHandler::ProcessRequest(CefRefPtr<CefRequest> request, CefRefPtr<CefCallback> callback)
 {
     // Since we have nothing to process yet, continue
-    callback->Continue();
+    callback.get()->Continue();
     return true;
 }
 
@@ -65,8 +66,8 @@ bool CAjaxResourceHandler::ReadResponse(void* data_out, int bytes_to_read, int& 
         bytes_read = 0;
         m_callback = callback;
 
-        if (callback.get())
-            callback.get()->Continue();
+        if (m_callback)
+            m_callback.get()->Continue();
 
         return true;
     }

--- a/Client/cefweb/CWebApp.cpp
+++ b/Client/cefweb/CWebApp.cpp
@@ -27,6 +27,9 @@ void CWebApp::OnRegisterCustomSchemes(CefRawPtr<CefSchemeRegistrar> registrar)
 
 void CWebApp::OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefCommandLine> command_line)
 {
+    if (!command_line)
+        return;
+
     CefCommandLine* pCommandLine = command_line.get();
 
     pCommandLine->AppendSwitch("disable-gpu-compositing");
@@ -47,7 +50,7 @@ CefRefPtr<CefResourceHandler> CWebApp::Create(CefRefPtr<CefBrowser> browser, Cef
     // browser or frame are NULL if the request does not orginate from a browser window
     // This is for exmaple true for the application cache or CEFURLRequests
     // (http://www.html5rocks.com/en/tutorials/appcache/beginner/)
-    if (!browser || !frame)
+    if (!browser || !frame || !request)
         return nullptr;
 
     CWebCore* pWebCore = static_cast<CWebCore*>(g_pCore->GetWebCore());
@@ -196,7 +199,7 @@ CefRefPtr<CefResourceHandler> CWebApp::Create(CefRefPtr<CefBrowser> browser, Cef
                 fileData = CBuffer("", sizeof(""));
 
             auto stream = CefStreamReader::CreateForData(fileData.GetData(), fileData.GetSize());
-            if (stream.get())
+            if (stream && stream.get())
                 return new CefStreamResourceHandler(mimeType, stream);
             return HandleError("404 - Not found", 404);
         }

--- a/Client/cefweb/CWebCore.cpp
+++ b/Client/cefweb/CWebCore.cpp
@@ -482,7 +482,13 @@ void CWebCore::OnPostScreenshot()
         auto browser = pWebView->GetCefBrowser();
 
         if (browser)
-            browser.get()->GetHost()->Invalidate(CefBrowserHost::PaintElementType::PET_VIEW);
+        {
+            auto host = browser.get()->GetHost();
+
+            if (host)
+                host->Invalidate(CefBrowserHost::PaintElementType::PET_VIEW);
+        }
+            
     }
 }
 

--- a/Client/cefweb/CWebDevTools.cpp
+++ b/Client/cefweb/CWebDevTools.cpp
@@ -12,9 +12,12 @@
 
 bool CWebDevTools::Show(CWebView* pWebView)
 {
-    auto pBrowser = pWebView->GetCefBrowser();
-    if (!pBrowser)
+    auto browser = pWebView->GetCefBrowser();
+
+    if (!browser)
         return false;
+
+    CefBrowser* pBrowser = browser.get();
 
     // Default settings are suitable
     CefBrowserSettings settings;
@@ -32,10 +35,11 @@ bool CWebDevTools::Show(CWebView* pWebView)
 
 bool CWebDevTools::Close(CWebView* pWebView)
 {
-    auto pBrowser = pWebView->GetCefBrowser();
-    if (!pBrowser)
+    auto browser = pWebView->GetCefBrowser();
+
+    if (!browser)
         return false;
 
-    pBrowser->GetHost()->CloseDevTools();
+    browser.get()->GetHost()->CloseDevTools();
     return true;
 }

--- a/Client/cefweb/CWebDevTools.cpp
+++ b/Client/cefweb/CWebDevTools.cpp
@@ -20,7 +20,7 @@ bool CWebDevTools::Show(CWebView* pWebView)
     CefBrowserSettings settings;
 
     CefWindowInfo windowInfo;
-    windowInfo.SetAsPopup(NULL, "CEF Dev Tools (MTA:SA)");
+    windowInfo.SetAsPopup(nullptr, "CEF Dev Tools (MTA:SA)");
 
     // Create independent CefClient (to bypass access restrictions)
     CefRefPtr<CefClient> client{new CDevToolsClient};

--- a/Client/cefweb/CWebDevTools.cpp
+++ b/Client/cefweb/CWebDevTools.cpp
@@ -40,6 +40,10 @@ bool CWebDevTools::Close(CWebView* pWebView)
     if (!browser)
         return false;
 
-    browser.get()->GetHost()->CloseDevTools();
+    auto host = browser.get()->GetHost();
+
+    if (host)
+        host->CloseDevTools();
+
     return true;
 }

--- a/Client/cefweb/CWebView.cpp
+++ b/Client/cefweb/CWebView.cpp
@@ -816,7 +816,7 @@ bool CWebView::OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>
        ERR_ABORTED.
     */
 
-    if (!request)
+    if (!request || !frame)
         return false;
 
     CefURLParts urlParts;

--- a/Client/cefweb/CWebView.cpp
+++ b/Client/cefweb/CWebView.cpp
@@ -79,8 +79,13 @@ void CWebView::CloseBrowser()
     // Make sure we don't dead lock the CEF render thread
     m_RenderData.cv.notify_all();
 
-    if (m_pWebView)
-        m_pWebView.get()->GetHost()->CloseBrowser(true);
+    if (!m_pWebView)
+        return;
+
+    auto host = m_pWebView.get()->GetHost();
+
+    if (host)
+        host->CloseBrowser(true);
 }
 
 bool CWebView::LoadURL(const SString& strURL, bool bFilterEnabled, const SString& strPostData, bool bURLEncoded)
@@ -969,6 +974,8 @@ bool CWebView::OnBeforePopup(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> 
                              bool* no_javascript_access)
 {
     // ATTENTION: This method is called on the IO thread
+    if (!frame)
+        return true; // block it
 
     // Trigger the popup/new tab event
     SString strTagetURL = UTF16ToMbUTF8(target_url);


### PR DESCRIPTION
Should resolve #2446 - due to:

```
Implicit conversion of CefRefPtr<T> or scoped_refptr<T> to T* is gone; use x.get() instead
```
(see https://bitbucket.org/chromiumembedded/cef/issues/3140/update-include-base-for-c-11-14-features)

Haven't tested these changes yet, upgrading to VS 2022 now - will report shortly 😅 