### PR TITLE
Update sqlite from 3.38.2 to 3.38.5

### DIFF
--- a/vendor/sqlite/sqlite3.h
+++ b/vendor/sqlite/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.38.2"
-#define SQLITE_VERSION_NUMBER 3038002
-#define SQLITE_SOURCE_ID      "2022-03-26 13:51:10 d33c709cc0af66bc5b6dc6216eba9f1f0b40960b9ae83694c986fbf4c1d6f08f"
+#define SQLITE_VERSION        "3.38.5"
+#define SQLITE_VERSION_NUMBER 3038005
+#define SQLITE_SOURCE_ID      "2022-05-06 15:25:27 78d9c993d404cdfaa7fdd2973fa1052e3da9f66215cff9c5540ebe55c407d9fe"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers


### PR DESCRIPTION
## Summary
- Contains a couple of fixes
- Changelogs
  - https://www.sqlite.org/changes.html#version_3_38_3
  - https://www.sqlite.org/changes.html#version_3_38_4
  - https://www.sqlite.org/changes.html#version_3_38_5

## Tests
Tested with [test_sqlite.zip](https://github.com/multitheftauto/mtasa-blue/files/2872064/test_sqlite.zip) (cheers to botder)

## Validation
To help validate the integrity of the update I have created the following bash script that diffs between my PR branch and the official package provided from the [SQLite website](https://www.sqlite.org/download.html).
```bash
#!/bin/bash

SQLITE_UPDATE_VERSION=3.38.5
SQLITE_PATH_NAME=sqlite-$SQLITE_UPDATE_VERSION

GIT_REPO_BRANCH=vendor/sqlite-$SQLITE_UPDATE_VERSION
GIT_REPO_URL=https://github.com/multitheftauto/mtasa-blue.git
GIT_REPO_SQLITE_PATH=vendor/sqlite/

echo 1. Download and extract $SQLITE_PATH_NAME...
curl https://www.sqlite.org/2022/sqlite-autoconf-3380500.tar.gz | tar -xz

echo 2. Fetch and checkout the vendor update branch $GIT_REPO_BRANCH from $GIT_REPO_URL...
git fetch $GIT_REPO_URL $GIT_REPO_BRANCH:$GIT_REPO_BRANCH
git checkout $GIT_REPO_BRANCH

echo 3. Start checking integrity...
diff -r --strip-trailing-cr $GIT_REPO_SQLITE_PATH sqlite-*

echo 4. Completed.
exec $SHELL
```

## Past SQLite updates in MTA
| Date | From | To | Link |
| :--- | :--- | :--- | :--- |
| April 2022 | 3.37.2 | 3.38.2 (current) | #2582 |
| January 2022 | 3.36.0 | 3.37.2 | #2503 |
| August 2021 | 3.35.5 | 3.36.0 | #2284 |
| June 2021 | 3.35.2 | 3.35.5 | #2245 |
| March 2021 | 3.34.0 | 3.35.2 | #2142 |
| December 2020 | 3.32.3 | 3.34.0 | #1960 |
| July 2020 | 3.31.1 | 3.32.3 | #1561 |
| March 2020 | 3.30.1 | 3.31.1 | #1260 |
| November 2019 | 3.29.0 | 3.30.1 | #1160 |
| August 2019 | 3.28.0 | 3.29.0 | #1028 |
| May 2019 | 3.27.1 | 3.28.0 | #913 |
| February 2019 | 3.24.0 | 3.27.1 | #818 |
| July 2018 | 3.13.0 | 3.24.0 | #245 |
| August 2016 | 3.7.17 | 3.13.0 | 3aa17532867c66818cc3a602c4b1ac2143694066 |
| August 2013 | 3.7.8 | 3.7.17 | fd195b799498f75496fe0c15adac3cab3aecb639 |
| October 2011 | 3.6.14 | 3.7.8 | ca063630631d56d5ba9aba5bf6771fe0299f5a9f |

## Changelog

### 3.38.3 (2022-04-27)
- Fix a case of the query planner be overly aggressive with optimizing automatic-index and Bloom-filter construction, using inappropriate ON clause terms to restrict the size of the automatic-index or Bloom filter, and resulting in missing rows in the output. [Forum thread 0d3200f4f3bcd3a3](https://sqlite.org/forum/forumpost/0d3200f4f3bcd3a3).
- Other minor patches. See the [timeline](https://sqlite.org/src/timeline?p=version-3.38.3&bt=version-3.38.2) for details.

### 3.38.4 (2022-05-04)
- Fix a byte-code problem in the Bloom filter pull-down optimization added by release 3.38.0 in which an error in the byte code causes the byte code engine to enter an infinite loop when the pull-down optimization encounters a NULL key. [Forum thread 2482b32700384a0f](https://sqlite.org/forum/forumpost/2482b32700384a0f).
- Other minor patches. See the [timeline](https://sqlite.org/src/timeline?p=branch-3.38&bt=version-3.38.3) for details.

### 3.38.5 (2022-05-06)
- None