### PR TITLE
Add new world special property (fireballdestruct)

### DIFF
--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -568,12 +568,9 @@ bool CGameSA::SetCheatEnabled(const char* szCheatName, bool bEnable)
 
 void CGameSA::ResetCheats()
 {
-    // Reset cheats that can't be set by setWorldSpecialPropertyEnabled
     std::map<std::string, SCheatSA*>::iterator it;
     for (it = m_Cheats.begin(); it != m_Cheats.end(); it++)
     {
-        if (it->second->m_bCanBeSet)
-            continue;
         if (it->second->m_byAddress > (BYTE*)0x8A4000)
             MemPutFast<BYTE>(it->second->m_byAddress, 0);
         else

--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -727,6 +727,21 @@ void CGameSA::SetBurnFlippedCarsEnabled(bool isEnabled)
     m_isBurnFlippedCarsEnabled = isEnabled;
 }
 
+void CGameSA::SetFireballDestructEnabled(bool isEnabled)
+{
+    if (isEnabled)
+    {
+        BYTE originalCodes[7] = {0x81, 0x66, 0x1C, 0x7E, 0xFF, 0xFF, 0xFF};
+        MemCpy((void*)0x6CCE45, &originalCodes, 7); // CPlane::BlowUpCar
+        MemCpy((void*)0x6C6E01, &originalCodes, 7); // CHeli::BlowUpCar
+    }
+    else
+    {
+        MemSet((void*)0x6CCE45, 0x90, 7); // CPlane::BlowUpCar
+        MemSet((void*)0x6C6E01, 0x90, 7); // CHeli::BlowUpCar
+    }
+}
+
 bool CGameSA::PerformChecks()
 {
     std::map<std::string, SCheatSA*>::iterator it;

--- a/Client/game_sa/CGameSA.h
+++ b/Client/game_sa/CGameSA.h
@@ -215,6 +215,9 @@ public:
     bool IsBurnFlippedCarsEnabled() const noexcept { return m_isBurnFlippedCarsEnabled; }
     void SetBurnFlippedCarsEnabled(bool isEnabled);
 
+    bool IsFireballDestructEnabled() const noexcept { return m_isFireballDestructEnabled; }
+    void SetFireballDestructEnabled(bool isEnabled);
+
     unsigned long GetMinuteDuration();
     void          SetMinuteDuration(unsigned long ulTime);
 
@@ -327,6 +330,7 @@ private:
     bool         m_isCoronaZTestEnabled{true};
     bool         m_areWaterCreaturesEnabled{true};
     bool         m_isBurnFlippedCarsEnabled{true};
+    bool         m_isFireballDestructEnabled{true};
 
     static unsigned int&  ClumpOffset;
     static unsigned long* VAR_SystemTime;

--- a/Client/game_sa/CGameSA.h
+++ b/Client/game_sa/CGameSA.h
@@ -206,17 +206,17 @@ public:
     void SetVehicleSunGlareEnabled(bool bEnabled);
     bool IsVehicleSunGlareEnabled();
 
-    void SetCoronaZTestEnabled(bool isEnabled);
-    bool IsCoronaZTestEnabled() const noexcept { return m_isCoronaZTestEnabled; }
+    void SetCoronaZTestEnabled(bool isEnabled) override;
+    bool IsCoronaZTestEnabled() const noexcept override { return m_isCoronaZTestEnabled; }
 
-    bool IsWaterCreaturesEnabled() const noexcept { return m_areWaterCreaturesEnabled; }
-    void SetWaterCreaturesEnabled(bool isEnabled);
+    bool IsWaterCreaturesEnabled() const noexcept override { return m_areWaterCreaturesEnabled; }
+    void SetWaterCreaturesEnabled(bool isEnabled) override;
 
-    bool IsBurnFlippedCarsEnabled() const noexcept { return m_isBurnFlippedCarsEnabled; }
-    void SetBurnFlippedCarsEnabled(bool isEnabled);
+    bool IsBurnFlippedCarsEnabled() const noexcept override { return m_isBurnFlippedCarsEnabled; }
+    void SetBurnFlippedCarsEnabled(bool isEnabled) override;
 
-    bool IsFireballDestructEnabled() const noexcept { return m_isFireballDestructEnabled; }
-    void SetFireballDestructEnabled(bool isEnabled);
+    bool IsFireballDestructEnabled() const noexcept override { return m_isFireballDestructEnabled; }
+    void SetFireballDestructEnabled(bool isEnabled) override;
 
     unsigned long GetMinuteDuration();
     void          SetMinuteDuration(unsigned long ulTime);

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -5934,6 +5934,9 @@ bool CClientGame::SetWorldSpecialProperty(WorldSpecialProperty property, bool is
         case WorldSpecialProperty::BURNFLIPPEDCARS:
             g_pGame->SetBurnFlippedCarsEnabled(isEnabled);
             return true;
+        case WorldSpecialProperty::FIREBALLDESTRUCT:
+            g_pGame->SetFireballDestructEnabled(isEnabled);
+            return true;
     }
     return false;
 }
@@ -5963,6 +5966,8 @@ bool CClientGame::IsWorldSpecialProperty(WorldSpecialProperty property)
             return g_pGame->IsWaterCreaturesEnabled();
         case WorldSpecialProperty::BURNFLIPPEDCARS:
             return g_pGame->IsBurnFlippedCarsEnabled();
+        case WorldSpecialProperty::FIREBALLDESTRUCT:
+            return g_pGame->IsFireballDestructEnabled();
     }
     return false;
 }

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -2368,7 +2368,7 @@ void CPacketHandler::Packet_MapInfo(NetBitStreamInterface& bitStream)
     g_pClientGame->SetWorldSpecialProperty(WorldSpecialProperty::CORONAZTEST, wsProps.data.coronaztest);
     g_pClientGame->SetWorldSpecialProperty(WorldSpecialProperty::WATERCREATURES, wsProps.data.watercreatures);
     g_pClientGame->SetWorldSpecialProperty(WorldSpecialProperty::BURNFLIPPEDCARS, wsProps.data.burnflippedcars);
