### PR TITLE
Refactor & fixed the code wording of PR 2526

### DIFF
--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -661,7 +661,7 @@ void CGameSA::ResetCheats()
     SetMoonEasterEggEnabled(false);
     SetExtraAirResistanceEnabled(true);
     SetUnderWorldWarpEnabled(true);
-    CVehicleSA::SetVehiclesSunGlareEnable(false);
+    CVehicleSA::SetVehiclesSunGlareEnabled(false);
 
     std::map<std::string, SCheatSA*>::iterator it;
     for (it = m_Cheats.begin(); it != m_Cheats.end(); it++)
@@ -738,12 +738,12 @@ void CGameSA::SetJetpackWeaponEnabled(eWeaponType weaponType, bool bEnabled)
 void CGameSA::SetVehicleSunGlareEnabled(bool bEnabled)
 {
     // State turning will be handled in hooks handler
-    CVehicleSA::SetVehiclesSunGlareEnable(bEnabled);
+    CVehicleSA::SetVehiclesSunGlareEnabled(bEnabled);
 }
 
 bool CGameSA::IsVehicleSunGlareEnabled()
 {
-    return CVehicleSA::GetVehiclesSunGlareEnable();
+    return CVehicleSA::GetVehiclesSunGlareEnabled();
 }
 
 bool CGameSA::PerformChecks()

--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -490,9 +490,6 @@ void CGameSA::Reset()
 
         // Restore vehicle model wheel sizes
         CModelInfoSA::ResetAllVehiclesWheelSizes();
-
-        // Reset the vehicle sun glare effect to default
-        CVehicleSA::SetVehiclesSunGlareEnable(false);
     }
 }
 
@@ -664,6 +661,7 @@ void CGameSA::ResetCheats()
     SetMoonEasterEggEnabled(false);
     SetExtraAirResistanceEnabled(true);
     SetUnderWorldWarpEnabled(true);
+    CVehicleSA::SetVehiclesSunGlareEnable(false);
 
     std::map<std::string, SCheatSA*>::iterator it;
     for (it = m_Cheats.begin(); it != m_Cheats.end(); it++)

--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -2348,12 +2348,12 @@ void CVehicleSA::StaticSetHooks()
     HookInstall(FUNC_CAutomobile_OnVehiclePreRender, (DWORD)HOOK_Vehicle_PreRender, 5);
 }
 
-void CVehicleSA::SetVehiclesSunGlareEnable(bool bEnabled)
+void CVehicleSA::SetVehiclesSunGlareEnabled(bool bEnabled)
 {
     m_bVehicleSunGlare = bEnabled;
 }
 
-bool CVehicleSA::GetVehiclesSunGlareEnable()
+bool CVehicleSA::GetVehiclesSunGlareEnabled()
 {
     return m_bVehicleSunGlare;
 }

--- a/Client/game_sa/CVehicleSA.h
+++ b/Client/game_sa/CVehicleSA.h
@@ -774,8 +774,8 @@ public:
     const CVector* GetDummyPositions() const override { return m_dummyPositions.data(); }
 
     static void StaticSetHooks();
-    static void SetVehiclesSunGlareEnable(bool bEnabled);
-    static bool GetVehiclesSunGlareEnable();
+    static void SetVehiclesSunGlareEnabled(bool bEnabled);
+    static bool GetVehiclesSunGlareEnabled();
 
 private:
     static void SetAutomobileDummyPosition(CAutomobileSAInterface* automobile, eVehicleDummies dummy, const CVector& position);


### PR DESCRIPTION
just a small code refactoring, fixing some wording issues.
- Put the `CVehicleSA::SetVehiclesSunGlareEnabled(false)` under `ResetCheats()`, keep consistent to MTA original code.
- `CVehicleSA::SetVehiclesSunGlareEnable` -> `CVehicleSA::SetVehiclesSunGlareEnabled`
- `CVehicleSA::GetVehiclesSunGlareEnable` -> `CVehicleSA::GetVehiclesSunGlareEnabled`
