### PR TITLE
Fix crashes caused by createBuilding with engineRequestModel

### DIFF
--- a/Client/game_sa/CPoolsSA.cpp
+++ b/Client/game_sa/CPoolsSA.cpp
@@ -416,8 +416,8 @@ void CPoolsSA::RemoveBuilding(CBuilding* pBuilding)
     coverList->RemoveItem(pInterface);
 
     // Remove plant
-    typedef CEntitySAInterface*(__cdecl * CPlantColEntEntry_Remove)(CEntitySAInterface * item);
-    ((CPlantColEntEntry_Remove)0x5DBEF0)(pInterface);
+    using CPlantColEntry_Remove = CEntitySAInterface* (*)(CEntitySAInterface*);
+    ((CPlantColEntry_Remove)0x5DBEF0)(pInterface);
 
     // Remove col reference
     auto modelInfo = pGame->GetModelInfo(pBuilding->GetModelIndex());

--- a/Client/game_sa/CPoolsSA.cpp
+++ b/Client/game_sa/CPoolsSA.cpp
@@ -26,6 +26,7 @@
 #include "CWorldSA.h"
 #include "CKeyGenSA.h"
 #include "CFileLoaderSA.h"
+#include "CPtrNodeSingleListSA.h"
 
 extern CGameSA* pGame;
 
@@ -409,6 +410,14 @@ void CPoolsSA::RemoveBuilding(CBuilding* pBuilding)
 
     // Remove building from world
     pGame->GetWorld()->Remove(pInterface, CBuildingPool_Destructor);
+
+    // Remove building from cover list
+    CPtrNodeSingleListSAInterface<CBuildingSAInterface>* coverList = reinterpret_cast<CPtrNodeSingleListSAInterface<CBuildingSAInterface>*>(0xC1A2B8);
+    coverList->RemoveItem(pInterface);
+
+    // Remove plant
+    typedef CEntitySAInterface*(__cdecl * CPlantColEntEntry_Remove)(CEntitySAInterface * item);
+    ((CPlantColEntEntry_Remove)0x5DBEF0)(pInterface);
 
     // Remove col reference
     auto modelInfo = pGame->GetModelInfo(pBuilding->GetModelIndex());

--- a/Client/game_sa/CPtrNodeSingleListSA.h
+++ b/Client/game_sa/CPtrNodeSingleListSA.h
@@ -10,14 +10,14 @@
 
 #pragma once
 
-template<class T>
+template <class T>
 struct CPtrNodeSingleLink
 {
     T*                  pItem;
     CPtrNodeSingleLink* pNext;
 };
 
-template<class T>
+template <class T>
 class CPtrNodeSingleListSAInterface
 {
 public:
@@ -31,7 +31,7 @@ private:
 template <class T>
 void CPtrNodeSingleListSAInterface<T>::RemoveItem(T* item)
 {
-    typedef void(__thiscall * CPtrNodeSingleList_RemoveItem_t)(CPtrNodeSingleListSAInterface<T> * pLinkList, void* item);
+    using CPtrNodeSingleList_RemoveItem_t = void(__thiscall*)(CPtrNodeSingleListSAInterface<T> * pLinkList, void* item);
     ((CPtrNodeSingleList_RemoveItem_t)0x533610)(this, item);
 }
 

--- a/Client/game_sa/CPtrNodeSingleListSA.h
+++ b/Client/game_sa/CPtrNodeSingleListSA.h
@@ -1,0 +1,45 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        game_sa/CPtrNodeSingleListSA.cpp
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#pragma once
+
+template<class T>
+struct CPtrNodeSingleLink
+{
+    T*                  pItem;
+    CPtrNodeSingleLink* pNext;
+};
+
+template<class T>
+class CPtrNodeSingleListSAInterface
+{
+public:
+    void RemoveItem(T* item);
+    void RemoveAllItems();
+
+private:
+    CPtrNodeSingleLink<T>* m_pList;
+};
+
+template <class T>
+void CPtrNodeSingleListSAInterface<T>::RemoveItem(T* item)
+{
+    typedef void(__thiscall * CPtrNodeSingleList_RemoveItem_t)(CPtrNodeSingleListSAInterface<T> * pLinkList, void* item);
+    ((CPtrNodeSingleList_RemoveItem_t)0x533610)(this, item);
+}
+
+template <class T>
+void CPtrNodeSingleListSAInterface<T>::RemoveAllItems()
+{
+    while (m_pList)
+    {
+        RemoveItem(m_pList->pItem);
+    }
+}


### PR DESCRIPTION
Fixes issues:
* Destroyed building leaves grass
* Crash occurs when a resource that uses createBuilding with engineRequestModel is stopped.