### PR TITLE
Minor Discord-RPC updates and Crowdin integration

### DIFF
--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -673,7 +673,7 @@ void CCore::SetConnected(bool bConnected)
 
         discord->SetPresenceState(bConnected ? _("In-game") : _("Main menu"), false);
         discord->SetPresenceStartTimestamp(0);
-        discord->SetPresenceDetails("");
+        discord->SetPresenceDetails("", false);
 
         if (bConnected)
             discord->SetPresenceStartTimestamp(time(nullptr));

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -667,7 +667,7 @@ void CCore::SetConnected(bool bConnected)
 
     if (g_pCore->GetCVars()->GetValue("allow_discord_rpc", false))
     {
-        auto discord = g_pCore->GetDiscord();
+        const auto discord = g_pCore->GetDiscord();
         if (!discord->IsDiscordRPCEnabled())
             discord->SetDiscordRPCEnabled(true);
 
@@ -1342,7 +1342,7 @@ void CCore::DoPostFramePulse()
     // Update Discord Rich Presence status
     if (const long long ticks = GetTickCount64_(); ticks > m_timeDiscordAppLastUpdate + TIME_DISCORD_UPDATE_RICH_PRESENCE_RATE)
     {
-        if (static auto discord = g_pCore->GetDiscord(); discord && discord->IsDiscordRPCEnabled())
+        if (static const auto discord = g_pCore->GetDiscord(); discord && discord->IsDiscordRPCEnabled())
         {
             discord->UpdatePresence();
             m_timeDiscordAppLastUpdate = ticks;

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -671,7 +671,7 @@ void CCore::SetConnected(bool bConnected)
         if (!discord->IsDiscordRPCEnabled())
             discord->SetDiscordRPCEnabled(true);
 
-        discord->SetPresenceState(bConnected ? "In-game" : "Main menu", false);
+        discord->SetPresenceState(bConnected ? _("In-game") : _("Main menu"), false);
         discord->SetPresenceStartTimestamp(0);
         discord->SetPresenceDetails("");
 

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -1342,7 +1342,7 @@ void CCore::DoPostFramePulse()
     // Update Discord Rich Presence status
     if (const long long ticks = GetTickCount64_(); ticks > m_timeDiscordAppLastUpdate + TIME_DISCORD_UPDATE_RICH_PRESENCE_RATE)
     {
-        if (static const auto discord = g_pCore->GetDiscord(); discord && discord->IsDiscordRPCEnabled())
+        if (const auto discord = g_pCore->GetDiscord(); discord && discord->IsDiscordRPCEnabled())
         {
             discord->UpdatePresence();
             m_timeDiscordAppLastUpdate = ticks;

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -1346,6 +1346,10 @@ void CCore::DoPostFramePulse()
         {
             discord->UpdatePresence();
             m_timeDiscordAppLastUpdate = ticks;
+#ifdef DISCORD_DISABLE_IO_THREAD
+            // Update manually if we're not using the IO thread
+            discord->UpdatePresenceConnection();
+#endif
         }
     }
 

--- a/Client/core/CCore.h
+++ b/Client/core/CCore.h
@@ -396,4 +396,6 @@ private:
     static void                        ParseCommandLine(std::map<std::string, std::string>& options, const char*& szArgs, const char** pszNoValOptions = NULL);
     std::map<std::string, std::string> m_CommandLineOptions;            // e.g. "-o option" -> {"o" = "option"}
     const char*                        m_szCommandLineArgs;             // Everything that comes after the options
+
+    long long m_timeDiscordAppLastUpdate;
 };

--- a/Client/core/CDiscordRichPresence.cpp
+++ b/Client/core/CDiscordRichPresence.cpp
@@ -77,6 +77,9 @@ void CDiscordRichPresence::SetDefaultData()
 
     m_iPartySize = 0;
     m_iPartyMax = 0;
+
+    m_iPlayersCount = 0;
+    m_iMaxPlayers = 0;
 }
 
 void CDiscordRichPresence::UpdatePresence()
@@ -111,8 +114,8 @@ void CDiscordRichPresence::UpdatePresence()
         discordPresence.buttons = buttons;
     }
 
-    discordPresence.partySize = (m_bDisallowCustomDetails) ? 0 : m_iPartySize;
-    discordPresence.partyMax = (m_bDisallowCustomDetails) ? 0 : m_iPartyMax;
+    discordPresence.partySize = (m_bDisallowCustomDetails) ? m_iPlayersCount : m_iPartySize;
+    discordPresence.partyMax = (m_bDisallowCustomDetails) ? m_iMaxPlayers : m_iPartyMax;
 
     Discord_UpdatePresence(&discordPresence);
     m_bUpdateRichPresence = false;
@@ -249,10 +252,18 @@ bool CDiscordRichPresence::IsDiscordCustomDetailsDisallowed() const
     return m_bDisallowCustomDetails;
 }
 
