### PR TITLE
Fix buildings removal

### DIFF
--- a/Client/game_sa/CWorldSA.cpp
+++ b/Client/game_sa/CWorldSA.cpp
@@ -1069,7 +1069,7 @@ bool CWorldSA::IsRemovedModelInRadius(SIPLInst* pInst)
 
             float fDistance = sqrt(fDistanceX * fDistanceX + fDistanceY * fDistanceY + fDistanceZ * fDistanceZ);
             // is it in the removal spheres radius if so return else keep looking
-            if (fDistance <= pFind->m_fRadius && (pFind->m_cInterior == -1 || pFind->m_cInterior == pInst->m_nInterior))
+            if (fDistance <= pFind->m_fRadius && (pFind->m_cInterior == -1 || pFind->m_cInterior == pInst->m_nAreaCode))
             {
                 return true;
             }

--- a/Client/sdk/game/CWorld.h
+++ b/Client/sdk/game/CWorld.h
@@ -95,15 +95,27 @@ struct SBuildingRemoval
     std::list<CEntitySAInterface*>* m_pBinaryRemoveList;
     std::list<CEntitySAInterface*>* m_pDataRemoveList;
 };
+
 struct SIPLInst
 {
-    CVector m_pPosition;
-    CVector m_pRotation;
-    float   m_fRotationCont;
-    WORD    m_nModelIndex;
-    BYTE    m_nInterior;
-    BYTE    m_bLOD;
+    CVector     m_pPosition;
+    CVector4D   m_pRotation;
+    int32_t     m_nModelIndex;
+    union {
+        struct {
+            uint32_t m_nAreaCode : 8;
+            uint32_t m_bRedundantStream : 1;
+            uint32_t m_bDontStream : 1;
+            uint32_t m_bUnderwater : 1;
+            uint32_t m_bTunnel : 1;
+            uint32_t m_bTunnelTransition : 1;
+            uint32_t m_nReserved : 19;
+        };
+        uint32_t m_nInstanceType;
+    };
+    int32_t m_nLodInstanceIndex;
 };
+static_assert(sizeof(SIPLInst) == 0x28, "Invalid sizeof(SIPLInst)");
 
 struct sDataBuildingRemovalItem
 {


### PR DESCRIPTION
This PR fixes the removal of buildings that are presented within binary IPLs. Without the PR most of the removed interior objects suddenly become visible, just after the change of an interior.

The steps of reproducing the problem:
1. Run map editor
2. Move to **Driving School** interior
3. Remove any object
4. Jump to any other interior
5. Jump back to **Driving School**
6. The object popped back