### PR TITLE
Add server side projectile events

### DIFF
--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -2079,6 +2079,11 @@ bool CStaticFunctionDefinitions::DetonateSatchels(CElement* pElement)
         CPlayer* pPlayer = static_cast<CPlayer*>(pElement);
         if (pPlayer->IsJoined())
         {
+            // Trigger Lua event and see if we are allowed to continue
+            CLuaArguments arguments;
+            if (!pPlayer->CallEvent("onPlayerDetonateSatchels", arguments))
+                return false;
+
             CDetonateSatchelsPacket Packet;
             Packet.SetSourceElement(pPlayer);
             m_pPlayerManager->BroadcastOnlyJoined(Packet);

--- a/Server/mods/deathmatch/logic/packets/CProjectileSyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CProjectileSyncPacket.cpp
@@ -39,11 +39,8 @@ bool CProjectileSyncPacket::Read(NetBitStreamInterface& BitStream)
         return false;
     m_ucWeaponType = weaponType.data.ucWeaponType;
 
-    if (BitStream.Version() >= 0x4F)
-    {
-        if (!BitStream.Read(m_usModel))
-            return false;
-    }
+    if (!BitStream.Read(m_usModel))
+        return false;
 
     switch (m_ucWeaponType)
     {
@@ -67,12 +64,11 @@ bool CProjectileSyncPacket::Read(NetBitStreamInterface& BitStream)
         case 19:            // WEAPONTYPE_ROCKET
         case 20:            // WEAPONTYPE_ROCKET_HS
         {
-            bool bHasTarget;
-            if (!BitStream.ReadBit(bHasTarget))
+            if (!BitStream.ReadBit(m_bHasTarget))
                 return false;
 
             m_TargetID = INVALID_ELEMENT_ID;
-            if (bHasTarget && !BitStream.Read(m_TargetID))
+            if (m_bHasTarget && !BitStream.Read(m_TargetID))
                 return false;
 
             SVelocitySync velocity;
@@ -127,10 +123,7 @@ bool CProjectileSyncPacket::Write(NetBitStreamInterface& BitStream) const
     weaponType.data.ucWeaponType = m_ucWeaponType;
     BitStream.Write(&weaponType);
 
-    if (BitStream.Version() >= 0x4F)
-    {
-        BitStream.Write(m_usModel);
-    }
+    BitStream.Write(m_usModel);
 
     switch (m_ucWeaponType)
     {

--- a/Server/mods/deathmatch/logic/packets/CProjectileSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CProjectileSyncPacket.h
@@ -29,7 +29,7 @@ public:
     ElementID      m_OriginID;
     CVector        m_vecOrigin;
     float          m_fForce;
-    unsigned char  m_ucHasTarget;
+    bool           m_bHasTarget;
     ElementID      m_TargetID;
     CVector        m_vecTarget;
     CVector        m_vecRotation;


### PR DESCRIPTION
Adds two events

`onPlayerProjectileCreation ( int weaponType, float posX, float posY, float posZ [, float force, element target, float rotX, float rotY, float rotZ, float velX, float velY, float velZ ] )`
**source**: player who created the projectile.
This event is triggered when player fires a projectile (e.g. a grenade, satchel, rocket)
or when a projectile is created through scripting function [createProjectile](https://wiki.multitheftauto.com/wiki/CreateProjectile).

If cancelled the projectile won't appear for other players on the server.

`onPlayerDetonateSatchels ( )`
**source**: player who wants to detonate his own satchels.
This event is triggered when a player attempts to detonate satchels with a detonator, or through scripting function [detonateSatchels](https://wiki.multitheftauto.com/wiki/DetonateSatchels).

If cancelled the satchels won't detonate - neither on client or remote players

Note to reviewer: The packet change only renames a previously unused variable and removes 10+ yr old bitstream checks.