### PR TITLE
Add UserID Sharing Capability with Consent Dialog (Related with Discord-RPC)

### DIFF
--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -354,7 +354,9 @@ void CClientVariables::LoadDefaults()
     DEFAULT("browser_remote_javascript", true);                                       // Execute javascript on remote websites?
     DEFAULT("filter_duplicate_log_lines", true);                                      // Filter duplicate log lines for debug view and clientscript.log
     DEFAULT("always_show_transferbox", false);                                        // Should the transfer box always be visible for downloads? (and ignore scripted control)
-    DEFAULT("allow_discord_rpc", true);                                              // Enable Discord Rich Presence 
+    DEFAULT("allow_discord_rpc", true);                                               // Enable Discord Rich Presence
+    DEFAULT("discord_rpc_share_data", false);                                         // Consistent Rich Presence data sharing
+    DEFAULT("discord_rpc_share_data_firsttime", false);                               // Display the user data sharing consent dialog box - for the first time
     DEFAULT("_beta_qc_rightclick_command", _S("reconnect"));                          // Command to run when right clicking quick connect (beta - can be removed at any time)
 
     if (!Exists("locale"))

--- a/Client/core/CDiscordRichPresence.cpp
+++ b/Client/core/CDiscordRichPresence.cpp
@@ -280,7 +280,7 @@ void CDiscordRichPresence::SetPresencePartySize(int iSize, int iMax, bool bCusto
     }
 }
 
-void CDiscordRichPresence::SetDiscordUserID(const char* strUserID)
+void CDiscordRichPresence::SetDiscordUserID(const std::string& strUserID)
 {
     if (CVARS_GET_VALUE<bool>("discord_rpc_share_data"))
         m_strDiscordUserID = strUserID;
@@ -291,7 +291,7 @@ std::string CDiscordRichPresence::GetDiscordUserID() const
     if (CVARS_GET_VALUE<bool>("discord_rpc_share_data"))
         return m_strDiscordUserID;
 
-    return "";
+    return {};
 };
 
 #ifdef DISCORD_DISABLE_IO_THREAD

--- a/Client/core/CDiscordRichPresence.cpp
+++ b/Client/core/CDiscordRichPresence.cpp
@@ -280,6 +280,20 @@ void CDiscordRichPresence::SetPresencePartySize(int iSize, int iMax, bool bCusto
     }
 }
 
+void CDiscordRichPresence::SetDiscordUserID(const char* strUserID)
+{
+    if (CVARS_GET_VALUE<bool>("discord_rpc_share_data"))
+        m_strDiscordUserID = strUserID;
+}
+
+std::string CDiscordRichPresence::GetDiscordUserID() const
+{
+    if (CVARS_GET_VALUE<bool>("discord_rpc_share_data"))
+        return m_strDiscordUserID;
+
+    return "";
+};
+
 #ifdef DISCORD_DISABLE_IO_THREAD
 void CDiscordRichPresence::UpdatePresenceConnection()
 {
@@ -290,7 +304,10 @@ void CDiscordRichPresence::UpdatePresenceConnection()
 void CDiscordRichPresence::HandleDiscordReady(const DiscordUser* pDiscordUser)
 {
     if (const auto discord = g_pCore->GetDiscord(); discord && discord->IsDiscordRPCEnabled())
+    {
         discord->SetDiscordClientConnected(true);
+        discord->SetDiscordUserID(pDiscordUser->userId);
+    }
 }
 
 void CDiscordRichPresence::HandleDiscordDisconnected(int iErrorCode, const char* szMessage)
@@ -298,7 +315,10 @@ void CDiscordRichPresence::HandleDiscordDisconnected(int iErrorCode, const char*
     WriteDebugEvent(SString("[DISCORD] Disconnected %s (error #%d)", szMessage, iErrorCode));
 
     if (const auto discord = g_pCore->GetDiscord(); discord)
+    {
+        discord->SetDiscordUserID("");
         discord->SetDiscordClientConnected(false);
+    }
 }
 
 void CDiscordRichPresence::HandleDiscordError(int iErrorCode, const char* szMessage)

--- a/Client/core/CDiscordRichPresence.h
+++ b/Client/core/CDiscordRichPresence.h
@@ -35,6 +35,7 @@ public:
     void SetAssetSmallData(const char* szAsset, const char* szAssetText);
     void SetDiscordClientConnected(bool bConnected) { m_bConnected = bConnected; };
     void SetPresencePartySize(int iSize, int iMax, bool bCustom);
+    void SetDiscordUserID(const char* strUserID);
 
     bool ResetDiscordData();
     bool SetPresenceState(const char* szState, bool bCustom);
@@ -47,6 +48,7 @@ public:
     bool IsDiscordClientConnected() const { return m_bConnected; };
 
     std::string GetDiscordResourceName() const { return m_strDiscordCustomResourceName; };
+    std::string GetDiscordUserID() const;
 
     // static handlers
     static void HandleDiscordReady(const struct DiscordUser* pDiscordUser);
@@ -54,6 +56,7 @@ public:
     static void HandleDiscordError(int iErrorCode, const char* szMessage);
 
 private:
+    std::string m_strDiscordUserID;
     std::string m_strDiscordAppId;
     std::string m_strDiscordAppAsset;
     std::string m_strDiscordAppAssetText;

--- a/Client/core/CDiscordRichPresence.h
+++ b/Client/core/CDiscordRichPresence.h
@@ -35,7 +35,7 @@ public:
     void SetAssetSmallData(const char* szAsset, const char* szAssetText);
     void SetDiscordClientConnected(bool bConnected) { m_bConnected = bConnected; };
     void SetPresencePartySize(int iSize, int iMax, bool bCustom);
-    void SetDiscordUserID(const char* strUserID);
+    void SetDiscordUserID(const std::string& strUserID);
 
     bool ResetDiscordData();
     bool SetPresenceState(const char* szState, bool bCustom);

--- a/Client/core/CMainMenu.cpp
+++ b/Client/core/CMainMenu.cpp
@@ -304,7 +304,6 @@ CMainMenu::CMainMenu(CGUI* pManager)
         discord->SetPresenceState(_("Main menu"), false);
         discord->SetPresenceStartTimestamp(0);
     }
