### PR TITLE
Hotfix Discord-RPC from nightly Feedbacks

### DIFF
--- a/Client/core/CDiscordRichPresence.cpp
+++ b/Client/core/CDiscordRichPresence.cpp
@@ -73,6 +73,9 @@ void CDiscordRichPresence::SetDefaultData()
 
     m_uiDiscordAppStart = 0;
     m_uiDiscordAppEnd = 0;
+
+    m_iPartySize = 0;
+    m_iPartyMax = 0;
 }
 
 void CDiscordRichPresence::UpdatePresence()

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDiscordDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDiscordDefs.cpp
@@ -58,7 +58,7 @@ bool CLuaDiscordDefs::ResetData()
 {
     auto discord = g_pCore->GetDiscord();
 
-     if (!discord || !discord->IsDiscordRPCEnabled())
+    if (!discord || !discord->IsDiscordRPCEnabled())
         return false;
 
     if (discord->IsDiscordCustomDetailsDisallowed())

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDiscordDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDiscordDefs.cpp
@@ -58,7 +58,13 @@ bool CLuaDiscordDefs::ResetData()
 {
     auto discord = g_pCore->GetDiscord();
 
-    if (!discord || !discord->IsDiscordRPCEnabled() || !discord->ResetDiscordData())
+     if (!discord || !discord->IsDiscordRPCEnabled())
+        return false;
+
+    if (discord->IsDiscordCustomDetailsDisallowed())
+        return false;
+
+    if (!discord->ResetDiscordData())
         return false;
 
     return true;


### PR DESCRIPTION
Introduces patches from feedback received from people testing on the nightly build.

- Fixed random display of numbers in the state.
- Blocked the resetDiscordRichPresenceData() function if a custom Application ID is not set.