### PR TITLE
Add ability to limit client triggered events (via triggerServerEvent)

### DIFF
--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -4714,19 +4714,16 @@ void CGame::RegisterClientTriggeredEventUsage(CPlayer* pPlayer)
     auto iter = m_mapClientTriggeredEvents.find(pPlayer);
 
     if (iter == m_mapClientTriggeredEvents.end())
-        iter = m_mapClientTriggeredEvents.insert({pPlayer, 0}).first;
+        m_mapClientTriggeredEvents.insert({pPlayer, 0});
 
-    iter->second++;
+    m_mapClientTriggeredEvents[pPlayer]++;
 }
 
 void CGame::ProcessClientTriggeredEventSpam()
 {
-    for (const auto& pair : m_mapClientTriggeredEvents)
+    for (const auto& [player, count]: m_mapClientTriggeredEvents)
     {
-        CPlayer* player = pair.first;
-        int      count = pair.second;
-
-        if (player && count > m_iMaxClientTriggeredEventsPerInterval)
+        if (player && player->IsPlayer() && !player->IsBeingDeleted() && count > m_iMaxClientTriggeredEventsPerInterval)
             player->CallEvent("onPlayerTriggerEventThreshold", {});
     }
 

--- a/Server/mods/deathmatch/logic/CGame.h
+++ b/Server/mods/deathmatch/logic/CGame.h
@@ -457,6 +457,7 @@ public:
     bool        IsBelowMinimumClient(const CMtaVersion& strVersion);
     bool        IsBelowRecommendedClient(const CMtaVersion& strVersion);
     void        ApplyAseSetting();
+    void        ApplyPlayerTriggeredEventIntervalChange();
     bool        IsUsingMtaServerConf() { return m_bUsingMtaServerConf; }
 
     void SetDevelopmentMode(bool enabled) { m_DevelopmentModeEnabled = enabled; }
@@ -507,6 +508,9 @@ private:
     void Packet_PlayerResourceStart(class CPlayerResourceStartPacket& Packet);
 
     static void PlayerCompleteConnect(CPlayer* pPlayer);
+
+    void ProcessClientTriggeredEventSpam();
+    void RegisterClientTriggeredEventUsage(CPlayer* pPlayer);
 
     // Technically, this could be put somewhere else.  It's a callback function
     // which the voice server library will call to send out data.
@@ -658,4 +662,10 @@ private:
 
     bool m_DevelopmentModeEnabled;
     bool m_showClientTransferBox = true;
+
+    int m_iMaxClientTriggeredEventsPerInterval = 100;
+    int m_iClientTriggeredEventsIntervalMs = 1000;
+    long long m_lClientTriggeredEventsLastCheck = 0;
+
+    std::map<CPlayer*, int> m_mapClientTriggeredEvents;
 };

--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -847,12 +847,7 @@ bool CMainConfig::AddMissingSettings()
     if (!g_pGame->IsUsingMtaServerConf())
         return false;
 
-    // Load template
-    const char* szTemplateText =
-        #include MTA_SERVER_CONF_TEMPLATE
-        ;
-    SString strTemplateFilename = PathJoin(g_pServerInterface->GetServerModPath(), "resource-cache", "conf.template");
-    FileSave(strTemplateFilename, szTemplateText);
+    SString strTemplateFilename = PathJoin(g_pServerInterface->GetServerModPath(), "mtaserver.conf.template");
     CXMLFile* pFileTemplate = g_pServerInterface->GetXML()->CreateXML(strTemplateFilename);
     CXMLNode* pRootNodeTemplate = pFileTemplate && pFileTemplate->Parse() ? pFileTemplate->GetRootNode() : nullptr;
     if (!pRootNodeTemplate)
@@ -1463,6 +1458,8 @@ const std::vector<SIntSetting>& CMainConfig::GetIntSettingList()
         {true, true, 0, 1, 1, "filter_duplicate_log_lines", &m_bFilterDuplicateLogLinesEnabled, NULL},
         {false, false, 0, 1, 1, "database_credentials_protection", &m_bDatabaseCredentialsProtectionEnabled, NULL},
         {false, false, 0, 0, 1, "fakelag", &m_bFakeLagCommandEnabled, NULL},
