### PR TITLE
IMG count extension

### DIFF
--- a/Client/game_sa/CStreamingSA.cpp
+++ b/Client/game_sa/CStreamingSA.cpp
@@ -20,8 +20,6 @@ extern CCoreInterface* g_pCore;
 
 // count: 26316 in unmodified game
 CStreamingInfo (&CStreamingSA::ms_aInfoForModel)[26316] = *(CStreamingInfo(*)[26316])0x8E4CC0;
-HANDLE (&CStreamingSA::m_aStreamingHandlers)[32] = *(HANDLE(*)[32])0x8E4010;                // Contains open files
-CArchiveInfo (&CStreamingSA::ms_aAchiveInfo)[8] = *(CArchiveInfo(*)[8])0x8E48D8;            // [8][0x30]
 HANDLE* phStreamingThread = (HANDLE*)0x8E4008;
 uint32(&CStreamingSA::ms_streamingHalfOfBufferSize) = *(uint32*)0x8E4CA8;
 void* (&CStreamingSA::ms_pStreamingBuffer)[2] = *(void* (*)[2])0x8E4CAC;
@@ -51,11 +49,177 @@ namespace
             memoryUsed = *(DWORD*)VAR_CStreaming_memoryUsed;
         }
     };
-}            // namespace
+
+    constexpr size_t MAX_IMAGES_NUM = 0xFF;
+    constexpr size_t MAX_STREAMS_NUM = 0xFF;
+    constexpr size_t STREAM_HANDLES_FACTOR = 4;
+} // namespace
 
 bool IsUpgradeModelId(DWORD dwModelID)
 {
     return dwModelID >= 1000 && dwModelID <= 1193;
+}
+
+CStreamingSA::CStreamingSA()
+{
+    SetArchivesNum(VAR_DefaultMaxArchives);
+
+    // Copy the default data
+    HANDLE (&defaultStreamingHandlers)[32] = *(HANDLE(*)[32])0x8E4010;
+    SStreamName (&defaultStreamingNames)[32] = *(SStreamName(*)[32])0x8E4098;
+    CArchiveInfo (&defaultAchiveInfo)[8] = *(CArchiveInfo(*)[8])0x8E48D8;
+
+    assert(m_StreamHandles.size() == VAR_DefaultStreamHandlersMaxCount);
+    assert(m_StreamNames.size() == VAR_DefaultStreamHandlersMaxCount);
+    assert(m_Imgs.size() == VAR_DefaultMaxArchives);
+
+    std::memcpy(m_StreamHandles.data(), defaultStreamingHandlers, sizeof(HANDLE) * VAR_DefaultStreamHandlersMaxCount);
+    std::memcpy(m_StreamNames.data(), defaultStreamingNames, sizeof(SStreamName) * VAR_DefaultStreamHandlersMaxCount);
+    std::memcpy(m_Imgs.data(), defaultAchiveInfo, sizeof(CArchiveInfo) * VAR_DefaultMaxArchives);
+}
+
+void CStreamingSA::SetArchivesNum(size_t imagesNum)
+{
+    if (imagesNum > MAX_IMAGES_NUM)
+        return;    
+
+    /*
+        IMGs
+    */
+    if (m_Imgs.size() != imagesNum)
+    {
+        try
+        {
+            m_Imgs.resize(imagesNum);
+        }
+        catch (const std::bad_alloc&)
+        {
+            return;
+        }
+
+        const auto pImgs = m_Imgs.data();
+        const size_t uiImgsSize = sizeof(CArchiveInfo) * m_Imgs.size();
+
+        // CStreaming::AddImageToList
+        MemPutFast<DWORD>((void*)0x1567B94, (DWORD)pImgs);
+        MemPutFast<DWORD>((void*)0x1567BA2, (DWORD)pImgs + uiImgsSize);
+        MemPutFast<DWORD>((void*)0x1567BBA, (DWORD)pImgs);
+        MemPutFast<DWORD>((void*)0x1567BD6, (DWORD)pImgs + 0x2C);
+        MemPutFast<DWORD>((void*)0x1567BE3, (DWORD)pImgs + 0x28);
+
+        // CStreaming::InitImageList
+        MemPut<DWORD>((void*)0x4083C1, (DWORD)pImgs + 0x2C);
+        MemPut<DWORD>((void*)0x4083DE, (DWORD)pImgs + 0x2C + uiImgsSize);
+        MemPut<DWORD>((void*)0x4083E9, (DWORD)pImgs);
+        MemPut<DWORD>((void*)0x4083FA, (DWORD)pImgs + uiImgsSize);
+        MemPut<DWORD>((void*)0x40840B, (DWORD)pImgs);
+        MemPut<DWORD>((void*)0x40841A, (DWORD)pImgs + uiImgsSize);
+        MemPut<DWORD>((void*)0x40843B, (DWORD)pImgs);
+        MemPut<DWORD>((void*)0x40845B, (DWORD)pImgs + 0x2C);
+        MemPut<DWORD>((void*)0x408461, (DWORD)pImgs + 0x28);
+        MemPut<DWORD>((void*)0x408479, (DWORD)pImgs);
+        MemPut<DWORD>((void*)0x4084A2, (DWORD)pImgs + 0x2C);
+        MemPut<DWORD>((void*)0x4084A8, (DWORD)pImgs + 0x28);
+
+        // CStreaming::loadArchives
+        MemPut<DWORD>((void*)0x5B82F1, (DWORD)pImgs);
+        MemPut<DWORD>((void*)0x5B82FD, (DWORD)pImgs);
+        MemPut<DWORD>((void*)0x5B8303, (DWORD)pImgs + uiImgsSize);
+
+        // CStreamingInfo::GetCdPosn
+        MemPut<DWORD>((void*)0x40757F, (DWORD)pImgs + 0x2C);
+
+        // CStreaming::GetNextFileOnCd
+        MemPut<DWORD>((void*)0x408FDC, (DWORD)pImgs + 0x2C);
+
+        // CStreaming::requestSpecialModel
+        MemPut<DWORD>((void*)0x409D5A, (DWORD)pImgs + 0x2C);
+
+        // CStreaming::RequestModelStream
+        MemPut<DWORD>((void*)0x40CC54, (DWORD)pImgs + 0x2C);
+        MemPut<DWORD>((void*)0x40CCC7, (DWORD)pImgs + 0x2C);
+
+        // CStreamingInfo::GetCdPosnAndSize
+        MemPutFast<DWORD>((void*)0x1560E68, (DWORD)pImgs + 0x2C);
+
+        // sub_40A080
+        MemPutFast<DWORD>((void*)0x15663E7, (DWORD)pImgs + 0x2C);
+    }
+
+    /*
+        Stream handles
+    */
+    const size_t handlesNum = std::min(imagesNum * STREAM_HANDLES_FACTOR, MAX_STREAMS_NUM);
+    if (m_StreamHandles.size() != handlesNum)
+    {
+        try
+        {
+            m_StreamHandles.resize(handlesNum);
+            m_StreamNames.resize(handlesNum);
+        }
+        catch (const std::bad_alloc&)
+        {
+            return;
+        }
+
+        const auto pStreamHandles = m_StreamHandles.data();
+        const auto pStreamNames = m_StreamNames.data();
+
+        // _GetFileSizeOfTheFirstStream
+        MemPutFast<DWORD>((void*)0x15700D1, (DWORD)pStreamHandles);
+
+        // _closeAllStreams
+        MemPut<DWORD>((void*)0x4066C7, (DWORD)pStreamNames);
+        MemPut<DWORD>((void*)0x4066D6, (DWORD)pStreamHandles);
+        MemPut<DWORD>((void*)0x4066ED, (DWORD)pStreamHandles);
+
+        // _sub_406710
+        MemPut<DWORD>((void*)0x406737, (DWORD)pStreamHandles);
+
+        // _sub_406750
+        MemPut<DWORD>((void*)0x40676C, (DWORD)pStreamNames);
+        MemPut<DWORD>((void*)0x406797, (DWORD)pStreamHandles);
+
+        // _openStream
+        DWORD dwExeCodePtr = (DWORD)0x01564A94;
+
+        MemPutFast<WORD>((void*)(dwExeCodePtr), (WORD)0x048B); // mov     eax, _streamHandles[esi*4]
+        MemPutFast<BYTE>((void*)(dwExeCodePtr + 2), (BYTE)0xB5);
+        MemPutFast<DWORD>((void*)(dwExeCodePtr + 3), (DWORD)pStreamHandles);
+
+        MemPutFast<WORD>((void*)(dwExeCodePtr + 7), (WORD)0xC085);
+
+        MemPutFast<WORD>((void*)(dwExeCodePtr + 9), (WORD)0x840F);
+        MemPutFast<DWORD>((void*)(dwExeCodePtr + 11), (DWORD)(0x01564B31 - (dwExeCodePtr+15)));
+
+        MemPutFast<BYTE>((void*)(dwExeCodePtr + 15), (BYTE)0x46);
+        MemPutFast<WORD>((void*)(dwExeCodePtr + 16), (WORD)0xFE81);
+        MemPutFast<DWORD>((void*)(dwExeCodePtr + 18), (DWORD)399); // MAX_NUMBER_OF_STREAM_HANDLES
+
+        MemPutFast<BYTE>((void*)(dwExeCodePtr + 22), (BYTE)0x7C);
+        MemPutFast<BYTE>((void*)(dwExeCodePtr + 23), (BYTE)(dwExeCodePtr - (dwExeCodePtr+24)));
+
+        MemPutFast<BYTE>((void*)(dwExeCodePtr + 24), (BYTE)0xE9);
+        MemPutFast<DWORD>((void*)(dwExeCodePtr + 25), (DWORD)(0x01564B31 - (dwExeCodePtr+29)));
+        // end of loop creation
+
+        MemPutFast<DWORD>((void*)0x1564B74, (DWORD)pStreamHandles);
+        MemPutFast<DWORD>((void*)0x1564B8C, (DWORD)pStreamNames);
+
+        // _sub_4068A0
+        MemPut<DWORD>((void*)0x4068AB, (DWORD)pStreamHandles);
+        MemPut<DWORD>((void*)0x4068C2, (DWORD)pStreamHandles);
+        MemPut<DWORD>((void*)0x4068D0, (DWORD)pStreamHandles);
+        MemPut<DWORD>((void*)0x4068DD, (DWORD)pStreamNames);
+
+        // _readStream
+        MemPutFast<DWORD>((void*)0x156C2E8, (DWORD)pStreamHandles);
+
+        // _initStreaming
+        MemPut<DWORD>((void*)0x406B7C, (DWORD)pStreamHandles);
+        MemPut<DWORD>((void*)0x406B81, (DWORD)pStreamNames);
+        MemPut<DWORD>((void*)0x406B98, (DWORD)(pStreamNames + sizeof(SStreamName) * (handlesNum - 1)));
+    }
 }
 
 void CStreamingSA::RequestModel(DWORD dwModelID, DWORD dwFlags)
