### PR TITLE
Fix #2510: setVehiclesLODDistance() & setPedsLodDistance() can't override player settings

### DIFF
--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -573,8 +573,8 @@ void CCore::ApplyGameSettings()
     CVARS_GET("tyre_smoke_enabled", bVal);
     m_pMultiplayer->SetTyreSmokeEnabled(bVal);
     pGameSettings->UpdateFieldOfViewFromSettings();
-    pGameSettings->ResetVehiclesLODDistanceFromScript();
-    pGameSettings->ResetPedsLODDistanceFromScript();
+    pGameSettings->ResetVehiclesLODDistance(false, true);
+    pGameSettings->ResetPedsLODDistance(false, true);
     pGameSettings->ResetCoronaReflectionsEnabled();
     pController->SetVerticalAimSensitivityRawValue(CVARS_GET_VALUE<float>("vertical_aim_sensitivity"));
     CVARS_GET("mastervolume", fVal);

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -573,8 +573,8 @@ void CCore::ApplyGameSettings()
     CVARS_GET("tyre_smoke_enabled", bVal);
     m_pMultiplayer->SetTyreSmokeEnabled(bVal);
     pGameSettings->UpdateFieldOfViewFromSettings();
-    pGameSettings->ResetVehiclesLODDistance(false);
-    pGameSettings->ResetPedsLODDistance(false);
+    pGameSettings->ResetVehiclesLODDistanceFromScript();
+    pGameSettings->ResetPedsLODDistanceFromScript();
     pGameSettings->ResetCoronaReflectionsEnabled();
     pController->SetVerticalAimSensitivityRawValue(CVARS_GET_VALUE<float>("vertical_aim_sensitivity"));
     CVARS_GET("mastervolume", fVal);

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -573,8 +573,8 @@ void CCore::ApplyGameSettings()
     CVARS_GET("tyre_smoke_enabled", bVal);
     m_pMultiplayer->SetTyreSmokeEnabled(bVal);
     pGameSettings->UpdateFieldOfViewFromSettings();
-    pGameSettings->ResetVehiclesLODDistance(false, true);
-    pGameSettings->ResetPedsLODDistance(false, true);
+    pGameSettings->ResetVehiclesLODDistance();
+    pGameSettings->ResetPedsLODDistance();
     pGameSettings->ResetCoronaReflectionsEnabled();
     pController->SetVerticalAimSensitivityRawValue(CVARS_GET_VALUE<float>("vertical_aim_sensitivity"));
     CVARS_GET("mastervolume", fVal);

--- a/Client/game_sa/CSettingsSA.cpp
+++ b/Client/game_sa/CSettingsSA.cpp
@@ -563,48 +563,35 @@ void CSettingsSA::SetFieldOfViewVehicleMax(float fAngle, bool bFromScript)
 // Vehicles LOD draw distance
 //
 ////////////////////////////////////////////////
-float ms_fClientMaxVehicleLODDistance = DEFAULT_VEHICLE_LOD_DISTANCE;
-float ms_fClientMaxTrainPlaneLODDistance = DEFAULT_VEHICLE_LOD_DISTANCE * TRAIN_LOD_DISTANCE_MULTIPLIER;
 bool  ms_bMaxVehicleLODDistanceFromScript = false;
 
 void CSettingsSA::SetVehiclesLODDistance(float fVehiclesLODDistance, float fTrainsPlanesLODDistance, bool bFromScript)
 {
-    if (!bFromScript)
-    {
-        ms_fClientMaxVehicleLODDistance = fVehiclesLODDistance;
-        ms_fClientMaxTrainPlaneLODDistance = fTrainsPlanesLODDistance;
-    }
-
     ms_fVehicleLODDistance = fVehiclesLODDistance;
     ms_fTrainPlaneLODDistance = fTrainsPlanesLODDistance;
     ms_bMaxVehicleLODDistanceFromScript = bFromScript;
 }
 
