### PR TITLE
Discord-RPC: IO Thread Disablement and minor security fixes

### DIFF
--- a/Client/core/CDiscordRichPresence.cpp
+++ b/Client/core/CDiscordRichPresence.cpp
@@ -51,9 +51,6 @@ void CDiscordRichPresence::InitializeDiscord()
 
 void CDiscordRichPresence::ShutdownDiscord()
 {
-    if (!m_bDiscordRPCEnabled)
-        return;
-
     Discord_ClearPresence();
     Discord_Shutdown();
 
@@ -62,9 +59,6 @@ void CDiscordRichPresence::ShutdownDiscord()
 
 void CDiscordRichPresence::RestartDiscord()
 {
-    if (!m_bDiscordRPCEnabled)
-        return;
-
     ShutdownDiscord();
     InitializeDiscord();
 }

--- a/Client/core/CDiscordRichPresence.cpp
+++ b/Client/core/CDiscordRichPresence.cpp
@@ -36,7 +36,7 @@ CDiscordRichPresence::~CDiscordRichPresence()
 
 void CDiscordRichPresence::InitializeDiscord()
 {
-    std::lock_guard<std::mutex> lock(m_mutexThread);
+    std::lock_guard<std::mutex> lock(m_threadSafetyMutex);
     DiscordEventHandlers handlers;
     memset(&handlers, 0, sizeof(handlers));
 
@@ -106,7 +106,7 @@ void CDiscordRichPresence::UpdatePresence()
     if (!m_bUpdateRichPresence)
         return;
 
-    std::lock_guard<std::mutex> lock(m_mutexThread);
+    std::lock_guard<std::mutex> lock(m_threadSafetyMutex);
     DiscordRichPresence discordPresence;
     memset(&discordPresence, 0, sizeof(discordPresence));
 

--- a/Client/core/CDiscordRichPresence.h
+++ b/Client/core/CDiscordRichPresence.h
@@ -69,7 +69,7 @@ private:
 
     std::optional<std::tuple<std::pair<std::string, std::string>, std::pair<std::string, std::string>>> m_aButtons;
 
-    std::mutex    m_mutexThread;
+    std::mutex m_threadSafetyMutex;
 
     unsigned long m_uiDiscordAppStart;
     unsigned long m_uiDiscordAppEnd;

--- a/Client/core/CDiscordRichPresence.h
+++ b/Client/core/CDiscordRichPresence.h
@@ -23,35 +23,35 @@ public:
     void ShutdownDiscord();
     void RestartDiscord();
     void SetDefaultData();
-
     void UpdatePresence();
+#ifdef DISCORD_DISABLE_IO_THREAD
+    void UpdatePresenceConnection();
+#endif
+
     void SetPresenceStartTimestamp(const unsigned long ulStart);
     void SetPresenceEndTimestamp(const unsigned long ulEnd);
     void SetAsset(const char* szAsset, const char* szAssetText, bool bIsLarge);
     void SetAssetLargeData(const char* szAsset, const char* szAssetText);
     void SetAssetSmallData(const char* szAsset, const char* szAssetText);
+    void SetDiscordClientConnected(bool bConnected) { m_bConnected = bConnected; };
+    void SetPresencePartySize(int iSize, int iMax, bool bCustom);
 
     bool ResetDiscordData();
     bool SetPresenceState(const char* szState, bool bCustom);
     bool SetPresenceDetails(const char* szDetails, bool bCustom);
     bool SetPresenceButtons(unsigned short int iIndex, const char* szName, const char* szUrl);
-    void SetPresencePartySize(int iSize, int iMax, bool bCustom);
     bool SetDiscordRPCEnabled(bool bEnabled);
-    bool IsDiscordCustomDetailsDisallowed() const;
-    bool IsDiscordRPCEnabled() const;
     bool SetApplicationID(const char* resourceName, const char* szAppID);
-    void SetDiscordClientConnected(bool bConnected) { m_bConnected = bConnected; };
-    bool IsDiscordClientConnected() const;
+    bool IsDiscordCustomDetailsDisallowed() const { return m_bDisallowCustomDetails; };
+    bool IsDiscordRPCEnabled() const { return m_bDiscordRPCEnabled; };
+    bool IsDiscordClientConnected() const { return m_bConnected; };
+
     std::string GetDiscordResourceName() const { return m_strDiscordCustomResourceName; };
 
-    // handlers
+    // static handlers
     static void HandleDiscordReady(const struct DiscordUser* pDiscordUser);
     static void HandleDiscordDisconnected(int iErrorCode, const char* szMessage);
     static void HandleDiscordError(int iErrorCode, const char* szMessage);
-
-#ifdef DISCORD_DISABLE_IO_THREAD
-    void UpdatePresenceConnection();
-#endif
 
 private:
     std::string m_strDiscordAppId;
@@ -68,6 +68,8 @@ private:
     std::string m_strDiscordAppCustomDetails;
 
     std::optional<std::tuple<std::pair<std::string, std::string>, std::pair<std::string, std::string>>> m_aButtons;
+
+    std::mutex    m_mutexThread;
 
     unsigned long m_uiDiscordAppStart;
     unsigned long m_uiDiscordAppEnd;

--- a/Client/sdk/core/CDiscordInterface.h
+++ b/Client/sdk/core/CDiscordInterface.h
@@ -9,7 +9,7 @@
  *****************************************************************************/
 
 #pragma once
-//#define DISCORD_DISABLE_IO_THREAD
+#define DISCORD_DISABLE_IO_THREAD
 // Uncomment to use manuall refresh of discord connection
 // (important) Don't forget to write same in discord-rpc.h
 

--- a/Client/sdk/core/CDiscordInterface.h
+++ b/Client/sdk/core/CDiscordInterface.h
@@ -18,25 +18,25 @@ class CDiscordInterface
 public:
     virtual ~CDiscordInterface() = default;
     virtual void UpdatePresence() = 0;
-    virtual bool SetPresenceDetails(const char* szDetails, bool bCustom) = 0;
-    virtual bool SetApplicationID(const char* szResourceName, const char* szAppID) = 0;
-    virtual bool ResetDiscordData() = 0;
-    virtual bool SetPresenceState(const char* szState, bool bCustom) = 0;
+#ifdef DISCORD_DISABLE_IO_THREAD
+    virtual void UpdatePresenceConnection() = 0;
+#endif
     virtual void SetAssetLargeData(const char* szAsset, const char* szAssetText) = 0;
     virtual void SetAssetSmallData(const char* szAsset, const char* szAssetText) = 0;
     virtual void SetPresenceStartTimestamp(const unsigned long ulStart) = 0;
     virtual void SetPresenceEndTimestamp(const unsigned long ulEnd) = 0;
-    virtual bool SetPresenceButtons(unsigned short int iIndex, const char* szName, const char* szUrl) = 0;
     virtual void SetPresencePartySize(int iSize, int iMax, bool bCustom) = 0;
-    virtual std::string GetDiscordResourceName() const = 0;
-
-    virtual bool SetDiscordRPCEnabled(bool bEnabled) = 0;
     virtual void SetDiscordClientConnected(bool bConnected) = 0;
+
+    virtual bool SetPresenceDetails(const char* szDetails, bool bCustom) = 0;
+    virtual bool SetApplicationID(const char* szResourceName, const char* szAppID) = 0;
+    virtual bool ResetDiscordData() = 0;
+    virtual bool SetPresenceState(const char* szState, bool bCustom) = 0;
+    virtual bool SetPresenceButtons(unsigned short int iIndex, const char* szName, const char* szUrl) = 0;
+    virtual bool SetDiscordRPCEnabled(bool bEnabled) = 0;
     virtual bool IsDiscordRPCEnabled() const = 0;
     virtual bool IsDiscordCustomDetailsDisallowed() const = 0;
     virtual bool IsDiscordClientConnected() const = 0;
 
-#ifdef DISCORD_DISABLE_IO_THREAD
-    virtual void UpdatePresenceConnection() = 0;
-#endif
+    virtual std::string GetDiscordResourceName() const = 0;
 };

--- a/vendor/discord-rpc/premake5.lua
+++ b/vendor/discord-rpc/premake5.lua
@@ -8,6 +8,10 @@ project "discord-rpc"
 		"discord/thirdparty/rapidjson/include"
 	}
 
+	defines {
+		"DISCORD_DISABLE_IO_THREAD"
+	}
+
 	files {
 		"premake5.lua",
 		"discord/src/discord_rpc.cpp",


### PR DESCRIPTION
This pull request introduces several fixes and security enhancements. 

The main goal of this pull request is to disable the IO thread and manually update Rich Presence. Will improve interoperability and compatibility with the MTA client - hopefully reducing the number of asserts triggered, for example, by the load on the iostream thread by MTA (resource fetching, etc.).
