### PR TITLE
Tweak Readme header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Multi Theft Auto: San Andreas
+# Multi Theft Auto
 
 [![Build Status](https://github.com/multitheftauto/mtasa-blue/workflows/Build/badge.svg?event=push&branch=master)](https://github.com/multitheftauto/mtasa-blue/actions?query=branch%3Amaster+event%3Apush) [![Unique servers online](https://img.shields.io/endpoint?url=https%3A%2F%2Fmultitheftauto.com%2Fapi%2Fservers-shields.io.json)](https://community.multitheftauto.com/index.php?p=servers) [![Unique players online](https://img.shields.io/endpoint?url=https%3A%2F%2Fmultitheftauto.com%2Fapi%2Fplayers-shields.io.json)](https://multitheftauto.com) [![Unique players last 24 hours](https://img.shields.io/endpoint?url=https%3A%2F%2Fmultitheftauto.com%2Fapi%2Funique-players-shields.io.json)](https://multitheftauto.com) [![Discord](https://img.shields.io/discord/278474088903606273?label=discord&logo=discord)](https://discord.com/invite/mtasa) [![Crowdin](https://badges.crowdin.net/e/f5dba7b9aa6594139af737c85d81d3aa/localized.svg)](https://multitheftauto.crowdin.com/multitheftauto)
 


### PR DESCRIPTION
Drops `San Andreas` from project header in Readme and enlarges it. `Multi Theft Auto` alone branding looks better in my opinion. This PR is up to discussion (and is super freaky minor change but why not). MTA in many places doesn't use `San Andreas` anymore (home page and main menu for example has big centered `Multi Theft Auto` text).