### PR TITLE
Feature: Changing model geometry at runtime

### DIFF
--- a/Client/game_sa/CRenderWareSA.cpp
+++ b/Client/game_sa/CRenderWareSA.cpp
@@ -1218,3 +1218,31 @@ bool CGeometryUpdate::FlushChanged(RpGeometry* pGeometry, std::string& frameName
     m_mapGeometryFrameUpdate[frameName].m_vecVertexSetColor.clear();
     RpGeometryUnlock(pGeometry);
 }
+
+typedef uint32_t(__cdecl* RpGeometryRegisterPluginStream_t)(int pluginID, void* readBC, void* writeCB, void* getSizeCB);
+
+#define RWPLUGINOFFSET(_type, _base, _offset) ((_type*)((unsigned char*)(_base) + (_offset)))
+
+
+bool CRenderWareSA::ExportModel(uint16_t usModelId, std::string& outString)
+{
+    CModelInfo* pModelInfo = g_pCore->GetGame()->GetModelInfo(usModelId);
+    if (pModelInfo == nullptr)
+        return false;
+
+    if (pModelInfo->GetRwObject() == nullptr)
+        return false;
+
+    RwStream* stream = nullptr;
+
+    std::string file("out.dff");
+    //stream = RwStreamOpen(STREAM_TYPE_FILENAME, STREAM_MODE_WRITE, file.c_str());
+    stream = RwStreamOpen(STREAM_TYPE_BUFFER, STREAM_MODE_WRITE, nullptr);
+    if (stream == nullptr)
+        return false;
+    RpClumpStreamWrite((RpClump*)pModelInfo->GetRwObject(), stream);
+    RwStreamClose(stream, nullptr);
+    outString = std::string((char*)stream->data.ptr_file, stream->data.size);
+    return true;
+    //return false;
+}

--- a/Client/game_sa/CRenderWareSA.cpp
+++ b/Client/game_sa/CRenderWareSA.cpp
@@ -986,3 +986,26 @@ void CRenderWareSA::RwMatrixSetScale(RwMatrix& rwInOutMatrix, const CVector& vec
     rwInOutMatrix.up = (RwV3d&)matTemp.vFront;
     rwInOutMatrix.at = (RwV3d&)matTemp.vUp;
 }
+
+void RwFrameDump(RwFrame* parent, std::vector<std::vector<std::string>>& frames)
+{
+    RwFrame* ret = parent->child;
+    while (ret != NULL)
+    {
+        // recurse into the child
+        if (ret->child != NULL)
+        {
+            RwFrameDump(ret, frames);
+        }
+        frames.push_back({ret->szName, parent->szName});
+        ret = ret->next;
+    }
+}
+
+void CRenderWareSA::GetFrameHierarchy(RpClump* pRoot, std::vector<std::vector<std::string>>& frames)
+{
+    if (RpGetFrame(pRoot) == nullptr)
+        return;
+    RwFrameDump(RpGetFrame(pRoot), frames);
+}
+

--- a/Client/game_sa/CRenderWareSA.h
+++ b/Client/game_sa/CRenderWareSA.h
@@ -114,6 +114,7 @@ public:
     void RwMatrixSetPosition(RwMatrix& rwInOutMatrix, const CVector& vecPosition);
     void RwMatrixGetScale(const RwMatrix& rwMatrix, CVector& vecOutScale);
     void RwMatrixSetScale(RwMatrix& rwInOutMatrix, const CVector& vecScale);
+    void GetFrameHierarchy(RpClump* pRoot, std::vector<std::vector<std::string>>& frames);
 
     // CRenderWareSA methods
     RwTexture*          RightSizeTexture(RwTexture* pTexture, uint uiSizeLimit, SString& strError);

--- a/Client/game_sa/CRenderWareSA.h
+++ b/Client/game_sa/CRenderWareSA.h
@@ -48,16 +48,25 @@ public:
     CVector position;
 };
 