@@ -198,34 +362,42 @@ unsigned char CStreamingSA::GetUnusedArchive()
 {
     // Get internal IMG id
     // By default gta sa uses 6 of 8 IMG archives
-    for (size_t i = 6; i < 8; i++)
+    for (size_t i = 6; i < m_Imgs.size(); i++)
     {
-        if (!GetArchiveInfo(i)->uiStreamHandleId)
+        if (!m_Imgs[i].uiStreamHandleId)
             return (unsigned char)i;
     }
-    return -1;
+    return INVALID_ARCHIVE_ID;
 }
 
 unsigned char CStreamingSA::GetUnusedStreamHandle()
 {
-    for (size_t i = 0; i < VAR_StreamHandlersMaxCount; i++)
+    for (size_t i = 0; i < m_StreamHandles.size(); i++)
     {
-        if (m_aStreamingHandlers[i])
+        if (!m_StreamHandles[i])
             return (unsigned char)i;
     }
-    return -1;
+    return INVALID_STREAM_ID;
 }
 
 unsigned char CStreamingSA::AddArchive(const char* szFilePath)
 {
-    const auto ucArchiveId = GetUnusedArchive();
-    if (ucArchiveId == -1)
-        return -1;
+    auto ucArchiveId = GetUnusedArchive();
+    if (ucArchiveId == INVALID_ARCHIVE_ID)
+    {
+        // Allocate some extra archives
+        AllocateArchive();
+
+        // Give it a second try
+        ucArchiveId = GetUnusedArchive();
+        if (ucArchiveId == INVALID_ARCHIVE_ID)
+            return INVALID_ARCHIVE_ID;
+    }
 
     // Get free stream handler id
     const auto ucStreamID = GetUnusedStreamHandle();
-    if (ucStreamID == -1)
-        return -1;
+    if (ucStreamID == INVALID_STREAM_ID)
+        return INVALID_ARCHIVE_ID;
 
     // Create new stream handler
     const auto streamCreateFlags = *(DWORD*)0x8E3FE0;
@@ -233,27 +405,27 @@ unsigned char CStreamingSA::AddArchive(const char* szFilePath)
                                streamCreateFlags | FILE_ATTRIBUTE_READONLY | FILE_FLAG_RANDOM_ACCESS, NULL);
 
     if (hFile == INVALID_HANDLE_VALUE)
