### PR TITLE
Render stages for 3D primitives

### DIFF
--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -2014,6 +2014,10 @@ void CCore::OnPreHUDRender()
 
     CGraphics::GetSingleton().EnteringMTARenderZone();
 
+    // Draw post-fx 3D primitives
+    CGraphics::GetSingleton().DrawPrimitive3DPostFXQueue();
+    CGraphics::GetSingleton().DrawLine3DPostFXQueue();
+
     // Maybe capture screen and other stuff
     CGraphics::GetSingleton().GetRenderItemManager()->DoPulse();
 

--- a/Client/core/Graphics/CGraphics.cpp
+++ b/Client/core/Graphics/CGraphics.cpp
@@ -55,12 +55,16 @@ CGraphics::CGraphics(CLocalGUI* pGUI)
     m_pRenderItemManager = new CRenderItemManager();
     m_pTileBatcher = new CTileBatcher();
     m_pLine3DBatcherPreGUI = new CLine3DBatcher(true);
+    m_pLine3DBatcherPostFX = new CLine3DBatcher(true);
     m_pLine3DBatcherPostGUI = new CLine3DBatcher(false);
     m_pMaterialLine3DBatcherPreGUI = new CMaterialLine3DBatcher(true);
+    m_pMaterialLine3DBatcherPostFX = new CMaterialLine3DBatcher(true);
     m_pMaterialLine3DBatcherPostGUI = new CMaterialLine3DBatcher(false);
     m_pPrimitive3DBatcherPreGUI = new CPrimitive3DBatcher(true);
+    m_pPrimitive3DBatcherPostFX = new CPrimitive3DBatcher(true);
     m_pPrimitive3DBatcherPostGUI = new CPrimitive3DBatcher(false);
     m_pMaterialPrimitive3DBatcherPreGUI = new CMaterialPrimitive3DBatcher(true, this);
+    m_pMaterialPrimitive3DBatcherPostFX = new CMaterialPrimitive3DBatcher(true, this);
     m_pMaterialPrimitive3DBatcherPostGUI = new CMaterialPrimitive3DBatcher(false, this);
     m_pPrimitiveBatcher = new CPrimitiveBatcher();
     m_pPrimitiveMaterialBatcher = new CPrimitiveMaterialBatcher(this);
@@ -83,14 +87,18 @@ CGraphics::~CGraphics()
     SAFE_DELETE(m_pRenderItemManager);
     SAFE_DELETE(m_pTileBatcher);
     SAFE_DELETE(m_pLine3DBatcherPreGUI);
+    SAFE_DELETE(m_pLine3DBatcherPostFX);
     SAFE_DELETE(m_pLine3DBatcherPostGUI);
     SAFE_DELETE(m_pMaterialLine3DBatcherPreGUI);
+    SAFE_DELETE(m_pMaterialLine3DBatcherPostFX);
     SAFE_DELETE(m_pMaterialLine3DBatcherPostGUI);
     SAFE_DELETE(m_pPrimitiveBatcher);
     SAFE_DELETE(m_pPrimitiveMaterialBatcher);
     SAFE_DELETE(m_pPrimitive3DBatcherPreGUI);
+    SAFE_DELETE(m_pPrimitive3DBatcherPostFX);
     SAFE_DELETE(m_pPrimitive3DBatcherPostGUI);
     SAFE_DELETE(m_pMaterialPrimitive3DBatcherPreGUI);
+    SAFE_DELETE(m_pMaterialPrimitive3DBatcherPostFX);
     SAFE_DELETE(m_pMaterialPrimitive3DBatcherPostGUI);
     SAFE_DELETE(m_pScreenGrabber);
     SAFE_DELETE(m_pPixelsManager);
@@ -207,7 +215,7 @@ void CGraphics::DrawStringOutline(const RECT& rect, unsigned long ulColor, const
 
 void CGraphics::DrawLine3D(const CVector& vecBegin, const CVector& vecEnd, unsigned long ulColor, float fWidth)
 {
-    DrawLine3DQueued(vecBegin, vecEnd, fWidth, ulColor, true);
+    DrawLine3DQueued(vecBegin, vecEnd, fWidth, ulColor, eRenderStage::POST_GUI);
 }
 
 void CGraphics::DrawRectangleInternal(float fX, float fY, float fWidth, float fHeight, unsigned long ulColor, bool bSubPixelPositioning)
@@ -831,21 +839,23 @@ void CGraphics::DrawLineQueued(float fX1, float fY1, float fX2, float fY2, float
     AddQueueItem(Item, bPostGUI);
 }
 
-void CGraphics::DrawLine3DQueued(const CVector& vecBegin, const CVector& vecEnd, float fWidth, unsigned long ulColor, bool bPostGUI)
+void CGraphics::DrawLine3DQueued(const CVector& vecBegin, const CVector& vecEnd, float fWidth, unsigned long ulColor, eRenderStage stage)
 {
     if (g_pCore->IsWindowMinimized())
         return;
 
     // Add it to the queue
-    if (bPostGUI && !CCore::GetSingleton().IsMenuVisible())
+    if (stage == eRenderStage::POST_GUI && !CCore::GetSingleton().IsMenuVisible())
         m_pLine3DBatcherPostGUI->AddLine3D(vecBegin, vecEnd, fWidth, ulColor);
-    else
+    else if (stage == eRenderStage::PRE_FX)
         m_pLine3DBatcherPreGUI->AddLine3D(vecBegin, vecEnd, fWidth, ulColor);
+    else
+        m_pLine3DBatcherPostFX->AddLine3D(vecBegin, vecEnd, fWidth, ulColor);
 }
 
 void CGraphics::DrawMaterialLine3DQueued(const CVector& vecBegin, const CVector& vecEnd, float fWidth, unsigned long ulColor, CMaterialItem* pMaterial,
                                          float fU, float fV, float fSizeU, float fSizeV, bool bRelativeUV, bool bFlipUV, bool bUseFaceToward,
-                                         const CVector& vecFaceToward, bool bPostGUI)
+                                         const CVector& vecFaceToward, eRenderStage stage)
 {
     if (g_pCore->IsWindowMinimized())
         return;
@@ -857,11 +867,14 @@ void CGraphics::DrawMaterialLine3DQueued(const CVector& vecBegin, const CVector&
     }
 
     // Add it to the queue
-    if (bPostGUI && !CCore::GetSingleton().IsMenuVisible())
+    if (stage == eRenderStage::POST_GUI && !CCore::GetSingleton().IsMenuVisible())
         m_pMaterialLine3DBatcherPostGUI->AddLine3D(vecBegin, vecEnd, fWidth, ulColor, pMaterial, fU, fV, fSizeU, fSizeV, bRelativeUV, bFlipUV, bUseFaceToward,
                                                    vecFaceToward);
-    else
+    else if (stage == eRenderStage::PRE_FX)
         m_pMaterialLine3DBatcherPreGUI->AddLine3D(vecBegin, vecEnd, fWidth, ulColor, pMaterial, fU, fV, fSizeU, fSizeV, bRelativeUV, bFlipUV, bUseFaceToward,
+                                                  vecFaceToward);
+    else
+        m_pMaterialLine3DBatcherPostFX->AddLine3D(vecBegin, vecEnd, fWidth, ulColor, pMaterial, fU, fV, fSizeU, fSizeV, bRelativeUV, bFlipUV, bUseFaceToward,
                                                   vecFaceToward);
 }
 
