### PR TITLE
Fix crash when pickup has invalid custom model

### DIFF
--- a/Client/mods/deathmatch/logic/CClientModel.cpp
+++ b/Client/mods/deathmatch/logic/CClientModel.cpp
@@ -114,6 +114,11 @@ void CClientModel::RestoreEntitiesUsingThisModel()
 
             unloadModelsAndCallEvents(objects->begin(), objects->end(), usParentID, [=](auto& element) { element.SetModel(usParentID); });
 
+            // Restore pickups with custom model
+            CClientPickupManager* pPickupManager = g_pClientGame->GetManager()->GetPickupManager();
+
+            unloadModelsAndCallEvents(pPickupManager->IterBegin(), pPickupManager->IterEnd(), usParentID, [=](auto& element) { element.SetModel(usParentID); });
+
             // Restore COL
             g_pClientGame->GetManager()->GetColModelManager()->RestoreModel(m_iModelID);
             break;


### PR DESCRIPTION
Fixes one case from #2473
Tested with commands
```
crun customModel = engineRequestModel("object")
crun pickup = createPickup(me.position.x, me.position.y, me.position.z, 3, customModel)
restart runcode
```