### PR TITLE
Fix ability to move server-side vehicles that are far away from the player

### DIFF
--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -1455,6 +1455,7 @@ const std::vector<SIntSetting>& CMainConfig::GetIntSettingList()
         {true, true, 10, 50, 1000, "update_cycle_messages_limit", &m_iUpdateCycleMessagesLimit, &CMainConfig::ApplyNetOptions},
         {true, true, 50, 100, 400, "ped_syncer_distance", &g_TickRateSettings.iPedSyncerDistance, &CMainConfig::OnTickRateChange},
         {true, true, 50, 130, 400, "unoccupied_vehicle_syncer_distance", &g_TickRateSettings.iUnoccupiedVehicleSyncerDistance, &CMainConfig::OnTickRateChange},
+        {true, true, 0, 30, 130, "vehicle_contact_sync_radius", &g_TickRateSettings.iVehicleContactSyncRadius, &CMainConfig::OnTickRateChange},
         {false, false, 0, 1, 2, "compact_internal_databases", &m_iCompactInternalDatabases, NULL},
         {true, true, 0, 1, 2, "minclientversion_auto_update", &m_iMinClientVersionAutoUpdate, NULL},
         {true, true, 0, 0, 100, "server_logic_fps_limit", &m_iServerLogicFpsLimit, NULL},

