### PR TITLE
Set `MTASA_VERSION_TYPE` back to `VERSION_TYPE_CUSTOM`

### DIFF
--- a/Shared/sdk/version.h
+++ b/Shared/sdk/version.h
@@ -27,7 +27,7 @@
 #define MTASA_VERSION_MAJOR         1
 #define MTASA_VERSION_MINOR         5
 #define MTASA_VERSION_MAINTENANCE   9
-#define MTASA_VERSION_TYPE          VERSION_TYPE_UNSTABLE
+#define MTASA_VERSION_TYPE          VERSION_TYPE_CUSTOM
 #define MTASA_VERSION_BUILD         0
 
 #include "../build_overrides.h"


### PR DESCRIPTION
Sets `MTASA_VERSION_TYPE` back to `VERSION_TYPE_CUSTOM`. It was changed in 19831ae4b19e7279575ae23ed9df720e1d695ff5. According to documentation `VERSION_TYPE_UNSTABLE` is meant for MTA forks. But by default we develop MTA, not MTA forks, right? Currently freshly built MTA server asks user to change version number which may be confusing for development.