### PR TITLE
Add CRemoteCall userdata class name 'helper'

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
@@ -873,6 +873,8 @@ SString GetUserDataClassName(void* ptr, lua_State* luaVM, bool bFindElementType)
         return GetClassTypeName(pVar);
     if (auto* pVar = UserDataCast((CLuaVector4D*)ptr, luaVM))
         return GetClassTypeName(pVar);
+    if (auto* pVar = UserDataCast((CRemoteCall*)ptr, luaVM))
+        return GetClassTypeName(pVar);
 
     return "";
 }

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
@@ -231,7 +231,7 @@ inline SString GetClassTypeName(CClientPed*)
 }
 inline SString GetClassTypeName(CRemoteCall*)
 {
-    return "remotecall";
+    return "request";
 }
 inline SString GetClassTypeName(CClientProjectile*)
 {

--- a/Server/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
@@ -519,6 +519,8 @@ SString GetUserDataClassName(void* ptr, lua_State* luaVM, bool bFindElementType)
         return GetClassTypeName(pVar);
     if (auto* pVar = UserDataCast((CLuaMatrix*)ptr, luaVM))
         return GetClassTypeName(pVar);
+    if (auto* pVar = UserDataCast((CRemoteCall*)ptr, luaVM))
+        return GetClassTypeName(pVar);
 
     return "";
 }

--- a/Server/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
@@ -172,7 +172,7 @@ inline SString GetClassTypeName(CPed*)
 }
 inline SString GetClassTypeName(class CRemoteCall*)
 {
-    return "remotecall";
+    return "request";
 }
 inline SString GetClassTypeName(CColShape*)
 {


### PR DESCRIPTION
Resolves #2807

```lua
function testRequest()
    local request = fetchRemote("google.com", function() end)
    iprint(getUserdataType(request))
end
addCommandHandler("req", testRequest)
```

Should print `request` on both server and client (renamed from `remotecall`, which was never used anyway, to match the [wiki description](https://wiki.multitheftauto.com/wiki/FetchRemote) of the object returned by fetchRemote)

**Post-merge actions:**

- [x] Add `request` to shared section of [getUserdataType wiki page](https://wiki.multitheftauto.com/wiki/GetUserdataType)