-
     // Store the pointer to the graphics subsystem
     m_pGraphics = CGraphics::GetSingletonPtr();
 
@@ -682,6 +681,19 @@ void CMainMenu::Update()
             CCore::GetSingletonPtr()->ShowErrorMessageBox("", XP_VISTA_WARNING, "au-revoir-xp-vista");
         }
 #endif
+
+        if (WaitForMenu == 299)
+        {
+            if (!g_pCore->GetCVars()->GetValue("discord_rpc_share_data_firsttime", false)
+                && g_pCore->GetCVars()->GetValue("allow_discord_rpc", false)
+                && !g_pCore->GetCVars()->GetValue("discord_rpc_share_data", false))
+            {
+                m_Settings.ShowRichPresenceShareDataQuestionBox();
+                CVARS_SET("discord_rpc_share_data_firsttime", true);
+            }
+            else
+                CVARS_SET("discord_rpc_share_data_firsttime", true);
+        }
 
         if (WaitForMenu < 300)
             WaitForMenu++;

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -4515,8 +4515,36 @@ bool CSettings::OnAllowExternalSoundsClick(CGUIElement* pElement)
 //
 bool CSettings::OnAllowDiscordRPC(CGUIElement* pElement)
 {
-    g_pCore->GetDiscord()->SetDiscordRPCEnabled(m_pCheckBoxAllowDiscordRPC->GetSelected());
+    bool isEnabled = m_pCheckBoxAllowDiscordRPC->GetSelected();
+    g_pCore->GetDiscord()->SetDiscordRPCEnabled(isEnabled);
+
+    if (isEnabled)
+        ShowRichPresenceShareDataQuestionBox(); // show question box
+
     return true;
+}
+
+static void ShowRichPresenceShareDataCallback(void* ptr, unsigned int uiButton)
+{
+    CCore::GetSingleton().GetLocalGUI()->GetMainMenu()->GetQuestionWindow()->Reset();
+
+    CVARS_SET("discord_rpc_share_data", static_cast<bool>(uiButton));
+}
+
+void CSettings::ShowRichPresenceShareDataQuestionBox() const
+{
+    SStringX strMessage(
+        _("It seems that you have the Rich Presence connection option enabled."
+          "\nDo you want to allow servers to share their data?"
+          "\n\nThis includes yours unique ID identifier."));
+    CQuestionBox* pQuestionBox = CCore::GetSingleton().GetLocalGUI()->GetMainMenu()->GetQuestionWindow();
+    pQuestionBox->Reset();
+    pQuestionBox->SetTitle(_("CONSENT TO ALLOW DATA SHARING"));
+    pQuestionBox->SetMessage(strMessage);
+    pQuestionBox->SetButton(0, _("No"));
+    pQuestionBox->SetButton(1, _("Yes"));
+    pQuestionBox->SetCallback(ShowRichPresenceShareDataCallback);
+    pQuestionBox->Show();
 }
 
 //

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -119,6 +119,7 @@ public:
     bool IsActive();
 
     void SetSelectedIndex(unsigned int uiIndex);