@@ -939,7 +952,7 @@ void CGraphics::DrawPrimitiveQueued(std::vector<PrimitiveVertice>* pVecVertices,
     AddQueueItem(Item, bPostGUI);
 }
 
-void CGraphics::DrawPrimitive3DQueued(std::vector<PrimitiveVertice>* pVecVertices, D3DPRIMITIVETYPE eType, bool bPostGUI)
+void CGraphics::DrawPrimitive3DQueued(std::vector<PrimitiveVertice>* pVecVertices, D3DPRIMITIVETYPE eType, eRenderStage stage)
 {
     // Prevent queuing when minimized
     if (g_pCore->IsWindowMinimized())
@@ -949,14 +962,16 @@ void CGraphics::DrawPrimitive3DQueued(std::vector<PrimitiveVertice>* pVecVertice
     }
 
     // Add it to the queue
-    if (bPostGUI && !CCore::GetSingleton().IsMenuVisible())
+    if (stage == eRenderStage::POST_GUI && !CCore::GetSingleton().IsMenuVisible())
         m_pPrimitive3DBatcherPostGUI->AddPrimitive(eType, pVecVertices);
-    else
+    else if (stage == eRenderStage::PRE_FX)
         m_pPrimitive3DBatcherPreGUI->AddPrimitive(eType, pVecVertices);
+    else
+        m_pPrimitive3DBatcherPostFX->AddPrimitive(eType, pVecVertices);
 }
 
 void CGraphics::DrawMaterialPrimitive3DQueued(std::vector<PrimitiveMaterialVertice>* pVecVertices, D3DPRIMITIVETYPE eType, CMaterialItem* pMaterial,
-                                              bool bPostGUI)
+                                              eRenderStage stage)
 {
     // Prevent queuing when minimized
     if (g_pCore->IsWindowMinimized())
@@ -972,10 +987,13 @@ void CGraphics::DrawMaterialPrimitive3DQueued(std::vector<PrimitiveMaterialVerti
     }
 
     // Add it to the queue
-    if (bPostGUI && !CCore::GetSingleton().IsMenuVisible())
+    if (stage == eRenderStage::POST_GUI && !CCore::GetSingleton().IsMenuVisible())
         m_pMaterialPrimitive3DBatcherPostGUI->AddPrimitive(eType, pMaterial, pVecVertices);
-    else
+    else if (stage == eRenderStage::PRE_FX)
         m_pMaterialPrimitive3DBatcherPreGUI->AddPrimitive(eType, pMaterial, pVecVertices);
+    else
+        m_pMaterialPrimitive3DBatcherPostFX->AddPrimitive(eType, pMaterial, pVecVertices);
+    
 }
 
 void CGraphics::DrawMaterialPrimitiveQueued(std::vector<PrimitiveMaterialVertice>* pVecVertices, D3DPRIMITIVETYPE eType, CMaterialItem* pMaterial,
@@ -1515,14 +1533,18 @@ void CGraphics::OnDeviceCreate(IDirect3DDevice9* pDevice)
 
     m_pTileBatcher->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pLine3DBatcherPreGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
+    m_pLine3DBatcherPostFX->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pLine3DBatcherPostGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pMaterialLine3DBatcherPreGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
+    m_pMaterialLine3DBatcherPostFX->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pMaterialLine3DBatcherPostGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pPrimitiveBatcher->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pPrimitiveMaterialBatcher->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pPrimitive3DBatcherPreGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
+    m_pPrimitive3DBatcherPostFX->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pPrimitive3DBatcherPostGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pMaterialPrimitive3DBatcherPreGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
+    m_pMaterialPrimitive3DBatcherPostFX->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pMaterialPrimitive3DBatcherPostGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pRenderItemManager->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pScreenGrabber->OnDeviceCreate(pDevice);
@@ -1612,6 +1634,12 @@ void CGraphics::DrawLine3DPreGUIQueue()
     m_pMaterialLine3DBatcherPreGUI->Flush();
 }
 
