### PR TITLE
Fix #1166: Allow getCursorPosition if console or chat input is open

### DIFF
--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -4973,7 +4973,7 @@ bool CStaticFunctionDefinitions::FadeCamera(bool bFadeIn, float fFadeTime, unsig
 
 bool CStaticFunctionDefinitions::GetCursorPosition(CVector2D& vecCursor, CVector& vecWorld)
 {
-    if (m_pClientGame->AreCursorEventsEnabled() || GUIGetInputEnabled())
+    if (m_pClientGame->AreCursorEventsEnabled() || GUIGetInputEnabled() || g_pCore->GetConsole()->IsVisible() || g_pCore->IsChatInputEnabled())
     {
         tagPOINT point;
         GetCursorPos(&point);


### PR DESCRIPTION
Fixes #1166

Allows getCursorPosition to return the cursor position if console or chat input is open. Previously it returned false.