### PR TITLE
Fix 3D primitives disappearing

### DIFF
--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -1994,16 +1994,12 @@ void CCore::OnDeviceRestore()
 //
 void CCore::OnPreFxRender()
 {
-    // Don't do nothing if nothing won't be drawn
-
-    if (CGraphics::GetSingleton().HasPrimitive3DPreGUIQueueItems())
-        CGraphics::GetSingleton().DrawPrimitive3DPreGUIQueue();
-
-    if (!CGraphics::GetSingleton().HasLine3DPreGUIQueueItems())
-        return;
+    if (!CGraphics::GetSingleton().HasLine3DPreGUIQueueItems() && !CGraphics::GetSingleton().HasPrimitive3DPreGUIQueueItems())
+        return;    
 
     CGraphics::GetSingleton().EnteringMTARenderZone();
 
+    CGraphics::GetSingleton().DrawPrimitive3DPreGUIQueue();
     CGraphics::GetSingleton().DrawLine3DPreGUIQueue();
 
     CGraphics::GetSingleton().LeavingMTARenderZone();


### PR DESCRIPTION
Fixes a problem with 3D primitives disappearing rendered with dxDrawMaterialPrimitive3D and dxDrawPrimitive3D functions. Inspired by the Ben's report in Discord dev server with attached video: https://youtu.be/5FZ8SPW8nJA?si=NzLazkxqmHcMPk7u. It also fixes #1204.

Steps to reproduce the bug:
1. Enable shadows
2. Draw a triangle via dxDrawMaterialPrimitive3D at Verdant Meadows Airfield
3. Set 12:00
4. Move the camera until you get the bug
