### PR TITLE
Do not display forbidden programs message on custom builds

### DIFF
--- a/Client/loader/Main.cpp
+++ b/Client/loader/Main.cpp
@@ -81,10 +81,8 @@ MTAEXPORT int DoWinMain(HINSTANCE hLauncherInstance, HINSTANCE hPrevInstance, LP
 
     // Stuff
     HandleCustomStartMessage();
-    #ifndef MTA_DEBUG
-    #if MTASA_VERSION_TYPE != VERSION_TYPE_CUSTOM
+    #if !defined(MTA_DEBUG) && MTASA_VERSION_TYPE != VERSION_TYPE_CUSTOM
     ForbodenProgramsMessage();
-    #endif
     #endif
     CycleEventLog();
     BsodDetectionPreLaunch();

--- a/Client/loader/Main.cpp
+++ b/Client/loader/Main.cpp
@@ -81,8 +81,10 @@ MTAEXPORT int DoWinMain(HINSTANCE hLauncherInstance, HINSTANCE hPrevInstance, LP
 
     // Stuff
     HandleCustomStartMessage();
+    #ifndef MTA_DEBUG
     #if MTASA_VERSION_TYPE != VERSION_TYPE_CUSTOM
     ForbodenProgramsMessage();
+    #endif
     #endif
     CycleEventLog();
     BsodDetectionPreLaunch();

--- a/Client/loader/Main.cpp
+++ b/Client/loader/Main.cpp
@@ -81,7 +81,7 @@ MTAEXPORT int DoWinMain(HINSTANCE hLauncherInstance, HINSTANCE hPrevInstance, LP
 
     // Stuff
     HandleCustomStartMessage();
-    #ifndef MTA_DEBUG
+    #if MTASA_VERSION_TYPE != VERSION_TYPE_CUSTOM
     ForbodenProgramsMessage();
     #endif
     CycleEventLog();


### PR DESCRIPTION
Skips displaying warning message window when forbidden programs are found running on custom build (instead of debug build only). This message can be very annoying during development.

![msg](https://user-images.githubusercontent.com/7338099/190017707-b60597bf-f04c-4c32-ac3e-5ec44b904263.png)
