### PR TITLE
Remove object contact checks

### DIFF
--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -1456,7 +1456,6 @@ const std::vector<SIntSetting>& CMainConfig::GetIntSettingList()
         {true, true, 50, 100, 400, "ped_syncer_distance", &g_TickRateSettings.iPedSyncerDistance, &CMainConfig::OnTickRateChange},
         {true, true, 50, 130, 400, "unoccupied_vehicle_syncer_distance", &g_TickRateSettings.iUnoccupiedVehicleSyncerDistance, &CMainConfig::OnTickRateChange},
         {true, true, 0, 30, 130, "vehicle_contact_sync_radius", &g_TickRateSettings.iVehicleContactSyncRadius, &CMainConfig::OnTickRateChange},
-        {true, true, 0, 200, 300, "object_contact_sync_radius", &g_TickRateSettings.iObjectContactSyncRadius, &CMainConfig::OnTickRateChange},
         {false, false, 0, 1, 2, "compact_internal_databases", &m_iCompactInternalDatabases, NULL},
         {true, true, 0, 1, 2, "minclientversion_auto_update", &m_iMinClientVersionAutoUpdate, NULL},
         {true, true, 0, 0, 100, "server_logic_fps_limit", &m_iServerLogicFpsLimit, NULL},

--- a/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
@@ -74,10 +74,9 @@ bool CPlayerPuresyncPacket::Read(NetBitStreamInterface& BitStream)
 
         // Player position
         SPositionSync position(false);
-        if (!BitStream.Read(&position))
-            return false;
+        bool          positionRead = BitStream.Read(&position);
 
-        if (pContactElement != nullptr)
+        if (positionRead && pContactElement != nullptr)
         {
             int32_t radius = -1;
 
@@ -86,10 +85,6 @@ bool CPlayerPuresyncPacket::Read(NetBitStreamInterface& BitStream)
                 case CElement::VEHICLE:
                     if (((CVehicle*)pContactElement)->GetSyncer() != pSourcePlayer)
                         radius = g_TickRateSettings.iVehicleContactSyncRadius;
-                    break;
-                case CElement::OBJECT:
-                    if (((CObject*)pContactElement)->GetSyncer() != pSourcePlayer)
-                        radius = g_TickRateSettings.iObjectContactSyncRadius;
                     break;
             }
 
@@ -121,6 +116,9 @@ bool CPlayerPuresyncPacket::Read(NetBitStreamInterface& BitStream)
 
             pSourcePlayer->CallEvent("onPlayerContact", Arguments);
         }
+
+        if (!positionRead)
+            return false;
 
         if (pContactElement)
         {

--- a/Server/mods/deathmatch/mtaserver.conf
+++ b/Server/mods/deathmatch/mtaserver.conf
@@ -139,10 +139,6 @@
          Available range: 0 to 130. Default - 30 -->
     <vehicle_contact_sync_radius>30</vehicle_contact_sync_radius>
 
-    <!-- This parameter specifies the radius in which any contact with a object will turn the player into its syncer.
-         Available range: 0 to 300. Default - 200 -->
-    <object_contact_sync_radius>200</object_contact_sync_radius>
-
     <!-- This parameter sets the amount of extrapolation that clients will apply to remote vehicles. This can reduce
          some of the latency induced location disparency by predicting where the remote vehicles will probably be.
          Depending on the gamemode, an incorrect prediction may have a negative effect. Therefore this setting

--- a/Server/mods/deathmatch/mtaserver.conf.template
+++ b/Server/mods/deathmatch/mtaserver.conf.template
@@ -140,10 +140,6 @@
          Available range: 0 to 130. Default - 30 -->
     <vehicle_contact_sync_radius>30</vehicle_contact_sync_radius>
 
-    <!-- This parameter specifies the radius in which any contact with a object will turn the player into its syncer.
-         Available range: 0 to 300. Default - 200 -->
-    <object_contact_sync_radius>200</object_contact_sync_radius>
-
     <!-- This parameter sets the amount of extrapolation that clients will apply to remote vehicles. This can reduce
          some of the latency induced location disparency by predicting where the remote vehicles will probably be.
          Depending on the gamemode, an incorrect prediction may have a negative effect. Therefore this setting

--- a/Shared/mods/deathmatch/logic/CTickRateSettings.h
+++ b/Shared/mods/deathmatch/logic/CTickRateSettings.h
@@ -26,7 +26,6 @@ public:
         iPedSyncerDistance = 100;
         iUnoccupiedVehicleSyncerDistance = 130;
         iVehicleContactSyncRadius = 30;
-        iObjectContactSyncRadius = 200;
     }
 
     int iPureSync;
@@ -42,7 +41,6 @@ public:
     int iPedSyncerDistance;
     int iUnoccupiedVehicleSyncerDistance;
     int iVehicleContactSyncRadius;
-    int iObjectContactSyncRadius;
 };
 
 extern CTickRateSettings g_TickRateSettings;


### PR DESCRIPTION
Multiple issues are reported that are causing by the object contact logic. As this logic was only put in place to future proof for https://github.com/multitheftauto/mtasa-blue/pull/3405, I have removed it for the time being. It'll be re-introduced in a future PR.

This PR also introduces a bool that allows the position check to be back in its original spot which should further fix issues with the contact logic.