### PR TITLE
Add isCapsLockEnabled client function

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaClientDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaClientDefs.cpp
@@ -15,13 +15,16 @@
 
 void CLuaClientDefs::LoadFunctions()
 {
-    constexpr static const std::pair<const char*, lua_CFunction> functions[]{{"setTransferBoxVisible", ArgumentParser<SetTransferBoxVisible>},
-                                                                             {"isTransferBoxVisible", ArgumentParser<IsTransferBoxVisible>},
-                                                                             {"isTransferBoxAlwaysVisible", ArgumentParser<IsTransferBoxAlwaysVisible>},
-                                                                             {"showChat", ArgumentParserWarn<false, ShowChat>},
-                                                                             {"isChatVisible", ArgumentParserWarn<false, IsChatVisible>},
-                                                                             {"isChatInputBlocked", ArgumentParser<IsChatInputBlocked>},
-                                                                             {"clearDebugBox", ArgumentParser<ClearDebug>}};
+    constexpr static const std::pair<const char*, lua_CFunction> functions[]{
+        {"setTransferBoxVisible", ArgumentParser<SetTransferBoxVisible>},
+        {"isTransferBoxVisible", ArgumentParser<IsTransferBoxVisible>},
+        {"isTransferBoxAlwaysVisible", ArgumentParser<IsTransferBoxAlwaysVisible>},
+        {"showChat", ArgumentParserWarn<false, ShowChat>},
+        {"isChatVisible", ArgumentParserWarn<false, IsChatVisible>},
+        {"isChatInputBlocked", ArgumentParser<IsChatInputBlocked>},
+        {"clearDebugBox", ArgumentParser<ClearDebug>},
+        {"isCapsLockEnabled", ArgumentParser<IsCapsLockEnabled>}
+    };
 
     for (const auto& [name, func] : functions)
         CLuaCFunctions::AddFunction(name, func);
@@ -67,4 +70,9 @@ bool CLuaClientDefs::ClearDebug()
 {
     g_pCore->DebugClear();
     return true;
+}
+
+bool CLuaClientDefs::IsCapsLockEnabled()
+{
+    return ((::GetKeyState(VK_CAPITAL) & 0x0001) != 0);
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaClientDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaClientDefs.h
@@ -26,4 +26,5 @@ private:
     static bool IsChatVisible();
     static bool IsChatInputBlocked();
     static bool ClearDebug();
+    static bool IsCapsLockEnabled();
 };


### PR DESCRIPTION
Self explanatory, there's no consistent method to determine whether a client has caps lock enabled (or disabled) currently. 

(you can probably find this out via JavaScript by creating a CEF instance, but that seems unnecessary)

```lua
function checkCaps()
    iprint(isCapsLockEnabled(), getTickCount())
end
addCommandHandler("caps", checkCaps)
```