### PR TITLE
Remove my name from credits

### DIFF
--- a/Client/core/CCredits.cpp
+++ b/Client/core/CCredits.cpp
@@ -124,7 +124,6 @@ CCredits::CCredits()
         "Philip \"Fenix\" Farquharson\n"
         "Seweryn \"Neproify\" Figura\n"
         "Alejandro \"AlexTMjugador\" González\n"
-        "Adrian \"AGraber\" Graber\n"
         "Kevin \"ciber96\" Gross\n"
         "Robin \"robhol\" Holm\n"
         "Bob \"NanoBob\" van Hooff\n"


### PR DESCRIPTION
Hi, this PR removes my name from the credits, as I apparently have "ill intent towards MTA", despite [numerous contributions towards the amx module](https://github.com/multitheftauto/amx/commits?author=AGraber), (hence my name in the credits). I intended to continue work on today after such a long time, but after connecting for a few times I found out I can no longer connect to even my localhost server. Working on AMX was motivated by my own desire to migrate over to MTA, but I guess I have to give up that idea now.

![image](https://user-images.githubusercontent.com/18301034/218894368-342552b8-d90a-4296-9c42-2314707dcb80.png)

I would love to try to appeal, etc.. but there's no longer an appeal process, and this ban seems to be permanent, so there's not really much I can do. So I don't really see the point in being credited on a project that I tried to improve.

Thanks.