-void CSettingsSA::ResetVehiclesLODDistance(bool bFromScript, bool bFromConfig)
+void CSettingsSA::ResetVehiclesLODDistance(bool bForceDefault)
 {
-    if (!bFromScript || bFromConfig)
+    if (ms_bMaxVehicleLODDistanceFromScript && !bForceDefault)
+        return;
+
+    bool bHighDetailVehicles;
+    g_pCore->GetCVars()->Get("high_detail_vehicles", bHighDetailVehicles);
+
+    if (bHighDetailVehicles)
     {
-        bool bHighDetailVehicles;
-        g_pCore->GetCVars()->Get("high_detail_vehicles", bHighDetailVehicles);
-
-        if (bHighDetailVehicles)
-        {
-            ms_fClientMaxVehicleLODDistance = MAX_VEHICLE_LOD_DISTANCE;
-            ms_fClientMaxTrainPlaneLODDistance = MAX_VEHICLE_LOD_DISTANCE;
-        }
-        else
-        {
-            ms_fClientMaxVehicleLODDistance = DEFAULT_VEHICLE_LOD_DISTANCE;
-            ms_fClientMaxTrainPlaneLODDistance = DEFAULT_VEHICLE_LOD_DISTANCE * TRAIN_LOD_DISTANCE_MULTIPLIER;
-        }
-
-        if (ms_bMaxVehicleLODDistanceFromScript && !bFromConfig)
-            return;
+        ms_fVehicleLODDistance = MAX_VEHICLE_LOD_DISTANCE;
+        ms_fTrainPlaneLODDistance = MAX_VEHICLE_LOD_DISTANCE;
+    }
+    else
+    {
+        ms_fVehicleLODDistance = DEFAULT_VEHICLE_LOD_DISTANCE;
+        ms_fTrainPlaneLODDistance = DEFAULT_VEHICLE_LOD_DISTANCE * TRAIN_LOD_DISTANCE_MULTIPLIER;
     }
 
     ms_bMaxVehicleLODDistanceFromScript = false;
-    ms_fVehicleLODDistance = ms_fClientMaxVehicleLODDistance;
-    ms_fTrainPlaneLODDistance = ms_fClientMaxTrainPlaneLODDistance;
 }
 
 void CSettingsSA::GetVehiclesLODDistance(float& fVehiclesLODDistance, float& fTrainsPlanesLODDistance)
@@ -618,36 +605,28 @@ void CSettingsSA::GetVehiclesLODDistance(float& fVehiclesLODDistance, float& fTr
 // Peds LOD draw distance
 //
 ////////////////////////////////////////////////
-float ms_fClientMaxPedsLODDistance = DEFAULT_PEDS_LOD_DISTANCE;
 bool  ms_bMaxPedsLODDistanceFromScript = false;
 
 void CSettingsSA::SetPedsLODDistance(float fPedsLODDistance, bool bFromScript)
 {
-    if (!bFromScript)
-        ms_fClientMaxPedsLODDistance = fPedsLODDistance;
-
     ms_fPedsLODDistance = fPedsLODDistance;
     ms_bMaxPedsLODDistanceFromScript = bFromScript;
 }
 
-void CSettingsSA::ResetPedsLODDistance(bool bFromScript, bool bFromConfig)
+void CSettingsSA::ResetPedsLODDistance(bool bForceDefault)
 {
-    if (!bFromScript || bFromConfig)
-    {
-        bool bHighDetailPeds;
-        g_pCore->GetCVars()->Get("high_detail_peds", bHighDetailPeds);
+    if (ms_bMaxPedsLODDistanceFromScript && !bForceDefault)
+        return;
 
-        if (bHighDetailPeds)
-            ms_fClientMaxPedsLODDistance = MAX_PEDS_LOD_DISTANCE;
-        else
-            ms_fClientMaxPedsLODDistance = DEFAULT_PEDS_LOD_DISTANCE;
+    bool bHighDetailPeds;
+    g_pCore->GetCVars()->Get("high_detail_peds", bHighDetailPeds);
 
-        if (ms_bMaxPedsLODDistanceFromScript && !bFromConfig)
-            return;
-    }
+    if (bHighDetailPeds)
+        ms_fPedsLODDistance = MAX_PEDS_LOD_DISTANCE;
+    else
+        ms_fPedsLODDistance = DEFAULT_PEDS_LOD_DISTANCE;
 
     ms_bMaxPedsLODDistanceFromScript = false;
-    ms_fPedsLODDistance = ms_fClientMaxPedsLODDistance;
 }
 
 float CSettingsSA::GetPedsLODDistance()

--- a/Client/game_sa/CSettingsSA.cpp
+++ b/Client/game_sa/CSettingsSA.cpp
@@ -580,9 +580,9 @@ void CSettingsSA::SetVehiclesLODDistance(float fVehiclesLODDistance, float fTrai
     ms_bMaxVehicleLODDistanceFromScript = bFromScript;
 }
 
-void CSettingsSA::ResetVehiclesLODDistance(bool bFromScript)
+void CSettingsSA::ResetVehiclesLODDistance(bool bFromScript, bool bFromConfig)
 {
-    if (!bFromScript)
+    if (!bFromScript || bFromConfig)
     {
         bool bHighDetailVehicles;
         g_pCore->GetCVars()->Get("high_detail_vehicles", bHighDetailVehicles);
@@ -598,19 +598,13 @@ void CSettingsSA::ResetVehiclesLODDistance(bool bFromScript)
             ms_fClientMaxTrainPlaneLODDistance = DEFAULT_VEHICLE_LOD_DISTANCE * TRAIN_LOD_DISTANCE_MULTIPLIER;
         }
 
-        if (ms_bMaxVehicleLODDistanceFromScript)
+        if (ms_bMaxVehicleLODDistanceFromScript && !bFromConfig)
             return;
     }
 
     ms_bMaxVehicleLODDistanceFromScript = false;
     ms_fVehicleLODDistance = ms_fClientMaxVehicleLODDistance;
     ms_fTrainPlaneLODDistance = ms_fClientMaxTrainPlaneLODDistance;
-}
-
-void CSettingsSA::ResetVehiclesLODDistanceFromScript()
-{
-    ms_bMaxVehicleLODDistanceFromScript = false;
-    ResetVehiclesLODDistance(false);
 }
 
 void CSettingsSA::GetVehiclesLODDistance(float& fVehiclesLODDistance, float& fTrainsPlanesLODDistance)
