### PR TITLE
Update object contact sync radius values

### DIFF
--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -1456,7 +1456,7 @@ const std::vector<SIntSetting>& CMainConfig::GetIntSettingList()
         {true, true, 50, 100, 400, "ped_syncer_distance", &g_TickRateSettings.iPedSyncerDistance, &CMainConfig::OnTickRateChange},
         {true, true, 50, 130, 400, "unoccupied_vehicle_syncer_distance", &g_TickRateSettings.iUnoccupiedVehicleSyncerDistance, &CMainConfig::OnTickRateChange},
         {true, true, 0, 30, 130, "vehicle_contact_sync_radius", &g_TickRateSettings.iVehicleContactSyncRadius, &CMainConfig::OnTickRateChange},
-        {true, true, 0, 200, 300, "object_contact_sync_radius", &g_TickRateSettings.iObjectContactSyncRadius, &CMainConfig::OnTickRateChange},
+        {true, true, 0, 400, 512, "object_contact_sync_radius", &g_TickRateSettings.iObjectContactSyncRadius, &CMainConfig::OnTickRateChange},
         {false, false, 0, 1, 2, "compact_internal_databases", &m_iCompactInternalDatabases, NULL},
         {true, true, 0, 1, 2, "minclientversion_auto_update", &m_iMinClientVersionAutoUpdate, NULL},
         {true, true, 0, 0, 100, "server_logic_fps_limit", &m_iServerLogicFpsLimit, NULL},

--- a/Server/mods/deathmatch/mtaserver.conf
+++ b/Server/mods/deathmatch/mtaserver.conf
@@ -140,8 +140,8 @@
     <vehicle_contact_sync_radius>30</vehicle_contact_sync_radius>
 
     <!-- This parameter specifies the radius in which any contact with a object will turn the player into its syncer.
-         Available range: 0 to 300. Default - 200 -->
-    <object_contact_sync_radius>200</object_contact_sync_radius>
+         Available range: 0 to 512. Default - 400 -->
+    <object_contact_sync_radius>400</object_contact_sync_radius>
 
     <!-- This parameter sets the amount of extrapolation that clients will apply to remote vehicles. This can reduce
          some of the latency induced location disparency by predicting where the remote vehicles will probably be.

--- a/Server/mods/deathmatch/mtaserver.conf.template
+++ b/Server/mods/deathmatch/mtaserver.conf.template
@@ -141,8 +141,8 @@
     <vehicle_contact_sync_radius>30</vehicle_contact_sync_radius>
 
     <!-- This parameter specifies the radius in which any contact with a object will turn the player into its syncer.
-         Available range: 0 to 300. Default - 200 -->
-    <object_contact_sync_radius>200</object_contact_sync_radius>
+         Available range: 0 to 512. Default - 400 -->
+    <object_contact_sync_radius>400</object_contact_sync_radius>
 
     <!-- This parameter sets the amount of extrapolation that clients will apply to remote vehicles. This can reduce
          some of the latency induced location disparency by predicting where the remote vehicles will probably be.


### PR DESCRIPTION
Aligns the values of the object_contact_sync_radius setting better with the object collision size limits of the game.