### PR TITLE
Fix #2932 (Fix CEF hardware acceleration not working)

### DIFF
--- a/Client/cefweb/CWebApp.cpp
+++ b/Client/cefweb/CWebApp.cpp
@@ -28,7 +28,10 @@ void CWebApp::OnRegisterCustomSchemes(CefRawPtr<CefSchemeRegistrar> registrar)
 void CWebApp::OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefCommandLine> command_line)
 {
     command_line->AppendSwitch("disable-gpu-compositing");
-    command_line->AppendSwitch("disable-gpu");
+    
+    // "disable-gpu" disables hardware acceleration and then WebGL is not working
+    // command_line->AppendSwitch("disable-gpu");
+     
     // command_line->AppendSwitch("disable-d3d11");
     command_line->AppendSwitch("enable-begin-frame-scheduling");
 

--- a/Client/cefweb/CWebApp.cpp
+++ b/Client/cefweb/CWebApp.cpp
@@ -28,10 +28,6 @@ void CWebApp::OnRegisterCustomSchemes(CefRawPtr<CefSchemeRegistrar> registrar)
 void CWebApp::OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefCommandLine> command_line)
 {
     command_line->AppendSwitch("disable-gpu-compositing");
-    
-    // "disable-gpu" disables hardware acceleration and then WebGL is not working
-    // command_line->AppendSwitch("disable-gpu");
-     
     // command_line->AppendSwitch("disable-d3d11");
     command_line->AppendSwitch("enable-begin-frame-scheduling");
 

--- a/Client/cefweb/CWebApp.cpp
+++ b/Client/cefweb/CWebApp.cpp
@@ -27,7 +27,6 @@ void CWebApp::OnRegisterCustomSchemes(CefRawPtr<CefSchemeRegistrar> registrar)
 
 void CWebApp::OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefCommandLine> command_line)
 {
-    command_line->AppendSwitch("disable-gpu-compositing");
     // command_line->AppendSwitch("disable-d3d11");
     command_line->AppendSwitch("enable-begin-frame-scheduling");
 


### PR DESCRIPTION
Fixes #2932 and fixes WebGL not working.

Current MTA:
https://youtu.be/Mca4FgfQqMo

Fixed:
https://youtu.be/tepQ-iWNKIM

No issues found, browser works as smooth as it was before this fix (but WebGL is now working)
