### PR TITLE
Add dynamic ped shadows

### DIFF
--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -330,6 +330,7 @@ void CClientVariables::LoadDefaults()
     DEFAULT("high_detail_vehicles", 0);                                               // Disable rendering high detail vehicles all the time
     DEFAULT("high_detail_peds", 0);                                                   // Disable rendering high detail peds all the time
     DEFAULT("corona_reflections", 0);                                                 // Disable corona rain reflections
+    DEFAULT("dynamic_ped_shadows", 0);                                                // Disable dynamic ped shadows
     DEFAULT("fast_clothes_loading", 1);                                               // 0-off 1-auto 2-on
     DEFAULT("allow_screen_upload", 1);                                                // 0-off 1-on
     DEFAULT("allow_external_sounds", 1);                                              // 0-off 1-on

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -576,6 +576,8 @@ void CCore::ApplyGameSettings()
     pGameSettings->ResetVehiclesLODDistance();
     pGameSettings->ResetPedsLODDistance();
     pGameSettings->ResetCoronaReflectionsEnabled();
+    CVARS_GET("dynamic_ped_shadows", bVal);
+    pGameSettings->SetDynamicPedShadowsEnabled(bVal);
     pController->SetVerticalAimSensitivityRawValue(CVARS_GET_VALUE<float>("vertical_aim_sensitivity"));
     CVARS_GET("mastervolume", fVal);
     pGameSettings->SetRadioVolume(pGameSettings->GetRadioVolume() * fVal);

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -856,6 +856,10 @@ void CSettings::CreateGUI()
     m_pCheckBoxCoronaReflections->SetPosition(CVector2D(vecTemp.fX + 245.0f, fPosY + 90.0f));
     m_pCheckBoxCoronaReflections->AutoSize(NULL, 20.0f);
 
+    m_pCheckBoxDynamicPedShadows = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabVideo, _("Dynamic ped shadows"), true));
+    m_pCheckBoxDynamicPedShadows->SetPosition(CVector2D(vecTemp.fX + 245.0f, fPosY + 110.0f));
+    m_pCheckBoxDynamicPedShadows->AutoSize(NULL, 20.0f);
+
     vecTemp.fY += 10;
 
     m_pTabs->GetSize(vecTemp);
@@ -1567,6 +1571,14 @@ void CSettings::UpdateVideoTab()
     CVARS_GET("corona_reflections", bCoronaReflections);
     m_pCheckBoxCoronaReflections->SetSelected(bCoronaReflections);
 
+    // Dynamic ped shadows
+    bool bDynamicPedShadows;
+    CVARS_GET("dynamic_ped_shadows", bDynamicPedShadows);
+    m_pCheckBoxDynamicPedShadows->SetSelected(bDynamicPedShadows);
+
+    // Enable dynamic ped shadows checkbox if visual quality option is set to high or very high
+    m_pCheckBoxDynamicPedShadows->SetEnabled(FxQuality >= 2);
+
     PopulateResolutionComboBox();
 
     // Fullscreen style
@@ -1792,6 +1804,7 @@ bool CSettings::OnVideoDefaultClick(CGUIElement* pElement)
     CVARS_SET("high_detail_vehicles", false);
     CVARS_SET("high_detail_peds", false);
     CVARS_SET("corona_reflections", false);
+    CVARS_SET("dynamic_ped_shadows", false);
     gameSettings->UpdateFieldOfViewFromSettings();
     gameSettings->SetDrawDistance(1.19625f);            // All values taken from a default SA install, no gta_sa.set or coreconfig.xml modifications.
     gameSettings->SetBrightness(253);
@@ -1799,6 +1812,7 @@ bool CSettings::OnVideoDefaultClick(CGUIElement* pElement)
     gameSettings->SetAntiAliasing(1, true);
     gameSettings->ResetVehiclesLODDistance(false);
     gameSettings->ResetPedsLODDistance(false);
+    gameSettings->SetDynamicPedShadowsEnabled(false);
 
     // change
     bool bIsVideoModeChanged = GetVideoModeManager()->SetVideoMode(0, false, false, FULLSCREEN_STANDARD);
@@ -3442,6 +3456,11 @@ void CSettings::SaveData()
     CVARS_SET("corona_reflections", bCoronaReflections);
     gameSettings->ResetCoronaReflectionsEnabled();
 
