### PR TITLE
Add getElementLighting()

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -1317,22 +1317,24 @@ std::variant<bool, float> CLuaElementDefs::GetElementLighting(CClientEntity* ent
         case CCLIENTPED:
         case CCLIENTPLAYER:
         {
-            CPlayerPed* Ped = static_cast<CClientPed*>(entity)->GetGamePlayer();
-            if (Ped) return Ped->GetLighting();
+            CPlayerPed* ped = static_cast<CClientPed*>(entity)->GetGamePlayer();
+            if (ped) return ped->GetLighting();
             break;
         }
         case CCLIENTVEHICLE:
         {
-            CVehicle* Vehicle = static_cast<CClientVehicle*>(entity)->GetGameVehicle();
-            if (Vehicle) return Vehicle->GetLighting();
+            CVehicle* vehicle = static_cast<CClientVehicle*>(entity)->GetGameVehicle();
+            if (vehicle) return vehicle->GetLighting();
             break;
         }
         case CCLIENTOBJECT:
         {
-            CObject* Object = static_cast<CClientObject*>(entity)->GetGameObject();
-            if (Object) return Object->GetLighting();
+            CObject* object = static_cast<CClientObject*>(entity)->GetGameObject();
+            if (object) return object->GetLighting();
             break;
         }
+        default:
+            break;
     }
     return false;
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -51,6 +51,7 @@ void CLuaElementDefs::LoadFunctions()
         {"hasElementData", HasElementData},
         {"getElementAttachedOffsets", GetElementAttachedOffsets},
         {"getElementAlpha", GetElementAlpha},
+        {"getElementLighting", ArgumentParser<GetElementLighting>},
         {"isElementOnScreen", IsElementOnScreen},
         {"getElementHealth", GetElementHealth},
         {"getElementModel", GetElementModel},
@@ -156,6 +157,7 @@ void CLuaElementDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getDimension", "getElementDimension");
     lua_classfunction(luaVM, "getColShape", "getElementColShape");
     lua_classfunction(luaVM, "getAlpha", "getElementAlpha");
+    lua_classfunction(luaVM, "getLighting", "getElementLighting");
     lua_classfunction(luaVM, "getHealth", "getElementHealth");
     lua_classfunction(luaVM, "getModel", "getElementModel");
     lua_classfunction(luaVM, "getLowLOD", "getLowLODElement");
@@ -1306,6 +1308,33 @@ int CLuaElementDefs::GetElementAlpha(lua_State* luaVM)
     // Failed
     lua_pushboolean(luaVM, false);
     return 1;
+}
+
+std::variant<bool, float> CLuaElementDefs::GetElementLighting(CClientEntity* entity)
+{
+    switch (entity->GetType())
+    {
+        case CCLIENTPED:
+        case CCLIENTPLAYER:
+        {
+            CPlayerPed* Ped = static_cast<CClientPed*>(entity)->GetGamePlayer();
+            if (Ped) return Ped->GetLighting();
+            break;
+        }
+        case CCLIENTVEHICLE:
+        {
+            CVehicle* Vehicle = static_cast<CClientVehicle*>(entity)->GetGameVehicle();
+            if (Vehicle) return Vehicle->GetLighting();
+            break;
+        }
+        case CCLIENTOBJECT:
+        {
+            CObject* Object = static_cast<CClientObject*>(entity)->GetGameObject();
+            if (Object) return Object->GetLighting();
+            break;
+        }
+    }
+    return false;
 }
 
 int CLuaElementDefs::GetElementHealth(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
@@ -53,6 +53,7 @@ public:
     LUA_DECLARE(IsElementLocal);
     LUA_DECLARE(GetElementAttachedOffsets);
     LUA_DECLARE(GetElementAlpha);
+    static std::variant<bool, float> GetElementLighting(CClientEntity* entity);
     LUA_DECLARE(IsElementOnScreen);
     LUA_DECLARE(GetElementHealth);
     LUA_DECLARE(IsElementStreamedIn);


### PR DESCRIPTION
Adds lua interface to `GetLighting()` for peds / players, vehicles and objects.

Test resource: [elight.zip](https://github.com/multitheftauto/mtasa-blue/files/9748117/elight.zip)

It's more efficient and accurate than [processLineOfSight](https://wiki.multitheftauto.com/wiki/ProcessLineOfSight) (for this particular purpose).

Example of what it could be used for:

![e-lighting-tests01](https://user-images.githubusercontent.com/25417477/194929377-10016be1-8690-4562-abef-41d86f5e7ed0.png)

There is also `SetLighting()`. It works for peds if called every frame. Not sure if we need it tho. But could be added.