### PR TITLE
Fix CEF crashing (#2446)

### DIFF
--- a/Client/cefweb/CAjaxResourceHandler.cpp
+++ b/Client/cefweb/CAjaxResourceHandler.cpp
@@ -32,9 +32,6 @@ void CAjaxResourceHandler::SetResponse(const SString& data)
 {
     m_strResponse = data;
     m_bHasData = true;
-
-    if (m_callback)
-        m_callback->Continue();
 }
 
 // CefResourceHandler implementation


### PR DESCRIPTION
Alright, hopefully the actual fix this time (#2451 was completely the wrong idea) 😅 

not sure why we're calling `m_callback->Continue()` here in the first place?

without these changes, I can reproduce a crash every single time from a **Release** build, setting the interval in `index.html` of the test resource in #2446 to 1ms (in **Debug** mode, the crash hardly ever happens, because of magic or whatever)

with these changes, I'm unable to reproduce the crash (@haron4igg also tested heavily, no crash)