+        {true, true, 50, 1000, 5000, "player_triggered_event_interval", &m_iPlayerTriggeredEventIntervalMs, &CMainConfig::OnPlayerTriggeredEventIntervalChange},
+        {true, true, 1, 100, 1000, "max_player_triggered_events_per_interval", &m_iMaxPlayerTriggeredEventsPerInterval, &CMainConfig::OnPlayerTriggeredEventIntervalChange},
     };
 
     static std::vector<SIntSetting> settingsList;
@@ -1505,4 +1502,15 @@ void CGame::ApplyAseSetting()
         if (!m_pLanBroadcast)
             m_pLanBroadcast = m_pASE->InitLan();
     }
+}
+
+void CMainConfig::OnPlayerTriggeredEventIntervalChange()
+{
+    g_pGame->ApplyPlayerTriggeredEventIntervalChange();
+}
+
+void CGame::ApplyPlayerTriggeredEventIntervalChange()
+{
+    m_iClientTriggeredEventsIntervalMs = m_pMainConfig->GetPlayerTriggeredEventInterval();
+    m_iMaxClientTriggeredEventsPerInterval = m_pMainConfig->GetMaxPlayerTriggeredEventsPerInterval();
 }

--- a/Server/mods/deathmatch/logic/CMainConfig.h
+++ b/Server/mods/deathmatch/logic/CMainConfig.h
@@ -142,6 +142,10 @@ public:
     const std::vector<SIntSetting>& GetIntSettingList();
     void                            OnTickRateChange();
     void                            OnAseSettingChange();
+    void                            OnPlayerTriggeredEventIntervalChange();
+
+    int GetPlayerTriggeredEventInterval() const { return m_iPlayerTriggeredEventIntervalMs; }
+    int GetMaxPlayerTriggeredEventsPerInterval() const { return m_iMaxPlayerTriggeredEventsPerInterval; }
 
 private:
     void RegisterCommand(const char* szName, FCommandHandler* pFunction, bool bRestricted, const char* szConsoleHelpText);
@@ -221,4 +225,6 @@ private:
     int                        m_bFilterDuplicateLogLinesEnabled;
     int                        m_bDatabaseCredentialsProtectionEnabled;
     int                        m_bFakeLagCommandEnabled;
+    int                        m_iPlayerTriggeredEventIntervalMs;
+    int                        m_iMaxPlayerTriggeredEventsPerInterval;
 };

--- a/Server/mods/deathmatch/mtaserver.conf
+++ b/Server/mods/deathmatch/mtaserver.conf
@@ -264,6 +264,13 @@
          Values: 0 - Off, 1 - Enabled.  Default - 1 -->
     <database_credentials_protection>1</database_credentials_protection>
 
+    <!-- These parameters specify the maximum amount of events that can be triggered by the client (via triggerServerEvent) within the given interval.
+          Note: The interval is given in milliseconds
+          Interval range: 50 to 5000. Default: 1000
+          Max events per interval range: 1 to 1000. Default: 100  -->
+    <player_triggered_event_interval>1000</player_triggered_event_interval>
+    <max_player_triggered_events_per_interval>100</max_player_triggered_events_per_interval>
+
     <!-- Specifies the module(s) which are loaded with the server. To load several modules, add more <module>
          parameter(s). Optional parameter. -->
     <!-- <module src="sample_win32.dll"/> -->

--- a/Server/mods/deathmatch/mtaserver.conf.template
+++ b/Server/mods/deathmatch/mtaserver.conf.template
@@ -1,4 +1,3 @@
-R"=====(
 <!-- This file is compiled into the server binary.
      It is used for inserting missing settings into mtaserver.conf at server startup -->
 <config>
@@ -265,5 +264,11 @@ R"=====(
          *NOTE* This only protects resources which use dbConnect with mysql
          Values: 0 - Off, 1 - Enabled.  Default - 1 -->
     <database_credentials_protection>1</database_credentials_protection>
