### PR TITLE
Fix typo in CCommandFuncs::FakeLag

### DIFF
--- a/Client/core/CCommandFuncs.cpp
+++ b/Client/core/CCommandFuncs.cpp
@@ -465,7 +465,7 @@ void CCommandFuncs::FakeLag(const char* szCmdLine)
 {
     if (!CCore::GetSingleton().IsFakeLagCommandEnabled())
     {
-        g_pCore->GetConsole()->Print("fakelag command no enabled");
+        g_pCore->GetConsole()->Print("fakelag command not enabled");
         return;
     }
 


### PR DESCRIPTION
no > **not**