### PR TITLE
Fix #501 Setting player model resets their current weapon slot

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -5220,6 +5220,9 @@ void CClientPed::Respawn(CVector* pvecPosition, bool bRestoreState, bool bCamera
 
             m_pPlayerPed->SetLanding(false);
 
+            // Set it to 0 (Fix #501)
+            SetCurrentWeaponSlot(eWeaponSlot::WEAPONSLOT_TYPE_UNARMED);
+
             if (bRestoreState)
             {
                 // Jax: restore all the things we saved


### PR DESCRIPTION
Fixed #501 

In the case of non-player peds weapon the slot is set correctly, but in the case of player peds the slot is not set.

This is due to the fact that the slot for the player is taken directly from the GTA memory

https://github.com/multitheftauto/mtasa-blue/blob/97920d83de400e0378f73ea93e87b27cf59dd758/Client/mods/deathmatch/logic/CClientPed.cpp#L2209-L2211

and when the skin respawns, the slot in the game memory is still the one we had before changing the skin. This causes the condition result is false.

https://github.com/multitheftauto/mtasa-blue/blob/97920d83de400e0378f73ea93e87b27cf59dd758/Client/mods/deathmatch/logic/CClientPed.cpp#L2148-L2152

As a result, the weapon slot is not set at all. Therefore, we first set the weapon slot to 0 to make this condition true.