### PR TITLE
Disable rendering ped dynamic shadows when they sit on bikes if vehicle volumetric shadows are disabled

### DIFF
--- a/Client/game_sa/CSettingsSA.cpp
+++ b/Client/game_sa/CSettingsSA.cpp
@@ -331,6 +331,10 @@ bool CSettingsSA::IsVolumetricShadowsEnabled()
 void CSettingsSA::SetVolumetricShadowsEnabled(bool bEnable)
 {
     m_bVolumetricShadowsEnabled = bEnable;
+
+    // Disable rendering ped real time shadows when they sit on bikes
+    // if vehicle volumetric shadows are disabled because it looks a bit weird
+    MemPut<BYTE>(0x5E682A + 1, bEnable);
 }
 
 void CSettingsSA::SetVolumetricShadowsSuspended(bool bSuspended)


### PR DESCRIPTION
Disables rendering ped dynamic shadows when they sit on bikes if vehicle volumetric shadows are disabled. Resolves #2799.