### PR TITLE
Disable addDebugHook so cheaters have to use brain to hack the server

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -226,7 +226,7 @@ void CLuaManager::LoadCFunctions()
         {"getPerformanceStats", CLuaFunctionDefs::GetPerformanceStats},
         {"setDevelopmentMode", CLuaFunctionDefs::SetDevelopmentMode},
         {"getDevelopmentMode", CLuaFunctionDefs::GetDevelopmentMode},
-        {"addDebugHook", CLuaFunctionDefs::AddDebugHook},
+        {"addDebugHook", CLuaUtilDefs::DisabledFunction},
         {"removeDebugHook", CLuaFunctionDefs::RemoveDebugHook},
 
         // Version functions

--- a/Server/mods/deathmatch/logic/luadefs/CLuaFunctionDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaFunctionDefs.cpp
@@ -11,6 +11,7 @@
 
 #include "StdInc.h"
 #include "CLuaFunctionDefs.h"
+#include <luadefs/CLuaUtilDefs.h>
 
 CTimeUsMarker<20> markerLatentEvent;            // For timing triggerLatentClientEvent
 
@@ -24,7 +25,7 @@ void CLuaFunctionDefs::LoadFunctions()
             {"cancelEvent", CLuaFunctionDefs::CancelEvent}, {"wasEventCancelled", CLuaFunctionDefs::WasEventCancelled},
             {"getCancelReason", CLuaFunctionDefs::GetCancelReason}, {"triggerLatentClientEvent", CLuaFunctionDefs::TriggerLatentClientEvent},
             {"getLatentEventHandles", CLuaFunctionDefs::GetLatentEventHandles}, {"getLatentEventStatus", CLuaFunctionDefs::GetLatentEventStatus},
-            {"cancelLatentEvent", CLuaFunctionDefs::CancelLatentEvent}, {"addDebugHook", CLuaFunctionDefs::AddDebugHook},
+            {"cancelLatentEvent", CLuaFunctionDefs::CancelLatentEvent}, {"addDebugHook", CLuaUtilDefs::DisabledFunction},
             {"removeDebugHook", CLuaFunctionDefs::RemoveDebugHook},
 
             // Explosion create funcs


### PR DESCRIPTION
Removes a goldmine for cheaters, make their life harder.
I know it breaks backwards compatibility with already existing cheats but we can deal with it. 😘