### PR TITLE
Fix onPedDamage event

### DIFF
--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -1580,6 +1580,7 @@ void CGame::AddBuiltInEvents()
     m_Events.AddEvent("onPedVehicleExit", "vehicle, reason, jacker", NULL, false);
     m_Events.AddEvent("onPedWasted", "ammo, killer, weapon, bodypart", NULL, false);
     m_Events.AddEvent("onPedWeaponSwitch", "previous, current", NULL, false);
+    m_Events.AddEvent("onPedDamage", "loss", NULL, false);
 
     // Element events
     m_Events.AddEvent("onElementColShapeHit", "colshape, matchingDimension", NULL, false);


### PR DESCRIPTION
When merged, this PR will register [onPedDamage](https://wiki.multitheftauto.com/wiki/OnPedDamage) event
https://github.com/multitheftauto/mtasa-blue/blob/4dac0e237865e5d13927b42c1c93b69b1eb9a401/Server/mods/deathmatch/logic/CPedSync.cpp#L245-L248
As we can see, the event was always called. But since the event is not registered, you cannot add an event handler unless you manually register it using [addEvent](https://wiki.multitheftauto.com/wiki/AddEvent). This PR will fix it.