### PR TITLE
Fix #3088: Resolve cursor being invisible with main menu open in certain scenarios

### DIFF
--- a/Client/core/CGUI.cpp
+++ b/Client/core/CGUI.cpp
@@ -430,9 +430,7 @@ void CLocalGUI::SetMainMenuVisible(bool bVisible)
             pGUI->SelectInputHandlers(INPUT_MOD);
         }
 
-        if (bVisible)
-            pGUI->SetCursorAlpha(1.0f);
-        else
+        if (!bVisible)
             pGUI->SetCursorAlpha(pGUI->GetCurrentServerCursorAlpha());
     }
 }

--- a/Client/core/CMainMenu.cpp
+++ b/Client/core/CMainMenu.cpp
@@ -76,6 +76,7 @@ CMainMenu::CMainMenu(CGUI* pManager)
     m_bStarted = false;
     m_fFader = 0;
     m_ucFade = FADE_INVISIBLE;
+    m_bCursorAlphaReset = false;
 
     // Adjust window size to resolution
     CVector2D ScreenSize = m_pManager->GetResolution();
@@ -587,6 +588,17 @@ void CMainMenu::Update()
         if (m_fFader > 0.0f)
         {
             m_bIsVisible = true;            // Make cursor appear faster
+
+            if (!m_bCursorAlphaReset)
+            {
+                CGUI* pGUI = g_pCore->GetGUI();
+
+                if (pGUI)
+                {
+                    pGUI->SetCursorAlpha(1.0f);
+                    m_bCursorAlphaReset = true;
+                }
+            }
         }
 
         // If the fade is complete
@@ -595,6 +607,7 @@ void CMainMenu::Update()
             m_ucFade = FADE_VISIBLE;
             m_bIsVisible = true;
             m_bIsFullyVisible = true;
+
         }
     }
     // Fade out
@@ -608,7 +621,11 @@ void CMainMenu::Update()
         m_pBackground->SetAlpha(Clamp(0.f, m_fFader, CORE_MTA_BG_MAX_ALPHA));
 
         if (m_fFader < 1.0f)
+        {
             m_bIsVisible = false;            // Make cursor disappear faster
+            m_bCursorAlphaReset = false;
+        }
+            
 
         // If the fade is complete
         if (m_fFader <= 0)

--- a/Client/core/CMainMenu.h
+++ b/Client/core/CMainMenu.h
@@ -150,6 +150,7 @@ private:
     // Fade variables
     unsigned char m_ucFade;
     float         m_fFader;
+    bool          m_bCursorAlphaReset;
 
     // Animation variables
     unsigned long ulPreviousTick;


### PR DESCRIPTION
Resolves #3088 - there was a potential race condition from main menu visibility being _triggered_ in `CLocalGUI::SetMainMenuVisible` and the actual state of the main menu being updated in `CMainMenu::Update()`. If a call from `setCursorAlpha` via Lua can get executed somewhere in there, it would override the cursor alpha.