### PR TITLE
Update lunasvg from 2.2.0 to 2.3.1

### DIFF
--- a/vendor/lunasvg/README.md
+++ b/vendor/lunasvg/README.md
@@ -1,4 +1,4 @@
-[![Releases](https://img.shields.io/badge/Version-2.2.0-orange.svg)](https://github.com/sammycage/lunasvg/releases)
+[![Releases](https://img.shields.io/badge/Version-2.3.1-orange.svg)](https://github.com/sammycage/lunasvg/releases)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/sammycage/lunasvg/blob/master/LICENSE)
 [![Build Status](https://github.com/sammycage/lunasvg/actions/workflows/ci.yml/badge.svg)](https://github.com/sammycage/lunasvg/actions)
 
@@ -9,7 +9,7 @@
 ## Example
 
 ```cpp
-#include <lunasvg/document.h>
+#include <lunasvg.h>
 
 using namespace lunasvg;
 
@@ -76,7 +76,9 @@ svg2png [filename] [resolution] [bgColor]
 - [PICsimLab](https://github.com/lcgamboa/picsimlab)
 - [MoneyManagerEx](https://github.com/moneymanagerex/moneymanagerex)
 - [RmlUi](https://github.com/mikke89/RmlUi)
-- [EKA2L1](https://github.com/EKA2L1/EKA2L1)
+- [EKA2L1](https://github.com/EKA2L/EKA2L1)
+- [ObEngine](https://github.com/ObEngine/ObEngine)
+- [OTTO](https://github.com/bitfieldaudio/OTTO)
 
 ## Support Me
 

--- a/vendor/lunasvg/include/lunasvg.h
+++ b/vendor/lunasvg/include/lunasvg.h
@@ -129,14 +129,14 @@ public:
     static std::unique_ptr<Document> loadFromData(const char* data);
 
     /**
-     * @brief Rotates the document matrix clockwise around the current origin
+     * @brief Pre-Rotates the document matrix clockwise around the current origin
      * @param angle - rotation angle, in degrees
      * @return this
      */
     Document* rotate(double angle);
 
     /**
-     * @brief Rotates the document matrix clockwise around the given point
+     * @brief Pre-Rotates the document matrix clockwise around the given point
      * @param angle - rotation angle, in degrees
      * @param cx - horizontal translation
      * @param cy - vertical translation
@@ -145,7 +145,7 @@ public:
     Document* rotate(double angle, double cx, double cy);
 
     /**
-     * @brief Scales the document matrix by sx horizontally and sy vertically
+     * @brief Pre-Scales the document matrix by sx horizontally and sy vertically
      * @param sx - horizontal scale factor
      * @param sy - vertical scale factor
      * @return this
@@ -153,7 +153,7 @@ public:
     Document* scale(double sx, double sy);
 
     /**
-     * @brief Shears the document matrix by shx horizontally and shy vertically
+     * @brief Pre-Shears the document matrix by shx horizontally and shy vertically
      * @param shx - horizontal skew factor, in degree
      * @param shy - vertical skew factor, in degree
      * @return this
@@ -161,7 +161,7 @@ public:
     Document* shear(double shx, double shy);
 
     /**
-     * @brief Translates the document matrix by tx horizontally and ty vertically
+     * @brief Pre-Translates the document matrix by tx horizontally and ty vertically
      * @param tx - horizontal translation
      * @param ty - vertical translation
      * @return this
@@ -169,7 +169,7 @@ public:
     Document* translate(double tx, double ty);
 
     /**
-     * @brief Multiplies the document matrix by Matrix(a, b, c, d, e, f)
+     * @brief Pre-Multiplies the document matrix by Matrix(a, b, c, d, e, f)
      * @param a - horizontal scale factor
      * @param b - horizontal skew factor
      * @param c - vertical skew factor

--- a/vendor/lunasvg/source/parser.cpp
+++ b/vendor/lunasvg/source/parser.cpp
@@ -188,7 +188,7 @@ Path Parser::parsePath(const std::string& string)
         case 'M':
         case 'm':
             if(!parseNumberList(ptr, end, c, 2))
-                break;
+                return path;
 
             if(command == 'm')
             {
@@ -204,7 +204,7 @@ Path Parser::parsePath(const std::string& string)
         case 'L':
         case 'l':
             if(!parseNumberList(ptr, end, c, 2))
-                break;
+                return path;
 
             if(command == 'l')
             {
@@ -219,7 +219,7 @@ Path Parser::parsePath(const std::string& string)
         case 'Q':
         case 'q':
             if(!parseNumberList(ptr, end, c, 4))
-                break;
+                return path;
 
             if(command == 'q')
             {
@@ -238,7 +238,7 @@ Path Parser::parsePath(const std::string& string)
         case 'C':
         case 'c':
             if(!parseNumberList(ptr, end, c, 6))
-                break;
+                return path;
 
             if(command == 'c')
             {
@@ -261,7 +261,7 @@ Path Parser::parsePath(const std::string& string)
             c[0] = 2 * currentPoint.x - controlPoint.x;
             c[1] = 2 * currentPoint.y - controlPoint.y;
             if(!parseNumberList(ptr, end, c + 2, 2))
-                break;
+                return path;
 
             if(command == 't')
             {
@@ -280,7 +280,7 @@ Path Parser::parsePath(const std::string& string)
             c[0] = 2 * currentPoint.x - controlPoint.x;
             c[1] = 2 * currentPoint.y - controlPoint.y;
             if(!parseNumberList(ptr, end, c + 2, 4))
-                break;
+                return path;
 
             if(command == 's')
             {
@@ -299,7 +299,7 @@ Path Parser::parsePath(const std::string& string)
         case 'H':
         case 'h':
             if(!parseNumberList(ptr, end, c, 1))
-                break;
+                return path;
 
             if(command == 'h')
                c[0] += currentPoint.x;
@@ -310,7 +310,7 @@ Path Parser::parsePath(const std::string& string)
         case 'V':
         case 'v':
             if(!parseNumberList(ptr, end, c + 1, 1))
-                break;
+                return path;
 
             if(command == 'v')
                c[1] += currentPoint.y;
@@ -324,7 +324,7 @@ Path Parser::parsePath(const std::string& string)
                     || !parseArcFlag(ptr, end, f[0])
                     || !parseArcFlag(ptr, end, f[1])
                     || !parseNumberList(ptr, end, c + 3, 2))
-                break;
+                return path;
 
             if(command == 'a')
             {
@@ -343,7 +343,7 @@ Path Parser::parsePath(const std::string& string)
             currentPoint.y = controlPoint.y = startPoint.y;
             break;
         default:
-            break;
+            return path;
         }
 
         Utils::skipWsComma(ptr, end);


### PR DESCRIPTION
## Summary
- Update lunasvg from 2.2.0 to 2.3.1
- Fixes and tweaks
- Versions: 2.3.0, 2.3.1

## Validation
To help validate the integrity of the update I have created the following bash script that diffs between my PR branch and the official release provided from the [GitHub releases page](https://github.com/sammycage/lunasvg/releases).
```bash
#!/bin/bash

LUNASVG_UPDATE_VERSION=2.3.1
LUNASVG_PATH_NAME=lunasvg-$LUNASVG_UPDATE_VERSION

GIT_REPO_BRANCH=vendor/lunasvg-$LUNASVG_UPDATE_VERSION
GIT_REPO_URL=https://github.com/patrikjuvonen/mtasa-blue.git
GIT_REPO_LUNASVG_PATH=vendor/lunasvg/

echo 1. Download and extract $LUNASVG_PATH_NAME...
curl -L https://github.com/sammycage/lunasvg/archive/refs/tags/v2.3.1.tar.gz | tar -xz

echo 2. Fetch and checkout the vendor update branch $GIT_REPO_BRANCH from $GIT_REPO_URL...
git fetch $GIT_REPO_URL $GIT_REPO_BRANCH:$GIT_REPO_BRANCH
git checkout $GIT_REPO_BRANCH

echo 3. Start checking integrity...
diff -r --strip-trailing-cr $GIT_REPO_LUNASVG_PATH $LUNASVG_PATH_NAME

echo 4. Completed.
exec $SHELL
```

## Past updates in MTA
| Date | From | To | Link |
| :--- | :--- | :--- | :--- |
| September 2021 | - | 2.2.0 (current) | #2380 |

## Copy of changelogs

### Version 2.3.0
- Change document.h to lunasvg.h https://github.com/sammycage/lunasvg/issues/56
- Add documentations

### Version 2.3.1
- Fix recursive path parsing https://github.com/sammycage/lunasvg/issues/62