### PR TITLE
Remove some strange undocumented logic from `Client/core/CCommandFuncs.cpp`

### DIFF
--- a/Client/core/CCommandFuncs.cpp
+++ b/Client/core/CCommandFuncs.cpp
@@ -21,12 +21,6 @@ extern bool   g_bBoundsChecker;
 void CCommandFuncs::Help(const char* szParameters)
 {
     CConsoleInterface* pConsole = g_pCore->GetConsole();
-
-    if (szParameters && atoi(szParameters) == 1)
-        CCore::GetSingleton().GetMultiplayer()->AllowWindowsCursorShowing(true);
-    else
-        CCore::GetSingleton().GetMultiplayer()->AllowWindowsCursorShowing(false);
-
     pConsole->Print(_("***[ COMMAND HELP ]***\n"));
 
     // Loop through all the available commands
@@ -47,10 +41,6 @@ void CCommandFuncs::Exit(const char* szParameters)
 
 void CCommandFuncs::Ver(const char* szParameters)
 {
-    ShowCursor(TRUE);
-    HCURSOR hc = LoadCursor(NULL, IDC_ARROW);
-    SetCursor(hc);
-
     // Compose version string
     unsigned short usNetRev = CCore::GetSingleton().GetNetwork()->GetNetRev();
     unsigned short usNetRel = CCore::GetSingleton().GetNetwork()->GetNetRel();


### PR DESCRIPTION
Removes some strange undocumented cursor-related logic from `Client/core/CCommandFuncs.cpp`.