### PR TITLE
Change max fpslimit to 500

### DIFF
--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -234,7 +234,7 @@ void CClientVariables::ValidateValues()
 
     ClampValue("console_pos", CVector2D(0, 0), CVector2D(uiViewportWidth - 32, uiViewportHeight - 32));
     ClampValue("console_size", CVector2D(50, 50), CVector2D(uiViewportWidth - 32, uiViewportHeight - 32));
-    ClampValue("fps_limit", 0, 100);
+    ClampValue("fps_limit", 0, 500);
     ClampValue("chat_font", 0, 3);
     ClampValue("chat_lines", 3, 62);
     ClampValue("chat_color", CColor(0, 0, 0, 0), CColor(255, 255, 255, 255));

--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -234,7 +234,7 @@ void CClientVariables::ValidateValues()
 
     ClampValue("console_pos", CVector2D(0, 0), CVector2D(uiViewportWidth - 32, uiViewportHeight - 32));
     ClampValue("console_size", CVector2D(50, 50), CVector2D(uiViewportWidth - 32, uiViewportHeight - 32));
-    ClampValue("fps_limit", 0, 500);
+    ClampValue("fps_limit", 0, std::numeric_limits<short>::max());
     ClampValue("chat_font", 0, 3);
     ClampValue("chat_lines", 3, 62);
     ClampValue("chat_color", CColor(0, 0, 0, 0), CColor(255, 255, 255, 255));

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -6817,7 +6817,7 @@ bool CStaticFunctionDefinitions::SetMoonSize(int iSize)
 
 bool CStaticFunctionDefinitions::SetFPSLimit(int iLimit)
 {
-    if (iLimit == 0 || (iLimit >= 25 && iLimit <= 500))
+    if (iLimit == 0 || (iLimit >= 25 && iLimit <= std::numeric_limits<short>::max()))
     {
         g_pCore->SetClientScriptFrameRateLimit(iLimit);
         return true;

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -6817,7 +6817,7 @@ bool CStaticFunctionDefinitions::SetMoonSize(int iSize)
 
 bool CStaticFunctionDefinitions::SetFPSLimit(int iLimit)
 {
-    if (iLimit == 0 || (iLimit >= 25 && iLimit <= 100))
+    if (iLimit == 0 || (iLimit >= 25 && iLimit <= 500))
     {
         g_pCore->SetClientScriptFrameRateLimit(iLimit);
         return true;

--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -349,7 +349,7 @@ bool CMainConfig::Load()
 
     // Grab the server fps limit
     int iFPSTemp = 0;
-    iResult = GetInteger(m_pRootNode, "fpslimit", iFPSTemp, 0, 100);
+    iResult = GetInteger(m_pRootNode, "fpslimit", iFPSTemp, 0, 500);
     if (iResult == IS_SUCCESS)
     {
         if (iFPSTemp == 0 || iFPSTemp >= 25)
@@ -929,7 +929,7 @@ bool CMainConfig::SetPassword(const char* szPassword, bool bSave)
 
 bool CMainConfig::SetFPSLimit(unsigned short usFPS, bool bSave)
 {
-    if (usFPS == 0 || (usFPS >= 25 && usFPS <= 100))
+    if (usFPS == 0 || (usFPS >= 25 && usFPS <= 500))
     {
         m_usFPSLimit = usFPS;
         if (bSave)

--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -349,7 +349,7 @@ bool CMainConfig::Load()
 
     // Grab the server fps limit
     int iFPSTemp = 0;
-    iResult = GetInteger(m_pRootNode, "fpslimit", iFPSTemp, 0, 500);
+    iResult = GetInteger(m_pRootNode, "fpslimit", iFPSTemp, 0, std::numeric_limits<short>::max());
     if (iResult == IS_SUCCESS)
     {
         if (iFPSTemp == 0 || iFPSTemp >= 25)
@@ -929,7 +929,7 @@ bool CMainConfig::SetPassword(const char* szPassword, bool bSave)
 
 bool CMainConfig::SetFPSLimit(unsigned short usFPS, bool bSave)
 {
-    if (usFPS == 0 || (usFPS >= 25 && usFPS <= 500))
+    if (usFPS == 0 || (usFPS >= 25 && usFPS <= std::numeric_limits<short>::max()))
     {
         m_usFPSLimit = usFPS;
         if (bSave)


### PR DESCRIPTION
Makes it easier to spot framerate issues.
Default values are unchanged, and server owners still need to change the limit if they want to let people have higher fps.