### PR TITLE
Skip "Are you having problems running MTA" message on custom builds

### DIFF
--- a/Client/loader/MainFunctions.cpp
+++ b/Client/loader/MainFunctions.cpp
@@ -284,12 +284,14 @@ void HandleTrouble()
     if (CheckAndShowFileOpenFailureMessage())
         return;
 
+#if !defined(MTA_DEBUG) && MTASA_VERSION_TYPE != VERSION_TYPE_CUSTOM
     int iResponse = MessageBoxUTF8(NULL, _("Are you having problems running MTA:SA?.\n\nDo you want to revert to an earlier version?"),
                                    "MTA: San Andreas" + _E("CL07"), MB_YESNO | MB_ICONQUESTION | MB_TOPMOST);
     if (iResponse == IDYES)
     {
         BrowseToSolution("crashing-before-gtagame", TERMINATE_PROCESS);
     }
+#endif
 }
 
 //////////////////////////////////////////////////////////


### PR DESCRIPTION
Skips displaying generic "Are you having problems running MTA" message window on debug and custom builds. This message is being displayed during MTA launch after 3 crashes before SA engine launch in a row and can be annoying during development.

![msg2](https://user-images.githubusercontent.com/7338099/190537190-68c11784-8928-4b4f-a7c2-8af73b80a8da.png)
