### PR TITLE
Hotfix for #2831(revert conditional variable)

### DIFF
--- a/Client/cefweb/CWebView.cpp
+++ b/Client/cefweb/CWebView.cpp
@@ -41,8 +41,11 @@ CWebView::~CWebView()
             g_pCore->GetWebCore()->SetFocusedWebView(nullptr);
     }
 
+    // Make sure we don't dead lock the CEF render thread
+    ResumeCefThread();
+
     // Ensure that CefRefPtr::~CefRefPtr doesn't try to release it twice (it has already been released in CWebView::OnBeforeClose)
-    m_pWebView = nullptr;
+    m_pWebView = nullptr;    
 
     OutputDebugLine("CWebView::~CWebView");
 }
@@ -76,6 +79,9 @@ void CWebView::CloseBrowser()
 {
     // CefBrowserHost::CloseBrowser calls the destructor after the browser has been destroyed
     m_bBeingDestroyed = true;
+
+    // Make sure we don't dead lock the CEF render thread
+    ResumeCefThread();
 
     if (m_pWebView)
         m_pWebView->GetHost()->CloseBrowser(true);
@@ -200,7 +206,7 @@ void CWebView::UpdateTexture()
 
     auto pSurface = m_pWebBrowserRenderItem->m_pD3DRenderTargetSurface;
     if (m_bBeingDestroyed || !pSurface)
-        return;
+        m_RenderData.changed = m_RenderData.popupShown = false;
 
     // Discard current buffer if size doesn't match
     // This happens when resizing the browser as OnPaint is called asynchronously
@@ -281,6 +287,9 @@ void CWebView::UpdateTexture()
             pSurface->UnlockRect();
         }
     }
+
+    m_RenderData.cefThreadState = ECefThreadState::Running;
+    m_RenderData.cefThreadCv.notify_all();
 }
 
 void CWebView::ExecuteJavascript(const SString& strJavascriptCode)
@@ -447,6 +456,8 @@ void CWebView::Resize(const CVector2D& size)
     // Send resize event to CEF
     if (m_pWebView)
         m_pWebView->GetHost()->WasResized();
+
+    ResumeCefThread();
 }
 
 CVector2D CWebView::GetSize()
@@ -709,6 +720,10 @@ void CWebView::OnPaint(CefRefPtr<CefBrowser> browser, CefRenderHandler::PaintEle
     m_RenderData.height = height;
     m_RenderData.dirtyRects = dirtyRects;
     m_RenderData.changed = true;
+
+    // Wait for the main thread to handle drawing the texture
+    m_RenderData.cefThreadState = ECefThreadState::Wait;    
+    m_RenderData.cefThreadCv.wait(lock, [&](){ return m_RenderData.cefThreadState == ECefThreadState::Running; });
 }
 
 ////////////////////////////////////////////////////////////////////
@@ -1068,4 +1083,15 @@ void CWebView::OnBeforeContextMenu(CefRefPtr<CefBrowser> browser, CefRefPtr<CefF
 {
     // Show no context menu
     model->Clear();
+}
+
+void CWebView::ResumeCefThread()
+{
+    {
+        // It's recommended to unlock a mutex before the cv notifying to avoid a possible pessimization
+        std::unique_lock<std::mutex> lock(m_RenderData.dataMutex);
+        m_RenderData.cefThreadState = ECefThreadState::Running;
+    }
+
+    m_RenderData.cefThreadCv.notify_all();
 }

--- a/Client/cefweb/CWebView.h
+++ b/Client/cefweb/CWebView.h
@@ -30,6 +30,12 @@
 
 #define MTA_CEF_USERAGENT "Multi Theft Auto: San Andreas Client " MTA_DM_BUILDTAG_LONG
 
+enum class ECefThreadState
+{
+    Running = 0, // CEF thread is currently running
+    Wait // CEF thread is waiting for the main thread
+};
+
 class CWebView : public CWebViewInterface,
                  private CefClient,
                  private CefRenderHandler,
@@ -173,6 +179,8 @@ public:
                                      CefRefPtr<CefMenuModel> model) override;
 
 private:
+    void ResumeCefThread();
+
     CefRefPtr<CefBrowser> m_pWebView;
     CWebBrowserItem*      m_pWebBrowserRenderItem;
 
@@ -192,6 +200,8 @@ private:
     {
         bool                    changed = false;
         std::mutex              dataMutex;
+        ECefThreadState         cefThreadState = ECefThreadState::Running;
+        std::condition_variable cefThreadCv;
 
         const void*                buffer;
         int                        width, height;


### PR DESCRIPTION
As it turned out I overlooked the actual sense of a conditional variable in PR #2831. This CV is intended to protect a memory buffer that CEF is passing to CWebView::OnPaint from the premature removal. It should be noted that it the previous implementation a CV was suffering from spurious wakeups (they have not been taken into account). This PR adds the CV again and handles the spurious wakeups problem.