+void CGraphics::DrawLine3DPostFXQueue(void)
+{
+    m_pLine3DBatcherPostFX->Flush();
+    m_pMaterialLine3DBatcherPostFX->Flush();
+}
+
 void CGraphics::DrawPrimitive3DPreGUIQueue(void)
 {
     m_pPrimitive3DBatcherPreGUI->Flush();
@@ -1621,6 +1649,12 @@ void CGraphics::DrawPrimitive3DPreGUIQueue(void)
 bool CGraphics::HasLine3DPreGUIQueueItems(void)
 {
     return m_pLine3DBatcherPreGUI->HasItems() || m_pMaterialLine3DBatcherPreGUI->HasItems();
+}
+
+void CGraphics::DrawPrimitive3DPostFXQueue(void)
+{
+    m_pPrimitive3DBatcherPostFX->Flush();
+    m_pMaterialPrimitive3DBatcherPostFX->Flush();
 }
 
 bool CGraphics::HasPrimitive3DPreGUIQueueItems(void)
@@ -2519,6 +2553,6 @@ void CGraphics::DrawWiredSphere(CVector vecPosition, float fRadius, SColor color
     {
         const CVector& vecBegin = model.vertexList[i] * fRadius + vecPosition;
         const CVector& vecEnd = model.vertexList[i + 1] * fRadius + vecPosition;
-        DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, false);
+        DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, eRenderStage::POST_FX);
     }
 }

--- a/Client/core/Graphics/CGraphics.h
+++ b/Client/core/Graphics/CGraphics.h
@@ -135,11 +135,11 @@ public:
     // Queued up drawing funcs
     void DrawLineQueued(float fX1, float fY1, float fX2, float fY2, float fWidth, unsigned long ulColor, bool bPostGUI);
 
-    void DrawLine3DQueued(const CVector& vecBegin, const CVector& vecEnd, float fWidth, unsigned long ulColor, bool bPostGUI);
+    void DrawLine3DQueued(const CVector& vecBegin, const CVector& vecEnd, float fWidth, unsigned long ulColor, eRenderStage stage = eRenderStage::PRE_FX);
 
     void DrawMaterialLine3DQueued(const CVector& vecBegin, const CVector& vecEnd, float fWidth, unsigned long ulColor, CMaterialItem* pMaterial, float fU = 0,
                                   float fV = 0, float fSizeU = 1, float fSizeV = 1, bool bRelativeUV = true, bool bFlipUV = false, bool bUseFaceToward = false,
-                                  const CVector& vecFaceToward = CVector(), bool bPostGUI = false) override;
+                                  const CVector& vecFaceToward = CVector(), eRenderStage stage = eRenderStage::PRE_FX) override;
 
     void DrawRectQueued(float fX, float fY, float fWidth, float fHeight, unsigned long ulColor, bool bPostGUI, bool bSubPixelPositioning = false);
 
@@ -153,8 +153,8 @@ public:
     void DrawPrimitiveQueued(std::vector<PrimitiveVertice>* pVecVertices, D3DPRIMITIVETYPE eType, bool bPostGUI = false);
     void DrawMaterialPrimitiveQueued(std::vector<PrimitiveMaterialVertice>* vertices, D3DPRIMITIVETYPE type, CMaterialItem* pMaterial, bool bPostGUI);
 
-    void DrawPrimitive3DQueued(std::vector<PrimitiveVertice>* pVecVertices, D3DPRIMITIVETYPE eType, bool bPostGUI);
-    void DrawMaterialPrimitive3DQueued(std::vector<PrimitiveMaterialVertice>* pVecVertices, D3DPRIMITIVETYPE eType, CMaterialItem* pMaterial, bool bPostGUI);
+    void DrawPrimitive3DQueued(std::vector<PrimitiveVertice>* pVecVertices, D3DPRIMITIVETYPE eType, eRenderStage stage = eRenderStage::PRE_FX);
+    void DrawMaterialPrimitive3DQueued(std::vector<PrimitiveMaterialVertice>* pVecVertices, D3DPRIMITIVETYPE eType, CMaterialItem* pMaterial, eRenderStage stage = eRenderStage::PRE_FX);
 
     void DrawCircleQueued(float fX, float fY, float fRadius, float fStartAngle, float fStopAngle, unsigned long ulColor, unsigned long ulColorCenter,
                           short siSegments, float fRatio, bool bPostGUI);
@@ -188,7 +188,9 @@ public:
     void DrawPreGUIQueue(void);
     void DrawPostGUIQueue(void);
     void DrawLine3DPreGUIQueue(void);
+    void DrawLine3DPostFXQueue(void);
     bool HasLine3DPreGUIQueueItems(void);
+    void DrawPrimitive3DPostFXQueue(void);
     void DrawPrimitive3DPreGUIQueue(void);
     bool HasPrimitive3DPreGUIQueueItems(void);
 
@@ -226,14 +228,18 @@ private:
     CPixelsManagerInterface*     m_pPixelsManager = nullptr;
     CTileBatcher*                m_pTileBatcher = nullptr;
     CLine3DBatcher*              m_pLine3DBatcherPreGUI = nullptr;
+    CLine3DBatcher*              m_pLine3DBatcherPostFX = nullptr;
     CLine3DBatcher*              m_pLine3DBatcherPostGUI = nullptr;
     CMaterialLine3DBatcher*      m_pMaterialLine3DBatcherPreGUI = nullptr;
+    CMaterialLine3DBatcher*      m_pMaterialLine3DBatcherPostFX = nullptr;
     CMaterialLine3DBatcher*      m_pMaterialLine3DBatcherPostGUI = nullptr;
     CPrimitiveBatcher*           m_pPrimitiveBatcher = nullptr;
     CPrimitiveMaterialBatcher*   m_pPrimitiveMaterialBatcher = nullptr;
     CPrimitive3DBatcher*         m_pPrimitive3DBatcherPreGUI = nullptr;
