### PR TITLE
Fix the reversed zoom in/out control states in getControlState (#2570)

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPad.cpp
+++ b/Client/mods/deathmatch/logic/CClientPad.cpp
@@ -330,10 +330,10 @@ bool CClientPad::GetControlState(const char* szName, CControllerState& State, bo
                     return State.LeftStickX == 128;
                     break;            // right
                 case 7:
-                    return State.RightShoulder2 == 255;
+                    return State.LeftShoulder2 == 255;
                     break;            // zoom in
                 case 8:
-                    return State.LeftShoulder2 == 255;
+                    return State.RightShoulder2 == 255;
                     break;            // zoom out
                 case 9:
                     return false;


### PR DESCRIPTION
Fixes #2570 (`getControlState` will return the correct state for `zoom_in` and `zoom_out`).
I believe this does not conflict with the changes in #2767