### PR TITLE
Fix collision streaming regression from #1714

### DIFF
--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -1511,6 +1511,7 @@ void CModelInfoSA::SetColModel(CColModel* pColModel)
 
         // SetColModel sets bDoWeOwnTheColModel if the last parameter is truthy
         m_pInterface->bDoWeOwnTheColModel = false;
+        m_pInterface->bIsColLoaded = false;
 
         // Fix random foliage on custom collisions by calling CPlantMgr::SetPlantFriendlyFlagInAtomicMI
         (reinterpret_cast<void(__cdecl*)(CBaseModelInfoSAInterface*)>(0x5DB650))(m_pInterface);


### PR DESCRIPTION
Fixed regression caused by #1714 

Restored original behavior for flag `bIsColLoaded` for 'SetColModel`

Test resource:
[collision_test_resource.zip](https://github.com/multitheftauto/mtasa-blue/files/11184009/collision_test_resource.zip)