-void CDiscordRichPresence::SetPresencePartySize(int iSize, int iMax)
+void CDiscordRichPresence::SetPresencePartySize(int iSize, int iMax, bool bCustom)
 {
-    m_iPartySize = iSize;
-    m_iPartyMax = iMax;
+    if (bCustom)
+    {
+        m_iPartySize = iSize;
+        m_iPartyMax = iMax;
+    }
+    else
+    {
+        m_iPlayersCount = iSize;
+        m_iMaxPlayers = iMax;
+    }
 }
 
 #ifdef DISCORD_DISABLE_IO_THREAD

--- a/Client/core/CDiscordRichPresence.cpp
+++ b/Client/core/CDiscordRichPresence.cpp
@@ -45,6 +45,7 @@ void CDiscordRichPresence::InitializeDiscord()
 
 void CDiscordRichPresence::ShutdownDiscord()
 {
+    Discord_ClearPresence();
     Discord_Shutdown();
 }
 
@@ -97,6 +98,7 @@ void CDiscordRichPresence::UpdatePresence()
         (!m_strDiscordAppCustomDetails.empty() || !m_bDisallowCustomDetails) ? m_strDiscordAppCustomDetails.c_str() : m_strDiscordAppDetails.c_str();
     discordPresence.startTimestamp = m_uiDiscordAppStart;
     discordPresence.endTimestamp = m_uiDiscordAppEnd;
+    discordPresence.instance = 0;
 
     DiscordButton buttons[2];
     if (m_aButtons)
@@ -127,7 +129,6 @@ void CDiscordRichPresence::SetPresenceEndTimestamp(const unsigned long ulEnd)
     m_uiDiscordAppEnd = ulEnd;
     m_bUpdateRichPresence = true;
 }
-
 
 void CDiscordRichPresence::SetAssetLargeData(const char* szAsset, const char* szAssetText)
 {

--- a/Client/core/CDiscordRichPresence.cpp
+++ b/Client/core/CDiscordRichPresence.cpp
@@ -254,3 +254,10 @@ void CDiscordRichPresence::SetPresencePartySize(int iSize, int iMax)
     m_iPartySize = iSize;
     m_iPartyMax = iMax;
 }
+
+#ifdef DISCORD_DISABLE_IO_THREAD
+void CDiscordRichPresence::UpdatePresenceConnection()
+{
+    Discord_UpdateConnection();
+}
+#endif

--- a/Client/core/CDiscordRichPresence.h
+++ b/Client/core/CDiscordRichPresence.h
@@ -27,15 +27,15 @@ public:
     void UpdatePresence();
     void SetPresenceStartTimestamp(const unsigned long ulStart);
     void SetPresenceEndTimestamp(const unsigned long ulEnd);
-    void SetAsset(const char* szAsset, const char* szAssetText, bool bIsLarge = false);
+    void SetAsset(const char* szAsset, const char* szAssetText, bool bIsLarge);
     void SetAssetLargeData(const char* szAsset, const char* szAssetText);
     void SetAssetSmallData(const char* szAsset, const char* szAssetText);
 
     bool ResetDiscordData();