-        return -1;
+        return INVALID_ARCHIVE_ID;
 
     // Register stream handler
-    m_aStreamingHandlers[ucStreamID] = hFile;
+    m_StreamHandles[ucStreamID] = hFile;
 
     // Register archive data
-    ms_aAchiveInfo[ucArchiveId].uiStreamHandleId = (ucStreamID << 24);
+    m_Imgs[ucArchiveId].uiStreamHandleId = (ucStreamID << 24);
 
     return ucArchiveId;
 }
 
 void CStreamingSA::RemoveArchive(unsigned char ucArhiveID)
 {
-    unsigned int uiStreamHandlerID = ms_aAchiveInfo[ucArhiveID].uiStreamHandleId >> 24;
+    unsigned int uiStreamHandlerID = m_Imgs[ucArhiveID].uiStreamHandleId >> 24;
     if (!uiStreamHandlerID)
         return;
 
-    ms_aAchiveInfo[ucArhiveID].uiStreamHandleId = 0;
+    m_Imgs[ucArhiveID].uiStreamHandleId = 0;
 
-    CloseHandle(m_aStreamingHandlers[uiStreamHandlerID]);
-    m_aStreamingHandlers[uiStreamHandlerID] = NULL;
+    CloseHandle(m_StreamHandles[uiStreamHandlerID]);
+    m_StreamHandles[uiStreamHandlerID] = nullptr;
 }
 
 void CStreamingSA::SetStreamingBufferSize(uint32 numBlocks)
