### PR TITLE
setWaterLevel: set water sound level outside of game boundaries

### DIFF
--- a/Client/game_sa/CWaterManagerSA.cpp
+++ b/Client/game_sa/CWaterManagerSA.cpp
@@ -785,6 +785,8 @@ void CWaterManagerSA::SetOutsideWorldWaterLevel(float fLevel)
     MemPut<float>(0x6EFFA6, fLevel);
     // Collision
     MemPut<float>(0x6E873F, fLevel);
+    // Sound
+    MemPut<float>(0x6EA238, fLevel);
 }
 
 float CWaterManagerSA::GetWaveLevel()


### PR DESCRIPTION
Improvement for PR #1402

Fixes water sound level outside of game boundaries (currently it's always 0 even if water level is set to -50).

```
setWaterLevel(-50, true, true, true, true)
```

It modifies hardcoded 0 to water level for ambient water sound check outside of game boundaries:

![image](https://user-images.githubusercontent.com/25417477/178362661-9cb19f1d-e52c-48df-9349-3e426f5d8a58.png)