-    bool SetPresenceState(const char* szState, bool bCustom = false);
-    bool SetPresenceDetails(const char* szDetails, bool bCustom = false);
+    bool SetPresenceState(const char* szState, bool bCustom);
+    bool SetPresenceDetails(const char* szDetails, bool bCustom);
     bool SetPresenceButtons(unsigned short int iIndex, const char* szName, const char* szUrl);
-    void SetPresencePartySize(int iSize, int iMax, bool bCustom = false);
+    void SetPresencePartySize(int iSize, int iMax, bool bCustom);
     bool SetDiscordRPCEnabled(bool bEnabled);
     bool IsDiscordCustomDetailsDisallowed() const;
     bool IsDiscordRPCEnabled() const;

--- a/Client/core/CDiscordRichPresence.h
+++ b/Client/core/CDiscordRichPresence.h
@@ -35,7 +35,7 @@ public:
     bool SetPresenceState(const char* szState, bool bCustom = false);
     bool SetPresenceDetails(const char* szDetails, bool bCustom = false);
     bool SetPresenceButtons(unsigned short int iIndex, const char* szName, const char* szUrl);
-    void SetPresencePartySize(int iSize, int iMax);
+    void SetPresencePartySize(int iSize, int iMax, bool bCustom = false);
     bool SetDiscordRPCEnabled(bool bEnabled);
     bool IsDiscordCustomDetailsDisallowed() const;
     bool IsDiscordRPCEnabled() const;
@@ -69,4 +69,7 @@ private:
 
     int m_iPartySize;
     int m_iPartyMax;
+
+    int m_iPlayersCount;
+    int m_iMaxPlayers;
 };

--- a/Client/core/CDiscordRichPresence.h
+++ b/Client/core/CDiscordRichPresence.h
@@ -41,9 +41,9 @@ public:
     bool IsDiscordRPCEnabled() const;
     bool SetApplicationID(const char* szAppID);
 
-    // void SetPresenceTimestamp();
-    // void SetPresenceImage();
-    // void SetPresenceText();
+#ifdef DISCORD_DISABLE_IO_THREAD
+    void UpdatePresenceConnection();
+#endif
 
 private:
     std::string m_strDiscordAppId;

--- a/Client/core/CDiscordRichPresence.h
+++ b/Client/core/CDiscordRichPresence.h
@@ -40,6 +40,13 @@ public:
     bool IsDiscordCustomDetailsDisallowed() const;
     bool IsDiscordRPCEnabled() const;
     bool SetApplicationID(const char* szAppID);
+    void SetDiscordClientConnected(bool bConnected) { m_bConnected = bConnected; };
+    bool IsDiscordClientConnected() const;
+
+    // handlers
+    static void HandleDiscordReady(const struct DiscordUser* pDiscordUser);
+    static void HandleDiscordDisconnected(int iErrorCode, const char* szMessage);
+    static void HandleDiscordError(int iErrorCode, const char* szMessage);
 
 #ifdef DISCORD_DISABLE_IO_THREAD
     void UpdatePresenceConnection();
@@ -66,6 +73,7 @@ private:
     bool m_bDisallowCustomDetails;
     bool m_bDiscordRPCEnabled;
     bool m_bUpdateRichPresence;
+    bool m_bConnected;
 
     int m_iPartySize;
     int m_iPartyMax;

--- a/Client/core/CMainMenu.cpp
+++ b/Client/core/CMainMenu.cpp
@@ -301,7 +301,7 @@ CMainMenu::CMainMenu(CGUI* pManager)
         if (!discord->IsDiscordRPCEnabled())
             discord->SetDiscordRPCEnabled(true);
 
