### PR TITLE
Add texture hit info to `processLineOfSight`

### DIFF
--- a/Client/game_sa/CColModelSA.h
+++ b/Client/game_sa/CColModelSA.h
@@ -72,13 +72,13 @@ struct CColSphereSA : CSphereSA
 {
     union
     {
-        EColSurface  m_material;
+        EColSurface  m_material{};
         std::uint8_t m_collisionSlot;
     };
 
     union
     {
-        std::uint8_t m_flags;
+        std::uint8_t m_flags{};
 
         struct
         {
@@ -93,15 +93,13 @@ struct CColSphereSA : CSphereSA
         };
     };
 
-    std::uint8_t m_lighting;
-    std::uint8_t m_light;
+    std::uint8_t m_lighting{};
+    std::uint8_t m_light{};
 
-    CColSphereSA()
+    CColSphereSA() = default;
+    CColSphereSA(const CSphereSA& sp) :
+        CSphereSA{ sp }
     {
-        m_collisionSlot = 0;
-        m_flags = 0;
-        m_lighting = 0;
-        m_light = 0;
     }
 };
 static_assert(sizeof(CColSphereSA) == 0x14, "Invalid size for CColSphereSA");

--- a/Client/game_sa/CCollisionSA.cpp
+++ b/Client/game_sa/CCollisionSA.cpp
@@ -1,3 +1,14 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        game_sa/CCollisionSA.cpp
+ *  PURPOSE:     Implementation of `CCollision` - collision detection related functions
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
 #include "StdInc.h"
 
 #include "CCollisionSA.h"

--- a/Client/game_sa/CCollisionSA.cpp
+++ b/Client/game_sa/CCollisionSA.cpp
@@ -1,0 +1,7 @@
+#include "StdInc.h"
+
+#include "CCollisionSA.h"
+
+bool CCollisionSA::TestLineSphere(const CColLineSA& line, const CColSphereSA& sphere) {
+    return reinterpret_cast<bool(__cdecl*)(const CColLineSA&, const CColSphereSA&)>(0x417470)(line, sphere);
+}

--- a/Client/game_sa/CCollisionSA.cpp
+++ b/Client/game_sa/CCollisionSA.cpp
@@ -2,6 +2,7 @@
 
 #include "CCollisionSA.h"
 
