### PR TITLE
Add missing chat_text_outline CVAR to getChatboxLayout function

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -30,7 +30,8 @@ static const SFixedArray<const char*, MAX_CHATBOX_LAYOUT_CVARS> g_chatboxLayoutC
                                                                                          "chat_line_life",
                                                                                          "chat_line_fade_out",
                                                                                          "chat_use_cegui",
-                                                                                         "text_scale"}};
+                                                                                         "text_scale",
+                                                                                         "chat_text_outline"}};
 
 void CLuaGUIDefs::LoadFunctions()
 {
@@ -3645,6 +3646,7 @@ int CLuaGUIDefs::GUIGetChatboxLayout(lua_State* luaVM)
     //* chat_line_fade_out - Returns how long takes for text to fade out
     //* chat_use_cegui - Returns whether CEGUI is used to render the chatbox
     //* text_scale - Returns text scale
+    //* chat_text_outline - Returns whether text black/white outline is used
 
     CScriptArgReader  argStream(luaVM);
     CCVarsInterface*  pCVars = g_pCore->GetCVars();

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
@@ -12,7 +12,7 @@
 #pragma once
 #include "CLuaDefs.h"
 
-#define MAX_CHATBOX_LAYOUT_CVARS 20
+#define MAX_CHATBOX_LAYOUT_CVARS 21
 
 class CLuaGUIDefs : public CLuaDefs
 {


### PR DESCRIPTION
As I was looking into the different chatbox functionalities, I noticed that this one CVAR used in CChat.cpp is not yet available through the Lua API provided by _getChatboxLayout()_. This PR adds the missing _chat_text_outline_ CVAR to the Lua API, quite straightforward.