-    CPrimitive3DBatcher*         m_pPrimitive3DBatcherPostGUI = nullptr;
+    CPrimitive3DBatcher*         m_pPrimitive3DBatcherPostFX = nullptr;
+    CPrimitive3DBatcher*         m_pPrimitive3DBatcherPostGUI = nullptr;    
     CMaterialPrimitive3DBatcher* m_pMaterialPrimitive3DBatcherPreGUI = nullptr;
+    CMaterialPrimitive3DBatcher* m_pMaterialPrimitive3DBatcherPostFX = nullptr;
     CMaterialPrimitive3DBatcher* m_pMaterialPrimitive3DBatcherPostGUI = nullptr;
     CAspectRatioConverter*       m_pAspectRatioConverter = nullptr;
 

--- a/Client/mods/deathmatch/logic/CClientColCircle.cpp
+++ b/Client/mods/deathmatch/logic/CClientColCircle.cpp
@@ -79,7 +79,7 @@ void CClientColCircle::DebugRender(const CVector& vecPosition, float fDrawRadius
             {
                 CVector vecBegin = vertexList[i] * vecMult + vecAdd;
                 CVector vecEnd = vertexList[(i + 1) % uiNumPoints] * vecMult + vecAdd;
-                pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, false);
+                pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, eRenderStage::POST_FX);
             }
         }
     }
@@ -94,7 +94,7 @@ void CClientColCircle::DebugRender(const CVector& vecPosition, float fDrawRadius
         {
             CVector vecBegin = vertexList[i] * vecMultB + vecAdd;
             CVector vecEnd = vertexList[i] * vecMultT + vecAdd;
-            pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, false);
+            pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, eRenderStage::POST_FX);
         }
     }
 }

--- a/Client/mods/deathmatch/logic/CClientColCuboid.cpp
+++ b/Client/mods/deathmatch/logic/CClientColCuboid.cpp
@@ -70,7 +70,7 @@ void CClientColCuboid::DebugRender(const CVector& vecPosition, float fDrawRadius
             {
                 const CVector& vecBegin = cornerPoints[i] * vecMult + vecAdd;
                 const CVector& vecEnd = cornerPoints[(i + 1) % 4] * vecMult + vecAdd;
-                pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, false);
+                pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, eRenderStage::POST_FX);
             }
         }
     }
@@ -89,7 +89,7 @@ void CClientColCuboid::DebugRender(const CVector& vecPosition, float fDrawRadius
             {
                 const CVector& vecBegin = cornerPoints[i] * vecMult + vecAdd;
                 const CVector& vecEnd = cornerPoints[(i + 1) % 4] * vecMult + vecAdd;
-                pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, false);
+                pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, eRenderStage::POST_FX);
             }
         }
     }
@@ -108,7 +108,7 @@ void CClientColCuboid::DebugRender(const CVector& vecPosition, float fDrawRadius
             {
                 const CVector& vecBegin = cornerPoints[i] * vecMult + vecAdd;
                 const CVector& vecEnd = cornerPoints[(i + 1) % 4] * vecMult + vecAdd;
-                pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, false);
+                pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, eRenderStage::POST_FX);
             }
         }
     }

--- a/Client/mods/deathmatch/logic/CClientColPolygon.cpp
+++ b/Client/mods/deathmatch/logic/CClientColPolygon.cpp
@@ -205,7 +205,7 @@ void CClientColPolygon::DebugRender(const CVector& vecPosition, float fDrawRadiu
 
                     CVector vecBegin(vecPointBegin.fX, vecPointBegin.fY, fZ);
                     CVector vecEnd(vecPointEnd.fX, vecPointEnd.fY, fZ);
-                    pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, false);
+                    pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, eRenderStage::POST_FX);
                 }
             }
         }
@@ -219,7 +219,7 @@ void CClientColPolygon::DebugRender(const CVector& vecPosition, float fDrawRadiu
 
             CVector vecBegin(vecPoint.fX, vecPoint.fY, std::max(vecPosition.fZ - fDrawRadius, m_fFloor));
             CVector vecEnd(vecPoint.fX, vecPoint.fY, std::min(vecPosition.fZ + fDrawRadius, m_fCeil));
-            pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, false);
+            pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, eRenderStage::POST_FX);
         }
     }
 
@@ -231,10 +231,10 @@ void CClientColPolygon::DebugRender(const CVector& vecPosition, float fDrawRadiu
 
         CVector vecFloorBegin(vecPointBegin.fX, vecPointBegin.fY, m_fFloor);
         CVector vecFloorEnd(vecPointEnd.fX, vecPointEnd.fY, m_fFloor);
-        pGraphics->DrawLine3DQueued(vecFloorBegin, vecFloorEnd, fLineWidth, color, false);
+        pGraphics->DrawLine3DQueued(vecFloorBegin, vecFloorEnd, fLineWidth, color, eRenderStage::POST_FX);
 
         CVector vecCeilBegin(vecPointBegin.fX, vecPointBegin.fY, m_fCeil);
         CVector vecCeilEnd(vecPointEnd.fX, vecPointEnd.fY, m_fCeil);
-        pGraphics->DrawLine3DQueued(vecCeilBegin, vecCeilEnd, fLineWidth, color, false);
+        pGraphics->DrawLine3DQueued(vecCeilBegin, vecCeilEnd, fLineWidth, color, eRenderStage::POST_FX);
     }
 }

