### PR TITLE
Fix crash when dxCreateTexture higher than 4096 pixels

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -1001,13 +1001,11 @@ int CLuaDrawingDefs::DxCreateTexture(lua_State* luaVM)
         // element dxCreateTexture( int width, int height [, string textureFormat = "argb", string textureEdge = "wrap", string textureType = "2d", int depth ]
         // )
         argStream.ReadNumber(width);
-        //if (width > 4096)
-        //    argStream.SetCustomError("Expected number lower than 4096 at argument 1");
+        if (width > 4096)
+            argStream.SetCustomError("Expected number lower than 4096 at argument 1");
         argStream.ReadNumber(height);
-        /*if (height > 4096)
-            argStream.SetCustomError("Expected number lower than 4096 at argument 2");*/
-
-
+        if (height > 4096)
+            argStream.SetCustomError("Expected number lower than 4096 at argument 2");
         argStream.ReadEnumString(renderFormat, RFORMAT_UNKNOWN);
         argStream.ReadEnumString(textureAddress, TADDRESS_WRAP);
         argStream.ReadEnumString(textureType, TTYPE_TEXTURE);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -1001,7 +1001,13 @@ int CLuaDrawingDefs::DxCreateTexture(lua_State* luaVM)
         // element dxCreateTexture( int width, int height [, string textureFormat = "argb", string textureEdge = "wrap", string textureType = "2d", int depth ]
         // )
         argStream.ReadNumber(width);
+        //if (width > 4096)
+        //    argStream.SetCustomError("Expected number lower than 4096 at argument 1");
         argStream.ReadNumber(height);
+        /*if (height > 4096)
+            argStream.SetCustomError("Expected number lower than 4096 at argument 2");*/
+
+
         argStream.ReadEnumString(renderFormat, RFORMAT_UNKNOWN);
         argStream.ReadEnumString(textureAddress, TADDRESS_WRAP);
         argStream.ReadEnumString(textureType, TTYPE_TEXTURE);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -1002,10 +1002,10 @@ int CLuaDrawingDefs::DxCreateTexture(lua_State* luaVM)
         // )
         argStream.ReadNumber(width);
         if (width > 4096)
-            argStream.SetCustomError("Expected number lower than 4096 at argument 1");
+            argStream.SetCustomError("Expected number <less/greater> than, or equal to 4096 at argument 1");
         argStream.ReadNumber(height);
         if (height > 4096)
-            argStream.SetCustomError("Expected number lower than 4096 at argument 2");
+            argStream.SetCustomError("Expected number <less/greater> than, or equal to 4096 at argument 1");
         argStream.ReadEnumString(renderFormat, RFORMAT_UNKNOWN);
         argStream.ReadEnumString(textureAddress, TADDRESS_WRAP);
         argStream.ReadEnumString(textureType, TTYPE_TEXTURE);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -1002,10 +1002,10 @@ int CLuaDrawingDefs::DxCreateTexture(lua_State* luaVM)
         // )
         argStream.ReadNumber(width);
         if (width > 4096)
-            argStream.SetCustomError("Expected number <less/greater> than, or equal to 4096 at argument 1");
+            argStream.SetCustomError("Expected number less than, or equal to 4096 at argument 1");
         argStream.ReadNumber(height);
         if (height > 4096)
-            argStream.SetCustomError("Expected number <less/greater> than, or equal to 4096 at argument 1");
+            argStream.SetCustomError("Expected number less than, or equal to 4096 at argument 2");
         argStream.ReadEnumString(renderFormat, RFORMAT_UNKNOWN);
         argStream.ReadEnumString(textureAddress, TADDRESS_WRAP);
         argStream.ReadEnumString(textureType, TTYPE_TEXTURE);


### PR DESCRIPTION
Should fix #287 according to
> When it comes to operations with textures MTA is relying on D3D9 API. But the largest texture size is 4096 × 4096 in DX9. Of course you can try to create a bigger texture but it's unsafe and can result in unpredictable consequences.

Test resource
[texture_test.zip](https://github.com/multitheftauto/mtasa-blue/files/9548718/texture_test.zip)