-bool CCollisionSA::TestLineSphere(const CColLineSA& line, const CColSphereSA& sphere) {
+bool CCollisionSA::TestLineSphere(const CColLineSA& line, const CColSphereSA& sphere) const
+{
     return reinterpret_cast<bool(__cdecl*)(const CColLineSA&, const CColSphereSA&)>(0x417470)(line, sphere);
 }

--- a/Client/game_sa/CCollisionSA.h
+++ b/Client/game_sa/CCollisionSA.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "game/CCollision.h"
+
+class CCollisionSA : CCollision {
+public:
+    bool TestLineSphere(const CColLineSA& line, const CColSphereSA& sphere) override;
+};

--- a/Client/game_sa/CCollisionSA.h
+++ b/Client/game_sa/CCollisionSA.h
@@ -4,5 +4,5 @@
 
 class CCollisionSA : CCollision {
 public:
-    bool TestLineSphere(const CColLineSA& line, const CColSphereSA& sphere) override;
+    bool TestLineSphere(const CColLineSA& line, const CColSphereSA& sphere) const override;
 };

--- a/Client/game_sa/CCollisionSA.h
+++ b/Client/game_sa/CCollisionSA.h
@@ -1,3 +1,14 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        game_sa/CCollisionSA.h
+ *  PURPOSE:     Header file for `CCollision` - collision detection related functions
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
 #pragma once
 
 #include "game/CCollision.h"

--- a/Client/game_sa/CRenderWareSA.cpp
+++ b/Client/game_sa/CRenderWareSA.cpp
@@ -149,7 +149,7 @@ static bool ReplaceAllCB(RpAtomic* atomic, void* pData)
             data->pReplacements[i].atomic->renderCallback = atomic->renderCallback;
             data->pReplacements[i].atomic->frame = atomic->frame;
             data->pReplacements[i].atomic->render = atomic->render;
-            data->pReplacements[i].atomic->interpolation = atomic->interpolation;
+            data->pReplacements[i].atomic->interpolator = atomic->interpolator;
             data->pReplacements[i].atomic->info = atomic->info;
 
             // add the new atomic to the vehicle clump

--- a/Client/game_sa/CWorldSA.cpp
+++ b/Client/game_sa/CWorldSA.cpp
@@ -382,8 +382,6 @@ bool CWorldSA::ProcessLineOfSight(const CVector* vecStart, const CVector* vecEnd
         c.minHitDistSq = c.dirOS.LengthSquared();            // By setting it to this value we avoid collisions that would be detected after the line segment
                                                              // [but are still ont the ray]
 
-        // const auto lineMagSq = (ctx.originOS - ctx.endOS).LengthSquared();
-
         // Do raycast against the DFF to get hit position material UV and name
         // This is very slow
         // Perhaps we could paralellize it somehow? [OpenMP?]
@@ -469,7 +467,7 @@ bool CWorldSA::ProcessLineOfSight(const CVector* vecStart, const CVector* vecEnd
             RpClumpForAllAtomics(targetEntity->m_pRwObject, ProcessOneAtomic, &c);
         }
         else
-        {            // Object is an atomic, so process directly
+        {            // Object is a single atomic, so process directly
             ProcessOneAtomic(reinterpret_cast<RpAtomic*>(targetEntity->m_pRwObject), &c);
         }
 

--- a/Client/game_sa/CWorldSA.cpp
+++ b/Client/game_sa/CWorldSA.cpp
@@ -15,6 +15,9 @@
 #include "CGameSA.h"
 #include "CPoolsSA.h"
 #include "CWorldSA.h"
+#include "CColModelSA.h"
+#include "gamesa_renderware.h"
+#include "CCollisionSA.h"
 
 extern CCoreInterface* g_pCore;
 extern CGameSA*        pGame;
@@ -252,7 +255,7 @@ void ConvertMatrixToEulerAngles(const CMatrix_Padded& matrixPadded, float& fX, f
 }
 
 bool CWorldSA::ProcessLineOfSight(const CVector* vecStart, const CVector* vecEnd, CColPoint** colCollision, CEntity** CollisionEntity,
-                                  const SLineOfSightFlags flags, SLineOfSightBuildingResult* pBuildingResult)
+                                  const SLineOfSightFlags flags, SLineOfSightBuildingResult* pBuildingResult, SProcessLineOfSightMaterialInfoResult* outMatInfo)
 {
     DWORD dwPadding[100];            // stops the function missbehaving and overwriting the return address
     dwPadding[0] = 0;                // prevent the warning and eventual compiler optimizations from removing it
@@ -350,6 +353,159 @@ bool CWorldSA::ProcessLineOfSight(const CVector* vecStart, const CVector* vecEnd
             }
         }
     }
+
+    if (outMatInfo && targetEntity && targetEntity->m_pRwObject)
+    {
+        struct Context
+        {
+            float               minHitDistSq{};                    //< [squared] hit distance from the line segment's origin
+            CVector             originOS, endOS, dirOS;            //< Line origin, end and dir [in object space]
+            CMatrix             entMat, entInvMat;                 //< The hit entity's matrix, and it's inverse
+            RpTriangle*         hitTri{};                          //< The triangle hit
+            RpAtomic*           hitAtomic{};                       //< The atomic of the hit triangle's geometry
+            RpGeometry*         hitGeo{};                          //< The geometry of the hit triangle
+            CVector             hitBary{};                         //< Barycentric coordinates [on the hit triangle] of the hit
+            CVector             hitPosOS{};                        //< Hit position in object space
+            CEntitySAInterface* entity{};                          //< The hit entity
+        } c = {};
+
+        c.entity = targetEntity;
+
+        // Get matrix, and it's inverse
+        targetEntity->Placeable.matrix->ConvertToMatrix(c.entMat);
+        c.entInvMat = c.entMat.Inverse();
+
+        // ...to transform the line origin and end into object space
+        c.originOS = c.entInvMat.TransformVector(*vecStart);
+        c.endOS = c.entInvMat.TransformVector(*vecEnd);
+        c.dirOS = c.endOS - c.originOS;
+        c.minHitDistSq = c.dirOS.LengthSquared();            // By setting it to this value we avoid collisions that would be detected after the line segment
+                                                             // [but are still ont the ray]
+
+        // const auto lineMagSq = (ctx.originOS - ctx.endOS).LengthSquared();
+
+        // Do raycast against the DFF to get hit position material UV and name
+        // This is very slow
+        // Perhaps we could paralellize it somehow? [OpenMP?]
+        const auto ProcessOneAtomic = [](RpAtomic* a, void* data)
+        {
+            const auto c = (Context*)data;
+            const auto f = RpAtomicGetFrame(a);
+
+            const auto GetFrameCMatrix = [](RwFrame* f)
+            {
+                CMatrix out;
+                pGame->GetRenderWare()->RwMatrixToCMatrix(*RwFrameGetMatrix(f), out);
+                return out;
+            };
+
+            // Atomic not visible
+            if (!a->renderCallback || !(a->object.object.flags & 0x04 /*rpATOMICRENDER*/))
+            {
+                return true;
+            }
+
+            // Sometimes atomics have no geometry [I don't think that should be possible, but okay]
+            const auto geo = a->geometry;
+            if (!geo)
+            {
+                return true;
+            }
+
+            // Calculate transformation by traversing the hierarchy from the bottom (this frame) -> top (root frame)
+            CMatrix localToObjTransform{};
+            for (auto i = f; i && i != i->root; i = RwFrameGetParent(i))
+            {
+                localToObjTransform = GetFrameCMatrix(i) * localToObjTransform;
+            }
+            const auto objToLocalTransform = localToObjTransform.Inverse();
+
+            const auto ObjectToLocalSpace = [&](const CVector& in) { return objToLocalTransform.TransformVector(in); };
+
+            // Transform from object space, into local (the frame's) space
+            const auto localOrigin = ObjectToLocalSpace(c->originOS);
+            const auto localEnd = ObjectToLocalSpace(c->endOS);
+
+#if 0
+            if (!CCollisionSA::TestLineSphere(
+                CColLineSA{localOrigin, 0.f, localEnd, 0.f},
+                reinterpret_cast<CColSphereSA&>(*RpAtomicGetBoundingSphere(a)) // Fine for now
+            )) {
+                return true; // Line segment doesn't touch bsp
+            }
+#endif
+            const auto localDir = localEnd - localOrigin;
+
+            const auto verts = reinterpret_cast<CVector*>(geo->morph_target->verts);            // It's fine, trust me bro
+            for (auto i = geo->triangles_size; i-- > 0;)
+            {
+                const auto tri = &geo->triangles[i];
+
+                // Process the line against the triangle
+                CVector hitBary, hitPos;
+                if (!localOrigin.IntersectsSegmentTriangle(localDir, verts[tri->verts[0]], verts[tri->verts[1]], verts[tri->verts[2]], &hitPos, &hitBary))
+                {
+                    continue;            // No intersection at all
+                }
+
+                // Intersection, check if it's closer than the previous one
+                const auto hitDistSq = (hitPos - localOrigin).LengthSquared();
+                if (c->minHitDistSq > hitDistSq)
+                {
+                    c->minHitDistSq = hitDistSq;
+                    c->hitGeo = geo;
+                    c->hitAtomic = a;
+                    c->hitTri = tri;
+                    c->hitBary = hitBary;
+                    c->hitPosOS = localToObjTransform.TransformVector(hitPos);            // Transform back into object space
+                }
+            }
+
+            return true;
+        };
+
+        if (targetEntity->m_pRwObject->object.type == 2 /*rpCLUMP*/)
+        {
+            RpClumpForAllAtomics(targetEntity->m_pRwObject, ProcessOneAtomic, &c);
+        }
+        else
+        {            // Object is an atomic, so process directly
+            ProcessOneAtomic(reinterpret_cast<RpAtomic*>(targetEntity->m_pRwObject), &c);
+        }
+
+        // It might be false if the collision model differs from the clump
+        // This is completely normal as collisions models are meant to be simplified
+        // compared to the clump's geometry
+        if (outMatInfo->valid = c.hitGeo != nullptr)
+        {
+            // Now, calculate texture UV, etc based on the hit [if we've hit anything at all]
+            // Since we have the barycentric coords of the hit, calculating it is easy
+            outMatInfo->uv = {};
+            for (auto i = 3u; i-- > 0;)
+            {
+                // UV set index - Usually models only use level 0 indices, so let's stick with that
+                const auto uvSetIdx = 0;
+
+                // Vertex's UV position
+                const auto vtxUV = &c.hitGeo->texcoords[uvSetIdx][c.hitTri->verts[i]];
+
+                // Now, just interpolate
+                outMatInfo->uv += CVector2D{vtxUV->u, vtxUV->v} * c.hitBary[i];
+            }
+
+            // Find out material texture name
+            // For some reason this is sometimes null
+            const auto tex = c.hitGeo->materials.materials[c.hitTri->materialId]->texture;
+            outMatInfo->textureName = tex ? tex->name : nullptr;
+
+            const auto frame = RpAtomicGetFrame(c.hitAtomic);            // `RpAtomicGetFrame`
+            outMatInfo->frameName = frame ? frame->szName : nullptr;
+
+            // Get hit position in world space
+            outMatInfo->hitPos = c.entMat.TransformVector(c.hitPosOS);
+        }
+    }
+
     if (colCollision)
         *colCollision = pColPointSA;
     else

--- a/Client/game_sa/CWorldSA.h
+++ b/Client/game_sa/CWorldSA.h
@@ -49,7 +49,7 @@ public:
     void  Remove(CEntitySAInterface* entityInterface, eDebugCaller CallerId);
     void  RemoveReferencesToDeletedObject(CEntitySAInterface* entity);
     bool  ProcessLineOfSight(const CVector* vecStart, const CVector* vecEnd, CColPoint** colCollision, CEntity** CollisionEntity, const SLineOfSightFlags flags,
-                             SLineOfSightBuildingResult* pBuildingResult);
+                             SLineOfSightBuildingResult* pBuildingResult, SProcessLineOfSightMaterialInfoResult* outMatInfo = nullptr);
     void  IgnoreEntity(CEntity* entity);
     float FindGroundZFor3DPosition(CVector* vecPosition);
     float FindRoofZFor3DCoord(CVector* pvecPosition, bool* pbOutResult);

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -6316,7 +6316,7 @@ bool CStaticFunctionDefinitions::SetTime(unsigned char ucHour, unsigned char ucM
 
 bool CStaticFunctionDefinitions::ProcessLineOfSight(const CVector& vecStart, const CVector& vecEnd, bool& bCollision, CColPoint** pColPoint,
                                                     CClientEntity** pColEntity, const SLineOfSightFlags& flags, CEntity* pIgnoredEntity,
-                                                    SLineOfSightBuildingResult* pBuildingResult)
+                                                    SLineOfSightBuildingResult* pBuildingResult, SProcessLineOfSightMaterialInfoResult* outMatInfo)
 {
     assert(pColPoint);
     assert(pColEntity);
@@ -6325,7 +6325,7 @@ bool CStaticFunctionDefinitions::ProcessLineOfSight(const CVector& vecStart, con
         g_pGame->GetWorld()->IgnoreEntity(pIgnoredEntity);
 
     CEntity* pColGameEntity = 0;
-    bCollision = g_pGame->GetWorld()->ProcessLineOfSight(&vecStart, &vecEnd, pColPoint, &pColGameEntity, flags, pBuildingResult);
+    bCollision = g_pGame->GetWorld()->ProcessLineOfSight(&vecStart, &vecEnd, pColPoint, &pColGameEntity, flags, pBuildingResult, outMatInfo);
 
     if (pIgnoredEntity)
         g_pGame->GetWorld()->IgnoreEntity(NULL);

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -561,7 +561,7 @@ public:
     static bool GetTime(unsigned char& ucHour, unsigned char& ucMin);
     static bool ProcessLineOfSight(const CVector& vecStart, const CVector& vecEnd, bool& bCollision, CColPoint** pColPoint, CClientEntity** pColEntity,
                                    const SLineOfSightFlags& flags = SLineOfSightFlags(), CEntity* pIgnoredEntity = NULL,
-                                   SLineOfSightBuildingResult* pBuildingResult = NULL);
+                                   SLineOfSightBuildingResult* pBuildingResult = NULL, SProcessLineOfSightMaterialInfoResult* outMatInfo = nullptr);
     static bool IsLineOfSightClear(const CVector& vecStart, const CVector& vecEnd, bool& bIsClear, const SLineOfSightFlags& flags = SLineOfSightFlags(),
                                    CEntity* pIgnoredEntity = NULL);
     static bool TestLineAgainstWater(CVector& vecStart, CVector& vecEnd, CVector& vecCollision);

--- a/Client/sdk/game/CCollision.h
+++ b/Client/sdk/game/CCollision.h
@@ -1,3 +1,14 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        sdk/game/CCollision.h
+ *  PURPOSE:     Interface file for `CCollisionSA`
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
 #pragma once
 
 struct CColLineSA;

--- a/Client/sdk/game/CCollision.h
+++ b/Client/sdk/game/CCollision.h
@@ -1,0 +1,9 @@
+#pragma once
+
+class CColLineSA;
+class CColSphereSA;
+
+class CCollision {
+public:
+    virtual bool TestLineSphere(const CColLineSA& line, const CColSphereSA& sphere) = 0;
+};

--- a/Client/sdk/game/CCollision.h
+++ b/Client/sdk/game/CCollision.h
@@ -5,5 +5,5 @@ struct CColSphereSA;
 
 class CCollision {
 public:
-    virtual bool TestLineSphere(const CColLineSA& line, const CColSphereSA& sphere) = 0;
+    virtual bool TestLineSphere(const CColLineSA& line, const CColSphereSA& sphere) const = 0;
 };

--- a/Client/sdk/game/CCollision.h
+++ b/Client/sdk/game/CCollision.h
@@ -1,7 +1,7 @@
 #pragma once
 
-class CColLineSA;
-class CColSphereSA;
+struct CColLineSA;
+struct CColSphereSA;
 
 class CCollision {
 public:

--- a/Client/sdk/game/CWorld.h
+++ b/Client/sdk/game/CWorld.h
@@ -51,6 +51,14 @@ struct SLineOfSightBuildingResult
     CEntitySAInterface* pInterface;
 };
 
+struct SProcessLineOfSightMaterialInfoResult {
+    CVector2D   uv;            //< On-texture UV coordinates of the intersection point
+    const char* textureName;   //< GTA texture name
+    const char* frameName;     //< The name of the frame the hit geometry belongs to
+    CVector     hitPos;        //< Precise hit position on the clump [World space]
+    bool        valid{};       //< Data found in this struct is only valid if this is `true`!
+};
+
 struct SBuildingRemoval
 {
     SBuildingRemoval()
@@ -308,7 +316,7 @@ public:
     virtual void  Remove(CEntity* entity, eDebugCaller CallerId) = 0;
     virtual void  Remove(CEntitySAInterface* entityInterface, eDebugCaller CallerId) = 0;
     virtual bool  ProcessLineOfSight(const CVector* vecStart, const CVector* vecEnd, CColPoint** colCollision, CEntity** CollisionEntity,
-                                     const SLineOfSightFlags flags = SLineOfSightFlags(), SLineOfSightBuildingResult* pBuildingResult = NULL) = 0;
+                                     const SLineOfSightFlags flags = SLineOfSightFlags(), SLineOfSightBuildingResult* pBuildingResult = NULL, SProcessLineOfSightMaterialInfoResult* outMatInfo = {}) = 0;
     virtual void  IgnoreEntity(CEntity* entity) = 0;
     virtual float FindGroundZFor3DPosition(CVector* vecPosition) = 0;
     virtual float FindRoofZFor3DCoord(CVector* pvecPosition, bool* pbOutResult) = 0;

--- a/Client/sdk/game/RenderWare.h
+++ b/Client/sdk/game/RenderWare.h
@@ -321,25 +321,35 @@ struct RwGeometry
     unsigned char  unknown1[14];
     unsigned short refs;
 };