--- a/Client/mods/deathmatch/logic/CClientColRectangle.cpp
+++ b/Client/mods/deathmatch/logic/CClientColRectangle.cpp
@@ -76,7 +76,7 @@ void CClientColRectangle::DebugRender(const CVector& vecPosition, float fDrawRad
             {
                 const CVector& vecBegin = cornerPoints[i] * vecMult + vecAdd;
                 const CVector& vecEnd = cornerPoints[(i + 1) % 4] * vecMult + vecAdd;
-                pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, false);
+                pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, eRenderStage::POST_FX);
             }
         }
     }
@@ -97,7 +97,7 @@ void CClientColRectangle::DebugRender(const CVector& vecPosition, float fDrawRad
                     continue;            // No end cap
                 const CVector& vecBegin = cornerPoints[i] * vecMult + vecAdd;
                 const CVector& vecEnd = cornerPoints[(i + 1) % 4] * vecMult + vecAdd;
-                pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, false);
+                pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, eRenderStage::POST_FX);
             }
         }
     }
@@ -118,7 +118,7 @@ void CClientColRectangle::DebugRender(const CVector& vecPosition, float fDrawRad
                     continue;            // No end cap
                 const CVector& vecBegin = cornerPoints[i] * vecMult + vecAdd;
                 const CVector& vecEnd = cornerPoints[(i + 1) % 4] * vecMult + vecAdd;
-                pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, false);
+                pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, eRenderStage::POST_FX);
             }
         }
     }

--- a/Client/mods/deathmatch/logic/CClientColTube.cpp
+++ b/Client/mods/deathmatch/logic/CClientColTube.cpp
@@ -72,7 +72,7 @@ void CClientColTube::DebugRender(const CVector& vecPosition, float fDrawRadius)
             {
                 const CVector& vecBegin = vertexList[i] * vecMult + vecAdd;
                 const CVector& vecEnd = vertexList[(i + 1) % uiNumPoints] * vecMult + vecAdd;
-                pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, false);
+                pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, eRenderStage::POST_FX);
             }
         }
     }
@@ -87,7 +87,7 @@ void CClientColTube::DebugRender(const CVector& vecPosition, float fDrawRadius)
         {
             const CVector& vecBegin = vertexList[i] * vecMultB + vecAdd;
             const CVector& vecEnd = vertexList[i] * vecMultT + vecAdd;
-            pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, false);
+            pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, eRenderStage::POST_FX);
         }
     }
 
@@ -100,7 +100,7 @@ void CClientColTube::DebugRender(const CVector& vecPosition, float fDrawRadius)
         for (uint i = 0; i < vertexList.size(); i++)
         {
             const CVector& vecEnd = vertexList[i] * vecMult + vecAdd;
-            pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, false);
+            pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, eRenderStage::POST_FX);
         }
     }
 
@@ -113,7 +113,7 @@ void CClientColTube::DebugRender(const CVector& vecPosition, float fDrawRadius)
         for (uint i = 0; i < vertexList.size(); i++)
         {
             const CVector& vecEnd = vertexList[i] * vecMult + vecAdd;
-            pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, false);
+            pGraphics->DrawLine3DQueued(vecBegin, vecEnd, fLineWidth, color, eRenderStage::POST_FX);
         }
     }
 }

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -2932,8 +2932,8 @@ void CClientGame::DrawPlayerDetails(CClientPlayer* pPlayer)
     const CVector&       vecAimTarget = pPlayer->GetAimTarget();
     eVehicleAimDirection ucDrivebyAim = pPlayer->GetVehicleAimAnim();
 
-    g_pCore->GetGraphics()->DrawLine3DQueued(vecAimSource, vecAimTarget, 1.0f, 0x10DE1212, true);
-    g_pCore->GetGraphics()->DrawLine3DQueued(vecAimSource, vecAimTarget, 1.0f, 0x90DE1212, false);
+    g_pCore->GetGraphics()->DrawLine3DQueued(vecAimSource, vecAimTarget, 1.0f, 0x10DE1212, eRenderStage::POST_GUI);
+    g_pCore->GetGraphics()->DrawLine3DQueued(vecAimSource, vecAimTarget, 1.0f, 0x90DE1212, eRenderStage::POST_FX);
 
     CTask* pPrimaryTask = pPlayer->GetCurrentPrimaryTask();
     int    iPrimaryTask = pPrimaryTask ? pPrimaryTask->GetTaskType() : -1;
@@ -2991,8 +2991,8 @@ void CClientGame::DrawWeaponsyncData(CClientPlayer* pPlayer)
 
         // red line: Draw their synced aim line
         pPlayer->GetShotData(&vecSource, &vecTarget);
-        g_pCore->GetGraphics()->DrawLine3DQueued(vecSource, vecTarget, 2.0f, 0x10DE1212, true);
-        g_pCore->GetGraphics()->DrawLine3DQueued(vecSource, vecTarget, 2.0f, 0x90DE1212, false);
+        g_pCore->GetGraphics()->DrawLine3DQueued(vecSource, vecTarget, 2.0f, 0x10DE1212, eRenderStage::POST_GUI);
+        g_pCore->GetGraphics()->DrawLine3DQueued(vecSource, vecTarget, 2.0f, 0x90DE1212, eRenderStage::POST_FX);
 
         // green line: Set muzzle as origin and perform a collision test for the target
         CColPoint* pCollision;
@@ -3005,8 +3005,8 @@ void CClientGame::DrawWeaponsyncData(CClientPlayer* pPlayer)
                 CVector vecBullet = pCollision->GetPosition() - vecSource;
                 vecBullet.Normalize();
                 CVector vecTarget = vecSource + (vecBullet * 200);
