### PR TITLE
Add onObjectMoveStart and onObjectMoveStop Events for Server-Side

### DIFF
--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -1548,6 +1548,8 @@ void CGame::AddBuiltInEvents()
     m_Events.AddEvent("onPlayerVoiceStop", "", NULL, false);
 
     // Object events
+    m_Events.AddEvent("onObjectMoveStart", "", nullptr, false);
+    m_Events.AddEvent("onObjectMoveStop", "", nullptr, false);
 
     // Pickup events
     m_Events.AddEvent("onPickupHit", "player", NULL, false);

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -8202,6 +8202,10 @@ bool CStaticFunctionDefinitions::MoveObject(CResource* pResource, CElement* pEle
         moveAnimation.SetEasing(a_easingType, a_fEasingPeriod, a_fEasingAmplitude, a_fEasingOvershoot);
         moveAnimation.SetDuration(ulTime);
 
+        CLuaArguments Arguments;
+        if (!pObject->CallEvent("onObjectMoveStart", Arguments)) // Call Event
+            return false;            // Event cancelled, return false
+        
         // Start moving it here so we can keep track of the position/rotation
         pObject->Move(moveAnimation);
 
@@ -8228,6 +8232,10 @@ bool CStaticFunctionDefinitions::StopObject(CElement* pElement)
     if (IS_OBJECT(pElement))
     {
         CObject* pObject = static_cast<CObject*>(pElement);
+
+        CLuaArguments Arguments;
+        if (!pObject->CallEvent("onObjectMoveStop", Arguments))
+            return false;            // Event cancelled, return false
 
         pObject->StopMoving();
 


### PR DESCRIPTION

This PR adds the onObjectMoveStart and onObjectMoveStop events for server-side, with support for cancelEvent.