-struct RpInterpolation
+
+/* Interpolator flags */
+enum RpInterpolatorFlag : int32
 {
-    unsigned int unknown1;
-    unsigned int unknown2;
-    float        unknown3;
-    float        unknown4;
-    float        unknown5;
+    rpINTERPOLATORDIRTYINSTANCE = 0x01,
+    rpINTERPOLATORDIRTYSPHERE = 0x02,
+    rpINTERPOLATORNOFRAMEDIRTY = 0x04,
 };
+struct RpInterpolator
+{
+    int32 flags;
+    int16 startMorphTarget;
+    int16 endMorphTarget;
+    float time;
+    float recipTime;
+    float position;
+};
+
 struct RpAtomic
 {
     RwObjectFrame    object;
     void*            info;
     RpGeometry*      geometry;
-    RwSphere         bsphereLocal;
-    RwSphere         bsphereWorld;
+    RwSphere         boundingSphere;
+    RwSphere         worldBoundingSphere;
     RpClump*         clump;
     RwListEntry      globalClumps;
     RpAtomicCallback renderCallback;
-    RpInterpolation  interpolation;
+    RpInterpolator   interpolator;
     unsigned short   frame;
     unsigned short   unknown7;
     RwList           sectors;
@@ -391,8 +401,15 @@ struct RpMaterials
 };
 struct RpTriangle
 {
-    unsigned short v1, v2, v3;
+    unsigned short verts[3];
     unsigned short materialId;
+};
+struct RpMorphTarget
+{
+    RpGeometry* parentGeom;
+    RwSphere   boundingSphere;
+    RwV3d* verts;
+    RwV3d* normals;
 };
 struct RpGeometry
 {
@@ -412,8 +429,34 @@ struct RpGeometry
     RwTextureCoordinates* texcoords[RW_MAX_TEXTURE_COORDS];
     void*                 unknown2;
     void*                 info;
-    void*                 unknown3;
+    RpMorphTarget*        morph_target;
 };