+struct SGeometryVertexSetColor
+{
+public:
+    int vertexIndex;
+    SColor color;
+};
+
 class CGeometryFrameUpdate
 {
 public:
     std::vector<SGeometryVertexSetPosition> m_vecVertexSetPosition;
+    std::vector<SGeometryVertexSetColor> m_vecVertexSetColor;
 };
 
 class CGeometryUpdate
 {
 public:
     void VertexSetPosition(std::string& frameName, int vertexIndex, CVector position);
+    void VertexSetColor(std::string& frameName, int vertexIndex, SColor color);
     bool FlushChanged(RpGeometry* pGeometry, std::string& frameName);
 
 private:
@@ -156,12 +165,13 @@ public:
     void RwMatrixSetPosition(RwMatrix& rwInOutMatrix, const CVector& vecPosition);
     void RwMatrixGetScale(const RwMatrix& rwMatrix, CVector& vecOutScale);
     void RwMatrixSetScale(RwMatrix& rwInOutMatrix, const CVector& vecScale);
-    void GetFrameHierarchy(RpClump* pRoot, std::vector<std::vector<std::string>>& frames);
-    bool GetFrameGeometryInfo(RpClump* pRoot, std::string& frameName, SFrameGeometryInfo& info);
-    bool GetFrameGeometry(RpClump* pRoot, std::string& frameName, SFrameGeometry& info);
+    void GetFrameHierarchy(RwObject* rwObject, std::vector<std::vector<std::string>>& frames);
+    bool GetFrameGeometryInfo(RwObject* rwObject, std::string& frameName, SFrameGeometryInfo& info);
+    bool GetFrameGeometry(RwObject* rwObject, std::string& frameName, SFrameGeometry& info);
     bool QueueSetVertexPositionUpdate(int16_t usModelId, std::string& frameName, int vertexIndex, CVector position);
+    bool QueueSetVertexColorUpdate(int16_t usModelId, std::string& frameName, int vertexIndex, SColor color);
     bool FlushChanged(int16_t usModelId, std::string& frameName);
-    RpAtomic* GetAtomicFromFrameName(RpClump* pRoot, std::string& frameName);
+    RpAtomic* GetAtomicFromFrameName(RwObject* rwObject, std::string& frameName);
 
     // CRenderWareSA methods
     RwTexture*          RightSizeTexture(RwTexture* pTexture, uint uiSizeLimit, SString& strError);

--- a/Client/game_sa/CRenderWareSA.h
+++ b/Client/game_sa/CRenderWareSA.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <variant>
 #include <game/CRenderWare.h>
 #include "CModelInfoSA.h"
 #include "CRenderWareSA.ShaderSupport.h"
@@ -21,6 +22,16 @@ struct RpAtomic;
 struct SShaderReplacementStats;
 struct STexInfo;
 struct STexTag;
+
+struct SFrameGeometryInfo
+{
+public:
+    int texCoordsCount;
+    int trianglesCount;
+    int verticesCount;
+    CVector boundingSphereCenter;
+    float boundingSphereRadius;
+};
 
 class CRenderWareSA : public CRenderWare
 {
@@ -115,6 +126,7 @@ public:
     void RwMatrixGetScale(const RwMatrix& rwMatrix, CVector& vecOutScale);
     void RwMatrixSetScale(RwMatrix& rwInOutMatrix, const CVector& vecScale);
     void GetFrameHierarchy(RpClump* pRoot, std::vector<std::vector<std::string>>& frames);
+    bool GetFrameGeometryInfo(RpClump* pRoot, std::string& frameName, SFrameGeometryInfo& info);
 
     // CRenderWareSA methods
     RwTexture*          RightSizeTexture(RwTexture* pTexture, uint uiSizeLimit, SString& strError);
@@ -142,6 +154,7 @@ public:
     void      DestroyTexInfo(STexInfo* pTexInfo);
 
     static void GetClumpAtomicList(RpClump* pClump, std::vector<RpAtomic*>& outAtomicList);
+    static void GetClumpAtomicsWithFrameName(RpClump* pClump, RwFrame* pFrame, std::vector<RpAtomic*>& outAtomicList);
     static bool DoContainTheSameGeometry(RpClump* pClumpA, RpClump* pClumpB, RpAtomic* pAtomicB);
 
     void OnTextureStreamIn(STexInfo* pTexInfo);

--- a/Client/game_sa/CRenderWareSA.h
+++ b/Client/game_sa/CRenderWareSA.h
@@ -33,6 +33,13 @@ public:
     float boundingSphereRadius;
 };
 
+struct SFrameGeometry
+{
+public:
+    std::vector<CVector> vertices;
+    std::vector<int> triangles;
+};
+
 class CRenderWareSA : public CRenderWare
 {
 public:
@@ -127,6 +134,7 @@ public:
     void RwMatrixSetScale(RwMatrix& rwInOutMatrix, const CVector& vecScale);
     void GetFrameHierarchy(RpClump* pRoot, std::vector<std::vector<std::string>>& frames);
     bool GetFrameGeometryInfo(RpClump* pRoot, std::string& frameName, SFrameGeometryInfo& info);
+    bool GetFrameGeometry(RpClump* pRoot, std::string& frameName, SFrameGeometry& info);
 
     // CRenderWareSA methods
     RwTexture*          RightSizeTexture(RwTexture* pTexture, uint uiSizeLimit, SString& strError);

--- a/Client/game_sa/CRenderWareSA.h
+++ b/Client/game_sa/CRenderWareSA.h
@@ -22,6 +22,7 @@ struct RpAtomic;
 struct SShaderReplacementStats;
 struct STexInfo;
 struct STexTag;
+struct RpGeometry;
 
 struct SFrameGeometryInfo
 {
@@ -38,6 +39,29 @@ struct SFrameGeometry
 public:
     std::vector<CVector> vertices;
     std::vector<int> triangles;
+};
+
+struct SGeometryVertexSetPosition
+{
+public:
+    int vertexIndex;
+    CVector position;
+};
+
+class CGeometryFrameUpdate
+{
+public:
+    std::vector<SGeometryVertexSetPosition> m_vecVertexSetPosition;
+};
+
+class CGeometryUpdate
+{
+public:
+    void VertexSetPosition(std::string& frameName, int vertexIndex, CVector position);
+    bool FlushChanged(RpGeometry* pGeometry, std::string& frameName);
+
+private:
+    std::map<std::string, CGeometryFrameUpdate> m_mapGeometryFrameUpdate;
 };
 
 class CRenderWareSA : public CRenderWare
@@ -135,6 +159,9 @@ public:
     void GetFrameHierarchy(RpClump* pRoot, std::vector<std::vector<std::string>>& frames);
     bool GetFrameGeometryInfo(RpClump* pRoot, std::string& frameName, SFrameGeometryInfo& info);
     bool GetFrameGeometry(RpClump* pRoot, std::string& frameName, SFrameGeometry& info);
+    bool QueueSetVertexPositionUpdate(int16_t usModelId, std::string& frameName, int vertexIndex, CVector position);
+    bool FlushChanged(int16_t usModelId, std::string& frameName);
+    RpAtomic* GetAtomicFromFrameName(RpClump* pRoot, std::string& frameName);
 
     // CRenderWareSA methods
     RwTexture*          RightSizeTexture(RwTexture* pTexture, uint uiSizeLimit, SString& strError);
@@ -186,4 +213,5 @@ public:
     bool                                m_bGTAVertexShadersEnabled;
     std::set<RwTexture*>                m_SpecialTextures;
     static int                          ms_iRenderingType;
+    std::map<int16_t, CGeometryUpdate*> m_mapGeometryUpdateQueue;
 };

--- a/Client/game_sa/CRenderWareSA.h
+++ b/Client/game_sa/CRenderWareSA.h
@@ -172,6 +172,7 @@ public:
     bool QueueSetVertexColorUpdate(int16_t usModelId, std::string& frameName, int vertexIndex, SColor color);
     bool FlushChanged(int16_t usModelId, std::string& frameName);
     RpAtomic* GetAtomicFromFrameName(RwObject* rwObject, std::string& frameName);
+    bool      ExportModel(uint16_t usModelId, std::string& outString);
 
     // CRenderWareSA methods
     RwTexture*          RightSizeTexture(RwTexture* pTexture, uint uiSizeLimit, SString& strError);

--- a/Client/game_sa/CWorldSA.cpp
+++ b/Client/game_sa/CWorldSA.cpp
@@ -367,6 +367,8 @@ bool CWorldSA::ProcessLineOfSight(const CVector* vecStart, const CVector* vecEnd
             CVector             hitBary{};                         //< Barycentric coordinates [on the hit triangle] of the hit
             CVector             hitPosOS{};                        //< Hit position in object space
             CEntitySAInterface* entity{};                          //< The hit entity
+            uint16_t            vertexIndices[3];
+            int                 triangleIndex;
         } c = {};
 
         c.entity = targetEntity;
@@ -456,6 +458,10 @@ bool CWorldSA::ProcessLineOfSight(const CVector* vecStart, const CVector* vecEnd
                     c->hitTri = tri;
                     c->hitBary = hitBary;
                     c->hitPosOS = localToObjTransform.TransformVector(hitPos);            // Transform back into object space
+                    c->triangleIndex = i;
+                    c->vertexIndices[0] = tri->verts[0];
+                    c->vertexIndices[1] = tri->verts[1];
+                    c->vertexIndices[2] = tri->verts[2];
                 }
             }
 