--- a/Server/mods/deathmatch/logic/CUnoccupiedVehicleSync.cpp
+++ b/Server/mods/deathmatch/logic/CUnoccupiedVehicleSync.cpp
@@ -488,7 +488,7 @@ void CUnoccupiedVehicleSync::Packet_UnoccupiedVehiclePushSync(CUnoccupiedVehicle
             // Is the player syncing this vehicle and there is no driver? Also only process
             // this packet if the time context matches.
             if (pVehicle->GetSyncer() != pPlayer && pVehicle->GetTimeSinceLastPush() >= MIN_PUSH_ANTISPAM_RATE &&
-                IsPointNearPoint3D(pVehicle->GetPosition(), pPlayer->GetPosition(), MAX_CONTACT_SYNC_RADIUS))
+                IsPointNearPoint3D(pVehicle->GetPosition(), pPlayer->GetPosition(), g_TickRateSettings.iVehicleContactSyncRadius))
             {
                 // Is there no player driver?
                 CPed* pOccupant = pVehicle->GetOccupant(0);

--- a/Server/mods/deathmatch/logic/CUnoccupiedVehicleSync.cpp
+++ b/Server/mods/deathmatch/logic/CUnoccupiedVehicleSync.cpp
@@ -488,7 +488,8 @@ void CUnoccupiedVehicleSync::Packet_UnoccupiedVehiclePushSync(CUnoccupiedVehicle
             // Is the player syncing this vehicle and there is no driver? Also only process
             // this packet if the time context matches.
             if (pVehicle->GetSyncer() != pPlayer && pVehicle->GetTimeSinceLastPush() >= MIN_PUSH_ANTISPAM_RATE &&
-                IsPointNearPoint3D(pVehicle->GetPosition(), pPlayer->GetPosition(), g_TickRateSettings.iVehicleContactSyncRadius))
+                IsPointNearPoint3D(pVehicle->GetPosition(), pPlayer->GetPosition(), g_TickRateSettings.iVehicleContactSyncRadius)
+                && pVehicle->GetDimension() == pPlayer->GetDimension())
             {
                 // Is there no player driver?
                 CPed* pOccupant = pVehicle->GetOccupant(0);

--- a/Server/mods/deathmatch/logic/CUnoccupiedVehicleSync.cpp
+++ b/Server/mods/deathmatch/logic/CUnoccupiedVehicleSync.cpp
@@ -488,7 +488,7 @@ void CUnoccupiedVehicleSync::Packet_UnoccupiedVehiclePushSync(CUnoccupiedVehicle
             // Is the player syncing this vehicle and there is no driver? Also only process
             // this packet if the time context matches.
             if (pVehicle->GetSyncer() != pPlayer && pVehicle->GetTimeSinceLastPush() >= MIN_PUSH_ANTISPAM_RATE &&
-                IsPointNearPoint3D(pVehicle->GetPosition(), pPlayer->GetPosition(), MIN_CONTACT_SYNC_RADIUS))
+                IsPointNearPoint3D(pVehicle->GetPosition(), pPlayer->GetPosition(), MAX_CONTACT_SYNC_RADIUS))
             {
                 // Is there no player driver?
                 CPed* pOccupant = pVehicle->GetOccupant(0);

--- a/Server/mods/deathmatch/logic/CUnoccupiedVehicleSync.cpp
+++ b/Server/mods/deathmatch/logic/CUnoccupiedVehicleSync.cpp
@@ -487,7 +487,8 @@ void CUnoccupiedVehicleSync::Packet_UnoccupiedVehiclePushSync(CUnoccupiedVehicle
             CVehicle* pVehicle = static_cast<CVehicle*>(pVehicleElement);
             // Is the player syncing this vehicle and there is no driver? Also only process
             // this packet if the time context matches.
-            if (pVehicle->GetSyncer() != pPlayer && pVehicle->GetTimeSinceLastPush() >= MIN_PUSH_ANTISPAM_RATE)
+            if (pVehicle->GetSyncer() != pPlayer && pVehicle->GetTimeSinceLastPush() >= MIN_PUSH_ANTISPAM_RATE &&
+                IsPointNearPoint3D(pVehicle->GetPosition(), pPlayer->GetPosition(), MIN_CONTACT_SYNC_RADIUS))
             {
                 // Is there no player driver?
                 CPed* pOccupant = pVehicle->GetOccupant(0);

--- a/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
@@ -70,6 +70,19 @@ bool CPlayerPuresyncPacket::Read(NetBitStreamInterface& BitStream)
                 return false;
             pContactElement = CElementIDs::GetElement(Temp);
         }
+
+        // Player position
+        SPositionSync position(false);
+        if (!BitStream.Read(&position))
+            return false;
+
+        if (pContactElement != nullptr && !IsPointNearPoint3D(pSourcePlayer->GetPosition(), pContactElement->GetPosition(), MIN_CONTACT_SYNC_RADIUS))
+        {
+            pContactElement = nullptr;
+            // Use current player position. They are not reporting their absolute position so we have to disregard it.
+            position.data.vecPosition = pSourcePlayer->GetPosition();
+        }
+
         CElement* pPreviousContactElement = pSourcePlayer->GetContactElement();
         pSourcePlayer->SetContactElement(pContactElement);
 
@@ -89,11 +102,6 @@ bool CPlayerPuresyncPacket::Read(NetBitStreamInterface& BitStream)
             pSourcePlayer->CallEvent("onPlayerContact", Arguments);
         }
 
-        // Player position
-        SPositionSync position(false);
-        if (!BitStream.Read(&position))
-            return false;
-
         if (pContactElement)
         {
             pSourcePlayer->SetContactPosition(position.data.vecPosition);
@@ -102,6 +110,7 @@ bool CPlayerPuresyncPacket::Read(NetBitStreamInterface& BitStream)
             CVector vecTempPos = pContactElement->GetPosition();
             position.data.vecPosition += vecTempPos;
         }
+
         pSourcePlayer->SetPosition(position.data.vecPosition);
 
         // Player rotation

--- a/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
@@ -14,6 +14,7 @@
 #include "CElementIDs.h"
 #include "CWeaponNames.h"
 #include "Utils.h"
+#include "CTickRateSettings.h"
 #include <net/SyncStructures.h>
 
 extern CGame* g_pGame;
@@ -76,7 +77,7 @@ bool CPlayerPuresyncPacket::Read(NetBitStreamInterface& BitStream)
         if (!BitStream.Read(&position))
             return false;
 
-        if (pContactElement != nullptr && !IsPointNearPoint3D(pSourcePlayer->GetPosition(), pContactElement->GetPosition(), MAX_CONTACT_SYNC_RADIUS))
+        if (pContactElement != nullptr && !IsPointNearPoint3D(pSourcePlayer->GetPosition(), pContactElement->GetPosition(), g_TickRateSettings.iVehicleContactSyncRadius))
         {
             pContactElement = nullptr;
             // Use current player position. They are not reporting their absolute position so we have to disregard it.

--- a/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
@@ -76,7 +76,7 @@ bool CPlayerPuresyncPacket::Read(NetBitStreamInterface& BitStream)
         if (!BitStream.Read(&position))
             return false;
 
-        if (pContactElement != nullptr && !IsPointNearPoint3D(pSourcePlayer->GetPosition(), pContactElement->GetPosition(), MIN_CONTACT_SYNC_RADIUS))
+        if (pContactElement != nullptr && !IsPointNearPoint3D(pSourcePlayer->GetPosition(), pContactElement->GetPosition(), MAX_CONTACT_SYNC_RADIUS))
         {
             pContactElement = nullptr;
             // Use current player position. They are not reporting their absolute position so we have to disregard it.

--- a/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
@@ -77,7 +77,9 @@ bool CPlayerPuresyncPacket::Read(NetBitStreamInterface& BitStream)
         if (!BitStream.Read(&position))
             return false;
 
-        if (pContactElement != nullptr && !IsPointNearPoint3D(pSourcePlayer->GetPosition(), pContactElement->GetPosition(), g_TickRateSettings.iVehicleContactSyncRadius))
+        if (pContactElement != nullptr &&
+            (!IsPointNearPoint3D(pSourcePlayer->GetPosition(), pContactElement->GetPosition(), g_TickRateSettings.iVehicleContactSyncRadius) ||
+                pSourcePlayer->GetDimension() != pContactElement->GetDimension()))
         {
             pContactElement = nullptr;
             // Use current player position. They are not reporting their absolute position so we have to disregard it.

--- a/Server/mods/deathmatch/mtaserver.conf
+++ b/Server/mods/deathmatch/mtaserver.conf
@@ -135,6 +135,10 @@
          Values: 0 - disabled , 1 - enabled ; default value: 1. -->
     <bullet_sync>1</bullet_sync>
 
+    <!-- This parameter specifies the radius in which any contact with a vehicle will turn the player into its syncer.
+         Available range: 0 to 130. Default - 30 -->
+    <vehicle_contact_sync_radius>30</vehicle_contact_sync_radius>
+
     <!-- This parameter sets the amount of extrapolation that clients will apply to remote vehicles. This can reduce
          some of the latency induced location disparency by predicting where the remote vehicles will probably be.
          Depending on the gamemode, an incorrect prediction may have a negative effect. Therefore this setting

--- a/Server/mods/deathmatch/mtaserver.conf.template
+++ b/Server/mods/deathmatch/mtaserver.conf.template
@@ -136,6 +136,10 @@
          Values: 0 - disabled , 1 - enabled ; default value: 1. -->
     <bullet_sync>1</bullet_sync>
 
+    <!-- This parameter specifies the radius in which any contact with a vehicle will turn the player into its syncer.
+         Available range: 0 to 130. Default - 30 -->
+    <vehicle_contact_sync_radius>30</vehicle_contact_sync_radius>
+
     <!-- This parameter sets the amount of extrapolation that clients will apply to remote vehicles. This can reduce
          some of the latency induced location disparency by predicting where the remote vehicles will probably be.
          Depending on the gamemode, an incorrect prediction may have a negative effect. Therefore this setting

--- a/Shared/mods/deathmatch/logic/CTickRateSettings.h
+++ b/Shared/mods/deathmatch/logic/CTickRateSettings.h
@@ -25,6 +25,7 @@ public:
         iNearListUpdate = 100;
         iPedSyncerDistance = 100;
         iUnoccupiedVehicleSyncerDistance = 130;
+        iVehicleContactSyncRadius = 30;
     }
 
     int iPureSync;
@@ -39,6 +40,7 @@ public:
     int iNearListUpdate;
     int iPedSyncerDistance;
     int iUnoccupiedVehicleSyncerDistance;
+    int iVehicleContactSyncRadius;
 };
 
 extern CTickRateSettings g_TickRateSettings;

--- a/Shared/sdk/net/SyncStructures.h
+++ b/Shared/sdk/net/SyncStructures.h
@@ -25,6 +25,9 @@
 
 // Used to make sure that any position values we receive are at least half sane
 #define SYNC_POSITION_LIMIT 100000.0f
+
+// Set a minimum radius at which we sync element collisions
+#define MIN_CONTACT_SYNC_RADIUS 30.0f
 // Note: Using SFloatSync < 14, 10 > also limits the range from -8191 to 8192
 
 #pragma pack(push)

--- a/Shared/sdk/net/SyncStructures.h
+++ b/Shared/sdk/net/SyncStructures.h
@@ -26,8 +26,8 @@
 // Used to make sure that any position values we receive are at least half sane
 #define SYNC_POSITION_LIMIT 100000.0f
 
-// Set a minimum radius at which we sync element collisions
-#define MIN_CONTACT_SYNC_RADIUS 30.0f
+// Set a maximum radius at which we sync element collisions
+#define MAX_CONTACT_SYNC_RADIUS 30.0f
 // Note: Using SFloatSync < 14, 10 > also limits the range from -8191 to 8192
 
 #pragma pack(push)

--- a/Shared/sdk/net/SyncStructures.h
+++ b/Shared/sdk/net/SyncStructures.h
@@ -25,9 +25,6 @@
 
 // Used to make sure that any position values we receive are at least half sane
 #define SYNC_POSITION_LIMIT 100000.0f
-
-// Set a maximum radius at which we sync element collisions
-#define MAX_CONTACT_SYNC_RADIUS 30.0f
 // Note: Using SFloatSync < 14, 10 > also limits the range from -8191 to 8192
 
 #pragma pack(push)


### PR DESCRIPTION
fixes https://github.com/multitheftauto/mtasa-blue/issues/3389

Adds extra checks to ensure that players cannot use setElementPosition client-side to move vehicles that are far away from them. Essentially closes loopholes that made it possible for players to become the syncer of said vehicles.