### PR TITLE
Update available range for fpslimit in mtaserver.conf

### DIFF
--- a/Server/mods/deathmatch/mtaserver.conf
+++ b/Server/mods/deathmatch/mtaserver.conf
@@ -188,7 +188,7 @@
     <filter_duplicate_log_lines>1</filter_duplicate_log_lines>
 
     <!-- Specifies the frame rate limit that will be applied to connecting clients.
-         Available range: 25 to 100. Default: 36. -->
+         Available range: 25 to 32767. Default: 36. You can also use 0 for uncapped fps. -->
     <fpslimit>36</fpslimit>
 
     <!-- This parameter specifies whether or not to enable player voice chat in-game


### PR DESCRIPTION
Because of #2682

Should we also change the default fps limit? We don't have that many FPS issues like before.