### PR TITLE
Fix outputDebugString level 4 not being logged

### DIFF
--- a/Client/mods/deathmatch/logic/CScriptDebugging.cpp
+++ b/Client/mods/deathmatch/logic/CScriptDebugging.cpp
@@ -10,23 +10,6 @@
 
 #include <StdInc.h>
 
-enum DebugScriptLevels : std::uint8_t
-{
-    NONE,
-    ERRORS_ONLY,
-    ERRORS_AND_WARNINGS,
-    ALL,
-};
-
-enum DebugMessageLevels : std::uint8_t
-{
-    MESSAGE_TYPE_DEBUG,
-    MESSAGE_TYPE_ERROR,
-    MESSAGE_TYPE_WARNING,
-    MESSAGE_TYPE_INFO,
-    MESSAGE_TYPE_CUSTOM,
-};
-
 FILE* CScriptDebugging::m_pLogFile;
 
 CScriptDebugging::CScriptDebugging(CLuaManager* pLuaManager)
@@ -58,28 +41,6 @@ CScriptDebugging::~CScriptDebugging()
         fclose(m_pLogFile);
         m_pLogFile = NULL;
     }
-}
-
-bool CScriptDebugging::CheckForSufficientDebugLevel(std::uint8_t playerDebugLevel, std::uint8_t messageDebugLevel) const noexcept
-{
-    bool sufficientDebugLevel = false;
-
-    switch (messageDebugLevel)
-    {
-        case MESSAGE_TYPE_ERROR:
-            sufficientDebugLevel = (playerDebugLevel >= ERRORS_ONLY);
-            break;
-        case MESSAGE_TYPE_WARNING:
-            sufficientDebugLevel = (playerDebugLevel >= ERRORS_AND_WARNINGS);
-            break;
-        case MESSAGE_TYPE_INFO:
-        case MESSAGE_TYPE_CUSTOM:
-        case MESSAGE_TYPE_DEBUG:
-            sufficientDebugLevel = (playerDebugLevel == ALL);
-            break;
-    }
-
-    return sufficientDebugLevel;
 }
 
 void CScriptDebugging::LogBadLevel(lua_State* luaVM, unsigned int uiRequiredLevel)

--- a/Client/mods/deathmatch/logic/CScriptDebugging.cpp
+++ b/Client/mods/deathmatch/logic/CScriptDebugging.cpp
@@ -10,6 +10,23 @@
 
 #include <StdInc.h>
 
+enum DebugScriptLevels : std::uint8_t
+{
+    NONE,
+    ERRORS_ONLY,
+    ERRORS_AND_WARNINGS,
+    ALL,
+};
+
+enum DebugMessageLevels : std::uint8_t
+{
+    MESSAGE_TYPE_DEBUG,
+    MESSAGE_TYPE_ERROR,
+    MESSAGE_TYPE_WARNING,
+    MESSAGE_TYPE_INFO,
+    MESSAGE_TYPE_CUSTOM,
+};
+
 FILE* CScriptDebugging::m_pLogFile;
 
 CScriptDebugging::CScriptDebugging(CLuaManager* pLuaManager)
@@ -41,6 +58,28 @@ CScriptDebugging::~CScriptDebugging()
         fclose(m_pLogFile);
         m_pLogFile = NULL;
     }
+}
+
+bool CScriptDebugging::CheckForSufficientDebugLevel(std::uint8_t playerDebugLevel, std::uint8_t messageDebugLevel) const noexcept
+{
+    bool sufficientDebugLevel = false;
+
+    switch (messageDebugLevel)
+    {
+        case MESSAGE_TYPE_ERROR:
+            sufficientDebugLevel = (playerDebugLevel >= ERRORS_ONLY);
+            break;
+        case MESSAGE_TYPE_WARNING:
+            sufficientDebugLevel = (playerDebugLevel >= ERRORS_AND_WARNINGS);
+            break;
+        case MESSAGE_TYPE_INFO:
+        case MESSAGE_TYPE_CUSTOM:
+        case MESSAGE_TYPE_DEBUG:
+            sufficientDebugLevel = (playerDebugLevel == ALL);
+            break;
+    }
+
+    return sufficientDebugLevel;
 }
 
 void CScriptDebugging::LogBadLevel(lua_State* luaVM, unsigned int uiRequiredLevel)
