### PR TITLE
Postfx stage fix

### DIFF
--- a/Client/core/CCore.h
+++ b/Client/core/CCore.h
@@ -244,7 +244,7 @@ public:
     void                                HandleCrashDumpEncryption();
 
     void                 OnPreFxRender();
-    void                 OnPreHUDRender();
+    void                 OnPreHUDRender(PreHUDRenderStage stage);
     void                 OnDeviceRestore();
     void                 OnCrashAverted(uint uiId);
     void                 OnEnterCrashZone(uint uiId);

--- a/Client/core/CCore.h
+++ b/Client/core/CCore.h
@@ -244,7 +244,7 @@ public:
     void                                HandleCrashDumpEncryption();
 
     void                 OnPreFxRender();
-    void                 OnPreHUDRender(PreHUDRenderStage stage);
+    void                 OnPreHUDRender();
     void                 OnDeviceRestore();
     void                 OnCrashAverted(uint uiId);
     void                 OnEnterCrashZone(uint uiId);
@@ -288,6 +288,8 @@ public:
 
     const SString& GetLastConnectedServerName() const { return m_strLastConnectedServerName; }
     void           SetLastConnectedServerName(const SString& strServerName) { m_strLastConnectedServerName = strServerName; }
+
+    void OnPostColorFilterRender() override;
 
 private:
     void ApplyCoreInitSettings();

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -271,6 +271,7 @@ CClientGame::CClientGame(bool bLocalPlay) : m_ServerInfo(new CServerInfo())
     g_pMultiplayer->SetPostWorldProcessHandler(CClientGame::StaticPostWorldProcessHandler);
     g_pMultiplayer->SetPostWorldProcessPedsAfterPreRenderHandler(CClientGame::StaticPostWorldProcessPedsAfterPreRenderHandler);
     g_pMultiplayer->SetPreFxRenderHandler(CClientGame::StaticPreFxRenderHandler);
+    g_pMultiplayer->SetPostColorFilterRenderHandler(CClientGame::StaticPostColorFilterRenderHandler);
     g_pMultiplayer->SetPreHudRenderHandler(CClientGame::StaticPreHudRenderHandler);
     g_pMultiplayer->DisableCallsToCAnimBlendNode(false);
     g_pMultiplayer->SetCAnimBlendAssocDestructorHandler(CClientGame::StaticCAnimBlendAssocDestructorHandler);
@@ -3607,9 +3608,14 @@ void CClientGame::StaticPreFxRenderHandler()
     g_pCore->OnPreFxRender();
 }
 
+void CClientGame::StaticPostColorFilterRenderHandler()
+{
+    g_pCore->OnPreHUDRender(PreHUDRenderStage::PostColorFilter);
+}
+
 void CClientGame::StaticPreHudRenderHandler()
 {
-    g_pCore->OnPreHUDRender();
+    g_pCore->OnPreHUDRender(PreHUDRenderStage::PostEffects);
 }
 
 bool CClientGame::StaticProcessCollisionHandler(CEntitySAInterface* pThisInterface, CEntitySAInterface* pOtherInterface)

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -3610,12 +3610,12 @@ void CClientGame::StaticPreFxRenderHandler()
 
 void CClientGame::StaticPostColorFilterRenderHandler()
 {
-    g_pCore->OnPreHUDRender(PreHUDRenderStage::PostColorFilter);
+    g_pCore->OnPostColorFilterRender();
 }
 
 void CClientGame::StaticPreHudRenderHandler()
 {
-    g_pCore->OnPreHUDRender(PreHUDRenderStage::PostEffects);
+    g_pCore->OnPreHUDRender();
 }
 
 bool CClientGame::StaticProcessCollisionHandler(CEntitySAInterface* pThisInterface, CEntitySAInterface* pOtherInterface)

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -511,6 +511,7 @@ private:
     static void                              StaticPostWorldProcessHandler();
     static void                              StaticPostWorldProcessPedsAfterPreRenderHandler();
     static void                              StaticPreFxRenderHandler();
+    static void                              StaticPostColorFilterRenderHandler();
     static void                              StaticPreHudRenderHandler();
     static void                              StaticCAnimBlendAssocDestructorHandler(CAnimBlendAssociationSAInterface* pThis);
     static CAnimBlendAssociationSAInterface* StaticAddAnimationHandler(RpClump* pClump, AssocGroupId animGroup, AnimationId animID);

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -198,6 +198,9 @@ DWORD RETURN_ProcessEntityCollision = 0x4185C0;
 #define HOOKPOS_PreFxRender                                     0x049E650
 DWORD RETURN_PreFxRender = 0x0404D1E;
 
