### PR TITLE
Fix a desync state after aborted carjacking

### DIFF
--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -1791,6 +1791,7 @@ void CPacketHandler::Packet_Vehicle_InOut(NetBitStreamInterface& bitStream)
                                         // For bikes and cars where jacked through passenger door, warp the passenger back in if desynced
                                         if (ucSeat == 0) {
                                             CClientPed* pPassenger = pJacked->GetOccupiedVehicle()->GetOccupant(1);
+                                            // Is the passenger a remote player or ped and is he physically outside but supposed to be in
                                             if (pPassenger &&
                                                 !pPassenger->IsLocalPlayer() &&
                                                 !pPassenger->IsSyncing() &&

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -1777,30 +1777,28 @@ void CPacketHandler::Packet_Vehicle_InOut(NetBitStreamInterface& bitStream)
                             CClientPed* pJacked = pVehicle->GetOccupant(ucSeat);
 
                             // If it's the local player or syncing ped getting jacked, reset some stuff
-                            if (pJacked)
-                                if ((pJacked->IsLocalPlayer() || pJacked->IsSyncing()))
-                                {
+                            if (pJacked) {
+                                if (pJacked->IsLocalPlayer() || pJacked->IsSyncing()) {
                                     pJacked->ResetVehicleInOut();
                                 }
                                 else {
-                                // Desynced? Outside but supposed to be in
-                                // For local player or synced peds this is taken care of in CClientPed::UpdateVehicleInOut()
-                                if (pJacked->GetOccupiedVehicle() && !pJacked->GetRealOccupiedVehicle())
-                                {
-                                    // Warp him back in
-                                    pJacked->WarpIntoVehicle(pJacked->GetOccupiedVehicle(), pJacked->GetOccupiedVehicleSeat());
+                                    // Desynced? Outside but supposed to be in
+                                    // For local player or synced peds this is taken care of in CClientPed::UpdateVehicleInOut()
+                                    if (pJacked->GetOccupiedVehicle() && !pJacked->GetRealOccupiedVehicle()) {
+                                        // Warp him back in
+                                        pJacked->WarpIntoVehicle(pJacked->GetOccupiedVehicle(), pJacked->GetOccupiedVehicleSeat());
 
-                                    // For bikes and cars where jacked through passenger door, warp the passenger back in if desynced
-                                    if (ucSeat == 0)
-                                    {
-                                        CClientPed* pPassenger = pJacked->GetOccupiedVehicle()->GetOccupant(1);
-                                        if (pPassenger &&
-                                            !pPassenger->IsLocalPlayer() &&
-                                            !pPassenger->IsSyncing() &&
-                                            pPassenger->GetOccupiedVehicle() &&
-                                            !pPassenger->GetRealOccupiedVehicle())
-                                        {
-                                            pPassenger->WarpIntoVehicle(pPassenger->GetOccupiedVehicle(), pPassenger->GetOccupiedVehicleSeat());
+                                        // For bikes and cars where jacked through passenger door, warp the passenger back in if desynced
+                                        if (ucSeat == 0) {
+                                            CClientPed* pPassenger = pJacked->GetOccupiedVehicle()->GetOccupant(1);
+                                            if (pPassenger &&
+                                                !pPassenger->IsLocalPlayer() &&
+                                                !pPassenger->IsSyncing() &&
+                                                pPassenger->GetOccupiedVehicle() &&
+                                                !pPassenger->GetRealOccupiedVehicle())
+                                            {
+                                                pPassenger->WarpIntoVehicle(pPassenger->GetOccupiedVehicle(), pPassenger->GetOccupiedVehicleSeat());
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
Sometimes driver and sometimes passenger is desynced on the screen of a remote player after a carjacking. The driver is stuck to the car but not actually inside. Sometimes the vehicle goes flying.
Happens with high latency or lag.

Looks like this. The desync remains even after jacking is aborted.

https://github.com/multitheftauto/mtasa-blue/assets/59518113/94e1b166-d9ae-42ce-a57d-d0677ab14c40

With the fix. The desync is corrected when the jacking is aborted.

https://github.com/multitheftauto/mtasa-blue/assets/59518113/ffea112f-bb8b-4e4a-86d7-964c61ba1226


