### PR TITLE
Add roadsignstext special world property

### DIFF
--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -729,6 +729,17 @@ void CGameSA::SetFireballDestructEnabled(bool isEnabled)
     m_isFireballDestructEnabled = isEnabled;
 }
 
+void CGameSA::SetRoadSignsTextEnabled(bool isEnabled)
+{
+    if (isEnabled == m_isRoadSignsTextEnabled)
+        return;
+
+    // Skip JMP to CCustomRoadsignMgr::RenderRoadsignAtomic
+    MemPut<BYTE>(0x5342ED, isEnabled ? 0xEB : 0x74);
+
+    m_isRoadSignsTextEnabled = isEnabled;
+}
+
 bool CGameSA::PerformChecks()
 {
     std::map<std::string, SCheatSA*>::iterator it;

--- a/Client/game_sa/CGameSA.h
+++ b/Client/game_sa/CGameSA.h
@@ -219,6 +219,9 @@ public:
     bool IsFireballDestructEnabled() const noexcept override { return m_isFireballDestructEnabled; }
     void SetFireballDestructEnabled(bool isEnabled) override;
 
+    bool IsRoadSignsTextEnabled() const noexcept override { return m_isRoadSignsTextEnabled; }
+    void SetRoadSignsTextEnabled(bool isEnabled) override;
+
     unsigned long GetMinuteDuration();
     void          SetMinuteDuration(unsigned long ulTime);
 
@@ -336,6 +339,7 @@ private:
     bool         m_areWaterCreaturesEnabled{true};
     bool         m_isBurnFlippedCarsEnabled{true};
     bool         m_isFireballDestructEnabled{true};
+    bool         m_isRoadSignsTextEnabled{true};
 
     static unsigned int&  ClumpOffset;
 

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -6091,6 +6091,9 @@ bool CClientGame::SetWorldSpecialProperty(WorldSpecialProperty property, bool is
         case WorldSpecialProperty::FIREBALLDESTRUCT:
             g_pGame->SetFireballDestructEnabled(isEnabled);
             return true;
+        case WorldSpecialProperty::ROADSIGNSTEXT:
+            g_pGame->SetRoadSignsTextEnabled(isEnabled);
+            return true;
     }
     return false;
 }
@@ -6122,6 +6125,8 @@ bool CClientGame::IsWorldSpecialProperty(WorldSpecialProperty property)
             return g_pGame->IsBurnFlippedCarsEnabled();
         case WorldSpecialProperty::FIREBALLDESTRUCT:
             return g_pGame->IsFireballDestructEnabled();
+        case WorldSpecialProperty::ROADSIGNSTEXT:
+            return g_pGame->IsRoadSignsTextEnabled();
     }
     return false;
 }

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -2387,7 +2387,7 @@ void CPacketHandler::Packet_MapInfo(NetBitStreamInterface& bitStream)
     g_pClientGame->SetWorldSpecialProperty(WorldSpecialProperty::WATERCREATURES, wsProps.data.watercreatures);
     g_pClientGame->SetWorldSpecialProperty(WorldSpecialProperty::BURNFLIPPEDCARS, wsProps.data.burnflippedcars);
     g_pClientGame->SetWorldSpecialProperty(WorldSpecialProperty::FIREBALLDESTRUCT, wsProps.data2.fireballdestruct);
-    g_pClientGame->SetWorldSpecialProperty(WorldSpecialProperty::ROADSIGNSTEXT, wsProps.data.roadsignstext);
+    g_pClientGame->SetWorldSpecialProperty(WorldSpecialProperty::ROADSIGNSTEXT, wsProps.data3.roadsignstext);
 
     float fJetpackMaxHeight = 100;
     if (!bitStream.Read(fJetpackMaxHeight))

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -2387,6 +2387,7 @@ void CPacketHandler::Packet_MapInfo(NetBitStreamInterface& bitStream)
     g_pClientGame->SetWorldSpecialProperty(WorldSpecialProperty::WATERCREATURES, wsProps.data.watercreatures);
     g_pClientGame->SetWorldSpecialProperty(WorldSpecialProperty::BURNFLIPPEDCARS, wsProps.data.burnflippedcars);
     g_pClientGame->SetWorldSpecialProperty(WorldSpecialProperty::FIREBALLDESTRUCT, wsProps.data2.fireballdestruct);
+    g_pClientGame->SetWorldSpecialProperty(WorldSpecialProperty::ROADSIGNSTEXT, wsProps.data.roadsignstext);
 
     float fJetpackMaxHeight = 100;
     if (!bitStream.Read(fJetpackMaxHeight))

--- a/Client/sdk/game/CGame.h
+++ b/Client/sdk/game/CGame.h
@@ -217,6 +217,9 @@ public:
     virtual bool IsFireballDestructEnabled() const noexcept = 0;
     virtual void SetFireballDestructEnabled(bool isEnabled) = 0;
 