+#define HOOKPOS_PostColorFilterRender                             0x705099
+DWORD RETURN_PostColorFilterRender = 0x70509E;
+
 #define HOOKPOS_PreHUDRender                                      0x053EAD8
 DWORD RETURN_PreHUDRender = 0x053EADD;
 
@@ -377,6 +380,7 @@ PostWorldProcessHandler*                   m_pPostWorldProcessHandler = NULL;
 PostWorldProcessPedsAfterPreRenderHandler* m_postWorldProcessPedsAfterPreRenderHandler = nullptr;
 IdleHandler*                               m_pIdleHandler = NULL;
 PreFxRenderHandler*                        m_pPreFxRenderHandler = NULL;
+PostColorFilterRenderHandler*              m_pPostColorFilterRenderHandler = nullptr;
 PreHudRenderHandler*                       m_pPreHudRenderHandler = NULL;
 ProcessCollisionHandler*                   m_pProcessCollisionHandler = NULL;
 HeliKillHandler*                           m_pHeliKillHandler = NULL;
@@ -479,6 +483,7 @@ void HOOK_Transmission_CalculateDriveAcceleration();
 void HOOK_isVehDriveTypeNotRWD();
 void HOOK_isVehDriveTypeNotFWD();
 void HOOK_PreFxRender();
+void HOOK_PostColorFilterRender();
 void HOOK_PreHUDRender();
 
 void HOOK_CTrafficLights_GetPrimaryLightState();
@@ -657,6 +662,7 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_VehColCB, (DWORD)HOOK_VehColCB, 29);
     HookInstall(HOOKPOS_VehCol, (DWORD)HOOK_VehCol, 9);
     HookInstall(HOOKPOS_PreFxRender, (DWORD)HOOK_PreFxRender, 5);
+    HookInstall(HOOKPOS_PostColorFilterRender, (DWORD)HOOK_PostColorFilterRender, 5);
     HookInstall(HOOKPOS_PreHUDRender, (DWORD)HOOK_PreHUDRender, 5);
     HookInstall(HOOKPOS_CAutomobile__ProcessSwingingDoor, (DWORD)HOOK_CAutomobile__ProcessSwingingDoor, 7);
 
@@ -2313,6 +2319,11 @@ void CMultiplayerSA::SetIdleHandler(IdleHandler* pHandler)
 void CMultiplayerSA::SetPreFxRenderHandler(PreFxRenderHandler* pHandler)
 {
     m_pPreFxRenderHandler = pHandler;
+}
+
+void CMultiplayerSA::SetPostColorFilterRenderHandler(PostColorFilterRenderHandler* pHandler)
+{
+    m_pPostColorFilterRenderHandler = pHandler;
 }
 
 void CMultiplayerSA::SetPreHudRenderHandler(PreHudRenderHandler* pHandler)
@@ -4777,6 +4788,24 @@ void _declspec(naked) HOOK_PreFxRender()
 skip:
         popad
         jmp     RETURN_PreFxRender  // 00404D1E
+    }
+}
+
+// Hooked from 00705099  5 bytes
+void _declspec(naked) HOOK_PostColorFilterRender()
+{
+    _asm
+    {
+        pushad
+    }
+
+    if (m_pPostColorFilterRenderHandler) m_pPostColorFilterRenderHandler();
+
+    _asm
+    {
+        popad
+        mov al, ds:0C402BAh
+        jmp     RETURN_PostColorFilterRender  // 0070509E
     }
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -115,6 +115,7 @@ public:
     void SetPostWorldProcessPedsAfterPreRenderHandler(PostWorldProcessPedsAfterPreRenderHandler* pHandler);
     void SetIdleHandler(IdleHandler* pHandler);
     void SetPreFxRenderHandler(PreFxRenderHandler* pHandler);
+    void SetPostColorFilterRenderHandler(PostColorFilterRenderHandler* pHandler) override;
     void SetPreHudRenderHandler(PreHudRenderHandler* pHandler);
     void DisableCallsToCAnimBlendNode(bool bDisableCalls);
     void SetCAnimBlendAssocDestructorHandler(CAnimBlendAssocDestructorHandler* pHandler);

--- a/Client/sdk/core/CCoreInterface.h
+++ b/Client/sdk/core/CCoreInterface.h
@@ -58,6 +58,12 @@ enum eCoreVersion
         }
 #endif
 