@@ -501,6 +507,11 @@ bool CWorldSA::ProcessLineOfSight(const CVector* vecStart, const CVector* vecEnd
 
             // Get hit position in world space
             outMatInfo->hitPos = c.entMat.TransformVector(c.hitPosOS);
+
+            outMatInfo->triangleIndex = c.triangleIndex;
+            outMatInfo->vertexIndices[0] = c.vertexIndices[0];
+            outMatInfo->vertexIndices[1] = c.vertexIndices[1];
+            outMatInfo->vertexIndices[2] = c.vertexIndices[2];
         }
     }
 

--- a/Client/game_sa/gamesa_renderware.h
+++ b/Client/game_sa/gamesa_renderware.h
@@ -86,6 +86,7 @@ typedef RwStream*(__cdecl* RwStreamOpen_t)(RwStreamType type, RwStreamMode mode,
 typedef int(__cdecl* RwStreamClose_t)(RwStream* stream, void* pData);
 typedef int(__cdecl* RwStreamRead_t)(RwStream* stream, void* pData, uint size);
 typedef int(__cdecl* RwStreamSkip_t)(RwStream* stream, uint size);
+typedef RwStream*(__cdecl* RwStreamWrite_t)(RwStream* stream, const void* buffer, uint32_t length);
 typedef int(__cdecl* RpClumpDestroy_t)(RpClump* clump);
 using RpClumpForAllAtomicsCB_t = bool(__cdecl*)(RpAtomic*, void*);
 typedef RpClump*(__cdecl* RpClumpForAllAtomics_t)(RpClump* clump, RpClumpForAllAtomicsCB_t callback, void* pData);
@@ -103,6 +104,7 @@ typedef RpHAnimHierarchy*(__cdecl* GetAnimHierarchyFromSkinClump_t)(RpClump*);
 typedef int(__cdecl* RpHAnimIDGetIndex_t)(RpHAnimHierarchy*, int);
 typedef RwMatrix*(__cdecl* RpHAnimHierarchyGetMatrixArray_t)(RpHAnimHierarchy*);
 typedef RtQuat*(__cdecl* RtQuatRotate_t)(RtQuat* quat, const RwV3d* axis, float angle, RwOpCombineType combineOp);
+typedef RpClump*(__cdecl* RpClumpStreamWrite_t)(RpClump* pClump, RwStream* pStream);
 
 /*****************************************************************************/
 /** Renderware function mappings                                            **/
@@ -122,6 +124,7 @@ RWFUNC(RwStreamOpen_t RwStreamOpen, (RwStreamOpen_t)0xDEAD)
 RWFUNC(RwStreamClose_t RwStreamClose, (RwStreamClose_t)0xDEAD)
 RWFUNC(RwStreamRead_t RwStreamRead, (RwStreamRead_t)0xDEAD)
 RWFUNC(RwStreamSkip_t RwStreamSkip, (RwStreamSkip_t)0xDEAD)
+RWFUNC(RwStreamWrite_t RwStreamWrite, (RwStreamWrite_t)0xDEAD)
 RWFUNC(RpClumpDestroy_t RpClumpDestroy, (RpClumpDestroy_t)0xDEAD)
 RWFUNC(RpClumpGetNumAtomics_t RpClumpGetNumAtomics, (RpClumpGetNumAtomics_t)0xDEAD)
 RWFUNC(RwFrameTranslate_t RwFrameTranslate, (RwFrameTranslate_t)0xDEAD)
@@ -191,6 +194,7 @@ RWFUNC(GetAnimHierarchyFromSkinClump_t GetAnimHierarchyFromSkinClump, (GetAnimHi
 RWFUNC(RpHAnimIDGetIndex_t RpHAnimIDGetIndex, (RpHAnimIDGetIndex_t)0xDEAD)
 RWFUNC(RpHAnimHierarchyGetMatrixArray_t RpHAnimHierarchyGetMatrixArray, (RpHAnimHierarchyGetMatrixArray_t)0xDEAD)
 RWFUNC(RtQuatRotate_t RtQuatRotate, (RtQuatRotate_t)0xDEAD)
+RWFUNC(RpClumpStreamWrite_t RpClumpStreamWrite, (RpClumpStreamWrite_t)0xDEAD)
 
 /*****************************************************************************/
 /** GTA function definitions and mappings                                   **/

--- a/Client/game_sa/gamesa_renderware.hpp
+++ b/Client/game_sa/gamesa_renderware.hpp
@@ -93,6 +93,8 @@ void InitRwFunctions(eGameVersion version)
             RpHAnimIDGetIndex = (RpHAnimIDGetIndex_t)0x7C51E0;
             RpHAnimHierarchyGetMatrixArray = (RpHAnimHierarchyGetMatrixArray_t)0x7C5160;
             RtQuatRotate = (RtQuatRotate_t)0x7EB800;
+            RpClumpStreamWrite = (RpClumpStreamWrite_t)0x74AA10;
+            RwStreamWrite = (RwStreamWrite_t)0x7ECB30;
 
             SetTextureDict = (SetTextureDict_t)0x007319C0;
             LoadClumpFile = (LoadClumpFile_t)0x005371F0;
@@ -190,6 +192,8 @@ void InitRwFunctions(eGameVersion version)
             RpHAnimIDGetIndex = (RpHAnimIDGetIndex_t)0x7C51A0;
             RpHAnimHierarchyGetMatrixArray = (RpHAnimHierarchyGetMatrixArray_t)0x7C5120;
             RtQuatRotate = (RtQuatRotate_t)0x7EB7C0;
+            RpClumpStreamWrite = (RpClumpStreamWrite_t)0x74AA10;
+            RwStreamWrite = (RwStreamWrite_t)0x7ECB30;
 
             SetTextureDict = (SetTextureDict_t)0x007319C0;
             LoadClumpFile = (LoadClumpFile_t)0x005371F0;

--- a/Client/game_sa/premake5.lua
+++ b/Client/game_sa/premake5.lua
@@ -11,6 +11,7 @@ project "Game SA"
 	pchheader "StdInc.h"
 	pchsource "StdInc.cpp"
 
+	links { "detours" }
 	vpaths {
 		["Headers/*"] = { "**.h", "**.hpp" },
 		["Sources/*"] = "**.cpp",
@@ -18,7 +19,10 @@ project "Game SA"
 	}
 
 	filter "system:windows"
-		includedirs { "../../vendor/sparsehash/src/windows" }
+		includedirs {
+			"../../vendor/sparsehash/src/windows",
+			"../../vendor/detours/4.0.1/src"
+		}
 
 	filter {}
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -66,6 +66,20 @@ size_t EngineStreamingGetBufferSize() {
     return g_pGame->GetStreaming()->GetStreamingBufferSize();
 }
 
+std::vector<std::vector<std::string>> EngineModelGetFramesHierarchy(uint16_t usModel)
+{
+    CModelInfo* pModelInfo = g_pGame->GetModelInfo(usModel);
+    if (pModelInfo == nullptr)
+        throw std::invalid_argument("Invalid model id");
+
+    if (pModelInfo->GetRwObject() == nullptr)
+        throw std::invalid_argument("Model not loaded");
+
+    std::vector<std::vector<std::string>> hierarchy;
+    g_pGame->GetRenderWare()->GetFrameHierarchy(reinterpret_cast<RpClump*>(pModelInfo->GetRwObject()), hierarchy);
+    return hierarchy;
+}
+
 void CLuaEngineDefs::LoadFunctions()
 {
     constexpr static const std::pair<const char*, lua_CFunction> functions[]{
@@ -131,6 +145,7 @@ void CLuaEngineDefs::LoadFunctions()
         {"engineStreamingSetBufferSize", ArgumentParser<EngineStreamingSetBufferSize>},
         {"engineStreamingGetBufferSize", ArgumentParser<EngineStreamingGetBufferSize>},
         {"engineStreamingSetModelCacheLimits", ArgumentParser<EngineStreamingSetModelCacheLimits>},
+        {"engineModelGetFramesHierarchy", ArgumentParser<EngineModelGetFramesHierarchy>},
         
         {"engineRequestTXD", ArgumentParser<EngineRequestTXD>},
         {"engineFreeTXD", ArgumentParser<EngineFreeTXD>},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -101,6 +101,23 @@ std::unordered_map<std::string, std::variant<float, CVector>> EngineModelGetFram
     return frameGeometryInfo;
 }
 
+std::unordered_map < std::string, std::variant<std::vector<CVectorAsTable>, std::vector<int>>> EngineModelGetFramesGeometry(uint16_t usModel, std::string frameName)
+{
+    CModelInfo* pModelInfo = g_pGame->GetModelInfo(usModel);
+    if (pModelInfo == nullptr)
+        throw std::invalid_argument("Invalid model id");
+
+    if (pModelInfo->GetRwObject() == nullptr)
+        throw std::invalid_argument("Model not loaded");
+
+    SFrameGeometry info;
+    g_pGame->GetRenderWare()->GetFrameGeometry(reinterpret_cast<RpClump*>(pModelInfo->GetRwObject()), frameName, info);
+    std::unordered_map<std::string, std::variant<std::vector<CVectorAsTable>, std::vector<int>>> frameGeometry;
+    frameGeometry["vertices"] = *reinterpret_cast<std::vector<CVectorAsTable>*>(&info.vertices);
+    frameGeometry["triangles"] = info.triangles;
+    return frameGeometry;
+}
+
 void CLuaEngineDefs::LoadFunctions()
 {
     constexpr static const std::pair<const char*, lua_CFunction> functions[]{
@@ -169,6 +186,7 @@ void CLuaEngineDefs::LoadFunctions()
 
         {"engineModelGetFramesHierarchy", ArgumentParser<EngineModelGetFramesHierarchy>},
         {"engineModelGetFramesGeometryInfo", ArgumentParser<EngineModelGetFramesGeometryInfo>},
+        {"engineModelGetFramesGeometry", ArgumentParser<EngineModelGetFramesGeometry>},
         
         {"engineRequestTXD", ArgumentParser<EngineRequestTXD>},
         {"engineFreeTXD", ArgumentParser<EngineFreeTXD>},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -81,7 +81,7 @@ std::vector<std::vector<std::string>> EngineModelGetFramesHierarchy(uint16_t usM
     return hierarchy;
 }
 
-std::unordered_map<std::string, std::variant<float, CVector>> EngineModelGetFramesGeometryInfo(uint16_t usModel, std::string frameName)
+std::unordered_map<std::string, std::variant<float, CVector>> EngineModelGetFrameGeometryInfo(uint16_t usModel, std::string frameName)
 {
     CModelInfo* pModelInfo = g_pGame->GetModelInfo(usModel);
     if (pModelInfo == nullptr)
@@ -101,7 +101,7 @@ std::unordered_map<std::string, std::variant<float, CVector>> EngineModelGetFram
     return frameGeometryInfo;
 }
 
-std::unordered_map < std::string, std::variant<std::vector<CVectorAsTable>, std::vector<int>>> EngineModelGetFramesGeometry(uint16_t usModel, std::string frameName)
+std::unordered_map < std::string, std::variant<std::vector<CVectorAsTable>, std::vector<int>>> EngineModelGetFrameGeometry(uint16_t usModel, std::string frameName)
 {
     CModelInfo* pModelInfo = g_pGame->GetModelInfo(usModel);
     if (pModelInfo == nullptr)
@@ -116,6 +116,17 @@ std::unordered_map < std::string, std::variant<std::vector<CVectorAsTable>, std:
     frameGeometry["vertices"] = *reinterpret_cast<std::vector<CVectorAsTable>*>(&info.vertices);
     frameGeometry["triangles"] = info.triangles;
     return frameGeometry;
+}
+
+bool EngineModelFrameSetVertexPosition(uint16_t usModel, std::string frameName, int vertexIndex, CVector vertexPosition)
+{
+    return g_pGame->GetRenderWare()->QueueSetVertexPositionUpdate(usModel, frameName, vertexIndex,
+                                                                  vertexPosition);
+}
+
+bool EngineModelFlushChanges(uint16_t usModel, std::string frameName)
+{
+    return g_pGame->GetRenderWare()->FlushChanged(usModel, frameName);
 }
 
 void CLuaEngineDefs::LoadFunctions()
@@ -185,8 +196,10 @@ void CLuaEngineDefs::LoadFunctions()
         {"engineStreamingSetModelCacheLimits", ArgumentParser<EngineStreamingSetModelCacheLimits>},
 
         {"engineModelGetFramesHierarchy", ArgumentParser<EngineModelGetFramesHierarchy>},
-        {"engineModelGetFramesGeometryInfo", ArgumentParser<EngineModelGetFramesGeometryInfo>},
-        {"engineModelGetFramesGeometry", ArgumentParser<EngineModelGetFramesGeometry>},
+        {"engineModelGetFrameGeometryInfo", ArgumentParser<EngineModelGetFrameGeometryInfo>},
+        {"engineModelGetFrameGeometry", ArgumentParser<EngineModelGetFrameGeometry>},
+        {"engineModelFrameSetVertexPosition", ArgumentParser<EngineModelFrameSetVertexPosition>},
+        {"engineModelFlushChanges", ArgumentParser<EngineModelFlushChanges>},
         
         {"engineRequestTXD", ArgumentParser<EngineRequestTXD>},
         {"engineFreeTXD", ArgumentParser<EngineFreeTXD>},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -77,7 +77,7 @@ std::vector<std::vector<std::string>> EngineModelGetFramesHierarchy(uint16_t usM
         throw std::invalid_argument("Model not loaded");
 
     std::vector<std::vector<std::string>> hierarchy;
-    g_pGame->GetRenderWare()->GetFrameHierarchy(reinterpret_cast<RpClump*>(pModelInfo->GetRwObject()), hierarchy);
+    g_pGame->GetRenderWare()->GetFrameHierarchy(pModelInfo->GetRwObject(), hierarchy);
     return hierarchy;
 }
 
@@ -91,7 +91,7 @@ std::unordered_map<std::string, std::variant<float, CVector>> EngineModelGetFram
         throw std::invalid_argument("Model not loaded");
 
     SFrameGeometryInfo info;
-    g_pGame->GetRenderWare()->GetFrameGeometryInfo(reinterpret_cast<RpClump*>(pModelInfo->GetRwObject()), frameName, info);
+    g_pGame->GetRenderWare()->GetFrameGeometryInfo(pModelInfo->GetRwObject(), frameName, info);
     std::unordered_map<std::string, std::variant<float, CVector>> frameGeometryInfo;
     frameGeometryInfo["texCoordsCount"] = info.texCoordsCount;
     frameGeometryInfo["trianglesCount"] = info.trianglesCount;
@@ -111,7 +111,7 @@ std::unordered_map < std::string, std::variant<std::vector<CVectorAsTable>, std:
         throw std::invalid_argument("Model not loaded");
 
     SFrameGeometry info;
-    g_pGame->GetRenderWare()->GetFrameGeometry(reinterpret_cast<RpClump*>(pModelInfo->GetRwObject()), frameName, info);
+    g_pGame->GetRenderWare()->GetFrameGeometry(pModelInfo->GetRwObject(), frameName, info);
     std::unordered_map<std::string, std::variant<std::vector<CVectorAsTable>, std::vector<int>>> frameGeometry;
     frameGeometry["vertices"] = *reinterpret_cast<std::vector<CVectorAsTable>*>(&info.vertices);
     frameGeometry["triangles"] = info.triangles;
@@ -123,6 +123,12 @@ bool EngineModelFrameSetVertexPosition(uint16_t usModel, std::string frameName, 
     return g_pGame->GetRenderWare()->QueueSetVertexPositionUpdate(usModel, frameName, vertexIndex,
                                                                   vertexPosition);
 }
+
+bool EngineModelFrameSetVertexColor(uint16_t usModel, std::string frameName, int vertexIndex, SColor color)
+{
+    return g_pGame->GetRenderWare()->QueueSetVertexColorUpdate(usModel, frameName, vertexIndex, color);
+}
+
 
 bool EngineModelFlushChanges(uint16_t usModel, std::string frameName)
 {
@@ -199,6 +205,7 @@ void CLuaEngineDefs::LoadFunctions()
         {"engineModelGetFrameGeometryInfo", ArgumentParser<EngineModelGetFrameGeometryInfo>},
         {"engineModelGetFrameGeometry", ArgumentParser<EngineModelGetFrameGeometry>},
         {"engineModelFrameSetVertexPosition", ArgumentParser<EngineModelFrameSetVertexPosition>},
+        {"engineModelFrameSetVertexColor", ArgumentParser<EngineModelFrameSetVertexColor>},
         {"engineModelFlushChanges", ArgumentParser<EngineModelFlushChanges>},
         
         {"engineRequestTXD", ArgumentParser<EngineRequestTXD>},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -14,6 +14,7 @@
 #include <game/CObjectGroupPhysicalProperties.h>
 #include <game/CStreaming.h>
 #include <lua/CLuaFunctionParser.h>
+#include "../../../../game_sa/CRenderWareSA.h"
 
 //! Set the CModelCacheManager limits
 //! By passing `nil`/no value the original values are restored
@@ -78,6 +79,26 @@ std::vector<std::vector<std::string>> EngineModelGetFramesHierarchy(uint16_t usM
     std::vector<std::vector<std::string>> hierarchy;
     g_pGame->GetRenderWare()->GetFrameHierarchy(reinterpret_cast<RpClump*>(pModelInfo->GetRwObject()), hierarchy);
     return hierarchy;
+}
+
+std::unordered_map<std::string, std::variant<float, CVector>> EngineModelGetFramesGeometryInfo(uint16_t usModel, std::string frameName)
+{
+    CModelInfo* pModelInfo = g_pGame->GetModelInfo(usModel);
+    if (pModelInfo == nullptr)
+        throw std::invalid_argument("Invalid model id");
+
+    if (pModelInfo->GetRwObject() == nullptr)
+        throw std::invalid_argument("Model not loaded");
+
+    SFrameGeometryInfo info;
+    g_pGame->GetRenderWare()->GetFrameGeometryInfo(reinterpret_cast<RpClump*>(pModelInfo->GetRwObject()), frameName, info);
+    std::unordered_map<std::string, std::variant<float, CVector>> frameGeometryInfo;
+    frameGeometryInfo["texCoordsCount"] = info.texCoordsCount;
+    frameGeometryInfo["trianglesCount"] = info.trianglesCount;
+    frameGeometryInfo["verticesCount"] = info.verticesCount;
+    frameGeometryInfo["boundingSphereCenter"] = info.boundingSphereCenter;
+    frameGeometryInfo["boundingSphereRadius"] = info.boundingSphereRadius;
+    return frameGeometryInfo;
 }
 
 void CLuaEngineDefs::LoadFunctions()
@@ -145,7 +166,9 @@ void CLuaEngineDefs::LoadFunctions()
         {"engineStreamingSetBufferSize", ArgumentParser<EngineStreamingSetBufferSize>},
         {"engineStreamingGetBufferSize", ArgumentParser<EngineStreamingGetBufferSize>},
         {"engineStreamingSetModelCacheLimits", ArgumentParser<EngineStreamingSetModelCacheLimits>},
+
         {"engineModelGetFramesHierarchy", ArgumentParser<EngineModelGetFramesHierarchy>},
+        {"engineModelGetFramesGeometryInfo", ArgumentParser<EngineModelGetFramesGeometryInfo>},
         
         {"engineRequestTXD", ArgumentParser<EngineRequestTXD>},
         {"engineFreeTXD", ArgumentParser<EngineFreeTXD>},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -129,10 +129,17 @@ bool EngineModelFrameSetVertexColor(uint16_t usModel, std::string frameName, int
     return g_pGame->GetRenderWare()->QueueSetVertexColorUpdate(usModel, frameName, vertexIndex, color);
 }
 
-
 bool EngineModelFlushChanges(uint16_t usModel, std::string frameName)
 {
     return g_pGame->GetRenderWare()->FlushChanged(usModel, frameName);
+}
+
+std::variant<bool, std::string> EngineExportModel(uint16_t usModel)
+{
+    std::string data;
+    if (g_pGame->GetRenderWare()->ExportModel(usModel, data))
+        return data;
+    return false;
 }
 
 void CLuaEngineDefs::LoadFunctions()
@@ -207,6 +214,7 @@ void CLuaEngineDefs::LoadFunctions()
         {"engineModelFrameSetVertexPosition", ArgumentParser<EngineModelFrameSetVertexPosition>},
         {"engineModelFrameSetVertexColor", ArgumentParser<EngineModelFrameSetVertexColor>},
         {"engineModelFlushChanges", ArgumentParser<EngineModelFlushChanges>},
+        {"engineExportModel", ArgumentParser<EngineExportModel>},
         
         {"engineRequestTXD", ArgumentParser<EngineRequestTXD>},
         {"engineFreeTXD", ArgumentParser<EngineFreeTXD>},

--- a/Client/mods/deathmatch/logic/luadefs/CLuaWorldDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaWorldDefs.cpp
@@ -331,7 +331,7 @@ int CLuaWorldDefs::ProcessLineOfSight(lua_State* L)
                     }
                 }
 
-                if (bIncludeExtraMateriaInfo && matInfo.valid)  { // 7 args
+                if (bIncludeExtraMateriaInfo && matInfo.valid)  { // 7+4 args
                     lua::Push(L, matInfo.uv.fX);
                     lua::Push(L, matInfo.uv.fY);
 
@@ -341,8 +341,13 @@ int CLuaWorldDefs::ProcessLineOfSight(lua_State* L)
                     lua::Push(L, matInfo.hitPos.fX);
                     lua::Push(L, matInfo.hitPos.fY);
                     lua::Push(L, matInfo.hitPos.fZ);
+
+                    lua::Push(L, matInfo.triangleIndex);
+                    lua::Push(L, matInfo.vertexIndices[0]);
+                    lua::Push(L, matInfo.vertexIndices[1]);
+                    lua::Push(L, matInfo.vertexIndices[2]);
                 } else {
-                    for (auto i = 2 + 1 + 1 + 3; i-- > 0;) {
+                    for (auto i = 2 + 1 + 1 + 3 + 4; i-- > 0;) {
                         lua_pushnil(L);
                     }
                 }

--- a/Client/sdk/game/CRenderWare.h
+++ b/Client/sdk/game/CRenderWare.h
@@ -27,6 +27,7 @@ struct RwTexture;
 struct RpClump;
 struct SFrameGeometryInfo;
 struct SFrameGeometry;
+struct RwObject;
 
 typedef CShaderItem CSHADERDUMMY;
 
@@ -122,9 +123,10 @@ public:
     virtual void RwMatrixSetPosition(RwMatrix& rwInOutMatrix, const CVector& vecPosition) = 0;
     virtual void RwMatrixGetScale(const RwMatrix& rwMatrix, CVector& vecOutScale) = 0;
     virtual void RwMatrixSetScale(RwMatrix& rwInOutMatrix, const CVector& vecScale) = 0;
-    virtual void GetFrameHierarchy(RpClump* pRoot, std::vector<std::vector<std::string>>& frames) = 0;
-    virtual bool GetFrameGeometryInfo(RpClump* pRoot, std::string& frameName, SFrameGeometryInfo& info) = 0;
-    virtual bool GetFrameGeometry(RpClump* pRoot, std::string& frameName, SFrameGeometry& info) = 0;
+    virtual void GetFrameHierarchy(RwObject* rwObject, std::vector<std::vector<std::string>>& frames) = 0;
+    virtual bool GetFrameGeometryInfo(RwObject* rwObject, std::string& frameName, SFrameGeometryInfo& info) = 0;
+    virtual bool GetFrameGeometry(RwObject* rwObject, std::string& frameName, SFrameGeometry& info) = 0;
     virtual bool QueueSetVertexPositionUpdate(int16_t usModelId, std::string& frameName, int vertexIndex, CVector position) = 0;
+    virtual bool QueueSetVertexColorUpdate(int16_t usModelId, std::string& frameName, int vertexIndex, SColor color) = 0;
     virtual bool FlushChanged(int16_t usModelId, std::string& frameName) = 0;
 };

--- a/Client/sdk/game/CRenderWare.h
+++ b/Client/sdk/game/CRenderWare.h
@@ -129,4 +129,5 @@ public:
     virtual bool QueueSetVertexPositionUpdate(int16_t usModelId, std::string& frameName, int vertexIndex, CVector position) = 0;
     virtual bool QueueSetVertexColorUpdate(int16_t usModelId, std::string& frameName, int vertexIndex, SColor color) = 0;
     virtual bool FlushChanged(int16_t usModelId, std::string& frameName) = 0;
+    virtual bool ExportModel(uint16_t usModelId, std::string& outString) = 0;
 };

--- a/Client/sdk/game/CRenderWare.h
+++ b/Client/sdk/game/CRenderWare.h
@@ -125,4 +125,6 @@ public:
     virtual void GetFrameHierarchy(RpClump* pRoot, std::vector<std::vector<std::string>>& frames) = 0;
     virtual bool GetFrameGeometryInfo(RpClump* pRoot, std::string& frameName, SFrameGeometryInfo& info) = 0;
     virtual bool GetFrameGeometry(RpClump* pRoot, std::string& frameName, SFrameGeometry& info) = 0;
+    virtual bool QueueSetVertexPositionUpdate(int16_t usModelId, std::string& frameName, int vertexIndex, CVector position) = 0;
+    virtual bool FlushChanged(int16_t usModelId, std::string& frameName) = 0;
 };

--- a/Client/sdk/game/CRenderWare.h
+++ b/Client/sdk/game/CRenderWare.h
@@ -26,6 +26,7 @@ struct RwTexDictionary;
 struct RwTexture;
 struct RpClump;
 struct SFrameGeometryInfo;
+struct SFrameGeometry;
 
 typedef CShaderItem CSHADERDUMMY;
 
@@ -123,4 +124,5 @@ public:
     virtual void RwMatrixSetScale(RwMatrix& rwInOutMatrix, const CVector& vecScale) = 0;
     virtual void GetFrameHierarchy(RpClump* pRoot, std::vector<std::vector<std::string>>& frames) = 0;
     virtual bool GetFrameGeometryInfo(RpClump* pRoot, std::string& frameName, SFrameGeometryInfo& info) = 0;
+    virtual bool GetFrameGeometry(RpClump* pRoot, std::string& frameName, SFrameGeometry& info) = 0;
 };

--- a/Client/sdk/game/CRenderWare.h
+++ b/Client/sdk/game/CRenderWare.h
@@ -121,4 +121,5 @@ public:
     virtual void RwMatrixSetPosition(RwMatrix& rwInOutMatrix, const CVector& vecPosition) = 0;
     virtual void RwMatrixGetScale(const RwMatrix& rwMatrix, CVector& vecOutScale) = 0;
     virtual void RwMatrixSetScale(RwMatrix& rwInOutMatrix, const CVector& vecScale) = 0;
+    virtual void GetFrameHierarchy(RpClump* pRoot, std::vector<std::vector<std::string>>& frames) = 0;
 };

--- a/Client/sdk/game/CRenderWare.h
+++ b/Client/sdk/game/CRenderWare.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include <vector>
-
 class CClientEntityBase;
 class CD3DDUMMY;
 class CMatrix;
@@ -26,6 +25,7 @@ struct RwMatrix;
 struct RwTexDictionary;
 struct RwTexture;
 struct RpClump;
+struct SFrameGeometryInfo;
 
 typedef CShaderItem CSHADERDUMMY;
 
@@ -122,4 +122,5 @@ public:
     virtual void RwMatrixGetScale(const RwMatrix& rwMatrix, CVector& vecOutScale) = 0;
     virtual void RwMatrixSetScale(RwMatrix& rwInOutMatrix, const CVector& vecScale) = 0;
     virtual void GetFrameHierarchy(RpClump* pRoot, std::vector<std::vector<std::string>>& frames) = 0;
+    virtual bool GetFrameGeometryInfo(RpClump* pRoot, std::string& frameName, SFrameGeometryInfo& info) = 0;
 };

--- a/Client/sdk/game/CWorld.h
+++ b/Client/sdk/game/CWorld.h
@@ -56,6 +56,10 @@ struct SProcessLineOfSightMaterialInfoResult {
     const char* textureName;   //< GTA texture name
     const char* frameName;     //< The name of the frame the hit geometry belongs to
     CVector     hitPos;        //< Precise hit position on the clump [World space]
+
+    int vertexIndices[3];
+    int triangleIndex;
+
     bool        valid{};       //< Data found in this struct is only valid if this is `true`!
 };
 

--- a/Shared/mods/deathmatch/logic/lua/LuaBasic.h
+++ b/Shared/mods/deathmatch/logic/lua/LuaBasic.h
@@ -20,7 +20,9 @@
 #include <variant>
 #include <array>
 
-/*
+class CVectorAsTable : public CVector { };
+
+    /*
     Basic Lua operations:
         void Push(L, T value)
         T PopPrimitive(L, int& stackIndex)
@@ -64,6 +66,20 @@ namespace lua
     inline void Push(lua_State* L, const CLuaArguments& args) { args.PushAsTable(L); }
 
     inline void Push(lua_State* L, const CVector2D& value) { lua_pushvector(L, value); }
+
+    inline void Push(lua_State* L, const CVectorAsTable& value)
+    {
+        lua_newtable(L);
+        Push(L, 1);
+        Push(L, value.fX);
+        lua_settable(L, -3);
+        Push(L, 2);
+        Push(L, value.fY);
+        lua_settable(L, -3);
+        Push(L, 3);
+        Push(L, value.fZ);
+        lua_settable(L, -3);
+    }
 
     inline void Push(lua_State* L, const CVector& value) { lua_pushvector(L, value); }
 


### PR DESCRIPTION
# The goal:
Add option to do basic modeling inside mta without any external tools. Provide for people tools  that help them easier and better integrate their models with rest of the world

# Changes in api

## New:
```lua
model-frame-hierarchy engineModelGetFrameHierarchy(modelId) -- return frame hierarchy in format { { frame, parentFrame}, ... }, returns empty table `{}` for atomic models
geometry-info engineModelGetFrameGeometry(modelId, frameName) -- return information about frame geometry, vertices count, triangles count and more
geometry-data engineModelGetFrameGeometry(modelId, frameName) -- return geometry data, vertices position, triangles
bool engineModelFrameSetVertexPosition(modelId, frameName, vertexIndex, x,y,z) -- queue setVertexPosition change for given model and frame
bool engineModelFrameSetVertexColor(modelId, frameName, vertexIndex, color) -- queue setVertexColor change for given model and frame
bool engineModelFlushChanges(modelID [, frameName]) -- updates visually model, don't use it more often than once every frame. If FrameName not provided, entire model get updated
dff-raw-data engineExportModel( modelID ) -- return raw data of the model

TODO:
1. Add function check if model is clump, or atomic. If atomic -> you don't need to provide frame name
2. Changing uv maps, night lighting, material id and rest of properties
3. Verify if it is required to update model bounding box
4. Add function to list all materials
5. (maybe) Add function to change lighting for all vertices with option to filter it by material id
6. Probably engineModelFlushChanges could return at second argument how many changes were commited
7. Test it with custom models
```

## Changes:
```
- ProcesLineOfSight now can return triangle index and it's vertices indices, 4 more return arguments
  - TODO: return frame name
```

# Scope of this pull request:
1. Getting basic informations about models,
8. Just modyfing model basic geometry properties, like vertices positions, color, materials ect.
9. Removing/Adding functions will be added in future pull requests

# Why api looks like above?
Wanted to avoid adding tons of functions, don't want to make api looks like:
```lua
local atomics = engineGetModelAtomics(1337)
local geometry = engineGetAtomicGeometry(atomics[1])
local ... = engineGetGeometrySomething(geometry)
```
instead, i treat atomic, geometry and frame as one thing, i'm aware that 1 frame can refer multiple geometries, atomics, atomics can have multiple of geometries ect ect ect.

# Examples
## Example 1
Changes windmill vertices to random positions +-10 units:
```lua
local hierarchy = engineModelGetFramesHierarchy(3425);        
local frame = hierarchy[1][1]
for i=1,200 do
  engineModelFrameSetVertexPosition(3425, frame, i, math.random(-10, 10), math.random(-10, 10), math.random(-10, 10))
end
engineModelFlushChanges(3425, frame)
```
and your model will look like on video:
https://www.youtube.com/watch?v=HYqlAipt5pI

## Example 2
If you want to vertex paint model using mouse, use:
```lua
function render()
    if(not getKeyState("mouse1") and not getKeyState("mouse2"))then
        return
    end

    local cx,cy = getCursorPosition()
    local swx,swy,swz = getWorldFromScreenPosition(cx * sx, cy * sy, 3)
    local ewx,ewy,ewz = getWorldFromScreenPosition(cx * sx, cy * sy, 100)
    local data = {processLineOfSight ( swx,swy,swz, ewx,ewy,ewz, true, true, true, true, true, false, false, false, nil, false, false, true)}

    local color = tocolor(255, 255, 255, 255)
    if(getKeyState("mouse2"))then
        color = tocolor(math.random(255),math.random(255),math.random(255),math.random(255))
    end

    if(data[5] and data[24])then
        local model = getElementModel(data[1])
        engineModelFrameSetVertexColor(model, "", data[24], color)
        engineModelFrameSetVertexColor(model, "", data[25], color)
        engineModelFrameSetVertexColor(model, "", data[26], color)
        engineModelFlushChanges(model, "")
    end
end
```
It gives following effect: https://www.youtube.com/watch?v=lQQb7Uo8urw

## Example 3
```lua
local hierarchy = engineModelGetFramesHierarchy(3425);        
local frame = hierarchy[1][2]
for i=1,200 do
    engineModelFrameSetVertexPosition(3425, frame, i, math.random(-1, 1), math.random(-1, 1), math.random(-1, 1))
end
engineModelFlushChanges(3425, frame)

local rawData = engineExportModel(3425)
local f;
if(not fileExists("out.dff"))then
    f = fileCreate("out.dff")
else
    f = fileOpen("out.dff")
end
fileWrite(f, rawData)
fileClose(f)
```
Modyfing first 200 vertices of windmill bottom frame, exports modified model to .dff
![image](https://github.com/multitheftauto/mtasa-blue/assets/22455534/fc6f3f73-7a61-4b5c-9337-9a7838577f62)



# What do i need?
- how api should looks like? i use "Frame" as frame/atomic/geometry right now for simplification, don't want to add functions such a "getFrameAtomic", "getAtomicGeometry" ect. If 1 frame has multiple geometries then current solution wont work
- initial code review, if current approach is okey. Created some class for update simillar to batchers
- maybe some feedback? :)
- feedback
- and feeedback
- Tederis, Piralux, TheNormalnij, heard you have some experience in that area? :)