### PR TITLE
Fix #2963: Add support for double click events in CEF

### DIFF
--- a/Client/cefweb/CWebView.cpp
+++ b/Client/cefweb/CWebView.cpp
@@ -343,7 +343,7 @@ void CWebView::InjectMouseMove(int iPosX, int iPosY)
     m_vecMousePosition.y = iPosY;
 }
 
-void CWebView::InjectMouseDown(eWebBrowserMouseButton mouseButton)
+void CWebView::InjectMouseDown(eWebBrowserMouseButton mouseButton, int count)
 {
     if (!m_pWebView)
         return;
@@ -355,7 +355,7 @@ void CWebView::InjectMouseDown(eWebBrowserMouseButton mouseButton)
     // Save mouse button states
     m_mouseButtonStates[static_cast<int>(mouseButton)] = true;
 
-    m_pWebView->GetHost()->SendMouseClickEvent(mouseEvent, static_cast<CefBrowserHost::MouseButtonType>(mouseButton), false, 1);
+    m_pWebView->GetHost()->SendMouseClickEvent(mouseEvent, static_cast<CefBrowserHost::MouseButtonType>(mouseButton), false, count);
 }
 
 void CWebView::InjectMouseUp(eWebBrowserMouseButton mouseButton)

--- a/Client/cefweb/CWebView.h
+++ b/Client/cefweb/CWebView.h
@@ -80,7 +80,7 @@ public:
     bool GetProperty(const SString& strKey, SString& outProperty);
 
     void InjectMouseMove(int iPosX, int iPosY);
-    void InjectMouseDown(eWebBrowserMouseButton mouseButton);
+    void InjectMouseDown(eWebBrowserMouseButton mouseButton, int count = 1);
     void InjectMouseUp(eWebBrowserMouseButton mouseButton);
     void InjectMouseWheel(int iScrollVert, int iScrollHorz);
     void InjectKeyboardEvent(const CefKeyEvent& keyEvent);

--- a/Client/cefweb/CWebView.h
+++ b/Client/cefweb/CWebView.h
@@ -80,7 +80,7 @@ public:
     bool GetProperty(const SString& strKey, SString& outProperty);
 
     void InjectMouseMove(int iPosX, int iPosY);
-    void InjectMouseDown(eWebBrowserMouseButton mouseButton, int count = 1);
+    void InjectMouseDown(eWebBrowserMouseButton mouseButton, int count);
     void InjectMouseUp(eWebBrowserMouseButton mouseButton);
     void InjectMouseWheel(int iScrollVert, int iScrollHorz);
     void InjectKeyboardEvent(const CefKeyEvent& keyEvent);

--- a/Client/gui/CGUIWebBrowser_Impl.cpp
+++ b/Client/gui/CGUIWebBrowser_Impl.cpp
@@ -39,6 +39,7 @@ CGUIWebBrowser_Impl::CGUIWebBrowser_Impl(CGUI_Impl* pGUI, CGUIElement* pParent)
     // Apply browser events
     m_pWindow->subscribeEvent(CEGUI::Window::EventMouseButtonDown, CEGUI::Event::Subscriber(&CGUIWebBrowser_Impl::Event_MouseButtonDown, this));
     m_pWindow->subscribeEvent(CEGUI::Window::EventMouseButtonUp, CEGUI::Event::Subscriber(&CGUIWebBrowser_Impl::Event_MouseButtonUp, this));
+    m_pWindow->subscribeEvent(CEGUI::Window::EventMouseDoubleClick, CEGUI::Event::Subscriber(&CGUIWebBrowser_Impl::Event_MouseDoubleClick, this));
     m_pWindow->subscribeEvent(CEGUI::Window::EventMouseMove, CEGUI::Event::Subscriber(&CGUIWebBrowser_Impl::Event_MouseMove, this));
     m_pWindow->subscribeEvent(CEGUI::Window::EventMouseWheel, CEGUI::Event::Subscriber(&CGUIWebBrowser_Impl::Event_MouseWheel, this));
     m_pWindow->subscribeEvent(CEGUI::Window::EventActivated, CEGUI::Event::Subscriber(&CGUIWebBrowser_Impl::Event_Activated, this));