+    // Dynamic ped shadows
+    bool bDynamicPedShadows = m_pCheckBoxDynamicPedShadows->GetSelected();
+    CVARS_SET("dynamic_ped_shadows", bDynamicPedShadows);
+    gameSettings->SetDynamicPedShadowsEnabled(bDynamicPedShadows);
+
     // Fast clothes loading
     if (CGUIListItem* pSelected = m_pFastClothesCombo->GetSelectedItem())
     {
@@ -4373,6 +4392,8 @@ bool CSettings::OnFxQualityChanged(CGUIElement* pElement)
         m_pCheckBoxGrass->SetEnabled(true);
     }
 
+    // Enable dynamic ped shadows checkbox if visual quality option is set to high or very high
+    m_pCheckBoxDynamicPedShadows->SetEnabled((int)pItem->GetData() >= 2);
     return true;
 }
 

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -161,6 +161,7 @@ protected:
     CGUICheckBox*  m_pCheckBoxHighDetailVehicles;
     CGUICheckBox*  m_pCheckBoxHighDetailPeds;
     CGUICheckBox*  m_pCheckBoxCoronaReflections;
+    CGUICheckBox*  m_pCheckBoxDynamicPedShadows;
     CGUILabel*     m_pFieldOfViewLabel;
     CGUIScrollBar* m_pFieldOfView;
     CGUILabel*     m_pFieldOfViewValueLabel;

--- a/Client/core/Graphics/CRenderItemManager.cpp
+++ b/Client/core/Graphics/CRenderItemManager.cpp
@@ -805,6 +805,11 @@ void CRenderItemManager::GetDxStatus(SDxStatus& outStatus)
         outStatus.settings.bGrassEffect = false;
     }
 
+    if (outStatus.settings.iFXQuality < 2)
+    {
+        outStatus.settings.bDynamicPedShadows = false;
+    }
+
     // Display color depth
     D3DFORMAT BackBufferFormat = g_pDeviceState->CreationState.PresentationParameters.BackBufferFormat;
     if (BackBufferFormat >= D3DFMT_R5G6B5 && BackBufferFormat < D3DFMT_A8R3G3B2)

--- a/Client/core/Graphics/CRenderItemManager.cpp
+++ b/Client/core/Graphics/CRenderItemManager.cpp
@@ -783,6 +783,7 @@ void CRenderItemManager::GetDxStatus(SDxStatus& outStatus)
     outStatus.settings.bHighDetailVehicles = false;
     outStatus.settings.bHighDetailPeds = false;
     outStatus.settings.bCoronaReflections = false;
+    outStatus.settings.bDynamicPedShadows = false;
 
     CVARS_GET("streaming_memory", outStatus.settings.iStreamingMemory);
     CVARS_GET("volumetric_shadows", outStatus.settings.bVolumetricShadows);
@@ -795,6 +796,7 @@ void CRenderItemManager::GetDxStatus(SDxStatus& outStatus)
     CVARS_GET("high_detail_vehicles", outStatus.settings.bHighDetailVehicles);
     CVARS_GET("high_detail_peds", outStatus.settings.bHighDetailPeds);
     CVARS_GET("corona_reflections", outStatus.settings.bCoronaReflections);
+    CVARS_GET("dynamic_ped_shadows", outStatus.settings.bDynamicPedShadows);
 
     if (outStatus.settings.iFXQuality == 0)
     {

--- a/Client/game_sa/CSettingsSA.cpp
+++ b/Client/game_sa/CSettingsSA.cpp
@@ -43,6 +43,7 @@ CSettingsSA::CSettingsSA()
     m_pInterface->bFrameLimiter = false;
     m_bVolumetricShadowsEnabled = false;
     m_bVolumetricShadowsSuspended = false;
+    m_bDynamicPedShadowsEnabled = false;
     m_bCoronaReflectionsViaScript = false;
     SetAspectRatio(ASPECT_RATIO_4_3);
     HookInstall(HOOKPOS_GetFxQuality, (DWORD)HOOK_GetFxQuality, 5);
@@ -328,6 +329,16 @@ void CSettingsSA::SetVolumetricShadowsSuspended(bool bSuspended)
     m_bVolumetricShadowsSuspended = bSuspended;
 }
 
+bool CSettingsSA::IsDynamicPedShadowsEnabled()
+{
+    return m_bDynamicPedShadowsEnabled;
+}
+
+void CSettingsSA::SetDynamicPedShadowsEnabled(bool bEnable)
+{
+    m_bDynamicPedShadowsEnabled = bEnable;
+}
+
 //
 // Volumetric shadow hooks
 //