+    void ShowRichPresenceShareDataQuestionBox() const;
 
 protected:
     const static int SecKeyNum = 3;            // Number of secondary keys

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDiscordDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDiscordDefs.cpp
@@ -272,7 +272,7 @@ std::string CLuaDiscordDefs::GetDiscordUserID()
     auto discord = g_pCore->GetDiscord();
 
     if (!discord || !discord->IsDiscordRPCEnabled())
-        return "";
+        return {};
 
     return discord->GetDiscordUserID();
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDiscordDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDiscordDefs.cpp
@@ -25,7 +25,7 @@ void CLuaDiscordDefs::LoadFunctions()
         {"setDiscordRichPresencePartySize", ArgumentParser<SetPartySize>},
         {"resetDiscordRichPresenceData", ArgumentParser<ResetData>},
         {"isDiscordRichPresenceConnected", ArgumentParser <IsDiscordRPCConnected>},
-
+        {"getDiscordRichPresenceUserID", ArgumentParser<GetDiscordUserID>},
     };
 
     // Add functions
@@ -265,4 +265,14 @@ bool CLuaDiscordDefs::IsDiscordRPCConnected()
         return false;
 
     return discord->IsDiscordClientConnected();
+}
+
+std::string CLuaDiscordDefs::GetDiscordUserID()
+{
+    auto discord = g_pCore->GetDiscord();
+
+    if (!discord || !discord->IsDiscordRPCEnabled())
+        return "";
+
+    return discord->GetDiscordUserID();
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDiscordDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDiscordDefs.h
@@ -29,6 +29,6 @@ private:
     static bool SetEndTime(unsigned long ulTime);
     static bool SetPartySize(int iMin, int iMax);
     static bool IsDiscordRPCConnected();
-
+    static std::string GetDiscordUserID();
 };
 

--- a/Client/sdk/core/CDiscordInterface.h
+++ b/Client/sdk/core/CDiscordInterface.h
@@ -27,7 +27,7 @@ public:
     virtual void SetPresenceEndTimestamp(const unsigned long ulEnd) = 0;
     virtual void SetPresencePartySize(int iSize, int iMax, bool bCustom) = 0;
     virtual void SetDiscordClientConnected(bool bConnected) = 0;
-    virtual void SetDiscordUserID(const char* strUserID) = 0;
+    virtual void SetDiscordUserID(const std::string& strUserID) = 0;
 
     virtual bool SetPresenceDetails(const char* szDetails, bool bCustom) = 0;
     virtual bool SetApplicationID(const char* szResourceName, const char* szAppID) = 0;

--- a/Client/sdk/core/CDiscordInterface.h
+++ b/Client/sdk/core/CDiscordInterface.h
@@ -27,6 +27,7 @@ public:
     virtual void SetPresenceEndTimestamp(const unsigned long ulEnd) = 0;
     virtual void SetPresencePartySize(int iSize, int iMax, bool bCustom) = 0;
     virtual void SetDiscordClientConnected(bool bConnected) = 0;
+    virtual void SetDiscordUserID(const char* strUserID) = 0;
 
     virtual bool SetPresenceDetails(const char* szDetails, bool bCustom) = 0;
     virtual bool SetApplicationID(const char* szResourceName, const char* szAppID) = 0;
@@ -39,4 +40,5 @@ public:
     virtual bool IsDiscordClientConnected() const = 0;
 
     virtual std::string GetDiscordResourceName() const = 0;
+    virtual std::string GetDiscordUserID() const = 0;
 };


### PR DESCRIPTION
This PR introduces the ability to share discord user IDs with servers if the user grants permission. 
A special dialog has been added (look below), prompting the user (only once) to allow sharing their **UserID**, specifically when '**Allow connecting with Rich Presence**' is enabled, and also when re-enabling this option.

Additionally, this PR adds the function:
`string getDiscordRichPresenceUserID()`

The function returns the user ID as a string if the user has granted permission; Otherwise, an empty string ("") is returned.

![rpc](https://github.com/multitheftauto/mtasa-blue/assets/6306267/eeb90f96-0ade-47c5-bb10-bff73abc903d)
