### PR TITLE
Fix outputDebugString level 4 colors

### DIFF
--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -1470,7 +1470,7 @@ void CPacketHandler::Packet_DebugEcho(NetBitStreamInterface& bitStream)
     if (!bitStream.Read(ucLevel))
         return;
 
-    if (ucLevel == 0)
+    if (ucLevel == 0 || ucLevel == 4)
     {
         // Read out the color
         if (!bitStream.Read(ucRed) || !bitStream.Read(ucGreen) || !bitStream.Read(ucBlue))
@@ -1480,7 +1480,7 @@ void CPacketHandler::Packet_DebugEcho(NetBitStreamInterface& bitStream)
     }
 
     // Valid length?
-    int iBytesRead = (ucLevel == 0) ? 4 : 1;
+    int iBytesRead = (ucLevel == 0 || ucLevel == 4) ? 4 : 1;
     int iNumberOfBytesUsed = bitStream.GetNumberOfBytesUsed() - iBytesRead;
     if (iNumberOfBytesUsed >= MIN_DEBUGECHO_LENGTH && iNumberOfBytesUsed <= MAX_DEBUGECHO_LENGTH)
     {

--- a/Server/mods/deathmatch/logic/packets/CDebugEchoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CDebugEchoPacket.cpp
@@ -16,7 +16,7 @@ bool CDebugEchoPacket::Write(NetBitStreamInterface& BitStream) const
 {
     // Write the level
     BitStream.Write(static_cast<unsigned char>(m_uiLevel));
-    if (m_uiLevel == 0)
+    if (m_uiLevel == 0 || m_uiLevel == 4)
     {
         // Write the color
         BitStream.Write(m_ucRed);


### PR DESCRIPTION
fixes https://github.com/multitheftauto/mtasa-blue/issues/3471

Some logic was missing for level 4 that caused the colors to be based on random memory values.