### PR TITLE
Raise default fps limit to 74

### DIFF
--- a/Server/mods/deathmatch/editor.conf
+++ b/Server/mods/deathmatch/editor.conf
@@ -190,8 +190,8 @@
     <filter_duplicate_log_lines>1</filter_duplicate_log_lines>
 
     <!-- Specifies the frame rate limit that will be applied to connecting clients.
-         Available range: 25 to 32767. Default: 60. You can also use 0 for uncapped fps. -->
-    <fpslimit>60</fpslimit>
+         Available range: 25 to 32767. Default: 74. You can also use 0 for uncapped fps. -->
+    <fpslimit>74</fpslimit>
 
     <!-- This parameter specifies whether or not to enable player voice chat in-game
          Values: 0 - disabled , 1 - enabled -->

--- a/Server/mods/deathmatch/local.conf
+++ b/Server/mods/deathmatch/local.conf
@@ -190,8 +190,8 @@
     <filter_duplicate_log_lines>1</filter_duplicate_log_lines>
 
     <!-- Specifies the frame rate limit that will be applied to connecting clients.
-         Available range: 25 to 32767. Default: 60. You can also use 0 for uncapped fps. -->
-    <fpslimit>60</fpslimit>
+         Available range: 25 to 32767. Default: 74. You can also use 0 for uncapped fps. -->
+    <fpslimit>74</fpslimit>
 
     <!-- This parameter specifies whether or not to enable player voice chat in-game
          Values: 0 - disabled , 1 - enabled -->

--- a/Server/mods/deathmatch/mtaserver.conf
+++ b/Server/mods/deathmatch/mtaserver.conf
@@ -190,8 +190,8 @@
     <filter_duplicate_log_lines>1</filter_duplicate_log_lines>
 
     <!-- Specifies the frame rate limit that will be applied to connecting clients.
-         Available range: 25 to 32767. Default: 60. You can also use 0 for uncapped fps. -->
-    <fpslimit>60</fpslimit>
+         Available range: 25 to 32767. Default: 74. You can also use 0 for uncapped fps. -->
+    <fpslimit>74</fpslimit>
 
     <!-- This parameter specifies whether or not to enable player voice chat in-game
          Values: 0 - disabled , 1 - enabled -->


### PR DESCRIPTION
I propose to use FPS limit of 74 over 60 (as added in b9f5c64), because 74 is the FPS with consensus that it avoids the majority of framerate-related GTA bugs just as well as other high values (lower than 74) do.

Despite that PR #2979 didn't have to mention it to go through, there has been plenty of discussion about the safe FPS (74..) in development discord over the past 3 years, besides that some of this knownledge and testing results made its way to being documented at [https://wiki.multitheftauto.com/wiki/SetFPSLimit](https://wiki.multitheftauto.com/wiki/SetFPSLimit) under "Issues when increasing FPS". An fps of 74 was called the breaking point after which GTA bugs really begin to appear, long before notable framerate bugfixes were made by contributors such as Merlin, so in reality the safe limit is definately beyond 74 (To be exact, it was the point after which "Aiming while moving sideways" bug first appeared, but it's since been [fixed](https://github.com/multitheftauto/mtasa-blue/commit/e64d311f62de2bd848c07b59f4f53a30826c1bed)). Although someone who has time for testing post-framerate fixes can determine a new base limit that gets labeled as the highest safe value, let's be moderate and go to 74 for now.

TL;DR - The jump from 60 to 74 FPS has no additional impact when it comes to framerate related bugs, but it does give that final push of smoothness that improves gameplay experience, this is a jump that your eyes can still perceive in SA.

Opinions differ a lot, some people believe that every increase in FPS worsens effects of higher framerates on things like vehicle physics for racing, but consider this proposal in the light that the leap from previous value (36) to 60 already did what those people complained about, and that my point is: it would've been better if the merged PR had initially settled on 74. It's key to realize this, as well as ` .. The jump from 60 to 74 FPS has no additional impact .. ` and put things into perspective like this, to avoid having a battle of opinions. We are to use higher FPS by default in MTA 1.6, and that already commits the 'evil' those people see, but it's very proportional as tiny effects they seem to perceive on racing physics vs. offering the best possible configuration out of the box, i.e visual smoothness and game experience. If racing server owners think that these higher FPS limits cause issues, they can always customize the value.