-    g_pClientGame->SetWorldSpecialProperty(WorldSpecialProperty::FIREBALLDESTRUCT, wsProps.data.fireballdestruct);
+    g_pClientGame->SetWorldSpecialProperty(WorldSpecialProperty::FIREBALLDESTRUCT, wsProps.data2.fireballdestruct);
 
     float fJetpackMaxHeight = 100;
     if (!bitStream.Read(fJetpackMaxHeight))

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -2368,6 +2368,7 @@ void CPacketHandler::Packet_MapInfo(NetBitStreamInterface& bitStream)
     g_pClientGame->SetWorldSpecialProperty(WorldSpecialProperty::CORONAZTEST, wsProps.data.coronaztest);
     g_pClientGame->SetWorldSpecialProperty(WorldSpecialProperty::WATERCREATURES, wsProps.data.watercreatures);
     g_pClientGame->SetWorldSpecialProperty(WorldSpecialProperty::BURNFLIPPEDCARS, wsProps.data.burnflippedcars);
+    g_pClientGame->SetWorldSpecialProperty(WorldSpecialProperty::FIREBALLDESTRUCT, wsProps.data.fireballdestruct);
 
     float fJetpackMaxHeight = 100;
     if (!bitStream.Read(fJetpackMaxHeight))

--- a/Client/sdk/game/CGame.h
+++ b/Client/sdk/game/CGame.h
@@ -205,15 +205,15 @@ public:
     virtual bool IsVehicleSunGlareEnabled() = 0;
 
     virtual void SetCoronaZTestEnabled(bool isEnabled) = 0;
-    virtual bool IsCoronaZTestEnabled() const = 0;
+    virtual bool IsCoronaZTestEnabled() const noexcept = 0;
 
-    virtual bool IsWaterCreaturesEnabled() const = 0;
+    virtual bool IsWaterCreaturesEnabled() const noexcept = 0;
     virtual void SetWaterCreaturesEnabled(bool isEnabled) = 0;
 
-    virtual bool IsBurnFlippedCarsEnabled() const = 0;
+    virtual bool IsBurnFlippedCarsEnabled() const noexcept = 0;
     virtual void SetBurnFlippedCarsEnabled(bool isEnabled) = 0;
 
-    virtual bool IsFireballDestructEnabled() const = 0;
+    virtual bool IsFireballDestructEnabled() const noexcept = 0;
     virtual void SetFireballDestructEnabled(bool isEnabled) = 0;
 
     virtual CWeapon*     CreateWeapon() = 0;

--- a/Client/sdk/game/CGame.h
+++ b/Client/sdk/game/CGame.h
@@ -213,6 +213,9 @@ public:
     virtual bool IsBurnFlippedCarsEnabled() const = 0;
     virtual void SetBurnFlippedCarsEnabled(bool isEnabled) = 0;
 
