### PR TITLE
Fix #414 Using setElementHealth on a dead ped makes it invincible

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -1761,6 +1761,11 @@ void CClientPed::InternalSetHealth(float fHealth)
             }
             else
             {
+                // Ped is alive again (Fix #414)
+                UnlockHealth();
+                UnlockArmor();
+                SetIsDead(false);
+
                 // Recreate the player
                 ReCreateModel();
             }

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1669,6 +1669,9 @@ bool CStaticFunctionDefinitions::SetElementHealth(CElement* pElement, float fHea
                 unsigned char ucHealth = static_cast<unsigned char>(fHealth * 1.25f);
                 fHealth = static_cast<float>(ucHealth) / 1.25f;
                 pPed->SetHealth(fHealth);
+
+                if (pPed->IsDead() && fHealth > 0)
+                    pPed->SetIsDead(false);
             }
             else
                 return false;

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1670,7 +1670,7 @@ bool CStaticFunctionDefinitions::SetElementHealth(CElement* pElement, float fHea
                 fHealth = static_cast<float>(ucHealth) / 1.25f;
                 pPed->SetHealth(fHealth);
 
-                if (pPed->IsDead() && fHealth > 0)
+                if (pPed->IsDead() && fHealth > 0.0f)
                     pPed->SetIsDead(false);
             }
             else


### PR DESCRIPTION
Fixed #414 

My previous PR "fixing" this bug was a long time ago, when I had no experience. Now I have solved this problem and I know what causes it.

Ped has locked health and armor when he dies. When the ped is re-created (ReCreateModel), health and armor are not unlocked. This is proven by the fact that when we move away from the invincible ped and come back again (stream out & stream in), the ped has unlocked health and armor and receives damage. This is because when stream in with ped, his health and armor are unlocked.

https://github.com/multitheftauto/mtasa-blue/blob/2c4e23211346248c836bbcac57baa2d5cf74be1b/Client/mods/deathmatch/logic/CPedSync.cpp#L134-L135

Additionally, the "isDead" state is now also set correctly after recreating a ped.

I don't think this should cause any synchronization problems. 