### PR TITLE
Added server side weapon related checks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Create build artifacts
         run: utils\premake5 compose_files
 
-      - uses: actions/upload-artifact@master
+      - uses: actions/upload-artifact@v3
         with:
           name: InstallFiles
           path: InstallFiles/

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -2443,6 +2443,10 @@ void CGame::Packet_Bulletsync(CBulletsyncPacket& Packet)
     CPlayer* pPlayer = Packet.GetSourcePlayer();
     if (pPlayer && pPlayer->IsJoined())
     {
+        // Early return when the player attempts to fire a weapon they do not have
+        if (!pPlayer->HasWeaponType(Packet.m_WeaponType))
+            return;
+
         // Relay to other players
         RelayNearbyPacket(Packet);
 

--- a/Server/mods/deathmatch/logic/CPed.cpp
+++ b/Server/mods/deathmatch/logic/CPed.cpp
@@ -356,6 +356,17 @@ void CPed::SetWeaponTotalAmmo(unsigned short usTotalAmmo, unsigned char ucSlot)
     }
 }
 
+bool CPed::HasWeaponType(unsigned char ucWeaponType)
+{
+    for (unsigned char slot = 0; slot < WEAPON_SLOTS; slot++)
+    {
+        if (GetWeaponType(slot) == ucWeaponType)
+            return true;
+    }
+
+    return false;
+}
+
 float CPed::GetMaxHealth()
 {
     // TODO: Verify this formula

--- a/Server/mods/deathmatch/logic/CPed.h
+++ b/Server/mods/deathmatch/logic/CPed.h
@@ -168,6 +168,7 @@ public:
     void           SetWeaponAmmoInClip(unsigned short uscAmmoInClip, unsigned char ucSlot = 0xFF);
     unsigned short GetWeaponTotalAmmo(unsigned char ucSlot = 0xFF);
     void           SetWeaponTotalAmmo(unsigned short usTotalAmmo, unsigned char ucSlot = 0xFF);
+    bool           HasWeaponType(unsigned char ucWeaponType);
 
     float GetMaxHealth();
     float GetHealth() { return m_fHealth; }

--- a/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
@@ -175,6 +175,12 @@ bool CPlayerPuresyncPacket::Read(NetBitStreamInterface& BitStream)
             // Set weapon slot
             if (bWeaponCorrect)
                 pSourcePlayer->SetWeaponSlot(uiSlot);
+            else
+            {
+                // remove invalid weapon data to prevent this from being relayed to other players
+                ucClientWeaponType = 0;
+                slot.data.uiSlot = 0;
+            }
 
             if (CWeaponNames::DoesSlotHaveAmmo(uiSlot))
             {


### PR DESCRIPTION
- Added a check to see if a player has a certain weapon before forwarding a bullet sync packet
- Clear the weapon related data from a puresync packet if the player doesn't currently have that weapon

The reasoning for both of these changes has to do with people running hacks and/or Lua injectors client sided. In cases like these (which I've verified with a client running such cheats) clients will trigger puresync packets and/or bullet sync packets for weapons the player doesn't actually have.

While the server doesn't process these puresync packets, they still relay them to other players. Meaning these weapons are visible to other players (even though according to the server the player will not have the weapons).

For the bullet sync packet the server would blindly forward them, meaning a compromised client would be able to fire any weapon, without even having that weapon.

This PR aims to add two relatively simple checks to prevent this from happening.