### PR TITLE
Fix #3143: Ped revives when syncer changes

### DIFF
--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -1970,6 +1970,8 @@ void CGame::Packet_PedWasted(CPedWastedPacket& Packet)
     if (pPed && !pPed->IsDead())
     {
         pPed->SetIsDead(true);
+        pPed->SetHealth(0.0f);
+        pPed->SetArmor(0.0f);
         pPed->SetPosition(Packet.m_vecPosition);
 
         // Reset his vehicle action, but only if not jacking


### PR DESCRIPTION
Small fix for #3143
When ped is killed and synced by player with some latency to server, the bug occurs.

The wasted packet is sent immediately as ped dies which increments sync context on server.
Before the new sync context is bounced back, the client has sent ped sync containing old sync context but the new health value (0). This is ignored by server.

The health value (0) is not re-sent because only changed values are sent.
So on server the ped is dead but ped has health value > 0 forever, this is sent to clients (and new syncer in video example) causing them to revive clientside.