+
+    <!-- These parameters specify the maximum amount of events that can be triggered by the client (via triggerServerEvent) within the given interval.
+          Note: The interval is given in milliseconds
+          Interval range: 50 to 5000. Default: 1000
+          Max events per interval range: 1 to 1000. Default: 100  -->
+    <player_triggered_event_interval>1000</player_triggered_event_interval>
+    <max_player_triggered_events_per_interval>100</max_player_triggered_events_per_interval>
 </config>
-)====="

--- a/utils/buildactions/compose_files.lua
+++ b/utils/buildactions/compose_files.lua
@@ -25,6 +25,7 @@ newaction {
 
 		-- Copy configs
 		os.copydir("Server/mods/deathmatch", OUTPUT_DIR.."/server/mods/deathmatch", "*.conf")
+		os.copydir("Server/mods/deathmatch", OUTPUT_DIR.."/server/mods/deathmatch", "mtaserver.conf.template")
 		os.copydir("Server/mods/deathmatch", OUTPUT_DIR.."/server/mods/deathmatch", "*.xml")
 		
 		-- Copy compiled binaries

--- a/utils/buildactions/install_data.lua
+++ b/utils/buildactions/install_data.lua
@@ -49,6 +49,13 @@ newaction {
 			return
 		end
 
+		local success, message = os.copydir("Server/mods/deathmatch", BIN_DIR.."/server/mods/deathmatch", "mtaserver.conf.template", false, true)
+		if not success then
+			errormsg("ERROR: Couldn't copy server config files", "\n"..message)
+			os.exit(1)
+			return
+		end
+
 		local success, message = os.copydir("Server/mods/deathmatch", BIN_DIR.."/server/mods/deathmatch", "*.xml", false, true)
 		if not success then
 			errormsg("ERROR: Couldn't copy server xml files", "\n"..message)


### PR DESCRIPTION
Currently, one of the only ways to limit the amount of events being sent from the client to server (via triggerServerEvent) is to track the calls manually for every event handler you add (in Lua) which results in a valid `client` variable being set, upon the handler function being executed.

That's fine for registered events (although a bit of a pain to add for every single event). However, unregistered events cannot be tracked this way. The only way to track unregistered events being called is by using `onDebugMessage` and catching a log entry such as below, which isn't ideal:

```
Client (lopsi) triggered serverside event myTestEvent, but event is not added serverside
```

This is also the same for events which do exist, but aren't remotely triggerable:

```
Client (lopsi) triggered serverside event myTestEvent, but event is not marked as remotely triggerable
```

A client spamming serverside events can cause lag, so I've added a way to deal with this in MTA itself. 

This PR adds a new serverside event, `onPlayerTriggerEventThreshold`, as well as two new mtaserver.conf settings:

- `player_triggered_event_interval`
- `max_player_triggered_events_per_interval`

These options can be set using `setServerConfigSetting` in Lua, or directly via mtaserver.conf before server startup.

Providing the player has triggered more than `max_player_triggered_events_per_interval` events per `player_triggered_event_interval` time (in milliseconds), the event will be fired, giving full control to the server how they deal with such players (log, kick, ban, etc).

This event counts ALL events triggered by the client, whether they are registered, unregistered or not remotely triggerable. Basically any usage of `triggerServerEvent` by the client will be counted.

Usage is fairly self-explanatory:

```lua
function processPlayerTriggerEventThreshold()
    kickPlayer(source, "Event spam")
end
addEventHandler("onPlayerTriggerEventThreshold", root, processPlayerTriggerEventThreshold)
```

I've also changed the way mtaserver.conf.template is loaded in the code, as adding these options took it over the 16,384 char string literal limit. That file will now be copied into the server deathmatch directory and read as XML directly, instead of `const char* szTemplateText = #include MTA_SERVER_CONF_TEMPLATE;` _shivers_

As it's currently possible for a client to abuse this event spamming, it's important that all server owners become aware of this and take necessary measures to implement (atleast) the example script above, once this PR has been merged. 

Until then, I have attached a Lua script which will prevent unregistered events from being spammed (default max 10 per 500 ms). Feel free to export the `registerEventUsage` function and track your own registered events in other resources too. 

Download the resource/script here: [events.zip](https://github.com/multitheftauto/mtasa-blue/files/13467266/events.zip)
