### PR TITLE
Fix std::unordered_map<std::string, std::string> parsing

### DIFF
--- a/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
@@ -463,10 +463,16 @@ struct CLuaFunctionParserBase
                 }
 
                 int  i = -2;
-                auto k = PopUnsafe<key_t>(L, i);
+
+                // When key_t is a string and the actual type of a key is number Lua will conduct an implicit value change
+                // that can confuse lua_next and lead to a crash. To fix it we can copy a key in order to save an original key
+                // that will be used during the next lua_next invocation.
+                lua_pushvalue(L, i);
+
                 auto v = PopUnsafe<value_t>(L, i);
+                auto k = PopUnsafe<key_t>(L, i);                
                 map.emplace(std::move(k), std::move(v));
-                lua_pop(L, 1);            // drop value, keep key for lua_next
+                lua_pop(L, 2);            // drop values(key copy and value), keep original key for lua_next
             }
             ++index;
             return map;


### PR DESCRIPTION
This PR is inspired by the problem appeared in #3211. It fixes a crash when `std::unordered_map<std::string, std::string>` is used as an argument for the new Lua parser.