### PR TITLE
Remove unnecessary debug assert in CFileLoaderSA

### DIFF
--- a/Client/game_sa/CFileLoaderSA.cpp
+++ b/Client/game_sa/CFileLoaderSA.cpp
@@ -44,7 +44,7 @@ void GetNameAndDamage(const char* nodeName, char(&outName)[OutBuffSize], bool& o
 
     const auto NodeNameEndsWith = [=](const char* with) {
         const auto withLen = strlen(with);
-        dassert(withLen <= nodeNameLen);
+        //dassert(withLen <= nodeNameLen);
         return withLen <= nodeNameLen /*dont bother checking otherwise, because it might cause a crash*/
                && strncmp(nodeName + nodeNameLen - withLen, with, withLen) == 0;
     };


### PR DESCRIPTION
There is a debug assert (dassert) in CFileLoaderSA.cpp where it checks if a node name ends with a certain suffix, the assert checks whether or not the string to check is at least as long as the suffix to check. The problem is that this assert is completely unnecessary and can actually cause crashes with a debug client, which is exactly what I experienced (nodeName was "UFO" and the suffix was "_dam").

In my opinion the assert can be safely removed, it should have no other side effects. The extra check in the return-statement is correct however, _strncmp_ makes no sense if the string to check is shorter than the suffix itself.