### PR TITLE
Refactoring MTA code - Part 1

### DIFF
--- a/Client/core/DXHook/CProxyDirect3DDevice9.cpp
+++ b/Client/core/DXHook/CProxyDirect3DDevice9.cpp
@@ -739,7 +739,7 @@ HRESULT CProxyDirect3DDevice9::SetNPatchMode(float nSegments)
     return m_pDevice->SetNPatchMode(nSegments);
 }
 
-FLOAT CProxyDirect3DDevice9::GetNPatchMode()
+float CProxyDirect3DDevice9::GetNPatchMode()
 {
     return m_pDevice->GetNPatchMode();
 }

--- a/Client/core/DXHook/CProxyDirect3DDevice9.h
+++ b/Client/core/DXHook/CProxyDirect3DDevice9.h
@@ -113,7 +113,7 @@ interface CProxyDirect3DDevice9 : public IDirect3DDevice9
     virtual HRESULT __stdcall SetSoftwareVertexProcessing(BOOL bSoftware);
     virtual BOOL __stdcall GetSoftwareVertexProcessing();
     virtual HRESULT __stdcall SetNPatchMode(float nSegments);
-    virtual FLOAT __stdcall GetNPatchMode();
+    virtual float __stdcall GetNPatchMode();
     virtual HRESULT __stdcall DrawPrimitive(D3DPRIMITIVETYPE PrimitiveType, UINT StartVertex, UINT PrimitiveCount);
     virtual HRESULT __stdcall DrawIndexedPrimitive(D3DPRIMITIVETYPE, INT BaseVertexIndex, UINT MinVertexIndex, UINT NumVertices, UINT startIndex,
                                                    UINT primCount);

--- a/Client/core/DXHook/CProxyDirect3DEffect.h
+++ b/Client/core/DXHook/CProxyDirect3DEffect.h
@@ -50,10 +50,10 @@ public:
     HRESULT __stdcall GetInt(D3DXHANDLE hParameter, INT* pn) { return m_pOriginal->GetInt(hParameter, pn); }
     HRESULT __stdcall SetIntArray(D3DXHANDLE hParameter, CONST INT* pn, UINT Count) { return m_pOriginal->SetIntArray(hParameter, pn, Count); }
     HRESULT __stdcall GetIntArray(D3DXHANDLE hParameter, INT* pn, UINT Count) { return m_pOriginal->GetIntArray(hParameter, pn, Count); }
-    HRESULT __stdcall SetFloat(D3DXHANDLE hParameter, FLOAT f) { return m_pOriginal->SetFloat(hParameter, f); }
-    HRESULT __stdcall GetFloat(D3DXHANDLE hParameter, FLOAT* pf) { return m_pOriginal->GetFloat(hParameter, pf); }
-    HRESULT __stdcall SetFloatArray(D3DXHANDLE hParameter, CONST FLOAT* pf, UINT Count) { return m_pOriginal->SetFloatArray(hParameter, pf, Count); }
-    HRESULT __stdcall GetFloatArray(D3DXHANDLE hParameter, FLOAT* pf, UINT Count) { return m_pOriginal->GetFloatArray(hParameter, pf, Count); }
+    HRESULT __stdcall SetFloat(D3DXHANDLE hParameter, float f) { return m_pOriginal->SetFloat(hParameter, f); }
+    HRESULT __stdcall GetFloat(D3DXHANDLE hParameter, float* pf) { return m_pOriginal->GetFloat(hParameter, pf); }
+    HRESULT __stdcall SetFloatArray(D3DXHANDLE hParameter, CONST float* pf, UINT Count) { return m_pOriginal->SetFloatArray(hParameter, pf, Count); }
+    HRESULT __stdcall GetFloatArray(D3DXHANDLE hParameter, float* pf, UINT Count) { return m_pOriginal->GetFloatArray(hParameter, pf, Count); }
     HRESULT __stdcall SetVector(D3DXHANDLE hParameter, CONST D3DXVECTOR4* pVector) { return m_pOriginal->SetVector(hParameter, pVector); }
     HRESULT __stdcall GetVector(D3DXHANDLE hParameter, D3DXVECTOR4* pVector) { return m_pOriginal->GetVector(hParameter, pVector); }
     HRESULT __stdcall SetVectorArray(D3DXHANDLE hParameter, CONST D3DXVECTOR4* pVector, UINT Count)

--- a/Client/game_sa/CCameraSA.h
+++ b/Client/game_sa/CCameraSA.h
@@ -50,7 +50,7 @@ public:
     {
         MAXPATHLENGTH = 800
     };
-    float* m_arr_PathData;            //    FLOAT m_arr_PathData[MAXPATHLENGTH];
+    float* m_arr_PathData;            //    float m_arr_PathData[MAXPATHLENGTH];
 };
 
 class CQueuedMode
@@ -356,7 +356,7 @@ public:
     CVector m_vecOldFrontForInter;
     CVector m_vecOldUpForInter;
     float   m_vecOldFOVForInter;
-    float   m_fFLOATingFade;            // variable representing the FLOAT version of CDraw::Fade. Necessary to stop loss of precision
+    float   m_fFLOATingFade;            // variable representing the float version of CDraw::Fade. Necessary to stop loss of precision
     float   m_fFLOATingFadeMusic;
     float   m_fTimeToFadeOut;
     float   m_fTimeToFadeMusic;

--- a/Client/game_sa/CDoorSA.cpp
+++ b/Client/game_sa/CDoorSA.cpp
@@ -14,7 +14,7 @@
 
 /**
  * \todo Find out what GetAngleOpenRatio actually does
- * @return FLOAT Not sure...
+ * @return float Not sure...
  */
 float CDoorSA::GetAngleOpenRatio()
 {

--- a/Client/game_sa/CPlayerInfoSA.h
+++ b/Client/game_sa/CPlayerInfoSA.h
@@ -17,7 +17,7 @@
 /**
  * \todo Confirm that AssocGroupId is a DWORD
  */
-typedef DWORD AssocGroupId;
+using AssocGroupId = std::uint32_t;
 
 class CPedClothesDesc;
 

--- a/Client/game_sa/CPlayerInfoSA.h
+++ b/Client/game_sa/CPlayerInfoSA.h
@@ -38,7 +38,7 @@ public:
     CVector2D m_vecFightMovement;            // 12
     float     m_moveBlendRatio;              // 20
     float     m_fSprintEnergy;               // 24
-    // FLOAT m_fSprintControlCounter; // Removed arbitatrily to aligned next byte, should be here really
+    // float m_fSprintControlCounter; // Removed arbitatrily to aligned next byte, should be here really
     BYTE                    m_nChosenWeapon;                   // 28
     BYTE                    m_nCarDangerCounter;               // 29
     BYTE                    m_pad0;                            // 30

--- a/Client/game_sa/CPlayerInfoSA.h
+++ b/Client/game_sa/CPlayerInfoSA.h
@@ -13,11 +13,7 @@
 
 #include <game/CPlayerInfo.h>
 #include "CPlayerPedSA.h"
-
-/**
- * \todo Confirm that AssocGroupId is a DWORD
- */
-using AssocGroupId = std::uint32_t;
+#include <SharedUtil.IntTypes.h>
 
 class CPedClothesDesc;
 

--- a/Client/game_sa/TaskAttackSA.h
+++ b/Client/game_sa/TaskAttackSA.h
@@ -49,8 +49,8 @@ class CWeaponInfo;
 // temporary
 class CAnimBlendAssociation;
 class CAnimBlendHierarchy;
-typedef unsigned long AssocGroupId;
-typedef unsigned long AnimationId;
+using AssocGroupId = std::uint32_t;
+using AnimationId = std::uint32_t;
 
 ///////////////////////
 // Do a gang driveby

--- a/Client/game_sa/TaskAttackSA.h
+++ b/Client/game_sa/TaskAttackSA.h
@@ -14,6 +14,7 @@
 #include <CVector2D.h>
 #include <game/TaskAttack.h>
 #include "TaskSA.h"
+#include <SharedUtil.IntTypes.h>
 
 class CWeaponInfo;
 
@@ -49,8 +50,6 @@ class CWeaponInfo;
 // temporary
 class CAnimBlendAssociation;
 class CAnimBlendHierarchy;
-using AssocGroupId = std::uint32_t;
-using AnimationId = std::uint32_t;
 
 ///////////////////////
 // Do a gang driveby

--- a/Client/game_sa/TaskBasicSA.h
+++ b/Client/game_sa/TaskBasicSA.h
@@ -15,6 +15,7 @@
 #include <game/CPed.h>
 #include <game/TaskBasic.h>
 #include "TaskSA.h"
+#include <SharedUtil.IntTypes.h>
 
 class CVehicleSAInterface;
 class CObjectSAInterface;
@@ -54,8 +55,6 @@ public:
 // temporary
 class CAnimBlendAssociation;
 class CAnimBlendHierarchy;
-using AssocGroupId = std::uint32_t;
-using AnimationId = std::uint32_t;
 
 class CTaskSimpleAnimSAInterface : public CTaskSimpleSAInterface
 {

--- a/Client/game_sa/TaskBasicSA.h
+++ b/Client/game_sa/TaskBasicSA.h
@@ -54,8 +54,8 @@ public:
 // temporary
 class CAnimBlendAssociation;
 class CAnimBlendHierarchy;
-typedef unsigned long AssocGroupId;
-typedef unsigned long AnimationId;
+using AssocGroupId = std::uint32_t;
+using AnimationId = std::uint32_t;
 
 class CTaskSimpleAnimSAInterface : public CTaskSimpleSAInterface
 {

--- a/Client/game_sa/TaskCarSA.h
+++ b/Client/game_sa/TaskCarSA.h
@@ -15,10 +15,11 @@
 #include "CVehicleSA.h"
 #include "TaskSA.h"
 
+#include <SharedUtil.IntTypes.h>
+
 // temporary
 class CAnimBlendAssociation;
 typedef DWORD CTaskUtilityLineUpPedWithCar;
-typedef DWORD AnimationId;
 
 #define FUNC_CTaskComplexEnterCarAsDriver__Constructor              0x6402F0
 #define FUNC_CTaskComplexEnterCarAsPassenger__Constructor           0x640340

--- a/Client/mods/deathmatch/logic/lua/CLuaTimerManager.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaTimerManager.cpp
@@ -79,8 +79,8 @@ void CLuaTimerManager::RemoveTimer(CLuaTimer* pLuaTimer)
         return;
 
     // Remove all references
-    ListRemove(m_TimerList, pLuaTimer);
-    ListRemove(m_ProcessQueue, pLuaTimer);
+    ListRemoveAll(m_TimerList, pLuaTimer);
+    ListRemoveAll(m_ProcessQueue, pLuaTimer);
 
     if (m_pProcessingTimer == pLuaTimer)
     {

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1677,21 +1677,22 @@ void CMultiplayerSA::SetColorFilter(DWORD dwPass0Color, DWORD dwPass1Color)
     }
 }
 
-void CMultiplayerSA::GetColorFilter(DWORD& dwPass0Color, DWORD& dwPass1Color, bool isOriginal)
+void CMultiplayerSA::GetColorFilter(std::uint32_t& uiPass0Color, std::uint32_t& uiPass1Color, bool isOriginal)
 {
     // GTASA PC has 2 color filters, one of them is static color filter, and another one is blended by time cycle
     bool bUseTimeCycle = *(BYTE*)0x7036EC == 0xC1;
-    if (bUseTimeCycle || isOriginal){ //If we are using color filter from time cycle or we specified color filter from time cycle
-        SColorRGBA pass0SColor(*(float*)0xB7C518, *(float*)0xB7C51C, *(float*)0xB7C520, *(float*)0xB7C524);
-        SColorRGBA pass1SColor(*(float*)0xB7C528, *(float*)0xB7C52C, *(float*)0xB7C530, *(float*)0xB7C534);
-        dwPass0Color = pass0SColor.ulARGB;
-        dwPass1Color = pass1SColor.ulARGB;
-    }
-    else
+    if (!bUseTimeCycle && !isOriginal)
     {
-        dwPass0Color = *(DWORD*)0x7036ED;
-        dwPass1Color = *(DWORD*)0x70373E;
+        uiPass0Color = *(std::uint32_t*)0x7036ED;
+        uiPass1Color = *(std::uint32_t*)0x70373E;
+        return;
     }
+
+    //If we are using color filter from time cycle or we specified color filter from time cycle
+    SColorRGBA pass0SColor(*(float*)0xB7C518, *(float*)0xB7C51C, *(float*)0xB7C520, *(float*)0xB7C524);
+    SColorRGBA pass1SColor(*(float*)0xB7C528, *(float*)0xB7C52C, *(float*)0xB7C530, *(float*)0xB7C534);
+    uiPass0Color = pass0SColor.ulARGB;
+    uiPass1Color = pass1SColor.ulARGB;
 }
 
 void DoSetHeatHazePokes(const SHeatHazeSettings& settings, int iHourStart, int iHourEnd, float fFadeSpeed, float fInsideBuildingFadeSpeed,

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -298,7 +298,7 @@ const DWORD RETURN_Idle_CWorld_ProcessPedsAfterPreRender = 0x53EA08;
 
 CPed*         pContextSwitchedPed = 0;
 CVector       vecCenterOfWorld;
-FLOAT         fFalseHeading;
+float         fFalseHeading;
 bool          bSetCenterOfWorld;
 DWORD         dwVectorPointer;
 bool          bInStreamingUpdate;
@@ -2389,7 +2389,7 @@ void CMultiplayerSA::DoSoundHacksOnLostFocus(bool bLostFocus)
     }
 }
 
-void CMultiplayerSA::SetCenterOfWorld(CEntity* entity, CVector* vecPosition, FLOAT fHeading)
+void CMultiplayerSA::SetCenterOfWorld(CEntity* entity, CVector* vecPosition, float fHeading)
 {
     if (vecPosition)
     {

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -154,7 +154,7 @@ public:
     void  GetHeatHaze(SHeatHazeSettings& settings);
     void  ResetColorFilter();
     void  SetColorFilter(DWORD dwPass0Color, DWORD dwPass1Color);
-    void  GetColorFilter(DWORD& dwPass0Color, DWORD& dwPass1Color, bool isOriginal);
+    void  GetColorFilter(std::uint32_t& uiPass0Color, std::uint32_t& uiPass1Color, bool isOriginal);
     void  SetGrainMultiplier(eGrainMultiplierType type, float fMultiplier);
     void  SetGrainLevel(BYTE ucLevel);
     void  ResetHeatHaze();

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -90,7 +90,7 @@ public:
 
     void PreventLeavingVehicles();
     void HideRadar(bool bHide);
-    void SetCenterOfWorld(CEntity* entity, CVector* vecPosition, FLOAT fHeading);
+    void SetCenterOfWorld(CEntity* entity, CVector* vecPosition, float fHeading);
     void DisablePadHandler(bool bDisabled);
     void DisableEnterExitVehicleKey(bool bDisabled);
     void DisableAllVehicleWeapons(bool bDisable);

--- a/Client/sdk/game/CAnimBlendAssocGroup.h
+++ b/Client/sdk/game/CAnimBlendAssocGroup.h
@@ -11,14 +11,14 @@
 
 #pragma once
 
+#include <SharedUtil.IntTypes.h>
+
 class CAnimBlendAssocGroupSAInterface;
 class CAnimBlendAssociation;
 class CAnimBlendAssociationSAInterface;
 class CAnimBlendStaticAssociation;
 class CAnimBlock;
 struct RpClump;
-using BYTE = std::uint8_t;
-using AssocGroupId = std::uint32_t;
 
 enum class eAnimGroup : int
 {

--- a/Client/sdk/game/CAnimBlendAssocGroup.h
+++ b/Client/sdk/game/CAnimBlendAssocGroup.h
@@ -17,8 +17,8 @@ class CAnimBlendAssociationSAInterface;
 class CAnimBlendStaticAssociation;
 class CAnimBlock;
 struct RpClump;
-typedef unsigned char BYTE;
-typedef unsigned long AssocGroupId;
+using BYTE = std::uint8_t;
+using AssocGroupId = std::uint32_t;
 
 enum class eAnimGroup : int
 {

--- a/Client/sdk/game/CAnimBlendAssociation.h
+++ b/Client/sdk/game/CAnimBlendAssociation.h
@@ -12,9 +12,7 @@
 #pragma once
 
 #include <memory>
-
-using AssocGroupId = std::uint32_t;
-using AnimationId = std::uint32_t;
+#include <SharedUtil.IntTypes.h>
 
 class CAnimBlendAssociationSAInterface;
 class CAnimBlendHierarchy;

--- a/Client/sdk/game/CAnimBlendAssociation.h
+++ b/Client/sdk/game/CAnimBlendAssociation.h
@@ -13,8 +13,8 @@
 
 #include <memory>
 
-typedef unsigned long AssocGroupId;
-typedef unsigned long AnimationId;
+using AssocGroupId = std::uint32_t;
+using AnimationId = std::uint32_t;
 
 class CAnimBlendAssociationSAInterface;
 class CAnimBlendHierarchy;

--- a/Client/sdk/game/CAnimManager.h
+++ b/Client/sdk/game/CAnimManager.h
@@ -18,8 +18,8 @@
 #define MAX_ANIMATIONS 500
 #define MAX_ANIM_BLOCKS 200
 
-typedef unsigned long AssocGroupId;
-typedef unsigned long AnimationId;
+using AssocGroupId = std::uint32_t;
+using AnimationId = std::uint32_t;
 
 class CAnimBlendAssocGroup;
 class CAnimBlendAssocGroupSAInterface;

--- a/Client/sdk/game/CAnimManager.h
+++ b/Client/sdk/game/CAnimManager.h
@@ -12,14 +12,12 @@
 #pragma once
 
 #include <memory>
+#include <SharedUtil.IntTypes.h>
 
 // Get correct values
 #define MAX_ANIM_GROUPS 200
 #define MAX_ANIMATIONS 500
 #define MAX_ANIM_BLOCKS 200
-
-using AssocGroupId = std::uint32_t;
-using AnimationId = std::uint32_t;
 
 class CAnimBlendAssocGroup;
 class CAnimBlendAssocGroupSAInterface;

--- a/Client/sdk/game/CEventDamage.h
+++ b/Client/sdk/game/CEventDamage.h
@@ -18,8 +18,8 @@ class CPedDamageResponse;
 enum ePedPieceTypes;
 enum eWeaponType;
 
-typedef unsigned long AnimationId;
-typedef unsigned long AssocGroupId;
+using AnimationId = std::uint32_t;
+using AssocGroupId = std::uint32_t;
 
 namespace EDamageReason
 {

--- a/Client/sdk/game/CEventDamage.h
+++ b/Client/sdk/game/CEventDamage.h
@@ -11,15 +11,14 @@
 
 #pragma once
 
+#include <SharedUtil.IntTypes.h>
+
 class CEntity;
 class CEventDamageSAInterface;
 class CPed;
 class CPedDamageResponse;
 enum ePedPieceTypes;
 enum eWeaponType;
-
-using AnimationId = std::uint32_t;
-using AssocGroupId = std::uint32_t;
 
 namespace EDamageReason
 {

--- a/Client/sdk/game/CPedModelInfo.h
+++ b/Client/sdk/game/CPedModelInfo.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-using AssocGroupId = std::uint32_t;
+#include <SharedUtil.IntTypes.h>
 
 class CPedModelInfo
 {

--- a/Client/sdk/game/CPedModelInfo.h
+++ b/Client/sdk/game/CPedModelInfo.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-typedef unsigned long AssocGroupId;
+using AssocGroupId = std::uint32_t;
 
 class CPedModelInfo
 {

--- a/Client/sdk/game/CStats.h
+++ b/Client/sdk/game/CStats.h
@@ -19,7 +19,7 @@
 enum
 {
     /*********************************
-     ALL FLOAT VALUES TO BE ADDED HERE
+     ALL float VALUES TO BE ADDED HERE
      *********************************/
     PROGRESS_MADE = 0,
     TOTAL_PROGRESS,

--- a/Client/sdk/game/CTasks.h
+++ b/Client/sdk/game/CTasks.h
@@ -49,8 +49,8 @@ class CTaskSimpleUseGun;
 class CVector;
 class CVehicle;
 
-typedef unsigned long AssocGroupId;
-typedef unsigned long AnimationId;
+using AssocGroupId = std::uint32_t;
+using AnimationId = std::uint32_t;
 
 enum eClimbHeights
 {

--- a/Client/sdk/game/CTasks.h
+++ b/Client/sdk/game/CTasks.h
@@ -14,6 +14,7 @@
 #include "CPed.h"
 #include "CWeaponInfo.h"
 #include "TaskSecondary.h"
+#include <SharedUtil.IntTypes.h>
 
 class CEntity;
 class CTaskComplexDie;
@@ -48,9 +49,6 @@ class CTaskSimpleTriggerLookAt;
 class CTaskSimpleUseGun;
 class CVector;
 class CVehicle;
-
-using AssocGroupId = std::uint32_t;
-using AnimationId = std::uint32_t;
 
 enum eClimbHeights
 {

--- a/Client/sdk/multiplayer/CMultiplayer.h
+++ b/Client/sdk/multiplayer/CMultiplayer.h
@@ -19,6 +19,7 @@
 #include "CLimits.h"
 #include <../Client/game_sa/CAnimBlendAssociationSA.h>
 #include <../Client/game_sa/CAnimBlendStaticAssociationSA.h>
+#include <SharedUtil.IntTypes.h>
 
 class CEntitySAInterface;
 
@@ -71,8 +72,6 @@ class CAnimBlendAssociationSAInterface;
 class CAnimBlendStaticAssociationSAInterface;
 class CAnimBlendAssocGroupSAInterface;
 class CIFPAnimations;
-using AssocGroupId = std::uint32_t;
-using AnimationId = std::uint32_t;
 enum class eAnimGroup;
 enum class eAnimID;
 
@@ -270,7 +269,7 @@ public:
     virtual void  GetHeatHaze(SHeatHazeSettings& settings) = 0;
     virtual void  ResetColorFilter() = 0;
     virtual void  SetColorFilter(DWORD dwPass0Color, DWORD dwPass1Color) = 0;
-    virtual void  GetColorFilter(DWORD& dwPass0Color, DWORD& dwPass1Color, bool isOriginal) = 0;
+    virtual void  GetColorFilter(std::uint32_t& uiPass0Color, std::uint32_t& uiPass1Color, bool isOriginal) = 0;
     virtual void  SetGrainMultiplier(eGrainMultiplierType type, float fMultiplier) = 0;
     virtual void  SetGrainLevel(BYTE ucLevel) = 0;
     virtual void  ResetHeatHaze() = 0;

--- a/Client/sdk/multiplayer/CMultiplayer.h
+++ b/Client/sdk/multiplayer/CMultiplayer.h
@@ -71,8 +71,8 @@ class CAnimBlendAssociationSAInterface;
 class CAnimBlendStaticAssociationSAInterface;
 class CAnimBlendAssocGroupSAInterface;
 class CIFPAnimations;
-typedef unsigned long AssocGroupId;
-typedef unsigned long AnimationId;
+using AssocGroupId = std::uint32_t;
+using AnimationId = std::uint32_t;
 enum class eAnimGroup;
 enum class eAnimID;
 

--- a/Client/sdk/multiplayer/CMultiplayer.h
+++ b/Client/sdk/multiplayer/CMultiplayer.h
@@ -206,7 +206,7 @@ public:
 
     virtual void PreventLeavingVehicles() = 0;
     virtual void HideRadar(bool bHide) = 0;
-    virtual void SetCenterOfWorld(class CEntity* entity, class CVector* vecPosition, FLOAT fHeading) = 0;
+    virtual void SetCenterOfWorld(class CEntity* entity, class CVector* vecPosition, float fHeading) = 0;
     virtual void DisablePadHandler(bool bDisabled) = 0;
     virtual void DisableAllVehicleWeapons(bool bDisable) = 0;
     virtual void DisableBirds(bool bDisabled) = 0;

--- a/Server/core/StdInc.h
+++ b/Server/core/StdInc.h
@@ -8,17 +8,11 @@
  *
  *****************************************************************************/
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <string>
 
-#ifndef WIN32
-// Linux allocation tracking doesn't work in this module for some reason
-    #define WITH_ALLOC_TRACKING 0
-#endif
-#include "SharedUtil.h"
-
-#ifdef WIN32
+#ifdef _WIN32
 //
 // Windows
 //
@@ -29,7 +23,7 @@
 //
 // POSIX
 //
-    #include <stdlib.h>
+    #include <cstdlib>
     #include <unistd.h>
     #include <fcntl.h>
     #include <dlfcn.h>
@@ -58,3 +52,9 @@
         #define Sleep(duration) usleep((duration)*1000)
     #endif
 #endif
+
+#ifndef _WIN32
+// Linux allocation tracking doesn't work in this module for some reason
+    #define WITH_ALLOC_TRACKING 0
+#endif
+#include "SharedUtil.h"

--- a/Server/mods/deathmatch/logic/ASE.h
+++ b/Server/mods/deathmatch/logic/ASE.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#ifdef WIN32
+#ifdef _WIN32
     #include <conio.h>
     #define sockclose closesocket
 #else
@@ -25,13 +25,14 @@
     #ifndef INVALID_SOCKET
         #define INVALID_SOCKET -1
     #endif
-typedef int SOCKET;
+using SOCKET = int;
 #endif
 
 #include "CConnectHistory.h"
 #include <string.h>
 #include <stdio.h>
 #include <list>
+#include <string>
 
 #define MAX_ASE_GAME_TYPE_LENGTH    200
 #define MAX_ASE_MAP_NAME_LENGTH     200
@@ -48,35 +49,39 @@ class ASE
 {
 public:
     ZERO_ON_NEW
-    ASE(CMainConfig* pMainConfig, CPlayerManager* pPlayerManager, unsigned short usPort, const SString& strServerIPList);
-    ~ASE();
+    ASE(CMainConfig* pMainConfig, CPlayerManager* pPlayerManager, std::uint16_t usPort,
+        const SString& strServerIPList) noexcept;
+    ~ASE() noexcept;
 
     void DoPulse();
     bool SetPortEnabled(bool bInternetEnabled, bool bLanEnabled);
 
-    static ASE* GetInstance() { return _instance; }
+    static ASE* GetInstance() noexcept { return _instance; }
 
-    unsigned long GetMasterServerQueryCount() { return m_ulMasterServerQueryCount; }
-    uint          GetTotalQueryCount() { return m_uiNumQueriesTotal; }
-    uint          GetQueriesPerMinute() { return m_uiNumQueriesPerMinute; }
+    std::uint32_t GetMasterServerQueryCount() noexcept { return m_ulMasterServerQueryCount; }
+    std::uint32_t GetTotalQueryCount() noexcept { return m_uiNumQueriesTotal; }
+    std::uint32_t GetQueriesPerMinute() noexcept { return m_uiNumQueriesPerMinute; }
 
     CLanBroadcast* InitLan();
 
-    const char* GetGameType() { return m_strGameType.c_str(); }
-    void        SetGameType(const char* szGameType);
-    const char* GetMapName() { return m_strMapName.c_str(); }
-    void        SetMapName(const char* szMapName);
+    const char* GetGameType() const noexcept { return m_strGameType.c_str(); }
+    void        SetGameType(const char* szGameType) noexcept;
+    const char* GetMapName() const noexcept { return m_strMapName.c_str(); }
+    void        SetMapName(const char* szMapName) noexcept;
 
-    CMainConfig*    GetMainConfig() { return m_pMainConfig; };
-    CPlayerManager* GetPlayerManager() { return m_pPlayerManager; };
+    CMainConfig*    GetMainConfig() const noexcept { return m_pMainConfig; };
+    CPlayerManager* GetPlayerManager() const noexcept { return m_pPlayerManager; };
 
-    const char* GetRuleValue(const char* szKey);
-    void        SetRuleValue(const char* szKey, const char* szValue);
-    bool        RemoveRuleValue(const char* szKey);
-    void        ClearRules();
+    const char* GetRuleValue(const char* szKey) const noexcept;
+    void        SetRuleValue(const char* szKey, const char* szValue) noexcept;
+    bool        RemoveRuleValue(const char* szKey) noexcept;
+    void        ClearRules() noexcept;
 
-    std::list<CASERule*>::iterator IterBegin() { return m_Rules.begin(); }
-    std::list<CASERule*>::iterator IterEnd() { return m_Rules.end(); }
+    std::list<CASERule*>::iterator begin() noexcept { return m_Rules.begin(); }
+    std::list<CASERule*>::iterator end() noexcept { return m_Rules.end(); }
+
+    std::list<CASERule*>::const_iterator begin() const noexcept { return m_Rules.cbegin(); }
+    std::list<CASERule*>::const_iterator end() const noexcept { return m_Rules.cend(); }
 
     std::string QueryLight();
 
@@ -87,8 +92,8 @@ private:
     const std::string* QueryXfireLightCached();
     std::string        QueryXfireLight();
 
-    long long m_llCurrentTime;
-    uint      m_uiCurrentPlayerCount;
+    std::int64_t  m_llCurrentTime;
+    std::uint32_t m_uiCurrentPlayerCount;
 
     CMainConfig*    m_pMainConfig;
     CPlayerManager* m_pPlayerManager;
@@ -105,34 +110,34 @@ private:
 
     std::vector<SOCKET> m_SocketList;
 
-    unsigned short m_usPortBase;
-    unsigned short m_usPort;
+    std::uint16_t m_usPortBase;
+    std::uint16_t m_usPort;
 
     // Full query cache
-    unsigned int m_uiFullLastPlayerCount;
-    long long    m_llFullLastTime;
-    long         m_lFullMinInterval;
-    std::string  m_strFullCached;
+    std::uint32_t m_uiFullLastPlayerCount;
+    std::int64_t  m_llFullLastTime;
+    std::int32_t  m_lFullMinInterval;
+    std::string   m_strFullCached;
 
     // Light query cache
-    unsigned int m_uiLightLastPlayerCount;
-    long long    m_llLightLastTime;
-    long         m_lLightMinInterval;
-    std::string  m_strLightCached;
+    std::uint32_t m_uiLightLastPlayerCount;
+    std::int64_t  m_llLightLastTime;
+    std::int32_t  m_lLightMinInterval;
+    std::string   m_strLightCached;
 
     // XFire Light query cache
-    unsigned int m_uiXfireLightLastPlayerCount;
-    long long    m_llXfireLightLastTime;
-    long         m_lXfireLightMinInterval;
-    std::string  m_strXfireLightCached;
+    std::uint32_t m_uiXfireLightLastPlayerCount;
+    std::int64_t  m_llXfireLightLastTime;
+    std::int32_t  m_lXfireLightMinInterval;
+    std::string   m_strXfireLightCached;
 
     std::string m_strMtaAseVersion;
 
     // Stats
-    unsigned long m_ulMasterServerQueryCount;
-    uint          m_uiNumQueriesTotal;
-    uint          m_uiNumQueriesPerMinute;
-    uint          m_uiTotalAtMinuteStart;
+    std::uint32_t m_ulMasterServerQueryCount;
+    std::uint32_t m_uiNumQueriesTotal;
+    std::uint32_t m_uiNumQueriesPerMinute;
+    std::uint32_t m_uiTotalAtMinuteStart;
     CElapsedTime  m_MinuteTimer;
 
     CConnectHistory m_QueryDosProtect;
@@ -142,14 +147,12 @@ class CASERule
 {
 public:
     CASERule(const char* szKey, const char* szValue)
-    {
-        m_strKey = szKey;
-        m_strValue = szValue;
-    }
-    const char* GetKey() { return m_strKey.c_str(); }
-    void        SetKey(const char* szKey) { m_strKey = szKey; }
-    const char* GetValue() { return m_strValue.c_str(); }
-    void        SetValue(const char* szValue) { m_strValue = szValue; }
+        noexcept : m_strKey(szKey), m_strValue(szValue) {}
+
+    const char* GetKey() const noexcept { return m_strKey.c_str(); }
+    void        SetKey(const char* szKey) noexcept { m_strKey = szKey; }
+    const char* GetValue() const noexcept { return m_strValue.c_str(); }
+    void        SetValue(const char* szValue) noexcept { m_strValue = szValue; }
 
 private:
     std::string m_strKey;

--- a/Server/mods/deathmatch/logic/CColManager.cpp
+++ b/Server/mods/deathmatch/logic/CColManager.cpp
@@ -198,26 +198,24 @@ void CColManager::DeleteAll()
 
 void CColManager::RemoveFromList(CColShape* pShape)
 {
-    if (m_bCanRemoveFromList)
+    if (!m_bCanRemoveFromList)
+        return;
+
+    // Dont wanna remove it if we're going through the list
+    if (m_bIteratingList)
     {
-        // Dont wanna remove it if we're going through the list
-        if (m_bIteratingList)
-        {
-            m_TrashCan.push_back(pShape);
-        }
-        else
-        {
-            ListRemove(m_List, pShape);
-        }
+        m_TrashCan.push_back(pShape);
+        return;
     }
+
+    ListRemoveFirst(m_List, pShape);
 }
 
 void CColManager::TakeOutTheTrash()
 {
-    std::vector<CColShape*>::const_iterator iter = m_TrashCan.begin();
-    for (; iter != m_TrashCan.end(); iter++)
+    for (const auto& pShape : m_TrashCan)
     {
-        ListRemove(m_List, *iter);
+        ListRemoveFirst(m_List, pShape);
     }
 
     m_TrashCan.clear();

--- a/Server/mods/deathmatch/logic/CDatabaseJobQueue.cpp
+++ b/Server/mods/deathmatch/logic/CDatabaseJobQueue.cpp
@@ -365,7 +365,7 @@ bool CDatabaseJobQueueImpl::PollCommand(CDbJobData* pJobData, uint uiTimeout)
         // See if result has come in yet
         if (ListContains(shared.m_ResultQueue, pJobData))
         {
-            ListRemove(shared.m_ResultQueue, pJobData);
+            ListRemoveAll(shared.m_ResultQueue, pJobData);
 
             pJobData->stage = EJobStage::FINISHED;
             MapInsert(m_FinishedList, pJobData);

--- a/Server/mods/deathmatch/logic/CHTTPD.cpp
+++ b/Server/mods/deathmatch/logic/CHTTPD.cpp
@@ -105,7 +105,7 @@ HttpResponse* CHTTPD::RouteRequest(HttpRequest* ipoHttpRequest)
         // create an HttpRespose object for the message
         HttpResponse* poHttpResponse = new HttpResponse(ipoHttpRequest->m_nRequestId, ipoHttpRequest->m_poSourceEHSConnection);
         SStringX      strWait("The server is not ready. Please try again in a minute.");
-        poHttpResponse->SetBody(strWait.c_str(), strWait.size());
+        poHttpResponse->SetBody(strWait.c_str(), static_cast<std::int32_t>(strWait.size()));
         poHttpResponse->m_nResponseCode = HTTPRESPONSECODE_200_OK;
         return poHttpResponse;
     }
@@ -149,7 +149,7 @@ ResponseCode CHTTPD::HandleRequest(HttpRequest* ipoHttpRequest, HttpResponse* ip
 
             if (!cipherText.empty())
             {
-                ipoHttpResponse->SetBody((const char*)cipherText.BytePtr(), cipherText.SizeInBytes());
+                ipoHttpResponse->SetBody((const char*)cipherText.BytePtr(), static_cast<std::int32_t>(cipherText.SizeInBytes()));
                 return HTTPRESPONSECODE_200_OK;
             }
             else
@@ -171,7 +171,7 @@ ResponseCode CHTTPD::HandleRequest(HttpRequest* ipoHttpRequest, HttpResponse* ip
         if (!m_strDefaultResourceName.empty())
         {
             SString strWelcome("<a href='/%s/'>This is the page you want</a>", m_strDefaultResourceName.c_str());
-            ipoHttpResponse->SetBody(strWelcome.c_str(), strWelcome.size());
+            ipoHttpResponse->SetBody(strWelcome.c_str(), static_cast<std::int32_t>(strWelcome.size()));
             SString strNewURL("http://%s/%s/", ipoHttpRequest->oRequestHeaders["host"].c_str(), m_strDefaultResourceName.c_str());
             ipoHttpResponse->oResponseHeaders["location"] = strNewURL.c_str();
             return HTTPRESPONSECODE_302_FOUND;
@@ -182,7 +182,7 @@ ResponseCode CHTTPD::HandleRequest(HttpRequest* ipoHttpRequest, HttpResponse* ip
         "You haven't set a default resource in your configuration file. You can either do this or visit http://%s/<i>resourcename</i>/ to see a specific "
         "resource.<br/><br/>Alternatively, the server may be still starting up, if so, please try again in a minute.",
         ipoHttpRequest->oRequestHeaders["host"].c_str());
-    ipoHttpResponse->SetBody(strWelcome.c_str(), strWelcome.size());
+    ipoHttpResponse->SetBody(strWelcome.c_str(), static_cast<std::int32_t>(strWelcome.size()));
     return HTTPRESPONSECODE_200_OK;
 }
 
@@ -195,12 +195,12 @@ ResponseCode CHTTPD::RequestLogin(HttpRequest* ipoHttpRequest, HttpResponse* ipo
         strMessage += SString("<br/><a href='%s'>See here for more information</a>",
                               "https:"
                               "//mtasa.com/authserialhttp");
-        ipoHttpResponse->SetBody(strMessage, strMessage.length());
+        ipoHttpResponse->SetBody(strMessage, static_cast<std::int32_t>(strMessage.length()));
         return HTTPRESPONSECODE_401_UNAUTHORIZED;
     }
 
     const char* szAuthenticateMessage = "Access denied, please login";
-    ipoHttpResponse->SetBody(szAuthenticateMessage, strlen(szAuthenticateMessage));
+    ipoHttpResponse->SetBody(szAuthenticateMessage, static_cast<std::int32_t>(strlen(szAuthenticateMessage)));
     SString strName("Basic realm=\"%s\"", g_pGame->GetConfig()->GetServerName().c_str());
     ipoHttpResponse->oResponseHeaders["WWW-Authenticate"] = strName.c_str();
     return HTTPRESPONSECODE_401_UNAUTHORIZED;

--- a/Server/mods/deathmatch/logic/CObject.cpp
+++ b/Server/mods/deathmatch/logic/CObject.cpp
@@ -16,7 +16,7 @@
 
 extern CGame* g_pGame;
 
-CObject::CObject(CElement* pParent, CObjectManager* pObjectManager, bool bIsLowLod) : CElement(pParent), m_bIsLowLod(bIsLowLod), m_pLowLodObject(NULL)
+CObject::CObject(CElement* pParent, CObjectManager* pObjectManager, bool bIsLowLod) : CElement(pParent), m_bIsLowLod(bIsLowLod), m_pLowLodObject(nullptr)
 {
     // Init
     m_iType = CElement::OBJECT;
@@ -24,12 +24,12 @@ CObject::CObject(CElement* pParent, CObjectManager* pObjectManager, bool bIsLowL
 
     m_pObjectManager = pObjectManager;
     m_usModel = 0xFFFF;
-    m_pMoveAnimation = NULL;
+    m_pMoveAnimation = nullptr;
     m_ucAlpha = 255;
     m_vecScale = CVector(1.0f, 1.0f, 1.0f);
     m_fHealth = 1000.0f;
     m_bSyncable = true;
-    m_pSyncer = NULL;
+    m_pSyncer = nullptr;
     m_bIsFrozen = false;
     m_bDoubleSided = false;
     m_bBreakable = false;
@@ -59,8 +59,8 @@ CObject::CObject(const CObject& Copy) : CElement(Copy.m_pParent), m_bIsLowLod(Co
     m_vecPosition = Copy.m_vecPosition;
     m_vecRotation = Copy.m_vecRotation;
 
-    m_pMoveAnimation = NULL;
-    if (Copy.m_pMoveAnimation != NULL)
+    m_pMoveAnimation = nullptr;
+    if (Copy.m_pMoveAnimation != nullptr)
     {
         m_pMoveAnimation = new CPositionRotationAnimation(*Copy.m_pMoveAnimation);
     }
@@ -74,14 +74,14 @@ CObject::CObject(const CObject& Copy) : CElement(Copy.m_pParent), m_bIsLowLod(Co
 
 CObject::~CObject()
 {
-    if (m_pMoveAnimation != NULL)
+    if (m_pMoveAnimation != nullptr)
     {
         delete m_pMoveAnimation;
-        m_pMoveAnimation = NULL;
+        m_pMoveAnimation = nullptr;
     }
 
     // Remove syncer
-    SetSyncer(NULL);
+    SetSyncer(nullptr);
 
     // Unlink us from manager
     Unlink();
@@ -98,9 +98,9 @@ void CObject::Unlink()
     m_pObjectManager->RemoveFromList(this);
 
     // Remove LowLod refs in others
-    SetLowLodObject(NULL);
+    SetLowLodObject(nullptr);
     while (!m_HighLodObjectList.empty())
-        m_HighLodObjectList[0]->SetLowLodObject(NULL);
+        m_HighLodObjectList[0]->SetLowLodObject(nullptr);
 }
 
 bool CObject::ReadSpecialData(const int iLine)
@@ -310,7 +310,7 @@ void CObject::SetRotation(const CVector& vecRotation)
 bool CObject::IsMoving()
 {
     // Are we currently moving?
-    if (m_pMoveAnimation != NULL)
+    if (m_pMoveAnimation != nullptr)
     {
         // Should we have stopped moving by now?
         if (!m_pMoveAnimation->IsRunning())
@@ -320,7 +320,7 @@ bool CObject::IsMoving()
         }
     }
     // Are we still moving after the above check?
-    return (m_pMoveAnimation != NULL);
+    return (m_pMoveAnimation != nullptr);
 }
 
 void CObject::Move(const CPositionRotationAnimation& a_rMoveAnimation)
@@ -351,7 +351,7 @@ void CObject::Move(const CPositionRotationAnimation& a_rMoveAnimation)
 void CObject::StopMoving()
 {
     // Were we moving in the first place
-    if (m_pMoveAnimation != NULL)
+    if (m_pMoveAnimation != nullptr)
     {
         SPositionRotation positionRotation;
         m_pMoveAnimation->GetValue(positionRotation);
@@ -359,7 +359,7 @@ void CObject::StopMoving()
         m_vecRotation = positionRotation.m_vecRotation;
 
         delete m_pMoveAnimation;
-        m_pMoveAnimation = NULL;
+        m_pMoveAnimation = nullptr;
 
         UpdateSpatialData();
     }
@@ -373,7 +373,7 @@ const CPositionRotationAnimation* CObject::GetMoveAnimation()
     }
     else
     {
-        return NULL;
+        return nullptr;
     }
 }
 
@@ -424,8 +424,8 @@ bool CObject::SetLowLodObject(CObject* pNewLowLodObject)
         assert(ListContains(m_pLowLodObject->m_HighLodObjectList, this));
 
         // Clear there and here
-        ListRemove(m_pLowLodObject->m_HighLodObjectList, this);
-        m_pLowLodObject = NULL;
+        ListRemoveFirst(m_pLowLodObject->m_HighLodObjectList, this);
+        m_pLowLodObject = nullptr;
         return true;
     }
     else
@@ -435,7 +435,7 @@ bool CObject::SetLowLodObject(CObject* pNewLowLodObject)
             return false;
 
         // Remove any previous link
-        SetLowLodObject(NULL);
+        SetLowLodObject(nullptr);
 
         // Make new link
         m_pLowLodObject = pNewLowLodObject;
@@ -447,6 +447,6 @@ bool CObject::SetLowLodObject(CObject* pNewLowLodObject)
 CObject* CObject::GetLowLodObject()
 {
     if (m_bIsLowLod)
-        return NULL;
+        return nullptr;
     return m_pLowLodObject;
 }

--- a/Server/mods/deathmatch/logic/CPlayerCamera.h
+++ b/Server/mods/deathmatch/logic/CPlayerCamera.h
@@ -51,10 +51,10 @@ public:
 
     void SetRotation(CVector& vecRotation);
 
-    unsigned char GetInterior() const { return m_ucInterior; }
-    void          SetInterior(unsigned char ucInterior) { m_ucInterior = ucInterior; }
+    unsigned char GetInterior() const noexcept { return m_ucInterior; }
+    void          SetInterior(unsigned char ucInterior) noexcept { m_ucInterior = ucInterior; }
 
-    CPlayer* GetPlayer() const { return m_pPlayer; }
+    CPlayer* GetPlayer() const noexcept { return m_pPlayer; }
 
     uchar GenerateSyncTimeContext();
     bool  CanUpdateSync(uchar ucRemote);

--- a/Server/mods/deathmatch/logic/CPlayerTextManager.cpp
+++ b/Server/mods/deathmatch/logic/CPlayerTextManager.cpp
@@ -92,33 +92,32 @@ void CPlayerTextManager::Update(CTextItem* pTextItem, bool bRemovedFromDisplay)
 // this is not the same as the parameter as the item on the queue is a CLONE of the original
 CTextItem* CPlayerTextManager::GetTextItemOnQueue(CTextItem* textItem)
 {
-    list<CTextItem*>::iterator iter = m_highQueue.begin();
-    for (; iter != m_highQueue.end(); iter++)
+    for (const auto& pItem : m_highQueue)
     {
-        if ((*iter)->GetUniqueID() == textItem->GetUniqueID())
+        if (pItem->GetUniqueID() == textItem->GetUniqueID())
         {
-            return (*iter);
+            return pItem;
         }
     }
 
-    for (iter = m_mediumQueue.begin(); iter != m_mediumQueue.end(); iter++)
+    for (const auto& pItem : m_mediumQueue)
     {
-        if ((*iter)->GetUniqueID() == textItem->GetUniqueID())
+        if (pItem->GetUniqueID() == textItem->GetUniqueID())
         {
-            return (*iter);
+            return pItem;
         }
     }
 
-    for (iter = m_lowQueue.begin(); iter != m_lowQueue.end(); iter++)
+    for (const auto& pItem : m_lowQueue)
     {
-        if ((*iter)->GetUniqueID() == textItem->GetUniqueID())
+        if (pItem->GetUniqueID() == textItem->GetUniqueID())
         {
-            return (*iter);
+            return pItem;
         }
     }
 
     // not found it
-    return NULL;
+    return nullptr;
 }
 
 CPlayer* CPlayerTextManager::GetPlayer()
@@ -129,7 +128,7 @@ CPlayer* CPlayerTextManager::GetPlayer()
 void CPlayerTextManager::Process()
 {
     // Pop some item off the queue
-    CTextItem* textItem = NULL;
+    CTextItem* textItem = nullptr;
     if (m_highQueue.size() != 0)
     {
         textItem = m_highQueue.front();
@@ -146,13 +145,15 @@ void CPlayerTextManager::Process()
         m_lowQueue.pop_front();
     }
 
-    if (textItem)
-    {
-        // Tell the player
-        m_pPlayer->Send(CServerTextItemPacket(textItem->m_ulUniqueId, textItem->m_bDeletable, textItem->m_vecPosition.fX, textItem->m_vecPosition.fY,
-                                              textItem->m_fScale, textItem->m_Color, textItem->m_ucFormat, textItem->m_ucShadowAlpha, textItem->m_strText));
+    if (!textItem)
+        return;
 
-        // Delete the text item created on the queue
-        delete textItem;
-    }
+    // Tell the player
+    m_pPlayer->Send(CServerTextItemPacket(textItem->m_ulUniqueId, textItem->m_bDeletable,
+        textItem->m_vecPosition.fX, textItem->m_vecPosition.fY, textItem->m_fScale,
+        textItem->m_Color, textItem->m_ucFormat, textItem->m_ucShadowAlpha,
+        textItem->m_strText));
+
+    // Delete the text item created on the queue
+    delete textItem;
 }

--- a/Server/mods/deathmatch/logic/CResource.h
+++ b/Server/mods/deathmatch/logic/CResource.h
@@ -197,7 +197,7 @@ public:
     bool CallExportedFunction(const char* szFunctionName, CLuaArguments& Arguments, CLuaArguments& Returns, CResource& Caller);
 
     std::list<CResource*>& GetDependents() { return m_Dependents; }
-    int                    GetDependentCount() const noexcept { return m_Dependents.size(); }
+    std::size_t GetDependentCount() const noexcept { return m_Dependents.size(); }
 
     std::list<CIncludedResources*>::iterator       GetIncludedResourcesBegin() { return m_IncludedResources.begin(); }
     std::list<CIncludedResources*>::const_iterator GetIncludedResourcesBegin() const noexcept { return m_IncludedResources.begin(); }

--- a/Server/mods/deathmatch/logic/CWeaponStat.h
+++ b/Server/mods/deathmatch/logic/CWeaponStat.h
@@ -14,8 +14,8 @@ struct sWeaponStats
 {
     eFireType m_eFireType;            // type - instant hit (e.g. pistol), projectile (e.g. rocket launcher), area effect (e.g. flame thrower)
 
-    FLOAT m_fTargetRange;            // max targeting range
-    FLOAT m_fWeaponRange;            // absolute gun range / default melee attack range
+    float m_fTargetRange;            // max targeting range
+    float m_fWeaponRange;            // absolute gun range / default melee attack range
     int   m_modelId;                 // modelinfo id
     int   m_modelId2;                // second modelinfo id
 
@@ -36,25 +36,25 @@ struct sWeaponStats
     // skill settings
     eWeaponSkill m_SkillLevel;               // what's the skill level of this weapontype
     int          m_nReqStatLevel;            // what stat level is required for this skill level
-    FLOAT        m_fAccuracy;                // modify accuracy of weapon
-    FLOAT        m_fMoveSpeed;               // how fast can move with weapon
+    float        m_fAccuracy;                // modify accuracy of weapon
+    float        m_fMoveSpeed;               // how fast can move with weapon
 
     // anim timings
-    FLOAT m_animLoopStart;            // start of animation loop
-    FLOAT m_animLoopEnd;              // end of animation loop
-    FLOAT m_animFireTime;             // time in animation when weapon should be fired
+    float m_animLoopStart;            // start of animation loop
+    float m_animLoopEnd;              // end of animation loop
+    float m_animFireTime;             // time in animation when weapon should be fired
 
-    FLOAT m_anim2LoopStart;            // start of animation2 loop
-    FLOAT m_anim2LoopEnd;              // end of animation2 loop
-    FLOAT m_anim2FireTime;             // time in animation2 when weapon should be fired
+    float m_anim2LoopStart;            // start of animation2 loop
+    float m_anim2LoopEnd;              // end of animation2 loop
+    float m_anim2FireTime;             // time in animation2 when weapon should be fired
 
-    FLOAT m_animBreakoutTime;            // time after which player can break out of attack and run off
+    float m_animBreakoutTime;            // time after which player can break out of attack and run off
 
     // projectile/area effect specific info
-    FLOAT m_fSpeed;               // speed of projectile
-    FLOAT m_fRadius;              // radius affected
-    FLOAT m_fLifeSpan;            // time taken for shot to dissipate
-    FLOAT m_fSpread;              // angle inside which shots are created
+    float m_fSpeed;               // speed of projectile
+    float m_fRadius;              // radius affected
+    float m_fLifeSpan;            // time taken for shot to dissipate
+    float m_fSpread;              // angle inside which shots are created
 
     short m_nAimOffsetIndex;            // index into array of aiming offsets
     //////////////////////////////////

--- a/Server/mods/deathmatch/logic/CWeaponStatManager.h
+++ b/Server/mods/deathmatch/logic/CWeaponStatManager.h
@@ -25,8 +25,8 @@ struct sWeaponInfo
 {
     eFireType fire_type;            // type - instant hit (e.g. pistol), projectile (e.g. rocket launcher), area effect (e.g. flame thrower)
 
-    FLOAT target_range;            // max targeting range
-    FLOAT weapon_range;            // absolute gun range / default melee attack range
+    float target_range;            // max targeting range
+    float weapon_range;            // absolute gun range / default melee attack range
     int   model;                   // modelinfo id
     int   model2;                  // second modelinfo id
 
@@ -47,25 +47,25 @@ struct sWeaponInfo
     // skill settings
     eWeaponSkill skill_level;                     // what's the skill level of this weapontype
     int          required_skill_level;            // what stat level is required for this skill level
-    FLOAT        accuracy;                        // modify accuracy of weapon
-    FLOAT        move_speed;                      // how fast can move with weapon
+    float        accuracy;                        // modify accuracy of weapon
+    float        move_speed;                      // how fast can move with weapon
 
     // anim timings
-    FLOAT anim_loop_start;                  // start of animation loop
-    FLOAT anim_loop_stop;                   // end of animation loop
-    FLOAT anim_loop_bullet_fire;            // time in animation when weapon should be fired
+    float anim_loop_start;                  // start of animation loop
+    float anim_loop_stop;                   // end of animation loop
+    float anim_loop_bullet_fire;            // time in animation when weapon should be fired
 
-    FLOAT anim2_loop_start;                  // start of animation2 loop
-    FLOAT anim2_loop_stop;                   // end of animation2 loop
-    FLOAT anim2_loop_bullet_fire;            // time in animation2 when weapon should be fired
+    float anim2_loop_start;                  // start of animation2 loop
+    float anim2_loop_stop;                   // end of animation2 loop
+    float anim2_loop_bullet_fire;            // time in animation2 when weapon should be fired
 
-    FLOAT anim_breakout_time;            // time after which player can break out of attack and run off
+    float anim_breakout_time;            // time after which player can break out of attack and run off
 
     // projectile/area effect specific info
-    FLOAT firing_speed;            // speed of projectile
-    FLOAT radius;                  // radius affected
-    FLOAT life_span;               // time taken for shot to dissipate
-    FLOAT spread;                  // angle inside which shots are created
+    float firing_speed;            // speed of projectile
+    float radius;                  // radius affected
+    float life_span;               // time taken for shot to dissipate
+    float spread;                  // angle inside which shots are created
 
     short aim_offset;            // index into array of aiming offsets
     //////////////////////////////////

--- a/Server/mods/deathmatch/logic/lua/CLuaCallback.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaCallback.h
@@ -59,7 +59,7 @@ public:
 
     void DestroyCallback(CLuaCallback* pCallback)
     {
-        ListRemove(m_CallbackList, pCallback);
+        ListRemoveFirst(m_CallbackList, pCallback);
         delete pCallback;
     }
 

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -701,7 +701,7 @@ int CLuaMain::OnUndump(const char* p, size_t n)
 // CLuaMain::GetElementCount
 //
 ///////////////////////////////////////////////////////////////
-unsigned long CLuaMain::GetElementCount() const
+std::uint32_t CLuaMain::GetElementCount() const noexcept
 {
     return m_pResource && m_pResource->GetElementGroup() ? m_pResource->GetElementGroup()->GetCount() : 0;
 }

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.h
@@ -70,12 +70,12 @@ public:
     bool          DestroyXML(CXMLNode* pRootNode);
     bool          SaveXML(CXMLNode* pRootNode);
     bool          XMLExists(CXMLFile* pFile);
-    unsigned long GetXMLFileCount() const { return m_XMLFiles.size(); };
-    unsigned long GetOpenFileCount() const { return m_OpenFilenameList.size(); };
-    unsigned long GetTimerCount() const { return m_pLuaTimerManager ? m_pLuaTimerManager->GetTimerCount() : 0; };
-    unsigned long GetElementCount() const;
-    unsigned long GetTextDisplayCount() const { return m_Displays.size(); };
-    unsigned long GetTextItemCount() const { return m_TextItems.size(); };
+    std::size_t   GetXMLFileCount() const { return m_XMLFiles.size(); };
+    std::size_t   GetOpenFileCount() const { return m_OpenFilenameList.size(); };
+    std::uint32_t GetTimerCount() const { return m_pLuaTimerManager ? m_pLuaTimerManager->GetTimerCount() : 0; };
+    std::uint32_t GetElementCount() const;
+    std::size_t GetTextDisplayCount() const { return m_Displays.size(); };
+    std::size_t GetTextItemCount() const { return m_TextItems.size(); };
     void          OnOpenFile(const SString& strFilename);
     void          OnCloseFile(const SString& strFilename);
 

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.h
@@ -70,12 +70,12 @@ public:
     bool          DestroyXML(CXMLNode* pRootNode);
     bool          SaveXML(CXMLNode* pRootNode);
     bool          XMLExists(CXMLFile* pFile);
-    std::size_t   GetXMLFileCount() const { return m_XMLFiles.size(); };
-    std::size_t   GetOpenFileCount() const { return m_OpenFilenameList.size(); };
-    std::uint32_t GetTimerCount() const { return m_pLuaTimerManager ? m_pLuaTimerManager->GetTimerCount() : 0; };
-    std::uint32_t GetElementCount() const;
-    std::size_t GetTextDisplayCount() const { return m_Displays.size(); };
-    std::size_t GetTextItemCount() const { return m_TextItems.size(); };
+    std::size_t   GetXMLFileCount() const noexcept { return m_XMLFiles.size(); }
+    std::size_t   GetOpenFileCount() const noexcept { return m_OpenFilenameList.size(); }
+    std::size_t   GetTimerCount() const noexcept { return m_pLuaTimerManager ? m_pLuaTimerManager->GetTimerCount() : 0; }
+    std::uint32_t GetElementCount() const noexcept;
+    std::size_t   GetTextDisplayCount() const noexcept { return m_Displays.size(); }
+    std::size_t   GetTextItemCount() const noexcept { return m_TextItems.size(); }
     void          OnOpenFile(const SString& strFilename);
     void          OnCloseFile(const SString& strFilename);
 

--- a/Server/mods/deathmatch/logic/lua/CLuaTimerManager.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaTimerManager.cpp
@@ -66,12 +66,12 @@ void CLuaTimerManager::DoPulse(CLuaMain* pLuaMain)
         if (m_pPendingDelete)
         {
             assert(m_pPendingDelete == m_pProcessingTimer);
-            m_pProcessingTimer = NULL;
+            m_pProcessingTimer = nullptr;
             delete m_pPendingDelete;
-            m_pPendingDelete = NULL;
+            m_pPendingDelete = nullptr;
         }
         else
-            m_pProcessingTimer = NULL;
+            m_pProcessingTimer = nullptr;
     }
 }
 
@@ -84,8 +84,8 @@ void CLuaTimerManager::RemoveTimer(CLuaTimer* pLuaTimer)
         return;
 
     // Remove all references
-    ListRemove(m_TimerList, pLuaTimer);
-    ListRemove(m_ProcessQueue, pLuaTimer);
+    ListRemoveAll(m_TimerList, pLuaTimer);
+    ListRemoveAll(m_ProcessQueue, pLuaTimer);
 
     if (m_pProcessingTimer == pLuaTimer)
     {
@@ -109,8 +109,8 @@ void CLuaTimerManager::RemoveAllTimers()
     // Clear the timer list
     m_TimerList.clear();
     m_ProcessQueue.clear();
-    m_pPendingDelete = NULL;
-    m_pProcessingTimer = NULL;
+    m_pPendingDelete = nullptr;
+    m_pProcessingTimer = nullptr;
 }
 
 void CLuaTimerManager::ResetTimer(CLuaTimer* pLuaTimer)
@@ -125,10 +125,10 @@ CLuaTimer* CLuaTimerManager::GetTimerFromScriptID(uint uiScriptID)
 {
     CLuaTimer* pLuaTimer = (CLuaTimer*)CIdArray::FindEntry(uiScriptID, EIdClass::TIMER);
     if (!pLuaTimer)
-        return NULL;
+        return nullptr;
 
     if (!ListContains(m_TimerList, pLuaTimer))
-        return NULL;
+        return nullptr;
     return pLuaTimer;
 }
 
@@ -136,7 +136,7 @@ CLuaTimer* CLuaTimerManager::AddTimer(const CLuaFunctionRef& iLuaFunction, CTick
 {
     // Check for the minimum interval
     if (llTimeDelay.ToLongLong() < LUA_TIMER_MIN_INTERVAL)
-        return NULL;
+        return nullptr;
 
     if (VERIFY_FUNCTION(iLuaFunction))
     {
@@ -149,5 +149,5 @@ CLuaTimer* CLuaTimerManager::AddTimer(const CLuaFunctionRef& iLuaFunction, CTick
         return pLuaTimer;
     }
 
-    return NULL;
+    return nullptr;
 }

--- a/Server/mods/deathmatch/logic/lua/CLuaTimerManager.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaTimerManager.h
@@ -31,11 +31,11 @@ public:
 
     CLuaTimer* GetTimerFromScriptID(unsigned int uiScriptID);
 
-    CLuaTimer*    AddTimer(const CLuaFunctionRef& iLuaFunction, CTickCount llTimeDelay, unsigned int uiRepeats, const CLuaArguments& Arguments);
-    void          RemoveTimer(CLuaTimer* pLuaTimer);
-    void          RemoveAllTimers();
-    unsigned long GetTimerCount() const { return m_TimerList.size(); }
-
+    CLuaTimer*  AddTimer(const CLuaFunctionRef& iLuaFunction, CTickCount llTimeDelay, unsigned int uiRepeats, const CLuaArguments& Arguments);
+    void        RemoveTimer(CLuaTimer* pLuaTimer);
+    void        RemoveAllTimers();
+    std::size_t GetTimerCount() const { return m_TimerList.size(); }
+    
     void ResetTimer(CLuaTimer* pLuaTimer);
 
     CFastList<CLuaTimer*>::const_iterator IterBegin() { return m_TimerList.begin(); }

--- a/Server/mods/deathmatch/logic/net/CSimBulletsyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/net/CSimBulletsyncPacket.cpp
@@ -10,7 +10,7 @@
 #include "StdInc.h"
 #include "SimHeaders.h"
 
-CSimBulletsyncPacket::CSimBulletsyncPacket(ElementID PlayerID) : m_PlayerID(PlayerID)
+CSimBulletsyncPacket::CSimBulletsyncPacket(ElementID PlayerID) noexcept : m_PlayerID(PlayerID)
 {
     m_Cache.ucOrderCounter = 0;
     m_Cache.fDamage = 0;
@@ -21,7 +21,7 @@ CSimBulletsyncPacket::CSimBulletsyncPacket(ElementID PlayerID) : m_PlayerID(Play
 //
 // Should do the same this as what CBulletsyncPacket::Read() does
 //
-bool CSimBulletsyncPacket::Read(NetBitStreamInterface& BitStream)
+bool CSimBulletsyncPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     char cWeaponType;
     BitStream.Read(cWeaponType);
@@ -34,12 +34,12 @@ bool CSimBulletsyncPacket::Read(NetBitStreamInterface& BitStream)
     if (!BitStream.Read(m_Cache.ucOrderCounter))
         return false;
 
-    if (BitStream.ReadBit())
-    {
-        BitStream.Read(m_Cache.fDamage);
-        BitStream.Read(m_Cache.ucHitZone);
-        BitStream.Read(m_Cache.DamagedPlayerID);
-    }
+    if (!BitStream.ReadBit())
+        return true;
+
+    BitStream.Read(m_Cache.fDamage);
+    BitStream.Read(m_Cache.ucHitZone);
+    BitStream.Read(m_Cache.DamagedPlayerID);
 
     return true;
 }
@@ -47,7 +47,7 @@ bool CSimBulletsyncPacket::Read(NetBitStreamInterface& BitStream)
 //
 // Should do the same this as what CBulletsyncPacket::Write() does
 //
-bool CSimBulletsyncPacket::Write(NetBitStreamInterface& BitStream) const
+bool CSimBulletsyncPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     // Write the source player id
     BitStream.Write(m_PlayerID);

--- a/Server/mods/deathmatch/logic/net/CSimBulletsyncPacket.h
+++ b/Server/mods/deathmatch/logic/net/CSimBulletsyncPacket.h
@@ -15,13 +15,13 @@ class CSimBulletsyncPacket : public CSimPacket
 public:
     ZERO_ON_NEW
 
-    CSimBulletsyncPacket(ElementID PlayerID);
+    CSimBulletsyncPacket(ElementID PlayerID) noexcept;
 
     ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_BULLETSYNC; }
     std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_RELIABLE; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
     // Set in constructor
     const ElementID m_PlayerID;
@@ -29,12 +29,12 @@ public:
     // Set in Read ()
     struct
     {
-        eWeaponType weaponType;
-        CVector     vecStart;
-        CVector     vecEnd;
-        uchar       ucOrderCounter;
-        float       fDamage;
-        uchar       ucHitZone;
-        ElementID   DamagedPlayerID;
+        eWeaponType  weaponType;
+        CVector      vecStart;
+        CVector      vecEnd;
+        std::uint8_t ucOrderCounter;
+        float        fDamage;
+        std::uint8_t ucHitZone;
+        ElementID    DamagedPlayerID;
     } m_Cache;
 };

--- a/Server/mods/deathmatch/logic/net/CSimBulletsyncPacket.h
+++ b/Server/mods/deathmatch/logic/net/CSimBulletsyncPacket.h
@@ -17,8 +17,8 @@ public:
 
     CSimBulletsyncPacket(ElementID PlayerID);
 
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_BULLETSYNC; };
-    unsigned long GetFlags() const { return PACKET_MEDIUM_PRIORITY | PACKET_RELIABLE; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_BULLETSYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_RELIABLE; }
 
     bool Read(NetBitStreamInterface& BitStream);
     bool Write(NetBitStreamInterface& BitStream) const;

--- a/Server/mods/deathmatch/logic/net/CSimKeysyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/net/CSimKeysyncPacket.cpp
@@ -13,9 +13,9 @@
 #include "CWeaponNames.h"
 #include "CVehicleManager.h"
 
-CSimKeysyncPacket::CSimKeysyncPacket(ElementID PlayerID, bool bPlayerHasOccupiedVehicle, ushort usVehicleGotModel, uchar ucPlayerGotWeaponType,
+CSimKeysyncPacket::CSimKeysyncPacket(ElementID PlayerID, bool bPlayerHasOccupiedVehicle, std::uint16_t usVehicleGotModel, std::uint8_t ucPlayerGotWeaponType,
                                      float fPlayerGotWeaponRange, bool bVehicleHasHydraulics, bool bVehicleIsPlaneOrHeli,
-                                     CControllerState& sharedControllerState)
+                                     CControllerState& sharedControllerState) noexcept
     : m_PlayerID(PlayerID),
       m_bPlayerHasOccupiedVehicle(bPlayerHasOccupiedVehicle),
       m_usVehicleGotModel(usVehicleGotModel),
@@ -30,7 +30,7 @@ CSimKeysyncPacket::CSimKeysyncPacket(ElementID PlayerID, bool bPlayerHasOccupied
 //
 // Should do the same this as what CKeysyncPacket::Read() does
 //
-bool CSimKeysyncPacket::Read(NetBitStreamInterface& BitStream)
+bool CSimKeysyncPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     // Read out the controller states
     if (!ReadSmallKeysync(m_sharedControllerState, BitStream))
@@ -49,16 +49,14 @@ bool CSimKeysyncPacket::Read(NetBitStreamInterface& BitStream)
     // If he's shooting or aiming
     if (m_sharedControllerState.ButtonCircle || m_sharedControllerState.RightShoulder1)
     {
-        bool bHasWeapon = BitStream.ReadBit();
-
-        if (bHasWeapon)
+        if (BitStream.ReadBit())
         {
             // Read client weapon data, but only apply it if the weapon matches with the server
-            uchar ucUseWeaponType = m_ucPlayerGotWeaponType;
+            std::uint8_t ucUseWeaponType = m_ucPlayerGotWeaponType;
             bool  bWeaponCorrect = true;
 
             // Check client has the weapon we think he has
-            unsigned char ucClientWeaponType;
+            std::uint8_t ucClientWeaponType;
             if (!BitStream.Read(ucClientWeaponType))
                 return false;
 
@@ -74,7 +72,7 @@ bool CSimKeysyncPacket::Read(NetBitStreamInterface& BitStream)
             SWeaponSlotSync slot;
             if (!BitStream.Read(&slot))
                 return false;
-            unsigned int uiSlot = slot.data.uiSlot;
+            std::uint32_t uiSlot = slot.data.uiSlot;
 
             if (bWeaponCorrect)
                 m_Cache.ucWeaponSlot = uiSlot;
@@ -147,7 +145,7 @@ bool CSimKeysyncPacket::Read(NetBitStreamInterface& BitStream)
 //
 // Should do the same this as what CKeysyncPacket::Write() does
 //
-bool CSimKeysyncPacket::Write(NetBitStreamInterface& BitStream) const
+bool CSimKeysyncPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     // Write the source player id
     BitStream.Write(m_PlayerID);
@@ -168,7 +166,8 @@ bool CSimKeysyncPacket::Write(NetBitStreamInterface& BitStream) const
     if (m_sharedControllerState.ButtonCircle || (m_sharedControllerState.RightShoulder1))
     {
         // Write his current weapon slot
-        unsigned int    uiSlot = m_Cache.ucWeaponSlot;            // check m_Cache.bWeaponCorrect !
+        // check m_Cache.bWeaponCorrect !
+        std::uint32_t   uiSlot = m_Cache.ucWeaponSlot;
         SWeaponSlotSync slot;
         slot.data.uiSlot = uiSlot;
         BitStream.Write(&slot);

--- a/Server/mods/deathmatch/logic/net/CSimKeysyncPacket.h
+++ b/Server/mods/deathmatch/logic/net/CSimKeysyncPacket.h
@@ -15,24 +15,24 @@ class CSimKeysyncPacket : public CSimPacket
 public:
     ZERO_ON_NEW
 
-    CSimKeysyncPacket(ElementID PlayerID, bool bPlayerHasOccupiedVehicle, ushort usVehicleGotModel, uchar ucPlayerGotWeaponType, float fPlayerGotWeaponRange,
-                      bool bVehicleHasHydraulics, bool bVehicleIsPlaneOrHeli, CControllerState& sharedControllerState);
+    CSimKeysyncPacket(ElementID PlayerID, bool bPlayerHasOccupiedVehicle, std::uint16_t usVehicleGotModel, std::uint8_t ucPlayerGotWeaponType, float fPlayerGotWeaponRange,
+                      bool bVehicleHasHydraulics, bool bVehicleIsPlaneOrHeli, CControllerState& sharedControllerState) noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_KEYSYNC; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_KEYSYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
     // Set in constructor
-    const ElementID   m_PlayerID;
-    const bool        m_bPlayerHasOccupiedVehicle;
-    const ushort      m_usVehicleGotModel;
-    const uchar       m_ucPlayerGotWeaponType;
-    const float       m_fPlayerGotWeaponRange;
-    const bool        m_bVehicleHasHydraulics;
-    const bool        m_bVehicleIsPlaneOrHeli;
-    CControllerState& m_sharedControllerState;
+    const ElementID     m_PlayerID;
+    const bool          m_bPlayerHasOccupiedVehicle;
+    const std::uint16_t m_usVehicleGotModel;
+    const std::uint8_t  m_ucPlayerGotWeaponType;
+    const float         m_fPlayerGotWeaponRange;
+    const bool          m_bVehicleHasHydraulics;
+    const bool          m_bVehicleIsPlaneOrHeli;
+    CControllerState&   m_sharedControllerState;
 
     // Set in Read ()
     struct
@@ -43,14 +43,14 @@ public:
         SKeysyncFlags flags;
 
         bool   bWeaponCorrect;
-        uchar  ucWeaponSlot;            // Only valid if bWeaponCorrect
-        ushort usAmmoInClip;            // Only valid if bWeaponCorrect
+        std::uint8_t  ucWeaponSlot;            // Only valid if bWeaponCorrect
+        std::uint16_t usAmmoInClip;            // Only valid if bWeaponCorrect
 
         float   fAimDirection;            // Only valid if bWeaponCorrect
         CVector vecSniperSource;
         CVector vecTargetting;
 
-        uchar ucDriveByDirection;
+        std::uint8_t ucDriveByDirection;
 
         SVehicleTurretSync turretSync;
     } m_Cache;

--- a/Server/mods/deathmatch/logic/net/CSimKeysyncPacket.h
+++ b/Server/mods/deathmatch/logic/net/CSimKeysyncPacket.h
@@ -18,8 +18,8 @@ public:
     CSimKeysyncPacket(ElementID PlayerID, bool bPlayerHasOccupiedVehicle, ushort usVehicleGotModel, uchar ucPlayerGotWeaponType, float fPlayerGotWeaponRange,
                       bool bVehicleHasHydraulics, bool bVehicleIsPlaneOrHeli, CControllerState& sharedControllerState);
 
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_KEYSYNC; };
-    unsigned long GetFlags() const { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_KEYSYNC; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
 
     bool Read(NetBitStreamInterface& BitStream);
     bool Write(NetBitStreamInterface& BitStream) const;

--- a/Server/mods/deathmatch/logic/net/CSimPedTaskPacket.cpp
+++ b/Server/mods/deathmatch/logic/net/CSimPedTaskPacket.cpp
@@ -10,30 +10,29 @@
 #include "StdInc.h"
 #include "SimHeaders.h"
 
-CSimPedTaskPacket::CSimPedTaskPacket(ElementID PlayerID) : m_PlayerID(PlayerID)
+CSimPedTaskPacket::CSimPedTaskPacket(ElementID PlayerID) noexcept : m_PlayerID(PlayerID)
 {
 }
 
 //
 // Should do the same this as what CPedTaskPacket::Read() does
 //
-bool CSimPedTaskPacket::Read(NetBitStreamInterface& BitStream)
+bool CSimPedTaskPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     // Read and save packet data
     m_Cache.uiNumBitsInPacketBody = BitStream.GetNumberOfUnreadBits();
     uint uiNumBytes = (m_Cache.uiNumBitsInPacketBody + 1) / 8;
     dassert(uiNumBytes < sizeof(m_Cache.DataBuffer));
-    if (uiNumBytes < sizeof(m_Cache.DataBuffer))
-        if (BitStream.ReadBits(m_Cache.DataBuffer, m_Cache.uiNumBitsInPacketBody))
-            return true;
+    if (uiNumBytes >= sizeof(m_Cache.DataBuffer))
+        return false;
 
-    return false;
+    return BitStream.ReadBits(m_Cache.DataBuffer, m_Cache.uiNumBitsInPacketBody);
 }
 
 //
 // Should do the same this as what CPedTaskPacket::Write() does
 //
-bool CSimPedTaskPacket::Write(NetBitStreamInterface& BitStream) const
+bool CSimPedTaskPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     // Write the source player id
     BitStream.Write(m_PlayerID);

--- a/Server/mods/deathmatch/logic/net/CSimPedTaskPacket.h
+++ b/Server/mods/deathmatch/logic/net/CSimPedTaskPacket.h
@@ -15,13 +15,13 @@ class CSimPedTaskPacket : public CSimPacket
 public:
     ZERO_ON_NEW
 
-    CSimPedTaskPacket(ElementID PlayerID);
+    CSimPedTaskPacket(ElementID PlayerID) noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PED_TASK; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PED_TASK; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
     // Set in constructor
     const ElementID m_PlayerID;
@@ -29,7 +29,7 @@ public:
     // Set in Read ()
     struct
     {
-        uint uiNumBitsInPacketBody;
-        char DataBuffer[56];
+        std::uint32_t uiNumBitsInPacketBody;
+        char          DataBuffer[56];
     } m_Cache;
 };

--- a/Server/mods/deathmatch/logic/net/CSimPedTaskPacket.h
+++ b/Server/mods/deathmatch/logic/net/CSimPedTaskPacket.h
@@ -17,8 +17,8 @@ public:
 
     CSimPedTaskPacket(ElementID PlayerID);
 
-    ePacketID     GetPacketID() const { return PACKET_ID_PED_TASK; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PED_TASK; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE; };
 
     bool Read(NetBitStreamInterface& BitStream);
     bool Write(NetBitStreamInterface& BitStream) const;

--- a/Server/mods/deathmatch/logic/net/CSimPlayerPuresyncPacket.h
+++ b/Server/mods/deathmatch/logic/net/CSimPlayerPuresyncPacket.h
@@ -14,15 +14,15 @@
 class CSimPacket
 {
 public:
-    CSimPacket() { DEBUG_CREATE_COUNT("CSimPacket"); }
-    virtual ~CSimPacket() { DEBUG_DESTROY_COUNT("CSimPacket"); }
+    CSimPacket() noexcept { DEBUG_CREATE_COUNT("CSimPacket"); }
+    virtual ~CSimPacket() noexcept { DEBUG_DESTROY_COUNT("CSimPacket"); }
 
-    virtual ePacketID       GetPacketID() const = 0;
-    virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_DEFAULT; }
-    virtual unsigned long   GetFlags() const = 0;
+    virtual ePacketID       GetPacketID() const noexcept = 0;
+    virtual ePacketOrdering GetPacketOrdering() const noexcept { return PACKET_ORDERING_DEFAULT; }
+    virtual unsigned long   GetFlags() const noexcept = 0;
 
-    virtual bool Read(NetBitStreamInterface& BitStream) { return false; };
-    virtual bool Write(NetBitStreamInterface& BitStream) const { return false; };
+    virtual bool Read(NetBitStreamInterface& BitStream) noexcept { return false; }
+    virtual bool Write(NetBitStreamInterface& BitStream) const noexcept{ return false; }
 };
 
 //
@@ -33,16 +33,17 @@ class CSimPlayerPuresyncPacket : public CSimPacket
 public:
     ZERO_ON_NEW
 
-    CSimPlayerPuresyncPacket(ElementID PlayerID, ushort PlayerLatency, uchar PlayerSyncTimeContext, uchar PlayerGotWeaponType, float WeaponRange,
-                             CControllerState& sharedControllerState);
+    CSimPlayerPuresyncPacket(ElementID PlayerID,
+        std::uint16_t PlayerLatency, std::uint8_t PlayerSyncTimeContext, std::uint8_t PlayerGotWeaponType, float WeaponRange,
+        CControllerState& sharedControllerState);
 
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_PURESYNC; };
-    unsigned long GetFlags() const { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_PURESYNC; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    bool CanUpdateSync(unsigned char ucRemote)
+    bool CanUpdateSync(std::uint8_t ucRemote) noexcept
     {
         // We can update this element's sync only if the sync time
         // matches or either of them are 0 (ignore).
@@ -51,16 +52,16 @@ public:
 
     // Set in constructor
     const ElementID   m_PlayerID;
-    const ushort      m_PlayerLatency;
-    const uchar       m_PlayerSyncTimeContext;
-    const uchar       m_PlayerGotWeaponType;
+    const std::uint16_t      m_PlayerLatency;
+    const std::uint8_t       m_PlayerSyncTimeContext;
+    const std::uint8_t       m_PlayerGotWeaponType;
     const float       m_WeaponRange;
     CControllerState& m_sharedControllerState;
 
     // Set in Read ()
     struct
     {
-        uchar                ucTimeContext;
+        std::uint8_t                ucTimeContext;
         SPlayerPuresyncFlags flags;
         ElementID            ContactElementID;
         CVector              Position;
@@ -73,9 +74,9 @@ public:
         CVector              vecCamFwd;
 
         bool   bWeaponCorrect;
-        uchar  ucWeaponSlot;            // Only valid if bWeaponCorrect
-        ushort usAmmoInClip;            // Only valid if bWeaponCorrect
-        ushort usTotalAmmo;             // Only valid if bWeaponCorrect
+        std::uint8_t  ucWeaponSlot;            // Only valid if bWeaponCorrect
+        std::uint16_t usAmmoInClip;            // Only valid if bWeaponCorrect
+        std::uint16_t usTotalAmmo;             // Only valid if bWeaponCorrect
 
         bool    bIsAimFull;
         float   fAimDirection;              // Only valid if bWeaponCorrect

--- a/Server/mods/deathmatch/logic/net/CSimPlayerPuresyncPacket.h
+++ b/Server/mods/deathmatch/logic/net/CSimPlayerPuresyncPacket.h
@@ -19,7 +19,7 @@ public:
 
     virtual ePacketID       GetPacketID() const noexcept = 0;
     virtual ePacketOrdering GetPacketOrdering() const noexcept { return PACKET_ORDERING_DEFAULT; }
-    virtual unsigned long   GetFlags() const noexcept = 0;
+    virtual std::uint32_t   GetFlags() const noexcept = 0;
 
     virtual bool Read(NetBitStreamInterface& BitStream) noexcept { return false; }
     virtual bool Write(NetBitStreamInterface& BitStream) const noexcept{ return false; }
@@ -33,12 +33,12 @@ class CSimPlayerPuresyncPacket : public CSimPacket
 public:
     ZERO_ON_NEW
 
-    CSimPlayerPuresyncPacket(ElementID PlayerID,
-        std::uint16_t PlayerLatency, std::uint8_t PlayerSyncTimeContext, std::uint8_t PlayerGotWeaponType, float WeaponRange,
-        CControllerState& sharedControllerState);
+    CSimPlayerPuresyncPacket(ElementID PlayerID, std::uint16_t PlayerLatency,
+        std::uint8_t PlayerSyncTimeContext, std::uint8_t PlayerGotWeaponType,
+        float WeaponRange, CControllerState& sharedControllerState) noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_PURESYNC; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_PURESYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; }
 
     bool Read(NetBitStreamInterface& BitStream) noexcept;
     bool Write(NetBitStreamInterface& BitStream) const noexcept;

--- a/Server/mods/deathmatch/logic/net/CSimVehiclePuresyncPacket.h
+++ b/Server/mods/deathmatch/logic/net/CSimVehiclePuresyncPacket.h
@@ -18,27 +18,27 @@ struct STrailerInfo
     CVector   m_TrailerRotationDeg;
 };
 
-enum class eVehicleAimDirection : unsigned char;
+enum class eVehicleAimDirection : std::uint8_t;
 
 class CSimVehiclePuresyncPacket : public CSimPacket
 {
 public:
     ZERO_ON_NEW
-    CSimVehiclePuresyncPacket(ElementID PlayerID, ushort usPlayerLatency, uchar ucPlayerSyncTimeContext, bool bPlayerHasOccupiedVehicle,
-                              ushort usVehicleGotModel, uchar ucPlayerGotOccupiedVehicleSeat, uchar ucPlayerGotWeaponType, float fPlayerGotWeaponRange,
-                              CControllerState& sharedControllerState, uint m_uiDamageInfoSendPhase, const SSimVehicleDamageInfo& damageInfo);
+    CSimVehiclePuresyncPacket(ElementID PlayerID, std::uint16_t usPlayerLatency, std::uint8_t ucPlayerSyncTimeContext, bool bPlayerHasOccupiedVehicle,
+                              std::uint16_t usVehicleGotModel, std::uint8_t ucPlayerGotOccupiedVehicleSeat, std::uint8_t ucPlayerGotWeaponType, float fPlayerGotWeaponRange,
+                              CControllerState& sharedControllerState, std::uint32_t m_uiDamageInfoSendPhase, const SSimVehicleDamageInfo& damageInfo) noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_VEHICLE_PURESYNC; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_VEHICLE_PURESYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
-    void ReadVehicleSpecific(NetBitStreamInterface& BitStream);
-    void WriteVehicleSpecific(NetBitStreamInterface& BitStream) const;
+    void ReadVehicleSpecific(NetBitStreamInterface& BitStream) noexcept;
+    void WriteVehicleSpecific(NetBitStreamInterface& BitStream) const noexcept;
 
-    bool CanUpdateSync(unsigned char ucRemote)
+    bool CanUpdateSync(std::uint8_t ucRemote) noexcept
     {
         // We can update this element's sync only if the sync time
         // matches or either of them are 0 (ignore).
@@ -47,21 +47,21 @@ private:
 
     // Set in constructor
     const ElementID              m_PlayerID;
-    const ushort                 m_usPlayerLatency;
-    const uchar                  m_ucPlayerSyncTimeContext;
+    const std::uint16_t          m_usPlayerLatency;
+    const std::uint8_t           m_ucPlayerSyncTimeContext;
     const bool                   m_bPlayerHasOccupiedVehicle;
-    const ushort                 m_usVehicleGotModel;
-    const uchar                  m_ucPlayerGotOccupiedVehicleSeat;
-    const uchar                  m_ucPlayerGotWeaponType;
+    const std::uint16_t          m_usVehicleGotModel;
+    const std::uint8_t           m_ucPlayerGotOccupiedVehicleSeat;
+    const std::uint8_t           m_ucPlayerGotWeaponType;
     const float                  m_fPlayerGotWeaponRange;
     CControllerState&            m_sharedControllerState;
-    const uint                   m_uiDamageInfoSendPhase;
+    const std::uint32_t          m_uiDamageInfoSendPhase;
     const SSimVehicleDamageInfo& m_DamageInfo;
 
     // Set in Read()
     struct
     {
-        uchar ucTimeContext;
+        std::uint8_t ucTimeContext;
 
         int iModelID;
 
@@ -82,10 +82,10 @@ private:
         float                 fArmor;
         SVehiclePuresyncFlags flags;
 
-        uchar ucWeaponSlot;
+        std::uint8_t ucWeaponSlot;
 
-        ushort usAmmoInClip;
-        ushort usTotalAmmo;
+        std::uint16_t usAmmoInClip;
+        std::uint16_t usTotalAmmo;
 
         float   fAimDirection;
         CVector vecSniperSource;
@@ -95,10 +95,10 @@ private:
 
         float  fTurretX;
         float  fTurretY;
-        ushort usAdjustableProperty;
+        std::uint16_t usAdjustableProperty;
 
         float fRailPosition;
-        uchar ucRailTrack;
+        std::uint8_t ucRailTrack;
         bool  bRailDirection;
         float fRailSpeed;
 

--- a/Server/mods/deathmatch/logic/net/CSimVehiclePuresyncPacket.h
+++ b/Server/mods/deathmatch/logic/net/CSimVehiclePuresyncPacket.h
@@ -28,8 +28,8 @@ public:
                               ushort usVehicleGotModel, uchar ucPlayerGotOccupiedVehicleSeat, uchar ucPlayerGotWeaponType, float fPlayerGotWeaponRange,
                               CControllerState& sharedControllerState, uint m_uiDamageInfoSendPhase, const SSimVehicleDamageInfo& damageInfo);
 
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_VEHICLE_PURESYNC; };
-    unsigned long GetFlags() const { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_VEHICLE_PURESYNC; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
 
     bool Read(NetBitStreamInterface& BitStream);
     bool Write(NetBitStreamInterface& BitStream) const;

--- a/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.h
@@ -20,8 +20,8 @@ public:
     CBulletsyncPacket(class CPlayer* pPlayer);
 
     bool          HasSimHandler() const { return true; }
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_BULLETSYNC; };
-    unsigned long GetFlags() const { return PACKET_MEDIUM_PRIORITY | PACKET_RELIABLE; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_BULLETSYNC; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_RELIABLE; };
 
     bool Read(NetBitStreamInterface& BitStream);
     bool Write(NetBitStreamInterface& BitStream) const;

--- a/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.h
@@ -16,21 +16,21 @@
 class CBulletsyncPacket final : public CPacket
 {
 public:
-    CBulletsyncPacket(){};
-    CBulletsyncPacket(class CPlayer* pPlayer);
+    CBulletsyncPacket() noexcept {};
+    CBulletsyncPacket(class CPlayer* pPlayer) noexcept;
 
-    bool          HasSimHandler() const { return true; }
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_BULLETSYNC; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_RELIABLE; };
+    bool          HasSimHandler() const noexcept { return true; }
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_BULLETSYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_RELIABLE; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    eWeaponType m_WeaponType;
-    CVector     m_vecStart;
-    CVector     m_vecEnd;
-    uchar       m_ucOrderCounter;
-    float       m_fDamage;
-    uchar       m_ucHitZone;
-    ElementID   m_DamagedPlayerID;
+    eWeaponType  m_WeaponType;
+    CVector      m_vecStart;
+    CVector      m_vecEnd;
+    std::uint8_t m_ucOrderCounter;
+    float        m_fDamage;
+    std::uint8_t m_ucHitZone;
+    ElementID    m_DamagedPlayerID;
 };

--- a/Server/mods/deathmatch/logic/packets/CCameraSyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CCameraSyncPacket.cpp
@@ -15,7 +15,7 @@
 #include "CPlayer.h"
 #include <net/SyncStructures.h>
 
-bool CCameraSyncPacket::Read(NetBitStreamInterface& BitStream)
+bool CCameraSyncPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     if (BitStream.Version() >= 0x5E)
     {
@@ -35,21 +35,17 @@ bool CCameraSyncPacket::Read(NetBitStreamInterface& BitStream)
     if (!BitStream.ReadBit(m_bFixed))
         return false;
 
-    if (m_bFixed)
-    {
-        SPositionSync position(false);
-        if (!BitStream.Read(&position))
-            return false;
-        m_vecPosition = position.data.vecPosition;
-
-        SPositionSync lookAt(false);
-        if (!BitStream.Read(&lookAt))
-            return false;
-        m_vecLookAt = lookAt.data.vecPosition;
-        return true;
-    }
-    else
-    {
+    if (!m_bFixed)
         return BitStream.Read(m_TargetID);
-    }
+
+    SPositionSync position(false);
+    if (!BitStream.Read(&position))
+        return false;
+    m_vecPosition = position.data.vecPosition;
+
+    SPositionSync lookAt(false);
+    if (!BitStream.Read(&lookAt))
+        return false;
+    m_vecLookAt = lookAt.data.vecPosition;
+    return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CCameraSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CCameraSyncPacket.h
@@ -18,10 +18,10 @@
 class CCameraSyncPacket final : public CPacket
 {
 public:
-    ePacketID     GetPacketID() const { return PACKET_ID_CAMERA_SYNC; };
-    unsigned long GetFlags() const { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_CAMERA_SYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
 
     bool      m_bFixed;
     CVector   m_vecPosition, m_vecLookAt;

--- a/Server/mods/deathmatch/logic/packets/CChatClearPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CChatClearPacket.cpp
@@ -11,9 +11,3 @@
 
 #include "StdInc.h"
 #include "CChatClearPacket.h"
-
-// Needed because compiler throwing LNK2001 and LNK1120 error.
-bool CChatClearPacket::Write(NetBitStreamInterface& BitStream) const
-{
-    return true;
-}

--- a/Server/mods/deathmatch/logic/packets/CChatClearPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CChatClearPacket.h
@@ -19,7 +19,7 @@ public:
     CChatClearPacket(){};
 
     // Chat uses low priority channel to avoid getting queued behind large map downloads #6877
-    ePacketID               GetPacketID() const { return PACKET_ID_CHAT_CLEAR; };
+    ePacketID               GetPacketID() const noexcept { return PACKET_ID_CHAT_CLEAR; };
     unsigned long           GetFlags() const { return PACKET_LOW_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
     virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_CHAT; }
 

--- a/Server/mods/deathmatch/logic/packets/CChatClearPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CChatClearPacket.h
@@ -16,12 +16,12 @@
 class CChatClearPacket final : public CPacket
 {
 public:
-    CChatClearPacket(){};
+    CChatClearPacket() noexcept {}
 
     // Chat uses low priority channel to avoid getting queued behind large map downloads #6877
-    ePacketID               GetPacketID() const noexcept { return PACKET_ID_CHAT_CLEAR; };
-    unsigned long           GetFlags() const { return PACKET_LOW_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
-    virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_CHAT; }
+    ePacketID               GetPacketID() const noexcept { return PACKET_ID_CHAT_CLEAR; }
+    std::uint32_t           GetFlags() const noexcept { return PACKET_LOW_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
+    virtual ePacketOrdering GetPacketOrdering() const noexcept { return PACKET_ORDERING_CHAT; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept { return true; }
 };

--- a/Server/mods/deathmatch/logic/packets/CChatEchoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CChatEchoPacket.cpp
@@ -13,7 +13,7 @@
 #include "CChatEchoPacket.h"
 #include "CElement.h"
 
-bool CChatEchoPacket::Write(NetBitStreamInterface& BitStream) const
+bool CChatEchoPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     // Write the color
     BitStream.Write(m_ucRed);
@@ -28,20 +28,18 @@ bool CChatEchoPacket::Write(NetBitStreamInterface& BitStream) const
     }
 
     // Too short?
-    size_t sizeMessage = m_strMessage.length();
-    if (sizeMessage >= MIN_CHATECHO_LENGTH)
+    std::size_t sizeMessage = m_strMessage.length();
+    if (sizeMessage < MIN_CHATECHO_LENGTH)
+        return false;
+
+    if (BitStream.Can(eBitStreamVersion::OnClientChatMessage_MessageType))
     {
-        if (BitStream.Can(eBitStreamVersion::OnClientChatMessage_MessageType))
-        {
-            // Write the message type
-            BitStream.Write(m_ucMessageType);
-        }
-
-        // Write the string
-        BitStream.Write(m_strMessage.c_str(), sizeMessage);
-
-        return true;
+        // Write the message type
+        BitStream.Write(m_ucMessageType);
     }
 
-    return false;
+    // Write the string
+    BitStream.Write(m_strMessage.c_str(), sizeMessage);
+
+    return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CChatEchoPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CChatEchoPacket.h
@@ -34,8 +34,9 @@ enum eMessageType
 class CChatEchoPacket final : public CPacket
 {
 public:
-    CChatEchoPacket(SString strMessage, unsigned char ucRed, unsigned char ucGreen, unsigned char ucBlue, bool bColorCoded = false,
-                    unsigned char ucMessageType = MESSAGE_TYPE_PLAYER)
+    CChatEchoPacket(SString strMessage,
+        std::uint8_t ucRed, std::uint8_t ucGreen, std::uint8_t ucBlue,
+        bool bColorCoded = false, std::uint8_t ucMessageType = MESSAGE_TYPE_PLAYER) noexcept
     {
         m_strMessage = strMessage;
         m_ucRed = ucRed;
@@ -46,17 +47,17 @@ public:
     };
 
     // Chat uses low priority channel to avoid getting queued behind large map downloads #6877
-    ePacketID               GetPacketID() const noexcept { return PACKET_ID_CHAT_ECHO; };
-    unsigned long           GetFlags() const { return PACKET_LOW_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
-    virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_CHAT; }
+    ePacketID               GetPacketID() const noexcept { return PACKET_ID_CHAT_ECHO; }
+    std::uint32_t           GetFlags() const noexcept { return PACKET_LOW_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
+    virtual ePacketOrdering GetPacketOrdering() const noexcept { return PACKET_ORDERING_CHAT; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
-    unsigned char m_ucRed;
-    unsigned char m_ucGreen;
-    unsigned char m_ucBlue;
-    SString       m_strMessage;
-    bool          m_bColorCoded;
-    unsigned char m_ucMessageType;
+    std::uint8_t m_ucRed;
+    std::uint8_t m_ucGreen;
+    std::uint8_t m_ucBlue;
+    SString      m_strMessage;
+    bool         m_bColorCoded;
+    std::uint8_t m_ucMessageType;
 };

--- a/Server/mods/deathmatch/logic/packets/CChatEchoPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CChatEchoPacket.h
@@ -46,7 +46,7 @@ public:
     };
 
     // Chat uses low priority channel to avoid getting queued behind large map downloads #6877
-    ePacketID               GetPacketID() const { return PACKET_ID_CHAT_ECHO; };
+    ePacketID               GetPacketID() const noexcept { return PACKET_ID_CHAT_ECHO; };
     unsigned long           GetFlags() const { return PACKET_LOW_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
     virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_CHAT; }
 

--- a/Server/mods/deathmatch/logic/packets/CCommandPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CCommandPacket.cpp
@@ -12,25 +12,25 @@
 #include "StdInc.h"
 #include "CCommandPacket.h"
 
-bool CCommandPacket::Read(NetBitStreamInterface& BitStream)
+bool CCommandPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     // Read out the command
     int iNumberOfBytesUsed = BitStream.GetNumberOfBytesUsed();
-    if (iNumberOfBytesUsed >= MIN_COMMAND_LENGTH && iNumberOfBytesUsed <= MAX_COMMAND_LENGTH * 4)
-    {
-        char* szBuffer = new char[iNumberOfBytesUsed + 1];
-        BitStream.Read(szBuffer, iNumberOfBytesUsed);
-        szBuffer[iNumberOfBytesUsed] = 0;
-        std::wstring strCommandUTF = MbUTF8ToUTF16(szBuffer);
+    if (iNumberOfBytesUsed < MIN_COMMAND_LENGTH || iNumberOfBytesUsed > MAX_COMMAND_LENGTH * 4)
+        return false;
 
-        if (strCommandUTF.size() <= MAX_COMMAND_LENGTH)
-        {
-            m_strCommand = szBuffer;
-            delete[] szBuffer;
-            return true;
-        }
+    char* szBuffer = new char[iNumberOfBytesUsed + 1];
+    BitStream.Read(szBuffer, iNumberOfBytesUsed);
+    szBuffer[iNumberOfBytesUsed] = 0;
+    std::wstring strCommandUTF = MbUTF8ToUTF16(szBuffer);
+
+    if (strCommandUTF.size() <= MAX_COMMAND_LENGTH)
+    {
+        m_strCommand = szBuffer;
         delete[] szBuffer;
+        return true;
     }
+    delete[] szBuffer;
 
     return false;
 }

--- a/Server/mods/deathmatch/logic/packets/CCommandPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CCommandPacket.h
@@ -16,15 +16,15 @@
 class CCommandPacket final : public CPacket
 {
 public:
-    CCommandPacket() { m_strCommand = ""; };
+    CCommandPacket() noexcept { m_strCommand = ""; };
 
-    ePacketID               GetPacketID() const { return static_cast<ePacketID>(PACKET_ID_COMMAND); };
-    unsigned long           GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
-    virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_CHAT; }
+    ePacketID               GetPacketID() const noexcept { return static_cast<ePacketID>(PACKET_ID_COMMAND); }
+    std::uint32_t           GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
+    virtual ePacketOrdering GetPacketOrdering() const noexcept { return PACKET_ORDERING_CHAT; }
 
-    bool Read(NetBitStreamInterface& BitStream);
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
 
-    const char* GetCommand() const { return m_strCommand.c_str(); };
+    const char* GetCommand() const noexcept { return m_strCommand.c_str(); };
 
 private:
     std::string m_strCommand;

--- a/Server/mods/deathmatch/logic/packets/CConsoleEchoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CConsoleEchoPacket.cpp
@@ -12,15 +12,13 @@
 #include "StdInc.h"
 #include "CConsoleEchoPacket.h"
 
-bool CConsoleEchoPacket::Write(NetBitStreamInterface& BitStream) const
+bool CConsoleEchoPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
-    // Not too short?
-    if (m_strMessage.length() >= MIN_CONSOLEECHO_LENGTH)
-    {
-        // Write the string
-        BitStream.WriteStringCharacters(m_strMessage);
-        return true;
-    }
+    // Too short?
+    if (m_strMessage.length() < MIN_CONSOLEECHO_LENGTH)
+        return false;
 
-    return false;
+    // Write the string
+    BitStream.WriteStringCharacters(m_strMessage);
+    return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CConsoleEchoPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CConsoleEchoPacket.h
@@ -19,7 +19,7 @@ class CConsoleEchoPacket final : public CPacket
 public:
     CConsoleEchoPacket(const char* szMessage) { m_strMessage.AssignLeft(szMessage, MAX_CONSOLEECHO_LENGTH); }
 
-    ePacketID               GetPacketID() const { return PACKET_ID_CONSOLE_ECHO; };
+    ePacketID               GetPacketID() const noexcept { return PACKET_ID_CONSOLE_ECHO; };
     unsigned long           GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
     virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_CHAT; }
 

--- a/Server/mods/deathmatch/logic/packets/CConsoleEchoPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CConsoleEchoPacket.h
@@ -17,16 +17,20 @@
 class CConsoleEchoPacket final : public CPacket
 {
 public:
-    CConsoleEchoPacket(const char* szMessage) { m_strMessage.AssignLeft(szMessage, MAX_CONSOLEECHO_LENGTH); }
+    CConsoleEchoPacket(const char* szMessage) noexcept {
+        m_strMessage.AssignLeft(szMessage, MAX_CONSOLEECHO_LENGTH);
+    }
 
-    ePacketID               GetPacketID() const noexcept { return PACKET_ID_CONSOLE_ECHO; };
-    unsigned long           GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
-    virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_CHAT; }
+    ePacketID               GetPacketID() const noexcept { return PACKET_ID_CONSOLE_ECHO; }
+    std::uint32_t           GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
+    virtual ePacketOrdering GetPacketOrdering() const noexcept { return PACKET_ORDERING_CHAT; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    const char* GetMessage() { return m_strMessage; };
-    void        SetMessage(const char* szMessage) { m_strMessage.AssignLeft(szMessage, MAX_CONSOLEECHO_LENGTH); }
+    const char* GetMessage() const noexcept { return m_strMessage; };
+    void        SetMessage(const char* szMessage) noexcept {
+        m_strMessage.AssignLeft(szMessage, MAX_CONSOLEECHO_LENGTH);
+    }
 
 private:
     SString m_strMessage;

--- a/Server/mods/deathmatch/logic/packets/CCustomDataPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CCustomDataPacket.cpp
@@ -13,37 +13,35 @@
 #include "CCustomDataPacket.h"
 #include "CCustomData.h"
 
-CCustomDataPacket::CCustomDataPacket()
+CCustomDataPacket::CCustomDataPacket() noexcept
 {
-    m_szName = NULL;
+    m_szName = nullptr;
 }
 
-CCustomDataPacket::~CCustomDataPacket()
+CCustomDataPacket::~CCustomDataPacket() noexcept
 {
     delete[] m_szName;
-    m_szName = NULL;
+    m_szName = nullptr;
 }
 
-bool CCustomDataPacket::Read(NetBitStreamInterface& BitStream)
+bool CCustomDataPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
-    unsigned short usNameLength;
-    if (BitStream.Read(m_ElementID) && BitStream.ReadCompressed(usNameLength) && usNameLength > 0 && usNameLength <= MAX_CUSTOMDATA_NAME_LENGTH)
-    {
-        m_szName = new char[usNameLength + 1];
-        if (BitStream.Read(m_szName, usNameLength))
-        {
-            m_szName[usNameLength] = 0;
-            if (m_Value.ReadFromBitStream(BitStream))
-            {
-                return true;
-            }
-        }
-    }
+    std::uint16_t usNameLength;
+    if (!BitStream.Read(m_ElementID) || !BitStream.ReadCompressed(usNameLength))
+        return false;
 
-    return false;
+    if (usNameLength <= 0 || usNameLength > MAX_CUSTOMDATA_NAME_LENGTH)
+        return false;
+
+    m_szName = new char[usNameLength + 1];
+    if (!BitStream.Read(m_szName, usNameLength))
+        return false;
+
+    m_szName[usNameLength] = 0;
+    return m_Value.ReadFromBitStream(BitStream);
 }
 
-bool CCustomDataPacket::Write(NetBitStreamInterface& BitStream) const
+bool CCustomDataPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CCustomDataPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CCustomDataPacket.h
@@ -17,18 +17,20 @@
 class CCustomDataPacket final : public CPacket
 {
 public:
-    CCustomDataPacket();
-    ~CCustomDataPacket();
+    CCustomDataPacket() noexcept;
+    ~CCustomDataPacket() noexcept;
 
-    ePacketID     GetPacketID() const { return PACKET_ID_CUSTOM_DATA; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_CUSTOM_DATA; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    ElementID     GetElementID() { return m_ElementID; }
-    char*         GetName() { return m_szName; }
-    CLuaArgument& GetValue() { return m_Value; }
+    ElementID     GetElementID() const noexcept { return m_ElementID; }
+    char*         GetName() const noexcept { return m_szName; }
+
+    CLuaArgument&       GetValue() noexcept { return m_Value; }
+    const CLuaArgument& GetValue() const noexcept { return m_Value; }
 
 private:
     ElementID    m_ElementID;

--- a/Server/mods/deathmatch/logic/packets/CCustomWeaponBulletSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CCustomWeaponBulletSyncPacket.h
@@ -19,8 +19,8 @@ public:
     CCustomWeaponBulletSyncPacket(){};
     CCustomWeaponBulletSyncPacket(class CPlayer* pPlayer);
 
-    ePacketID     GetPacketID() const { return PACKET_ID_WEAPON_BULLETSYNC; };
-    unsigned long GetFlags() const { return PACKET_MEDIUM_PRIORITY | PACKET_RELIABLE; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_WEAPON_BULLETSYNC; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_RELIABLE; };
 
     bool Read(NetBitStreamInterface& BitStream);
     bool Write(NetBitStreamInterface& BitStream) const;

--- a/Server/mods/deathmatch/logic/packets/CCustomWeaponBulletSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CCustomWeaponBulletSyncPacket.h
@@ -16,22 +16,22 @@
 class CCustomWeaponBulletSyncPacket final : public CPacket
 {
 public:
-    CCustomWeaponBulletSyncPacket(){};
-    CCustomWeaponBulletSyncPacket(class CPlayer* pPlayer);
+    CCustomWeaponBulletSyncPacket() noexcept {}
+    CCustomWeaponBulletSyncPacket(class CPlayer* pPlayer) noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_WEAPON_BULLETSYNC; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_RELIABLE; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_WEAPON_BULLETSYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_RELIABLE; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    CPlayer*       GetWeaponOwner() { return m_pWeapon != NULL ? m_pWeapon->GetOwner() : NULL; };
-    CCustomWeapon* GetWeapon() { return m_pWeapon; };
-    CVector        GetStart() { return m_vecStart; };
-    CVector        GetEnd() { return m_vecEnd; };
+    CPlayer*       GetWeaponOwner() const noexcept { return m_pWeapon ? m_pWeapon->GetOwner() : nullptr; }
+    CCustomWeapon* GetWeapon() const noexcept { return m_pWeapon; }
+    CVector        GetStart() const noexcept { return m_vecStart; }
+    CVector        GetEnd() const noexcept { return m_vecEnd; }
 
     CCustomWeapon* m_pWeapon;
     CVector        m_vecStart;
     CVector        m_vecEnd;
-    uchar          m_ucOrderCounter;
+    std::uint8_t   m_ucOrderCounter;
 };

--- a/Server/mods/deathmatch/logic/packets/CDebugEchoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CDebugEchoPacket.cpp
@@ -12,10 +12,10 @@
 #include "StdInc.h"
 #include "CDebugEchoPacket.h"
 
-bool CDebugEchoPacket::Write(NetBitStreamInterface& BitStream) const
+bool CDebugEchoPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     // Write the level
-    BitStream.Write(static_cast<unsigned char>(m_uiLevel));
+    BitStream.Write(static_cast<std::uint8_t>(m_uiLevel));
     if (m_uiLevel == 0)
     {
         // Write the color
@@ -25,12 +25,10 @@ bool CDebugEchoPacket::Write(NetBitStreamInterface& BitStream) const
     }
 
     // Too short?
-    if (m_strMessage.length() >= MIN_DEBUGECHO_LENGTH)
-    {
-        // Write the string
-        BitStream.WriteStringCharacters(m_strMessage);
-        return true;
-    }
+    if (m_strMessage.length() < MIN_DEBUGECHO_LENGTH)
+        return false;
 
-    return false;
+    // Write the string
+    BitStream.WriteStringCharacters(m_strMessage);
+    return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CDebugEchoPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CDebugEchoPacket.h
@@ -21,7 +21,8 @@
 class CDebugEchoPacket final : public CPacket
 {
 public:
-    CDebugEchoPacket(const char* szMessage, unsigned int uiLevel = 0, unsigned char ucRed = 255, unsigned char ucGreen = 255, unsigned char ucBlue = 255)
+    CDebugEchoPacket(const char* szMessage, std::uint32_t uiLevel = 0,
+        std::uint8_t ucRed = 255, std::uint8_t ucGreen = 255, std::uint8_t ucBlue = 255) noexcept
     {
         m_strMessage.AssignLeft(szMessage, MAX_DEBUGECHO_LENGTH);
         m_ucRed = ucRed;
@@ -30,16 +31,16 @@ public:
         m_uiLevel = uiLevel;
     }
 
-    ePacketID               GetPacketID() const noexcept { return PACKET_ID_DEBUG_ECHO; };
-    unsigned long           GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
-    virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_CHAT; }
+    ePacketID               GetPacketID() const noexcept { return PACKET_ID_DEBUG_ECHO; }
+    std::uint32_t           GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
+    virtual ePacketOrdering GetPacketOrdering() const noexcept { return PACKET_ORDERING_CHAT; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
-    unsigned char m_ucRed;
-    unsigned char m_ucGreen;
-    unsigned char m_ucBlue;
-    unsigned int  m_uiLevel;
+    std::uint8_t  m_ucRed;
+    std::uint8_t  m_ucGreen;
+    std::uint8_t  m_ucBlue;
+    std::uint32_t m_uiLevel;
     SString       m_strMessage;
 };

--- a/Server/mods/deathmatch/logic/packets/CDebugEchoPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CDebugEchoPacket.h
@@ -30,7 +30,7 @@ public:
         m_uiLevel = uiLevel;
     }
 
-    ePacketID               GetPacketID() const { return PACKET_ID_DEBUG_ECHO; };
+    ePacketID               GetPacketID() const noexcept { return PACKET_ID_DEBUG_ECHO; };
     unsigned long           GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
     virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_CHAT; }
 

--- a/Server/mods/deathmatch/logic/packets/CDestroySatchelsPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CDestroySatchelsPacket.cpp
@@ -13,24 +13,19 @@
 #include "CDestroySatchelsPacket.h"
 #include "CElement.h"
 
-CDestroySatchelsPacket::CDestroySatchelsPacket()
-{
-}
+CDestroySatchelsPacket::CDestroySatchelsPacket() noexcept {}
 
-bool CDestroySatchelsPacket::Read(NetBitStreamInterface& BitStream)
+bool CDestroySatchelsPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     return true;
 }
 
-bool CDestroySatchelsPacket::Write(NetBitStreamInterface& BitStream) const
+bool CDestroySatchelsPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     // Write the source player.
-    if (m_pSourceElement)
-    {
-        BitStream.Write(m_pSourceElement->GetID());
-    }
-    else
+    if (!m_pSourceElement)
         return false;
 
+    BitStream.Write(m_pSourceElement->GetID());
     return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CDestroySatchelsPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CDestroySatchelsPacket.h
@@ -16,11 +16,11 @@
 class CDestroySatchelsPacket final : public CPacket
 {
 public:
-    CDestroySatchelsPacket();
+    CDestroySatchelsPacket() noexcept;
 
-    ePacketID     GetPacketID() const { return PACKET_ID_DESTROY_SATCHELS; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_DESTROY_SATCHELS; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 };

--- a/Server/mods/deathmatch/logic/packets/CDetonateSatchelsPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CDetonateSatchelsPacket.cpp
@@ -13,27 +13,25 @@
 #include "CDetonateSatchelsPacket.h"
 #include "CPlayer.h"
 
-CDetonateSatchelsPacket::CDetonateSatchelsPacket()
+CDetonateSatchelsPacket::CDetonateSatchelsPacket() noexcept
 {
 }
 
-bool CDetonateSatchelsPacket::Read(NetBitStreamInterface& BitStream)
+bool CDetonateSatchelsPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     return true;
 }
 
-bool CDetonateSatchelsPacket::Write(NetBitStreamInterface& BitStream) const
+bool CDetonateSatchelsPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     // Write the source player and latency if any.
-    if (m_pSourceElement)
-    {
-        BitStream.Write(m_pSourceElement->GetID());
-
-        unsigned short usLatency = static_cast<CPlayer*>(m_pSourceElement)->GetPing();
-        BitStream.WriteCompressed(usLatency);
-    }
-    else
+    if (!m_pSourceElement)
         return false;
+
+    BitStream.Write(m_pSourceElement->GetID());
+
+    std::uint16_t usLatency = static_cast<CPlayer*>(m_pSourceElement)->GetPing();
+    BitStream.WriteCompressed(usLatency);
 
     return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CDetonateSatchelsPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CDetonateSatchelsPacket.h
@@ -16,11 +16,11 @@
 class CDetonateSatchelsPacket final : public CPacket
 {
 public:
-    CDetonateSatchelsPacket();
+    CDetonateSatchelsPacket() noexcept;
 
-    ePacketID     GetPacketID() const { return PACKET_ID_DETONATE_SATCHELS; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_DETONATE_SATCHELS; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 };

--- a/Server/mods/deathmatch/logic/packets/CElementRPCPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CElementRPCPacket.cpp
@@ -13,7 +13,7 @@
 #include "CElementRPCPacket.h"
 #include "CElement.h"
 
-bool CElementRPCPacket::Write(NetBitStreamInterface& BitStream) const
+bool CElementRPCPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     // Write the action ID
     BitStream.Write(m_ucActionID);
@@ -22,8 +22,8 @@ bool CElementRPCPacket::Write(NetBitStreamInterface& BitStream) const
     BitStream.Write(m_pSourceElement->GetID());
 
     // Copy each byte from the bitstream we have to this one
-    unsigned char ucTemp;
-    int           iLength = m_BitStream.GetNumberOfBitsUsed();
+    std::uint8_t ucTemp;
+    auto iLength = m_BitStream.GetNumberOfBitsUsed();
     while (iLength > 8)
     {
         m_BitStream.Read(ucTemp);

--- a/Server/mods/deathmatch/logic/packets/CElementRPCPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CElementRPCPacket.h
@@ -16,16 +16,17 @@
 class CElementRPCPacket final : public CPacket
 {
 public:
-    CElementRPCPacket(CElement* pSourceElement, unsigned char ucActionID, NetBitStreamInterface& BitStream)
-        : m_ucActionID(ucActionID), m_BitStream(BitStream), m_pSourceElement(pSourceElement){};
+    CElementRPCPacket(CElement* pSourceElement, std::uint8_t ucActionID, NetBitStreamInterface& BitStream) noexcept
+        : m_ucActionID(ucActionID), m_BitStream(BitStream), m_pSourceElement(pSourceElement)
+    {}
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_LUA_ELEMENT_RPC; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_LUA_ELEMENT_RPC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
-    unsigned char          m_ucActionID;
+    std::uint8_t           m_ucActionID;
     NetBitStreamInterface& m_BitStream;
     CElement*              m_pSourceElement;
 };

--- a/Server/mods/deathmatch/logic/packets/CElementRPCPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CElementRPCPacket.h
@@ -19,8 +19,8 @@ public:
     CElementRPCPacket(CElement* pSourceElement, unsigned char ucActionID, NetBitStreamInterface& BitStream)
         : m_ucActionID(ucActionID), m_BitStream(BitStream), m_pSourceElement(pSourceElement){};
 
-    ePacketID     GetPacketID() const { return PACKET_ID_LUA_ELEMENT_RPC; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_LUA_ELEMENT_RPC; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CEntityAddPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CEntityAddPacket.cpp
@@ -31,1081 +31,1075 @@
 // Temporary helper functions for fixing crashes on pre r6459 clients.
 // Cause of #IND numbers should be handled before it gets here. (To avoid desync)
 //
-bool IsIndeterminate(float fValue)
+constexpr bool IsIndeterminate(float fValue) noexcept
 {
     return fValue - fValue != 0;
 }
 
-void SilentlyFixIndeterminate(float& fValue)
+constexpr void SilentlyFixIndeterminate(float& fValue) noexcept
 {
     if (IsIndeterminate(fValue))
         fValue = 0;
 }
 
-void SilentlyFixIndeterminate(CVector& vecValue)
+constexpr void SilentlyFixIndeterminate(CVector& vecValue) noexcept
 {
     SilentlyFixIndeterminate(vecValue.fX);
     SilentlyFixIndeterminate(vecValue.fY);
     SilentlyFixIndeterminate(vecValue.fZ);
 }
 
-void SilentlyFixIndeterminate(CVector2D& vecValue)
+constexpr void SilentlyFixIndeterminate(CVector2D& vecValue) noexcept
 {
     SilentlyFixIndeterminate(vecValue.fX);
     SilentlyFixIndeterminate(vecValue.fY);
 }
 
-void CEntityAddPacket::Add(CElement* pElement)
+void CEntityAddPacket::Add(CElement* pElement) noexcept
 {
     // Only add it if it has a parent.
-    if (pElement->GetParentEntity())
+    if (!pElement->GetParentEntity())
+        return;
+
+    // Jax: adding some checks here because map/element loading is all over the fucking place!
+    switch (pElement->GetType())
     {
-        // Jax: adding some checks here because map/element loading is all over the fucking place!
+        case CElement::COLSHAPE:
+        {
+            CColShape* pColShape = static_cast<CColShape*>(pElement);
+            // If its a server side element only, dont send it
+            if (pColShape->IsPartnered())
+            {
+                return;
+            }
+            break;
+        }
+        default:
+            break;
+    }
+
+    m_Entities.push_back(pElement);
+}
+
+bool CEntityAddPacket::Write(NetBitStreamInterface& BitStream) const noexcept
+{
+    SPositionSync position(false);
+
+    // Check that we have any entities
+    if (m_Entities.empty())
+        return false;
+
+    // Write the number of entities
+    std::uint32_t NumElements = m_Entities.size();
+    BitStream.WriteCompressed(NumElements);
+
+    // For each entity ...
+    CVector vecTemp;
+    for (const auto& pElement : m_Entities)
+    {
+        // Entity id
+        BitStream.Write(pElement->GetID());
+
+        // Entity type id
+        auto ucEntityTypeID = static_cast<std::uint8_t>(pElement->GetType());
+        BitStream.Write(ucEntityTypeID);
+
+        // Entity parent
+        CElement* pParent = pElement->GetParentEntity();
+        ElementID ParentID = INVALID_ELEMENT_ID;
+        if (pParent)
+            ParentID = pParent->GetID();
+        BitStream.Write(ParentID);
+
+        // Entity interior
+        BitStream.Write(pElement->GetInterior());
+
+        // Entity dimension
+        BitStream.WriteCompressed(pElement->GetDimension());
+
+        // Entity attached to
+        CElement* pElementAttachedTo = pElement->GetAttachedToElement();
+        if (pElementAttachedTo)
+        {
+            BitStream.WriteBit(true);
+            BitStream.Write(pElementAttachedTo->GetID());
+
+            // Attached position and rotation
+            SPositionSync        attachedPosition(false);
+            SRotationDegreesSync attachedRotation(false);
+            pElement->GetAttachedOffsets(attachedPosition.data.vecPosition,
+                attachedRotation.data.vecRotation);
+            BitStream.Write(&attachedPosition);
+            BitStream.Write(&attachedRotation);
+        }
+        else
+            BitStream.WriteBit(false);
+
+        // Entity collisions enabled
+        bool bCollisionsEnabled = true;
+
         switch (pElement->GetType())
         {
-            case CElement::COLSHAPE:
+            case CElement::VEHICLE:
             {
-                CColShape* pColShape = static_cast<CColShape*>(pElement);
-                // If its a server side element only, dont send it
-                if (pColShape->IsPartnered())
-                {
-                    return;
-                }
+                CVehicle* pVehicle = static_cast<CVehicle*>(pElement);
+                bCollisionsEnabled = pVehicle->GetCollisionEnabled();
+                break;
+            }
+            case CElement::OBJECT:
+            case CElement::WEAPON:
+            {
+                CObject* pObject = static_cast<CObject*>(pElement);
+                bCollisionsEnabled = pObject->GetCollisionEnabled();
+                break;
+            }
+            case CElement::PED:
+            case CElement::PLAYER:
+            {
+                CPed* pPed = static_cast<CPed*>(pElement);
+                bCollisionsEnabled = pPed->GetCollisionEnabled();
                 break;
             }
             default:
                 break;
         }
 
-        m_Entities.push_back(pElement);
-    }
-}
+        BitStream.WriteBit(bCollisionsEnabled);
 
-bool CEntityAddPacket::Write(NetBitStreamInterface& BitStream) const
-{
-    SPositionSync position(false);
+        if (BitStream.Version() >= 0x56)
+            BitStream.WriteBit(pElement->IsCallPropagationEnabled());
 
-    // Check that we have any entities
-    if (m_Entities.size() > 0)
-    {
-        // Write the number of entities
-        unsigned int NumElements = m_Entities.size();
-        BitStream.WriteCompressed(NumElements);
-
-        // For each entity ...
-        CVector                           vecTemp;
-        vector<CElement*>::const_iterator iter = m_Entities.begin();
-        for (; iter != m_Entities.end(); ++iter)
+        // Write custom data
+        CCustomData& pCustomData = pElement->GetCustomDataManager();
+        BitStream.WriteCompressed(pCustomData.CountOnlySynchronized());
+        map<string, SCustomData>::const_iterator iter = pCustomData.SyncedIterBegin();
+        for (; iter != pCustomData.SyncedIterEnd(); ++iter)
         {
-            // Entity id
-            CElement* pElement = *iter;
-            BitStream.Write(pElement->GetID());
+            const char*         szName = iter->first.c_str();
+            const CLuaArgument* pArgument = &iter->second.Variable;
 
-            // Entity type id
-            unsigned char ucEntityTypeID = static_cast<unsigned char>(pElement->GetType());
-            BitStream.Write(ucEntityTypeID);
+            auto ucNameLength = static_cast<std::uint8_t>(strlen(szName));
+            BitStream.Write(ucNameLength);
+            BitStream.Write(szName, ucNameLength);
+            pArgument->WriteToBitStream(BitStream);
+        }
 
-            // Entity parent
-            CElement* pParent = pElement->GetParentEntity();
-            ElementID ParentID = INVALID_ELEMENT_ID;
-            if (pParent)
-                ParentID = pParent->GetID();
-            BitStream.Write(ParentID);
+        // Grab its name
+        char szEmpty[1];
+        szEmpty[0] = 0;
+        const char* szName = pElement->GetName().c_str();
+        if (!szName)
+            szName = szEmpty;
 
-            // Entity interior
-            BitStream.Write(pElement->GetInterior());
+        // Write the name. It can be empty.
+        auto usNameLength = static_cast<std::uint16_t>(strlen(szName));
+        BitStream.WriteCompressed(usNameLength);
+        if (usNameLength > 0)
+        {
+            BitStream.Write(szName, usNameLength);
+        }
 
-            // Entity dimension
-            BitStream.WriteCompressed(pElement->GetDimension());
+        // Write the sync time context
+        BitStream.Write(pElement->GetSyncTimeContext());
 
-            // Entity attached to
-            CElement* pElementAttachedTo = pElement->GetAttachedToElement();
-            if (pElementAttachedTo)
+        // Write the rest depending on the type
+        switch (ucEntityTypeID)
+        {
+            case CElement::OBJECT:
+            case CElement::WEAPON:
             {
-                BitStream.WriteBit(true);
-                BitStream.Write(pElementAttachedTo->GetID());
+                CObject* pObject = static_cast<CObject*>(pElement);
 
-                // Attached position and rotation
-                SPositionSync        attachedPosition(false);
-                SRotationDegreesSync attachedRotation(false);
-                pElement->GetAttachedOffsets(attachedPosition.data.vecPosition, attachedRotation.data.vecRotation);
-                BitStream.Write(&attachedPosition);
-                BitStream.Write(&attachedRotation);
-            }
-            else
-                BitStream.WriteBit(false);
+                // Position
+                position.data.vecPosition = pObject->GetPosition();
+                SilentlyFixIndeterminate(position.data.vecPosition);            // Crash fix for pre r6459 clients
+                BitStream.Write(&position);
 
-            // Entity collisions enabled
-            bool bCollisionsEnabled = true;
+                // Rotation
+                SRotationRadiansSync rotationRadians(false);
+                pObject->GetRotation(rotationRadians.data.vecRotation);
+                BitStream.Write(&rotationRadians);
 
-            switch (pElement->GetType())
-            {
-                case CElement::VEHICLE:
+                // Object id
+                BitStream.WriteCompressed(pObject->GetModel());
+
+                // Alpha
+                SEntityAlphaSync alpha;
+                alpha.data.ucAlpha = pObject->GetAlpha();
+                BitStream.Write(&alpha);
+
+                // Low LOD stuff
+                bool bIsLowLod = pObject->IsLowLod();
+                BitStream.WriteBit(bIsLowLod);
+
+                CObject*  pLowLodObject = pObject->GetLowLodObject();
+                ElementID LowLodObjectID = pLowLodObject ? pLowLodObject->GetID() : INVALID_ELEMENT_ID;
+                BitStream.Write(LowLodObjectID);
+
+                // Double sided
+                bool bIsDoubleSided = pObject->IsDoubleSided();
+                BitStream.WriteBit(bIsDoubleSided);
+
+                // Breakable
+                if (BitStream.Can(eBitStreamVersion::CEntityAddPacket_ObjectBreakable))
+                    BitStream.WriteBit(pObject->IsBreakable());
+
+                // Visible in all dimensions
+                if (BitStream.Can(eBitStreamVersion::DimensionOmnipresence))
                 {
-                    CVehicle* pVehicle = static_cast<CVehicle*>(pElement);
-                    bCollisionsEnabled = pVehicle->GetCollisionEnabled();
-                    break;
+                    bool bIsVisibleInAllDimensions = pObject->IsVisibleInAllDimensions();
+                    BitStream.WriteBit(bIsVisibleInAllDimensions);
                 }
-                case CElement::OBJECT:
-                case CElement::WEAPON:
+
+                // Moving
+                const CPositionRotationAnimation* pMoveAnimation = pObject->GetMoveAnimation();
+                if (pMoveAnimation)
                 {
-                    CObject* pObject = static_cast<CObject*>(pElement);
-                    bCollisionsEnabled = pObject->GetCollisionEnabled();
-                    break;
+                    BitStream.WriteBit(true);
+                    pMoveAnimation->ToBitStream(BitStream, true);
                 }
-                case CElement::PED:
-                case CElement::PLAYER:
+                else
                 {
-                    CPed* pPed = static_cast<CPed*>(pElement);
-                    bCollisionsEnabled = pPed->GetCollisionEnabled();
-                    break;
+                    BitStream.WriteBit(false);
                 }
-                default:
-                    break;
-            }
 
-            BitStream.WriteBit(bCollisionsEnabled);
-
-            if (BitStream.Version() >= 0x56)
-                BitStream.WriteBit(pElement->IsCallPropagationEnabled());
-
-            // Write custom data
-            CCustomData& pCustomData = pElement->GetCustomDataManager();
-            BitStream.WriteCompressed(pCustomData.CountOnlySynchronized());
-            map<string, SCustomData>::const_iterator iter = pCustomData.SyncedIterBegin();
-            for (; iter != pCustomData.SyncedIterEnd(); ++iter)
-            {
-                const char*         szName = iter->first.c_str();
-                const CLuaArgument* pArgument = &iter->second.Variable;
-
-                unsigned char ucNameLength = static_cast<unsigned char>(strlen(szName));
-                BitStream.Write(ucNameLength);
-                BitStream.Write(szName, ucNameLength);
-                pArgument->WriteToBitStream(BitStream);
-            }
-
-            // Grab its name
-            char szEmpty[1];
-            szEmpty[0] = 0;
-            const char* szName = pElement->GetName().c_str();
-            if (!szName)
-                szName = szEmpty;
-
-            // Write the name. It can be empty.
-            unsigned short usNameLength = static_cast<unsigned short>(strlen(szName));
-            BitStream.WriteCompressed(usNameLength);
-            if (usNameLength > 0)
-            {
-                BitStream.Write(szName, usNameLength);
-            }
-
-            // Write the sync time context
-            BitStream.Write(pElement->GetSyncTimeContext());
-
-            // Write the rest depending on the type
-            switch (ucEntityTypeID)
-            {
-                case CElement::OBJECT:
-                case CElement::WEAPON:
+                // Scale
+                const CVector& vecScale = pObject->GetScale();
+                if (BitStream.Version() >= 0x41)
                 {
-                    CObject* pObject = static_cast<CObject*>(pElement);
-
-                    // Position
-                    position.data.vecPosition = pObject->GetPosition();
-                    SilentlyFixIndeterminate(position.data.vecPosition);            // Crash fix for pre r6459 clients
-                    BitStream.Write(&position);
-
-                    // Rotation
-                    SRotationRadiansSync rotationRadians(false);
-                    pObject->GetRotation(rotationRadians.data.vecRotation);
-                    BitStream.Write(&rotationRadians);
-
-                    // Object id
-                    BitStream.WriteCompressed(pObject->GetModel());
-
-                    // Alpha
-                    SEntityAlphaSync alpha;
-                    alpha.data.ucAlpha = pObject->GetAlpha();
-                    BitStream.Write(&alpha);
-
-                    // Low LOD stuff
-                    bool bIsLowLod = pObject->IsLowLod();
-                    BitStream.WriteBit(bIsLowLod);
-
-                    CObject*  pLowLodObject = pObject->GetLowLodObject();
-                    ElementID LowLodObjectID = pLowLodObject ? pLowLodObject->GetID() : INVALID_ELEMENT_ID;
-                    BitStream.Write(LowLodObjectID);
-
-                    // Double sided
-                    bool bIsDoubleSided = pObject->IsDoubleSided();
-                    BitStream.WriteBit(bIsDoubleSided);
-
-                    // Breakable
-                    if (BitStream.Can(eBitStreamVersion::CEntityAddPacket_ObjectBreakable))
-                        BitStream.WriteBit(pObject->IsBreakable());
-
-                    // Visible in all dimensions
-                    if (BitStream.Can(eBitStreamVersion::DimensionOmnipresence))
+                    bool bIsUniform = (vecScale.fX == vecScale.fY && vecScale.fX == vecScale.fZ);
+                    BitStream.WriteBit(bIsUniform);
+                    if (bIsUniform)
                     {
-                        bool bIsVisibleInAllDimensions = pObject->IsVisibleInAllDimensions();
-                        BitStream.WriteBit(bIsVisibleInAllDimensions);
-                    }
-
-                    // Moving
-                    const CPositionRotationAnimation* pMoveAnimation = pObject->GetMoveAnimation();
-                    if (pMoveAnimation)
-                    {
-                        BitStream.WriteBit(true);
-                        pMoveAnimation->ToBitStream(BitStream, true);
-                    }
-                    else
-                    {
-                        BitStream.WriteBit(false);
-                    }
-
-                    // Scale
-                    const CVector& vecScale = pObject->GetScale();
-                    if (BitStream.Version() >= 0x41)
-                    {
-                        bool bIsUniform = (vecScale.fX == vecScale.fY && vecScale.fX == vecScale.fZ);
-                        BitStream.WriteBit(bIsUniform);
-                        if (bIsUniform)
-                        {
-                            bool bIsUnitSize = (vecScale.fX == 1.0f);
-                            BitStream.WriteBit(bIsUnitSize);
-                            if (!bIsUnitSize)
-                                BitStream.Write(vecScale.fX);
-                        }
-                        else
-                        {
+                        bool bIsUnitSize = (vecScale.fX == 1.0f);
+                        BitStream.WriteBit(bIsUnitSize);
+                        if (!bIsUnitSize)
                             BitStream.Write(vecScale.fX);
-                            BitStream.Write(vecScale.fY);
-                            BitStream.Write(vecScale.fZ);
-                        }
                     }
                     else
                     {
                         BitStream.Write(vecScale.fX);
+                        BitStream.Write(vecScale.fY);
+                        BitStream.Write(vecScale.fZ);
                     }
-
-                    // Frozen
-                    bool bFrozen = pObject->IsFrozen();
-                    BitStream.WriteBit(bFrozen);
-
-                    // Health
-                    SObjectHealthSync health;
-                    health.data.fValue = pObject->GetHealth();
-                    BitStream.Write(&health);
-
-                    if (ucEntityTypeID == CElement::WEAPON)
-                    {
-                        CCustomWeapon* pWeapon = static_cast<CCustomWeapon*>(pElement);
-                        unsigned char  targetType = pWeapon->GetTargetType();
-                        BitStream.WriteBits(&targetType, 3);            // 3 bits = 4 possible values.
-
-                        switch (targetType)
-                        {
-                            case TARGET_TYPE_FIXED:
-                            {
-                                break;
-                            }
-                            case TARGET_TYPE_ENTITY:
-                            {
-                                CElement* pTarget = pWeapon->GetElementTarget();
-                                ElementID targetID = pTarget->GetID();
-
-                                BitStream.Write(targetID);
-                                if (IS_PED(pTarget))
-                                {
-                                    // Send full unsigned char... bone documentation looks scarce.
-                                    unsigned char ucSubTarget = pWeapon->GetTargetBone();
-                                    BitStream.Write(ucSubTarget);            // Send the entire unsigned char as there are a lot of bones.
-                                }
-                                else if (IS_VEHICLE(pTarget))
-                                {
-                                    unsigned char ucSubTarget = pWeapon->GetTargetWheel();
-                                    BitStream.WriteBits(&ucSubTarget, 4);            // 4 bits = 8 possible values.
-                                }
-                                break;
-                            }
-                            case TARGET_TYPE_VECTOR:
-                            {
-                                CVector vecTarget = pWeapon->GetVectorTarget();
-                                BitStream.WriteVector(vecTarget.fX, vecTarget.fY, vecTarget.fZ);
-                                break;
-                            }
-                        }
-                        bool bChanged = false;
-                        BitStream.WriteBit(bChanged);
-                        if (bChanged)
-                        {
-                            CWeaponStat*   pWeaponStat = pWeapon->GetWeaponStat();
-                            unsigned short usDamage = pWeaponStat->GetDamagePerHit();
-                            float          fAccuracy = pWeaponStat->GetAccuracy();
-                            float          fTargetRange = pWeaponStat->GetTargetRange();
-                            float          fWeaponRange = pWeaponStat->GetWeaponRange();
-                            BitStream.WriteBits(&usDamage, 12);            // 12 bits = 2048 values... plenty.
-                            BitStream.Write(fAccuracy);
-                            BitStream.Write(fTargetRange);
-                            BitStream.Write(fWeaponRange);
-                        }
-                        SWeaponConfiguration weaponConfig = pWeapon->GetFlags();
-
-                        BitStream.WriteBit(weaponConfig.bDisableWeaponModel);
-                        BitStream.WriteBit(weaponConfig.bInstantReload);
-                        BitStream.WriteBit(weaponConfig.bShootIfTargetBlocked);
-                        BitStream.WriteBit(weaponConfig.bShootIfTargetOutOfRange);
-                        BitStream.WriteBit(weaponConfig.flags.bCheckBuildings);
-                        BitStream.WriteBit(weaponConfig.flags.bCheckCarTires);
-                        BitStream.WriteBit(weaponConfig.flags.bCheckDummies);
-                        BitStream.WriteBit(weaponConfig.flags.bCheckObjects);
-                        BitStream.WriteBit(weaponConfig.flags.bCheckPeds);
-                        BitStream.WriteBit(weaponConfig.flags.bCheckVehicles);
-                        BitStream.WriteBit(weaponConfig.flags.bIgnoreSomeObjectsForCamera);
-                        BitStream.WriteBit(weaponConfig.flags.bSeeThroughStuff);
-                        BitStream.WriteBit(weaponConfig.flags.bShootThroughStuff);
-
-                        unsigned short usAmmo = pWeapon->GetAmmo();
-                        unsigned short usClipAmmo = pWeapon->GetAmmo();
-                        ElementID      OwnerID = pWeapon->GetOwner() == NULL ? INVALID_ELEMENT_ID : pWeapon->GetOwner()->GetID();
-                        unsigned char  ucWeaponState = pWeapon->GetWeaponState();
-                        BitStream.WriteBits(&ucWeaponState, 4);            // 4 bits = 8 possible values for weapon state
-                        BitStream.Write(usAmmo);
-                        BitStream.Write(usClipAmmo);
-                        BitStream.Write(OwnerID);
-                    }
-
-                    break;
+                }
+                else
+                {
+                    BitStream.Write(vecScale.fX);
                 }
 
-                case CElement::PICKUP:
+                // Frozen
+                bool bFrozen = pObject->IsFrozen();
+                BitStream.WriteBit(bFrozen);
+
+                // Health
+                SObjectHealthSync health;
+                health.data.fValue = pObject->GetHealth();
+                BitStream.Write(&health);
+
+                if (ucEntityTypeID == CElement::WEAPON)
                 {
-                    CPickup* pPickup = static_cast<CPickup*>(pElement);
+                    CCustomWeapon* pWeapon = static_cast<CCustomWeapon*>(pElement);
+                    unsigned char  targetType = pWeapon->GetTargetType();
+                    BitStream.WriteBits(&targetType, 3);            // 3 bits = 4 possible values.
 
-                    // Position
-                    position.data.vecPosition = pPickup->GetPosition();
-                    SilentlyFixIndeterminate(position.data.vecPosition);            // Crash fix for pre r6459 clients
-                    BitStream.Write(&position);
-
-                    // Grab the model and write it
-                    unsigned short usModel = pPickup->GetModel();
-                    BitStream.WriteCompressed(usModel);
-
-                    // Write if it's visible
-                    bool bVisible = pPickup->IsVisible();
-                    BitStream.WriteBit(bVisible);
-
-                    // Write the type
-                    SPickupTypeSync pickupType;
-                    pickupType.data.ucType = pPickup->GetPickupType();
-                    BitStream.Write(&pickupType);
-
-                    switch (pPickup->GetPickupType())
+                    switch (targetType)
                     {
-                        case CPickup::ARMOR:
+                        case TARGET_TYPE_FIXED:
                         {
-                            SPlayerArmorSync armor;
-                            armor.data.fValue = pPickup->GetAmount();
-                            BitStream.Write(&armor);
                             break;
                         }
-                        case CPickup::HEALTH:
+                        case TARGET_TYPE_ENTITY:
                         {
-                            SPlayerHealthSync health;
-                            health.data.fValue = pPickup->GetAmount();
-                            BitStream.Write(&health);
-                            break;
-                        }
-                        case CPickup::WEAPON:
-                        {
-                            SWeaponTypeSync weaponType;
-                            weaponType.data.ucWeaponType = pPickup->GetWeaponType();
-                            BitStream.Write(&weaponType);
+                            CElement* pTarget = pWeapon->GetElementTarget();
+                            ElementID targetID = pTarget->GetID();
 
-                            SWeaponAmmoSync ammo(weaponType.data.ucWeaponType, true, false);
-                            ammo.data.usTotalAmmo = pPickup->GetAmmo();
-                            BitStream.Write(&ammo);
-                            break;
-                        }
-                        default:
-                            break;
-                    }
-
-                    break;
-                }
-
-                case CElement::VEHICLE:
-                {
-                    CVehicle* pVehicle = static_cast<CVehicle*>(pElement);
-
-                    // Write the vehicle position and rotation
-                    position.data.vecPosition = pVehicle->GetPosition();
-                    SRotationDegreesSync rotationDegrees(false);
-                    pVehicle->GetRotationDegrees(rotationDegrees.data.vecRotation);
-
-                    // Write it
-                    BitStream.Write(&position);
-                    BitStream.Write(&rotationDegrees);
-
-                    // Vehicle id as a char
-                    // I'm assuming the "-400" is for adjustment so that all car values can
-                    // fit into a char?  Why doesn't someone document this?
-                    //
-                    // --slush
-                    BitStream.Write(static_cast<unsigned char>(pVehicle->GetModel() - 400));
-
-                    // Health
-                    SVehicleHealthSync health;
-                    health.data.fValue = pVehicle->GetHealth();
-                    BitStream.Write(&health);
-
-                    // Blow state
-                    if (BitStream.Can(eBitStreamVersion::VehicleBlowStateSupport))
-                    {
-                        unsigned char blowState = 0;
-
-                        switch (pVehicle->GetBlowState())
-                        {
-                            case VehicleBlowState::AWAITING_EXPLOSION_SYNC:
-                                blowState = 1;
-                                break;
-                            case VehicleBlowState::BLOWN:
-                                blowState = 2;
-                                break;
-                        }
-
-                        BitStream.WriteBits(&blowState, 2);
-                    }
-
-                    // Color
-                    CVehicleColor& vehColor = pVehicle->GetColor();
-                    uchar          ucNumColors = vehColor.GetNumColorsUsed() - 1;
-                    BitStream.WriteBits(&ucNumColors, 2);
-                    for (uint i = 0; i <= ucNumColors; i++)
-                    {
-                        SColor RGBColor = vehColor.GetRGBColor(i);
-                        BitStream.Write(RGBColor.R);
-                        BitStream.Write(RGBColor.G);
-                        BitStream.Write(RGBColor.B);
-                    }
-
-                    // Paintjob
-                    SPaintjobSync paintjob;
-                    paintjob.data.ucPaintjob = pVehicle->GetPaintjob();
-                    BitStream.Write(&paintjob);
-
-                    // Write the damage model
-                    SVehicleDamageSync damage(true, true, true, true, false);
-                    damage.data.ucDoorStates = pVehicle->m_ucDoorStates;
-                    damage.data.ucWheelStates = pVehicle->m_ucWheelStates;
-                    damage.data.ucPanelStates = pVehicle->m_ucPanelStates;
-                    damage.data.ucLightStates = pVehicle->m_ucLightStates;
-                    BitStream.Write(&damage);
-
-                    unsigned char ucVariant = pVehicle->GetVariant();
-                    BitStream.Write(ucVariant);
-
-                    unsigned char ucVariant2 = pVehicle->GetVariant2();
-                    BitStream.Write(ucVariant2);
-
-                    // If the vehicle has a turret, send its position too
-                    unsigned short usModel = pVehicle->GetModel();
-                    if (CVehicleManager::HasTurret(usModel))
-                    {
-                        SVehicleTurretSync specific;
-                        specific.data.fTurretX = pVehicle->GetTurretPositionX();
-                        specific.data.fTurretY = pVehicle->GetTurretPositionY();
-                        BitStream.Write(&specific);
-                    }
-
-                    // If the vehicle has an adjustable property send its value
-                    if (CVehicleManager::HasAdjustableProperty(usModel))
-                    {
-                        BitStream.WriteCompressed(pVehicle->GetAdjustableProperty());
-                    }
-
-                    // If the vehicle has doors, sync their open angle ratios.
-                    if (CVehicleManager::HasDoors(usModel))
-                    {
-                        SDoorOpenRatioSync door;
-                        for (unsigned char i = 0; i < 6; ++i)
-                        {
-                            door.data.fRatio = pVehicle->GetDoorOpenRatio(i);
-                            BitStream.Write(&door);
-                        }
-                    }
-
-                    // Write all the upgrades
-                    CVehicleUpgrades*  pUpgrades = pVehicle->GetUpgrades();
-                    unsigned char      ucNumUpgrades = pUpgrades->Count();
-                    const SSlotStates& usSlotStates = pUpgrades->GetSlotStates();
-                    BitStream.Write(ucNumUpgrades);
-
-                    if (ucNumUpgrades > 0)
-                    {
-                        unsigned char ucSlot = 0;
-                        for (; ucSlot < VEHICLE_UPGRADE_SLOTS; ucSlot++)
-                        {
-                            unsigned short usUpgrade = usSlotStates[ucSlot];
-
-                            /*
-                             * This is another retarded modification in an attempt to save
-                             * a byte.  We're apparently subtracting 1000 so we can store the
-                             * information in a single byte instead of two.  This only gives us
-                             * a maximum of 256 vehicle slots.
-                             *
-                             * --slush
-                             * -- ChrML: Ehm, GTA only has 17 upgrade slots... This is a valid optimization.
-                             */
-                            if (usUpgrade)
-                                BitStream.Write(static_cast<unsigned char>(usSlotStates[ucSlot] - 1000));
-                        }
-                    }
-
-                    // Get the vehicle's reg plate as 8 bytes of chars with the not used bytes
-                    // nulled.
-                    const char* cszRegPlate = pVehicle->GetRegPlate();
-                    BitStream.Write(cszRegPlate, 8);
-
-                    // Light override
-                    SOverrideLightsSync overrideLights;
-                    overrideLights.data.ucOverride = pVehicle->GetOverrideLights();
-                    BitStream.Write(&overrideLights);
-
-                    // Grab various vehicle flags
-                    BitStream.WriteBit(pVehicle->IsLandingGearDown());
-                    BitStream.WriteBit(pVehicle->IsSirenActive());
-                    BitStream.WriteBit(pVehicle->IsFuelTankExplodable());
-                    BitStream.WriteBit(pVehicle->IsEngineOn());
-                    BitStream.WriteBit(pVehicle->IsLocked());
-                    BitStream.WriteBit(pVehicle->AreDoorsUndamageable());
-                    BitStream.WriteBit(pVehicle->IsDamageProof());
-                    BitStream.WriteBit(pVehicle->IsFrozen());
-                    BitStream.WriteBit(pVehicle->IsDerailed());
-                    BitStream.WriteBit(pVehicle->IsDerailable());
-                    BitStream.WriteBit(pVehicle->GetTrainDirection());
-                    BitStream.WriteBit(pVehicle->IsTaxiLightOn());
-
-                    // Write alpha
-                    SEntityAlphaSync alpha;
-                    alpha.data.ucAlpha = pVehicle->GetAlpha();
-                    BitStream.Write(&alpha);
-
-                    // Write headlight color
-                    SColor color = pVehicle->GetHeadLightColor();
-                    if (color.R != 255 || color.G != 255 || color.B != 255)
-                    {
-                        BitStream.WriteBit(true);
-                        BitStream.Write(color.R);
-                        BitStream.Write(color.G);
-                        BitStream.Write(color.B);
-                    }
-                    else
-                        BitStream.WriteBit(false);
-
-                    // Write handling
-                    if (g_pGame->GetHandlingManager()->HasModelHandlingChanged(static_cast<eVehicleTypes>(pVehicle->GetModel())) ||
-                        pVehicle->HasHandlingChanged())
-                    {
-                        BitStream.WriteBit(true);
-                        SVehicleHandlingSync handling;
-                        CHandlingEntry*      pEntry = pVehicle->GetHandlingData();
-
-                        handling.data.fMass = pEntry->GetMass();
-                        handling.data.fTurnMass = pEntry->GetTurnMass();
-                        handling.data.fDragCoeff = pEntry->GetDragCoeff();
-                        handling.data.vecCenterOfMass = pEntry->GetCenterOfMass();
-                        handling.data.ucPercentSubmerged = pEntry->GetPercentSubmerged();
-                        handling.data.fTractionMultiplier = pEntry->GetTractionMultiplier();
-                        handling.data.ucDriveType = pEntry->GetCarDriveType();
-                        handling.data.ucEngineType = pEntry->GetCarEngineType();
-                        handling.data.ucNumberOfGears = pEntry->GetNumberOfGears();
-                        handling.data.fEngineAcceleration = pEntry->GetEngineAcceleration();
-                        handling.data.fEngineInertia = pEntry->GetEngineInertia();
-                        handling.data.fMaxVelocity = pEntry->GetMaxVelocity();
-                        handling.data.fBrakeDeceleration = pEntry->GetBrakeDeceleration();
-                        handling.data.fBrakeBias = pEntry->GetBrakeBias();
-                        handling.data.bABS = pEntry->GetABS();
-                        handling.data.fSteeringLock = pEntry->GetSteeringLock();
-                        handling.data.fTractionLoss = pEntry->GetTractionLoss();
-                        handling.data.fTractionBias = pEntry->GetTractionBias();
-                        handling.data.fSuspensionForceLevel = pEntry->GetSuspensionForceLevel();
-                        handling.data.fSuspensionDamping = pEntry->GetSuspensionDamping();
-                        handling.data.fSuspensionHighSpdDamping = pEntry->GetSuspensionHighSpeedDamping();
-                        handling.data.fSuspensionUpperLimit = pEntry->GetSuspensionUpperLimit();
-                        handling.data.fSuspensionLowerLimit = pEntry->GetSuspensionLowerLimit();
-                        handling.data.fSuspensionFrontRearBias = pEntry->GetSuspensionFrontRearBias();
-                        handling.data.fSuspensionAntiDiveMultiplier = pEntry->GetSuspensionAntiDiveMultiplier();
-                        handling.data.fCollisionDamageMultiplier = pEntry->GetCollisionDamageMultiplier();
-                        handling.data.uiModelFlags = pEntry->GetModelFlags();
-                        handling.data.uiHandlingFlags = pEntry->GetHandlingFlags();
-                        handling.data.fSeatOffsetDistance = pEntry->GetSeatOffsetDistance();
-                        // handling.data.uiMonetary                    = pEntry->GetMonetary ();
-                        // handling.data.ucHeadLight                   = pEntry->GetHeadLight ();
-                        // handling.data.ucTailLight                   = pEntry->GetTailLight ();
-                        handling.data.ucAnimGroup = pEntry->GetAnimGroup();
-
-                        // Lower and Upper limits cannot match or LSOD (unless boat)
-                        // if ( pVehicle->GetModel() != VEHICLE_BOAT )     // Commented until fully tested
-                        {
-                            float fSuspensionLimitSize = handling.data.fSuspensionUpperLimit - handling.data.fSuspensionLowerLimit;
-                            if (fSuspensionLimitSize > -0.1f && fSuspensionLimitSize < 0.1f)
+                            BitStream.Write(targetID);
+                            if (IS_PED(pTarget))
                             {
-                                if (fSuspensionLimitSize >= 0.f)
-                                    handling.data.fSuspensionUpperLimit = handling.data.fSuspensionLowerLimit + 0.1f;
-                                else
-                                    handling.data.fSuspensionUpperLimit = handling.data.fSuspensionLowerLimit - 0.1f;
+                                // Send full unsigned char... bone documentation looks scarce.
+                                unsigned char ucSubTarget = pWeapon->GetTargetBone();
+                                BitStream.Write(ucSubTarget);            // Send the entire unsigned char as there are a lot of bones.
                             }
-                        }
-                        BitStream.Write(&handling);
-                    }
-                    else
-                        BitStream.WriteBit(false);
-
-                    if (BitStream.Version() >= 0x02B)
-                    {
-                        unsigned char ucSirenCount = pVehicle->m_tSirenBeaconInfo.m_ucSirenCount;
-                        unsigned char ucSirenType = pVehicle->m_tSirenBeaconInfo.m_ucSirenType;
-                        bool          bSync = pVehicle->m_tSirenBeaconInfo.m_bOverrideSirens;
-                        BitStream.WriteBit(bSync);
-                        if (bSync)
-                        {
-                            BitStream.Write(ucSirenCount);
-                            BitStream.Write(ucSirenType);
-
-                            for (int i = 0; i < ucSirenCount; i++)
+                            else if (IS_VEHICLE(pTarget))
                             {
-                                SVehicleSirenSync syncData;
-                                syncData.data.m_bOverrideSirens = true;
-                                syncData.data.m_b360Flag = pVehicle->m_tSirenBeaconInfo.m_b360Flag;
-                                syncData.data.m_bDoLOSCheck = pVehicle->m_tSirenBeaconInfo.m_bDoLOSCheck;
-                                syncData.data.m_bUseRandomiser = pVehicle->m_tSirenBeaconInfo.m_bUseRandomiser;
-                                syncData.data.m_bEnableSilent = pVehicle->m_tSirenBeaconInfo.m_bSirenSilent;
-                                syncData.data.m_ucSirenID = i;
-                                syncData.data.m_vecSirenPositions = pVehicle->m_tSirenBeaconInfo.m_tSirenInfo[i].m_vecSirenPositions;
-                                syncData.data.m_colSirenColour = pVehicle->m_tSirenBeaconInfo.m_tSirenInfo[i].m_RGBBeaconColour;
-                                syncData.data.m_dwSirenMinAlpha = pVehicle->m_tSirenBeaconInfo.m_tSirenInfo[i].m_dwMinSirenAlpha;
-                                BitStream.Write(&syncData);
+                                unsigned char ucSubTarget = pWeapon->GetTargetWheel();
+                                BitStream.WriteBits(&ucSubTarget, 4);            // 4 bits = 8 possible values.
                             }
+                            break;
                         }
-                    }
-                    break;
-                }
-
-                case CElement::MARKER:
-                {
-                    CMarker* pMarker = static_cast<CMarker*>(pElement);
-
-                    // Position
-                    position.data.vecPosition = pMarker->GetPosition();
-                    SilentlyFixIndeterminate(position.data.vecPosition);            // Crash fix for pre r6459 clients
-                    BitStream.Write(&position);
-
-                    // Type
-                    SMarkerTypeSync markerType;
-                    markerType.data.ucType = pMarker->GetMarkerType();
-                    BitStream.Write(&markerType);
-
-                    // Size
-                    float fSize = pMarker->GetSize();
-                    BitStream.Write(fSize);
-
-                    // Colour
-                    SColorSync color;
-                    color = pMarker->GetColor();
-                    BitStream.Write(&color);
-
-                    // Write the target position vector eventually
-                    if (markerType.data.ucType == CMarker::TYPE_CHECKPOINT || markerType.data.ucType == CMarker::TYPE_RING)
-                    {
-                        if (pMarker->HasTarget())
+                        case TARGET_TYPE_VECTOR:
                         {
-                            BitStream.WriteBit(true);
-
-                            position.data.vecPosition = pMarker->GetTarget();
-                            BitStream.Write(&position);
+                            CVector vecTarget = pWeapon->GetVectorTarget();
+                            BitStream.WriteVector(vecTarget.fX, vecTarget.fY, vecTarget.fZ);
+                            break;
                         }
-                        else
-                            BitStream.WriteBit(false);
+                    }
+                    bool bChanged = false;
+                    BitStream.WriteBit(bChanged);
+                    if (bChanged)
+                    {
+                        CWeaponStat*   pWeaponStat = pWeapon->GetWeaponStat();
+                        unsigned short usDamage = pWeaponStat->GetDamagePerHit();
+                        float          fAccuracy = pWeaponStat->GetAccuracy();
+                        float          fTargetRange = pWeaponStat->GetTargetRange();
+                        float          fWeaponRange = pWeaponStat->GetWeaponRange();
+                        BitStream.WriteBits(&usDamage, 12);            // 12 bits = 2048 values... plenty.
+                        BitStream.Write(fAccuracy);
+                        BitStream.Write(fTargetRange);
+                        BitStream.Write(fWeaponRange);
+                    }
+                    SWeaponConfiguration weaponConfig = pWeapon->GetFlags();
+
+                    BitStream.WriteBit(weaponConfig.bDisableWeaponModel);
+                    BitStream.WriteBit(weaponConfig.bInstantReload);
+                    BitStream.WriteBit(weaponConfig.bShootIfTargetBlocked);
+                    BitStream.WriteBit(weaponConfig.bShootIfTargetOutOfRange);
+                    BitStream.WriteBit(weaponConfig.flags.bCheckBuildings);
+                    BitStream.WriteBit(weaponConfig.flags.bCheckCarTires);
+                    BitStream.WriteBit(weaponConfig.flags.bCheckDummies);
+                    BitStream.WriteBit(weaponConfig.flags.bCheckObjects);
+                    BitStream.WriteBit(weaponConfig.flags.bCheckPeds);
+                    BitStream.WriteBit(weaponConfig.flags.bCheckVehicles);
+                    BitStream.WriteBit(weaponConfig.flags.bIgnoreSomeObjectsForCamera);
+                    BitStream.WriteBit(weaponConfig.flags.bSeeThroughStuff);
+                    BitStream.WriteBit(weaponConfig.flags.bShootThroughStuff);
+
+                    unsigned short usAmmo = pWeapon->GetAmmo();
+                    unsigned short usClipAmmo = pWeapon->GetAmmo();
+                    ElementID      OwnerID = pWeapon->GetOwner() == NULL ? INVALID_ELEMENT_ID : pWeapon->GetOwner()->GetID();
+                    unsigned char  ucWeaponState = pWeapon->GetWeaponState();
+                    BitStream.WriteBits(&ucWeaponState, 4);            // 4 bits = 8 possible values for weapon state
+                    BitStream.Write(usAmmo);
+                    BitStream.Write(usClipAmmo);
+                    BitStream.Write(OwnerID);
+                }
+
+                break;
+            }
+
+            case CElement::PICKUP:
+            {
+                CPickup* pPickup = static_cast<CPickup*>(pElement);
+
+                // Position
+                position.data.vecPosition = pPickup->GetPosition();
+                SilentlyFixIndeterminate(position.data.vecPosition);            // Crash fix for pre r6459 clients
+                BitStream.Write(&position);
+
+                // Grab the model and write it
+                unsigned short usModel = pPickup->GetModel();
+                BitStream.WriteCompressed(usModel);
+
+                // Write if it's visible
+                bool bVisible = pPickup->IsVisible();
+                BitStream.WriteBit(bVisible);
+
+                // Write the type
+                SPickupTypeSync pickupType;
+                pickupType.data.ucType = pPickup->GetPickupType();
+                BitStream.Write(&pickupType);
+
+                switch (pPickup->GetPickupType())
+                {
+                    case CPickup::ARMOR:
+                    {
+                        SPlayerArmorSync armor;
+                        armor.data.fValue = pPickup->GetAmount();
+                        BitStream.Write(&armor);
+                        break;
+                    }
+                    case CPickup::HEALTH:
+                    {
+                        SPlayerHealthSync health;
+                        health.data.fValue = pPickup->GetAmount();
+                        BitStream.Write(&health);
+                        break;
+                    }
+                    case CPickup::WEAPON:
+                    {
+                        SWeaponTypeSync weaponType;
+                        weaponType.data.ucWeaponType = pPickup->GetWeaponType();
+                        BitStream.Write(&weaponType);
+
+                        SWeaponAmmoSync ammo(weaponType.data.ucWeaponType, true, false);
+                        ammo.data.usTotalAmmo = pPickup->GetAmmo();
+                        BitStream.Write(&ammo);
+                        break;
+                    }
+                    default:
+                        break;
+                }
+
+                break;
+            }
+
+            case CElement::VEHICLE:
+            {
+                CVehicle* pVehicle = static_cast<CVehicle*>(pElement);
+
+                // Write the vehicle position and rotation
+                position.data.vecPosition = pVehicle->GetPosition();
+                SRotationDegreesSync rotationDegrees(false);
+                pVehicle->GetRotationDegrees(rotationDegrees.data.vecRotation);
+
+                // Write it
+                BitStream.Write(&position);
+                BitStream.Write(&rotationDegrees);
+
+                // Vehicle id as a char
+                // I'm assuming the "-400" is for adjustment so that all car values can
+                // fit into a char?  Why doesn't someone document this?
+                //
+                // --slush
+                BitStream.Write(static_cast<unsigned char>(pVehicle->GetModel() - 400));
+
+                // Health
+                SVehicleHealthSync health;
+                health.data.fValue = pVehicle->GetHealth();
+                BitStream.Write(&health);
+
+                // Blow state
+                if (BitStream.Can(eBitStreamVersion::VehicleBlowStateSupport))
+                {
+                    unsigned char blowState = 0;
+
+                    switch (pVehicle->GetBlowState())
+                    {
+                        case VehicleBlowState::AWAITING_EXPLOSION_SYNC:
+                            blowState = 1;
+                            break;
+                        case VehicleBlowState::BLOWN:
+                            blowState = 2;
+                            break;
                     }
 
-                    break;
+                    BitStream.WriteBits(&blowState, 2);
                 }
 
-                case CElement::BLIP:
+                // Color
+                CVehicleColor& vehColor = pVehicle->GetColor();
+                uchar          ucNumColors = vehColor.GetNumColorsUsed() - 1;
+                BitStream.WriteBits(&ucNumColors, 2);
+                for (uint i = 0; i <= ucNumColors; i++)
                 {
-                    CBlip* pBlip = static_cast<CBlip*>(pElement);
-
-                    // Grab the blip position
-                    position.data.vecPosition = pBlip->GetPosition();
-                    BitStream.Write(&position);
-
-                    // Write the ordering id
-                    BitStream.WriteCompressed(pBlip->m_sOrdering);
-
-                    // Write the visible distance - 14 bits allows 16383.
-                    SIntegerSync<unsigned short, 14> visibleDistance(std::min(pBlip->m_usVisibleDistance, (unsigned short)16383));
-                    BitStream.Write(&visibleDistance);
-
-                    // Write the icon
-                    SIntegerSync<unsigned char, 6> icon(pBlip->m_ucIcon);
-                    BitStream.Write(&icon);
-
-                    // Write the size
-                    SIntegerSync<unsigned char, 5> size(pBlip->m_ucSize);
-                    BitStream.Write(&size);
-
-                    // Write the color
-                    SColorSync color;
-                    color = pBlip->GetColor();
-                    BitStream.Write(&color);
-
-                    break;
+                    SColor RGBColor = vehColor.GetRGBColor(i);
+                    BitStream.Write(RGBColor.R);
+                    BitStream.Write(RGBColor.G);
+                    BitStream.Write(RGBColor.B);
                 }
 
-                case CElement::RADAR_AREA:
+                // Paintjob
+                SPaintjobSync paintjob;
+                paintjob.data.ucPaintjob = pVehicle->GetPaintjob();
+                BitStream.Write(&paintjob);
+
+                // Write the damage model
+                SVehicleDamageSync damage(true, true, true, true, false);
+                damage.data.ucDoorStates = pVehicle->m_ucDoorStates;
+                damage.data.ucWheelStates = pVehicle->m_ucWheelStates;
+                damage.data.ucPanelStates = pVehicle->m_ucPanelStates;
+                damage.data.ucLightStates = pVehicle->m_ucLightStates;
+                BitStream.Write(&damage);
+
+                BitStream.Write(pVehicle->GetVariant());
+                BitStream.Write(pVehicle->GetVariant2());
+
+                // If the vehicle has a turret, send its position too
+                std::uint16_t usModel = pVehicle->GetModel();
+                if (CVehicleManager::HasTurret(usModel))
                 {
-                    CRadarArea* pArea = static_cast<CRadarArea*>(pElement);
+                    SVehicleTurretSync specific;
+                    specific.data.fTurretX = pVehicle->GetTurretPositionX();
+                    specific.data.fTurretY = pVehicle->GetTurretPositionY();
+                    BitStream.Write(&specific);
+                }
 
-                    // Write the position
-                    SPosition2DSync position2D(false);
-                    position2D.data.vecPosition = pArea->GetPosition();
-                    SilentlyFixIndeterminate(position2D.data.vecPosition);            // Crash fix for pre r6459 clients
-                    BitStream.Write(&position2D);
+                // If the vehicle has an adjustable property send its value
+                if (CVehicleManager::HasAdjustableProperty(usModel))
+                {
+                    BitStream.WriteCompressed(pVehicle->GetAdjustableProperty());
+                }
 
-                    // Write the size
-                    SPosition2DSync size2D(false);
-                    size2D.data.vecPosition = pArea->GetSize();
-                    SilentlyFixIndeterminate(size2D.data.vecPosition);            // Crash fix for pre r6459 clients
-                    BitStream.Write(&size2D);
+                // If the vehicle has doors, sync their open angle ratios.
+                if (CVehicleManager::HasDoors(usModel))
+                {
+                    SDoorOpenRatioSync door;
+                    for (auto i = 0; i < 6; ++i)
+                    {
+                        door.data.fRatio = pVehicle->GetDoorOpenRatio(i);
+                        BitStream.Write(&door);
+                    }
+                }
 
-                    // And the color
-                    SColor color = pArea->GetColor();
+                // Write all the upgrades
+                CVehicleUpgrades*  pUpgrades = pVehicle->GetUpgrades();
+                std::uint8_t       ucNumUpgrades = pUpgrades->Count();
+                const SSlotStates& usSlotStates = pUpgrades->GetSlotStates();
+                BitStream.Write(ucNumUpgrades);
+
+                if (ucNumUpgrades > 0)
+                {
+                    unsigned char ucSlot = 0;
+                    for (; ucSlot < VEHICLE_UPGRADE_SLOTS; ucSlot++)
+                    {
+                        unsigned short usUpgrade = usSlotStates[ucSlot];
+
+                        /*
+                            * This is another retarded modification in an attempt to save
+                            * a byte.  We're apparently subtracting 1000 so we can store the
+                            * information in a single byte instead of two.  This only gives us
+                            * a maximum of 256 vehicle slots.
+                            *
+                            * --slush
+                            * -- ChrML: Ehm, GTA only has 17 upgrade slots... This is a valid optimization.
+                            */
+                        if (usUpgrade)
+                            BitStream.Write(static_cast<unsigned char>(usSlotStates[ucSlot] - 1000));
+                    }
+                }
+
+                // Get the vehicle's reg plate as 8 bytes of chars with the not used bytes
+                // nulled.
+                const char* cszRegPlate = pVehicle->GetRegPlate();
+                BitStream.Write(cszRegPlate, 8);
+
+                // Light override
+                SOverrideLightsSync overrideLights;
+                overrideLights.data.ucOverride = pVehicle->GetOverrideLights();
+                BitStream.Write(&overrideLights);
+
+                // Grab various vehicle flags
+                BitStream.WriteBit(pVehicle->IsLandingGearDown());
+                BitStream.WriteBit(pVehicle->IsSirenActive());
+                BitStream.WriteBit(pVehicle->IsFuelTankExplodable());
+                BitStream.WriteBit(pVehicle->IsEngineOn());
+                BitStream.WriteBit(pVehicle->IsLocked());
+                BitStream.WriteBit(pVehicle->AreDoorsUndamageable());
+                BitStream.WriteBit(pVehicle->IsDamageProof());
+                BitStream.WriteBit(pVehicle->IsFrozen());
+                BitStream.WriteBit(pVehicle->IsDerailed());
+                BitStream.WriteBit(pVehicle->IsDerailable());
+                BitStream.WriteBit(pVehicle->GetTrainDirection());
+                BitStream.WriteBit(pVehicle->IsTaxiLightOn());
+
+                // Write alpha
+                SEntityAlphaSync alpha;
+                alpha.data.ucAlpha = pVehicle->GetAlpha();
+                BitStream.Write(&alpha);
+
+                // Write headlight color
+                SColor color = pVehicle->GetHeadLightColor();
+                if (color.R != 255 || color.G != 255 || color.B != 255)
+                {
+                    BitStream.WriteBit(true);
                     BitStream.Write(color.R);
                     BitStream.Write(color.G);
                     BitStream.Write(color.B);
-                    BitStream.Write(color.A);
-
-                    // Write whether it is flashing
-                    bool bIsFlashing = pArea->IsFlashing();
-                    BitStream.WriteBit(bIsFlashing);
-
-                    break;
                 }
+                else
+                    BitStream.WriteBit(false);
 
-                case CElement::WORLD_MESH_UNUSED:
+                // Write handling
+                if (g_pGame->GetHandlingManager()->HasModelHandlingChanged(static_cast<eVehicleTypes>(pVehicle->GetModel())) ||
+                    pVehicle->HasHandlingChanged())
                 {
-                    /*
-                    CWorldMesh* pMesh = static_cast < CWorldMesh* > ( pElement );
+                    BitStream.WriteBit(true);
+                    SVehicleHandlingSync handling;
+                    CHandlingEntry*      pEntry = pVehicle->GetHandlingData();
 
-                    // Write the name
-                    char* szName = pMesh->GetName ();
-                    unsigned short usNameLength = static_cast < unsigned short > ( strlen ( szName ) );
-                    BitStream.Write ( usNameLength );
-                    BitStream.Write ( szName, static_cast < int > ( usNameLength ) );
+                    handling.data.fMass = pEntry->GetMass();
+                    handling.data.fTurnMass = pEntry->GetTurnMass();
+                    handling.data.fDragCoeff = pEntry->GetDragCoeff();
+                    handling.data.vecCenterOfMass = pEntry->GetCenterOfMass();
+                    handling.data.ucPercentSubmerged = pEntry->GetPercentSubmerged();
+                    handling.data.fTractionMultiplier = pEntry->GetTractionMultiplier();
+                    handling.data.ucDriveType = pEntry->GetCarDriveType();
+                    handling.data.ucEngineType = pEntry->GetCarEngineType();
+                    handling.data.ucNumberOfGears = pEntry->GetNumberOfGears();
+                    handling.data.fEngineAcceleration = pEntry->GetEngineAcceleration();
+                    handling.data.fEngineInertia = pEntry->GetEngineInertia();
+                    handling.data.fMaxVelocity = pEntry->GetMaxVelocity();
+                    handling.data.fBrakeDeceleration = pEntry->GetBrakeDeceleration();
+                    handling.data.fBrakeBias = pEntry->GetBrakeBias();
+                    handling.data.bABS = pEntry->GetABS();
+                    handling.data.fSteeringLock = pEntry->GetSteeringLock();
+                    handling.data.fTractionLoss = pEntry->GetTractionLoss();
+                    handling.data.fTractionBias = pEntry->GetTractionBias();
+                    handling.data.fSuspensionForceLevel = pEntry->GetSuspensionForceLevel();
+                    handling.data.fSuspensionDamping = pEntry->GetSuspensionDamping();
+                    handling.data.fSuspensionHighSpdDamping = pEntry->GetSuspensionHighSpeedDamping();
+                    handling.data.fSuspensionUpperLimit = pEntry->GetSuspensionUpperLimit();
+                    handling.data.fSuspensionLowerLimit = pEntry->GetSuspensionLowerLimit();
+                    handling.data.fSuspensionFrontRearBias = pEntry->GetSuspensionFrontRearBias();
+                    handling.data.fSuspensionAntiDiveMultiplier = pEntry->GetSuspensionAntiDiveMultiplier();
+                    handling.data.fCollisionDamageMultiplier = pEntry->GetCollisionDamageMultiplier();
+                    handling.data.uiModelFlags = pEntry->GetModelFlags();
+                    handling.data.uiHandlingFlags = pEntry->GetHandlingFlags();
+                    handling.data.fSeatOffsetDistance = pEntry->GetSeatOffsetDistance();
+                    // handling.data.uiMonetary                    = pEntry->GetMonetary ();
+                    // handling.data.ucHeadLight                   = pEntry->GetHeadLight ();
+                    // handling.data.ucTailLight                   = pEntry->GetTailLight ();
+                    handling.data.ucAnimGroup = pEntry->GetAnimGroup();
 
-                    // Write the position and rotation
-                    CVector vecTemp = pMesh->GetPosition ();
-                    BitStream.Write ( vecTemp.fX );
-                    BitStream.Write ( vecTemp.fY );
-                    BitStream.Write ( vecTemp.fZ );
-
-                    vecTemp = pMesh->GetRotation ();
-                    BitStream.Write ( vecTemp.fX );
-                    BitStream.Write ( vecTemp.fY );
-                    BitStream.Write ( vecTemp.fZ );
-                    */
-
-                    break;
+                    // Lower and Upper limits cannot match or LSOD (unless boat)
+                    // if ( pVehicle->GetModel() != VEHICLE_BOAT )     // Commented until fully tested
+                    {
+                        float fSuspensionLimitSize = handling.data.fSuspensionUpperLimit - handling.data.fSuspensionLowerLimit;
+                        if (fSuspensionLimitSize > -0.1f && fSuspensionLimitSize < 0.1f)
+                        {
+                            if (fSuspensionLimitSize >= 0.f)
+                                handling.data.fSuspensionUpperLimit = handling.data.fSuspensionLowerLimit + 0.1f;
+                            else
+                                handling.data.fSuspensionUpperLimit = handling.data.fSuspensionLowerLimit - 0.1f;
+                        }
+                    }
+                    BitStream.Write(&handling);
                 }
+                else
+                    BitStream.WriteBit(false);
 
-                case CElement::TEAM:
+                if (BitStream.Version() >= 0x02B)
                 {
-                    CTeam* pTeam = static_cast<CTeam*>(pElement);
+                    unsigned char ucSirenCount = pVehicle->m_tSirenBeaconInfo.m_ucSirenCount;
+                    unsigned char ucSirenType = pVehicle->m_tSirenBeaconInfo.m_ucSirenType;
+                    bool          bSync = pVehicle->m_tSirenBeaconInfo.m_bOverrideSirens;
+                    BitStream.WriteBit(bSync);
+                    if (bSync)
+                    {
+                        BitStream.Write(ucSirenCount);
+                        BitStream.Write(ucSirenType);
 
-                    // Write the name
-                    const char*    szTeamName = pTeam->GetTeamName();
-                    unsigned short usNameLength = static_cast<unsigned short>(strlen(szTeamName));
-                    unsigned char  ucRed, ucGreen, ucBlue;
-                    pTeam->GetColor(ucRed, ucGreen, ucBlue);
-                    bool bFriendlyFire = pTeam->GetFriendlyFire();
-                    BitStream.WriteCompressed(usNameLength);
-                    BitStream.Write(szTeamName, usNameLength);
-                    BitStream.Write(ucRed);
-                    BitStream.Write(ucGreen);
-                    BitStream.Write(ucBlue);
-                    BitStream.WriteBit(bFriendlyFire);
-                    BitStream.Write(pTeam->CountPlayers());
-                    for (list<CPlayer*>::const_iterator iter = pTeam->PlayersBegin(); iter != pTeam->PlayersEnd(); ++iter)
-                        BitStream.Write((*iter)->GetID());
-
-                    break;
+                        for (int i = 0; i < ucSirenCount; i++)
+                        {
+                            SVehicleSirenSync syncData;
+                            syncData.data.m_bOverrideSirens = true;
+                            syncData.data.m_b360Flag = pVehicle->m_tSirenBeaconInfo.m_b360Flag;
+                            syncData.data.m_bDoLOSCheck = pVehicle->m_tSirenBeaconInfo.m_bDoLOSCheck;
+                            syncData.data.m_bUseRandomiser = pVehicle->m_tSirenBeaconInfo.m_bUseRandomiser;
+                            syncData.data.m_bEnableSilent = pVehicle->m_tSirenBeaconInfo.m_bSirenSilent;
+                            syncData.data.m_ucSirenID = i;
+                            syncData.data.m_vecSirenPositions = pVehicle->m_tSirenBeaconInfo.m_tSirenInfo[i].m_vecSirenPositions;
+                            syncData.data.m_colSirenColour = pVehicle->m_tSirenBeaconInfo.m_tSirenInfo[i].m_RGBBeaconColour;
+                            syncData.data.m_dwSirenMinAlpha = pVehicle->m_tSirenBeaconInfo.m_tSirenInfo[i].m_dwMinSirenAlpha;
+                            BitStream.Write(&syncData);
+                        }
+                    }
                 }
+                break;
+            }
 
-                case CElement::PED:
+            case CElement::MARKER:
+            {
+                CMarker* pMarker = static_cast<CMarker*>(pElement);
+
+                // Position
+                position.data.vecPosition = pMarker->GetPosition();
+                SilentlyFixIndeterminate(position.data.vecPosition);            // Crash fix for pre r6459 clients
+                BitStream.Write(&position);
+
+                // Type
+                SMarkerTypeSync markerType;
+                markerType.data.ucType = pMarker->GetMarkerType();
+                BitStream.Write(&markerType);
+
+                // Size
+                float fSize = pMarker->GetSize();
+                BitStream.Write(fSize);
+
+                // Colour
+                SColorSync color;
+                color = pMarker->GetColor();
+                BitStream.Write(&color);
+
+                // Write the target position vector eventually
+                if (markerType.data.ucType == CMarker::TYPE_CHECKPOINT || markerType.data.ucType == CMarker::TYPE_RING)
                 {
-                    CPed* pPed = static_cast<CPed*>(pElement);
-
-                    // position
-                    position.data.vecPosition = pPed->GetPosition();
-                    BitStream.Write(&position);
-
-                    // model
-                    unsigned short usModel = pPed->GetModel();
-                    BitStream.WriteCompressed(usModel);
-
-                    // rotation
-                    SPedRotationSync pedRotation;
-                    pedRotation.data.fRotation = pPed->GetRotation();
-                    BitStream.Write(&pedRotation);
-
-                    // health
-                    SPlayerHealthSync health;
-                    health.data.fValue = pPed->GetHealth();
-                    BitStream.Write(&health);
-
-                    // Armor
-                    SPlayerArmorSync armor;
-                    armor.data.fValue = pPed->GetArmor();
-                    BitStream.Write(&armor);
-
-                    // vehicle
-                    CVehicle* pVehicle = pPed->GetOccupiedVehicle();
-                    if (pVehicle)
+                    if (pMarker->HasTarget())
                     {
                         BitStream.WriteBit(true);
-                        BitStream.Write(pVehicle->GetID());
 
-                        SOccupiedSeatSync seat;
-                        seat.data.ucSeat = pPed->GetOccupiedVehicleSeat();
-                        BitStream.Write(&seat);
-                    }
-                    else
-                        BitStream.WriteBit(false);
-
-                    // flags
-                    BitStream.WriteBit(pPed->HasJetPack());
-                    BitStream.WriteBit(pPed->IsSyncable());
-                    BitStream.WriteBit(pPed->IsHeadless());
-                    BitStream.WriteBit(pPed->IsFrozen());
-
-                    // alpha
-                    SEntityAlphaSync alpha;
-                    alpha.data.ucAlpha = pPed->GetAlpha();
-                    BitStream.Write(&alpha);
-
-                    // Move anim
-                    if (BitStream.Version() > 0x4B)
-                    {
-                        uchar ucMoveAnim = pPed->GetMoveAnim();
-                        BitStream.Write(ucMoveAnim);
-                    }
-
-                    // clothes
-                    unsigned char   ucNumClothes = 0;
-                    CPlayerClothes* pClothes = pPed->GetClothes();
-                    for (unsigned char ucType = 0; ucType < PLAYER_CLOTHING_SLOTS; ucType++)
-                    {
-                        const SPlayerClothing* pClothing = pClothes->GetClothing(ucType);
-                        if (pClothing)
-                        {
-                            ucNumClothes++;
-                        }
-                    }
-                    BitStream.Write(ucNumClothes);
-                    for (unsigned char ucType = 0; ucType < PLAYER_CLOTHING_SLOTS; ucType++)
-                    {
-                        const SPlayerClothing* pClothing = pClothes->GetClothing(ucType);
-                        if (pClothing)
-                        {
-                            unsigned char ucTextureLength = static_cast<uchar>(strlen(pClothing->szTexture));
-                            unsigned char ucModelLength = static_cast<uchar>(strlen(pClothing->szModel));
-
-                            BitStream.Write(ucTextureLength);
-                            BitStream.Write(pClothing->szTexture, ucTextureLength);
-                            BitStream.Write(ucModelLength);
-                            BitStream.Write(pClothing->szModel, ucModelLength);
-                            BitStream.Write(ucType);
-                        }
-                    }
-
-                    // weapons
-                    if (BitStream.Version() >= 0x61)
-                    {
-                        // Get a list of weapons
-                        for (unsigned char slot = 0; slot < WEAPONSLOT_MAX; ++slot)
-                        {
-                            CWeapon* pWeapon = pPed->GetWeapon(slot);
-                            if (pWeapon->ucType != 0)
-                            {
-                                BitStream.Write(slot);
-                                BitStream.Write(pWeapon->ucType);
-                                BitStream.Write(pWeapon->usAmmo);
-
-                                // ammoInClip is not implemented generally
-                                // BitStream.Write ( pWeapon->usAmmoInClip );
-                            }
-                        }
-
-                        // Write end marker (slot)
-                        BitStream.Write((unsigned char)0xFF);
-
-                        // Send the current weapon spot
-                        unsigned char currentWeaponSlot = pPed->GetWeaponSlot();
-                        BitStream.Write(currentWeaponSlot);
-                    }
-
-                    break;
-                }
-
-                case CElement::DUMMY:
-                {
-                    CDummy* pDummy = static_cast<CDummy*>(pElement);
-
-                    // Type Name
-                    const char*    szTypeName = pDummy->GetTypeName().c_str();
-                    unsigned short usTypeNameLength = static_cast<unsigned short>(strlen(szTypeName));
-                    BitStream.WriteCompressed(usTypeNameLength);
-                    BitStream.Write(szTypeName, usTypeNameLength);
-
-                    // Position
-                    position.data.vecPosition = pDummy->GetPosition();
-                    if (position.data.vecPosition != CVector(0.0f, 0.0f, 0.0f))
-                    {
-                        BitStream.WriteBit(true);
+                        position.data.vecPosition = pMarker->GetTarget();
                         BitStream.Write(&position);
                     }
                     else
                         BitStream.WriteBit(false);
-
-                    break;
                 }
 
-                case CElement::PLAYER:
+                break;
+            }
+
+            case CElement::BLIP:
+            {
+                CBlip* pBlip = static_cast<CBlip*>(pElement);
+
+                // Grab the blip position
+                position.data.vecPosition = pBlip->GetPosition();
+                BitStream.Write(&position);
+
+                // Write the ordering id
+                BitStream.WriteCompressed(pBlip->m_sOrdering);
+
+                // Write the visible distance - 14 bits allows 16383.
+                SIntegerSync<unsigned short, 14> visibleDistance(std::min(pBlip->m_usVisibleDistance, (unsigned short)16383));
+                BitStream.Write(&visibleDistance);
+
+                // Write the icon
+                SIntegerSync<unsigned char, 6> icon(pBlip->m_ucIcon);
+                BitStream.Write(&icon);
+
+                // Write the size
+                SIntegerSync<unsigned char, 5> size(pBlip->m_ucSize);
+                BitStream.Write(&size);
+
+                // Write the color
+                SColorSync color;
+                color = pBlip->GetColor();
+                BitStream.Write(&color);
+
+                break;
+            }
+
+            case CElement::RADAR_AREA:
+            {
+                CRadarArea* pArea = static_cast<CRadarArea*>(pElement);
+
+                // Write the position
+                SPosition2DSync position2D(false);
+                position2D.data.vecPosition = pArea->GetPosition();
+                SilentlyFixIndeterminate(position2D.data.vecPosition);            // Crash fix for pre r6459 clients
+                BitStream.Write(&position2D);
+
+                // Write the size
+                SPosition2DSync size2D(false);
+                size2D.data.vecPosition = pArea->GetSize();
+                SilentlyFixIndeterminate(size2D.data.vecPosition);            // Crash fix for pre r6459 clients
+                BitStream.Write(&size2D);
+
+                // And the color
+                SColor color = pArea->GetColor();
+                BitStream.Write(color.R);
+                BitStream.Write(color.G);
+                BitStream.Write(color.B);
+                BitStream.Write(color.A);
+
+                // Write whether it is flashing
+                bool bIsFlashing = pArea->IsFlashing();
+                BitStream.WriteBit(bIsFlashing);
+
+                break;
+            }
+
+            case CElement::WORLD_MESH_UNUSED:
+            {
+                /*
+                CWorldMesh* pMesh = static_cast < CWorldMesh* > ( pElement );
+
+                // Write the name
+                char* szName = pMesh->GetName ();
+                unsigned short usNameLength = static_cast < unsigned short > ( strlen ( szName ) );
+                BitStream.Write ( usNameLength );
+                BitStream.Write ( szName, static_cast < int > ( usNameLength ) );
+
+                // Write the position and rotation
+                CVector vecTemp = pMesh->GetPosition ();
+                BitStream.Write ( vecTemp.fX );
+                BitStream.Write ( vecTemp.fY );
+                BitStream.Write ( vecTemp.fZ );
+
+                vecTemp = pMesh->GetRotation ();
+                BitStream.Write ( vecTemp.fX );
+                BitStream.Write ( vecTemp.fY );
+                BitStream.Write ( vecTemp.fZ );
+                */
+
+                break;
+            }
+
+            case CElement::TEAM:
+            {
+                CTeam* pTeam = static_cast<CTeam*>(pElement);
+
+                // Write the name
+                const char*    szTeamName = pTeam->GetTeamName();
+                unsigned short usNameLength = static_cast<unsigned short>(strlen(szTeamName));
+                unsigned char  ucRed, ucGreen, ucBlue;
+                pTeam->GetColor(ucRed, ucGreen, ucBlue);
+                bool bFriendlyFire = pTeam->GetFriendlyFire();
+                BitStream.WriteCompressed(usNameLength);
+                BitStream.Write(szTeamName, usNameLength);
+                BitStream.Write(ucRed);
+                BitStream.Write(ucGreen);
+                BitStream.Write(ucBlue);
+                BitStream.WriteBit(bFriendlyFire);
+                BitStream.Write(pTeam->CountPlayers());
+                for (list<CPlayer*>::const_iterator iter = pTeam->PlayersBegin(); iter != pTeam->PlayersEnd(); ++iter)
+                    BitStream.Write((*iter)->GetID());
+
+                break;
+            }
+
+            case CElement::PED:
+            {
+                CPed* pPed = static_cast<CPed*>(pElement);
+
+                // position
+                position.data.vecPosition = pPed->GetPosition();
+                BitStream.Write(&position);
+
+                // model
+                unsigned short usModel = pPed->GetModel();
+                BitStream.WriteCompressed(usModel);
+
+                // rotation
+                SPedRotationSync pedRotation;
+                pedRotation.data.fRotation = pPed->GetRotation();
+                BitStream.Write(&pedRotation);
+
+                // health
+                SPlayerHealthSync health;
+                health.data.fValue = pPed->GetHealth();
+                BitStream.Write(&health);
+
+                // Armor
+                SPlayerArmorSync armor;
+                armor.data.fValue = pPed->GetArmor();
+                BitStream.Write(&armor);
+
+                // vehicle
+                CVehicle* pVehicle = pPed->GetOccupiedVehicle();
+                if (pVehicle)
                 {
-                    break;
+                    BitStream.WriteBit(true);
+                    BitStream.Write(pVehicle->GetID());
+
+                    SOccupiedSeatSync seat;
+                    seat.data.ucSeat = pPed->GetOccupiedVehicleSeat();
+                    BitStream.Write(&seat);
+                }
+                else
+                    BitStream.WriteBit(false);
+
+                // flags
+                BitStream.WriteBit(pPed->HasJetPack());
+                BitStream.WriteBit(pPed->IsSyncable());
+                BitStream.WriteBit(pPed->IsHeadless());
+                BitStream.WriteBit(pPed->IsFrozen());
+
+                // alpha
+                SEntityAlphaSync alpha;
+                alpha.data.ucAlpha = pPed->GetAlpha();
+                BitStream.Write(&alpha);
+
+                // Move anim
+                if (BitStream.Version() > 0x4B)
+                {
+                    uchar ucMoveAnim = pPed->GetMoveAnim();
+                    BitStream.Write(ucMoveAnim);
                 }
 
-                case CElement::SCRIPTFILE:
+                // clothes
+                unsigned char   ucNumClothes = 0;
+                CPlayerClothes* pClothes = pPed->GetClothes();
+                for (unsigned char ucType = 0; ucType < PLAYER_CLOTHING_SLOTS; ucType++)
                 {
-                    // No extra data
-                    break;
-                }
-
-                case CElement::COLSHAPE:
-                {
-                    CColShape* pColShape = static_cast<CColShape*>(pElement);
-                    if (!pColShape->GetParentEntity())
+                    const SPlayerClothing* pClothing = pClothes->GetClothing(ucType);
+                    if (pClothing)
                     {
-                        // Jax: i'm pretty sure this is fucking up our packet somehow..
-                        // all valid col-shapes should have a parent!
-                        assert(false);
+                        ucNumClothes++;
+                    }
+                }
+                BitStream.Write(ucNumClothes);
+                for (unsigned char ucType = 0; ucType < PLAYER_CLOTHING_SLOTS; ucType++)
+                {
+                    const SPlayerClothing* pClothing = pClothes->GetClothing(ucType);
+                    if (pClothing)
+                    {
+                        unsigned char ucTextureLength = static_cast<uchar>(strlen(pClothing->szTexture));
+                        unsigned char ucModelLength = static_cast<uchar>(strlen(pClothing->szModel));
+
+                        BitStream.Write(ucTextureLength);
+                        BitStream.Write(pClothing->szTexture, ucTextureLength);
+                        BitStream.Write(ucModelLength);
+                        BitStream.Write(pClothing->szModel, ucModelLength);
+                        BitStream.Write(ucType);
+                    }
+                }
+
+                // weapons
+                if (BitStream.Version() >= 0x61)
+                {
+                    // Get a list of weapons
+                    for (unsigned char slot = 0; slot < WEAPONSLOT_MAX; ++slot)
+                    {
+                        CWeapon* pWeapon = pPed->GetWeapon(slot);
+                        if (pWeapon->ucType != 0)
+                        {
+                            BitStream.Write(slot);
+                            BitStream.Write(pWeapon->ucType);
+                            BitStream.Write(pWeapon->usAmmo);
+
+                            // ammoInClip is not implemented generally
+                            // BitStream.Write ( pWeapon->usAmmoInClip );
+                        }
                     }
 
-                    // Type
-                    SColshapeTypeSync colType;
-                    colType.data.ucType = static_cast<unsigned char>(pColShape->GetShapeType());
-                    BitStream.Write(&colType);
+                    // Write end marker (slot)
+                    BitStream.Write((unsigned char)0xFF);
 
-                    // Position
-                    position.data.vecPosition = pColShape->GetPosition();
+                    // Send the current weapon spot
+                    unsigned char currentWeaponSlot = pPed->GetWeaponSlot();
+                    BitStream.Write(currentWeaponSlot);
+                }
+
+                break;
+            }
+
+            case CElement::DUMMY:
+            {
+                CDummy* pDummy = static_cast<CDummy*>(pElement);
+
+                // Type Name
+                const char*    szTypeName = pDummy->GetTypeName().c_str();
+                unsigned short usTypeNameLength = static_cast<unsigned short>(strlen(szTypeName));
+                BitStream.WriteCompressed(usTypeNameLength);
+                BitStream.Write(szTypeName, usTypeNameLength);
+
+                // Position
+                position.data.vecPosition = pDummy->GetPosition();
+                if (position.data.vecPosition != CVector(0.0f, 0.0f, 0.0f))
+                {
+                    BitStream.WriteBit(true);
                     BitStream.Write(&position);
-
-                    // Enabled
-                    BitStream.WriteBit(pColShape->IsEnabled());
-
-                    // Auto Call Event
-                    BitStream.WriteBit(pColShape->GetAutoCallEvent());
-
-                    switch (pColShape->GetShapeType())
-                    {
-                        case COLSHAPE_CIRCLE:
-                        {
-                            BitStream.Write(static_cast<CColCircle*>(pColShape)->GetRadius());
-                            break;
-                        }
-                        case COLSHAPE_CUBOID:
-                        {
-                            SPositionSync size(false);
-                            size.data.vecPosition = static_cast<CColCuboid*>(pColShape)->GetSize();
-                            BitStream.Write(&size);
-                            break;
-                        }
-                        case COLSHAPE_SPHERE:
-                        {
-                            BitStream.Write(static_cast<CColSphere*>(pColShape)->GetRadius());
-                            break;
-                        }
-                        case COLSHAPE_RECTANGLE:
-                        {
-                            SPosition2DSync size(false);
-                            size.data.vecPosition = static_cast<CColRectangle*>(pColShape)->GetSize();
-                            BitStream.Write(&size);
-                            break;
-                        }
-                        case COLSHAPE_TUBE:
-                        {
-                            BitStream.Write(static_cast<CColTube*>(pColShape)->GetRadius());
-                            BitStream.Write(static_cast<CColTube*>(pColShape)->GetHeight());
-                            break;
-                        }
-                        case COLSHAPE_POLYGON:
-                        {
-                            CColPolygon* pPolygon = static_cast<CColPolygon*>(pColShape);
-                            BitStream.WriteCompressed(pPolygon->CountPoints());
-                            std::vector<CVector2D>::const_iterator iter = pPolygon->IterBegin();
-                            for (; iter != pPolygon->IterEnd(); ++iter)
-                            {
-                                SPosition2DSync vertex(false);
-                                vertex.data.vecPosition = *iter;
-                                BitStream.Write(&vertex);
-                            }
-
-                            if (BitStream.Can(eBitStreamVersion::SetColPolygonHeight))
-                            {
-                                float fFloor, fCeil;
-                                pPolygon->GetHeight(fFloor, fCeil);
-
-                                BitStream.Write(fFloor);
-                                BitStream.Write(fCeil);
-                            }
-                            break;
-                        }
-                        default:
-                            break;
-                    }
-                    break;
                 }
+                else
+                    BitStream.WriteBit(false);
 
-                case CElement::WATER:
+                break;
+            }
+
+            case CElement::PLAYER:
+            {
+                break;
+            }
+
+            case CElement::SCRIPTFILE:
+            {
+                // No extra data
+                break;
+            }
+
+            case CElement::COLSHAPE:
+            {
+                CColShape* pColShape = static_cast<CColShape*>(pElement);
+                if (!pColShape->GetParentEntity())
                 {
-                    CWater*       pWater = static_cast<CWater*>(pElement);
-                    unsigned char ucNumVertices = (unsigned char)pWater->GetNumVertices();
-                    BitStream.Write(ucNumVertices);
-                    CVector vecVertex;
-                    for (int i = 0; i < ucNumVertices; i++)
-                    {
-                        pWater->GetVertex(i, vecVertex);
-                        BitStream.Write((short)vecVertex.fX);
-                        BitStream.Write((short)vecVertex.fY);
-                        BitStream.Write(vecVertex.fZ);
-                    }
-                    if (BitStream.Can(eBitStreamVersion::Water_bShallow_ServerSide))
-                        BitStream.WriteBit(pWater->IsWaterShallow());
-                    break;
+                    // Jax: i'm pretty sure this is fucking up our packet somehow..
+                    // all valid col-shapes should have a parent!
+                    assert(false);
                 }
 
-                default:
+                // Type
+                SColshapeTypeSync colType;
+                colType.data.ucType = static_cast<unsigned char>(pColShape->GetShapeType());
+                BitStream.Write(&colType);
+
+                // Position
+                position.data.vecPosition = pColShape->GetPosition();
+                BitStream.Write(&position);
+
+                // Enabled
+                BitStream.WriteBit(pColShape->IsEnabled());
+
+                // Auto Call Event
+                BitStream.WriteBit(pColShape->GetAutoCallEvent());
+
+                switch (pColShape->GetShapeType())
                 {
-                    assert(0);
-                    CLogger::LogPrintf("not sending this element - id: %i\n", pElement->GetType());
+                    case COLSHAPE_CIRCLE:
+                    {
+                        BitStream.Write(static_cast<CColCircle*>(pColShape)->GetRadius());
+                        break;
+                    }
+                    case COLSHAPE_CUBOID:
+                    {
+                        SPositionSync size(false);
+                        size.data.vecPosition = static_cast<CColCuboid*>(pColShape)->GetSize();
+                        BitStream.Write(&size);
+                        break;
+                    }
+                    case COLSHAPE_SPHERE:
+                    {
+                        BitStream.Write(static_cast<CColSphere*>(pColShape)->GetRadius());
+                        break;
+                    }
+                    case COLSHAPE_RECTANGLE:
+                    {
+                        SPosition2DSync size(false);
+                        size.data.vecPosition = static_cast<CColRectangle*>(pColShape)->GetSize();
+                        BitStream.Write(&size);
+                        break;
+                    }
+                    case COLSHAPE_TUBE:
+                    {
+                        BitStream.Write(static_cast<CColTube*>(pColShape)->GetRadius());
+                        BitStream.Write(static_cast<CColTube*>(pColShape)->GetHeight());
+                        break;
+                    }
+                    case COLSHAPE_POLYGON:
+                    {
+                        CColPolygon* pPolygon = static_cast<CColPolygon*>(pColShape);
+                        BitStream.WriteCompressed(pPolygon->CountPoints());
+                        std::vector<CVector2D>::const_iterator iter = pPolygon->IterBegin();
+                        for (; iter != pPolygon->IterEnd(); ++iter)
+                        {
+                            SPosition2DSync vertex(false);
+                            vertex.data.vecPosition = *iter;
+                            BitStream.Write(&vertex);
+                        }
+
+                        if (BitStream.Can(eBitStreamVersion::SetColPolygonHeight))
+                        {
+                            float fFloor, fCeil;
+                            pPolygon->GetHeight(fFloor, fCeil);
+
+                            BitStream.Write(fFloor);
+                            BitStream.Write(fCeil);
+                        }
+                        break;
+                    }
+                    default:
+                        break;
                 }
+                break;
+            }
+
+            case CElement::WATER:
+            {
+                CWater*       pWater = static_cast<CWater*>(pElement);
+                unsigned char ucNumVertices = (unsigned char)pWater->GetNumVertices();
+                BitStream.Write(ucNumVertices);
+                CVector vecVertex;
+                for (int i = 0; i < ucNumVertices; i++)
+                {
+                    pWater->GetVertex(i, vecVertex);
+                    BitStream.Write((short)vecVertex.fX);
+                    BitStream.Write((short)vecVertex.fY);
+                    BitStream.Write(vecVertex.fZ);
+                }
+                if (BitStream.Can(eBitStreamVersion::Water_bShallow_ServerSide))
+                    BitStream.WriteBit(pWater->IsWaterShallow());
+                break;
+            }
+
+            default:
+            {
+                assert(0);
+                CLogger::LogPrintf("not sending this element - id: %i\n", pElement->GetType());
             }
         }
-
-        // Success
-        return true;
     }
 
-    return false;
+    // Success
+    return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CEntityAddPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CEntityAddPacket.h
@@ -17,8 +17,8 @@
 class CEntityAddPacket final : public CPacket
 {
 public:
-    ePacketID     GetPacketID() const { return PACKET_ID_ENTITY_ADD; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_ENTITY_ADD; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CEntityAddPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CEntityAddPacket.h
@@ -17,13 +17,13 @@
 class CEntityAddPacket final : public CPacket
 {
 public:
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_ENTITY_ADD; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_ENTITY_ADD; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    void Add(class CElement* pElement);
-    void Clear() { m_Entities.clear(); };
+    void Add(class CElement* pElement) noexcept;
+    void Clear() noexcept { m_Entities.clear(); }
 
 private:
     std::vector<class CElement*> m_Entities;

--- a/Server/mods/deathmatch/logic/packets/CEntityRemovePacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CEntityRemovePacket.cpp
@@ -13,13 +13,12 @@
 #include "CEntityRemovePacket.h"
 #include "CElement.h"
 
-bool CEntityRemovePacket::Write(NetBitStreamInterface& BitStream) const
+bool CEntityRemovePacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     // Write each entity type then id to it
-    std::vector<CElement*>::const_iterator iter = m_List.begin();
-    for (; iter != m_List.end(); ++iter)
+    for (const auto& pElem : m_List)
     {
-        BitStream.Write((*iter)->GetID());
+        BitStream.Write(pElem->GetID());
     }
 
     return m_List.size() > 0;

--- a/Server/mods/deathmatch/logic/packets/CEntityRemovePacket.h
+++ b/Server/mods/deathmatch/logic/packets/CEntityRemovePacket.h
@@ -17,13 +17,13 @@
 class CEntityRemovePacket final : public CPacket
 {
 public:
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_ENTITY_REMOVE; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_ENTITY_REMOVE; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    void Add(class CElement* pElement) { m_List.push_back(pElement); };
-    void Clear() { m_List.clear(); };
+    void Add(class CElement* pElement) noexcept { m_List.push_back(pElement); }
+    void Clear() noexcept { m_List.clear(); }
 
 private:
     std::vector<class CElement*> m_List;

--- a/Server/mods/deathmatch/logic/packets/CEntityRemovePacket.h
+++ b/Server/mods/deathmatch/logic/packets/CEntityRemovePacket.h
@@ -17,8 +17,8 @@
 class CEntityRemovePacket final : public CPacket
 {
 public:
-    ePacketID     GetPacketID() const { return PACKET_ID_ENTITY_REMOVE; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_ENTITY_REMOVE; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CExplosionSyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CExplosionSyncPacket.cpp
@@ -27,7 +27,7 @@ CExplosionSyncPacket::CExplosionSyncPacket(const CVector& vecPosition, std::uint
     m_ucType = ucType;
 }
 
-bool CExplosionSyncPacket::Read(NetBitStreamInterface& BitStream)
+bool CExplosionSyncPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     bool bHasOrigin;
     if (!BitStream.ReadBit(bHasOrigin))
@@ -59,7 +59,7 @@ bool CExplosionSyncPacket::Read(NetBitStreamInterface& BitStream)
     return true;
 }
 
-bool CExplosionSyncPacket::Write(NetBitStreamInterface& BitStream) const
+bool CExplosionSyncPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     // Write the source player and latency if any. Otherwize 0
     if (m_pSourceElement)
@@ -68,7 +68,7 @@ bool CExplosionSyncPacket::Write(NetBitStreamInterface& BitStream) const
         ElementID ID = m_pSourceElement->GetID();
         BitStream.Write(ID);
 
-        unsigned short usLatency = static_cast<CPlayer*>(m_pSourceElement)->GetPing();
+        std::uint16_t usLatency = static_cast<CPlayer*>(m_pSourceElement)->GetPing();
         BitStream.WriteCompressed(usLatency);
     }
     else

--- a/Server/mods/deathmatch/logic/packets/CExplosionSyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CExplosionSyncPacket.cpp
@@ -14,13 +14,13 @@
 #include "CPlayer.h"
 #include <net/SyncStructures.h>
 
-CExplosionSyncPacket::CExplosionSyncPacket()
+CExplosionSyncPacket::CExplosionSyncPacket() noexcept
 {
     m_OriginID = INVALID_ELEMENT_ID;
     m_ucType = EXPLOSION_SMALL;
 }
 
-CExplosionSyncPacket::CExplosionSyncPacket(const CVector& vecPosition, unsigned char ucType)
+CExplosionSyncPacket::CExplosionSyncPacket(const CVector& vecPosition, std::uint8_t ucType) noexcept
 {
     m_OriginID = INVALID_ELEMENT_ID;
     m_vecPosition = vecPosition;
@@ -47,18 +47,16 @@ bool CExplosionSyncPacket::Read(NetBitStreamInterface& BitStream)
     }
 
     SPositionSync position(false);
-    if (BitStream.Read(&position))
-    {
-        SExplosionTypeSync explosionType;
-        if (BitStream.Read(&explosionType))
-        {
-            m_vecPosition = position.data.vecPosition;
-            m_ucType = explosionType.data.uiType;
-            return true;
-        }
-    }
+    if (!BitStream.Read(&position))
+        return false;
+    
+    SExplosionTypeSync explosionType;
+    if (!BitStream.Read(&explosionType))
+        return false;
 
-    return false;
+    m_vecPosition = position.data.vecPosition;
+    m_ucType = explosionType.data.uiType;
+    return true;
 }
 
 bool CExplosionSyncPacket::Write(NetBitStreamInterface& BitStream) const

--- a/Server/mods/deathmatch/logic/packets/CExplosionSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CExplosionSyncPacket.h
@@ -34,18 +34,18 @@ public:
         EXPLOSION_TINY,
     };
 
-    CExplosionSyncPacket();
-    CExplosionSyncPacket(const CVector& vecPosition, unsigned char ucType);
+    CExplosionSyncPacket() noexcept;
+    CExplosionSyncPacket(const CVector& vecPosition, std::uint8_t ucType) noexcept;
 
-    ePacketID     GetPacketID() const { return PACKET_ID_EXPLOSION; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_EXPLOSION; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    ElementID     m_OriginID;
-    CVector       m_vecPosition;
-    unsigned char m_ucType;
+    ElementID    m_OriginID;
+    CVector      m_vecPosition;
+    std::uint8_t m_ucType;
 
     bool m_isVehicleResponsible = false;
     bool m_blowVehicleWithoutExplosion = false;

--- a/Server/mods/deathmatch/logic/packets/CFireSyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CFireSyncPacket.cpp
@@ -13,24 +13,25 @@
 #include "CFireSyncPacket.h"
 #include "CPlayer.h"
 
-CFireSyncPacket::CFireSyncPacket()
+CFireSyncPacket::CFireSyncPacket() noexcept
 {
     // Default size
     m_fSize = 1.8f;
 }
 
-CFireSyncPacket::CFireSyncPacket(const CVector& vecPosition, float fSize)
+CFireSyncPacket::CFireSyncPacket(const CVector& vecPosition, float fSize) noexcept
 {
     m_vecPosition = vecPosition;
     m_fSize = fSize;
 }
 
-bool CFireSyncPacket::Read(NetBitStreamInterface& BitStream)
+bool CFireSyncPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
-    return (BitStream.Read(m_vecPosition.fX) && BitStream.Read(m_vecPosition.fY) && BitStream.Read(m_vecPosition.fZ) && BitStream.Read(m_fSize));
+    return BitStream.Read(m_vecPosition.fX) && BitStream.Read(m_vecPosition.fY)
+        && BitStream.Read(m_vecPosition.fZ) && BitStream.Read(m_fSize);
 }
 
-bool CFireSyncPacket::Write(NetBitStreamInterface& BitStream) const
+bool CFireSyncPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     // Write the source player and latency if any. Otherwize 0
     if (m_pSourceElement)
@@ -38,13 +39,13 @@ bool CFireSyncPacket::Write(NetBitStreamInterface& BitStream) const
         ElementID ID = m_pSourceElement->GetID();
         BitStream.Write(ID);
 
-        unsigned short usLatency = static_cast<CPlayer*>(m_pSourceElement)->GetPing();
+        std::uint16_t usLatency = static_cast<CPlayer*>(m_pSourceElement)->GetPing();
         BitStream.WriteCompressed(usLatency);
     }
     else
     {
         BitStream.Write(static_cast<ElementID>(INVALID_ELEMENT_ID));
-        BitStream.WriteCompressed(static_cast<unsigned short>(0));
+        BitStream.WriteCompressed(static_cast<std::uint16_t>(0));
     }
 
     // Write position and size

--- a/Server/mods/deathmatch/logic/packets/CFireSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CFireSyncPacket.h
@@ -17,14 +17,14 @@
 class CFireSyncPacket final : public CPacket
 {
 public:
-    CFireSyncPacket();
-    CFireSyncPacket(const CVector& vecPosition, float fSize);
+    CFireSyncPacket() noexcept;
+    CFireSyncPacket(const CVector& vecPosition, float fSize) noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_FIRE; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_FIRE; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
     CVector m_vecPosition;

--- a/Server/mods/deathmatch/logic/packets/CFireSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CFireSyncPacket.h
@@ -20,8 +20,8 @@ public:
     CFireSyncPacket();
     CFireSyncPacket(const CVector& vecPosition, float fSize);
 
-    ePacketID     GetPacketID() const { return PACKET_ID_FIRE; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_FIRE; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Read(NetBitStreamInterface& BitStream);
     bool Write(NetBitStreamInterface& BitStream) const;

--- a/Server/mods/deathmatch/logic/packets/CKeysyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CKeysyncPacket.h
@@ -21,8 +21,8 @@ public:
     CKeysyncPacket(class CPlayer* pPlayer);
 
     bool          HasSimHandler() const { return true; }
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_KEYSYNC; };
-    unsigned long GetFlags() const { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_KEYSYNC; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
 
     bool Read(NetBitStreamInterface& BitStream);
     bool Write(NetBitStreamInterface& BitStream) const;

--- a/Server/mods/deathmatch/logic/packets/CKeysyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CKeysyncPacket.h
@@ -17,17 +17,17 @@
 class CKeysyncPacket final : public CPacket
 {
 public:
-    CKeysyncPacket(){};
-    CKeysyncPacket(class CPlayer* pPlayer);
+    CKeysyncPacket() noexcept {};
+    CKeysyncPacket(class CPlayer* pPlayer) noexcept;
 
-    bool          HasSimHandler() const { return true; }
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_KEYSYNC; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
+    bool          HasSimHandler() const noexcept { return true; }
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_KEYSYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
-    void ReadVehicleSpecific(class CVehicle* pVehicle, NetBitStreamInterface& BitStream);
-    void WriteVehicleSpecific(class CVehicle* pVehicle, NetBitStreamInterface& BitStream) const;
+    void ReadVehicleSpecific(class CVehicle* pVehicle, NetBitStreamInterface& BitStream) noexcept;
+    void WriteVehicleSpecific(class CVehicle* pVehicle, NetBitStreamInterface& BitStream) const noexcept;
 };

--- a/Server/mods/deathmatch/logic/packets/CLightsyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CLightsyncPacket.h
@@ -20,12 +20,12 @@ class CLightsyncPacket final : public CPacket
 public:
     CLightsyncPacket() {}
 
-    ePacketID     GetPacketID() const { return PACKET_ID_LIGHTSYNC; };
-    unsigned long GetFlags() const { return PACKET_LOW_PRIORITY; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_LIGHTSYNC; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_LOW_PRIORITY; };
 
-    void         AddPlayer(CPlayer* pPlayer) { m_players.push_back(pPlayer); }
-    unsigned int Count() const { return m_players.size(); }
-    void         Reset() { m_players.clear(); }
+    void         AddPlayer(CPlayer* pPlayer) noexcept { m_players.push_back(pPlayer); }
+    std::size_t  Count() const noexcept { return m_players.size(); }
+    void         Reset() noexcept { m_players.clear(); }
 
     bool Read(NetBitStreamInterface& BitStream);
     bool Write(NetBitStreamInterface& BitStream) const;

--- a/Server/mods/deathmatch/logic/packets/CLightsyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CLightsyncPacket.h
@@ -18,17 +18,17 @@
 class CLightsyncPacket final : public CPacket
 {
 public:
-    CLightsyncPacket() {}
+    CLightsyncPacket() noexcept {}
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_LIGHTSYNC; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_LOW_PRIORITY; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_LIGHTSYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_LOW_PRIORITY; }
 
     void         AddPlayer(CPlayer* pPlayer) noexcept { m_players.push_back(pPlayer); }
     std::size_t  Count() const noexcept { return m_players.size(); }
     void         Reset() noexcept { m_players.clear(); }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
     std::vector<CPlayer*> m_players;

--- a/Server/mods/deathmatch/logic/packets/CLuaEventPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CLuaEventPacket.cpp
@@ -12,20 +12,20 @@
 #include "StdInc.h"
 #include "CLuaEventPacket.h"
 
-CLuaEventPacket::CLuaEventPacket()
+CLuaEventPacket::CLuaEventPacket() noexcept
 {
     m_ElementID = INVALID_ELEMENT_ID;
     m_pArguments = &m_ArgumentsStore;
 }
 
-CLuaEventPacket::CLuaEventPacket(const char* szName, ElementID ID, CLuaArguments* pArguments)
+CLuaEventPacket::CLuaEventPacket(const char* szName, ElementID ID, CLuaArguments* pArguments) noexcept
 {
     m_strName.AssignLeft(szName, MAX_EVENT_NAME_LENGTH);
     m_ElementID = ID;
     m_pArguments = pArguments;            // Use a pointer to save copying the arguments
 }
 
-bool CLuaEventPacket::Read(NetBitStreamInterface& BitStream)
+bool CLuaEventPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     std::uint16_t usNameLength;
     if (!BitStream.ReadCompressed(usNameLength))

--- a/Server/mods/deathmatch/logic/packets/CLuaEventPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CLuaEventPacket.h
@@ -17,18 +17,18 @@
 class CLuaEventPacket final : public CPacket
 {
 public:
-    CLuaEventPacket();
-    CLuaEventPacket(const char* szName, ElementID ID, CLuaArguments* pArguments);
+    CLuaEventPacket() noexcept;
+    CLuaEventPacket(const char* szName, ElementID ID, CLuaArguments* pArguments) noexcept;
 
-    ePacketID     GetPacketID() const { return PACKET_ID_LUA_EVENT; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_LUA_EVENT; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    const char*    GetName() { return m_strName; }
-    ElementID      GetElementID() { return m_ElementID; }
-    CLuaArguments* GetArguments() { return m_pArguments; }
+    const char*    GetName() const noexcept { return m_strName; }
+    ElementID      GetElementID() const noexcept { return m_ElementID; }
+    CLuaArguments* GetArguments() const noexcept { return m_pArguments; }
 
 private:
     SString        m_strName;

--- a/Server/mods/deathmatch/logic/packets/CLuaPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CLuaPacket.cpp
@@ -12,14 +12,14 @@
 #include "StdInc.h"
 #include "CLuaPacket.h"
 
-bool CLuaPacket::Write(NetBitStreamInterface& BitStream) const
+bool CLuaPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     // Write the action ID
     BitStream.Write(m_ucActionID);
 
     // Copy each byte from the bitstream we have to this one
-    unsigned char ucTemp;
-    int           iLength = m_BitStream.GetNumberOfBitsUsed();
+    std::uint8_t ucTemp;
+    auto iLength = m_BitStream.GetNumberOfBitsUsed();
     while (iLength > 8)
     {
         m_BitStream.Read(ucTemp);

--- a/Server/mods/deathmatch/logic/packets/CLuaPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CLuaPacket.h
@@ -16,14 +16,14 @@
 class CLuaPacket final : public CPacket
 {
 public:
-    CLuaPacket(unsigned char ucActionID, NetBitStreamInterface& BitStream) : m_ucActionID(ucActionID), m_BitStream(BitStream){};
+    CLuaPacket(std::uint8_t ucActionID, NetBitStreamInterface& BitStream) noexcept : m_ucActionID(ucActionID), m_BitStream(BitStream){};
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_LUA; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_LUA; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
-    unsigned char          m_ucActionID;
+    std::uint8_t           m_ucActionID;
     NetBitStreamInterface& m_BitStream;
 };

--- a/Server/mods/deathmatch/logic/packets/CLuaPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CLuaPacket.h
@@ -18,8 +18,8 @@ class CLuaPacket final : public CPacket
 public:
     CLuaPacket(unsigned char ucActionID, NetBitStreamInterface& BitStream) : m_ucActionID(ucActionID), m_BitStream(BitStream){};
 
-    ePacketID     GetPacketID() const { return PACKET_ID_LUA; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_LUA; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CMapInfoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CMapInfoPacket.cpp
@@ -17,18 +17,18 @@
 #include "CBuildingRemovalManager.h"
 #include <net/SyncStructures.h>
 
-CMapInfoPacket::CMapInfoPacket(unsigned char ucWeather, unsigned char ucWeatherBlendingTo, unsigned char ucBlendedWeatherHour, unsigned char ucClockHour,
-                               unsigned char ucClockMin, unsigned long ulMinuteDuration, bool bShowNametags, bool bShowRadar, float fGravity, float fGameSpeed,
+CMapInfoPacket::CMapInfoPacket(std::uint8_t ucWeather, std::uint8_t ucWeatherBlendingTo, std::uint8_t ucBlendedWeatherHour, std::uint8_t ucClockHour,
+                               std::uint8_t ucClockMin, unsigned long ulMinuteDuration, bool bShowNametags, bool bShowRadar, float fGravity, float fGameSpeed,
                                float fWaveHeight, const SWorldWaterLevelInfo& worldWaterLevelInfo, bool bHasSkyGradient, const SGarageStates& garageStates,
-                               unsigned char ucSkyGradientTR, unsigned char ucSkyGradientTG, unsigned char ucSkyGradientTB, unsigned char ucSkyGradientBR,
-                               unsigned char ucSkyGradientBG, unsigned char ucSkyGradientBB, bool bHasHeatHaze, const SHeatHazeSettings& heatHazeSettings,
-                               unsigned short usFPSLimit, bool bCloudsEnabled, float fJetpackMaxHeight, bool bOverrideWaterColor, unsigned char ucWaterRed,
-                               unsigned char ucWaterGreen, unsigned char ucWaterBlue, unsigned char ucWaterAlpha, bool bInteriorSoundsEnabled,
+                               std::uint8_t ucSkyGradientTR, std::uint8_t ucSkyGradientTG, std::uint8_t ucSkyGradientTB, std::uint8_t ucSkyGradientBR,
+                               std::uint8_t ucSkyGradientBG, std::uint8_t ucSkyGradientBB, bool bHasHeatHaze, const SHeatHazeSettings& heatHazeSettings,
+                               std::uint16_t usFPSLimit, bool bCloudsEnabled, float fJetpackMaxHeight, bool bOverrideWaterColor, std::uint8_t ucWaterRed,
+                               std::uint8_t ucWaterGreen, std::uint8_t ucWaterBlue, std::uint8_t ucWaterAlpha, bool bInteriorSoundsEnabled,
                                bool bOverrideRainLevel, float fRainLevel, bool bOverrideSunSize, float fSunSize, bool bOverrideSunColor,
-                               unsigned char ucSunCoreR, unsigned char ucSunCoreG, unsigned char ucSunCoreB, unsigned char ucSunCoronaR,
-                               unsigned char ucSunCoronaG, unsigned char ucSunCoronaB, bool bOverrideWindVelocity, float fWindVelX, float fWindVelY,
+                               std::uint8_t ucSunCoreR, std::uint8_t ucSunCoreG, std::uint8_t ucSunCoreB, std::uint8_t ucSunCoronaR,
+                               std::uint8_t ucSunCoronaG, std::uint8_t ucSunCoronaB, bool bOverrideWindVelocity, float fWindVelX, float fWindVelY,
                                float fWindVelZ, bool bOverrideFarClipDistance, float fFarClip, bool bOverrideFogDistance, float fFogDistance,
-                               float fAircraftMaxHeight, float fAircraftMaxVelocity, bool bOverrideMoonSize, int iMoonSize)
+                               float fAircraftMaxHeight, float fAircraftMaxVelocity, bool bOverrideMoonSize, int iMoonSize) noexcept
 {
     m_ucWeather = ucWeather;
     m_ucWeatherBlendingTo = ucWeatherBlendingTo;
@@ -86,7 +86,7 @@ CMapInfoPacket::CMapInfoPacket(unsigned char ucWeather, unsigned char ucWeatherB
     m_iMoonSize = iMoonSize;
 }
 
-bool CMapInfoPacket::Write(NetBitStreamInterface& BitStream) const
+bool CMapInfoPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     // Write the map weather
     BitStream.Write(m_ucWeather);
@@ -153,7 +153,7 @@ bool CMapInfoPacket::Write(NetBitStreamInterface& BitStream) const
     BitStream.WriteCompressed(m_usFPSLimit);
 
     // Write the garage states
-    for (unsigned char i = 0; i < MAX_GARAGES; i++)
+    for (auto i = 0; i < MAX_GARAGES; i++)
     {
         const SGarageStates& garageStates = *m_pGarageStates;
         BitStream.WriteBit(garageStates[i]);
@@ -314,7 +314,7 @@ bool CMapInfoPacket::Write(NetBitStreamInterface& BitStream) const
     {
         sWeaponPropertySync WeaponProperty;
         BitStream.WriteBit(true);
-        for (int j = 0; j <= 2; j++)
+        for (auto j = 0; j <= 2; j++)
         {
             CWeaponStat* pWeaponStat = g_pGame->GetWeaponStatManager()->GetWeaponStats((eWeaponType)i, (eWeaponSkill)j);
             WeaponProperty.data.weaponType = (int)pWeaponStat->GetWeaponType();
@@ -352,7 +352,7 @@ bool CMapInfoPacket::Write(NetBitStreamInterface& BitStream) const
         }
     }
 
-    multimap<unsigned short, CBuildingRemoval*>::const_iterator iter = g_pGame->GetBuildingRemovalManager()->IterBegin();
+    auto iter = g_pGame->GetBuildingRemovalManager()->IterBegin();
     for (; iter != g_pGame->GetBuildingRemovalManager()->IterEnd(); ++iter)
     {
         CBuildingRemoval* pBuildingRemoval = (*iter).second;

--- a/Server/mods/deathmatch/logic/packets/CMapInfoPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CMapInfoPacket.h
@@ -41,8 +41,8 @@ public:
                             bool bOverrideFarClipDistance = false, float fFarClip = 0, bool bOverrideFogDistance = false, float fFogDistance = 0,
                             float fAircraftMaxHeight = 800, float fAircraftMaxVelocity = 1.5f, bool bOverrideMoonSize = false, int iMoonSize = 3);
 
-    ePacketID     GetPacketID() const { return PACKET_ID_MAP_INFO; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_MAP_INFO; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CMapInfoPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CMapInfoPacket.h
@@ -27,31 +27,43 @@ struct SWorldWaterLevelInfo
 class CMapInfoPacket final : public CPacket
 {
 public:
-    explicit CMapInfoPacket(unsigned char ucWeather, unsigned char ucWeatherBlendingTo, unsigned char ucBlendedWeatherHour, unsigned char ucClockHour,
-                            unsigned char ucClockMin, unsigned long ulMinuteDuration, bool bShowNametags, bool bShowRadar, float fGravity, float fGameSpeed,
-                            float fWaveHeight, const SWorldWaterLevelInfo& worldWaterLevelInfo, bool bHasSkyGradient, const SGarageStates& garageStates,
-                            unsigned char ucSkyGradientTR, unsigned char ucSkyGradientTG, unsigned char ucSkyGradientTB, unsigned char ucSkyGradientBR,
-                            unsigned char ucSkyGradientBG, unsigned char ucSkyGradientBB, bool bHasHeatHaze, const SHeatHazeSettings& heatHazeSettings,
-                            unsigned short usFPSLimit = 36, bool bCloudsEnabled = true, float fJetpackMaxHeight = 100, bool bOverrideWaterColor = false,
-                            unsigned char ucWaterRed = 0, unsigned char ucWaterGreen = 0, unsigned char ucWaterBlue = 0, unsigned char ucWaterAlpha = 0,
-                            bool bInteriorSoundsEnabled = true, bool bOverrideRainLevel = false, float fRainLevel = 0, bool bOverrideSunSize = false,
-                            float fSunSize = 0, bool bOverrideSunColor = false, unsigned char ucSunCoreR = 0, unsigned char ucSunCoreG = 0,
-                            unsigned char ucSunCoreB = 0, unsigned char ucSunCoronaR = 0, unsigned char ucSunCoronaG = 0, unsigned char ucSunCoronaB = 0,
-                            bool bOverrideWindVelocity = false, float fWindVelX = 0, float fWindVelY = 0, float fWindVelZ = 0,
-                            bool bOverrideFarClipDistance = false, float fFarClip = 0, bool bOverrideFogDistance = false, float fFogDistance = 0,
-                            float fAircraftMaxHeight = 800, float fAircraftMaxVelocity = 1.5f, bool bOverrideMoonSize = false, int iMoonSize = 3);
+    explicit CMapInfoPacket(std::uint8_t ucWeather, std::uint8_t ucWeatherBlendingTo,
+        std::uint8_t ucBlendedWeatherHour, std::uint8_t ucClockHour,
+        std::uint8_t ucClockMin, unsigned long ulMinuteDuration, bool bShowNametags,
+        bool bShowRadar, float fGravity, float fGameSpeed, float fWaveHeight,
+        const SWorldWaterLevelInfo& worldWaterLevelInfo, bool bHasSkyGradient,
+        const SGarageStates& garageStates, std::uint8_t ucSkyGradientTR,
+        std::uint8_t ucSkyGradientTG, std::uint8_t ucSkyGradientTB,
+        std::uint8_t ucSkyGradientBR, std::uint8_t ucSkyGradientBG,
+        std::uint8_t ucSkyGradientBB, bool bHasHeatHaze,
+        const SHeatHazeSettings& heatHazeSettings, std::uint16_t usFPSLimit = 36,
+        bool bCloudsEnabled = true, float fJetpackMaxHeight = 100,
+        bool bOverrideWaterColor = false, std::uint8_t ucWaterRed = 0,
+        std::uint8_t ucWaterGreen = 0, std::uint8_t ucWaterBlue = 0,
+        std::uint8_t ucWaterAlpha = 0, bool bInteriorSoundsEnabled = true,
+        bool bOverrideRainLevel = false, float fRainLevel = 0, bool bOverrideSunSize = false,
+        float fSunSize = 0, bool bOverrideSunColor = false, std::uint8_t ucSunCoreR = 0,
+        std::uint8_t ucSunCoreG = 0, std::uint8_t ucSunCoreB = 0,
+        std::uint8_t ucSunCoronaR = 0, std::uint8_t ucSunCoronaG = 0,
+        std::uint8_t ucSunCoronaB = 0, bool bOverrideWindVelocity = false,
+        float fWindVelX = 0, float fWindVelY = 0, float fWindVelZ = 0,
+        bool bOverrideFarClipDistance = false, float fFarClip = 0,
+        bool bOverrideFogDistance = false, float fFogDistance = 0,
+        float fAircraftMaxHeight = 800, float fAircraftMaxVelocity = 1.5f,
+        bool bOverrideMoonSize = false, int iMoonSize = 3
+    ) noexcept;
 
     ePacketID     GetPacketID() const noexcept { return PACKET_ID_MAP_INFO; };
     std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
-    unsigned char        m_ucWeather;
-    unsigned char        m_ucWeatherBlendingTo;
-    unsigned char        m_ucBlendedWeatherHour;
-    unsigned char        m_ucClockHour;
-    unsigned char        m_ucClockMin;
+    std::uint8_t         m_ucWeather;
+    std::uint8_t         m_ucWeatherBlendingTo;
+    std::uint8_t         m_ucBlendedWeatherHour;
+    std::uint8_t         m_ucClockHour;
+    std::uint8_t         m_ucClockMin;
     unsigned long        m_ulMinuteDuration;
     bool                 m_bShowNametags;
     bool                 m_bShowRadar;
@@ -60,31 +72,31 @@ private:
     float                m_fWaveHeight;
     SWorldWaterLevelInfo m_WorldWaterLevelInfo;
     bool                 m_bHasSkyGradient;
-    unsigned char        m_ucSkyGradientTR, m_ucSkyGradientTG, m_ucSkyGradientTB;
-    unsigned char        m_ucSkyGradientBR, m_ucSkyGradientBG, m_ucSkyGradientBB;
+    std::uint8_t         m_ucSkyGradientTR, m_ucSkyGradientTG, m_ucSkyGradientTB;
+    std::uint8_t         m_ucSkyGradientBR, m_ucSkyGradientBG, m_ucSkyGradientBB;
     bool                 m_bHasHeatHaze;
     SHeatHazeSettings    m_HeatHazeSettings;
-    unsigned short       m_usFPSLimit;
+    std::uint16_t        m_usFPSLimit;
     const SGarageStates* m_pGarageStates;
     bool                 m_bCloudsEnabled;
     float                m_fJetpackMaxHeight;
     bool                 m_bOverrideWaterColor;
-    unsigned char        m_ucWaterRed;
-    unsigned char        m_ucWaterGreen;
-    unsigned char        m_ucWaterBlue;
-    unsigned char        m_ucWaterAlpha;
+    std::uint8_t         m_ucWaterRed;
+    std::uint8_t         m_ucWaterGreen;
+    std::uint8_t         m_ucWaterBlue;
+    std::uint8_t         m_ucWaterAlpha;
     bool                 m_bInteriorSoundsEnabled;
     bool                 m_bOverrideRainLevel;
     float                m_fRainLevel;
     bool                 m_bOverrideSunSize;
     float                m_fSunSize;
     bool                 m_bOverrideSunColor;
-    unsigned char        m_ucSunCoreR;
-    unsigned char        m_ucSunCoreG;
-    unsigned char        m_ucSunCoreB;
-    unsigned char        m_ucSunCoronaR;
-    unsigned char        m_ucSunCoronaG;
-    unsigned char        m_ucSunCoronaB;
+    std::uint8_t         m_ucSunCoreR;
+    std::uint8_t         m_ucSunCoreG;
+    std::uint8_t         m_ucSunCoreB;
+    std::uint8_t         m_ucSunCoronaR;
+    std::uint8_t         m_ucSunCoronaG;
+    std::uint8_t         m_ucSunCoronaB;
     bool                 m_bOverrideWindVelocity;
     float                m_fWindVelX;
     float                m_fWindVelY;

--- a/Server/mods/deathmatch/logic/packets/CObjectStartSyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CObjectStartSyncPacket.cpp
@@ -14,7 +14,7 @@
 #include "CObject.h"
 #include <net/SyncStructures.h>
 
-bool CObjectStartSyncPacket::Write(NetBitStreamInterface& BitStream) const
+bool CObjectStartSyncPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     if (!m_pObject)
         return false;

--- a/Server/mods/deathmatch/logic/packets/CObjectStartSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CObjectStartSyncPacket.h
@@ -18,12 +18,12 @@ class CObject;
 class CObjectStartSyncPacket final : public CPacket
 {
 public:
-    CObjectStartSyncPacket(CObject* pObject) { m_pObject = pObject; };
+    CObjectStartSyncPacket(CObject* pObject) noexcept { m_pObject = pObject; }
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_OBJECT_STARTSYNC; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_OBJECT_STARTSYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
     CObject* m_pObject;

--- a/Server/mods/deathmatch/logic/packets/CObjectStartSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CObjectStartSyncPacket.h
@@ -20,8 +20,8 @@ class CObjectStartSyncPacket final : public CPacket
 public:
     CObjectStartSyncPacket(CObject* pObject) { m_pObject = pObject; };
 
-    ePacketID     GetPacketID() const { return PACKET_ID_OBJECT_STARTSYNC; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_OBJECT_STARTSYNC; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CObjectStopSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CObjectStopSyncPacket.h
@@ -18,8 +18,8 @@ class CObjectStopSyncPacket final : public CPacket
 public:
     CObjectStopSyncPacket(CObject* pObject) { m_pObject = pObject; };
 
-    ePacketID     GetPacketID() const { return PACKET_ID_OBJECT_STOPSYNC; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_OBJECT_STOPSYNC; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const
     {

--- a/Server/mods/deathmatch/logic/packets/CObjectSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CObjectSyncPacket.h
@@ -20,26 +20,29 @@ class CObjectSyncPacket final : public CPacket
 public:
     struct SyncData
     {
-        ElementID     ID;
-        CVector       vecPosition;
-        CVector       vecRotation;
-        float         fHealth;
-        unsigned char ucSyncTimeContext;
-        unsigned char ucFlags;
-        bool          bSend;
+        ElementID    ID;
+        CVector      vecPosition;
+        CVector      vecRotation;
+        float        fHealth;
+        std::uint8_t ucSyncTimeContext;
+        std::uint8_t ucFlags;
+        bool         bSend;
     };
 
 public:
-    ~CObjectSyncPacket();
+    ~CObjectSyncPacket() noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_OBJECT_SYNC; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_OBJECT_SYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    std::vector<SyncData*>::const_iterator IterBegin() { return m_Syncs.begin(); };
-    std::vector<SyncData*>::const_iterator IterEnd() { return m_Syncs.end(); };
+    std::vector<SyncData*>::iterator begin() noexcept { return m_Syncs.begin(); }
+    std::vector<SyncData*>::iterator end() noexcept { return m_Syncs.end(); }
+
+    std::vector<SyncData*>::const_iterator begin() const noexcept { return m_Syncs.cbegin(); }
+    std::vector<SyncData*>::const_iterator end() const noexcept { return m_Syncs.cend(); }
 
     std::vector<SyncData*> m_Syncs;
 };

--- a/Server/mods/deathmatch/logic/packets/CObjectSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CObjectSyncPacket.h
@@ -32,8 +32,8 @@ public:
 public:
     ~CObjectSyncPacket();
 
-    ePacketID     GetPacketID() const { return PACKET_ID_OBJECT_SYNC; };
-    unsigned long GetFlags() const { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_OBJECT_SYNC; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
 
     bool Read(NetBitStreamInterface& BitStream);
     bool Write(NetBitStreamInterface& BitStream) const;

--- a/Server/mods/deathmatch/logic/packets/CPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPacket.cpp
@@ -13,14 +13,9 @@
 #include "CPacket.h"
 #include "CPlayer.h"
 
-CPacket::CPacket()
-{
-    // Init
-    m_pSourceElement = NULL;
-    m_Source = NetServerPlayerID(0, 0);
-}
+CPacket::CPacket() noexcept : m_Source(NetServerPlayerID(0, 0)) {}
 
-CPlayer* CPacket::GetSourcePlayer()
+CPlayer* CPacket::GetSourcePlayer() noexcept
 {
     return static_cast<CPlayer*>(m_pSourceElement);
 }

--- a/Server/mods/deathmatch/logic/packets/CPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPacket.cpp
@@ -15,7 +15,7 @@
 
 CPacket::CPacket() noexcept : m_Source(NetServerPlayerID(0, 0)) {}
 
-CPlayer* CPacket::GetSourcePlayer() noexcept
+CPlayer* CPacket::GetSourcePlayer() const noexcept
 {
     return static_cast<CPlayer*>(m_pSourceElement);
 }

--- a/Server/mods/deathmatch/logic/packets/CPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPacket.h
@@ -48,7 +48,7 @@ public:
 
     void                     SetSourceElement(CElement* pSource) noexcept { m_pSourceElement = pSource; }
     CElement*                GetSourceElement() const noexcept { return m_pSourceElement; }
-    CPlayer*                 GetSourcePlayer();
+    CPlayer*                 GetSourcePlayer() const noexcept;
     void                     SetSourceSocket(const NetServerPlayerID& Source) noexcept { m_Source = Source; }
     const NetServerPlayerID& GetSourceSocket() const noexcept { return m_Source; }
     std::uint32_t            GetSourceIP() const noexcept { return m_Source.GetBinaryAddress(); }

--- a/Server/mods/deathmatch/logic/packets/CPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPacket.h
@@ -34,27 +34,27 @@ enum
 class CPacket
 {
 public:
-    CPacket();
-    virtual ~CPacket(){};
+    CPacket() noexcept;
+    virtual ~CPacket() noexcept {};
 
-    virtual bool            RequiresSourcePlayer() const { return true; }
-    virtual bool            HasSimHandler() const { return false; }
-    virtual ePacketID       GetPacketID() const = 0;
-    virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_DEFAULT; }
-    virtual unsigned long   GetFlags() const = 0;
+    virtual bool            RequiresSourcePlayer() const noexcept { return true; }
+    virtual bool            HasSimHandler() const noexcept { return false; }
+    virtual ePacketID       GetPacketID() const noexcept = 0;
+    virtual ePacketOrdering GetPacketOrdering() const noexcept { return PACKET_ORDERING_DEFAULT; }
+    virtual std::uint32_t   GetFlags() const noexcept = 0;
 
-    virtual bool Read(NetBitStreamInterface& BitStream) { return false; };
-    virtual bool Write(NetBitStreamInterface& BitStream) const { return false; };
+    virtual bool Read(NetBitStreamInterface& BitStream) noexcept { return false; }
+    virtual bool Write(NetBitStreamInterface& BitStream) const noexcept { return false; }
 
-    void                     SetSourceElement(CElement* pSource) { m_pSourceElement = pSource; };
-    CElement*                GetSourceElement() const { return m_pSourceElement; };
+    void                     SetSourceElement(CElement* pSource) noexcept { m_pSourceElement = pSource; }
+    CElement*                GetSourceElement() const noexcept { return m_pSourceElement; }
     CPlayer*                 GetSourcePlayer();
-    void                     SetSourceSocket(const NetServerPlayerID& Source) { m_Source = Source; };
-    const NetServerPlayerID& GetSourceSocket() const { return m_Source; };
-    unsigned long            GetSourceIP() const { return m_Source.GetBinaryAddress(); };
-    unsigned short           GetSourcePort() const { return m_Source.GetPort(); };
+    void                     SetSourceSocket(const NetServerPlayerID& Source) noexcept { m_Source = Source; }
+    const NetServerPlayerID& GetSourceSocket() const noexcept { return m_Source; }
+    std::uint32_t            GetSourceIP() const noexcept { return m_Source.GetBinaryAddress(); }
+    std::uint16_t            GetSourcePort() const noexcept { return m_Source.GetPort(); }
 
 protected:
-    CElement*         m_pSourceElement;
+    CElement*         m_pSourceElement{nullptr};
     NetServerPlayerID m_Source;
 };

--- a/Server/mods/deathmatch/logic/packets/CPedStartSyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPedStartSyncPacket.cpp
@@ -13,7 +13,7 @@
 #include "CPedStartSyncPacket.h"
 #include "CPed.h"
 
-bool CPedStartSyncPacket::Write(NetBitStreamInterface& BitStream) const
+bool CPedStartSyncPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     if (!m_pPed)
         return false;

--- a/Server/mods/deathmatch/logic/packets/CPedStartSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPedStartSyncPacket.h
@@ -20,8 +20,8 @@ class CPedStartSyncPacket final : public CPacket
 public:
     CPedStartSyncPacket(CPed* pPed) { m_pPed = pPed; };
 
-    ePacketID     GetPacketID() const { return PACKET_ID_PED_STARTSYNC; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PED_STARTSYNC; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CPedStartSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPedStartSyncPacket.h
@@ -18,12 +18,12 @@ class CPed;
 class CPedStartSyncPacket final : public CPacket
 {
 public:
-    CPedStartSyncPacket(CPed* pPed) { m_pPed = pPed; };
+    CPedStartSyncPacket(CPed* pPed) noexcept { m_pPed = pPed; }
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PED_STARTSYNC; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PED_STARTSYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
     CPed* m_pPed;

--- a/Server/mods/deathmatch/logic/packets/CPedStopSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPedStopSyncPacket.h
@@ -16,16 +16,16 @@
 class CPedStopSyncPacket final : public CPacket
 {
 public:
-    CPedStopSyncPacket(ElementID ID) { m_ID = ID; };
+    CPedStopSyncPacket(ElementID ID) noexcept { m_ID = ID; }
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PED_STOPSYNC; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PED_STOPSYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const
+    bool Write(NetBitStreamInterface& BitStream) const noexcept
     {
         BitStream.Write(m_ID);
         return true;
-    };
+    }
 
 private:
     ElementID m_ID;

--- a/Server/mods/deathmatch/logic/packets/CPedStopSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPedStopSyncPacket.h
@@ -18,8 +18,8 @@ class CPedStopSyncPacket final : public CPacket
 public:
     CPedStopSyncPacket(ElementID ID) { m_ID = ID; };
 
-    ePacketID     GetPacketID() const { return PACKET_ID_PED_STOPSYNC; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PED_STOPSYNC; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const
     {

--- a/Server/mods/deathmatch/logic/packets/CPedSyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPedSyncPacket.cpp
@@ -12,13 +12,13 @@
 #include "StdInc.h"
 #include "CPedSyncPacket.h"
 
-CPedSyncPacket::CPedSyncPacket(SyncData& ReadData)
+CPedSyncPacket::CPedSyncPacket(SyncData& ReadData) noexcept
 {
     // Copy the struct
     m_Syncs.push_back(ReadData);
 }
 
-bool CPedSyncPacket::Read(NetBitStreamInterface& BitStream)
+bool CPedSyncPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     // While we're not out of bytes
     while (BitStream.GetNumberOfUnreadBits() > 32)
@@ -94,7 +94,7 @@ bool CPedSyncPacket::Read(NetBitStreamInterface& BitStream)
     return m_Syncs.size() > 0;
 }
 
-bool CPedSyncPacket::Write(NetBitStreamInterface& BitStream) const
+bool CPedSyncPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     const SyncData& Data = m_Syncs.front();
     if (!&Data)

--- a/Server/mods/deathmatch/logic/packets/CPedSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPedSyncPacket.h
@@ -20,29 +20,29 @@ class CPedSyncPacket final : public CPacket
 public:
     struct SyncData
     {
-        ElementID     ID;
-        unsigned char ucFlags;
-        unsigned char ucSyncTimeContext;
-        CVector       vecPosition;
-        float         fRotation;
-        CVector       vecVelocity;
-        float         fHealth;
-        float         fArmor;
-        bool          bOnFire;
-        bool          bIsInWater;
+        ElementID    ID;
+        std::uint8_t ucFlags;
+        std::uint8_t ucSyncTimeContext;
+        CVector      vecPosition;
+        float        fRotation;
+        CVector      vecVelocity;
+        float        fHealth;
+        float        fArmor;
+        bool         bOnFire;
+        bool         bIsInWater;
     };
 
 public:
     // Used when receiving ped sync from clients, can contain multiple SyncData
-    CPedSyncPacket(){};
+    CPedSyncPacket() noexcept {};
     // Used when sending ped sync to clients, only contains one SyncData
-    CPedSyncPacket(SyncData& pReadData);
+    CPedSyncPacket(SyncData& pReadData) noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PED_SYNC; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PED_SYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
     std::vector<SyncData> m_Syncs;
 };

--- a/Server/mods/deathmatch/logic/packets/CPedSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPedSyncPacket.h
@@ -38,8 +38,8 @@ public:
     // Used when sending ped sync to clients, only contains one SyncData
     CPedSyncPacket(SyncData& pReadData);
 
-    ePacketID     GetPacketID() const { return PACKET_ID_PED_SYNC; };
-    unsigned long GetFlags() const { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PED_SYNC; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
 
     bool Read(NetBitStreamInterface& BitStream);
     bool Write(NetBitStreamInterface& BitStream) const;

--- a/Server/mods/deathmatch/logic/packets/CPedTaskPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPedTaskPacket.h
@@ -18,8 +18,8 @@ public:
     CPedTaskPacket();
 
     bool          HasSimHandler() const { return true; }
-    ePacketID     GetPacketID() const { return PACKET_ID_PED_TASK; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PED_TASK; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE; };
 
     bool Read(NetBitStreamInterface& BitStream);
     bool Write(NetBitStreamInterface& BitStream) const;

--- a/Server/mods/deathmatch/logic/packets/CPedTaskPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPedTaskPacket.h
@@ -15,15 +15,15 @@
 class CPedTaskPacket final : public CPacket
 {
 public:
-    CPedTaskPacket();
+    CPedTaskPacket() noexcept;
 
-    bool          HasSimHandler() const { return true; }
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PED_TASK; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE; };
+    bool          HasSimHandler() const noexcept { return true; }
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PED_TASK; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    uint m_uiNumBitsInPacketBody;
-    char m_DataBuffer[56];
+    std::uint32_t m_uiNumBitsInPacketBody;
+    char          m_DataBuffer[56];
 };

--- a/Server/mods/deathmatch/logic/packets/CPedWastedPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPedWastedPacket.h
@@ -15,8 +15,8 @@
 #include <CVector.h>
 
 class CPed;
-typedef unsigned long AssocGroupId;
-typedef unsigned long AnimationId;
+using AssocGroupId = std::uint32_t;
+using AnimationId = std::uint32_t;
 
 class CPedWastedPacket final : public CPacket
 {

--- a/Server/mods/deathmatch/logic/packets/CPedWastedPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPedWastedPacket.h
@@ -21,23 +21,25 @@ typedef unsigned long AnimationId;
 class CPedWastedPacket final : public CPacket
 {
 public:
-    CPedWastedPacket();
-    CPedWastedPacket(CPed* pPed, CElement* pKiller, unsigned char ucKillerWeapon, unsigned char ucBodyPart, bool bStealth, AssocGroupId animGroup = 0,
-                     AnimationId animID = 15);
+    CPedWastedPacket() noexcept;
+    CPedWastedPacket(CPed* pPed, CElement* pKiller,
+        std::uint8_t ucKillerWeapon, std::uint8_t ucBodyPart, bool bStealth,
+        AssocGroupId animGroup = 0, AnimationId animID = 15) noexcept;
 
-    ePacketID     GetPacketID() const { return PACKET_ID_PED_WASTED; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PED_WASTED; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    ElementID      m_PedID;
-    ElementID      m_Killer;
-    unsigned char  m_ucKillerWeapon;
-    unsigned char  m_ucBodyPart;
-    CVector        m_vecPosition;
-    unsigned short m_usAmmo;
-    bool           m_bStealth;
-    unsigned char  m_ucTimeContext;
-    unsigned long  m_AnimGroup, m_AnimID;
+    ElementID     m_PedID;
+    ElementID     m_Killer;
+    std::uint8_t  m_ucKillerWeapon;
+    std::uint8_t  m_ucBodyPart;
+    CVector       m_vecPosition;
+    std::uint16_t m_usAmmo;
+    bool          m_bStealth;
+    std::uint8_t  m_ucTimeContext;
+    std::uint32_t m_AnimGroup;
+    std::uint32_t m_AnimID;
 };

--- a/Server/mods/deathmatch/logic/packets/CPedWastedPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPedWastedPacket.h
@@ -13,10 +13,9 @@
 
 #include "CPacket.h"
 #include <CVector.h>
+#include <SharedUtil.IntTypes.h>
 
 class CPed;
-using AssocGroupId = std::uint32_t;
-using AnimationId = std::uint32_t;
 
 class CPedWastedPacket final : public CPacket
 {

--- a/Server/mods/deathmatch/logic/packets/CPickupHideShowPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPickupHideShowPacket.h
@@ -19,8 +19,8 @@ class CPickupHideShowPacket final : public CPacket
 public:
     CPickupHideShowPacket(bool bShow) { m_bShow = bShow; };
 
-    ePacketID     GetPacketID() const { return PACKET_ID_PICKUP_HIDESHOW; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PICKUP_HIDESHOW; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CPickupHideShowPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPickupHideShowPacket.h
@@ -17,19 +17,19 @@
 class CPickupHideShowPacket final : public CPacket
 {
 public:
-    CPickupHideShowPacket(bool bShow) { m_bShow = bShow; };
+    CPickupHideShowPacket(bool bShow) noexcept { m_bShow = bShow; }
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PICKUP_HIDESHOW; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PICKUP_HIDESHOW; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    bool GetShow() { return m_bShow; };
-    void SetShow(bool bShow) { m_bShow = bShow; };
+    bool GetShow() const noexcept { return m_bShow; }
+    void SetShow(bool bShow) noexcept { m_bShow = bShow; }
 
-    void         Add(class CPickup* pPickup) { m_List.push_back(pPickup); };
-    void         Clear() { m_List.clear(); };
-    unsigned int Count() { return static_cast<unsigned int>(m_List.size()); };
+    void         Add(class CPickup* pPickup) noexcept { m_List.push_back(pPickup); }
+    void         Clear() noexcept { m_List.clear(); }
+    std::size_t  Count() const noexcept { return m_List.size(); }
 
 private:
     bool                        m_bShow;

--- a/Server/mods/deathmatch/logic/packets/CPickupHitConfirmPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPickupHitConfirmPacket.cpp
@@ -13,23 +13,21 @@
 #include "CPickupHitConfirmPacket.h"
 #include "CPickup.h"
 
-bool CPickupHitConfirmPacket::Write(NetBitStreamInterface& BitStream) const
+bool CPickupHitConfirmPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     // unsigned short   (2)     - pickup id
     // bool                     - hide it?
 
     // Got a pickup to send?
-    if (m_pPickup)
-    {
-        // Write the pickup id and visibily state
-        BitStream.Write(m_pPickup->GetID());
+    if (!m_pPickup)
+        return false;
 
-        // WRite the flags
-        BitStream.WriteBit(m_pPickup->IsVisible());
-        BitStream.WriteBit(m_bPlaySound);
+    // Write the pickup id and visibily state
+    BitStream.Write(m_pPickup->GetID());
 
-        return true;
-    }
+    // WRite the flags
+    BitStream.WriteBit(m_pPickup->IsVisible());
+    BitStream.WriteBit(m_bPlaySound);
 
-    return false;
+    return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CPickupHitConfirmPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPickupHitConfirmPacket.h
@@ -22,8 +22,8 @@ public:
         m_bPlaySound = bPlaySound;
     };
 
-    ePacketID     GetPacketID() const { return PACKET_ID_PICKUP_HIT_CONFIRM; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PICKUP_HIT_CONFIRM; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CPickupHitConfirmPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPickupHitConfirmPacket.h
@@ -16,16 +16,16 @@
 class CPickupHitConfirmPacket final : public CPacket
 {
 public:
-    explicit CPickupHitConfirmPacket(class CPickup* pPickup, bool bPlaySound)
+    explicit CPickupHitConfirmPacket(class CPickup* pPickup, bool bPlaySound) noexcept
     {
         m_pPickup = pPickup;
         m_bPlaySound = bPlaySound;
-    };
+    }
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PICKUP_HIT_CONFIRM; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PICKUP_HIT_CONFIRM; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
     class CPickup* m_pPickup;

--- a/Server/mods/deathmatch/logic/packets/CPlayerACInfoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerACInfoPacket.cpp
@@ -12,14 +12,14 @@
 #include "StdInc.h"
 #include "CPlayerACInfoPacket.h"
 
-bool CPlayerACInfoPacket::Read(NetBitStreamInterface& BitStream)
+bool CPlayerACInfoPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     // Read type
-    uchar ucNumItems = 0;
+    std::uint8_t ucNumItems = 0;
     BitStream.Read(ucNumItems);
-    for (uint i = 0; i < ucNumItems; i++)
+    for (auto i = 0; i < ucNumItems; i++)
     {
-        uchar ucId;
+        std::uint8_t ucId;
         if (!BitStream.Read(ucId))
             return false;
         m_IdList.push_back(ucId);

--- a/Server/mods/deathmatch/logic/packets/CPlayerACInfoPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerACInfoPacket.h
@@ -16,13 +16,13 @@
 class CPlayerACInfoPacket final : public CPacket
 {
 public:
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_ACINFO; };
-    unsigned long GetFlags() const { return 0; };            // Not used
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_ACINFO; }
+    std::uint32_t GetFlags() const noexcept { return 0; } // Not used
 
-    bool Read(NetBitStreamInterface& BitStream);
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
 
     std::vector<uchar> m_IdList;
-    uint               m_uiD3d9Size;
+    std::uint32_t      m_uiD3d9Size;
     SString            m_strD3d9MD5;
     SString            m_strD3d9SHA256;
 };

--- a/Server/mods/deathmatch/logic/packets/CPlayerChangeNickPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerChangeNickPacket.cpp
@@ -13,23 +13,21 @@
 #include "CPlayerChangeNickPacket.h"
 #include "CElement.h"
 
-CPlayerChangeNickPacket::CPlayerChangeNickPacket(const char* szNewNick)
+CPlayerChangeNickPacket::CPlayerChangeNickPacket(const char* szNewNick) noexcept
 {
     m_strNewNick.AssignLeft(szNewNick, MAX_PLAYER_NICK_LENGTH);
 }
 
-bool CPlayerChangeNickPacket::Write(NetBitStreamInterface& BitStream) const
+bool CPlayerChangeNickPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
-    if (m_pSourceElement)
-    {
-        // Write the source player id
-        ElementID ID = m_pSourceElement->GetID();
-        BitStream.Write(ID);
+    if (!m_pSourceElement)
+        return false;
 
-        // Write the nick
-        BitStream.WriteStringCharacters(m_strNewNick);
-        return true;
-    }
+    // Write the source player id
+    ElementID ID = m_pSourceElement->GetID();
+    BitStream.Write(ID);
 
-    return false;
+    // Write the nick
+    BitStream.WriteStringCharacters(m_strNewNick);
+    return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CPlayerChangeNickPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerChangeNickPacket.h
@@ -18,8 +18,8 @@ class CPlayerChangeNickPacket final : public CPacket
 public:
     explicit CPlayerChangeNickPacket(const char* szNewNick);
 
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_CHANGE_NICK; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_CHANGE_NICK; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CPlayerChangeNickPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerChangeNickPacket.h
@@ -16,15 +16,15 @@
 class CPlayerChangeNickPacket final : public CPacket
 {
 public:
-    explicit CPlayerChangeNickPacket(const char* szNewNick);
+    explicit CPlayerChangeNickPacket(const char* szNewNick) noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_CHANGE_NICK; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_CHANGE_NICK; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    const char* GetNewNick() { return m_strNewNick; }
-    void        SetNewNick(const char* szNewNick) { m_strNewNick.AssignLeft(szNewNick, MAX_PLAYER_NICK_LENGTH); }
+    const char* GetNewNick() const noexcept { return m_strNewNick; }
+    void        SetNewNick(const char* szNewNick) noexcept { m_strNewNick.AssignLeft(szNewNick, MAX_PLAYER_NICK_LENGTH); }
 
 private:
     SString m_strNewNick;

--- a/Server/mods/deathmatch/logic/packets/CPlayerClothesPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerClothesPacket.h
@@ -24,16 +24,16 @@ struct SPlayerClothes
 class CPlayerClothesPacket final : public CPacket
 {
 public:
-    ~CPlayerClothesPacket();
+    ~CPlayerClothesPacket() noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_CLOTHES; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_CLOTHES; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    void         Add(const char* szTexture, const char* szModel, unsigned char ucType);
-    void         Add(CPlayerClothes* pClothes);
-    unsigned int Count() { return static_cast<unsigned int>(m_List.size()); }
+    void        Add(const char* szTexture, const char* szModel, std::uint8_t ucType) noexcept;
+    void        Add(CPlayerClothes* pClothes) noexcept;
+    std::size_t Count() const noexcept { return m_List.size(); }
 
 private:
     std::vector<SPlayerClothes*> m_List;

--- a/Server/mods/deathmatch/logic/packets/CPlayerClothesPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerClothesPacket.h
@@ -26,8 +26,8 @@ class CPlayerClothesPacket final : public CPacket
 public:
     ~CPlayerClothesPacket();
 
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_CLOTHES; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_CLOTHES; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CPlayerConnectCompletePacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerConnectCompletePacket.cpp
@@ -16,7 +16,7 @@
 
 #define MAX_CONN_TEXT_LEN 128
 
-bool CPlayerConnectCompletePacket::Write(NetBitStreamInterface& BitStream) const
+bool CPlayerConnectCompletePacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     // Send the connection string
     SString strConnText("%s %s [%s]", MTA_DM_FULL_STRING, MTA_DM_VERSIONSTRING, MTA_OS_STRING);

--- a/Server/mods/deathmatch/logic/packets/CPlayerConnectCompletePacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerConnectCompletePacket.h
@@ -16,8 +16,8 @@
 class CPlayerConnectCompletePacket final : public CPacket
 {
 public:
-    ePacketID     GetPacketID() const noexcept { return static_cast<ePacketID>(PACKET_ID_SERVER_JOIN_COMPLETE); };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return static_cast<ePacketID>(PACKET_ID_SERVER_JOIN_COMPLETE); }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 };

--- a/Server/mods/deathmatch/logic/packets/CPlayerConnectCompletePacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerConnectCompletePacket.h
@@ -16,8 +16,8 @@
 class CPlayerConnectCompletePacket final : public CPacket
 {
 public:
-    ePacketID     GetPacketID() const { return static_cast<ePacketID>(PACKET_ID_SERVER_JOIN_COMPLETE); };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return static_cast<ePacketID>(PACKET_ID_SERVER_JOIN_COMPLETE); };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 };

--- a/Server/mods/deathmatch/logic/packets/CPlayerDiagnosticPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerDiagnosticPacket.cpp
@@ -12,14 +12,13 @@
 #include "StdInc.h"
 #include "CPlayerDiagnosticPacket.h"
 
-bool CPlayerDiagnosticPacket::Read(NetBitStreamInterface& BitStream)
+bool CPlayerDiagnosticPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
-    if (BitStream.ReadString(m_strMessage))
-    {
-        SString strLevel;
-        m_strMessage.Split(",", &strLevel, &m_strMessage);
-        m_uiLevel = atoi(strLevel);
-        return true;
-    }
-    return false;
+    if (!BitStream.ReadString(m_strMessage))
+        return false;
+
+    SString strLevel;
+    m_strMessage.Split(",", &strLevel, &m_strMessage);
+    m_uiLevel = atoi(strLevel);
+    return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CPlayerDiagnosticPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerDiagnosticPacket.h
@@ -16,11 +16,11 @@
 class CPlayerDiagnosticPacket final : public CPacket
 {
 public:
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_DIAGNOSTIC; };
-    unsigned long GetFlags() const { return 0; };            // Not used
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_DIAGNOSTIC; }
+    std::uint32_t GetFlags() const noexcept { return 0; } // Not used
 
-    bool Read(NetBitStreamInterface& BitStream);
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
 
-    uint    m_uiLevel;
-    SString m_strMessage;
+    std::uint32_t m_uiLevel;
+    SString       m_strMessage;
 };

--- a/Server/mods/deathmatch/logic/packets/CPlayerDisconnectedPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerDisconnectedPacket.cpp
@@ -12,28 +12,28 @@
 #include "StdInc.h"
 #include "CPlayerDisconnectedPacket.h"
 
-CPlayerDisconnectedPacket::CPlayerDisconnectedPacket(const char* szReason)
+CPlayerDisconnectedPacket::CPlayerDisconnectedPacket(const char* szReason) noexcept
 {
     m_eType = CPlayerDisconnectedPacket::CUSTOM;
     m_strReason = szReason;
     m_Duration = 0;
 }
 
-CPlayerDisconnectedPacket::CPlayerDisconnectedPacket(ePlayerDisconnectType eType, const char* szReason)
+CPlayerDisconnectedPacket::CPlayerDisconnectedPacket(ePlayerDisconnectType eType, const char* szReason) noexcept
 {
     m_eType = eType;
+    m_strReason = szReason;
     m_Duration = 0;
-    m_strReason = szReason;
 }
 
-CPlayerDisconnectedPacket::CPlayerDisconnectedPacket(ePlayerDisconnectType eType, time_t BanDuration, const char* szReason)
+CPlayerDisconnectedPacket::CPlayerDisconnectedPacket(ePlayerDisconnectType eType, time_t BanDuration, const char* szReason) noexcept
 {
     m_eType = eType;
-    m_Duration = BanDuration;
     m_strReason = szReason;
+    m_Duration = BanDuration;
 }
 
-bool CPlayerDisconnectedPacket::Write(NetBitStreamInterface& BitStream) const
+bool CPlayerDisconnectedPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     BitStream.WriteBits(&m_eType, 5);
 

--- a/Server/mods/deathmatch/logic/packets/CPlayerDisconnectedPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerDisconnectedPacket.h
@@ -42,17 +42,17 @@ public:
         SHUTDOWN
     };
 
-    CPlayerDisconnectedPacket(const char* szReason);
-    CPlayerDisconnectedPacket(CPlayerDisconnectedPacket::ePlayerDisconnectType eType, const char* szReason = "");
-    CPlayerDisconnectedPacket(CPlayerDisconnectedPacket::ePlayerDisconnectType eType, time_t BanDuration = 0, const char* szReason = "");
+    CPlayerDisconnectedPacket(const char* szReason) noexcept;
+    CPlayerDisconnectedPacket(ePlayerDisconnectType eType, const char* szReason = "") noexcept;
+    CPlayerDisconnectedPacket(ePlayerDisconnectType eType, std::time_t BanDuration = 0, const char* szReason = "") noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_SERVER_DISCONNECTED; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_SERVER_DISCONNECTED; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    const char* GetReason() { return m_strReason; }
-    void        SetReason(const char* szReason) { m_strReason = szReason; }
+    const char* GetReason() const noexcept { return m_strReason; }
+    void        SetReason(const char* szReason) noexcept { m_strReason = szReason; }
 
 private:
     SString               m_strReason;

--- a/Server/mods/deathmatch/logic/packets/CPlayerDisconnectedPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerDisconnectedPacket.h
@@ -46,8 +46,8 @@ public:
     CPlayerDisconnectedPacket(CPlayerDisconnectedPacket::ePlayerDisconnectType eType, const char* szReason = "");
     CPlayerDisconnectedPacket(CPlayerDisconnectedPacket::ePlayerDisconnectType eType, time_t BanDuration = 0, const char* szReason = "");
 
-    ePacketID     GetPacketID() const { return PACKET_ID_SERVER_DISCONNECTED; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_SERVER_DISCONNECTED; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CPlayerJoinCompletePacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerJoinCompletePacket.cpp
@@ -15,7 +15,7 @@
 #include "CMainConfig.h"
 #include <net/SyncStructures.h>
 
-CPlayerJoinCompletePacket::CPlayerJoinCompletePacket()
+CPlayerJoinCompletePacket::CPlayerJoinCompletePacket() noexcept
 {
     m_PlayerID = INVALID_ELEMENT_ID;
     m_RootElementID = INVALID_ELEMENT_ID;
@@ -31,9 +31,9 @@ CPlayerJoinCompletePacket::CPlayerJoinCompletePacket()
 }
 
 CPlayerJoinCompletePacket::CPlayerJoinCompletePacket(ElementID PlayerID, ElementID RootElementID, eHTTPDownloadType ucHTTPDownloadType,
-                                                     unsigned short usHTTPDownloadPort, const char* szHTTPDownloadURL, int iHTTPMaxConnectionsPerClient,
-                                                     int iEnableClientChecks, bool bVoiceEnabled, unsigned char ucSampleRate, unsigned char ucVoiceQuality,
-                                                     unsigned int uiBitrate, const char* szServerName)
+                                                     std::uint16_t usHTTPDownloadPort, const char* szHTTPDownloadURL, int iHTTPMaxConnectionsPerClient,
+                                                     int iEnableClientChecks, bool bVoiceEnabled, std::uint8_t ucSampleRate, std::uint8_t ucVoiceQuality,
+                                                     std::uint32_t uiBitrate, const char* szServerName) noexcept
 {
     m_PlayerID = PlayerID;
     m_RootElementID = RootElementID;
@@ -60,14 +60,14 @@ CPlayerJoinCompletePacket::CPlayerJoinCompletePacket(ElementID PlayerID, Element
     }
 }
 
-bool CPlayerJoinCompletePacket::Write(NetBitStreamInterface& BitStream) const
+bool CPlayerJoinCompletePacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     BitStream.Write(m_PlayerID);
 
     // For protocol backwards compatibility: write a non-zero single byte value.
     // This used to hold the number of players, it was never used on the client side,
     // and it caused protocol error 14 whenever the value wrapped back to zero (uint32_t -> uint8_t).
-    uint8_t numPlayers = 1;
+    std::uint8_t numPlayers = 1;
     BitStream.Write(numPlayers);
 
     BitStream.Write(m_RootElementID);
@@ -79,11 +79,11 @@ bool CPlayerJoinCompletePacket::Write(NetBitStreamInterface& BitStream) const
     BitStream.WriteBit(m_bVoiceEnabled);
 
     // Transmit the sample rate for voice
-    SIntegerSync<unsigned char, 2> sampleRate(m_ucSampleRate);
+    SIntegerSync<std::uint8_t, 2> sampleRate(m_ucSampleRate);
     BitStream.Write(&sampleRate);
 
     // Transmit the quality for voice
-    SIntegerSync<unsigned char, 4> voiceQuality(m_ucQuality);
+    SIntegerSync<std::uint8_t, 4> voiceQuality(m_ucQuality);
     BitStream.Write(&voiceQuality);
 
     // Transmit the max bitrate for voice
@@ -98,7 +98,7 @@ bool CPlayerJoinCompletePacket::Write(NetBitStreamInterface& BitStream) const
     // Tellclient about maybe throttling back http client requests
     BitStream.Write(m_iHTTPMaxConnectionsPerClient);
 
-    BitStream.Write(static_cast<unsigned char>(m_ucHTTPDownloadType));
+    BitStream.Write(static_cast<std::uint8_t>(m_ucHTTPDownloadType));
 
     switch (m_ucHTTPDownloadType)
     {

--- a/Server/mods/deathmatch/logic/packets/CPlayerJoinCompletePacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerJoinCompletePacket.h
@@ -18,27 +18,27 @@
 class CPlayerJoinCompletePacket final : public CPacket
 {
 public:
-    CPlayerJoinCompletePacket();
-    CPlayerJoinCompletePacket(ElementID PlayerID, ElementID RootElementID, eHTTPDownloadType ucHTTPDownloadType, unsigned short usHTTPDownloadPort,
+    CPlayerJoinCompletePacket() noexcept;
+    CPlayerJoinCompletePacket(ElementID PlayerID, ElementID RootElementID, eHTTPDownloadType ucHTTPDownloadType, std::uint16_t usHTTPDownloadPort,
                               const char* szHTTPDownloadURL, int iHTTPMaxConnectionsPerClient, int iEnableClientChecks, bool bVoiceEnabled,
-                              unsigned char ucSampleRate, unsigned char ucVoiceQuality, unsigned int uiBitrate, const char* szServerName);
+                              std::uint8_t ucSampleRate, std::uint8_t ucVoiceQuality, std::uint32_t uiBitrate, const char* szServerName) noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_SERVER_JOINEDGAME; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_SERVER_JOINEDGAME; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
     ElementID         m_PlayerID;
     ElementID         m_RootElementID;
     eHTTPDownloadType m_ucHTTPDownloadType;
-    unsigned short    m_usHTTPDownloadPort;
+    std::uint16_t    m_usHTTPDownloadPort;
     SString           m_strHTTPDownloadURL;
     int               m_iHTTPMaxConnectionsPerClient;
     int               m_iEnableClientChecks;
     bool              m_bVoiceEnabled;
-    unsigned char     m_ucSampleRate;
-    unsigned char     m_ucQuality;
-    unsigned int      m_uiBitrate;
+    std::uint8_t     m_ucSampleRate;
+    std::uint8_t     m_ucQuality;
+    std::uint32_t      m_uiBitrate;
     const char*       m_szServerName;
 };

--- a/Server/mods/deathmatch/logic/packets/CPlayerJoinCompletePacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerJoinCompletePacket.h
@@ -23,8 +23,8 @@ public:
                               const char* szHTTPDownloadURL, int iHTTPMaxConnectionsPerClient, int iEnableClientChecks, bool bVoiceEnabled,
                               unsigned char ucSampleRate, unsigned char ucVoiceQuality, unsigned int uiBitrate, const char* szServerName);
 
-    ePacketID     GetPacketID() const { return PACKET_ID_SERVER_JOINEDGAME; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_SERVER_JOINEDGAME; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CPlayerJoinDataPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerJoinDataPacket.cpp
@@ -12,7 +12,7 @@
 #include "StdInc.h"
 #include "CPlayerJoinDataPacket.h"
 
-bool CPlayerJoinDataPacket::Read(NetBitStreamInterface& BitStream)
+bool CPlayerJoinDataPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     // Read out the stuff
     if (!BitStream.Read(m_usNetVersion) || !BitStream.Read(m_usMTAVersion))
@@ -25,14 +25,19 @@ bool CPlayerJoinDataPacket::Read(NetBitStreamInterface& BitStream)
 
     m_bOptionalUpdateInfoRequired = BitStream.ReadBit();
 
-    if (BitStream.Read(m_ucGameVersion) && BitStream.ReadStringCharacters(m_strNick, MAX_PLAYER_NICK_LENGTH) &&
-        BitStream.Read(reinterpret_cast<char*>(&m_Password), 16) && BitStream.ReadStringCharacters(m_strSerialUser, MAX_SERIAL_LENGTH))
-    {
-        // Shrink string sizes to fit
-        m_strNick = *m_strNick;
-        m_strSerialUser = *m_strSerialUser;
+    if (!BitStream.Read(m_ucGameVersion))
+        return false;
 
-        return true;
-    }
-    return false;
+    if (!BitStream.ReadStringCharacters(m_strNick, MAX_PLAYER_NICK_LENGTH))
+        return false;
+    if (!BitStream.Read(reinterpret_cast<char*>(&m_Password), 16))
+        return false;
+    if (!BitStream.ReadStringCharacters(m_strSerialUser, MAX_SERIAL_LENGTH))
+        return false;
+
+    // Shrink string sizes to fit
+    m_strNick = *m_strNick;
+    m_strSerialUser = *m_strSerialUser;
+
+    return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CPlayerJoinDataPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerJoinDataPacket.h
@@ -17,41 +17,45 @@
 class CPlayerJoinDataPacket final : public CPacket
 {
 public:
-    virtual bool  RequiresSourcePlayer() const { return false; }
-    ePacketID     GetPacketID() const { return static_cast<ePacketID>(PACKET_ID_PLAYER_JOINDATA); };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    virtual bool  RequiresSourcePlayer() const noexcept { return false; }
+    ePacketID     GetPacketID() const noexcept { return static_cast<ePacketID>(PACKET_ID_PLAYER_JOINDATA); }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
 
-    unsigned short GetNetVersion() { return m_usNetVersion; };
-    unsigned char  GetGameVersion() { return m_ucGameVersion; };
+    std::uint16_t GetNetVersion() const noexcept { return m_usNetVersion; }
+    std::uint8_t  GetGameVersion() const noexcept { return m_ucGameVersion; }
 
-    void SetNetVersion(unsigned short usNetVersion) { m_usNetVersion = usNetVersion; };
-    void SetGameVersion(unsigned char ucGameVersion) { m_ucGameVersion = ucGameVersion; };
+    void SetNetVersion(const std::uint16_t usNetVersion) noexcept { m_usNetVersion = usNetVersion; }
+    void SetGameVersion(const std::uint8_t ucGameVersion) noexcept { m_ucGameVersion = ucGameVersion; }
 
-    unsigned short     GetMTAVersion() { return m_usMTAVersion; };
-    unsigned short     GetBitStreamVersion() { return m_usBitStreamVersion; };
-    const CMtaVersion& GetPlayerVersion() { return m_strPlayerVersion; };
+    std::uint16_t      GetMTAVersion() const noexcept { return m_usMTAVersion; }
+    std::uint16_t      GetBitStreamVersion() const noexcept { return m_usBitStreamVersion; }
+    const CMtaVersion& GetPlayerVersion() const noexcept { return m_strPlayerVersion; }
 
-    const char* GetNick() { return m_strNick; };
-    void        SetNick(const char* szNick) { m_strNick.AssignLeft(szNick, MAX_PLAYER_NICK_LENGTH); };
+    const char* GetNick() const noexcept { return m_strNick; }
+    void        SetNick(const char* szNick) noexcept {
+        m_strNick.AssignLeft(szNick, MAX_PLAYER_NICK_LENGTH);
+    }
 
-    const MD5& GetPassword() { return m_Password; };
-    void       SetPassword(const MD5& Password) { m_Password = Password; };
+    const MD5& GetPassword() const noexcept { return m_Password; }
+    void       SetPassword(const MD5& Password) noexcept { m_Password = Password; }
 
-    const char* GetSerialUser() { return m_strSerialUser; }
-    void        SetSerialUser(const char* szSerialUser) { m_strSerialUser.AssignLeft(szSerialUser, MAX_SERIAL_LENGTH); }
+    const char* GetSerialUser() const noexcept { return m_strSerialUser; }
+    void        SetSerialUser(const char* szSerialUser) noexcept {
+        m_strSerialUser.AssignLeft(szSerialUser, MAX_SERIAL_LENGTH);
+    }
 
-    bool IsOptionalUpdateInfoRequired() { return m_bOptionalUpdateInfoRequired; }
+    bool IsOptionalUpdateInfoRequired() const noexcept { return m_bOptionalUpdateInfoRequired; }
 
 private:
-    unsigned short m_usNetVersion;
-    unsigned short m_usMTAVersion;
-    unsigned short m_usBitStreamVersion;
-    unsigned char  m_ucGameVersion;
-    bool           m_bOptionalUpdateInfoRequired;
-    SString        m_strNick;
-    MD5            m_Password;
-    SString        m_strSerialUser;
-    CMtaVersion    m_strPlayerVersion;
+    std::uint16_t m_usNetVersion;
+    std::uint16_t m_usMTAVersion;
+    std::uint16_t m_usBitStreamVersion;
+    std::uint8_t  m_ucGameVersion;
+    bool          m_bOptionalUpdateInfoRequired;
+    SString       m_strNick;
+    MD5           m_Password;
+    SString       m_strSerialUser;
+    CMtaVersion   m_strPlayerVersion;
 };

--- a/Server/mods/deathmatch/logic/packets/CPlayerJoinPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerJoinPacket.h
@@ -16,9 +16,9 @@
 class CPlayerJoinPacket final : public CPacket
 {
 public:
-    virtual bool  RequiresSourcePlayer() const { return false; }
+    virtual bool  RequiresSourcePlayer() const noexcept { return false; }
     ePacketID     GetPacketID() const noexcept { return static_cast<ePacketID>(PACKET_ID_PLAYER_JOIN); };
     std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
-    bool Read(NetBitStreamInterface& BitStream) { return true; };
+    bool Read(NetBitStreamInterface& BitStream) noexcept { return true; }
 };

--- a/Server/mods/deathmatch/logic/packets/CPlayerJoinPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerJoinPacket.h
@@ -17,8 +17,8 @@ class CPlayerJoinPacket final : public CPacket
 {
 public:
     virtual bool  RequiresSourcePlayer() const { return false; }
-    ePacketID     GetPacketID() const { return static_cast<ePacketID>(PACKET_ID_PLAYER_JOIN); };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return static_cast<ePacketID>(PACKET_ID_PLAYER_JOIN); };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Read(NetBitStreamInterface& BitStream) { return true; };
 };

--- a/Server/mods/deathmatch/logic/packets/CPlayerListPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerListPacket.h
@@ -17,8 +17,8 @@
 class CPlayerListPacket final : public CPacket
 {
 public:
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_LIST; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_LIST; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CPlayerListPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerListPacket.h
@@ -17,17 +17,17 @@
 class CPlayerListPacket final : public CPacket
 {
 public:
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_LIST; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_LIST; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    void AddPlayer(CPlayer* pPlayer) { m_List.push_back(pPlayer); };
-    void RemovePlayer(CPlayer* pPlayer) { m_List.remove(pPlayer); };
-    void RemoveAllPlayers() { m_List.clear(); };
+    void AddPlayer(CPlayer* pPlayer) noexcept { m_List.push_back(pPlayer); }
+    void RemovePlayer(CPlayer* pPlayer) noexcept { m_List.remove(pPlayer); }
+    void RemoveAllPlayers() noexcept { m_List.clear(); }
 
-    bool GetShowInChat() { return m_bShowInChat; };
-    void SetShowInChat(bool bShowInChat) { m_bShowInChat = bShowInChat; };
+    bool GetShowInChat() const noexcept { return m_bShowInChat; }
+    void SetShowInChat(bool bShowInChat) noexcept { m_bShowInChat = bShowInChat; }
 
 private:
     std::list<CPlayer*> m_List;

--- a/Server/mods/deathmatch/logic/packets/CPlayerModInfoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerModInfoPacket.cpp
@@ -12,7 +12,7 @@
 #include "StdInc.h"
 #include "CPlayerModInfoPacket.h"
 
-bool CPlayerModInfoPacket::Read(NetBitStreamInterface& BitStream)
+bool CPlayerModInfoPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     // Read type
     if (!BitStream.ReadString(m_strInfoType))
@@ -24,7 +24,7 @@ bool CPlayerModInfoPacket::Read(NetBitStreamInterface& BitStream)
         return false;
 
     // Read each item
-    for (uint i = 0; i < uiCount; i++)
+    for (auto i = 0; i < uiCount; i++)
     {
         SModInfoItem item;
 

--- a/Server/mods/deathmatch/logic/packets/CPlayerModInfoPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerModInfoPacket.h
@@ -33,10 +33,10 @@ struct SModInfoItem
 class CPlayerModInfoPacket final : public CPacket
 {
 public:
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_MODINFO; };
-    unsigned long GetFlags() const { return 0; };            // Not used
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_MODINFO; }
+    std::uint32_t GetFlags() const noexcept { return 0; } // Not used
 
-    bool Read(NetBitStreamInterface& BitStream);
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
 
     SString                   m_strInfoType;
     std::vector<SModInfoItem> m_ModInfoItemList;

--- a/Server/mods/deathmatch/logic/packets/CPlayerNetworkStatusPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerNetworkStatusPacket.cpp
@@ -11,10 +11,8 @@
 #include "StdInc.h"
 #include "CPlayerNetworkStatusPacket.h"
 
-bool CPlayerNetworkStatusPacket::Read(NetBitStreamInterface& BitStream)
+bool CPlayerNetworkStatusPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     BitStream.Read(m_ucType);
-    if (!BitStream.Read(m_uiTicks))
-        return false;
-    return true;
+    return BitStream.Read(m_uiTicks);
 }

--- a/Server/mods/deathmatch/logic/packets/CPlayerNetworkStatusPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerNetworkStatusPacket.h
@@ -15,16 +15,16 @@
 class CPlayerNetworkStatusPacket final : public CPacket
 {
 public:
-    virtual bool  RequiresSourcePlayer() const { return true; }
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_NETWORK_STATUS; };
-    unsigned long GetFlags() const
+    virtual bool  RequiresSourcePlayer() const noexcept { return true; }
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_NETWORK_STATUS; }
+    std::uint32_t GetFlags() const noexcept
     {
         assert(0);
         return 0;
     };
 
-    bool Read(NetBitStreamInterface& BitStream);
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
 
-    uchar m_ucType;
-    uint  m_uiTicks;
+    std::uint8_t  m_ucType;
+    std::uint32_t m_uiTicks;
 };

--- a/Server/mods/deathmatch/logic/packets/CPlayerNetworkStatusPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerNetworkStatusPacket.h
@@ -16,7 +16,7 @@ class CPlayerNetworkStatusPacket final : public CPacket
 {
 public:
     virtual bool  RequiresSourcePlayer() const { return true; }
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_NETWORK_STATUS; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_NETWORK_STATUS; };
     unsigned long GetFlags() const
     {
         assert(0);

--- a/Server/mods/deathmatch/logic/packets/CPlayerNoSocketPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerNoSocketPacket.h
@@ -13,7 +13,7 @@ class CPlayerNoSocketPacket final : public CPacket
 {
 public:
     virtual bool  RequiresSourcePlayer() const { return true; }
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_NO_SOCKET; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_NO_SOCKET; };
     unsigned long GetFlags() const
     {
         assert(0);

--- a/Server/mods/deathmatch/logic/packets/CPlayerNoSocketPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerNoSocketPacket.h
@@ -12,13 +12,14 @@
 class CPlayerNoSocketPacket final : public CPacket
 {
 public:
-    virtual bool  RequiresSourcePlayer() const { return true; }
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_NO_SOCKET; };
-    unsigned long GetFlags() const
+    virtual bool  RequiresSourcePlayer() const noexcept { return true; }
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_NO_SOCKET; }
+    std::uint32_t GetFlags() const noexcept
     {
+        // ???
         assert(0);
         return 0;
-    };
+    }
 
-    bool Read(NetBitStreamInterface& BitStream) { return true; };
+    bool Read(NetBitStreamInterface& BitStream) noexcept { return true; }
 };

--- a/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
@@ -19,389 +19,385 @@
 
 extern CGame* g_pGame;
 
-CPlayerPuresyncPacket::CPlayerPuresyncPacket(CPlayer* pPlayer)
+CPlayerPuresyncPacket::CPlayerPuresyncPacket(CPlayer* pPlayer) noexcept
 {
     m_pSourceElement = pPlayer;
 }
 
-bool CPlayerPuresyncPacket::Read(NetBitStreamInterface& BitStream)
+bool CPlayerPuresyncPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
-    if (m_pSourceElement)
+    if (!m_pSourceElement)
+        return false;
+
+    CPlayer* pSourcePlayer = static_cast<CPlayer*>(m_pSourceElement);
+
+    // Read out the time context
+    unsigned char ucTimeContext = 0;
+    if (!BitStream.Read(ucTimeContext))
+        return false;
+
+    // Only read this packet if it matches the current time context that
+    // player is in.
+    if (!pSourcePlayer->CanUpdateSync(ucTimeContext))
     {
-        CPlayer* pSourcePlayer = static_cast<CPlayer*>(m_pSourceElement);
+        return false;
+    }
 
-        // Read out the time context
-        unsigned char ucTimeContext = 0;
-        if (!BitStream.Read(ucTimeContext))
+    // Read out keys
+    CControllerState ControllerState;
+    ReadFullKeysync(ControllerState, BitStream);
+    pSourcePlayer->GetPad()->NewControllerState(ControllerState);
+
+    // Read the flags
+    SPlayerPuresyncFlags flags;
+    if (!BitStream.Read(&flags))
+        return false;
+
+    pSourcePlayer->SetInWater(flags.data.bIsInWater);
+    pSourcePlayer->SetOnGround(flags.data.bIsOnGround);
+    pSourcePlayer->SetHasJetPack(flags.data.bHasJetPack);
+    pSourcePlayer->SetDucked(flags.data.bIsDucked);
+    pSourcePlayer->SetWearingGoggles(flags.data.bWearsGoogles);
+    pSourcePlayer->SetChoking(flags.data.bIsChoking);
+    pSourcePlayer->SetAkimboArmUp(flags.data.bAkimboTargetUp);
+    pSourcePlayer->SetOnFire(flags.data.bIsOnFire);
+    pSourcePlayer->SetStealthAiming(flags.data.bStealthAiming);
+
+    // Contact element
+    CElement* pContactElement = NULL;
+    if (flags.data.bHasContact)
+    {
+        ElementID Temp;
+        if (!BitStream.Read(Temp))
             return false;
+        pContactElement = CElementIDs::GetElement(Temp);
+    }
 
-        // Only read this packet if it matches the current time context that
-        // player is in.
-        if (!pSourcePlayer->CanUpdateSync(ucTimeContext))
-        {
-            return false;
-        }
+    // Player position
+    SPositionSync position(false);
+    if (!BitStream.Read(&position))
+        return false;
 
-        // Read out keys
-        CControllerState ControllerState;
-        ReadFullKeysync(ControllerState, BitStream);
-        pSourcePlayer->GetPad()->NewControllerState(ControllerState);
+    if (pContactElement != nullptr &&
+        (!IsPointNearPoint3D(pSourcePlayer->GetPosition(), pContactElement->GetPosition(), g_TickRateSettings.iVehicleContactSyncRadius) ||
+            pSourcePlayer->GetDimension() != pContactElement->GetDimension()))
+    {
+        pContactElement = nullptr;
+        // Use current player position. They are not reporting their absolute position so we have to disregard it.
+        position.data.vecPosition = pSourcePlayer->GetPosition();
+    }
 
-        // Read the flags
-        SPlayerPuresyncFlags flags;
-        if (!BitStream.Read(&flags))
-            return false;
+    CElement* pPreviousContactElement = pSourcePlayer->GetContactElement();
+    pSourcePlayer->SetContactElement(pContactElement);
 
-        pSourcePlayer->SetInWater(flags.data.bIsInWater);
-        pSourcePlayer->SetOnGround(flags.data.bIsOnGround);
-        pSourcePlayer->SetHasJetPack(flags.data.bHasJetPack);
-        pSourcePlayer->SetDucked(flags.data.bIsDucked);
-        pSourcePlayer->SetWearingGoggles(flags.data.bWearsGoogles);
-        pSourcePlayer->SetChoking(flags.data.bIsChoking);
-        pSourcePlayer->SetAkimboArmUp(flags.data.bAkimboTargetUp);
-        pSourcePlayer->SetOnFire(flags.data.bIsOnFire);
-        pSourcePlayer->SetStealthAiming(flags.data.bStealthAiming);
-
-        // Contact element
-        CElement* pContactElement = NULL;
-        if (flags.data.bHasContact)
-        {
-            ElementID Temp;
-            if (!BitStream.Read(Temp))
-                return false;
-            pContactElement = CElementIDs::GetElement(Temp);
-        }
-
-        // Player position
-        SPositionSync position(false);
-        if (!BitStream.Read(&position))
-            return false;
-
-        if (pContactElement != nullptr &&
-            (!IsPointNearPoint3D(pSourcePlayer->GetPosition(), pContactElement->GetPosition(), g_TickRateSettings.iVehicleContactSyncRadius) ||
-                pSourcePlayer->GetDimension() != pContactElement->GetDimension()))
-        {
-            pContactElement = nullptr;
-            // Use current player position. They are not reporting their absolute position so we have to disregard it.
-            position.data.vecPosition = pSourcePlayer->GetPosition();
-        }
-
-        CElement* pPreviousContactElement = pSourcePlayer->GetContactElement();
-        pSourcePlayer->SetContactElement(pContactElement);
-
-        if (pPreviousContactElement != pContactElement)
-        {
-            // Call our onPlayerContact event
-            CLuaArguments Arguments;
-            if (pPreviousContactElement)
-                Arguments.PushElement(pPreviousContactElement);
-            else
-                Arguments.PushNil();
-            if (pContactElement)
-                Arguments.PushElement(pContactElement);
-            else
-                Arguments.PushNil();
-
-            pSourcePlayer->CallEvent("onPlayerContact", Arguments);
-        }
-
+    if (pPreviousContactElement != pContactElement)
+    {
+        // Call our onPlayerContact event
+        CLuaArguments Arguments;
+        if (pPreviousContactElement)
+            Arguments.PushElement(pPreviousContactElement);
+        else
+            Arguments.PushNil();
         if (pContactElement)
-        {
-            pSourcePlayer->SetContactPosition(position.data.vecPosition);
+            Arguments.PushElement(pContactElement);
+        else
+            Arguments.PushNil();
 
-            // Get the true position
-            CVector vecTempPos = pContactElement->GetPosition();
-            position.data.vecPosition += vecTempPos;
+        pSourcePlayer->CallEvent("onPlayerContact", Arguments);
+    }
+
+    if (pContactElement)
+    {
+        pSourcePlayer->SetContactPosition(position.data.vecPosition);
+
+        // Get the true position
+        CVector vecTempPos = pContactElement->GetPosition();
+        position.data.vecPosition += vecTempPos;
+    }
+
+    pSourcePlayer->SetPosition(position.data.vecPosition);
+
+    // Player rotation
+    SPedRotationSync rotation;
+    if (!BitStream.Read(&rotation))
+        return false;
+    pSourcePlayer->SetRotation(rotation.data.fRotation);
+
+    // Move speed vector
+    if (flags.data.bSyncingVelocity)
+    {
+        SVelocitySync velocity;
+        if (!BitStream.Read(&velocity))
+            return false;
+        pSourcePlayer->SetVelocity(velocity.data.vecVelocity);
+    }
+
+    // Health ( stored with damage )
+    SPlayerHealthSync health;
+    if (!BitStream.Read(&health))
+        return false;
+    float fHealth = health.data.fValue;
+
+    // Armor
+    SPlayerArmorSync armor;
+    if (!BitStream.Read(&armor))
+        return false;
+
+    float fArmor = armor.data.fValue;
+    float fOldArmor = pSourcePlayer->GetArmor();
+    float fArmorLoss = fOldArmor - fArmor;
+
+    pSourcePlayer->SetArmor(fArmor);
+
+    // Read out and set the camera rotation
+    SCameraRotationSync camRotation;
+    BitStream.Read(&camRotation);
+    pSourcePlayer->SetCameraRotation(camRotation.data.fRotation);
+
+    // Read the camera orientation
+    CVector vecCamPosition, vecCamFwd;
+    ReadCameraOrientation(position.data.vecPosition, BitStream, vecCamPosition, vecCamFwd);
+    pSourcePlayer->SetCameraOrientation(vecCamPosition, vecCamFwd);
+
+    if (flags.data.bHasAWeapon)
+    {
+        // Read client weapon data, but only apply it if the weapon matches with the server
+        uchar ucUseWeaponType = pSourcePlayer->GetWeaponType();
+        bool  bWeaponCorrect = true;
+
+        // Check client has the weapon we think he has
+        unsigned char ucClientWeaponType;
+        if (!BitStream.Read(ucClientWeaponType))
+            return false;
+
+        if (pSourcePlayer->GetWeaponType() != ucClientWeaponType)
+        {
+            bWeaponCorrect = false;                          // Possibly old weapon data.
+            ucUseWeaponType = ucClientWeaponType;            // Use the packet supplied weapon type to skip over the correct amount of data
         }
 
-        pSourcePlayer->SetPosition(position.data.vecPosition);
+        // Update check counts
+        pSourcePlayer->SetWeaponCorrect(bWeaponCorrect);
 
-        // Player rotation
-        SPedRotationSync rotation;
-        if (!BitStream.Read(&rotation))
+        // Current weapon slot
+        SWeaponSlotSync slot;
+        if (!BitStream.Read(&slot))
             return false;
-        pSourcePlayer->SetRotation(rotation.data.fRotation);
+        unsigned int uiSlot = slot.data.uiSlot;
 
-        // Move speed vector
-        if (flags.data.bSyncingVelocity)
+        // Set weapon slot
+        if (bWeaponCorrect)
+            pSourcePlayer->SetWeaponSlot(uiSlot);
+        else
         {
-            SVelocitySync velocity;
-            if (!BitStream.Read(&velocity))
-                return false;
-            pSourcePlayer->SetVelocity(velocity.data.vecVelocity);
+            // remove invalid weapon data to prevent this from being relayed to other players
+            ucClientWeaponType = 0;
+            slot.data.uiSlot = 0;
         }
 
-        // Health ( stored with damage )
-        SPlayerHealthSync health;
-        if (!BitStream.Read(&health))
-            return false;
-        float fHealth = health.data.fValue;
-
-        // Armor
-        SPlayerArmorSync armor;
-        if (!BitStream.Read(&armor))
-            return false;
-
-        float fArmor = armor.data.fValue;
-        float fOldArmor = pSourcePlayer->GetArmor();
-        float fArmorLoss = fOldArmor - fArmor;
-
-        pSourcePlayer->SetArmor(fArmor);
-
-        // Read out and set the camera rotation
-        SCameraRotationSync camRotation;
-        BitStream.Read(&camRotation);
-        pSourcePlayer->SetCameraRotation(camRotation.data.fRotation);
-
-        // Read the camera orientation
-        CVector vecCamPosition, vecCamFwd;
-        ReadCameraOrientation(position.data.vecPosition, BitStream, vecCamPosition, vecCamFwd);
-        pSourcePlayer->SetCameraOrientation(vecCamPosition, vecCamFwd);
-
-        if (flags.data.bHasAWeapon)
+        if (CWeaponNames::DoesSlotHaveAmmo(uiSlot))
         {
-            // Read client weapon data, but only apply it if the weapon matches with the server
-            uchar ucUseWeaponType = pSourcePlayer->GetWeaponType();
-            bool  bWeaponCorrect = true;
-
-            // Check client has the weapon we think he has
-            unsigned char ucClientWeaponType;
-            if (!BitStream.Read(ucClientWeaponType))
+            // Read out the ammo states
+            SWeaponAmmoSync ammo(ucUseWeaponType, true, true);
+            if (!BitStream.Read(&ammo))
                 return false;
 
-            if (pSourcePlayer->GetWeaponType() != ucClientWeaponType)
-            {
-                bWeaponCorrect = false;                          // Possibly old weapon data.
-                ucUseWeaponType = ucClientWeaponType;            // Use the packet supplied weapon type to skip over the correct amount of data
-            }
+            float fWeaponRange = pSourcePlayer->GetWeaponRangeFromSlot(uiSlot);
 
-            // Update check counts
-            pSourcePlayer->SetWeaponCorrect(bWeaponCorrect);
-
-            // Current weapon slot
-            SWeaponSlotSync slot;
-            if (!BitStream.Read(&slot))
+            // Read out the aim data
+            SWeaponAimSync sync(fWeaponRange, (ControllerState.RightShoulder1 || ControllerState.ButtonCircle));
+            if (!BitStream.Read(&sync))
                 return false;
-            unsigned int uiSlot = slot.data.uiSlot;
 
-            // Set weapon slot
             if (bWeaponCorrect)
-                pSourcePlayer->SetWeaponSlot(uiSlot);
-            else
             {
-                // remove invalid weapon data to prevent this from being relayed to other players
-                ucClientWeaponType = 0;
-                slot.data.uiSlot = 0;
-            }
+                // Set the ammo states
+                pSourcePlayer->SetWeaponAmmoInClip(ammo.data.usAmmoInClip);
+                pSourcePlayer->SetWeaponTotalAmmo(ammo.data.usTotalAmmo);
 
-            if (CWeaponNames::DoesSlotHaveAmmo(uiSlot))
-            {
-                // Read out the ammo states
-                SWeaponAmmoSync ammo(ucUseWeaponType, true, true);
-                if (!BitStream.Read(&ammo))
-                    return false;
+                // Set the arm directions and whether or not arms are up
+                pSourcePlayer->SetAimDirection(sync.data.fArm);
 
-                float fWeaponRange = pSourcePlayer->GetWeaponRangeFromSlot(uiSlot);
-
-                // Read out the aim data
-                SWeaponAimSync sync(fWeaponRange, (ControllerState.RightShoulder1 || ControllerState.ButtonCircle));
-                if (!BitStream.Read(&sync))
-                    return false;
-
-                if (bWeaponCorrect)
+                // Read the aim data only if he's shooting or aiming
+                if (sync.isFull())
                 {
-                    // Set the ammo states
-                    pSourcePlayer->SetWeaponAmmoInClip(ammo.data.usAmmoInClip);
-                    pSourcePlayer->SetWeaponTotalAmmo(ammo.data.usTotalAmmo);
-
-                    // Set the arm directions and whether or not arms are up
-                    pSourcePlayer->SetAimDirection(sync.data.fArm);
-
-                    // Read the aim data only if he's shooting or aiming
-                    if (sync.isFull())
-                    {
-                        pSourcePlayer->SetSniperSourceVector(sync.data.vecOrigin);
-                        pSourcePlayer->SetTargettingVector(sync.data.vecTarget);
-                    }
-                }
-            }
-            else
-            {
-                if (bWeaponCorrect)
-                {
-                    pSourcePlayer->SetWeaponAmmoInClip(1);
-                    pSourcePlayer->SetWeaponTotalAmmo(1);
+                    pSourcePlayer->SetSniperSourceVector(sync.data.vecOrigin);
+                    pSourcePlayer->SetTargettingVector(sync.data.vecTarget);
                 }
             }
         }
         else
         {
-            pSourcePlayer->SetWeaponSlot(0);
-            pSourcePlayer->SetWeaponAmmoInClip(1);
-            pSourcePlayer->SetWeaponTotalAmmo(1);
-        }
-
-        // Read out damage info if changed
-        if (BitStream.ReadBit() == true)
-        {
-            ElementID DamagerID;
-            if (!BitStream.Read(DamagerID))
-                return false;
-
-            SWeaponTypeSync weaponType;
-            if (!BitStream.Read(&weaponType))
-                return false;
-
-            SBodypartSync bodyPart;
-            if (!BitStream.Read(&bodyPart))
-                return false;
-
-            pSourcePlayer->SetDamageInfo(DamagerID, weaponType.data.ucWeaponType, bodyPart.data.uiBodypart);
-        }
-
-        // If we know the player's dead, make sure the health we send on is 0
-        if (pSourcePlayer->IsDead())
-            fHealth = 0.0f;
-
-        float fOldHealth = pSourcePlayer->GetHealth();
-        float fHealthLoss = fOldHealth - fHealth;
-        pSourcePlayer->SetHealth(fHealth);
-
-        // Less than last packet's frame?
-        if (fHealthLoss > 0 || fArmorLoss > 0)
-        {
-            float fDamage = 0.0f;
-            if (fHealthLoss > 0)
-                fDamage += fHealthLoss;
-            if (fArmorLoss > 0)
-                fDamage += fArmorLoss;
-
-            // Call the onPlayerDamage event
-            CLuaArguments Arguments;
-            CElement*     pKillerElement = CElementIDs::GetElement(pSourcePlayer->GetPlayerAttacker());
-            if (pKillerElement)
-                Arguments.PushElement(pKillerElement);
-            else
-                Arguments.PushNil();
-            Arguments.PushNumber(pSourcePlayer->GetAttackWeapon());
-            Arguments.PushNumber(pSourcePlayer->GetAttackBodyPart());
-            Arguments.PushNumber(fDamage);
-
-            pSourcePlayer->CallEvent("onPlayerDamage", Arguments);
-        }
-
-        // Success
-        return true;
-    }
-
-    return false;
-}
-
-bool CPlayerPuresyncPacket::Write(NetBitStreamInterface& BitStream) const
-{
-    if (m_pSourceElement)
-    {
-        CPlayer* pSourcePlayer = static_cast<CPlayer*>(m_pSourceElement);
-
-        ElementID               PlayerID = pSourcePlayer->GetID();
-        unsigned short          usLatency = pSourcePlayer->GetPing();
-        const CControllerState& ControllerState = pSourcePlayer->GetPad()->GetCurrentControllerState();
-        CElement*               pContactElement = pSourcePlayer->GetContactElement();
-
-        // Get current weapon slot
-        unsigned char ucWeaponSlot = pSourcePlayer->GetWeaponSlot();
-
-        // Flags
-        SPlayerPuresyncFlags flags;
-        flags.data.bIsInWater = (pSourcePlayer->IsInWater() == true);
-        flags.data.bIsOnGround = (pSourcePlayer->IsOnGround() == true);
-        flags.data.bHasJetPack = (pSourcePlayer->HasJetPack() == true);
-        flags.data.bIsDucked = (pSourcePlayer->IsDucked() == true);
-        flags.data.bWearsGoogles = (pSourcePlayer->IsWearingGoggles() == true);
-        flags.data.bHasContact = (pContactElement != NULL);
-        flags.data.bIsChoking = (pSourcePlayer->IsChoking() == true);
-        flags.data.bAkimboTargetUp = (pSourcePlayer->IsAkimboArmUp() == true);
-        flags.data.bIsOnFire = (pSourcePlayer->IsOnFire() == true);
-        flags.data.bHasAWeapon = (ucWeaponSlot != 0);
-        flags.data.bSyncingVelocity = (!flags.data.bIsOnGround || pSourcePlayer->IsSyncingVelocity());
-        flags.data.bStealthAiming = (pSourcePlayer->IsStealthAiming() == true);
-
-        CVector vecPosition = pSourcePlayer->GetPosition();
-        if (pContactElement)
-            pSourcePlayer->GetContactPosition(vecPosition);
-
-        BitStream.Write(PlayerID);
-
-        // Write the time context
-        BitStream.Write(pSourcePlayer->GetSyncTimeContext());
-
-        BitStream.WriteCompressed(usLatency);
-        WriteFullKeysync(ControllerState, BitStream);
-
-        BitStream.Write(&flags);
-
-        if (pContactElement)
-            BitStream.Write(pContactElement->GetID());
-
-        SPositionSync position(false);
-        position.data.vecPosition = vecPosition;
-        BitStream.Write(&position);
-
-        SPedRotationSync rotation;
-        rotation.data.fRotation = pSourcePlayer->GetRotation();
-        BitStream.Write(&rotation);
-
-        if (flags.data.bSyncingVelocity)
-        {
-            SVelocitySync velocity;
-            pSourcePlayer->GetVelocity(velocity.data.vecVelocity);
-            BitStream.Write(&velocity);
-        }
-
-        // Player health and armor
-        SPlayerHealthSync health;
-        health.data.fValue = pSourcePlayer->GetHealth();
-        BitStream.Write(&health);
-
-        SPlayerArmorSync armor;
-        armor.data.fValue = pSourcePlayer->GetArmor();
-        BitStream.Write(&armor);
-
-        SCameraRotationSync camRotation;
-        camRotation.data.fRotation = pSourcePlayer->GetCameraRotation();
-        BitStream.Write(&camRotation);
-
-        if (flags.data.bHasAWeapon)
-        {
-            unsigned int    uiSlot = ucWeaponSlot;
-            SWeaponSlotSync slot;
-            slot.data.uiSlot = uiSlot;
-            BitStream.Write(&slot);
-
-            if (CWeaponNames::DoesSlotHaveAmmo(uiSlot))
+            if (bWeaponCorrect)
             {
-                unsigned short usWeaponAmmoInClip = pSourcePlayer->GetWeaponAmmoInClip();
-
-                SWeaponAmmoSync ammo(pSourcePlayer->GetWeaponType(), false, true);
-                ammo.data.usAmmoInClip = usWeaponAmmoInClip;
-                BitStream.Write(&ammo);
-
-                SWeaponAimSync aim(0.0f, (ControllerState.RightShoulder1 || ControllerState.ButtonCircle));
-                aim.data.fArm = pSourcePlayer->GetAimDirection();
-
-                // Write the aim data only if he's aiming or shooting
-                if (aim.isFull())
-                {
-                    aim.data.vecOrigin = pSourcePlayer->GetSniperSourceVector();
-                    pSourcePlayer->GetTargettingVector(aim.data.vecTarget);
-                }
-                BitStream.Write(&aim);
+                pSourcePlayer->SetWeaponAmmoInClip(1);
+                pSourcePlayer->SetWeaponTotalAmmo(1);
             }
         }
-
-        // Success
-        return true;
+    }
+    else
+    {
+        pSourcePlayer->SetWeaponSlot(0);
+        pSourcePlayer->SetWeaponAmmoInClip(1);
+        pSourcePlayer->SetWeaponTotalAmmo(1);
     }
 
-    return false;
+    // Read out damage info if changed
+    if (BitStream.ReadBit() == true)
+    {
+        ElementID DamagerID;
+        if (!BitStream.Read(DamagerID))
+            return false;
+
+        SWeaponTypeSync weaponType;
+        if (!BitStream.Read(&weaponType))
+            return false;
+
+        SBodypartSync bodyPart;
+        if (!BitStream.Read(&bodyPart))
+            return false;
+
+        pSourcePlayer->SetDamageInfo(DamagerID, weaponType.data.ucWeaponType, bodyPart.data.uiBodypart);
+    }
+
+    // If we know the player's dead, make sure the health we send on is 0
+    if (pSourcePlayer->IsDead())
+        fHealth = 0.0f;
+
+    float fOldHealth = pSourcePlayer->GetHealth();
+    float fHealthLoss = fOldHealth - fHealth;
+    pSourcePlayer->SetHealth(fHealth);
+
+    // Less than last packet's frame?
+    if (fHealthLoss > 0 || fArmorLoss > 0)
+    {
+        float fDamage = 0.0f;
+        if (fHealthLoss > 0)
+            fDamage += fHealthLoss;
+        if (fArmorLoss > 0)
+            fDamage += fArmorLoss;
+
+        // Call the onPlayerDamage event
+        CLuaArguments Arguments;
+        CElement*     pKillerElement = CElementIDs::GetElement(pSourcePlayer->GetPlayerAttacker());
+        if (pKillerElement)
+            Arguments.PushElement(pKillerElement);
+        else
+            Arguments.PushNil();
+        Arguments.PushNumber(pSourcePlayer->GetAttackWeapon());
+        Arguments.PushNumber(pSourcePlayer->GetAttackBodyPart());
+        Arguments.PushNumber(fDamage);
+
+        pSourcePlayer->CallEvent("onPlayerDamage", Arguments);
+    }
+
+    // Success
+    return true;
+}
+
+bool CPlayerPuresyncPacket::Write(NetBitStreamInterface& BitStream) const noexcept
+{
+    if (!m_pSourceElement)
+        return false;
+
+    CPlayer* pSourcePlayer = static_cast<CPlayer*>(m_pSourceElement);
+
+    ElementID     PlayerID = pSourcePlayer->GetID();
+    std::uint16_t usLatency = pSourcePlayer->GetPing();
+
+    const CControllerState& ControllerState = pSourcePlayer->GetPad()->GetCurrentControllerState();
+    CElement*               pContactElement = pSourcePlayer->GetContactElement();
+
+    // Get current weapon slot
+    std::uint8_t ucWeaponSlot = pSourcePlayer->GetWeaponSlot();
+
+    // Flags
+    SPlayerPuresyncFlags flags;
+    flags.data.bIsInWater = pSourcePlayer->IsInWater();
+    flags.data.bIsOnGround = pSourcePlayer->IsOnGround();
+    flags.data.bHasJetPack = pSourcePlayer->HasJetPack();
+    flags.data.bIsDucked = pSourcePlayer->IsDucked();
+    flags.data.bWearsGoogles = pSourcePlayer->IsWearingGoggles();
+    flags.data.bHasContact = pContactElement != nullptr;
+    flags.data.bIsChoking = pSourcePlayer->IsChoking();
+    flags.data.bAkimboTargetUp = pSourcePlayer->IsAkimboArmUp();
+    flags.data.bIsOnFire = pSourcePlayer->IsOnFire();
+    flags.data.bHasAWeapon = ucWeaponSlot != 0;
+    flags.data.bSyncingVelocity = !flags.data.bIsOnGround || pSourcePlayer->IsSyncingVelocity();
+    flags.data.bStealthAiming = pSourcePlayer->IsStealthAiming();
+
+    CVector vecPosition = pSourcePlayer->GetPosition();
+    if (pContactElement)
+        pSourcePlayer->GetContactPosition(vecPosition);
+
+    BitStream.Write(PlayerID);
+
+    // Write the time context
+    BitStream.Write(pSourcePlayer->GetSyncTimeContext());
+
+    BitStream.WriteCompressed(usLatency);
+    WriteFullKeysync(ControllerState, BitStream);
+
+    BitStream.Write(&flags);
+
+    if (pContactElement)
+        BitStream.Write(pContactElement->GetID());
+
+    SPositionSync position(false);
+    position.data.vecPosition = vecPosition;
+    BitStream.Write(&position);
+
+    SPedRotationSync rotation;
+    rotation.data.fRotation = pSourcePlayer->GetRotation();
+    BitStream.Write(&rotation);
+
+    if (flags.data.bSyncingVelocity)
+    {
+        SVelocitySync velocity;
+        pSourcePlayer->GetVelocity(velocity.data.vecVelocity);
+        BitStream.Write(&velocity);
+    }
+
+    // Player health and armor
+    SPlayerHealthSync health;
+    health.data.fValue = pSourcePlayer->GetHealth();
+    BitStream.Write(&health);
+
+    SPlayerArmorSync armor;
+    armor.data.fValue = pSourcePlayer->GetArmor();
+    BitStream.Write(&armor);
+
+    SCameraRotationSync camRotation;
+    camRotation.data.fRotation = pSourcePlayer->GetCameraRotation();
+    BitStream.Write(&camRotation);
+
+    if (!flags.data.bHasAWeapon)
+        return true;
+
+    unsigned int    uiSlot = ucWeaponSlot;
+    SWeaponSlotSync slot;
+    slot.data.uiSlot = uiSlot;
+    BitStream.Write(&slot);
+
+    if (!CWeaponNames::DoesSlotHaveAmmo(uiSlot))
+        return true;
+
+    unsigned short usWeaponAmmoInClip = pSourcePlayer->GetWeaponAmmoInClip();
+
+    SWeaponAmmoSync ammo(pSourcePlayer->GetWeaponType(), false, true);
+    ammo.data.usAmmoInClip = usWeaponAmmoInClip;
+    BitStream.Write(&ammo);
+
+    SWeaponAimSync aim(0.0f, (ControllerState.RightShoulder1 || ControllerState.ButtonCircle));
+    aim.data.fArm = pSourcePlayer->GetAimDirection();
+
+    // Write the aim data only if he's aiming or shooting
+    if (aim.isFull())
+    {
+        aim.data.vecOrigin = pSourcePlayer->GetSniperSourceVector();
+        pSourcePlayer->GetTargettingVector(aim.data.vecTarget);
+    }
+    BitStream.Write(&aim);
+
+    return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.h
@@ -16,13 +16,13 @@
 class CPlayerPuresyncPacket final : public CPacket
 {
 public:
-    CPlayerPuresyncPacket(){};
-    explicit CPlayerPuresyncPacket(CPlayer* pPlayer);
+    CPlayerPuresyncPacket() noexcept {};
+    explicit CPlayerPuresyncPacket(CPlayer* pPlayer) noexcept;
 
-    bool          HasSimHandler() const { return true; }
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_PURESYNC; };
-    unsigned long GetFlags() const { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
+    bool          HasSimHandler() const noexcept { return true; }
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_PURESYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 };

--- a/Server/mods/deathmatch/logic/packets/CPlayerQuitPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerQuitPacket.cpp
@@ -13,13 +13,13 @@
 #include "CPlayerQuitPacket.h"
 #include <net/SyncStructures.h>
 
-CPlayerQuitPacket::CPlayerQuitPacket()
+CPlayerQuitPacket::CPlayerQuitPacket() noexcept
 {
     m_PlayerID = INVALID_ELEMENT_ID;
     m_ucQuitReason = 0;
 }
 
-bool CPlayerQuitPacket::Write(NetBitStreamInterface& BitStream) const
+bool CPlayerQuitPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     if (m_PlayerID == INVALID_ELEMENT_ID)
         return false;

--- a/Server/mods/deathmatch/logic/packets/CPlayerQuitPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerQuitPacket.h
@@ -16,21 +16,23 @@
 class CPlayerQuitPacket final : public CPacket
 {
 public:
-    CPlayerQuitPacket();
+    CPlayerQuitPacket() noexcept;
 
-    ePacketID     GetPacketID() const { return static_cast<ePacketID>(PACKET_ID_PLAYER_QUIT); };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return static_cast<ePacketID>(PACKET_ID_PLAYER_QUIT); }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream) { return true; };
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept { return true; }
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    ElementID GetPlayer() { return m_PlayerID; };
-    void      SetPlayer(ElementID PlayerID) { m_PlayerID = PlayerID; };
+    ElementID GetPlayer() const noexcept { return m_PlayerID; };
+    void      SetPlayer(const ElementID PlayerID) noexcept { m_PlayerID = PlayerID; };
 
-    unsigned char GetQuitReason() { return m_ucQuitReason; }
-    void          SetQuitReason(unsigned char ucQuitReason) { m_ucQuitReason = ucQuitReason; }
+    std::uint8_t GetQuitReason() const noexcept { return m_ucQuitReason; }
+    void         SetQuitReason(const std::uint8_t ucQuitReason) noexcept {
+        m_ucQuitReason = ucQuitReason;
+    }
 
 private:
-    ElementID     m_PlayerID;
-    unsigned char m_ucQuitReason;
+    ElementID    m_PlayerID;
+    std::uint8_t m_ucQuitReason;
 };

--- a/Server/mods/deathmatch/logic/packets/CPlayerResourceStartPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerResourceStartPacket.cpp
@@ -13,7 +13,7 @@
 #include "CGame.h"
 #include "CResourceManager.h"
 
-bool CPlayerResourceStartPacket::Read(NetBitStreamInterface& BitStream)
+bool CPlayerResourceStartPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     ushort usResourceNetId;
     BitStream.Read(usResourceNetId);

--- a/Server/mods/deathmatch/logic/packets/CPlayerResourceStartPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerResourceStartPacket.h
@@ -19,7 +19,7 @@ class CPlayerResourceStartPacket final : public CPacket
 public:
     CPlayerResourceStartPacket() {}
 
-    ePacketID               GetPacketID() const { return PACKET_ID_PLAYER_RESOURCE_START; }
+    ePacketID               GetPacketID() const noexcept { return PACKET_ID_PLAYER_RESOURCE_START; }
     unsigned long           GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
     virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_DEFAULT; }
 

--- a/Server/mods/deathmatch/logic/packets/CPlayerResourceStartPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerResourceStartPacket.h
@@ -17,15 +17,15 @@ class CResource;
 class CPlayerResourceStartPacket final : public CPacket
 {
 public:
-    CPlayerResourceStartPacket() {}
+    CPlayerResourceStartPacket() noexcept {}
 
     ePacketID               GetPacketID() const noexcept { return PACKET_ID_PLAYER_RESOURCE_START; }
-    unsigned long           GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
-    virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_DEFAULT; }
+    std::uint32_t           GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
+    virtual ePacketOrdering GetPacketOrdering() const noexcept { return PACKET_ORDERING_DEFAULT; }
 
-    bool Read(NetBitStreamInterface& BitStream);
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
 
-    CResource* GetResource() const { return m_pResource; }
+    CResource* GetResource() const noexcept { return m_pResource; }
 
 private:
     CResource* m_pResource;

--- a/Server/mods/deathmatch/logic/packets/CPlayerScreenShotPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerScreenShotPacket.cpp
@@ -15,9 +15,9 @@
 #include "CGame.h"
 #include "CResourceManager.h"
 
-bool CPlayerScreenShotPacket::Read(NetBitStreamInterface& BitStream)
+bool CPlayerScreenShotPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
-    m_pResource = NULL;
+    m_pResource = nullptr;
 
     CPlayer* pPlayer = GetSourcePlayer();
     if (!pPlayer)

--- a/Server/mods/deathmatch/logic/packets/CPlayerScreenShotPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerScreenShotPacket.h
@@ -18,23 +18,23 @@ class CResource;
 class CPlayerScreenShotPacket final : public CPacket
 {
 public:
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_SCREENSHOT; };
-    unsigned long GetFlags() const { return 0; };            // Not used
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_SCREENSHOT; }
+    std::uint32_t GetFlags() const noexcept { return 0; } // Not used
 
-    bool Read(NetBitStreamInterface& BitStream);
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
 
-    uchar m_ucStatus;            // 1 = has image, 2 = minimized, 3 = disabled, 4 = error
+    std::uint8_t m_ucStatus; // 1 = has image, 2 = minimized, 3 = disabled, 4 = error
 
     // With every packet if status is 1
-    ushort  m_usScreenShotId;
-    ushort  m_usPartNumber;
+    std::uint16_t m_usScreenShotId;
+    std::uint16_t m_usPartNumber;
     CBuffer m_buffer;
 
     // When uiPartNumber is 0:
-    long long  m_llServerGrabTime;
-    uint       m_uiTotalBytes;
-    ushort     m_usTotalParts;
-    CResource* m_pResource;
-    SString    m_strTag;
-    SString    m_strError;
+    std::int64_t  m_llServerGrabTime;
+    std::uint32_t m_uiTotalBytes;
+    std::uint16_t m_usTotalParts;
+    CResource*    m_pResource;
+    SString       m_strTag;
+    SString       m_strError;
 };

--- a/Server/mods/deathmatch/logic/packets/CPlayerSpawnPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerSpawnPacket.cpp
@@ -12,15 +12,15 @@
 #include "StdInc.h"
 #include "CPlayerSpawnPacket.h"
 
-CPlayerSpawnPacket::CPlayerSpawnPacket()
+CPlayerSpawnPacket::CPlayerSpawnPacket() noexcept
 {
     m_PlayerID = INVALID_ELEMENT_ID;
     m_fSpawnRotation = 0;
     m_usPlayerSkin = 0;
 }
 
-CPlayerSpawnPacket::CPlayerSpawnPacket(ElementID PlayerID, const CVector& vecSpawnPosition, float fSpawnRotation, unsigned short usPlayerSkin,
-                                       unsigned char ucInterior, unsigned short usDimension, ElementID Team, unsigned char ucTimeContext)
+CPlayerSpawnPacket::CPlayerSpawnPacket(ElementID PlayerID, const CVector& vecSpawnPosition, float fSpawnRotation, std::uint16_t usPlayerSkin,
+                                       std::uint8_t ucInterior, std::uint16_t usDimension, ElementID Team, std::uint8_t ucTimeContext) noexcept
 {
     m_PlayerID = PlayerID;
     m_vecSpawnPosition = vecSpawnPosition;
@@ -32,12 +32,12 @@ CPlayerSpawnPacket::CPlayerSpawnPacket(ElementID PlayerID, const CVector& vecSpa
     m_ucTimeContext = ucTimeContext;
 }
 
-bool CPlayerSpawnPacket::Write(NetBitStreamInterface& BitStream) const
+bool CPlayerSpawnPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     BitStream.Write(m_PlayerID);
 
     // No flags atm
-    BitStream.Write(static_cast<unsigned char>(0));
+    BitStream.Write(static_cast<std::uint8_t>(0));
 
     BitStream.Write(m_vecSpawnPosition.fX);
     BitStream.Write(m_vecSpawnPosition.fY);

--- a/Server/mods/deathmatch/logic/packets/CPlayerSpawnPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerSpawnPacket.h
@@ -21,8 +21,8 @@ public:
     CPlayerSpawnPacket(ElementID PlayerID, const CVector& vecSpawnPosition, float fSpawnRotation, unsigned short usPlayerSkin, unsigned char ucInterior,
                        unsigned short usDimension, ElementID Team, unsigned char ucTimeContext);
 
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_SPAWN; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_SPAWN; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CPlayerSpawnPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerSpawnPacket.h
@@ -17,38 +17,39 @@
 class CPlayerSpawnPacket final : public CPacket
 {
 public:
-    CPlayerSpawnPacket();
-    CPlayerSpawnPacket(ElementID PlayerID, const CVector& vecSpawnPosition, float fSpawnRotation, unsigned short usPlayerSkin, unsigned char ucInterior,
-                       unsigned short usDimension, ElementID Team, unsigned char ucTimeContext);
+    CPlayerSpawnPacket() noexcept;
+    CPlayerSpawnPacket(ElementID PlayerID, const CVector& vecSpawnPosition, float fSpawnRotation, std::uint16_t usPlayerSkin, std::uint8_t ucInterior,
+                       std::uint16_t usDimension, ElementID Team, std::uint8_t ucTimeContext) noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_SPAWN; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_SPAWN; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    ElementID      GetPlayer() { return m_PlayerID; };
-    CVector&       GetSpawnPosition() { return m_vecSpawnPosition; };
-    float          GetSpawnRotation() { return m_fSpawnRotation; };
-    unsigned short GetPlayerSkin() { return m_usPlayerSkin; };
-    ElementID      GetTeam() { return m_Team; }
-    unsigned char  GetInterior() { return m_ucInterior; }
-    unsigned short GetDimension() { return m_usDimension; }
+    ElementID      GetPlayer() const noexcept { return m_PlayerID; }
+    CVector&       GetSpawnPosition() noexcept { return m_vecSpawnPosition; }
+    const CVector& GetSpawnPosition() const noexcept { return m_vecSpawnPosition; }
+    float          GetSpawnRotation() const noexcept { return m_fSpawnRotation; }
+    std::uint16_t  GetPlayerSkin() const noexcept { return m_usPlayerSkin; }
+    ElementID      GetTeam() const noexcept { return m_Team; }
+    std::uint8_t   GetInterior() const noexcept { return m_ucInterior; }
+    std::uint16_t  GetDimension() const noexcept { return m_usDimension; }
 
-    void SetPlayer(ElementID PlayerID) { m_PlayerID = PlayerID; };
-    void SetSpawnPosition(CVector& vecPosition) { m_vecSpawnPosition = vecPosition; };
-    void SetSpawnRotation(float fRotation) { m_fSpawnRotation = fRotation; };
-    void SetPlayerSkin(unsigned short usPlayerSkin) { m_usPlayerSkin = usPlayerSkin; };
-    void SetTeam(ElementID TeamID) { m_Team = TeamID; }
-    void SetInterior(unsigned char ucInterior) { m_ucInterior = ucInterior; }
-    void SetDimension(unsigned short usDimension) { m_usDimension = usDimension; }
+    void SetPlayer(const ElementID PlayerID) noexcept { m_PlayerID = PlayerID; }
+    void SetSpawnPosition(const CVector& vecPosition) noexcept { m_vecSpawnPosition = vecPosition; }
+    void SetSpawnRotation(const float fRotation) noexcept { m_fSpawnRotation = fRotation; }
+    void SetPlayerSkin(const std::uint16_t usPlayerSkin) noexcept { m_usPlayerSkin = usPlayerSkin; }
+    void SetTeam(const ElementID TeamID) noexcept { m_Team = TeamID; }
+    void SetInterior(const std::uint8_t ucInterior) noexcept { m_ucInterior = ucInterior; }
+    void SetDimension(const std::uint16_t usDimension) noexcept { m_usDimension = usDimension; }
 
 private:
-    ElementID      m_PlayerID;
-    CVector        m_vecSpawnPosition;
-    float          m_fSpawnRotation;
-    unsigned short m_usPlayerSkin;
-    ElementID      m_Team;
-    unsigned char  m_ucInterior;
-    unsigned short m_usDimension;
-    unsigned char  m_ucTimeContext;
+    CVector       m_vecSpawnPosition;
+    ElementID     m_PlayerID{0};
+    float         m_fSpawnRotation{0};
+    std::uint16_t m_usPlayerSkin{0};
+    ElementID     m_Team{0};
+    std::uint8_t  m_ucInterior{0};
+    std::uint16_t m_usDimension{0};
+    std::uint8_t  m_ucTimeContext{0};
 };

--- a/Server/mods/deathmatch/logic/packets/CPlayerStatsPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerStatsPacket.cpp
@@ -13,7 +13,7 @@
 #include "CPlayerStatsPacket.h"
 #include "CElement.h"
 
-bool CPlayerStatsPacket::Write(NetBitStreamInterface& BitStream) const
+bool CPlayerStatsPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     if (!m_pSourceElement)
         return false;
@@ -21,7 +21,8 @@ bool CPlayerStatsPacket::Write(NetBitStreamInterface& BitStream) const
     // Write the source elements's ID
     BitStream.Write(m_pSourceElement->GetID());
 
-    BitStream.WriteCompressed(static_cast<unsigned short>(m_map.size()));            // Write stat count
+    // Write stat count
+    BitStream.WriteCompressed(static_cast<std::uint16_t>(m_map.size()));
     for (auto&& [statID, value] : m_map)
     {
         BitStream.Write(statID);
@@ -31,7 +32,7 @@ bool CPlayerStatsPacket::Write(NetBitStreamInterface& BitStream) const
     return true;
 }
 
-void CPlayerStatsPacket::Add(unsigned short usID, float fValue)
+void CPlayerStatsPacket::Add(const std::uint16_t usID, const float fValue) noexcept
 {
     if (auto iter = m_map.find(usID); iter != m_map.end())
     {

--- a/Server/mods/deathmatch/logic/packets/CPlayerStatsPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerStatsPacket.h
@@ -17,19 +17,19 @@
 class CPlayerStatsPacket final : public CPacket
 {
 public:
-    ~CPlayerStatsPacket() = default;
+    ~CPlayerStatsPacket() noexcept = default;
 
     ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_STATS; }
     std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    void Add(unsigned short usID, float fValue);
-    void Remove(unsigned short usID, float fValue) { m_map.erase(usID); }
+    void Add(const std::uint16_t usID, const float fValue) noexcept;
+    void Remove(const std::uint16_t usID, const float fValue) noexcept { m_map.erase(usID); }
 
-    void   Clear() noexcept { m_map.clear(); }
-    size_t GetSize() const noexcept { return m_map.size(); }
+    void        Clear() noexcept { m_map.clear(); }
+    std::size_t GetSize() const noexcept { return m_map.size(); }
 
 private:
-    std::map<unsigned short, float> m_map;            // id - value pairs
+    std::map<std::uint16_t, float> m_map; // id - value pairs
 };

--- a/Server/mods/deathmatch/logic/packets/CPlayerStatsPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerStatsPacket.h
@@ -19,8 +19,8 @@ class CPlayerStatsPacket final : public CPacket
 public:
     ~CPlayerStatsPacket() = default;
 
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_STATS; }
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_STATS; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CPlayerTimeoutPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerTimeoutPacket.h
@@ -16,9 +16,9 @@
 class CPlayerTimeoutPacket final : public CPacket
 {
 public:
-    ePacketID     GetPacketID() const { return static_cast<ePacketID>(PACKET_ID_PLAYER_TIMEOUT); };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return static_cast<ePacketID>(PACKET_ID_PLAYER_TIMEOUT); }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream) { return true; };
-    bool Write(NetBitStreamInterface& BitStream) const { return true; };
+    bool Read(NetBitStreamInterface& BitStream) noexcept { return true; }
+    bool Write(NetBitStreamInterface& BitStream) const noexcept { return true; }
 };

--- a/Server/mods/deathmatch/logic/packets/CPlayerTransgressionPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerTransgressionPacket.cpp
@@ -12,7 +12,7 @@
 #include "StdInc.h"
 #include "CPlayerTransgressionPacket.h"
 
-bool CPlayerTransgressionPacket::Read(NetBitStreamInterface& BitStream)
+bool CPlayerTransgressionPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     return BitStream.Read(m_uiLevel) && BitStream.ReadString(m_strMessage);
 }

--- a/Server/mods/deathmatch/logic/packets/CPlayerTransgressionPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerTransgressionPacket.h
@@ -16,11 +16,11 @@
 class CPlayerTransgressionPacket final : public CPacket
 {
 public:
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_TRANSGRESSION; };
-    unsigned long GetFlags() const { return 0; };            // Not used
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_TRANSGRESSION; }
+    std::uint32_t GetFlags() const noexcept { return 0; } // Not used
 
-    bool Read(NetBitStreamInterface& BitStream);
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
 
-    uint    m_uiLevel;
-    SString m_strMessage;
+    std::uint32_t m_uiLevel;
+    SString       m_strMessage;
 };

--- a/Server/mods/deathmatch/logic/packets/CPlayerWastedPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerWastedPacket.cpp
@@ -14,7 +14,7 @@
 #include "CPed.h"
 #include <net/SyncStructures.h>
 
-CPlayerWastedPacket::CPlayerWastedPacket()
+CPlayerWastedPacket::CPlayerWastedPacket() noexcept
 {
     m_PlayerID = INVALID_ELEMENT_ID;
     m_Killer = INVALID_ELEMENT_ID;
@@ -23,8 +23,9 @@ CPlayerWastedPacket::CPlayerWastedPacket()
     m_bStealth = false;
 }
 
-CPlayerWastedPacket::CPlayerWastedPacket(CPed* pPed, CElement* pKiller, unsigned char ucKillerWeapon, unsigned char ucBodyPart, bool bStealth,
-                                         AssocGroupId animGroup, AnimationId animID)
+CPlayerWastedPacket::CPlayerWastedPacket(CPed* pPed, CElement* pKiller,
+    std::uint8_t ucKillerWeapon, std::uint8_t ucBodyPart, bool bStealth,
+    AssocGroupId animGroup, AnimationId animID) noexcept
 {
     m_PlayerID = pPed->GetID();
     m_Killer = (pKiller) ? pKiller->GetID() : INVALID_ELEMENT_ID;
@@ -39,29 +40,29 @@ CPlayerWastedPacket::CPlayerWastedPacket(CPed* pPed, CElement* pKiller, unsigned
     m_ucTimeContext = pPed->GenerateSyncTimeContext();
 }
 
-bool CPlayerWastedPacket::Read(NetBitStreamInterface& BitStream)
+bool CPlayerWastedPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     SWeaponTypeSync weapon;
     SBodypartSync   bodyPart;
     SPositionSync   pos(false);
 
-    if (BitStream.ReadCompressed(m_AnimGroup) && BitStream.ReadCompressed(m_AnimID) && BitStream.Read(m_Killer) && BitStream.Read(&weapon) &&
-        BitStream.Read(&bodyPart) && BitStream.Read(&pos))
-    {
-        SWeaponAmmoSync ammo(weapon.data.ucWeaponType, true, false);
-        if (BitStream.Read(&ammo))
-        {
-            m_vecPosition = pos.data.vecPosition;
-            m_ucBodyPart = bodyPart.data.uiBodypart;
-            m_ucKillerWeapon = weapon.data.ucWeaponType;
-            m_usAmmo = ammo.data.usTotalAmmo;
-            return true;
-        }
-    }
-    return false;
+    if (!BitStream.ReadCompressed(m_AnimGroup) || !BitStream.ReadCompressed(m_AnimID) ||
+        !BitStream.Read(m_Killer) || !BitStream.Read(&weapon) ||
+        !BitStream.Read(&bodyPart) || !BitStream.Read(&pos))
+        return false;
+
+    SWeaponAmmoSync ammo(weapon.data.ucWeaponType, true, false);
+    if (!BitStream.Read(&ammo))
+        return false;
+
+    m_vecPosition = pos.data.vecPosition;
+    m_ucBodyPart = bodyPart.data.uiBodypart;
+    m_ucKillerWeapon = weapon.data.ucWeaponType;
+    m_usAmmo = ammo.data.usTotalAmmo;
+    return true;
 }
 
-bool CPlayerWastedPacket::Write(NetBitStreamInterface& BitStream) const
+bool CPlayerWastedPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     SWeaponTypeSync weapon;
     SBodypartSync   bodyPart;

--- a/Server/mods/deathmatch/logic/packets/CPlayerWastedPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerWastedPacket.h
@@ -15,29 +15,30 @@
 #include <CVector.h>
 
 class CPed;
-typedef unsigned long AssocGroupId;
-typedef unsigned long AnimationId;
+using AssocGroupId = std::uint32_t;
+using AnimationId = std::uint32_t;
 
 class CPlayerWastedPacket final : public CPacket
 {
 public:
-    CPlayerWastedPacket();
-    CPlayerWastedPacket(CPed* pPed, CElement* pKiller, unsigned char ucKillerWeapon, unsigned char ucBodyPart, bool bStealth, AssocGroupId animGroup = 0,
-                        AnimationId animID = 15);
+    CPlayerWastedPacket() noexcept;
+    CPlayerWastedPacket(CPed* pPed, CElement* pKiller,
+        std::uint8_t ucKillerWeapon, std::uint8_t ucBodyPart, bool bStealth,
+        AssocGroupId animGroup = 0, AnimationId animID = 15) noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_WASTED; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_WASTED; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
     ElementID      m_PlayerID;
     ElementID      m_Killer;
-    unsigned char  m_ucKillerWeapon;
-    unsigned char  m_ucBodyPart;
+    std::uint8_t   m_ucKillerWeapon;
+    std::uint8_t   m_ucBodyPart;
     CVector        m_vecPosition;
-    unsigned short m_usAmmo;
+    std::uint16_t  m_usAmmo;
     bool           m_bStealth;
-    unsigned char  m_ucTimeContext;
-    unsigned long  m_AnimGroup, m_AnimID;
+    std::uint8_t   m_ucTimeContext;
+    std::uint32_t  m_AnimGroup, m_AnimID;
 };

--- a/Server/mods/deathmatch/logic/packets/CPlayerWastedPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerWastedPacket.h
@@ -25,8 +25,8 @@ public:
     CPlayerWastedPacket(CPed* pPed, CElement* pKiller, unsigned char ucKillerWeapon, unsigned char ucBodyPart, bool bStealth, AssocGroupId animGroup = 0,
                         AnimationId animID = 15);
 
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_WASTED; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_WASTED; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Read(NetBitStreamInterface& BitStream);
     bool Write(NetBitStreamInterface& BitStream) const;

--- a/Server/mods/deathmatch/logic/packets/CPlayerWastedPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerWastedPacket.h
@@ -13,10 +13,9 @@
 
 #include "CPacket.h"
 #include <CVector.h>
+#include <SharedUtil.IntTypes.h>
 
 class CPed;
-using AssocGroupId = std::uint32_t;
-using AnimationId = std::uint32_t;
 
 class CPlayerWastedPacket final : public CPacket
 {

--- a/Server/mods/deathmatch/logic/packets/CProjectileSyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CProjectileSyncPacket.cpp
@@ -14,12 +14,7 @@
 #include "CPlayer.h"
 #include <net/SyncStructures.h>
 
-CProjectileSyncPacket::CProjectileSyncPacket()
-{
-    m_usModel = 0;
-}
-
-bool CProjectileSyncPacket::Read(NetBitStreamInterface& BitStream)
+bool CProjectileSyncPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     bool bHasOrigin;
     if (!BitStream.ReadBit(bHasOrigin))
@@ -93,7 +88,7 @@ bool CProjectileSyncPacket::Read(NetBitStreamInterface& BitStream)
     return true;
 }
 
-bool CProjectileSyncPacket::Write(NetBitStreamInterface& BitStream) const
+bool CProjectileSyncPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     // Write the source player and latency if any. Otherwize 0
     if (m_pSourceElement)

--- a/Server/mods/deathmatch/logic/packets/CProjectileSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CProjectileSyncPacket.h
@@ -17,22 +17,22 @@
 class CProjectileSyncPacket final : public CPacket
 {
 public:
-    CProjectileSyncPacket();
+    CProjectileSyncPacket() noexcept {}
 
-    ePacketID     GetPacketID() const { return PACKET_ID_PROJECTILE; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PROJECTILE; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    unsigned char  m_ucWeaponType;
-    ElementID      m_OriginID;
-    CVector        m_vecOrigin;
-    float          m_fForce;
-    bool           m_bHasTarget;
-    ElementID      m_TargetID;
-    CVector        m_vecTarget;
-    CVector        m_vecRotation;
-    CVector        m_vecMoveSpeed;
-    unsigned short m_usModel;
+    std::uint16_t m_usModel;
+    std::uint8_t  m_ucWeaponType;
+    ElementID     m_OriginID;
+    CVector       m_vecOrigin;
+    float         m_fForce;
+    bool          m_bHasTarget;
+    ElementID     m_TargetID;
+    CVector       m_vecTarget;
+    CVector       m_vecRotation;
+    CVector       m_vecMoveSpeed;
 };

--- a/Server/mods/deathmatch/logic/packets/CResourceClientScriptsPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CResourceClientScriptsPacket.cpp
@@ -12,32 +12,31 @@
 #include "StdInc.h"
 #include "CResourceClientScriptsPacket.h"
 
-CResourceClientScriptsPacket::CResourceClientScriptsPacket(CResource* pResource) : m_pResource(pResource)
-{
-}
+CResourceClientScriptsPacket::CResourceClientScriptsPacket(CResource* pResource) noexcept
+    : m_pResource(pResource) {}
 
-void CResourceClientScriptsPacket::AddItem(CResourceClientScriptItem* pItem)
+void CResourceClientScriptsPacket::AddItem(CResourceClientScriptItem* pItem) noexcept
 {
     m_vecItems.push_back(pItem);
 }
 
-bool CResourceClientScriptsPacket::Write(NetBitStreamInterface& BitStream) const
+bool CResourceClientScriptsPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
-    if (m_vecItems.size() == 0)
+    if (m_vecItems.empty())
         return false;
 
     BitStream.Write(m_pResource->GetNetID());
 
-    auto usItemCount = static_cast<unsigned short>(m_vecItems.size());
+    auto usItemCount = static_cast<std::uint16_t>(m_vecItems.size());
     BitStream.Write(usItemCount);
 
-    for (std::vector<CResourceClientScriptItem*>::const_iterator iter = m_vecItems.begin(); iter != m_vecItems.end(); ++iter)
+    for (const auto& pItem : m_vecItems)
     {
         if (BitStream.Version() >= 0x50)
-            BitStream.WriteString(ConformResourcePath((*iter)->GetFullName()));
+            BitStream.WriteString(ConformResourcePath(pItem->GetFullName()));
 
-        const SString& data = (*iter)->GetSourceCode();
-        unsigned int   len = data.length();
+        const auto& data = pItem->GetSourceCode();
+        std::uint32_t len = data.length();
         BitStream.Write(len);
         BitStream.Write(data.c_str(), len);
     }

--- a/Server/mods/deathmatch/logic/packets/CResourceClientScriptsPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CResourceClientScriptsPacket.h
@@ -18,14 +18,14 @@
 class CResourceClientScriptsPacket final : public CPacket
 {
 public:
-    CResourceClientScriptsPacket(CResource* pResource);
+    CResourceClientScriptsPacket(CResource* pResource) noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_RESOURCE_CLIENT_SCRIPTS; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_RESOURCE_CLIENT_SCRIPTS; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    void AddItem(CResourceClientScriptItem* pItem);
+    void AddItem(CResourceClientScriptItem* pItem) noexcept;
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
     std::vector<CResourceClientScriptItem*> m_vecItems;

--- a/Server/mods/deathmatch/logic/packets/CResourceClientScriptsPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CResourceClientScriptsPacket.h
@@ -20,8 +20,8 @@ class CResourceClientScriptsPacket final : public CPacket
 public:
     CResourceClientScriptsPacket(CResource* pResource);
 
-    ePacketID     GetPacketID() const { return PACKET_ID_RESOURCE_CLIENT_SCRIPTS; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_RESOURCE_CLIENT_SCRIPTS; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     void AddItem(CResourceClientScriptItem* pItem);
 

--- a/Server/mods/deathmatch/logic/packets/CResourceStartPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CResourceStartPacket.cpp
@@ -18,137 +18,134 @@
 #include "CResource.h"
 #include "CDummy.h"
 
-CResourceStartPacket::CResourceStartPacket(const char* szResourceName, CResource* pResource)
-{
-    m_strResourceName = szResourceName;
-    m_pResource = pResource;
-}
+CResourceStartPacket::CResourceStartPacket(
+    const char* szResourceName,
+    CResource* pResource
+) noexcept : m_strResourceName(szResourceName), m_pResource(pResource) {}
 
-bool CResourceStartPacket::Write(NetBitStreamInterface& BitStream) const
+bool CResourceStartPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
-    if (!m_strResourceName.empty())
+    if (m_strResourceName.empty())
+        return false;
+
+    // Write the resource name
+    unsigned char sizeResourceName = static_cast<unsigned char>(m_strResourceName.size());
+    BitStream.Write(sizeResourceName);
+    if (sizeResourceName > 0)
     {
-        // Write the resource name
-        unsigned char sizeResourceName = static_cast<unsigned char>(m_strResourceName.size());
-        BitStream.Write(sizeResourceName);
-        if (sizeResourceName > 0)
-        {
-            BitStream.Write(m_strResourceName.c_str(), sizeResourceName);
-        }
-
-        // Write the resource id
-        BitStream.Write(m_pResource->GetNetID());
-
-        // Write the resource element id
-        BitStream.Write(m_pResource->GetResourceRootElement()->GetID());
-
-        // Write the resource dynamic element id
-        BitStream.Write(m_pResource->GetDynamicElementRoot()->GetID());
-
-        // Count the amount of 'no client cache' scripts
-        unsigned short usNoClientCacheScriptCount = 0;
-        if (m_pResource->IsClientScriptsOn() == true)
-        {
-            std::list<CResourceFile*>::iterator iter = m_pResource->IterBegin();
-            for (; iter != m_pResource->IterEnd(); ++iter)
-            {
-                if ((*iter)->GetType() == CResourceScriptItem::RESOURCE_FILE_TYPE_CLIENT_SCRIPT &&
-                    static_cast<CResourceClientScriptItem*>(*iter)->IsNoClientCache() == true)
-                {
-                    ++usNoClientCacheScriptCount;
-                }
-            }
-        }
-        BitStream.Write(usNoClientCacheScriptCount);
-
-        // Write the declared min client version for this resource
-        if (BitStream.Version() >= 0x32)
-        {
-            BitStream.WriteString(m_pResource->GetMinServerRequirement());
-            BitStream.WriteString(m_pResource->GetMinClientRequirement());
-        }
-        if (BitStream.Version() >= 0x45)
-        {
-            BitStream.WriteBit(m_pResource->IsOOPEnabledInMetaXml());
-        }
-
-        if (BitStream.Version() >= 0x62)
-        {
-            BitStream.Write(m_pResource->GetDownloadPriorityGroup());
-        }
-
-        // Send the resource files info
-        std::list<CResourceFile*>::iterator iter = m_pResource->IterBegin();
-        for (; iter != m_pResource->IterEnd(); iter++)
-        {
-            if (((*iter)->GetType() == CResourceScriptItem::RESOURCE_FILE_TYPE_CLIENT_CONFIG && m_pResource->IsClientConfigsOn()) ||
-                ((*iter)->GetType() == CResourceScriptItem::RESOURCE_FILE_TYPE_CLIENT_SCRIPT && m_pResource->IsClientScriptsOn() &&
-                 static_cast<CResourceClientScriptItem*>(*iter)->IsNoClientCache() == false) ||
-                ((*iter)->GetType() == CResourceScriptItem::RESOURCE_FILE_TYPE_CLIENT_FILE && m_pResource->IsClientFilesOn()))
-            {
-                // Write the Type of chunk to read (F - File, E - Exported Function)
-                BitStream.Write(static_cast<unsigned char>('F'));
-
-                // Write the map name
-                const char* szFileName = (*iter)->GetWindowsName();
-                size_t      sizeFileName = strlen(szFileName);
-
-                // Make sure we don't have any backslashes in the name
-                char* szCleanedFilename = new char[sizeFileName + 1];
-                strcpy(szCleanedFilename, szFileName);
-                for (unsigned int i = 0; i < sizeFileName; i++)
-                {
-                    if (szCleanedFilename[i] == '\\')
-                        szCleanedFilename[i] = '/';
-                }
-
-                BitStream.Write(static_cast<unsigned char>(sizeFileName));
-                if (sizeFileName > 0)
-                {
-                    BitStream.Write(szCleanedFilename, sizeFileName);
-                }
-
-                // ChrML: Don't forget this...
-                delete[] szCleanedFilename;
-
-                BitStream.Write(static_cast<unsigned char>((*iter)->GetType()));
-                CChecksum checksum = (*iter)->GetLastChecksum();
-                BitStream.Write(checksum.ulCRC);
-                BitStream.Write((const char*)checksum.md5.data, sizeof(checksum.md5.data));
-                BitStream.Write((*iter)->GetApproxSize());
-                if ((*iter)->GetType() == CResourceScriptItem::RESOURCE_FILE_TYPE_CLIENT_FILE)
-                {
-                    CResourceClientFileItem* pRCFItem = reinterpret_cast<CResourceClientFileItem*>(*iter);
-                    // write bool whether to download or not
-                    BitStream.WriteBit(pRCFItem->IsAutoDownload());
-                }
-            }
-        }
-
-        // Loop through the exported functions
-        std::list<CExportedFunction>::iterator iterExportedFunction = m_pResource->IterBeginExportedFunctions();
-        for (; iterExportedFunction != m_pResource->IterEndExportedFunctions(); iterExportedFunction++)
-        {
-            // Check to see if the exported function is 'client'
-            if (iterExportedFunction->GetType() == CExportedFunction::EXPORTED_FUNCTION_TYPE_CLIENT)
-            {
-                // Write the Type of chunk to read (F - File, E - Exported Function)
-                BitStream.Write(static_cast<unsigned char>('E'));
-
-                // Write the exported function
-                std::string strFunctionName = iterExportedFunction->GetFunctionName();
-                size_t      sizeFunctionName = strFunctionName.length();
-
-                BitStream.Write(static_cast<unsigned char>(sizeFunctionName));
-                if (sizeFunctionName > 0)
-                {
-                    BitStream.Write(strFunctionName.c_str(), sizeFunctionName);
-                }
-            }
-        }
-
-        return true;
+        BitStream.Write(m_strResourceName.c_str(), sizeResourceName);
     }
 
-    return false;
+    // Write the resource id
+    BitStream.Write(m_pResource->GetNetID());
+
+    // Write the resource element id
+    BitStream.Write(m_pResource->GetResourceRootElement()->GetID());
+
+    // Write the resource dynamic element id
+    BitStream.Write(m_pResource->GetDynamicElementRoot()->GetID());
+
+    // Count the amount of 'no client cache' scripts
+    unsigned short usNoClientCacheScriptCount = 0;
+    if (m_pResource->IsClientScriptsOn() == true)
+    {
+        std::list<CResourceFile*>::iterator iter = m_pResource->IterBegin();
+        for (; iter != m_pResource->IterEnd(); ++iter)
+        {
+            if ((*iter)->GetType() == CResourceScriptItem::RESOURCE_FILE_TYPE_CLIENT_SCRIPT &&
+                static_cast<CResourceClientScriptItem*>(*iter)->IsNoClientCache() == true)
+            {
+                ++usNoClientCacheScriptCount;
+            }
+        }
+    }
+    BitStream.Write(usNoClientCacheScriptCount);
+
+    // Write the declared min client version for this resource
+    if (BitStream.Version() >= 0x32)
+    {
+        BitStream.WriteString(m_pResource->GetMinServerRequirement());
+        BitStream.WriteString(m_pResource->GetMinClientRequirement());
+    }
+    if (BitStream.Version() >= 0x45)
+    {
+        BitStream.WriteBit(m_pResource->IsOOPEnabledInMetaXml());
+    }
+
+    if (BitStream.Version() >= 0x62)
+    {
+        BitStream.Write(m_pResource->GetDownloadPriorityGroup());
+    }
+
+    // Send the resource files info
+    std::list<CResourceFile*>::iterator iter = m_pResource->IterBegin();
+    for (; iter != m_pResource->IterEnd(); iter++)
+    {
+        if (((*iter)->GetType() == CResourceScriptItem::RESOURCE_FILE_TYPE_CLIENT_CONFIG && m_pResource->IsClientConfigsOn()) ||
+            ((*iter)->GetType() == CResourceScriptItem::RESOURCE_FILE_TYPE_CLIENT_SCRIPT && m_pResource->IsClientScriptsOn() &&
+                static_cast<CResourceClientScriptItem*>(*iter)->IsNoClientCache() == false) ||
+            ((*iter)->GetType() == CResourceScriptItem::RESOURCE_FILE_TYPE_CLIENT_FILE && m_pResource->IsClientFilesOn()))
+        {
+            // Write the Type of chunk to read (F - File, E - Exported Function)
+            BitStream.Write(static_cast<unsigned char>('F'));
+
+            // Write the map name
+            const char* szFileName = (*iter)->GetWindowsName();
+            size_t      sizeFileName = strlen(szFileName);
+
+            // Make sure we don't have any backslashes in the name
+            char* szCleanedFilename = new char[sizeFileName + 1];
+            strcpy(szCleanedFilename, szFileName);
+            for (unsigned int i = 0; i < sizeFileName; i++)
+            {
+                if (szCleanedFilename[i] == '\\')
+                    szCleanedFilename[i] = '/';
+            }
+
+            BitStream.Write(static_cast<unsigned char>(sizeFileName));
+            if (sizeFileName > 0)
+            {
+                BitStream.Write(szCleanedFilename, sizeFileName);
+            }
+
+            // ChrML: Don't forget this...
+            delete[] szCleanedFilename;
+
+            BitStream.Write(static_cast<unsigned char>((*iter)->GetType()));
+            CChecksum checksum = (*iter)->GetLastChecksum();
+            BitStream.Write(checksum.ulCRC);
+            BitStream.Write((const char*)checksum.md5.data, sizeof(checksum.md5.data));
+            BitStream.Write((*iter)->GetApproxSize());
+            if ((*iter)->GetType() == CResourceScriptItem::RESOURCE_FILE_TYPE_CLIENT_FILE)
+            {
+                CResourceClientFileItem* pRCFItem = reinterpret_cast<CResourceClientFileItem*>(*iter);
+                // write bool whether to download or not
+                BitStream.WriteBit(pRCFItem->IsAutoDownload());
+            }
+        }
+    }
+
+    // Loop through the exported functions
+    std::list<CExportedFunction>::iterator iterExportedFunction = m_pResource->IterBeginExportedFunctions();
+    for (; iterExportedFunction != m_pResource->IterEndExportedFunctions(); iterExportedFunction++)
+    {
+        // Check to see if the exported function is 'client'
+        if (iterExportedFunction->GetType() == CExportedFunction::EXPORTED_FUNCTION_TYPE_CLIENT)
+        {
+            // Write the Type of chunk to read (F - File, E - Exported Function)
+            BitStream.Write(static_cast<unsigned char>('E'));
+
+            // Write the exported function
+            std::string strFunctionName = iterExportedFunction->GetFunctionName();
+            size_t      sizeFunctionName = strFunctionName.length();
+
+            BitStream.Write(static_cast<unsigned char>(sizeFunctionName));
+            if (sizeFunctionName > 0)
+            {
+                BitStream.Write(strFunctionName.c_str(), sizeFunctionName);
+            }
+        }
+    }
+
+    return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CResourceStartPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CResourceStartPacket.h
@@ -17,12 +17,12 @@
 class CResourceStartPacket final : public CPacket
 {
 public:
-    CResourceStartPacket(const char* szResourceName, class CResource* pResource);
+    CResourceStartPacket(const char* szResourceName, class CResource* pResource) noexcept;
 
-    ePacketID     GetPacketID() const { return PACKET_ID_RESOURCE_START; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_RESOURCE_START; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
     std::string m_strResourceName;

--- a/Server/mods/deathmatch/logic/packets/CResourceStopPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CResourceStopPacket.cpp
@@ -12,12 +12,10 @@
 #include "StdInc.h"
 #include "CResourceStopPacket.h"
 
-CResourceStopPacket::CResourceStopPacket(unsigned short usID)
-{
-    m_usID = usID;
-}
+CResourceStopPacket::CResourceStopPacket(const std::uint16_t usID) noexcept
+    : m_usID(usID) {}
 
-bool CResourceStopPacket::Write(NetBitStreamInterface& BitStream) const
+bool CResourceStopPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     // Write the resource id
     BitStream.Write(m_usID);

--- a/Server/mods/deathmatch/logic/packets/CResourceStopPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CResourceStopPacket.h
@@ -16,13 +16,13 @@
 class CResourceStopPacket final : public CPacket
 {
 public:
-    CResourceStopPacket(unsigned short usID);
+    CResourceStopPacket(const std::uint16_t usID) noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_RESOURCE_STOP; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_RESOURCE_STOP; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
-    unsigned short m_usID;
+    std::uint16_t m_usID;
 };

--- a/Server/mods/deathmatch/logic/packets/CResourceStopPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CResourceStopPacket.h
@@ -18,8 +18,8 @@ class CResourceStopPacket final : public CPacket
 public:
     CResourceStopPacket(unsigned short usID);
 
-    ePacketID     GetPacketID() const { return PACKET_ID_RESOURCE_STOP; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_RESOURCE_STOP; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CReturnSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CReturnSyncPacket.h
@@ -16,10 +16,10 @@
 class CReturnSyncPacket final : public CPacket
 {
 public:
-    CReturnSyncPacket(class CPlayer* pPlayer);
+    CReturnSyncPacket(class CPlayer* pPlayer) noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_RETURN_SYNC; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_RETURN_SYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 };

--- a/Server/mods/deathmatch/logic/packets/CReturnSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CReturnSyncPacket.h
@@ -18,8 +18,8 @@ class CReturnSyncPacket final : public CPacket
 public:
     CReturnSyncPacket(class CPlayer* pPlayer);
 
-    ePacketID     GetPacketID() const { return PACKET_ID_RETURN_SYNC; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_RETURN_SYNC; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 };

--- a/Server/mods/deathmatch/logic/packets/CServerInfoSyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CServerInfoSyncPacket.cpp
@@ -12,21 +12,19 @@
 #include "CServerInfoSyncPacket.h"
 #include "CStaticFunctionDefinitions.h"
 
-bool CServerInfoSyncPacket::Write(NetBitStreamInterface& BitStream) const
+bool CServerInfoSyncPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
-    if (m_ActualInfo)            // Flag is set
+    // Flag is set
+    if (!m_ActualInfo)
+        return false;
+
+    BitStream.Write(m_ActualInfo);
+
+    // Check the flags one by one & write in order
+    if (maxPlayers)
     {
-        BitStream.Write(m_ActualInfo);
-
-        // Check the flags one by one & write in order
-        if (maxPlayers)
-            BitStream.Write(static_cast<uint>(
-                CStaticFunctionDefinitions::GetMaxPlayers()));            // static_cast ensures the type is uint in case it's changed in future
-
-        // other info
-
-        return true;
+        BitStream.Write(CStaticFunctionDefinitions::GetMaxPlayers());
     }
 
-    return false;
+    return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CServerInfoSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CServerInfoSyncPacket.h
@@ -24,7 +24,7 @@ class CServerInfoSyncPacket final : public CPacket
 public:
     CServerInfoSyncPacket(uint8 flags) { m_ActualInfo = flags; }
 
-    ePacketID               GetPacketID() const { return PACKET_ID_SERVER_INFO_SYNC; }
+    ePacketID               GetPacketID() const noexcept { return PACKET_ID_SERVER_INFO_SYNC; }
     unsigned long           GetFlags() const { return PACKET_LOW_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
     virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_DEFAULT; }
 

--- a/Server/mods/deathmatch/logic/packets/CServerInfoSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CServerInfoSyncPacket.h
@@ -12,7 +12,7 @@
 
 #include "CPacket.h"
 
-enum EServerInfoSyncFlag : uint8
+enum EServerInfoSyncFlag : std::uint8_t
 {
     SERVER_INFO_FLAG_ALL = 0xFF,                  // 0b11111111
     SERVER_INFO_FLAG_MAX_PLAYERS = 1,             // 0b00000001
@@ -22,18 +22,18 @@ enum EServerInfoSyncFlag : uint8
 class CServerInfoSyncPacket final : public CPacket
 {
 public:
-    CServerInfoSyncPacket(uint8 flags) { m_ActualInfo = flags; }
+    CServerInfoSyncPacket(std::uint8_t flags) noexcept { m_ActualInfo = flags; }
 
     ePacketID               GetPacketID() const noexcept { return PACKET_ID_SERVER_INFO_SYNC; }
-    unsigned long           GetFlags() const { return PACKET_LOW_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
-    virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_DEFAULT; }
+    std::uint32_t           GetFlags() const noexcept { return PACKET_LOW_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
+    virtual ePacketOrdering GetPacketOrdering() const noexcept { return PACKET_ORDERING_DEFAULT; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
     union
     {
-        uint8 m_ActualInfo;
+        std::uint8_t m_ActualInfo;
         struct
         {
             bool maxPlayers : 1;

--- a/Server/mods/deathmatch/logic/packets/CServerTextItemPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CServerTextItemPacket.h
@@ -16,13 +16,13 @@
 class CServerTextItemPacket final : public CPacket
 {
 public:
-    CServerTextItemPacket(unsigned long ulUniqueId, bool bDeleteable, float fX, float fY, float fScale, const SColor color, unsigned char format,
-                          unsigned char ucShadowAlpha, const char* szText);
+    CServerTextItemPacket(std::uint32_t ulUniqueId, bool bDeleteable, float fX, float fY, float fScale, const SColor color, std::uint8_t format,
+                          std::uint8_t ucShadowAlpha, const char* szText) noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_TEXT_ITEM; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_TEXT_ITEM; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
     SString       m_strText;
@@ -30,8 +30,8 @@ private:
     float         m_fY;
     SColor        m_Color;
     float         m_fScale;
-    unsigned char m_ucFormat;
-    unsigned char m_ucShadowAlpha;
-    unsigned long m_ulUniqueId;
+    std::uint8_t  m_ucFormat;
+    std::uint8_t  m_ucShadowAlpha;
+    std::uint32_t m_ulUniqueId;
     bool          m_bDeletable;
 };

--- a/Server/mods/deathmatch/logic/packets/CServerTextItemPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CServerTextItemPacket.h
@@ -19,8 +19,8 @@ public:
     CServerTextItemPacket(unsigned long ulUniqueId, bool bDeleteable, float fX, float fY, float fScale, const SColor color, unsigned char format,
                           unsigned char ucShadowAlpha, const char* szText);
 
-    ePacketID     GetPacketID() const { return PACKET_ID_TEXT_ITEM; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_TEXT_ITEM; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CSyncSettingsPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CSyncSettingsPacket.cpp
@@ -13,10 +13,12 @@
 #include "CCommon.h"
 #include <net/SyncStructures.h>
 
-CSyncSettingsPacket::CSyncSettingsPacket(const std::set<eWeaponType>& weaponTypesUsingBulletSync, uchar ucVehExtrapolateEnabled, short sVehExtrapolateBaseMs,
-                                         short sVehExtrapolatePercent, short sVehExtrapolateMaxMs, uchar ucUseAltPulseOrder, uchar ucAllowFastSprintFix,
-                                         uchar ucAllowDrivebyAnimationFix, uchar ucAllowShotgunDamageFix)
-{
+CSyncSettingsPacket::CSyncSettingsPacket(const std::set<eWeaponType>& weaponTypesUsingBulletSync,
+    std::uint8_t ucVehExtrapolateEnabled, std::int16_t sVehExtrapolateBaseMs,
+    std::int16_t sVehExtrapolatePercent, std::int16_t sVehExtrapolateMaxMs,
+    std::uint8_t ucUseAltPulseOrder, std::uint8_t ucAllowFastSprintFix,
+    std::uint8_t ucAllowDrivebyAnimationFix, std::uint8_t ucAllowShotgunDamageFix
+) noexcept {
     m_weaponTypesUsingBulletSync = weaponTypesUsingBulletSync;
     m_ucVehExtrapolateEnabled = ucVehExtrapolateEnabled;
     m_sVehExtrapolateBaseMs = sVehExtrapolateBaseMs;
@@ -28,19 +30,19 @@ CSyncSettingsPacket::CSyncSettingsPacket(const std::set<eWeaponType>& weaponType
     m_ucAllowShotgunDamageFix = ucAllowShotgunDamageFix;
 }
 
-bool CSyncSettingsPacket::Read(NetBitStreamInterface& BitStream)
+bool CSyncSettingsPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     return false;
 }
 
-bool CSyncSettingsPacket::Write(NetBitStreamInterface& BitStream) const
+bool CSyncSettingsPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
-    uchar ucNumWeapons = static_cast<uchar>(m_weaponTypesUsingBulletSync.size());
+    std::uint8_t ucNumWeapons = static_cast<std::uint8_t>(m_weaponTypesUsingBulletSync.size());
     BitStream.Write(ucNumWeapons);
 
-    for (std::set<eWeaponType>::const_iterator iter = m_weaponTypesUsingBulletSync.begin(); iter != m_weaponTypesUsingBulletSync.end(); ++iter)
+    for (const auto& pType : m_weaponTypesUsingBulletSync)
     {
-        BitStream.Write((uchar)*iter);
+        BitStream.Write((std::uint8_t)pType);
     }
 
     if (BitStream.Version() >= 0x35)

--- a/Server/mods/deathmatch/logic/packets/CSyncSettingsPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CSyncSettingsPacket.h
@@ -21,8 +21,8 @@ public:
                         short sVehExtrapolatePercent, short sVehExtrapolateMaxMs, uchar ucUseAltPulseOrder, uchar ucAllowFastSprintFix,
                         uchar ucAllowDrivebyAnimationFix, uchar ucAllowShotgunDamageFix);
 
-    ePacketID     GetPacketID() const { return PACKET_ID_SYNC_SETTINGS; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_SYNC_SETTINGS; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Read(NetBitStreamInterface& BitStream);
     bool Write(NetBitStreamInterface& BitStream) const;

--- a/Server/mods/deathmatch/logic/packets/CSyncSettingsPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CSyncSettingsPacket.h
@@ -16,24 +16,27 @@
 class CSyncSettingsPacket final : public CPacket
 {
 public:
-    CSyncSettingsPacket(){};
-    CSyncSettingsPacket(const std::set<eWeaponType>& weaponTypesUsingBulletSync, uchar ucVehExtrapolateEnabled, short sVehExtrapolateBaseMs,
-                        short sVehExtrapolatePercent, short sVehExtrapolateMaxMs, uchar ucUseAltPulseOrder, uchar ucAllowFastSprintFix,
-                        uchar ucAllowDrivebyAnimationFix, uchar ucAllowShotgunDamageFix);
+    CSyncSettingsPacket() noexcept {}
+    CSyncSettingsPacket(const std::set<eWeaponType>& weaponTypesUsingBulletSync,
+        std::uint8_t ucVehExtrapolateEnabled, std::int16_t sVehExtrapolateBaseMs,
+        std::int16_t sVehExtrapolatePercent, std::int16_t sVehExtrapolateMaxMs,
+        std::uint8_t ucUseAltPulseOrder, std::uint8_t ucAllowFastSprintFix,
+        std::uint8_t ucAllowDrivebyAnimationFix, std::uint8_t ucAllowShotgunDamageFix
+    ) noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_SYNC_SETTINGS; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_SYNC_SETTINGS; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
     std::set<eWeaponType> m_weaponTypesUsingBulletSync;
-    uchar                 m_ucVehExtrapolateEnabled;
-    short                 m_sVehExtrapolateBaseMs;
-    short                 m_sVehExtrapolatePercent;
-    short                 m_sVehExtrapolateMaxMs;
-    uchar                 m_ucUseAltPulseOrder;
-    uchar                 m_ucAllowFastSprintFix;
-    uchar                 m_ucAllowDrivebyAnimationFix;
-    uchar                 m_ucAllowShotgunDamageFix;
+    std::uint8_t          m_ucVehExtrapolateEnabled{0};
+    std::int16_t          m_sVehExtrapolateBaseMs{0};
+    std::int16_t          m_sVehExtrapolatePercent{0};
+    std::int16_t          m_sVehExtrapolateMaxMs{0};
+    std::uint8_t          m_ucUseAltPulseOrder{0};
+    std::uint8_t          m_ucAllowFastSprintFix{0};
+    std::uint8_t          m_ucAllowDrivebyAnimationFix{0};
+    std::uint8_t          m_ucAllowShotgunDamageFix{0};
 };

--- a/Server/mods/deathmatch/logic/packets/CUnoccupiedVehiclePushPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CUnoccupiedVehiclePushPacket.cpp
@@ -12,11 +12,7 @@
 #include "StdInc.h"
 #include "CUnoccupiedVehiclePushPacket.h"
 
-bool CUnoccupiedVehiclePushPacket::Read(NetBitStreamInterface& BitStream)
+bool CUnoccupiedVehiclePushPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
-    if (BitStream.Read(&vehicle))
-    {
-        return true;
-    }
-    return false;
+    return BitStream.Read(&vehicle);
 }

--- a/Server/mods/deathmatch/logic/packets/CUnoccupiedVehiclePushPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CUnoccupiedVehiclePushPacket.h
@@ -19,12 +19,12 @@ class CVehicle;
 class CUnoccupiedVehiclePushPacket final : public CPacket
 {
 public:
-    CUnoccupiedVehiclePushPacket(){};
+    CUnoccupiedVehiclePushPacket() noexcept {}
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_VEHICLE_PUSH_SYNC; };
-    std::uint32_t GetFlags() const noexcept { return 0; };            // Not used
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_VEHICLE_PUSH_SYNC; }
+    std::uint32_t GetFlags() const noexcept { return 0; } // Not used
 
-    bool Read(NetBitStreamInterface& BitStream);
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
 
     SUnoccupiedPushSync vehicle;
 };

--- a/Server/mods/deathmatch/logic/packets/CUnoccupiedVehiclePushPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CUnoccupiedVehiclePushPacket.h
@@ -21,8 +21,8 @@ class CUnoccupiedVehiclePushPacket final : public CPacket
 public:
     CUnoccupiedVehiclePushPacket(){};
 
-    ePacketID     GetPacketID() const { return PACKET_ID_VEHICLE_PUSH_SYNC; };
-    unsigned long GetFlags() const { return 0; };            // Not used
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_VEHICLE_PUSH_SYNC; };
+    std::uint32_t GetFlags() const noexcept { return 0; };            // Not used
 
     bool Read(NetBitStreamInterface& BitStream);
 

--- a/Server/mods/deathmatch/logic/packets/CUnoccupiedVehicleStartSyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CUnoccupiedVehicleStartSyncPacket.cpp
@@ -13,7 +13,7 @@
 #include "CUnoccupiedVehicleStartSyncPacket.h"
 #include "CVehicle.h"
 
-bool CUnoccupiedVehicleStartSyncPacket::Write(NetBitStreamInterface& BitStream) const
+bool CUnoccupiedVehicleStartSyncPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     if (!m_pVehicle)
         return false;

--- a/Server/mods/deathmatch/logic/packets/CUnoccupiedVehicleStartSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CUnoccupiedVehicleStartSyncPacket.h
@@ -20,8 +20,8 @@ class CUnoccupiedVehicleStartSyncPacket final : public CPacket
 public:
     CUnoccupiedVehicleStartSyncPacket(CVehicle* pVehicle) { m_pVehicle = pVehicle; };
 
-    ePacketID     GetPacketID() const { return PACKET_ID_UNOCCUPIED_VEHICLE_STARTSYNC; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_UNOCCUPIED_VEHICLE_STARTSYNC; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CUnoccupiedVehicleStartSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CUnoccupiedVehicleStartSyncPacket.h
@@ -18,12 +18,12 @@ class CVehicle;
 class CUnoccupiedVehicleStartSyncPacket final : public CPacket
 {
 public:
-    CUnoccupiedVehicleStartSyncPacket(CVehicle* pVehicle) { m_pVehicle = pVehicle; };
+    CUnoccupiedVehicleStartSyncPacket(CVehicle* pVehicle) noexcept { m_pVehicle = pVehicle; }
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_UNOCCUPIED_VEHICLE_STARTSYNC; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_UNOCCUPIED_VEHICLE_STARTSYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
     CVehicle* m_pVehicle;

--- a/Server/mods/deathmatch/logic/packets/CUnoccupiedVehicleStopSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CUnoccupiedVehicleStopSyncPacket.h
@@ -18,8 +18,8 @@ class CUnoccupiedVehicleStopSyncPacket final : public CPacket
 public:
     CUnoccupiedVehicleStopSyncPacket(ElementID ID) { m_ID = ID; };
 
-    ePacketID     GetPacketID() const { return PACKET_ID_UNOCCUPIED_VEHICLE_STOPSYNC; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_UNOCCUPIED_VEHICLE_STOPSYNC; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const
     {

--- a/Server/mods/deathmatch/logic/packets/CUnoccupiedVehicleStopSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CUnoccupiedVehicleStopSyncPacket.h
@@ -16,16 +16,16 @@
 class CUnoccupiedVehicleStopSyncPacket final : public CPacket
 {
 public:
-    CUnoccupiedVehicleStopSyncPacket(ElementID ID) { m_ID = ID; };
+    CUnoccupiedVehicleStopSyncPacket(ElementID ID) noexcept { m_ID = ID; }
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_UNOCCUPIED_VEHICLE_STOPSYNC; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_UNOCCUPIED_VEHICLE_STOPSYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const
+    bool Write(NetBitStreamInterface& BitStream) const noexcept
     {
         BitStream.Write(m_ID);
         return true;
-    };
+    }
 
 private:
     ElementID m_ID;

--- a/Server/mods/deathmatch/logic/packets/CUnoccupiedVehicleSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CUnoccupiedVehicleSyncPacket.h
@@ -26,17 +26,20 @@ public:
     };
 
 public:
-    CUnoccupiedVehicleSyncPacket(){};
-    ~CUnoccupiedVehicleSyncPacket();
+    CUnoccupiedVehicleSyncPacket() noexcept {}
+    ~CUnoccupiedVehicleSyncPacket() noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_UNOCCUPIED_VEHICLE_SYNC; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_UNOCCUPIED_VEHICLE_SYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    std::vector<SyncData>::iterator IterBegin() { return m_Syncs.begin(); };
-    std::vector<SyncData>::iterator IterEnd() { return m_Syncs.end(); };
+    std::vector<SyncData>::iterator begin() noexcept { return m_Syncs.begin(); }
+    std::vector<SyncData>::iterator end() noexcept { return m_Syncs.end(); }
+
+    std::vector<SyncData>::const_iterator begin() const noexcept { return m_Syncs.cbegin(); }
+    std::vector<SyncData>::const_iterator end() const noexcept { return m_Syncs.cend(); }
 
     std::vector<SyncData> m_Syncs;
 };

--- a/Server/mods/deathmatch/logic/packets/CUnoccupiedVehicleSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CUnoccupiedVehicleSyncPacket.h
@@ -29,8 +29,8 @@ public:
     CUnoccupiedVehicleSyncPacket(){};
     ~CUnoccupiedVehicleSyncPacket();
 
-    ePacketID     GetPacketID() const { return PACKET_ID_UNOCCUPIED_VEHICLE_SYNC; };
-    unsigned long GetFlags() const { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_UNOCCUPIED_VEHICLE_SYNC; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
 
     bool Read(NetBitStreamInterface& BitStream);
     bool Write(NetBitStreamInterface& BitStream) const;

--- a/Server/mods/deathmatch/logic/packets/CUpdateInfoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CUpdateInfoPacket.cpp
@@ -12,22 +12,22 @@
 #include "StdInc.h"
 #include "CUpdateInfoPacket.h"
 
-CUpdateInfoPacket::CUpdateInfoPacket()
+CUpdateInfoPacket::CUpdateInfoPacket() noexcept
 {
 }
 
-CUpdateInfoPacket::CUpdateInfoPacket(const SString& strType, const SString& strData)
+CUpdateInfoPacket::CUpdateInfoPacket(const SString& strType, const SString& strData) noexcept
 {
     m_strType = strType;
     m_strData = strData;
 }
 
-bool CUpdateInfoPacket::Write(NetBitStreamInterface& BitStream) const
+bool CUpdateInfoPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
-    BitStream.Write((unsigned short)m_strType.length());
+    BitStream.Write((std::uint16_t)m_strType.length());
     BitStream.Write(m_strType.c_str(), m_strType.length());
 
-    BitStream.Write((unsigned short)m_strData.length());
+    BitStream.Write((std::uint16_t)m_strData.length());
     BitStream.Write(m_strData.c_str(), m_strData.length());
 
     return true;

--- a/Server/mods/deathmatch/logic/packets/CUpdateInfoPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CUpdateInfoPacket.h
@@ -16,13 +16,13 @@
 class CUpdateInfoPacket final : public CPacket
 {
 public:
-    CUpdateInfoPacket();
-    CUpdateInfoPacket(const SString& m_strType, const SString& strData);
+    CUpdateInfoPacket() noexcept;
+    CUpdateInfoPacket(const SString& m_strType, const SString& strData) noexcept;
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_UPDATE_INFO; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_UPDATE_INFO; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
     SString m_strType;

--- a/Server/mods/deathmatch/logic/packets/CUpdateInfoPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CUpdateInfoPacket.h
@@ -19,8 +19,8 @@ public:
     CUpdateInfoPacket();
     CUpdateInfoPacket(const SString& m_strType, const SString& strData);
 
-    ePacketID     GetPacketID() const { return PACKET_ID_UPDATE_INFO; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_UPDATE_INFO; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CVehicleDamageSyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CVehicleDamageSyncPacket.cpp
@@ -13,16 +13,15 @@
 #include "CVehicleDamageSyncPacket.h"
 #include "CVehicle.h"
 
-CVehicleDamageSyncPacket::CVehicleDamageSyncPacket() : m_damage(true, true, true, true, true)
+CVehicleDamageSyncPacket::CVehicleDamageSyncPacket() noexcept
+    : m_damage(true, true, true, true, true) {}
+
+bool CVehicleDamageSyncPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
+    return BitStream.Read(m_Vehicle) && BitStream.Read(&m_damage);
 }
 
-bool CVehicleDamageSyncPacket::Read(NetBitStreamInterface& BitStream)
-{
-    return (BitStream.Read(m_Vehicle) && BitStream.Read(&m_damage));
-}
-
-bool CVehicleDamageSyncPacket::Write(NetBitStreamInterface& BitStream) const
+bool CVehicleDamageSyncPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     BitStream.Write(m_Vehicle);
     BitStream.Write(&m_damage);
@@ -30,19 +29,20 @@ bool CVehicleDamageSyncPacket::Write(NetBitStreamInterface& BitStream) const
     return true;
 }
 
-void CVehicleDamageSyncPacket::SetFromVehicle(CVehicle* pVehicle)
+void CVehicleDamageSyncPacket::SetFromVehicle(CVehicle* pVehicle) noexcept
 {
     m_Vehicle = pVehicle->GetID();
     m_damage.data.ucDoorStates = pVehicle->m_ucDoorStates;
     m_damage.data.ucWheelStates = pVehicle->m_ucWheelStates;
     m_damage.data.ucPanelStates = pVehicle->m_ucPanelStates;
     m_damage.data.ucLightStates = pVehicle->m_ucLightStates;
-    for (unsigned int i = 0; i < MAX_DOORS; ++i)
+
+    for (auto i = 0; i < MAX_DOORS; ++i)
         m_damage.data.bDoorStatesChanged[i] = true;
-    for (unsigned int i = 0; i < MAX_WHEELS; ++i)
+    for (auto i = 0; i < MAX_WHEELS; ++i)
         m_damage.data.bWheelStatesChanged[i] = true;
-    for (unsigned int i = 0; i < MAX_PANELS; ++i)
+    for (auto i = 0; i < MAX_PANELS; ++i)
         m_damage.data.bPanelStatesChanged[i] = true;
-    for (unsigned int i = 0; i < MAX_LIGHTS; ++i)
+    for (auto i = 0; i < MAX_LIGHTS; ++i)
         m_damage.data.bLightStatesChanged[i] = true;
 }

--- a/Server/mods/deathmatch/logic/packets/CVehicleDamageSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CVehicleDamageSyncPacket.h
@@ -19,15 +19,15 @@ class CVehicle;
 class CVehicleDamageSyncPacket final : public CPacket
 {
 public:
-    CVehicleDamageSyncPacket();
+    CVehicleDamageSyncPacket() noexcept;
 
-    ePacketID     GetPacketID() const { return PACKET_ID_VEHICLE_DAMAGE_SYNC; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_VEHICLE_DAMAGE_SYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept; 
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    void SetFromVehicle(CVehicle* pVehicle);
+    void SetFromVehicle(CVehicle* pVehicle) noexcept;
 
     ElementID          m_Vehicle;
     SVehicleDamageSync m_damage;

--- a/Server/mods/deathmatch/logic/packets/CVehicleInOutPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CVehicleInOutPacket.h
@@ -17,51 +17,74 @@
 class CVehicleInOutPacket final : public CPacket
 {
 public:
-    CVehicleInOutPacket();
-    CVehicleInOutPacket(ElementID PedID, ElementID VehicleID, unsigned char ucSeat, unsigned char ucAction);
-    CVehicleInOutPacket(ElementID PedID, ElementID VehicleID, unsigned char ucSeat, unsigned char ucAction, unsigned char ucDoor);
-    CVehicleInOutPacket(ElementID PedID, ElementID VehicleID, unsigned char ucSeat, unsigned char ucAction, ElementID PedIn, ElementID PedOut);
-    virtual ~CVehicleInOutPacket();
+    CVehicleInOutPacket() noexcept;
+    CVehicleInOutPacket(ElementID PedID, ElementID VehicleID, std::uint8_t ucSeat, std::uint8_t ucAction) noexcept;
+    CVehicleInOutPacket(ElementID PedID, ElementID VehicleID, std::uint8_t ucSeat, std::uint8_t ucAction, std::uint8_t ucDoor) noexcept;
+    CVehicleInOutPacket(ElementID PedID, ElementID VehicleID, std::uint8_t ucSeat, std::uint8_t ucAction, ElementID PedIn, ElementID PedOut) noexcept;
+    virtual ~CVehicleInOutPacket() noexcept;
 
-    ePacketID     GetPacketID() const { return PACKET_ID_VEHICLE_INOUT; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_VEHICLE_INOUT; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    unsigned char GetDoor() { return m_ucDoor; };
-    bool          GetOnWater() { return m_bOnWater; };
-    ElementID     GetVehicleID() { return m_VehicleID; };
-    ElementID     GetPedID() { return m_PedID; };
-    unsigned char GetSeat() { return m_ucSeat; };
-    float         GetDoorAngle() { return m_fDoorAngle; }
-    unsigned char GetAction() { return m_ucAction; };
-    ElementID     GetPedIn() { return m_PedIn; };
-    ElementID     GetPedOut() { return m_PedOut; };
-    unsigned char GetStartedJacking() { return m_ucStartedJacking; };
+    std::uint8_t GetDoor() const noexcept { return m_ucDoor; }
+    bool         GetOnWater() const noexcept { return m_bOnWater; }
+    ElementID    GetVehicleID() const noexcept { return m_VehicleID; }
+    ElementID    GetPedID() const noexcept { return m_PedID; }
+    std::uint8_t GetSeat() const noexcept { return m_ucSeat; }
+    float        GetDoorAngle() const noexcept { return m_fDoorAngle; }
+    std::uint8_t GetAction() const noexcept { return m_ucAction; }
+    ElementID    GetPedIn() const noexcept { return m_PedIn; }
+    ElementID    GetPedOut() const noexcept { return m_PedOut; }
+    std::uint8_t GetStartedJacking() const noexcept { return m_ucStartedJacking; }
 
-    void SetPedID(ElementID ID) { m_PedID = ID; };
-    void SetVehicleID(ElementID ID) { m_VehicleID = ID; };
-    void SetSeat(unsigned char ucSeat) { m_ucSeat = ucSeat; };
-    void SetDoor(unsigned char ucDoor) { m_ucDoor = ucDoor; }
-    void SetDoorAngle(float fDoorAngle) { m_fDoorAngle = fDoorAngle; }
-    void SetAction(unsigned char ucAction) { m_ucAction = ucAction; };
-    void SetPedIn(ElementID PedIn) { m_PedIn = PedIn; };
-    void SetPedOut(ElementID PedOut) { m_PedOut = PedOut; };
-    void SetFailReason(unsigned char ucReason) { m_ucFailReason = ucReason; }
-    void SetCorrectVector(const CVector& vector) { m_pCorrectVector = new CVector(vector.fX, vector.fY, vector.fZ); }
+    void SetPedID(const ElementID ID) noexcept { m_PedID = ID; }
+    void SetVehicleID(const ElementID ID) noexcept { m_VehicleID = ID; }
+    void SetSeat(const std::uint8_t ucSeat) noexcept { m_ucSeat = ucSeat; }
+    void SetDoor(const std::uint8_t ucDoor) noexcept { m_ucDoor = ucDoor; }
+    void SetDoorAngle(const float fDoorAngle) noexcept { m_fDoorAngle = fDoorAngle; }
+    void SetAction(const std::uint8_t ucAction) noexcept { m_ucAction = ucAction; }
+    void SetPedIn(const ElementID PedIn) noexcept { m_PedIn = PedIn; }
+    void SetPedOut(const ElementID PedOut) noexcept { m_PedOut = PedOut; }
+    void SetFailReason(const std::uint8_t ucReason) noexcept { m_ucFailReason = ucReason; }
+    void SetCorrectVector(const CVector& vector) noexcept { m_pCorrectVector = new CVector(vector.fX, vector.fY, vector.fZ); }
 
 private:
-    ElementID     m_PedID;                       // The ped
-    ElementID     m_VehicleID;                   // The vehicle
-    unsigned char m_ucSeat;                      // The seat
-    unsigned char m_ucAction;                    // The action, see CGame.h
-    ElementID     m_PedIn;                       // The ped jacking
-    ElementID     m_PedOut;                      // The ped getting jacked
-    unsigned char m_ucStartedJacking;            // 1 = client reports he started jacking
-    unsigned char m_ucFailReason;                // eFailReasons
-    CVector*      m_pCorrectVector;              // Ped position reported by client
-    bool          m_bOnWater;                    // Vehicle in water reported by client
-    unsigned char m_ucDoor;                      // Door ID
-    float         m_fDoorAngle;                  // Door angle
+    // The ped
+    ElementID m_PedID;
+
+    // The vehicle
+    ElementID m_VehicleID;
+
+    // The seat
+    std::uint8_t m_ucSeat;
+
+    // The action, see CGame.h
+    std::uint8_t m_ucAction;
+
+    // The ped jacking
+    ElementID m_PedIn;
+
+    // The ped getting jacked
+    ElementID m_PedOut;
+
+    // 1 = client reports he started jacking
+    std::uint8_t m_ucStartedJacking;
+
+    // eFailReasons
+    std::uint8_t m_ucFailReason;
+
+    // Ped position reported by client
+    CVector* m_pCorrectVector;
+
+    // Vehicle in water reported by client
+    bool m_bOnWater;
+
+    // Door ID
+    std::uint8_t m_ucDoor;
+
+    // Door angle
+    float m_fDoorAngle;
 };

--- a/Server/mods/deathmatch/logic/packets/CVehiclePuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CVehiclePuresyncPacket.cpp
@@ -21,7 +21,7 @@
 
 extern CGame* g_pGame;
 
-CVehiclePuresyncPacket::CVehiclePuresyncPacket(CPlayer* pPlayer)
+CVehiclePuresyncPacket::CVehiclePuresyncPacket(CPlayer* pPlayer) noexcept
 {
     m_pSourceElement = pPlayer;
 }
@@ -29,659 +29,653 @@ CVehiclePuresyncPacket::CVehiclePuresyncPacket(CPlayer* pPlayer)
 //
 // NOTE: Any changes to this function will require similar changes to CSimVehiclePuresyncPacket::Read()
 //
-bool CVehiclePuresyncPacket::Read(NetBitStreamInterface& BitStream)
+bool CVehiclePuresyncPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     // Got a player to read?
-    if (m_pSourceElement)
+    if (!m_pSourceElement)
+        return false;
+
+    CPlayer* pSourcePlayer = static_cast<CPlayer*>(m_pSourceElement);
+
+    // Player is in a vehicle?
+    CVehicle* pVehicle = pSourcePlayer->GetOccupiedVehicle();
+    if (!pVehicle)
+        return false;
+
+    // Read out the time context
+    unsigned char ucTimeContext = 0;
+    if (!BitStream.Read(ucTimeContext))
+        return false;
+
+    // Only read this packet if it matches the current time context that
+    // player is in.
+    if (!pSourcePlayer->CanUpdateSync(ucTimeContext))
     {
-        CPlayer* pSourcePlayer = static_cast<CPlayer*>(m_pSourceElement);
+        return false;
+    }
 
-        // Player is in a vehicle?
-        CVehicle* pVehicle = pSourcePlayer->GetOccupiedVehicle();
-        if (pVehicle)
+    // Read out the keysync data
+    CControllerState ControllerState;
+    if (!ReadFullKeysync(ControllerState, BitStream))
+        return false;
+
+    // Read out the remote model
+    int iModelID = pVehicle->GetModel();
+    int iRemoteModelID = iModelID;
+
+    if (BitStream.Version() >= 0x05F)
+        BitStream.Read(iRemoteModelID);
+
+    eVehicleType vehicleType = pVehicle->GetVehicleType();
+    eVehicleType remoteVehicleType = CVehicleManager::GetVehicleType(iRemoteModelID);
+
+    // Read out its position
+    SPositionSync position(false);
+    if (!BitStream.Read(&position))
+        return false;
+    pSourcePlayer->SetPosition(position.data.vecPosition);
+
+    // If the remote vehicle is a train, we want to read special train-specific data
+    if (remoteVehicleType == VEHICLE_TRAIN)
+    {
+        float        fPosition;
+        bool         bDirection;
+        CTrainTrack* pTrainTrack;
+        float        fSpeed;
+
+        BitStream.Read(fPosition);
+        BitStream.ReadBit(bDirection);
+        BitStream.Read(fSpeed);
+
+        // TODO(qaisjp, feature/custom-train-tracks): this needs to be changed to an ElementID when the time is right (in a backwards compatible manner)
+        // Note: here we use a uchar, in the CTT branch this is a uint. Just don't forget that, it might be important
+        uchar trackIndex;
+        BitStream.Read(trackIndex);
+        pTrainTrack = g_pGame->GetTrainTrackManager()->GetTrainTrackByIndex(trackIndex);
+
+        // But we should only actually apply that train-specific data if that vehicle is train on our side
+        if (vehicleType == VEHICLE_TRAIN)
         {
-            // Read out the time context
-            unsigned char ucTimeContext = 0;
-            if (!BitStream.Read(ucTimeContext))
-                return false;
+            pVehicle->SetTrainPosition(fPosition);
+            pVehicle->SetTrainDirection(bDirection);
+            pVehicle->SetTrainTrack(pTrainTrack);
+            pVehicle->SetTrainSpeed(fSpeed);
+        }
+    }
 
-            // Only read this packet if it matches the current time context that
-            // player is in.
-            if (!pSourcePlayer->CanUpdateSync(ucTimeContext))
+    // Read the camera orientation
+    CVector vecCamPosition, vecCamFwd;
+    ReadCameraOrientation(position.data.vecPosition, BitStream, vecCamPosition, vecCamFwd);
+    pSourcePlayer->SetCameraOrientation(vecCamPosition, vecCamFwd);
+
+    // Jax: don't allow any outdated packets through
+    SOccupiedSeatSync seat;
+    if (!BitStream.Read(&seat))
+        return false;
+    if (seat.data.ucSeat != pSourcePlayer->GetOccupiedVehicleSeat())
+    {
+        // Mis-matching seats can happen when we warp into a different one,
+        // which will screw up the whole packet
+        return false;
+    }
+
+    // Read out the vehicle matrix only if he's the driver
+    unsigned int uiSeat = pSourcePlayer->GetOccupiedVehicleSeat();
+    if (uiSeat == 0)
+    {
+        // Read out the vehicle rotation in degrees
+        SRotationDegreesSync rotation;
+        if (!BitStream.Read(&rotation))
+            return false;
+
+        // Set it
+        pVehicle->SetPosition(position.data.vecPosition);
+        pVehicle->SetRotationDegrees(rotation.data.vecRotation);
+
+        // Move speed vector
+        SVelocitySync velocity;
+        if (!BitStream.Read(&velocity))
+            return false;
+
+        pVehicle->SetVelocity(velocity.data.vecVelocity);
+        pSourcePlayer->SetVelocity(velocity.data.vecVelocity);
+
+        // Turn speed vector
+        SVelocitySync turnSpeed;
+        if (!BitStream.Read(&turnSpeed))
+            return false;
+
+        pVehicle->SetTurnSpeed(turnSpeed.data.vecVelocity);
+
+        // Health
+        SVehicleHealthSync health;
+        if (!BitStream.Read(&health))
+            return false;
+
+        float fPreviousHealth = pVehicle->GetLastSyncedHealth();
+        float fHealth = health.data.fValue;
+
+        // Less than last time?
+        if (fHealth < fPreviousHealth)
+        {
+            // Grab the delta health
+            float fDeltaHealth = fPreviousHealth - fHealth;
+
+            if (fDeltaHealth > 0.0f)
             {
-                return false;
+                // Call the onVehicleDamage event
+                CLuaArguments Arguments;
+                Arguments.PushNumber(fDeltaHealth);
+                pVehicle->CallEvent("onVehicleDamage", Arguments);
             }
+        }
+        pVehicle->SetHealth(fHealth);
+        // Stops sync + fixVehicle/setElementHealth conflicts triggering onVehicleDamage by having a separate stored float keeping track of ONLY what
+        // comes in via sync
+        // - Caz
+        pVehicle->SetLastSyncedHealth(fHealth);
 
-            // Read out the keysync data
-            CControllerState ControllerState;
-            if (!ReadFullKeysync(ControllerState, BitStream))
+        // Trailer chain
+        CVehicle* pTowedByVehicle = pVehicle;
+        ElementID TrailerID;
+        bool      bHasTrailer;
+        if (!BitStream.ReadBit(bHasTrailer))
+            return false;
+
+        while (bHasTrailer)
+        {
+            BitStream.Read(TrailerID);
+            CVehicle* pTrailer = GetElementFromId<CVehicle>(TrailerID);
+
+            // Read out the trailer position and rotation
+            SPositionSync trailerPosition(false);
+            if (!BitStream.Read(&trailerPosition))
                 return false;
 
-            // Read out the remote model
-            int iModelID = pVehicle->GetModel();
-            int iRemoteModelID = iModelID;
-
-            if (BitStream.Version() >= 0x05F)
-                BitStream.Read(iRemoteModelID);
-
-            eVehicleType vehicleType = pVehicle->GetVehicleType();
-            eVehicleType remoteVehicleType = CVehicleManager::GetVehicleType(iRemoteModelID);
-
-            // Read out its position
-            SPositionSync position(false);
-            if (!BitStream.Read(&position))
+            SRotationDegreesSync trailerRotation;
+            if (!BitStream.Read(&trailerRotation))
                 return false;
-            pSourcePlayer->SetPosition(position.data.vecPosition);
 
-            // If the remote vehicle is a train, we want to read special train-specific data
-            if (remoteVehicleType == VEHICLE_TRAIN)
+            // If we found the trailer
+            if (!pTrailer)
+                break;
+
+            // Set its position and rotation
+            pTrailer->SetPosition(trailerPosition.data.vecPosition);
+            pTrailer->SetRotationDegrees(trailerRotation.data.vecRotation);
+
+            // Is this a new trailer, attached?
+            CVehicle* pCurrentTrailer = pTowedByVehicle->GetTowedVehicle();
+            if (pCurrentTrailer != pTrailer)
             {
-                float        fPosition;
-                bool         bDirection;
-                CTrainTrack* pTrainTrack;
-                float        fSpeed;
-
-                BitStream.Read(fPosition);
-                BitStream.ReadBit(bDirection);
-                BitStream.Read(fSpeed);
-
-                // TODO(qaisjp, feature/custom-train-tracks): this needs to be changed to an ElementID when the time is right (in a backwards compatible manner)
-                // Note: here we use a uchar, in the CTT branch this is a uint. Just don't forget that, it might be important
-                uchar trackIndex;
-                BitStream.Read(trackIndex);
-                pTrainTrack = g_pGame->GetTrainTrackManager()->GetTrainTrackByIndex(trackIndex);
-
-                // But we should only actually apply that train-specific data if that vehicle is train on our side
-                if (vehicleType == VEHICLE_TRAIN)
-                {
-                    pVehicle->SetTrainPosition(fPosition);
-                    pVehicle->SetTrainDirection(bDirection);
-                    pVehicle->SetTrainTrack(pTrainTrack);
-                    pVehicle->SetTrainSpeed(fSpeed);
-                }
-            }
-
-            // Read the camera orientation
-            CVector vecCamPosition, vecCamFwd;
-            ReadCameraOrientation(position.data.vecPosition, BitStream, vecCamPosition, vecCamFwd);
-            pSourcePlayer->SetCameraOrientation(vecCamPosition, vecCamFwd);
-
-            // Jax: don't allow any outdated packets through
-            SOccupiedSeatSync seat;
-            if (!BitStream.Read(&seat))
-                return false;
-            if (seat.data.ucSeat != pSourcePlayer->GetOccupiedVehicleSeat())
-            {
-                // Mis-matching seats can happen when we warp into a different one,
-                // which will screw up the whole packet
-                return false;
-            }
-
-            // Read out the vehicle matrix only if he's the driver
-            unsigned int uiSeat = pSourcePlayer->GetOccupiedVehicleSeat();
-            if (uiSeat == 0)
-            {
-                // Read out the vehicle rotation in degrees
-                SRotationDegreesSync rotation;
-                if (!BitStream.Read(&rotation))
-                    return false;
-
-                // Set it
-                pVehicle->SetPosition(position.data.vecPosition);
-                pVehicle->SetRotationDegrees(rotation.data.vecRotation);
-
-                // Move speed vector
-                SVelocitySync velocity;
-                if (!BitStream.Read(&velocity))
-                    return false;
-
-                pVehicle->SetVelocity(velocity.data.vecVelocity);
-                pSourcePlayer->SetVelocity(velocity.data.vecVelocity);
-
-                // Turn speed vector
-                SVelocitySync turnSpeed;
-                if (!BitStream.Read(&turnSpeed))
-                    return false;
-
-                pVehicle->SetTurnSpeed(turnSpeed.data.vecVelocity);
-
-                // Health
-                SVehicleHealthSync health;
-                if (!BitStream.Read(&health))
-                    return false;
-
-                float fPreviousHealth = pVehicle->GetLastSyncedHealth();
-                float fHealth = health.data.fValue;
-
-                // Less than last time?
-                if (fHealth < fPreviousHealth)
-                {
-                    // Grab the delta health
-                    float fDeltaHealth = fPreviousHealth - fHealth;
-
-                    if (fDeltaHealth > 0.0f)
-                    {
-                        // Call the onVehicleDamage event
-                        CLuaArguments Arguments;
-                        Arguments.PushNumber(fDeltaHealth);
-                        pVehicle->CallEvent("onVehicleDamage", Arguments);
-                    }
-                }
-                pVehicle->SetHealth(fHealth);
-                // Stops sync + fixVehicle/setElementHealth conflicts triggering onVehicleDamage by having a separate stored float keeping track of ONLY what
-                // comes in via sync
-                // - Caz
-                pVehicle->SetLastSyncedHealth(fHealth);
-
-                // Trailer chain
-                CVehicle* pTowedByVehicle = pVehicle;
-                ElementID TrailerID;
-                bool      bHasTrailer;
-                if (!BitStream.ReadBit(bHasTrailer))
-                    return false;
-
-                while (bHasTrailer)
-                {
-                    BitStream.Read(TrailerID);
-                    CVehicle* pTrailer = GetElementFromId<CVehicle>(TrailerID);
-
-                    // Read out the trailer position and rotation
-                    SPositionSync trailerPosition(false);
-                    if (!BitStream.Read(&trailerPosition))
-                        return false;
-
-                    SRotationDegreesSync trailerRotation;
-                    if (!BitStream.Read(&trailerRotation))
-                        return false;
-
-                    // If we found the trailer
-                    if (pTrailer)
-                    {
-                        // Set its position and rotation
-                        pTrailer->SetPosition(trailerPosition.data.vecPosition);
-                        pTrailer->SetRotationDegrees(trailerRotation.data.vecRotation);
-
-                        // Is this a new trailer, attached?
-                        CVehicle* pCurrentTrailer = pTowedByVehicle->GetTowedVehicle();
-                        if (pCurrentTrailer != pTrailer)
-                        {
-                            // If theres a trailer already attached
-                            if (pCurrentTrailer)
-                            {
-                                pTowedByVehicle->SetTowedVehicle(NULL);
-                                pCurrentTrailer->SetTowedByVehicle(NULL);
-
-                                // Tell everyone to detach them
-                                CVehicleTrailerPacket DetachPacket(pTowedByVehicle, pCurrentTrailer, false);
-                                g_pGame->GetPlayerManager()->BroadcastOnlyJoined(DetachPacket);
-
-                                // Execute the attach trailer script function
-                                CLuaArguments Arguments;
-                                Arguments.PushElement(pTowedByVehicle);
-                                pCurrentTrailer->CallEvent("onTrailerDetach", Arguments);
-                            }
-
-                            // If something else is towing this trailer
-                            CVehicle* pCurrentVehicle = pTrailer->GetTowedByVehicle();
-                            if (pCurrentVehicle)
-                            {
-                                pCurrentVehicle->SetTowedVehicle(NULL);
-                                pTrailer->SetTowedByVehicle(NULL);
-
-                                // Tell everyone to detach them
-                                CVehicleTrailerPacket DetachPacket(pCurrentVehicle, pTrailer, false);
-                                g_pGame->GetPlayerManager()->BroadcastOnlyJoined(DetachPacket);
-
-                                // Execute the attach trailer script function
-                                CLuaArguments Arguments;
-                                Arguments.PushElement(pCurrentVehicle);
-                                pTrailer->CallEvent("onTrailerDetach", Arguments);
-                            }
-
-                            pTowedByVehicle->SetTowedVehicle(pTrailer);
-                            pTrailer->SetTowedByVehicle(pTowedByVehicle);
-
-                            // Execute the attach trailer script function
-                            CLuaArguments Arguments;
-                            Arguments.PushElement(pTowedByVehicle);
-                            bool bContinue = pTrailer->CallEvent("onTrailerAttach", Arguments);
-
-                            // Attach or detach trailers depending on the event outcome
-                            CVehicleTrailerPacket TrailerPacket(pTowedByVehicle, pTrailer, bContinue);
-                            g_pGame->GetPlayerManager()->BroadcastOnlyJoined(TrailerPacket);
-                        }
-                    }
-                    else
-                        break;
-
-                    pTowedByVehicle = pTrailer;
-
-                    if (BitStream.ReadBit(bHasTrailer) == false)
-                        return false;
-                }
-
-                // If there was a trailer before
-                CVehicle* pCurrentTrailer = pTowedByVehicle->GetTowedVehicle();
+                // If theres a trailer already attached
                 if (pCurrentTrailer)
                 {
-                    pTowedByVehicle->SetTowedVehicle(NULL);
-                    pCurrentTrailer->SetTowedByVehicle(NULL);
+                    pTowedByVehicle->SetTowedVehicle(nullptr);
+                    pCurrentTrailer->SetTowedByVehicle(nullptr);
 
-                    // Tell everyone else to detach them
+                    // Tell everyone to detach them
                     CVehicleTrailerPacket DetachPacket(pTowedByVehicle, pCurrentTrailer, false);
                     g_pGame->GetPlayerManager()->BroadcastOnlyJoined(DetachPacket);
 
-                    // Execute the detach trailer script function
+                    // Execute the attach trailer script function
                     CLuaArguments Arguments;
                     Arguments.PushElement(pTowedByVehicle);
                     pCurrentTrailer->CallEvent("onTrailerDetach", Arguments);
                 }
-            }
 
-            // Update Damage info
-            if (BitStream.Version() >= 0x047)
-            {
-                if (BitStream.ReadBit() == true)
+                // If something else is towing this trailer
+                CVehicle* pCurrentVehicle = pTrailer->GetTowedByVehicle();
+                if (pCurrentVehicle)
                 {
-                    ElementID DamagerID;
-                    if (!BitStream.Read(DamagerID))
-                        return false;
+                    pCurrentVehicle->SetTowedVehicle(nullptr);
+                    pTrailer->SetTowedByVehicle(nullptr);
 
-                    SWeaponTypeSync weaponType;
-                    if (!BitStream.Read(&weaponType))
-                        return false;
+                    // Tell everyone to detach them
+                    CVehicleTrailerPacket DetachPacket(pCurrentVehicle, pTrailer, false);
+                    g_pGame->GetPlayerManager()->BroadcastOnlyJoined(DetachPacket);
 
-                    SBodypartSync bodyPart;
-                    if (!BitStream.Read(&bodyPart))
-                        return false;
-
-                    pSourcePlayer->SetDamageInfo(DamagerID, weaponType.data.ucWeaponType, bodyPart.data.uiBodypart);
+                    // Execute the attach trailer script function
+                    CLuaArguments Arguments;
+                    Arguments.PushElement(pCurrentVehicle);
+                    pTrailer->CallEvent("onTrailerDetach", Arguments);
                 }
+
+                pTowedByVehicle->SetTowedVehicle(pTrailer);
+                pTrailer->SetTowedByVehicle(pTowedByVehicle);
+
+                // Execute the attach trailer script function
+                CLuaArguments Arguments;
+                Arguments.PushElement(pTowedByVehicle);
+                bool bContinue = pTrailer->CallEvent("onTrailerAttach", Arguments);
+
+                // Attach or detach trailers depending on the event outcome
+                CVehicleTrailerPacket TrailerPacket(pTowedByVehicle, pTrailer, bContinue);
+                g_pGame->GetPlayerManager()->BroadcastOnlyJoined(TrailerPacket);
             }
 
-            // Player health
-            SPlayerHealthSync health;
-            if (!BitStream.Read(&health))
+            pTowedByVehicle = pTrailer;
+
+            if (!BitStream.ReadBit(bHasTrailer))
                 return false;
-            float fHealth = health.data.fValue;
+        }
 
-            float fOldHealth = pSourcePlayer->GetHealth();
-            float fHealthLoss = fOldHealth - fHealth;
+        // If there was a trailer before
+        CVehicle* pCurrentTrailer = pTowedByVehicle->GetTowedVehicle();
+        if (pCurrentTrailer)
+        {
+            pTowedByVehicle->SetTowedVehicle(nullptr);
+            pCurrentTrailer->SetTowedByVehicle(nullptr);
 
-            // Less than last packet's frame?
-            if (fHealth < fOldHealth && fHealthLoss > 0)
-            {
-                if (BitStream.Version() <= 0x046)
-                {
-                    // Call the onPlayerDamage event
-                    CLuaArguments Arguments;
-                    Arguments.PushNil();
-                    Arguments.PushNumber(false);
-                    Arguments.PushNumber(false);
-                    Arguments.PushNumber(fHealthLoss);
-                    pSourcePlayer->CallEvent("onPlayerDamage", Arguments);
-                }
-                else
-                {
-                    // Call the onPlayerDamage event
-                    CLuaArguments Arguments;
+            // Tell everyone else to detach them
+            CVehicleTrailerPacket DetachPacket(pTowedByVehicle, pCurrentTrailer, false);
+            g_pGame->GetPlayerManager()->BroadcastOnlyJoined(DetachPacket);
 
-                    CElement* pDamageSource = CElementIDs::GetElement(pSourcePlayer->GetPlayerAttacker());
-                    if (pDamageSource)
-                        Arguments.PushElement(pDamageSource);
-                    else
-                        Arguments.PushNil();
-                    Arguments.PushNumber(pSourcePlayer->GetAttackWeapon());
-                    Arguments.PushNumber(pSourcePlayer->GetAttackBodyPart());
-                    Arguments.PushNumber(fHealthLoss);
-                    pSourcePlayer->CallEvent("onPlayerDamage", Arguments);
-                }
-            }
-            pSourcePlayer->SetHealth(fHealth);
-
-            // Armor
-            SPlayerArmorSync armor;
-            if (!BitStream.Read(&armor))
-                return false;
-            float fArmor = armor.data.fValue;
-
-            float fOldArmor = pSourcePlayer->GetArmor();
-            float fArmorLoss = fOldArmor - fArmor;
-
-            // Less than last packet's frame?
-            if (fArmor < fOldArmor && fArmorLoss > 0)
-            {
-                if (BitStream.Version() <= 0x046)
-                {
-                    // Call the onPlayerDamage event
-                    CLuaArguments Arguments;
-                    Arguments.PushNil();
-                    Arguments.PushNumber(false);
-                    Arguments.PushNumber(false);
-                    Arguments.PushNumber(fArmorLoss);
-                    pSourcePlayer->CallEvent("onPlayerDamage", Arguments);
-                }
-                else
-                {
-                    // Call the onPlayerDamage event
-                    CLuaArguments Arguments;
-
-                    CElement* pDamageSource = CElementIDs::GetElement(pSourcePlayer->GetPlayerAttacker());
-                    if (pDamageSource)
-                        Arguments.PushElement(pDamageSource);
-                    else
-                        Arguments.PushNil();
-                    Arguments.PushNumber(pSourcePlayer->GetAttackWeapon());
-                    Arguments.PushNumber(pSourcePlayer->GetAttackBodyPart());
-                    Arguments.PushNumber(fArmorLoss);
-                    pSourcePlayer->CallEvent("onPlayerDamage", Arguments);
-                }
-            }
-            pSourcePlayer->SetArmor(fArmor);
-
-            // Flags
-            SVehiclePuresyncFlags flags;
-            if (!BitStream.Read(&flags))
-                return false;
-
-            pSourcePlayer->SetWearingGoggles(flags.data.bIsWearingGoggles);
-            pSourcePlayer->SetDoingGangDriveby(flags.data.bIsDoingGangDriveby);
-
-            // Weapon sync
-            if (flags.data.bHasAWeapon)
-            {
-                SWeaponSlotSync slot;
-                if (!BitStream.Read(&slot))
-                    return false;
-
-                pSourcePlayer->SetWeaponSlot(slot.data.uiSlot);
-
-                if (flags.data.bIsDoingGangDriveby && CWeaponNames::DoesSlotHaveAmmo(slot.data.uiSlot))
-                {
-                    float fWeaponRange = pSourcePlayer->GetWeaponRangeFromSlot(slot.data.uiSlot);
-
-                    // Read the ammo states
-                    SWeaponAmmoSync ammo(pSourcePlayer->GetWeaponType(), BitStream.Version() >= 0x44, true);
-                    if (!BitStream.Read(&ammo))
-                        return false;
-                    pSourcePlayer->SetWeaponAmmoInClip(ammo.data.usAmmoInClip);
-                    if (BitStream.Version() >= 0x44)
-                        pSourcePlayer->SetWeaponTotalAmmo(ammo.data.usTotalAmmo);
-
-                    // Read aim data
-                    SWeaponAimSync aim(fWeaponRange, true);
-                    if (!BitStream.Read(&aim))
-                        return false;
-                    pSourcePlayer->SetAimDirection(aim.data.fArm);
-                    pSourcePlayer->SetSniperSourceVector(aim.data.vecOrigin);
-                    pSourcePlayer->SetTargettingVector(aim.data.vecTarget);
-
-                    // Read the driveby direction
-                    SDrivebyDirectionSync driveby;
-                    if (!BitStream.Read(&driveby))
-                        return false;
-                    pSourcePlayer->SetDriveByDirection(driveby.data.ucDirection);
-                }
-            }
-            else
-                pSourcePlayer->SetWeaponSlot(0);
-
-            // Vehicle specific data if he's the driver
-            if (uiSeat == 0)
-            {
-                ReadVehicleSpecific(pVehicle, BitStream, iRemoteModelID);
-
-                // Set vehicle specific stuff if he's the driver
-                pVehicle->SetSirenActive(flags.data.bIsSirenOrAlarmActive);
-                pVehicle->SetSmokeTrailEnabled(flags.data.bIsSmokeTrailEnabled);
-                pVehicle->SetLandingGearDown(flags.data.bIsLandingGearDown);
-                pVehicle->SetOnGround(flags.data.bIsOnGround);
-                pVehicle->SetInWater(flags.data.bIsInWater);
-                pVehicle->SetDerailed(flags.data.bIsDerailed);
-                pVehicle->SetHeliSearchLightVisible(flags.data.bIsHeliSearchLightVisible);
-            }
-
-            // Read the vehicle_look_left and vehicle_look_right control states
-            // if it's an aircraft.
-            if (flags.data.bIsAircraft)
-            {
-                ControllerState.LeftShoulder2 = BitStream.ReadBit() * 255;
-                ControllerState.RightShoulder2 = BitStream.ReadBit() * 255;
-            }
-
-            pSourcePlayer->GetPad()->NewControllerState(ControllerState);
-
-            // Success
-            return true;
+            // Execute the detach trailer script function
+            CLuaArguments Arguments;
+            Arguments.PushElement(pTowedByVehicle);
+            pCurrentTrailer->CallEvent("onTrailerDetach", Arguments);
         }
     }
 
-    return false;
+    // Update Damage info
+    if (BitStream.Version() >= 0x047)
+    {
+        if (BitStream.ReadBit())
+        {
+            ElementID DamagerID;
+            if (!BitStream.Read(DamagerID))
+                return false;
+
+            SWeaponTypeSync weaponType;
+            if (!BitStream.Read(&weaponType))
+                return false;
+
+            SBodypartSync bodyPart;
+            if (!BitStream.Read(&bodyPart))
+                return false;
+
+            pSourcePlayer->SetDamageInfo(DamagerID, weaponType.data.ucWeaponType, bodyPart.data.uiBodypart);
+        }
+    }
+
+    // Player health
+    SPlayerHealthSync health;
+    if (!BitStream.Read(&health))
+        return false;
+    float fHealth = health.data.fValue;
+
+    float fOldHealth = pSourcePlayer->GetHealth();
+    float fHealthLoss = fOldHealth - fHealth;
+
+    // Less than last packet's frame?
+    if (fHealth < fOldHealth && fHealthLoss > 0)
+    {
+        if (BitStream.Version() <= 0x046)
+        {
+            // Call the onPlayerDamage event
+            CLuaArguments Arguments;
+            Arguments.PushNil();
+            Arguments.PushNumber(false);
+            Arguments.PushNumber(false);
+            Arguments.PushNumber(fHealthLoss);
+            pSourcePlayer->CallEvent("onPlayerDamage", Arguments);
+        }
+        else
+        {
+            // Call the onPlayerDamage event
+            CLuaArguments Arguments;
+
+            CElement* pDamageSource = CElementIDs::GetElement(pSourcePlayer->GetPlayerAttacker());
+            if (pDamageSource)
+                Arguments.PushElement(pDamageSource);
+            else
+                Arguments.PushNil();
+            Arguments.PushNumber(pSourcePlayer->GetAttackWeapon());
+            Arguments.PushNumber(pSourcePlayer->GetAttackBodyPart());
+            Arguments.PushNumber(fHealthLoss);
+            pSourcePlayer->CallEvent("onPlayerDamage", Arguments);
+        }
+    }
+    pSourcePlayer->SetHealth(fHealth);
+
+    // Armor
+    SPlayerArmorSync armor;
+    if (!BitStream.Read(&armor))
+        return false;
+    float fArmor = armor.data.fValue;
+
+    float fOldArmor = pSourcePlayer->GetArmor();
+    float fArmorLoss = fOldArmor - fArmor;
+
+    // Less than last packet's frame?
+    if (fArmor < fOldArmor && fArmorLoss > 0)
+    {
+        if (BitStream.Version() <= 0x046)
+        {
+            // Call the onPlayerDamage event
+            CLuaArguments Arguments;
+            Arguments.PushNil();
+            Arguments.PushNumber(false);
+            Arguments.PushNumber(false);
+            Arguments.PushNumber(fArmorLoss);
+            pSourcePlayer->CallEvent("onPlayerDamage", Arguments);
+        }
+        else
+        {
+            // Call the onPlayerDamage event
+            CLuaArguments Arguments;
+
+            CElement* pDamageSource = CElementIDs::GetElement(pSourcePlayer->GetPlayerAttacker());
+            if (pDamageSource)
+                Arguments.PushElement(pDamageSource);
+            else
+                Arguments.PushNil();
+            Arguments.PushNumber(pSourcePlayer->GetAttackWeapon());
+            Arguments.PushNumber(pSourcePlayer->GetAttackBodyPart());
+            Arguments.PushNumber(fArmorLoss);
+            pSourcePlayer->CallEvent("onPlayerDamage", Arguments);
+        }
+    }
+    pSourcePlayer->SetArmor(fArmor);
+
+    // Flags
+    SVehiclePuresyncFlags flags;
+    if (!BitStream.Read(&flags))
+        return false;
+
+    pSourcePlayer->SetWearingGoggles(flags.data.bIsWearingGoggles);
+    pSourcePlayer->SetDoingGangDriveby(flags.data.bIsDoingGangDriveby);
+
+    // Weapon sync
+    if (flags.data.bHasAWeapon)
+    {
+        SWeaponSlotSync slot;
+        if (!BitStream.Read(&slot))
+            return false;
+
+        pSourcePlayer->SetWeaponSlot(slot.data.uiSlot);
+
+        if (flags.data.bIsDoingGangDriveby && CWeaponNames::DoesSlotHaveAmmo(slot.data.uiSlot))
+        {
+            float fWeaponRange = pSourcePlayer->GetWeaponRangeFromSlot(slot.data.uiSlot);
+
+            // Read the ammo states
+            SWeaponAmmoSync ammo(pSourcePlayer->GetWeaponType(), BitStream.Version() >= 0x44, true);
+            if (!BitStream.Read(&ammo))
+                return false;
+            pSourcePlayer->SetWeaponAmmoInClip(ammo.data.usAmmoInClip);
+            if (BitStream.Version() >= 0x44)
+                pSourcePlayer->SetWeaponTotalAmmo(ammo.data.usTotalAmmo);
+
+            // Read aim data
+            SWeaponAimSync aim(fWeaponRange, true);
+            if (!BitStream.Read(&aim))
+                return false;
+            pSourcePlayer->SetAimDirection(aim.data.fArm);
+            pSourcePlayer->SetSniperSourceVector(aim.data.vecOrigin);
+            pSourcePlayer->SetTargettingVector(aim.data.vecTarget);
+
+            // Read the driveby direction
+            SDrivebyDirectionSync driveby;
+            if (!BitStream.Read(&driveby))
+                return false;
+            pSourcePlayer->SetDriveByDirection(driveby.data.ucDirection);
+        }
+    }
+    else
+        pSourcePlayer->SetWeaponSlot(0);
+
+    // Vehicle specific data if he's the driver
+    if (uiSeat == 0)
+    {
+        ReadVehicleSpecific(pVehicle, BitStream, iRemoteModelID);
+
+        // Set vehicle specific stuff if he's the driver
+        pVehicle->SetSirenActive(flags.data.bIsSirenOrAlarmActive);
+        pVehicle->SetSmokeTrailEnabled(flags.data.bIsSmokeTrailEnabled);
+        pVehicle->SetLandingGearDown(flags.data.bIsLandingGearDown);
+        pVehicle->SetOnGround(flags.data.bIsOnGround);
+        pVehicle->SetInWater(flags.data.bIsInWater);
+        pVehicle->SetDerailed(flags.data.bIsDerailed);
+        pVehicle->SetHeliSearchLightVisible(flags.data.bIsHeliSearchLightVisible);
+    }
+
+    // Read the vehicle_look_left and vehicle_look_right control states
+    // if it's an aircraft.
+    if (flags.data.bIsAircraft)
+    {
+        ControllerState.LeftShoulder2 = BitStream.ReadBit() * 255;
+        ControllerState.RightShoulder2 = BitStream.ReadBit() * 255;
+    }
+
+    pSourcePlayer->GetPad()->NewControllerState(ControllerState);
+
+    // Success
+    return true;
 }
 
 //
 // NOTE: Any changes to this function will require similar changes to CSimVehiclePuresyncPacket::Write()
 //
-bool CVehiclePuresyncPacket::Write(NetBitStreamInterface& BitStream) const
+bool CVehiclePuresyncPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     // Got a player to send?
-    if (m_pSourceElement)
+    if (!m_pSourceElement)
+        return false;
+
+    CPlayer* pSourcePlayer = static_cast<CPlayer*>(m_pSourceElement);
+
+    // Player is in a vehicle and is the driver?
+    CVehicle* pVehicle = pSourcePlayer->GetOccupiedVehicle();
+    if (!pVehicle)
+        return false;
+
+    // Player ID
+    ElementID PlayerID = pSourcePlayer->GetID();
+    BitStream.Write(PlayerID);
+
+    // Write the time context of that player
+    BitStream.Write(pSourcePlayer->GetSyncTimeContext());
+
+    // Write his ping divided with 2 plus a small number so the client can find out when this packet was sent
+    unsigned short usLatency = pSourcePlayer->GetPing();
+    BitStream.WriteCompressed(usLatency);
+
+    // Write the keysync data
+    const CControllerState& ControllerState = pSourcePlayer->GetPad()->GetCurrentControllerState();
+    WriteFullKeysync(ControllerState, BitStream);
+
+    // Write the serverside model (#8800)
+    if (BitStream.Version() >= 0x05F)
+        BitStream.Write((int)pVehicle->GetModel());
+
+    // Write the vehicle matrix only if he's the driver
+    CVector      vecTemp;
+    unsigned int uiSeat = pSourcePlayer->GetOccupiedVehicleSeat();
+    if (uiSeat == 0)
     {
-        CPlayer* pSourcePlayer = static_cast<CPlayer*>(m_pSourceElement);
+        // Vehicle position
+        SPositionSync position(false);
+        position.data.vecPosition = pVehicle->GetPosition();
+        BitStream.Write(&position);
 
-        // Player is in a vehicle and is the driver?
-        CVehicle* pVehicle = pSourcePlayer->GetOccupiedVehicle();
-        if (pVehicle)
+        // If the remote vehicle is a train, we want to read special train-specific data
+        if (pVehicle->GetVehicleType() == VEHICLE_TRAIN)
         {
-            // Player ID
-            ElementID PlayerID = pSourcePlayer->GetID();
-            BitStream.Write(PlayerID);
+            // Train specific data
+            float fPosition = pVehicle->GetTrainPosition();
+            bool  bDirection = pVehicle->GetTrainDirection();
+            float fSpeed = pVehicle->GetTrainSpeed();
 
-            // Write the time context of that player
-            BitStream.Write(pSourcePlayer->GetSyncTimeContext());
+            BitStream.Write(fPosition);
+            BitStream.WriteBit(bDirection);
+            BitStream.Write(fSpeed);
 
-            // Write his ping divided with 2 plus a small number so the client can find out when this packet was sent
-            unsigned short usLatency = pSourcePlayer->GetPing();
-            BitStream.WriteCompressed(usLatency);
-
-            // Write the keysync data
-            const CControllerState& ControllerState = pSourcePlayer->GetPad()->GetCurrentControllerState();
-            WriteFullKeysync(ControllerState, BitStream);
-
-            // Write the serverside model (#8800)
-            if (BitStream.Version() >= 0x05F)
-                BitStream.Write((int)pVehicle->GetModel());
-
-            // Write the vehicle matrix only if he's the driver
-            CVector      vecTemp;
-            unsigned int uiSeat = pSourcePlayer->GetOccupiedVehicleSeat();
-            if (uiSeat == 0)
+            // Push the train track information
+            const auto trainTrack = pVehicle->GetTrainTrack();
+            if (!trainTrack || pVehicle->IsDerailed())
             {
-                // Vehicle position
-                SPositionSync position(false);
-                position.data.vecPosition = pVehicle->GetPosition();
-                BitStream.Write(&position);
+                // NOTE(qaisjp, feature/custom-train-tracks): when can a train both be on a track AND derailed?
+                // I suppose it's possible for some weirdness here. We should make sure that whenever we set the train track,
+                // we set that the train is NOT derailed; and that whenever we derail the track, we set the train track to nil.
+                // Note: here we use a uchar, in the CTT branch this is a uint. Just don't forget that, it might be important
+                BitStream.Write((uchar)0);
+            }
+            else if (trainTrack && trainTrack->IsDefault())
+            {
+                BitStream.Write(trainTrack->GetDefaultTrackId());
+            }
+            else
+            {
+                // TODO(qaisjp, feature/custom-train-tracks): implement behaviour for non-default tracks
+                assert(0 && "It is impossible for custom train tracks to exist right now, so this should never be reached.");
+            }
+        }
 
-                // If the remote vehicle is a train, we want to read special train-specific data
-                if (pVehicle->GetVehicleType() == VEHICLE_TRAIN)
-                {
-                    // Train specific data
-                    float fPosition = pVehicle->GetTrainPosition();
-                    bool  bDirection = pVehicle->GetTrainDirection();
-                    float fSpeed = pVehicle->GetTrainSpeed();
+        // Vehicle rotation
+        SRotationDegreesSync rotation;
+        pVehicle->GetRotationDegrees(rotation.data.vecRotation);
+        BitStream.Write(&rotation);
 
-                    BitStream.Write(fPosition);
-                    BitStream.WriteBit(bDirection);
-                    BitStream.Write(fSpeed);
+        // Move speed vector
+        SVelocitySync velocity;
+        velocity.data.vecVelocity = pVehicle->GetVelocity();
+        BitStream.Write(&velocity);
 
-                    // Push the train track information
-                    const auto trainTrack = pVehicle->GetTrainTrack();
-                    if (!trainTrack || pVehicle->IsDerailed())
-                    {
-                        // NOTE(qaisjp, feature/custom-train-tracks): when can a train both be on a track AND derailed?
-                        // I suppose it's possible for some weirdness here. We should make sure that whenever we set the train track,
-                        // we set that the train is NOT derailed; and that whenever we derail the track, we set the train track to nil.
-                        // Note: here we use a uchar, in the CTT branch this is a uint. Just don't forget that, it might be important
-                        BitStream.Write((uchar)0);
-                    }
-                    else if (trainTrack && trainTrack->IsDefault())
-                    {
-                        BitStream.Write(trainTrack->GetDefaultTrackId());
-                    }
-                    else
-                    {
-                        // TODO(qaisjp, feature/custom-train-tracks): implement behaviour for non-default tracks
-                        assert(0 && "It is impossible for custom train tracks to exist right now, so this should never be reached.");
-                    }
-                }
+        // Turn speed vector
+        SVelocitySync turnSpeed;
+        turnSpeed.data.vecVelocity = pVehicle->GetTurnSpeed();
+        BitStream.Write(&turnSpeed);
 
-                // Vehicle rotation
-                SRotationDegreesSync rotation;
-                pVehicle->GetRotationDegrees(rotation.data.vecRotation);
-                BitStream.Write(&rotation);
+        // Health
+        SVehicleHealthSync health;
+        health.data.fValue = pVehicle->GetHealth();
+        BitStream.Write(&health);
 
-                // Move speed vector
-                SVelocitySync velocity;
-                velocity.data.vecVelocity = pVehicle->GetVelocity();
-                BitStream.Write(&velocity);
+        // Write the trailer chain
+        if (BitStream.Version() >= 0x42)
+        {
+            CVehicle* pTrailer = pVehicle->GetTowedVehicle();
+            while (pTrailer)
+            {
+                BitStream.WriteBit(true);
+                BitStream.Write(pTrailer->GetID());
 
-                // Turn speed vector
-                SVelocitySync turnSpeed;
-                turnSpeed.data.vecVelocity = pVehicle->GetTurnSpeed();
-                BitStream.Write(&turnSpeed);
+                // Write the position and rotation
+                CVector vecTrailerPosition, vecTrailerRotationDegrees;
 
-                // Health
-                SVehicleHealthSync health;
-                health.data.fValue = pVehicle->GetHealth();
-                BitStream.Write(&health);
+                // Write the matrix
+                vecTrailerPosition = pTrailer->GetPosition();
+                pTrailer->GetRotationDegrees(vecTrailerRotationDegrees);
 
-                // Write the trailer chain
-                if (BitStream.Version() >= 0x42)
-                {
-                    CVehicle* pTrailer = pVehicle->GetTowedVehicle();
-                    while (pTrailer)
-                    {
-                        BitStream.WriteBit(true);
-                        BitStream.Write(pTrailer->GetID());
+                SPositionSync trailerPosition(false);
+                trailerPosition.data.vecPosition = vecTrailerPosition;
+                BitStream.Write(&trailerPosition);
 
-                        // Write the position and rotation
-                        CVector vecTrailerPosition, vecTrailerRotationDegrees;
+                SRotationDegreesSync trailerRotation;
+                trailerRotation.data.vecRotation = vecTrailerRotationDegrees;
+                BitStream.Write(&trailerRotation);
 
-                        // Write the matrix
-                        vecTrailerPosition = pTrailer->GetPosition();
-                        pTrailer->GetRotationDegrees(vecTrailerRotationDegrees);
-
-                        SPositionSync trailerPosition(false);
-                        trailerPosition.data.vecPosition = vecTrailerPosition;
-                        BitStream.Write(&trailerPosition);
-
-                        SRotationDegreesSync trailerRotation;
-                        trailerRotation.data.vecRotation = vecTrailerRotationDegrees;
-                        BitStream.Write(&trailerRotation);
-
-                        // Get the next towed vehicle
-                        pTrailer = pTrailer->GetTowedVehicle();
-                    }
-
-                    // End of our trailer chain
-                    BitStream.WriteBit(false);
-                }
+                // Get the next towed vehicle
+                pTrailer = pTrailer->GetTowedVehicle();
             }
 
-            // Player health and armor
-            SPlayerHealthSync health;
-            health.data.fValue = pSourcePlayer->GetHealth();
-            BitStream.Write(&health);
-
-            SPlayerArmorSync armor;
-            armor.data.fValue = pSourcePlayer->GetArmor();
-            BitStream.Write(&armor);
-
-            // Weapon
-            unsigned char ucWeaponType = pSourcePlayer->GetWeaponType();
-
-            // Flags
-            SVehiclePuresyncFlags flags;
-            flags.data.bIsWearingGoggles = pSourcePlayer->IsWearingGoggles();
-            flags.data.bIsDoingGangDriveby = pSourcePlayer->IsDoingGangDriveby();
-            flags.data.bIsSirenOrAlarmActive = pVehicle->IsSirenActive();
-            flags.data.bIsSmokeTrailEnabled = pVehicle->IsSmokeTrailEnabled();
-            flags.data.bIsLandingGearDown = pVehicle->IsLandingGearDown();
-            flags.data.bIsOnGround = pVehicle->IsOnGround();
-            flags.data.bIsInWater = pVehicle->IsInWater();
-            flags.data.bIsDerailed = pVehicle->IsDerailed();
-            flags.data.bIsAircraft = (pVehicle->GetVehicleType() == VEHICLE_PLANE || pVehicle->GetVehicleType() == VEHICLE_HELI);
-            flags.data.bHasAWeapon = (ucWeaponType != 0);
-            flags.data.bIsHeliSearchLightVisible = pVehicle->IsHeliSearchLightVisible();
-            BitStream.Write(&flags);
-
-            // Write the weapon stuff
-            if (flags.data.bHasAWeapon)
-            {
-                // Write the weapon slot
-                SWeaponSlotSync slot;
-                slot.data.uiSlot = pSourcePlayer->GetWeaponSlot();
-                BitStream.Write(&slot);
-
-                if (flags.data.bIsDoingGangDriveby && CWeaponNames::DoesSlotHaveAmmo(slot.data.uiSlot))
-                {
-                    // Write the ammo states
-                    SWeaponAmmoSync ammo(ucWeaponType, BitStream.Version() >= 0x44, true);
-                    ammo.data.usAmmoInClip = pSourcePlayer->GetWeaponAmmoInClip();
-                    ammo.data.usTotalAmmo = pSourcePlayer->GetWeaponTotalAmmo();
-                    BitStream.Write(&ammo);
-
-                    // Sync aim data
-                    SWeaponAimSync aim(0.0f, true);
-                    aim.data.vecOrigin = pSourcePlayer->GetSniperSourceVector();
-                    pSourcePlayer->GetTargettingVector(aim.data.vecTarget);
-                    aim.data.fArm = pSourcePlayer->GetAimDirection();
-                    BitStream.Write(&aim);
-
-                    // Sync driveby direction
-                    SDrivebyDirectionSync driveby;
-                    driveby.data.ucDirection = pSourcePlayer->GetDriveByDirection();
-                    BitStream.Write(&driveby);
-                }
-            }
-
-            // Vehicle specific data only if he's the driver
-            if (uiSeat == 0)
-            {
-                WriteVehicleSpecific(pVehicle, BitStream);
-            }
-
-            // Write vehicle_look_left and vehicle_look_right control states when
-            // it's an aircraft.
-            if (flags.data.bIsAircraft)
-            {
-                BitStream.WriteBit(ControllerState.LeftShoulder2 != 0);
-                BitStream.WriteBit(ControllerState.RightShoulder2 != 0);
-            }
-
-            // Write parts state
-            if (BitStream.Version() >= 0x5D)
-            {
-                SVehicleDamageSyncMethodeB damage;
-                // Check where we are in the cycle
-                uchar ucMode = (pVehicle->m_uiDamageInfoSendPhase & 3);
-                damage.data.bSyncDoors = (ucMode == 0);
-                damage.data.bSyncWheels = (ucMode == 1);
-                damage.data.bSyncPanels = (ucMode == 2);
-                damage.data.bSyncLights = (ucMode == 3);
-                damage.data.doors.data.ucStates = pVehicle->m_ucDoorStates;
-                damage.data.wheels.data.ucStates = pVehicle->m_ucWheelStates;
-                damage.data.panels.data.ucStates = pVehicle->m_ucPanelStates;
-                damage.data.lights.data.ucStates = pVehicle->m_ucLightStates;
-                BitStream.Write(&damage);
-            }
-
-            // Success
-            return true;
+            // End of our trailer chain
+            BitStream.WriteBit(false);
         }
     }
 
-    return false;
+    // Player health and armor
+    SPlayerHealthSync health;
+    health.data.fValue = pSourcePlayer->GetHealth();
+    BitStream.Write(&health);
+
+    SPlayerArmorSync armor;
+    armor.data.fValue = pSourcePlayer->GetArmor();
+    BitStream.Write(&armor);
+
+    // Weapon
+    unsigned char ucWeaponType = pSourcePlayer->GetWeaponType();
+
+    // Flags
+    SVehiclePuresyncFlags flags;
+    flags.data.bIsWearingGoggles = pSourcePlayer->IsWearingGoggles();
+    flags.data.bIsDoingGangDriveby = pSourcePlayer->IsDoingGangDriveby();
+    flags.data.bIsSirenOrAlarmActive = pVehicle->IsSirenActive();
+    flags.data.bIsSmokeTrailEnabled = pVehicle->IsSmokeTrailEnabled();
+    flags.data.bIsLandingGearDown = pVehicle->IsLandingGearDown();
+    flags.data.bIsOnGround = pVehicle->IsOnGround();
+    flags.data.bIsInWater = pVehicle->IsInWater();
+    flags.data.bIsDerailed = pVehicle->IsDerailed();
+    flags.data.bIsAircraft = (pVehicle->GetVehicleType() == VEHICLE_PLANE || pVehicle->GetVehicleType() == VEHICLE_HELI);
+    flags.data.bHasAWeapon = (ucWeaponType != 0);
+    flags.data.bIsHeliSearchLightVisible = pVehicle->IsHeliSearchLightVisible();
+    BitStream.Write(&flags);
+
+    // Write the weapon stuff
+    if (flags.data.bHasAWeapon)
+    {
+        // Write the weapon slot
+        SWeaponSlotSync slot;
+        slot.data.uiSlot = pSourcePlayer->GetWeaponSlot();
+        BitStream.Write(&slot);
+
+        if (flags.data.bIsDoingGangDriveby && CWeaponNames::DoesSlotHaveAmmo(slot.data.uiSlot))
+        {
+            // Write the ammo states
+            SWeaponAmmoSync ammo(ucWeaponType, BitStream.Version() >= 0x44, true);
+            ammo.data.usAmmoInClip = pSourcePlayer->GetWeaponAmmoInClip();
+            ammo.data.usTotalAmmo = pSourcePlayer->GetWeaponTotalAmmo();
+            BitStream.Write(&ammo);
+
+            // Sync aim data
+            SWeaponAimSync aim(0.0f, true);
+            aim.data.vecOrigin = pSourcePlayer->GetSniperSourceVector();
+            pSourcePlayer->GetTargettingVector(aim.data.vecTarget);
+            aim.data.fArm = pSourcePlayer->GetAimDirection();
+            BitStream.Write(&aim);
+
+            // Sync driveby direction
+            SDrivebyDirectionSync driveby;
+            driveby.data.ucDirection = pSourcePlayer->GetDriveByDirection();
+            BitStream.Write(&driveby);
+        }
+    }
+
+    // Vehicle specific data only if he's the driver
+    if (uiSeat == 0)
+    {
+        WriteVehicleSpecific(pVehicle, BitStream);
+    }
+
+    // Write vehicle_look_left and vehicle_look_right control states when
+    // it's an aircraft.
+    if (flags.data.bIsAircraft)
+    {
+        BitStream.WriteBit(ControllerState.LeftShoulder2 != 0);
+        BitStream.WriteBit(ControllerState.RightShoulder2 != 0);
+    }
+
+    // Write parts state
+    if (BitStream.Version() >= 0x5D)
+    {
+        SVehicleDamageSyncMethodeB damage;
+        // Check where we are in the cycle
+        uchar ucMode = (pVehicle->m_uiDamageInfoSendPhase & 3);
+        damage.data.bSyncDoors = (ucMode == 0);
+        damage.data.bSyncWheels = (ucMode == 1);
+        damage.data.bSyncPanels = (ucMode == 2);
+        damage.data.bSyncLights = (ucMode == 3);
+        damage.data.doors.data.ucStates = pVehicle->m_ucDoorStates;
+        damage.data.wheels.data.ucStates = pVehicle->m_ucWheelStates;
+        damage.data.panels.data.ucStates = pVehicle->m_ucPanelStates;
+        damage.data.lights.data.ucStates = pVehicle->m_ucLightStates;
+        BitStream.Write(&damage);
+    }
+
+    // Success
+    return true;
 }
 
 void CVehiclePuresyncPacket::ReadVehicleSpecific(CVehicle* pVehicle, NetBitStreamInterface& BitStream, int iRemoteModel)

--- a/Server/mods/deathmatch/logic/packets/CVehiclePuresyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CVehiclePuresyncPacket.h
@@ -19,15 +19,15 @@ class CVehicle;
 class CVehiclePuresyncPacket final : public CPacket
 {
 public:
-    CVehiclePuresyncPacket(){};
-    explicit CVehiclePuresyncPacket(class CPlayer* pPlayer);
+    CVehiclePuresyncPacket() noexcept {};
+    explicit CVehiclePuresyncPacket(class CPlayer* pPlayer) noexcept;
 
-    bool          HasSimHandler() const { return true; }
-    ePacketID     GetPacketID() const { return PACKET_ID_PLAYER_VEHICLE_PURESYNC; };
-    unsigned long GetFlags() const { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; };
+    bool          HasSimHandler() const noexcept { return true; }
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_PLAYER_VEHICLE_PURESYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_MEDIUM_PRIORITY | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
     void ReadVehicleSpecific(class CVehicle* pVehicle, NetBitStreamInterface& BitStream, int iRemoteModel);

--- a/Server/mods/deathmatch/logic/packets/CVehicleResyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CVehicleResyncPacket.cpp
@@ -14,13 +14,13 @@
 #include "CVehicle.h"
 #include "net/SyncStructures.h"
 
-bool CVehicleResyncPacket::Read(NetBitStreamInterface& BitStream)
+bool CVehicleResyncPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     // Only the server sends these.
     return false;
 }
 
-bool CVehicleResyncPacket::Write(NetBitStreamInterface& BitStream) const
+bool CVehicleResyncPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
     if (!m_pVehicle)
         return false;

--- a/Server/mods/deathmatch/logic/packets/CVehicleResyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CVehicleResyncPacket.h
@@ -21,8 +21,8 @@ class CVehicleResyncPacket final : public CPacket
 public:
     explicit CVehicleResyncPacket(CVehicle* pVehicle) { m_pVehicle = pVehicle; };
 
-    ePacketID     GetPacketID() const { return PACKET_ID_VEHICLE_RESYNC; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_VEHICLE_RESYNC; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Read(NetBitStreamInterface& BitStream);
     bool Write(NetBitStreamInterface& BitStream) const;

--- a/Server/mods/deathmatch/logic/packets/CVehicleResyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CVehicleResyncPacket.h
@@ -19,13 +19,13 @@ class CVehicle;
 class CVehicleResyncPacket final : public CPacket
 {
 public:
-    explicit CVehicleResyncPacket(CVehicle* pVehicle) { m_pVehicle = pVehicle; };
+    explicit CVehicleResyncPacket(CVehicle* pVehicle) noexcept { m_pVehicle = pVehicle; }
 
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_VEHICLE_RESYNC; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
-
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_VEHICLE_RESYNC; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
+    
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
 private:
     CVehicle* m_pVehicle;

--- a/Server/mods/deathmatch/logic/packets/CVehicleSpawnPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CVehicleSpawnPacket.h
@@ -19,8 +19,8 @@ class CVehicle;
 class CVehicleSpawnPacket final : public CPacket
 {
 public:
-    ePacketID     GetPacketID() const { return PACKET_ID_VEHICLE_SPAWN; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_VEHICLE_SPAWN; };
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
 
     bool Write(NetBitStreamInterface& BitStream) const;
 

--- a/Server/mods/deathmatch/logic/packets/CVehicleSpawnPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CVehicleSpawnPacket.h
@@ -19,13 +19,13 @@ class CVehicle;
 class CVehicleSpawnPacket final : public CPacket
 {
 public:
-    ePacketID     GetPacketID() const noexcept { return PACKET_ID_VEHICLE_SPAWN; };
-    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_VEHICLE_SPAWN; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    void Add(CVehicle* pVehicle) { m_List.push_back(pVehicle); };
-    void Clear() { m_List.clear(); };
+    void Add(CVehicle* pVehicle) noexcept { m_List.push_back(pVehicle); }
+    void Clear() noexcept { m_List.clear(); }
 
 private:
     std::vector<CVehicle*> m_List;

--- a/Server/mods/deathmatch/logic/packets/CVehicleTrailerPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CVehicleTrailerPacket.h
@@ -19,21 +19,21 @@ class CVehicle;
 class CVehicleTrailerPacket final : public CPacket
 {
 public:
-    CVehicleTrailerPacket(){};
-    CVehicleTrailerPacket(CVehicle* pVehicle, CVehicle* pTrailer, bool bAttached);
+    CVehicleTrailerPacket() noexcept {};
+    CVehicleTrailerPacket(CVehicle* pVehicle, CVehicle* pTrailer, bool bAttached) noexcept;
 
-    ePacketID     GetPacketID() const { return PACKET_ID_VEHICLE_TRAILER; };
-    unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    ePacketID     GetPacketID() const noexcept { return PACKET_ID_VEHICLE_TRAILER; }
+    std::uint32_t GetFlags() const noexcept { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    ElementID GetVehicle() { return m_Vehicle; };
-    ElementID GetAttachedVehicle() { return m_AttachedVehicle; };
-    bool      GetAttached() { return m_bAttached; }
-    CVector   GetPosition() { return m_vecPosition; }
-    CVector   GetRotationDegrees() { return m_vecRotationDegrees; }
-    CVector   GetTurnSpeed() { return m_vecTurnSpeed; }
+    ElementID GetVehicle() const noexcept { return m_Vehicle; }
+    ElementID GetAttachedVehicle() const noexcept { return m_AttachedVehicle; }
+    bool      GetAttached() const noexcept { return m_bAttached; }
+    CVector   GetPosition() const noexcept { return m_vecPosition; }
+    CVector   GetRotationDegrees() const noexcept { return m_vecRotationDegrees; }
+    CVector   GetTurnSpeed() const noexcept { return m_vecTurnSpeed; }
 
 private:
     ElementID m_Vehicle;

--- a/Server/mods/deathmatch/logic/packets/CVoiceDataPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CVoiceDataPacket.cpp
@@ -13,96 +13,93 @@
 #include "CVoiceDataPacket.h"
 #include "CPlayer.h"
 
-CVoiceDataPacket::CVoiceDataPacket()
+CVoiceDataPacket::CVoiceDataPacket() noexcept
 {
-    m_pBuffer = NULL;
+    m_pBuffer = nullptr;
     m_usDataBufferSize = 0;
     m_usActualDataLength = 0;
 
     AllocateBuffer(1024);
 }
 
-CVoiceDataPacket::CVoiceDataPacket(CPlayer* pPlayer, const unsigned char* pbSrcBuffer, unsigned short usLength)
+CVoiceDataPacket::CVoiceDataPacket(CPlayer* pPlayer, const std::uint8_t* pbSrcBuffer, std::uint16_t usLength) noexcept
 {
-    m_pBuffer = NULL;
+    m_pBuffer = nullptr;
     m_usDataBufferSize = 0;
     m_usActualDataLength = 0;
 
     SetSourceElement(pPlayer);
     SetData(pbSrcBuffer, usLength);
 }
-CVoiceDataPacket::~CVoiceDataPacket()
+
+CVoiceDataPacket::~CVoiceDataPacket() noexcept
 {
     DeallocateBuffer();
 }
 
-bool CVoiceDataPacket::Read(NetBitStreamInterface& BitStream)
+bool CVoiceDataPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
-    if (m_pBuffer)
-    {
-        BitStream.Read(m_usActualDataLength);
-        if (m_usActualDataLength)
-        {
-            BitStream.Read(reinterpret_cast<char*>(m_pBuffer), m_usActualDataLength <= m_usDataBufferSize ? m_usActualDataLength : m_usDataBufferSize);
-        }
-        return true;
-    }
-
-    return false;
-}
-
-bool CVoiceDataPacket::Write(NetBitStreamInterface& BitStream) const
-{
+    if (!m_pBuffer)
+        return false;
+    
+    BitStream.Read(m_usActualDataLength);
     if (m_usActualDataLength)
     {
-        // Write the source player
-        ElementID ID = m_pSourceElement->GetID();
-        BitStream.Write(ID);
-        // Write the length as an unsigned short and then write the string
-        BitStream.Write(m_usActualDataLength);
-        BitStream.Write(reinterpret_cast<const char*>(m_pBuffer), m_usActualDataLength);
-        return true;
+        BitStream.Read(reinterpret_cast<char*>(m_pBuffer), m_usActualDataLength <= m_usDataBufferSize ? m_usActualDataLength : m_usDataBufferSize);
     }
-
-    return false;
+    return true;
 }
 
-void CVoiceDataPacket::AllocateBuffer(unsigned short usBufferSize)
+bool CVoiceDataPacket::Write(NetBitStreamInterface& BitStream) const noexcept
+{
+    if (!m_usActualDataLength)
+        return false;
+
+    // Write the source player
+    ElementID ID = m_pSourceElement->GetID();
+    BitStream.Write(ID);
+    // Write the length as an std::uint16_t and then write the string
+    BitStream.Write(m_usActualDataLength);
+    BitStream.Write(reinterpret_cast<const char*>(m_pBuffer), m_usActualDataLength);
+    return true;
+}
+
+void CVoiceDataPacket::AllocateBuffer(std::uint16_t usBufferSize) noexcept
 {
     // Test to see if we already have an allocated buffer
     // that will hold the requested size.
-    if (m_usDataBufferSize < usBufferSize)
-    {
-        // It's not... resize the buffer.
-        if (m_pBuffer)
-        {
-            // Free the current buffer.
-            delete[] m_pBuffer;
-        }
+    if (m_usDataBufferSize >= usBufferSize)
+        return;
 
-        // Allocate new buffer.
-        m_pBuffer = new unsigned char[usBufferSize];
-
-        // Clear buffer.
-        memset(m_pBuffer, 0, usBufferSize);
-
-        // Save the new size.
-        m_usDataBufferSize = usBufferSize;
-    }
-}
-
-void CVoiceDataPacket::DeallocateBuffer()
-{
+    // It's not... resize the buffer.
     if (m_pBuffer)
     {
+        // Free the current buffer.
         delete[] m_pBuffer;
-        m_pBuffer = NULL;
-        m_usDataBufferSize = 0;
-        m_usActualDataLength = 0;
     }
+
+    // Allocate new buffer.
+    m_pBuffer = new std::uint8_t[usBufferSize];
+
+    // Clear buffer.
+    memset(m_pBuffer, 0, usBufferSize);
+
+    // Save the new size.
+    m_usDataBufferSize = usBufferSize;
 }
 
-void CVoiceDataPacket::SetData(const unsigned char* pbSrcBuffer, unsigned short usLength)
+void CVoiceDataPacket::DeallocateBuffer() noexcept
+{
+    if (!m_pBuffer)
+        return;
+
+    delete[] m_pBuffer;
+    m_pBuffer = nullptr;
+    m_usDataBufferSize = 0;
+    m_usActualDataLength = 0;
+}
+
+void CVoiceDataPacket::SetData(const std::uint8_t* pbSrcBuffer, std::uint16_t usLength) noexcept
 {
     // Allocate new buffer.
     AllocateBuffer(usLength);
@@ -115,12 +112,12 @@ void CVoiceDataPacket::SetData(const unsigned char* pbSrcBuffer, unsigned short 
     }
 }
 
-const unsigned char* CVoiceDataPacket::GetData() const
+const std::uint8_t* CVoiceDataPacket::GetData() const noexcept
 {
     return m_pBuffer;
 }
 
-unsigned short CVoiceDataPacket::GetDataLength() const
+std::uint16_t CVoiceDataPacket::GetDataLength() const noexcept
 {
     return m_usActualDataLength;
 }

--- a/Server/mods/deathmatch/logic/packets/CVoiceDataPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CVoiceDataPacket.h
@@ -16,27 +16,27 @@
 class CVoiceDataPacket final : public CPacket
 {
 public:
-    CVoiceDataPacket(CPlayer* pPlayer, const unsigned char* pbSrcBuffer, unsigned short usLength);
-    CVoiceDataPacket();
-    ~CVoiceDataPacket();
+    CVoiceDataPacket() noexcept;
+    CVoiceDataPacket(CPlayer* pPlayer, const std::uint8_t* pbSrcBuffer, std::uint16_t usLength) noexcept;
+    ~CVoiceDataPacket() noexcept;
 
-    ePacketID               GetPacketID() const { return PACKET_ID_VOICE_DATA; }
-    unsigned long           GetFlags() const { return PACKET_LOW_PRIORITY | PACKET_SEQUENCED; };
-    virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_VOICE; }
+    ePacketID               GetPacketID() const noexcept { return PACKET_ID_VOICE_DATA; }
+    std::uint32_t           GetFlags() const noexcept { return PACKET_LOW_PRIORITY | PACKET_SEQUENCED; }
+    virtual ePacketOrdering GetPacketOrdering() const noexcept { return PACKET_ORDERING_VOICE; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    void SetData(const unsigned char* pbSrcBuffer, unsigned short usLength);
+    void SetData(const std::uint8_t* pbSrcBuffer, std::uint16_t usLength) noexcept;
 
-    unsigned short       GetDataLength() const;
-    const unsigned char* GetData() const;
+    std::uint16_t       GetDataLength() const noexcept;
+    const std::uint8_t* GetData() const noexcept;
 
 private:
-    void AllocateBuffer(unsigned short usBufferSize);
-    void DeallocateBuffer();
+    void AllocateBuffer(std::uint16_t usBufferSize) noexcept;
+    void DeallocateBuffer() noexcept;
 
-    unsigned char* m_pBuffer;
-    unsigned short m_usDataBufferSize;
-    unsigned short m_usActualDataLength;
+    std::uint8_t* m_pBuffer;
+    std::uint16_t m_usDataBufferSize;
+    std::uint16_t m_usActualDataLength;
 };

--- a/Server/mods/deathmatch/logic/packets/CVoiceEndPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CVoiceEndPacket.cpp
@@ -13,30 +13,29 @@
 #include "CVoiceEndPacket.h"
 #include "CPlayer.h"
 
-CVoiceEndPacket::CVoiceEndPacket(CPlayer* pPlayer)
+CVoiceEndPacket::CVoiceEndPacket(CPlayer* pPlayer) noexcept
 {
     m_PlayerID = INVALID_ELEMENT_ID;
     if (pPlayer)
         SetSourceElement(pPlayer);
 }
 
-CVoiceEndPacket::~CVoiceEndPacket()
+CVoiceEndPacket::~CVoiceEndPacket() noexcept
 {
 }
 
-bool CVoiceEndPacket::Read(NetBitStreamInterface& BitStream)
+bool CVoiceEndPacket::Read(NetBitStreamInterface& BitStream) noexcept
 {
     return true;
 }
 
-bool CVoiceEndPacket::Write(NetBitStreamInterface& BitStream) const
+bool CVoiceEndPacket::Write(NetBitStreamInterface& BitStream) const noexcept
 {
-    if (m_pSourceElement)
-    {
-        // Write the source player
-        ElementID ID = m_pSourceElement->GetID();
-        BitStream.Write(ID);
-        return true;
-    }
-    return false;
+    if (!m_pSourceElement)
+        return false;
+
+    // Write the source player
+    ElementID ID = m_pSourceElement->GetID();
+    BitStream.Write(ID);
+    return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CVoiceEndPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CVoiceEndPacket.h
@@ -19,7 +19,7 @@ public:
     CVoiceEndPacket(class CPlayer* pPlayer = NULL);
     ~CVoiceEndPacket();
 
-    ePacketID               GetPacketID() const { return PACKET_ID_VOICE_END; }
+    ePacketID               GetPacketID() const noexcept { return PACKET_ID_VOICE_END; }
     unsigned long           GetFlags() const { return PACKET_LOW_PRIORITY | PACKET_SEQUENCED; };
     virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_VOICE; }
 

--- a/Server/mods/deathmatch/logic/packets/CVoiceEndPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CVoiceEndPacket.h
@@ -16,18 +16,18 @@
 class CVoiceEndPacket final : public CPacket
 {
 public:
-    CVoiceEndPacket(class CPlayer* pPlayer = NULL);
-    ~CVoiceEndPacket();
+    CVoiceEndPacket(class CPlayer* pPlayer = nullptr) noexcept;
+    ~CVoiceEndPacket() noexcept;
 
     ePacketID               GetPacketID() const noexcept { return PACKET_ID_VOICE_END; }
-    unsigned long           GetFlags() const { return PACKET_LOW_PRIORITY | PACKET_SEQUENCED; };
-    virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_VOICE; }
+    std::uint32_t           GetFlags() const noexcept { return PACKET_LOW_PRIORITY | PACKET_SEQUENCED; }
+    virtual ePacketOrdering GetPacketOrdering() const noexcept { return PACKET_ORDERING_VOICE; }
 
-    bool Read(NetBitStreamInterface& BitStream);
-    bool Write(NetBitStreamInterface& BitStream) const;
+    bool Read(NetBitStreamInterface& BitStream) noexcept;
+    bool Write(NetBitStreamInterface& BitStream) const noexcept;
 
-    ElementID GetPlayer();
-    void      SetPlayer(ElementID PlayerID);
+    ElementID GetPlayer() const noexcept;
+    void      SetPlayer(ElementID PlayerID) noexcept;
 
 private:
     ElementID m_PlayerID;

--- a/Server/mods/deathmatch/utils/CHqComms.h
+++ b/Server/mods/deathmatch/utils/CHqComms.h
@@ -113,29 +113,25 @@ public:
     //
     // Process response from hq
     //
-    void DownloadFinishedCallback(const SHttpDownloadResult& result)
+    void DownloadFinishedCallback(const SHttpDownloadResult& result) noexcept
     {
-        if (result.bSuccess)
-        {
-            m_Stage = HQCOMMS_STAGE_TIMER;
-            CBitStream bitStream(result.pData, result.dataSize);
+        m_Stage = HQCOMMS_STAGE_TIMER;
+        if (!result.bSuccess)
+            return;
 
-            // Process various parts of returned data
-            ProcessPollInterval(bitStream);
-            ProcessMinClientVersion(bitStream);
-            ProcessMessage(bitStream);
-            ProcessBadFileHashes(bitStream);
-            ProcessCrashInfo(bitStream);
-            ProcessAseServers(bitStream);
-        }
-        else
-        {
-            m_Stage = HQCOMMS_STAGE_TIMER;
-        }
+        CBitStream bitStream(result.pData, result.dataSize);
+
+        // Process various parts of returned data
+        ProcessPollInterval(bitStream);
+        ProcessMinClientVersion(bitStream);
+        ProcessMessage(bitStream);
+        ProcessBadFileHashes(bitStream);
+        ProcessCrashInfo(bitStream);
+        ProcessAseServers(bitStream);
     }
 
     // Interval until next HQ check
-    void ProcessPollInterval(CBitStream& bitStream)
+    void ProcessPollInterval(CBitStream& bitStream) noexcept
     {
         int iPollInterval = 0;
         bitStream->Read(iPollInterval);

--- a/Server/sdk/net/ns_playerid.h
+++ b/Server/sdk/net/ns_playerid.h
@@ -1,4 +1,4 @@
-/*****************************************************************************
+/*************************************************************************
  *
  *  PROJECT:     Multi Theft Auto v1.0
  *  LICENSE:     See LICENSE in the top level directory
@@ -7,63 +7,92 @@
  *
  *  Multi Theft Auto is available from http://www.multitheftauto.com/
  *
- *****************************************************************************/
+ *************************************************************************/
 
 #pragma once
 
 #include <MTAPlatform.h>
+#include <cstdint>
 
 class SNetExtraInfo : public CRefCountable
 {
 protected:
-    SNetExtraInfo(const SNetExtraInfo&);
-    const SNetExtraInfo& operator=(const SNetExtraInfo&);
-    ~SNetExtraInfo() {}
+    SNetExtraInfo(const SNetExtraInfo&) noexcept;
+    ~SNetExtraInfo() noexcept {}
 
+    const SNetExtraInfo& operator=(const SNetExtraInfo&) noexcept;
 public:
     ZERO_ON_NEW
-    SNetExtraInfo() {}
+    constexpr SNetExtraInfo() noexcept {}
 
-    bool m_bHasPing;
-    uint m_uiPing;
+    bool m_bHasPing{ false };
+    std::uint32_t m_uiPing{0};
 };
 
 class NetServerPlayerID
 {
 protected:
-    unsigned long  m_uiBinaryAddress;
-    unsigned short m_usPort;
+    std::uint32_t m_uiBinaryAddress;
+    std::uint16_t m_usPort;
 
 public:
-    NetServerPlayerID()
-    {
-        m_uiBinaryAddress = 0xFFFFFFFF;
-        m_usPort = 0xFFFF;
-    };
+    constexpr NetServerPlayerID(
+        const std::uint32_t uiBinaryAddress = -1,
+        const std::uint16_t usPort = -1
+    ) noexcept : m_uiBinaryAddress(uiBinaryAddress), m_usPort(usPort) {}
 
-    NetServerPlayerID(unsigned long uiBinaryAddress, unsigned short usPort)
-    {
-        m_uiBinaryAddress = uiBinaryAddress;
-        m_usPort = usPort;
-    };
+    ~NetServerPlayerID() noexcept {}
 
-    ~NetServerPlayerID(){};
+    friend constexpr bool operator==(
+        const NetServerPlayerID& left,
+        const NetServerPlayerID& right
+    ) noexcept {
+        if (left.m_uiBinaryAddress != right.m_uiBinaryAddress)
+            return false;
 
-    friend inline int operator==(const NetServerPlayerID& left, const NetServerPlayerID& right)
-    {
-        return left.m_uiBinaryAddress == right.m_uiBinaryAddress && left.m_usPort == right.m_usPort;
-    };
+        if (left.m_usPort != right.m_usPort)
+            return false;
 
-    friend inline int operator!=(const NetServerPlayerID& left, const NetServerPlayerID& right)
-    {
-        return ((left.m_uiBinaryAddress != right.m_uiBinaryAddress) || (left.m_usPort != right.m_usPort));
-    };
-
-    friend inline bool operator<(const NetServerPlayerID& left, const NetServerPlayerID& right)
-    {
-        return left.m_uiBinaryAddress < right.m_uiBinaryAddress || (left.m_uiBinaryAddress == right.m_uiBinaryAddress && left.m_usPort < right.m_usPort);
+        return true;
     }
 
-    unsigned long  GetBinaryAddress() const { return m_uiBinaryAddress; };
-    unsigned short GetPort() const { return m_usPort; };
+    friend constexpr bool operator!=(
+        const NetServerPlayerID& left,
+        const NetServerPlayerID& right
+    ) noexcept {
+        return !operator==(left, right);
+    }
+
+    friend constexpr bool operator<(
+        const NetServerPlayerID& left,
+        const NetServerPlayerID& right
+    ) noexcept {
+        if (left.m_uiBinaryAddress >= right.m_uiBinaryAddress)
+            return false;
+
+        if (left.m_usPort >= right.m_usPort)
+            return false;
+
+        return true;
+    }
+
+    friend constexpr bool operator>(
+        const NetServerPlayerID& left,
+        const NetServerPlayerID& right
+    ) noexcept {
+        if (left.m_uiBinaryAddress <= right.m_uiBinaryAddress)
+            return false;
+
+        if (left.m_usPort <= right.m_usPort)
+            return false;
+
+        return true;
+    }
+
+    constexpr std::uint32_t GetBinaryAddress() const noexcept {
+        return m_uiBinaryAddress;
+    }
+    constexpr std::uint16_t GetPort() const noexcept {
+        return m_usPort;
+    }
 };

--- a/Shared/mods/deathmatch/logic/Utils.cpp
+++ b/Shared/mods/deathmatch/logic/Utils.cpp
@@ -497,10 +497,10 @@ bool RemoteLoadLibrary(HANDLE hProcess, const char* szLibPath)
 #else
 bool IsValidFilePath(const char* szDir)
 {
-    if (szDir == NULL)
+    if (!szDir)
         return false;
 
-    unsigned int uiLen = strlen(szDir);
+    auto uiLen = strlen(szDir);
 
     if (uiLen > 0 && szDir[uiLen - 1] == '/')            // will return false if ending with an invalid character, mainly used for linux (#6871)
         return false;
@@ -508,7 +508,7 @@ bool IsValidFilePath(const char* szDir)
     unsigned char c, c_d;
 
     // iterate through the char array
-    for (unsigned int i = 0; i < uiLen; i++)
+    for (auto i = 0; i < uiLen; i++)
     {
         c = szDir[i];                                          // current character
         c_d = (i < (uiLen - 1)) ? szDir[i + 1] : 0;            // one character ahead, if any
@@ -520,7 +520,7 @@ bool IsValidFilePath(const char* szDir)
 
 bool IsValidOrganizationPath(const char* szDir)
 {
-    if (szDir == NULL)
+    if (!szDir)
         return false;
 
     unsigned int uiLen = strlen(szDir);

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaBitDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaBitDefs.cpp
@@ -63,7 +63,7 @@ int CLuaBitDefs::bitAnd(lua_State* luaVM)
 int CLuaBitDefs::bitNot(lua_State* luaVM)
 {
     //  uint bitNot ( uint var )
-    uint uiVar;
+    std::uint32_t uiVar;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadNumber(uiVar, false);
@@ -83,8 +83,8 @@ int CLuaBitDefs::bitNot(lua_State* luaVM)
 int CLuaBitDefs::bitOr(lua_State* luaVM)
 {
     //  uint bitOr ( uint var1, uint var2, ... )
-    uint uiVar1;
-    uint uiVar2;
+    std::uint32_t uiVar1;
+    std::uint32_t uiVar2;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadNumber(uiVar1, false);
@@ -92,10 +92,10 @@ int CLuaBitDefs::bitOr(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        uint uiResult = uiVar1 | uiVar2;
+        auto uiResult = uiVar1 | uiVar2;
         while (argStream.NextIsNumber())
         {
-            uint uiVar;
+            std::uint32_t uiVar;
             argStream.ReadNumber(uiVar, false);
 
             uiResult |= uiVar;

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
@@ -777,7 +777,7 @@ int CLuaFileDefs::fileWrite(lua_State* luaVM)
                 continue;
 
             // Write the data
-            long lArgBytesWritten = pFile->Write(strData.uiSize, strData.pData);
+            auto lArgBytesWritten = pFile->Write(strData.uiSize, strData.pData);
 
             // Did the file mysteriously disappear?
             if (lArgBytesWritten == -1)

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
@@ -728,13 +728,13 @@ int CLuaUtilDefs::tocolor(lua_State* luaVM)
     if (!argStream.HasErrors())
     {
         // Make it into an unsigned long
-        unsigned long ulColor = COLOR_RGBA(iRed, iGreen, iBlue, iAlpha);
+        std::int64_t ulColor = COLOR_RGBA(iRed, iGreen, iBlue, iAlpha);
         lua_pushinteger(luaVM, static_cast<lua_Integer>(ulColor));
         return 1;
     }
 
     // Make it black so funcs dont break
-    unsigned long ulColor = COLOR_RGBA(0, 0, 0, 255);
+    std::int64_t ulColor = COLOR_RGBA(0, 0, 0, 255);
     lua_pushnumber(luaVM, static_cast<lua_Number>(ulColor));
     return 1;
 }

--- a/Shared/sdk/CFastList.h
+++ b/Shared/sdk/CFastList.h
@@ -314,7 +314,7 @@ bool ListContains(const CFastList<T*>& itemList, const U& item)
 
 // Remove all occurrences of item from itemList (There should never be more than one anyway)
 template <class T, class U>
-void ListRemove(CFastList<T*>& itemList, const U& item)
+void ListRemoveAll(CFastList<T*>& itemList, const U& item)
 {
     itemList.remove(item);
 }

--- a/Shared/sdk/CScriptArgReader.h
+++ b/Shared/sdk/CScriptArgReader.h
@@ -1019,8 +1019,7 @@ public:
                 int iArgument = lua_type(m_luaVM, -1);
                 if (iArgument == LUA_TSTRING || iArgument == LUA_TNUMBER)
                 {
-                    uint uiLength = lua_strlen(m_luaVM, -1);
-                    outList.push_back(SStringX(lua_tostring(m_luaVM, -1), uiLength));
+                    outList.push_back(SStringX(lua_tostring(m_luaVM, -1), lua_strlen(m_luaVM, -1)));
                 }
             }
             m_iIndex++;
@@ -1111,8 +1110,7 @@ protected:
             SString value;
             if (valueType == LUA_TSTRING || valueType == LUA_TNUMBER)
             {
-                uint uiLength = lua_strlen(m_luaVM, -1);
-                value.assign(lua_tostring(m_luaVM, -1), uiLength);
+                value.assign(lua_tostring(m_luaVM, -1), lua_strlen(m_luaVM, -1));
             }
             else if (valueType == LUA_TBOOLEAN)
             {
@@ -1199,8 +1197,7 @@ protected:
                 SStringMapValue value;
                 if (valueType == LUA_TSTRING || valueType == LUA_TNUMBER)
                 {
-                    uint uiLength = lua_strlen(m_luaVM, -1);
-                    value.assign(lua_tostring(m_luaVM, -1), uiLength);
+                    value.assign(lua_tostring(m_luaVM, -1), lua_strlen(m_luaVM, -1));
                 }
                 else if (valueType == LUA_TBOOLEAN)
                 {

--- a/Shared/sdk/SString.h
+++ b/Shared/sdk/SString.h
@@ -101,8 +101,9 @@ public:
 class SStringX : public SString
 {
 public:
-    SStringX(const char* szText) : SString(std::string(szText ? szText : "")) {}
-    SStringX(const char* szText, uint uiLength) : SString(std::string(szText ? szText : "", uiLength)) {}
+    SStringX(const char* szText) noexcept : SString(std::string(szText ? szText : "")) {}
+    SStringX(const char* szText, std::size_t uiLength) noexcept
+        : SString(std::string(szText ? szText : "", uiLength)) {}
 };
 
 //

--- a/Shared/sdk/SharedUtil.IntTypes.h
+++ b/Shared/sdk/SharedUtil.IntTypes.h
@@ -31,12 +31,9 @@ using int16 = std::int16_t;        //       16
 using int8 = std::int8_t;          //        8
 
 // Windowsesq types
-// DWORD must be set to uint32 and not unsigned long
-// due to the nature of DWORD ("A DWORD is a 32-bit unsigned integer")
-using DWORD = std::uint32_t;       //       32      32      32
+using DWORD = unsigned long;       //       32      32      32
 using WORD = std::uint16_t;        //       16      16      16
 using BYTE = std::uint8_t;         //        8       8       8
-using FLOAT = float;
 
 using AnimationId = std::uint32_t;
 using AssocGroupId = std::uint32_t;

--- a/Shared/sdk/SharedUtil.IntTypes.h
+++ b/Shared/sdk/SharedUtil.IntTypes.h
@@ -14,31 +14,29 @@
 *************************************************************************/
 //                                                  VS      GCC
 //                      Actual sizes:      32bit   64bit   64bit
-typedef unsigned long  ulong;             //  32      32      64
-typedef unsigned int   uint;              //  32
-typedef unsigned short ushort;            //  16
-typedef unsigned char  uchar;             //  8
+using ulong = unsigned long;       //       32      32      64
+using uint = std::uint32_t;        //       32      32      32
+using ushort = std::uint16_t;      //       16      16      16
+using uchar = std::uint8_t;        //        8       8       8
 
-typedef unsigned long long uint64;            //  64
-typedef unsigned int       uint32;            //  32
-typedef unsigned short     uint16;            //  16
-typedef unsigned char      uint8;             //  8
+using uint64 = std::uint64_t;      //       64      64      64
+using uint32 = std::uint32_t;      //       32      32      32
+using uint16 = std::uint16_t;      //       16      16      16
+using uint8 = std::uint8_t;        //        8       8       8
 
 // signed types
-typedef signed long long int64;            //  64
-typedef signed int       int32;            //  32
-typedef signed short     int16;            //  16
-typedef signed char      int8;             //  8
+using int64 = std::int64_t;        //       64
+using int32 = std::int32_t;        //       32
+using int16 = std::int16_t;        //       16
+using int8 = std::int8_t;          //        8
 
 // Windowsesq types
-typedef unsigned char  BYTE;             //  8
-typedef unsigned short WORD;             //  16
-typedef unsigned long  DWORD;            //  32      32      64
-typedef float          FLOAT;            //  32
-
-// Type: considerations:
-// a) long (and therefore DWORD) is 64 bits when compiled using 64 bit GCC
-// b) char range can be -127 to 128 or 0 to 255 depending on compiler options/mood
+// DWORD must be set to uint32 and not unsigned long
+// due to the nature of DWORD ("A DWORD is a 32-bit unsigned integer")
+using DWORD = std::uint32_t;       //       32      32      32
+using WORD = std::uint16_t;        //       16      16      16
+using BYTE = std::uint8_t;         //        8       8       8
+using FLOAT = float;
 
 using AnimationId = std::uint32_t;
 using AssocGroupId = std::uint32_t;

--- a/Shared/sdk/SharedUtil.IntTypes.h
+++ b/Shared/sdk/SharedUtil.IntTypes.h
@@ -7,6 +7,8 @@
  *
  *****************************************************************************/
 
+#include <cstdint>
+
 /*************************************************************************
     Simplification of some 'unsigned' types
 *************************************************************************/
@@ -37,3 +39,6 @@ typedef float          FLOAT;            //  32
 // Type: considerations:
 // a) long (and therefore DWORD) is 64 bits when compiled using 64 bit GCC
 // b) char range can be -127 to 128 or 0 to 255 depending on compiler options/mood
+
+using AnimationId = std::uint32_t;
+using AssocGroupId = std::uint32_t;

--- a/Shared/sdk/SharedUtil.Misc.h
+++ b/Shared/sdk/SharedUtil.Misc.h
@@ -851,19 +851,19 @@ namespace SharedUtil
     {
     public:
         // map only
-        bool Contains(const T& item) const { return MapContains(m_Map, item); }
+        bool Contains(const T& item) const noexcept { return MapContains(m_Map, item); }
 
         // list only
-        typename LIST_TYPE ::iterator         begin() { return m_List.begin(); }
-        typename LIST_TYPE ::iterator         end() { return m_List.end(); }
-        typename LIST_TYPE ::const_iterator   begin() const { return m_List.begin(); }
-        typename LIST_TYPE ::const_iterator   end() const { return m_List.end(); }
-        typename LIST_TYPE ::reverse_iterator rbegin() { return m_List.rbegin(); }
-        typename LIST_TYPE ::reverse_iterator rend() { return m_List.rend(); }
-        std::uint32_t                                  size() const { return m_List.size(); }
-        bool                                  empty() const { return m_List.empty(); }
-        const T&                              back() const { return m_List.back(); }
-        const T&                              front() const { return m_List.front(); }
+        typename LIST_TYPE ::iterator         begin() noexcept { return m_List.begin(); }
+        typename LIST_TYPE ::iterator         end() noexcept { return m_List.end(); }
+        typename LIST_TYPE ::const_iterator   begin() const noexcept { return m_List.begin(); }
+        typename LIST_TYPE ::const_iterator   end() const noexcept { return m_List.end(); }
+        typename LIST_TYPE ::reverse_iterator rbegin() noexcept { return m_List.rbegin(); }
+        typename LIST_TYPE ::reverse_iterator rend() noexcept { return m_List.rend(); }
+        std::size_t                           size() const noexcept { return m_List.size(); }
+        bool                                  empty() const noexcept { return m_List.empty(); }
+        const T&                              back() const noexcept { return m_List.back(); }
+        const T&                              front() const noexcept { return m_List.front(); }
 
         // list and map
         void push_back(const T& item)

--- a/Shared/sdk/SharedUtil.Misc.h
+++ b/Shared/sdk/SharedUtil.Misc.h
@@ -515,11 +515,13 @@ namespace SharedUtil
         ) noexcept : SColor(ucA, ucR, ucG, ucB) {}
 
         template <class T, class U, class V, class W>
-        constexpr SColorARGB(const T a, const U r, const V g, const W b) noexcept :
-            A(Clamp<std::uint8_t>(0, static_cast<std::uint8_t>(a), 255)),
-            R(Clamp<std::uint8_t>(0, static_cast<std::uint8_t>(r), 255)),
-            G(Clamp<std::uint8_t>(0, static_cast<std::uint8_t>(g), 255)),
-            B(Clamp<std::uint8_t>(0, static_cast<std::uint8_t>(b), 255)) {}
+        constexpr SColorARGB(const T a, const U r, const V g, const W b) noexcept
+            : SColor(
+                Clamp<std::uint8_t>(0, static_cast<std::uint8_t>(a), 255),
+                Clamp<std::uint8_t>(0, static_cast<std::uint8_t>(r), 255),
+                Clamp<std::uint8_t>(0, static_cast<std::uint8_t>(g), 255),
+                Clamp<std::uint8_t>(0, static_cast<std::uint8_t>(b), 255)
+            ) {}
     };
 
     //

--- a/Shared/sdk/SharedUtil.Misc.h
+++ b/Shared/sdk/SharedUtil.Misc.h
@@ -25,12 +25,12 @@
 namespace SharedUtil
 {
     class CArgMap;
-#ifdef WIN32
+#ifdef _WIN32
 
     SString GetMajorVersionString();
 
     // Get a system registry value
-    SString GetSystemRegistryValue(uint hKey, const SString& strPath, const SString& strName);
+    SString GetSystemRegistryValue(std::uint32_t hKey, const SString& strPath, const SString& strName);
 
     // Get/set registry values for the current version
     void    SetRegistryValue(const SString& strPath, const SString& strName, const SString& strValue, bool bFlush = false);
@@ -100,8 +100,8 @@ namespace SharedUtil
     //
     // For tracking results of new features
     //
-    void    AddReportLog(uint uiId, const SString& strText, uint uiAmountLimit = 0);
-    void    AddExceptionReportLog(uint uiId, const char* szExceptionName, const char* szExceptionText);
+    void    AddReportLog(std::uint32_t uiId, const SString& strText, std::uint32_t uiAmountLimit = 0);
+    void    AddExceptionReportLog(std::uint32_t uiId, const char* szExceptionName, const char* szExceptionText);
     void    SetReportLogContents(const SString& strText);
     SString GetReportLogContents();
     SString GetReportLogProcessTag();
@@ -163,7 +163,7 @@ namespace SharedUtil
     bool ProcessPendingBrowseToSolution();
     void ClearPendingBrowseToSolution();
 
-    SString GetSystemErrorMessage(uint uiErrorCode, bool bRemoveNewlines = true, bool bPrependCode = true);
+    SString GetSystemErrorMessage(std::uint32_t uiErrorCode, bool bRemoveNewlines = true, bool bPrependCode = true);
     void    SetClipboardText(const SString& strText);
     SString GetClipboardText();
 
@@ -191,7 +191,7 @@ namespace SharedUtil
     // CPU stats
     struct SThreadCPUTimes
     {
-        uint  uiProcessorNumber = 0;
+        std::uint32_t uiProcessorNumber = 0;
         float fUserPercent = 0;
         float fKernelPercent = 0;
         float fTotalCPUPercent = 0;
@@ -209,7 +209,7 @@ namespace SharedUtil
     };
     DWORD _GetCurrentProcessorNumber();
     void  GetThreadCPUTimes(uint64& outUserTime, uint64& outKernelTime);
-    void  UpdateThreadCPUTimes(SThreadCPUTimesStore& store, long long* pllTickCount = NULL);
+    void  UpdateThreadCPUTimes(SThreadCPUTimesStore& store, long long* pllTickCount = nullptr);
 
     SString EscapeString(const SString& strText, const SString& strDisallowedChars, char cSpecialChar = '#', uchar ucLowerLimit = 0, uchar ucUpperLimit = 255);
     SString UnescapeString(const SString& strText, char cSpecialChar = '#');
@@ -238,13 +238,13 @@ namespace SharedUtil
 
     std::wstring ANSIToUTF16(const SString& s);
 
-    int GetUTF8Confidence(const unsigned char* input, int len);
+    int GetUTF8Confidence(const std::uint8_t* input, int len);
 
-    bool IsUTF8BOM(const void* pData, uint uiLength);
+    bool IsUTF8BOM(const void* pData, std::uint32_t uiLength);
 
     // Buffer identification
-    bool IsLuaCompiledScript(const void* pData, uint uiLength);
-    bool IsLuaObfuscatedScript(const void* pData, uint uiLength);
+    bool IsLuaCompiledScript(const void* pData, std::uint32_t uiLength);
+    bool IsLuaObfuscatedScript(const void* pData, std::uint32_t uiLength);
 
     // Return a pointer to the (shifted) trimmed string
     // @ref https://stackoverflow.com/a/26984026
@@ -255,7 +255,7 @@ namespace SharedUtil
     //
     // Clamps a value between two other values ( min < a < max )
     template <class T>
-    T Clamp(const T& min, const T& a, const T& max)
+    constexpr T Clamp(const T& min, const T& a, const T& max) noexcept
     {
         return a < min ? min : a > max ? max : a;
     }
@@ -310,14 +310,15 @@ namespace SharedUtil
     };
 
     template <class T>
-    T EvalSamplePosition(const SSamplePoint<T>* pPoints, uint uiNumPoints, const T& samplePosition)
-    {
+    T EvalSamplePosition(const SSamplePoint<T>* pPoints,
+        std::uint32_t uiNumPoints, const T& samplePosition
+    ) noexcept {
         // Before first point
         if (samplePosition < pPoints[0].in)
             return pPoints[0].out;
 
         // Between points
-        for (uint i = 1; i < uiNumPoints; i++)
+        for (auto i = 1; i < uiNumPoints; i++)
         {
             if (samplePosition < pPoints[i].in)
             {
@@ -346,12 +347,15 @@ namespace SharedUtil
     {
         if (itemList.empty())
             return false;
-        typename TL ::const_iterator it = itemList.begin();
-        for (; it != itemList.end(); ++it)
-            if (item == *it)
+
+        for (const auto& elem : itemList)
+        {
+            if (elem == item)
                 return true;
+        }
         return false;
     }
+
     // Add item if it does not aleady exist in itemList
     template <class TL, class T>
     void ListAddUnique(TL& itemList, const T& item)
@@ -384,40 +388,52 @@ namespace SharedUtil
         itemList.remove(item);
     }
 
+    template <class Value>
+    void ListRemoveIf(std::list<Value>& list, const Value& item) noexcept
+    {
+        list.remove_if([&](const Value& value) { return value == item; });
+    }
+
+    template <class Value, class Pred>
+    void ListRemoveIf(std::list<Value>& list, const Pred& pred) noexcept
+    {
+        list.remove_if(pred);
+    }
+
     //
     // std::vector helpers
     //
 
     // Remove first occurrence of item from itemList
     template <class T>
-    void ListRemoveFirst(std::vector<T>& itemList, const T& item)
+    constexpr void ListRemove(std::vector<T>& itemList, const T& item) noexcept
     {
-        typename std::vector<T>::iterator it = itemList.begin();
-        for (; it != itemList.end(); ++it)
-            if (item == *it)
-            {
-                itemList.erase(it);
-                break;
-            }
+        auto it = std::find(itemList.begin(), itemList.end(), item);
+        if (it != itemList.end())
+        {
+            itemList.erase(it);
+        }
+    }
+
+    // Remove first occurrence of item from itemList
+    template <class T>
+    constexpr void ListRemoveFirst(std::vector<T>& itemList, const T& item) noexcept {
+        ListRemove(itemList, item);
     }
 
     // Remove all occurrences of item from itemList
     template <class T>
-    void ListRemove(std::vector<T>& itemList, const T& item)
+    constexpr void ListRemoveAll(std::vector<T>& itemList, const T& item) noexcept
     {
-        typename std::vector<T>::iterator it = itemList.begin();
-        while (it != itemList.end())
-        {
-            if (item == *it)
-                it = itemList.erase(it);
-            else
-                ++it;
-        }
+        itemList.erase(
+            std::remove(itemList.begin(), itemList.end(), item),
+            itemList.end()
+        );
     }
 
     // Remove item at index from itemList
     template <class T>
-    void ListRemoveIndex(std::vector<T>& itemList, uint index)
+    void ListRemoveIndex(std::vector<T>& itemList, std::uint32_t index)
     {
         if (index < itemList.size())
             itemList.erase(itemList.begin() + index);
@@ -445,16 +461,12 @@ namespace SharedUtil
 
     // Remove all occurrences of item from itemList
     template <class T>
-    void ListRemove(std::deque<T>& itemList, const T& item)
+    void ListRemoveAll(std::deque<T>& itemList, const T& item) noexcept
     {
-        typename std::deque<T>::iterator it = itemList.begin();
-        while (it != itemList.end())
-        {
-            if (item == *it)
-                it = itemList.erase(it);
-            else
-                ++it;
-        }
+        itemList.erase(
+            std::remove(itemList.begin(), itemList.end(), item),
+            itemList.end()
+        );
     }
 
     //
@@ -470,16 +482,21 @@ namespace SharedUtil
         {
             struct
             {
-                unsigned char B, G, R, A;
+                std::uint8_t B, G, R, A;
             };
-            unsigned long ulARGB;
+            std::uint32_t ulARGB;
         };
 
-        SColor() : ulARGB(0) {}
+        constexpr SColor() noexcept : ulARGB(0) {}
+        constexpr SColor(const std::uint32_t ulValue) noexcept : ulARGB(ulValue) {}
+        constexpr SColor(
+            const std::uint8_t ucA,
+            const std::uint8_t ucR,
+            const std::uint8_t ucG,
+            const std::uint8_t ucB
+        ) noexcept : A(ucA), R(ucR), G(ucG), B(ucB) {}
 
-        SColor(unsigned long ulValue) { ulARGB = ulValue; }
-
-        operator unsigned long() const { return ulARGB; }
+        constexpr operator std::uint32_t() const noexcept { return ulARGB; }
     };
 
     //
@@ -490,22 +507,19 @@ namespace SharedUtil
     class SColorARGB : public SColor
     {
     public:
-        SColorARGB(unsigned char ucA, unsigned char ucR, unsigned char ucG, unsigned char ucB)
-        {
-            A = ucA;
-            R = ucR;
-            G = ucG;
-            B = ucB;
-        }
+        constexpr SColorARGB(
+            const std::uint8_t ucA,
+            const std::uint8_t ucR,
+            const std::uint8_t ucG,
+            const std::uint8_t ucB
+        ) noexcept : SColor(ucA, ucR, ucG, ucB) {}
 
         template <class T, class U, class V, class W>
-        SColorARGB(T a, U r, V g, W b)
-        {
-            A = Clamp<unsigned char>(0, static_cast<unsigned char>(a), 255);
-            R = Clamp<unsigned char>(0, static_cast<unsigned char>(r), 255);
-            G = Clamp<unsigned char>(0, static_cast<unsigned char>(g), 255);
-            B = Clamp<unsigned char>(0, static_cast<unsigned char>(b), 255);
-        }
+        constexpr SColorARGB(const T a, const U r, const V g, const W b) noexcept :
+            A(Clamp<std::uint8_t>(0, static_cast<std::uint8_t>(a), 255)),
+            R(Clamp<std::uint8_t>(0, static_cast<std::uint8_t>(r), 255)),
+            G(Clamp<std::uint8_t>(0, static_cast<std::uint8_t>(g), 255)),
+            B(Clamp<std::uint8_t>(0, static_cast<std::uint8_t>(b), 255)) {}
     };
 
     //
@@ -516,38 +530,55 @@ namespace SharedUtil
     class SColorRGBA : public SColor
     {
     public:
-        SColorRGBA(unsigned char ucR, unsigned char ucG, unsigned char ucB, unsigned char ucA)
-        {
-            A = ucA;
-            R = ucR;
-            G = ucG;
-            B = ucB;
-        }
+        constexpr SColorRGBA(
+            const std::uint8_t ucR,
+            const std::uint8_t ucG,
+            const std::uint8_t ucB,
+            const std::uint8_t ucA
+        )
+            noexcept : SColor(ucA, ucR, ucG, ucB) {}
 
         template <class T, class U, class V, class W>
-        SColorRGBA(T r, U g, V b, W a)
-        {
-            A = Clamp<unsigned char>(0, static_cast<unsigned char>(a), 255);
-            R = Clamp<unsigned char>(0, static_cast<unsigned char>(r), 255);
-            G = Clamp<unsigned char>(0, static_cast<unsigned char>(g), 255);
-            B = Clamp<unsigned char>(0, static_cast<unsigned char>(b), 255);
-        }
+        constexpr SColorRGBA(T r, U g, V b, W a) noexcept
+            : SColor(
+                Clamp<std::uint8_t>(0, static_cast<std::uint8_t>(a), 255),
+                Clamp<std::uint8_t>(0, static_cast<std::uint8_t>(r), 255),
+                Clamp<std::uint8_t>(0, static_cast<std::uint8_t>(g), 255),
+                Clamp<std::uint8_t>(0, static_cast<std::uint8_t>(b), 255)
+            ) {}
     };
 
     //
     // Things to make it simpler to use SColor with the source code as it stands
     //
-    typedef SColor RGBA;
+    using RGBA = SColor;
 
-    inline unsigned char COLOR_RGBA_R(SColor color) { return color.R; }
-    inline unsigned char COLOR_RGBA_G(SColor color) { return color.G; }
-    inline unsigned char COLOR_RGBA_B(SColor color) { return color.B; }
-    inline unsigned char COLOR_RGBA_A(SColor color) { return color.A; }
-    inline unsigned char COLOR_ARGB_A(SColor color) { return color.A; }
+    inline std::uint8_t COLOR_RGBA_R(const SColor color) noexcept { return color.R; }
+    inline std::uint8_t COLOR_RGBA_G(const SColor color) noexcept { return color.G; }
+    inline std::uint8_t COLOR_RGBA_B(const SColor color) noexcept { return color.B; }
+    inline std::uint8_t COLOR_RGBA_A(const SColor color) noexcept { return color.A; }
+    inline std::uint8_t COLOR_ARGB_A(const SColor color) noexcept { return color.A; }
 
-    inline SColor COLOR_RGBA(unsigned char R, unsigned char G, unsigned char B, unsigned char A) { return SColorRGBA(R, G, B, A); }
-    inline SColor COLOR_ARGB(unsigned char A, unsigned char R, unsigned char G, unsigned char B) { return SColorRGBA(R, G, B, A); }
-    inline SColor COLOR_ABGR(unsigned char A, unsigned char B, unsigned char G, unsigned char R) { return SColorRGBA(R, G, B, A); }
+    inline SColor COLOR_RGBA(
+        const std::uint8_t R,
+        const std::uint8_t G,
+        const std::uint8_t B,
+        const std::uint8_t A
+    ) noexcept { return SColorRGBA(R, G, B, A); }
+
+    inline SColor COLOR_ARGB(
+        const std::uint8_t A,
+        const std::uint8_t R,
+        const std::uint8_t G,
+        const std::uint8_t B
+    ) noexcept { return SColorRGBA(R, G, B, A); }
+
+    inline SColor COLOR_ABGR(
+        const std::uint8_t A,
+        const std::uint8_t B,
+        const std::uint8_t G,
+        const std::uint8_t R
+    ) noexcept { return SColorRGBA(R, G, B, A); }
 
     //
     // Cross platform critical section
@@ -803,7 +834,7 @@ namespace SharedUtil
         GetOption<T>(strText, strKey, strNumbers);
         std::vector<SString> numberList;
         strNumbers.Split(szSeperator, numberList);
-        for (uint i = 0; i < numberList.size(); i++)
+        for (std::uint32_t i = 0; i < numberList.size(); i++)
             if (!numberList[i].empty())
                 MapInsert(outValues, static_cast<U>(atoi(numberList[i])));
     }
@@ -829,7 +860,7 @@ namespace SharedUtil
         typename LIST_TYPE ::const_iterator   end() const { return m_List.end(); }
         typename LIST_TYPE ::reverse_iterator rbegin() { return m_List.rbegin(); }
         typename LIST_TYPE ::reverse_iterator rend() { return m_List.rend(); }
-        uint                                  size() const { return m_List.size(); }
+        std::uint32_t                                  size() const { return m_List.size(); }
         bool                                  empty() const { return m_List.empty(); }
         const T&                              back() const { return m_List.back(); }
         const T&                              front() const { return m_List.front(); }
@@ -966,13 +997,14 @@ namespace SharedUtil
     class CIntrusiveListNode
     {
     public:
-        typedef CIntrusiveListNode<T> Node;
+        using Node = CIntrusiveListNode<T>;
 
-        CIntrusiveListNode(T* pOuterItem) : m_pOuterItem(pOuterItem), m_pPrev(NULL), m_pNext(NULL) {}
+        constexpr CIntrusiveListNode(T* pOuterItem) noexcept
+            : m_pOuterItem(pOuterItem) {}
 
         T*    m_pOuterItem;            // Item this node is inside
-        Node* m_pPrev;
-        Node* m_pNext;
+        Node* m_pPrev{};
+        Node* m_pNext{};
     };
 
     ///////////////////////////////////////////////////////////////
@@ -985,20 +1017,26 @@ namespace SharedUtil
     template <typename T>
     class CIntrusiveList
     {
-        void operator=(const CIntrusiveList& other);            // Copy will probably not work as expected
-        // CIntrusiveList ( const CIntrusiveList& other );       // Default copy constructor is required by dense_hash for some reason
+        // Copy will probably not work as expected
+        void operator=(const CIntrusiveList& other);
+        // Default copy constructor is required by dense_hash for some reason
+        // CIntrusiveList ( const CIntrusiveList& other );
 
     public:
         class IteratorBase;
 
     protected:
-        typedef CIntrusiveListNode<T> Node;
+        using Node = CIntrusiveListNode<T>;
 
         size_t m_Size;
         Node*  m_pFirst;
         Node*  m_pLast;
-        Node T::*                  m_pNodePtr;                   // Pointer to the CIntrusiveListNode member variable in T
-        std::vector<IteratorBase*> m_ActiveIterators;            // Keep track of iterators
+
+        // Pointer to the CIntrusiveListNode member variable in T
+        Node T::*m_pNodePtr;
+
+        // Keep track of iterators
+        std::vector<IteratorBase*> m_ActiveIterators;
 
     public:
         //
@@ -1010,11 +1048,18 @@ namespace SharedUtil
             CIntrusiveList<T>* m_pList;
 
         public:
-            Node* m_pNode;
-            IteratorBase(CIntrusiveList<T>* pList, Node* pNode) : m_pList(pList), m_pNode(pNode) { m_pList->m_ActiveIterators.push_back(this); }
-            ~IteratorBase() { ListRemove(m_pList->m_ActiveIterators, this); }
-            T*           operator*() { return m_pNode->m_pOuterItem; }
+            IteratorBase(CIntrusiveList<T>* pList, Node* pNode)
+                noexcept : m_pList(pList), m_pNode(pNode) {
+                m_pList->m_ActiveIterators.push_back(this);
+            }
+            ~IteratorBase() noexcept {
+                ListRemove(m_pList->m_ActiveIterators, this);
+            }
+
+            T*           operator*() noexcept { return m_pNode->m_pOuterItem; }
             virtual void NotifyRemovingNode(Node* pNode) = 0;
+
+            Node* m_pNode;
         };
 
         //
@@ -1060,8 +1105,8 @@ namespace SharedUtil
         {
             assert(m_pNodePtr);            // This must be set upon construction
             m_Size = 0;
-            m_pFirst = NULL;
-            m_pLast = NULL;
+            m_pFirst = nullptr;
+            m_pLast = nullptr;
         }
 
         ~CIntrusiveList() { assert(m_ActiveIterators.empty()); }
@@ -1100,14 +1145,14 @@ namespace SharedUtil
                 {
                     // Only item in list
                     assert(!pNode->m_pPrev && !pNode->m_pNext);
-                    m_pFirst = NULL;
-                    m_pLast = NULL;
+                    m_pFirst = nullptr;
+                    m_pLast = nullptr;
                 }
                 else
                 {
                     // First item in list
                     assert(!pNode->m_pPrev && pNode->m_pNext && pNode->m_pNext->m_pPrev == pNode);
-                    pNode->m_pNext->m_pPrev = NULL;
+                    pNode->m_pNext->m_pPrev = nullptr;
                     m_pFirst = pNode->m_pNext;
                 }
             }
@@ -1115,7 +1160,7 @@ namespace SharedUtil
             {
                 // Last item in list
                 assert(pNode->m_pPrev && !pNode->m_pNext && pNode->m_pPrev->m_pNext == pNode);
-                pNode->m_pPrev->m_pNext = NULL;
+                pNode->m_pPrev->m_pNext = nullptr;
                 m_pLast = pNode->m_pPrev;
             }
             else
@@ -1125,8 +1170,8 @@ namespace SharedUtil
                 pNode->m_pPrev->m_pNext = pNode->m_pNext;
                 pNode->m_pNext->m_pPrev = pNode->m_pPrev;
             }
-            pNode->m_pNext = NULL;
-            pNode->m_pPrev = NULL;
+            pNode->m_pNext = nullptr;
+            pNode->m_pPrev = nullptr;
             m_Size--;
         }
 
@@ -1176,11 +1221,11 @@ namespace SharedUtil
 
         Iterator begin() { return Iterator(this, m_pFirst); }
 
-        Iterator end() { return Iterator(this, NULL); }
+        Iterator end() { return Iterator(this, nullptr); }
 
         ReverseIterator rbegin() { return ReverseIterator(this, m_pLast); }
 
-        ReverseIterator rend() { return ReverseIterator(this, NULL); }
+        ReverseIterator rend() { return ReverseIterator(this, nullptr); }
 
         // Allow use of std iterator names
         typedef Iterator        iterator;
@@ -1240,12 +1285,12 @@ namespace SharedUtil
     template <typename T>
     inline T tolower(T c)
     {
-        return static_cast<T>(ms_ucTolowerTab[static_cast<unsigned char>(c)]);
+        return static_cast<T>(ms_ucTolowerTab[static_cast<std::uint8_t>(c)]);
     }
     template <typename T>
     inline T toupper(T c)
     {
-        return static_cast<T>(ms_ucToupperTab[static_cast<unsigned char>(c)]);
+        return static_cast<T>(ms_ucToupperTab[static_cast<std::uint8_t>(c)]);
     }
 
     //
@@ -1264,12 +1309,12 @@ namespace SharedUtil
             const char* szName;
         };
 
-        CEnumInfo(const SString& strTypeName, const SEnumItem* pItemList, uint uiAmount, eDummy defaultValue, const SString& strDefaultName)
+        CEnumInfo(const SString& strTypeName, const SEnumItem* pItemList, std::uint32_t uiAmount, eDummy defaultValue, const SString& strDefaultName)
         {
             m_strTypeName = strTypeName;
             m_strDefaultName = strDefaultName;
             m_DefaultValue = defaultValue;
-            for (uint i = 0; i < uiAmount; i++)
+            for (std::uint32_t i = 0; i < uiAmount; i++)
             {
                 const SEnumItem& item = pItemList[i];
                 m_ValueMap[item.szName] = (eDummy)item.iValue;
@@ -1350,7 +1395,7 @@ namespace SharedUtil
         // Written by Jack Handy - jakkhandy@hotmail.com
         assert(wild && string);
 
-        const char *cp = NULL, *mp = NULL;
+        const char *cp = nullptr, *mp = nullptr;
 
         while ((*string) && (*wild != '*'))
         {
@@ -1400,7 +1445,7 @@ namespace SharedUtil
         // Written by Jack Handy - jakkhandy@hotmail.com
         assert(wild && string);
 
-        const char *cp = NULL, *mp = NULL;
+        const char *cp = nullptr, *mp = nullptr;
 
         while ((*string) && (*wild != '*'))
         {
@@ -1496,7 +1541,7 @@ namespace SharedUtil
         {
             std::vector<SString> partList;
             strFilterDesc.Split(",", partList);
-            for (uint i = 0; i < partList.size(); i++)
+            for (std::uint32_t i = 0; i < partList.size(); i++)
             {
                 const SString& part = partList[i];
                 char           cType = part.Left(1)[0];
@@ -1540,7 +1585,7 @@ namespace SharedUtil
             cDefaultType = cType;
         }
 
-        std::map<uint, bool> idMap;
+        std::map<std::uint32_t, bool> idMap;
         char                 cDefaultType;
     };
 
@@ -1555,14 +1600,15 @@ namespace SharedUtil
     class CRefCountable
     {
         int                     m_iRefCount;
-        CCriticalSection*       m_pCS;            // Use a pointer incase the static variable exists more than once
+        // Use a pointer incase the static variable exists more than once
+        CCriticalSection*       m_pCS;
         static CCriticalSection ms_CS;
 
     protected:
-        virtual ~CRefCountable() {}
+        virtual ~CRefCountable() noexcept {}
 
     public:
-        CRefCountable() : m_iRefCount(1), m_pCS(&ms_CS) {}
+        constexpr CRefCountable() noexcept : m_iRefCount(1), m_pCS(&ms_CS) {}
 
         void AddRef()
         {
@@ -1593,13 +1639,13 @@ namespace SharedUtil
     template <class T, int SIZE>
     struct SFixedArray
     {
-        T& operator[](uint uiIndex)
+        T& operator[](std::uint32_t uiIndex)
         {
             assert(uiIndex < SIZE);
             return data[uiIndex];
         }
 
-        const T& operator[](uint uiIndex) const
+        const T& operator[](std::uint32_t uiIndex) const
         {
             assert(uiIndex < SIZE);
             return data[uiIndex];
@@ -1615,7 +1661,7 @@ namespace SharedUtil
     template <class T, int SIZE>
     struct SFixedArrayInit : SFixedArray<T, SIZE>
     {
-        SFixedArrayInit(const T* pInitData, uint uiInitCount)
+        SFixedArrayInit(const T* pInitData, std::uint32_t uiInitCount)
         {
             dassert(SIZE == uiInitCount);
             memcpy(SFixedArray<T, SIZE>::data, pInitData, sizeof(SFixedArray<T, SIZE>::data));
@@ -1632,17 +1678,17 @@ namespace SharedUtil
     class CRanges
     {
     public:
-        void SetRange(uint uiStart, uint uiLength);
-        void UnsetRange(uint uiStart, uint uiLength);
-        bool IsRangeSet(uint uiStart, uint uiLength);            // Returns true if any part of the range already exists in the map
+        void SetRange(std::uint32_t uiStart, std::uint32_t uiLength);
+        void UnsetRange(std::uint32_t uiStart, std::uint32_t uiLength);
+        bool IsRangeSet(std::uint32_t uiStart, std::uint32_t uiLength);            // Returns true if any part of the range already exists in the map
 
     protected:
-        typedef std::map<uint, uint>::iterator IterType;
+        typedef std::map<std::uint32_t, std::uint32_t>::iterator IterType;
 
-        void RemoveObscuredRanges(uint uiStart, uint uiLast);
-        bool GetRangeOverlappingPoint(uint uiPoint, IterType& result);
+        void RemoveObscuredRanges(std::uint32_t uiStart, std::uint32_t uiLast);
+        bool GetRangeOverlappingPoint(std::uint32_t uiPoint, IterType& result);
 
-        std::map<uint, uint> m_StartLastMap;
+        std::map<std::uint32_t, std::uint32_t> m_StartLastMap;
     };
 
     //
@@ -1674,9 +1720,9 @@ namespace SharedUtil
         CRefedPointer<T>* pPointer;
 
     public:
-        CAutoRefedPointer() { pPointer = new CRefedPointer<T>(); }
+        CAutoRefedPointer() noexcept { pPointer = new CRefedPointer<T>(); }
 
-        CAutoRefedPointer(const CAutoRefedPointer<T>& other)
+        CAutoRefedPointer(const CAutoRefedPointer<T>& other)noexcept 
         {
             pPointer = other.pPointer;
             pPointer->AddRef();
@@ -1713,5 +1759,5 @@ using namespace SharedUtil;
 //
 // For checking MTA library module versions
 //
-typedef void(FUNC_GetMtaVersion)(char* pBuffer, uint uiMaxSize);
-MTAEXPORT void GetLibMtaVersion(char* pBuffer, uint uiMaxSize);
+using FUNC_GetMtaVersion = void(char* pBuffer, std::uint32_t uiMaxSize);
+MTAEXPORT void GetLibMtaVersion(char* pBuffer, std::uint32_t uiMaxSize);

--- a/Shared/sdk/SharedUtil.h
+++ b/Shared/sdk/SharedUtil.h
@@ -10,22 +10,23 @@
  *****************************************************************************/
 #pragma once
 
-#include "SharedUtil.IntTypes.h"
-#include <assert.h>
-#include "SharedUtil.Defines.h"
-#include "SharedUtil.AllocTracking.h"
+#include <cassert>
 #include <list>
 #include <vector>
 #include <map>
 #include <set>
 #include <deque>
 #include <algorithm>
-#include <limits.h>
-#include <stdio.h>
-#include <string.h>
+#include <climits>
+#include <cstdio>
+#include <cstring>
 #include <string>
-#include <stdarg.h>
+#include <cstdarg>
 #include <chrono>
+
+#include "SharedUtil.IntTypes.h"
+#include "SharedUtil.Defines.h"
+#include "SharedUtil.AllocTracking.h"
 
 // Vendor
 #ifndef _

--- a/Shared/sdk/net/SyncStructures.h
+++ b/Shared/sdk/net/SyncStructures.h
@@ -2482,26 +2482,26 @@ struct sWeaponPropertySync : public ISyncStructure
     struct
     {
         int   weaponType;
-        FLOAT fTargetRange;            // max targeting range
-        FLOAT fWeaponRange;            // absolute gun range / default melee attack range
+        float fTargetRange;            // max targeting range
+        float fWeaponRange;            // absolute gun range / default melee attack range
 
         int nFlags;            // flags defining characteristics
 
         short nAmmo;              // ammo in one clip
         short nDamage;            // damage inflicted per hit
 
-        FLOAT fAccuracy;             // modify accuracy of weapon
-        FLOAT fMoveSpeed;            // how fast can move with weapon
+        float fAccuracy;             // modify accuracy of weapon
+        float fMoveSpeed;            // how fast can move with weapon
 
-        FLOAT anim_loop_start;                  // start of animation loop
-        FLOAT anim_loop_stop;                   // end of animation loop
-        FLOAT anim_loop_bullet_fire;            // time in animation when weapon should be fired
+        float anim_loop_start;                  // start of animation loop
+        float anim_loop_stop;                   // end of animation loop
+        float anim_loop_bullet_fire;            // time in animation when weapon should be fired
 
-        FLOAT anim2_loop_start;                  // start of animation2 loop
-        FLOAT anim2_loop_stop;                   // end of animation2 loop
-        FLOAT anim2_loop_bullet_fire;            // time in animation2 when weapon should be fired
+        float anim2_loop_start;                  // start of animation2 loop
+        float anim2_loop_stop;                   // end of animation2 loop
+        float anim2_loop_bullet_fire;            // time in animation2 when weapon should be fired
 
-        FLOAT anim_breakout_time;            // time after which player can break out of attack and run off
+        float anim_breakout_time;            // time after which player can break out of attack and run off
     } data;
 };
 

--- a/Shared/sdk/net/bitstream.h
+++ b/Shared/sdk/net/bitstream.h
@@ -219,7 +219,7 @@ public:
     }
 
     // Write all characters in `value` (incl. length as `SizeType`)
-    template <typename SizeType = unsigned short>
+    template <typename SizeType = std::uint16_t>
     void WriteString(std::string_view value)
     {
         // Write the length
@@ -232,7 +232,7 @@ public:
     // Write a string (incl. variable size header)
     void WriteStr(std::string_view value)
     {
-        WriteLength(value.length());
+        WriteLength(static_cast<std::uint32_t>(value.length()));
         return WriteStringCharacters(value, value.length());
     }
 #else

--- a/Shared/sdk/sha1.h
+++ b/Shared/sdk/sha1.h
@@ -24,14 +24,17 @@
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+
+#pragma once
 #ifndef SHA1_H
 #define SHA1_H
+
+#include <SharedUtil.IntTypes.h>
 
 #include <string.h>
 
 #if defined(_MSC_VER) && !defined(EFIX64) && !defined(EFI32)
 #include <basetsd.h>
-typedef UINT32 uint32_t;
 #else
 #include <inttypes.h>
 #endif

--- a/Shared/sdk/sha2.h
+++ b/Shared/sdk/sha2.h
@@ -31,8 +31,11 @@
  * SUCH DAMAGE.
  */
 
+#pragma once
 #ifndef SHA2_H
 #define SHA2_H
+
+#include <SharedUtil.IntTypes.h>
 
 #define SHA224_DIGEST_SIZE ( 224 / 8)
 #define SHA256_DIGEST_SIZE ( 256 / 8)
@@ -46,9 +49,6 @@
 
 #ifndef SHA2_TYPES
 #define SHA2_TYPES
-typedef unsigned char      uint8;
-typedef unsigned int       uint32;
-typedef unsigned long long uint64;
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Currently most mta's code uses generic `unsigned` types which are platform dependent. `cstdint` header however is (_should_ be) platform independent.
This PR focuses on that irregularity and replaces all `unsigned` (and somewhere `long long`) into the `cstdint` types.


MTA's source code is **huuge**. So there is a gigantic number of changes
Splitting the PR into multiple PR's with the same changes would bring too much troubles