### PR TITLE
Fix #3254: Add FileExists check to CMainConfig::AddMissingSettings

### DIFF
--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -848,6 +848,10 @@ bool CMainConfig::AddMissingSettings()
         return false;
 
     SString strTemplateFilename = PathJoin(g_pServerInterface->GetServerModPath(), "mtaserver.conf.template");
+
+    if (!FileExists(strTemplateFilename))
+        return false;
+
     CXMLFile* pFileTemplate = g_pServerInterface->GetXML()->CreateXML(strTemplateFilename);
     CXMLNode* pRootNodeTemplate = pFileTemplate && pFileTemplate->Parse() ? pFileTemplate->GetRootNode() : nullptr;
     if (!pRootNodeTemplate)


### PR DESCRIPTION
Resolves #3254 