@@ -305,6 +477,13 @@ void CStreamingSA::MakeSpaceFor(std::uint32_t memoryToCleanInBytes)
 std::uint32_t CStreamingSA::GetMemoryUsed() const
 {
     return *reinterpret_cast<std::uint32_t*>(0x8E4CB4);
+}
+
+void CStreamingSA::AllocateArchive()
+{
+    // Preallocate some extra archives to skip this procedure for the next several archives
+    const size_t archivesNum = std::min(m_Imgs.size() + m_Imgs.size() * 2 + 1, MAX_IMAGES_NUM);
+    SetArchivesNum(archivesNum);
 }
 
 void CStreamingSA::RemoveBigBuildings()

--- a/Client/game_sa/CStreamingSA.cpp
+++ b/Client/game_sa/CStreamingSA.cpp
@@ -63,7 +63,8 @@ bool IsUpgradeModelId(DWORD dwModelID)
 
 CStreamingSA::CStreamingSA()
 {
-    SetArchivesNum(MIN_IMAGES_NUM);
+    // Allocate the default number of archives in order to keep modded games working as before.
+    SetArchivesNum(VAR_DefaultMaxArchives);
 
     // Copy the default data
     HANDLE (&defaultStreamingHandlers)[32] = *(HANDLE(*)[32])0x8E4010;
@@ -149,7 +150,7 @@ void CStreamingSA::SetArchivesNum(size_t imagesNum)
     /*
         Stream handles
     */
-    const size_t handlesNum = std::min(imagesNum + RESERVED_STREAMS_NUM, MAX_STREAMS_NUM);
+    const size_t handlesNum = Clamp((size_t)VAR_DefaultStreamHandlersMaxCount, imagesNum + RESERVED_STREAMS_NUM, MAX_STREAMS_NUM);
     if (m_StreamHandles.size() != handlesNum)
     {
         try

--- a/Client/game_sa/CStreamingSA.cpp
+++ b/Client/game_sa/CStreamingSA.cpp
@@ -417,13 +417,13 @@ unsigned char CStreamingSA::AddArchive(const char* szFilePath)
     return ucArchiveId;
 }
 
-void CStreamingSA::RemoveArchive(unsigned char ucArhiveID)
+void CStreamingSA::RemoveArchive(unsigned char ucArchiveID)
 {
-    unsigned int uiStreamHandlerID = m_Imgs[ucArhiveID].uiStreamHandleId >> 24;
+    unsigned int uiStreamHandlerID = m_Imgs[ucArchiveID].uiStreamHandleId >> 24;
     if (!uiStreamHandlerID)
         return;
 
-    m_Imgs[ucArhiveID].uiStreamHandleId = 0;
+    m_Imgs[ucArchiveID].uiStreamHandleId = 0;
 
     CloseHandle(m_StreamHandles[uiStreamHandlerID]);
     m_StreamHandles[uiStreamHandlerID] = nullptr;

--- a/Client/game_sa/CStreamingSA.cpp
+++ b/Client/game_sa/CStreamingSA.cpp
@@ -426,7 +426,7 @@ void CStreamingSA::RemoveArchive(unsigned char ucArchiveID)
     m_Imgs[ucArchiveID].uiStreamHandleId = 0;
 
     CloseHandle(m_StreamHandles[uiStreamHandlerID]);
-    m_StreamHandles[uiStreamHandlerID] = nullptr;
+    m_StreamHandles[uiStreamHandlerID] = NULL;
 }
 
 void CStreamingSA::SetStreamingBufferSize(uint32 numBlocks)

--- a/Client/game_sa/CStreamingSA.cpp
+++ b/Client/game_sa/CStreamingSA.cpp
@@ -195,7 +195,7 @@ void CStreamingSA::SetArchivesNum(size_t imagesNum)
 
         MemPutFast<BYTE>((void*)(dwExeCodePtr + 15), (BYTE)0x46);
         MemPutFast<WORD>((void*)(dwExeCodePtr + 16), (WORD)0xFE81);
-        MemPutFast<DWORD>((void*)(dwExeCodePtr + 18), (DWORD)399); // MAX_NUMBER_OF_STREAM_HANDLES
+        MemPutFast<DWORD>((void*)(dwExeCodePtr + 18), (DWORD)(handlesNum - 1)); // MAX_NUMBER_OF_STREAM_HANDLES
 
         MemPutFast<BYTE>((void*)(dwExeCodePtr + 22), (BYTE)0x7C);
         MemPutFast<BYTE>((void*)(dwExeCodePtr + 23), (BYTE)(dwExeCodePtr - (dwExeCodePtr+24)));

--- a/Client/game_sa/CStreamingSA.h
+++ b/Client/game_sa/CStreamingSA.h
@@ -70,7 +70,7 @@ public:
     unsigned char   GetUnusedArchive();
     unsigned char   GetUnusedStreamHandle();
     unsigned char   AddArchive(const char* szFilePath);
-    void            RemoveArchive(unsigned char ucStreamHandler);
+    void            RemoveArchive(unsigned char ucArchiveID);
     void            SetStreamingBufferSize(uint32 uiSize);
     uint32          GetStreamingBufferSize() { return ms_streamingHalfOfBufferSize * 2; }; // In bytes
 

--- a/Client/game_sa/CStreamingSA.h
+++ b/Client/game_sa/CStreamingSA.h
@@ -13,8 +13,8 @@
 
 #include <game/CStreaming.h>
 
-#define VAR_StreamHandlersMaxCount                   32
-#define VAR_MaxArchives                              8
+#define VAR_DefaultStreamHandlersMaxCount                   32
+#define VAR_DefaultMaxArchives                              8
 
 #define FUNC_CStreaming__RequestModel                0x4087E0
 #define FUNC_LoadAllRequestedModels                  0x40EA10
@@ -26,7 +26,7 @@ struct CArchiveInfo
     char  szName[40];
     BYTE  bUnknow = 1;            // Only in player.img is 0. Maybe, it is DWORD value
     BYTE  bUnused[3];
-    DWORD uiStreamHandleId;
+    DWORD uiStreamHandleId{};
 };
 
 struct SGtaStream
