### PR TITLE
Update json-c from 0.15 to 0.16

### DIFF
--- a/vendor/json-c/ChangeLog
+++ b/vendor/json-c/ChangeLog
@@ -1,6 +1,60 @@
 
-Next Release 0.15
-=====================
+0.16 (up to commit 66dcdf5, 2022-04-13)
+========================================
+
+Deprecated and removed features:
+--------------------------------
+* JSON_C_OBJECT_KEY_IS_CONSTANT is deprecated in favor of
+  JSON_C_OBJECT_ADD_CONSTANT_KEY
+* Direct access to lh_table and lh_entry structure members is deprecated.  
+  Use access functions instead, lh_table_head(), lh_entry_next(), etc...
+* Drop REFCOUNT_DEBUG code.
+
+New features
+------------
+* The 0.16 release introduces no new features
+
+Build changes
+-------------
+* Add a DISABLE_EXTRA_LIBS option to skip using libbsd
+* Add a DISABLE_JSON_POINTER option to skip compiling in json_pointer support.
+
+Significant changes and bug fixes
+---------------------------------
+* Cap string length at INT_MAX to avoid various issues with very long strings.
+* json_object_deep_copy: fix deep copy of strings containing '\0'
+* Fix read past end of buffer in the "json_parse" command
+* Avoid out of memory accesses in the locally provided vasprintf() function
+  (for those platforms that use it)
+* Handle allocation failure in json_tokener_new_ex
+* Fix use-after-free in json_tokener_new_ex() in the event of printbuf_new() returning NULL
+* printbuf_memset(): set gaps to zero - areas within the print buffer which
+  have not been initialized by using printbuf_memset
+* printbuf: return -1 on invalid arguments (len < 0 or total buffer > INT_MAX)
+* sprintbuf(): propagate printbuf_memappend errors back to the caller
+
+Optimizations
+--------------
+* Speed up parsing by replacing ctype functions with simplified, faster 
+  non-locale-sensitive ones in json_tokener and json_object_to_json_string.
+* Neither vertical tab nor formfeed are considered whitespace per the JSON spec
+* json_object: speed up creation of objects, calloc() -> malloc() + set fields
+* Avoid needless extra strlen() call in json_c_shallow_copy_default() and
+  json_object_equal() when the object is known to be a json_type_string.
+
+Other changes
+-------------
+* Validate size arguments in arraylist functions.
+* Use getrandom() if available; with GRND_NONBLOCK to allow use of json-c
+  very early during boot, such as part of cryptsetup.
+* Use arc4random() if it's available.
+* random_seed: on error, continue to next method instead of exiting the process
+* Close file when unable to read from /dev/urandom in get_dev_random_seed()
+
+***
+
+0.15 (up to commit 870965e, 2020/07/26)
+========================================
 
 Deprecated and removed features:
 --------------------------------
@@ -59,7 +113,7 @@ Other changes
 * #589 - Detect broken RDRAND during initialization; also, fix segfault
     in the CPUID check.
 * #592 - Fix integer overflows to prevert out of bounds write on large input.
-* Protect against division by zero in linkhash, when creaed with zero size.
+* Protect against division by zero in linkhash, when created with zero size.
 * #602 - Fix json_parse_uint64() internal error checking, leaving the retval
     untouched in more failure cases.
 * #614 - Prevent truncation when custom double formatters insert extra \0's
@@ -185,7 +239,7 @@ Behavior changes:
 * Use size_t for array length and size.  Platforms where sizeof(size_t) != sizeof(int) may not be backwards compatible
 	See commits 45c56b, 92e9a5 and others.
 
-* Check for failue when allocating memory, returning NULL and errno=ENOMEM.
+* Check for failure when allocating memory, returning NULL and errno=ENOMEM.
 	 See commit 2149a04.
 
 * Change json_object_object_add() return type from void to int, and will return -1 on failures, instead of exiting. (Note: this is not an ABI change)
@@ -376,7 +430,7 @@ List of new functions added:
   * Add an alternative iterator implementation, see json_object_iterator.h
   * Make json_object_iter public to enable external use of the
      json_object_object_foreachC macro.
-  * Add a printbuf_memset() function to provide an effecient way to set and
+  * Add a printbuf_memset() function to provide an efficient way to set and
      append things like whitespace indentation.
   * Adjust json_object_is_type and json_object_get_type so they return
       json_type_null for NULL objects and handle NULL passed to
@@ -462,7 +516,7 @@ List of new functions added:
 0.7
 ===
   * Add escaping of backslash to json output
-  * Add escaping of foward slash on tokenizing and output
+  * Add escaping of forward slash on tokenizing and output
   * Changes to internal tokenizer from using recursion to
     using a depth state structure to allow incremental parsing
 

