### PR TITLE
Update acl.xml: add resource.ip2c to RPC group

### DIFF
--- a/Server/mods/deathmatch/acl.xml
+++ b/Server/mods/deathmatch/acl.xml
@@ -33,6 +33,7 @@
    </group>
    <group name="RPC">
       <acl name="RPC" />
+      <object name="resource.ip2c" />
    </group>
    <group name="MapEditor">
       <acl name="Default" />


### PR DESCRIPTION
As discussed in [mtasa-resources/pull/414](https://github.com/multitheftauto/mtasa-resources/pull/414), ip2c is a new default resource which is activated by default and needs to make use of `fetchRemote`.

This PR adds `resource.ip2c` to `acl.xml`'s RPC group which satisfies this need.