-                g_pCore->GetGraphics()->DrawLine3DQueued(vecSource, vecTarget, 0.5f, 0x1012DE12, true);
-                g_pCore->GetGraphics()->DrawLine3DQueued(vecSource, vecTarget, 0.5f, 0x9012DE12, false);
+                g_pCore->GetGraphics()->DrawLine3DQueued(vecSource, vecTarget, 0.5f, 0x1012DE12, eRenderStage::POST_GUI);
+                g_pCore->GetGraphics()->DrawLine3DQueued(vecSource, vecTarget, 0.5f, 0x9012DE12, eRenderStage::POST_FX);
             }
             pCollision->Destroy();
         }

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
@@ -824,6 +824,12 @@ ADD_ENUM(_D3DFORMAT::D3DFMT_G32R32F, "g32r32f")
 ADD_ENUM(_D3DFORMAT::D3DFMT_A32B32G32R32F, "a32b32g32r32f")
 IMPLEMENT_ENUM_CLASS_END("surface-format")
 
+IMPLEMENT_ENUM_CLASS_BEGIN(eRenderStage)
+ADD_ENUM(eRenderStage::PRE_FX, "prefx")
+ADD_ENUM(eRenderStage::POST_FX, "postfx")
+ADD_ENUM(eRenderStage::POST_GUI, "postgui")
+IMPLEMENT_ENUM_CLASS_END("render-stage")
+
 //
 // CResource from userdata
 //

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
@@ -81,6 +81,7 @@ DECLARE_ENUM_CLASS(eSoundEffectParams::ParamEq);
 DECLARE_ENUM_CLASS(eSoundEffectParams::Reverb);
 DECLARE_ENUM_CLASS(eModelIdeFlag);
 DECLARE_ENUM_CLASS(_D3DFORMAT);
+DECLARE_ENUM_CLASS(eRenderStage);
 
 class CRemoteCall;
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -192,18 +192,21 @@ int CLuaDrawingDefs::DxDrawLine3D(lua_State* luaVM)
     CVector vecEnd;
     SColor  color;
     float   fWidth;
-    bool    bPostGUI;
+    eRenderStage renderStage{eRenderStage::POST_FX};
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadVector3D(vecBegin);
     argStream.ReadVector3D(vecEnd);
     argStream.ReadColor(color, 0xFFFFFFFF);
     argStream.ReadNumber(fWidth, 1);
-    argStream.ReadBool(bPostGUI, false);
+    if (bool bPostGUI = argStream.ReadIfNextIsBool())
+        renderStage = bPostGUI ? eRenderStage::POST_GUI : eRenderStage::POST_FX;
+    else
+        argStream.ReadIfNextIsEnumString(renderStage, eRenderStage::POST_FX);
 
     if (!argStream.HasErrors())
     {
-        g_pCore->GetGraphics()->DrawLine3DQueued(vecBegin, vecEnd, fWidth, color, bPostGUI);
+        g_pCore->GetGraphics()->DrawLine3DQueued(vecBegin, vecEnd, fWidth, color, renderStage);
         lua_pushboolean(luaVM, true);
         return 1;
     }
@@ -226,9 +229,9 @@ int CLuaDrawingDefs::DxDrawMaterialLine3D(lua_State* luaVM)
     CClientMaterial* pMaterial;
     float            fWidth;
     SColor           color;
-    bool             bPostGUI;
     CVector          vecFaceToward;
     bool             bUseFaceToward = false;
+    eRenderStage renderStage{eRenderStage::POST_FX};
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadVector3D(vecBegin);
@@ -237,7 +240,11 @@ int CLuaDrawingDefs::DxDrawMaterialLine3D(lua_State* luaVM)
     argStream.ReadUserData(pMaterial);
     argStream.ReadNumber(fWidth);
     argStream.ReadColor(color, 0xFFFFFFFF);
-    argStream.ReadIfNextIsBool(bPostGUI, false);
+    if (bool bPostGUI = argStream.ReadIfNextIsBool())
+        renderStage = bPostGUI ? eRenderStage::POST_GUI : eRenderStage::POST_FX;
+    else
+        argStream.ReadIfNextIsEnumString(renderStage, eRenderStage::POST_FX);
+
     if (argStream.NextIsVector3D())
     {
         argStream.ReadVector3D(vecFaceToward);
@@ -247,7 +254,7 @@ int CLuaDrawingDefs::DxDrawMaterialLine3D(lua_State* luaVM)
     if (!argStream.HasErrors())
     {
         g_pCore->GetGraphics()->DrawMaterialLine3DQueued(vecBegin, vecEnd, fWidth, color, pMaterial->GetMaterialItem(), 0, 0, 1, 1, true, bFlipUV,
-                                                         bUseFaceToward, vecFaceToward, bPostGUI);
+                                                         bUseFaceToward, vecFaceToward, renderStage);
         lua_pushboolean(luaVM, true);
         return 1;
     }
@@ -272,9 +279,9 @@ int CLuaDrawingDefs::DxDrawMaterialSectionLine3D(lua_State* luaVM)
     CClientMaterial* pMaterial;
     float            fWidth;
     SColor           color;
-    bool             bPostGUI;
     CVector          vecFaceToward;
     bool             bUseFaceToward = false;
+    eRenderStage renderStage{eRenderStage::POST_FX};
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadVector3D(vecBegin);
@@ -285,7 +292,10 @@ int CLuaDrawingDefs::DxDrawMaterialSectionLine3D(lua_State* luaVM)
     argStream.ReadUserData(pMaterial);
     argStream.ReadNumber(fWidth);
     argStream.ReadColor(color, 0xFFFFFFFF);