@@ -359,8 +370,7 @@ __declspec(noinline) void _cdecl MaybeAlterFxQualityValue(DWORD dwAddrCalledFrom
         // Handle all calls from CPed::PreRenderAfterTest
         if (dwAddrCalledFrom > 0x5E65A0 && dwAddrCalledFrom < 0x5E7680)
     {
-        // Always use blob shadows for peds as realtime shadows are disabled in MTA (context switching issues)
-        dwFxQualityValue = 0;
+        dwFxQualityValue = pGame->GetSettings()->IsDynamicPedShadowsEnabled() ? 2 : 0;
     }
 }
 

--- a/Client/game_sa/CSettingsSA.h
+++ b/Client/game_sa/CSettingsSA.h
@@ -86,6 +86,7 @@ private:
     CSettingsSAInterface* m_pInterface;
     bool                  m_bVolumetricShadowsEnabled;
     bool                  m_bVolumetricShadowsSuspended;
+    bool                  m_bDynamicPedShadowsEnabled;
     eAspectRatio          m_AspectRatio;
     int                   m_iDesktopWidth;
     int                   m_iDesktopHeight;
@@ -139,6 +140,9 @@ public:
     bool IsVolumetricShadowsEnabled();
     void SetVolumetricShadowsEnabled(bool bEnable);
     void SetVolumetricShadowsSuspended(bool bSuspended);
+
+    bool IsDynamicPedShadowsEnabled();
+    void SetDynamicPedShadowsEnabled(bool bEnable);
 
     float        GetAspectRatioValue();
     eAspectRatio GetAspectRatio();

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -1716,6 +1716,10 @@ int CLuaDrawingDefs::DxGetStatus(lua_State* luaVM)
         lua_pushboolean(luaVM, dxStatus.settings.bCoronaReflections);
         lua_settable(luaVM, -3);
 
+        lua_pushstring(luaVM, "SettingDynamicPedShadows");
+        lua_pushboolean(luaVM, dxStatus.settings.bDynamicPedShadows);
+        lua_settable(luaVM, -3);
+
         lua_pushstring(luaVM, "TotalPhysicalMemory");
         lua_pushnumber(luaVM, static_cast<lua_Number>(SharedUtil::GetWMITotalPhysicalMemory()) / 1024.0 / 1024.0);
         lua_settable(luaVM, -3);

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -28,7 +28,6 @@ unsigned long CMultiplayerSA::HOOKPOS_CStreaming_Update_Caller;
 unsigned long CMultiplayerSA::HOOKPOS_CHud_Draw_Caller;
 unsigned long CMultiplayerSA::HOOKPOS_CRunningScript_Process;
 unsigned long CMultiplayerSA::HOOKPOS_CExplosion_AddExplosion;
-unsigned long CMultiplayerSA::HOOKPOS_CRealTimeShadowManager__ReturnRealTimeShadow;
 unsigned long CMultiplayerSA::HOOKPOS_CCustomRoadsignMgr__RenderRoadsignAtomic;
 unsigned long CMultiplayerSA::HOOKPOS_Trailer_BreakTowLink;
 unsigned long CMultiplayerSA::HOOKPOS_CRadar__DrawRadarGangOverlay;
@@ -392,7 +391,6 @@ void HOOK_CStreaming_Update_Caller();
 void HOOK_CHud_Draw_Caller();
 void HOOK_CRunningScript_Process();
 void HOOK_CExplosion_AddExplosion();
-void HOOK_CRealTimeShadowManager__ReturnRealTimeShadow();
 void HOOK_CCustomRoadsignMgr__RenderRoadsignAtomic();
 void HOOK_Trailer_BreakTowLink();
 void HOOK_CRadar__DrawRadarGangOverlay();
@@ -622,7 +620,6 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_CHud_Draw_Caller, (DWORD)HOOK_CHud_Draw_Caller, 10);
     HookInstall(HOOKPOS_CRunningScript_Process, (DWORD)HOOK_CRunningScript_Process, 6);
     HookInstall(HOOKPOS_CExplosion_AddExplosion, (DWORD)HOOK_CExplosion_AddExplosion, 6);
