### PR TITLE
Update user agent for youtube.com/tv

### DIFF
--- a/Client/cefweb/CWebView.cpp
+++ b/Client/cefweb/CWebView.cpp
@@ -846,7 +846,7 @@ CefResourceRequestHandler::ReturnValue CWebView::OnBeforeResourceLoad(CefRefPtr<
 
             // Allow YouTube TV to work (#1162)
             if (domain == "www.youtube.com" && UTF16ToMbUTF8(urlParts.path.str) == "/tv")
-                iter->second = iter->second.ToString() + "; SMART-TV; Tizen 4.0";
+                iter->second = iter->second.ToString() + "; Roku 3/7.0";
 
             request->SetHeaderMap(headerMap);
         }


### PR DESCRIPTION
Youtube has once again changed their platform so it no longer supports video resume for most user agents, however roku user agent seems to still work fine with no problems similar to the old user agent.