### PR TITLE
Alter #2452 (Fix CEF crashing)

### DIFF
--- a/Client/cefweb/CAjaxResourceHandler.cpp
+++ b/Client/cefweb/CAjaxResourceHandler.cpp
@@ -32,6 +32,9 @@ void CAjaxResourceHandler::SetResponse(const SString& data)
 {
     m_strResponse = data;
     m_bHasData = true;
+
+    if (m_callback)
+        m_callback->Continue();
 }
 
 // CefResourceHandler implementation
@@ -61,7 +64,7 @@ bool CAjaxResourceHandler::ReadResponse(void* data_out, int bytes_to_read, int& 
     {
         bytes_read = 0;
         m_callback = callback;
-        callback->Continue();
+
         return true;
     }
 


### PR DESCRIPTION
Upon further review of #2452 - it seems I read something backwards:

### ReadResponse
```cpp
public virtual bool ReadResponse( void* data_out, int bytes_to_read, int& bytes_read, CefRefPtr< CefCallback > callback );
```
Read response data. If data is available immediately copy up to `bytes_to_read` bytes into `data_out` set `bytes_read` to the number of bytes copied, and return true. To read the data at a later time set `bytes_read` to 0, return true and **call CefCallback::Continue() when the data is available**.

So we shouldn't be calling `CefCallback::Continue()` if we have no data - only when the data is received later in `CAjaxResourceHandler::SetResponse()` (as it was originally).

The original reason for crashing before #2452 is due to `Continue()` being called twice. It should only be called later when the data is available, if it wasn't available initially.

Needs testing again by others but fine here.