@@ -177,6 +178,20 @@ bool CGUIWebBrowser_Impl::Event_MouseButtonUp(const CEGUI::EventArgs& e)
         m_pWebView->InjectMouseUp(eWebBrowserMouseButton::BROWSER_MOUSEBUTTON_MIDDLE);
     else if (args.button == CEGUI::MouseButton::RightButton)
         m_pWebView->InjectMouseUp(eWebBrowserMouseButton::BROWSER_MOUSEBUTTON_RIGHT);
+
+    return true;
+}
+
+bool CGUIWebBrowser_Impl::Event_MouseDoubleClick(const CEGUI::EventArgs& e)
+{
+    const CEGUI::MouseEventArgs& args = reinterpret_cast<const CEGUI::MouseEventArgs&>(e);
+
+    if (args.button == CEGUI::MouseButton::LeftButton)
+        m_pWebView->InjectMouseDown(eWebBrowserMouseButton::BROWSER_MOUSEBUTTON_LEFT, 2);
+    else if (args.button == CEGUI::MouseButton::MiddleButton)
+        m_pWebView->InjectMouseDown(eWebBrowserMouseButton::BROWSER_MOUSEBUTTON_MIDDLE, 2);
+    else if (args.button == CEGUI::MouseButton::RightButton)
+        m_pWebView->InjectMouseDown(eWebBrowserMouseButton::BROWSER_MOUSEBUTTON_RIGHT, 2);
 
     return true;
 }

--- a/Client/gui/CGUIWebBrowser_Impl.cpp
+++ b/Client/gui/CGUIWebBrowser_Impl.cpp
@@ -159,11 +159,11 @@ bool CGUIWebBrowser_Impl::Event_MouseButtonDown(const CEGUI::EventArgs& e)
     const CEGUI::MouseEventArgs& args = reinterpret_cast<const CEGUI::MouseEventArgs&>(e);
 
     if (args.button == CEGUI::MouseButton::LeftButton)
-        m_pWebView->InjectMouseDown(eWebBrowserMouseButton::BROWSER_MOUSEBUTTON_LEFT);
+        m_pWebView->InjectMouseDown(eWebBrowserMouseButton::BROWSER_MOUSEBUTTON_LEFT, 1);
     else if (args.button == CEGUI::MouseButton::MiddleButton)
-        m_pWebView->InjectMouseDown(eWebBrowserMouseButton::BROWSER_MOUSEBUTTON_MIDDLE);
+        m_pWebView->InjectMouseDown(eWebBrowserMouseButton::BROWSER_MOUSEBUTTON_MIDDLE, 1);
     else if (args.button == CEGUI::MouseButton::RightButton)
-        m_pWebView->InjectMouseDown(eWebBrowserMouseButton::BROWSER_MOUSEBUTTON_RIGHT);
+        m_pWebView->InjectMouseDown(eWebBrowserMouseButton::BROWSER_MOUSEBUTTON_RIGHT, 1);
 
     return true;
 }

--- a/Client/gui/CGUIWebBrowser_Impl.h
+++ b/Client/gui/CGUIWebBrowser_Impl.h
@@ -46,6 +46,7 @@ public:
 protected:
     bool Event_MouseButtonDown(const CEGUI::EventArgs& e);
     bool Event_MouseButtonUp(const CEGUI::EventArgs& e);
+    bool Event_MouseDoubleClick(const CEGUI::EventArgs& e);
     bool Event_MouseWheel(const CEGUI::EventArgs& e);
     bool Event_MouseMove(const CEGUI::EventArgs& e);
     bool Event_Activated(const CEGUI::EventArgs& e);

--- a/Client/mods/deathmatch/logic/CClientWebBrowser.cpp
+++ b/Client/mods/deathmatch/logic/CClientWebBrowser.cpp
@@ -101,9 +101,9 @@ void CClientWebBrowser::InjectMouseMove(int iPosX, int iPosY)
     m_pWebView->InjectMouseMove(iPosX, iPosY);
 }
 
-void CClientWebBrowser::InjectMouseDown(eWebBrowserMouseButton mouseButton)
+void CClientWebBrowser::InjectMouseDown(eWebBrowserMouseButton mouseButton, int count)
 {
-    m_pWebView->InjectMouseDown(mouseButton);
+    m_pWebView->InjectMouseDown(mouseButton, count);
 }
 
 void CClientWebBrowser::InjectMouseUp(eWebBrowserMouseButton mouseButton)

