### PR TITLE
Fix #3015: ignore empty string in executeBrowserJavascript

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.cpp
@@ -459,7 +459,7 @@ int CLuaBrowserDefs::ExecuteBrowserJavascript(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        if (pWebBrowser->ExecuteJavascript(strJavascriptCode))
+        if (strJavascriptCode.empty() || pWebBrowser->ExecuteJavascript(strJavascriptCode))
         {
             lua_pushboolean(luaVM, true);
             return 1;


### PR DESCRIPTION
Fixes #3015 