### PR TITLE
Set MacOS builder version to macOS-13

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
 
   macOS:
     name: macOS
-    runs-on: macOS-latest
+    runs-on: macOS-13
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This PR fixes broken mac os build actions.

I suggest using this until we have support for Macs with Intel chips.