+    virtual bool IsRoadSignsTextEnabled() const noexcept = 0;
+    virtual void SetRoadSignsTextEnabled(bool isEnabled) = 0;
+
     virtual CWeapon*     CreateWeapon() = 0;
     virtual CWeaponStat* CreateWeaponStat(eWeaponType weaponType, eWeaponSkill weaponSkill) = 0;
 

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -246,6 +246,7 @@ CGame::CGame() : m_FloodProtect(4, 30000, 30000)            // Max of 4 connecti
     m_WorldSpecialProps[WorldSpecialProperty::WATERCREATURES] = true;
     m_WorldSpecialProps[WorldSpecialProperty::BURNFLIPPEDCARS] = true;
     m_WorldSpecialProps[WorldSpecialProperty::FIREBALLDESTRUCT] = true;
+    m_WorldSpecialProps[WorldSpecialProperty::ROADSIGNSTEXT] = true;
 
     m_JetpackWeapons[WEAPONTYPE_MICRO_UZI] = true;
     m_JetpackWeapons[WEAPONTYPE_TEC9] = true;

--- a/Server/mods/deathmatch/logic/packets/CMapInfoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CMapInfoPacket.cpp
@@ -189,7 +189,7 @@ bool CMapInfoPacket::Write(NetBitStreamInterface& BitStream) const
         wsProps.data.watercreatures = g_pGame->IsWorldSpecialPropertyEnabled(WorldSpecialProperty::WATERCREATURES);
         wsProps.data.burnflippedcars = g_pGame->IsWorldSpecialPropertyEnabled(WorldSpecialProperty::BURNFLIPPEDCARS);
         wsProps.data2.fireballdestruct = g_pGame->IsWorldSpecialPropertyEnabled(WorldSpecialProperty::FIREBALLDESTRUCT);
-        wsProps.data.roadsignstext = g_pGame->IsWorldSpecialPropertyEnabled(WorldSpecialProperty::ROADSIGNSTEXT);
+        wsProps.data3.roadsignstext = g_pGame->IsWorldSpecialPropertyEnabled(WorldSpecialProperty::ROADSIGNSTEXT);
         BitStream.Write(&wsProps);
     }
 

--- a/Server/mods/deathmatch/logic/packets/CMapInfoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CMapInfoPacket.cpp
@@ -189,6 +189,7 @@ bool CMapInfoPacket::Write(NetBitStreamInterface& BitStream) const
         wsProps.data.watercreatures = g_pGame->IsWorldSpecialPropertyEnabled(WorldSpecialProperty::WATERCREATURES);
         wsProps.data.burnflippedcars = g_pGame->IsWorldSpecialPropertyEnabled(WorldSpecialProperty::BURNFLIPPEDCARS);
         wsProps.data2.fireballdestruct = g_pGame->IsWorldSpecialPropertyEnabled(WorldSpecialProperty::FIREBALLDESTRUCT);
+        wsProps.data.roadsignstext = g_pGame->IsWorldSpecialPropertyEnabled(WorldSpecialProperty::ROADSIGNSTEXT);
         BitStream.Write(&wsProps);
     }
 

--- a/Shared/mods/deathmatch/logic/Enums.cpp
+++ b/Shared/mods/deathmatch/logic/Enums.cpp
@@ -98,6 +98,7 @@ ADD_ENUM(WorldSpecialProperty::CORONAZTEST, "coronaztest")
 ADD_ENUM(WorldSpecialProperty::WATERCREATURES, "watercreatures")
 ADD_ENUM(WorldSpecialProperty::BURNFLIPPEDCARS, "burnflippedcars")
 ADD_ENUM(WorldSpecialProperty::FIREBALLDESTRUCT, "fireballdestruct")
+ADD_ENUM(WorldSpecialProperty::ROADSIGNSTEXT, "roadsignstext")
 IMPLEMENT_ENUM_CLASS_END("world-special-property")
 
 IMPLEMENT_ENUM_BEGIN(ePacketID)

--- a/Shared/mods/deathmatch/logic/Enums.h
+++ b/Shared/mods/deathmatch/logic/Enums.h
@@ -88,6 +88,7 @@ enum class WorldSpecialProperty
     WATERCREATURES,
     BURNFLIPPEDCARS,
     FIREBALLDESTRUCT,
+    ROADSIGNSTEXT,
 };
 DECLARE_ENUM_CLASS(WorldSpecialProperty);
 

