### PR TITLE
Possible crash fix for libcef(0x3705563)

### DIFF
--- a/Client/cefweb/CWebApp.cpp
+++ b/Client/cefweb/CWebApp.cpp
@@ -32,6 +32,9 @@ void CWebApp::OnBeforeCommandLineProcessing(const CefString& process_type, CefRe
     // command_line->AppendSwitch("disable-d3d11");
     command_line->AppendSwitch("enable-begin-frame-scheduling");
 
+    // browser-signin switch(or lack thereof) produces crashes when GOOGLE API keys are present in the OS registry
+    command_line->AppendSwitchWithValue("allow-browser-signin", "false");
+
     if (process_type.empty())
     {
         command_line->AppendSwitchWithValue("autoplay-policy", "no-user-gesture-required");


### PR DESCRIPTION
After some research and having access to some player's dumps I've found the source of crashes within libcef.dll(at 0x3705563). These crashes appear when GOOGLE API keys are registered in OS. You can reproduce the crash by specifying a value for system registry keys GOOGLE_API_KEY, GOOGLE_DEFAULT_CLIENT_ID and GOOGLE_DEFAULT_CLIENT_SECRET. For some reason key signin.allowed_on_next_startup is not registered in the chromium preferences and chrome is trying to dereference a null pointer. I tried different ways to add signin.allowed_on_next_startup into preferences but failed at everything. The only way I found to bypass this is using CEF command line to override allow-browser-signin switch. It works for me, but comprehensive tests required.