-    argStream.ReadIfNextIsBool(bPostGUI, false);
+    if (bool bPostGUI = argStream.ReadIfNextIsBool())
+        renderStage = bPostGUI ? eRenderStage::POST_GUI : eRenderStage::POST_FX;
+    else
+        argStream.ReadIfNextIsEnumString(renderStage, eRenderStage::POST_FX);
     if (argStream.NextIsVector3D())
     {
         argStream.ReadVector3D(vecFaceToward);
@@ -295,7 +305,7 @@ int CLuaDrawingDefs::DxDrawMaterialSectionLine3D(lua_State* luaVM)
     if (!argStream.HasErrors())
     {
         g_pCore->GetGraphics()->DrawMaterialLine3DQueued(vecBegin, vecEnd, fWidth, color, pMaterial->GetMaterialItem(), vecSectionPos.fX, vecSectionPos.fY,
-                                                         vecSectionSize.fX, vecSectionSize.fY, false, bFlipUV, bUseFaceToward, vecFaceToward, bPostGUI);
+                                                         vecSectionSize.fX, vecSectionSize.fY, false, bFlipUV, bUseFaceToward, vecFaceToward, renderStage);
         lua_pushboolean(luaVM, true);
         return 1;
     }
@@ -586,10 +596,13 @@ int CLuaDrawingDefs::DxDrawPrimitive3D(lua_State* luaVM)
     // bool DxDrawPrimitive3D (string primitiveType, bool postGUI, table vertice1, ...)
     D3DPRIMITIVETYPE ePrimitiveType;
     auto             pVecVertices = new std::vector<PrimitiveVertice>();
-    bool             bPostGUI;
+    eRenderStage renderStage{eRenderStage::POST_FX};
     CScriptArgReader argStream(luaVM);
     argStream.ReadEnumString(ePrimitiveType);
-    argStream.ReadBool(bPostGUI, false);
+    if (bool bPostGUI = argStream.ReadIfNextIsBool())
+        renderStage = bPostGUI ? eRenderStage::POST_GUI : eRenderStage::POST_FX;
+    else
+        argStream.ReadIfNextIsEnumString(renderStage, eRenderStage::POST_FX);
 
     std::vector<double> vecTableContent;
 
@@ -619,7 +632,7 @@ int CLuaDrawingDefs::DxDrawPrimitive3D(lua_State* luaVM)
 
     if (g_pCore->GetGraphics()->IsValidPrimitiveSize(pVecVertices->size(), ePrimitiveType))
     {
-        g_pCore->GetGraphics()->DrawPrimitive3DQueued(pVecVertices, ePrimitiveType, bPostGUI);
+        g_pCore->GetGraphics()->DrawPrimitive3DQueued(pVecVertices, ePrimitiveType, renderStage);
         lua_pushboolean(luaVM, true);
         return 1;
     }
@@ -636,12 +649,15 @@ int CLuaDrawingDefs::DxDrawMaterialPrimitive3D(lua_State* luaVM)
     D3DPRIMITIVETYPE ePrimitiveType;
     auto             pVecVertices = new std::vector<PrimitiveMaterialVertice>();
     CClientMaterial* pMaterialElement;
-    bool             bPostGUI;
+    eRenderStage renderStage{eRenderStage::POST_FX};
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadEnumString(ePrimitiveType);
     MixedReadMaterialString(argStream, pMaterialElement);
-    argStream.ReadBool(bPostGUI, false);
+    if (bool bPostGUI = argStream.ReadIfNextIsBool())
+        renderStage = bPostGUI ? eRenderStage::POST_GUI : eRenderStage::POST_FX;
+    else
+        argStream.ReadIfNextIsEnumString(renderStage, eRenderStage::POST_FX);
 
     std::vector<double> vecTableContent;
 
@@ -674,7 +690,7 @@ int CLuaDrawingDefs::DxDrawMaterialPrimitive3D(lua_State* luaVM)
 
     if (g_pCore->GetGraphics()->IsValidPrimitiveSize(pVecVertices->size(), ePrimitiveType))
     {
-        g_pCore->GetGraphics()->DrawMaterialPrimitive3DQueued(pVecVertices, ePrimitiveType, pMaterialElement->GetMaterialItem(), bPostGUI);
+        g_pCore->GetGraphics()->DrawMaterialPrimitive3DQueued(pVecVertices, ePrimitiveType, pMaterialElement->GetMaterialItem(), renderStage);
         lua_pushboolean(luaVM, true);
         return 1;
     }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -602,7 +602,7 @@ int CLuaDrawingDefs::DxDrawPrimitive3D(lua_State* luaVM)
     if (bool bPostGUI = argStream.ReadIfNextIsBool())
         renderStage = bPostGUI ? eRenderStage::POST_GUI : eRenderStage::POST_FX;
     else
-        argStream.ReadIfNextIsEnumString(renderStage, eRenderStage::POST_FX);
+        argStream.ReadEnumString(renderStage, eRenderStage::POST_FX);
 
     std::vector<double> vecTableContent;
 
@@ -657,7 +657,7 @@ int CLuaDrawingDefs::DxDrawMaterialPrimitive3D(lua_State* luaVM)
     if (bool bPostGUI = argStream.ReadIfNextIsBool())
         renderStage = bPostGUI ? eRenderStage::POST_GUI : eRenderStage::POST_FX;
     else
-        argStream.ReadIfNextIsEnumString(renderStage, eRenderStage::POST_FX);
+        argStream.ReadEnumString(renderStage, eRenderStage::POST_FX);
 
     std::vector<double> vecTableContent;
 

--- a/Client/sdk/core/CGraphicsInterface.h
+++ b/Client/sdk/core/CGraphicsInterface.h
@@ -96,6 +96,13 @@ namespace EBlendMode
 }
 using EBlendMode::EBlendModeType;
 