+    virtual bool IsFireballDestructEnabled() const = 0;
+    virtual void SetFireballDestructEnabled(bool isEnabled) = 0;
+
     virtual CWeapon*     CreateWeapon() = 0;
     virtual CWeaponStat* CreateWeaponStat(eWeaponType weaponType, eWeaponSkill weaponSkill) = 0;
 

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -243,6 +243,7 @@ CGame::CGame() : m_FloodProtect(4, 30000, 30000)            // Max of 4 connecti
     m_WorldSpecialProps[WorldSpecialProperty::CORONAZTEST] = true;
     m_WorldSpecialProps[WorldSpecialProperty::WATERCREATURES] = true;
     m_WorldSpecialProps[WorldSpecialProperty::BURNFLIPPEDCARS] = true;
+    m_WorldSpecialProps[WorldSpecialProperty::FIREBALLDESTRUCT] = true;
 
     m_JetpackWeapons[WEAPONTYPE_MICRO_UZI] = true;
     m_JetpackWeapons[WEAPONTYPE_TEC9] = true;

--- a/Server/mods/deathmatch/logic/packets/CMapInfoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CMapInfoPacket.cpp
@@ -188,6 +188,7 @@ bool CMapInfoPacket::Write(NetBitStreamInterface& BitStream) const
         wsProps.data.coronaztest = g_pGame->IsWorldSpecialPropertyEnabled(WorldSpecialProperty::CORONAZTEST);
         wsProps.data.watercreatures = g_pGame->IsWorldSpecialPropertyEnabled(WorldSpecialProperty::WATERCREATURES);
         wsProps.data.burnflippedcars = g_pGame->IsWorldSpecialPropertyEnabled(WorldSpecialProperty::BURNFLIPPEDCARS);
+        wsProps.data.fireballdestruct = g_pGame->IsWorldSpecialPropertyEnabled(WorldSpecialProperty::FIREBALLDESTRUCT);
         BitStream.Write(&wsProps);
     }
 

--- a/Server/mods/deathmatch/logic/packets/CMapInfoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CMapInfoPacket.cpp
@@ -188,7 +188,7 @@ bool CMapInfoPacket::Write(NetBitStreamInterface& BitStream) const
         wsProps.data.coronaztest = g_pGame->IsWorldSpecialPropertyEnabled(WorldSpecialProperty::CORONAZTEST);
         wsProps.data.watercreatures = g_pGame->IsWorldSpecialPropertyEnabled(WorldSpecialProperty::WATERCREATURES);
         wsProps.data.burnflippedcars = g_pGame->IsWorldSpecialPropertyEnabled(WorldSpecialProperty::BURNFLIPPEDCARS);
-        wsProps.data.fireballdestruct = g_pGame->IsWorldSpecialPropertyEnabled(WorldSpecialProperty::FIREBALLDESTRUCT);
+        wsProps.data2.fireballdestruct = g_pGame->IsWorldSpecialPropertyEnabled(WorldSpecialProperty::FIREBALLDESTRUCT);
         BitStream.Write(&wsProps);
     }
 

--- a/Shared/mods/deathmatch/logic/Enums.cpp
+++ b/Shared/mods/deathmatch/logic/Enums.cpp
@@ -95,6 +95,7 @@ ADD_ENUM(WorldSpecialProperty::VEHICLESUNGLARE, "vehiclesunglare")
 ADD_ENUM(WorldSpecialProperty::CORONAZTEST, "coronaztest")
 ADD_ENUM(WorldSpecialProperty::WATERCREATURES, "watercreatures")
 ADD_ENUM(WorldSpecialProperty::BURNFLIPPEDCARS, "burnflippedcars")
+ADD_ENUM(WorldSpecialProperty::FIREBALLDESTRUCT, "fireballdestruct")
 IMPLEMENT_ENUM_CLASS_END("world-special-property")
 
 IMPLEMENT_ENUM_BEGIN(ePacketID)

--- a/Shared/mods/deathmatch/logic/Enums.h
+++ b/Shared/mods/deathmatch/logic/Enums.h
@@ -87,6 +87,7 @@ enum class WorldSpecialProperty
     CORONAZTEST,
     WATERCREATURES,
     BURNFLIPPEDCARS,
+    FIREBALLDESTRUCT,
 };
 DECLARE_ENUM_CLASS(WorldSpecialProperty);
 