@@ -123,7 +162,9 @@ void CScriptDebugging::UpdateLogOutput()
     while (m_DuplicateLineFilter.PopOutputLine(line))
     {
         // Log it to the file if enough level
-        if (m_uiLogFileLevel >= line.uiMinimumDebugLevel)
+        bool sufficientDebugLevel = CheckForSufficientDebugLevel(m_uiLogFileLevel, line.uiMinimumDebugLevel);
+
+        if (sufficientDebugLevel)
         {
             PrintLog(line.strText);
         }

--- a/Client/mods/deathmatch/logic/CScriptDebugging.h
+++ b/Client/mods/deathmatch/logic/CScriptDebugging.h
@@ -68,6 +68,7 @@ private:
     SString ComposeErrorMessage(const char* szPrePend, const SLuaDebugInfo& luaDebugInfo, const char* szMessage);
     void LogString(const char* szPrePend, const SLuaDebugInfo& luaDebugInfo, const char* szMessage, unsigned int uiMinimumDebugLevel, unsigned char ucRed = 255,
                    unsigned char ucGreen = 255, unsigned char ucBlue = 255);
+    bool CheckForSufficientDebugLevel(std::uint8_t playerDebugLevel, std::uint8_t messageDebugLevel) const noexcept;
     void PrintLog(const char* szText);
 
 public:

--- a/Server/mods/deathmatch/logic/CScriptDebugging.cpp
+++ b/Server/mods/deathmatch/logic/CScriptDebugging.cpp
@@ -15,23 +15,6 @@
 
 extern CGame* g_pGame;
 
-enum DebugScriptLevels : std::uint8_t
-{
-    NONE,
-    ERRORS_ONLY,
-    ERRORS_AND_WARNINGS,
-    ALL,
-};
-
-enum DebugMessageLevels : std::uint8_t
-{
-    MESSAGE_TYPE_DEBUG,
-    MESSAGE_TYPE_ERROR,
-    MESSAGE_TYPE_WARNING,
-    MESSAGE_TYPE_INFO,
-    MESSAGE_TYPE_CUSTOM,
-};
-
 CScriptDebugging::CScriptDebugging()
 {
     m_uiLogFileLevel = 0;
@@ -158,28 +141,6 @@ void CScriptDebugging::PrintLog(const char* szText)
         fprintf(m_pLogFile, "[%s] %s\n", *GetLocalTimeString(true), szText);
         fflush(m_pLogFile);
     }
-}
-
-bool CScriptDebugging::CheckForSufficientDebugLevel(std::uint8_t playerDebugLevel, std::uint8_t messageDebugLevel) const noexcept
-{
-    bool sufficientDebugLevel = false;
-
-    switch (messageDebugLevel)
-    {
-        case MESSAGE_TYPE_ERROR:
-            sufficientDebugLevel = (playerDebugLevel >= ERRORS_ONLY);
-            break;
-        case MESSAGE_TYPE_WARNING:
-            sufficientDebugLevel = (playerDebugLevel >= ERRORS_AND_WARNINGS);
-            break;
-        case MESSAGE_TYPE_INFO:
-        case MESSAGE_TYPE_CUSTOM:
-        case MESSAGE_TYPE_DEBUG:
-            sufficientDebugLevel = (playerDebugLevel == ALL);
-            break;
-    }
-
-    return sufficientDebugLevel;
 }
 
 void CScriptDebugging::Broadcast(const CPacket& Packet, unsigned int uiMinimumDebugLevel)

--- a/Shared/mods/deathmatch/logic/CScriptDebugging.cpp
+++ b/Shared/mods/deathmatch/logic/CScriptDebugging.cpp
@@ -20,6 +20,23 @@
 
 #define MAX_STRING_LENGTH 2048
 
+enum DebugScriptLevels : std::uint8_t
+{
+    NONE,
+    ERRORS_ONLY,
+    ERRORS_AND_WARNINGS,
+    ALL,
+};
+
+enum DebugMessageLevels : std::uint8_t
+{
+    MESSAGE_TYPE_DEBUG,
+    MESSAGE_TYPE_ERROR,
+    MESSAGE_TYPE_WARNING,
+    MESSAGE_TYPE_INFO,
+    MESSAGE_TYPE_CUSTOM,
+};
+
 // Handle filename/line number in string
 void CScriptDebugging::LogPCallError(lua_State* luaVM, const SString& strRes, bool bInitialCall)
 {
@@ -49,6 +66,28 @@ void CScriptDebugging::LogPCallError(lua_State* luaVM, const SString& strRes, bo
         // File+line info not present
         LogError(luaVM, "%s", strRes.c_str());
     }
+}
+
+bool CScriptDebugging::CheckForSufficientDebugLevel(std::uint8_t playerDebugLevel, std::uint8_t messageDebugLevel) const noexcept
+{
+    bool sufficientDebugLevel = false;
+
+    switch (messageDebugLevel)
+    {
+        case MESSAGE_TYPE_ERROR:
+            sufficientDebugLevel = (playerDebugLevel >= ERRORS_ONLY);
+            break;
+        case MESSAGE_TYPE_WARNING:
+            sufficientDebugLevel = (playerDebugLevel >= ERRORS_AND_WARNINGS);
+            break;
+        case MESSAGE_TYPE_INFO:
+        case MESSAGE_TYPE_CUSTOM:
+        case MESSAGE_TYPE_DEBUG:
+            sufficientDebugLevel = (playerDebugLevel == ALL);
+            break;
+    }
+
+    return sufficientDebugLevel;
 }
 
 void CScriptDebugging::LogCustom(lua_State* luaVM, unsigned char ucRed, unsigned char ucGreen, unsigned char ucBlue, const char* szFormat, ...)


### PR DESCRIPTION
fixes https://github.com/multitheftauto/mtasa-blue/issues/3552

Essentially a client-side port of https://github.com/multitheftauto/mtasa-blue/pull/3499 by moving the enum and CheckForSufficientDebugLevel into a shared class. Using this check makes level 4 equal to level 0 for the purposes of the level sufficiency check which allows its contents to be written to clientscript.log as intended.

At this moment the level check doesn't serve much of a purpose (as it's always set to 3 client-side, through setLogFile) but it does pave the way to someday only log down items based on the debugscript client-side if desired. Either way it's a cleaner solution than adding a secondary check for level 4.