@@ -636,9 +630,9 @@ void CSettingsSA::SetPedsLODDistance(float fPedsLODDistance, bool bFromScript)
     ms_bMaxPedsLODDistanceFromScript = bFromScript;
 }
 
-void CSettingsSA::ResetPedsLODDistance(bool bFromScript)
+void CSettingsSA::ResetPedsLODDistance(bool bFromScript, bool bFromConfig)
 {
-    if (!bFromScript)
+    if (!bFromScript || bFromConfig)
     {
         bool bHighDetailPeds;
         g_pCore->GetCVars()->Get("high_detail_peds", bHighDetailPeds);
@@ -648,18 +642,12 @@ void CSettingsSA::ResetPedsLODDistance(bool bFromScript)
         else
             ms_fClientMaxPedsLODDistance = DEFAULT_PEDS_LOD_DISTANCE;
 
-        if (ms_bMaxPedsLODDistanceFromScript)
+        if (ms_bMaxPedsLODDistanceFromScript && !bFromConfig)
             return;
     }
 
     ms_bMaxPedsLODDistanceFromScript = false;
     ms_fPedsLODDistance = ms_fClientMaxPedsLODDistance;
-}
-
-void CSettingsSA::ResetPedsLODDistanceFromScript()
-{
-    ms_bMaxPedsLODDistanceFromScript = false;
-    ResetPedsLODDistance(false);
 }
 
 float CSettingsSA::GetPedsLODDistance()

--- a/Client/game_sa/CSettingsSA.cpp
+++ b/Client/game_sa/CSettingsSA.cpp
@@ -565,34 +565,19 @@ void CSettingsSA::SetFieldOfViewVehicleMax(float fAngle, bool bFromScript)
 ////////////////////////////////////////////////
 float ms_fClientMaxVehicleLODDistance = DEFAULT_VEHICLE_LOD_DISTANCE;
 float ms_fClientMaxTrainPlaneLODDistance = DEFAULT_VEHICLE_LOD_DISTANCE * TRAIN_LOD_DISTANCE_MULTIPLIER;
-float ms_fScriptMaxVehicleLODDistance = ms_fClientMaxVehicleLODDistance;
-float ms_fScriptMaxTrainPlaneLODDistance = ms_fClientMaxTrainPlaneLODDistance;
 bool  ms_bMaxVehicleLODDistanceFromScript = false;
 
 void CSettingsSA::SetVehiclesLODDistance(float fVehiclesLODDistance, float fTrainsPlanesLODDistance, bool bFromScript)
 {
-    if (bFromScript)
-    {
-        ms_fScriptMaxVehicleLODDistance = fVehiclesLODDistance;
-        ms_fScriptMaxTrainPlaneLODDistance = fTrainsPlanesLODDistance;
-        ms_bMaxVehicleLODDistanceFromScript = bFromScript;
-    }
-    else
+    if (!bFromScript)
     {
         ms_fClientMaxVehicleLODDistance = fVehiclesLODDistance;
         ms_fClientMaxTrainPlaneLODDistance = fTrainsPlanesLODDistance;
     }
 
-    if (ms_bMaxVehicleLODDistanceFromScript)
-    {
-        ms_fVehicleLODDistance = Min(ms_fClientMaxVehicleLODDistance, ms_fScriptMaxVehicleLODDistance);
-        ms_fTrainPlaneLODDistance = Min(ms_fClientMaxTrainPlaneLODDistance, ms_fScriptMaxTrainPlaneLODDistance);
-    }
-    else
-    {
-        ms_fVehicleLODDistance = Min(fVehiclesLODDistance, ms_fClientMaxVehicleLODDistance);
-        ms_fTrainPlaneLODDistance = Min(fTrainsPlanesLODDistance, ms_fClientMaxTrainPlaneLODDistance);
-    }
+    ms_fVehicleLODDistance = fVehiclesLODDistance;
+    ms_fTrainPlaneLODDistance = fTrainsPlanesLODDistance;
+    ms_bMaxVehicleLODDistanceFromScript = bFromScript;
 }
 
 void CSettingsSA::ResetVehiclesLODDistance(bool bFromScript)