--- a/Shared/sdk/net/SyncStructures.h
+++ b/Shared/sdk/net/SyncStructures.h
@@ -2026,12 +2026,20 @@ struct SWorldSpecialPropertiesStateSync : public ISyncStructure
 {
     enum
     {
-        BITCOUNT = 13
+        BITCOUNT = 12
+    };
+    enum
+    {
+        BITCOUNT2 = 1
     };
 
     bool Read(NetBitStreamInterface& bitStream)
     {
         bool isOK = bitStream.ReadBits(reinterpret_cast<char*>(&data), BITCOUNT);
+        if (bitStream.Can(eBitStreamVersion::WorldSpecialProperty_FireballDestruct))
+             isOK &= bitStream.ReadBits(reinterpret_cast<char*>(&data2), BITCOUNT2);
+         else
+             data2.fireballdestruct = true;
 
         //// Example for adding item:
         // if (bitStream.Can(eBitStreamVersion::YourProperty))
@@ -2044,6 +2052,8 @@ struct SWorldSpecialPropertiesStateSync : public ISyncStructure
     void Write(NetBitStreamInterface& bitStream) const
     {
         bitStream.WriteBits(reinterpret_cast<const char*>(&data), BITCOUNT);
+        if (bitStream.Can(eBitStreamVersion::WorldSpecialProperty_FireballDestruct))
+            bitStream.WriteBits(reinterpret_cast<const char*>(&data2), BITCOUNT2);
 
         //// Example for adding item:
         // if (bitStream.Can(eBitStreamVersion::YourProperty))
@@ -2064,10 +2074,13 @@ struct SWorldSpecialPropertiesStateSync : public ISyncStructure
         bool coronaztest : 1;
         bool watercreatures : 1;
         bool burnflippedcars : 1;
-        bool fireballdestruct : 1;
     } data;
 
     // Add new ones in separate structs
+    struct
+    {
+        bool fireballdestruct : 1;
+    } data2;
 
     SWorldSpecialPropertiesStateSync()
     {
@@ -2078,7 +2091,7 @@ struct SWorldSpecialPropertiesStateSync : public ISyncStructure
         data.coronaztest = true;
         data.watercreatures = true;
         data.burnflippedcars = true;
-        data.fireballdestruct = true;
+        data2.fireballdestruct = true;
     }
 };
 

--- a/Shared/sdk/net/SyncStructures.h
+++ b/Shared/sdk/net/SyncStructures.h
@@ -2026,7 +2026,7 @@ struct SWorldSpecialPropertiesStateSync : public ISyncStructure
 {
     enum
     {
-        BITCOUNT = 12
+        BITCOUNT = 13
     };
 
     bool Read(NetBitStreamInterface& bitStream)
@@ -2064,6 +2064,7 @@ struct SWorldSpecialPropertiesStateSync : public ISyncStructure
         bool coronaztest : 1;
         bool watercreatures : 1;
         bool burnflippedcars : 1;
+        bool fireballdestruct : 1;
     } data;
 
     // Add new ones in separate structs
@@ -2077,6 +2078,7 @@ struct SWorldSpecialPropertiesStateSync : public ISyncStructure
         data.coronaztest = true;
         data.watercreatures = true;
         data.burnflippedcars = true;
+        data.fireballdestruct = true;
     }
 };
 

--- a/Shared/sdk/net/bitstream.h
+++ b/Shared/sdk/net/bitstream.h
@@ -532,6 +532,10 @@ enum class eBitStreamVersion : unsigned short
     // 2023-08-17
     WorldSpecialProperties,
 
+    // Add "fireballdestruct" to setWorldSpecialPropertyEnabled
+    // 2023-09-09
+    WorldSpecialProperty_FireballDestruct,
+
     // This allows us to automatically increment the BitStreamVersion when things are added to this enum.
     // Make sure you only add things above this comment.
     Next,


### PR DESCRIPTION
Suggested by @Dutchman101 

This property toggles destruction of airplane / helicopter model on explosion (default is `true`). By default game destroys aircraft model when you collide with hard surface at too high speed or after direct missile hit (also if [blowVehicle](https://wiki.multitheftauto.com/wiki/BlowVehicle) is used with driver inside).

It should be easy to review. 2 nops.
~~I will increment sync version if it's not going to be possible to merge it before new build.~~

This PR includes small changes intended to fix `AC #1` false positive kicks introduced by adding server-side setWorldSpecialPropertyEnabled.

> setWorldSpecialPropertyEnabled("fireballdestruct", false)

Before (`true`):
![before](https://github.com/multitheftauto/mtasa-blue/assets/25417477/7ff7ce6d-efd9-42ae-a6e5-4fec381bb861)
After (`false`):
![after](https://github.com/multitheftauto/mtasa-blue/assets/25417477/f697fa47-f265-4a20-9742-3339f74ab620)