+enum class PreHUDRenderStage
+{
+    PostColorFilter,
+    PostEffects
+};
+
 class CCoreInterface
 {
 public:
@@ -150,7 +156,7 @@ public:
     virtual void SetClientScriptFrameRateLimit(uint uiClientScriptFrameRateLimit) = 0;
 
     virtual void                 OnPreFxRender() = 0;
-    virtual void                 OnPreHUDRender() = 0;
+    virtual void                 OnPreHUDRender(PreHUDRenderStage stage) = 0;
     virtual uint                 GetMinStreamingMemory() = 0;
     virtual uint                 GetMaxStreamingMemory() = 0;
     virtual void                 OnCrashAverted(uint uiId) = 0;

--- a/Client/sdk/core/CCoreInterface.h
+++ b/Client/sdk/core/CCoreInterface.h
@@ -58,12 +58,6 @@ enum eCoreVersion
         }
 #endif
 
-enum class PreHUDRenderStage
-{
-    PostColorFilter,
-    PostEffects
-};
-
 class CCoreInterface
 {
 public:
@@ -156,7 +150,7 @@ public:
     virtual void SetClientScriptFrameRateLimit(uint uiClientScriptFrameRateLimit) = 0;
 
     virtual void                 OnPreFxRender() = 0;
-    virtual void                 OnPreHUDRender(PreHUDRenderStage stage) = 0;
+    virtual void                 OnPreHUDRender() = 0;
     virtual uint                 GetMinStreamingMemory() = 0;
     virtual uint                 GetMaxStreamingMemory() = 0;
     virtual void                 OnCrashAverted(uint uiId) = 0;
@@ -198,6 +192,8 @@ public:
 
     virtual const SString& GetLastConnectedServerName() const = 0;
     virtual void           SetLastConnectedServerName(const SString& strServerName) = 0;
+
+    virtual void OnPostColorFilterRender() = 0;
 };
 
 class CClientTime

--- a/Client/sdk/multiplayer/CMultiplayer.h
+++ b/Client/sdk/multiplayer/CMultiplayer.h
@@ -102,6 +102,7 @@ typedef void(PostWorldProcessHandler)();
 typedef void(PostWorldProcessPedsAfterPreRenderHandler)();
 typedef void(IdleHandler)();
 typedef void(PreFxRenderHandler)();
+typedef void(PostColorFilterRenderHandler)();
 typedef void(PreHudRenderHandler)();
 typedef CAnimBlendAssociationSAInterface*(AddAnimationHandler)(RpClump* pClump, AssocGroupId animGroup, AnimationId animID);
 typedef CAnimBlendAssociationSAInterface*(AddAnimationAndSyncHandler)(RpClump* pClump, CAnimBlendAssociationSAInterface* pAnimAssocToSyncWith,
@@ -231,6 +232,7 @@ public:
     virtual void  SetPostWorldProcessPedsAfterPreRenderHandler(PostWorldProcessPedsAfterPreRenderHandler* pHandler) = 0;
     virtual void  SetIdleHandler(IdleHandler* pHandler) = 0;
     virtual void  SetPreFxRenderHandler(PreFxRenderHandler* pHandler) = 0;
+    virtual void  SetPostColorFilterRenderHandler(PostColorFilterRenderHandler* pHandler) = 0;
     virtual void  SetPreHudRenderHandler(PreHudRenderHandler* pHandler) = 0;
     virtual void  DisableCallsToCAnimBlendNode(bool bDisableCalls) = 0;
     virtual void  SetCAnimBlendAssocDestructorHandler(CAnimBlendAssocDestructorHandler* pHandler) = 0;


### PR DESCRIPTION
Fixes the bug described in #3457. This PR changes the render order in the following way: 

1. Color filter, grain, radiosity, infrared and nightvision effects are still occured before the `"postfx"` stage.
2. Heat haze and CCTV effects are now rendered after the `"postfx"` stage.
This is due to specifics of the bug(see https://github.com/multitheftauto/mtasa-blue/issues/3457#issuecomment-2167423832).