### PR TITLE
Update available range for fpslimit in all server configuration files

### DIFF
--- a/Server/mods/deathmatch/editor.conf
+++ b/Server/mods/deathmatch/editor.conf
@@ -188,7 +188,7 @@
     <filter_duplicate_log_lines>1</filter_duplicate_log_lines>
 
     <!-- Specifies the frame rate limit that will be applied to connecting clients.
-         Available range: 25 to 100. Default: 50. -->
+         Available range: 25 to 32767. Default: 50. You can also use 0 for uncapped fps. -->
     <fpslimit>50</fpslimit>
 
     <!-- This parameter specifies whether or not to enable player voice chat in-game

--- a/Server/mods/deathmatch/local.conf
+++ b/Server/mods/deathmatch/local.conf
@@ -188,7 +188,7 @@
     <filter_duplicate_log_lines>1</filter_duplicate_log_lines>
 
     <!-- Specifies the frame rate limit that will be applied to connecting clients.
-         Available range: 25 to 100. Default: 36. -->
+         Available range: 25 to 32767. Default: 36. You can also use 0 for uncapped fps. -->
     <fpslimit>36</fpslimit>
 
     <!-- This parameter specifies whether or not to enable player voice chat in-game

--- a/Server/mods/deathmatch/mtaserver.conf.template
+++ b/Server/mods/deathmatch/mtaserver.conf.template
@@ -190,7 +190,7 @@ R"=====(
     <filter_duplicate_log_lines>1</filter_duplicate_log_lines>
 
     <!-- Specifies the frame rate limit that will be applied to connecting clients.
-         Available range: 25 to 100. Default: 36. -->
+         Available range: 25 to 32767. Default: 36. You can also use 0 for uncapped fps. -->
     <fpslimit>36</fpslimit>
 
     <!-- This parameter specifies whether or not to enable player voice chat in-game


### PR DESCRIPTION
The changes in PR #2751 only changed the comment in the mtaserver.conf file, but this comment is also present in other files. This PR fixes that.