### PR TITLE
Update CTimer::m_FrameCounter only every 33+ ms

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -288,8 +288,6 @@ DWORD       RETURN_CTaskSimpleSwim_ProcessSwimmingResistance = 0x68A50E;
 const DWORD HOOKPOS_Idle_CWorld_ProcessPedsAfterPreRender = 0x53EA03;
 const DWORD RETURN_Idle_CWorld_ProcessPedsAfterPreRender = 0x53EA08;
 
-#define HOOKPOS_CHud_RenderHealthBar 0x5892AF
-
 #define HOOKPOS_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StartRadio    0x4D7198
 #define HOOKPOS_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StopRadio     0x4D71E7
 
@@ -534,8 +532,6 @@ void HOOK_CAEVehicleAudioEntity__ProcessDummyProp();
 void HOOK_CTaskSimpleSwim_ProcessSwimmingResistance();
 void HOOK_Idle_CWorld_ProcessPedsAfterPreRender();
 
-void HOOK_CHud_RenderHealthBar();
-
 void HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StartRadio();
 void HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StopRadio();
 
@@ -769,8 +765,6 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_CAnimManager_AddAnimation, (DWORD)HOOK_CAnimManager_AddAnimation, 10);
     HookInstall(HOOKPOS_CAnimManager_AddAnimationAndSync, (DWORD)HOOK_CAnimManager_AddAnimationAndSync, 10);
     HookInstall(HOOKPOS_CAnimManager_BlendAnimation_Hierarchy, (DWORD)HOOK_CAnimManager_BlendAnimation_Hierarchy, 5);
-
-    HookInstall(HOOKPOS_CHud_RenderHealthBar, (DWORD)HOOK_CHud_RenderHealthBar, 9);
 
     HookInstall(HOOKPOS_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StartRadio,
                 (DWORD)HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StartRadio, 5);
@@ -6965,29 +6959,6 @@ void _declspec(naked) HOOK_Idle_CWorld_ProcessPedsAfterPreRender()
        call CWorld_ProcessPedsAfterPreRender
        call PostCWorld_ProcessPedsAfterPreRender
        jmp RETURN_Idle_CWorld_ProcessPedsAfterPreRender
-    }
-}
-
-const DWORD RETURN_CHud_RenderHealthBar = 0x5892B8;
-const DWORD RETURN_CHud_RenderHealthBarNoRender = 0x58939E;
-void _declspec(naked) HOOK_CHud_RenderHealthBar()
-{
-    __asm {
-        //(CTimer::m_snTimeInMilliseconds / 250) % 2
-        mov eax, 0xB7CB84
-        mov eax, [eax]
-        xor edx, edx
-        mov ecx, 250
-        div ecx
-        xor edx, edx
-        mov ecx, 2
-        div ecx
-        test edx, edx
-        jz norender
-        jmp RETURN_CHud_RenderHealthBar
-
-norender:
-        jmp RETURN_CHud_RenderHealthBarNoRender
     }
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
@@ -10,6 +10,9 @@
 
 #include "StdInc.h"
 
+static bool bWouldBeNewFrame = false;
+static unsigned int nLastFrameTime = 0;
+
 constexpr float kOriginalTimeStep = 50.0f / 30.0f;
 
 #define HOOKPOS_CTaskSimpleUseGun__SetMoveAnim 0x61E4F2
@@ -30,7 +33,34 @@ void _declspec(naked) HOOK_CTaskSimpleUseGun__SetMoveAnim()
     }
 }
 
+#define HOOKPOS_CTimer__Update 0x561C5D
+#define HOOKSIZE_CTimer__Update 0xE
+void _declspec(naked) HOOK_CTimer__Update()
+{
+    _asm {
+        add esp, 0x4
+
+        mov bWouldBeNewFrame, 0
+        mov eax, nLastFrameTime
+        add eax, 33                 // 33 = 1000 / 30
+        mov ecx, ds:[0xB7CB84]      // CTimer::m_snTimeInMilliseconds
+        cmp ecx, eax
+        jb skip
+
+        mov bWouldBeNewFrame, 1
+        mov nLastFrameTime, ecx
+        mov eax, ds:[0xB7CB4C]      // CTimer::m_FrameCounter
+        inc eax
+        mov ds:[0xB7CB4C], eax      // CTimer::m_FrameCounter
+
+    skip:
+        add esp, 0xC
+        ret
+    }
+}
+
 void CMultiplayerSA::InitHooks_FrameRateFixes()
 {
     EZHookInstall(CTaskSimpleUseGun__SetMoveAnim);
+    EZHookInstall(CTimer__Update);
 }


### PR DESCRIPTION
Fixes aircraft and boats lights blinking faster on high fps. Probably fixes more stuff that's done with CTimer::m_FrameCounter.
This is also the base for more frame based fixes I will do.

Right now CTimer::m_FrameCounter is incremented every frame. This PR changes this to be updated only if 33ms passed.
That way we have multiple frames with the same frame counter.

Also removes CHud::RenderHealthBar hook as it's not needed anymore with this fix.

https://www.youtube.com/watch?v=DJv-4vKHB3g