### PR TITLE
Fix removeWorldModel crash

### DIFF
--- a/Client/game_sa/CBuildingRemovalSA.cpp
+++ b/Client/game_sa/CBuildingRemovalSA.cpp
@@ -716,4 +716,10 @@ void CBuildingRemovalSA::DropCaches()
 
     m_pBinaryBuildings->clear();
     m_pDataBuildings->clear();
+
+    for (auto &pRemoval : *m_pBuildingRemovals)
+    {
+        pRemoval.second->m_pDataRemoveList->clear();
+        pRemoval.second->m_pBinaryRemoveList->clear();
+    }
 }

--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -1009,6 +1009,11 @@ void CGameSA::RemoveAllBuildings()
 
     m_pPools->GetDummyPool().RemoveAllBuildingLods();
     m_pPools->GetBuildingsPool().RemoveAllBuildings();
+
+    auto pBuildingRemoval = static_cast<CBuildingRemovalSA*>(m_pBuildingRemoval);
+    pBuildingRemoval->ClearRemovedBuildingLists();
+    pBuildingRemoval->DropCaches();
+
     m_isBuildingsRemoved = true;
 }
 

--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -1003,7 +1003,7 @@ void CGameSA::GetShaderReplacementStats(SShaderReplacementStats& outStats)
     m_pRenderWare->GetShaderReplacementStats(outStats);
 }
 
-void CGameSA::RemoveAllBuildings()
+void CGameSA::RemoveAllBuildings(bool clearBuildingRemoval)
 {
     m_pIplStore->SetDynamicIplStreamingEnabled(false);
 
@@ -1011,7 +1011,10 @@ void CGameSA::RemoveAllBuildings()
     m_pPools->GetBuildingsPool().RemoveAllBuildings();
 
     auto pBuildingRemoval = static_cast<CBuildingRemovalSA*>(m_pBuildingRemoval);
-    pBuildingRemoval->ClearRemovedBuildingLists();
+    if (clearBuildingRemoval)
+    {
+        pBuildingRemoval->ClearRemovedBuildingLists();
+    }
     pBuildingRemoval->DropCaches();
 
     m_isBuildingsRemoved = true;
@@ -1031,10 +1034,13 @@ bool CGameSA::SetBuildingPoolSize(size_t size)
     const bool shouldRemoveBuilding = !m_isBuildingsRemoved;
     if (shouldRemoveBuilding)
     {
-        RemoveAllBuildings();
+        RemoveAllBuildings(false);
+    }
+    else
+    {
+        static_cast<CBuildingRemovalSA*>(m_pBuildingRemoval)->DropCaches();
     }
 
-    ((CBuildingRemovalSA*)GetBuildingRemoval())->DropCaches();
     bool status = m_pPools->GetBuildingsPool().Resize(size);
 
     if (shouldRemoveBuilding)

--- a/Client/game_sa/CGameSA.h
+++ b/Client/game_sa/CGameSA.h
@@ -303,7 +303,7 @@ public:
     PostWeaponFireHandler*  m_pPostWeaponFireHandler;
     TaskSimpleBeHitHandler* m_pTaskSimpleBeHitHandler;
 
-    void RemoveAllBuildings();
+    void RemoveAllBuildings(bool clearBuildingRemoval = true);
     void RestoreGameBuildings();
 
     bool SetBuildingPoolSize(size_t size);

--- a/Client/sdk/game/CGame.h
+++ b/Client/sdk/game/CGame.h
@@ -268,7 +268,7 @@ public:
     virtual int32_t GetBaseIDforSCM() = 0;
     virtual int32_t GetCountOfAllFileIDs() = 0;
 
-    virtual void RemoveAllBuildings() = 0;
+    virtual void RemoveAllBuildings(bool clearBuildingRemoval = true) = 0;
     virtual void RestoreGameBuildings() = 0;
 
     virtual bool SetBuildingPoolSize(size_t size) = 0;


### PR DESCRIPTION
Fixes crash related to removeAllGameBuildings and removeWorldModel usage.

WTR:
1. Run code:
```lua
local pos = Vector3(0, 200, 0)
local rot = Vector3(0, 0, 0)


local building = createBuilding(8395, pos, rot)
removeAllGameBuildings()
for i = 550, 19999, 1 do
    removeWorldModel(i, 100000, 0, 0, 0)
end
```
2. Reconnect
