### PR TITLE
Fix disappearing of server browser search input

### DIFF
--- a/Client/core/ServerBrowser/CServerBrowser.cpp
+++ b/Client/core/ServerBrowser/CServerBrowser.cpp
@@ -761,6 +761,9 @@ void CServerBrowser::SetVisible(bool bVisible)
         m_pEditAddress[Type]->Activate();
         m_pEditAddress[Type]->SetCaretAtEnd();
 
+        // Make sure search box is visible
+        m_pEditSearch[Type]->SetVisible(true);
+
         // Flash search box if it is not empty
         for (uint i = 0; i < SERVER_BROWSER_TYPE_COUNT; i++)
         {

--- a/Client/core/ServerBrowser/CServerBrowser.cpp
+++ b/Client/core/ServerBrowser/CServerBrowser.cpp
@@ -761,9 +761,6 @@ void CServerBrowser::SetVisible(bool bVisible)
         m_pEditAddress[Type]->Activate();
         m_pEditAddress[Type]->SetCaretAtEnd();
 
-        // Make sure search box is visible
-        m_pEditSearch[Type]->SetVisible(true);
-
         // Flash search box if it is not empty
         for (uint i = 0; i < SERVER_BROWSER_TYPE_COUNT; i++)
         {
@@ -777,6 +774,11 @@ void CServerBrowser::SetVisible(bool bVisible)
         m_pGeneralHelpWindow->SetVisible(false);
         m_pQuickConnectHelpWindow->SetVisible(false);
         CServerInfo::GetSingletonPtr()->Hide();
+
+        for (uint i = 0; i < SERVER_BROWSER_TYPE_COUNT; i++)
+        {
+            m_FlashSearchBox[i].uiCount = 0;
+        }
     }
 }
 


### PR DESCRIPTION
This is a test fix for #2644. Hard to say if it really work because it's random and quite rare bug.

There is some logic which makes search input flash after player type something in it, close server browser and then open it again to give signal to player that server list is being filtered:
https://github.com/multitheftauto/mtasa-blue/blob/16769b8d1c94e2b9fe6323dcba46d1305f87a190/Client/core/ServerBrowser/CServerBrowser.cpp#L704-L712

Stuff in `m_FlashSearchBox` is not being cleared after closing server browser while `CServerBrowser::Update()` is being called even if server browser is closed so I think it might be race condition.