### PR TITLE
Entity cleanup

### DIFF
--- a/Client/mods/deathmatch/logic/CClientEntity.h
+++ b/Client/mods/deathmatch/logic/CClientEntity.h
@@ -339,7 +339,6 @@ protected:
     CCustomData* m_pCustomData;
 
     ElementID m_ID;
-    CVector   m_vecRelativePosition;
 
     unsigned short m_usDimension;
 

--- a/Client/mods/deathmatch/logic/CClientEntity.h
+++ b/Client/mods/deathmatch/logic/CClientEntity.h
@@ -342,8 +342,6 @@ protected:
 
     unsigned short m_usDimension;
 
-    unsigned int m_uiLine;
-
 private:
     unsigned int m_uiTypeHash;
     SString      m_strTypeName;


### PR DESCRIPTION
Removes unused **CClientEntity** variables **m_vecRelativePosition** and **m_uiLine**.
