### PR TITLE
Fix random toggle of world special properties

### DIFF
--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -568,12 +568,18 @@ bool CGameSA::SetCheatEnabled(const char* szCheatName, bool bEnable)
 
 void CGameSA::ResetCheats()
 {
-    // Reset cheats that can't be set by setWorldSpecialPropertyEnabled
+    SetRandomFoliageEnabled(true);
+    SetMoonEasterEggEnabled(false);
+    SetExtraAirResistanceEnabled(true);
+    SetUnderWorldWarpEnabled(true);
+    SetCoronaZTestEnabled(true);
+    CVehicleSA::SetVehiclesSunGlareEnabled(false);
+    SetWaterCreaturesEnabled(true);
+    SetBurnFlippedCarsEnabled(true);
+
     std::map<std::string, SCheatSA*>::iterator it;
     for (it = m_Cheats.begin(); it != m_Cheats.end(); it++)
     {
-        if (it->second->m_bCanBeSet)
-            continue;
         if (it->second->m_byAddress > (BYTE*)0x8A4000)
             MemPutFast<BYTE>(it->second->m_byAddress, 0);
         else

--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -568,18 +568,12 @@ bool CGameSA::SetCheatEnabled(const char* szCheatName, bool bEnable)
 
 void CGameSA::ResetCheats()
 {
-    SetRandomFoliageEnabled(true);
-    SetMoonEasterEggEnabled(false);
-    SetExtraAirResistanceEnabled(true);
-    SetUnderWorldWarpEnabled(true);
-    SetCoronaZTestEnabled(true);
-    CVehicleSA::SetVehiclesSunGlareEnabled(false);
-    SetWaterCreaturesEnabled(true);
-    SetBurnFlippedCarsEnabled(true);
-
+    // Reset cheats that can't be set by setWorldSpecialPropertyEnabled
     std::map<std::string, SCheatSA*>::iterator it;
     for (it = m_Cheats.begin(); it != m_Cheats.end(); it++)
     {
+        if (it->second->m_bCanBeSet)
+            continue;
         if (it->second->m_byAddress > (BYTE*)0x8A4000)
             MemPutFast<BYTE>(it->second->m_byAddress, 0);
         else

--- a/Shared/sdk/net/SyncStructures.h
+++ b/Shared/sdk/net/SyncStructures.h
@@ -2070,10 +2070,16 @@ struct SWorldSpecialPropertiesStateSync : public ISyncStructure
 
     SWorldSpecialPropertiesStateSync()
     {
-        // Override default values (default = false)
+        // Set default states
+        data.hovercars = false;
+        data.aircars = false;
+        data.extrabunny = false;
+        data.extrajump = false;
         data.randomfoliage = true;
+        data.snipermoon = false;
         data.extraairresistance = true;
         data.underworldwarp = true;
+        data.vehiclesunglare = false;
         data.coronaztest = true;
         data.watercreatures = true;
         data.burnflippedcars = true;


### PR DESCRIPTION
Fixes bug caused by #3161

Discovered this bug in latest build (22195) by connecting to server of older version multiple times. It's inconsistent (different properties, different states). Latest server version (22195) appears to be not affected.

~~For some weird reason I can't reproduce this bug with custom builds.~~

> If someone else experiencing this issue right now - setting all properties to default states (or states you need) on client side should be enough (tested).