+enum class eRenderStage
+{
+    PRE_FX,
+    POST_FX,
+    POST_GUI
+};
+
 class CGraphicsInterface
 {
 public:
@@ -145,11 +152,11 @@ public:
     // Queued up drawing
     virtual void DrawLineQueued(float fX1, float fY1, float fX2, float fY2, float fWidth, unsigned long ulColor, bool bPostGUI) = 0;
 
-    virtual void DrawLine3DQueued(const CVector& vecBegin, const CVector& vecEnd, float fWidth, unsigned long ulColor, bool bPostGUI) = 0;
+    virtual void DrawLine3DQueued(const CVector& vecBegin, const CVector& vecEnd, float fWidth, unsigned long ulColor, eRenderStage stage = eRenderStage::PRE_FX) = 0;
 
     virtual void DrawMaterialLine3DQueued(const CVector& vecBegin, const CVector& vecEnd, float fWidth, unsigned long ulColor, CMaterialItem* pMaterial,
                                           float fU = 0, float fV = 0, float fSizeU = 1, float fSizeV = 1, bool bRelativeUV = true, bool bFlipUV = false,
-                                          bool bUseFaceToward = false, const CVector& vecFaceToward = CVector(), bool bPostGUI = false) = 0;
+                                          bool bUseFaceToward = false, const CVector& vecFaceToward = CVector(), eRenderStage renderStage = eRenderStage::POST_FX) = 0;
 
     virtual void DrawRectQueued(float fX, float fY, float fWidth, float fHeight, unsigned long ulColor, bool bPostGUI, bool bSubPixelPositioning = false) = 0;
 
@@ -165,9 +172,9 @@ public:
     virtual void DrawMaterialPrimitiveQueued(std::vector<PrimitiveMaterialVertice>* pVecVertices, D3DPRIMITIVETYPE eType, CMaterialItem* pMaterial,
                                              bool bPostGUI) = 0;
 
-    virtual void DrawPrimitive3DQueued(std::vector<PrimitiveVertice>* pVecVertices, D3DPRIMITIVETYPE eType, bool bPostGUI) = 0;
+    virtual void DrawPrimitive3DQueued(std::vector<PrimitiveVertice>* pVecVertices, D3DPRIMITIVETYPE eType, eRenderStage stage = eRenderStage::PRE_FX) = 0;
     virtual void DrawMaterialPrimitive3DQueued(std::vector<PrimitiveMaterialVertice>* pVecVertices, D3DPRIMITIVETYPE eType, CMaterialItem* pMaterial,
-                                               bool bPostGUI) = 0;
+                                               eRenderStage stage = eRenderStage::PRE_FX) = 0;
 
     virtual void DrawCircleQueued(float fX, float fY, float fRadius, float fStartAngle, float fStopAngle, unsigned long ulColor, unsigned long ulColorCenter,
                                   short siSegments, float fRatio, bool bPostGUI) = 0;

--- a/Shared/sdk/CScriptArgReader.h
+++ b/Shared/sdk/CScriptArgReader.h
@@ -1331,6 +1331,14 @@ public:
             bOutValue = bDefaultValue;
     }
 
+    bool ReadIfNextIsBool(const bool bDefaultValue = false)
+    {
+        bool bOutValue{bDefaultValue};
+        if (NextIsBool())
+            ReadBool(bOutValue, bDefaultValue);
+        return bOutValue;
+    }
+
     template <class T>
     void ReadIfNextIsUserData(T*& outValue, T* defaultValue)
     {


### PR DESCRIPTION
This PR is aiming to fix a series of problems related to the purity of color of 3D lines and primitives(see #3399 and the discussion below #3321). It adds a new argument `"stage"` that can hold three values: `"prefx"`, `"postfx"` and `"postgui"`. 

The syntax:
```Lua
bool dxDrawLine3D ( float startX, float startY, float startZ, float endX, float endY, float endZ [, int color = 0xFFFFFFFF, float width = 1.0, bool postGUI = false / string stage = "prefx,postfx,postgui" ] )
```
```Lua
bool dxDrawMaterialLine3D ( float startX, float startY, float startZ, float endX, float endY, float endZ, [ bool flipUV = false, ] element material, float width, [ int color = white, [ bool postGUI = false / string stage = "prefx,postfx,postgui", ] float faceTowardX, float faceTowardY, float faceTowardZ ] )
```
```Lua
bool dxDrawMaterialSectionLine3D ( float startX, float startY, float startZ, float endX, float endY, float endZ, float u, float v, float usize, float vsize, [ bool flipUV = false, ] element material, float width, [ int color = white, [ bool postGUI = false / string stage = "prefx,postfx,postgui", ] float faceTowardX, float faceTowardY, float faceTowardZ ] )
```
```Lua
bool dxDrawMaterialPrimitive3D ( primitiveType pType, mixed material, bool postGUI / string stage = "prefx,postfx,postgui", table vertex1 [, table vertex2, ...] )
```
```Lua
bool dxDrawPrimitive3D ( string primitiveType, bool postGUI / string stage = "prefx,postfx,postgui", table vertex1, table vertex2, table vertex3 [, table vertex4, ...] )
```

To make colors correct out of the box the stage `"postfx"` is used by default. For the sake of backward compatibility the `"postGUI"` argument was preserved. 

The meaning of render stages:
- prefx - Primitives are renderer before the color correction which leads to distorted primitive's colors. This render stage was known as `postGUI = false`.
- postfx - Primitives are renderer after the color correction. This is a new render stage that should be used in most situations as it fixes the colors distortion.
- postgui - Primitives are rendered after GUI. This render stage was known as `postGUI = true`.

![Colors](https://github.com/multitheftauto/mtasa-blue/assets/12121551/7489b93b-1f13-45ff-a09e-519f42537fc1)

The color that is used for these primitives: #4199d7.