--- a/vendor/json-c/arraylist.c
+++ b/vendor/json-c/arraylist.c
@@ -45,6 +45,8 @@ struct array_list *array_list_new2(array_list_free_fn *free_fn, int initial_size
 {
 	struct array_list *arr;
 
+	if (initial_size < 0 || (size_t)initial_size >= SIZE_T_MAX / sizeof(void *))
+		return NULL;
 	arr = (struct array_list *)malloc(sizeof(struct array_list));
 	if (!arr)
 		return NULL;
@@ -106,6 +108,8 @@ int array_list_shrink(struct array_list *arr, size_t empty_slots)
 	void *t;
 	size_t new_size;
 
+	if (empty_slots >= SIZE_T_MAX / sizeof(void *) - arr->length)
+		return -1;
 	new_size = arr->length + empty_slots;
 	if (new_size == arr->size)
 		return 0;

--- a/vendor/json-c/arraylist.h
+++ b/vendor/json-c/arraylist.h
@@ -15,8 +15,8 @@
  *        Although this is exposed by the json_object_get_array() method,
  *        it is not recommended for direct use.
  */
-#ifndef _arraylist_h_
-#define _arraylist_h_
+#ifndef _json_c_arraylist_h_
+#define _json_c_arraylist_h_
 
 #ifdef __cplusplus
 extern "C" {

--- a/vendor/json-c/config-linux.h
+++ b/vendor/json-c/config-linux.h
@@ -74,6 +74,12 @@
 /* Define to 1 if you have the <xlocale.h> header file. */
 /* #undef HAVE_XLOCALE_H */
 
+/* Define to 1 if you have the <bsd/stdlib.h> header file. */
+/* #undef HAVE_BSD_STDLIB_H */
+
+/* Define to 1 if you have `arc4random' */
+/* #undef HAVE_ARC4RANDOM */
+
 /* Define to 1 if you don't have `vprintf' but do have `_doprnt.' */
 /* #undef HAVE_DOPRNT */
 
@@ -177,7 +183,7 @@
 #define PACKAGE_NAME "json-c"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "json-c 0.15.99"
+#define PACKAGE_STRING "json-c 0.16."
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "json-c"
@@ -186,7 +192,7 @@
 #define PACKAGE_URL "https://github.com/json-c/json-c"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "0.15.99"
+#define PACKAGE_VERSION "0.16."
 
 /* The number of bytes in type int */
 #define SIZEOF_INT 4
@@ -213,7 +219,7 @@
 #define STDC_HEADERS
 
 /* Version number of package */
-#define VERSION "0.15.99"
+#define VERSION "0.16."
 
 /* Define to empty if `const' does not conform to ANSI C. */
 /* #undef const */

--- a/vendor/json-c/config-macos.h
+++ b/vendor/json-c/config-macos.h
@@ -56,6 +56,9 @@
 /* Define to 1 if you have the <sys/param.h> header file. */
 #define HAVE_SYS_PARAM_H 1
 
+/* Define to 1 if you have the <sys/random.h> header file. */
+#define HAVE_SYS_RANDOM_H
+
 /* Define to 1 if you have the <sys/resource.h> header file. */
 #define HAVE_SYS_RESOURCE_H
 
@@ -70,6 +73,12 @@
 
 /* Define to 1 if you have the <xlocale.h> header file. */
 #define HAVE_XLOCALE_H
+
+/* Define to 1 if you have the <bsd/stdlib.h> header file. */
+/* #undef HAVE_BSD_STDLIB_H */
+
+/* Define to 1 if you have `arc4random' */
+#define HAVE_ARC4RANDOM
 
 /* Define to 1 if you don't have `vprintf' but do have `_doprnt.' */
 /* #undef HAVE_DOPRNT */
@@ -140,6 +149,9 @@
 /* Define to 1 if you have the `vsyslog' function. */
 #define HAVE_VSYSLOG 1
 
+/* Define if you have the `getrandom' function. */
+/* #undef HAVE_GETRANDOM */
+
 /* Define if you have the `getrusage' function. */
 #define HAVE_GETRUSAGE
 
@@ -171,7 +183,7 @@
 #define PACKAGE_NAME "json-c"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "json-c 0.15."
+#define PACKAGE_STRING "json-c 0.16."
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "json-c"
@@ -180,7 +192,7 @@
 #define PACKAGE_URL "https://github.com/json-c/json-c"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "0.15."
+#define PACKAGE_VERSION "0.16."
 
 /* The number of bytes in type int */
 #define SIZEOF_INT 4
@@ -207,7 +219,7 @@
 #define STDC_HEADERS
 
 /* Version number of package */
-#define VERSION "0.15."
+#define VERSION "0.16."
 
 /* Define to empty if `const' does not conform to ANSI C. */
 /* #undef const */

--- a/vendor/json-c/config-win32.h
+++ b/vendor/json-c/config-win32.h
@@ -56,6 +56,9 @@
 /* Define to 1 if you have the <sys/param.h> header file. */
 /* #undef HAVE_SYS_PARAM_H */
 
+/* Define to 1 if you have the <sys/random.h> header file. */
+/* #undef HAVE_SYS_RANDOM_H */
+
 /* Define to 1 if you have the <sys/resource.h> header file. */
 /* #undef HAVE_SYS_RESOURCE_H */
 
@@ -70,6 +73,12 @@
 
 /* Define to 1 if you have the <xlocale.h> header file. */
 /* #undef HAVE_XLOCALE_H */
+
+/* Define to 1 if you have the <bsd/stdlib.h> header file. */
+/* #undef HAVE_BSD_STDLIB_H */
+
+/* Define to 1 if you have `arc4random' */
+/* #undef HAVE_ARC4RANDOM */
 
 /* Define to 1 if you don't have `vprintf' but do have `_doprnt.' */
 /* #undef HAVE_DOPRNT */
@@ -140,6 +149,9 @@
 /* Define to 1 if you have the `vsyslog' function. */
 /* #undef HAVE_VSYSLOG */
 
+/* Define if you have the `getrandom' function. */
+/* #undef HAVE_GETRANDOM */
+
 /* Define if you have the `getrusage' function. */
 /* #undef HAVE_GETRUSAGE */
 
@@ -171,7 +183,7 @@
 #define PACKAGE_NAME "json-c"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "json-c 0.15."
+#define PACKAGE_STRING "json-c 0.16."
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "json-c"
@@ -180,7 +192,7 @@
 #define PACKAGE_URL "https://github.com/json-c/json-c"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "0.15."
+#define PACKAGE_VERSION "0.16."
 
 /* The number of bytes in type int */
 #define SIZEOF_INT 4
@@ -207,7 +219,7 @@
 #define STDC_HEADERS
 
 /* Version number of package */
-#define VERSION "0.15."
+#define VERSION "0.16."
 
 /* Define to empty if `const' does not conform to ANSI C. */
 /* #undef const */

--- a/vendor/json-c/debug.h
+++ b/vendor/json-c/debug.h
@@ -14,8 +14,8 @@
  * @file
  * @brief Do not use, json-c internal, may be changed or removed at any time.
  */
-#ifndef _DEBUG_H_
-#define _DEBUG_H_
+#ifndef _JSON_C_DEBUG_H_
+#define _JSON_C_DEBUG_H_
 
 #include <stdlib.h>
 
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 #ifndef JSON_EXPORT
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(JSON_C_DLL)
 #define JSON_EXPORT __declspec(dllexport)
 #else
 #define JSON_EXPORT extern

--- a/vendor/json-c/json_c_version.h
+++ b/vendor/json-c/json_c_version.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012,2017,2019,2020 Eric Hawicz
+ * Copyright (c) 2012,2017-2022 Eric Haszlakiewicz
  *
  * This library is free software; you can redistribute it and/or modify
  * it under the terms of the MIT license. See COPYING for details.
@@ -17,14 +17,14 @@ extern "C" {
 #endif
 
 #define JSON_C_MAJOR_VERSION 0
-#define JSON_C_MINOR_VERSION 15
+#define JSON_C_MINOR_VERSION 16
 #define JSON_C_MICRO_VERSION 0
 #define JSON_C_VERSION_NUM \
 	((JSON_C_MAJOR_VERSION << 16) | (JSON_C_MINOR_VERSION << 8) | JSON_C_MICRO_VERSION)
-#define JSON_C_VERSION "0.15"
+#define JSON_C_VERSION "0.16"
 
 #ifndef JSON_EXPORT
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(JSON_C_DLL)
 #define JSON_EXPORT __declspec(dllexport)
 #else
 #define JSON_EXPORT extern

--- a/vendor/json-c/json_object.c
+++ b/vendor/json-c/json_object.c
@@ -13,7 +13,6 @@
 #include "strerror_override.h"
 
 #include <assert.h>
-#include <ctype.h>
 #ifdef HAVE_LIMITS_H
 #include <limits.h>
 #endif
@@ -35,8 +34,11 @@
 #include "snprintf_compat.h"
 #include "strdup_compat.h"
 
+/* Avoid ctype.h and locale overhead */
+#define is_plain_digit(c) ((c) >= '0' && (c) <= '9')
+
 #if SIZEOF_LONG_LONG != SIZEOF_INT64_T
-#error "The long long type isn't 64-bits"
+#error The long long type is not 64-bits
 #endif
 
 #ifndef SSIZE_T_MAX
@@ -50,9 +52,6 @@
 #error Unable to determine size of ssize_t
 #endif
 #endif
-
-// Don't define this.  It's not thread-safe.
-/* #define REFCOUNT_DEBUG 1 */
 
 const char *json_hex_chars = "0123456789abcdefABCDEF";
 
@@ -159,41 +158,6 @@ static json_object_to_json_string_fn _json_object_userdata_to_json_string;
  * */
 JSON_NORETURN static void json_abort(const char *message);
 
-/* ref count debugging */
-
-#ifdef REFCOUNT_DEBUG
-
-static struct lh_table *json_object_table;
-
-static void json_object_init(void) __attribute__((constructor));
-static void json_object_init(void)
-{
-	MC_DEBUG("json_object_init: creating object table\n");
-	json_object_table = lh_kptr_table_new(128, NULL);
-}
-
-static void json_object_fini(void) __attribute__((destructor));
-static void json_object_fini(void)
-{
-	struct lh_entry *ent;
-	if (MC_GET_DEBUG())
-	{
-		if (json_object_table->count)
-		{
-			MC_DEBUG("json_object_fini: %d referenced objects at exit\n",
-			         json_object_table->count);
-			lh_foreach(json_object_table, ent)
-			{
-				struct json_object *obj = (struct json_object *)lh_entry_v(ent);
-				MC_DEBUG("\t%s:%p\n", json_type_to_name(obj->o_type), obj);
-			}
-		}
-	}
-	MC_DEBUG("json_object_fini: freeing object table\n");
-	lh_table_free(json_object_table);
-}
-#endif /* REFCOUNT_DEBUG */
-
 /* helper for accessing the optimized string data component in json_object
  */
 static inline char *get_string_component_mutable(struct json_object *jso)
@@ -214,10 +178,11 @@ static inline const char *get_string_component(const struct json_object *jso)
 
 static int json_escape_str(struct printbuf *pb, const char *str, size_t len, int flags)
 {
-	int pos = 0, start_offset = 0;
+	size_t pos = 0, start_offset = 0;
 	unsigned char c;
-	while (len--)
+	while (len)
 	{
+		--len;
 		c = str[pos];
 		switch (c)
 		{
@@ -235,7 +200,7 @@ static int json_escape_str(struct printbuf *pb, const char *str, size_t len, int
 				break;
 			}
 
-			if (pos - start_offset > 0)
+			if (pos > start_offset)
 				printbuf_memappend(pb, str + start_offset, pos - start_offset);
 
 			if (c == '\b')
@@ -261,7 +226,7 @@ static int json_escape_str(struct printbuf *pb, const char *str, size_t len, int
 			if (c < ' ')
 			{
 				char sbuf[7];
-				if (pos - start_offset > 0)
+				if (pos > start_offset)
 					printbuf_memappend(pb, str + start_offset,
 					                   pos - start_offset);
 				snprintf(sbuf, sizeof(sbuf), "\\u00%c%c", json_hex_chars[c >> 4],
@@ -273,7 +238,7 @@ static int json_escape_str(struct printbuf *pb, const char *str, size_t len, int
 				pos++;
 		}
 	}
-	if (pos - start_offset > 0)
+	if (pos > start_offset)
 		printbuf_memappend(pb, str + start_offset, pos - start_offset);
 	return 0;
 }
@@ -337,10 +302,6 @@ int json_object_put(struct json_object *jso)
 
 static void json_object_generic_delete(struct json_object *jso)
 {
-#ifdef REFCOUNT_DEBUG
-	MC_DEBUG("json_object_delete_%s: %p\n", json_type_to_name(jso->o_type), jso);
-	lh_table_delete(json_object_table, jso);
-#endif /* REFCOUNT_DEBUG */
 	printbuf_free(jso->_pb);
 	free(jso);
 }
@@ -362,10 +323,6 @@ static inline struct json_object *json_object_new(enum json_type o_type, size_t 
 	jso->_userdata = NULL;
 	//jso->...   // Type-specific fields must be set by caller
 
-#ifdef REFCOUNT_DEBUG
-	lh_table_insert(json_object_table, jso, jso);
-	MC_DEBUG("json_object_new_%s: %p\n", json_type_to_name(jso->o_type), jso);
-#endif /* REFCOUNT_DEBUG */
 	return jso;
 }
 
@@ -542,7 +499,7 @@ static int json_object_object_to_json_string(struct json_object *jso, struct pri
 
 static void json_object_lh_entry_free(struct lh_entry *ent)
 {
-	if (!ent->k_is_constant)
+	if (!lh_entry_k_is_constant(ent))
 		free(lh_entry_k(ent));
 	json_object_put((struct json_object *)lh_entry_v(ent));
 }
@@ -605,7 +562,7 @@ int json_object_object_add_ex(struct json_object *jso, const char *const key,
 	if (!existing_entry)
 	{
 		const void *const k =
-		    (opts & JSON_C_OBJECT_KEY_IS_CONSTANT) ? (const void *)key : strdup(key);
+		    (opts & JSON_C_OBJECT_ADD_CONSTANT_KEY) ? (const void *)key : strdup(key);
 		if (k == NULL)
 			return -1;
 		return lh_table_insert_w_hash(JC_OBJECT(jso)->c_object, k, val, hash, opts);
@@ -613,7 +570,7 @@ int json_object_object_add_ex(struct json_object *jso, const char *const key,
 	existing_value = (json_object *)lh_entry_v(existing_entry);
 	if (existing_value)
 		json_object_put(existing_value);
-	existing_entry->v = val;
+	lh_entry_set_val(existing_entry, val);
 	return 0;
 }
 
@@ -735,7 +692,7 @@ struct json_object *json_object_new_int(int32_t i)
 
 int32_t json_object_get_int(const struct json_object *jso)
 {
-	int64_t cint64=0;
+	int64_t cint64 = 0;
 	double cdouble;
 	enum json_type o_type;
 
@@ -976,7 +933,21 @@ int json_c_set_serialization_double_format(const char *double_format, int global
 #endif
 		if (global_serialization_float_format)
 			free(global_serialization_float_format);
-		global_serialization_float_format = double_format ? strdup(double_format) : NULL;
+		if (double_format)
+		{
+			char *p = strdup(double_format);
+			if (p == NULL)
+			{
+				_json_c_set_last_err("json_c_set_serialization_double_format: "
+				                     "out of memory\n");
+				return -1;
+			}
+			global_serialization_float_format = p;
+		}
+		else
+		{
+			global_serialization_float_format = NULL;
+		}
 	}
 	else if (global_or_thread == JSON_C_OPTION_THREAD)
 	{
@@ -986,16 +957,31 @@ int json_c_set_serialization_double_format(const char *double_format, int global
 			free(tls_serialization_float_format);
 			tls_serialization_float_format = NULL;
 		}
-		tls_serialization_float_format = double_format ? strdup(double_format) : NULL;
+		if (double_format)
+		{
+			char *p = strdup(double_format);
+			if (p == NULL)
+			{
+				_json_c_set_last_err("json_c_set_serialization_double_format: "
+				                     "out of memory\n");
+				return -1;
+			}
+			tls_serialization_float_format = p;
+		}
+		else
+		{
+			tls_serialization_float_format = NULL;
+		}
 #else
-		_json_c_set_last_err("json_c_set_option: not compiled with __thread support\n");
+		_json_c_set_last_err("json_c_set_serialization_double_format: not compiled "
+		                     "with __thread support\n");
 		return -1;
 #endif
 	}
 	else
 	{
-		_json_c_set_last_err("json_c_set_option: invalid global_or_thread value: %d\n",
-		                     global_or_thread);
+		_json_c_set_last_err("json_c_set_serialization_double_format: invalid "
+		                     "global_or_thread value: %d\n", global_or_thread);
 		return -1;
 	}
 	return 0;
@@ -1056,8 +1042,7 @@ static int json_object_double_to_json_string_format(struct json_object *jso, str
 			format_drops_decimals = 1;
 
 		looks_numeric = /* Looks like *some* kind of number */
-		    isdigit((unsigned char)buf[0]) ||
-		    (size > 1 && buf[0] == '-' && isdigit((unsigned char)buf[1]));
+		    is_plain_digit(buf[0]) || (size > 1 && buf[0] == '-' && is_plain_digit(buf[1]));
 
 		if (size < (int)sizeof(buf) - 2 && looks_numeric && !p && /* Has no decimal point */
 		    strchr(buf, 'e') == NULL && /* Not scientific notation */
@@ -1254,17 +1239,17 @@ static struct json_object *_json_object_new_string(const char *s, const size_t l
 	struct json_object_string *jso;
 
 	/*
-     * Structures           Actual memory layout
-     * -------------------  --------------------
+	 * Structures           Actual memory layout
+	 * -------------------  --------------------
 	 * [json_object_string  [json_object_string
 	 *  [json_object]        [json_object]
-     *  ...other fields...   ...other fields...
+	 *  ...other fields...   ...other fields...
 	 *  c_string]            len
-     *                       bytes
+	 *                       bytes
 	 *                       of
 	 *                       string
 	 *                       data
-     *                       \0]
+	 *                       \0]
 	 */
 	if (len > (SSIZE_T_MAX - (sizeof(*jso) - sizeof(jso->c_string)) - 1))
 		return NULL;
@@ -1281,7 +1266,8 @@ static struct json_object *_json_object_new_string(const char *s, const size_t l
 		return NULL;
 	jso->len = len;
 	memcpy(jso->c_string.idata, s, len);
-	jso->c_string.idata[len] = '\0';
+	// Cast below needed for Clang UB sanitizer
+	((char *)jso->c_string.idata)[len] = '\0';
 	return &jso->base;
 }
 
@@ -1305,18 +1291,20 @@ const char *json_object_get_string(struct json_object *jso)
 	default: return json_object_to_json_string(jso);
 	}
 }
-int json_object_get_string_len(const struct json_object *jso)
+
+static inline ssize_t _json_object_get_string_len(const struct json_object_string *jso)
 {
 	ssize_t len;
+	len = jso->len;
+	return (len < 0) ? -(ssize_t)len : len;
+}
+int json_object_get_string_len(const struct json_object *jso)
+{
 	if (!jso)
 		return 0;
 	switch (jso->o_type)
 	{
-	case json_type_string:
-	{
-		len = JC_STRING_C(jso)->len;
-		return (len < 0) ? -(ssize_t)len : len;
-	}
+	case json_type_string: return _json_object_get_string_len(JC_STRING_C(jso));
 	default: return 0;
 	}
 }
@@ -1329,9 +1317,10 @@ static int _json_object_set_string_len(json_object *jso, const char *s, size_t l
 	if (jso == NULL || jso->o_type != json_type_string)
 		return 0;
 
-	if (len >= SSIZE_T_MAX - 1)
+	if (len >= INT_MAX - 1)
 		// jso->len is a signed ssize_t, so it can't hold the
-		// full size_t range.
+		// full size_t range. json_object_get_string_len returns
+		// length as int, cap length at INT_MAX.
 		return 0;
 
 	dstbuf = get_string_component_mutable(jso);
@@ -1605,9 +1594,10 @@ int json_object_equal(struct json_object *jso1, struct json_object *jso2)
 
 	case json_type_string:
 	{
-		return (json_object_get_string_len(jso1) == json_object_get_string_len(jso2) &&
+		return (_json_object_get_string_len(JC_STRING(jso1)) ==
+		            _json_object_get_string_len(JC_STRING(jso2)) &&
 		        memcmp(get_string_component(jso1), get_string_component(jso2),
-		               json_object_get_string_len(jso1)) == 0);
+		               _json_object_get_string_len(JC_STRING(jso1))) == 0);
 	}
 
 	case json_type_object: return json_object_all_values_equal(jso1, jso2);
@@ -1628,14 +1618,22 @@ static int json_object_copy_serializer_data(struct json_object *src, struct json
 	if (dst->_to_json_string == json_object_userdata_to_json_string ||
 	    dst->_to_json_string == _json_object_userdata_to_json_string)
 	{
-		dst->_userdata = strdup(src->_userdata);
+		char *p;
+		assert(src->_userdata);
+		p = strdup(src->_userdata);
+		if (p == NULL)
+		{
+			_json_c_set_last_err("json_object_copy_serializer_data: out of memory\n");
+			return -1;
+		}
+		dst->_userdata = p;
 	}
 	// else if ... other supported serializers ...
 	else
 	{
 		_json_c_set_last_err(
-		    "json_object_deep_copy: unable to copy unknown serializer data: %p\n",
-		    (void *)dst->_to_json_string);
+		    "json_object_copy_serializer_data: unable to copy unknown serializer data: "
+		    "%p\n", (void *)dst->_to_json_string);
 		return -1;
 	}
 	dst->_user_delete = src->_user_delete;
@@ -1672,7 +1670,10 @@ int json_c_shallow_copy_default(json_object *src, json_object *parent, const cha
 		}
 		break;
 
-	case json_type_string: *dst = json_object_new_string(get_string_component(src)); break;
+	case json_type_string:
+		*dst = json_object_new_string_len(get_string_component(src),
+		                                  _json_object_get_string_len(JC_STRING(src)));
+		break;
 
 	case json_type_object: *dst = json_object_new_object(); break;
 
@@ -1724,8 +1725,8 @@ static int json_object_deep_copy_recursive(struct json_object *src, struct json_
 			/* This handles the `json_type_null` case */
 			if (!iter.val)
 				jso = NULL;
-			else if (json_object_deep_copy_recursive(iter.val, src, iter.key, -1, &jso,
-			                                         shallow_copy) < 0)
+			else if (json_object_deep_copy_recursive(iter.val, src, iter.key, UINT_MAX,
+			                                         &jso, shallow_copy) < 0)
 			{
 				json_object_put(jso);
 				return -1;
@@ -1789,7 +1790,7 @@ int json_object_deep_copy(struct json_object *src, struct json_object **dst,
 	if (shallow_copy == NULL)
 		shallow_copy = json_c_shallow_copy_default;
 
-	rc = json_object_deep_copy_recursive(src, NULL, NULL, -1, dst, shallow_copy);
+	rc = json_object_deep_copy_recursive(src, NULL, NULL, UINT_MAX, dst, shallow_copy);
 	if (rc < 0)
 	{
 		json_object_put(*dst);

--- a/vendor/json-c/json_object.h
+++ b/vendor/json-c/json_object.h
@@ -52,7 +52,7 @@ extern "C" {
  * json_object_to_file_ext() functions which causes
  * the output to be formatted.
  *
- * See the "Two Space Tab" option at http://jsonformatter.curiousconcept.com/
+ * See the "Two Space Tab" option at https://jsonformatter.curiousconcept.com/
  * for an example of the format.
  */
 #define JSON_C_TO_STRING_PRETTY (1 << 1)
@@ -100,9 +100,17 @@ extern "C" {
  * key is given as a real constant value in the function
  * call, e.g. as in
  *   json_object_object_add_ex(obj, "ip", json,
- *       JSON_C_OBJECT_KEY_IS_CONSTANT);
+ *       JSON_C_OBJECT_ADD_CONSTANT_KEY);
  */
-#define JSON_C_OBJECT_KEY_IS_CONSTANT (1 << 2)
+#define JSON_C_OBJECT_ADD_CONSTANT_KEY (1 << 2)
+/**
+ * This flag is an alias to JSON_C_OBJECT_ADD_CONSTANT_KEY.
+ * Historically, this flag was used first and the new name
+ * JSON_C_OBJECT_ADD_CONSTANT_KEY was introduced for version
+ * 0.16.00 in order to have regular naming.
+ * Use of this flag is now legacy.
+ */
+#define JSON_C_OBJECT_KEY_IS_CONSTANT  JSON_C_OBJECT_ADD_CONSTANT_KEY
 
 /**
  * Set the global value of an option, which will apply to all
@@ -131,7 +139,7 @@ extern "C" {
  *    beyond the lifetime of the parent object.
  * - Detaching an object field or array index from its parent object
  *    (using `json_object_object_del()` or `json_object_array_del_idx()`)
- * - Sharing a json_object with multiple (not necesarily parallel) threads
+ * - Sharing a json_object with multiple (not necessarily parallel) threads
  *    of execution that all expect to free it (with `json_object_put()`) when
  *    they're done.
  *
@@ -470,19 +478,19 @@ JSON_EXPORT void json_object_object_del(struct json_object *obj, const char *key
  * @param val the local name for the json_object* object variable defined in
  *            the body
  */
-#if defined(__GNUC__) && !defined(__STRICT_ANSI__) && __STDC_VERSION__ >= 199901L
+#if defined(__GNUC__) && !defined(__STRICT_ANSI__) && (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L)
 
 #define json_object_object_foreach(obj, key, val)                                \
 	char *key = NULL;                                                        \
 	struct json_object *val __attribute__((__unused__)) = NULL;              \
-	for (struct lh_entry *entry##key = json_object_get_object(obj)->head,    \
+	for (struct lh_entry *entry##key = lh_table_head(json_object_get_object(obj)),    \
 	                     *entry_next##key = NULL;                            \
 	     ({                                                                  \
 		     if (entry##key)                                             \
 		     {                                                           \
 			     key = (char *)lh_entry_k(entry##key);               \
 			     val = (struct json_object *)lh_entry_v(entry##key); \
-			     entry_next##key = entry##key->next;                 \
+			     entry_next##key = lh_entry_next(entry##key);        \
 		     };                                                          \
 		     entry##key;                                                 \
 	     });                                                                 \
@@ -495,25 +503,25 @@ JSON_EXPORT void json_object_object_del(struct json_object *obj, const char *key
 	struct json_object *val = NULL;                                        \
 	struct lh_entry *entry##key;                                           \
 	struct lh_entry *entry_next##key = NULL;                               \
-	for (entry##key = json_object_get_object(obj)->head;                   \
+	for (entry##key = lh_table_head(json_object_get_object(obj));          \
 	     (entry##key ? (key = (char *)lh_entry_k(entry##key),              \
 	                   val = (struct json_object *)lh_entry_v(entry##key), \
-	                   entry_next##key = entry##key->next, entry##key)     \
+	                   entry_next##key = lh_entry_next(entry##key), entry##key)     \
 	                 : 0);                                                 \
 	     entry##key = entry_next##key)
 
-#endif /* defined(__GNUC__) && !defined(__STRICT_ANSI__) && __STDC_VERSION__ >= 199901L */
+#endif /* defined(__GNUC__) && !defined(__STRICT_ANSI__) && (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) */
 
 /** Iterate through all keys and values of an object (ANSI C Safe)
  * @param obj the json_object instance
  * @param iter the object iterator, use type json_object_iter
  */
 #define json_object_object_foreachC(obj, iter)                                                  \
-	for (iter.entry = json_object_get_object(obj)->head;                                    \
+	for (iter.entry = lh_table_head(json_object_get_object(obj));                                    \
 	     (iter.entry ? (iter.key = (char *)lh_entry_k(iter.entry),                          \
 	                   iter.val = (struct json_object *)lh_entry_v(iter.entry), iter.entry) \
 	                 : 0);                                                                  \
-	     iter.entry = iter.entry->next)
+	     iter.entry = lh_entry_next(iter.entry))
 
 /* Array type methods */
 
@@ -656,8 +664,9 @@ JSON_EXPORT struct json_object *json_object_new_boolean(json_bool b);
  * The type is coerced to a json_bool if the passed object is not a json_bool.
  * integer and double objects will return 0 if there value is zero
  * or 1 otherwise. If the passed object is a string it will return
- * 1 if it has a non zero length. If any other object type is passed
- * 1 will be returned if the object is not NULL.
+ * 1 if it has a non zero length. 
+ * If any other object type is passed 0 will be returned, even non-empty
+ *  json_type_array and json_type_object objects.
  *
  * @param obj the json_object instance
  * @returns a json_bool
@@ -738,7 +747,7 @@ JSON_EXPORT int json_object_set_int(struct json_object *obj, int new_value);
  *
  * @param obj the json_object instance
  * @param val the value to add
- * @returns 1 if the increment succeded, 0 otherwise
+ * @returns 1 if the increment succeeded, 0 otherwise
  */
 JSON_EXPORT int json_object_int_inc(struct json_object *obj, int64_t val);
 
@@ -1055,7 +1064,7 @@ JSON_EXPORT json_c_shallow_copy_fn json_c_shallow_copy_default;
  *                     when custom serializers are in use.  See also
  *                     json_object set_serializer.
  *
- * @returns 0 if the copy went well, -1 if an error occured during copy
+ * @returns 0 if the copy went well, -1 if an error occurred during copy
  *          or if the destination pointer is non-NULL
  */
 

--- a/vendor/json-c/json_object_iterator.c
+++ b/vendor/json-c/json_object_iterator.c
@@ -71,7 +71,7 @@ struct json_object_iterator json_object_iter_begin(struct json_object *obj)
 
 	/// @note For a pair-less Object, head is NULL, which matches our
 	///       definition of the "end" iterator
-	iter.opaque_ = pTable->head;
+	iter.opaque_ = lh_table_head(pTable);
 	return iter;
 }
 
@@ -98,7 +98,7 @@ void json_object_iter_next(struct json_object_iterator *iter)
 	JASSERT(NULL != iter);
 	JASSERT(kObjectEndIterValue != iter->opaque_);
 
-	iter->opaque_ = ((const struct lh_entry *)iter->opaque_)->next;
+	iter->opaque_ = lh_entry_next(((const struct lh_entry *)iter->opaque_));
 }
 
 /**

--- a/vendor/json-c/json_pointer.c
+++ b/vendor/json-c/json_pointer.c
@@ -10,7 +10,6 @@
 
 #include "strerror_override.h"
 
-#include <ctype.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -19,6 +18,9 @@
 #include "json_pointer.h"
 #include "strdup_compat.h"
 #include "vasprintf_compat.h"
+
+/* Avoid ctype.h and locale overhead */
+#define is_plain_digit(c) ((c) >= '0' && (c) <= '9')
 
 /**
  * JavaScript Object Notation (JSON) Pointer
@@ -47,7 +49,7 @@ static int is_valid_index(struct json_object *jo, const char *path, int32_t *idx
 	 */
 	if (len == 1)
 	{
-		if (isdigit((unsigned char)path[0]))
+		if (is_plain_digit(path[0]))
 		{
 			*idx = (path[0] - '0');
 			goto check_oob;
@@ -64,7 +66,7 @@ static int is_valid_index(struct json_object *jo, const char *path, int32_t *idx
 	/* RFC states base-10 decimals */
 	for (i = 0; i < len; i++)
 	{
-		if (!isdigit((unsigned char)path[i]))
+		if (!is_plain_digit(path[i]))
 		{
 			errno = EINVAL;
 			return 0;

--- a/vendor/json-c/json_tokener.c
+++ b/vendor/json-c/json_tokener.c
@@ -10,14 +10,13 @@
  *
  * Copyright (c) 2008-2009 Yahoo! Inc.  All rights reserved.
  * The copyrights to the contents of this file are licensed under the MIT License
- * (http://www.opensource.org/licenses/mit-license.php)
+ * (https://www.opensource.org/licenses/mit-license.php)
  */
 
 #include "config.h"
 
 #include "math_compat.h"
 #include <assert.h>
-#include <ctype.h>
 #include <limits.h>
 #include <math.h>
 #include <stddef.h>
@@ -53,6 +52,34 @@
 #error You do not have strncasecmp on your system.
 #endif /* HAVE_STRNCASECMP */
 
+#if defined(_MSC_VER) && (_MSC_VER <= 1800)
+/* VS2013 doesn't know about "inline" */
+#define inline __inline
+#elif defined(AIX_CC)
+#define inline
+#endif
+
+/* The following helper functions are used to speed up parsing. They
+ * are faster than their ctype counterparts because they assume that
+ * the input is in ASCII and that the locale is set to "C". The
+ * compiler will also inline these functions, providing an additional
+ * speedup by saving on function calls.
+ */
+static inline int is_ws_char(char c)
+{
+	return c == ' '
+	    || c == '\t'
+	    || c == '\n'
+	    || c == '\r';
+}
+
+static inline int is_hex_char(char c)
+{
+	return (c >= '0' && c <= '9')
+	    || (c >= 'A' && c <= 'F')
+	    || (c >= 'a' && c <= 'f');
+}
+
 /* Use C99 NAN by default; if not available, nan("") should work too. */
 #ifndef NAN
 #define NAN nan("")
@@ -61,7 +88,8 @@
 static const char json_null_str[] = "null";
 static const int json_null_str_len = sizeof(json_null_str) - 1;
 static const char json_inf_str[] = "Infinity";
-static const char json_inf_str_lower[] = "infinity";
+/* Swapped case "Infinity" to avoid need to call tolower() on input chars: */
+static const char json_inf_str_invert[] = "iNFINITY";
 static const unsigned int json_inf_str_len = sizeof(json_inf_str) - 1;
 static const char json_nan_str[] = "NaN";
 static const int json_nan_str_len = sizeof(json_nan_str) - 1;
@@ -134,6 +162,12 @@ struct json_tokener *json_tokener_new_ex(int depth)
 		return NULL;
 	}
 	tok->pb = printbuf_new();
+	if (!tok->pb)
+	{
+		free(tok->stack);
+		free(tok);
+		return NULL;
+	}
 	tok->max_depth = depth;
 	json_tokener_reset(tok);
 	return tok;
@@ -316,7 +350,7 @@ struct json_object *json_tokener_parse_ex(struct json_tokener *tok, const char *
 
 		case json_tokener_state_eatws:
 			/* Advance until we change state */
-			while (isspace((unsigned char)c))
+			while (is_ws_char(c))
 			{
 				if ((!ADVANCE_CHAR(str, tok)) || (!PEEK_CHAR(c, tok)))
 					goto out;
@@ -421,17 +455,15 @@ struct json_object *json_tokener_parse_ex(struct json_tokener *tok, const char *
 			 * complicated with likely little performance benefit.
 			 */
 			int is_negative = 0;
-			const char *_json_inf_str = json_inf_str;
-			if (!(tok->flags & JSON_TOKENER_STRICT))
-				_json_inf_str = json_inf_str_lower;
 
 			/* Note: tok->st_pos must be 0 when state is set to json_tokener_state_inf */
 			while (tok->st_pos < (int)json_inf_str_len)
 			{
 				char inf_char = *str;
-				if (!(tok->flags & JSON_TOKENER_STRICT))
-					inf_char = tolower((unsigned char)*str);
-				if (inf_char != _json_inf_str[tok->st_pos])
+				if (inf_char != json_inf_str[tok->st_pos] &&
+				    ((tok->flags & JSON_TOKENER_STRICT) ||
+				      inf_char != json_inf_str_invert[tok->st_pos])
+				   )
 				{
 					tok->err = json_tokener_error_parse_unexpected;
 					goto out;
@@ -647,7 +679,7 @@ struct json_object *json_tokener_parse_ex(struct json_tokener *tok, const char *
 			/* Handle a 4-byte \uNNNN sequence, or two sequences if a surrogate pair */
 			while (1)
 			{
-				if (!c || !strchr(json_hex_chars, c))
+				if (!c || !is_hex_char(c))
 				{
 					tok->err = json_tokener_error_parse_string;
 					goto out;
@@ -714,7 +746,7 @@ struct json_object *json_tokener_parse_ex(struct json_tokener *tok, const char *
 				 * we can't simply peek ahead here, because the
 				 * characters we need might not be passed to us
 				 * until a subsequent call to json_tokener_parse.
-				 * Instead, transition throug a couple of states.
+				 * Instead, transition through a couple of states.
 				 * (now):
 				 *   _escape_unicode => _unicode_need_escape
 				 * (see a '\\' char):
@@ -920,7 +952,7 @@ struct json_object *json_tokener_parse_ex(struct json_tokener *tok, const char *
 				next call to json_tokener_parse().
 			 */
 			if (tok->depth > 0 && c != ',' && c != ']' && c != '}' && c != '/' &&
-			    c != 'I' && c != 'i' && !isspace((unsigned char)c))
+			    c != 'I' && c != 'i' && !is_ws_char(c))
 			{
 				tok->err = json_tokener_error_parse_number;
 				goto out;

--- a/vendor/json-c/json_types.h
+++ b/vendor/json-c/json_types.h
@@ -18,7 +18,7 @@ extern "C" {
 #endif
 
 #ifndef JSON_EXPORT
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(JSON_C_DLL)
 #define JSON_EXPORT __declspec(dllexport)
 #else
 #define JSON_EXPORT extern

--- a/vendor/json-c/json_util.c
+++ b/vendor/json-c/json_util.c
@@ -14,7 +14,6 @@
 
 #include "strerror_override.h"
 
-#include <ctype.h>
 #include <limits.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -92,7 +91,7 @@ struct json_object *json_object_from_fd_ex(int fd, int in_depth)
 
 	if (!(pb = printbuf_new()))
 	{
-		_json_c_set_last_err("json_object_from_file: printbuf_new failed\n");
+		_json_c_set_last_err("json_object_from_fd_ex: printbuf_new failed\n");
 		return NULL;
 	}
 
@@ -102,7 +101,7 @@ struct json_object *json_object_from_fd_ex(int fd, int in_depth)
 	if (!tok)
 	{
 		_json_c_set_last_err(
-		    "json_object_from_fd: unable to allocate json_tokener(depth=%d): %s\n", depth,
+		    "json_object_from_fd_ex: unable to allocate json_tokener(depth=%d): %s\n", depth,
 		    strerror(errno));
 		printbuf_free(pb);
 		return NULL;
@@ -114,7 +113,7 @@ struct json_object *json_object_from_fd_ex(int fd, int in_depth)
 	}
 	if (ret < 0)
 	{
-		_json_c_set_last_err("json_object_from_fd: error reading fd %d: %s\n", fd,
+		_json_c_set_last_err("json_object_from_fd_ex: error reading fd %d: %s\n", fd,
 		                     strerror(errno));
 		json_tokener_free(tok);
 		printbuf_free(pb);
@@ -138,8 +137,8 @@ struct json_object *json_object_from_file(const char *filename)
 
 	if ((fd = open(filename, O_RDONLY)) < 0)
 	{
-		_json_c_set_last_err("json_object_from_file: error opening file %s: %s\n", filename,
-		                     strerror(errno));
+		_json_c_set_last_err("json_object_from_file: error opening file %s: %s\n",
+		                     filename, strerror(errno));
 		return NULL;
 	}
 	obj = json_object_from_fd(fd);
@@ -156,14 +155,14 @@ int json_object_to_file_ext(const char *filename, struct json_object *obj, int f
 
 	if (!obj)
 	{
-		_json_c_set_last_err("json_object_to_file: object is null\n");
+		_json_c_set_last_err("json_object_to_file_ext: object is null\n");
 		return -1;
 	}
 
 	if ((fd = open(filename, O_WRONLY | O_TRUNC | O_CREAT, 0644)) < 0)
 	{
-		_json_c_set_last_err("json_object_to_file: error opening file %s: %s\n", filename,
-		                     strerror(errno));
+		_json_c_set_last_err("json_object_to_file_ext: error opening file %s: %s\n",
+		                     filename, strerror(errno));
 		return -1;
 	}
 	ret = _json_object_to_fd(fd, obj, flags, filename);
@@ -203,7 +202,7 @@ static int _json_object_to_fd(int fd, struct json_object *obj, int flags, const 
 	{
 		if ((ret = write(fd, json_str + wpos, wsize - wpos)) < 0)
 		{
-			_json_c_set_last_err("json_object_to_file: error writing file %s: %s\n",
+			_json_c_set_last_err("json_object_to_fd: error writing file %s: %s\n",
 			                     filename, strerror(errno));
 			return -1;
 		}
@@ -289,8 +288,8 @@ const char *json_type_to_name(enum json_type o_type)
 	int o_type_int = (int)o_type;
 	if (o_type_int < 0 || o_type_int >= (int)NELEM(json_type_name))
 	{
-		_json_c_set_last_err("json_type_to_name: type %d is out of range [0,%d]\n", o_type,
-		                     NELEM(json_type_name));
+		_json_c_set_last_err("json_type_to_name: type %d is out of range [0,%u]\n", o_type,
+		                     (unsigned)NELEM(json_type_name));
 		return NULL;
 	}
 	return json_type_name[o_type];

--- a/vendor/json-c/linkhash.c
+++ b/vendor/json-c/linkhash.c
@@ -65,9 +65,9 @@ int lh_ptr_equal(const void *k1, const void *k2)
 
 /*
  * hashlittle from lookup3.c, by Bob Jenkins, May 2006, Public Domain.
- * http://burtleburtle.net/bob/c/lookup3.c
+ * https://burtleburtle.net/bob/c/lookup3.c
  * minor modifications to make functions static so no symbols are exported
- * minor mofifications to compile with -Werror
+ * minor modifications to compile with -Werror
  */
 
 /*
@@ -81,7 +81,7 @@ if SELF_TEST is defined.  You can use this free for any purpose.  It's in
 the public domain.  It has no warranty.
 
 You probably want to use hashlittle().  hashlittle() and hashbig()
-hash byte arrays.  hashlittle() is is faster than hashbig() on
+hash byte arrays.  hashlittle() is faster than hashbig() on
 little-endian machines.  Intel and AMD are little-endian machines.
 On second thought, you probably want hashlittle2(), which is identical to
 hashlittle() except it returns two 32-bit hashes for the price of one.
@@ -156,7 +156,7 @@ satisfy this are
    14  9  3  7 17  3
 Well, "9 15 3 18 27 15" didn't quite get 32 bits diffing
 for "differ" defined as + with a one-bit base and a two-bit delta.  I
-used http://burtleburtle.net/bob/hash/avalanche.html to choose
+used https://burtleburtle.net/bob/hash/avalanche.html to choose
 the operations, constants, and arrangements of the variables.
 
 This does not achieve avalanche.  There are input bits of (a,b,c)
@@ -285,9 +285,9 @@ static uint32_t hashlittle(const void *key, size_t length, uint32_t initval)
 		 * rest of the string.  Every machine with memory protection I've seen
 		 * does it on word boundaries, so is OK with this.  But VALGRIND will
 		 * still catch it and complain.  The masking trick does make the hash
-		 * noticably faster for short strings (like English words).
+		 * noticeably faster for short strings (like English words).
 		 * AddressSanitizer is similarly picky about overrunning
-		 * the buffer. (http://clang.llvm.org/docs/AddressSanitizer.html
+		 * the buffer. (https://clang.llvm.org/docs/AddressSanitizer.html)
 		 */
 #ifdef VALGRIND
 #define PRECISE_MEMORY_ACCESS 1
@@ -439,8 +439,8 @@ static uint32_t hashlittle(const void *key, size_t length, uint32_t initval)
 }
 /* clang-format on */
 
-/* a simple hash function similiar to what perl does for strings.
- * for good results, the string should not be excessivly large.
+/* a simple hash function similar to what perl does for strings.
+ * for good results, the string should not be excessively large.
  */
 static unsigned long lh_perllike_str_hash(const void *k)
 {
@@ -465,7 +465,7 @@ static unsigned long lh_char_hash(const void *k)
 	if (random_seed == -1)
 	{
 		RANDOM_SEED_TYPE seed;
-		/* we can't use -1 as it is the unitialized sentinel */
+		/* we can't use -1 as it is the uninitialized sentinel */
 		while ((seed = json_c_get_random_seed()) == -1) {}
 #if SIZEOF_INT == 8 && defined __GCC_HAVE_SYNC_COMPARE_AND_SWAP_8
 #define USE_SYNC_COMPARE_AND_SWAP 1
@@ -481,12 +481,12 @@ static unsigned long lh_char_hash(const void *k)
 #elif defined _MSC_VER || defined __MINGW32__
 		InterlockedCompareExchange(&random_seed, seed, -1);
 #else
-		//#warning "racy random seed initializtion if used by multiple threads"
+		//#warning "racy random seed initialization if used by multiple threads"
 		random_seed = seed; /* potentially racy */
 #endif
 	}
 
-	return hashlittle((const char *)k, strlen((const char *)k), random_seed);
+	return hashlittle((const char *)k, strlen((const char *)k), (uint32_t)random_seed);
 }
 
 int lh_char_equal(const void *k1, const void *k2)
@@ -546,7 +546,7 @@ int lh_table_resize(struct lh_table *t, int new_size)
 		unsigned long h = lh_get_hash(new_t, ent->k);
 		unsigned int opts = 0;
 		if (ent->k_is_constant)
-			opts = JSON_C_OBJECT_KEY_IS_CONSTANT;
+			opts = JSON_C_OBJECT_ADD_CONSTANT_KEY;
 		if (lh_table_insert_w_hash(new_t, ent->k, ent->v, h, opts) != 0)
 		{
 			lh_table_free(new_t);
@@ -599,7 +599,7 @@ int lh_table_insert_w_hash(struct lh_table *t, const void *k, const void *v, con
 	}
 
 	t->table[n].k = k;
-	t->table[n].k_is_constant = (opts & JSON_C_OBJECT_KEY_IS_CONSTANT);
+	t->table[n].k_is_constant = (opts & JSON_C_OBJECT_ADD_CONSTANT_KEY);
 	t->table[n].v = v;
 	t->count++;
 

--- a/vendor/json-c/linkhash.h
+++ b/vendor/json-c/linkhash.h
@@ -16,8 +16,8 @@
  *        this is exposed by the json_object_get_object() function and within the
  *        json_object_iter type, it is not recommended for direct use.
  */
-#ifndef _linkhash_h_
-#define _linkhash_h_
+#ifndef _json_c_linkhash_h_
+#define _json_c_linkhash_h_
 
 #include "json_object.h"
 
@@ -80,64 +80,84 @@ typedef unsigned long(lh_hash_fn)(const void *k);
 typedef int(lh_equal_fn)(const void *k1, const void *k2);
 
 /**
- * An entry in the hash table
+ * An entry in the hash table.  Outside of linkhash.c, treat this as opaque.
  */
 struct lh_entry
 {
 	/**
-	 * The key.  Use lh_entry_k() instead of accessing this directly.
+	 * The key.
+	 * @deprecated Use lh_entry_k() instead of accessing this directly.
 	 */
 	const void *k;
 	/**
 	 * A flag for users of linkhash to know whether or not they
 	 * need to free k.
+	 * @deprecated use lh_entry_k_is_constant() instead.
 	 */
 	int k_is_constant;
 	/**
-	 * The value.  Use lh_entry_v() instead of accessing this directly.
+	 * The value.
+	 * @deprecated Use lh_entry_v() instead of accessing this directly.
 	 */
 	const void *v;
 	/**
-	 * The next entry
+	 * The next entry.
+	 * @deprecated Use lh_entry_next() instead of accessing this directly.
 	 */
 	struct lh_entry *next;
 	/**
 	 * The previous entry.
+	 * @deprecated Use lh_entry_prev() instead of accessing this directly.
 	 */
 	struct lh_entry *prev;
 };
 
 /**
- * The hash table structure.
+ * The hash table structure.  Outside of linkhash.c, treat this as opaque.
  */
 struct lh_table
 {
 	/**
 	 * Size of our hash.
+	 * @deprecated do not use outside of linkhash.c
 	 */
 	int size;
 	/**
 	 * Numbers of entries.
+	 * @deprecated Use lh_table_length() instead.
 	 */
 	int count;
 
 	/**
 	 * The first entry.
+	 * @deprecated Use lh_table_head() instead.
 	 */
 	struct lh_entry *head;
 
 	/**
 	 * The last entry.
+	 * @deprecated Do not use, may be removed in a future release.
 	 */
 	struct lh_entry *tail;
 
+	/**
+	 * Internal storage of the actual table of entries.
+	 * @deprecated do not use outside of linkhash.c
+	 */
 	struct lh_entry *table;
 
 	/**
-	 * A pointer onto the function responsible for freeing an entry.
+	 * A pointer to the function responsible for freeing an entry.
+	 * @deprecated do not use outside of linkhash.c
 	 */
 	lh_entry_free_fn *free_fn;
+	/**
+	 * @deprecated do not use outside of linkhash.c
+	 */
 	lh_hash_fn *hash_fn;
+	/**
+	 * @deprecated do not use outside of linkhash.c
+	 */
 	lh_equal_fn *equal_fn;
 };
 typedef struct lh_table lh_table;
@@ -145,7 +165,7 @@ typedef struct lh_table lh_table;
 /**
  * Convenience list iterator.
  */
-#define lh_foreach(table, entry) for (entry = table->head; entry; entry = entry->next)
+#define lh_foreach(table, entry) for (entry = lh_table_head(table); entry; entry = lh_entry_next(entry))
 
 /**
  * lh_foreach_safe allows calling of deletion routine while iterating.
@@ -155,7 +175,7 @@ typedef struct lh_table lh_table;
  * @param tmp a struct lh_entry * variable to hold a temporary pointer to the next element
  */
 #define lh_foreach_safe(table, entry, tmp) \
-	for (entry = table->head; entry && ((tmp = entry->next) || 1); entry = tmp)
+	for (entry = lh_table_head(table); entry && ((tmp = lh_entry_next(entry)) || 1); entry = tmp)
 
 /**
  * Create a new linkhash table.
@@ -231,7 +251,7 @@ extern int lh_table_insert(struct lh_table *t, const void *k, const void *v);
  * @param k a pointer to the key to insert.
  * @param v a pointer to the value to insert.
  * @param h hash value of the key to insert
- * @param opts if set to JSON_C_OBJECT_KEY_IS_CONSTANT, sets lh_entry.k_is_constant
+ * @param opts if set to JSON_C_OBJECT_ADD_CONSTANT_KEY, sets lh_entry.k_is_constant
  *             so t's free function knows to avoid freeing the key.
  */
 extern int lh_table_insert_w_hash(struct lh_table *t, const void *k, const void *v,
@@ -295,6 +315,9 @@ extern int lh_table_delete_entry(struct lh_table *t, struct lh_entry *e);
  */
 extern int lh_table_delete(struct lh_table *t, const void *k);
 
+/**
+ * Return the number of entries in the table.
+ */
 extern int lh_table_length(struct lh_table *t);
 
 /**
@@ -319,9 +342,18 @@ int lh_table_resize(struct lh_table *t, int new_size);
 #endif
 
 /**
+ * Return the first entry in the lh_table.
+ * @see lh_entry_next()
+ */
+static _LH_INLINE struct lh_entry *lh_table_head(const lh_table *t)
+{
+	return t->head;
+}
+
+/**
  * Calculate the hash of a key for a given table.
  *
- * This is an exension to support functions that need to calculate
+ * This is an extension to support functions that need to calculate
  * the hash several times and allows them to do it just once and then pass
  * in the hash to all utility functions. Depending on use case, this can be a
  * considerable performance improvement.
@@ -334,7 +366,6 @@ static _LH_INLINE unsigned long lh_get_hash(const struct lh_table *t, const void
 	return t->hash_fn(k);
 }
 
-#undef _LH_INLINE
 
 /**
  * @deprecated Don't use this outside of linkhash.h:
@@ -350,9 +381,22 @@ static _LH_INLINE unsigned long lh_get_hash(const struct lh_table *t, const void
  *
  * lh_entry.k is const to indicate and help ensure that linkhash itself doesn't modify
  * it, but callers are allowed to do what they want with it.
- * See also lh_entry.k_is_constant
+ * @see lh_entry_k_is_constant()
  */
-#define lh_entry_k(entry) _LH_UNCONST((entry)->k)
+static _LH_INLINE void *lh_entry_k(const struct lh_entry *e)
+{
+	return _LH_UNCONST(e->k);
+}
+
+/**
+ * Returns 1 if the key for the given entry is constant, and thus
+ *  does not need to be freed when the lh_entry is freed.
+ * @see lh_table_insert_w_hash()
+ */
+static _LH_INLINE int lh_entry_k_is_constant(const struct lh_entry *e)
+{
+	return e->k_is_constant;
+}
 
 /**
  * Return a non-const version of lh_entry.v.
@@ -360,7 +404,41 @@ static _LH_INLINE unsigned long lh_get_hash(const struct lh_table *t, const void
  * v is const to indicate and help ensure that linkhash itself doesn't modify
  * it, but callers are allowed to do what they want with it.
  */
-#define lh_entry_v(entry) _LH_UNCONST((entry)->v)
+static _LH_INLINE void *lh_entry_v(const struct lh_entry *e)
+{
+	return _LH_UNCONST(e->v);
+}
+
+/**
+ * Change the value for an entry.  The caller is responsible for freeing
+ *  the previous value.
+ */
+static _LH_INLINE void lh_entry_set_val(struct lh_entry *e, void *newval)
+{
+	e->v = newval;
+}
+
+/**
+ * Return the next element, or NULL if there is no next element.
+ * @see lh_table_head()
+ * @see lh_entry_prev()
+ */
+static _LH_INLINE struct lh_entry *lh_entry_next(const struct lh_entry *e)
+{
+	return e->next;
+}
+
+/**
+ * Return the previous element, or NULL if there is no previous element.
+ * @see lh_table_head()
+ * @see lh_entry_next()
+ */
+static _LH_INLINE struct lh_entry *lh_entry_prev(const struct lh_entry *e)
+{
+	return e->prev;
+}
+
+#undef _LH_INLINE
 
 #ifdef __cplusplus
 }

--- a/vendor/json-c/printbuf.c
+++ b/vendor/json-c/printbuf.c
@@ -10,7 +10,7 @@
  *
  * Copyright (c) 2008-2009 Yahoo! Inc.  All rights reserved.
  * The copyrights to the contents of this file are licensed under the MIT License
- * (http://www.opensource.org/licenses/mit-license.php)
+ * (https://www.opensource.org/licenses/mit-license.php)
  */
 
 #include "config.h"
@@ -91,7 +91,7 @@ static int printbuf_extend(struct printbuf *p, int min_size)
 int printbuf_memappend(struct printbuf *p, const char *buf, int size)
 {
 	/* Prevent signed integer overflows with large buffers. */
-	if (size > INT_MAX - p->bpos - 1)
+	if (size < 0 || size > INT_MAX - p->bpos - 1)
 		return -1;
 	if (p->size <= p->bpos + size + 1)
 	{
@@ -111,7 +111,7 @@ int printbuf_memset(struct printbuf *pb, int offset, int charvalue, int len)
 	if (offset == -1)
 		offset = pb->bpos;
 	/* Prevent signed integer overflows with large buffers. */
-	if (len > INT_MAX - offset)
+	if (len < 0 || offset < -1 || len > INT_MAX - offset)
 		return -1;
 	size_needed = offset + len;
 	if (pb->size < size_needed)
@@ -120,6 +120,8 @@ int printbuf_memset(struct printbuf *pb, int offset, int charvalue, int len)
 			return -1;
 	}
 
+	if (pb->bpos < offset)
+		memset(pb->buf + pb->bpos, '\0', offset - pb->bpos);
 	memset(pb->buf + offset, charvalue, len);
 	if (pb->bpos < size_needed)
 		pb->bpos = size_needed;
@@ -134,16 +136,16 @@ int sprintbuf(struct printbuf *p, const char *msg, ...)
 	int size;
 	char buf[128];
 
-	/* user stack buffer first */
+	/* use stack buffer first */
 	va_start(ap, msg);
 	size = vsnprintf(buf, 128, msg, ap);
 	va_end(ap);
 	/* if string is greater than stack buffer, then use dynamic string
-	 * with vasprintf.  Note: some implementation of vsnprintf return -1
+	 * with vasprintf.  Note: some implementations of vsnprintf return -1
 	 * if output is truncated whereas some return the number of bytes that
 	 * would have been written - this code handles both cases.
 	 */
-	if (size == -1 || size > 127)
+	if (size < 0 || size > 127)
 	{
 		va_start(ap, msg);
 		if ((size = vasprintf(&t, msg, ap)) < 0)
@@ -152,15 +154,14 @@ int sprintbuf(struct printbuf *p, const char *msg, ...)
 			return -1;
 		}
 		va_end(ap);
-		printbuf_memappend(p, t, size);
+		size = printbuf_memappend(p, t, size);
 		free(t);
-		return size;
 	}
 	else
 	{
-		printbuf_memappend(p, buf, size);
-		return size;
+		size = printbuf_memappend(p, buf, size);
 	}
+	return size;
 }
 
 void printbuf_reset(struct printbuf *p)

--- a/vendor/json-c/printbuf.h
+++ b/vendor/json-c/printbuf.h
@@ -10,21 +10,21 @@
  *
  * Copyright (c) 2008-2009 Yahoo! Inc.  All rights reserved.
  * The copyrights to the contents of this file are licensed under the MIT License
- * (http://www.opensource.org/licenses/mit-license.php)
+ * (https://www.opensource.org/licenses/mit-license.php)
  */
 
 /**
  * @file
- * @brief Internal string buffer handing.  Unless you're writing a
+ * @brief Internal string buffer handling.  Unless you're writing a
  *        json_object_to_json_string_fn implementation for use with
  *        json_object_set_serializer() direct use of this is not
  *        recommended.
  */
-#ifndef _printbuf_h_
-#define _printbuf_h_
+#ifndef _json_c_printbuf_h_
+#define _json_c_printbuf_h_
 
 #ifndef JSON_EXPORT
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && defined(JSON_C_DLL)
 #define JSON_EXPORT __declspec(dllexport)
 #else
 #define JSON_EXPORT extern

--- a/vendor/json-c/random_seed.c
+++ b/vendor/json-c/random_seed.c
@@ -13,8 +13,22 @@
 #include "config.h"
 #include "strerror_override.h"
 #include <stdio.h>
+#include <stdlib.h>
+#ifdef HAVE_BSD_STDLIB_H
+#include <bsd/stdlib.h>
+#endif
 
 #define DEBUG_SEED(s)
+
+#if defined(__APPLE__) || defined(__unix__) || defined(__linux__)
+#define HAVE_DEV_RANDOM 1
+#endif
+
+#ifdef HAVE_ARC4RANDOM
+#undef HAVE_GETRANDOM
+#undef HAVE_DEV_RANDOM
+#undef HAVE_CRYPTGENRANDOM
+#endif
 
 #if defined ENABLE_RDRAND
 
@@ -155,9 +169,45 @@ retry:
 
 #endif /* defined ENABLE_RDRAND */
 
-/* has_dev_urandom */
+#ifdef HAVE_GETRANDOM
 
-#if defined(__APPLE__) || defined(__unix__) || defined(__linux__)
+#include <stdlib.h>
+#ifdef HAVE_SYS_RANDOM_H
+#include <sys/random.h>
+#endif
+
+static int get_getrandom_seed(int *seed)
+{
+	DEBUG_SEED("get_getrandom_seed");
+
+	ssize_t ret;
+
+	do
+	{
+		ret = getrandom(seed, sizeof(*seed), GRND_NONBLOCK);
+	} while ((ret == -1) && (errno == EINTR));
+
+	if (ret == -1)
+	{
+		if (errno == ENOSYS) /* syscall not available in kernel */
+			return -1;
+		if (errno == EAGAIN) /* entropy not yet initialized */
+			return -1;
+
+		fprintf(stderr, "error from getrandom(): %s", strerror(errno));
+		return -1;
+	}
+
+	if (ret != sizeof(*seed))
+		return -1;
+
+	return 0;
+}
+#endif /* defined HAVE_GETRANDOM */
+
+/* get_dev_random_seed */
+
+#ifdef HAVE_DEV_RANDOM
 
 #include <fcntl.h>
 #include <string.h>
@@ -167,43 +217,36 @@ retry:
 #include <stdlib.h>
 #include <sys/stat.h>
 
-#define HAVE_DEV_RANDOM 1
-
 static const char *dev_random_file = "/dev/urandom";
 
-static int has_dev_urandom(void)
-{
-	struct stat buf;
-	if (stat(dev_random_file, &buf))
-	{
-		return 0;
-	}
-	return ((buf.st_mode & S_IFCHR) != 0);
-}
-
-/* get_dev_random_seed */
-
-static int get_dev_random_seed(void)
+static int get_dev_random_seed(int *seed)
 {
 	DEBUG_SEED("get_dev_random_seed");
+
+	struct stat buf;
+	if (stat(dev_random_file, &buf))
+		return -1;
+	if ((buf.st_mode & S_IFCHR) == 0)
+		return -1;
 
 	int fd = open(dev_random_file, O_RDONLY);
 	if (fd < 0)
 	{
 		fprintf(stderr, "error opening %s: %s", dev_random_file, strerror(errno));
-		exit(1);
+		return -1;
 	}
 
-	int r;
-	ssize_t nread = read(fd, &r, sizeof(r));
-	if (nread != sizeof(r))
-	{
-		fprintf(stderr, "error short read %s: %s", dev_random_file, strerror(errno));
-		exit(1);
-	}
+	ssize_t nread = read(fd, seed, sizeof(*seed));
 
 	close(fd);
-	return r;
+
+	if (nread != sizeof(*seed))
+	{
+		fprintf(stderr, "error short read %s: %s", dev_random_file, strerror(errno));
+		return -1;
+	}
+
+	return 0;
 }
 
 #endif
@@ -226,13 +269,10 @@ static int get_dev_random_seed(void)
 #pragma comment(lib, "advapi32.lib")
 #endif
 
-static int get_time_seed(void);
-
-static int get_cryptgenrandom_seed(void)
+static int get_cryptgenrandom_seed(int *seed)
 {
 	HCRYPTPROV hProvider = 0;
 	DWORD dwFlags = CRYPT_VERIFYCONTEXT;
-	int r;
 
 	DEBUG_SEED("get_cryptgenrandom_seed");
 
@@ -243,34 +283,36 @@ static int get_cryptgenrandom_seed(void)
 	if (!CryptAcquireContextA(&hProvider, 0, 0, PROV_RSA_FULL, dwFlags))
 	{
 		fprintf(stderr, "error CryptAcquireContextA 0x%08lx", GetLastError());
-		r = get_time_seed();
+		return -1;
 	}
 	else
 	{
-		BOOL ret = CryptGenRandom(hProvider, sizeof(r), (BYTE*)&r);
+		BOOL ret = CryptGenRandom(hProvider, sizeof(*seed), (BYTE *)seed);
 		CryptReleaseContext(hProvider, 0);
 		if (!ret)
 		{
 			fprintf(stderr, "error CryptGenRandom 0x%08lx", GetLastError());
-			r = get_time_seed();
+			return -1;
 		}
 	}
 
-	return r;
+	return 0;
 }
 
 #endif
 
 /* get_time_seed */
 
+#ifndef HAVE_ARC4RANDOM
 #include <time.h>
 
 static int get_time_seed(void)
 {
 	DEBUG_SEED("get_time_seed");
 
-	return (int)time(NULL) * 433494437;
+	return (unsigned)time(NULL) * 433494437;
 }
+#endif
 
 /* json_c_get_random_seed */
 
@@ -283,12 +325,31 @@ int json_c_get_random_seed(void)
 	if (has_rdrand())
 		return get_rdrand_seed();
 #endif
+#ifdef HAVE_ARC4RANDOM
+	/* arc4random never fails, so use it if it's available */
+	return arc4random();
+#else
+#ifdef HAVE_GETRANDOM
+	{
+		int seed = 0;
+		if (get_getrandom_seed(&seed) == 0)
+			return seed;
+	}
+#endif
 #if defined HAVE_DEV_RANDOM && HAVE_DEV_RANDOM
-	if (has_dev_urandom())
-		return get_dev_random_seed();
+	{
+		int seed = 0;
+		if (get_dev_random_seed(&seed) == 0)
+			return seed;
+	}
 #endif
 #if defined HAVE_CRYPTGENRANDOM && HAVE_CRYPTGENRANDOM
-	return get_cryptgenrandom_seed();
+	{
+		int seed = 0;
+		if (get_cryptgenrandom_seed(&seed) == 0)
+			return seed;
+	}
 #endif
 	return get_time_seed();
+#endif /* !HAVE_ARC4RANDOM */
 }

--- a/vendor/json-c/strerror_override.c
+++ b/vendor/json-c/strerror_override.c
@@ -94,7 +94,7 @@ char *_json_c_strerror(int errno_in)
 	}
 
 	// It's not one of the known errno values, return the numeric value.
-	for (ii = 0; errno_in > 10; errno_in /= 10, ii++)
+	for (ii = 0; errno_in >= 10; errno_in /= 10, ii++)
 	{
 		digbuf[ii] = "0123456789"[(errno_in % 10)];
 	}
@@ -105,5 +105,6 @@ char *_json_c_strerror(int errno_in)
 	{
 		errno_buf[start_idx] = digbuf[ii];
 	}
+	errno_buf[start_idx] = '\0';
 	return errno_buf;
 }

--- a/vendor/json-c/vasprintf_compat.h
+++ b/vendor/json-c/vasprintf_compat.h
@@ -8,6 +8,10 @@
 
 #include "snprintf_compat.h"
 
+#ifndef WIN32
+#include <stdarg.h>
+#endif /* !defined(WIN32) */
+#include <stdint.h>
 #include <stdlib.h>
 
 #if !defined(HAVE_VASPRINTF)
@@ -16,6 +20,7 @@ static int vasprintf(char **buf, const char *fmt, va_list ap)
 {
 #ifndef WIN32
 	static char _T_emptybuffer = '\0';
+	va_list ap2;
 #endif /* !defined(WIN32) */
 	int chars;
 	char *b;
@@ -26,19 +31,21 @@ static int vasprintf(char **buf, const char *fmt, va_list ap)
 	}
 
 #ifdef WIN32
-	chars = _vscprintf(fmt, ap) + 1;
+	chars = _vscprintf(fmt, ap);
 #else  /* !defined(WIN32) */
 	/* CAW: RAWR! We have to hope to god here that vsnprintf doesn't overwrite
-	 * our buffer like on some 64bit sun systems.... but hey, its time to move on
+	 * our buffer like on some 64bit sun systems... but hey, it's time to move on
 	 */
-	chars = vsnprintf(&_T_emptybuffer, 0, fmt, ap) + 1;
-	if (chars < 0)
-	{
-		chars *= -1;
-	} /* CAW: old glibc versions have this problem */
+	va_copy(ap2, ap);
+	chars = vsnprintf(&_T_emptybuffer, 0, fmt, ap2);
+	va_end(ap2);
 #endif /* defined(WIN32) */
+	if (chars < 0 || (size_t)chars + 1 > SIZE_MAX / sizeof(char))
+	{
+		return -1;
+	}
 
-	b = (char *)malloc(sizeof(char) * chars);
+	b = (char *)malloc(sizeof(char) * ((size_t)chars + 1));
 	if (!b)
 	{
 		return -1;


### PR DESCRIPTION
## Summary
- Contains bug fixes and optimizations
- **Change in json-c code (double precision):** json-c has changed it a few times, by default it's set to `%.17g` but we've had it at `%.16g` so it had to be edited (due to backwards compatibility reasons) in the source code at `json_object.c:1028` (issue: https://bugs.mtasa.com/view.php?id=8853) (commit: https://github.com/multitheftauto/mtasa-blue/commit/4cc6fdaf990013f7d50bcc6f6036a9131c0e3ea6)
- Changelogs
  - https://github.com/json-c/json-c/blob/7d303478a40e8bbb0cfd2e82ac99dc8e407cf014/ChangeLog#L2-L52

## Tests
Tested with [test_json.zip](https://github.com/multitheftauto/mtasa-blue/files/8497256/test_json.zip)

## Validation
To help validate the integrity of the update I have created the following bash script that diffs between my PR branch and the official package provided from the [json-c repository](https://github.com/json-c/json-c/releases/tag/json-c-0.16-20220414).
```bash
#!/bin/bash

JSONC_UPDATE_VERSION=0.16
JSONC_PATH_NAME=json-c-0.16-20220414

GIT_REPO_BRANCH=vendor/json-c-$JSONC_UPDATE_VERSION
GIT_REPO_URL=https://github.com/patrikjuvonen/mtasa-blue.git
GIT_REPO_JSONC_PATH=vendor/json-c/

echo 1. Download and extract $JSONC_PATH_NAME...
curl -L https://github.com/json-c/json-c/archive/refs/tags/$JSONC_PATH_NAME.tar.gz | tar -xz --transform 's/^json-c-json-c/json-c/'

echo 2. Fetch and checkout the vendor update branch $GIT_REPO_BRANCH from $GIT_REPO_URL...
git fetch $GIT_REPO_URL $GIT_REPO_BRANCH:$GIT_REPO_BRANCH
git checkout $GIT_REPO_BRANCH

echo 3. Start checking integrity...
diff -r --strip-trailing-cr $GIT_REPO_JSONC_PATH $JSONC_PATH_NAME

echo 4. Completed.
exec $SHELL
```

## Past json-c updates in MTA
| Date | From | To | Link |
| :--- | :--- | :--- | :--- |
| October 2020 | 0.13.1 | 0.15 (current) | #1605 |
| August 2018 | 0.12 | 0.13.1 | #269 |

## Copy of json-c changelogs
### 0.16
```
0.16 (up to commit 66dcdf5, 2022-04-13)
========================================

Deprecated and removed features:
--------------------------------
* JSON_C_OBJECT_KEY_IS_CONSTANT is deprecated in favor of
  JSON_C_OBJECT_ADD_CONSTANT_KEY
* Direct access to lh_table and lh_entry structure members is deprecated.  
  Use access functions instead, lh_table_head(), lh_entry_next(), etc...
* Drop REFCOUNT_DEBUG code.

New features
------------
* The 0.16 release introduces no new features

Build changes
-------------
* Add a DISABLE_EXTRA_LIBS option to skip using libbsd
* Add a DISABLE_JSON_POINTER option to skip compiling in json_pointer support.

Significant changes and bug fixes
---------------------------------
* Cap string length at INT_MAX to avoid various issues with very long strings.
* json_object_deep_copy: fix deep copy of strings containing '\0'
* Fix read past end of buffer in the "json_parse" command
* Avoid out of memory accesses in the locally provided vasprintf() function
  (for those platforms that use it)
* Handle allocation failure in json_tokener_new_ex
* Fix use-after-free in json_tokener_new_ex() in the event of printbuf_new() returning NULL
* printbuf_memset(): set gaps to zero - areas within the print buffer which
  have not been initialized by using printbuf_memset
* printbuf: return -1 on invalid arguments (len < 0 or total buffer > INT_MAX)
* sprintbuf(): propagate printbuf_memappend errors back to the caller

Optimizations
--------------
* Speed up parsing by replacing ctype functions with simplified, faster 
  non-locale-sensitive ones in json_tokener and json_object_to_json_string.
* Neither vertical tab nor formfeed are considered whitespace per the JSON spec
* json_object: speed up creation of objects, calloc() -> malloc() + set fields
* Avoid needless extra strlen() call in json_c_shallow_copy_default() and
  json_object_equal() when the object is known to be a json_type_string.

Other changes
-------------
* Validate size arguments in arraylist functions.
* Use getrandom() if available; with GRND_NONBLOCK to allow use of json-c
  very early during boot, such as part of cryptsetup.
* Use arc4random() if it's available.
* random_seed: on error, continue to next method instead of exiting the process
* Close file when unable to read from /dev/urandom in get_dev_random_seed()
```