+
+inline auto rwObjectGetParent(RwObject* o) {
+    return (RwObject*)o->parent;
+}
+
+inline auto RpAtomicGetFrame(RpAtomic* atomic) {
+    return (RwFrame*)atomic->object.object.parent;
+}
+
+inline auto RwFrameGetParent(RwFrame* f) {
+    return (RwFrame*)rwObjectGetParent((RwObject*)f);
+}
+
+inline auto RwFrameGetMatrix(RwFrame* f) {
+    return &f->modelling;
+}
+
+inline void _rpAtomicResyncInterpolatedSphere(RpAtomic* atomic) {
+    ((void(__cdecl*)(RpAtomic*))0x7491F0)(atomic);
+}
+
+/* NB "RpAtomicGetBoundingSphere(atomic++)" will break it */
+#define RpAtomicGetBoundingSphere(_atomic)                              \
+    ((((_atomic)->interpolator.flags & rpINTERPOLATORDIRTYSPHERE)?      \
+      _rpAtomicResyncInterpolatedSphere(_atomic), 0: 0),                \
+      &((_atomic)->boundingSphere))
 
 /*****************************************************************************/
 /** RenderWare I/O                                                          **/

--- a/Client/sdk/game/RenderWare.h
+++ b/Client/sdk/game/RenderWare.h
@@ -323,7 +323,7 @@ struct RwGeometry
 };
 
 /* Interpolator flags */
