### PR TITLE
Fix #418: addCommandHandler: Returning False for Existing Built-in Commands

### DIFF
--- a/Client/mods/deathmatch/logic/CRegisteredCommands.cpp
+++ b/Client/mods/deathmatch/logic/CRegisteredCommands.cpp
@@ -27,6 +27,9 @@ bool CRegisteredCommands::AddCommand(CLuaMain* pLuaMain, const char* szKey, cons
     assert(pLuaMain);
     assert(szKey);
 
+    if (g_pCore->GetCommands()->Get(szKey))
+        return false;
+
     // Check if we already have this key and handler
     SCommand* pCommand = GetCommand(szKey, pLuaMain);
     if (pCommand)

--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -660,6 +660,8 @@ bool CMainConfig::LoadExtended()
         }
     } while (pNode);
 
+    RegisterCommands();
+
     // Handle the <resource> nodes
     pNode = NULL;
     uiCurrentIndex = 0;
@@ -749,7 +751,11 @@ bool CMainConfig::LoadExtended()
 
     CLogger::ProgressDotsEnd();
     CLogger::SetMinLogLevel(LOGLEVEL_LOW);
+    return true;
+}
 
+void CMainConfig::RegisterCommands()
+{
     // Register the commands
     RegisterCommand("start", CConsoleCommands::StartResource, false, "Usage: start <resource-name>\nStart a loaded resource eg: start admin");
     RegisterCommand("stop", CConsoleCommands::StopResource, false, "Usage: stop <resource-name>\nStop a resource eg: stop admin");
@@ -819,7 +825,6 @@ bool CMainConfig::LoadExtended()
     RegisterCommand("sfakelag", CConsoleCommands::FakeLag, false,
                     "Usage: sfakelag <packet loss> <extra ping> <ping variance> [<KBPS limit>]\nOnly available if enabled in the mtaserver.conf file.\nAdds "
                     "artificial packet loss, ping, jitter and bandwidth limits to the server-client connections.");
-    return true;
 }
 
 bool CMainConfig::Save()

--- a/Server/mods/deathmatch/logic/CMainConfig.h
+++ b/Server/mods/deathmatch/logic/CMainConfig.h
@@ -47,6 +47,7 @@ public:
 
     bool Load();
     bool LoadExtended();
+    void RegisterCommands();
     bool Save();
 
     const std::string& GetServerName() { return m_strServerName; };

--- a/Server/mods/deathmatch/logic/CRegisteredCommands.cpp
+++ b/Server/mods/deathmatch/logic/CRegisteredCommands.cpp
@@ -18,6 +18,7 @@
 #include "CClient.h"
 #include "CConsoleClient.h"
 #include "CPlayer.h"
+#include "CGame.h"
 
 CRegisteredCommands::CRegisteredCommands(CAccessControlListManager* pACLManager)
 {
@@ -34,6 +35,9 @@ bool CRegisteredCommands::AddCommand(CLuaMain* pLuaMain, const char* szKey, cons
 {
     assert(pLuaMain);
     assert(szKey);
+
+    if (g_pGame->GetConsole()->GetCommand(szKey))
+        return false;
 
     // Check if we already have this key and handler
     SCommand* pCommand = GetCommand(szKey, pLuaMain);


### PR DESCRIPTION
Fixes #418
```lua
iprint(addCommandHandler("help", function()end)) -- false
iprint(addCommandHandler("asd", function()end)) -- true
```

+ fix tiny bug where server console commands are added after resource starts what would make "help" command in example above to return true for first time