### PR TITLE
Fix permission check in File.create method

### DIFF
--- a/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
@@ -109,8 +109,8 @@ int CLuaFileDefs::File(lua_State* luaVM)
 
             if (CResourceManager::ParseResourcePathInput(strInputPath, pResource, &strAbsPath, &strMetaPath))
             {
-                CheckCanModifyOtherResource(argStream, pResource, pResource);
-                CheckCanAccessOtherResourceFile(argStream, pResource, pResource, strAbsPath);
+                CheckCanModifyOtherResource(argStream, pThisResource, pResource);
+                CheckCanAccessOtherResourceFile(argStream, pThisResource, pResource, strAbsPath);
 
                 if (!argStream.HasErrors())
                 {


### PR DESCRIPTION
As the title says, this PR fixes permission check in `File.create` method.