### PR TITLE
Fix #1905: Refresh rate limited at 60Hz in full screen mode

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA_Direct3D.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Direct3D.cpp
@@ -47,6 +47,11 @@ void _cdecl OnPreCreateDevice(IDirect3D9* pDirect3D, UINT Adapter, D3DDEVTYPE De
     ms_BehaviorFlags = *BehaviorFlags;
     ms_pPresentationParameters = pPresentationParameters;
     ms_ppReturnedDeviceInterface = ppReturnedDeviceInterface;
+
+    // Set fullscreen refresh rate to display adapter's value
+    D3DDISPLAYMODE DisplayMode;
+    if (!FAILED(ms_pDirect3D->GetAdapterDisplayMode(Adapter, &DisplayMode)))
+        ms_pPresentationParameters->FullScreen_RefreshRateInHz = DisplayMode.RefreshRate;
 }
 
 // Hook info


### PR DESCRIPTION
Fixes #1905 

Hardcoded places mentioned in [this comment](https://github.com/multitheftauto/mtasa-blue/issues/1905#issuecomment-952182365) by @Dutchman101 are used for failsafe mode (if **CreateDevice** fails) and testing. I don't think we should modify it to use adapter's refresh rate.
> Either way, the places it gets hardcoded:
> 
> 1. https://github.com/multitheftauto/mtasa-blue/blob/c58c3678f263d810f61eb5aecba48e6c4b4dce0c/Client/core/DXHook/CProxyDirect3D9.cpp#L421
> 2. https://github.com/multitheftauto/mtasa-blue/blob/c58c3678f263d810f61eb5aecba48e6c4b4dce0c/Client/core/DXHook/CProxyDirect3D9.cpp#L446