@@ -613,13 +598,8 @@ void CSettingsSA::ResetVehiclesLODDistance(bool bFromScript)
             ms_fClientMaxTrainPlaneLODDistance = DEFAULT_VEHICLE_LOD_DISTANCE * TRAIN_LOD_DISTANCE_MULTIPLIER;
         }
 
-        // Script still wants to override client setting, let's make sure we use latest max
         if (ms_bMaxVehicleLODDistanceFromScript)
-        {
-            ms_fVehicleLODDistance = Min(ms_fClientMaxVehicleLODDistance, ms_fScriptMaxVehicleLODDistance);
-            ms_fTrainPlaneLODDistance = Min(ms_fClientMaxTrainPlaneLODDistance, ms_fScriptMaxTrainPlaneLODDistance);
             return;
-        }
     }
 
     ms_bMaxVehicleLODDistanceFromScript = false;
@@ -645,23 +625,15 @@ void CSettingsSA::GetVehiclesLODDistance(float& fVehiclesLODDistance, float& fTr
 //
 ////////////////////////////////////////////////
 float ms_fClientMaxPedsLODDistance = DEFAULT_PEDS_LOD_DISTANCE;
-float ms_fScriptMaxPedsLODDistance = ms_fClientMaxPedsLODDistance;
 bool  ms_bMaxPedsLODDistanceFromScript = false;
 
 void CSettingsSA::SetPedsLODDistance(float fPedsLODDistance, bool bFromScript)
 {
-    if (bFromScript)
-    {
-        ms_fScriptMaxPedsLODDistance = fPedsLODDistance;
-        ms_bMaxPedsLODDistanceFromScript = bFromScript;
-    }
-    else
+    if (!bFromScript)
         ms_fClientMaxPedsLODDistance = fPedsLODDistance;
 
-    if (ms_bMaxPedsLODDistanceFromScript)
-        ms_fPedsLODDistance = Min(ms_fClientMaxPedsLODDistance, ms_fScriptMaxPedsLODDistance);
-    else
-        ms_fPedsLODDistance = Min(fPedsLODDistance, ms_fClientMaxPedsLODDistance);
+    ms_fPedsLODDistance = fPedsLODDistance;
+    ms_bMaxPedsLODDistanceFromScript = bFromScript;
 }
 
 void CSettingsSA::ResetPedsLODDistance(bool bFromScript)
@@ -676,12 +648,8 @@ void CSettingsSA::ResetPedsLODDistance(bool bFromScript)
         else
             ms_fClientMaxPedsLODDistance = DEFAULT_PEDS_LOD_DISTANCE;
 
-        // Script still wants to override client setting, let's make sure we use latest max
         if (ms_bMaxPedsLODDistanceFromScript)
-        {
-            ms_fPedsLODDistance = Min(ms_fClientMaxPedsLODDistance, ms_fScriptMaxPedsLODDistance);
             return;
-        }
     }
 
     ms_bMaxPedsLODDistanceFromScript = false;

--- a/Client/game_sa/CSettingsSA.h
+++ b/Client/game_sa/CSettingsSA.h
@@ -160,8 +160,7 @@ public:
     float GetFieldOfViewVehicleMax();
 
     void SetVehiclesLODDistance(float fVehiclesLODDistance, float fTrainsPlanesLODDistance, bool bFromScript);
-    void ResetVehiclesLODDistance(bool bFromScript);
-    void ResetVehiclesLODDistanceFromScript();
+    void ResetVehiclesLODDistance(bool bFromScript, bool bFromConfig = false);
     void GetVehiclesLODDistance(float& fVehiclesLODDistance, float& fTrainsPlanesLODDistance);
 
     void ResetCoronaReflectionsEnabled();
@@ -170,8 +169,7 @@ public:
     void Save();
 
     void  SetPedsLODDistance(float fPedsLODDistance, bool bFromScript);