--- a/Client/mods/deathmatch/logic/CClientWebBrowser.h
+++ b/Client/mods/deathmatch/logic/CClientWebBrowser.h
@@ -40,7 +40,7 @@ public:
     bool GetProperty(const SString& strKey, SString& outValue);
 
     void InjectMouseMove(int iPosX, int iPosY);
-    void InjectMouseDown(eWebBrowserMouseButton mouseButton, int count = 1);
+    void InjectMouseDown(eWebBrowserMouseButton mouseButton, int count);
     void InjectMouseUp(eWebBrowserMouseButton mouseButton);
     void InjectMouseWheel(int iScrollVert, int iScrollHorz);
 

--- a/Client/mods/deathmatch/logic/CClientWebBrowser.h
+++ b/Client/mods/deathmatch/logic/CClientWebBrowser.h
@@ -40,7 +40,7 @@ public:
     bool GetProperty(const SString& strKey, SString& outValue);
 
     void InjectMouseMove(int iPosX, int iPosY);
-    void InjectMouseDown(eWebBrowserMouseButton mouseButton);
+    void InjectMouseDown(eWebBrowserMouseButton mouseButton, int count = 1);
     void InjectMouseUp(eWebBrowserMouseButton mouseButton);
     void InjectMouseWheel(int iScrollVert, int iScrollHorz);
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.cpp
@@ -310,17 +310,19 @@ int CLuaBrowserDefs::InjectBrowserMouseMove(lua_State* luaVM)
 
 int CLuaBrowserDefs::InjectBrowserMouseDown(lua_State* luaVM)
 {
-    //  bool injectBrowserMouseDown ( browser webBrowser, string mouseButton )
-    CClientWebBrowser*     pWebBrowser;
-    eWebBrowserMouseButton mouseButton;
+    //  bool injectBrowserMouseDown ( browser webBrowser, string mouseButton [ , bool doubleClick = false ] )
+    CClientWebBrowser*     pWebBrowser{};
+    eWebBrowserMouseButton mouseButton{};
+    bool                   doubleClick{};
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pWebBrowser);
     argStream.ReadEnumString(mouseButton);
+    argStream.ReadBool(doubleClick, false);
 
     if (!argStream.HasErrors())
     {
-        pWebBrowser->InjectMouseDown(mouseButton);
+        pWebBrowser->InjectMouseDown(mouseButton, doubleClick ? 2 : 1);
         lua_pushboolean(luaVM, true);
         return 1;
     }

--- a/Client/sdk/core/CWebViewInterface.h
+++ b/Client/sdk/core/CWebViewInterface.h
@@ -36,7 +36,7 @@ public:
     virtual bool GetProperty(const SString& strKey, SString& outProperty) = 0;
 
     virtual void InjectMouseMove(int iPosX, int iPosY) = 0;
-    virtual void InjectMouseDown(eWebBrowserMouseButton mouseButton) = 0;
+    virtual void InjectMouseDown(eWebBrowserMouseButton mouseButton, int count = 1) = 0;
     virtual void InjectMouseUp(eWebBrowserMouseButton mouseButton) = 0;
     virtual void InjectMouseWheel(int iScrollVert, int iScrollHorz) = 0;
 

--- a/Client/sdk/core/CWebViewInterface.h
+++ b/Client/sdk/core/CWebViewInterface.h
@@ -36,7 +36,7 @@ public:
     virtual bool GetProperty(const SString& strKey, SString& outProperty) = 0;
 
     virtual void InjectMouseMove(int iPosX, int iPosY) = 0;
-    virtual void InjectMouseDown(eWebBrowserMouseButton mouseButton, int count = 1) = 0;
+    virtual void InjectMouseDown(eWebBrowserMouseButton mouseButton, int count) = 0;
     virtual void InjectMouseUp(eWebBrowserMouseButton mouseButton) = 0;
     virtual void InjectMouseWheel(int iScrollVert, int iScrollHorz) = 0;
 


### PR DESCRIPTION
Resolves #2963

As mentioned in the issue description above, double click events previously weren't being sent to CEF.

Test resource: 
[cef.zip](https://github.com/multitheftauto/mtasa-blue/files/11559836/cef.zip)

Usage: start the resource & click your mouse. a status (`single` or `double` click) will be displayed on the browser page, as well as in the console