### PR TITLE
Ped sync improvements

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -3325,7 +3325,7 @@ void CClientPed::SetTargetRotation(unsigned long ulDelay, float fRotation, float
 {
     m_ulBeginRotationTime = CClientTime::GetTime();
     m_ulEndRotationTime = m_ulBeginRotationTime + ulDelay;
-    m_fBeginRotation = (m_pPlayerPed) ? m_pPlayerPed->GetTargetRotation() : m_fCurrentRotation;
+    m_fBeginRotation = (m_pPlayerPed) ? m_pPlayerPed->GetCurrentRotation() : m_fCurrentRotation;
     m_fTargetRotationA = fRotation;
     m_fBeginCameraRotation = GetCameraRotation();
     m_fTargetCameraRotation = fCameraRotation;
@@ -3383,23 +3383,24 @@ void CClientPed::Interpolate()
         {
             // We're not at the end?
             if (ulCurrentTime < m_ulEndRotationTime)
-            {
-                // Interpolate the player rotation
-                float fDeltaTime = float(m_ulEndRotationTime - m_ulBeginRotationTime);
-                float fDelta = GetOffsetDegrees(m_fBeginRotation, m_fTargetRotationA);
-                float fCameraDelta = GetOffsetDegrees(m_fBeginCameraRotation, m_fTargetCameraRotation);
-                float fProgress = float(ulCurrentTime - m_ulBeginRotationTime);
-                float fNewRotation = m_fBeginRotation + (fDelta / fDeltaTime * fProgress);
-                float fNewCameraRotation = m_fBeginCameraRotation + (fCameraDelta / fDeltaTime * fProgress);
+            {                              
+                const float fDelta = GetOffsetRadians(m_fBeginRotation, m_fTargetRotationA);                
 
                 // Hack for the wrap-around (the edge seems to be varying...)
-                if (fDelta < -5.0f || fDelta > 5.0f)
+                if (fDelta < -M_PI || fDelta > M_PI)
                 {
                     SetCurrentRotation(m_fTargetRotationA);
                     SetCameraRotation(m_fTargetCameraRotation);
                 }
                 else
                 {
+                    // Interpolate the player rotation  
+                    const float fDeltaTime = float(m_ulEndRotationTime - m_ulBeginRotationTime);
+                    const float fCameraDelta = GetOffsetRadians(m_fBeginCameraRotation, m_fTargetCameraRotation);
+                    const float fProgress = float(ulCurrentTime - m_ulBeginRotationTime);
+                    const float fNewRotation = m_fBeginRotation + fDelta * (fProgress / fDeltaTime);
+                    const float fNewCameraRotation = m_fBeginCameraRotation + fCameraDelta * (fProgress / fDeltaTime);
+
                     SetCurrentRotation(fNewRotation);
                     SetCameraRotation(fNewCameraRotation);
                 }

--- a/Server/mods/deathmatch/logic/CPedSync.cpp
+++ b/Server/mods/deathmatch/logic/CPedSync.cpp
@@ -234,13 +234,13 @@ void CPedSync::Packet_PedSync(CPedSyncPacket& Packet)
         // Apply the data to the ped
         if (Data.ucFlags & 0x01)
         {
-            pPed->SetPosition(Data.vecPosition);
+            pPed->SetPosition(Data.position.data.vecPosition);
             g_pGame->GetColManager()->DoHitDetection(pPed->GetPosition(), pPed);
         }
         if (Data.ucFlags & 0x02)
-            pPed->SetRotation(Data.fRotation);
+            pPed->SetRotation(Data.rotation.data.fRotation);
         if (Data.ucFlags & 0x04)
-            pPed->SetVelocity(Data.vecVelocity);
+            pPed->SetVelocity(Data.velocity.data.vecVelocity);
 
         if (Data.ucFlags & 0x08)
         {

--- a/Server/mods/deathmatch/logic/packets/CPedSyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPedSyncPacket.cpp
@@ -41,21 +41,21 @@ bool CPedSyncPacket::Read(NetBitStreamInterface& BitStream)
         // Did we recieve position?
         if (ucFlags & 0x01)
         {
-            if (!BitStream.Read(Data.vecPosition.fX) || !BitStream.Read(Data.vecPosition.fY) || !BitStream.Read(Data.vecPosition.fZ))
+            if (!BitStream.Read(&Data.position))
                 return false;
         }
 
         // Rotation
         if (ucFlags & 0x02)
         {
-            if (!BitStream.Read(Data.fRotation))
+            if (!BitStream.Read(&Data.rotation))
                 return false;
         }
 
         // Velocity
         if (ucFlags & 0x04)
         {
-            if (!BitStream.Read(Data.vecVelocity.fX) || !BitStream.Read(Data.vecVelocity.fY) || !BitStream.Read(Data.vecVelocity.fZ))
+            if (!BitStream.Read(&Data.velocity))
                 return false;
         }
 
@@ -110,24 +110,14 @@ bool CPedSyncPacket::Write(NetBitStreamInterface& BitStream) const
 
     // Position and rotation
     if (Data.ucFlags & 0x01)
-    {
-        BitStream.Write(Data.vecPosition.fX);
-        BitStream.Write(Data.vecPosition.fY);
-        BitStream.Write(Data.vecPosition.fZ);
-    }
+        BitStream.Write(&Data.position);
 
     if (Data.ucFlags & 0x02)
-    {
-        BitStream.Write(Data.fRotation);
-    }
+        BitStream.Write(&Data.rotation);
 
     // Velocity
     if (Data.ucFlags & 0x04)
-    {
-        BitStream.Write(Data.vecVelocity.fX);
-        BitStream.Write(Data.vecVelocity.fY);
-        BitStream.Write(Data.vecVelocity.fZ);
-    }
+        BitStream.Write(&Data.velocity);
 
     // Health, armour, on fire and is in water
     if (Data.ucFlags & 0x08)

--- a/Server/mods/deathmatch/logic/packets/CPedSyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPedSyncPacket.cpp
@@ -40,12 +40,10 @@ bool CPedSyncPacket::Read(NetBitStreamInterface& BitStream)
 
         // Did we recieve position?
         if (ucFlags & 0x01)
-        {
-            if (BitStream.Can(eBitStreamVersion::PedSync_Revision))
-                Data.ReadSpatialData(BitStream);
-            else
-                Data.ReadSpatialDataBC(BitStream);
-        }        
+        {    
+            if (!(BitStream.Can(eBitStreamVersion::PedSync_Revision) ? Data.ReadSpatialData(BitStream) : Data.ReadSpatialDataBC(BitStream)))
+                return false;
+        }
 
         // Health and armour
         if (ucFlags & 0x08)

--- a/Server/mods/deathmatch/logic/packets/CPedSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPedSyncPacket.h
@@ -13,6 +13,7 @@
 
 #include <CVector.h>
 #include "CPacket.h"
+#include <net/SyncStructures.h>
 #include <vector>
 
 class CPedSyncPacket final : public CPacket
@@ -20,16 +21,16 @@ class CPedSyncPacket final : public CPacket
 public:
     struct SyncData
     {
-        ElementID     ID;
-        unsigned char ucFlags;
-        unsigned char ucSyncTimeContext;
-        CVector       vecPosition;
-        float         fRotation;
-        CVector       vecVelocity;
-        float         fHealth;
-        float         fArmor;
-        bool          bOnFire;
-        bool          bIsInWater;
+        ElementID           ID;
+        unsigned char       ucFlags;
+        unsigned char       ucSyncTimeContext;
+        SPositionSync       position;
+        SPedRotationSync    rotation;
+        SVelocitySync       velocity;
+        float               fHealth;
+        float               fArmor;
+        bool                bOnFire;
+        bool                bIsInWater;
     };
 
 public:

--- a/Server/mods/deathmatch/logic/packets/CPedSyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPedSyncPacket.h
@@ -31,6 +31,10 @@ public:
         float               fArmor;
         bool                bOnFire;
         bool                bIsInWater;
+
+        bool ReadSpatialData(NetBitStreamInterface& BitStream);
+        // Backward compatibility
+        bool ReadSpatialDataBC(NetBitStreamInterface& BitStream);
     };
 
 public:

--- a/Shared/mods/deathmatch/logic/Utils.h
+++ b/Shared/mods/deathmatch/logic/Utils.h
@@ -233,6 +233,15 @@ inline float GetOffsetDegrees(float a, float b)
         c = (360.0f + c);
     return c;
 }
+inline float GetOffsetRadians(float a, float b)
+{
+    float c = (b > a) ? b - a : 0.0f - (a - b);
+    if (c > PI)
+        c = 0.0f - (2 * PI - c);
+    else if (c <= -PI)
+        c = (2 * PI + c);
+    return c;
+}
 
 // Assuming fValue is the result of a difference calculation, calculate
 // the shortest positive distance after wrapping

--- a/Shared/sdk/CVector.h
+++ b/Shared/sdk/CVector.h
@@ -26,11 +26,15 @@ private:
     static constexpr float FLOAT_EPSILON = 0.0001f;
 
 public:
-    float fX = 0.0f;
-    float fY = 0.0f;
-    float fZ = 0.0f;
+    float fX;
+    float fY;
+    float fZ;
 
-    constexpr CVector() = default;
+    struct NoInit{};
+
+    CVector(NoInit) {}
+
+    constexpr CVector() : fX(0.0f), fY(0.0f), fZ(0.0f) {}
 
     constexpr CVector(float x, float y, float z) : fX(x), fY(y), fZ(z) {}
 

--- a/Shared/sdk/net/bitstream.h
+++ b/Shared/sdk/net/bitstream.h
@@ -552,6 +552,10 @@ enum class eBitStreamVersion : unsigned short
     // 2024-05-31
     BreakObject_Serverside,
 
+    // Ped syncronization revision
+    // 2024-06-16
+    PedSync_Revision,
+
     // This allows us to automatically increment the BitStreamVersion when things are added to this enum.
     // Make sure you only add things above this comment.
     Next,


### PR DESCRIPTION
This PR is a reimplementation of #800 with additional fixes in rotation interpolation. 

The video below demonstrates that even without animations a ped is well synchronized (in comparison to the pre-PR). 
https://youtu.be/17vEh7k_RSI?si=8kxGwODs7lIn8OaF

Note that since peds are correctly syncronized now, there may be problems with old scripts relying on a ped's animation speed. These scripts will have to use animation without a root motion or use `setPedAnalogControlState`.