### PR TITLE
GameSA inline assembly cleanup

### DIFF
--- a/Client/game_sa/C3DMarkerSA.cpp
+++ b/Client/game_sa/C3DMarkerSA.cpp
@@ -148,13 +148,8 @@ VOID C3DMarkerSA::DeleteMarkerObject()
 {
     if (this->GetInterface()->m_pRwObject)
     {
-        DWORD dwFunc = FUNC_DeleteMarkerObject;
-        DWORD dwThis = (DWORD)this->GetInterface();
-        _asm
-        {
-            mov     ecx, dwThis
-            call    dwFunc
-        }
+        // C3DMarkers::DeleteMarkerObject
+        ((void(__thiscall*)(C3DMarkerSAInterface*))FUNC_DeleteMarkerObject)(this->GetInterface());
 
         // OutputDebugString ( "Object destroyed!" );
     }

--- a/Client/game_sa/C3DMarkersSA.cpp
+++ b/Client/game_sa/C3DMarkersSA.cpp
@@ -38,59 +38,16 @@ C3DMarker* C3DMarkersSA::CreateMarker(DWORD Identifier, e3DMarkerType dwType, CV
     unsigned short nPeriod, float fPulseFrac, short nRotRate, float normalX = 0.0f,
     float normalY = 0.0f, float normalZ = 0.0f, bool zCheck = FALSE);
     */
-    WORD wType = dwType;
-    dwType = (e3DMarkerType)wType;
-    bool bZCheck = true;
 
-    DWORD dwFunc = FUNC_PlaceMarker;
-    DWORD dwReturn = 0;
-    _asm
-    {
-        push    bZCheck     // zCheck  ##SA##
-        push    0           // normalZ ##SA##
-        push    0           // normalY ##SA##
-        push    0           // normalX ##SA##
-        push    0           // rotate rate
-        push    fPulseFraction      // pulse
-        push    0           // period
-        push    a           // alpha
-        push    b           // blue
-        push    g           // green
-        push    r           // red
-        push    fSize       // size
-        push    vecPosition // position
-        push    dwType      // type
-        push    Identifier  // identifier
-        call    dwFunc
-        mov     dwReturn, eax
-        add     esp, 0x3C
-    }
-    /*
-        DWORD dwFunc = 0x0726D40;
-        DWORD dwReturn = 0;
-        _asm
-        {
-            push    0           // uses collision
-            push    5           // rotate rate
-            push    0x3F800000  // pulse (1.0)
-            push    1024        // period
-            push    255         // alpha
-            push    0           // blue
-            push    255         // green
-            push    255         // red
-            push    0x40000000      // size (2.0)
-            push    vecPosition // position
-            push    Identifier  // identifier
-            call    dwFunc
-            mov     dwReturn, eax
-            add     esp, 0x2C
-        }
-        */
-    if (dwReturn)
+    // C3DMarkers::PlaceMarker
+    C3DMarkerSAInterface* marker = ((C3DMarkerSAInterface * (__cdecl*)(unsigned int, unsigned short, CVector&, float, unsigned char, unsigned char,
+                                                                       unsigned char, unsigned char, unsigned short, float, short, float, float, float, bool))
+                                        FUNC_PlaceMarker)(Identifier, dwType, *vecPosition, fSize, r, g, b, a, 0, fPulseFraction, 0, 0.0f, 0.0f, 0.0f, true);
+    if (marker)
     {
         for (int i = 0; i < MAX_3D_MARKERS; i++)
         {
-            if (Markers[i]->GetInterface() == (C3DMarkerSAInterface*)dwReturn)
+            if (Markers[i]->GetInterface() == marker)
             {
                 // Markers[i]->Reset(); // debug stuff
                 return Markers[i];

--- a/Client/game_sa/CAEAudioHardwareSA.cpp
+++ b/Client/game_sa/CAEAudioHardwareSA.cpp
@@ -18,33 +18,14 @@ CAEAudioHardwareSA::CAEAudioHardwareSA(CAEAudioHardwareSAInterface* pInterface)
 
 bool CAEAudioHardwareSA::IsSoundBankLoaded(short wSoundBankID, short wSoundBankSlotID)
 {
-    DWORD dwSoundBankID = wSoundBankID;
-    DWORD dwSoundBankSlotID = wSoundBankSlotID;
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAEAudioHardware__IsSoundBankLoaded;
-    bool  bReturn = false;
-    _asm
-    {
-        push    dwSoundBankSlotID
-        push    dwSoundBankID
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CAEAudioHardware::IsSoundBankLoaded
+    return ((bool(__thiscall*)(CAEAudioHardwareSAInterface*, unsigned short, short))FUNC_CAEAudioHardware__IsSoundBankLoaded)(m_pInterface, wSoundBankID,
+                                                                                                                              wSoundBankSlotID);
 }
 
 void CAEAudioHardwareSA::LoadSoundBank(short wSoundBankID, short wSoundBankSlotID)
 {
-    DWORD dwSoundBankID = wSoundBankID;
-    DWORD dwSoundBankSlotID = wSoundBankSlotID;
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAEAudioHardware__LoadSoundBank;
-    _asm
-    {
-        push    dwSoundBankSlotID
-        push    dwSoundBankID
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CAEAudioHardware::LoadSoundBank
+    ((void(__thiscall*)(CAEAudioHardwareSAInterface*, unsigned short, short))FUNC_CAEAudioHardware__LoadSoundBank)(m_pInterface, wSoundBankID,
+                                                                                                                   wSoundBankSlotID);
 }

--- a/Client/game_sa/CAERadioTrackManagerSA.cpp
+++ b/Client/game_sa/CAERadioTrackManagerSA.cpp
@@ -14,102 +14,55 @@
 BYTE CAERadioTrackManagerSA::GetCurrentRadioStationID()
 {
     DEBUG_TRACE("BYTE CAERadioTrackManagerSA::GetCurrentRadioStationID()");
-    DWORD dwFunc = FUNC_GetCurrentRadioStationID;
-    BYTE  bReturn = 0;
-    _asm
-    {
-        mov     ecx, CLASS_CAERadioTrackManager
-        call    dwFunc
-        mov     bReturn, al
-    }
 
-    return bReturn;
+    // CAERadioTrackManager::GetCurrentRadioStationID
+    return ((BYTE(__thiscall*)(int))FUNC_GetCurrentRadioStationID)(CLASS_CAERadioTrackManager);
 }
 
 BYTE CAERadioTrackManagerSA::IsVehicleRadioActive()
 {
     DEBUG_TRACE("BYTE CAERadioTrackManagerSA::IsVehicleRadioActive()");
-    DWORD dwFunc = FUNC_IsVehicleRadioActive;
-    BYTE  bReturn = 0;
-    _asm
-    {
-        mov     ecx, CLASS_CAERadioTrackManager
-        call    dwFunc
-        mov     bReturn, al
-    }
 
-    return bReturn;
+    // CAERadioTrackManager::IsVehicleRadioActive
+    return ((bool(__thiscall*)(int))FUNC_IsVehicleRadioActive)(CLASS_CAERadioTrackManager);
 }
 
 char* CAERadioTrackManagerSA::GetRadioStationName(BYTE bStationID)
 {
     DEBUG_TRACE("char * CAERadioTrackManagerSA::GetRadioStationName(BYTE bStationID)");
-    DWORD dwFunc = FUNC_GetRadioStationName;
-    char* cReturn = 0;
-    DWORD dwStationID = bStationID;
-    _asm
-    {
-        mov     ecx, CLASS_CAERadioTrackManager
-        push    dwStationID
-        call    dwFunc
-        mov     cReturn, eax
-    }
 
-    return cReturn;
+    // CAERadioTrackManager::GetRadioStationName
+    return ((char*(__thiscall*)(int, char))FUNC_GetRadioStationName)(CLASS_CAERadioTrackManager, bStationID);
 }
 
 BOOL CAERadioTrackManagerSA::IsRadioOn()
 {
     DEBUG_TRACE("BOOL CAERadioTrackManagerSA::IsRadioOn()");
-    DWORD dwFunc = FUNC_IsRadioOn;
-    BYTE  bReturn = 0;
-    _asm
-    {
-        mov     ecx, CLASS_CAERadioTrackManager
-        call    dwFunc
-        mov     bReturn, al
-    }
 
-    return bReturn;
+    // CAERadioTrackManager::IsRadioOn
+    return ((bool(__thiscall*)(int))FUNC_IsRadioOn)(CLASS_CAERadioTrackManager);
 }
 
 VOID CAERadioTrackManagerSA::SetBassSetting(DWORD dwBass)
 {
     DEBUG_TRACE("VOID CAERadioTrackManagerSA::SetBassSetting(DWORD dwBass)");
-    DWORD dwFunc = FUNC_SetBassSetting;
-    _asm
-    {
-        mov     ecx, CLASS_CAERadioTrackManager
-        push    0x3F800000 // 1.0f
-        push    dwBass
-        call    dwFunc
-    }
+
+    // CAERadioTrackManager::SetBassSetting
+    ((void(__thiscall*)(int, char, float))FUNC_SetBassSetting)(CLASS_CAERadioTrackManager, dwBass, 1.0f);
 }
 
 VOID CAERadioTrackManagerSA::Reset()
 {
     DEBUG_TRACE("VOID CAERadioTrackManagerSA::Reset()");
-    DWORD dwFunc = FUNC_Reset;
-    _asm
-    {
-        mov     ecx, CLASS_CAERadioTrackManager
-        call    dwFunc
-    }
+
+    // CAERadioTrackManager::Reset
+    ((void(__thiscall*)(int))FUNC_Reset)(CLASS_CAERadioTrackManager);
 }
 
 VOID CAERadioTrackManagerSA::StartRadio(BYTE bStationID, BYTE bUnknown)
 {
     DEBUG_TRACE("VOID CAERadioTrackManagerSA::StartRadio(BYTE bStationID, BYTE bUnknown)");
-    DWORD dwFunc = FUNC_StartRadio;
-    DWORD dwStationID = bStationID;
-    DWORD dwUnknown = bUnknown;
-    _asm
-    {
-        mov     ecx, CLASS_CAERadioTrackManager
-        push    0
-        push    0
-        push    dwUnknown
-        push    dwStationID
-        call    dwFunc
-    }
+
+    // CAERadioTrackManager::StartRadio
+    ((void(__thiscall*)(int, char, char, float, unsigned char))FUNC_StartRadio)(CLASS_CAERadioTrackManager, bStationID, bUnknown, 0, 0);
 }

--- a/Client/game_sa/CAEVehicleAudioEntitySA.cpp
+++ b/Client/game_sa/CAEVehicleAudioEntitySA.cpp
@@ -19,49 +19,31 @@ CAEVehicleAudioEntitySA::CAEVehicleAudioEntitySA(CAEVehicleAudioEntitySAInterfac
 void CAEVehicleAudioEntitySA::JustGotInVehicleAsDriver()
 {
     m_pInterface->m_bPlayerDriver = true;
-    DWORD dwFunc = FUNC_CAEVehicleAudioEntity__JustGotInVehicleAsDriver;
-    DWORD dwThis = (DWORD)m_pInterface;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+
+    // CAEVehicleAudioEntity::JustGotInVehicleAsDriver
+    ((void(__thiscall*)(CAEVehicleAudioEntitySAInterface*))FUNC_CAEVehicleAudioEntity__JustGotInVehicleAsDriver)(m_pInterface);
 }
 
 void CAEVehicleAudioEntitySA::JustGotOutOfVehicleAsDriver()
 {
     m_pInterface->m_bPlayerDriver = false;
-    DWORD dwFunc = FUNC_CAEVehicleAudioEntity__JustGotOutOfVehicleAsDriver;
-    DWORD dwThis = (DWORD)m_pInterface;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+
+    // CAEVehicleAudioEntity::JustGotInVehicleAsDriver
+    ((void(__thiscall*)(CAEVehicleAudioEntitySAInterface*))FUNC_CAEVehicleAudioEntity__JustGotOutOfVehicleAsDriver)(m_pInterface);
 }
 
 void CAEVehicleAudioEntitySA::TurnOnRadioForVehicle()
 {
-    DWORD dwFunc = FUNC_CAEVehicleAudioEntity__TurnOnRadioForVehicle;
-    DWORD dwThis = (DWORD)m_pInterface;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CAEVehicleAudioEntity::TurnOnRadioForVehicle
+    ((void(__thiscall*)(CAEVehicleAudioEntitySAInterface*))FUNC_CAEVehicleAudioEntity__TurnOnRadioForVehicle)(m_pInterface);
 }
 
 void CAEVehicleAudioEntitySA::StopVehicleEngineSound(unsigned char ucSlot)
 {
-    DWORD          dwFunc = FUNC_CAESound__Stop;
     tVehicleSound* pVehicleSound = &m_pInterface->m_aEngineSounds[ucSlot];
     if (pVehicleSound->m_pSound)
     {
-        DWORD dwThis = (DWORD)pVehicleSound->m_pSound;
-        _asm
-        {
-            mov     ecx, dwThis
-            call    dwFunc
-        }
+        // CAESound::Stop
+        ((void(__thiscall*)(CAESound*))FUNC_CAESound__Stop)(pVehicleSound->m_pSound);
     }
 }

--- a/Client/game_sa/CAnimBlendAssocGroupSA.cpp
+++ b/Client/game_sa/CAnimBlendAssocGroupSA.cpp
@@ -20,58 +20,27 @@ CAnimBlendAssocGroupSA::CAnimBlendAssocGroupSA(CAnimBlendAssocGroupSAInterface* 
 
 CAnimBlendAssociationSAInterface* CAnimBlendAssocGroupSA::CopyAnimation(unsigned int AnimID)
 {
-    CAnimBlendAssociationSAInterface* pAnimAssociationReturn = nullptr;
-
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAnimBlendAssocGroup_CopyAnimation;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    AnimID
-        call    dwFunc
-        mov     pAnimAssociationReturn, eax
-    }
-    return pAnimAssociationReturn;
+    // CAnimBlendAssocGroup::CopyAnimation
+    return ((CAnimBlendAssociationSAInterface * (__thiscall*)(CAnimBlendAssocGroupSAInterface*, unsigned int)) FUNC_CAnimBlendAssocGroup_CopyAnimation)(
+        m_pInterface, AnimID);
 }
 
 void CAnimBlendAssocGroupSA::InitEmptyAssociations(RpClump* pClump)
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAnimBlendAssocGroup_InitEmptyAssociations;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    pClump
-        call    dwFunc
-    }
+    // CAnimBlendAssocGroup::InitEmptyAssociations
+    return ((void(__thiscall*)(CAnimBlendAssocGroupSAInterface*, RpClump*))FUNC_CAnimBlendAssocGroup_InitEmptyAssociations)(m_pInterface, pClump);
 }
 
 bool CAnimBlendAssocGroupSA::IsCreated()
 {
-    bool  bReturn;
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAnimBlendAssocGroup_IsCreated;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CAnimBlendAssocGroup::IsCreated
+    return ((bool(__thiscall*)(CAnimBlendAssocGroupSAInterface*))FUNC_CAnimBlendAssocGroup_IsCreated)(m_pInterface);
 }
 
 int CAnimBlendAssocGroupSA::GetNumAnimations()
 {
-    int   iReturn;
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAnimBlendAssocGroup_GetNumAnimations;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     iReturn, eax
-    }
-    return iReturn;
+    // CAnimBlendAssocGroup::GetNumAnimations
+    return ((int(__thiscall*)(CAnimBlendAssocGroupSAInterface*))FUNC_CAnimBlendAssocGroup_GetNumAnimations)(m_pInterface);
 }
 
 CAnimBlock* CAnimBlendAssocGroupSA::GetAnimBlock()
@@ -83,18 +52,9 @@ CAnimBlock* CAnimBlendAssocGroupSA::GetAnimBlock()
 
 CAnimBlendStaticAssociation* CAnimBlendAssocGroupSA::GetAnimation(unsigned int ID)
 {
-    // ppAssociations [ ID - this->iIDOffset ] ??
-    CAnimBlendStaticAssociation* pReturn;
-    DWORD                        dwThis = (DWORD)m_pInterface;
-    DWORD                        dwFunc = FUNC_CAnimBlendAssocGroup_GetAnimation;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    ID
-        call    dwFunc
-        mov     pReturn, eax
-    }
-    return pReturn;
+    // CAnimBlendAssocGroup::GetAnimation
+    return ((CAnimBlendStaticAssociation * (__thiscall*)(CAnimBlendAssocGroupSAInterface*, unsigned int)) FUNC_CAnimBlendAssocGroup_GetAnimation)(m_pInterface,
+                                                                                                                                                  ID);
 }
 
 eAnimGroup CAnimBlendAssocGroupSA::GetGroupID()
@@ -117,14 +77,8 @@ bool CAnimBlendAssocGroupSA::IsLoaded()
 
 void CAnimBlendAssocGroupSA::CreateAssociations(const char* szBlockName)
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAnimBlendAssocGroup_CreateAssociations;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    szBlockName
-        call    dwFunc
-    }
+    // CAnimBlendAssocGroup::CreateAssociations
+    ((void(__thiscall*)(CAnimBlendAssocGroupSAInterface*, const char*))FUNC_CAnimBlendAssocGroup_CreateAssociations)(m_pInterface, szBlockName);
 }
 
 void CAnimBlendAssocGroupSA::SetupAnimBlock()

--- a/Client/game_sa/CAnimBlendAssociationSA.cpp
+++ b/Client/game_sa/CAnimBlendAssociationSA.cpp
@@ -26,27 +26,16 @@ AnimBlendFrameData* CAnimBlendClumpDataSAInterface::GetFrameDataByNodeId(unsigne
 
 CAnimBlendAssociationSAInterface* CAnimBlendAssociationSA::Constructor(CAnimBlendStaticAssociationSAInterface& staticAssociationByReference)
 {
-    DWORD DwFunc = 0x4CF080;
-    DWORD DwThisInterface = reinterpret_cast<DWORD>(m_pInterface);
-    _asm
-    {
-        mov     ecx, DwThisInterface
-        push    staticAssociationByReference
-        call    DwFunc
-    };
+    // CAnimBlendAssociation::CAnimBlendAssociation
+    return ((CAnimBlendAssociationSAInterface * (__thiscall*)(CAnimBlendAssociationSAInterface*, CAnimBlendStaticAssociationSAInterface&))0x4CF080)(
+        m_pInterface, staticAssociationByReference);
 }
 
 CAnimBlendAssociationSAInterface* CAnimBlendAssociationSA::Constructor(RpClump* pClump, CAnimBlendHierarchySAInterface* pAnimHierarchy)
 {
-    DWORD DwFunc = 0x4CEFC0;
-    DWORD DwThisInterface = reinterpret_cast<DWORD>(m_pInterface);
-    _asm
-    {
-        mov     ecx, DwThisInterface
-        push    pAnimHierarchy
-        push    pClump
-        call    DwFunc
-    };
+    // CAnimBlendAssociation::CAnimBlendAssociation
+    return ((CAnimBlendAssociationSAInterface * (__thiscall*)(CAnimBlendAssociationSAInterface*, RpClump*, CAnimBlendHierarchySAInterface*))0x4CEFC0)(
+        m_pInterface, pClump, pAnimHierarchy);
 }
 
 CAnimBlendAssociationSAInterface* CAnimBlendAssociationSA::InitializeForCustomAnimation(RpClump* pClump, CAnimBlendHierarchySAInterface* pAnimHierarchy)
@@ -70,38 +59,20 @@ CAnimBlendAssociationSAInterface* CAnimBlendAssociationSA::InitializeForCustomAn
 
 void CAnimBlendAssociationSA::Init(RpClump* pClump, CAnimBlendHierarchySAInterface* pAnimHierarchy)
 {
-    DWORD DwFunc = 0x4CED50;
-    DWORD DwThisInterface = reinterpret_cast<DWORD>(m_pInterface);
-    _asm
-    {
-        mov     ecx, DwThisInterface
-        push    pAnimHierarchy
-        push    pClump
-        call    DwFunc
-    };
+    // CAnimBlendAssociation::Init
+    ((void(__thiscall*)(CAnimBlendAssociationSAInterface*, RpClump*, CAnimBlendHierarchySAInterface*))0x4CED50)(m_pInterface, pClump, pAnimHierarchy);
 }
 
 void CAnimBlendAssociationSA::AllocateAnimBlendNodeArray(int iCount)
 {
-    DWORD DwFunc = 0x4CE9F0;
-    DWORD DwThisInterface = reinterpret_cast<DWORD>(m_pInterface);
-    _asm
-    {
-        mov     ecx, DwThisInterface
-        push    iCount
-        call    DwFunc
-    };
+    // CAnimBlendAssociation::AllocateAnimBlendNodeArray
+    ((void(__thiscall*)(CAnimBlendAssociationSAInterface*, int))0x4CE9F0)(m_pInterface, iCount);
 }
 
 void CAnimBlendAssociationSA::FreeAnimBlendNodeArray()
 {
-    DWORD DwFunc = 0x4CEA40;
-    DWORD DwThisInterface = reinterpret_cast<DWORD>(m_pInterface);
-    _asm
-    {
-        mov     ecx, DwThisInterface
-        call    DwFunc
-    };
+    // CAnimBlendAssociation::FreeAnimBlendNodeArray
+    ((void(__thiscall*)(CAnimBlendAssociationSAInterface*))0x4CEA40)(m_pInterface);
 }
 
 std::unique_ptr<CAnimBlendHierarchy> CAnimBlendAssociationSA::GetAnimHierarchy()
@@ -113,12 +84,6 @@ void CAnimBlendAssociationSA::SetCurrentProgress(float fProgress)
 {
     float fTime = m_pInterface->pAnimHierarchy->fTotalTime * fProgress;
 
-    DWORD DwFunc = 0x4CEA80;
-    DWORD DwThisInterface = reinterpret_cast<DWORD>(m_pInterface);
-    _asm
-    {
-        mov     ecx, DwThisInterface
-        push    fTime
-        call    DwFunc
-    };
+    // CAnimBlendAssociation::SetCurrentProgress
+    ((void(__thiscall*)(CAnimBlendAssociationSAInterface*, float))0x4CEA80)(m_pInterface, fProgress);
 }

--- a/Client/game_sa/CAnimBlendHierarchySA.cpp
+++ b/Client/game_sa/CAnimBlendHierarchySA.cpp
@@ -30,58 +30,32 @@ void CAnimBlendHierarchySA::Initialize()
 
 void CAnimBlendHierarchySA::SetName(const char* szName)
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAnimBlendHierarchy_SetName;
-    _asm
-    {
-        push    szName
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CAnimBlendHierarchy::SetName
+    ((void(__thiscall*)(CAnimBlendHierarchySAInterface*, const char*))FUNC_CAnimBlendHierarchy_SetName)(m_pInterface, szName);
 }
 
 void CAnimBlendHierarchySA::RemoveAnimSequences()
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAnimBlendHierarchy_RemoveAnimSequences;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CAnimBlendHierarchy::RemoveAnimSequences
+    ((void(__thiscall*)(CAnimBlendHierarchySAInterface*))FUNC_CAnimBlendHierarchy_RemoveAnimSequences)(m_pInterface);
 }
 
 void CAnimBlendHierarchySA::RemoveFromUncompressedCache()
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAnimBlendHierarchy_RemoveFromUncompressedCache;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CAnimBlendHierarchy::RemoveFromUncompressedCache
+    ((void(__thiscall*)(CAnimBlendHierarchySAInterface*))FUNC_CAnimBlendHierarchy_RemoveFromUncompressedCache)(m_pInterface);
 }
 
 void CAnimBlendHierarchySA::RemoveQuaternionFlips()
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAnimBlendHierarchy_RemoveQuaternionFlips;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CAnimBlendHierarchy::RemoveQuaternionFlips
+    ((void(__thiscall*)(CAnimBlendHierarchySAInterface*))FUNC_CAnimBlendHierarchy_RemoveQuaternionFlips)(m_pInterface);
 }
 
 void CAnimBlendHierarchySA::CalculateTotalTime()
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAnimBlendHierarchy_CalculateTotalTime;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CAnimBlendHierarchy::CalculateTotalTime
+    ((void(__thiscall*)(CAnimBlendHierarchySAInterface*))FUNC_CAnimBlendHierarchy_CalculateTotalTime)(m_pInterface);
 }
 
 CAnimBlendSequenceSAInterface* CAnimBlendHierarchySA::GetSequence(DWORD dwIndex)

--- a/Client/game_sa/CAnimBlendSequenceSA.cpp
+++ b/Client/game_sa/CAnimBlendSequenceSA.cpp
@@ -21,41 +21,21 @@ void CAnimBlendSequenceSA::Initialize()
 
 void CAnimBlendSequenceSA::SetName(const char* szName)
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAnimBlendSequence_SetName;
-    _asm
-    {
-        push    szName
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CAnimBlendSequence::SetName
+    ((void(__thiscall*)(CAnimBlendSequenceSAInterface*))FUNC_CAnimBlendSequence_SetName)(m_pInterface);
 }
 
 void CAnimBlendSequenceSA::SetBoneTag(int32_t i32BoneID)
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAnimBlendSequence_SetBoneTag;
-    _asm
-    {
-        push    i32BoneID
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CAnimBlendSequence::SetBoneTag
+    ((void(__thiscall*)(CAnimBlendSequenceSAInterface*, int))FUNC_CAnimBlendSequence_SetBoneTag)(m_pInterface, i32BoneID);
 }
 
 void CAnimBlendSequenceSA::SetKeyFrames(size_t cKeyFrames, bool bRoot, bool bCompressed, void* pKeyFrames)
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAnimBlendSequence_SetKeyFrames;
-    _asm
-    {
-        push    pKeyFrames
-        push    bCompressed
-        push    bRoot
-        push    cKeyFrames
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CAnimBlendSequence::SetKeyFrames
+    ((void(__thiscall*)(CAnimBlendSequenceSAInterface*, size_t, bool, bool, void*))FUNC_CAnimBlendSequence_SetKeyFrames)(m_pInterface, cKeyFrames, bRoot,
+                                                                                                                         bCompressed, pKeyFrames);
 }
 
 void CAnimBlendSequenceSA::CopySequenceProperties(CAnimBlendSequenceSAInterface* pAnimSequenceInterface)

--- a/Client/game_sa/CAnimBlendStaticAssociationSA.cpp
+++ b/Client/game_sa/CAnimBlendStaticAssociationSA.cpp
@@ -13,13 +13,7 @@
 
 void CAnimBlendStaticAssociationSA::Initialize(RpClump* pClump, CAnimBlendHierarchySAInterface* pAnimBlendHierarchyInterface)
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAnimBlendStaticAssociation_Initialize;
-    _asm
-    {
-        push    pAnimBlendHierarchyInterface
-        push    pClump
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CAnimBlendStaticAssociation::Initialize
+    ((void(__thiscall*)(CAnimBlendStaticAssociationSAInterface*, RpClump*, CAnimBlendHierarchySAInterface*))FUNC_CAnimBlendStaticAssociation_Initialize)(
+        m_pInterface, pClump, pAnimBlendHierarchyInterface);
 }

--- a/Client/game_sa/CAnimManagerSA.cpp
+++ b/Client/game_sa/CAnimManagerSA.cpp
@@ -31,20 +31,14 @@ CAnimManagerSA::~CAnimManagerSA()
 
 void CAnimManagerSA::Initialize()
 {
-    DWORD dwFunc = FUNC_CAnimManager_Initialize;
-    _asm
-    {
-        call    dwFunc
-    }
+    // CAnimManager::Initialize
+    ((void(__cdecl*)())FUNC_CAnimManager_Initialize)();
 }
 
 void CAnimManagerSA::Shutdown()
 {
-    DWORD dwFunc = FUNC_CAnimManager_Shutdown;
-    _asm
-    {
-        call    dwFunc
-    }
+    // CAnimManager::Shutdown
+    ((void(__cdecl*)())FUNC_CAnimManager_Shutdown)();
 }
 
 int CAnimManagerSA::GetNumAnimations()
@@ -65,14 +59,10 @@ int CAnimManagerSA::GetNumAnimAssocDefinitions()
 std::unique_ptr<CAnimBlendHierarchy> CAnimManagerSA::GetAnimation(int ID)
 {
     CAnimBlendHierarchySAInterface* pInterface = nullptr;
-    DWORD                           dwFunc = FUNC_CAnimManager_GetAnimation_int;
-    _asm
-    {
-        push    ID
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x4
-    }
+
+    // CAnimManager::GetAnimation
+    pInterface = ((CAnimBlendHierarchySAInterface * (__cdecl*)(int)) FUNC_CAnimManager_GetAnimation_int)(ID);
+
     if (pInterface)
     {
         return std::make_unique<CAnimBlendHierarchySA>(pInterface);
@@ -83,16 +73,11 @@ std::unique_ptr<CAnimBlendHierarchy> CAnimManagerSA::GetAnimation(int ID)
 std::unique_ptr<CAnimBlendHierarchy> CAnimManagerSA::GetAnimation(const char* szName, std::unique_ptr<CAnimBlock>& pBlock)
 {
     CAnimBlendHierarchySAInterface* pInterface = nullptr;
-    DWORD                           dwFunc = FUNC_CAnimManager_GetAnimation_str_block;
-    CAnimBlockSAInterface*          pBlockInterface = pBlock->GetInterface();
-    _asm
-    {
-        push    pBlockInterface
-        push    szName
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x8
-    }
+
+    // CAnimManager::GetAnimation
+    pInterface = ((CAnimBlendHierarchySAInterface * (__cdecl*)(const char*, CAnimBlockSAInterface*)) FUNC_CAnimManager_GetAnimation_str_block)(
+        szName, pBlock->GetInterface());
+
     if (pInterface)
     {
         return std::make_unique<CAnimBlendHierarchySA>(pInterface);
@@ -103,17 +88,11 @@ std::unique_ptr<CAnimBlendHierarchy> CAnimManagerSA::GetAnimation(const char* sz
 std::unique_ptr<CAnimBlendHierarchy> CAnimManagerSA::GetAnimation(unsigned int uiIndex, std::unique_ptr<CAnimBlock>& pBlock)
 {
     CAnimBlendHierarchySAInterface* pInterface = nullptr;
-    ;
-    DWORD                  dwFunc = FUNC_CAnimManager_GetAnimation_int_block;
-    CAnimBlockSAInterface* pBlockInterface = pBlock->GetInterface();
-    _asm
-    {
-        push    pBlockInterface
-        push    uiIndex
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x8
-    }
+
+    // CAnimManager::GetAnimation
+    pInterface = ((CAnimBlendHierarchySAInterface * (__cdecl*)(unsigned int, CAnimBlockSAInterface*)) FUNC_CAnimManager_GetAnimation_int_block)(
+        uiIndex, pBlock->GetInterface());
+
     if (pInterface)
     {
         return std::make_unique<CAnimBlendHierarchySA>(pInterface);
@@ -124,14 +103,10 @@ std::unique_ptr<CAnimBlendHierarchy> CAnimManagerSA::GetAnimation(unsigned int u
 std::unique_ptr<CAnimBlock> CAnimManagerSA::GetAnimationBlock(int ID)
 {
     CAnimBlockSAInterface* pInterface = nullptr;
-    DWORD                  dwFunc = FUNC_CAnimManager_GetAnimationBlock_int;
-    _asm
-    {
-        push    ID
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x4
-    }
+
+    // CAnimManager::GetAnimationBlock
+    pInterface = ((CAnimBlockSAInterface * (__cdecl*)(int)) FUNC_CAnimManager_GetAnimationBlock_int)(ID);
+
     if (pInterface)
     {
         return std::make_unique<CAnimBlockSA>(pInterface);
@@ -142,14 +117,10 @@ std::unique_ptr<CAnimBlock> CAnimManagerSA::GetAnimationBlock(int ID)
 std::unique_ptr<CAnimBlock> CAnimManagerSA::GetAnimationBlock(const char* szName)
 {
     CAnimBlockSAInterface* pInterface = nullptr;
-    DWORD                  dwFunc = FUNC_CAnimManager_GetAnimationBlock_str;
-    _asm
-    {
-        push    szName
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x4
-    }
+
+    // CAnimManager::GetAnimationBlock
+    pInterface = ((CAnimBlockSAInterface * (__cdecl*)(const char*)) FUNC_CAnimManager_GetAnimationBlock_str)(szName);
+
     if (pInterface)
     {
         return std::make_unique<CAnimBlockSA>(pInterface);
@@ -159,43 +130,23 @@ std::unique_ptr<CAnimBlock> CAnimManagerSA::GetAnimationBlock(const char* szName
 
 int CAnimManagerSA::GetAnimationBlockIndex(const char* szName)
 {
-    int   iReturn;
-    DWORD dwFunc = FUNC_CAnimManager_GetAnimationBlockIndex;
-    _asm
-    {
-        push    szName
-        call    dwFunc
-        mov     iReturn, eax
-        add     esp, 0x4
-    }
-    return iReturn;
+    // CAnimManager::GetAnimationBlockIndex
+    return ((int(__cdecl*)(const char*))FUNC_CAnimManager_GetAnimationBlockIndex)(szName);
 }
 
 int CAnimManagerSA::RegisterAnimBlock(const char* szName)
 {
-    int   iReturn;
-    DWORD dwFunc = FUNC_CAnimManager_RegisterAnimBlock;
-    _asm
-    {
-        push    szName
-        call    dwFunc
-        mov     iReturn, eax
-        add     esp, 0x4
-    }
-    return iReturn;
+    // CAnimManager::RegisterAnimBlock
+    return ((int(__cdecl*)(const char*))FUNC_CAnimManager_RegisterAnimBlock)(szName);
 }
 
 std::unique_ptr<CAnimBlendAssocGroup> CAnimManagerSA::GetAnimBlendAssoc(AssocGroupId groupID)
 {
     CAnimBlendAssocGroupSAInterface* pInterface = nullptr;
-    DWORD                            dwFunc = FUNC_CAnimManager_GetAnimBlendAssoc;
-    _asm
-    {
-        push    groupID
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x4
-    }
+
+    // CAnimManager::GetAnimBlendAssoc
+    pInterface = ((CAnimBlendAssocGroupSAInterface * (__cdecl*)(AssocGroupId)) FUNC_CAnimManager_GetAnimBlendAssoc)(groupID);
+
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssocGroupSA>(pInterface);
@@ -205,58 +156,29 @@ std::unique_ptr<CAnimBlendAssocGroup> CAnimManagerSA::GetAnimBlendAssoc(AssocGro
 
 AssocGroupId CAnimManagerSA::GetFirstAssocGroup(const char* szName)
 {
-    AssocGroupId groupReturn;
-    DWORD        dwFunc = FUNC_CAnimManager_GetFirstAssocGroup;
-    _asm
-    {
-        push    szName
-        call    dwFunc
-        mov     groupReturn, eax
-        add     esp, 0x4
-    }
-    return groupReturn;
+    // CAnimManager::GetFirstAssocGroup
+    return ((AssocGroupId(__cdecl*)(const char*))FUNC_CAnimManager_GetFirstAssocGroup)(szName);
 }
 
 const char* CAnimManagerSA::GetAnimGroupName(AssocGroupId groupID)
 {
-    const char* szReturn;
-    DWORD       dwFunc = FUNC_CAnimManager_GetAnimGroupName;
-    _asm
-    {
-        push    groupID
-        call    dwFunc
-        mov     szReturn, eax
-        add     esp, 0x4
-    }
-    return szReturn;
+    // CAnimManager::GetAnimGroupName
+    return ((const char*(__cdecl*)(AssocGroupId))FUNC_CAnimManager_GetAnimGroupName)(groupID);
 }
 
 const char* CAnimManagerSA::GetAnimBlockName(AssocGroupId groupID)
 {
-    const char* szReturn;
-    DWORD       dwFunc = FUNC_CAnimManager_GetAnimBlockName;
-    _asm
-    {
-        push    groupID
-        call    dwFunc
-        mov     szReturn, eax
-        add     esp, 0x4
-    }
-    return szReturn;
+    // CAnimManager::GetAnimBlockName
+    return ((const char*(__cdecl*)(AssocGroupId))FUNC_CAnimManager_GetAnimBlockName)(groupID);
 }
 
 std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::CreateAnimAssociation(AssocGroupId animGroup, AnimationId animID)
 {
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
-    DWORD                             dwFunc = FUNC_CAnimManager_CreateAnimAssociation;
-    _asm
-    {
-        push    animID
-        push    animGroup
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x8
-    }
+
+    // CAnimManager::CreateAnimAssociation
+    pInterface = ((CAnimBlendAssociationSAInterface * (__cdecl*)(AssocGroupId, AnimationId)) FUNC_CAnimManager_CreateAnimAssociation)(animGroup, animID);
+
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -267,15 +189,10 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::CreateAnimAssociation(Ass
 CAnimManagerSA::StaticAssocIntface_type CAnimManagerSA::GetAnimStaticAssociation(eAnimGroup animGroup, eAnimID animID)
 {
     CAnimBlendStaticAssociationSAInterface* pInterface = nullptr;
-    DWORD                                   dwFunc = FUNC_CAnimManager_GetAnimAssociation;
-    _asm
-    {
-        push    animID
-        push    animGroup
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x8
-    }
+
+    // CAnimManager::GetAnimAssociation
+    pInterface = ((CAnimBlendStaticAssociationSAInterface * (__cdecl*)(eAnimGroup, eAnimID)) FUNC_CAnimManager_GetAnimAssociation)(animGroup, animID);
+
     if (pInterface)
     {
         return std::make_unique<CAnimBlendStaticAssociationSA>(pInterface);
@@ -286,15 +203,10 @@ CAnimManagerSA::StaticAssocIntface_type CAnimManagerSA::GetAnimStaticAssociation
 std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::GetAnimAssociation(AssocGroupId animGroup, const char* szAnimName)
 {
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
-    DWORD                             dwFunc = FUNC_CAnimManager_GetAnimAssociation_str;
-    _asm
-    {
-        push    szAnimName
-        push    animGroup
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x8
-    }
+
+    // CAnimManager::GetAnimAssociation
+    pInterface = ((CAnimBlendAssociationSAInterface * (__cdecl*)(AssocGroupId, const char*)) FUNC_CAnimManager_GetAnimAssociation_str)(animGroup, szAnimName);
+
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -308,16 +220,11 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::AddAnimation(RpClump* pCl
         return NULL;
 
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
-    DWORD                             dwFunc = FUNC_CAnimManager_AddAnimation;
-    _asm
-    {
-        push    animID
-        push    animGroup
-        push    pClump
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0xC
-    }
+
+    // CAnimManager::AddAnimation
+    pInterface =
+        ((CAnimBlendAssociationSAInterface * (__cdecl*)(RpClump*, AssocGroupId, AnimationId)) FUNC_CAnimManager_AddAnimation)(pClump, animGroup, animID);
+
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -331,17 +238,11 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::AddAnimation(RpClump* pCl
         return NULL;
 
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
-    DWORD                             dwFunc = FUNC_CAnimManager_AddAnimation_hier;
-    CAnimBlendHierarchySAInterface*   pHierarchyInterface = pHierarchy->GetInterface();
-    _asm
-    {
-        push    ID
-        push    pHierarchyInterface
-        push    pClump
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0xC
-    }
+
+    // CAnimManager::AddAnimation
+    pInterface = ((CAnimBlendAssociationSAInterface * (__cdecl*)(RpClump*, CAnimBlendHierarchySAInterface*, int)) FUNC_CAnimManager_AddAnimation_hier)(
+        pClump, pHierarchy->GetInterface(), ID);
+
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -356,18 +257,11 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::AddAnimationAndSync(RpClu
         return NULL;
 
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
-    DWORD                             dwFunc = FUNC_CAnimManager_AddAnimationAndSync;
-    CAnimBlendAssociationSAInterface* pAssociationInterface = pAssociation->GetInterface();
-    _asm
-    {
-        push    animID
-        push    animGroup
-        push    pAssociationInterface
-        push    pClump
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x10
-    }
+
+    // CAnimManager::AddAnimationAndSync
+    pInterface = ((CAnimBlendAssociationSAInterface * (__cdecl*)(RpClump*, CAnimBlendAssociationSAInterface*, AssocGroupId, AnimationId))
+                      FUNC_CAnimManager_AddAnimationAndSync)(pClump, pAssociation->GetInterface(), animGroup, animID);
+
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -381,17 +275,11 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::BlendAnimation(RpClump* p
         return NULL;
 
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
-    DWORD                             dwFunc = FUNC_CAnimManager_BlendAnimation;
-    _asm
-    {
-        push    fBlendDelta
-        push    animID
-        push    animGroup
-        push    pClump
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x10
-    }
+
+    // CAnimManager::BlendAnimation
+    pInterface = ((CAnimBlendAssociationSAInterface * (__cdecl*)(RpClump*, AssocGroupId, AnimationId, float)) FUNC_CAnimManager_BlendAnimation)(
+        pClump, animGroup, animID, fBlendDelta);
+
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -405,18 +293,11 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::BlendAnimation(RpClump* p
         return NULL;
 
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
-    DWORD                             dwFunc = FUNC_CAnimManager_BlendAnimation_hier;
-    CAnimBlendHierarchySAInterface*   pHierarchyInterface = pHierarchy->GetInterface();
-    _asm
-    {
-        push    fBlendDelta
-        push    ID
-        push    pHierarchyInterface
-        push    pClump
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x10
-    }
+
+    // CAnimManager::BlendAnimation
+    pInterface = ((CAnimBlendAssociationSAInterface * (__cdecl*)(RpClump*, CAnimBlendHierarchySAInterface*, int, float)) FUNC_CAnimManager_BlendAnimation_hier)(
+        pClump, pHierarchy->GetInterface(), ID, fBlendDelta);
+
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -426,213 +307,112 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::BlendAnimation(RpClump* p
 
 void CAnimManagerSA::AddAnimBlockRef(int ID)
 {
-    DWORD dwFunc = FUNC_CAnimManager_AddAnimBlockRef;
-    _asm
-    {
-        push    ID
-        call    dwFunc
-        add     esp, 0x4
-    }
+    // CAnimManager::AddAnimBlockRef
+    ((void(__cdecl*)(int))FUNC_CAnimManager_AddAnimBlockRef)(ID);
 }
 
 void CAnimManagerSA::RemoveAnimBlockRef(int ID)
 {
-    DWORD dwFunc = FUNC_CAnimManager_RemoveAnimBlockRef;
-    _asm
-    {
-        push    ID
-        call    dwFunc
-        add     esp, 0x4
-    }
+    // CAnimManager::RemoveAnimBlockRef
+    ((void(__cdecl*)(int))FUNC_CAnimManager_RemoveAnimBlockRef)(ID);
 }
 
 void CAnimManagerSA::RemoveAnimBlockRefWithoutDelete(int ID)
 {
-    DWORD dwFunc = FUNC_CAnimManager_RemoveAnimBlockRefWithoutDelete;
-    _asm
-    {
-        push    ID
-        call    dwFunc
-        add     esp, 0x4
-    }
+    // CAnimManager::RemoveAnimBlockRefWithoutDelete
+    ((void(__cdecl*)(int))FUNC_CAnimManager_RemoveAnimBlockRefWithoutDelete)(ID);
 }
 
 int CAnimManagerSA::GetNumRefsToAnimBlock(int ID)
 {
-    int   iReturn;
-    DWORD dwFunc = FUNC_CAnimManager_GetNumRefsToAnimBlock;
-    _asm
-    {
-        push    ID
-        call    dwFunc
-        mov     iReturn, eax
-        add     esp, 0x4
-    }
-    return iReturn;
+    // CAnimManager::GetNumRefsToAnimBlock
+    return ((int(__cdecl*)(int))FUNC_CAnimManager_GetNumRefsToAnimBlock)(ID);
 }
 
 void CAnimManagerSA::RemoveAnimBlock(int ID)
 {
-    DWORD dwFunc = FUNC_CAnimManager_RemoveAnimBlock;
-    _asm
-    {
-        push    ID
-        call    dwFunc
-        add     esp, 0x4
-    }
+    // CAnimManager::RemoveAnimBlock
+    ((void(__cdecl*)(int))FUNC_CAnimManager_RemoveAnimBlock)(ID);
 }
 
 AnimAssocDefinition* CAnimManagerSA::AddAnimAssocDefinition(const char* szBlockName, const char* szAnimName, AssocGroupId animGroup, AnimationId animID,
                                                             AnimDescriptor* pDescriptor)
 {
-    AnimAssocDefinition* pReturn;
-    DWORD                dwFunc = FUNC_CAnimManager_AddAnimAssocDefinition;
-    _asm
-    {
-        push    pDescriptor
-        push    animID
-        push    animGroup
-        push    szAnimName
-        push    szBlockName
-        call    dwFunc
-        mov     pReturn, eax
-        add     esp, 0x14
-    }
-    return NULL;
+    // CAnimManager::AddAnimAssocDefinition
+    ((AnimAssocDefinition * (__cdecl*)(const char*, const char*, AssocGroupId, AnimationId, AnimDescriptor*)) FUNC_CAnimManager_AddAnimAssocDefinition)(
+        szBlockName, szAnimName, animGroup, animID, pDescriptor);
+    return nullptr;
 }
 
 void CAnimManagerSA::ReadAnimAssociationDefinitions()
 {
-    DWORD dwFunc = FUNC_CAnimManager_ReadAnimAssociationDefinitions;
-    _asm
-    {
-        call    dwFunc
-    }
+    // CAnimManager::ReadAnimAssociationDefinitions
+    ((void(__cdecl*)())FUNC_CAnimManager_ReadAnimAssociationDefinitions)();
 }
 
 void CAnimManagerSA::CreateAnimAssocGroups()
 {
-    DWORD dwFunc = FUNC_CAnimManager_CreateAnimAssocGroups;
-    _asm
-    {
-        call    dwFunc
-    }
+    // CAnimManager::CreateAnimAssocGroups
+    ((void(__cdecl*)())FUNC_CAnimManager_CreateAnimAssocGroups)();
 }
 
 void CAnimManagerSA::UncompressAnimation(CAnimBlendHierarchy* pHierarchy)
 {
-    DWORD                           dwFunc = FUNC_CAnimManager_UncompressAnimation;
-    CAnimBlendHierarchySAInterface* pHierarchyInterface = pHierarchy->GetInterface();
-    _asm
-    {
-        push    pHierarchyInterface
-        call    dwFunc
-        add     esp, 0x4
-    }
+    // CAnimManager::UncompressAnimation
+    ((void(__cdecl*)(CAnimBlendHierarchySAInterface*))FUNC_CAnimManager_UncompressAnimation)(pHierarchy->GetInterface());
 }
 
 void CAnimManagerSA::RemoveFromUncompressedCache(CAnimBlendHierarchy* pHierarchy)
 {
-    DWORD                           dwFunc = FUNC_CAnimManager_RemoveFromUncompressedCache;
-    CAnimBlendHierarchySAInterface* pHierarchyInterface = pHierarchy->GetInterface();
-    _asm
-    {
-        push    pHierarchyInterface
-        call    dwFunc
-        add     esp, 0x4
-    }
+    CAnimManagerSA::RemoveFromUncompressedCache(pHierarchy->GetInterface());
 }
 
 void CAnimManagerSA::RemoveFromUncompressedCache(CAnimBlendHierarchySAInterface* pHierarchyInterface)
 {
-    DWORD dwFunc = FUNC_CAnimManager_RemoveFromUncompressedCache;
-    _asm
-    {
-        push    pHierarchyInterface
-        call    dwFunc
-        add     esp, 0x4
-    }
+    // CAnimManager::RemoveFromUncompressedCache
+    ((void(__cdecl*)(CAnimBlendHierarchySAInterface*))FUNC_CAnimManager_RemoveFromUncompressedCache)(pHierarchyInterface);
 }
 
 void CAnimManagerSA::LoadAnimFile(const char* szFile)
 {
-    DWORD dwFunc = FUNC_CAnimManager_LoadAnimFile;
-    _asm
-    {
-        push    szFile
-        call    dwFunc
-        add     esp, 0x4
-    }
+    // CAnimManager::LoadAnimFile
+    ((void(__cdecl*)(const char*))FUNC_CAnimManager_LoadAnimFile)(szFile);
 }
 
 void CAnimManagerSA::LoadAnimFile(RwStream* pStream, bool b1, const char* sz1)
 {
-    DWORD dwFunc = FUNC_CAnimManager_LoadAnimFile_stream;
-    _asm
-    {
-        push    sz1
-        push    b1
-        push    pStream
-        call    dwFunc
-        add     esp, 0xC
-    }
+    // CAnimManager::LoadAnimFile
+    ((void(__cdecl*)(RwStream*, bool, const char*))FUNC_CAnimManager_LoadAnimFile_stream)(pStream, b1, sz1);
 }
 
 void CAnimManagerSA::LoadAnimFiles()
 {
-    DWORD dwFunc = FUNC_CAnimManager_LoadAnimFiles;
-    _asm
-    {
-        call    dwFunc
-    }
+    // CAnimManager::LoadAnimFiles
+    ((void(__cdecl*)())FUNC_CAnimManager_LoadAnimFiles)();
 }
 
 void CAnimManagerSA::RemoveLastAnimFile()
 {
-    DWORD dwFunc = FUNC_CAnimManager_RemoveLastAnimFile;
-    _asm
-    {
-        call    dwFunc
-    }
+    // CAnimManager::RemoveLastAnimFile
+    ((void(__cdecl*)())FUNC_CAnimManager_RemoveLastAnimFile)();
 }
 
 BYTE* CAnimManagerSA::AllocateKeyFramesMemory(uint32_t u32BytesToAllocate)
 {
-    BYTE* pKeyFrames = nullptr;
-    DWORD dwFunc = FUNC_CAnimManager_AllocateKeyFramesMemory;
-    _asm
-    {
-        push    u32BytesToAllocate
-        call    dwFunc
-        add     esp, 0x4
-        mov     pKeyFrames, eax
-    }
-    return pKeyFrames;
+    // CAnimManager::AllocateKeyFramesMemory
+    return ((BYTE * (__cdecl*)(unsigned int)) FUNC_CAnimManager_AllocateKeyFramesMemory)(u32BytesToAllocate);
 }
 
 void CAnimManagerSA::FreeKeyFramesMemory(void* pKeyFrames)
 {
-    DWORD dwFunc = FUNC_CAnimManager_FreeKeyFramesMemory;
-    _asm
-    {
-        push    pKeyFrames
-        call    dwFunc
-        add     esp, 0x4
-    }
+    // CAnimManager::FreeKeyFramesMemory
+    ((void(__cdecl*)(void*))FUNC_CAnimManager_FreeKeyFramesMemory)(pKeyFrames);
 }
 
 bool CAnimManagerSA::HasAnimGroupLoaded(AssocGroupId groupID)
 {
-    bool  bReturn;
-    DWORD dwFunc = FUNC_HasAnimGroupLoaded;
-    _asm
-    {
-        push    groupID
-        call    dwFunc
-        mov     bReturn, al
-        add     esp, 0x4
-    }
-    return bReturn;
+    // CAnimManager::AllocateKeyFramesMemory
+    return ((bool(__cdecl*)(AssocGroupId))FUNC_HasAnimGroupLoaded)(groupID);
 }
 
 std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::RpAnimBlendClumpGetFirstAssociation(RpClump* pClump)
@@ -641,14 +421,10 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::RpAnimBlendClumpGetFirstA
         return NULL;
 
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
-    DWORD                             dwFunc = FUNC_RpAnimBlendClumpGetFirstAssociation;
-    _asm
-    {
-        push    pClump
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x4
-    }
+
+    // RpAnimBlendClumpGetFirstAssociation
+    pInterface = ((CAnimBlendAssociationSAInterface * (__cdecl*)(RpClump*)) FUNC_RpAnimBlendClumpGetFirstAssociation)(pClump);
+
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -662,15 +438,10 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::RpAnimBlendClumpGetAssoci
         return NULL;
 
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
-    DWORD                             dwFunc = FUNC_RpAnimBlendClumpGetAssociation_str;
-    _asm
-    {
-        push    szAnimName
-        push    pClump
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x8
-    }
+
+    // RpAnimBlendClumpGetAssociation
+    pInterface = ((CAnimBlendAssociationSAInterface * (__cdecl*)(RpClump*, const char*)) FUNC_RpAnimBlendClumpGetAssociation_str)(pClump, szAnimName);
+
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -684,15 +455,10 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::RpAnimBlendClumpGetAssoci
         return NULL;
 
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
-    DWORD                             dwFunc = FUNC_RpAnimBlendClumpGetAssociation_int;
-    _asm
-    {
-        push    animID
-        push    pClump
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x8
-    }
+
+    // RpAnimBlendClumpGetAssociation
+    pInterface = ((CAnimBlendAssociationSAInterface * (__cdecl*)(RpClump*, AnimationId)) FUNC_RpAnimBlendClumpGetAssociation_int)(pClump, animID);
+
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -703,15 +469,11 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::RpAnimBlendClumpGetAssoci
 std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::RpAnimBlendGetNextAssociation(std::unique_ptr<CAnimBlendAssociation>& pAssociation)
 {
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
-    DWORD                             dwFunc = FUNC_RpAnimBlendGetNextAssociation;
-    CAnimBlendAssociationSAInterface* pAssociationInterface = pAssociation->GetInterface();
-    _asm
-    {
-        push    pAssociationInterface
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x4
-    }
+
+    // RpAnimBlendGetNextAssociation
+    pInterface =
+        ((CAnimBlendAssociationSAInterface * (__cdecl*)(CAnimBlendAssociationSAInterface*)) FUNC_RpAnimBlendGetNextAssociation)(pAssociation->GetInterface());
+
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -724,16 +486,8 @@ int CAnimManagerSA::RpAnimBlendClumpGetNumAssociations(RpClump* pClump)
     if (!pClump)
         return 0;
 
-    int   iReturn;
-    DWORD dwFunc = FUNC_RpAnimBlendClumpGetNumAssociations;
-    _asm
-    {
-        push    pClump
-        call    dwFunc
-        mov     iReturn, eax
-        add     esp, 0x4
-    }
-    return iReturn;
+    // RpAnimBlendClumpGetNumAssociations
+    return ((int(__cdecl*)(RpClump*))FUNC_RpAnimBlendClumpGetNumAssociations)(pClump);
 }
 
 void CAnimManagerSA::RpAnimBlendClumpUpdateAnimations(RpClump* pClump, float f1, bool b1)
@@ -741,15 +495,8 @@ void CAnimManagerSA::RpAnimBlendClumpUpdateAnimations(RpClump* pClump, float f1,
     if (!pClump)
         return;
 
-    DWORD dwFunc = FUNC_RpAnimBlendClumpUpdateAnimations;
-    _asm
-    {
-        push    b1
-        push    f1
-        push    pClump
-        call    dwFunc
-        add     esp, 0xC
-    }
+    // RpAnimBlendClumpUpdateAnimations
+    ((void(__cdecl*)(RpClump*, float, bool))FUNC_RpAnimBlendClumpUpdateAnimations)(pClump, f1, b1);
 }
 
 std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::GetAnimBlendAssociation(CAnimBlendAssociationSAInterface* pInterface)

--- a/Client/game_sa/CAudioEngineSA.cpp
+++ b/Client/game_sa/CAudioEngineSA.cpp
@@ -154,42 +154,25 @@ VOID CAudioEngineSA::PlayFrontEndSound(DWORD dwEventID)
     if (*(DWORD*)VAR_AudioEventVolumes != 0 && dwEventID <= 101)            // may prevent a crash
     {
         DEBUG_TRACE("VOID CAudioEngineSA::PlayFrontEndSound(DWORD dwSound)");
-        DWORD dwFunc = FUNC_ReportFrontendAudioEvent;
-        FLOAT fSpeed = 1.0f;
-        FLOAT fVolumeChange = 0.0f;
-        _asm
-        {
-            push    fSpeed
-            push    fVolumeChange
-            push    dwEventID
-            mov     ecx, CLASS_CAudioEngine
-            call    dwFunc
-        }
+
+        float fSpeed = 1.0f;
+        float fVolumeChange = 0.0f;
+
+        // CAudioEngine::ReportFrontendAudioEvent
+        ((void(__thiscall*)(CAudioEngineSAInterface*, int, float, float))FUNC_ReportFrontendAudioEvent)(m_pInterface, dwEventID, fVolumeChange, fSpeed);
     }
 }
 
 VOID CAudioEngineSA::SetEffectsMasterVolume(BYTE bVolume)
 {
-    DWORD dwFunc = FUNC_SetEffectsMasterVolume;
-    DWORD dwVolume = bVolume;
-    _asm
-    {
-        mov     ecx, CLASS_CAudioEngine
-        push    dwVolume
-        call    dwFunc
-    }
+    // CAudioEngine::SetEffectsMasterVolume
+    ((void(__thiscall*)(CAudioEngineSAInterface*, char))FUNC_SetEffectsMasterVolume)(m_pInterface, bVolume);
 }
 
 VOID CAudioEngineSA::SetMusicMasterVolume(BYTE bVolume)
 {
-    DWORD dwFunc = FUNC_SetMusicMasterVolume;
-    DWORD dwVolume = bVolume;
-    _asm
-    {
-        mov     ecx, CLASS_CAudioEngine
-        push    dwVolume
-        call    dwFunc
-    }
+    // CAudioEngine::SetMusicMasterVolume
+    ((void(__thiscall*)(CAudioEngineSAInterface*, char))FUNC_SetMusicMasterVolume)(m_pInterface, bVolume);
 
     //
     // See if radio stream should be stopped/started
@@ -221,75 +204,37 @@ VOID CAudioEngineSA::PlayBeatTrack(short iTrack)
     if (*(DWORD*)VAR_AudioEventVolumes != 0)            // may prevent a crash
     {
         DEBUG_TRACE("VOID CAudioEngineSA::PlayBeatTrack ( short iTrack )");
-        DWORD dwFunc = FUNC_PreloadBeatTrack;
-        DWORD dwTrack = iTrack;
-        _asm
-        {
-            mov     ecx, CLASS_CAudioEngine
-            push    dwTrack
-            call    dwFunc
-        }
 
-        dwFunc = FUNC_PlayPreloadedBeatTrack;
-        _asm
-        {
-            mov     ecx, CLASS_CAudioEngine
-            push    1
-            call    dwFunc
-        }
+        // CAudioEngine::PreloadBeatTrack
+        ((void(__thiscall*)(CAudioEngineSAInterface*, short))FUNC_PreloadBeatTrack)(m_pInterface, iTrack);
+
+        // CAudioEngine::PlayPreloadedBeatTrack
+        ((void(__thiscall*)(CAudioEngineSAInterface*, unsigned char))FUNC_PlayPreloadedBeatTrack)(m_pInterface, 1);
     }
 }
 
 VOID CAudioEngineSA::ClearMissionAudio(int slot)
 {
-    DWORD dwFunc = 0x5072F0;            // CAudioEngine::ClearMissionAudio(unsigned char)
-    _asm
-    {
-        mov     ecx, CLASS_CAudioEngine
-        push    slot // sound bank slot?
-        call    dwFunc
-    }
+    // CAudioEngine::ClearMissionAudio
+    ((void(__thiscall*)(CAudioEngineSAInterface*, unsigned char))0x5072F0)(m_pInterface, slot);
 }
 
 bool CAudioEngineSA::IsMissionAudioSampleFinished(int slot)
 {
-    DWORD dwFunc = 0x5072C0;            // CAudioEngine::IsMissionAudioSampleFinished
-    bool  cret = 0;
-    _asm
-    {
-        mov     ecx, CLASS_CAudioEngine
-        push    slot
-        call    dwFunc
-        mov     cret, al
-    }
-    return cret;
+    // CAudioEngine::IsMissionAudioSampleFinished
+    return ((bool(__thiscall*)(CAudioEngineSAInterface*, unsigned char))0x5072C0)(m_pInterface, slot);
 }
 
 VOID CAudioEngineSA::PreloadMissionAudio(unsigned short usAudioEvent, int slot)
 {
-    DWORD dwFunc = 0x507290;            // CAudioEngine__PreloadMissionAudio
-    DWORD AudioEvent = usAudioEvent;
-    _asm
-    {
-        mov     ecx, CLASS_CAudioEngine
-        push    AudioEvent
-        push    slot
-        call    dwFunc
-    }
+    // CAudioEngine::PreloadMissionAudio
+    ((void(__thiscall*)(CAudioEngineSAInterface*, unsigned char, int))0x507290)(m_pInterface, slot, usAudioEvent);
 }
 
 unsigned char CAudioEngineSA::GetMissionAudioLoadingStatus(int slot)
 {
-    DWORD         dwFunc = 0x5072A0;            // get load status
-    unsigned char cret = 0;
-    _asm
-    {
-        mov     ecx, CLASS_CAudioEngine
-        push    slot
-        call    dwFunc
-        mov     cret, al
-    }
-    return cret;
+    // CAudioEngine::IsMissionAudioSampleFinished
+    return ((unsigned char(__thiscall*)(CAudioEngineSAInterface*, unsigned char))0x5072A0)(m_pInterface, slot);
 }
 
 VOID CAudioEngineSA::AttachMissionAudioToPhysical(CPhysical* physical, int slot)
@@ -302,39 +247,23 @@ VOID CAudioEngineSA::AttachMissionAudioToPhysical(CPhysical* physical, int slot)
             entity = pPhysical->GetInterface();
     }
 
-    DWORD dwFunc = 0x507330;            // AttachMissionAudioToPhysical
-    _asm
-    {
-        mov     ecx, CLASS_CAudioEngine
-        push    entity
-        push    slot
-        call    dwFunc
-    }
+    // CAudioEngine::AttachMissionAudioToPhysical
+    ((void(__thiscall*)(CAudioEngineSAInterface*, unsigned char, CEntitySAInterface*))0x507330)(m_pInterface, slot, entity);
 }
 
 VOID CAudioEngineSA::SetMissionAudioPosition(CVector* position, int slot)
 {
-    DWORD dwFunc = 0x507300;            // CAudioEngine__SetMissionAudioPosition
-    _asm
-    {
-        mov     ecx, CLASS_CAudioEngine
-        push    position
-        push    slot
-        call    dwFunc
-    }
+    // CAudioEngine::AttachMissionAudioToPhysical
+    ((void(__thiscall*)(CAudioEngineSAInterface*, unsigned char, CVector&))0x507300)(m_pInterface, slot, *position);
 }
 
 bool CAudioEngineSA::PlayLoadedMissionAudio(int slot)
 {
     if (GetMissionAudioLoadingStatus(slot) == 1)
     {
-        DWORD dwFunc = 0x5072B0;            // CAudioEngine::PlayLoadedMissionAudio(unsigned char)
-        _asm
-        {
-            mov     ecx, CLASS_CAudioEngine
-            push    slot
-            call    dwFunc
-        }
+        // CAudioEngine::PlayLoadedMissionAudio
+        ((void(__thiscall*)(CAudioEngineSAInterface*, unsigned char))0x5072B0)(m_pInterface, slot);
+
         return true;
     }
     return false;
@@ -344,21 +273,13 @@ VOID CAudioEngineSA::PauseAllSound(bool bPaused)
 {
     if (bPaused)
     {
-        DWORD dwFunc = FUNC_PauseAllSounds;
-        _asm
-        {
-            mov     ecx, CLASS_CAudioEngine
-            call    dwFunc
-        }
+        // CAudioEngine::PauseAllSounds
+        ((void(__thiscall*)(CAudioEngineSAInterface*))FUNC_PauseAllSounds)(m_pInterface);
     }
     else
     {
-        DWORD dwFunc = FUNC_ResumeAllSounds;
-        _asm
-        {
-            mov     ecx, CLASS_CAudioEngine
-            call    dwFunc
-        }
+        // CAudioEngine::ResumeAllSounds
+        ((void(__thiscall*)(CAudioEngineSAInterface*))FUNC_ResumeAllSounds)(m_pInterface);
     }
 }
 
@@ -533,35 +454,14 @@ skip:   // Skip playing sound
 
 void CAudioEngineSA::ReportBulletHit(CEntity* pEntity, unsigned char ucSurfaceType, CVector* pvecPosition, float f_2)
 {
-    DWORD dwEntityInterface = 0;
-    if (pEntity)
-        dwEntityInterface = (DWORD)pEntity->GetInterface();
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAudioEngine_ReportBulletHit;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    f_2
-        push    pvecPosition
-        push    ucSurfaceType
-        push    dwEntityInterface
-        call    dwFunc
-    }
+    // CAudioEngine::ReportBulletHit
+    ((void(__thiscall*)(CAudioEngineSAInterface*, CEntitySAInterface*, unsigned char, CVector&, float))FUNC_CAudioEngine_ReportBulletHit)(
+        m_pInterface, pEntity ? pEntity->GetInterface() : nullptr, ucSurfaceType, *pvecPosition, f_2);
 }
 
 void CAudioEngineSA::ReportWeaponEvent(int iEvent, eWeaponType weaponType, CPhysical* pPhysical)
 {
-    DWORD dwPhysicalInterface = NULL;
-    if (pPhysical)
-        dwPhysicalInterface = (DWORD)pPhysical->GetInterface();
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAudioEngine_ReportWeaponEvent;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    dwPhysicalInterface
-        push    weaponType
-        push    iEvent
-        call    dwFunc
-    }
+    // CAudioEngine::ReportWeaponEvent
+    ((void(__thiscall*)(CAudioEngineSAInterface*, int, eWeaponType, CEntitySAInterface*))FUNC_CAudioEngine_ReportWeaponEvent)(
+        m_pInterface, iEvent, weaponType, pPhysical ? pPhysical->GetInterface() : nullptr);
 }

--- a/Client/game_sa/CAutomobileSA.cpp
+++ b/Client/game_sa/CAutomobileSA.cpp
@@ -59,108 +59,58 @@ CAutomobileSA::~CAutomobileSA()
 bool CAutomobileSA::BurstTyre(DWORD dwTyreID)
 {
     DEBUG_TRACE("bool CAutomobileSA::BurstTyre ( DWORD dwTyreID )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_BurstTyre;
-    bool  bReturn;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        push    dwTyreID
-        call    dwFunc;
-        mov     bReturn, al
-    }
-
-    return bReturn;
+    // CAutomobile::BurstTyre
+    return ((bool(__thiscall*)(CAutomobileSAInterface*, unsigned char, bool))FUNC_CAutomobile_BurstTyre)(GetAutomobileInterface(), dwTyreID, true);
 }
 
 bool CAutomobileSA::BreakTowLink()
 {
     DEBUG_TRACE("bool CAutomobileSA::BreakTowLink ( void )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_BreakTowLink;
-    bool  bReturn;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     bReturn, al
-    }
-
-    return bReturn;
+    // CAutomobile::BreakTowLink
+    return ((bool(__thiscall*)(CAutomobileSAInterface*))FUNC_CAutomobile_BreakTowLink)(GetAutomobileInterface());
 }
 
 void CAutomobileSA::BlowUpCar(CEntity* pEntity)
 {
     DEBUG_TRACE("void CAutomobileSA::BlowUpCar ( CEntity* pEntity )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_BlowUpCar;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        push    pEntity
-        call    dwFunc
-    }
+    // ?
+    // CAutomobile::BlowUpCar
+    ((void(__thiscall*)(CAutomobileSAInterface*, CEntity*))FUNC_CAutomobile_BlowUpCar)(GetAutomobileInterface(), pEntity);
 }
 
 void CAutomobileSA::BlowUpCarsInPath()
 {
     DEBUG_TRACE("void CAutomobileSA::BlowUpCarsInPath ( void )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_BlowUpCarsInPath;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CAutomobile::BlowUpCarsInPath
+    ((void(__thiscall*)(CAutomobileSAInterface*))FUNC_CAutomobile_BlowUpCarsInPath)(GetAutomobileInterface());
 }
 
 void CAutomobileSA::CloseAllDoors()
 {
     DEBUG_TRACE("void CAutomobileSA::CloseAllDoors ( void )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_CloseAllDoors;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CAutomobile::CloseAllDoors
+    ((void(__thiscall*)(CAutomobileSAInterface*))FUNC_CAutomobile_CloseAllDoors)(GetAutomobileInterface());
 }
 
 void CAutomobileSA::CloseBoot()
 {
     DEBUG_TRACE("void CAutomobileSA::CloseBoot ( void )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_CloseBoot;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CAutomobile::CloseBoot
+    ((void(__thiscall*)(CAutomobileSAInterface*))FUNC_CAutomobile_CloseBoot)(GetAutomobileInterface());
 }
 
-float CAutomobileSA::FindWheelWidth(bool bUnknown)
+float CAutomobileSA::FindWheelWidth(bool bRear)
 {
     DEBUG_TRACE("float CAutomobileSA::FindWheelWidth ( bool bUnknown )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwUnknown = (DWORD)bUnknown;
-    DWORD dwFunc = FUNC_CAutomobile_FindWheelWidth;
-    float fReturn;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        push    dwUnknown
-        call    dwFunc
-        fstp    fReturn;
-    }
-
-    return fReturn;
+    // CAutomobile::FindWheelWidth
+    return ((float(__thiscall*)(CAutomobileSAInterface*, bool))FUNC_CAutomobile_FindWheelWidth)(GetAutomobileInterface(), bRear);
 }
 
 /*
@@ -180,101 +130,49 @@ void CAutomobileSA::Fix ( void )
 void CAutomobileSA::FixDoor(int iCarNodeIndex, eDoorsSA Door)
 {
     DEBUG_TRACE("void CAutomobileSA::FixDoor ( int iCarNodeIndex, eDoorsSA Door )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_FixDoor;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        push    Door
-        push    iCarNodeIndex
-        call    dwFunc
-    }
+    // CAutomobile::FixDoor
+    ((void(__thiscall*)(CAutomobileSAInterface*, int, eDoorsSA))FUNC_CAutomobile_FixDoor)(GetAutomobileInterface(), iCarNodeIndex, Door);
 }
 
 int CAutomobileSA::FixPanel(int iCarNodeIndex, ePanelsSA Panel)
 {
     DEBUG_TRACE("int CAutomobileSA::FixPanel ( int iCarNodeIndex, ePanelsSA Panel )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_FixPanel;
-    int   iReturn;
-
-    _asm
-    {
-        mov     ecx, dwThis
-        push    Panel
-        push    iCarNodeIndex
-        call    dwFunc
-        mov     iReturn, eax
-    }
-
-    return iReturn;
+ 
+    // CAutomobile::FixDoor
+    return ((int(__thiscall*)(CAutomobileSAInterface*, int, ePanelsSA))FUNC_CAutomobile_FixPanel)(GetAutomobileInterface(), iCarNodeIndex, Panel);
 }
 
 bool CAutomobileSA::GetAllWheelsOffGround()
 {
     DEBUG_TRACE("bool CAutomobileSA::GetAllWheelsOffGround ( void )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_GetAllWheelsOffGround;
-    bool  bReturn;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     bReturn, al
-    }
-
-    return bReturn;
+    // CAutomobile::GetAllWheelsOffGround
+    return ((bool(__thiscall*)(CAutomobileSAInterface*))FUNC_CAutomobile_GetAllWheelsOffGround)(GetAutomobileInterface());
 }
 
 float CAutomobileSA::GetCarPitch()
 {
     DEBUG_TRACE("float CAutomobileSA::GetCarPitch ( void )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_GetCarPitch;
-    float fReturn;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        fstp    fReturn
-    }
-
-    return fReturn;
+    // CAutomobile::GetCarPitch
+    return ((float(__thiscall*)(CAutomobileSAInterface*))FUNC_CAutomobile_GetCarPitch)(GetAutomobileInterface());
 }
 
 float CAutomobileSA::GetCarRoll()
 {
     DEBUG_TRACE("float CAutomobileSA::GetCarRoll ( void )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_GetCarRoll;
-    float fReturn;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        fstp    fReturn
-    }
-
-    return fReturn;
+    // CAutomobile::GetCarRoll
+    return ((float(__thiscall*)(CAutomobileSAInterface*))FUNC_CAutomobile_GetCarRoll)(GetAutomobileInterface());
 }
 
 void CAutomobileSA::GetComponentWorldPosition(int iComponentID, CVector* pVector)
 {
     DEBUG_TRACE("void CAutomobileSA::GetComponentWorldPosition ( int iComponentID, CVector* pVector)");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_GetComponentWorldPosition;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        push    pVector
-        push    iComponentID
-        call    dwFunc
-    }
+    // CAutomobile::GetComponentWorldPosition
+    ((void(__thiscall*)(CAutomobileSAInterface*, int, CVector&))FUNC_CAutomobile_GetComponentWorldPosition)(GetAutomobileInterface(), iComponentID, *pVector);
 }
 
 /*float CAutomobileSA::GetHeightAboveRoad ( void )
@@ -285,309 +183,157 @@ void CAutomobileSA::GetComponentWorldPosition(int iComponentID, CVector* pVector
 DWORD CAutomobileSA::GetNumContactWheels()
 {
     DEBUG_TRACE("DWORD CAutomobileSA::GetNumContactWheels ( void )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_GetNumContactWheels;
-    DWORD dwReturn;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     dwReturn, eax
-    }
-
-    return dwReturn;
+    // CAutomobile::GetNumContactWheels
+    return ((DWORD(__thiscall*)(CAutomobileSAInterface*))FUNC_CAutomobile_GetNumContactWheels)(GetAutomobileInterface());
 }
 
 float CAutomobileSA::GetRearHeightAboveRoad()
 {
     DEBUG_TRACE("float CAutomobileSA::GetRearHeightAboveRoad ( void )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_GetRearHeightAboveRoad;
-    float fReturn;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        fstp    fReturn
-    }
-
-    return fReturn;
+    // CAutomobile::GetRearHeightAboveRoad
+    return ((float(__thiscall*)(CAutomobileSAInterface*))FUNC_CAutomobile_GetRearHeightAboveRoad)(GetAutomobileInterface());
 }
 
 bool CAutomobileSA::IsComponentPresent(int iComponentID)
 {
     DEBUG_TRACE("bool CAutomobileSA::IsComponentPresent ( int iComponentID )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_IsComponentPresent;
-    bool  bReturn;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        push    iComponentID
-        call    dwFunc
-        mov     bReturn, al
-    }
-
-    return bReturn;
+    // CAutomobile::IsComponentPresent
+    return ((bool(__thiscall*)(CAutomobileSAInterface*, int))FUNC_CAutomobile_IsComponentPresent)(GetAutomobileInterface(), iComponentID);
 }
 
 bool CAutomobileSA::IsDoorClosed(eDoorsSA Door)
 {
     DEBUG_TRACE("bool CAutomobileSA::IsDoorClosed ( eDoorsSA Door )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_IsDoorClosed;
-    bool  bReturn;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        push    Door
-        call    dwFunc
-        mov     bReturn, al
-    }
-
-    return bReturn;
+    // CAutomobile::IsDoorClosed
+    return ((bool(__thiscall*)(CAutomobileSAInterface*, eDoorsSA))FUNC_CAutomobile_IsDoorClosed)(GetAutomobileInterface(), Door);
 }
 
 bool CAutomobileSA::IsDoorFullyOpen(eDoorsSA Door)
 {
     DEBUG_TRACE("bool CAutomobileSA::IsDoorFullyOpen ( eDoorsSA Door )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_IsDoorFullyOpen;
-    bool  bReturn;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        push    Door
-        call    dwFunc
-        mov     bReturn, al
-    }
-
-    return bReturn;
+    // CAutomobile::IsDoorFullyOpen
+    return ((bool(__thiscall*)(CAutomobileSAInterface*, eDoorsSA))FUNC_CAutomobile_IsDoorFullyOpen)(GetAutomobileInterface(), Door);
 }
 
 bool CAutomobileSA::IsDoorMissing(eDoorsSA Door)
 {
     DEBUG_TRACE("bool CAutomobileSA::IsDoorMissing ( eDoorsSA Door )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_IsDoorMissing;
-    bool  bReturn;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        push    Door
-        call    dwFunc
-        mov     bReturn, al
-    }
-
-    return bReturn;
+    // CAutomobile::IsDoorMissing
+    return ((bool(__thiscall*)(CAutomobileSAInterface*, eDoorsSA))FUNC_CAutomobile_IsDoorMissing)(GetAutomobileInterface(), Door);
 }
 
 bool CAutomobileSA::IsDoorReady(eDoorsSA Door)
 {
     DEBUG_TRACE("bool CAutomobileSA::IsDoorReady ( eDoorsSA Door )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_IsDoorReady;
-    bool  bReturn;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        push    Door
-        call    dwFunc
-        mov     bReturn, al
-    }
-
-    return bReturn;
+    // CAutomobile::IsDoorReady
+    return ((bool(__thiscall*)(CAutomobileSAInterface*, eDoorsSA))FUNC_CAutomobile_IsDoorReady)(GetAutomobileInterface(), Door);
 }
 
 bool CAutomobileSA::IsInAir()
 {
     DEBUG_TRACE("bool CAutomobileSA::IsInAir ( void )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_IsInAir;
-    bool  bReturn;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     bReturn, al
-    }
-
-    return bReturn;
+    // CAutomobile::IsInAir
+    return ((bool(__thiscall*)(CAutomobileSAInterface*))FUNC_CAutomobile_IsInAir)(GetAutomobileInterface());
 }
 
 bool CAutomobileSA::IsOpenTopCar()
 {
     DEBUG_TRACE("bool CAutomobileSA::IsOpenTopCar ( void )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_IsOpenTopCar;
-    bool  bReturn;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     bReturn, al
-    }
-
-    return bReturn;
+    // CAutomobile::IsOpenTopCar
+    return ((bool(__thiscall*)(CAutomobileSAInterface*))FUNC_CAutomobile_IsOpenTopCar)(GetAutomobileInterface());
 }
 
 void CAutomobileSA::PlayCarHorn()
 {
     DEBUG_TRACE("void CAutomobileSA::PlayCarHorn ( void )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_PlayCarHorn;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CAutomobile::PlayCarHorn
+    ((void(__thiscall*)(CAutomobileSAInterface*))FUNC_CAutomobile_PlayCarHorn)(GetAutomobileInterface());
 }
 
 void CAutomobileSA::PopBoot()
 {
     DEBUG_TRACE("void CAutomobileSA::PopBoot ( void )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_PopBoot;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CAutomobile::PopBoot
+    ((void(__thiscall*)(CAutomobileSAInterface*))FUNC_CAutomobile_PopBoot)(GetAutomobileInterface());
 }
 
 void CAutomobileSA::PopBootUsingPhysics()
 {
     DEBUG_TRACE("void CAutomobileSA::PopBootUsingPhysics ( void )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_PopBootUsingPhysics;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CAutomobile::PopBootUsingPhysics
+    ((void(__thiscall*)(CAutomobileSAInterface*))FUNC_CAutomobile_PopBootUsingPhysics)(GetAutomobileInterface());
 }
 
 void CAutomobileSA::PopDoor(int iCarNodeIndex, eDoorsSA Door, bool bUnknown)
 {
     DEBUG_TRACE("void CAutomobileSA::PopDoor ( int iCarNodeIndex, eDoorsSA Door, bool bUnknown )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwUnknown = (DWORD)bUnknown;
-    DWORD dwFunc = FUNC_CAutomobile_PopDoor;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        push    dwUnknown
-        push    Door
-        push    iCarNodeIndex
-        call    dwFunc
-    }
+    // CAutomobile::PopDoor
+    ((void(__thiscall*)(CAutomobileSAInterface*, int, eDoorsSA, bool))FUNC_CAutomobile_PopDoor)(GetAutomobileInterface(), iCarNodeIndex, Door,
+                                                                                                            bUnknown);
 }
 
 void CAutomobileSA::PopPanel(int iCarNodeIndex, ePanelsSA Panel, bool bFallOffFast)
 {
     DEBUG_TRACE("void CAutomobileSA::PopPanel ( int iCarNodeIndex, ePanelsSA Panel, bool bFallOffFast )");
     DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFallOffFast = (DWORD)bFallOffFast;
-    DWORD dwFunc = FUNC_CAutomobile_PopPanel;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        push    dwFallOffFast
-        push    Panel
-        push    iCarNodeIndex
-        call    dwFunc
-    }
+    // CAutomobile::PopPanel
+    ((void(__thiscall*)(CAutomobileSAInterface*, int, ePanelsSA, bool))FUNC_CAutomobile_PopPanel)(GetAutomobileInterface(), iCarNodeIndex, Panel,
+                                                                                                             bFallOffFast);
 }
 
 void CAutomobileSA::ResetSuspension()
 {
     DEBUG_TRACE("void CAutomobileSA::ResetSuspension ( void )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwFunc = FUNC_CAutomobile_ResetSuspension;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CAutomobile::ResetSuspension
+    ((void(__thiscall*)(CAutomobileSAInterface*))FUNC_CAutomobile_ResetSuspension)(GetAutomobileInterface());
 }
 
 void CAutomobileSA::SetRandomDamage(bool bUnknown)
 {
     DEBUG_TRACE("void CAutomobileSA::SetRandomDamage ( bool bUnknown )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwUnknown = (DWORD)bUnknown;
-    DWORD dwFunc = FUNC_CAutomobile_SetRandomDamage;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        push    dwUnknown
-        call    dwFunc
-    }
+    // CAutomobile::SetRandomDamage
+    ((void(__thiscall*)(CAutomobileSAInterface*, bool))FUNC_CAutomobile_SetRandomDamage)(GetAutomobileInterface(), bUnknown);
 }
 
 void CAutomobileSA::SetTaxiLight(bool bState)
 {
     DEBUG_TRACE("void CAutomobileSA::SetTaxiLight ( bool bState )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwState = (DWORD)bState;
-    DWORD dwFunc = FUNC_CAutomobile_SetTaxiLight;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        push    dwState
-        call    dwFunc
-    }
+    // CAutomobile::SetTaxiLight
+    ((void(__thiscall*)(CAutomobileSAInterface*, bool))FUNC_CAutomobile_SetTaxiLight)(GetAutomobileInterface(), bState);
 }
 
 void CAutomobileSA::SetTotalDamage(bool bUnknown)
 {
     DEBUG_TRACE("void CAutomobileSA::SetTotalDamage (bool bUnknown )");
-    DWORD dwThis = (DWORD)GetInterface();
-    DWORD dwUnknown = (DWORD)bUnknown;
-    DWORD dwFunc = FUNC_CAutomobile_SetTotalDamage;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        push    dwUnknown
-        call    dwFunc
-    }
+    // CAutomobile::SetTotalDamage
+    ((void(__thiscall*)(CAutomobileSAInterface*, bool))FUNC_CAutomobile_SetTotalDamage)(GetAutomobileInterface(), bUnknown);
 }
 
 CPhysical* CAutomobileSA::SpawnFlyingComponent(int iCarNodeIndex, int iUnknown)
 {
     DEBUG_TRACE("CPhysical* CAutomobileSA::SpawnFlyingComponent ( int iCarNodeIndex, int iUnknown )");
-    DWORD      dwThis = (DWORD)GetInterface();
-    DWORD      dwFunc = FUNC_CAutomobile_SpawnFlyingComponent;
-    CPhysical* pReturn;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        push    iUnknown
-        push    iCarNodeIndex
-        call    dwFunc
-        mov     pReturn, eax
-    }
-
-    return pReturn;
+    // ?
+    // CAutomobile::SpawnFlyingComponent
+    return ((CPhysical*(__thiscall*)(CAutomobileSAInterface*, int, int))FUNC_CAutomobile_SpawnFlyingComponent)(GetAutomobileInterface(), iCarNodeIndex, iUnknown);
 }
 
 CDoor* CAutomobileSA::GetDoor(eDoors doorID)

--- a/Client/game_sa/CAutomobileSA.h
+++ b/Client/game_sa/CAutomobileSA.h
@@ -204,6 +204,8 @@ public:
     CAutomobileSA(CAutomobileSAInterface* automobile);
     ~CAutomobileSA();
 
+    CAutomobileSAInterface* GetAutomobileInterface() { return (CAutomobileSAInterface*)m_pInterface; }
+
     bool  BurstTyre(DWORD dwTyreID);
     bool  BreakTowLink();
     void  BlowUpCar(CEntity* pEntity);

--- a/Client/game_sa/CCameraSA.cpp
+++ b/Client/game_sa/CCameraSA.cpp
@@ -48,31 +48,20 @@ CCameraSA::~CCameraSA()
 VOID CCameraSA::Restore()
 {
     DEBUG_TRACE("VOID CCameraSA::Restore()");
-    DWORD               dwFunc = FUNC_Restore;
-    CCameraSAInterface* cameraInterface = this->GetInterface();
-    _asm
-    {
-        mov     ecx, cameraInterface
-        call    dwFunc
-    }
+
+    // CCamera::Restore
+    ((void(__thiscall*)(CCameraSAInterface*))FUNC_Restore)(GetInterface());
 }
 
 VOID CCameraSA::RestoreWithJumpCut()
 {
     DEBUG_TRACE("VOID CCameraSA::RestoreWithJumpCut()");
-    CCameraSAInterface* cameraInterface = this->GetInterface();
-    DWORD               dwFunc = 0x50BD40;
-    _asm
-    {
-        mov     ecx, cameraInterface
-        call    dwFunc
-    }
-    dwFunc = 0x50BAB0;
-    _asm
-    {
-        mov     ecx, cameraInterface
-        call    dwFunc
-    }
+
+    // CCamera::SetCameraDirectlyBehindForFollowPed_CamOnAString
+    ((void(__thiscall*)(CCameraSAInterface*))0x50BD40)(GetInterface());
+
+    // CCamera::RestoreWithJumpCut
+    ((void(__thiscall*)(CCameraSAInterface*))0x50BAB0)(GetInterface()); 
 }
 
 /**
@@ -86,60 +75,22 @@ VOID CCameraSA::TakeControl(CEntity* entity, eCamMode CamMode, int CamSwitchStyl
     if (!pEntitySA)
         return;
 
-    CEntitySAInterface* entityInterface = pEntitySA->GetInterface();
-    CCameraSAInterface* cameraInterface = this->GetInterface();
-    // __thiscall
-
-    DWORD CCamera__TakeControl = FUNC_TakeControl;
-    _asm
-    {
-        mov ecx, cameraInterface
-        push 1
-        push CamSwitchStyle
-        push CamMode
-        push entityInterface
-        call CCamera__TakeControl
-    }
+    // CCamera::TakeControl
+    ((void(__thiscall*)(CCameraSAInterface*, CEntitySAInterface*, short, short, int))FUNC_TakeControl)(GetInterface(), pEntitySA->GetInterface(), CamMode,
+                                                                                                       CamSwitchStyle, SCRIPT_CAM_CONTROL);
 }
 
 VOID CCameraSA::TakeControl(CVector* position, int CamSwitchStyle)
 {
     DEBUG_TRACE("VOID CCameraSA::TakeControl(CVector * position, int CamSwitchStyle)");
-    CCameraSAInterface* cameraInterface = this->GetInterface();
-    // __thiscall
+
     CVector vecOffset;
-    /*  vecOffset.fZ = 0.5f;
-        vecOffset.fY = 0.5f;
-        vecOffset.fX = 0.5f;*/
-    /*  DWORD dwFunc = 0x50BEC0;
-        _asm
-        {
-            mov ecx, cameraInterface
-            lea     eax, vecOffset
-            push    eax
-            push    position
-            call    dwFunc
-        }*/
 
-    DWORD CCamera__TakeControlNoEntity = FUNC_TakeControlNoEntity;
-    _asm
-        {
-        mov ecx, cameraInterface
-        push 1
-        push CamSwitchStyle
-        push position
-        call CCamera__TakeControlNoEntity
-        }
+    // CCamera::TakeControlNoEntity
+    ((void(__thiscall*)(CCameraSAInterface*, CVector&, int, int))FUNC_TakeControlNoEntity)(GetInterface(), *position, CamSwitchStyle, SCRIPT_CAM_CONTROL);
 
-    DWORD dwFunc = 0x50BEC0;
-    _asm
-    {
-        mov ecx, cameraInterface
-        lea     eax, vecOffset
-        push    eax
-        push    position
-        call    dwFunc
-    }
+    // CCamera::SetCamPositionForFixedMode
+    ((void(__thiscall*)(CCameraSAInterface*, CVector&, CVector&))0x50BEC0)(GetInterface(), *position, vecOffset);
 }
 
 // vecOffset: an offset from 0,0,0
@@ -171,26 +122,13 @@ VOID CCameraSA::TakeControlAttachToEntity(CEntity* TargetEntity, CEntity* Attach
     if (!attachEntityInterface)
         return;
 
-    CCameraSAInterface* cameraInterface = this->GetInterface();
-    // __thiscall
-
     //  void    TakeControlAttachToEntity(CEntity* NewTarget, CEntity* AttachEntity,
     //  CVector& vecOffset, CVector& vecLookAt, float fTilt, short CamSwitchStyle,
     //  int WhoIsTakingControl=SCRIPT_CAM_CONTROL);
-    DWORD CCamera__TakeControlAttachToEntity = FUNC_TakeControlAttachToEntity;
 
-    _asm
-    {
-        mov ecx, cameraInterface
-        push 1
-        push CamSwitchStyle
-        push fTilt
-        push vecLookAt
-        push vecOffset
-        push attachEntityInterface
-        push targetEntityInterface
-        call CCamera__TakeControlAttachToEntity
-    }
+    // CCamera::TakeControlAttachToEntity
+    ((void(__thiscall*)(CCameraSAInterface*, CEntitySAInterface*, CEntitySAInterface*, CVector&, CVector&, float, short, int))FUNC_TakeControlAttachToEntity)(
+        GetInterface(), targetEntityInterface, attachEntityInterface, *vecOffset, *vecLookAt, fTilt, CamSwitchStyle, SCRIPT_CAM_CONTROL);
 }
 
 // LSOD recovery
@@ -282,51 +220,25 @@ VOID CCameraSA::SetMatrix(CMatrix* matrix)
 
 VOID CCameraSA::SetCamPositionForFixedMode(CVector* vecPosition, CVector* vecUpOffset)
 {
-    DWORD               dwFunc = FUNC_SetCamPositionForFixedMode;
-    CCameraSAInterface* cameraInterface = this->GetInterface();
-    _asm
-    {
-        mov     ecx, cameraInterface
-        push    vecUpOffset
-        push    vecPosition
-        call    dwFunc
-    }
+    // CCamera::SetCamPositionForFixedMode
+    ((void(__thiscall*)(CCameraSAInterface*, CVector&, CVector&))FUNC_SetCamPositionForFixedMode)(GetInterface(), *vecPosition, *vecUpOffset);
 }
 
 VOID CCameraSA::Find3rdPersonCamTargetVector(FLOAT fDistance, CVector* vecGunMuzzle, CVector* vecSource, CVector* vecTarget)
 {
     DEBUG_TRACE("VOID CCameraSA::Find3rdPersonCamTargetVector ( FLOAT fDistance, CVector * vecGunMuzzle, CVector * vecSource, CVector * vecTarget )");
-    FLOAT               fOriginX = vecGunMuzzle->fX;
-    FLOAT               fOriginY = vecGunMuzzle->fY;
-    FLOAT               fOriginZ = vecGunMuzzle->fZ;
-    DWORD               dwFunc = FUNC_Find3rdPersonCamTargetVector;
-    CCameraSAInterface* cameraInterface = this->GetInterface();
-    _asm
-    {
-        mov     ecx, cameraInterface
-        push    vecTarget
-        push    vecSource
-        push    fOriginZ
-        push    fOriginY
-        push    fOriginX
-        push    fDistance
-        call    dwFunc
-    }
+
+    // CCamera::Find3rdPersonCamTargetVector
+    ((void(__thiscall*)(CCameraSAInterface*, float, float, float, float, CVector&, CVector&))FUNC_Find3rdPersonCamTargetVector)(
+        GetInterface(), fDistance, vecGunMuzzle->fX, vecGunMuzzle->fY, vecGunMuzzle->fZ, *vecSource, *vecTarget);
 }
 
 float CCameraSA::Find3rdPersonQuickAimPitch()
 {
     DEBUG_TRACE("float CCameraSA::Find3rdPersonQuickAimPitch ( void )");
-    float               fReturn;
-    DWORD               dwFunc = FUNC_Find3rdPersonQuickAimPitch;
-    CCameraSAInterface* cameraInterface = this->GetInterface();
-    _asm
-    {
-        mov     ecx, cameraInterface
-        call    dwFunc
-        fstp    fReturn
-    }
-    return fReturn;
+
+    // CCamera::Find3rdPersonQuickAimPitch
+    return ((float(__thiscall*)(CCameraSAInterface*))FUNC_Find3rdPersonQuickAimPitch)(GetInterface());
 }
 
 BYTE CCameraSA::GetActiveCam()
@@ -405,6 +317,7 @@ VOID CCameraSA::SetCarZoom(float fCarZoom)
 bool CCameraSA::TryToStartNewCamMode(DWORD dwCamMode)
 {
     DEBUG_TRACE("VOID CCameraSA::TryToStartNewCamMode(DWORD dwCamMode)");
+    /*
     DWORD               dwFunc = FUNC_TryToStartNewCamMode;
     bool                bReturn = false;
     CCameraSAInterface* cameraInterface = this->GetInterface();
@@ -415,100 +328,45 @@ bool CCameraSA::TryToStartNewCamMode(DWORD dwCamMode)
         call    dwFunc
         mov     bReturn, al
     }
-    return bReturn;
+    return bReturn;*/
+    return false;
 }
 
 bool CCameraSA::ConeCastCollisionResolve(CVector* pPos, CVector* pLookAt, CVector* pDest, float rad, float minDist, float* pDist)
 {
-    DWORD               dwFunc = FUNC_ConeCastCollisionResolve;
-    bool                bReturn = false;
-    CCameraSAInterface* cameraInterface = this->GetInterface();
-    _asm
-    {
-        mov     ecx, cameraInterface
-        push    pDist
-        push    minDist
-        push    rad
-        push    pDest
-        push    pLookAt
-        push    pPos
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CCamera::ConeCastCollisionResolve
+    return ((bool(__thiscall*)(CCameraSAInterface*, CVector&, CVector&, CVector&, float, float, float*))FUNC_ConeCastCollisionResolve)(
+        GetInterface(), *pPos, *pLookAt, *pDest, rad, minDist, pDist);
 }
 
 void CCameraSA::VectorTrackLinear(CVector* pTo, CVector* pFrom, float time, bool bSmoothEnds)
 {
-    DWORD               dwFunc = FUNC_VectorTrackLinear;
-    CCameraSAInterface* cameraInterface = this->GetInterface();
-    _asm
-    {
-        mov     ecx, cameraInterface
-        push    bSmoothEnds
-        push    time
-        push    pFrom
-        push    pTo
-        call    dwFunc
-    }
+    // CCamera::VectorTrackLinear
+    ((void(__thiscall*)(CCameraSAInterface*, CVector*, CVector*, float, bool))FUNC_VectorTrackLinear)(GetInterface(), pTo, pFrom, time, bSmoothEnds);
 }
 
 bool CCameraSA::IsFading()
 {
-    DWORD               dwFunc = FUNC_GetFading;
-    CCameraSAInterface* cameraInterface = this->GetInterface();
-    bool                bRet = false;
-    _asm
-    {
-        mov     ecx, cameraInterface
-        call    dwFunc
-        mov     bRet, al
-    }
-    return bRet;
+    // CCamera::GetFading
+    return ((bool(__thiscall*)(CCameraSAInterface*))FUNC_GetFading)(GetInterface());
 }
 
 int CCameraSA::GetFadingDirection()
 {
-    DWORD               dwFunc = FUNC_GetFadingDirection;
-    CCameraSAInterface* cameraInterface = this->GetInterface();
-    int                 dwRet = false;
-    _asm
-    {
-        mov     ecx, cameraInterface
-        call    dwFunc
-        mov     dwRet, eax
-    }
-    return dwRet;
+    // CCamera::GetFadingDirection
+    return ((int(__thiscall*)(CCameraSAInterface*))FUNC_GetFadingDirection)(GetInterface());
 }
 
 void CCameraSA::Fade(float fFadeOutTime, int iOutOrIn)
 {
-    DWORD               dwFunc = FUNC_Fade;
-    CCameraSAInterface* cameraInterface = this->GetInterface();
-    _asm
-    {
-        mov     ecx, cameraInterface
-        push    iOutOrIn
-        push    fFadeOutTime
-        call    dwFunc
-    }
+    // CCamera::Fade
+    ((void(__thiscall*)(CCameraSAInterface*, float, int))FUNC_Fade)(GetInterface(), fFadeOutTime, iOutOrIn);
 }
 
 void CCameraSA::SetFadeColor(unsigned char ucRed, unsigned char ucGreen, unsigned char ucBlue)
 {
-    DWORD               dwFunc = FUNC_SetFadeColour;
-    CCameraSAInterface* cameraInterface = this->GetInterface();
-    DWORD               dwRed = ucRed;
-    DWORD               dwGreen = ucGreen;
-    DWORD               dwBlue = ucBlue;
-    _asm
-    {
-        mov     ecx, cameraInterface
-        push    dwBlue
-        push    dwGreen
-        push    dwRed
-        call    dwFunc
-    }
+    // CCamera::SetFadeColour
+    ((void(__thiscall*)(CCameraSAInterface*, unsigned char, unsigned char, unsigned char))FUNC_SetFadeColour)(GetInterface(), ucRed, ucGreen, ucBlue);
 }
 
 float CCameraSA::GetCameraRotation()
@@ -518,16 +376,8 @@ float CCameraSA::GetCameraRotation()
 
 RwMatrix* CCameraSA::GetLTM()
 {
-    DWORD frame = *(DWORD*)(((DWORD)this->GetInterface()->m_pRwCamera) + 4);
-    DWORD dwReturn;
-    _asm
-    {
-        push    frame
-        call    FUNC_RwFrameGetLTM
-        add     esp, 4
-        mov     dwReturn, eax
-    }
-    return (RwMatrix*)dwReturn;
+    // RwFrameGetLTM
+    return ((RwMatrix*(_cdecl*)(void*))FUNC_RwFrameGetLTM)(GetInterface()->m_pRwCamera->object.object.parent);
 }
 
 CEntity* CCameraSA::GetTargetEntity()

--- a/Client/game_sa/CCameraSA.h
+++ b/Client/game_sa/CCameraSA.h
@@ -316,7 +316,7 @@ public:
     FLOAT   m_fAttachedCamAngle;            // for giving the attached camera a tilt.
 
     // RenderWare camera pointer
-    DWORD* m_pRwCamera;            // was RwCamera *
+    RwCamera* m_pRwCamera;
     /// stuff for cut scenes
     CEntitySAInterface* pTargetEntity;
     CEntitySAInterface* pAttachedEntity;

--- a/Client/game_sa/CCarEnterExitSA.cpp
+++ b/Client/game_sa/CCarEnterExitSA.cpp
@@ -13,71 +13,37 @@
 
 bool CCarEnterExitSA::GetNearestCarDoor(CPed* pPed, CVehicle* pVehicle, CVector* pVector, int* pDoor)
 {
-    DWORD dwFunc = FUNC_GetNearestCarDoor;
-    bool  bReturn = false;
-
     CPedSA*     pPedSA = dynamic_cast<CPedSA*>(pPed);
     CVehicleSA* pVehicleSA = dynamic_cast<CVehicleSA*>(pVehicle);
 
     if (pPedSA && pVehicleSA)
     {
-        CPedSAInterface*     pPedInterface = pPedSA->GetPedInterface();
-        CVehicleSAInterface* pVehicleInterface = pVehicleSA->GetVehicleInterface();
-        _asm
-        {
-            push    pDoor
-            push    pVector
-            push    pVehicleInterface
-            push    pPedInterface
-            call    dwFunc
-            add     esp, 0x10
-            mov     bReturn, al
-        }
+        // CCarEnterExit::GetNearestCarDoor
+        return ((bool(__cdecl*)(CPedSAInterface*, CVehicleSAInterface*, CVector*, int*))(FUNC_GetNearestCarDoor))(
+            pPedSA->GetPedInterface(), pVehicleSA->GetVehicleInterface(), pVector, pDoor);
     }
 
-    return bReturn;
+    return false;
 }
 
 bool CCarEnterExitSA::GetNearestCarPassengerDoor(CPed* pPed, CVehicle* pVehicle, CVector* pVector, int* pDoor, bool bUnknown, bool bUnknown2,
                                                  bool bCheckIfRoomToGetIn)
 {
-    DWORD dwFunc = FUNC_GetNearestCarPassengerDoor;
-    bool  bReturn = false;
-
     CPedSA*     pPedSA = dynamic_cast<CPedSA*>(pPed);
     CVehicleSA* pVehicleSA = dynamic_cast<CVehicleSA*>(pVehicle);
 
     if (pPedSA && pVehicleSA)
     {
-        CPedSAInterface*     pPedInterface = pPedSA->GetPedInterface();
-        CVehicleSAInterface* pVehicleInterface = pVehicleSA->GetVehicleInterface();
-        _asm
-        {
-            push    ebx
-            xor     ebx, ebx
-            mov     bl, bCheckIfRoomToGetIn
-            push    ebx
-            mov     bl, bUnknown2
-            push    ebx
-            mov     bl, bUnknown
-            push    ebx
-            push    pDoor
-            push    pVector
-            push    pVehicleInterface
-            push    pPedInterface
-            call    dwFunc
-            add     esp, 0x1C
-            mov     bReturn, al
-            pop     ebx
-        }
+        // CCarEnterExit::GetNearestCarPassengerDoor
+        return ((bool(__cdecl*)(CPedSAInterface*, CVehicleSAInterface*, CVector*, int*, bool, bool, bool))(FUNC_GetNearestCarPassengerDoor))(
+            pPedSA->GetPedInterface(), pVehicleSA->GetVehicleInterface(), pVector, pDoor, bUnknown, bUnknown2, bCheckIfRoomToGetIn);
     }
 
-    return bReturn;
+    return false;
 }
 
 int CCarEnterExitSA::ComputeTargetDoorToExit(CPed* pPed, CVehicle* pVehicle)
 {
-    DWORD dwFunc = FUNC_ComputeTargetDoorToExit;
     int   door = -1;
 
     CPedSA*     pPedSA = dynamic_cast<CPedSA*>(pPed);
@@ -85,16 +51,9 @@ int CCarEnterExitSA::ComputeTargetDoorToExit(CPed* pPed, CVehicle* pVehicle)
 
     if (pPedSA && pVehicleSA)
     {
-        CPedSAInterface*     pPedInterface = pPedSA->GetPedInterface();
-        CVehicleSAInterface* pVehicleInterface = pVehicleSA->GetVehicleInterface();
-        _asm
-        {
-            push    pPedInterface
-            push    pVehicleInterface
-            call    dwFunc
-            add     esp, 8
-            mov     door, eax
-        }
+        // CCarEnterExit::ComputeTargetDoorToExit
+        door = ((int(__cdecl*)(CVehicleSAInterface*, CPedSAInterface*))(FUNC_ComputeTargetDoorToExit))(pVehicleSA->GetVehicleInterface(),
+                                                                                                      pPedSA->GetPedInterface());
 
         switch (door)
         {
@@ -158,9 +117,6 @@ int CCarEnterExitSA::ComputeTargetDoorToExit(CPed* pPed, CVehicle* pVehicle)
 
 bool CCarEnterExitSA::IsRoomForPedToLeaveCar(CVehicle* pVehicle, int iDoor, CVector* pUnknown)
 {
-    DWORD dwFunc = FUNC_IsRoomForPedToLeaveCar;
-    bool  bRet = true;
-
     if (iDoor >= 0 && iDoor <= 5)
     {
         static int  s_iCarNodeIndexes[6] = {0x10, 0x11, 0x0A, 0x08, 0x0B, 0x09};
@@ -168,18 +124,10 @@ bool CCarEnterExitSA::IsRoomForPedToLeaveCar(CVehicle* pVehicle, int iDoor, CVec
         DWORD       dwIdx = s_iCarNodeIndexes[iDoor];
         if (pVehicleSA)
         {
-            CVehicleSAInterface* pVehicleInterface = pVehicleSA->GetVehicleInterface();
-            _asm
-            {
-                push    pUnknown
-                push    dwIdx
-                push    pVehicleInterface
-                call    dwFunc
-                add     esp, 12
-                mov     bRet, al
-            }
+            // CCarEnterExit::IsRoomForPedToLeaveCar
+            return ((bool(__cdecl*)(CVehicleSAInterface*, int, CVector*))(FUNC_IsRoomForPedToLeaveCar))(pVehicleSA->GetVehicleInterface(), dwIdx, pUnknown);
         }
     }
 
-    return bRet;
+    return true;
 }

--- a/Client/game_sa/CColModelSA.cpp
+++ b/Client/game_sa/CColModelSA.cpp
@@ -13,14 +13,8 @@
 
 CColModelSA::CColModelSA()
 {
-    m_pInterface = new CColModelSAInterface;
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CColModel_Constructor;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CColModel::CColModel
+    m_pInterface = ((CColModelSAInterface*(__thiscall*)(CColModelSAInterface*))(FUNC_CColModel_Constructor))(new CColModelSAInterface);
     m_bDestroyInterface = true;
 }
 
@@ -34,13 +28,8 @@ CColModelSA::~CColModelSA()
 {
     if (m_bDestroyInterface)
     {
-        DWORD dwThis = (DWORD)m_pInterface;
-        DWORD dwFunc = FUNC_CColModel_Destructor;
-        _asm
-        {
-            mov     ecx, dwThis
-            call    dwFunc
-        }
+        // CColModel::~CColModel
+        ((void(__thiscall*)(CColModelSAInterface*))(FUNC_CColModel_Destructor))(m_pInterface);
         delete m_pInterface;
     }
 }

--- a/Client/game_sa/CControllerConfigManagerSA.cpp
+++ b/Client/game_sa/CControllerConfigManagerSA.cpp
@@ -32,56 +32,29 @@ CControllerConfigManagerSA::CControllerConfigManagerSA()
 
 void CControllerConfigManagerSA::SetControllerKeyAssociatedWithAction(eControllerAction action, int iKey, eControllerType controllerType)
 {
-    DWORD dwFunc = FUNC_SetControllerKeyAssociatedWithAction;
-    _asm
-    {
-        mov     ecx, CLASS_CControllerConfigManager
-        push    controllerType
-        push    iKey
-        push    action
-        call    dwFunc
-    }
+    // CControllerConfigManager::SetControllerKeyAssociatedWithAction
+    ((void(__thiscall*)(int, eControllerAction, int, eControllerType))(FUNC_SetControllerKeyAssociatedWithAction))(
+        CLASS_CControllerConfigManager, action, iKey, controllerType);
 }
 
 int CControllerConfigManagerSA::GetControllerKeyAssociatedWithAction(eControllerAction action, eControllerType controllerType)
 {
-    int   iReturn = 0;
-    DWORD dwFunc = FUNC_GetControllerKeyAssociatedWithAction;
-    _asm
-    {
-        mov     ecx, CLASS_CControllerConfigManager
-        push    controllerType
-        push    action
-        call    dwFunc
-        mov     iReturn, eax
-    }
-    return iReturn;
+    // CControllerConfigManager::GetControllerKeyAssociatedWithAction
+    return ((int(__thiscall*)(int, eControllerAction, eControllerType))(FUNC_GetControllerKeyAssociatedWithAction))(
+        CLASS_CControllerConfigManager, action, controllerType);
 }
 
 int CControllerConfigManagerSA::GetNumOfSettingsForAction(eControllerAction action)
 {
-    int   iReturn = 0;
-    DWORD dwFunc = FUNC_GetNumOfSettingsForAction;
-    _asm
-    {
-        mov     ecx, CLASS_CControllerConfigManager
-        push    action
-        call    dwFunc
-        mov     iReturn, eax
-    }
-    return iReturn;
+    // CControllerConfigManager::GetNumOfSettingsForAction
+    return ((int(__thiscall*)(int, eControllerAction))(FUNC_GetNumOfSettingsForAction))(CLASS_CControllerConfigManager, action);
 }
 
 void CControllerConfigManagerSA::ClearSettingsAssociatedWithAction(eControllerAction action, eControllerType controllerType)
 {
-    DWORD dwFunc = FUNC_ClearSettingsAssociatedWithAction;
-    _asm
-    {
-        mov     ecx, CLASS_CControllerConfigManager
-        push    controllerType
-        push    action
-        call    dwFunc
-    }
+    // CControllerConfigManager::ClearSettingsAssociatedWithAction
+    ((void(__thiscall*)(int, eControllerAction, eControllerType))(FUNC_ClearSettingsAssociatedWithAction))(
+        CLASS_CControllerConfigManager, action, controllerType);
 }
 
 void CControllerConfigManagerSA::SetClassicControls(bool bClassicControls)

--- a/Client/game_sa/CDamageManagerSA.cpp
+++ b/Client/game_sa/CDamageManagerSA.cpp
@@ -45,6 +45,8 @@ VOID CDamageManagerSA::SetDoorStatus(eDoors bDoor, BYTE bDoorStatus, bool spawnF
             // Set it
             internalInterface->Door[bDoor] = bDoorStatus;
 
+            CAutomobileSAInterface* pAutomobile = (CAutomobileSAInterface*)internalEntityInterface;
+
             // Are we making it intact?
             if (bDoorStatus == DT_DOOR_INTACT || bDoorStatus == DT_DOOR_SWINGING_FREE)
             {
@@ -52,32 +54,14 @@ VOID CDamageManagerSA::SetDoorStatus(eDoors bDoor, BYTE bDoorStatus, bool spawnF
                 static int s_iCarNodeIndexes[6] = {0x10, 0x11, 0x0A, 0x08, 0x0B, 0x09};
 
                 // Call CAutomobile::FixDoor to update the model
-                DWORD dwFunc = 0x6A35A0;
-                DWORD dwThis = (DWORD)internalEntityInterface;
-                int   iCarNodeIndex = s_iCarNodeIndexes[bDoor];
-                DWORD dwDoor = (DWORD)bDoor;
-                _asm
-                {
-                    mov     ecx, dwThis
-                    push    dwDoor
-                    push    iCarNodeIndex
-                    call    dwFunc
-                }
+                // CAutomobile::FixDoor
+                ((void(__thiscall*)(CAutomobileSAInterface*, int, int))(0x6A35A0))(pAutomobile, s_iCarNodeIndexes[bDoor], bDoor);
             }
             else
             {
                 // Call CAutomobile::SetDoorDamage to update the model
-                DWORD dwFunc = 0x6B1600;
-                DWORD dwThis = (DWORD)internalEntityInterface;
-                DWORD dwDoor = (DWORD)bDoor;
-                bool  bQuiet = !spawnFlyingComponent;
-                _asm
-                {
-                    mov     ecx, dwThis
-                    push    bQuiet
-                    push    dwDoor
-                    call    dwFunc
-                }
+                // CAutomobile::SetDoorDamage
+                ((void(__thiscall*)(CAutomobileSAInterface*, int, bool))(0x6B1600))(pAutomobile, bDoor, !spawnFlyingComponent);
             }
         }
     }
@@ -114,18 +98,10 @@ VOID CDamageManagerSA::SetPanelStatus(BYTE bPanel, BYTE bPanelStatus)
         // Different than already?
         if (GetPanelStatus(bPanel) != bPanelStatus)
         {
-            // Call the function to set it
-            DWORD dwFunction = FUNC_SetPanelStatus;
-            DWORD dwThis = (DWORD)internalInterface;
-            DWORD dwPanel = bPanel;
-            DWORD dwStatus = bPanelStatus;
-            _asm
-            {
-                mov     ecx, dwThis
-                push    dwStatus
-                push    dwPanel
-                call    dwFunction
-            }
+            // CDamageManager::SetPanelStatus
+            ((void(__thiscall*)(CDamageManagerSAInterface*, unsigned char, int))(FUNC_SetPanelStatus))(internalInterface, bPanel, bPanelStatus);
+
+            CAutomobileSAInterface* pAutomobile = (CAutomobileSAInterface*)internalEntityInterface;
 
             // Intact?
             if (bPanelStatus == DT_PANEL_INTACT)
@@ -134,30 +110,15 @@ VOID CDamageManagerSA::SetPanelStatus(BYTE bPanel, BYTE bPanelStatus)
                 static int s_iCarNodeIndexes[7] = {0x0F, 0x0E, 0x00 /*?*/, 0x00 /*?*/, 0x12, 0x0C, 0x0D};
 
                 //  Call CAutomobile::FixPanel to update the vehicle
-                dwFunction = 0x6A3670;
-                dwThis = (DWORD)internalEntityInterface;
-                int iCarNodeIndex = s_iCarNodeIndexes[bPanel];
-                _asm
-                {
-                    mov     ecx, dwThis
-                    push    dwPanel
-                    push    iCarNodeIndex
-                    call    dwFunction
-                }
+                // CAutomobile::FixPanel
+                ((void(__thiscall*)(CAutomobileSAInterface*, int, int))(0x6A3670))(pAutomobile, s_iCarNodeIndexes[bPanel], bPanel);
             }
             else
             {
                 // Call CAutomobile::SetPanelDamage to update the vehicle
-                dwFunction = 0x6B1480;
-                dwThis = (DWORD)internalEntityInterface;
-                bool bUnknown = false;
-                _asm
-                {
-                    mov     ecx, dwThis
-                    push    bUnknown
-                    push    dwPanel
-                    call    dwFunction
-                }
+
+                // CAutomobile::SetPanelDamage
+                ((void(__thiscall*)(CAutomobileSAInterface*, int, bool))(0x6B1480))(pAutomobile, bPanel, false);
             }
         }
     }
@@ -179,19 +140,9 @@ BYTE CDamageManagerSA::GetPanelStatus(BYTE bPanel)
     if (bPanel < MAX_PANELS)
     {
         DEBUG_TRACE("BYTE CDamageManagerSA::GetPanelStatus ( BYTE bPannel )");
-        DWORD dwFunction = FUNC_GetPanelStatus;
-        DWORD dwPointer = (DWORD)internalInterface;
-        BYTE  bReturn = 0;
-        DWORD dwPanel = bPanel;
-        _asm
-        {
-            mov     ecx, dwPointer
-            push    dwPanel
-            call    dwFunction
-            mov     bReturn, al
-        }
 
-        return bReturn;
+        // CDamageManager::GetPanelStatus
+        return ((BYTE(__thiscall*)(CDamageManagerSAInterface*, int))(FUNC_GetPanelStatus))(internalInterface, bPanel);
     }
 
     return 0;
@@ -205,17 +156,9 @@ unsigned long CDamageManagerSA::GetPanelStatus()
 VOID CDamageManagerSA::SetLightStatus(BYTE bLight, BYTE bLightStatus)
 {
     DEBUG_TRACE("BYTE CDamageManagerSA::SetLightStatus ( BYTE bLight, BYTE bLightStatus )");
-    DWORD dwFunction = FUNC_SetLightStatus;
-    DWORD dwPointer = (DWORD)internalInterface;
-    DWORD dwLight = bLight;
-    DWORD dwStatus = bLightStatus;
-    _asm
-    {
-        mov     ecx, dwPointer
-        push    dwStatus
-        push    dwLight
-        call    dwFunction
-    }
+
+    // CDamageManager::SetLightStatus
+    ((void(__thiscall*)(CDamageManagerSAInterface*, int, int))(FUNC_SetLightStatus))(internalInterface, bLight, bLightStatus);
 }
 
 void CDamageManagerSA::SetLightStatus(unsigned char ucStatus)
@@ -226,18 +169,9 @@ void CDamageManagerSA::SetLightStatus(unsigned char ucStatus)
 BYTE CDamageManagerSA::GetLightStatus(BYTE bLight)
 {
     DEBUG_TRACE("BYTE CDamageManagerSA::GetLightStatus ( BYTE bLight )");
-    DWORD dwFunction = FUNC_GetLightStatus;
-    DWORD dwPointer = (DWORD)internalInterface;
-    BYTE  bReturn = 0;
-    DWORD dwLight = bLight;
-    _asm
-    {
-        mov     ecx, dwPointer
-        push    dwLight
-        call    dwFunction
-        mov     bReturn, al
-    }
-    return bReturn;
+
+    // CDamageManager::SetLightStatus
+    return ((BYTE(__thiscall*)(CDamageManagerSAInterface*, int))(FUNC_GetLightStatus))(internalInterface, bLight);
 }
 
 unsigned char CDamageManagerSA::GetLightStatus()
@@ -248,44 +182,22 @@ unsigned char CDamageManagerSA::GetLightStatus()
 VOID CDamageManagerSA::SetAeroplaneCompStatus(BYTE CompID, BYTE Status)
 {
     DEBUG_TRACE("VOID CDamageManagerSA::SetAeroplaneCompStatus( BYTE CompID, BYTE Status)");
-    DWORD dwFunction = FUNC_SetAeroplaneCompStatus;
-    DWORD dwPointer = (DWORD)internalInterface;
-    DWORD dwPannel = CompID;
-    _asm
-    {
-        mov     ecx, dwPointer
-        push    Status
-        push    dwPannel
-        call    dwFunction
-    }
+
+    // CDamageManager::SetAeroplaneCompStatus
+    ((void(__thiscall*)(CDamageManagerSAInterface*, int, uint))(FUNC_SetAeroplaneCompStatus))(internalInterface, CompID, Status);
 }
 
 BYTE CDamageManagerSA::GetAeroplaneCompStatus(BYTE CompID)
 {
     DEBUG_TRACE("BYTE CDamageManagerSA::GetAeroplaneCompStatus( BYTE CompID )");
-    DWORD dwFunction = FUNC_GetAeroplaneCompStatus;
-    DWORD dwPointer = (DWORD)internalInterface;
-    BYTE  bReturn = 0;
-    DWORD dwPannel = CompID;
-    _asm
-    {
-        mov     ecx, dwPointer
-        push    dwPannel
-        call    dwFunction
-        mov     bReturn, al
-    }
-    return bReturn;
+
+    // CDamageManager::GetAeroplaneCompStatus
+    return ((BYTE(__thiscall*)(CDamageManagerSAInterface*, int))(FUNC_GetAeroplaneCompStatus))(internalInterface, CompID);
 }
 
 VOID CDamageManagerSA::FuckCarCompletely(BOOL bKeepWheels)
 {
     DEBUG_TRACE("VOID CDamageManagerSA::FuckCarCompletely ( BOOL bKeepWheels )");
-    DWORD dwFunc = FUNC_FuckCarCompletely;
-    DWORD dwPointer = (DWORD)internalInterface;
-    _asm
-    {
-        mov     ecx, dwPointer
-        push    bKeepWheels
-        call    dwFunc
-    }
+    // CDamageManager::FuckCarCompletely
+    ((void(__thiscall*)(CDamageManagerSAInterface*, bool))(FUNC_FuckCarCompletely))(internalInterface, bKeepWheels);
 }

--- a/Client/game_sa/CDoorSA.cpp
+++ b/Client/game_sa/CDoorSA.cpp
@@ -18,21 +18,14 @@
 FLOAT CDoorSA::GetAngleOpenRatio()
 {
     DEBUG_TRACE("FLOAT CDoorSA::GetAngleOpenRatio ( )");
-    DWORD dwFunction = FUNC_GetAngleOpenRatio;
-    DWORD dwPointer = (DWORD)GetInterface();
-    FLOAT fReturn = 0.0f;
 
-    if (dwPointer != 0)
+    if (GetInterface())
     {
-        _asm
-        {
-            mov     ecx, dwPointer
-            call    dwFunction
-            fstp    fReturn
-        }
+        // CDoor::GetAngleOpenRatio
+        return ((float(__thiscall*)(CDoorSAInterface*))(FUNC_GetAngleOpenRatio))(GetInterface());
     }
 
-    return fReturn;
+    return 0.0f;
 }
 
 /**
@@ -42,21 +35,14 @@ FLOAT CDoorSA::GetAngleOpenRatio()
 BOOL CDoorSA::IsClosed()
 {
     DEBUG_TRACE("BOOL CDoorSA::IsClosed (  )");
-    DWORD dwFunction = FUNC_IsClosed;
-    DWORD dwPointer = (DWORD)GetInterface();
-    BYTE  bReturn = 0;
 
-    if (dwPointer != 0)
+    if (GetInterface())
     {
-        _asm
-        {
-            mov     ecx, dwPointer
-            call    dwFunction
-            mov     bReturn, al
-        }
+        // CDoor::IsClosed
+        return ((bool(__thiscall*)(CDoorSAInterface*))(FUNC_IsClosed))(GetInterface());
     }
 
-    return bReturn;
+    return FALSE;
 }
 
 /**
@@ -67,21 +53,14 @@ BOOL CDoorSA::IsClosed()
 BOOL CDoorSA::IsFullyOpen()
 {
     DEBUG_TRACE("BOOL CDoorSA::IsFullyOpen (  )");
-    DWORD dwFunction = FUNC_IsFullyOpen;
-    DWORD dwPointer = (DWORD)GetInterface();
-    BYTE  bReturn = 0;
 
-    if (dwPointer != 0)
+    if (GetInterface())
     {
-        _asm
-        {
-            mov     ecx, dwPointer
-            call    dwFunction
-            mov     bReturn, al
-        }
+        // CDoor::IsFullyOpen
+        return ((bool(__thiscall*)(CDoorSAInterface*))(FUNC_IsFullyOpen))(GetInterface());
     }
 
-    return bReturn;
+    return FALSE;
 }
 
 /**
@@ -92,16 +71,10 @@ BOOL CDoorSA::IsFullyOpen()
 VOID CDoorSA::Open(float fOpenRatio)
 {
     DEBUG_TRACE("VOID CDoorSA::Open ( float fOpenRatio )");
-    DWORD dwFunction = FUNC_Open;
-    DWORD dwPointer = (DWORD)GetInterface();
 
-    if (dwPointer != 0)
+    if (GetInterface())
     {
-        _asm
-        {
-            mov     ecx, dwPointer
-            push    fOpenRatio
-            call    dwFunction
-        }
+        // CDoor::Open
+        ((void(__thiscall*)(CDoorSAInterface*, float))(FUNC_Open))(GetInterface(), fOpenRatio);
     }
 }

--- a/Client/game_sa/CEntitySA.cpp
+++ b/Client/game_sa/CEntitySA.cpp
@@ -470,7 +470,7 @@ VOID CEntitySA::MatrixConvertToEulerAngles(float* fX, float* fY, float* fZ, int 
 bool CEntitySA::IsPlayingAnimation(char* szAnimName)
 {
     // RpAnimBlendClumpGetAssociation
-    return ((CAnimBlendAssociation*(__cdecl*)(RpClump*, const char*))FUNC_RpAnimBlendClumpGetAssociation)(m_pInterface->m_pRwObject, szAnimName) ? true : false;
+    return ((CAnimBlendAssociation*(__cdecl*)(RpClump*, const char*))FUNC_RpAnimBlendClumpGetAssociation)(m_pInterface->m_pRwObject, szAnimName) != nullptr;
 }
 
 RwMatrixTag* CEntitySA::GetBoneRwMatrix(eBone boneId)

--- a/Client/game_sa/CEntitySA.cpp
+++ b/Client/game_sa/CEntitySA.cpp
@@ -125,13 +125,9 @@ VOID CEntitySA::SetPosition(float fX, float fY, float fZ)
     if (wModelID == 537 || wModelID == 538 || wModelID == 569 || wModelID == 570 || wModelID == 590 || wModelID == 449)
     {
         // If it's a train, recalculate its rail position parameter (does not affect derailed state)
-        DWORD dwThis = (DWORD)m_pInterface;
-        DWORD dwFunc = FUNC_CTrain_FindPositionOnTrackFromCoors;
-        _asm
-        {
-            mov     ecx, dwThis
-            call    dwFunc
-        }
+
+        // CTrain::FindPositionOnTrackFromCoors
+        ((void(__thiscall*)(void*))FUNC_CTrain_FindPositionOnTrackFromCoors)(m_pInterface);
     }
     if (m_pInterface->nType == ENTITY_TYPE_OBJECT)
     {
@@ -146,17 +142,7 @@ VOID CEntitySA::Teleport(float fX, float fY, float fZ)
     {
         SetPosition(fX, fY, fZ);
 
-        DWORD dwFunc = m_pInterface->vtbl->Teleport;
-        DWORD dwThis = (DWORD)m_pInterface;
-        _asm
-        {
-            mov     ecx, dwThis
-            push    1
-            push    fZ
-            push    fY
-            push    fX
-            call    dwFunc
-        }
+        ((void(__thiscall*)(CEntitySAInterface*, float, float, float, bool))m_pInterface->vtbl->Teleport)(m_pInterface, fX, fY, fZ, true);
     }
     else
     {
@@ -167,86 +153,40 @@ VOID CEntitySA::Teleport(float fX, float fY, float fZ)
 VOID CEntitySA::ProcessControl()
 {
     DEBUG_TRACE("VOID CEntitySA::ProcessControl ( void )");
-    DWORD dwFunc = m_pInterface->vtbl->ProcessControl;
-    DWORD dwThis = (DWORD)m_pInterface;
-    if (dwFunc)
-    {
-        _asm
-        {
-            mov     ecx, dwThis
-            call    dwFunc
-        }
-    }
+
+    if (m_pInterface->vtbl->ProcessControl)
+        ((void(__thiscall*)(CEntitySAInterface*))m_pInterface->vtbl->ProcessControl)(m_pInterface);
 }
 
 VOID CEntitySA::SetupLighting()
 {
     DEBUG_TRACE("VOID CEntitySA::SetupLighting ( )");
-    DWORD dwFunc = m_pInterface->vtbl->SetupLighting;
-    DWORD dwThis = (DWORD)m_pInterface;
-    if (dwFunc)
-    {
-        _asm
-        {
-            mov     ecx, dwThis
-            call    dwFunc
-        }
-    }
+
+    if (m_pInterface->vtbl->SetupLighting)
+        ((void(__thiscall*)(CEntitySAInterface*))m_pInterface->vtbl->SetupLighting)(m_pInterface);
 }
 
 VOID CEntitySA::Render()
 {
     DEBUG_TRACE("VOID CEntitySA::Render ( )");
-    DWORD dwFunc = 0x59F180;            // m_pInterface->vtbl->Render;
-    DWORD dwThis = (DWORD)m_pInterface;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
 
-    /*  DWORD dwFunc = 0x553260;
-        DWORD dwThis = (DWORD) m_pInterface;
-
-        _asm
-        {
-            push    dwThis
-            call    dwFunc
-            add     esp, 4
-        }*/
+    // CObject::Render
+    ((void(__thiscall*)(CEntitySAInterface*))0x59F180)(m_pInterface);
 }
 
 VOID CEntitySA::SetOrientation(float fX, float fY, float fZ)
 {
     DEBUG_TRACE("VOID CEntitySA::SetOrientation ( float fX, float fY, float fZ )");
     pGame->GetWorld()->Remove(this, CEntity_SetOrientation);
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_SetOrientation;
-    _asm
-    {
-        // ChrML: I've switched the X and Z at this level because that's how the real rotation
-        //        is. GTA has kinda swapped them in this function.
 
-        push    fZ
-        push    fY
-        push    fX
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CPlaceable::SetOrientation
+    ((void(__thiscall*)(CEntitySAInterface*, float, float, float))FUNC_SetOrientation)(m_pInterface, fX, fY, fZ);
 
-    dwFunc = 0x446F90;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CEntity::UpdateRwMatrix
+    ((void(__thiscall*)(CEntitySAInterface*))0x446F90)(m_pInterface);
 
-    dwFunc = 0x532B00;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CEntity::UpdateRwFrame
+    ((void(__thiscall*)(CEntitySAInterface*))0x532B00)(m_pInterface);
 
     if (m_pInterface->nType == ENTITY_TYPE_OBJECT)
     {
@@ -260,20 +200,12 @@ VOID CEntitySA::FixBoatOrientation()
 {
     DEBUG_TRACE("VOID CEntitySA::FixBoatOrientation ( void )");
     pGame->GetWorld()->Remove(this, CEntity_FixBoatOrientation);
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = 0x446F90;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
 
-    dwFunc = 0x532B00;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CEntity::UpdateRwMatrix
+    ((void(__thiscall*)(CEntitySAInterface*))0x446F90)(m_pInterface);
+
+    // CEntity::UpdateRwFrame
+    ((void(__thiscall*)(CEntitySAInterface*))0x532B00)(m_pInterface);
 
     pGame->GetWorld()->Add(this, CEntity_FixBoatOrientation);
 }
@@ -404,20 +336,12 @@ VOID CEntitySA::SetMatrix(CMatrix* matrix)
         */
 
         pGame->GetWorld()->Remove(this, CEntity_SetMatrix);
-        DWORD dwThis = (DWORD)m_pInterface;
-        DWORD dwFunc = 0x446F90;            // CEntity::UpdateRwMatrix
-        _asm
-        {
-            mov     ecx, dwThis
-            call    dwFunc
-        }
 
-        dwFunc = 0x532B00;            // CEntity::UpdateRwFrame
-        _asm
-        {
-            mov     ecx, dwThis
-            call    dwFunc
-        }
+        // CEntity::UpdateRwMatrix
+        ((void(__thiscall*)(CEntitySAInterface*))0x446F90)(m_pInterface);
+
+        // CEntity::UpdateRwFrame
+        ((void(__thiscall*)(CEntitySAInterface*))0x532B00)(m_pInterface);
 
         if (m_pInterface->nType == ENTITY_TYPE_OBJECT)
         {
@@ -443,16 +367,9 @@ eEntityType CEntitySA::GetEntityType()
 FLOAT CEntitySA::GetDistanceFromCentreOfMassToBaseOfModel()
 {
     DEBUG_TRACE("FLOAT CEntitySA::GetDistanceFromCentreOfMassToBaseOfModel()");
-    DWORD dwFunc = FUNC_GetDistanceFromCentreOfMassToBaseOfModel;
-    DWORD dwThis = (DWORD)m_pInterface;
-    FLOAT fReturn;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        fstp    fReturn
-    }
-    return fReturn;
+
+    // CEntity::GetDistanceFromCentreOfMassToBaseOfModel
+    return ((float(__thiscall*)(CEntitySAInterface*))FUNC_GetDistanceFromCentreOfMassToBaseOfModel)(m_pInterface);
 }
 
 VOID CEntitySA::SetEntityStatus(eEntityStatus bStatus)
@@ -469,17 +386,8 @@ eEntityStatus CEntitySA::GetEntityStatus()
 
 RwFrame* CEntitySA::GetFrameFromId(int id)
 {
-    DWORD dwClump = (DWORD)m_pInterface->m_pRwObject;
-    DWORD dwReturn;
-    _asm
-    {
-        push    id
-        push    dwClump
-        call    FUNC_CClumpModelInfo__GetFrameFromId
-        add     esp, 8
-        mov     dwReturn, eax
-    }
-    return (RwFrame*)dwReturn;
+    // CClumpModelInfo::GetFrameFromId
+    return ((RwFrame*(__cdecl*)(RpClump*, int))FUNC_CClumpModelInfo__GetFrameFromId)(m_pInterface->m_pRwObject, id);
 }
 
 RpClump* CEntitySA::GetRpClump()
@@ -489,29 +397,16 @@ RpClump* CEntitySA::GetRpClump()
 
 RwMatrix* CEntitySA::GetLTMFromId(int id)
 {
-    DWORD    dwReturn;
-    RwFrame* frame = GetFrameFromId(id);
-    _asm
-    {
-        push    frame
-        call    FUNC_RwFrameGetLTM
-        add     esp, 4
-        mov     dwReturn, eax
-    }
-    return (RwMatrix*)dwReturn;
+    // RwFrameGetLTM
+    return ((RwMatrix*(__cdecl*)(RwFrame*))FUNC_RwFrameGetLTM)(GetFrameFromId(id));
 }
 
 VOID CEntitySA::SetAlpha(DWORD dwAlpha)
 {
     DEBUG_TRACE("VOID CEntitySA::SetAlpha(DWORD dwAlpha)");
-    DWORD dwFunc = FUNC_SetRwObjectAlpha;
-    DWORD dwThis = (DWORD)m_pInterface;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    dwAlpha
-        call    dwFunc
-    }
+
+    // CEntity::SetRwObjectAlpha
+    ((void(__thiscall*)(CEntitySAInterface*, int))FUNC_SetRwObjectAlpha)(m_pInterface, dwAlpha);
 }
 
 bool CEntitySA::IsOnScreen()
@@ -520,21 +415,15 @@ bool CEntitySA::IsOnScreen()
     MemPut < BYTE > ( 0x534541, 0xEC );
     MemPut < BYTE > ( 0x534542, 0x10 );
 */
-    DWORD dwFunc = FUNC_IsVisible;            // FUNC_IsOnScreen;
-    DWORD dwThis = (DWORD)m_pInterface;
-    bool  bReturn = false;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     bReturn, al
-    }
+
+    // CEntity::IsVisible
+    return ((bool(__thiscall*)(CEntitySAInterface*))FUNC_IsVisible)(m_pInterface);
+
     /*
         MemPut < BYTE > ( 0x534540, 0xB0 );
         MemPut < BYTE > ( 0x534541, 0x01 );
         MemPut < BYTE > ( 0x534542, 0xC3 );
     */
-    return bReturn;
 }
 
 bool CEntitySA::IsFullyVisible()
@@ -563,16 +452,8 @@ VOID CEntitySA::MatrixConvertFromEulerAngles(float fX, float fY, float fZ, int i
     CMatrix_Padded* matrixPadded = m_pInterface->Placeable.matrix;
     if (matrixPadded)
     {
-        DWORD dwFunc = FUNC_CMatrix__ConvertFromEulerAngles;
-        _asm
-        {
-            push    iUnknown
-            push    fZ
-            push    fY
-            push    fX
-            mov     ecx, matrixPadded
-            call    dwFunc
-        }
+        // CMatrix::ConvertFromEulerAngles
+        ((void(__thiscall*)(CMatrix_Padded*, float, float, float, int))FUNC_CMatrix__ConvertFromEulerAngles)(matrixPadded, fX, fY, fZ, iUnknown);
     }
 }
 
@@ -581,35 +462,15 @@ VOID CEntitySA::MatrixConvertToEulerAngles(float* fX, float* fY, float* fZ, int 
     CMatrix_Padded* matrixPadded = m_pInterface->Placeable.matrix;
     if (matrixPadded)
     {
-        DWORD dwFunc = FUNC_CMatrix__ConvertToEulerAngles;
-        _asm
-        {
-            push    iUnknown
-            push    fZ
-            push    fY
-            push    fX
-            mov     ecx, matrixPadded
-            call    dwFunc
-        }
+        // CMatrix::ConvertToEulerAngles
+        ((void(__thiscall*)(CMatrix_Padded*, float*, float*, float*, int))FUNC_CMatrix__ConvertToEulerAngles)(matrixPadded, fX, fY, fZ, iUnknown);
     }
 }
 
 bool CEntitySA::IsPlayingAnimation(char* szAnimName)
 {
-    DWORD dwReturn = 0;
-    DWORD dwFunc = FUNC_RpAnimBlendClumpGetAssociation;
-    DWORD dwThis = (DWORD)m_pInterface->m_pRwObject;
-
-    _asm
-    {
-        push    szAnimName
-        push    dwThis
-        call    dwFunc
-        add     esp, 8
-        mov     dwReturn, eax
-    }
-    if (dwReturn) return true;
-    else return false;
+    // RpAnimBlendClumpGetAssociation
+    return ((CAnimBlendAssociation*(__cdecl*)(RpClump*, const char*))FUNC_RpAnimBlendClumpGetAssociation)(m_pInterface->m_pRwObject, szAnimName) ? true : false;
 }
 
 RwMatrixTag* CEntitySA::GetBoneRwMatrix(eBone boneId)

--- a/Client/game_sa/CEventDamageSA.cpp
+++ b/Client/game_sa/CEventDamageSA.cpp
@@ -18,21 +18,9 @@ CEventDamageSA::CEventDamageSA(CEntity* pEntity, unsigned int i_1, eWeaponType w
     m_bDestroyInterface = true;
     m_DamageReason = EDamageReason::OTHER;
 
-    DWORD dwEntityInterface = (DWORD)pEntity->GetInterface();
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CEventDamage_Constructor;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    b_4
-        push    b_3
-        push    uc_2
-        push    hitZone
-        push    weaponType
-        push    i_1
-        push    dwEntityInterface
-        call    dwFunc
-    }
+    // CEventDamage::CEventDamage
+    ((CEventDamageSAInterface*(__thiscall*)(CEventDamageSAInterface*, CEntitySAInterface*, unsigned int, eWeaponType, ePedPieceTypes, unsigned char, bool, bool))
+         FUNC_CEventDamage_Constructor)(m_pInterface, pEntity->GetInterface(), i_1, weaponType, hitZone, uc_2, b_3, b_4);
 }
 
 CEventDamageSA::CEventDamageSA(CEventDamageSAInterface* pInterface)
@@ -49,13 +37,9 @@ CEventDamageSA::~CEventDamageSA()
 
     if (m_bDestroyInterface)
     {
-        DWORD dwThis = (DWORD)m_pInterface;
-        DWORD dwFunc = FUNC_CEventDamage_Destructor;
-        _asm
-        {
-            mov     ecx, dwThis
-            call    dwFunc
-        }
+        // CEventDamage::~CEventDamage
+        ((void(__thiscall*)(CEventDamageSAInterface*))FUNC_CEventDamage_Destructor)(m_pInterface);
+
         delete m_pInterface;
     }
 }
@@ -74,114 +58,48 @@ CEntity* CEventDamageSA::GetInflictingEntity()
 
 bool CEventDamageSA::HasKilledPed()
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CEventDamage_HasKilledPed;
-    bool  bReturn = false;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CEventDamage::HasKilledPed
+    return ((bool(__thiscall*)(CEventDamageSAInterface*))FUNC_CEventDamage_HasKilledPed)(m_pInterface);
 }
 
 float CEventDamageSA::GetDamageApplied()
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CEventDamage_GetDamageApplied;
-    float fReturn = 0.0f;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        fstp    fReturn
-    }
-    return fReturn;
+    // CEventDamage::GetDamageApplied
+    return ((float(__thiscall*)(CEventDamageSAInterface*))FUNC_CEventDamage_GetDamageApplied)(m_pInterface);
 }
 
 AssocGroupId CEventDamageSA::GetAnimGroup()
 {
-    DWORD        dwThis = (DWORD)m_pInterface;
-    DWORD        dwFunc = FUNC_CEventDamage_GetAnimGroup;
-    AssocGroupId animGroup = 0;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     animGroup, eax
-    }
-    return animGroup;
+    // CEventDamage::GetAnimGroup
+    return ((AssocGroupId(__thiscall*)(CEventDamageSAInterface*))FUNC_CEventDamage_GetAnimGroup)(m_pInterface);
 }
 
 AnimationId CEventDamageSA::GetAnimId()
 {
-    DWORD       dwThis = (DWORD)m_pInterface;
-    DWORD       dwFunc = FUNC_CEventDamage_GetAnimId;
-    AnimationId animID = 0;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     animID, eax
-    }
-    return animID;
+    // CEventDamage::GetAnimGroup
+    return ((AnimationId(__thiscall*)(CEventDamageSAInterface*))FUNC_CEventDamage_GetAnimId)(m_pInterface);
 }
 
 bool CEventDamageSA::GetAnimAdded()
 {
-    bool  bReturn;
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CEventDamage_GetAnimAdded;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CEventDamage::GetAnimAdded
+    return ((bool(__thiscall*)(CEventDamageSAInterface*))FUNC_CEventDamage_GetAnimAdded)(m_pInterface);
 }
 
 void CEventDamageSA::ComputeDeathAnim(CPed* pPed, bool bUnk)
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwPed = (DWORD)pPed->GetInterface();
-    DWORD dwFunc = FUNC_CEventDamage_ComputeDeathAnim;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    bUnk
-        push    dwPed
-        call    dwFunc
-    }
+    // CEventDamage::ComputeDeathAnim
+    ((void(__thiscall*)(CEventDamageSAInterface*, CEntitySAInterface*, bool))FUNC_CEventDamage_ComputeDeathAnim)(m_pInterface, pPed->GetInterface(), bUnk);
 }
 
 void CEventDamageSA::ComputeDamageAnim(CPed* pPed, bool bUnk)
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwPed = (DWORD)pPed->GetInterface();
-    DWORD dwFunc = FUNC_CEventDamage_ComputeDamageAnim;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    bUnk
-        push    dwPed
-        call    dwFunc
-    }
+    // CEventDamage::ComputeDamageAnim
+    ((void(__thiscall*)(CEventDamageSAInterface*, CEntitySAInterface*, bool))FUNC_CEventDamage_ComputeDamageAnim)(m_pInterface, pPed->GetInterface(), bUnk);
 }
 
 bool CEventDamageSA::AffectsPed(CPed* pPed)
 {
-    bool  bReturn;
-    DWORD dwPedInterface = (DWORD)pPed->GetInterface();
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CEventDamage_AffectsPed;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    dwPedInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CEventDamage::AffectsPed
+    return ((bool(__thiscall*)(CEventDamageSAInterface*, CEntitySAInterface*))FUNC_CEventDamage_AffectsPed)(m_pInterface, pPed->GetInterface());
 }

--- a/Client/game_sa/CEventGroupSA.cpp
+++ b/Client/game_sa/CEventGroupSA.cpp
@@ -13,17 +13,8 @@
 
 CEvent* CEventGroupSA::Add(CEvent* pEvent, bool b_1)
 {
-    CEventSAInterface* pReturnInterface = NULL;
-    DWORD              dwEventInterface = (DWORD)pEvent->GetInterface();
-    DWORD              dwThis = (DWORD)m_pInterface;
-    DWORD              dwFunc = FUNC_CEventGroup_Add;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    b_1
-        push    dwEventInterface
-        call    dwFunc
-        mov     pReturnInterface, eax
-    }
-    return NULL;
+    // CEventGroup::Add
+    ((CEventSAInterface*(__cdecl*)(CEventGroupSAInterface*, CEventSAInterface*, bool))FUNC_CEventGroup_Add)(m_pInterface, pEvent->GetInterface(), b_1);
+
+    return nullptr;
 }

--- a/Client/game_sa/CEventGunShotSA.cpp
+++ b/Client/game_sa/CEventGunShotSA.cpp
@@ -15,39 +15,19 @@ CEventGunShotSA::CEventGunShotSA(CEntity* pEntity, CVector& vecOrigin, CVector& 
 {
     m_pInterface = new CEventGunShotSAInterface;
 
-    DWORD dwEntityInterface = 0;
-    if (pEntity)
-        dwEntityInterface = (DWORD)pEntity->GetInterface();
-    float originX = vecOrigin.fX, originY = vecOrigin.fY, originZ = vecOrigin.fZ;
-    float targetX = vecTarget.fX, targetY = vecTarget.fY, targetZ = vecTarget.fZ;
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CEventGunShot_Constructor;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    b_1
-        push    targetZ
-        push    targetY
-        push    targetX
-        push    originZ
-        push    originY
-        push    originX
-        push    dwEntityInterface
-        call    dwFunc
-    }
+    // CEventGunShot::CEventGunShot
+    ((CEventGunShotSAInterface*(__thiscall*)(CEventGunShotSAInterface*, CEntitySAInterface*, float, float, float, float, float, float, bool))
+         FUNC_CEventGunShot_Constructor)(m_pInterface, pEntity ? pEntity->GetInterface() : nullptr, vecOrigin.fX, vecOrigin.fY, vecOrigin.fZ, vecTarget.fX, vecTarget.fY,
+                                         vecTarget.fZ, b_1);
 }
 
 void CEventGunShotSA::Destroy(bool bDestroyInterface)
 {
     if (bDestroyInterface)
     {
-        DWORD dwThis = (DWORD)m_pInterface;
-        DWORD dwFunc = FUNC_CEventGunShot_Destructor;
-        _asm
-        {
-            mov     ecx, dwThis
-            call    dwFunc
-        }
+        // CEventGunShot::~CEventGunShot
+        ((CEventGunShotSAInterface*(__thiscall*)(CEventGunShotSAInterface*))FUNC_CEventGunShot_Destructor)(m_pInterface);
+
         delete m_pInterface;
     }
     delete this;

--- a/Client/game_sa/CFireManagerSA.cpp
+++ b/Client/game_sa/CFireManagerSA.cpp
@@ -32,20 +32,10 @@ CFireManagerSA::~CFireManagerSA()
 VOID CFireManagerSA::ExtinguishPoint(CVector& vecPosition, float fRadius)
 {
     DEBUG_TRACE("VOID CFireManagerSA::ExtinguishPoint ( CVector & vecPosition, float fRadius )");
-    FLOAT fX = vecPosition.fX;
-    FLOAT fY = vecPosition.fY;
-    FLOAT fZ = vecPosition.fZ;
-    DWORD dwFunction = FUNC_ExtinguishPoint;
 
-    _asm
-    {
-        mov     ecx, CLASS_CFireManager
-        push    fRadius
-        push    fZ
-        push    fY
-        push    fX
-        call    dwFunction
-    }
+    // CFireManager::ExtinguishPoint
+    ((void(__thiscall*)(int, float, float, float, float))FUNC_ExtinguishPoint)(CLASS_CFireManager, vecPosition.fX, vecPosition.fY,
+                                                                                                    vecPosition.fZ, fRadius);
 }
 
 CFire* CFireManagerSA::StartFire(CEntity* entityTarget, CEntity* entityCreator, float fSize = DEFAULT_FIRE_PARTICLE_SIZE)

--- a/Client/game_sa/CFireSA.cpp
+++ b/Client/game_sa/CFireSA.cpp
@@ -17,13 +17,10 @@
 VOID CFireSA::Extinguish()
 {
     DEBUG_TRACE("VOID CFireSA::Extinguish (  )");
-    DWORD dwFunction = FUNC_Extinguish;
-    DWORD dwPointer = (DWORD)this->internalInterface;
-    _asm
-    {
-        mov     ecx, dwPointer
-        call    dwFunction
-    }
+
+    // CFire::Extinguish
+    ((void(__thiscall*)(CFireSAInterface*))(FUNC_Extinguish))(this->internalInterface);
+
     this->internalInterface->bActive = FALSE;
 }
 
@@ -187,16 +184,8 @@ VOID CFireSA::Ignite()
     DEBUG_TRACE("VOID CFireSA::Ignite( )");
     this->internalInterface->bActive = TRUE;
 
-    CVector* vecPosition = this->GetPosition();
-    DWORD    dwFunc = FUNC_CreateFxSysForStrength;
-    DWORD    dwThis = (DWORD)this->internalInterface;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    0
-        push    vecPosition
-        call    dwFunc
-    }
+    // CFire::CreateFxSysForStrength
+    ((void(__thiscall*)(CFireSAInterface*, CVector*, RwMatrix*))(FUNC_CreateFxSysForStrength))(this->internalInterface, GetPosition(), nullptr);
 
     this->internalInterface->bBeingExtinguished = 0;
     this->internalInterface->bFirstGeneration = 1;

--- a/Client/game_sa/CFxManagerSA.cpp
+++ b/Client/game_sa/CFxManagerSA.cpp
@@ -14,21 +14,10 @@
 CFxSystem* CFxManagerSA::CreateFxSystem(const char* szBlueprint, const CVector& vecPosition, RwMatrix* pRwMatrixTag, unsigned char bSkipCameraFrustumCheck,
                                         bool bSoundEnable)
 {
-    const CVector*        pvecPosition = &vecPosition;
-    DWORD                 dwThis = (DWORD)m_pInterface;
-    DWORD                 dwFunc = FUNC_FxManager_c__CreateFxSystem;
-    CFxSystemSAInterface* pFxSystem;
 
-    _asm
-    {
-        mov     ecx, dwThis
-        push    bSkipCameraFrustumCheck
-        push    pRwMatrixTag
-        push    pvecPosition
-        push    szBlueprint
-        call    dwFunc
-        mov     pFxSystem, eax
-    }
+    // FxManager_c::CreateFxSystem
+    CFxSystemSAInterface* pFxSystem = ((CFxSystemSAInterface*(__thiscall*)(CFxManagerSAInterface*, const char*, const CVector&, RwMatrix*, unsigned char))
+                  FUNC_FxManager_c__CreateFxSystem)(m_pInterface, szBlueprint, vecPosition, pRwMatrixTag, bSkipCameraFrustumCheck);
 
     if (pFxSystem)
     {
@@ -43,17 +32,8 @@ CFxSystem* CFxManagerSA::CreateFxSystem(const char* szBlueprint, const CVector& 
 
 void CFxManagerSA::DestroyFxSystem(CFxSystem* pFxSystem)
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_FxManager_c__DestroyFxSystem;
-
-    void* pFxSA = pFxSystem->GetInterface();
-
-    _asm
-    {
-        mov     ecx, dwThis
-        push    pFxSA
-        call    dwFunc
-    }
+    // FxManager_c::DestroyFxSystem
+    ((void(__thiscall*)(CFxManagerSAInterface*, void*))FUNC_FxManager_c__DestroyFxSystem)(m_pInterface, pFxSystem->GetInterface());
 }
 
 //

--- a/Client/game_sa/CFxSA.cpp
+++ b/Client/game_sa/CFxSA.cpp
@@ -13,227 +13,87 @@
 
 void CFxSA::AddBlood(CVector& vecPosition, CVector& vecDirection, int iCount, float fBrightness)
 {
-    CVector* pvecPosition = &vecPosition;
-    CVector* pvecDirection = &vecDirection;
-    DWORD    dwThis = (DWORD)m_pInterface;
-    DWORD    dwFunc = FUNC_CFx_AddBlood;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    fBrightness
-        push    iCount
-        push    pvecDirection
-        push    pvecPosition
-        call    dwFunc
-    }
+    // CFx::AddBlood
+    ((void(__thiscall*)(CFxSAInterface*, CVector&, CVector&, int, float))FUNC_CFx_AddBlood)(m_pInterface, vecPosition, vecDirection, iCount, fBrightness);
 }
 
 void CFxSA::AddWood(CVector& vecPosition, CVector& vecDirection, int iCount, float fBrightness)
 {
-    CVector* pvecPosition = &vecPosition;
-    CVector* pvecDirection = &vecDirection;
-    DWORD    dwThis = (DWORD)m_pInterface;
-    DWORD    dwFunc = FUNC_CFx_AddWood;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    fBrightness
-        push    iCount
-        push    pvecDirection
-        push    pvecPosition
-        call    dwFunc
-    }
+    // CFx::AddWood
+    ((void(__thiscall*)(CFxSAInterface*, CVector&, CVector&, int, float))FUNC_CFx_AddWood)(m_pInterface, vecPosition, vecDirection, iCount, fBrightness);
 }
 
 void CFxSA::AddSparks(CVector& vecPosition, CVector& vecDirection, float fForce, int iCount, CVector vecAcrossLine, unsigned char ucBlurIf0, float fSpread,
                       float fLife)
 {
-    CVector* pvecPosition = &vecPosition;
-    CVector* pvecDirection = &vecDirection;
-    float    fX = vecAcrossLine.fX, fY = vecAcrossLine.fY, fZ = vecAcrossLine.fZ;
-    DWORD    dwThis = (DWORD)m_pInterface;
-    DWORD    dwFunc = FUNC_CFx_AddSparks;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    fLife
-        push    fSpread
-        push    ucBlurIf0
-        push    fZ
-        push    fY
-        push    fX
-        push    iCount
-        push    fForce
-        push    pvecDirection
-        push    pvecPosition
-        call    dwFunc
-    }
+    // CFx::AddSparks
+    ((void(__thiscall*)(CFxSAInterface*, CVector&, CVector&, float, int, float, float, float, unsigned char, float, float))FUNC_CFx_AddSparks)(
+        m_pInterface, vecPosition, vecDirection, fForce, iCount, vecAcrossLine.fX, vecAcrossLine.fY, vecAcrossLine.fZ, ucBlurIf0, fSpread, fLife);
 }
 
 void CFxSA::AddTyreBurst(CVector& vecPosition, CVector& vecDirection)
 {
-    CVector* pvecPosition = &vecPosition;
-    CVector* pvecDirection = &vecDirection;
-    DWORD    dwThis = (DWORD)m_pInterface;
-    DWORD    dwFunc = FUNC_CFx_AddTyreBurst;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    pvecDirection
-        push    pvecPosition
-        call    dwFunc
-    }
+    // CFx::AddTyreBurst
+    ((void(__thiscall*)(CFxSAInterface*, CVector&, CVector&))FUNC_CFx_AddTyreBurst)(m_pInterface, vecPosition, vecDirection);
 }
 
 void CFxSA::AddBulletImpact(CVector& vecPosition, CVector& vecDirection, int iSmokeSize, int iSparkCount, float fSmokeIntensity)
 {
-    CVector* pvecPosition = &vecPosition;
-    CVector* pvecDirection = &vecDirection;
-    DWORD    dwThis = (DWORD)m_pInterface;
-    DWORD    dwFunc = FUNC_CFx_AddBulletImpact;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    fSmokeIntensity
-        push    iSparkCount
-        push    iSmokeSize
-        push    pvecDirection
-        push    pvecPosition
-        call    dwFunc
-    }
+    // CFx::AddBulletImpact
+    ((void(__thiscall*)(CFxSAInterface*, CVector&, CVector&, int, int, float))FUNC_CFx_AddBulletImpact)(m_pInterface, vecPosition, vecDirection, iSmokeSize,
+                                                                                                        iSparkCount, fSmokeIntensity);
 }
 
 void CFxSA::AddPunchImpact(CVector& vecPosition, CVector& vecDirection, int i)
 {
-    CVector* pvecPosition = &vecPosition;
-    CVector* pvecDirection = &vecDirection;
-    DWORD    dwThis = (DWORD)m_pInterface;
-    DWORD    dwFunc = FUNC_CFx_AddPunchImpact;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    i
-        push    pvecDirection
-        push    pvecPosition
-        call    dwFunc
-    }
+    // CFx::AddPunchImpact
+    ((void(__thiscall*)(CFxSAInterface*, CVector&, CVector&, int))FUNC_CFx_AddPunchImpact)(m_pInterface, vecPosition, vecDirection, i);
 }
 
 void CFxSA::AddDebris(CVector& vecPosition, RwColor& rwColor, float fDebrisScale, int iCount)
 {
-    CVector* pvecPosition = &vecPosition;
-    RwColor* pColor = &rwColor;
-    DWORD    dwThis = (DWORD)m_pInterface;
-    DWORD    dwFunc = FUNC_CFx_AddDebris;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    iCount
-        push    fDebrisScale
-        push    pColor
-        push    pvecPosition
-        call    dwFunc
-    }
+    // CFx::AddDebris
+    ((void(__thiscall*)(CFxSAInterface*, CVector&, RwColor&, float, int))FUNC_CFx_AddDebris)(m_pInterface, vecPosition, rwColor, fDebrisScale, iCount);
 }
 
 void CFxSA::AddGlass(CVector& vecPosition, RwColor& rwColor, float fDebrisScale, int iCount)
 {
-    CVector* pvecPosition = &vecPosition;
-    RwColor* pColor = &rwColor;
-    DWORD    dwThis = (DWORD)m_pInterface;
-    DWORD    dwFunc = FUNC_CFx_AddGlass;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    iCount
-        push    fDebrisScale
-        push    pColor
-        push    pvecPosition
-        call    dwFunc
-    }
+    // CFx::AddGlass
+    ((void(__thiscall*)(CFxSAInterface*, CVector&, RwColor&, float, int))FUNC_CFx_AddGlass)(m_pInterface, vecPosition, rwColor, fDebrisScale, iCount);
 }
 
 void CFxSA::TriggerWaterHydrant(CVector& vecPosition)
 {
-    CVector* pvecPosition = &vecPosition;
-    DWORD    dwThis = (DWORD)m_pInterface;
-    DWORD    dwFunc = FUNC_CFx_TriggerWaterHydrant;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    pvecPosition
-        call    dwFunc
-    }
+    // CFx::TriggerWaterHydrant
+    ((void(__thiscall*)(CFxSAInterface*, CVector&))FUNC_CFx_TriggerWaterHydrant)(m_pInterface, vecPosition);
 }
 
 void CFxSA::TriggerGunshot(CEntity* pEntity, CVector& vecPosition, CVector& vecDirection, bool bIncludeSparks)
 {
-    DWORD    dwEntity = (pEntity) ? (DWORD)pEntity->GetInterface() : NULL;
-    CVector* pvecPosition = &vecPosition;
-    CVector* pvecDirection = &vecDirection;
-    DWORD    dwThis = (DWORD)m_pInterface;
-    DWORD    dwFunc = FUNC_CFx_TriggerGunshot;
-        _asm
-    {
-        mov     ecx, dwThis
-        push    bIncludeSparks
-        push    pvecDirection
-        push    pvecPosition
-        push    dwEntity
-        call    dwFunc
-    }
+    // CFx::TriggerGunshot
+    ((void(__thiscall*)(CFxSAInterface*, CEntitySAInterface*, CVector&, CVector&, bool))FUNC_CFx_TriggerGunshot)(m_pInterface, pEntity? pEntity->GetInterface() : nullptr, vecPosition, vecDirection, bIncludeSparks);
 }
 
 void CFxSA::TriggerTankFire(CVector& vecPosition, CVector& vecDirection)
 {
-    CVector* pvecPosition = &vecPosition;
-    CVector* pvecDirection = &vecDirection;
-    DWORD    dwThis = (DWORD)m_pInterface;
-    DWORD    dwFunc = FUNC_CFx_TriggerTankFire;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    pvecDirection
-        push    pvecPosition
-        call    dwFunc
-    }
+    // CFx::TriggerTankFire
+    ((void(__thiscall*)(CFxSAInterface*, CVector&, CVector&))FUNC_CFx_TriggerTankFire)(m_pInterface, vecPosition, vecDirection);
 }
 
 void CFxSA::TriggerWaterSplash(CVector& vecPosition)
 {
-    CVector* pvecPosition = &vecPosition;
-    DWORD    dwThis = (DWORD)m_pInterface;
-    DWORD    dwFunc = FUNC_CFx_TriggerWaterSplash;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    pvecPosition
-        call    dwFunc
-    }
+    // CFx::TriggerWaterSplash
+    ((void(__thiscall*)(CFxSAInterface*, CVector&))FUNC_CFx_TriggerWaterSplash)(m_pInterface, vecPosition);
 }
 
 void CFxSA::TriggerBulletSplash(CVector& vecPosition)
 {
-    CVector* pvecPosition = &vecPosition;
-    DWORD    dwThis = (DWORD)m_pInterface;
-    DWORD    dwFunc = FUNC_CFx_TriggerBulletSplash;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    pvecPosition
-        call    dwFunc
-    }
+    // CFx::TriggerBulletSplash
+    ((void(__thiscall*)(CFxSAInterface*, CVector&))FUNC_CFx_TriggerBulletSplash)(m_pInterface, vecPosition);
 }
 
 void CFxSA::TriggerFootSplash(CVector& vecPosition)
 {
-    CVector* pvecPosition = &vecPosition;
-    DWORD    dwThis = (DWORD)m_pInterface;
-    DWORD    dwFunc = FUNC_CFx_TriggerFootSplash;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    pvecPosition
-        call    dwFunc
-    }
+    // CFx::TriggerFootSplash
+    ((void(__thiscall*)(CFxSAInterface*, CVector&))FUNC_CFx_TriggerFootSplash)(m_pInterface, vecPosition);
 }

--- a/Client/game_sa/CFxSystemSA.cpp
+++ b/Client/game_sa/CFxSystemSA.cpp
@@ -35,13 +35,8 @@ CFxSystemSA::~CFxSystemSA()
 
 void CFxSystemSA::PlayAndKill()
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_FxSystem_c__PlayAndKill;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // FxSystem_c::PlayAndKill
+    ((void(__thiscall*)(CFxSystemSAInterface*))(FUNC_FxSystem_c__PlayAndKill))(m_pInterface);
 }
 
 void CFxSystemSA::GetMatrix(CMatrix& matrix)

--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -440,16 +440,9 @@ VOID CGameSA::SetRenderHook(InRenderer* pInRenderer)
 
 VOID CGameSA::TakeScreenshot(char* szFileName)
 {
-    DWORD dwFunc = FUNC_JPegCompressScreenToFile;
-    _asm
-    {
-        mov     eax, CLASS_RwCamera
-        mov     eax, [eax]
-        push    szFileName
-        push    eax
-        call    dwFunc
-        add     esp,8
-    }
+    // JPegCompressScreenToFile
+    CCameraSAInterface& TheCamera = *(CCameraSAInterface*)0xB6F028;
+    ((void(__cdecl*)(RwCamera*, const char*))(FUNC_JPegCompressScreenToFile))(TheCamera.m_pRwCamera, szFileName);
 }
 
 DWORD* CGameSA::GetMemoryValue(DWORD dwOffset)

--- a/Client/game_sa/CHudSA.cpp
+++ b/Client/game_sa/CHudSA.cpp
@@ -139,62 +139,21 @@ bool CHudSA::IsDisabled()
 
 VOID CHudSA::DrawBarChart(float fX, float fY, DWORD dwWidth, DWORD dwHeight, float fPercentage, DWORD dwForeColor, DWORD dwBorderColor)
 {
-    DWORD dwFunc = FUNC_DrawBarChart;
-    _asm
-    {
-        push    dwBorderColor
-        push    dwForeColor
-        push    1
-        push    0
-        push    0
-        push    fPercentage
-        push    dwHeight
-        push    dwWidth
-        push    fY
-        push    fX
-        call    dwFunc
-        add     esp, 0x28
-    }
+    // CSprite2d::DrawBarChart
+    ((void(__cdecl*)(float, float, unsigned short, unsigned char, float, char, unsigned char, unsigned char, DWORD, DWORD))FUNC_DrawBarChart)(
+        fX, fY, dwWidth, dwHeight, fPercentage, 0, 0, 1, dwForeColor, dwBorderColor);
 }
 
 bool CHudSA::CalcScreenCoors(CVector* vecPosition1, CVector* vecPosition2, float* fX, float* fY, bool bSetting1, bool bSetting2)
 {
-    DWORD dwFunc = 0x71DA00;
-    bool  bReturn = false;
-    _asm
-    {
-        //push  bSetting2
-        //push  bSetting1
-        push    fY
-        push    fX
-        push    vecPosition2
-        push    vecPosition1
-        call    dwFunc
-        add     esp, 0x18
-        sub     esp, 8
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CalcScreenCoors
+    return ((bool(__cdecl*)(CVector&, CVector&, float*, float*))0x71DA00)(*vecPosition1, *vecPosition2, fX, fY);
 }
 
 void CHudSA::Draw2DPolygon(float fX1, float fY1, float fX2, float fY2, float fX3, float fY3, float fX4, float fY4, DWORD dwColor)
 {
-    DWORD dwFunc = FUNC_Draw2DPolygon;
-    _asm
-    {
-        lea     eax, dwColor
-        push    eax
-        push    fY4
-        push    fX4
-        push    fY3
-        push    fX3
-        push    fY2
-        push    fX2
-        push    fY1
-        push    fX1
-        call    dwFunc
-        add     esp, 36
-    }
+    // CSprite2d::Draw2DPolygon
+    ((void(__cdecl*)(float, float, float, float, float, float, float, float, DWORD))FUNC_Draw2DPolygon)(fX1, fY1, fX2, fY2, fX3, fY3, fX4, fY4, dwColor);
 }
 
 //

--- a/Client/game_sa/CHudSA.cpp
+++ b/Client/game_sa/CHudSA.cpp
@@ -153,7 +153,7 @@ bool CHudSA::CalcScreenCoors(CVector* vecPosition1, CVector* vecPosition2, float
 void CHudSA::Draw2DPolygon(float fX1, float fY1, float fX2, float fY2, float fX3, float fY3, float fX4, float fY4, DWORD dwColor)
 {
     // CSprite2d::Draw2DPolygon
-    ((void(__cdecl*)(float, float, float, float, float, float, float, float, DWORD))FUNC_Draw2DPolygon)(fX1, fY1, fX2, fY2, fX3, fY3, fX4, fY4, dwColor);
+    ((void(__cdecl*)(float, float, float, float, float, float, float, float, DWORD*))FUNC_Draw2DPolygon)(fX1, fY1, fX2, fY2, fX3, fY3, fX4, fY4, &dwColor);
 }
 
 //

--- a/Client/game_sa/CKeyGenSA.cpp
+++ b/Client/game_sa/CKeyGenSA.cpp
@@ -13,58 +13,24 @@
 
 unsigned int CKeyGenSA::GetKey(const char* szString, int iLength)
 {
-    unsigned int uiReturn;
-    DWORD        dwFunc = FUNC_CKeyGen_GetKey_len;
-    _asm
-    {
-        push    iLength
-        push    szString
-        call    dwFunc
-        add     esp, 0x8
-        mov     uiReturn, eax
-    }
-    return uiReturn;
+    // CKeyGen::GetKey
+    return ((unsigned int(__cdecl*)(const char*, int))FUNC_CKeyGen_GetKey_len)(szString, iLength);
 }
 
 unsigned int CKeyGenSA::GetKey(const char* szString)
 {
-    unsigned int uiReturn;
-    DWORD        dwFunc = FUNC_CKeyGen_GetKey;
-    _asm
-    {
-        push    szString
-        call    dwFunc
-        add     esp, 0x4
-        mov     uiReturn, eax
-    }
-    return uiReturn;
+    // CKeyGen::GetKey
+    return ((unsigned int(__cdecl*)(const char*))FUNC_CKeyGen_GetKey)(szString);
 }
 
 unsigned int CKeyGenSA::GetUppercaseKey(const char* szString)
 {
-    unsigned int uiReturn;
-    DWORD        dwFunc = FUNC_CKeyGen_GetUppercaseKey;
-    _asm
-    {
-        push    szString
-        call    dwFunc
-        add     esp, 0x4
-        mov     uiReturn, eax
-    }
-    return uiReturn;
+    // CKeyGen::GetUppercaseKey
+    return ((unsigned int(__cdecl*)(const char*))FUNC_CKeyGen_GetUppercaseKey)(szString);
 }
 
 unsigned int CKeyGenSA::AppendStringToKey(unsigned int uiKey, const char* szString)
 {
-    unsigned int uiReturn;
-    DWORD        dwFunc = FUNC_CKeyGen_AppendStringToKey;
-    _asm
-    {
-        push    szString
-        push    uiKey
-        call    dwFunc
-        add     esp, 0x8
-        mov     uiReturn, eax
-    }
-    return uiReturn;
+    // CKeyGen::AppendStringToKey
+    return ((unsigned int(__cdecl*)(unsigned int, const char*))FUNC_CKeyGen_AppendStringToKey)(uiKey, szString);
 }

--- a/Client/game_sa/CMenuManagerSA.cpp
+++ b/Client/game_sa/CMenuManagerSA.cpp
@@ -23,27 +23,12 @@ BYTE CMenuManagerSA::GetPreviousScreen()
 
 void CMenuManagerSA::SwitchToNewScreen(BYTE ScreenID)
 {
-    DWORD dwThis = (DWORD)this->GetInterface();
-    DWORD dwFunc = FUNC_SwitchToNewScreen;
-    DWORD dwScreenID = ScreenID;
-
-    _asm
-    {
-        mov     eax, dwThis
-        push    dwScreenID
-        call    dwFunc
-    }
+    // CMenuManager::SwitchToNewScreen
+    ((void(__cdecl*)(BYTE))FUNC_SwitchToNewScreen)(ScreenID);
 }
 
 void CMenuManagerSA::DisplayHelpText(char* szHelpText)            // DisplayHelperText
 {
-    DWORD dwThis = (DWORD)this->GetInterface();
-    DWORD dwFunc = FUNC_DisplayHelperText;
-
-    _asm
-    {
-        mov     eax, dwThis
-        push    szHelpText
-        call    dwFunc
-    }
+    // CMenuManager::DisplayHelperText
+    ((void(__cdecl*)(const char*))FUNC_DisplayHelperText)(szHelpText);
 }

--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -62,194 +62,98 @@ CBaseModelInfoSAInterface* CModelInfoSA::GetInterface()
 BOOL CModelInfoSA::IsBoat()
 {
     DEBUG_TRACE("BOOL CModelInfoSA::IsBoat ( )");
-    DWORD dwFunction = FUNC_IsBoatModel;
-    DWORD ModelID = m_dwModelID;
-    BYTE  bReturn = 0;
-    _asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
-    return (BOOL)bReturn;
+
+    // CModelInfo::IsBoatModel
+    return ((bool(__cdecl*)(int))FUNC_IsBoatModel)(m_dwModelID);
 }
 
 BOOL CModelInfoSA::IsCar()
 {
     DEBUG_TRACE("BOOL CModelInfoSA::IsCar ( )");
-    DWORD dwFunction = FUNC_IsCarModel;
-    DWORD ModelID = m_dwModelID;
-    BYTE  bReturn = 0;
-    _asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
-    return (BOOL)bReturn;
+
+    // CModelInfo::IsCarModel
+    return ((bool(__cdecl*)(int))FUNC_IsCarModel)(m_dwModelID);
 }
 
 BOOL CModelInfoSA::IsTrain()
 {
     DEBUG_TRACE("BOOL CModelInfoSA::IsTrain ( )");
-    DWORD dwFunction = FUNC_IsTrainModel;
-    DWORD ModelID = m_dwModelID;
-    BYTE  bReturn = 0;
-    _asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
-    return (BOOL)bReturn;
+
+    // CModelInfo::IsTrainModel
+    return ((bool(__cdecl*)(int))FUNC_IsTrainModel)(m_dwModelID);
 }
 
 BOOL CModelInfoSA::IsHeli()
 {
     DEBUG_TRACE("BOOL CModelInfoSA::IsHeli ( )");
-    DWORD dwFunction = FUNC_IsHeliModel;
-    DWORD ModelID = m_dwModelID;
-    BYTE  bReturn = 0;
-    _asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
-    return (BOOL)bReturn;
+
+    // CModelInfo::IsHeliModel
+    return ((bool(__cdecl*)(int))FUNC_IsHeliModel)(m_dwModelID);
 }
 
 BOOL CModelInfoSA::IsPlane()
 {
     DEBUG_TRACE("BOOL CModelInfoSA::IsPlane ( )");
-    DWORD dwFunction = FUNC_IsPlaneModel;
-    DWORD ModelID = m_dwModelID;
-    BYTE  bReturn = 0;
-    _asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
-    return (BOOL)bReturn;
+
+    // CModelInfo::IsPlaneModel
+    return ((bool(__cdecl*)(int))FUNC_IsPlaneModel)(m_dwModelID);
 }
 
 BOOL CModelInfoSA::IsBike()
 {
     DEBUG_TRACE("BOOL CModelInfoSA::IsBike ( )");
-    DWORD dwFunction = FUNC_IsBikeModel;
-    DWORD ModelID = m_dwModelID;
-    BYTE  bReturn = 0;
-    _asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
-    return (BOOL)bReturn;
+
+    // CModelInfo::IsBikeModel
+    return ((bool(__cdecl*)(int))FUNC_IsBikeModel)(m_dwModelID);
 }
 
 BOOL CModelInfoSA::IsFakePlane()
 {
     DEBUG_TRACE("BOOL CModelInfoSA::IsFakePlane ( )");
-    DWORD dwFunction = FUNC_IsFakePlaneModel;
-    DWORD ModelID = m_dwModelID;
-    BYTE  bReturn = 0;
-    _asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
-    return (BOOL)bReturn;
+
+    // CModelInfo::IsFakePlaneModel
+    return ((bool(__cdecl*)(int))FUNC_IsFakePlaneModel)(m_dwModelID);
 }
 
 BOOL CModelInfoSA::IsMonsterTruck()
 {
     DEBUG_TRACE("BOOL CModelInfoSA::IsMonsterTruck ( )");
-    DWORD dwFunction = FUNC_IsMonsterTruckModel;
-    DWORD ModelID = m_dwModelID;
-    BYTE  bReturn = 0;
-    _asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
-    return (BOOL)bReturn;
+
+    // CModelInfo::IsMonsterTruckModel
+    return ((bool(__cdecl*)(int))FUNC_IsMonsterTruckModel)(m_dwModelID);
 }
 
 BOOL CModelInfoSA::IsQuadBike()
 {
     DEBUG_TRACE("BOOL CModelInfoSA::IsQuadBike ( )");
-    DWORD dwFunction = FUNC_IsQuadBikeModel;
-    DWORD ModelID = m_dwModelID;
-    BYTE  bReturn = 0;
-    _asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
-    return (BOOL)bReturn;
+
+    // CModelInfo::IsQuadBikeModel
+    return ((bool(__cdecl*)(int))FUNC_IsQuadBikeModel)(m_dwModelID);
 }
 
 BOOL CModelInfoSA::IsBmx()
 {
     DEBUG_TRACE("BOOL CModelInfoSA::IsBmx ( )");
-    DWORD dwFunction = FUNC_IsBmxModel;
-    DWORD ModelID = m_dwModelID;
-    BYTE  bReturn = 0;
-    _asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
-    return (BOOL)bReturn;
+
+    // CModelInfo::IsBmxModel
+    return ((bool(__cdecl*)(int))FUNC_IsBmxModel)(m_dwModelID);
 }
 
 BOOL CModelInfoSA::IsTrailer()
 {
     DEBUG_TRACE("BOOL CModelInfoSA::IsTrailer ( )");
-    DWORD dwFunction = FUNC_IsTrailerModel;
-    DWORD ModelID = m_dwModelID;
-    BYTE  bReturn = 0;
-    _asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
-    return (BOOL)bReturn;
+
+    // CModelInfo::IsTrailerModel
+    return ((bool(__cdecl*)(int))FUNC_IsTrailerModel)(m_dwModelID);
 }
 
 BYTE CModelInfoSA::GetVehicleType()
 {
     DEBUG_TRACE("BOOL CModelInfoSA::IsVehicle ( )");
     // This function will return a vehicle type for vehicles or 0xFF on failure
-    DWORD dwFunction = FUNC_IsVehicleModelType;
-    DWORD ModelID = m_dwModelID;
-    BYTE  bReturn = -1;
-    _asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
-    return bReturn;
+
+    // CModelInfo::IsVehicleModelType
+    return ((BYTE(__cdecl*)(int))FUNC_IsVehicleModelType)(m_dwModelID);
 }
 
 bool CModelInfoSA::IsVehicle() const
@@ -276,55 +180,17 @@ BOOL CModelInfoSA::IsUpgrade()
 char* CModelInfoSA::GetNameIfVehicle()
 {
     DEBUG_TRACE("char * CModelInfoSA::GetNameIfVehicle ( )");
-    //  if(this->IsVehicle())
-    //  {
-    DWORD dwModelInfo = (DWORD)ARRAY_ModelInfo;
-    DWORD dwFunc = FUNC_CText_Get;
-    DWORD ModelID = m_dwModelID;
-    DWORD dwReturn = 0;
 
-        _asm
-        {
-            push    eax
-            push    ebx
-            push    ecx
+    CVehicleModelInfoSAInterface* pVehicleMI = (CVehicleModelInfoSAInterface*)(ppModelInfo[m_dwModelID]);
 
-            mov     ebx, ModelID
-            lea     ebx, [ebx*4]
-            add     ebx, dword ptr[ARRAY_ModelInfo]
-            mov     eax, [ebx]
-            add     eax, 50
+    // CText::Get
+    return ((char*(__thiscall*)(int, char*))FUNC_CText_Get)(CLASS_CText, pVehicleMI->gameName);
 
-            push    eax
-            mov     ecx, CLASS_CText
-            call    dwFunc
-
-            mov     dwReturn, eax
-
-            pop     ecx
-            pop     ebx
-            pop     eax
-        }
-    return (char*)dwReturn;
-    //  }
-    //  return NULL;
 }
 
 uint CModelInfoSA::GetAnimFileIndex()
 {
-    DWORD dwFunc = m_pInterface->VFTBL->GetAnimFileIndex;
-    DWORD dwThis = (DWORD)m_pInterface;
-    uint  uiReturn = 0;
-    if (dwFunc)
-    {
-        _asm
-        {
-            mov     ecx, dwThis
-            call    dwFunc
-            mov     uiReturn, eax
-        }
-    }
-    return uiReturn;
+    return ((unsigned int(__thiscall*)(CBaseModelInfoSAInterface*))m_pInterface->VFTBL->GetAnimFileIndex)(m_pInterface);
 }
 
 VOID CModelInfoSA::Request(EModelRequestType requestType, const char* szTag)
@@ -438,16 +304,9 @@ VOID CModelInfoSA::Remove()
 BYTE CModelInfoSA::GetLevelFromPosition(CVector* vecPosition)
 {
     DEBUG_TRACE("BYTE CModelInfoSA::GetLevelFromPosition ( CVector * vecPosition )");
-    DWORD dwFunction = FUNC_GetLevelFromPosition;
-    BYTE  bReturn = 0;
-    _asm
-    {
-        push    vecPosition
-        call    dwFunction
-        add     esp, 4
-        mov     bReturn, al
-    }
-    return bReturn;
+
+    // ?
+    return 0;//((BYTE(__cdecl*)(CVector*))FUNC_GetLevelFromPosition)(vecPosition);
 }
 
 BOOL CModelInfoSA::IsLoaded()
@@ -489,32 +348,14 @@ BOOL CModelInfoSA::DoIsLoaded()
 
 BYTE CModelInfoSA::GetFlags()
 {
-    DWORD dwFunc = FUNC_GetModelFlags;
-    DWORD ModelID = m_dwModelID;
-    BYTE  bFlags = 0;
-    _asm
-    {
-        push    ModelID
-        call    dwFunc
-        add     esp, 4
-        mov     bFlags, al
-    }
-    return bFlags;
+    // CStreaming::GetFlags
+    return ((BYTE(__cdecl*)(int))FUNC_GetModelFlags)(m_dwModelID);
 }
 
 CBoundingBox* CModelInfoSA::GetBoundingBox()
 {
-    DWORD         dwFunc = FUNC_GetBoundingBox;
-    DWORD         ModelID = m_dwModelID;
-    CBoundingBox* dwReturn = 0;
-    _asm
-    {
-        push    ModelID
-        call    dwFunc
-        add     esp, 4
-        mov     dwReturn, eax
-    }
-    return dwReturn;
+    // CBoundingBox is actually CBoundingBox + CSphere from CColModel
+    return (CBoundingBox*)(ppModelInfo[m_dwModelID]->pColModel);
 }
 
 bool CModelInfoSA::IsValid()
@@ -535,26 +376,8 @@ bool CModelInfoSA::IsAllocatedInArchive()
 
 float CModelInfoSA::GetDistanceFromCentreOfMassToBaseOfModel()
 {
-    DWORD dwModelInfo = 0;
-    DWORD ModelID = m_dwModelID;
-    FLOAT fReturn = 0;
-    _asm {
-        mov     eax, ModelID
-
-        push    ecx
-        mov     ecx, dword ptr[ARRAY_ModelInfo]
-        mov     eax, dword ptr[ecx + eax*4]
-        pop     ecx
-
-        mov     eax, [eax+20]
-        cmp     eax, 0
-        jz      skip
-        fld     [eax + 8]
-        fchs
-        fstp    fReturn
-skip:
-    }
-    return fReturn;
+    CColModelSAInterface* pColModel = ppModelInfo[m_dwModelID]->pColModel;
+    return pColModel ? -pColModel->m_bounds.m_vecMin.fZ : 0.0f;
 }
 
 unsigned short CModelInfoSA::GetTextureDictionaryID()
@@ -738,12 +561,8 @@ void CModelInfoSA::StaticFlushPendingRestreamIPL()
             {
                 if (!pEntity->bStreamingDontDelete && !pEntity->bImBeingRendered)
                 {
-                    _asm
-                    {
-                        mov ecx, pEntity
-                        mov eax, [ecx]
-                        call dword ptr [eax+20h]
-                    }
+                    ((void(__thiscall*)(CEntitySAInterface*))pEntity->vtbl->DeleteRwObject)(pEntity);
+
                     removedModels.insert(pEntity->m_nModelIndex);
                 }
             }
@@ -762,12 +581,8 @@ void CModelInfoSA::StaticFlushPendingRestreamIPL()
             {
                 if (!pEntity->bStreamingDontDelete && !pEntity->bImBeingRendered)
                 {
-                    _asm
-                    {
-                        mov ecx, pEntity
-                        mov eax, [ecx]
-                        call dword ptr [eax+20h]
-                    }
+                    ((void(__thiscall*)(CEntitySAInterface*))pEntity->vtbl->DeleteRwObject)(pEntity);
+
                     removedModels.insert(pEntity->m_nModelIndex);
                 }
             }
@@ -836,13 +651,8 @@ void CModelInfoSA::RemoveRef(bool bRemoveExtraGTARef)
         // Remove ref added by GTA.
         if (m_pInterface->usNumberOfRefs > 1)
         {
-            DWORD                      dwFunction = FUNC_RemoveRef;
-            CBaseModelInfoSAInterface* pInterface = m_pInterface;
-            _asm
-            {
-                mov     ecx, pInterface
-                call    dwFunction
-            }
+            // CBaseModelInfo::RemoveRef
+            ((void(__thiscall*)(CBaseModelInfoSAInterface*))FUNC_RemoveRef)(m_pInterface);
         }
     }
 
@@ -925,77 +735,34 @@ short CModelInfoSA::GetAvailableVehicleMod(unsigned short usUpgrade)
             mov     ax, [eax+edx*2+0x2D6]
             mov     sreturn, ax
         }
+        // short CVehicleModelInfo::m_asUpgrades[18]
+        //return ((CVehicleModelInfoSAInterface*)ppModelInfo[m_dwModelID])->upgrades[usUpgrade];
     }
     return sreturn;
 }
 
 bool CModelInfoSA::IsUpgradeAvailable(eVehicleUpgradePosn posn)
 {
-    bool  bRet = false;
-    DWORD ModelID = m_dwModelID;
-    _asm
-    {
-        mov     eax, ModelID
-        mov ecx, dword ptr[ARRAY_ModelInfo]
-        mov     ecx, dword ptr[ecx + eax*4]
-
-        mov     eax, posn
-        mov     ecx, [ecx+0x5C]
-        shl     eax, 5
-        push    esi
-        mov     esi, [ecx+eax+0D0h]
-        xor     edx, edx
-        test    esi, esi
-        setnl   dl
-        mov     al, dl
-        pop     esi
-
-        mov     bRet, al
-    }
-    return bRet;
+    CVehicleModelInfoSAInterface* pVehicleMI = (CVehicleModelInfoSAInterface*)ppModelInfo[m_dwModelID];
+    // CVehicleModelInfo::IsUpgradeAvailable
+    return ((bool(__thiscall*)(CVehicleModelInfoSAInterface*, eVehicleUpgradePosn))0x4C8200)(pVehicleMI, posn);
 }
 
 void CModelInfoSA::SetCustomCarPlateText(const char* szText)
 {
-    char* szStoredText;
-    DWORD ModelID = m_dwModelID;
-    _asm
-    {
-        push    ecx
-        mov     ecx, ModelID
-
-        push    eax
-        mov     eax, dword ptr[ARRAY_ModelInfo]
-        mov     ecx, dword ptr[eax + ecx*4]
-        pop     eax
-
-        add     ecx, 40
-        mov     szStoredText, ecx
-        pop     ecx
-    }
-
-    if (szText) strncpy(szStoredText, szText, 8);
-    else szStoredText[0] = 0;
+    CVehicleModelInfoSAInterface* pVehicleMI = (CVehicleModelInfoSAInterface*)ppModelInfo[m_dwModelID];
+    if (szText)
+        strncpy(pVehicleMI->plateText, szText, 8);
+    else
+        pVehicleMI->plateText[0] = 0;
 }
 
 unsigned int CModelInfoSA::GetNumRemaps()
 {
-    DWORD        dwFunc = FUNC_CVehicleModelInfo__GetNumRemaps;
-    DWORD        ModelID = m_dwModelID;
-    unsigned int uiReturn = 0;
-    _asm
-    {
-        mov     ecx, ModelID
+    CVehicleModelInfoSAInterface* pVehicleMI = (CVehicleModelInfoSAInterface*)ppModelInfo[m_dwModelID];
 
-        push    eax
-        mov     eax, dword ptr[ARRAY_ModelInfo]
-        mov     ecx, dword ptr[eax + ecx*4]
-        pop     eax
-
-        call    dwFunc
-        mov     uiReturn, eax
-    }
-    return uiReturn;
+    // CVehicleModelInfo::GetNumRemaps
+    return ((unsigned int(__thiscall*)(CVehicleModelInfoSAInterface*))FUNC_CVehicleModelInfo__GetNumRemaps)(pVehicleMI);
 }
 
 void* CModelInfoSA::GetVehicleSuspensionData()

--- a/Client/game_sa/CObjectSA.cpp
+++ b/Client/game_sa/CObjectSA.cpp
@@ -226,7 +226,7 @@ CObjectSA::~CObjectSA()
                 CWorldSA* world = (CWorldSA*)pGame->GetWorld();
                 world->Remove(pInterface, CObject_Destructor);
 
-                ((void(__thiscall*)(void*))pInterface->vtbl->SCALAR_DELETING_DESTRUCTOR)(pInterface);
+                ((void(__thiscall*)(void*, unsigned int))pInterface->vtbl->SCALAR_DELETING_DESTRUCTOR)(pInterface, 1);
 
 #ifdef MTA_USE_BUILDINGS_AS_OBJECTS
                 DWORD dwModelID = this->internalInterface->m_nModelIndex;

--- a/Client/game_sa/CPathFindSA.cpp
+++ b/Client/game_sa/CPathFindSA.cpp
@@ -56,7 +56,7 @@ void CPathFindSA::SwitchRoadsOffInArea(CVector* vecAreaCorner1, CVector* vecArea
     float fZ2 = vecAreaCorner2->fZ;
 
     ((void(__thiscall*)(int, float, float, float, float, float, float, bool, bool, bool))FUNC_SwitchRoadsOffInArea)(CLASS_CPathFind, fX1, fX2, fY1, fY2, fZ1,
-                                                                                                                    fZ2, bEnable, true, false);
+                                                                                                                    fZ2, !bEnable, true, false);
 }
 
 void CPathFindSA::SwitchPedRoadsOffInArea(CVector* vecAreaCorner1, CVector* vecAreaCorner2, bool bEnable)
@@ -70,7 +70,7 @@ void CPathFindSA::SwitchPedRoadsOffInArea(CVector* vecAreaCorner1, CVector* vecA
     float fZ2 = vecAreaCorner2->fZ;
 
     ((void(__thiscall*)(int, float, float, float, float, float, float, bool, bool))FUNC_SwitchPedRoadsOffInArea)(CLASS_CPathFind, fX1, fX2, fY1, fY2, fZ1, fZ2,
-                                                                                                                 bEnable, false);
+                                                                                                                 !bEnable, false);
 }
 
 void CPathFindSA::SetPedDensity(float fPedDensity)

--- a/Client/game_sa/CPathFindSA.cpp
+++ b/Client/game_sa/CPathFindSA.cpp
@@ -20,7 +20,7 @@ CNodeAddress* CPathFindSA::FindNthNodeClosestToCoors(CVector* vecCoors, int iNod
 
     // CPathFind::FindNthNodeClosestToCoors
     ((CNodeAddress * (__thiscall*)(int, CNodeAddress*, CVector, unsigned char, float, bool, bool, int, bool, bool, CNodeAddress*))
-         FUNC_FindNthNodeClosestToCoors)(CLASS_CPathFind, nodeptr, *vecCoors, 0, fDistance, false, false, iNodeNumber, iType, false, &node);
+         FUNC_FindNthNodeClosestToCoors)(CLASS_CPathFind, &nodeptr, *vecCoors, 0, fDistance, false, false, iNodeNumber, iType, false, &node);
 
     *pNodeAddress = node;
     return pNodeAddress;

--- a/Client/game_sa/CPathFindSA.cpp
+++ b/Client/game_sa/CPathFindSA.cpp
@@ -18,26 +18,9 @@ CNodeAddress* CPathFindSA::FindNthNodeClosestToCoors(CVector* vecCoors, int iNod
     CNodeAddress  node;
     CNodeAddress* nodeptr;
 
-    _asm
-    {
-        lea     eax, node
-        push    eax
-        push    0
-        push    iType  // Type : 0 - cars, 1 - boats
-        push    iNodeNumber // Nth
-        push    0
-        push    0
-        push    fDistance
-        push    0
-        mov     eax, vecCoors
-        push    [eax+8]
-        push    [eax+4]
-        push    [eax]
-        lea     eax, nodeptr
-        push    eax
-        mov     ecx, CLASS_CPathFind
-        call    dwFunc
-    }
+    // CPathFind::FindNthNodeClosestToCoors
+    ((CNodeAddress * (__thiscall*)(int, CNodeAddress*, CVector, unsigned char, float, bool, bool, int, bool, bool, CNodeAddress*))
+         FUNC_FindNthNodeClosestToCoors)(CLASS_CPathFind, nodeptr, *vecCoors, 0, fDistance, false, false, iNodeNumber, iType, false, &node);
 
     *pNodeAddress = node;
     return pNodeAddress;
@@ -45,32 +28,15 @@ CNodeAddress* CPathFindSA::FindNthNodeClosestToCoors(CVector* vecCoors, int iNod
 
 CPathNode* CPathFindSA::GetPathNode(CNodeAddress* node)
 {
-    DWORD dwFunc = FUNC_FindNodePointer;
     if (node->sRegion >= 0 && node->sIndex >= 0)
-    {
-        DWORD dwPathNode = 0;
-        _asm
-        {
-            push    node
-            mov     ecx, CLASS_CPathFind
-            call    dwFunc
-            mov     dwPathNode, eax
-        }
-        return (CPathNode*)dwPathNode;
-    }
-    return NULL;
+        return ((CPathNode * (__thiscall*)(int, CNodeAddress*)) FUNC_FindNodePointer)(CLASS_CPathFind, node);
+
+    return nullptr;
 }
 
 CVector* CPathFindSA::GetNodePosition(CPathNode* pNode, CVector* pPosition)
 {
-    DWORD dwFunc = FUNC_CPathNode_GetCoors;
-    _asm
-    {
-        push    pPosition
-        mov     ecx, pNode
-        call    dwFunc
-    }
-    return pPosition;
+    return ((CVector * (__thiscall*)(CPathNode*, CVector*)) FUNC_CPathNode_GetCoors)(pNode, pPosition);
 }
 
 CVector* CPathFindSA::GetNodePosition(CNodeAddress* pNode, CVector* pPosition)
@@ -89,24 +55,8 @@ void CPathFindSA::SwitchRoadsOffInArea(CVector* vecAreaCorner1, CVector* vecArea
     float fY2 = vecAreaCorner2->fY;
     float fZ2 = vecAreaCorner2->fZ;
 
-    DWORD dwEnable = !bEnable;
-
-    DWORD dwFunc = FUNC_SwitchRoadsOffInArea;
-
-    _asm
-    {
-        mov     ecx, CLASS_CPathFind
-        push    0
-        push    1
-        push    dwEnable
-        push    fZ2
-        push    fZ1
-        push    fY2
-        push    fY1
-        push    fX2
-        push    fX1
-        call    dwFunc
-    }
+    ((void(__thiscall*)(int, float, float, float, float, float, float, bool, bool, bool))FUNC_SwitchRoadsOffInArea)(CLASS_CPathFind, fX1, fX2, fY1, fY2, fZ1,
+                                                                                                                    fZ2, bEnable, true, false);
 }
 
 void CPathFindSA::SwitchPedRoadsOffInArea(CVector* vecAreaCorner1, CVector* vecAreaCorner2, bool bEnable)
@@ -119,23 +69,8 @@ void CPathFindSA::SwitchPedRoadsOffInArea(CVector* vecAreaCorner1, CVector* vecA
     float fY2 = vecAreaCorner2->fY;
     float fZ2 = vecAreaCorner2->fZ;
 
-    DWORD dwEnable = !bEnable;
-
-    DWORD dwFunc = FUNC_SwitchPedRoadsOffInArea;
-
-    _asm
-    {
-        mov     ecx, CLASS_CPathFind
-        push    0
-        push    dwEnable
-        push    fZ2
-        push    fZ1
-        push    fY2
-        push    fY1
-        push    fX2
-        push    fX1
-        call    dwFunc
-    }
+    ((void(__thiscall*)(int, float, float, float, float, float, float, bool, bool))FUNC_SwitchPedRoadsOffInArea)(CLASS_CPathFind, fX1, fX2, fY1, fY2, fZ1, fZ2,
+                                                                                                                 bEnable, false);
 }
 
 void CPathFindSA::SetPedDensity(float fPedDensity)

--- a/Client/game_sa/CPathFindSA.cpp
+++ b/Client/game_sa/CPathFindSA.cpp
@@ -13,17 +13,7 @@
 
 CNodeAddress* CPathFindSA::FindNthNodeClosestToCoors(CVector* vecCoors, int iNodeNumber, int iType, CNodeAddress* pNodeAddress, float fDistance)
 {
-    DWORD dwFunc = FUNC_FindNthNodeClosestToCoors;
-
-    CNodeAddress  node;
-    CNodeAddress* nodeptr;
-
-    // CPathFind::FindNthNodeClosestToCoors
-    ((CNodeAddress * (__thiscall*)(int, CNodeAddress*, CVector, unsigned char, float, bool, bool, int, bool, bool, CNodeAddress*))
-         FUNC_FindNthNodeClosestToCoors)(CLASS_CPathFind, &nodeptr, *vecCoors, 0, fDistance, false, false, iNodeNumber, iType, false, &node);
-
-    *pNodeAddress = node;
-    return pNodeAddress;
+    return nullptr;
 }
 
 CPathNode* CPathFindSA::GetPathNode(CNodeAddress* node)

--- a/Client/game_sa/CPedDamageResponseCalculatorSA.cpp
+++ b/Client/game_sa/CPedDamageResponseCalculatorSA.cpp
@@ -16,19 +16,10 @@ CPedDamageResponseCalculatorSA::CPedDamageResponseCalculatorSA(CEntity* pEntity,
     m_pInterface = new CPedDamageResponseCalculatorSAInterface;
     m_bDestroyInterface = true;
 
-    DWORD dwEntityInterface = (DWORD)pEntity->GetInterface();
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CPedDamageResponseCalculator_Constructor;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    b_1
-        push    bodyPart
-        push    weaponType
-        push    fDamage
-        push    dwEntityInterface
-        call    dwFunc
-    }
+    // CPedDamageResponseCalculator::CPedDamageResponseCalculator
+    ((CPedDamageResponseCalculatorSAInterface*
+      (__thiscall*)(CPedDamageResponseCalculatorSAInterface*, CEntitySAInterface*, float, eWeaponType, ePedPieceTypes, bool))
+         FUNC_CPedDamageResponseCalculator_Constructor)(m_pInterface, pEntity->GetInterface(), fDamage, weaponType, bodyPart, b_1);
 }
 
 CPedDamageResponseCalculatorSA::CPedDamageResponseCalculatorSA(CPedDamageResponseCalculatorSAInterface* pInterface)
@@ -41,29 +32,17 @@ CPedDamageResponseCalculatorSA::~CPedDamageResponseCalculatorSA()
 {
     if (m_bDestroyInterface)
     {
-        DWORD dwThis = (DWORD)m_pInterface;
-        DWORD dwFunc = FUNC_CPedDamageResponseCalculator_Destructor;
-        _asm
-        {
-            mov     ecx, dwThis
-            call    dwFunc
-        }
+        // CPedDamageResponseCalculator::~CPedDamageResponseCalculator
+        ((void(__thiscall*)(CPedDamageResponseCalculatorSAInterface*))FUNC_CPedDamageResponseCalculator_Destructor)(m_pInterface);
+
         delete m_pInterface;
     }
 }
 
 void CPedDamageResponseCalculatorSA::ComputeDamageResponse(CPed* pPed, CPedDamageResponse* pDamageResponse, bool bSpeak)
 {
-    DWORD dwPedInterface = (DWORD)pPed->GetInterface();
-    DWORD dwResponseInterface = (DWORD)pDamageResponse->GetInterface();
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CPedDamageResponseCalculator_ComputeDamageResponse;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    bSpeak
-        push    dwResponseInterface
-        push    dwPedInterface
-        call    dwFunc
-    }
+    // CPedDamageResponseCalculator::ComputeDamageResponse
+    ((void(__thiscall*)(CPedDamageResponseCalculatorSAInterface*, CPedSAInterface*, CPedDamageResponseSAInterface*,
+                        bool))FUNC_CPedDamageResponseCalculator_ComputeDamageResponse)(m_pInterface, pPed->GetPedInterface(), pDamageResponse->GetInterface(),
+                                                                                       bSpeak);
 }

--- a/Client/game_sa/CPedIntelligenceSA.cpp
+++ b/Client/game_sa/CPedIntelligenceSA.cpp
@@ -46,16 +46,8 @@ bool CPedIntelligenceSA::IsRespondingToEvent()
 
 int CPedIntelligenceSA::GetCurrentEventType()
 {
-    DWORD dwFunc = FUNC_GetCurrentEventType;
-    DWORD dwRet = 0;
-    DWORD dwThis = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     dwRet, eax
-    }
-    return dwRet;
+    // CPedIntelligence::GetCurrentEventType
+    return ((int(__thiscall*)(CPedIntelligenceSAInterface*))FUNC_GetCurrentEventType)(this->GetInterface());
 }
 
 CEvent* CPedIntelligenceSA::GetCurrentEvent()
@@ -65,34 +57,15 @@ CEvent* CPedIntelligenceSA::GetCurrentEvent()
 
 bool CPedIntelligenceSA::TestForStealthKill(CPed* pPed, bool bUnk)
 {
-    bool  bReturn;
-    DWORD dwThis = (DWORD)internalInterface;
-    DWORD dwPed = (DWORD)pPed->GetInterface();
-    DWORD dwFunc = FUNC_CPedIntelligence_TestForStealthKill;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    bUnk
-        push    dwPed
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CPedIntelligence::TestForStealthKill
+    return ((bool(__thiscall*)(CPedIntelligenceSAInterface*, CPedSAInterface*, bool))FUNC_CPedIntelligence_TestForStealthKill)(this->GetInterface(),
+                                                                                                                               pPed->GetPedInterface(), bUnk);
 }
 
 CTaskSimpleUseGunSAInterface* CPedIntelligenceSA::GetTaskUseGun()
 {
-    CTaskSimpleUseGunSAInterface* pTaskUseGun;
-    DWORD                         dwThis = (DWORD)internalInterface;
-    DWORD                         dwFunc = FUNC_CPedIntelligence_GetTaskUseGun;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     pTaskUseGun, eax
-    }
-
-    return pTaskUseGun;
+    // CPedIntelligence::GetTaskUseGun
+    return ((CTaskSimpleUseGunSAInterface*(__thiscall*)(CPedIntelligenceSAInterface*))FUNC_CPedIntelligence_GetTaskUseGun)(this->GetInterface());
 }
 
 CTaskSAInterface* CPedIntelligenceSA::SetTaskDuckSecondary(unsigned short nLengthOfDuck)

--- a/Client/game_sa/CPedModelInfoSA.cpp
+++ b/Client/game_sa/CPedModelInfoSA.cpp
@@ -26,12 +26,6 @@ CPedModelInfoSA::CPedModelInfoSA() : CModelInfoSA()
 
 void CPedModelInfoSA::SetMotionAnimGroup(AssocGroupId animGroup)
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = (DWORD)FUNC_SetMotionAnimGroup;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    animGroup
-        call    dwFunc
-    }
+    // CPedModelInfo::SetMotionAnimGroup
+    ((void(__thiscall*)(CPedModelInfoSAInterface*, AssocGroupId))FUNC_SetMotionAnimGroup)(GetPedModelInfoInterface(), animGroup);
 }

--- a/Client/game_sa/CPedSoundSA.cpp
+++ b/Client/game_sa/CPedSoundSA.cpp
@@ -28,71 +28,32 @@ void CPedSoundSA::SetVoiceID(short sVoiceID)
 
 bool CPedSoundSA::IsSpeechDisabled()
 {
-    bool  bReturn;
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAEPedSound__IsSpeedDisabled;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CPedSound::IsSpeechDisabled
+    return ((bool(__thiscall*)(CPedSoundSAInterface*))FUNC_CAEPedSound__IsSpeedDisabled)(m_pInterface);
 }
 
 void CPedSoundSA::EnablePedSpeech()
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAEPedSound__EnablePedSpeech;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CPedSound::EnablePedSpeech
+    ((void(__thiscall*)(CPedSoundSAInterface*))FUNC_CAEPedSound__EnablePedSpeech)(m_pInterface);
 }
 
 void CPedSoundSA::DisablePedSpeech(bool bStopCurrent)
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAEPedSound__DisablePedSpeech;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    bStopCurrent
-        call    dwFunc
-    }
+    // CPedSound::DisablePedSpeech
+    ((void(__thiscall*)(CPedSoundSAInterface*, bool))FUNC_CAEPedSound__DisablePedSpeech)(m_pInterface, bStopCurrent);
 }
 
 short CPedSoundSA::GetVoiceTypeIDFromName(const char* szVoiceTypeName)
 {
-    DWORD dwFunc = (DWORD)FUNC_CAEPedSound__GetAudioPedType;
-    short sVoiceTypeID;
-
-    _asm
-    {
-        push    szVoiceTypeName
-        call    dwFunc
-        add     esp, 4
-        mov     sVoiceTypeID, ax
-    }
-    return sVoiceTypeID;
+    // CAEPedSpeechAudioEntity::GetAudioPedType
+    return ((short(__cdecl*)(const char*))FUNC_CAEPedSound__GetAudioPedType)(szVoiceTypeName);
 }
 
 short CPedSoundSA::GetVoiceIDFromName(short sVoiceTypeID, const char* szVoiceName)
 {
-    DWORD dwFunc = (DWORD)FUNC_CAEPedSound__GetVoice;
-    short sVoiceID;
-
-    _asm
-    {
-        movzx eax, sVoiceTypeID
-        push    eax
-        push    szVoiceName
-        call    dwFunc
-        add     esp, 8
-        mov     sVoiceID, ax
-    }
-    return sVoiceID;
+    // CAEPedSpeechAudioEntity::GetVoice
+    return ((short(__cdecl*)(const char*, short))FUNC_CAEPedSound__GetVoice)(szVoiceName, sVoiceTypeID);
 }
 
 short CPedSoundSA::GetVoiceIDFromName(const char* szVoiceTypeName, const char* szVoiceName)

--- a/Client/game_sa/CPhysicalSA.h
+++ b/Client/game_sa/CPhysicalSA.h
@@ -123,6 +123,8 @@ public:
     void         SetMoveSpeed(CVector* vecMoveSpeed);
     void         SetTurnSpeed(CVector* vecTurnSpeed);
 
+    CPhysicalSAInterface* GetPhysicalInterface() { return (CPhysicalSAInterface*)m_pInterface; };
+
     float GetMass();
     void  SetMass(float fMass);
     float GetTurnMass();

--- a/Client/game_sa/CPickupSA.cpp
+++ b/Client/game_sa/CPickupSA.cpp
@@ -139,16 +139,11 @@ BYTE CPickupSA::IsNearby()
 VOID CPickupSA::GiveUsAPickUpObject(int ForcedObjectIndex)
 {
     DEBUG_TRACE("VOID CPickupSA::GiveUsAPickUpObject(int ForcedObjectIndex)");
-    DWORD GiveUsAPickUpObject = FUNC_GIVEUSAPICKUP;
-    DWORD dwObject = (DWORD) & (this->GetInterface()->pObject);
-    DWORD dwThis = (DWORD)this->GetInterface();
-    _asm
-    {
-        push    ForcedObjectIndex
-        push    dwObject
-        mov     ecx, dwThis
-        call    GiveUsAPickUpObject
-    }
+
+    // CPickup::GiveUsAPickUpObject
+    ((void(__thiscall*)(CPickupSAInterface*, CObjectSAInterface**, int))FUNC_GIVEUSAPICKUP)(this->GetInterface(), &this->GetInterface()->pObject,
+                                                                                            ForcedObjectIndex);
+
     if (this->GetInterface()->pObject)
     {
         if (this->object)
@@ -177,13 +172,8 @@ VOID CPickupSA::GetRidOfObjects()
 
 VOID CPickupSA::Remove()
 {
-    DWORD dwFunc = FUNC_CPickup_Remove;
-    DWORD dwThis = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    // CPickup::GiveUsAPickUpObject
+    ((void(__thiscall*)(CPickupSAInterface*))FUNC_CPickup_Remove)(this->GetInterface());
 
     // CPickup::Remove also destroys the owned object, so we need to delete our CObjectSA class
     if (this->object)

--- a/Client/game_sa/CPlayerInfoSA.cpp
+++ b/Client/game_sa/CPlayerInfoSA.cpp
@@ -69,11 +69,9 @@ void CPlayerInfoSA::SetPlayerMoney(long lMoney, bool bInstant)
 VOID CPlayerInfoSA::GivePlayerParachute()
 {
     DEBUG_TRACE("VOID CPlayerInfoSA::GivePlayerParachute ( VOID )");
-    DWORD dwFunction = FUNC_GivePlayerParachute;
-    _asm
-    {
-        call dwFunction
-    }
+
+    // CPlayerInfo::GivePlayerParachute
+    ((void(__cdecl*)())FUNC_GivePlayerParachute)();
 }
 
 /**
@@ -82,12 +80,9 @@ VOID CPlayerInfoSA::GivePlayerParachute()
 VOID CPlayerInfoSA::StreamParachuteWeapon(bool bAllowParachute)
 {
     DEBUG_TRACE("VOID CPlayerInfoSA::StreamParachuteWeapon ( bool bAllowParachute )");
-    DWORD dwFunction = FUNC_StreamParachuteWeapon;
-    _asm
-    {
-        push bAllowParachute
-        call dwFunction
-    }
+
+    // CPlayerInfo::StreamParachuteWeapon
+    ((void(__cdecl*)(bool))FUNC_StreamParachuteWeapon)(bAllowParachute);
 }
 
 /**
@@ -98,12 +93,9 @@ VOID CPlayerInfoSA::StreamParachuteWeapon(bool bAllowParachute)
 VOID CPlayerInfoSA::MakePlayerSafe(BOOL boolSafe)
 {
     DEBUG_TRACE("VOID CPlayerInfoSA::MakePlayerSafe ( BOOL boolSafe )");
-    DWORD dwFunction = FUNC_MakePlayerSafe;
-    _asm
-    {
-        push    boolSafe
-        call    dwFunction
-    }
+
+    // CPlayerInfo::MakePlayerSafe
+    ((void(__cdecl*)(bool))FUNC_MakePlayerSafe)(boolSafe);
 }
 
 /**
@@ -114,12 +106,7 @@ VOID CPlayerInfoSA::MakePlayerSafe(BOOL boolSafe)
 VOID CPlayerInfoSA::CancelPlayerEnteringCars(CVehicle* vehicle)
 {
     DEBUG_TRACE("VOID CPlayerInfoSA::CancelPlayerEnteringCars ( CVehicle * vehicle )");
-    DWORD dwFunction = FUNC_CancelPlayerEnteringCars;
-    _asm
-    {
-        push    vehicle
-        call    dwFunction
-    }
+
 }
 
 /**
@@ -130,11 +117,9 @@ VOID CPlayerInfoSA::CancelPlayerEnteringCars(CVehicle* vehicle)
 VOID CPlayerInfoSA::ArrestPlayer()
 {
     DEBUG_TRACE("VOID CPlayerInfoSA::ArrestPlayer (  )");
-    DWORD dwFunction = FUNC_ArrestPlayer;
-    _asm
-    {
-        call    dwFunction
-    }
+
+    // CPlayerInfo::ArrestPlayer
+    ((void(__cdecl*)())FUNC_ArrestPlayer)();
 }
 
 /**
@@ -145,11 +130,9 @@ VOID CPlayerInfoSA::ArrestPlayer()
 VOID CPlayerInfoSA::KillPlayer()
 {
     DEBUG_TRACE("VOID CPlayerInfoSA::KillPlayer (  )");
-    DWORD dwFunction = FUNC_KillPlayer;
-    _asm
-    {
-        call    dwFunction
-    }
+
+    // CPlayerInfo::KillPlayer
+    ((void(__cdecl*)())FUNC_KillPlayer)();
 }
 
 /**
@@ -163,20 +146,12 @@ CVehicle* CPlayerInfoSA::GivePlayerRemoteControlledCar(eVehicleTypes vehicletype
     /**
      * \todo Add the player's X, Y, Z as the initial start position
      */
-    DWORD dwFunction = FUNC_GivePlayerRemoteControlledCar;
     // this->GetPlayerPed();
     float fX, fY, fZ;
     float fRotation;
-    _asm
-    {
-        push    vehicletype
-        push    fRotation;
-        push    fZ
-        push    fY
-        push    fX
-        call    dwFunction
-        add     esp, 0x14
-    }
+
+    // CRemote::GivePlayerRemoteControlledCar
+    ((void(__cdecl*)(float, float, float, float, unsigned short))FUNC_GivePlayerRemoteControlledCar)(fX, fY, fZ, fRotation, vehicletype);
 
     return this->GetPlayerRemoteControlledCar();
 }
@@ -187,14 +162,9 @@ CVehicle* CPlayerInfoSA::GivePlayerRemoteControlledCar(eVehicleTypes vehicletype
 VOID CPlayerInfoSA::TakeRemoteControlledCarFromPlayer()
 {
     DEBUG_TRACE("VOID CPlayerInfoSA::TakeRemoteControlledCarFromPlayer (  )");
-    DWORD dwFunction = FUNC_TakeRemoteControlledCarFromPlayer;
-    _asm
-    {
-        push    ecx
-        push    1
-        call    dwFunction
-        pop     ecx
-    }
+
+    // CRemote::TakeRemoteControlledCarFromPlayer
+    ((void(__cdecl*)(bool))FUNC_TakeRemoteControlledCarFromPlayer)(true);
 }
 
 /**

--- a/Client/game_sa/CPointLightsSA.cpp
+++ b/Client/game_sa/CPointLightsSA.cpp
@@ -18,32 +18,13 @@ using CHeli_PostSearchLightCone_t = int(__cdecl*)();
 void CPointLightsSA::AddLight(int iMode, const CVector vecPosition, CVector vecDirection, float fRadius, SColor color, unsigned char uc_8, bool bCreatesShadow,
                               CEntity* pAffected)
 {
-    DWORD dwEntityInterface = 0;
-    if (pAffected)
-        dwEntityInterface = (DWORD)pAffected->GetInterface();
-    DWORD dwFunc = FUNC_CPointLights_AddLight;
-    float fPosX = vecPosition.fX, fPosY = vecPosition.fY, fPosZ = vecPosition.fZ;
-    float fDirX = vecDirection.fX, fDirY = vecDirection.fY, fDirZ = vecDirection.fZ;
+    CEntitySAInterface* pEntityInterface = pAffected ? pAffected->GetInterface() : nullptr;
+
     float fRed = (float)color.R / 255, fGreen = (float)color.G / 255, fBlue = (float)color.B / 255;
-    _asm
-    {
-        push    dwEntityInterface
-        push    bCreatesShadow
-        push    uc_8
-        push    fBlue
-        push    fGreen
-        push    fRed
-        push    fRadius
-        push    fDirZ
-        push    fDirY
-        push    fDirX
-        push    fPosZ
-        push    fPosY
-        push    fPosX
-        push    iMode
-        call    dwFunc
-        add     esp, 56
-    }
+
+    // CPointLights::AddLight
+    ((void(__cdecl*)(unsigned char, CVector, CVector, float, float, float, float, unsigned char, bool, CEntitySAInterface*))FUNC_CPointLights_AddLight)(
+        iMode, vecPosition, vecDirection, fRadius, fRed, fGreen, fBlue, uc_8, bCreatesShadow, pEntityInterface);
 }
 
 void CPointLightsSA::PreRenderHeliLights()

--- a/Client/game_sa/CPoolsSA.cpp
+++ b/Client/game_sa/CPoolsSA.cpp
@@ -231,61 +231,33 @@ DWORD CPoolsSA::GetVehicleRef(CVehicle* pVehicle)
 {
     DEBUG_TRACE("DWORD CPoolsSA::GetVehicleRef ( CVehicle* pVehicle )");
 
-    DWORD       dwRef = 0;
     CVehicleSA* pVehicleSA = dynamic_cast<CVehicleSA*>(pVehicle);
-    if (pVehicleSA)
-    {
-        CVehicleSAInterface* pInterface = pVehicleSA->GetVehicleInterface();
-        DWORD                dwFunc = FUNC_GetVehicleRef;
-        _asm
-        {
-            push    pInterface
-            call    dwFunc
-            add     esp, 0x4
-            mov     dwRef, eax
-        }
-    }
+    if (!pVehicleSA)
+        return 0;
 
-    return dwRef;
+    // CPools::GetVehicleRef
+    return ((int(__cdecl*)(CVehicleSAInterface*))FUNC_GetVehicleRef)(pVehicleSA->GetVehicleInterface());
 }
 
 DWORD CPoolsSA::GetVehicleRef(DWORD* pGameInterface)
 {
     DEBUG_TRACE("DWORD CPoolsSA::GetVehicleRef ( DWORD* pGameInterface )");
 
-    DWORD                dwRef = 0;
     CVehicleSAInterface* pInterface = reinterpret_cast<CVehicleSAInterface*>(pGameInterface);
-    if (pInterface)
-    {
-        DWORD dwFunc = FUNC_GetVehicleRef;
-        _asm
-        {
-            push    pInterface
-            call    dwFunc
-            add     esp, 0x4
-            mov     dwRef, eax
-        }
-    }
+    if (!pInterface)
+        return 0;
 
-    return dwRef;
+    // CPools::GetVehicleRef
+    return ((int(__cdecl*)(CVehicleSAInterface*))FUNC_GetVehicleRef)(pInterface);
 }
 
 CVehicle* CPoolsSA::GetVehicleFromRef(DWORD dwGameRef)
 {
     DEBUG_TRACE("CVehicle* CPoolsSA::GetVehicleFromRef ( DWORD dwGameRef )");
 
-    DWORD dwReturn;
-    DWORD dwFunction = FUNC_GetVehicle;
+    // CPools::GetVehicle
+    CVehicleSAInterface* pInterface = ((CVehicleSAInterface*(__thiscall*)(void*, int))FUNC_GetVehicleRef)(*(void**)CLASS_CPool_Vehicle, dwGameRef);
 
-    _asm {
-        mov     ecx, dword ptr ds : [CLASS_CPool_Vehicle]
-        push    dwGameRef
-        call    dwFunction
-        add     esp, 0x4
-        mov     dwReturn, eax
-    }
-
-    CVehicleSAInterface* pInterface = (CVehicleSAInterface*)dwReturn;
     if (pInterface)
     {
         DWORD       dwElementIndexInPool = dwGameRef >> 8;
@@ -430,22 +402,12 @@ DWORD CPoolsSA::GetObjectRef(CObject* pObject)
 {
     DEBUG_TRACE("DWORD CPoolsSA::GetObjectRef ( CObject* pObject )");
 
-    DWORD      dwRef = 0;
     CObjectSA* pObjectSA = dynamic_cast<CObjectSA*>(pObject);
-    if (pObjectSA)
-    {
-        CObjectSAInterface* pInterface = pObjectSA->GetObjectInterface();
-        DWORD               dwFunc = FUNC_GetObjectRef;
-        _asm
-        {
-            push    pInterface
-            call    dwFunc
-            add     esp, 0x4
-            mov     dwRef, eax
-        }
-    }
+    if (!pObjectSA)
+        return 0;
 
-    return dwRef;
+    // CPools::GetObjectRef
+    return ((int(__cdecl*)(CObjectSAInterface*))FUNC_GetObjectRef)(pObjectSA->GetObjectInterface());
 }
 
 DWORD CPoolsSA::GetObjectRef(DWORD* pGameInterface)
@@ -455,36 +417,18 @@ DWORD CPoolsSA::GetObjectRef(DWORD* pGameInterface)
     DWORD               dwRef = 0;
     CObjectSAInterface* pInterface = reinterpret_cast<CObjectSAInterface*>(pGameInterface);
     if (pInterface)
-    {
-        DWORD dwFunc = FUNC_GetObjectRef;
-        _asm
-        {
-            push    pInterface
-            call    dwFunc
-            add     esp, 0x4
-            mov     dwRef, eax
-        }
-    }
+        return 0;
 
-    return dwRef;
+    // CPools::GetObjectRef
+    return ((int(__cdecl*)(CObjectSAInterface*))FUNC_GetObjectRef)(pInterface);
 }
 
 CObject* CPoolsSA::GetObjectFromRef(DWORD dwGameRef)
 {
     DEBUG_TRACE("CObject* CPoolsSA::GetObjectFromRef ( DWORD dwGameRef )");
 
-    DWORD dwReturn;
-    DWORD dwFunction = FUNC_GetObject;
-
-    _asm {
-        mov     ecx, dword ptr ds : [CLASS_CPool_Object]
-        push    dwGameRef
-        call    dwFunction
-        add     esp, 0x4
-        mov     dwReturn, eax
-    }
-
-    CObjectSAInterface* pInterface = (CObjectSAInterface*)dwReturn;
+    // CPools::GetObject
+    CObjectSAInterface* pInterface = ((CObjectSAInterface*(__thiscall*)(void*, int))FUNC_GetObject)(*(void**)CLASS_CPool_Object, dwGameRef);
 
     if (pInterface)
     {
@@ -729,42 +673,24 @@ DWORD CPoolsSA::GetPedRef(CPed* pPed)
 {
     DEBUG_TRACE("DWORD CPoolsSA::GetPedRef ( CPed* pPed )");
 
-    DWORD   dwRef = 0;
     CPedSA* pPedSA = dynamic_cast<CPedSA*>(pPed);
-    if (pPedSA)
-    {
-        CPedSAInterface* pInterface = pPedSA->GetPedInterface();
-        DWORD            dwFunc = FUNC_GetPedRef;
-        _asm
-        {
-            push    pInterface
-            call    dwFunc
-            add     esp, 0x4
-            mov     dwRef, eax
-        }
-    }
+    if (!pPedSA)
+        return 0;
 
-    return dwRef;
+    // CPools::GetPedRef
+    return ((int(__cdecl*)(CPedSAInterface*))FUNC_GetPedRef)(pPedSA->GetPedInterface());
 }
 
 DWORD CPoolsSA::GetPedRef(DWORD* pGameInterface)
 {
     DEBUG_TRACE("DWORD CPoolsSA::GetPedRef ( DWORD* pGameInterface )");
 
-    DWORD            dwRef = 0;
     CPedSAInterface* pInterface = reinterpret_cast<CPedSAInterface*>(pGameInterface);
-    if (pInterface)
-    {
-        DWORD dwFunc = FUNC_GetPedRef;
-        _asm
-        {
-            push    pInterface
-            call    dwFunc
-            add     esp, 0x4
-            mov     dwRef, eax
-        }
-    }
-    return dwRef;
+    if (!pInterface)
+        return 0;
+
+    // CPools::GetPedRef
+    return ((int(__cdecl*)(CPedSAInterface*))FUNC_GetPedRef)(pInterface);
 }
 
 CPed* CPoolsSA::GetPedFromRef(DWORD dwGameRef)
@@ -789,19 +715,8 @@ CPedSAInterface* CPoolsSA::GetPedInterface(DWORD dwGameRef)
 {
     DEBUG_TRACE("CPedSAInterface* CPoolsSA::GetPedInterface ( DWORD dwGameRef )");
 
-    DWORD dwReturn;
-    DWORD dwFunction = FUNC_GetPed;
-
-    _asm {
-        mov     ecx, dword ptr ds : [CLASS_CPool_Ped]
-        push    dwGameRef
-        call    dwFunction
-        add     esp, 0x4
-        mov     dwReturn, eax
-    }
-
-    CPedSAInterface* pInterface = (CPedSAInterface*)dwReturn;
-    return pInterface;
+    // CPools::GetPed
+    return ((CPedSAInterface*(__cdecl*)(int))FUNC_GetPed)(dwGameRef);
 }
 
 void CPoolsSA::DeleteAllPeds()
@@ -903,8 +818,8 @@ CVehicle* CPoolsSA::AddTrain(CClientVehicle* pClientVehicle, CVector* vecPositio
         }
     }
 
-    CVehicleSAInterface* pTrainBeginning = NULL;
-    CVehicleSAInterface* pTrainEnd = NULL;
+    CTrainSAInterface* pTrainBeginning = NULL;
+    CTrainSAInterface* pTrainEnd = NULL;
 
     float fX = vecPosition->fX;
     float fY = vecPosition->fY;
@@ -916,27 +831,10 @@ CVehicle* CPoolsSA::AddTrain(CClientVehicle* pClientVehicle, CVector* vecPositio
     // Find closest track node
     float fRailDistance;
     int   iNodeId = pGame->GetWorld()->FindClosestRailTrackNode(*vecPosition, ucTrackId, fRailDistance);
-    int   iDesiredTrackId = ucTrackId;
 
-    DWORD dwFunc = FUNC_CTrain_CreateMissionTrain;
-    _asm
-    {
-        push    0            // place as close to point as possible (rather than at node)? (maybe) (actually seems to have an effect on the speed, so changed from
-                             // 1 to 0)
-                             push    iDesiredTrackId            // track ID
-                             push    iNodeId            // node to start at (-1 for closest node)
-                             lea     ecx, pTrainEnd
-                             push    ecx            // end of train
-                             lea     ecx, pTrainBeginning
-                             push    ecx            // begining of train
-                             push    0            // train type (always use 0 as thats where we're writing to)
-                             push    bDirection            // direction
-                             push    fZ            // z
-                             push    fY            // y
-                             push    fX            // x
-                             call    dwFunc
-                             add     esp, 0x28
-    }
+    // CTrain::CreateMissionTrain
+    ((void(__cdecl*)(CVector, bool, unsigned int, CTrainSAInterface**, CTrainSAInterface**, int, int, bool))FUNC_CTrain_CreateMissionTrain)(
+        *vecPosition, bDirection, 0, &pTrainBeginning, &pTrainEnd, iNodeId, ucTrackId, false);
 
     // Enable GetVehicle
     m_bGetVehicleEnabled = true;
@@ -1358,20 +1256,10 @@ int CPoolsSA::GetNumberOfUsedSpaces(ePools pool)
             return -1;
     }
 
-    int iOut = -2;
     if (*(DWORD*)dwThis != NULL)
-    {
-        _asm
-        {
-            mov     ecx, dwThis
-            mov     ecx, [ecx]
-            call    dwFunc
-            mov     iOut, eax
+        return ((int(__thiscall*)(void*))dwFunc)(*(void**)dwThis);
 
-        }
-    }
-
-    return iOut;
+    return -2;
 }
 
 CEntryInfoNodePool* CPoolsSA::GetEntryInfoNodePool()
@@ -1381,17 +1269,8 @@ CEntryInfoNodePool* CPoolsSA::GetEntryInfoNodePool()
 
 int CEntryInfoNodePoolSA::GetNumberOfUsedSpaces()
 {
-    DWORD dwFunc = FUNC_CEntryInfoNodePool_GetNoOfUsedSpaces;
-    int   iOut = 0;
-    _asm
-    {
-        mov     ecx, CLASS_CEntryInfoNodePool
-        mov     ecx, [ecx]
-        call    dwFunc
-        mov     iOut, eax
-    }
-
-    return iOut;
+    // CPool<CEntryInfoNode>::GetNoOfUsedSpaces
+    return ((int(__thiscall*)(void*))FUNC_CEntryInfoNodePool_GetNoOfUsedSpaces)(*(void**)CLASS_CEntryInfoNodePool);
 }
 
 CPointerNodeDoubleLinkPool* CPoolsSA::GetPointerNodeDoubleLinkPool()
@@ -1401,17 +1280,8 @@ CPointerNodeDoubleLinkPool* CPoolsSA::GetPointerNodeDoubleLinkPool()
 
 int CPointerNodeDoubleLinkPoolSA::GetNumberOfUsedSpaces()
 {
-    DWORD dwFunc = FUNC_CPtrNodeDoubleLinkPool_GetNoOfUsedSpaces;
-    int   iOut = 0;
-    _asm
-    {
-        mov     ecx, CLASS_CPtrNodeDoubleLinkPool
-        mov     ecx, [ecx]
-        call    dwFunc
-        mov     iOut, eax
-    }
-
-    return iOut;
+    // CPool<CPtrNodeDoubleLink>::GetNoOfUsedSpaces
+    return ((int(__thiscall*)(void*))FUNC_CPtrNodeDoubleLinkPool_GetNoOfUsedSpaces)(*(void**)CLASS_CPtrNodeDoubleLinkPool);
 }
 
 CPointerNodeSingleLinkPool* CPoolsSA::GetPointerNodeSingleLinkPool()
@@ -1426,15 +1296,6 @@ void CPoolsSA::InvalidateLocalPlayerClientEntity()
 
 int CPointerNodeSingleLinkPoolSA::GetNumberOfUsedSpaces()
 {
-    DWORD dwFunc = FUNC_CPtrNodeSingleLinkPool_GetNoOfUsedSpaces;
-    int   iOut = 0;
-    _asm
-    {
-        mov     ecx, CLASS_CPtrNodeSingleLinkPool
-        mov     ecx, [ecx]
-        call    dwFunc
-        mov     iOut, eax
-    }
-
-    return iOut;
+    // CPool<CPtrNodeSingleLink>::GetNoOfUsedSpaces
+    return ((int(__thiscall*)(void*))FUNC_CPtrNodeSingleLinkPool_GetNoOfUsedSpaces)(*(void**)CLASS_CPtrNodeSingleLinkPool);
 }

--- a/Client/game_sa/CRadarSA.cpp
+++ b/Client/game_sa/CRadarSA.cpp
@@ -180,19 +180,7 @@ VOID CRadarSA::DrawAreaOnRadar(float fX1, float fY1, float fX2, float fY2, const
     // Convert color to required abgr at the last moment
     unsigned long abgr = color.A << 24 | color.B << 16 | color.G << 8 | color.R;
     CRect         myRect(fX1, fY2, fX2, fY1);
-    DWORD         dwFunc = FUNC_DrawAreaOnRadar;
-    _asm
-    {
-        push    eax
 
-        push    1           //bool
-        lea     eax, abgr
-        push    eax
-        lea     eax, myRect
-        push    eax
-        call    dwFunc
-        add     esp, 12
-
-        pop     eax
-    }
+    // CRadar::DrawAreaOnRadar
+    ((void(__cdecl*)(const CRect&, const unsigned long&, bool))FUNC_DrawAreaOnRadar)(myRect, abgr, true);
 }

--- a/Client/game_sa/CRestartSA.cpp
+++ b/Client/game_sa/CRestartSA.cpp
@@ -43,15 +43,9 @@ VOID CRestartSA::OverrideNextRestart(CVector* vecPosition, FLOAT fRotation)
 VOID CRestartSA::FindClosestPoliceRestartPoint(CVector* vecClosestTo, CVector* vecClosestRestartPoint, FLOAT* fRotation)
 {
     DEBUG_TRACE("VOID CRestartSA::FindClosestPoliceRestartPoint ( CVector * vecClosestTo, CVector * vecClosestRestartPoint, FLOAT * fRotation )");
-    DWORD dwFunction = FUNC_FindClosestPoliceRestartPoint;
-    _asm
-    {
-        push    fRotation
-        push    vecClosestRestartPoint
-        push    vecClosestTo
-        call    dwFunction
-        add     esp, 0xC
-    }
+
+    // CRestart::FindClosestPoliceRestartPoint
+    ((void(__cdecl*)(CVector, CVector*, float*))FUNC_FindClosestPoliceRestartPoint)(*vecClosestTo, vecClosestRestartPoint, fRotation);
 }
 
 /**
@@ -63,15 +57,9 @@ VOID CRestartSA::FindClosestPoliceRestartPoint(CVector* vecClosestTo, CVector* v
 VOID CRestartSA::FindClosestHospitalRestartPoint(CVector* vecClosestTo, CVector* vecClosestRestartPoint, FLOAT* fRotation)
 {
     DEBUG_TRACE("VOID CRestartSA::FindClosestHospitalRestartPoint ( CVector * vecClosestTo, CVector * vecClosestRestartPoint, FLOAT * fRotation )");
-    DWORD dwFunction = FUNC_FindClosestHospitalRestartPoint;
-    _asm
-    {
-        push    fRotation
-        push    vecClosestRestartPoint
-        push    vecClosestTo
-        call    dwFunction
-        add     esp, 0xC
-    }
+
+    // CRestart::FindClosestHospitalRestartPoint
+    ((void(__cdecl*)(CVector, CVector*, float*))FUNC_FindClosestHospitalRestartPoint)(*vecClosestTo, vecClosestRestartPoint, fRotation);
 }
 
 /**
@@ -83,14 +71,9 @@ VOID CRestartSA::FindClosestHospitalRestartPoint(CVector* vecClosestTo, CVector*
 VOID CRestartSA::AddPoliceRestartPoint(CVector* vecPosition, FLOAT fRotation)
 {
     DEBUG_TRACE("VOID CRestartSA::AddPoliceRestartPoint ( CVector * vecPosition, FLOAT fRotation )");
-    DWORD dwFunction = FUNC_AddPoliceRestartPoint;
-    _asm
-    {
-        push    fRotation
-        push    vecPosition
-        call    dwFunction
-        add     esp, 8
-    }
+
+    // CRestart::AddPoliceRestartPoint
+    ((void(__cdecl*)(CVector&, float, unsigned int))FUNC_AddPoliceRestartPoint)(*vecPosition, fRotation, 0);
 }
 
 /**
@@ -102,14 +85,9 @@ VOID CRestartSA::AddPoliceRestartPoint(CVector* vecPosition, FLOAT fRotation)
 VOID CRestartSA::AddHospitalRestartPoint(CVector* vecPosition, FLOAT fRotation)
 {
     DEBUG_TRACE("VOID CRestartSA::AddHospitalRestartPoint ( CVector * vecPosition, FLOAT fRotation )");
-    DWORD dwFunction = FUNC_AddHospitalRestartPoint;
-    _asm
-    {
-        push    fRotation
-        push    vecPosition
-        call    dwFunction
-        add     esp, 8
-    }
+
+    // CRestart::AddHospitalRestartPoint
+    ((void(__cdecl*)(CVector&, float, unsigned int))FUNC_AddHospitalRestartPoint)(*vecPosition, fRotation, 0);
 }
 
 /**
@@ -119,14 +97,9 @@ VOID CRestartSA::AddHospitalRestartPoint(CVector* vecPosition, FLOAT fRotation)
 BOOL CRestartSA::IsRestartingAfterArrest()
 {
     DEBUG_TRACE("BOOL CRestartSA::IsRestartingAfterArrest  (  )");
-    DWORD dwFunction = FUNC_IsRestartingAfterArrest;
-    DWORD dwReturn = 0;
-    _asm
-    {
-        call    dwFunction
-        mov     dwReturn, eax
-    }
-    return dwReturn;
+
+    // CRestart::AddHospitalRestartPoint
+    return ((bool(__cdecl*)())FUNC_IsRestartingAfterArrest)();
 }
 
 /**
@@ -136,12 +109,7 @@ BOOL CRestartSA::IsRestartingAfterArrest()
 BOOL CRestartSA::IsRestartingAfterDeath()
 {
     DEBUG_TRACE("BOOL CRestartSA::IsRestartingAfterDeath (  )");
-    DWORD dwFunction = FUNC_IsRestartingAfterDeath;
-    DWORD dwReturn = 0;
-    _asm
-    {
-        call    dwFunction
-        mov     dwReturn, eax
-    }
-    return dwReturn;
+
+    // CRestart::IsRestartingAfterDeath
+    return ((bool(__cdecl*)())FUNC_IsRestartingAfterDeath)();
 }

--- a/Client/game_sa/CRopesSA.cpp
+++ b/Client/game_sa/CRopesSA.cpp
@@ -17,17 +17,13 @@ CRopesSAInterface (&CRopesSA::ms_aRopes)[8] = *(CRopesSAInterface(*)[8])0xB768B8
 int CRopesSA::CreateRopeForSwatPed(const CVector& vecPosition, DWORD dwDuration)
 {
     int      iReturn;
-    DWORD    dwFunc = FUNC_CRopes_CreateRopeForSwatPed;
-    CVector* pvecPosition = const_cast<CVector*>(&vecPosition);
+
     // First Push @ 0x558D1D is the duration.
     MemPut((void*)(dwDurationAddress), dwDuration);
-    _asm
-    {
-        push    pvecPosition
-        call    dwFunc
-        add     esp, 0x4
-        mov     iReturn, eax
-    }
+
+    // CRopes::CreateRopeForSwatPed
+    iReturn = ((int(__cdecl*)(const CVector&))FUNC_CRopes_CreateRopeForSwatPed)(vecPosition);
+
     // Set it back for SA in case we ever do some other implementation.
     MemPut((DWORD*)(dwDurationAddress), 4000);
     return iReturn;

--- a/Client/game_sa/CSettingsSA.cpp
+++ b/Client/game_sa/CSettingsSA.cpp
@@ -71,51 +71,27 @@ void CSettingsSA::SetWideScreenEnabled(bool bEnabled)
 
 unsigned int CSettingsSA::GetNumVideoModes()
 {
-    unsigned int uiReturn = 0;
-    _asm
-    {
-        call    FUNC_GetNumVideoModes
-        mov     uiReturn, eax
-    }
-    return uiReturn;
+    // RwEngineGetNumVideoModes
+    return ((unsigned int(__cdecl*)())FUNC_GetNumVideoModes)();
 }
 
 VideoMode* CSettingsSA::GetVideoModeInfo(VideoMode* modeInfo, unsigned int modeIndex)
 {
-    VideoMode* pReturn = NULL;
-    _asm
-    {
-        push    modeIndex
-        push    modeInfo
-        call    FUNC_GetVideoModeInfo
-        mov     pReturn, eax
-        add     esp, 8
-    }
-    return pReturn;
+    // RwEngineGetVideoModeInfo
+    return ((VideoMode*(__cdecl*)(VideoMode*, unsigned int))FUNC_GetVideoModeInfo)(modeInfo, modeIndex);
 }
 
 unsigned int CSettingsSA::GetCurrentVideoMode()
 {
-    unsigned int uiReturn = 0;
-    _asm
-    {
-        call    FUNC_GetCurrentVideoMode
-        mov     uiReturn, eax
-    }
-    return uiReturn;
+    // RwEngineGetCurrentVideoMode
+    return ((unsigned int(__cdecl*)())FUNC_GetCurrentVideoMode)();
 }
 
 void CSettingsSA::SetCurrentVideoMode(unsigned int modeIndex, bool bOnRestart)
 {
     if (!bOnRestart)
-    {
-        _asm
-        {
-            push    modeIndex
-            call    FUNC_SetCurrentVideoMode
-            add     esp, 4
-        }
-    }
+        ((void(__cdecl*)(unsigned int))FUNC_SetCurrentVideoMode)(modeIndex);
+
     // Only update settings variables for fullscreen modes
     if (modeIndex)
         m_pInterface->dwVideoMode = modeIndex;
@@ -123,34 +99,20 @@ void CSettingsSA::SetCurrentVideoMode(unsigned int modeIndex, bool bOnRestart)
 
 uint CSettingsSA::GetNumAdapters()
 {
-    unsigned int uiReturn = 0;
-    _asm
-    {
-        call    FUNC_GetNumSubSystems
-        mov     uiReturn, eax
-    }
-    return uiReturn;
+    // RwEngineGetNumSubSystems
+    return ((unsigned int(__cdecl*)())FUNC_GetNumSubSystems)();
 }
 
 void CSettingsSA::SetAdapter(unsigned int uiAdapterIndex)
 {
-    _asm
-    {
-        push    uiAdapterIndex
-        call    FUNC_SetSubSystem
-        add     esp, 4
-    }
+    // RwEngineSetSubSystem
+    ((void(__cdecl*)(unsigned int))FUNC_SetSubSystem)(uiAdapterIndex);
 }
 
 unsigned int CSettingsSA::GetCurrentAdapter()
 {
-    unsigned int uiReturn = 0;
-    _asm
-    {
-        call    FUNC_GetCurrentSubSystem
-        mov     uiReturn, eax
-    }
-    return uiReturn;
+    // RwEngineGetCurrentSubSystem
+    return ((unsigned int(__cdecl*)())FUNC_GetCurrentSubSystem)();
 }
 
 unsigned char CSettingsSA::GetRadioVolume()
@@ -227,12 +189,7 @@ float CSettingsSA::GetDrawDistance()
 
 void CSettingsSA::SetDrawDistance(float fDistance)
 {
-    _asm
-    {
-        push    fDistance
-        call    FUNC_SetDrawDistance
-        add     esp, 4
-    }
+    ((void(__cdecl*)(float))FUNC_SetDrawDistance)(fDistance);
     m_pInterface->fDrawDistance = fDistance;
 }
 
@@ -280,13 +237,9 @@ void CSettingsSA::SetAntiAliasing(unsigned int uiAntiAliasing, bool bOnRestart)
 {
     if (!bOnRestart)
     {
-        DWORD dwFunc = FUNC_SetAntiAliasing;
-        _asm
-        {
-            push    uiAntiAliasing
-            call    dwFunc
-            add     esp, 4
-        }
+        // RwD3D9ChangeMultiSamplingLevels
+        ((void(__cdecl*)(unsigned int))FUNC_SetAntiAliasing)(uiAntiAliasing);
+
         SetCurrentVideoMode(m_pInterface->dwVideoMode, false);
     }
 
@@ -305,12 +258,8 @@ void CSettingsSA::SetMipMappingEnabled(bool bEnable)
 
 void CSettingsSA::Save()
 {
-    _asm
-    {
-        mov ecx, CLASS_CMenuManager
-        mov eax, FUNC_CMenuManager_Save
-        call eax
-    }
+    // CMenuManager::SaveSettings
+    ((void(__thiscall*)(int))FUNC_CMenuManager_Save)(CLASS_CMenuManager);
 }
 
 bool CSettingsSA::IsVolumetricShadowsEnabled()

--- a/Client/game_sa/CStatsSA.cpp
+++ b/Client/game_sa/CStatsSA.cpp
@@ -13,87 +13,36 @@
 
 float CStatsSA::GetStatValue(unsigned short usIndex)
 {
-    DWORD dwFunc = FUNC_GetStatValue;
-    float fReturn = 0.0f;
-    DWORD dwStatIndex = usIndex;
-
-    _asm
-    {
-        push    dwStatIndex
-        call    dwFunc
-        add     esp, 4
-        fstp    fReturn
-    }
-    return fReturn;
+    // CStats::GetStatValue
+    return ((float(__cdecl*)(unsigned short))FUNC_GetStatValue)(usIndex);
 }
 
 void CStatsSA::ModifyStat(unsigned short usIndex, float fAmmount)
 {
-    DWORD dwFunc = FUNC_ModifyStat;
-    DWORD dwStatIndex = usIndex;
-
-    _asm
-    {
-        push    fAmmount
-        push    dwStatIndex
-        call    dwFunc
-        add     esp, 8
-    }
+    // CStats::ModifyStat
+    ((void(__cdecl*)(unsigned short, float))FUNC_ModifyStat)(usIndex, fAmmount);
 }
 
 void CStatsSA::IncrementStat(unsigned short usIndex, float fAmmount)
 {
-    DWORD dwFunc = FUNC_IncrementStat;
-    DWORD dwStatIndex = usIndex;
-
-    _asm
-    {
-        push    fAmmount
-        push    dwStatIndex
-        call    dwFunc
-        add     esp, 8
-    }
+    // CStats::IncrementStat
+    ((void(__cdecl*)(unsigned short, float))FUNC_IncrementStat)(usIndex, fAmmount);
 }
 
 void CStatsSA::DecrementStat(unsigned short usIndex, float fAmmount)
 {
-    DWORD dwFunc = FUNC_DecrementStat;
-    DWORD dwStatIndex = usIndex;
-
-    _asm
-    {
-        push    fAmmount
-        push    dwStatIndex
-        call    dwFunc
-        add     esp, 8
-    }
+    // CStats::DecrementStat
+    ((void(__cdecl*)(unsigned short, float))FUNC_DecrementStat)(usIndex, fAmmount);
 }
 
 void CStatsSA::SetStatValue(unsigned short usIndex, float fAmmount)
 {
-    DWORD dwFunc = FUNC_SetStatValue;
-    DWORD dwStatIndex = usIndex;
-
-    _asm
-    {
-        push    fAmmount
-        push    dwStatIndex
-        call    dwFunc
-        add     esp, 8
-    }
+    // CStats::SetStatValue
+    ((void(__cdecl*)(unsigned short, float))FUNC_SetStatValue)(usIndex, fAmmount);
 }
 
 unsigned short CStatsSA::GetSkillStatIndex(eWeaponType type)
 {
-    int   weaponType = (int)type;
-    int   iIndex;
-    DWORD dwFunc = FUNC_CWeaponInfo_GetSkillStatIndex;
-    _asm
-    {
-        push    weaponType
-        call    dwFunc
-        add     esp, 0x4
-        mov     iIndex, eax
-    }
-    return (unsigned short)iIndex;
+    // CStats::SetStatValue
+    return ((int(__cdecl*)(eWeaponType))FUNC_CWeaponInfo_GetSkillStatIndex)(type);
 }

--- a/Client/game_sa/CStreamingSA.cpp
+++ b/Client/game_sa/CStreamingSA.cpp
@@ -52,25 +52,13 @@ void CStreamingSA::RequestModel(DWORD dwModelID, DWORD dwFlags)
 {
     if (IsUpgradeModelId(dwModelID))
     {
-        DWORD dwFunc = FUNC_RequestVehicleUpgrade;
-        _asm
-        {
-            push    dwFlags
-            push    dwModelID
-            call    dwFunc
-            add     esp, 8
-        }
+        // CStreaming::RequestVehicleUpgrade
+        ((void(__cdecl*)(int, int))FUNC_RequestVehicleUpgrade)(dwModelID, dwFlags);
     }
     else
     {
-        DWORD dwFunction = FUNC_CStreaming__RequestModel;
-        _asm
-        {
-            push    dwFlags
-            push    dwModelID
-            call    dwFunction
-            add     esp, 8
-        }
+        // CStreaming::RequestModel
+        ((void(__cdecl*)(int, int))FUNC_CStreaming__RequestModel)(dwModelID, dwFlags);
     }
 }
 
@@ -85,14 +73,8 @@ void CStreamingSA::LoadAllRequestedModels(BOOL bOnlyPriorityModels, const char* 
 {
     TIMEUS startTime = GetTimeUs();
 
-    DWORD dwFunction = FUNC_LoadAllRequestedModels;
-    DWORD dwOnlyPriorityModels = bOnlyPriorityModels;
-    _asm
-    {
-        push    dwOnlyPriorityModels
-        call    dwFunction
-        add     esp, 4
-    }
+    // CStreaming::LoadAllRequestedModels
+    ((void(__cdecl*)(bool))FUNC_LoadAllRequestedModels)(bOnlyPriorityModels);
 
     if (IS_TIMING_CHECKPOINTS())
     {
@@ -106,45 +88,20 @@ BOOL CStreamingSA::HasModelLoaded(DWORD dwModelID)
 {
     if (IsUpgradeModelId(dwModelID))
     {
-        bool  bReturn;
-        DWORD dwFunc = FUNC_CStreaming__HasVehicleUpgradeLoaded;
-        _asm
-        {
-            push    dwModelID
-            call    dwFunc
-            add     esp, 0x4
-            mov     bReturn, al
-        }
-        return bReturn;
+        // CStreaming::HasVehicleUpgradeLoaded
+        return ((bool(__cdecl*)(int))FUNC_CStreaming__HasVehicleUpgradeLoaded)(dwModelID);
     }
     else
     {
-        DWORD dwFunc = FUNC_CStreaming__HasModelLoaded;
-        BOOL  bReturn = 0;
-        _asm
-        {
-            push    dwModelID
-            call    dwFunc
-            movzx   eax, al
-            mov     bReturn, eax
-            pop     eax
-        }
-
-        return bReturn;
+        // CStreaming::HasModelLoaded
+        return ((bool(__cdecl*)(int))FUNC_CStreaming__HasModelLoaded)(dwModelID);
     }
 }
 
 void CStreamingSA::RequestSpecialModel(DWORD model, const char* szTexture, DWORD channel)
 {
-    DWORD dwFunc = FUNC_CStreaming_RequestSpecialModel;
-    _asm
-    {
-        push    channel
-        push    szTexture
-        push    model
-        call    dwFunc
-        add     esp, 0xC
-    }
+    // CStreaming::RequestSpecialModel
+    ((void(__cdecl*)(int, const char*, int))FUNC_CStreaming_RequestSpecialModel)(model, szTexture, channel);
 }
 
 CStreamingInfo* CStreamingSA::GetStreamingInfoFromModelId(uint32 id)

--- a/Client/game_sa/CTaskManagementSystemSA.cpp
+++ b/Client/game_sa/CTaskManagementSystemSA.cpp
@@ -111,12 +111,7 @@ CTask* CTaskManagementSystemSA::GetTask(CTaskSAInterface* pTaskInterface)
     DWORD dwFunc = pTaskInterface->VTBL->GetTaskType;
     if (dwFunc && dwFunc != 0x82263A)
     {
-        _asm
-        {
-            mov     ecx, pTaskInterface
-            call    dwFunc
-            mov     iTaskType, eax
-        }
+        iTaskType = ((int(__thiscall*)(void*))dwFunc)(pTaskInterface);
     }
 
     // Create it and add it to our list

--- a/Client/game_sa/CTaskManagerSA.cpp
+++ b/Client/game_sa/CTaskManagerSA.cpp
@@ -31,22 +31,10 @@ void CTaskManagerSA::SetTask(CTaskSA* pTaskPrimary, const int iTaskPriority, con
 {
     DEBUG_TRACE("void CTaskManagerSA::SetTask(CTask* pTaskPrimary, const int iTaskPriority, const bool bForceNewTask)");
 
-    DWORD             dwFunc = FUNC_SetTask;
-    CTaskSAInterface* taskInterface = NULL;
-    if (pTaskPrimary)
-        taskInterface = pTaskPrimary->GetInterface();
+    CTaskSAInterface* pTaskInterface = pTaskPrimary ? pTaskPrimary->GetInterface() : nullptr;
 
-    DWORD dwInterface = (DWORD)this->GetInterface();
-    _asm
-    {
-        xor     eax, eax
-        movzx   eax, bForceNewTask
-        push    eax
-        push    iTaskPriority
-        push    taskInterface
-        mov     ecx, dwInterface
-        call    dwFunc
-    }
+    // CTaskManager::SetTask
+    ((void(__thiscall*)(void*, CTaskSAInterface*, int, bool))FUNC_SetTask)(GetInterface(), pTaskInterface, iTaskPriority, bForceNewTask);
 }
 
 CTask* CTaskManagerSA::GetTask(const int iTaskPriority)
@@ -59,94 +47,69 @@ CTask* CTaskManagerSA::GetTask(const int iTaskPriority)
 CTask* CTaskManagerSA::GetActiveTask()
 {
     DEBUG_TRACE("CTask* CTaskManagerSA::GetActiveTask()");
-    DWORD dwFunc = FUNC_GetActiveTask;
-    DWORD dwReturn = 0;
-    DWORD dwThis = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     dwReturn, eax
-    }
 
-    CTaskSAInterface* pActiveTask = (CTaskSAInterface*)dwReturn;
-    if (dwReturn)
-        return m_pTaskManagementSystem->GetTask((CTaskSAInterface*)dwReturn);
-    else
-        return NULL;
+    // CTaskManager::GetActiveTask
+    CTaskSAInterface* pTaskInterface = ((CTaskSAInterface * (__thiscall*)(CTaskManagerSAInterface*)) FUNC_GetActiveTask)(this->GetInterface());
+
+    if (pTaskInterface)
+        return m_pTaskManagementSystem->GetTask(pTaskInterface);
+
+    return nullptr;
 }
 
 CTask* CTaskManagerSA::GetSimplestActiveTask()
 {
     DEBUG_TRACE("CTask* CTaskManagerSA::GetSimplestActiveTask()");
-    DWORD dwFunc = FUNC_GetSimplestActiveTask;
-    DWORD dwReturn = 0;
-    DWORD dwThis = (DWORD)this->GetInterface();
 
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     dwReturn, eax
-    }
+    // CTaskManager::GetSimplestActiveTask
+    CTaskSAInterface* pTaskInterface = ((CTaskSAInterface * (__thiscall*)(CTaskManagerSAInterface*)) FUNC_GetSimplestActiveTask)(this->GetInterface());
 
-    if (dwReturn) return m_pTaskManagementSystem->GetTask((CTaskSAInterface*)dwReturn);
-    else return NULL;
+    if (pTaskInterface)
+        return m_pTaskManagementSystem->GetTask(pTaskInterface);
+
+    return nullptr;
 }
 
 CTask* CTaskManagerSA::GetSimplestTask(const int iPriority)
 {
     DEBUG_TRACE("CTask* CTaskManagerSA::GetSimplestTask(const int iPriority)");
-    DWORD dwFunc = FUNC_GetSimplestTask;
-    DWORD dwReturn = 0;
-    DWORD dwThis = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThis
-        push    iPriority
-        call    dwFunc
-        mov     dwReturn, eax
-    }
 
-    if (dwReturn) return m_pTaskManagementSystem->GetTask((CTaskSAInterface*)dwReturn);
-    else return NULL;
+    // CTaskManager::GetSimplestTask
+    CTaskSAInterface* pTaskInterface =
+        ((CTaskSAInterface * (__thiscall*)(CTaskManagerSAInterface*, int)) FUNC_GetSimplestTask)(this->GetInterface(), iPriority);
+
+    if (pTaskInterface)
+        return m_pTaskManagementSystem->GetTask(pTaskInterface);
+
+    return nullptr;
 }
 
 CTask* CTaskManagerSA::FindActiveTaskByType(const int iTaskType)
 {
     DEBUG_TRACE("CTask* CTaskManagerSA::FindActiveTaskByType(const int iTaskType)");
-    DWORD dwFunc = FUNC_FindActiveTaskByType;
-    DWORD dwReturn = 0;
-    DWORD dwThis = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThis
-        push    iTaskType
-        call    dwFunc
-        mov     dwReturn, eax
-    }
 
-    if (dwReturn) return m_pTaskManagementSystem->GetTask((CTaskSAInterface*)dwReturn);
-    else return NULL;
+    // CTaskManager::FindActiveTaskByType
+    CTaskSAInterface* pTaskInterface =
+        ((CTaskSAInterface * (__thiscall*)(CTaskManagerSAInterface*, int)) FUNC_FindActiveTaskByType)(this->GetInterface(), iTaskType);
+
+    if (pTaskInterface)
+        return m_pTaskManagementSystem->GetTask(pTaskInterface);
+
+    return nullptr;
 }
 
 CTask* CTaskManagerSA::FindTaskByType(const int iPriority, const int iTaskType)
 {
     DEBUG_TRACE("CTask* CTaskManagerSA::FindTaskByType(const int iPriority, const int iTaskType)");
-    DWORD dwFunc = FUNC_FindTaskByType;
-    DWORD dwReturn = 0;
-    DWORD dwThis = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThis
-        push    iTaskType
-        push    iPriority
-        call    dwFunc
-        mov     dwReturn, eax
-    }
 
-    if (dwReturn) return m_pTaskManagementSystem->GetTask((CTaskSAInterface*)dwReturn);
-    else return NULL;
+    // CTaskManager::FindTaskByType
+    CTaskSAInterface* pTaskInterface =
+        ((CTaskSAInterface * (__thiscall*)(CTaskManagerSAInterface*, int, int)) FUNC_FindTaskByType)(this->GetInterface(), iPriority, iTaskType);
+
+    if (pTaskInterface)
+        return m_pTaskManagementSystem->GetTask(pTaskInterface);
+
+    return nullptr;
 }
 
 void CTaskManagerSA::RemoveTaskSecondary(const int iTaskPriority)
@@ -157,18 +120,11 @@ void CTaskManagerSA::RemoveTaskSecondary(const int iTaskPriority)
 void CTaskManagerSA::SetTaskSecondary(CTaskSA* pTaskSecondary, const int iType)
 {
     DEBUG_TRACE("void CTaskManagerSA::SetTaskSecondary(CTask* pTaskSecondary, const int iType)");
-    DWORD             dwFunc = FUNC_SetTaskSecondary;
-    CTaskSAInterface* taskInterface = NULL;
-    if (pTaskSecondary)
-        taskInterface = pTaskSecondary->GetInterface();
-    DWORD dwInterface = (DWORD)this->GetInterface();
-    _asm
-    {
-        push    iType
-        push    taskInterface
-        mov     ecx, dwInterface
-        call    dwFunc
-    }
+
+    CTaskSAInterface* pTaskInterface = pTaskSecondary ? pTaskSecondary->GetInterface() : nullptr;
+
+    // CTaskManager::SetTaskSecondary
+    ((void(__thiscall*)(void*, CTaskSAInterface*, int))FUNC_SetTaskSecondary)(GetInterface(), pTaskInterface, iType);
 }
 
 /**
@@ -186,25 +142,17 @@ CTask* CTaskManagerSA::GetTaskSecondary(const int iType)
 bool CTaskManagerSA::HasTaskSecondary(const CTask* pTaskSecondary)
 {
     DEBUG_TRACE("bool CTaskManagerSA::HasTaskSecondary(const CTask* pTaskSecondary)");
-    DWORD dwFunc = FUNC_HasTaskSecondary;
-    bool  bReturn = false;
-    _asm
-    {
-        push    pTaskSecondary
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // was not called as thiscall and pushes CTask* where it should be CTaskSAInterface*
+    // CTaskManager::HasTaskSecondary
+    return ((bool(__thiscall*)(void*, const CTask*))FUNC_HasTaskSecondary)(GetInterface(), pTaskSecondary);
 }
 
 void CTaskManagerSA::ClearTaskEventResponse()
 {
     DEBUG_TRACE("void CTaskManagerSA::ClearTaskEventResponse()");
-    DWORD dwFunc = FUNC_ClearTaskEventResponse;
-    _asm
-    {
-        call    dwFunc
-    }
+
+    // CTaskManager::ClearTaskEventResponse
+    ((void(__thiscall*)(void*))FUNC_ClearTaskEventResponse)(GetInterface());
 }
 
 void CTaskManagerSA::Flush(const int iPriority)

--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -661,14 +661,13 @@ CDoorSA* CVehicleSA::GetDoor(unsigned char ucDoor)
 
 void CVehicleSA::OpenDoor(unsigned char ucDoor, float fRatio, bool bMakeNoise)
 {
-    DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = ((CVehicleSAInterfaceVTBL*)GetVehicleInterface()->vtbl)->OpenDoor;
 
     // Grab the car node index for the given door id
     static int s_iCarNodeIndexes[6] = {0x10, 0x11, 0x0A, 0x08, 0x0B, 0x09};
     DWORD      dwIdx = s_iCarNodeIndexes[ucDoor];
 
-    ((void(__thiscall*)(void*, CPedSAInterface*, int, unsigned char, float, bool))dwFunc)(GetInterface(), nullptr, dwIdx, ucDoor, fRatio, bMakeNoise);
+    ((void(__thiscall*)(void*, CPedSAInterface*, int, unsigned int, float, bool))dwFunc)(GetInterface(), nullptr, dwIdx, ucDoor, fRatio, bMakeNoise);
 }
 
 void CVehicleSA::SetSwingingDoorsAllowed(bool bAllowed)

--- a/Client/game_sa/CVisibilityPluginsSA.cpp
+++ b/Client/game_sa/CVisibilityPluginsSA.cpp
@@ -13,14 +13,8 @@
 
 void CVisibilityPluginsSA::SetClumpAlpha(RpClump* pClump, int iAlpha)
 {
-    DWORD dwFunc = FUNC_CVisiblityPlugins_SetClumpAlpha;
-    _asm
-    {
-        push    iAlpha
-        push    pClump
-        call    dwFunc
-        add     esp, 0x8
-    }
+    // CVisibilityPlugins::SetClumpAlpha
+    ((void(__cdecl*)(RpClump*, int))FUNC_CVisiblityPlugins_SetClumpAlpha)(pClump, iAlpha);
 }
 
 // Some AtomicId bits are:
@@ -39,14 +33,6 @@ void CVisibilityPluginsSA::SetClumpAlpha(RpClump* pClump, int iAlpha)
 //      0x8000 - Some door flag?
 int CVisibilityPluginsSA::GetAtomicId(RwObject* pAtomic)
 {
-    DWORD dwFunc = FUNC_CVisibilityPlugins_GetAtomicId;
-    int   iResult = 0;
-    _asm
-    {
-        push    pAtomic
-        call    dwFunc
-        add     esp, 0x4
-        mov     iResult, eax
-    }
-    return iResult;
+    // CVisibilityPlugins::GetAtomicId
+    return ((int(__cdecl*)(RwObject*))FUNC_CVisibilityPlugins_GetAtomicId)(pAtomic);
 }

--- a/Client/game_sa/CWantedSA.cpp
+++ b/Client/game_sa/CWantedSA.cpp
@@ -39,25 +39,14 @@ CWantedSA::~CWantedSA()
 
 void CWantedSA::SetMaximumWantedLevel(DWORD dwWantedLevel)
 {
-    DWORD dwFunc = FUNC_SetMaximumWantedLevel;
-    _asm
-    {
-        push    dwWantedLevel
-        call    dwFunc
-        add     esp, 4
-    }
+    // CWanted::SetMaximumWantedLevel
+    ((void(__cdecl*)(int))FUNC_SetMaximumWantedLevel)(dwWantedLevel);
 }
 
 void CWantedSA::SetWantedLevel(DWORD dwWantedLevel)
 {
-    DWORD dwThis = (DWORD)this->GetInterface();
-    DWORD dwFunc = FUNC_SetWantedLevel;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    dwWantedLevel
-        call    dwFunc
-    }
+    // CWanted::SetWantedLevel
+    ((void(__thiscall*)(CWantedSAInterface*, int))FUNC_SetWantedLevel)(this->GetInterface(), dwWantedLevel);
 }
 void CWantedSA::SetWantedLevelNoFlash(DWORD dwWantedLevel)
 {
@@ -68,12 +57,6 @@ void CWantedSA::SetWantedLevelNoFlash(DWORD dwWantedLevel)
 
 void CWantedSA::SetWantedLevelNoDrop(DWORD dwWantedLevel)
 {
-    DWORD dwThis = (DWORD)this->GetInterface();
-    DWORD dwFunc = FUNC_SetWantedLevelNoDrop;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    dwWantedLevel
-        call    dwFunc
-    }
+    // CWanted::SetWantedLevelNoDrop
+    ((void(__thiscall*)(CWantedSAInterface*, int))FUNC_SetWantedLevelNoDrop)(this->GetInterface(), dwWantedLevel);
 }

--- a/Client/game_sa/CWeaponSA.cpp
+++ b/Client/game_sa/CWeaponSA.cpp
@@ -97,13 +97,9 @@ VOID CWeaponSA::SetAsCurrentWeapon()
 void CWeaponSA::Remove()
 {
     DEBUG_TRACE("void CWeaponSA::Remove ()");
-    DWORD dwFunc = FUNC_Shutdown;
-    DWORD dwThis = (DWORD)this->internalInterface;
-    _asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+
+    // CWeapon::Shutdown
+    ((void(__thiscall*)(CWeaponSAInterface*))FUNC_Shutdown)(this->internalInterface);
 
     // If the removed weapon was the currently active weapon, switch to empty-handed
     if (owner->GetCurrentWeaponSlot() == m_weaponSlot)
@@ -120,126 +116,59 @@ void CWeaponSA::Remove()
 
 void CWeaponSA::Initialize(eWeaponType type, unsigned int uiAmmo, CPed* pPed)
 {
-    DWORD dwPedInterface = 0;
-    if (pPed)
-        dwPedInterface = (DWORD)pPed->GetInterface();
-    unsigned int uiType = (unsigned int)type;
-    DWORD        dwThis = (DWORD)internalInterface;
-    DWORD        dwFunc = FUNC_CWeapon_Initialize;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    dwPedInterface
-        push    uiAmmo
-        push    uiType
-        call    dwFunc
-    }
+    CPedSAInterface* pPedInterface = pPed ? pPed->GetPedInterface() : nullptr;
+
+    // CWeapon::Initialise
+    ((void(__thiscall*)(CWeaponSAInterface*, eWeaponType, int, CPedSAInterface*))FUNC_CWeapon_Initialize)(this->internalInterface, type, uiAmmo, pPedInterface);
 }
 
 void CWeaponSA::Update(CPed* pPed)
 {
     // Note: CWeapon::Update is called mainly to check for reload
-    DWORD dwPedInterface = (DWORD)pPed->GetInterface();
-    DWORD dwThis = (DWORD)internalInterface;
-    DWORD dwFunc = FUNC_CWeapon_Update;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    dwPedInterface
-        call    dwFunc
-    }
+
+    // CWeapon::Update
+    ((void(__thiscall*)(CWeaponSAInterface*, CPedSAInterface*))FUNC_CWeapon_Update)(internalInterface, pPed->GetPedInterface());
 }
 
 bool CWeaponSA::Fire(CEntity* pFiringEntity, CVector* pvecOrigin, CVector* pvecTarget, CEntity* pTargetEntity, CVector* pvec_1, CVector* pvec_2)
 {
-    bool  bReturn;
-    DWORD dwFiringInterface = 0;
-    if (pFiringEntity)
-        dwFiringInterface = (DWORD)pFiringEntity->GetInterface();
-    DWORD dwTargetInterface = 0;
-    if (pTargetEntity)
-        dwTargetInterface = (DWORD)pTargetEntity->GetInterface();
-    DWORD dwThis = (DWORD)internalInterface;
-    DWORD dwFunc = FUNC_CWeapon_Fire;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    pvec_2
-        push    pvec_1
-        push    dwTargetInterface
-        push    pvecTarget
-        push    pvecOrigin
-        push    dwFiringInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    CEntitySAInterface* pFiringInterface = pFiringEntity ? pFiringEntity->GetInterface() : nullptr;
+    CEntitySAInterface* pTargetInterface = pTargetEntity ? pTargetEntity->GetInterface() : nullptr;
+
+    // CWeapon::Fire
+    return ((bool(__thiscall*)(CWeaponSAInterface*, CEntitySAInterface*, CVector*, CVector*, CEntitySAInterface*, CVector*, CVector*))FUNC_CWeapon_Fire)(
+        this->internalInterface, pFiringInterface, pvecOrigin, pvecTarget, pTargetInterface, pvec_1, pvec_2);
 }
 
 void CWeaponSA::AddGunshell(CEntity* pFiringEntity, CVector* pvecOrigin, CVector2D* pvecDirection, float fSize)
 {
-    DWORD dwEntityInterface = 0;
-    if (pFiringEntity)
-        dwEntityInterface = (DWORD)pFiringEntity->GetInterface();
-    DWORD dwThis = (DWORD)internalInterface;
-    DWORD dwFunc = FUNC_CWeapon_AddGunshell;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    fSize
-        push    pvecDirection
-        push    pvecOrigin
-        push    dwEntityInterface
-        call    dwFunc
-    }
+    CEntitySAInterface* pFiringInterface = pFiringEntity ? pFiringEntity->GetInterface() : nullptr;
+
+    // CWeapon::AddGunshell
+    ((void(__thiscall*)(CWeaponSAInterface*, CEntitySAInterface*, CVector&, CVector2D&, float))FUNC_CWeapon_AddGunshell)(
+        this->internalInterface, pFiringInterface, *pvecOrigin, *pvecDirection, fSize);
 }
 
 void CWeaponSA::DoBulletImpact(CEntity* pFiringEntity, CEntitySAInterface* pEntityInterface, CVector* pvecOrigin, CVector* pvecTarget, CColPoint* pColPoint,
                                int i_1)
 {
-    DWORD dwEntityInterface = 0;
-    if (pFiringEntity)
-        dwEntityInterface = (DWORD)pFiringEntity->GetInterface();
-    DWORD dwEntityInterface_2 = (DWORD)pEntityInterface;
-    DWORD dwColPointInterface = 0;
-    if (pColPoint)
-        dwColPointInterface = (DWORD)pColPoint->GetInterface();
-    DWORD dwThis = (DWORD)internalInterface;
-    DWORD dwFunc = FUNC_CWeapon_DoBulletImpact;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    i_1
-        push    dwColPointInterface
-        push    pvecTarget
-        push    pvecOrigin
-        push    dwEntityInterface_2
-        push    dwEntityInterface
-        call    dwFunc
-    }
+    CEntitySAInterface*   pFiringInterface = pFiringEntity ? pFiringEntity->GetInterface() : nullptr;
+    CColPointSAInterface* pColPointInterface = pColPoint ? pColPoint->GetInterface() : nullptr;
+
+    // CWeapon::DoBulletImpact
+    ((void(__thiscall*)(CWeaponSAInterface*, CEntitySAInterface*, CEntitySAInterface*, CVector*, CVector*, CColPointSAInterface*,
+                        int))FUNC_CWeapon_DoBulletImpact)(this->internalInterface, pFiringInterface, pEntityInterface, pvecOrigin, pvecTarget,
+                                                          pColPointInterface, i_1);
 }
 
 unsigned char CWeaponSA::GenerateDamageEvent(CPed* pPed, CEntity* pResponsible, eWeaponType weaponType, int iDamagePerHit, ePedPieceTypes hitZone, int i_2)
 {
-    unsigned int ucReturn;
-    DWORD        dwPedInterface = (DWORD)pPed->GetInterface();
-    DWORD        dwResponsibleInterface = 0;
-    if (pResponsible)
-        dwResponsibleInterface = (DWORD)pResponsible->GetInterface();
-    DWORD dwFunc = FUNC_CWeapon_GenerateDamageEvent;
-    _asm
-    {
-        push    i_2
-        push    hitZone
-        push    iDamagePerHit
-        push    weaponType
-        push    dwResponsibleInterface
-        push    dwPedInterface
-        call    dwFunc
-        add     esp, 24
-        mov     ucReturn, eax
-    }
-    return (unsigned char)ucReturn;
+    CPedSAInterface*    pPedInterface = pPed->GetPedInterface();
+    CEntitySAInterface* pResponsibleInterface = pResponsible ? pResponsible->GetInterface() : nullptr;
+
+    // CWeapon::GenerateDamageEvent
+    return ((unsigned char(__cdecl*)(CPedSAInterface*, CEntitySAInterface*, eWeaponType, int, ePedPieceTypes, int))FUNC_CWeapon_GenerateDamageEvent)(
+        pPedInterface, pResponsibleInterface, weaponType, iDamagePerHit, hitZone, i_2);
 }
 
 bool CWeaponSA::FireBullet(CEntity* pFiringEntity, const CVector& vecOrigin, const CVector& vecTarget)
@@ -304,55 +233,26 @@ bool CWeaponSA::FireBullet(CEntity* pFiringEntity, const CVector& vecOrigin, con
 bool CWeaponSA::FireInstantHit(CEntity* pFiringEntity, const CVector* pvecOrigin, const CVector* pvecMuzzle, CEntity* pTargetEntity, const CVector* pvecTarget,
                                const CVector* pvec, bool bFlag1, bool bFlag2)
 {
-    bool  bReturn;
-    DWORD dwEntityInterface = 0;
-    if (pFiringEntity)
-        dwEntityInterface = (DWORD)pFiringEntity->GetInterface();
-    DWORD dwTargetInterface = 0;
-    if (pTargetEntity)
-        dwTargetInterface = (DWORD)pTargetEntity->GetInterface();
-    DWORD dwThis = (DWORD)internalInterface;
-    DWORD dwFunc = FUNC_CWeapon_FireInstantHit;
-    _asm
-    {
-        mov     ecx, dwThis
-        push    bFlag2
-        push    bFlag1
-        push    pvec
-        push    pvecTarget
-        push    dwTargetInterface
-        push    pvecMuzzle
-        push    pvecOrigin
-        push    dwEntityInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    CEntitySAInterface* pFiringInterface = pFiringEntity ? pFiringEntity->GetInterface() : nullptr;
+    CEntitySAInterface* pTargetInterface = pTargetEntity ? pTargetEntity->GetInterface() : nullptr;
+
+    // CWeapon::FireInstantHit
+    return ((bool(__thiscall*)(CWeaponSAInterface*, CEntitySAInterface*, const CVector*, const CVector*, CEntitySAInterface*, const CVector*, const CVector*,
+                               bool, bool))FUNC_CWeapon_FireInstantHit)(internalInterface, pFiringInterface, pvecOrigin, pvecMuzzle, pTargetInterface,
+                                                                        pvecTarget, pvec, bFlag1, bFlag2);
 }
 
 bool CWeaponSA::ProcessLineOfSight(const CVector* vecStart, const CVector* vecEnd, CColPoint** colCollision, CEntity** CollisionEntity,
                                    const SLineOfSightFlags flags, SLineOfSightBuildingResult* pBuildingResult, eWeaponType weaponType,
                                    CEntitySAInterface** pEntity)
 {
-    DWORD dwFunction = FUNC_CBirds_CheckForHit;
-    _asm
-    {
-        push vecEnd
-        push vecStart
-        call dwFunction
-    }
-    dwFunction = FUNC_CShadows_CheckForHit;
-    _asm
-    {
-        push vecEnd
-        push vecStart
-        call dwFunction
-    }
+    // CBirds::HandleGunShot
+    ((void(__cdecl*)(const CVector*, const CVector*))FUNC_CBirds_CheckForHit)(vecStart, vecEnd);
+
+    // CShadows::GunShotSetsOilOnFire
+    ((void(__cdecl*)(const CVector*, const CVector*))FUNC_CShadows_CheckForHit)(vecStart, vecEnd);
+
     bool bReturn = g_pCore->GetGame()->GetWorld()->ProcessLineOfSight(vecStart, vecEnd, colCollision, CollisionEntity, flags, pBuildingResult);
-    _asm
-    {
-        add esp, 10h
-    }
 
     if (bReturn)
     {
@@ -368,20 +268,9 @@ bool CWeaponSA::ProcessLineOfSight(const CVector* vecStart, const CVector* vecEn
     }
     if (*pEntity && (*pEntity)->nType == ENTITY_TYPE_VEHICLE)
     {
-        CEntitySAInterface*   pHitInterface = *pEntity;
-        CColPointSAInterface* pColPointSAInterface = (*colCollision)->GetInterface();
-        DWORD                 dwFunc = FUNC_CWeapon_CheckForShootingVehicleOccupant;
-        _asm
-        {
-            push vecEnd
-            push vecStart
-            push weaponType
-            push pColPointSAInterface
-            lea eax, pHitInterface
-            push eax
-            call dwFunc
-            add esp, 14h
-        }
+        // CWeapons::CheckForShootingVehicleOccupant
+        ((void(__cdecl*)(CEntitySAInterface**, CColPointSAInterface*, eWeaponType, const CVector*,
+                         const CVector*))FUNC_CWeapon_CheckForShootingVehicleOccupant)(pEntity, (*colCollision)->GetInterface(), weaponType, vecStart, vecEnd);
     }
     return bReturn;
 }
@@ -389,16 +278,9 @@ bool CWeaponSA::ProcessLineOfSight(const CVector* vecStart, const CVector* vecEn
 int CWeaponSA::GetWeaponReloadTime(CWeaponStat* pWeaponStat)
 {
     CWeaponStatSA* pWeaponStats = (CWeaponStatSA*)pWeaponStat;
-    DWORD          dwReturn = 0;
-    DWORD          dwFunction = FUNC_CWeaponInfo_GetWeaponReloadTime;
-    DWORD          dwInterface = (DWORD)pWeaponStats->GetInterface();
-    _asm
-    {
-        mov ecx, dwInterface
-        call dwFunction
-        mov dwReturn, eax
-    }
-    return dwReturn;
+
+    // CWeaponInfo::GetWeaponReloadTime
+    return ((int(__thiscall*)(CWeaponInfoSAInterface*))FUNC_CWeaponInfo_GetWeaponReloadTime)(pWeaponStats->GetInterface());
 }
 
 int CWeaponSA::GetWeaponFireTime(CWeaponStat* pWeaponStat)

--- a/Client/game_sa/CWeatherSA.cpp
+++ b/Client/game_sa/CWeatherSA.cpp
@@ -68,14 +68,7 @@ void CWeatherSA::Release()
 bool CWeatherSA::IsRaining()
 {
     DEBUG_TRACE("bool CWeatherSA::IsRaining ( void )");
-    DWORD dwFunc = FUNC_IsRaining;
-    bool  bReturn = false;
-    _asm
-    {
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    return ((bool(__cdecl*)())FUNC_IsRaining)();
 }
 
 float CWeatherSA::GetAmountOfRain()

--- a/Client/game_sa/CWorldSA.cpp
+++ b/Client/game_sa/CWorldSA.cpp
@@ -138,32 +138,24 @@ void CWorldSA::Add(CEntity* pEntity, eDebugCaller CallerId)
             SString strMessage("Caller: %i ", CallerId);
             LogEvent(506, "CWorld::Add ( CEntity * ) Crash", "", strMessage);
         }
-        DWORD dwEntity = (DWORD)pEntitySA->GetInterface();
-        DWORD dwFunction = FUNC_Add;
-        _asm
-        {
-            push    dwEntity
-            call    dwFunction
-            add     esp, 4
-        }
+
+        // CWorld::Add
+        ((void(__cdecl*)(CEntitySAInterface*))FUNC_Add)(pEntitySA->GetInterface());
     }
 }
 
 void CWorldSA::Add(CEntitySAInterface* entityInterface, eDebugCaller CallerId)
 {
     DEBUG_TRACE("VOID CWorldSA::Add ( CEntitySAInterface * entityInterface )");
-    DWORD dwFunction = FUNC_Add;
+
     if ((DWORD)entityInterface->vtbl == VTBL_CPlaceable)
     {
         SString strMessage("Caller: %i ", CallerId);
         LogEvent(506, "CWorld::Add ( CEntitySAInterface * ) Crash", "", strMessage);
     }
-    _asm
-    {
-        push    entityInterface
-        call    dwFunction
-        add     esp, 4
-    }
+
+    // CWorld::Add
+    ((void(__cdecl*)(CEntitySAInterface*))FUNC_Add)(entityInterface);
 }
 
 void CWorldSA::Remove(CEntity* pEntity, eDebugCaller CallerId)
@@ -180,14 +172,9 @@ void CWorldSA::Remove(CEntity* pEntity, eDebugCaller CallerId)
             SString strMessage("Caller: %i ", CallerId);
             LogEvent(507, "CWorld::Remove ( CEntity * ) Crash", "", strMessage);
         }
-        DWORD dwEntity = (DWORD)pInterface;
-        DWORD dwFunction = FUNC_Remove;
-        _asm
-        {
-            push    dwEntity
-            call    dwFunction
-            add     esp, 4
-        }
+
+        // CWorld::Remove
+        ((void(__cdecl*)(CEntitySAInterface*))FUNC_Remove)(pInterface);
     }
 }
 
@@ -199,83 +186,26 @@ void CWorldSA::Remove(CEntitySAInterface* entityInterface, eDebugCaller CallerId
         SString strMessage("Caller: %i ", CallerId);
         LogEvent(507, "CWorld::Remove ( CEntitySAInterface * ) Crash", "", strMessage);
     }
-    DWORD dwFunction = FUNC_Remove;
-    _asm
-    {
-        push    entityInterface
-        call    dwFunction
-        add     esp, 4
 
-    /*  mov     ecx, entityInterface
-        mov     esi, [ecx]
-        push    1
-        call    dword ptr [esi+8]*/
-    }
+    // CWorld::Remove
+    ((void(__cdecl*)(CEntitySAInterface*))FUNC_Remove)(entityInterface);
 }
 
 void CWorldSA::RemoveReferencesToDeletedObject(CEntitySAInterface* entity)
 {
-    DWORD dwFunc = FUNC_RemoveReferencesToDeletedObject;
-    DWORD dwEntity = (DWORD)entity;
-    _asm
-    {
-        push    dwEntity
-        call    dwFunc
-        add     esp, 4
-    }
+    // CWorld::RemoveReferencesToDeletedObject
+    ((void(__cdecl*)(CEntitySAInterface*))FUNC_RemoveReferencesToDeletedObject)(entity);
 }
 
 // THIS FUNCTION IS INCOMPLETE AND SHOULD NOT BE USED
 bool CWorldSA::TestLineSphere(CVector* vecStart, CVector* vecEnd, CVector* vecSphereCenter, float fSphereRadius, CColPoint** colCollision)
 {
-    // Create a CColLine for us
-    DWORD dwFunc = FUNC_CColLine_Constructor;
-    DWORD dwCColLine[10];            // I don't know how big CColLine is, so we'll just be safe
-    _asm
-    {
-        lea     ecx, dwCColLine
-        push    vecEnd
-        push    vecStart
-        call    dwFunc
-    }
-
-    // Now, lets make a CColSphere
-    BYTE byteColSphere[18];            // looks like its 18 bytes { vecPos, fSize, byteUnk, byteUnk, byteUnk }
-    dwFunc = FUNC_CColSphere_Set;
-    _asm
-    {
-        lea     ecx, byteColSphere
-        push    255
-        push    0
-        push    0
-        push    vecSphereCenter
-        push    fSphereRadius
-        call    dwFunc
-    }
+    return false;
 }
 
 void ConvertMatrixToEulerAngles(const CMatrix_Padded& matrixPadded, float& fX, float& fY, float& fZ)
 {
-    // Convert the given matrix to a padded matrix
-    // CMatrix_Padded matrixPadded ( Matrix );
-
-    // Grab its pointer and call gta's func
-    const CMatrix_Padded* pMatrixPadded = &matrixPadded;
-    DWORD                 dwFunc = FUNC_CMatrix__ConvertToEulerAngles;
-
-    float* pfX = &fX;
-    float* pfY = &fY;
-    float* pfZ = &fZ;
-    int    iUnknown = 21;
-    _asm
-    {
-        push    iUnknown
-            push    pfZ
-            push    pfY
-            push    pfX
-            mov     ecx, pMatrixPadded
-            call    dwFunc
-    }
+    ((void(__thiscall*)(const CMatrix_Padded*, float&, float&, float&, int))FUNC_CMatrix__ConvertToEulerAngles)(&matrixPadded, fX, fY, fZ, 21);
 }
 
 bool CWorldSA::ProcessLineOfSight(const CVector* vecStart, const CVector* vecEnd, CColPoint** colCollision, CEntity** CollisionEntity,
@@ -290,33 +220,16 @@ bool CWorldSA::ProcessLineOfSight(const CVector* vecStart, const CVector* vecEnd
 
     // DWORD targetEntity;
     CEntitySAInterface* targetEntity = NULL;
-    bool                bReturn = false;
 
-    DWORD dwFunc = FUNC_ProcessLineOfSight;
     // bool bCheckBuildings = true,                 bool bCheckVehicles = true,     bool bCheckPeds = true,
     // bool bCheckObjects = true,                   bool bCheckDummies = true,      bool bSeeThroughStuff = false,
     // bool bIgnoreSomeObjectsForCamera = false,    bool bShootThroughStuff = false
     MemPutFast<BYTE>(VAR_CWorld_bIncludeCarTires, flags.bCheckCarTires);
 
-    _asm
-    {
-        push    flags.bShootThroughStuff
-        push    flags.bIgnoreSomeObjectsForCamera
-        push    flags.bSeeThroughStuff
-        push    flags.bCheckDummies
-        push    flags.bCheckObjects
-        push    flags.bCheckPeds
-        push    flags.bCheckVehicles
-        push    flags.bCheckBuildings
-        lea     eax, targetEntity
-        push    eax
-        push    pColPointSAInterface
-        push    vecEnd
-        push    vecStart
-        call    dwFunc
-        mov     bReturn, al
-        add     esp, 0x30
-    }
+    bool bReturn = ((bool(__cdecl*)(const CVector*, const CVector*, CColPointSAInterface*, CEntitySAInterface**, bool, bool, bool, bool, bool, bool, bool,
+                                    bool))FUNC_ProcessLineOfSight)(vecStart, vecEnd, pColPointSAInterface, &targetEntity, flags.bCheckBuildings,
+                                                                   flags.bCheckVehicles, flags.bCheckPeds, flags.bCheckObjects, flags.bCheckDummies,
+                                                                   flags.bSeeThroughStuff, flags.bIgnoreSomeObjectsForCamera, flags.bShootThroughStuff);
 
     MemPutFast<BYTE>(VAR_CWorld_bIncludeCarTires, 0);
 
@@ -402,54 +315,27 @@ void CWorldSA::IgnoreEntity(CEntity* pEntity)
 BYTE CWorldSA::GetLevelFromPosition(CVector* vecPosition)
 {
     DEBUG_TRACE("BYTE CWorldSA::GetLevelFromPosition(CVector * vecPosition)");
-    DWORD dwFunc = FUNC_GetLevelFromPosition;
-    BYTE  bReturn = 0;
-    _asm
-    {
-        push    vecPosition
-        call    dwFunc
-        mov     bReturn, al
-        pop     eax
-    }
-    return bReturn;
+
+    // CTheZones::GetLevelFromPosition
+    return ((bool(__cdecl*)(CVector*))FUNC_GetLevelFromPosition)(vecPosition);
 }
 
 float CWorldSA::FindGroundZForPosition(float fX, float fY)
 {
     DEBUG_TRACE("FLOAT CWorldSA::FindGroundZForPosition(FLOAT fX, FLOAT fY)");
-    DWORD dwFunc = FUNC_FindGroundZFor3DCoord;
-    FLOAT fReturn = 0;
-    _asm
-    {
-        push    fY
-        push    fX
-        call    dwFunc
-        fstp    fReturn
-        add     esp, 8
-    }
-    return fReturn;
+
+    // calls the wrong function should call CWorld::FindGroundZForCoord(0x569660)
+    // CWorld::FindGroundZFor3DCoord
+    return ((float(__cdecl*)(float, float))FUNC_FindGroundZFor3DCoord)(fX, fY);
 }
 
 float CWorldSA::FindGroundZFor3DPosition(CVector* vecPosition)
 {
     DEBUG_TRACE("FLOAT CWorldSA::FindGroundZFor3DPosition(CVector * vecPosition)");
-    DWORD dwFunc = FUNC_FindGroundZFor3DCoord;
-    FLOAT fReturn = 0;
-    FLOAT fX = vecPosition->fX;
-    FLOAT fY = vecPosition->fY;
-    FLOAT fZ = vecPosition->fZ;
-    _asm
-    {
-        push    0
-        push    0
-        push    fZ
-        push    fY
-        push    fX
-        call    dwFunc
-        fstp    fReturn
-        add     esp, 0x14
-    }
-    return fReturn;
+
+    // CWorld::FindGroundZFor3DCoord
+    return ((float(__cdecl*)(float, float, float, bool*, CEntity**))FUNC_FindGroundZFor3DCoord)(vecPosition->fX, vecPosition->fY, vecPosition->fZ, nullptr,
+                                                                                                nullptr);
 }
 
 float CWorldSA::FindRoofZFor3DCoord(CVector* pvecPosition, bool* pbOutResult)
@@ -463,76 +349,36 @@ float CWorldSA::FindRoofZFor3DCoord(CVector* pvecPosition, bool* pbOutResult)
 void CWorldSA::LoadMapAroundPoint(CVector* vecPosition, FLOAT fRadius)
 {
     DEBUG_TRACE("VOID CWorldSA::LoadMapAroundPoint(CVector * vecPosition, FLOAT fRadius)");
-    DWORD dwFunc = FUNC_CTimer_Stop;
-    _asm
-    {
-        call    dwFunc
-    }
 
-    dwFunc = FUNC_CRenderer_RequestObjectsInDirection;
-    _asm
-    {
-        push    32
-        push    fRadius
-        push    vecPosition
-        call    dwFunc
-        add     esp, 12
-    }
+    // CTimer::Stop
+    ((void(__cdecl*)())FUNC_CTimer_Stop)();
 
-    dwFunc = FUNC_CStreaming_LoadScene;
-    _asm
-    {
-        push    vecPosition
-        call    dwFunc
-        add     esp, 4
-    }
+    // CRenderer::RequestObjectsInDirection
+    ((void(__cdecl*)(CVector&, float, int))FUNC_CRenderer_RequestObjectsInDirection)(*vecPosition, fRadius, 32);
 
-    dwFunc = FUNC_CTimer_Update;
-    _asm
-    {
-        call    dwFunc
-    }
+    // CStreaming::LoadScene
+    ((void(__cdecl*)(CVector&))FUNC_CStreaming_LoadScene)(*vecPosition);
+
+    // CTimer::Update
+    ((void(__cdecl*)())FUNC_CTimer_Update)();
 }
 
 bool CWorldSA::IsLineOfSightClear(const CVector* vecStart, const CVector* vecEnd, const SLineOfSightFlags flags)
 {
-    DWORD dwFunc = FUNC_IsLineOfSightClear;
-    bool  bReturn = false;
     // bool bCheckBuildings = true, bool bCheckVehicles = true, bool bCheckPeds = true,
     // bool bCheckObjects = true, bool bCheckDummies = true, bool bSeeThroughStuff = false,
     // bool bIgnoreSomeObjectsForCamera = false
 
-    _asm
-    {
-        push    flags.bIgnoreSomeObjectsForCamera
-        push    flags.bSeeThroughStuff
-        push    flags.bCheckDummies
-        push    flags.bCheckObjects
-        push    flags.bCheckPeds
-        push    flags.bCheckVehicles
-        push    flags.bCheckBuildings
-        push    vecEnd
-        push    vecStart
-        call    dwFunc
-        mov     bReturn, al
-        add     esp, 0x24
-    }
-    return bReturn;
+    // CWorld::GetIsLineOfSightClear
+    return ((bool(__cdecl*)(const CVector&, const CVector&, bool, bool, bool, bool, bool, bool, bool))FUNC_IsLineOfSightClear)(
+        *vecStart, *vecEnd, flags.bCheckBuildings, flags.bCheckVehicles, flags.bCheckPeds, flags.bCheckObjects, flags.bCheckDummies, flags.bSeeThroughStuff,
+        flags.bIgnoreSomeObjectsForCamera);
 }
 
 bool CWorldSA::HasCollisionBeenLoaded(CVector* vecPosition)
 {
-    DWORD dwFunc = FUNC_HasCollisionBeenLoaded;
-    bool  bRet = false;
-    _asm
-    {
-        push    0
-        push    vecPosition
-        call    dwFunc
-        mov     bRet, al
-        add     esp, 8
-    }
-    return bRet;
+    // CColStore::HasCollisionLoaded
+    return ((bool(__cdecl*)(CVector&, int))FUNC_HasCollisionBeenLoaded)(*vecPosition, 0);
 }
 
 DWORD CWorldSA::GetCurrentArea()
@@ -544,13 +390,8 @@ void CWorldSA::SetCurrentArea(DWORD dwArea)
 {
     MemPutFast<DWORD>(VAR_currArea, dwArea);
 
-    DWORD dwFunc = FUNC_RemoveBuildingsNotInArea;
-    _asm
-    {
-        push    dwArea
-        call    dwFunc
-        add     esp, 4
-    }
+    // CStreaming::RemoveBuildingsNotInArea
+    ((void(__cdecl*)(int))FUNC_RemoveBuildingsNotInArea)(dwArea);
 }
 
 void CWorldSA::SetJetpackMaxHeight(float fHeight)
@@ -607,16 +448,8 @@ bool CWorldSA::GetOcclusionsEnabled()
 
 void CWorldSA::FindWorldPositionForRailTrackPosition(float fRailTrackPosition, int iTrackId, CVector* pOutVecPosition)
 {
-    DWORD dwFunc = FUNC_CWorld_FindPositionForTrackPosition;            // __cdecl
-
-    _asm
-    {
-        push pOutVecPosition
-        push iTrackId
-        push fRailTrackPosition
-        call dwFunc
-        add  esp, 3*4
-    }
+    // CTrain::FindCoorsFromPositionOnTrack
+    ((void(__cdecl*)(float, int, CVector*))FUNC_CWorld_FindPositionForTrackPosition)(fRailTrackPosition, iTrackId, pOutVecPosition);
 }
 
 int CWorldSA::FindClosestRailTrackNode(const CVector& vecPosition, uchar& ucOutTrackId, float& fOutRailDistance)

--- a/Client/game_sa/TaskAttackSA.cpp
+++ b/Client/game_sa/TaskAttackSA.cpp
@@ -21,20 +21,12 @@ CTaskSimpleGangDriveBySA::CTaskSimpleGangDriveBySA(CEntity* pTargetEntity, const
     this->CreateTaskInterface(sizeof(CTaskSimpleGangDriveBySAInterface));
     if (!IsValid())
         return;
-    DWORD dwFunc = FUNC_CTaskSimpleGangDriveBy__Constructor;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwTargetEntity = (pTargetEntity) ? (DWORD)pTargetEntity->GetInterface() : 0;
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    bSeatRHS
-        push    nDrivebyStyle
-        push    FrequencyPercentage
-        push    fAbortRange
-        push    pVecTarget
-        push    dwTargetEntity
-        call    dwFunc
-    }
+
+    CEntitySAInterface* pTargetEntityInterface = pTargetEntity ? pTargetEntity->GetInterface() : nullptr;
+
+    // CTaskSimpleGangDriveBy::CTaskSimpleGangDriveBy
+    ((void*(__thiscall*)(void*, CEntitySAInterface*, const CVector*, float, char, char, bool))FUNC_CTaskSimpleGangDriveBy__Constructor)(
+        GetInterface(), pTargetEntityInterface, pVecTarget, fAbortRange, FrequencyPercentage, nDrivebyStyle, bSeatRHS);
 }
 
 CTaskSimpleUseGunSA::CTaskSimpleUseGunSA(CEntity* pTargetEntity, CVector vecTarget, char nCommand, short nBurstLength, unsigned char bAimImmediate)
@@ -46,398 +38,180 @@ CTaskSimpleUseGunSA::CTaskSimpleUseGunSA(CEntity* pTargetEntity, CVector vecTarg
     this->CreateTaskInterface(sizeof(CTaskSimpleUseGunSAInterface));
     if (!IsValid())
         return;
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun__Constructor;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwTargetEntity = (pTargetEntity) ? (DWORD)pTargetEntity->GetInterface() : 0;
-    float fTargetX = vecTarget.fX, fTargetY = vecTarget.fY, fTargetZ = vecTarget.fZ;
-    DWORD dwBurstLength = nBurstLength;
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    bAimImmediate
-        push    dwBurstLength
-        push    nCommand
-        push    fTargetZ
-        push    fTargetY
-        push    fTargetX
-        push    dwTargetEntity
-        call    dwFunc
-    }
+
+    CEntitySAInterface* pTargetEntityInterface = pTargetEntity ? pTargetEntity->GetInterface() : nullptr;
+
+    // CTaskSimpleUseGun::CTaskSimpleUseGun
+    ((void*(__thiscall*)(void*, CEntitySAInterface*, float, float, float, unsigned char, unsigned short, unsigned char))FUNC_CTaskSimpleUseGun__Constructor)(
+        GetInterface(), pTargetEntityInterface, vecTarget.fX, vecTarget.fY, vecTarget.fZ, nCommand, nBurstLength, bAimImmediate);
 }
 
 bool CTaskSimpleUseGunSA::SetPedPosition(CPed* pPed)
 {
-    bool  bReturn;
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_SetPedPosition;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
+    CPedSAInterface* pPedInterface = pPed->GetPedInterface();
+    ((BYTE*)pPedInterface)[0x0d] = 2;
 
-    BYTE* ptr = (BYTE*)dwThisInterface;
-    ptr[0x0d] = 2;
+    BYTE currentWeaponSlot = pPedInterface->bCurrentWeaponSlot;
 
-    CPedSAInterface* dwPedInterface = (CPedSAInterface*)pPed->GetInterface();
-
-    BYTE currentWeaponSlot = dwPedInterface->bCurrentWeaponSlot;
-
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    dwPedInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CTaskSimpleUseGun::SetPedPosition
+    return ((bool(__thiscall*)(void*, CPedSAInterface*))FUNC_CTaskSimpleUseGun_SetPedPosition)(GetInterface(), pPedInterface);
 }
 
 void CTaskSimpleUseGunSA::FireGun(CPed* pPed, bool bFlag)
 {
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_FireGun;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwPedInterface = (DWORD)pPed->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    bFlag
-        push    dwPedInterface
-        call    dwFunc
-    }
+    // CTaskSimpleUseGun::FireGun
+    ((void(__thiscall*)(void*, CPedSAInterface*, bool))FUNC_CTaskSimpleUseGun_FireGun)(GetInterface(), pPed->GetPedInterface(), bFlag);
 }
 
 bool CTaskSimpleUseGunSA::ControlGun(CPed* pPed, CEntity* pTargetEntity, char nCommand)
 {
-    bool  bReturn;
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_ControlGun;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwPedInterface = (DWORD)pPed->GetInterface();
-    DWORD dwTargetEntity = (pTargetEntity) ? (DWORD)pTargetEntity->GetInterface() : 0;
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    nCommand
-        push    dwTargetEntity
-        push    dwPedInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    CEntitySAInterface* pTargetEntityInterface = pTargetEntity ? pTargetEntity->GetInterface() : nullptr;
+
+    // CTaskSimpleUseGun::ControlGun
+    return ((bool(__thiscall*)(void*, CPedSAInterface*, CEntitySAInterface*, char))FUNC_CTaskSimpleUseGun_ControlGun)(GetInterface(), pPed->GetPedInterface(),
+                                                                                                                      pTargetEntityInterface, nCommand);
 }
 
 bool CTaskSimpleUseGunSA::ControlGunMove(CVector2D* pMoveVec)
 {
-    bool  bReturn;
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_ControlGunMove;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    pMoveVec
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CTaskSimpleUseGun::ControlGunMove
+    return ((bool(__thiscall*)(void*, CVector2D*))FUNC_CTaskSimpleUseGun_ControlGunMove)(GetInterface(), pMoveVec);
 }
 
 void CTaskSimpleUseGunSA::Reset(CPed* pPed, CEntity* pTargetEntity, CVector vecTarget, char nCommand, short nBurstLength)
 {
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_Reset;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwPedInterface = (DWORD)pPed->GetInterface();
-    DWORD dwTargetEntity = (pTargetEntity) ? (DWORD)pTargetEntity->GetInterface() : 0;
-    float fTargetX = vecTarget.fX, fTargetY = vecTarget.fY, fTargetZ = vecTarget.fZ;
-    DWORD dwBurstLength = nBurstLength;
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    dwBurstLength
-        push    nCommand
-        push    fTargetZ
-        push    fTargetY
-        push    fTargetX
-        push    dwTargetEntity
-        push    dwPedInterface
-        call    dwFunc
-    }
+    CEntitySAInterface* pTargetEntityInterface = pTargetEntity ? pTargetEntity->GetInterface() : nullptr;
+
+    // CTaskSimpleUseGun::Reset
+    ((void(__thiscall*)(void*, CPedSAInterface*, CEntitySAInterface*, CVector, char, short))FUNC_CTaskSimpleUseGun_Reset)(
+        GetInterface(), pPed->GetPedInterface(), pTargetEntityInterface, vecTarget, nCommand, nBurstLength);
 }
 
 int CTaskSimpleUseGunSA::GetTaskType()
 {
-    int   iReturn;
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_GetTaskType;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-        mov     iReturn, eax
-    }
-    return iReturn;
+    // CTaskSimpleUseGun::GetTaskType
+    return ((int(__thiscall*)(void*))FUNC_CTaskSimpleUseGun_GetTaskType)(GetInterface());
 }
 
 // If flag is 1 or 2 then do magic stop stuff else set m_nNextCommand to 6
 // (pEvent not used)
 bool CTaskSimpleUseGunSA::MakeAbortable(CPed* pPed, int iPriority, CEvent const* pEvent)
 {
-    bool  bReturn;
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_MakeAbortable;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwPedInterface = (DWORD)pPed->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    pEvent
-        push    iPriority
-        push    dwPedInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CTaskSimpleUseGun::MakeAbortable
+    return ((bool(__thiscall*)(void*, CPedSAInterface*, int, const CEvent*))FUNC_CTaskSimpleUseGun_MakeAbortable)(GetInterface(), pPed->GetPedInterface(),
+                                                                                                                  iPriority, pEvent);
 }
 
 bool CTaskSimpleUseGunSA::ProcessPed(CPed* pPed)
 {
-    bool  bReturn;
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_ProcessPed;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwPedInterface = (DWORD)pPed->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    dwPedInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CTaskSimpleUseGun::ProcessPed
+    return ((bool(__thiscall*)(void*, CPedSAInterface*))FUNC_CTaskSimpleUseGun_ProcessPed)(GetInterface(), pPed->GetPedInterface());
 }
 
 void CTaskSimpleUseGunSA::AbortIK(CPed* pPed)
 {
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_AbortIK;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwPedInterface = (DWORD)pPed->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    dwPedInterface
-        call    dwFunc
-    }
+    // CTaskSimpleUseGun::AbortIK
+    ((void(__thiscall*)(void*, CPedSAInterface*))FUNC_CTaskSimpleUseGun_AbortIK)(GetInterface(), pPed->GetPedInterface());
 }
 
 void CTaskSimpleUseGunSA::AimGun(CPed* pPed)
 {
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_AimGun;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwPedInterface = (DWORD)pPed->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    dwPedInterface
-        call    dwFunc
-    }
+    // CTaskSimpleUseGun::AimGun
+    ((void(__thiscall*)(void*, CPedSAInterface*))FUNC_CTaskSimpleUseGun_AimGun)(GetInterface(), pPed->GetPedInterface());
 }
 
 void CTaskSimpleUseGunSA::ClearAnim(CPed* pPed)
 {
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_ClearAnim;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwPedInterface = (DWORD)pPed->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    dwPedInterface
-        call    dwFunc
-    }
+    // CTaskSimpleUseGun::ClearAnim
+    ((void(__thiscall*)(void*, CPedSAInterface*))FUNC_CTaskSimpleUseGun_ClearAnim)(GetInterface(), pPed->GetPedInterface());
 }
 
 signed char CTaskSimpleUseGunSA::GetCurrentCommand()
 {
-    signed char bReturn;
-    DWORD       dwFunc = FUNC_CTaskSimpleUseGun_GetCurrentCommand;
-    DWORD       dwThisInterface = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CTaskSimpleUseGun::GetCurrentCommand
+    return ((signed char(__thiscall*)(void*))FUNC_CTaskSimpleUseGun_GetCurrentCommand)(GetInterface());
 }
 
 bool CTaskSimpleUseGunSA::GetDoneFiring()
 {
-    bool  bReturn;
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_GetDoneFiring;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CTaskSimpleUseGun::GetDoneFiring
+    return ((bool(__thiscall*)(void*))FUNC_CTaskSimpleUseGun_GetDoneFiring)(GetInterface());
 }
 
 bool CTaskSimpleUseGunSA::GetIsFinished()
 {
-    bool  bReturn;
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_GetIsFinished;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CTaskSimpleUseGun::GetIsFinished
+    return ((bool(__thiscall*)(void*))FUNC_CTaskSimpleUseGun_GetIsFinished)(GetInterface());
 }
 
 bool CTaskSimpleUseGunSA::IsLineOfSightBlocked()
 {
-    bool  bReturn;
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_IsLineOfSightBlocked;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CTaskSimpleUseGun::IsLineOfSightBlocked
+    return ((bool(__thiscall*)(void*))FUNC_CTaskSimpleUseGun_IsLineOfSightBlocked)(GetInterface());
 }
 
 bool CTaskSimpleUseGunSA::GetIsFiring()
 {
-    bool  bReturn;
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_GetIsFiring;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CTaskSimpleUseGun::GetIsFiring
+    return ((bool(__thiscall*)(void*))FUNC_CTaskSimpleUseGun_GetIsFiring)(GetInterface());
 }
 
 bool CTaskSimpleUseGunSA::GetIsReloading()
 {
-    bool  bReturn;
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_GetIsReloading;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CTaskSimpleUseGun::GetIsReloading
+    return ((bool(__thiscall*)(void*))FUNC_CTaskSimpleUseGun_GetIsReloading)(GetInterface());
 }
 
 bool CTaskSimpleUseGunSA::GetSkipAim()
 {
-    bool  bReturn;
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_GetSkipAim;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CTaskSimpleUseGun::GetSkipAim
+    return ((bool(__thiscall*)(void*))FUNC_CTaskSimpleUseGun_GetSkipAim)(GetInterface());
 }
 
 bool CTaskSimpleUseGunSA::PlayerPassiveControlGun()
 {
-    bool  bReturn;
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_PlayerPassiveControlGun;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    // CTaskSimpleUseGun::PlayerPassiveControlGun
+    return ((bool(__thiscall*)(void*))FUNC_CTaskSimpleUseGun_PlayerPassiveControlGun)(GetInterface());
 }
 
 void CTaskSimpleUseGunSA::RemoveStanceAnims(CPed* pPed, float f)
 {
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_RemoveStanceAnims;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwPedInterface = (DWORD)pPed->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    f
-        push    dwPedInterface
-        call    dwFunc
-    }
+    // CTaskSimpleUseGun::RemoveStanceAnims
+    ((void(__thiscall*)(void*, CPedSAInterface*, float))FUNC_CTaskSimpleUseGun_RemoveStanceAnims)(GetInterface(), pPed->GetPedInterface(), f);
 }
 
 bool CTaskSimpleUseGunSA::RequirePistolWhip(CPed* pPed, CEntity* pTargetEntity)
 {
-    bool  bReturn;
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_ControlGun;
-    DWORD dwPedInterface = (DWORD)pPed->GetInterface();
-    DWORD dwTargetEntity = (pTargetEntity) ? (DWORD)pTargetEntity->GetInterface() : 0;
-    _asm
-    {
-        push    dwTargetEntity
-        push    dwPedInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
-    return bReturn;
+    CPedSAInterface*    pPedInterface = pPed->GetPedInterface();
+    CEntitySAInterface* pTargetEntityInterface = pTargetEntity ? pTargetEntity->GetInterface() : nullptr;
+
+    // actually thiscall
+    // CTaskSimpleUseGun::ControlGun
+    return ((bool(__cdecl*)(CPedSAInterface*, CEntitySAInterface*))FUNC_CTaskSimpleUseGun_ControlGun)(pPedInterface, pTargetEntityInterface);
 }
 
 void CTaskSimpleUseGunSA::SetBurstLength(short a)
 {
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_SetBurstLength;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    a
-        call    dwFunc
-    }
+    // CTaskSimpleUseGun::SetBurstLength
+    ((void(__thiscall*)(void*, short))FUNC_CTaskSimpleUseGun_SetBurstLength)(GetInterface(), a);
 }
 
 void CTaskSimpleUseGunSA::SetMoveAnim(CPed* pPed)
 {
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_SetMoveAnim;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwPedInterface = (DWORD)pPed->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    dwPedInterface
-        call    dwFunc
-    }
+    // CTaskSimpleUseGun::SetMoveAnim
+    ((void(__thiscall*)(void*, CPedSAInterface*))FUNC_CTaskSimpleUseGun_SetMoveAnim)(GetInterface(), pPed->GetPedInterface());
 }
 
 void CTaskSimpleUseGunSA::StartAnim(class CPed* pPed)
 {
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_StartAnim;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwPedInterface = (DWORD)pPed->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    dwPedInterface
-        call    dwFunc
-    }
+    // CTaskSimpleUseGun::StartAnim
+    ((void(__thiscall*)(void*, CPedSAInterface*))FUNC_CTaskSimpleUseGun_StartAnim)(GetInterface(), pPed->GetPedInterface());
 }
 
 void CTaskSimpleUseGunSA::StartCountDown(unsigned char a, bool b)
 {
-    DWORD dwFunc = FUNC_CTaskSimpleUseGun_StartCountDown;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    b
-        push    a
-        call    dwFunc
-    }
+    // CTaskSimpleUseGun::StartCountDown
+    ((void(__thiscall*)(void*, unsigned char, bool))FUNC_CTaskSimpleUseGun_StartCountDown)(GetInterface(), a, b);
 }
 
 CTaskSimpleFightSA::CTaskSimpleFightSA(CEntity* pTargetEntity, int nCommand, unsigned int nIdlePeriod)
@@ -447,15 +221,10 @@ CTaskSimpleFightSA::CTaskSimpleFightSA(CEntity* pTargetEntity, int nCommand, uns
     this->CreateTaskInterface(sizeof(CTaskSimpleFightSAInterface));
     if (!IsValid())
         return;
-    DWORD dwFunc = FUNC_CTaskSimpleFight__Constructor;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwTargetEntity = (pTargetEntity) ? (DWORD)pTargetEntity->GetInterface() : 0;
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    nIdlePeriod
-        push    nCommand
-        push    dwTargetEntity
-        call    dwFunc
-    }
+
+    CEntitySAInterface* pTargetEntityInterface = pTargetEntity ? pTargetEntity->GetInterface() : nullptr;
+
+    // CTaskSimpleFight::CTaskSimpleFight
+    ((void*(__thiscall*)(void*, CEntitySAInterface*, int, unsigned int))FUNC_CTaskSimpleFight__Constructor)(GetInterface(), pTargetEntityInterface, nCommand,
+                                                                                                            nIdlePeriod);
 }

--- a/Client/game_sa/TaskBasicSA.cpp
+++ b/Client/game_sa/TaskBasicSA.cpp
@@ -18,15 +18,9 @@ CTaskComplexUseMobilePhoneSA::CTaskComplexUseMobilePhoneSA(const int iDuration)
     this->CreateTaskInterface(sizeof(CTaskComplexUseMobilePhoneSAInterface));
     if (!IsValid())
         return;
-    DWORD dwFunc = FUNC_CTaskComplexUseMobilePhone__Constructor;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
 
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    iDuration
-        call    dwFunc
-    }
+    // CTaskComplexUseMobilePhone::CTaskComplexUseMobilePhone
+    ((void*(__thiscall*)(void*, int))FUNC_CTaskComplexUseMobilePhone__Constructor)(GetInterface(), iDuration);
 }
 
 CTaskSimpleRunAnimSA::CTaskSimpleRunAnimSA(const AssocGroupId animGroup, const AnimationId animID, const float fBlendDelta, const int iTaskType,
@@ -40,20 +34,10 @@ CTaskSimpleRunAnimSA::CTaskSimpleRunAnimSA(const AssocGroupId animGroup, const A
     this->CreateTaskInterface(1024);
     if (!IsValid())
         return;
-    DWORD dwFunc = FUNC_CTaskSimpleRunAnim__Constructor;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
 
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    bHoldLastFrame
-        push    pTaskName
-        push    iTaskType
-        push    fBlendDelta
-        push    animID
-        push    animGroup
-        call    dwFunc
-    }
+    // CTaskSimpleRunAnim::CTaskSimpleRunAnim
+    ((void*(__thiscall*)(void*, AssocGroupId, AnimationId, float, int, const char*, bool))FUNC_CTaskSimpleRunAnim__Constructor)(
+        GetInterface(), animGroup, animID, fBlendDelta, iTaskType, pTaskName, bHoldLastFrame);
 }
 
 CTaskSimpleRunNamedAnimSA::CTaskSimpleRunNamedAnimSA(const char* pAnimName, const char* pAnimGroupName, const int flags, const float fBlendDelta,
@@ -69,23 +53,10 @@ CTaskSimpleRunNamedAnimSA::CTaskSimpleRunNamedAnimSA(const char* pAnimName, cons
     this->CreateTaskInterface(sizeof(CTaskSimpleRunNamedAnimSAInterface));
     if (!IsValid())
         return;
-    DWORD dwFunc = FUNC_CTaskSimpleRunNamedAnim__Constructor;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
 
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    bHoldLastFrame
-        push    bOffsetPed
-        push    bRunInSequence
-        push    bDontInterrupt
-        push    iTime
-        push    fBlendDelta
-        push    flags
-        push    pAnimGroupName
-        push    pAnimName
-        call    dwFunc
-    }
+    // CTaskSimpleRunNamedAnim::CTaskSimpleRunNamedAnim
+    ((void*(__thiscall*)(void*, const char*, const char*, int, float, int, bool, bool, bool, bool))FUNC_CTaskSimpleRunNamedAnim__Constructor)(
+        GetInterface(), pAnimName, pAnimGroupName, flags, fBlendDelta, iTime, bDontInterrupt, bRunInSequence, bOffsetPed, bHoldLastFrame);
 }
 
 CTaskComplexDieSA::CTaskComplexDieSA(const eWeaponType eMeansOfDeath, const AssocGroupId animGroup, const AnimationId anim, const float fBlendDelta,
@@ -101,23 +72,11 @@ CTaskComplexDieSA::CTaskComplexDieSA(const eWeaponType eMeansOfDeath, const Asso
     this->CreateTaskInterface(1024);
     if (!IsValid())
         return;
-    DWORD dwFunc = FUNC_CTaskComplexDie__Constructor;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
 
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    bFallToDeathOverRailing
-        push    iFallToDeathDir
-        push    bFallingToDeath
-        push    bBeingKilledByStealth
-        push    fAnimSpeed
-        push    fBlendDelta
-        push    anim
-        push    animGroup
-        push    eMeansOfDeath
-        call    dwFunc
-    }
+    // CTaskComplexDie::CTaskComplexDie
+    ((void*(__thiscall*)(void*, eWeaponType, AssocGroupId, AnimationId, float, float, bool, bool, int, bool))FUNC_CTaskComplexDie__Constructor)(
+        GetInterface(), eMeansOfDeath, animGroup, anim, fBlendDelta, fAnimSpeed, bBeingKilledByStealth, bFallingToDeath, iFallToDeathDir,
+        bFallToDeathOverRailing);
 }
 
 CTaskSimpleStealthKillSA::CTaskSimpleStealthKillSA(bool bKiller, CPed* pPed, const AssocGroupId animGroup)
@@ -128,18 +87,12 @@ CTaskSimpleStealthKillSA::CTaskSimpleStealthKillSA(bool bKiller, CPed* pPed, con
     this->CreateTaskInterface(1024);
     if (!IsValid())
         return;
-    DWORD dwFunc = FUNC_CTaskSimpleStealthKill__Constructor;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwPedInterface = (DWORD)pPed->GetPedInterface();
 
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    animGroup
-        push    dwPedInterface
-        push    bKiller
-        call    dwFunc
-    }
+    CPedSAInterface* pPedInterface = pPed->GetPedInterface();
+
+    // CTaskSimpleStealthKill::CTaskSimpleStealthKill
+    ((void*(__thiscall*)(void*, bool, CPedSAInterface*, AssocGroupId))FUNC_CTaskSimpleStealthKill__Constructor)(GetInterface(), bKiller, pPedInterface,
+                                                                                                                animGroup);
 }
 
 CTaskSimpleDeadSA::CTaskSimpleDeadSA(unsigned int uiDeathTimeMS, bool bUnk2)
@@ -149,16 +102,9 @@ CTaskSimpleDeadSA::CTaskSimpleDeadSA(unsigned int uiDeathTimeMS, bool bUnk2)
     this->CreateTaskInterface(sizeof(CTaskSimpleDeadSAInterface));
     if (!IsValid())
         return;
-    DWORD dwFunc = FUNC_CTaskSimpleDead__Constructor;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
 
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    bUnk2
-        push    uiDeathTimeMS
-        call    dwFunc
-    }
+    // CTaskSimpleDead::CTaskSimpleDead
+    ((void*(__thiscall*)(void*, unsigned int, bool))FUNC_CTaskSimpleDead__Constructor)(GetInterface(), uiDeathTimeMS, bUnk2);
 }
 
 CTaskSimpleBeHitSA::CTaskSimpleBeHitSA(CPed* pPedAttacker, ePedPieceTypes hitBodyPart, int hitBodySide, int weaponId)
@@ -168,19 +114,12 @@ CTaskSimpleBeHitSA::CTaskSimpleBeHitSA(CPed* pPedAttacker, ePedPieceTypes hitBod
     this->CreateTaskInterface(sizeof(CTaskSimpleBeHitSAInterface));
     if (!IsValid())
         return;
-    DWORD dwFunc = FUNC_CTaskSimpleBeHit__Constructor;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwPedInterface = (DWORD)pPedAttacker->GetPedInterface();
 
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    weaponId
-        push    hitBodySide
-        push    hitBodyPart
-        push    dwPedInterface
-        call    dwFunc
-    }
+    CPedSAInterface* pPedInterface = pPedAttacker->GetPedInterface();
+
+    // CTaskSimpleBeHit::CTaskSimpleBeHit
+    ((void*(__thiscall*)(void*, CPedSAInterface*, ePedPieceTypes, int, int))FUNC_CTaskSimpleBeHit__Constructor)(GetInterface(), pPedInterface, hitBodyPart,
+                                                                                                                hitBodySide, weaponId);
 }
 
 CTaskComplexSunbatheSA::CTaskComplexSunbatheSA(CObject* pTowel, const bool bStartStanding)
@@ -191,19 +130,11 @@ CTaskComplexSunbatheSA::CTaskComplexSunbatheSA(CObject* pTowel, const bool bStar
     this->CreateTaskInterface(1024);
     if (!IsValid())
         return;
-    DWORD dwFunc = FUNC_CTaskComplexSunbathe__Constructor;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwObjectInterface = 0;
-    if (pTowel)
-        dwObjectInterface = (DWORD)pTowel->GetObjectInterface();
 
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    bStartStanding
-        push    dwObjectInterface;
-        call    dwFunc
-    }
+    CObjectSAInterface* pTowelInterface = pTowel ? pTowel->GetObjectInterface() : nullptr;
+
+    // CTaskComplexSunbathe::CTaskComplexSunbathe
+    ((void*(__thiscall*)(void*, CObjectSAInterface*, bool))FUNC_CTaskComplexSunbathe__Constructor)(GetInterface(), pTowelInterface, bStartStanding);
 }
 
 void CTaskComplexSunbatheSA::SetEndTime(DWORD dwTime)
@@ -221,14 +152,9 @@ CTaskSimplePlayerOnFootSA::CTaskSimplePlayerOnFootSA()
     this->CreateTaskInterface(sizeof(CTaskSimplePlayerOnFootSAInterface));
     if (!IsValid())
         return;
-    DWORD dwFunc = (DWORD)FUNC_CTASKSimplePlayerOnFoot__Constructor;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
 
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-    }
+    // CTaskSimplePlayerOnFoot::CTaskSimplePlayerOnFoot
+    ((void*(__thiscall*)(void*))FUNC_CTASKSimplePlayerOnFoot__Constructor)(GetInterface());
 }
 
 ////////////////////
@@ -240,12 +166,7 @@ CTaskComplexFacialSA::CTaskComplexFacialSA()
     this->CreateTaskInterface(sizeof(CTaskComplexFacialSAInterface));
     if (!IsValid())
         return;
-    DWORD dwFunc = (DWORD)FUNC_CTASKComplexFacial__Constructor;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
 
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-    }
+    // CTaskComplexFacial::CTaskComplexFacial
+    ((void*(__thiscall*)(void*))FUNC_CTASKComplexFacial__Constructor)(GetInterface());
 }

--- a/Client/game_sa/TaskCarAccessoriesSA.cpp
+++ b/Client/game_sa/TaskCarAccessoriesSA.cpp
@@ -27,17 +27,10 @@ CTaskSimpleCarSetPedInAsDriverSA::CTaskSimpleCarSetPedInAsDriverSA(CVehicle* pTa
         this->CreateTaskInterface(sizeof(CTaskSimpleCarSetPedInAsDriverSAInterface));
         if (!IsValid())
             return;
-        DWORD dwFunc = FUNC_CTaskSimpleCarSetPedInAsDriver__Constructor;
-        DWORD dwVehiclePtr = (DWORD)pTargetVehicleSA->GetInterface();
-        DWORD dwThisInterface = (DWORD)this->GetInterface();
 
-        _asm
-        {
-            mov     ecx, dwThisInterface
-            push    pUtility
-            push    dwVehiclePtr
-            call    dwFunc
-        }
+        // CTaskSimpleCarSetPedInAsDriver::CTaskSimpleCarSetPedInAsDriver
+        ((CTaskSAInterface * (__thiscall*)(void*, CEntitySAInterface*, CTaskUtilityLineUpPedWithCar*)) FUNC_CTaskSimpleCarSetPedInAsDriver__Constructor)(
+            this->GetInterface(), pTargetVehicleSA->GetInterface(), pUtility);
     }
     else
     {
@@ -81,17 +74,10 @@ CTaskSimpleCarSetPedInAsPassengerSA::CTaskSimpleCarSetPedInAsPassengerSA(CVehicl
         this->CreateTaskInterface(sizeof(CTaskSimpleCarSetPedInAsPassengerSAInterface));
         if (!IsValid())
             return;
-        DWORD dwFunc = FUNC_CTaskSimpleCarSetPedInAsPassenger__Constructor;
-        DWORD dwVehiclePtr = (DWORD)pTargetVehicleSA->GetInterface();
-        DWORD dwThisInterface = (DWORD)this->GetInterface();
-        _asm
-        {
-            mov     ecx, dwThisInterface
-            push    pUtility
-            push    iTargetDoor
-            push    dwVehiclePtr
-            call    dwFunc
-        }
+
+        // CTaskSimpleCarSetPedInAsPassenger::CTaskSimpleCarSetPedInAsPassenger
+        ((CTaskSAInterface * (__thiscall*)(void*, CEntitySAInterface*, int, CTaskUtilityLineUpPedWithCar*))
+             FUNC_CTaskSimpleCarSetPedInAsPassenger__Constructor)(this->GetInterface(), pTargetVehicleSA->GetInterface(), iTargetDoor, pUtility);
     }
     else
     {
@@ -133,19 +119,10 @@ CTaskSimpleCarSetPedOutSA::CTaskSimpleCarSetPedOutSA(CVehicle* pTargetVehicle, i
         this->CreateTaskInterface(sizeof(CTaskSimpleCarSetPedOutSAInterface));
         if (!IsValid())
             return;
-        DWORD dwFunc = FUNC_CTaskSimpleCarSetPedOut__Constructor;
-        DWORD dwVehiclePtr = (DWORD)pTargetVehicleSA->GetInterface();
-        DWORD dwThisInterface = (DWORD)this->GetInterface();
-        _asm
-        {
-            mov     ecx, dwThisInterface
-            xor     eax, eax
-            movzx   eax, bSwitchOffEngine
-            push    eax
-            push    iTargetDoor
-            push    dwVehiclePtr
-            call    dwFunc
-        }
+
+        // CTaskSimpleCarSetPedOut::CTaskSimpleCarSetPedOut
+        ((CTaskSAInterface * (__thiscall*)(void*, CEntitySAInterface*, int, bool)) FUNC_CTaskSimpleCarSetPedOut__Constructor)(
+            this->GetInterface(), pTargetVehicleSA->GetInterface(), iTargetDoor, bSwitchOffEngine);
     }
     else
     {
@@ -181,14 +158,11 @@ void CTaskSimpleCarSetPedOutSA::SetNumGettingInToClear(const unsigned char nNumG
 void CTaskSimpleCarSetPedOutSA::PositionPedOutOfCollision(CPed* ped, CVehicle* vehicle, int nDoor)
 {
     DEBUG_TRACE("void CTaskSimpleCarSetPedOutSA::PositionPedOutOfCollision(CPed * ped, CVehicle * vehicle, int nDoor)");
-    DWORD dwFunc = FUNC_CTaskSimpleCarSetPedOut__PositionPedOutOfCollision;
-    DWORD dwVehiclePtr = (DWORD)((CEntitySA*)vehicle)->GetInterface();
-    DWORD dwPedPtr = (DWORD)((CEntitySA*)ped)->GetInterface();
-    _asm
-    {
-        push    nDoor
-        push    dwVehiclePtr
-        push    dwPedPtr
-        call    dwFunc
-    }
+
+    CPedSAInterface*     pPedInterface = dynamic_cast<CPedSA*>(ped)->GetPedInterface();
+    CVehicleSAInterface* pVehicleInterface = dynamic_cast<CVehicleSA*>(vehicle)->GetVehicleInterface();
+
+    // CTaskSimpleCarSetPedOut::PositionPedOutOfCollision
+    ((void(__cdecl*)(CPedSAInterface*, CVehicleSAInterface*, int))FUNC_CTaskSimpleCarSetPedOut__PositionPedOutOfCollision)(pPedInterface, pVehicleInterface,
+                                                                                                                           nDoor);
 }

--- a/Client/game_sa/TaskCarSA.cpp
+++ b/Client/game_sa/TaskCarSA.cpp
@@ -40,16 +40,10 @@ CTaskComplexEnterCarAsDriverSA::CTaskComplexEnterCarAsDriverSA(CVehicle* pTarget
         this->CreateTaskInterface(sizeof(CTaskComplexEnterCarAsDriverSAInterface));
         if (!IsValid())
             return;
-        DWORD dwFunc = FUNC_CTaskComplexEnterCarAsDriver__Constructor;
-        DWORD dwVehiclePtr = (DWORD)pTargetVehicleSA->GetInterface();
-        DWORD dwThisInterface = (DWORD)this->GetInterface();
 
-        _asm
-        {
-            mov     ecx, dwThisInterface
-            push    dwVehiclePtr
-            call    dwFunc
-        }
+        // CTaskComplexEnterCarAsDriver::CTaskComplexEnterCarAsDriver
+        ((CTaskSAInterface * (__thiscall*)(CTaskSAInterface*, CVehicleSAInterface*)) FUNC_CTaskComplexEnterCarAsDriver__Constructor)(
+            GetInterface(), pTargetVehicleSA->GetVehicleInterface());
     }
     else
     {
@@ -74,22 +68,10 @@ CTaskComplexEnterCarAsPassengerSA::CTaskComplexEnterCarAsPassengerSA(CVehicle* p
         this->CreateTaskInterface(sizeof(CTaskComplexEnterCarAsPassengerSAInterface));
         if (!IsValid())
             return;
-        DWORD dwFunc = FUNC_CTaskComplexEnterCarAsPassenger__Constructor;
-        DWORD dwVehiclePtr = (DWORD)pTargetVehicleSA->GetInterface();
-        DWORD dwThisInterface = (DWORD)this->GetInterface();
 
-        _asm
-        {
-            push    edx
-            xor     edx, edx
-            movzx   edx, bCarryOnAfterFallingOff
-            mov     ecx, dwThisInterface
-            push    edx
-            push    iTargetSeat
-            push    dwVehiclePtr
-            call    dwFunc
-            pop     edx
-        }
+        // CTaskComplexEnterCarAsPassenger::CTaskComplexEnterCarAsPassenger
+        ((CTaskSAInterface * (__thiscall*)(CTaskSAInterface*, CVehicleSAInterface*, int, bool)) FUNC_CTaskComplexEnterCarAsPassenger__Constructor)(
+            GetInterface(), pTargetVehicleSA->GetVehicleInterface(), iTargetSeat, bCarryOnAfterFallingOff);
     }
     else
     {
@@ -113,16 +95,10 @@ CTaskComplexEnterBoatAsDriverSA::CTaskComplexEnterBoatAsDriverSA(CVehicle* pTarg
         this->CreateTaskInterface(sizeof(CTaskComplexEnterBoatAsDriverSAInterface));
         if (!IsValid())
             return;
-        DWORD dwFunc = FUNC_CTaskComplexEnterBoatAsDriver__Constructor;
-        DWORD dwVehiclePtr = (DWORD)pTargetVehicleSA->GetInterface();
-        DWORD dwThisInterface = (DWORD)this->GetInterface();
 
-        _asm
-        {
-            mov     ecx, dwThisInterface
-            push    dwVehiclePtr
-            call    dwFunc
-        }
+        // CTaskComplexEnterBoatAsDriver::CTaskComplexEnterBoatAsDriver
+        ((CTaskSAInterface * (__thiscall*)(CTaskSAInterface*, CVehicleSAInterface*)) FUNC_CTaskComplexEnterBoatAsDriver__Constructor)(
+            GetInterface(), pTargetVehicleSA->GetVehicleInterface());
     }
     else
     {
@@ -150,30 +126,16 @@ CTaskComplexLeaveCarSA::CTaskComplexLeaveCarSA(CVehicle* pTargetVehicle, const i
         this->CreateTaskInterface(sizeof(CTaskComplexLeaveCarSAInterface));
         if (!IsValid())
             return;
-        DWORD      dwFunc = FUNC_CTaskComplexLeaveCar__Constructor;
-        DWORD      dwVehiclePtr = (DWORD)pTargetVehicleSA->GetInterface();
-        DWORD      dwThisInterface = (DWORD)this->GetInterface();
+
         DWORD      dwDoorIdx = 0;
         static int s_iCarNodeIndexes[6] = {0x10, 0x11, 0x0A, 0x08, 0x0B, 0x09};
 
         if (iTargetDoor >= 0 && iTargetDoor <= 5)
             dwDoorIdx = s_iCarNodeIndexes[iTargetDoor];
 
-        _asm
-        {
-            mov     ecx, dwThisInterface
-            push    ebx
-            xor     ebx, ebx
-            movzx   ebx, bForceGetOut
-            push    ebx
-            movzx   ebx, bSensibleLeaveCar
-            push    ebx
-            push    iDelayTime
-            push    dwDoorIdx
-            push    dwVehiclePtr
-            call    dwFunc
-            pop     ebx
-        }
+        // CTaskComplexLeaveCar::CTaskComplexLeaveCar
+        ((CTaskSAInterface * (__thiscall*)(CTaskSAInterface*, CVehicleSAInterface*, int, int, bool, bool)) FUNC_CTaskComplexLeaveCar__Constructor)(
+            GetInterface(), pTargetVehicleSA->GetVehicleInterface(), dwDoorIdx, iDelayTime, bSensibleLeaveCar, bForceGetOut);
     }
     else
     {

--- a/Client/game_sa/TaskGoToSA.cpp
+++ b/Client/game_sa/TaskGoToSA.cpp
@@ -22,18 +22,11 @@ int CTaskComplexWanderSA::GetWanderType()
     DEBUG_TRACE("int CTaskComplexWander::GetWanderType()");
     CTaskSAInterface* pTaskInterface = this->GetInterface();
     DWORD             dwFunc = ((TaskComplexWanderVTBL*)pTaskInterface->VTBL)->GetWanderType;
-    int               iReturn = NO_WANDER_TYPE;
 
     if (dwFunc && dwFunc != 0x82263A)            // some tasks have no wander type 0x82263A is purecal (assert?)
-    {
-        _asm
-        {
-            mov     ecx, pTaskInterface
-            call    dwFunc
-            mov     iReturn, eax
-        }
-    }
-    return iReturn;
+        return ((int(__thiscall*)(CTaskSAInterface*))dwFunc)(pTaskInterface);
+
+    return NO_WANDER_TYPE;
 }
 
 CNodeAddress* CTaskComplexWanderSA::GetNextNode()
@@ -57,14 +50,7 @@ CTaskComplexWanderStandardSA::CTaskComplexWanderStandardSA(const int iMoveState,
     this->CreateTaskInterface(sizeof(CTaskComplexWanderStandardSAInterface));
     if (!IsValid())
         return;
-    DWORD dwFunc = FUNC_CTaskComplexWanderStandard__Constructor;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    bWanderSensibly
-        push    iDir
-        push    iMoveState
-        call    dwFunc
-    }
+
+    // CTaskComplexWanderStandard::CTaskComplexWanderStandard
+    ((void(__thiscall*)(CTaskSAInterface*, int, unsigned char, bool))FUNC_CTaskComplexWanderStandard__Constructor)(this->GetInterface(), iMoveState, iDir, bWanderSensibly);
 }

--- a/Client/game_sa/TaskIKSA.cpp
+++ b/Client/game_sa/TaskIKSA.cpp
@@ -16,67 +16,32 @@ extern CGameSA* pGame;
 CTaskSimpleIKChainSA::CTaskSimpleIKChainSA(char* idString, int effectorBoneTag, CVector effectorVec, int pivotBoneTag, CEntity* pEntity, int offsetBoneTag,
                                            CVector offsetPos, float speed, int time, int blendTime)
 {
-    DWORD dwFunc = FUNC_CTaskSimpleIKChain__Constructor;
     // TODO: Find out the real size
     this->CreateTaskInterface(1024);
     if (!IsValid())
         return;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwEntityInterface = 0;
-    if (pEntity)
-        dwEntityInterface = (DWORD)pEntity->GetInterface();
-    float fEffectorX = effectorVec.fX, fEffectorY = effectorVec.fY, fEffectorZ = effectorVec.fZ;
-    float fX = offsetPos.fX, fY = offsetPos.fY, fZ = offsetPos.fZ;
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    blendTime
-        push    time
-        push    speed
-        push    fZ
-        push    fY
-        push    fX
-        push    offsetBoneTag
-        push    dwEntityInterface
-        push    pivotBoneTag
-        push    fEffectorZ
-        push    fEffectorY
-        push    fEffectorX
-        push    effectorBoneTag
-        push    idString
-        call    dwFunc
-    }
+
+    CEntitySAInterface* pEntityInterface = pEntity ? pEntity->GetInterface() : nullptr;
+
+    // CTaskSimpleIKChain::CTaskSimpleIKChain
+    ((void*(__thiscall*)(CTaskSAInterface*, char*, int, CVector, int, CEntitySAInterface*, int, CVector, float, int, int))FUNC_CTaskSimpleIKChain__Constructor)(
+        this->GetInterface(), idString, effectorBoneTag, effectorVec, pivotBoneTag, pEntityInterface, offsetBoneTag, offsetPos, speed, time, blendTime);
 }
 
 CTaskSimpleIKLookAtSA::CTaskSimpleIKLookAtSA(char* idString, CEntity* pEntity, int time, int offsetBoneTag, CVector offsetPos, unsigned char useTorso,
                                              float speed, int blendTime, int m_priority)
 {
-    DWORD dwFunc = FUNC_CTaskSimpleIKLookAt__Constructor;
     // TODO: Find out the real size
     this->CreateTaskInterface(1024);
     if (!IsValid())
         return;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwEntityInterface = 0;
-    if (pEntity)
-        dwEntityInterface = (DWORD)pEntity->GetInterface();
-    float fX = offsetPos.fX, fY = offsetPos.fY, fZ = offsetPos.fZ;
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    m_priority
-        push    blendTime
-        push    speed
-        push    useTorso
-        push    fZ
-        push    fY
-        push    fX
-        push    offsetBoneTag
-        push    time
-        push    dwEntityInterface
-        push    idString
-        call    dwFunc
-    }
+
+    CEntitySAInterface* pEntityInterface = pEntity ? pEntity->GetInterface() : nullptr;
+
+    // CTaskSimpleIKLookAt::CTaskSimpleIKLookAt
+    ((void*(__thiscall*)(CTaskSAInterface*, char*, CEntitySAInterface*, int, int, CVector, unsigned char, float, int,
+                         int))FUNC_CTaskSimpleIKLookAt__Constructor)(this->GetInterface(), idString, pEntityInterface, time, offsetBoneTag, offsetPos, useTorso,
+                                                                     speed, blendTime, m_priority);
 }
 
 CTaskSimpleIKManagerSA::CTaskSimpleIKManagerSA()
@@ -143,29 +108,14 @@ CTaskSimpleIKChain* CTaskSimpleIKManagerSA::GetTaskAtSlot(int slotID)
 CTaskSimpleTriggerLookAtSA::CTaskSimpleTriggerLookAtSA(CEntity* pEntity, int time, int offsetBoneTag, CVector offsetPos, unsigned char useTorso, float speed,
                                                        int blendTime, int priority)
 {
-    DWORD dwFunc = FUNC_CTaskSimpleTriggerLookAt__Constructor;
     // TODO: Find out the real size
     this->CreateTaskInterface(1024);
     if (!IsValid())
         return;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwEntityInterface = 0;
-    if (pEntity)
-        dwEntityInterface = (DWORD)pEntity->GetInterface();
-    float fX = offsetPos.fX, fY = offsetPos.fY, fZ = offsetPos.fZ;
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    priority
-        push    blendTime
-        push    speed
-        push    useTorso
-        push    fZ
-        push    fY
-        push    fX
-        push    offsetBoneTag
-        push    time
-        push    dwEntityInterface
-        call    dwFunc
-    }
+
+    CEntitySAInterface* pEntityInterface = pEntity ? pEntity->GetInterface() : nullptr;
+
+    // CTaskSimpleTriggerLookAt::CTaskSimpleTriggerLookAt
+    ((void*(__thiscall*)(CTaskSAInterface*, CEntitySAInterface*, int, int, CVector, unsigned char, float, int, int))FUNC_CTaskSimpleTriggerLookAt__Constructor)(
+        this->GetInterface(), pEntityInterface, time, offsetBoneTag, offsetPos, useTorso, speed, blendTime, priority);
 }

--- a/Client/game_sa/TaskJumpFallSA.cpp
+++ b/Client/game_sa/TaskJumpFallSA.cpp
@@ -21,20 +21,10 @@ CTaskSimpleClimbSA::CTaskSimpleClimbSA(CEntity* pClimbEnt, const CVector& vecTar
     this->CreateTaskInterface(sizeof(CTaskSimpleClimbSAInterface));
     if (!IsValid())
         return;
-    DWORD dwFunc = FUNC_CTaskSimpleClimb__Constructor;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    bForceClimb
-        push    nHeight
-        push    nSurfaceType
-        push    fHeading
-        push    vecTarget
-        push    pClimbEnt
-        call    dwFunc
-    }
+ 
+    // CTaskSimpleClimb::CTaskSimpleClimb
+    ((CTaskSAInterface*(__thiscall*)(CTaskSAInterface*, CEntity*, const CVector&, float, unsigned char, char, const bool))
+         FUNC_CTaskSimpleClimb__Constructor)(this->GetInterface(), pClimbEnt, vecTarget, fHeading, nSurfaceType, nHeight, bForceClimb);
 }
 
 // ##############################################################################
@@ -48,16 +38,8 @@ CTaskSimpleJetPackSA::CTaskSimpleJetPackSA(const CVector* pVecTargetPos, float f
     this->CreateTaskInterface(sizeof(CTaskSimpleJetPackSAInterface));
     if (!IsValid())
         return;
-    DWORD dwFunc = FUNC_CTaskSimpleJetPack__Constructor;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
 
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    0               // pTargetEnt - ignored for simplicity's sake (we really don't need it)
-        push    nHoverTime
-        push    fCruiseHeight
-        push    pVecTargetPos
-        call    dwFunc
-    }
+    // CTaskSimpleJetPack::CTaskSimpleJetPack
+    ((CTaskSAInterface*(__thiscall*)(CTaskSAInterface*, const CVector*, float, int, CEntitySAInterface*))FUNC_CTaskSimpleJetPack__Constructor)(
+        this->GetInterface(), pVecTargetPos, fCruiseHeight, nHoverTime, nullptr);
 }

--- a/Client/game_sa/TaskPhysicalResponseSA.cpp
+++ b/Client/game_sa/TaskPhysicalResponseSA.cpp
@@ -31,16 +31,10 @@ CTaskSimpleChokingSA::CTaskSimpleChokingSA(CPed* pAttacker, bool bIsTearGas)
     this->CreateTaskInterface(sizeof(CTaskSimpleChokingSAInterface));
     if (!IsValid())
         return;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    ebx
-        push    bIsTearGas
-        push    pAttackerInterface
-        call    dwFunc
-        pop     ebx
-    }
+
+    // CTaskSimpleChoking::CTaskSimpleChoking
+    ((void*(__thiscall*)(void*, CPedSAInterface*, unsigned char))FUNC_CTaskSimpleChoking__Constructor)(
+        this->GetInterface(), pAttackerInterface, bIsTearGas);
 }
 
 CPed* CTaskSimpleChokingSA::GetAttacker()
@@ -91,15 +85,7 @@ void CTaskSimpleChokingSA::UpdateChoke(CPed* pPed, CPed* pAttacker, bool bIsTear
             pAttackerInterface = pAttackerSA->GetPedInterface();
     }
 
-    // Call the func
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    DWORD dwFunc = FUNC_CTaskSimpleChoking__UpdateChoke;
-    _asm
-    {
-        mov         ecx, dwThisInterface
-        push        bIsTearGas
-        push        pAttackerInterface
-        push        pPedInterface
-        call        dwFunc
-    }
+    // CTaskSimpleChoking::UpdateChoke
+    ((void(__thiscall*)(void*, CPedSAInterface*, CPedSAInterface*, unsigned char))FUNC_CTaskSimpleChoking__UpdateChoke)(
+        this->GetInterface(), pPedInterface, pAttackerInterface, bIsTearGas);
 }

--- a/Client/game_sa/TaskSecondarySA.cpp
+++ b/Client/game_sa/TaskSecondarySA.cpp
@@ -22,17 +22,8 @@ CTaskSimpleDuckSA::CTaskSimpleDuckSA(eDuckControlTypes nDuckControl, unsigned sh
     this->CreateTaskInterface(sizeof(CTaskSimpleDuckSAInterface));
     if (!IsValid())
         return;
-    DWORD dwThisInterface = (DWORD)this->GetInterface();
-    _asm
-    {
-        mov     ecx, dwThisInterface
-        push    ebx
-        mov     bx, nUseShotsWhizzingEvents
-        push    ebx
-        mov     bx, nLengthOfDuck
-        push    ebx
-        push    nDuckControl
-        call    dwFunc
-        pop     ebx
-    }
+
+    // CTaskSimpleDuck::CTaskSimpleDuck
+    ((void*(__thiscall*)(void*, eDuckControlTypes, unsigned short, short))FUNC_CTaskSimpleDuck__Constructor)(this->GetInterface(), nDuckControl, nLengthOfDuck,
+                                                                                                             nUseShotsWhizzingEvents);
 }


### PR DESCRIPTION
Removes most of the inline assembly for GameSA.
Only hooks and some function calls that are patched or unused are left.

I looked over all the files. But I may have messed up somewhere and didn't spot it.

Next thing I would like to do is cleaning up all the includes. 
And move all the *SAInterface classes to their own files and remove unused classes like CFont and a bunch of unused methods.

But before I do any of that it would be nice to know if these changes would be merged.