### PR TITLE
Remove unused CClientVehicle variables

### DIFF
--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -94,7 +94,6 @@ CClientVehicle::CClientVehicle(CClientManager* pManager, ElementID ID, unsigned 
     m_Matrix.vFront.fY = 1.0f;
     m_Matrix.vUp.fZ = 1.0f;
     m_Matrix.vRight.fX = 1.0f;
-    m_MatrixLast = m_Matrix;
     m_dLastRotationTime = 0;
     m_fHealth = DEFAULT_VEHICLE_HEALTH;
     m_fTurretHorizontal = 0.0f;
@@ -528,7 +527,6 @@ bool CClientVehicle::SetMatrix(const CMatrix& Matrix)
 
     m_Matrix = Matrix;
     m_matFrozen = Matrix;
-    m_MatrixPure = Matrix;
 
     // If we have any occupants, update their positions
     // Make sure we dont update their position if they are getting out and have physically left the car
@@ -556,18 +554,6 @@ void CClientVehicle::GetMoveSpeed(CVector& vecMoveSpeed) const
         {
             vecMoveSpeed = m_vecMoveSpeed;
         }
-    }
-}
-
-void CClientVehicle::GetMoveSpeedMeters(CVector& vecMoveSpeed) const
-{
-    if (m_bIsFrozen)
-    {
-        vecMoveSpeed = CVector(0, 0, 0);
-    }
-    else
-    {
-        vecMoveSpeed = m_vecMoveSpeedMeters;
     }
 }
 
@@ -2188,13 +2174,6 @@ void CClientVehicle::StreamedInPulse()
                 m_pVehicle->SetUsesCollision(false);
             }
         }
-
-        // Calculate the velocity
-        CMatrix MatrixCurrent;
-        m_pVehicle->GetMatrix(&MatrixCurrent);
-        m_vecMoveSpeedMeters = (MatrixCurrent.vPos - m_MatrixLast.vPos) * g_pGame->GetFPS();
-        // Store the current matrix
-        m_MatrixLast = MatrixCurrent;
 
         // We dont interpolate attached trailers
         if (m_pTowedByVehicle)
@@ -4279,7 +4258,6 @@ void CClientVehicle::HandleWaitingForGroundToLoad()
     m_pVehicle->SetMatrix(&m_matFrozen);
     m_pVehicle->SetMoveSpeed(&vecTemp);
     m_pVehicle->SetTurnSpeed(&vecTemp);
-    m_vecMoveSpeedMeters = vecTemp;
     m_vecMoveSpeed = vecTemp;
     m_vecTurnSpeed = vecTemp;
 

--- a/Client/mods/deathmatch/logic/CClientVehicle.h
+++ b/Client/mods/deathmatch/logic/CClientVehicle.h
@@ -187,7 +187,6 @@ public:
     virtual CSphere GetWorldBoundingSphere();
 
     void GetMoveSpeed(CVector& vecMoveSpeed) const;
-    void GetMoveSpeedMeters(CVector& vecMoveSpeed) const;
     void SetMoveSpeed(const CVector& vecMoveSpeed);
     void GetTurnSpeed(CVector& vecTurnSpeed) const;
     void SetTurnSpeed(const CVector& vecTurnSpeed);
@@ -572,10 +571,6 @@ protected:
     CClientVehiclePtr            m_pPreviousLink;
     CClientVehiclePtr            m_pNextLink;
     CMatrix                      m_Matrix;
-    CMatrix                      m_MatrixLast;
-    CMatrix                      m_MatrixPure;
-    CVector                      m_vecMoveSpeedInterpolate;
-    CVector                      m_vecMoveSpeedMeters;
     CVector                      m_vecMoveSpeed;
     CVector                      m_vecTurnSpeed;
     float                        m_fHealth;


### PR DESCRIPTION
Removes unused CClientVehicle member variables that obviously do nothing but spending memory(120 bytes) and CPU time by calculating a wrong speed.