### PR TITLE
Addendum to 1c00ef9b - fix crash happening on debug builds

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -7120,11 +7120,18 @@ void _declspec(naked) HOOK_CCollision__CheckCameraCollisionObjects()
         jz      out2
         movsx   edx, word ptr [esi+22h]
 
+        // Store all registers
+        pushad
+
         // Do our stuff
         push    esi // pEntity
         call    CanEntityCollideWithCamera
         add     esp, 4
         test    al, al
+
+        // Restore registers
+        popad
+
         jnz     out1
         jmp     RETURN_CCollision__CheckCameraCollisionObjects_2
 


### PR DESCRIPTION
Fixes crash happening on debug builds introduced in 1c00ef9b13dae5b8b23abcb94b236790252ecd42 (#2746).