### PR TITLE
Add bUseIDs parameter to CXMLNodeImpl constructor & fix #2456 (svgCreate crashing)

### DIFF
--- a/Shared/XML/CXMLImpl.cpp
+++ b/Shared/XML/CXMLImpl.cpp
@@ -53,7 +53,7 @@ std::unique_ptr<SXMLString> CXMLImpl::ParseString(const char* strXmlContent)
 
             if (xmlDocumentRoot)
             {
-                CXMLNodeImpl* xmlBaseNode = new CXMLNodeImpl(nullptr, nullptr, *xmlDocumentRoot);
+                CXMLNodeImpl* xmlBaseNode = new CXMLNodeImpl(nullptr, nullptr, *xmlDocumentRoot, false);
 
                 if (xmlBaseNode && xmlBaseNode->IsValid())
                 {

--- a/Shared/XML/CXMLNodeImpl.cpp
+++ b/Shared/XML/CXMLNodeImpl.cpp
@@ -13,11 +13,11 @@
 #define BLANK_LINE_COMMENT_MAGIC "##BLANK-LINE##"
 using std::list;
 
-CXMLNodeImpl::CXMLNodeImpl(CXMLFileImpl* pFile, CXMLNodeImpl* pParent, TiXmlElement& Node)
+CXMLNodeImpl::CXMLNodeImpl(CXMLFileImpl* pFile, CXMLNodeImpl* pParent, TiXmlElement& Node, bool bUseIDs)
     : m_ulID(INVALID_XML_ID),
-      m_bUsingIDs((!pFile) || pFile && pFile->IsUsingIDs()),
+      m_bUsingIDs((!pFile) ? bUseIDs : pFile && pFile->IsUsingIDs()),
       m_pNode(&Node),
-      m_Attributes(Node, (!pFile) || pFile && pFile->IsUsingIDs())
+      m_Attributes(Node, (!pFile) ? bUseIDs : pFile && pFile->IsUsingIDs())
 {
     // Init
     m_pFile = pFile;
@@ -85,7 +85,7 @@ void CXMLNodeImpl::BuildFromDocument()
         auto xmlChildElement = xmlChild->ToElement();
         if (xmlChildElement)
         {
-            auto xmlChildNode = new CXMLNodeImpl(nullptr, this, *xmlChildElement);
+            auto xmlChildNode = new CXMLNodeImpl(nullptr, this, *xmlChildElement, false);
             xmlChildNode->BuildFromDocument();
         }
     }

--- a/Shared/XML/CXMLNodeImpl.cpp
+++ b/Shared/XML/CXMLNodeImpl.cpp
@@ -15,9 +15,9 @@ using std::list;
 
 CXMLNodeImpl::CXMLNodeImpl(CXMLFileImpl* pFile, CXMLNodeImpl* pParent, TiXmlElement& Node, bool bUseIDs)
     : m_ulID(INVALID_XML_ID),
-      m_bUsingIDs((!pFile) ? bUseIDs : pFile && pFile->IsUsingIDs()),
+      m_bUsingIDs((!pFile) ? bUseIDs : pFile->IsUsingIDs()),
       m_pNode(&Node),
-      m_Attributes(Node, (!pFile) ? bUseIDs : pFile && pFile->IsUsingIDs())
+      m_Attributes(Node, (!pFile) ? bUseIDs : pFile->IsUsingIDs())
 {
     // Init
     m_pFile = pFile;

--- a/Shared/XML/CXMLNodeImpl.h
+++ b/Shared/XML/CXMLNodeImpl.h
@@ -21,7 +21,7 @@
 class CXMLNodeImpl : public CXMLNode
 {
 public:
-    CXMLNodeImpl(class CXMLFileImpl* pFile, CXMLNodeImpl* pParent, TiXmlElement& Node);
+    CXMLNodeImpl(class CXMLFileImpl* pFile, CXMLNodeImpl* pParent, TiXmlElement& Node, bool bUseIDs = true);
     ~CXMLNodeImpl();
 
     // BuildFromDocument recursively builds child CXMLNodeImpl from the underlying TiXmlElement.
@@ -65,7 +65,6 @@ public:
     eXMLClass     GetClassType() { return CXML_NODE; };
     unsigned long GetID()
     {
-        dassert((!m_pFile) || m_pFile && m_pFile->IsUsingIDs());
         return m_ulID;
     };
     bool IsUsingIDs() { return m_bUsingIDs; };


### PR DESCRIPTION
This PR adds a parameter to CXMLNodeImpl constructor (`bUseIDs`) which defaults to true. It's only effective for non file-based xml nodes. 

This new parameter is used within `CXMLImpl::ParseString` (set to false).

I also removed the debug assert from `CXMLNodeImpl::GetID`... why would we need a debug specific assert here, or rather why do we have an assert in the first place? We should always be able to use this method, even if the ID is `INVALID_XML_ID` - other code shouldn't be relying on an assert here, it should just check for `INVALID_XML_ID` and assert itself.

Resolves #2456