--- a/Shared/sdk/net/SyncStructures.h
+++ b/Shared/sdk/net/SyncStructures.h
@@ -2026,7 +2026,7 @@ struct SWorldSpecialPropertiesStateSync : public ISyncStructure
 {
     enum
     {
-        BITCOUNT = 12
+        BITCOUNT = 13
     };
     enum
     {
@@ -2074,6 +2074,7 @@ struct SWorldSpecialPropertiesStateSync : public ISyncStructure
         bool coronaztest : 1;
         bool watercreatures : 1;
         bool burnflippedcars : 1;
+        bool roadsignstext : 1;
     } data;
 
     // Add new ones in separate structs
@@ -2098,6 +2099,7 @@ struct SWorldSpecialPropertiesStateSync : public ISyncStructure
         data.watercreatures = true;
         data.burnflippedcars = true;
         data2.fireballdestruct = true;
+        data.roadsignstext = true;
     }
 };
 

--- a/Shared/sdk/net/SyncStructures.h
+++ b/Shared/sdk/net/SyncStructures.h
@@ -2026,11 +2026,15 @@ struct SWorldSpecialPropertiesStateSync : public ISyncStructure
 {
     enum
     {
-        BITCOUNT = 13
+        BITCOUNT = 12
     };
     enum
     {
         BITCOUNT2 = 1
+    };
+    enum
+    {
+        BITCOUNT3 = 1
     };
 
     bool Read(NetBitStreamInterface& bitStream)
@@ -2040,6 +2044,12 @@ struct SWorldSpecialPropertiesStateSync : public ISyncStructure
              isOK &= bitStream.ReadBits(reinterpret_cast<char*>(&data2), BITCOUNT2);
          else
              data2.fireballdestruct = true;
+
+        if (bitStream.Can(eBitStreamVersion::WorldSpecialProperty_RoadSignsText))
+             isOK &= bitStream.ReadBits(reinterpret_cast<char*>(&data3), BITCOUNT3);
+         else
+             data3.roadsignstext = true;
+
 
         //// Example for adding item:
         // if (bitStream.Can(eBitStreamVersion::YourProperty))
@@ -2054,6 +2064,9 @@ struct SWorldSpecialPropertiesStateSync : public ISyncStructure
         bitStream.WriteBits(reinterpret_cast<const char*>(&data), BITCOUNT);
         if (bitStream.Can(eBitStreamVersion::WorldSpecialProperty_FireballDestruct))
             bitStream.WriteBits(reinterpret_cast<const char*>(&data2), BITCOUNT2);
+
+        if (bitStream.Can(eBitStreamVersion::WorldSpecialProperty_RoadSignsText))
+            bitStream.WriteBits(reinterpret_cast<const char*>(&data3), BITCOUNT3);
 
         //// Example for adding item:
         // if (bitStream.Can(eBitStreamVersion::YourProperty))
@@ -2074,7 +2087,6 @@ struct SWorldSpecialPropertiesStateSync : public ISyncStructure
         bool coronaztest : 1;
         bool watercreatures : 1;
         bool burnflippedcars : 1;
-        bool roadsignstext : 1;
     } data;
 
     // Add new ones in separate structs
@@ -2082,6 +2094,11 @@ struct SWorldSpecialPropertiesStateSync : public ISyncStructure
     {
         bool fireballdestruct : 1;
     } data2;
+
+    struct
+    {
+        bool roadsignstext : 1;
+    } data3;
 
     SWorldSpecialPropertiesStateSync()
     {
@@ -2099,7 +2116,7 @@ struct SWorldSpecialPropertiesStateSync : public ISyncStructure
         data.watercreatures = true;
         data.burnflippedcars = true;
         data2.fireballdestruct = true;
-        data.roadsignstext = true;
+        data3.roadsignstext = true;
     }
 };
 

--- a/Shared/sdk/net/bitstream.h
+++ b/Shared/sdk/net/bitstream.h
@@ -540,6 +540,10 @@ enum class eBitStreamVersion : unsigned short
     // 2023-10-12
     CPlayerJoinCompletePacket_ServerName,
 
+    // Add "roadsignstext" to setWorldSpecialPropertyEnabled
+    // 2024-05-17
+    WorldSpecialProperty_RoadSignsText,
+
     // This allows us to automatically increment the BitStreamVersion when things are added to this enum.
     // Make sure you only add things above this comment.
     Next,


### PR DESCRIPTION
Added ``roadsignstext`` special world property, which allows you to disable text rendering on road signs. Thanks to this, we have the opportunity to make our own road signs, which was suggested e.g. in #672 

Enabled:
![image](https://github.com/multitheftauto/mtasa-blue/assets/26044224/8654c376-cd95-49cd-b0b2-ed1cdad1a8d2)

Disabled:
![image](https://github.com/multitheftauto/mtasa-blue/assets/26044224/a4f12845-132e-4a11-bb03-84a12d1b4adb)
