### PR TITLE
Fix #3439 - onClientDebugMessage/onDebugMessage recognize level 4 as 0

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Output.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Output.cpp
@@ -127,25 +127,23 @@ int CLuaFunctionDefs::OutputClientDebugString(lua_State* luaVM)
         CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
         if (pLuaMain)
         {
-            if (uiLevel == 1)
+            switch (uiLevel)
             {
-                m_pScriptDebugging->LogError(luaVM, "%s", strText.c_str());
-            }
-            else if (uiLevel == 2)
-            {
-                m_pScriptDebugging->LogWarning(luaVM, "%s", strText.c_str());
-            }
-            else if (uiLevel == 3)
-            {
-                m_pScriptDebugging->LogInformation(luaVM, "%s", strText.c_str());
-            }
-            else if (uiLevel == 4)
-            {
-                m_pScriptDebugging->LogCustom(luaVM, ucRed, ucGreen, ucBlue, "%s", strText.c_str());
-            }
-            else if (uiLevel == 0)
-            {
-                m_pScriptDebugging->LogDebug(luaVM, ucRed, ucGreen, ucBlue, "%s", strText.c_str());
+                case 0:
+                    m_pScriptDebugging->LogDebug(luaVM, ucRed, ucGreen, ucBlue, "%s", strText.c_str());
+                    break;
+                case 1:
+                    m_pScriptDebugging->LogError(luaVM, "%s", strText.c_str());
+                    break;
+                case 2:
+                    m_pScriptDebugging->LogWarning(luaVM, "%s", strText.c_str());
+                    break;
+                case 3:
+                    m_pScriptDebugging->LogInformation(luaVM, "%s", strText.c_str());
+                    break;
+                case 4:
+                    m_pScriptDebugging->LogCustom(luaVM, ucRed, ucGreen, ucBlue, "%s", strText.c_str());
+                    break;
             }
 
             // Success

--- a/Shared/mods/deathmatch/logic/CScriptDebugging.cpp
+++ b/Shared/mods/deathmatch/logic/CScriptDebugging.cpp
@@ -62,8 +62,7 @@ void CScriptDebugging::LogCustom(lua_State* luaVM, unsigned char ucRed, unsigned
     VSNPRINTF(szBuffer, MAX_STRING_LENGTH, szFormat, marker);
     va_end(marker);
 
-    SLuaDebugInfo luaDebugInfo;
-    LogString("", luaDebugInfo, szBuffer, 0, ucRed, ucGreen, ucBlue);
+    LogString("", GetLuaDebugInfo(luaVM), szBuffer, 4, ucRed, ucGreen, ucBlue);
 }
 
 void CScriptDebugging::LogDebug(lua_State* luaVM, unsigned char ucRed, unsigned char ucGreen, unsigned char ucBlue, const char* szFormat, ...)


### PR DESCRIPTION
Fixes #3439
Fixes #2857
`LogCustom`'s log level was set to `0` instead of `4`