### PR TITLE
Fix createBuilding crash after engineSetPoolCapacity

### DIFF
--- a/Client/game_sa/CBuildingsPoolSA.cpp
+++ b/Client/game_sa/CBuildingsPoolSA.cpp
@@ -43,7 +43,7 @@ inline bool CBuildingsPoolSA::AddBuildingToPool(CClientBuilding* pClientBuilding
     m_buildingPool.entities[dwElementIndexInPool] = {pBuilding, (CClientEntity*)pClientBuilding};
 
     // Increase the count of objects
-    ++m_buildingPool.ulCount;
+    ++m_buildingPool.count;
 
     return true;
 }
@@ -118,7 +118,7 @@ void CBuildingsPoolSA::RemoveBuilding(CBuilding* pBuilding)
     (*m_ppBuildingPoolInterface)->Release(dwElementIndexInPool);
 
     // Decrease the count of elements in the pool
-    --m_buildingPool.ulCount;
+    --m_buildingPool.count;
 }
 
 void CBuildingsPoolSA::RemoveAllBuildings()

--- a/Client/game_sa/CBuildingsPoolSA.cpp
+++ b/Client/game_sa/CBuildingsPoolSA.cpp
@@ -40,7 +40,7 @@ inline bool CBuildingsPoolSA::AddBuildingToPool(CClientBuilding* pClientBuilding
     if (dwElementIndexInPool == UINT_MAX)
         return false;
 
-    m_buildingPool.arrayOfClientEntities[dwElementIndexInPool] = {pBuilding, (CClientEntity*)pClientBuilding};
+    m_buildingPool.entities[dwElementIndexInPool] = {pBuilding, (CClientEntity*)pClientBuilding};
 
     // Increase the count of objects
     ++m_buildingPool.ulCount;
@@ -108,8 +108,8 @@ void CBuildingsPoolSA::RemoveBuilding(CBuilding* pBuilding)
     modelInfo->RemoveColRef();
 
     // Remove from BuildingSA pool
-    auto* pBuildingSA = m_buildingPool.arrayOfClientEntities[dwElementIndexInPool].pEntity;
-    m_buildingPool.arrayOfClientEntities[dwElementIndexInPool] = {nullptr, nullptr};
+    auto* pBuildingSA = m_buildingPool.entities[dwElementIndexInPool].pEntity;
+    m_buildingPool.entities[dwElementIndexInPool] = {nullptr, nullptr};
 
     // Delete it from memory
     delete pBuildingSA;
@@ -191,7 +191,9 @@ void CBuildingsPoolSA::RemoveBuildingFromWorld(CBuildingSAInterface* pBuilding)
 bool CBuildingsPoolSA::Resize(int size)
 {
     auto*     pool = (*m_ppBuildingPoolInterface);
-    const int curretnSize = pool->m_nSize;
+    const int currentSize = pool->m_nSize;
+
+    m_buildingPool.entities.resize(size);
 
     void* oldPool = pool->m_pObjects;
 
@@ -210,7 +212,7 @@ bool CBuildingsPoolSA::Resize(int size)
     CBuildingSAInterface* newObjects = MemSA::malloc_struct<CBuildingSAInterface>(size);
     if (newObjects == nullptr)
     {
-        Resize(curretnSize);
+        Resize(currentSize);
         return false;
     }
 
@@ -218,7 +220,7 @@ bool CBuildingsPoolSA::Resize(int size)
     if (newBytemap == nullptr)
     {
         MemSA::free(newObjects);
-        Resize(curretnSize);
+        Resize(currentSize);
         return false;
     }
 

--- a/Client/game_sa/CBuildingsPoolSA.h
+++ b/Client/game_sa/CBuildingsPoolSA.h
@@ -40,8 +40,8 @@ private:
     void RemovePedsContactEnityLinks();
 
 private:
-    SPoolData<CBuildingSA, CBuildingSAInterface, MAX_BUILDINGS> m_buildingPool;
-    CPoolSAInterface<CBuildingSAInterface>**         m_ppBuildingPoolInterface;
+    SVectorPoolData<CBuildingSA, CBuildingSAInterface> m_buildingPool{MAX_BUILDINGS};
+    CPoolSAInterface<CBuildingSAInterface>**           m_ppBuildingPoolInterface;
 
     std::unique_ptr<std::array<std::pair<bool, CBuildingSAInterface>, MAX_BUILDINGS>> m_pOriginalBuildingsBackup;
 };

--- a/Client/game_sa/CBuildingsPoolSA.h
+++ b/Client/game_sa/CBuildingsPoolSA.h
@@ -40,7 +40,7 @@ private:
     void RemovePedsContactEnityLinks();
 
 private:
-    SVectorPoolData<CBuildingSA, CBuildingSAInterface> m_buildingPool{MAX_BUILDINGS};
+    SVectorPoolData<CBuildingSA> m_buildingPool{MAX_BUILDINGS};
     CPoolSAInterface<CBuildingSAInterface>**           m_ppBuildingPoolInterface;
 
     std::unique_ptr<std::array<std::pair<bool, CBuildingSAInterface>, MAX_BUILDINGS>> m_pOriginalBuildingsBackup;

--- a/Client/game_sa/CPoolSAInterface.h
+++ b/Client/game_sa/CPoolSAInterface.h
@@ -149,3 +149,16 @@ public:
         }
     }
 };
+
+template <class T, class I>
+struct SVectorPoolData
+{
+    std::vector<SClientEntity<T>> entities;
+    unsigned long                 ulCount;
+
+public:
+    SVectorPoolData(size_t defaultSize) : ulCount(0UL)
+    {
+        entities.resize(defaultSize, {nullptr, nullptr});
+    }
+};

--- a/Client/game_sa/CPoolSAInterface.h
+++ b/Client/game_sa/CPoolSAInterface.h
@@ -150,14 +150,14 @@ public:
     }
 };
 
-template <class T, class I>
+template <class T>
 struct SVectorPoolData
 {
     std::vector<SClientEntity<T>> entities;
-    unsigned long                 ulCount;
+    size_t                        count;
 
 public:
-    SVectorPoolData(size_t defaultSize) : ulCount(0UL)
+    SVectorPoolData(size_t defaultSize) : count(0)
     {
         entities.resize(defaultSize, {nullptr, nullptr});
     }


### PR DESCRIPTION
Fixes the missing resize operation for `m_buildingPool`. 
It was causing out-of-buffer writing and random crash.