### PR TITLE
Generic exception type for argument parser instead of std::invalid_argument

### DIFF
--- a/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
@@ -727,7 +727,7 @@ struct CLuaFunctionParser<ErrorOnFailure, ReturnOnFailure, Func> : CLuaFunctionP
         {
             iResult = Call(L);
         }
-        catch (std::invalid_argument& e)
+        catch (std::logic_error& e)
         {
             // This exception can be thrown from the called function
             // as an additional way to provide further argument errors


### PR DESCRIPTION
Currently the only exceptions that a Lua function can throw is std::invalid_argument. But sometimes this is not enough, because although we technically can use std::invalid_argument for different applications, it's better to use dedicated exceptions for their own purposes. std::invalid_argument - for invalid arguments, std::logic_error - for common cases. This PR also allows to create new exception types and use them with the argument parser.