### PR TITLE
Fix onVehicleExit doesn't trigger if pulled out 

### DIFF
--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -3709,10 +3709,10 @@ void CGame::Packet_Vehicle_InOut(CVehicleInOutPacket& Packet)
                                         }
 
                                         CLuaArguments Arguments2;
-                                        Arguments2.PushElement(pJacked);                 // player / ped
-                                        Arguments2.PushNumber(ucOccupiedSeat);            // seat
-                                        Arguments2.PushElement(pPed);                     // jacker
-                                        Arguments2.PushBoolean(false);     
+                                        Arguments2.PushElement(pJacked);                 // jacked
+                                        Arguments2.PushNumber(ucOccupiedSeat);           // seat
+                                        Arguments2.PushElement(pPed);                    // jacker
+                                        Arguments2.PushBoolean(false);                   // forcedByScript
     
                                         pVehicle->CallEvent("onVehicleExit", Arguments2);
 

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -3694,9 +3694,9 @@ void CGame::Packet_Vehicle_InOut(CVehicleInOutPacket& Packet)
                                         m_pPlayerManager->BroadcastOnlyJoined(JackedReply);
 
                                         CLuaArguments Arguments;
-                                        Arguments.PushElement(pPed);                     // player / ped
+                                        Arguments.PushElement(pJacked);                  // player / ped
                                         Arguments.PushNumber(ucOccupiedSeat);            // seat
-                                        Arguments.PushElement(pJacked);                  // jacker
+                                        Arguments.PushElement(pPed);                       // jacker                                    
                                         Arguments.PushBoolean(false);                    // forcedByScript
 
                                         if (pJacked->IsPlayer())

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -3696,7 +3696,7 @@ void CGame::Packet_Vehicle_InOut(CVehicleInOutPacket& Packet)
                                         CLuaArguments Arguments;
                                         Arguments.PushElement(pPed);                     // player / ped
                                         Arguments.PushNumber(ucOccupiedSeat);            // seat
-                                        Arguments.PushElement(pJacked);                  // jacked
+                                        Arguments.PushElement(pJacked);                  // jacker
                                         Arguments.PushBoolean(false);                    // forcedByScript
 
                                         if (pJacked->IsPlayer())

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -3696,7 +3696,7 @@ void CGame::Packet_Vehicle_InOut(CVehicleInOutPacket& Packet)
                                         CLuaArguments Arguments;
                                         Arguments.PushElement(pVehicle);                 // vehicle 
                                         Arguments.PushNumber(ucOccupiedSeat);            // seat
-                                        Arguments.PushElement(pJacked);                  // jacked                                    
+                                        Arguments.PushElement(pPed);                     // jacker                                    
                                         Arguments.PushBoolean(false);                    // forcedByScript
 
                                         if (pJacked->IsPlayer())

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -3696,7 +3696,7 @@ void CGame::Packet_Vehicle_InOut(CVehicleInOutPacket& Packet)
                                         CLuaArguments Arguments;
                                         Arguments.PushElement(pJacked);                  // player / ped
                                         Arguments.PushNumber(ucOccupiedSeat);            // seat
