### PR TITLE
Fix "Climbing over certain objects kills you, when you have high FPS" (#602)

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -589,6 +589,7 @@ CMultiplayerSA::CMultiplayerSA()
     m_bHeatHazeEnabled = true;
     m_bHeatHazeCustomized = false;
     m_fMaddDoggPoolLevel = 1082.73f;
+    m_fOrgTimeStep = 5.0f / 3.0f;
     m_dwLastStaticAnimGroupID = eAnimGroup::ANIM_GROUP_DEFAULT;
     m_dwLastStaticAnimID = eAnimID::ANIM_ID_WALK;
 }
@@ -1550,6 +1551,10 @@ void CMultiplayerSA::InitHooks()
 
     // Skip check for disabled HUD
     MemSet((void*)0x58FBC4, 0x90, 9);
+
+    // Fix "Climbing over certain objects kills you, when you have high FPS" (#602)
+    // By using constant timestep in CTaskSimpleClimb::ProcessPed
+    MemPut(0x6811E9, &m_fOrgTimeStep);
 
     InitHooks_CrashFixHacks();
 

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -315,6 +315,7 @@ private:
     bool                m_bHeatHazeCustomized;
     float               m_fNearClipDistance;
     float               m_fMaddDoggPoolLevel;
+    float               m_fOrgTimeStep;
     eAnimGroup          m_dwLastStaticAnimGroupID;
     eAnimID             m_dwLastStaticAnimID;
     DWORD               m_dwLastAnimArrayAddress;


### PR DESCRIPTION
Fixes #602 by patching `CTaskSimpleClimb::ProcessPed` SA method and making it use constant, original timestep instead.

30 FPS timestep: 1.66
100 FPS timestep: 0.5

```
ped->m_vecMoveSpeed = relPosn / CTimer::ms_fTimeStep;
```

```
Vector3(1, 1, 1) / 1.66 = Vector3(0.602, 0.602, 0.602)
Vector3(1, 1, 1) / 0.5 = Vector3(2, 2, 2)
```

On 100 FPS it basically doubles ped velocity inducing fall damage which eventually kills player.