### PR TITLE
Fix wrong function name for OOP debug level

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
@@ -95,7 +95,7 @@ void CLuaPlayerDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "ping", NULL, "getPlayerPing");
     lua_classvariable(luaVM, "name", NULL, "getPlayerName");
     lua_classvariable(luaVM, "team", NULL, "getPlayerTeam");
-    lua_classvariable(luaVM, "debugLevel", nullptr, "getScriptDebugLevel");
+    lua_classvariable(luaVM, "debugLevel", nullptr, "getPlayerScriptDebugLevel");
     lua_classvariable(luaVM, "nametagText", "setPlayerNametagText", "getPlayerNametagText");
     lua_classvariable(luaVM, "nametagShowing", "setPlayerNametagShowing", "isPlayerNametagShowing");
 


### PR DESCRIPTION
Fixes crash related to a wrong function name in #3502. Report here: https://github.com/multitheftauto/mtasa-blue/commit/8403da54ecfd20d6b9740fb79d90ac936d316112#commitcomment-143691757