-enum RpInterpolatorFlag : int32
+enum RpInterpolatorFlag : int32_t
 {
     rpINTERPOLATORDIRTYINSTANCE = 0x01,
     rpINTERPOLATORDIRTYSPHERE = 0x02,
@@ -331,12 +331,12 @@ enum RpInterpolatorFlag : int32
 };
 struct RpInterpolator
 {
-    int32 flags;
-    int16 startMorphTarget;
-    int16 endMorphTarget;
-    float time;
-    float recipTime;
-    float position;
+    int32_t flags;
+    int16_t startMorphTarget;
+    int16_t endMorphTarget;
+    float   time;
+    float   recipTime;
+    float   position;
 };
 
 struct RpAtomic
@@ -449,7 +449,7 @@ inline auto RwFrameGetMatrix(RwFrame* f) {
 }
 
 inline void _rpAtomicResyncInterpolatedSphere(RpAtomic* atomic) {
-    ((void(__cdecl*)(RpAtomic*))0x7491F0)(atomic);
+    reinterpret_cast<void(__cdecl*)(RpAtomic*)>(0x7491F0)(atomic);
 }
 
 /* NB "RpAtomicGetBoundingSphere(atomic++)" will break it */

--- a/Client/sdk/game/RenderWare.h
+++ b/Client/sdk/game/RenderWare.h
@@ -444,12 +444,12 @@ inline auto RwFrameGetParent(RwFrame* f) {
     return (RwFrame*)rwObjectGetParent((RwObject*)f);
 }
 