@@ -45,12 +45,18 @@ struct SGtaStream
 };
 static_assert(sizeof(SGtaStream) == 0x30, "Invalid size for SGtaStream");
 
+struct SStreamName
+{
+    char szName[64];
+};
+
 class CStreamingSA final : public CStreaming
 {
-private:
-    static CArchiveInfo* GetArchiveInfo(uint id) { return &ms_aAchiveInfo[id]; };
-
 public:
+    CStreamingSA();
+
+    void SetArchivesNum(size_t imagesNum);
+
     void RequestModel(DWORD dwModelID, DWORD dwFlags);
     void RemoveModel(std::uint32_t model) override;
     void LoadAllRequestedModels(bool bOnlyPriorityModels = false, const char* szTag = NULL);
@@ -72,9 +78,13 @@ public:
     std::uint32_t GetMemoryUsed() const override;
 
 private:
+    void AllocateArchive();
+
+    std::vector<CArchiveInfo> m_Imgs;
+    std::vector<HANDLE> m_StreamHandles;
+    std::vector<SStreamName> m_StreamNames;
+
     static void* (&ms_pStreamingBuffer)[2];
     static uint32(&ms_streamingHalfOfBufferSize);
     static CStreamingInfo (&ms_aInfoForModel)[26316];            // count: 26316 in unmodified game
-    static HANDLE (&m_aStreamingHandlers)[32];
-    static CArchiveInfo (&ms_aAchiveInfo)[8];
 };

--- a/Client/mods/deathmatch/logic/CClientIMG.cpp
+++ b/Client/mods/deathmatch/logic/CClientIMG.cpp
@@ -11,8 +11,6 @@
 #include <StdInc.h>
 #include "game/CStreaming.h"
 
-#define INVALID_ARCHIVE_ID 0xFF
-
 struct tImgHeader
 {
     char         szMagic[4];

--- a/Client/sdk/game/CStreaming.h
+++ b/Client/sdk/game/CStreaming.h
@@ -13,6 +13,9 @@
 
 #include <stdint.h>
 
+#define INVALID_ARCHIVE_ID 0xFF
+#define INVALID_STREAM_ID 0xFF
+
 struct CStreamingInfo
 {
     uint16_t prevId = (uint16_t)-1;


### PR DESCRIPTION
An attempt to extend a number of allowed IMG archives that can be simultaneously used and added through **engineAddImage**. The maximum possible number now is 245 in total(and 239 accessible from Lua). It allocates archives on demand which minimize the memory footprint. It also includes changes from #3110.