-    void  ResetPedsLODDistance(bool bFromScript);
-    void  ResetPedsLODDistanceFromScript();
+    void  ResetPedsLODDistance(bool bFromScript, bool bFromConfig = false);
     float GetPedsLODDistance();
 
     static void StaticSetHooks();

--- a/Client/game_sa/CSettingsSA.h
+++ b/Client/game_sa/CSettingsSA.h
@@ -160,7 +160,7 @@ public:
     float GetFieldOfViewVehicleMax();
 
     void SetVehiclesLODDistance(float fVehiclesLODDistance, float fTrainsPlanesLODDistance, bool bFromScript);
-    void ResetVehiclesLODDistance(bool bFromScript, bool bFromConfig = false);
+    void ResetVehiclesLODDistance(bool bForceDefault = false);
     void GetVehiclesLODDistance(float& fVehiclesLODDistance, float& fTrainsPlanesLODDistance);
 
     void ResetCoronaReflectionsEnabled();
@@ -169,7 +169,7 @@ public:
     void Save();
 
     void  SetPedsLODDistance(float fPedsLODDistance, bool bFromScript);
-    void  ResetPedsLODDistance(bool bFromScript, bool bFromConfig = false);
+    void  ResetPedsLODDistance(bool bForceDefault = false);
     float GetPedsLODDistance();
 
     static void StaticSetHooks();

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -5293,10 +5293,10 @@ void CClientGame::ResetMapInfo()
     g_pMultiplayer->RestoreFogDistance();
 
     // Vehicles LOD distance
-    g_pGame->GetSettings()->ResetVehiclesLODDistanceFromScript();
+    g_pGame->GetSettings()->ResetVehiclesLODDistance(true);
 
     // Peds LOD distance
-    g_pGame->GetSettings()->ResetPedsLODDistanceFromScript();
+    g_pGame->GetSettings()->ResetPedsLODDistance(true);
 
     // Corona rain reflections
     g_pGame->GetSettings()->SetCoronaReflectionsControlledByScript(false);

--- a/Client/sdk/game/CSettings.h
+++ b/Client/sdk/game/CSettings.h
@@ -157,11 +157,11 @@ public:
     virtual float GetFieldOfViewVehicleMax() = 0;
 
     virtual void SetVehiclesLODDistance(float fVehiclesLODDistance, float fTrainsPlanesLODDistance, bool bFromScript) = 0;
-    virtual void ResetVehiclesLODDistance(bool bFromScript, bool bFromConfig = false) = 0;
+    virtual void ResetVehiclesLODDistance(bool bForceDefault = false) = 0;
     virtual void GetVehiclesLODDistance(float& fVehiclesLODDistance, float& fTrainsPlanesLODDistance) = 0;
 
     virtual void  SetPedsLODDistance(float fPedsLODDistance, bool bFromScript) = 0;
-    virtual void  ResetPedsLODDistance(bool bFromScript, bool bFromConfig = false) = 0;
+    virtual void  ResetPedsLODDistance(bool bForceDefault = false) = 0;
     virtual float GetPedsLODDistance() = 0;
 
     virtual void ResetCoronaReflectionsEnabled() = 0;

--- a/Client/sdk/game/CSettings.h
+++ b/Client/sdk/game/CSettings.h
@@ -157,13 +157,11 @@ public:
     virtual float GetFieldOfViewVehicleMax() = 0;
 
     virtual void SetVehiclesLODDistance(float fVehiclesLODDistance, float fTrainsPlanesLODDistance, bool bFromScript) = 0;
-    virtual void ResetVehiclesLODDistance(bool bFromScript) = 0;
-    virtual void ResetVehiclesLODDistanceFromScript() = 0;
+    virtual void ResetVehiclesLODDistance(bool bFromScript, bool bFromConfig = false) = 0;
     virtual void GetVehiclesLODDistance(float& fVehiclesLODDistance, float& fTrainsPlanesLODDistance) = 0;
 
     virtual void  SetPedsLODDistance(float fPedsLODDistance, bool bFromScript) = 0;
-    virtual void  ResetPedsLODDistance(bool bFromScript) = 0;
-    virtual void  ResetPedsLODDistanceFromScript() = 0;
+    virtual void  ResetPedsLODDistance(bool bFromScript, bool bFromConfig = false) = 0;
     virtual float GetPedsLODDistance() = 0;
 
     virtual void ResetCoronaReflectionsEnabled() = 0;


### PR DESCRIPTION
Fixes #2510

LOD distances will be restored to player settings on connection or if server calls reset functions.

Now server owners will be able to resolve disbalance issues caused by these checkboxes using appropriate server defined values instead of forcing default small distances for everyone.