### PR TITLE
Fix build failing since 66a16ff (unrar update)

### DIFF
--- a/vendor/unrar/premake5.lua
+++ b/vendor/unrar/premake5.lua
@@ -67,3 +67,9 @@ project "unrar"
 		"threadpool.cpp",
 		"ui.cpp"
 	}
+
+	filter "system:Mac*"
+		defines { "__APPLE__" }
+
+	filter { "system:Unix", "system:Linux" }
+		defines { "_UNIX" }

--- a/vendor/unrar/premake5.lua
+++ b/vendor/unrar/premake5.lua
@@ -34,7 +34,6 @@ project "unrar"
 		"find.cpp",
 		"getbits.cpp",
 		"global.cpp",
-		"isnt.cpp",
 		"list.cpp",
 		"match.cpp",
 		"options.cpp",
@@ -68,8 +67,5 @@ project "unrar"
 		"ui.cpp"
 	}
 
-	filter "system:Mac*"
-		defines { "__APPLE__" }
-
-	filter { "system:Unix", "system:Linux" }
-		defines { "_UNIX" }
+	filter "system:Windows*"
+		files { "isnt.cpp" }


### PR DESCRIPTION
Starting with updating premake file to ensure the macros are defined properly (as seen in `os.hpp`)

I'm pretty sure that's not going to fix it, but I'll use this PR in order to debug the issue as I don't have a Mac / Linux system to hand with a build environment for MTA.