-    HookInstall(HOOKPOS_CRealTimeShadowManager__ReturnRealTimeShadow, (DWORD)HOOK_CRealTimeShadowManager__ReturnRealTimeShadow, 6);
     HookInstall(HOOKPOS_CCustomRoadsignMgr__RenderRoadsignAtomic, (DWORD)HOOK_CCustomRoadsignMgr__RenderRoadsignAtomic, 6);
     HookInstall(HOOKPOS_Trailer_BreakTowLink, (DWORD)HOOK_Trailer_BreakTowLink, 6);
     HookInstall(HOOKPOS_CRadar__DrawRadarGangOverlay, (DWORD)HOOK_CRadar__DrawRadarGangOverlay, 6);
@@ -1163,13 +1160,6 @@ void CMultiplayerSA::InitHooks()
     // Prevent the game deleting _any_ far away vehicles - will cause issues for population vehicles in the future
     MemPut<BYTE>(0x42CD10, 0xC3);
 
-    // DISABLE real-time shadows for peds
-    MemPut<BYTE>(0x5E68A0, 0xEB);
-
-    // and some more, just to be safe
-    // 00542483   EB 0B            JMP SHORT gta_sa.00542490
-    MemPut<BYTE>(0x542483, 0xEB);
-
     // DISABLE weapon pickups
     MemPut<BYTE>(0x5B47B0, 0xC3);
 
@@ -1183,12 +1173,6 @@ void CMultiplayerSA::InitHooks()
         MemPut < BYTE > ( 0x51D471, 0x10 );
         MemPut < BYTE > ( 0x51D472, 0x00 );
     */
-
-    // HACK to prevent RealTimeShadowManager crash
-    // 00542483     EB 0B          JMP SHORT gta_sa_u.00542490
-    /*
-    MemPut < BYTE > ( 0x542483, 0xEB );
-*/
 
     // InitShotsyncHooks();
 
@@ -1547,6 +1531,26 @@ void CMultiplayerSA::InitHooks()
 
     // Show muzzle flash for last bullet in magazine
     MemSet((void*)0x61ECD2, 0x90, 20);
+
+    // Fix ped real time shadows by processing them always like for a non player ped
+    // Change JZ to JMP instruction in CRealTimeShadowManager::GetRealTimeShadow()
+    MemPut<BYTE>(0x7069F5, 0xEB);
+
+    // Modify CRealTimeShadowManager::GetRealTimeShadow()
+    // Start iterating over shadow array from 0 instead 1 (so we will have max 16 shadows, not 15)
+    // Originally, first shadow from the shadow array is used for player ped only
+    // Array: CRealTimeShadowManager::pShadowData[16]
+    // Array size: 0x40 (16 elements)
+    // Array element size: 0x04
+    MemPut<BYTE>(0x7069FE, 0x08);
+
+    // Fix ped real time shadows do not render on some objects
+    // by skipping some entity flag check in CShadows::CastRealTimeShadowSectorList()
+    MemSet((void*)0x70A83B, 0x90, 6);
+
+    // Fix vehicle blob shadows and light textures do not render on some objects when vehicle is empty
+    // by skipping some entity flag check in CShadows::CastPlayerShadowSectorList()
+    MemSet((void*)0x70A4CB, 0x90, 6);
 
     InitHooks_CrashFixHacks();
 
@@ -2856,19 +2860,6 @@ void _declspec(naked) HOOK_CExplosion_AddExplosion()
         mov     edx, CMultiplayerSA::HOOKPOS_CExplosion_AddExplosion
         add     edx, 6
         jmp     edx
-    }
-}
-
-void _declspec(naked) HOOK_CRealTimeShadowManager__ReturnRealTimeShadow()
-{
-    _asm
-    {
-        cmp     ecx, 0
-        jz      dontclear
-        mov     [ecx+308], 0
-        mov     [eax], 0
-dontclear:
-        retn    4
     }
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -346,7 +346,6 @@ private:
     static unsigned long HOOKPOS_CHud_Draw_Caller;
     static unsigned long HOOKPOS_CRunningScript_Process;
     static unsigned long HOOKPOS_CExplosion_AddExplosion;
-    static unsigned long HOOKPOS_CRealTimeShadowManager__ReturnRealTimeShadow;
     static unsigned long HOOKPOS_CCustomRoadsignMgr__RenderRoadsignAtomic;
     static unsigned long HOOKPOS_Trailer_BreakTowLink;
     static unsigned long HOOKPOS_CRadar__DrawRadarGangOverlay;

--- a/Client/multiplayer_sa/CMultiplayerSA_1.3.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_1.3.cpp
@@ -237,8 +237,6 @@ void CMultiplayerSA::InitMemoryCopies_13()
     // Fixes
     // MemPut < BYTE > ( 0x685AC1, 0xEB );
     // MemPut < BYTE > ( 0x685C2D, 0xEB );
-
-    MemPut<BYTE>(0x0706AB0, 0xC3);            // Skip CRealTimeShadowManager::Update
 }
 
 // Siren Stuff

