### PR TITLE
Add dbConnect option for MySQL "use_ssl=0"

### DIFF
--- a/Server/dbconmy/CDatabaseConnectionMySql.cpp
+++ b/Server/dbconmy/CDatabaseConnectionMySql.cpp
@@ -57,6 +57,7 @@ public:
     bool           m_bInAutomaticTransaction;
     CTickCount     m_AutomaticTransactionStartTime;
     int            m_bMultipleStatements;
+    int            m_bUseSSL;
 };
 
 ///////////////////////////////////////////////////////////////
@@ -85,6 +86,7 @@ CDatabaseConnectionMySql::CDatabaseConnectionMySql(CDatabaseType* pManager, cons
     optionsMap.Get("autoreconnect", m_bAutomaticReconnect, 1);
     optionsMap.Get("batch", m_bAutomaticTransactionsEnabled, 1);
     optionsMap.Get("multi_statements", m_bMultipleStatements, 0);
+    optionsMap.Get("use_ssl", m_bUseSSL, 0);
 
     SString strHostname;
     SString strDatabaseName;
@@ -106,7 +108,9 @@ CDatabaseConnectionMySql::CDatabaseConnectionMySql(CDatabaseType* pManager, cons
     if (m_handle)
     {
         bool reconnect = m_bAutomaticReconnect;
+        uint const ssl_mode = m_bUseSSL ? SSL_MODE_REQUIRED : SSL_MODE_DISABLED;
         mysql_options(m_handle, MYSQL_OPT_RECONNECT, &reconnect);
+        mysql_options(m_handle, MYSQL_OPT_SSL_MODE, &ssl_mode);
         if (!strCharset.empty())
             mysql_options(m_handle, MYSQL_SET_CHARSET_NAME, strCharset);
         if (m_bMultipleStatements)


### PR DESCRIPTION
Should resolve #3270

Will need those experiencing the issue to test this works, cc @Xenius97 @TheNormalnij 

Note: SSL never worked in MTA anyway; recent update enables it by default. We should try to add support in another PR

Download artifacts: https://github.com/multitheftauto/mtasa-blue/actions/runs/7776595239/artifacts/1218776160