-                                        Arguments.PushElement(pPed);                       // jacker                                    
+                                        Arguments.PushElement(pPed);                     // jacker                                    
                                         Arguments.PushBoolean(false);                    // forcedByScript
 
                                         if (pJacked->IsPlayer())

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -3659,6 +3659,7 @@ void CGame::Packet_Vehicle_InOut(CVehicleInOutPacket& Packet)
                             if (pPed->GetVehicleAction() == CPed::VEHICLEACTION_JACKING)
                             {
                                 unsigned char ucDoor = Packet.GetDoor();
+                                unsigned char ucOccupiedSeat = pPed->GetOccupiedVehicleSeat();  
                                 float         fAngle = Packet.GetDoorAngle();
                                 CPed*         pJacked = pVehicle->GetOccupant(0);
 
@@ -3691,6 +3692,23 @@ void CGame::Packet_Vehicle_InOut(CVehicleInOutPacket& Packet)
                                         // Tell everyone to get the jacked person out
                                         CVehicleInOutPacket JackedReply(pJacked->GetID(), VehicleID, 0, VEHICLE_NOTIFY_OUT_RETURN);
                                         m_pPlayerManager->BroadcastOnlyJoined(JackedReply);
+
+                                        CLuaArguments Arguments;
+                                        Arguments.PushElement(pPed);                     // player / ped
+                                        Arguments.PushNumber(ucOccupiedSeat);            // seat
+                                        Arguments.PushElement(pJacked);                  // jacked
+                                        Arguments.PushBoolean(false);                    // forcedByScript
+
+                                        if (pJacked->IsPlayer())
+                                        {
+                                         pJacked->CallEvent("onPlayerVehicleExit", Arguments);
+                                        }
+                                        else
+                                        {
+                                         pJacked->CallEvent("onPedVehicleExit", Arguments);
+                                        }
+    
+                                        pVehicle->CallEvent("onVehicleExit", Arguments);
 
                                         if (!sendListIncompatiblePlayers.empty())
                                         {

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -3694,7 +3694,7 @@ void CGame::Packet_Vehicle_InOut(CVehicleInOutPacket& Packet)
                                         m_pPlayerManager->BroadcastOnlyJoined(JackedReply);
 
                                         CLuaArguments Arguments;
-                                        Arguments.PushElement(pJacked);                  // player / ped
+                                        Arguments.PushElement(pVehicle);                 // vehicle 
                                         Arguments.PushNumber(ucOccupiedSeat);            // seat
                                         Arguments.PushElement(pPed);                     // jacker                                    
                                         Arguments.PushBoolean(false);                    // forcedByScript
@@ -3707,8 +3707,14 @@ void CGame::Packet_Vehicle_InOut(CVehicleInOutPacket& Packet)
                                         {
                                          pJacked->CallEvent("onPedVehicleExit", Arguments);
                                         }
+
+                                        CLuaArguments Arguments2;
+                                        Arguments2.PushElement(pJacked);                 // player / ped
+                                        Arguments2.PushNumber(ucOccupiedSeat);            // seat
+                                        Arguments2.PushElement(pPed);                     // jacker
+                                        Arguments2.PushBoolean(false);     
     
-                                        pVehicle->CallEvent("onVehicleExit", Arguments);
+                                        pVehicle->CallEvent("onVehicleExit", Arguments2);
 
                                         if (!sendListIncompatiblePlayers.empty())
                                         {

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -3659,7 +3659,7 @@ void CGame::Packet_Vehicle_InOut(CVehicleInOutPacket& Packet)
                             if (pPed->GetVehicleAction() == CPed::VEHICLEACTION_JACKING)
                             {
                                 unsigned char ucDoor = Packet.GetDoor();
-                                unsigned char ucOccupiedSeat = pPed->GetOccupiedVehicleSeat();  
+                                unsigned char ucOccupiedSeat = pPed->GetOccupiedVehicleSeat();
                                 float         fAngle = Packet.GetDoorAngle();
                                 CPed*         pJacked = pVehicle->GetOccupant(0);
 
@@ -3694,26 +3694,26 @@ void CGame::Packet_Vehicle_InOut(CVehicleInOutPacket& Packet)
                                         m_pPlayerManager->BroadcastOnlyJoined(JackedReply);
 
                                         CLuaArguments Arguments;
-                                        Arguments.PushElement(pVehicle);                 // vehicle 
+                                        Arguments.PushElement(pVehicle);                 // vehicle
                                         Arguments.PushNumber(ucOccupiedSeat);            // seat
-                                        Arguments.PushElement(pPed);                     // jacker                                    
+                                        Arguments.PushElement(pPed);                     // jacker
                                         Arguments.PushBoolean(false);                    // forcedByScript
 
                                         if (pJacked->IsPlayer())
                                         {
-                                         pJacked->CallEvent("onPlayerVehicleExit", Arguments);
+                                            pJacked->CallEvent("onPlayerVehicleExit", Arguments);
                                         }
                                         else
                                         {
-                                         pJacked->CallEvent("onPedVehicleExit", Arguments);
+                                            pJacked->CallEvent("onPedVehicleExit", Arguments);
                                         }
 
                                         CLuaArguments Arguments2;
-                                        Arguments2.PushElement(pJacked);                 // jacked
-                                        Arguments2.PushNumber(ucOccupiedSeat);           // seat
-                                        Arguments2.PushElement(pPed);                    // jacker
-                                        Arguments2.PushBoolean(false);                   // forcedByScript
-    
+                                        Arguments2.PushElement(pJacked);                  // jacked
+                                        Arguments2.PushNumber(ucOccupiedSeat);            // seat
+                                        Arguments2.PushElement(pPed);                     // jacker
+                                        Arguments2.PushBoolean(false);                    // forcedByScript
+
                                         pVehicle->CallEvent("onVehicleExit", Arguments2);
 
                                         if (!sendListIncompatiblePlayers.empty())

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -3696,7 +3696,7 @@ void CGame::Packet_Vehicle_InOut(CVehicleInOutPacket& Packet)
                                         CLuaArguments Arguments;
                                         Arguments.PushElement(pVehicle);                 // vehicle 
                                         Arguments.PushNumber(ucOccupiedSeat);            // seat
-                                        Arguments.PushElement(pPed);                     // jacker                                    
+                                        Arguments.PushElement(pJacked);                  // jacked                                    
                                         Arguments.PushBoolean(false);                    // forcedByScript
 
                                         if (pJacked->IsPlayer())


### PR DESCRIPTION
Fixes #476
on case VEHICLE_NOTIFY_JACK_ABORT:
`  if (Packet.GetStartedJacking() == 1)`
call the events