--- a/Client/multiplayer_sa/COffsets.cpp
+++ b/Client/multiplayer_sa/COffsets.cpp
@@ -36,7 +36,6 @@ void COffsetsMP::Initialize11()
     CMultiplayerSA::HOOKPOS_CHud_Draw_Caller = 0x53E99A;                                        // 1.01
     CMultiplayerSA::HOOKPOS_CRunningScript_Process = 0x469F80;                                  // 1.01
     CMultiplayerSA::HOOKPOS_CExplosion_AddExplosion = 0x737280;                                 // 1.01
-    CMultiplayerSA::HOOKPOS_CRealTimeShadowManager__ReturnRealTimeShadow = 0x70636B;            // 1.01
     CMultiplayerSA::HOOKPOS_CCustomRoadsignMgr__RenderRoadsignAtomic = 0x6FFB8B;                // 1.01
     CMultiplayerSA::HOOKPOS_CTrain_ProcessControl_Derail = 0x6F8DBA;                            // 1.01???? ACHTUNG!
     CMultiplayerSA::FUNC_CStreaming_Update = 0x40E6F0;                                          // 1.01
@@ -59,7 +58,6 @@ void COffsetsMP::InitializeCommon10()
     CMultiplayerSA::HOOKPOS_CHud_Draw_Caller = 0x53E4FA;
     CMultiplayerSA::HOOKPOS_CRunningScript_Process = 0x469F00;
     CMultiplayerSA::HOOKPOS_CExplosion_AddExplosion = 0x736A50;
-    CMultiplayerSA::HOOKPOS_CRealTimeShadowManager__ReturnRealTimeShadow = 0x705B3B;
     CMultiplayerSA::HOOKPOS_CCustomRoadsignMgr__RenderRoadsignAtomic = 0x6FF35B;
     CMultiplayerSA::HOOKPOS_Trailer_BreakTowLink = 0x6E0027;
     CMultiplayerSA::HOOKPOS_CRadar__DrawRadarGangOverlay = 0x586650;

--- a/Client/sdk/core/CRenderItemManagerInterface.h
+++ b/Client/sdk/core/CRenderItemManagerInterface.h
@@ -129,6 +129,7 @@ struct SDxStatus
         bool         bHighDetailVehicles;
         bool         bHighDetailPeds;
         bool         bCoronaReflections;
+        bool         bDynamicPedShadows;
     } settings;
 };
 

--- a/Client/sdk/game/CSettings.h
+++ b/Client/sdk/game/CSettings.h
@@ -136,6 +136,9 @@ public:
     virtual void SetVolumetricShadowsEnabled(bool bEnable) = 0;
     virtual void SetVolumetricShadowsSuspended(bool bSuspended) = 0;
 
+    virtual bool IsDynamicPedShadowsEnabled() = 0;
+    virtual void SetDynamicPedShadowsEnabled(bool bEnable) = 0;
+
     virtual float        GetAspectRatioValue() = 0;
     virtual eAspectRatio GetAspectRatio() = 0;
     virtual void         SetAspectRatio(eAspectRatio aspectRatio, bool bAdjustmentEnabled = true) = 0;


### PR DESCRIPTION
This PR adds dynamic ped shadows feature found originally in single player version of GTA:SA. It can be enabled via new "Dynamic ped shadows" checkbox found in visual settings. This checkbox is enabled only if visual quality option is set to "high" or "very high". It's disabled by default.

In single player, these shadows are enabled for player ped only when quality is set to "high". When quality is set to "very high", these are enabled also for non player peds. I ditched that and this checkbox enables it for all peds. The limit is 16 shadows, after that game starts rendering blob shadows.

These shadows - just like blob shadows - do not render on custom placed objects (see #450).

Value of this option can be retrieved in scripts via `dxGetStatus().SettingDynamicPedShadows`.

In addition, this PR fixes vehicle blob shadows and lights not rendering on some objects when such vehicle is unoccupied (example position: `2463.023, -1713.818, 13.508`). Similar thing was happening to these shadows aswell which is also fixed.

Video: https://youtu.be/7wvIl9jzEE0
