### PR TITLE
Fix file lock after img:destroy()

### DIFF
--- a/Client/mods/deathmatch/logic/CClientIMG.cpp
+++ b/Client/mods/deathmatch/logic/CClientIMG.cpp
@@ -28,6 +28,11 @@ CClientIMG::CClientIMG(class CClientManager* pManager, ElementID ID)
 CClientIMG::~CClientIMG()
 {
     m_pImgManager->RemoveFromList(this);
+    Unlink();
+}
+
+void CClientIMG::Unlink()
+{
     if (IsStreamed())
         StreamDisable();
 

--- a/Client/mods/deathmatch/logic/CClientIMG.h
+++ b/Client/mods/deathmatch/logic/CClientIMG.h
@@ -50,7 +50,7 @@ public:
     CClientIMG(class CClientManager* pManager, ElementID ID);
     ~CClientIMG();
 
-    void Unlink(){};
+    void Unlink();
     void GetPosition(CVector& vecPosition) const {};
     void SetPosition(const CVector& vecPosition){};
 


### PR DESCRIPTION
Fixes #3062

Old behavior:
IMG file remains locked for two frames after img:destroy().
New behavior:
IMG file removes lock after img:detroy call imedeatly.
