### PR TITLE
Fix CStreamingSA::GetUnusedStreamHandle

### DIFF
--- a/Client/game_sa/CStreamingSA.cpp
+++ b/Client/game_sa/CStreamingSA.cpp
@@ -210,7 +210,7 @@ unsigned char CStreamingSA::GetUnusedStreamHandle()
 {
     for (size_t i = 0; i < VAR_StreamHandlersMaxCount; i++)
     {
-        if (m_aStreamingHandlers[i])
+        if (!m_aStreamingHandlers[i])
             return (unsigned char)i;
     }
     return -1;


### PR DESCRIPTION
Seems like CStreamingSA::GetUnusedArchive returns not what is declared in the method's name. It always returns 0 that leads to an unexpected behaviour when engineAddImage called. engineAddImage is always adding an image to a slot 6. And furthermore, it can break the default SA streaming because of overriding of the first streaming handle.