### PR TITLE
Get rid of std::function in AsyncTaskSched

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaVectorGraphicDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVectorGraphicDefs.cpp
@@ -151,7 +151,7 @@ CClientVectorGraphic* CLuaVectorGraphicDefs::SVGCreate(lua_State* luaVM, CVector
             {
                 CLuaFunctionRef funcRef = luaFunctionRef.value();
 
-                CLuaShared::GetAsyncTaskScheduler()->PushTask<bool>(
+                CLuaShared::GetAsyncTaskScheduler()->PushTask(
                     [funcRef, pVectorGraphic, strRawData] { return LoadFromData(funcRef.GetLuaVM(), pVectorGraphic, strRawData); },
                     [funcRef](const bool didLoad) {
                         CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(funcRef.GetLuaVM());
@@ -186,7 +186,7 @@ CClientVectorGraphic* CLuaVectorGraphicDefs::SVGCreate(lua_State* luaVM, CVector
                     CLuaFunctionRef funcRef = luaFunctionRef.value();
                     std::string     path = pathOrRawData.value();
 
-                    CLuaShared::GetAsyncTaskScheduler()->PushTask<bool>(
+                    CLuaShared::GetAsyncTaskScheduler()->PushTask(
                         [funcRef, pFile, pVectorGraphic, path] {
                             lua_State* luaVM = funcRef.GetLuaVM();
 
@@ -248,7 +248,7 @@ bool CLuaVectorGraphicDefs::SVGSetDocumentXML(CClientVectorGraphic* pVectorGraph
     {
         CLuaFunctionRef funcRef = luaFunctionRef.value();
 
-        CLuaShared::GetAsyncTaskScheduler()->PushTask<bool>([pVectorGraphic, pXMLNode] { return SetDocument(pVectorGraphic, pXMLNode); },
+        CLuaShared::GetAsyncTaskScheduler()->PushTask([pVectorGraphic, pXMLNode] { return SetDocument(pVectorGraphic, pXMLNode); },
                                                             [funcRef](const bool didLoad) {
                                                                 CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(funcRef.GetLuaVM());
                                                                 if (pLuaMain)
@@ -282,7 +282,7 @@ bool CLuaVectorGraphicDefs::SVGSetSize(CClientVectorGraphic* pVectorGraphic, CVe
     {
         CLuaFunctionRef funcRef = luaFunctionRef.value();
 
-        CLuaShared::GetAsyncTaskScheduler()->PushTask<bool>([pVectorGraphic, size] { return SetSize(pVectorGraphic, size); },
+        CLuaShared::GetAsyncTaskScheduler()->PushTask([pVectorGraphic, size] { return SetSize(pVectorGraphic, size); },
                                                             [funcRef](const bool didLoad) {
                                                                 CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(funcRef.GetLuaVM());
                                                                 if (pLuaMain)

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaCryptDefs.cpp
@@ -108,7 +108,7 @@ std::variant<std::string, bool> CLuaCryptDefs::PasswordHash(lua_State* luaVM, st
                 CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
                 if (pLuaMain)
                 {
-                    CLuaShared::GetAsyncTaskScheduler()->PushTask<SString>(
+                    CLuaShared::GetAsyncTaskScheduler()->PushTask(
                         [password, salt = options["salt"], cost] {
                             // Execute time-consuming task
                             return SharedUtil::BcryptHash(password, salt, cost);
@@ -199,7 +199,7 @@ int CLuaCryptDefs::PasswordVerify(lua_State* luaVM)
                 CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
                 if (pLuaMain)
                 {
-                    CLuaShared::GetAsyncTaskScheduler()->PushTask<bool>(
+                    CLuaShared::GetAsyncTaskScheduler()->PushTask(
                         [password, hash] {
                             // Execute time-consuming task
                             return SharedUtil::BcryptVerify(password, hash);
@@ -253,7 +253,7 @@ std::variant<bool, CLuaMultiReturn<SString, SString>> CLuaCryptDefs::GenerateKey
                 CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
                 if (pLuaMain)
                 {
-                    CLuaShared::GetAsyncTaskScheduler()->PushTask<std::variant<KeyPair, SString>>(
+                    CLuaShared::GetAsyncTaskScheduler()->PushTask(
                         [size]() -> std::variant<KeyPair, SString> {
                             // Execute time-consuming task
                             try
@@ -346,7 +346,7 @@ int CLuaCryptDefs::EncodeString(lua_State* luaVM)
                     CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
                     if (pLuaMain)
                     {
-                        CLuaShared::GetAsyncTaskScheduler()->PushTask<SString>(
+                        CLuaShared::GetAsyncTaskScheduler()->PushTask(
                             [data, key] {
                                 // Execute time-consuming task
                                 SString result;
@@ -391,7 +391,7 @@ int CLuaCryptDefs::EncodeString(lua_State* luaVM)
                     CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
                     if (pLuaMain)
                     {
-                        CLuaShared::GetAsyncTaskScheduler()->PushTask<std::pair<SString, SString>>(
+                        CLuaShared::GetAsyncTaskScheduler()->PushTask(
                             [data, key] {
                                 std::pair<SString, SString> result;
                                 try
@@ -459,7 +459,7 @@ int CLuaCryptDefs::EncodeString(lua_State* luaVM)
                     CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
                     if (pLuaMain)
                     {
-                        CLuaShared::GetAsyncTaskScheduler()->PushTask<std::pair<SString, bool>>(
+                        CLuaShared::GetAsyncTaskScheduler()->PushTask(
                             [data, key] {
                                 try
                                 {
@@ -558,7 +558,7 @@ int CLuaCryptDefs::DecodeString(lua_State* luaVM)
                     CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
                     if (pLuaMain)
                     {
-                        CLuaShared::GetAsyncTaskScheduler()->PushTask<SString>(
+                        CLuaShared::GetAsyncTaskScheduler()->PushTask(
                             [data, key] {
                                 // Execute time-consuming task
                                 SString result;
@@ -611,7 +611,7 @@ int CLuaCryptDefs::DecodeString(lua_State* luaVM)
                     CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
                     if (pLuaMain)
                     {
-                        CLuaShared::GetAsyncTaskScheduler()->PushTask<SString>(
+                        CLuaShared::GetAsyncTaskScheduler()->PushTask(
                             [data, key, iv] {
                                 // Execute time-consuming task
                                 SString result;
@@ -678,7 +678,7 @@ int CLuaCryptDefs::DecodeString(lua_State* luaVM)
                     CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
                     if (pLuaMain)
                     {
-                        CLuaShared::GetAsyncTaskScheduler()->PushTask<std::pair<SString, bool>>(
+                        CLuaShared::GetAsyncTaskScheduler()->PushTask(
                             [data, key] {
                                 try
                                 {

--- a/Shared/sdk/SharedUtil.AsyncTaskScheduler.h
+++ b/Shared/sdk/SharedUtil.AsyncTaskScheduler.h
@@ -1,9 +1,17 @@
 #pragma once
+
+#include <version>
+
+// Workaround MultiplayerSA including this header for whatever reason..
+#ifdef __cpp_lib_is_invocable
+#define HAS_ASYNC_TASK_SCHED
+
 #include <queue>
 #include <functional>
 #include <memory>
 #include <thread>
 #include <mutex>
+#include <type_traits>
 
 namespace SharedUtil
 {
@@ -24,17 +32,19 @@ namespace SharedUtil
             virtual void ProcessResult() = 0;
         };
 
-        template <typename ResultType>
+        template <typename TaskFn, typename ReadyFn>
         struct STask : public SBaseTask
         {
-            using TaskFunction_t = std::function<ResultType()>;
-            using ReadyFunction_t = std::function<void(const ResultType&)>;
+            using Result = std::invoke_result_t<TaskFn>;
 
-            TaskFunction_t  m_TaskFunction;
-            ReadyFunction_t m_ReadyFunction;
-            ResultType      m_Result;
+            TaskFn  m_TaskFunction;
+            ReadyFn m_ReadyFunction;
+            Result  m_Result;
 
-            STask(const TaskFunction_t& taskFunc, const ReadyFunction_t& readyFunc) : m_TaskFunction(taskFunc), m_ReadyFunction(readyFunc) {}
+            STask(TaskFn&& task, ReadyFn&& ready) :
+                m_TaskFunction(std::move(task)),
+                m_ReadyFunction(std::move(ready))
+            {}
 
             void Execute() override { m_Result = std::move(m_TaskFunction()); }
 
@@ -60,13 +70,13 @@ namespace SharedUtil
         // taskFunc: Time-consuming function that is executed on the secondary thread (be aware of thread safety!)
         // readyFunc: Function that is called once the result is ready (called on the main thread)
         //
-        template <typename ResultType>
-        void PushTask(const std::function<ResultType()>& taskFunc, const std::function<void(const ResultType&)>& readyFunc)
+        template <typename TaskFn, typename ReadyFn>
+        void PushTask(TaskFn&& task, ReadyFn&& ready)
         {
-            std::unique_ptr<SBaseTask> pTask{new STask<ResultType>{taskFunc, readyFunc}};
+            std::unique_ptr<SBaseTask> pTask{new STask{std::move(task), std::move(ready)}};
 
-            std::lock_guard<std::mutex> lock{m_TasksMutex};
-            m_Tasks.push(std::move(pTask));
+            std::scoped_lock<std::mutex> lock{m_TasksMutex};
+            m_Tasks.emplace(std::move(pTask));
         }
 
         //
@@ -90,3 +100,4 @@ namespace SharedUtil
         std::mutex                              m_TaskResultsMutex;
     };
 }            // namespace SharedUtil
+#endif

--- a/Shared/sdk/SharedUtil.AsyncTaskScheduler.hpp
+++ b/Shared/sdk/SharedUtil.AsyncTaskScheduler.hpp
@@ -1,5 +1,8 @@
 #include "SharedUtil.AsyncTaskScheduler.h"
 
+// Workaround MultiplayerSA including this header for whatever reason..
+#ifdef HAS_ASYNC_TASK_SCHED
+
 namespace SharedUtil
 {
     CAsyncTaskScheduler::CAsyncTaskScheduler(std::size_t numWorkers)
@@ -65,3 +68,4 @@ namespace SharedUtil
         }
     }
 }            // namespace SharedUtil
+#endif


### PR DESCRIPTION
As a bonus the return type doesn't have to be given as the template parameter! Yay!

Why? `std::function` is unnecessary overhead in this case (As it allocates memory for itself). This way we eliminate copies, and memory allocations.