-inline auto RwFrameGetMatrix(RwFrame* f) {
+inline RwMatrix* RwFrameGetMatrix(RwFrame* f) {
     return &f->modelling;
 }
 
 inline void _rpAtomicResyncInterpolatedSphere(RpAtomic* atomic) {
-    ((void(__cdecl*)(RpAtomic*))0x7491F0)(atomic);
+    reinterpret_cast<void(__cdecl*)(RpAtomic*)>(0x7491F0)(atomic);
 }
 
 /* NB "RpAtomicGetBoundingSphere(atomic++)" will break it */

--- a/Shared/sdk/CVector.h
+++ b/Shared/sdk/CVector.h
@@ -15,6 +15,8 @@
 
 #include "CVector4D.h"
 
+class CVector2D;
+
 /**
  * CVector Structure used to store a 3D vertex.
  */
@@ -137,15 +139,15 @@ public:
     }
 
     // https://en.wikipedia.org/wiki/M%C3%B6ller%E2%80%93Trumbore_intersection_algorithm
-    bool IntersectsSegmentTriangle(const CVector& vecSegment, const CVector& vecVert1, const CVector& vecVert2, const CVector& vecVert3,
-                                   CVector* outVec) const noexcept
+    bool IntersectsSegmentTriangle(const CVector& dir, const CVector& vecVert1, const CVector& vecVert2, const CVector& vecVert3,
+                                   CVector* outVec, CVector* outHitBary = nullptr) const noexcept
     {
         constexpr float fEpsilon = 1e-6f;
 
         CVector vecEdge1, vecEdge2, h, s;
         float   a, f, u, v;
 
-        CVector vecRay = vecSegment;
+        CVector vecRay = dir;
         vecRay.Normalize();
         h = vecRay;
 
@@ -177,11 +179,15 @@ public:
         }
 
         float t = f * vecEdge2.DotProduct(&sCrossE1);
-        if (t > fEpsilon && t <= vecSegment.Length())
+        if (t > fEpsilon && t <= dir.Length())
         {
             *outVec = *this + vecRay * t;
+            if (outHitBary) { // Calculate all barycentric coords if necessary
+                *outHitBary = { 1.f - u - v, u, v }; // For vertices A, B, C [I assume?]
+            }
             return true;
         }
+
         return false;
     }
 
@@ -261,4 +267,6 @@ public:
     }
 
     bool operator!=(const CVector& param) const noexcept { return !(*this == param); }
+
+    float operator[](size_t i) const noexcept { return ((float*)this)[i]; }
 };


### PR DESCRIPTION
Fixes #645 

This PR aims to add texture related info to hits [Such as hit texture UV, and name], and a more precise "clump hit" position [that is the intersection point of the clump and the line segment]
It uses the hit entity's clump to do so [As it contains all the necessary UV information]