### PR TITLE
Render cursor in current frame

### DIFF
--- a/Client/gui/CGUI_Impl.cpp
+++ b/Client/gui/CGUI_Impl.cpp
@@ -232,7 +232,13 @@ void CGUI_Impl::Restore()
 
 void CGUI_Impl::DrawMouseCursor()
 {
+    // Disable render queueing in order to render cursor in current frame
+    GetRenderer()->setQueueingEnabled(false);
+
     CEGUI::MouseCursor::getSingleton().draw();
+
+    // Enable render queueing back
+    GetRenderer()->setQueueingEnabled(true);
 }
 
 void CGUI_Impl::ProcessMouseInput(CGUIMouseInput eMouseInput, unsigned long ulX, unsigned long ulY, CGUIMouseButton eMouseButton)


### PR DESCRIPTION
Currently mouse cursor seems to be queued for render in the next frame. This change disables render queueing for the mouse cursor thus it renders in the current frame now.

https://github.com/multitheftauto/mtasa-blue/blob/76d350ba29d3416c8af21dc21c270664ea66f33b/Client/core/DXHook/CDirect3DEvents9.cpp#L163-L174