### PR TITLE
Add unsafe resource marker

### DIFF
--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -5007,6 +5007,13 @@ void CPacketHandler::Packet_ResourceStart(NetBitStreamInterface& bitStream)
         bitStream.Read(iDownloadPriorityGroup);
     }
 
+    // A boolean whether the resource will run in unsafe mode or not. To remain backwards compatible, we have to run in unsafe mode by default.
+    bool isUnsafe{true};
+    if (bitStream.Can(eBitStreamVersion::IsUnsafeResource))
+    {
+        bitStream.ReadBit(isUnsafe);
+    }
+
     // Get the resource entity
     CClientEntity* pResourceEntity = CElementIDs::GetElement(ResourceEntityID);
 
@@ -5022,7 +5029,7 @@ void CPacketHandler::Packet_ResourceStart(NetBitStreamInterface& bitStream)
     bool bFatalError = false;
 
     CResource* pResource = g_pClientGame->m_pResourceManager->Add(usResourceID, szResourceName, pResourceEntity, pResourceDynamicEntity, strMinServerReq,
-                                                                  strMinClientReq, bEnableOOP);
+                                                                  strMinClientReq, bEnableOOP, isUnsafe);
     if (pResource)
     {
         pResource->SetRemainingNoClientCacheScripts(usNoClientCacheScriptCount);

--- a/Client/mods/deathmatch/logic/CResource.cpp
+++ b/Client/mods/deathmatch/logic/CResource.cpp
@@ -21,7 +21,8 @@ extern CClientGame* g_pClientGame;
 int CResource::m_iShowingCursor = 0;
 
 CResource::CResource(unsigned short usNetID, const char* szResourceName, CClientEntity* pResourceEntity, CClientEntity* pResourceDynamicEntity,
-                     const CMtaVersion& strMinServerReq, const CMtaVersion& strMinClientReq, bool bEnableOOP)
+                     const CMtaVersion& strMinServerReq, const CMtaVersion& strMinClientReq, bool bEnableOOP, bool isUnsafe)
+    : m_bOOPEnabled{bEnableOOP}, m_isUnsafe{isUnsafe}
 {
     m_uiScriptID = CIdArray::PopUniqueId(this, EIdClass::RESOURCE);
     m_usNetID = usNetID;
@@ -80,12 +81,7 @@ CResource::CResource(unsigned short usNetID, const char* szResourceName, CClient
     if (!m_strResourcePrivateDirectoryPathOld.empty())
         m_strResourcePrivateDirectoryPathOld = PathJoin(m_strResourcePrivateDirectoryPathOld, m_strResourceName);
 
-    // Move this after the CreateVirtualMachine line and heads will roll
-    m_bOOPEnabled = bEnableOOP;
-    m_iDownloadPriorityGroup = 0;
-
-    m_pLuaVM = m_pLuaManager->CreateVirtualMachine(this, bEnableOOP);
-    if (m_pLuaVM)
+    if (m_pLuaVM = m_pLuaManager->CreateVirtualMachine(this, bEnableOOP, isUnsafe); m_pLuaVM != nullptr)
     {
         m_pLuaVM->SetScriptName(szResourceName);
         m_pLuaVM->LoadEmbeddedScripts();

--- a/Client/mods/deathmatch/logic/CResource.h
+++ b/Client/mods/deathmatch/logic/CResource.h
@@ -38,7 +38,7 @@ class CResource
 {
 public:
     CResource(unsigned short usNetID, const char* szResourceName, CClientEntity* pResourceEntity, CClientEntity* pResourceDynamicEntity,
-              const CMtaVersion& strMinServerReq, const CMtaVersion& strMinClientReq, bool bEnableOOP);
+              const CMtaVersion& strMinServerReq, const CMtaVersion& strMinClientReq, bool bEnableOOP, bool isUnsafe);
     ~CResource();
 
     unsigned short GetNetID() { return m_usNetID; };
@@ -93,11 +93,18 @@ public:
     void               LoadNoClientCacheScript(const char* chunk, unsigned int length, const SString& strFilename);
     const CMtaVersion& GetMinServerReq() const { return m_strMinServerReq; }
     const CMtaVersion& GetMinClientReq() const { return m_strMinClientReq; }
-    bool               IsOOPEnabled() { return m_bOOPEnabled; }
+    bool               IsOOPEnabled() const noexcept { return m_bOOPEnabled; }
     void               HandleDownloadedFileTrouble(CResourceFile* pResourceFile, bool bScript);
     bool               IsWaitingForInitialDownloads();
     int                GetDownloadPriorityGroup() { return m_iDownloadPriorityGroup; }
     void               SetDownloadPriorityGroup(int iDownloadPriorityGroup) { m_iDownloadPriorityGroup = iDownloadPriorityGroup; }
+
+    /**
+     * @brief Returns a boolean whether this resource is running in unsafe mode.
+     *
+     * The unsafe mode is controlled by the server and this value never changes on the client.
+     */
+    bool IsUnsafe() const noexcept { return m_isUnsafe; }
 
 private:
     unsigned short       m_usNetID;
@@ -121,8 +128,9 @@ private:
     bool                 m_bLoadAfterReceivingNoClientCacheScripts;
     CMtaVersion          m_strMinServerReq;
     CMtaVersion          m_strMinClientReq;
-    bool                 m_bOOPEnabled;
-    int                  m_iDownloadPriorityGroup;
+    bool                 m_bOOPEnabled{false};
+    bool                 m_isUnsafe{false};            // A boolean whether this resource is running in unsafe mode.
+    int                  m_iDownloadPriorityGroup{0};
 
     // To control cursor show/hide
     static int m_iShowingCursor;

--- a/Client/mods/deathmatch/logic/CResourceManager.cpp
+++ b/Client/mods/deathmatch/logic/CResourceManager.cpp
@@ -30,9 +30,10 @@ CResourceManager::~CResourceManager()
 }
 
 CResource* CResourceManager::Add(unsigned short usNetID, const char* szResourceName, CClientEntity* pResourceEntity, CClientEntity* pResourceDynamicEntity,
-                                 const CMtaVersion& strMinServerReq, const CMtaVersion& strMinClientReq, bool bEnableOOP)
+                                 const CMtaVersion& strMinServerReq, const CMtaVersion& strMinClientReq, bool bEnableOOP, bool isUnsafe)
 {
-    CResource* pResource = new CResource(usNetID, szResourceName, pResourceEntity, pResourceDynamicEntity, strMinServerReq, strMinClientReq, bEnableOOP);
+    CResource* pResource =
+        new CResource(usNetID, szResourceName, pResourceEntity, pResourceDynamicEntity, strMinServerReq, strMinClientReq, bEnableOOP, isUnsafe);
     if (pResource)
     {
         m_resources.push_back(pResource);

--- a/Client/mods/deathmatch/logic/CResourceManager.h
+++ b/Client/mods/deathmatch/logic/CResourceManager.h
@@ -32,7 +32,7 @@ public:
     ~CResourceManager();
 
     CResource* Add(unsigned short usNetID, const char* szResourceName, CClientEntity* pResourceEntity, CClientEntity* pResourceDynamicEntity,
-                   const CMtaVersion& strMinServerReq, const CMtaVersion& strMinClientReq, bool bEnableOOP);
+                   const CMtaVersion& strMinServerReq, const CMtaVersion& strMinClientReq, bool bEnableOOP, bool isUnsafe);
     CResource* GetResource(const char* szResourceName);
     CResource* GetResourceFromNetID(unsigned short usNetID);
     CResource* GetResourceFromScriptID(uint uiScriptID);

--- a/Client/mods/deathmatch/logic/lua/CLuaMain.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaMain.h
@@ -37,7 +37,7 @@ class CLuaMain            //: public CClient
 {
 public:
     ZERO_ON_NEW
-    CLuaMain(class CLuaManager* pLuaManager, CResource* pResourceOwner, bool bEnableOOP);
+    CLuaMain(class CLuaManager* pLuaManager, CResource* pResourceOwner, bool bEnableOOP, bool isUnsafe);
     ~CLuaMain();
 
     bool LoadScriptFromBuffer(const char* cpBuffer, unsigned int uiSize, const char* szFileName);
@@ -80,6 +80,11 @@ public:
 
     bool IsOOPEnabled() { return m_bEnableOOP; }
 
+    /**
+     * @brief Returns a boolean whether this Lua virtual machine is running in unsafe mode.
+     */
+    bool IsUnsafe() const noexcept { return m_isUnsafe; }
+
 private:
     void InitSecurity();
 
@@ -100,7 +105,8 @@ private:
     std::unordered_set<std::unique_ptr<SXMLString>> m_XMLStringNodes;
     static SString                                  ms_strExpectedUndumpHash;
 
-    bool m_bEnableOOP;
+    bool m_bEnableOOP{false};
+    bool m_isUnsafe{false};            // A boolean whether this Lua virtual machine is running in unsafe mode.
 
 public:
     CFastHashMap<const void*, CRefInfo> m_CallbackTable;

--- a/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -56,10 +56,10 @@ CLuaManager::~CLuaManager()
     CLuaCFunctions::RemoveAllFunctions();
 }
 
-CLuaMain* CLuaManager::CreateVirtualMachine(CResource* pResourceOwner, bool bEnableOOP)
+CLuaMain* CLuaManager::CreateVirtualMachine(CResource* pResourceOwner, bool bEnableOOP, bool isUnsafe)
 {
     // Create it and add it to the list over VM's
-    CLuaMain* pLuaMain = new CLuaMain(this, pResourceOwner, bEnableOOP);
+    CLuaMain* pLuaMain = new CLuaMain(this, pResourceOwner, bEnableOOP, isUnsafe);
     m_virtualMachines.push_back(pLuaMain);
     pLuaMain->InitVM();
     return pLuaMain;

--- a/Client/mods/deathmatch/logic/lua/CLuaManager.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaManager.h
@@ -27,7 +27,7 @@ public:
     CLuaManager(class CClientGame* pClientGame);
     ~CLuaManager();
 
-    CLuaMain* CreateVirtualMachine(CResource* pResourceOwner, bool bEnableOOP);
+    CLuaMain* CreateVirtualMachine(CResource* pResourceOwner, bool bEnableOOP, bool isUnsafe);
     bool      RemoveVirtualMachine(CLuaMain* vm);
     CLuaMain* GetVirtualMachine(lua_State* luaVM);
     void      OnLuaMainOpenVM(CLuaMain* pLuaMain, lua_State* luaVM);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
@@ -433,6 +433,14 @@ int CLuaResourceDefs::GetResourceState(lua_State* luaVM)
 
 int CLuaResourceDefs::LoadString(lua_State* luaVM)
 {
+    CLuaMain& luaMain = lua_getownercluamain(luaVM);
+
+    if (!luaMain.IsUnsafe())
+    {
+        lua_pushboolean(luaVM, false);
+        return 1;
+    }
+
     //  func,err loadstring( string text[, string name] )
     SString strInput;
     SString strName;
@@ -483,6 +491,14 @@ int CLuaResourceDefs::LoadString(lua_State* luaVM)
 
 int CLuaResourceDefs::Load(lua_State* luaVM)
 {
+    CLuaMain& luaMain = lua_getownercluamain(luaVM);
+
+    if (!luaMain.IsUnsafe())
+    {
+        lua_pushboolean(luaVM, false);
+        return 1;
+    }
+
     //  func,err load( callback callbackFunction[, string name] )
     CLuaFunctionRef iLuaFunction;
     SString         strName;
@@ -498,18 +514,19 @@ int CLuaResourceDefs::Load(lua_State* luaVM)
         // Should apply some limit here?
         SString       strInput;
         CLuaArguments callbackArguments;
-        CLuaMain*     pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
-        while (pLuaMain)
+
+        while (true)
         {
             CLuaArguments returnValues;
-            callbackArguments.Call(pLuaMain, iLuaFunction, &returnValues);
+            callbackArguments.Call(&luaMain, iLuaFunction, &returnValues);
+
             if (returnValues.Count())
             {
                 CLuaArgument* returnedValue = *returnValues.IterBegin();
                 int           iType = returnedValue->GetType();
+
                 if (iType == LUA_TNIL)
                     break;
-
                 else if (iType == LUA_TSTRING)
                 {
                     std::string str = returnedValue->GetString();
@@ -520,6 +537,7 @@ int CLuaResourceDefs::Load(lua_State* luaVM)
                     continue;
                 }
             }
+
             break;
         }
 

--- a/Server/mods/deathmatch/logic/CResource.h
+++ b/Server/mods/deathmatch/logic/CResource.h
@@ -308,6 +308,14 @@ public:
 
     bool IsOOPEnabledInMetaXml() const noexcept { return m_bOOPEnabledInMetaXml; }
 
+    /**
+     * @brief Returns a boolean whether this resource is running in unsafe mode.
+     * 
+     * The return value is meaningless if the resource is not running.
+     * An unsafe resource has access to the loadstring function, but only if the resource has no grant for "general.ModifyOtherObjects".
+    */
+    bool IsUnsafe() const noexcept { return m_isUnsafe; }
+
     bool CheckFunctionRightCache(lua_CFunction f, bool* pbOutAllowed);
     void UpdateFunctionRightCache(lua_CFunction f, bool bAllowed);
 
@@ -344,7 +352,7 @@ private:
     bool ReadIncludedHTML(CXMLNode* pRoot);
     bool ReadIncludedExports(CXMLNode* pRoot);
     bool ReadIncludedFiles(CXMLNode* pRoot);
-    bool CreateVM(bool bEnableOOP);
+    bool CreateVM(bool bEnableOOP, bool isUnsafe);
     bool DestroyVM();
     void TidyUp();
 
@@ -412,8 +420,11 @@ private:
 
     bool m_bOOPEnabledInMetaXml = false;
     bool m_bLinked = false;                  // if true, the included resources are already linked to this resource
-    bool m_bIsPersistent = false;            // if true, the resource will remain even if it has no Dependents, mainly if started by the user or the startup
+    bool m_bIsPersistent = false;            // if true, this resource will remain even if it has no Dependents, mainly if started by the user or the startup
     bool m_bDestroyed = false;
+
+    bool m_isUnsafeInMetaXml = false;            // If true, this resource is marked as unsafe in the meta.xml file.
+    bool m_isUnsafe = false;                     // A boolean whether this resource is running in unsafe mode. Use only when the resource is running.
 
     CXMLNode* m_pNodeSettings = nullptr;            // Settings XML node, read from meta.xml and copied into it's own instance
     CXMLNode* m_pNodeStorage = nullptr;             // Dummy XML node used for temporary storage of stuff returned by CSettings::Get

--- a/Server/mods/deathmatch/logic/CResourceHTMLItem.cpp
+++ b/Server/mods/deathmatch/logic/CResourceHTMLItem.cpp
@@ -25,7 +25,7 @@ extern CGame*            g_pGame;
 
 CResourceHTMLItem::CResourceHTMLItem(CResource* resource, const char* szShortName, const char* szResourceFileName, CXMLAttributes* xmlAttributes,
                                      bool bIsDefault, bool bIsRaw, bool bRestricted, bool bOOPEnabled)
-    : CResourceFile(resource, szShortName, szResourceFileName, xmlAttributes)
+    : CResourceFile(resource, szShortName, szResourceFileName, xmlAttributes), m_bOOPEnabled{bOOPEnabled}
 {
     m_bIsRaw = bIsRaw;
     m_type = RESOURCE_FILE_TYPE_HTML;
@@ -33,7 +33,6 @@ CResourceHTMLItem::CResourceHTMLItem(CResource* resource, const char* szShortNam
     m_pVM = NULL;
     m_bIsBeingRequested = false;
     m_bRestricted = bRestricted;
-    m_bOOPEnabled = bOOPEnabled;
 }
 
 CResourceHTMLItem::~CResourceHTMLItem()
@@ -298,7 +297,7 @@ bool CResourceHTMLItem::Start()
              fwrite ( m_szBuffer, 1, strlen(m_szBuffer), debug );
              fclose ( debug );*/
 
-        m_pVM = g_pGame->GetLuaManager()->CreateVirtualMachine(m_resource, m_bOOPEnabled);
+        m_pVM = g_pGame->GetLuaManager()->CreateVirtualMachine(m_resource, m_bOOPEnabled, m_resource->IsUnsafe());
         m_pVM->LoadEmbeddedScripts();
         m_pVM->RegisterModuleFunctions();
         m_pVM->LoadScript(strScript.c_str());

--- a/Server/mods/deathmatch/logic/CResourceHTMLItem.h
+++ b/Server/mods/deathmatch/logic/CResourceHTMLItem.h
@@ -51,7 +51,7 @@ private:
     std::string m_strMime;
     bool        m_bRestricted;
 
-    bool m_bOOPEnabled;
+    bool m_bOOPEnabled{false};
 
     ResponseCode  m_responseCode;
     HttpResponse* m_currentResponse;

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.h
@@ -40,7 +40,8 @@ class CLuaMain            //: public CClient
 public:
     ZERO_ON_NEW
     CLuaMain(class CLuaManager* pLuaManager, CObjectManager* pObjectManager, CPlayerManager* pPlayerManager, CVehicleManager* pVehicleManager,
-             CBlipManager* pBlipManager, CRadarAreaManager* pRadarAreaManager, CMapManager* pMapManager, CResource* pResourceOwner, bool bEnableOOP);
+             CBlipManager* pBlipManager, CRadarAreaManager* pRadarAreaManager, CMapManager* pMapManager, CResource* pResourceOwner, bool bEnableOOP,
+             bool isUnsafe);
 
     ~CLuaMain();
 
@@ -114,7 +115,12 @@ private:
     void InitClasses(lua_State* luaVM);
 
 public:
-    bool IsOOPEnabled() { return m_bEnableOOP; }
+    bool IsOOPEnabled() const noexcept { return m_bEnableOOP; }
+
+    /**
+     * @brief Returns a boolean whether this Lua virtual machine is running in unsafe mode.
+    */
+    bool IsUnsafe() const noexcept { return m_isUnsafe; }
 
 private:
     static void InstructionCountHook(lua_State* luaVM, lua_Debug* pDebug);
@@ -138,9 +144,9 @@ private:
     list<CTextDisplay*>                             m_Displays;
     list<CTextItem*>                                m_TextItems;
 
-    bool m_bEnableOOP;
-
-    bool m_bBeingDeleted;            // prevent it being deleted twice
+    bool m_bEnableOOP{};
+    bool m_isUnsafe{};                 // A boolean whether this Lua virtual machine is running in unsafe mode.
+    bool m_bBeingDeleted{};            // prevent it being deleted twice
 
     CElapsedTime         m_FunctionEnterTimer;
     CElapsedTimeApprox   m_WarningTimer;

--- a/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -88,11 +88,11 @@ CLuaManager::~CLuaManager()
     delete m_pLuaModuleManager;
 }
 
-CLuaMain* CLuaManager::CreateVirtualMachine(CResource* pResourceOwner, bool bEnableOOP)
+CLuaMain* CLuaManager::CreateVirtualMachine(CResource* pResourceOwner, bool bEnableOOP, bool isUnsafe)
 {
     // Create it and add it to the list over VM's
     CLuaMain* pLuaMain = new CLuaMain(this, m_pObjectManager, m_pPlayerManager, m_pVehicleManager, m_pBlipManager, m_pRadarAreaManager, m_pMapManager,
-                                      pResourceOwner, bEnableOOP);
+                                      pResourceOwner, bEnableOOP, isUnsafe);
     m_virtualMachines.push_back(pLuaMain);
     pLuaMain->Initialize();
 

--- a/Server/mods/deathmatch/logic/lua/CLuaManager.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaManager.h
@@ -36,7 +36,7 @@ public:
                 CRadarAreaManager* pRadarAreaManager, CRegisteredCommands* pRegisteredCommands, CMapManager* pMapManager, CEvents* pEvents);
     ~CLuaManager();
 
-    CLuaMain*  CreateVirtualMachine(CResource* pResourceOwner, bool bEnableOOP);
+    CLuaMain*  CreateVirtualMachine(CResource* pResourceOwner, bool bEnableOOP, bool isUnsafe);
     bool       RemoveVirtualMachine(CLuaMain* vm);
     CLuaMain*  GetVirtualMachine(lua_State* luaVM);
     CResource* GetVirtualMachineResource(lua_State* luaVM);

--- a/Server/mods/deathmatch/logic/packets/CResourceStartPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CResourceStartPacket.cpp
@@ -77,6 +77,11 @@ bool CResourceStartPacket::Write(NetBitStreamInterface& BitStream) const
             BitStream.Write(m_pResource->GetDownloadPriorityGroup());
         }
 
+        if (BitStream.Can(eBitStreamVersion::IsUnsafeResource))
+        {
+            BitStream.WriteBit(m_pResource->IsUnsafe());
+        }
+
         // Send the resource files info
         std::list<CResourceFile*>::iterator iter = m_pResource->IterBegin();
         for (; iter != m_pResource->IterEnd(); iter++)

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
@@ -47,6 +47,7 @@ void CLuaUtilDefs::LoadFunctions()
         {"getRealTime", GetCTime},
         {"split", Split},
         {"isOOPEnabled", IsOOPEnabled},
+        {"isUnsafeResource", IsUnsafeResource},
         {"getUserdataType", GetUserdataType},
         {"print", luaB_print},
         {"getColorFromString", GetColorFromString},
@@ -241,12 +242,15 @@ int CLuaUtilDefs::Split(lua_State* luaVM)
 
 int CLuaUtilDefs::IsOOPEnabled(lua_State* luaVM)
 {
-    CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
-    if (pLuaMain)
-        lua_pushboolean(luaVM, pLuaMain->IsOOPEnabled());
-    else
-        lua_pushnil(luaVM);
+    CLuaMain& luaMain = lua_getownercluamain(luaVM);
+    lua_pushboolean(luaVM, luaMain.IsOOPEnabled());
+    return 1;
+}
 
+int CLuaUtilDefs::IsUnsafeResource(lua_State* luaVM)
+{
+    CLuaMain& luaMain = lua_getownercluamain(luaVM);
+    lua_pushboolean(luaVM, luaMain.IsUnsafe());
     return 1;
 }
 

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.h
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.h
@@ -27,6 +27,7 @@ public:
     LUA_DECLARE(GetCTime);
     LUA_DECLARE(Split);
     LUA_DECLARE(IsOOPEnabled);
+    LUA_DECLARE(IsUnsafeResource);
     LUA_DECLARE(GetUserdataType);
     LUA_DECLARE(luaB_print);
     LUA_DECLARE(GetColorFromString);

--- a/Shared/sdk/net/bitstream.h
+++ b/Shared/sdk/net/bitstream.h
@@ -526,7 +526,12 @@ enum class eBitStreamVersion : unsigned short
     // 1.6.0 RELEASED - 2023-04-07
     //
 
+    // 0x77
     CEntityAddPacket_ObjectBreakable,
+
+    // Add unsafe resource marker to disable load/loadstring functions
+    // 2022-07-25 0x78
+    IsUnsafeResource,
 
     // This allows us to automatically increment the BitStreamVersion when things are added to this enum.
     // Make sure you only add things above this comment.


### PR DESCRIPTION
This pull request introduces an `<unsafe>true</unsafe>` marker requirement for every resource that utilizes either the `load` or `loadstring` function. Furthermore, an unsafe resource is not allowed to be granted the `general.ModifyOtherObjects` permission. An unsafe resource can still use `general.ModifyOtherObjects.<resourceName>` to receive access to specific resources, if desired.

Without this unsafe marker, these two functions will not work, not on the server neither on the client (if the bitstream version supports it). If a player with a newer client joins a server which doesn't support the unsafe marker yet, the client will default to unsafe mode and thus allow the usage of  `load` and `loadstring` functions.

For developers I have added the `isUnsafeResource` function, which returns a boolean whether the current resource is marked as unsafe. For security reasons this function should never be capable of returning the unsafe marker for another resource. Now, if you want to use either `load` or `loadstring` in your resource, you need to:

- add `<unsafe>true</unsafe>` to the meta.xml
- grant `function.loadstring` and/or `function.load` permissions for the resource
- ensure that `general.ModifyOtherObjects` is not granted to the resource

At last, the server now also restricts the functions `load` and `loadstring` by default. That means the permission to use either of those must be explicitly granted by the ACL.