### PR TITLE
Fix #1860 Markers with type "arrow" or "checkpoint" won't be affected by alpha color argument 

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1529,6 +1529,10 @@ void CMultiplayerSA::InitHooks()
     MemPut<BYTE>(0x524084, 0xFF);
     MemPut<BYTE>(0x524089, 0xFF);
 
+    // Allow change alpha for arrow & checkpoint markers (#1860)
+    MemSet((void*)0x7225F5, 0x90, 4);
+    MemCpy((void*)0x725DDE, "\xFF\x76\xB\x90\x90", 5);
+
     InitHooks_CrashFixHacks();
 
     // Init our 1.3 hooks.


### PR DESCRIPTION
Fixed #1860 

![image](https://github.com/multitheftauto/mtasa-blue/assets/26044224/04a20548-f142-43c3-8059-f20f96d6b16e)

After merge #2989 , I will add the ability to change the color and alpha of the checkpoint marker target arrow. By default it is red with alpha 255.
![image](https://github.com/multitheftauto/mtasa-blue/assets/26044224/30d9c5d9-a688-4319-9f9b-bbbf8ac350e9)
