### PR TITLE
Fix chatbox when using recently added inputBlocked argument

### DIFF
--- a/Client/core/CChat.cpp
+++ b/Client/core/CChat.cpp
@@ -165,6 +165,15 @@ void CChat::Draw(bool bUseCacheTexture, bool bAllowOutline)
     bool bUsingOutline = m_bTextBlackOutline && bAllowOutline && bUseCacheTexture;
     DrawInputLine(bUsingOutline);
 
+    if (m_bInputVisible)
+    {
+        // ChrML: Hack so chatbox input always works. It might get unfocused..
+        if (!m_pBackground->IsActive())
+        {
+            m_pBackground->Activate();
+        }
+    }
+
     // Are we visible?
     if (!m_bVisible)
         return;
@@ -296,15 +305,6 @@ void CChat::GetDrawList(SDrawList& outDrawList, bool bUsingOutline)
         m_pBackground->SetVisible(true);
         m_pBackground->Render();
         m_pBackground->SetVisible(false);
-    }
-
-    if (m_bInputVisible)
-    {
-        // ChrML: Hack so chatbox input always works. It might get unfocused..
-        if (!m_pBackground->IsActive())
-        {
-            m_pBackground->Activate();
-        }
     }
 
     // Used for render clipping in CChat::DrawTextString


### PR DESCRIPTION
There is a "hack by ChrML" in the source code for the chatbox that makes sure it always gets focus when the chatbox is shown, this is needed for the _CharacterKeyHandler_ to get triggered. After some more intensive testing I found out that my PR #2170 partially broke that functionality when using _showChat(false, false)_.

Basically the code responsible for setting the focus was only called as part of getting the draw list for the chatbox, but when only the input of the chatbox is visible it was not called anymore. This new PR fixes the issue by moving the "hack" from _CChat::GetDrawList_ to an earlier point in the _CChat::Draw_ method which is also reached in case only the input is visible.