### PR TITLE
Appendum #3490

### DIFF
--- a/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
@@ -711,7 +711,7 @@ std::variant<bool, std::string> CLuaFileDefs::fileRead (
         -> std::variant<bool, std::string>
     {
         if (count == 0)
-            return std::string();
+            return std::string{};
 
         SString buffer;
         auto    bytesRead = pFile->Read(count, buffer);

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
@@ -711,7 +711,7 @@ std::variant<bool, std::string> CLuaFileDefs::fileRead (
         -> std::variant<bool, std::string>
     {
         if (count == 0)
-            return "";
+            return std::string();
 
         SString buffer;
         auto    bytesRead = pFile->Read(count, buffer);


### PR DESCRIPTION
Appendum #3490 

`std::variant` recognized `""` as `true` instead of a `std::string`.