-        discord->SetPresenceState("Main menu", false);
+        discord->SetPresenceState(_("Main menu"), false);
         discord->SetPresenceStartTimestamp(0);
     }
 

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -3458,11 +3458,11 @@ void CSettings::SaveData()
 
         if (discord)
         {
-            const char* state = "Main menu";
+            const char* state = _("Main menu");
 
             if (g_pCore->IsConnected())
             {                
-                state = "In-game";
+                state = _("In-game");
 
                 const SString& serverName = g_pCore->GetLastConnectedServerName();
                 discord->SetPresenceDetails(serverName.c_str(), false);

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -3454,7 +3454,7 @@ void CSettings::SaveData()
 
     if (bAllowDiscordRPC)
     {
-        auto discord = g_pCore->GetDiscord();
+        const auto discord = g_pCore->GetDiscord();
 
         if (discord)
         {

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -520,7 +520,7 @@ CClientGame::~CClientGame()
     SetCursorEventsEnabled(false);
 
     // Reset discord stuff
-    auto discord = g_pCore->GetDiscord();
+    const auto discord = g_pCore->GetDiscord();
     if (discord && discord->IsDiscordRPCEnabled())
     {
         discord->ResetDiscordData();
@@ -996,9 +996,9 @@ void CClientGame::DoPulsePostFrame()
         // Check if we need to update the Discord Rich Presence state
         if (const long long ticks = GetTickCount64_(); ticks > m_timeLastDiscordStateUpdate + TIME_DISCORD_UPDATE_RATE)
         {
-            auto discord = g_pCore->GetDiscord();
+            const auto discord = g_pCore->GetDiscord();
 
-            if (discord && discord->IsDiscordRPCEnabled())
+            if (discord && discord->IsDiscordRPCEnabled() && discord->IsDiscordCustomDetailsDisallowed())
             {
                 if (auto pLocalPlayer = g_pClientGame->GetLocalPlayer())
                 {
@@ -5686,8 +5686,8 @@ void CClientGame::DoWastedCheck(ElementID damagerID, unsigned char ucWeapon, uns
             g_pNet->SendPacket(PACKET_ID_PLAYER_WASTED, pBitStream, PACKET_PRIORITY_HIGH, PACKET_RELIABILITY_RELIABLE_ORDERED);
             g_pNet->DeallocateNetBitStream(pBitStream);
 
-            auto discord = g_pCore->GetDiscord();
-            if (discord->IsDiscordRPCEnabled())
+            const auto discord = g_pCore->GetDiscord();
+            if (discord && discord->IsDiscordRPCEnabled() && discord->IsDiscordCustomDetailsDisallowed())
             {
                 static const std::vector<std::string> states{
                     _("In a ditch"), _("En-route to hospital"), _("Meeting their maker"),

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -1054,6 +1054,7 @@ void CClientGame::DoPulsePostFrame()
                     discord->SetPresenceState("In-game", false);
                 }
 
+                discord->SetPresencePartySize(m_pPlayerManager->Count(), g_pClientGame->GetServerInfo()->GetMaxPlayers(), false);
                 m_timeLastDiscordStateUpdate = ticks;
             }
         }

--- a/Client/mods/deathmatch/logic/CClientTask.h
+++ b/Client/mods/deathmatch/logic/CClientTask.h
@@ -33,26 +33,7 @@ struct STaskState
     std::optional<eSecondaryTaskType> eSecondaryType = {};
 };
 
-static const std::unordered_multimap<eTaskType, STaskState> g_playerTaskStates{
-    {TASK_COMPLEX_JUMP, {true, "Climbing around in", TASK_SIMPLE_CLIMB}},
-    {TASK_SIMPLE_GANG_DRIVEBY, {true, "Doing a drive-by in"}},
-    {TASK_SIMPLE_DRIVEBY_SHOOT, {true, "Doing a drive-by in"}},
-    {TASK_SIMPLE_DIE, {false, "Blub blub...", TASK_SIMPLE_DROWN}},
-    {TASK_SIMPLE_DIE, {false, "Breathing water", TASK_SIMPLE_DROWN}},
-    {TASK_SIMPLE_DIE, {true, "Drowning in", TASK_SIMPLE_DROWN}},
-    {TASK_SIMPLE_PLAYER_ON_FOOT, {true, "Ducking for cover in", {}, TASK_SIMPLE_DUCK, TASK_SECONDARY_DUCK}},
-    {TASK_SIMPLE_PLAYER_ON_FOOT, {true, "Fighting in", {}, TASK_SIMPLE_FIGHT, TASK_SECONDARY_ATTACK}},
-    {TASK_SIMPLE_PLAYER_ON_FOOT, {true, "Throwing fists in", {}, TASK_SIMPLE_FIGHT, TASK_SECONDARY_ATTACK}},
-    {TASK_SIMPLE_PLAYER_ON_FOOT, {true, "Blastin' fools in", {}, TASK_SIMPLE_USE_GUN, TASK_SECONDARY_ATTACK}},
-    {TASK_SIMPLE_PLAYER_ON_FOOT, {true, "Shooting up", {}, TASK_SIMPLE_USE_GUN, TASK_SECONDARY_ATTACK}},
-    {TASK_SIMPLE_JETPACK, {true, "Jetpacking in"}},
-    {TASK_SIMPLE_PLAYER_ON_FOOT, {true, "Literally on fire in", {}, TASK_SIMPLE_PLAYER_ON_FIRE, TASK_SECONDARY_PARTIAL_ANIM}},
-    {TASK_SIMPLE_PLAYER_ON_FOOT, {true, "Burning up in", {}, TASK_SIMPLE_PLAYER_ON_FIRE, TASK_SECONDARY_PARTIAL_ANIM}},
-    {TASK_COMPLEX_IN_WATER, {true, "Swimming in", TASK_SIMPLE_SWIM}},
-    {TASK_COMPLEX_IN_WATER, {true, "Floating around in", TASK_SIMPLE_SWIM}},
-    {TASK_COMPLEX_IN_WATER, {false, "Being chased by a shark", TASK_SIMPLE_SWIM}},
-    {TASK_SIMPLE_CHOKING, {true, "Choking to death in"}},
-};
+static std::unordered_multimap<eTaskType, STaskState> g_playerTaskStates;
 
 class CClientTask
 {

--- a/Client/mods/deathmatch/logic/CClientVehicle.h
+++ b/Client/mods/deathmatch/logic/CClientVehicle.h
@@ -147,9 +147,7 @@ struct SVehicleComponentData
     bool    m_bVisible;
 };
 
-static const std::array<std::string, NUM_VEHICLE_TYPES> g_vehicleTypePrefixes = {
-    "Flying a UFO around", "Cruising around",         "Riding the waves of", "Riding the train in",  "Flying around",       "Flying around",
-    "Riding around",       "Monster truckin' around", "Quaddin' around",     "Bunny hopping around", "Doing weird stuff in"};
+static std::array<std::string, NUM_VEHICLE_TYPES> g_vehicleTypePrefixes;
 
 class CClientVehicle : public CClientStreamElement
 {

--- a/Client/mods/deathmatch/logic/CResource.cpp
+++ b/Client/mods/deathmatch/logic/CResource.cpp
@@ -361,6 +361,16 @@ void CResource::Stop()
     CLuaArguments Arguments;
     Arguments.PushResource(this);
     m_pResourceEntity->CallEvent("onClientResourceStop", Arguments, true);
+
+    // When a custom application is used - reset discord stuff
+    const auto discord = g_pCore->GetDiscord();
+    if (discord && discord->IsDiscordRPCEnabled() && !discord->IsDiscordCustomDetailsDisallowed())
+    {
+        discord->ResetDiscordData();
+        discord->SetPresenceState(_("In-game"), false);
+        discord->SetPresenceStartTimestamp(time(nullptr));
+        discord->UpdatePresence();
+    }
 }
 
 SString CResource::GetState()

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDiscordDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDiscordDefs.cpp
@@ -24,7 +24,7 @@ void CLuaDiscordDefs::LoadFunctions()
         {"setDiscordRichPresenceEndTime", ArgumentParser<SetEndTime>},
         {"setDiscordRichPresencePartySize", ArgumentParser<SetPartySize>},
         {"resetDiscordRichPresenceData", ArgumentParser<ResetData>},
-        {"isDiscordRichPresenceConnected", ArgumentParser < IsDiscordRPCConnected>},
+        {"isDiscordRichPresenceConnected", ArgumentParser <IsDiscordRPCConnected>},
 
     };
 
@@ -178,7 +178,7 @@ bool CLuaDiscordDefs::SetPartySize(int iSize, int iMax)
     if (discord->IsDiscordCustomDetailsDisallowed())
         return false;
 
-    discord->SetPresencePartySize(iSize, iMax);
+    discord->SetPresencePartySize(iSize, iMax, true);
     return true;
 }
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDiscordDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDiscordDefs.cpp
@@ -252,8 +252,8 @@ bool CLuaDiscordDefs::IsDiscordRPCConnected()
 {
     auto discord = g_pCore->GetDiscord();
 
-    if (!discord)
+    if (!discord || !discord->IsDiscordRPCEnabled())
         return false;
 
-    return discord->IsDiscordRPCEnabled();
+    return discord->IsDiscordClientConnected();
 }

--- a/Client/sdk/core/CDiscordInterface.h
+++ b/Client/sdk/core/CDiscordInterface.h
@@ -27,7 +27,7 @@ public:
     virtual void SetPresenceStartTimestamp(const unsigned long ulStart) = 0;
     virtual void SetPresenceEndTimestamp(const unsigned long ulEnd) = 0;
     virtual bool SetPresenceButtons(unsigned short int iIndex, const char* szName, const char* szUrl) = 0;
-    virtual void SetPresencePartySize(int iSize, int iMax) = 0;
+    virtual void SetPresencePartySize(int iSize, int iMax, bool bCustom) = 0;
 
     virtual bool SetDiscordRPCEnabled(bool bEnabled = false) = 0;
     virtual bool IsDiscordRPCEnabled() const = 0;

--- a/Client/sdk/core/CDiscordInterface.h
+++ b/Client/sdk/core/CDiscordInterface.h
@@ -18,7 +18,7 @@ class CDiscordInterface
 public:
     virtual ~CDiscordInterface() = default;
     virtual void UpdatePresence() = 0;
-    virtual bool SetPresenceDetails(const char* szDetails, bool bCustom = false) = 0;
+    virtual bool SetPresenceDetails(const char* szDetails, bool bCustom) = 0;
     virtual bool SetApplicationID(const char* szAppID) = 0;
     virtual bool ResetDiscordData() = 0;
     virtual bool SetPresenceState(const char* szState, bool bCustom) = 0;
@@ -29,9 +29,11 @@ public:
     virtual bool SetPresenceButtons(unsigned short int iIndex, const char* szName, const char* szUrl) = 0;
     virtual void SetPresencePartySize(int iSize, int iMax, bool bCustom) = 0;
 
-    virtual bool SetDiscordRPCEnabled(bool bEnabled = false) = 0;
+    virtual bool SetDiscordRPCEnabled(bool bEnabled) = 0;
+    virtual void SetDiscordClientConnected(bool bConnected) = 0;
     virtual bool IsDiscordRPCEnabled() const = 0;
     virtual bool IsDiscordCustomDetailsDisallowed() const = 0;
+    virtual bool IsDiscordClientConnected() const = 0;
 
 #ifdef DISCORD_DISABLE_IO_THREAD
     virtual void UpdatePresenceConnection() = 0;

--- a/Client/sdk/core/CDiscordInterface.h
+++ b/Client/sdk/core/CDiscordInterface.h
@@ -9,6 +9,9 @@
  *****************************************************************************/
 
 #pragma once
+//#define DISCORD_DISABLE_IO_THREAD
+// Uncomment to use manuall refresh of discord connection
+// (important) Don't forget to write same in discord-rpc.h
 
 class CDiscordInterface
 {
@@ -29,4 +32,8 @@ public:
     virtual bool SetDiscordRPCEnabled(bool bEnabled = false) = 0;
     virtual bool IsDiscordRPCEnabled() const = 0;
     virtual bool IsDiscordCustomDetailsDisallowed() const = 0;
+
+#ifdef DISCORD_DISABLE_IO_THREAD
+    virtual void UpdatePresenceConnection() = 0;
+#endif
 };

--- a/Client/sdk/core/CDiscordInterface.h
+++ b/Client/sdk/core/CDiscordInterface.h
@@ -25,7 +25,6 @@ public:
     virtual void SetPresenceEndTimestamp(const unsigned long ulEnd) = 0;
     virtual bool SetPresenceButtons(unsigned short int iIndex, const char* szName, const char* szUrl) = 0;
     virtual void SetPresencePartySize(int iSize, int iMax) = 0;
-    //virtual void SetPresenceEndTimestamp(const unsigned long ulEnd) = 0;
 
     virtual bool SetDiscordRPCEnabled(bool bEnabled = false) = 0;
     virtual bool IsDiscordRPCEnabled() const = 0;

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -58,6 +58,7 @@
 #include "packets/CPlayerNetworkStatusPacket.h"
 #include "packets/CPlayerListPacket.h"
 #include "packets/CPlayerClothesPacket.h"
+#include "packets/CServerInfoSyncPacket.h"
 #include "../utils/COpenPortsTester.h"
 #include "../utils/CMasterServerAnnouncer.h"
 #include "../utils/CHqComms.h"
@@ -1808,6 +1809,8 @@ void CGame::Packet_PlayerJoinData(CPlayerJoinDataPacket& Packet)
                             pPlayer->SetSerial(strExtra, 1);
                             pPlayer->SetPlayerVersion(strPlayerVersion);
 
+                            pPlayer->Send(CServerInfoSyncPacket(EServerInfoSyncFlag::SERVER_INFO_FLAG_MAX_PLAYERS));
+
                             // Check if client must update
                             if (IsBelowMinimumClient(pPlayer->GetPlayerVersion()) && !pPlayer->ShouldIgnoreMinClientVersionChecks())
                             {
@@ -2287,6 +2290,11 @@ void CGame::Packet_PlayerPuresync(CPlayerPuresyncPacket& Packet)
         // Only every 4 packets.
         if ((pPlayer->GetPuresyncCount() % 4) == 0)
             pPlayer->Send(CReturnSyncPacket(pPlayer));
+
+        // Send a server info sync packet to the player
+        // Only every 512 packets
+        if ((pPlayer->GetPuresyncCount() % 512) == 0)
+            pPlayer->Send(CServerInfoSyncPacket(EServerInfoSyncFlag::SERVER_INFO_FLAG_MAX_PLAYERS));
 
         CLOCK("PlayerPuresync", "RelayPlayerPuresync");
         // Relay to other players


### PR DESCRIPTION
This PR introduces several features and improvements:

- Crowdin Integration: This feature enables the integration with Crowdin, allowing statuses to be displayed in the language used by the client. This enhances the localization of the application for users who prefer a different language.

- Minor Fixes: The PR includes several minor fixes, addressing issues and bugs that have been identified and resolved for a smoother user experience.

- Player Count Display: A new feature has been added that allows the display of the number of players in the status when using the default MTA Rich Presence application. This provides users with information about the current player count, which can be helpful for server management and user engagement.
 
- Increased Rich Presence Refresh Time: The refresh time for Rich Presence has been increased. This adjustment is aimed at mitigating potential game fluidity issues, ensuring a smoother and more stable gaming experience for users.
 
- Custom Application Handling: With the changes introduced in this PR, if a custom application is used and a resource is stopped (triggered the **onClientResourceStop** event), it will now trigger a reset and set the default MTA Rich Presence application. This ensures that the default Rich Presence functionality is retained when using custom applications. Additionally, a more precise method for checking if the client is connected with a custom application has been added, enhancing the reliability and accuracy of custom application detection.

Overall, this PR enhances localization, improves the user experience, and addresses potential issues related to game fluidity, resource handling, and custom application detection.