### PR TITLE
Fix #2774: Prevent kick during redirect

### DIFF
--- a/Server/mods/deathmatch/logic/CPlayer.h
+++ b/Server/mods/deathmatch/logic/CPlayer.h
@@ -262,6 +262,9 @@ public:
     void SetLeavingServer(bool bLeaving) noexcept { m_bIsLeavingServer = bLeaving; }
     bool IsLeavingServer() const noexcept { return m_bIsLeavingServer; }
 
+    void SetRedirecting(bool bRedirecting) noexcept { m_bIsRedirecting = bRedirecting; }
+    bool IsRedirecting() const noexcept { return m_bIsRedirecting; }
+
 protected:
     bool ReadSpecialData(const int iLine) override { return true; }
 
@@ -359,6 +362,7 @@ private:
     CMtaVersion    m_strPlayerVersion;
     bool           m_bIsMuted;
     bool           m_bIsLeavingServer;
+    bool           m_bIsRedirecting;
     bool           m_bIsJoined;
 
     bool m_bNametagColorOverridden;

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -3462,6 +3462,7 @@ bool CStaticFunctionDefinitions::RedirectPlayer(CElement* pElement, const char* 
             BitStream.pBitStream->Write(ucPasswordLength);
             BitStream.pBitStream->Write(szPassword, ucPasswordLength);
         }
+        pPlayer->SetRedirecting(true);
         pPlayer->Send(CLuaPacket(FORCE_RECONNECT, *BitStream.pBitStream));
 
         usPort = usPort ? usPort : g_pGame->GetConfig()->GetServerPort();

--- a/Server/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
@@ -1929,6 +1929,12 @@ int CLuaPlayerDefs::KickPlayer(lua_State* luaVM)
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pPlayer);
 
+    if (pPlayer->IsRedirecting())
+    {
+        lua_pushboolean(luaVM, false);
+        return 1;
+    }
+
     if (argStream.NextIsUserData())
     {
         CClient* pResponsible;


### PR DESCRIPTION
Prevents the function "kickPlayer" from kicking a player being redirected to another server.

Here is a test code:

```Lua
local plr = getRandomPlayer()
redirectPlayer(plr, "10.0.0.8", 22003)
local result = kickPlayer(plr)

print(result)
```

Result:
![image](https://user-images.githubusercontent.com/9326932/230849127-4c02cefa-14d6-4966-a7c6-5f714d536dc1.png)

After conducting a 5-hour long investigation reading through MTA's code (🙄), I realized my last pull request (#2902) actually caused a catastrophe. It left the net module thinking that the player is still in the server and caused a loop of "dead connection" errors on the console while they're being redirected using `directPlayer`. In my defense, I warned that it is untested on discord.

I fixed the issue by adding a flag variable in the `CPlayer` class that tells whether the player is being redirected or not.