### PR TITLE
Allow unload model with custom col

### DIFF
--- a/Client/game_sa/CModelInfoSA.h
+++ b/Client/game_sa/CModelInfoSA.h
@@ -307,7 +307,6 @@ protected:
     static std::map<CTimeInfoSAInterface*, CTimeInfoSAInterface*>                ms_ModelDefaultModelTimeInfo;
     static std::unordered_map<DWORD, unsigned short>                             ms_OriginalObjectPropertiesGroups;
     static std::unordered_map<DWORD, std::pair<float, float>>                    ms_VehicleModelDefaultWheelSizes;
-    bool                                                                         m_bAddedRefForCollision;
     SVehicleSupportedUpgrades                                                    m_ModelSupportedUpgrades;
 
 public:


### PR DESCRIPTION
This code removes old behavior from 2f0c101640acaa56675c6b490155b679079e9dd5. So engineRestremWorld can reload models with custom collisions.
This change makes #1677 a little bit stable for objects.