### PR TITLE
Add destructor to CAnimBlendAssocGroupSA

### DIFF
--- a/Client/game_sa/CAnimBlendAssocGroupSA.cpp
+++ b/Client/game_sa/CAnimBlendAssocGroupSA.cpp
@@ -18,6 +18,11 @@ CAnimBlendAssocGroupSA::CAnimBlendAssocGroupSA(CAnimBlendAssocGroupSAInterface* 
     SetupAnimBlock();
 }
 
+CAnimBlendAssocGroupSA::~CAnimBlendAssocGroupSA()
+{
+    delete m_pAnimBlock;
+}
+
 CAnimBlendAssociationSAInterface* CAnimBlendAssocGroupSA::CopyAnimation(unsigned int AnimID)
 {
     CAnimBlendAssociationSAInterface* pAnimAssociationReturn = nullptr;

--- a/Client/game_sa/CAnimBlendAssocGroupSA.h
+++ b/Client/game_sa/CAnimBlendAssocGroupSA.h
@@ -54,6 +54,7 @@ class CAnimBlendAssocGroupSA : public CAnimBlendAssocGroup
 
 public:
     CAnimBlendAssocGroupSA(CAnimBlendAssocGroupSAInterface* pInterface);
+    ~CAnimBlendAssocGroupSA();
 
     CAnimBlendAssociationSAInterface* CopyAnimation(unsigned int AnimID);
     void                              InitEmptyAssociations(RpClump* pClump);

--- a/Client/sdk/game/CAnimBlendAssocGroup.h
+++ b/Client/sdk/game/CAnimBlendAssocGroup.h
@@ -179,6 +179,8 @@ enum class eAnimID : int
 class CAnimBlendAssocGroup
 {
 public:
+    virtual ~CAnimBlendAssocGroup() = default;
+
     virtual CAnimBlendAssociationSAInterface* CopyAnimation(unsigned int AnimID) = 0;
     virtual void                              InitEmptyAssociations(RpClump* pClump) = 0;
     virtual bool                              IsCreated() = 0;


### PR DESCRIPTION
Resolves #2672

Here's a [test resource](https://github.com/multitheftauto/mtasa-blue/files/9128490/model.zip) for both of the reproducible scenarios mentioned in that issue. Simply start the resource and use `/mode skin` or `/mode spawn` to switch between different modes/scenarios.

The memory should no longer increase when spawning peds or changing models.

