### PR TITLE
Fix `SetStreamingBufferSize`possibly  accessing memory out-of-bounds

### DIFF
--- a/Client/game_sa/CStreamingSA.cpp
+++ b/Client/game_sa/CStreamingSA.cpp
@@ -431,6 +431,8 @@ void CStreamingSA::RemoveArchive(unsigned char ucArchiveID)
 
 bool CStreamingSA::SetStreamingBufferSize(uint32 numBlocks)
 {
+    numBlocks &= ~1; // Make it be even [Otherwise it can't be split in half properly]
+    
     // Check if the size is the same already
     if (numBlocks == ms_streamingHalfOfBufferSizeBlocks * 2)
         return true;
@@ -453,10 +455,6 @@ bool CStreamingSA::SetStreamingBufferSize(uint32 numBlocks)
 
     // Suspend streaming thread [otherwise data might become corrupted]
     SuspendThread(*phStreamingThread);
-    
-    // Create new buffer
-    if (numBlocks & 1) // Make it be even [Otherwise it can't be split in half properly]
-        numBlocks++;
 
     // Calculate new buffer pointers
     void* const pNewBuff0 = pNewBuffer;

--- a/Client/game_sa/CStreamingSA.cpp
+++ b/Client/game_sa/CStreamingSA.cpp
@@ -431,7 +431,7 @@ void CStreamingSA::RemoveArchive(unsigned char ucArchiveID)
 
 bool CStreamingSA::SetStreamingBufferSize(uint32 numBlocks)
 {
-    numBlocks &= ~1; // Make it be even [Otherwise it can't be split in half properly]
+    numBlocks += numBlocks % 2; // Make sure number is even by "rounding" it upwards. [Otherwise it can't be split in half properly]
     
     // Check if the size is the same already
     if (numBlocks == ms_streamingHalfOfBufferSizeBlocks * 2)


### PR DESCRIPTION
`numBlocks` was rounded upwards after the allocation was done, this could've caused OOB reads/writes.
