### PR TITLE
Add fileGetContents function to server and client

### DIFF
--- a/Client/mods/deathmatch/logic/CResource.cpp
+++ b/Client/mods/deathmatch/logic/CResource.cpp
@@ -440,6 +440,19 @@ SString CResource::GetResourceDirectoryPath(eAccessType accessType, const SStrin
     return PathJoin(m_strResourceDirectoryPath, strMetaPath);
 }
 
+CResourceFile* CResource::GetResourceFile(const SString& relativePath) const
+{
+    for (CResourceFile* resourceFile : m_ResourceFiles)
+    {
+        if (!stricmp(relativePath.c_str(), resourceFile->GetShortName()))
+        {
+            return resourceFile;
+        }
+    }
+
+    return nullptr;
+}
+
 void CResource::LoadNoClientCacheScript(const char* chunk, unsigned int len, const SString& strFilename)
 {
     if (m_usRemainingNoClientCacheScripts > 0)

--- a/Client/mods/deathmatch/logic/CResource.h
+++ b/Client/mods/deathmatch/logic/CResource.h
@@ -89,6 +89,13 @@ public:
     std::list<CResourceFile*>::iterator IterBeginResourceFiles() { return m_ResourceFiles.begin(); }
     std::list<CResourceFile*>::iterator IterEndResourceFiles() { return m_ResourceFiles.end(); }
 
+    /**
+     * @brief Searches for a CResourceFile with the given relative path.
+     * @param relativePath Relative resource file path (from meta)
+     * @return A pointer to CResourceFile on success, null otherwise
+     */
+    CResourceFile* GetResourceFile(const SString& relativePath) const;
+
     void               SetRemainingNoClientCacheScripts(unsigned short usRemaining) { m_usRemainingNoClientCacheScripts = usRemaining; }
     void               LoadNoClientCacheScript(const char* chunk, unsigned int length, const SString& strFilename);
     const CMtaVersion& GetMinServerReq() const { return m_strMinServerReq; }

--- a/Client/mods/deathmatch/logic/CScriptFile.cpp
+++ b/Client/mods/deathmatch/logic/CScriptFile.cpp
@@ -223,3 +223,8 @@ CResource* CScriptFile::GetResource()
 {
     return m_pResource;
 }
+
+CResourceFile* CScriptFile::GetResourceFile() const
+{
+    return m_pResource->GetResourceFile(m_strFilename);
+}

--- a/Client/mods/deathmatch/logic/CScriptFile.h
+++ b/Client/mods/deathmatch/logic/CScriptFile.h
@@ -14,6 +14,8 @@
 #include <stdio.h>
 #include <string>
 
+class CResourceFile;
+
 class CScriptFile final : public CClientEntity
 {
     DECLARE_CLASS(CScriptFile, CClientEntity)
@@ -45,6 +47,14 @@ public:
 
     // Get the owning resource
     CResource* GetResource();
+
+    // Get the respective resource file (null if not found).
+
+    /**
+     * @brief Returns a pointer to CResourceFile if the script file points to one.
+     * @return A pointer to CResourceFile on success, null otherwise
+    */
+    CResourceFile* GetResourceFile() const;
 
     // Only call functions below this if you're sure that the file is loaded.
     // Or you will crash.

--- a/Server/mods/deathmatch/logic/CResource.cpp
+++ b/Server/mods/deathmatch/logic/CResource.cpp
@@ -3407,3 +3407,16 @@ bool CResource::IsFileDbConnectMysqlProtected(const SString& strAbsFilename, boo
 
     return false;
 }
+
+CResourceFile* CResource::GetResourceFile(const SString& relativePath) const
+{
+    for (CResourceFile* resourceFile : m_ResourceFiles)
+    {
+        if (!stricmp(relativePath.c_str(), resourceFile->GetName()))
+        {
+            return resourceFile;
+        }
+    }
+
+    return nullptr;
+}

--- a/Server/mods/deathmatch/logic/CResource.h
+++ b/Server/mods/deathmatch/logic/CResource.h
@@ -319,6 +319,13 @@ public:
     bool IsUsingDbConnectMysql();
     bool IsFileDbConnectMysqlProtected(const SString& strFilename, bool bReadOnly);
 
+    /**
+     * @brief Searches for a CResourceFile with the given relative path.
+     * @param relativePath Relative resource file path (from meta)
+     * @return A pointer to CResourceFile on success, null otherwise
+     */
+    CResourceFile* GetResourceFile(const SString& relativePath) const;
+
 public:
     static std::list<CResource*> m_StartedResources;
 

--- a/Server/mods/deathmatch/logic/CScriptFile.cpp
+++ b/Server/mods/deathmatch/logic/CScriptFile.cpp
@@ -213,3 +213,8 @@ CResource* CScriptFile::GetResource()
 {
     return m_pResource;
 }
+
+CResourceFile* CScriptFile::GetResourceFile() const
+{
+    return m_pResource->GetResourceFile(m_strFilename);
+}

--- a/Server/mods/deathmatch/logic/CScriptFile.h
+++ b/Server/mods/deathmatch/logic/CScriptFile.h
@@ -16,6 +16,8 @@
 #include <stdio.h>
 #include <string>
 
+class CResourceFile;
+
 class CScriptFile final : public CElement
 {
 public:
@@ -40,6 +42,12 @@ public:
 
     // Get the owning resource
     CResource* GetResource();
+
+    /**
+     * @brief Returns a pointer to CResourceFile if the script file points to one.
+     * @return A pointer to CResourceFile on success, null otherwise
+     */
+    CResourceFile* GetResourceFile() const;
 
     // Only call functions belw this if you're sure that the file is loaded.
     // Or you will crash.

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.h
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.h
@@ -30,6 +30,7 @@ private:
     LUA_DECLARE(fileFlush);
     LUA_DECLARE(fileRead);
     LUA_DECLARE(fileWrite);
+    LUA_DECLARE(fileGetContents);
 
     LUA_DECLARE(fileGetPos);
     LUA_DECLARE(fileGetSize);

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.h
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.h
@@ -30,7 +30,7 @@ private:
     LUA_DECLARE(fileFlush);
     LUA_DECLARE(fileRead);
     LUA_DECLARE(fileWrite);
-    LUA_DECLARE(fileGetContents);
+    static std::optional<SString> fileGetContents(lua_State* L, CScriptFile* scriptFile, std::optional<bool> maybeVerifyContents);
 
     LUA_DECLARE(fileGetPos);
     LUA_DECLARE(fileGetSize);


### PR DESCRIPTION
Adds a function to read the entire content of a file in a secure manner (can be turned off via parameter) to both client and server side. This function should enable scripters to safely read the contents of a file with additional verification to eliminate the risk of loading a manipulated file (by outside forces). This is really important if you plan to or already use `loadstring` without further verification of the contents you retrieved from a file.

## Syntax
```cpp
nil|string fileGetContents ( file target [ , bool verifyContents = true ] )
```
**target:** A file handle (from `fileCreate` or `fileOpen`)
**verifyContents:** If true, only return the contents if the (server provided _on client_ | computed on start _on server_) checksum matches

## Example
```lua
local f = fileOpen("code.lua", true)
local b = fileGetContents(f) -- code.lua must be listed in meta.xml (for example as <file> for this example)
fileClose(f)
loadstring(b)()
```

> **Note**
> For convenience, if you call this function like `fileGetContents(f, false)` you retrieve the contents of the file without verification. The function defaults to verification to be secure by default.