### PR TITLE
Fix #3659 weapon switching (scroll and Q+E) while using Jetpack 

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1568,6 +1568,9 @@ void CMultiplayerSA::InitHooks()
     MemSet((void*)0x7225F5, 0x90, 4);
     MemCpy((void*)0x725DDE, "\xFF\x76\xB\x90\x90", 5);
 
+    // Allow switch weapon during jetpack task (#3569)
+    MemSetFast((void*)0x60D86F, 0x90, 19);
+
     InitHooks_CrashFixHacks();
 
     // Init our 1.3 hooks.

--- a/Server/mods/deathmatch/logic/CPed.cpp
+++ b/Server/mods/deathmatch/logic/CPed.cpp
@@ -534,3 +534,25 @@ void CPed::SetJackingVehicle(CVehicle* pVehicle)
     if (m_pJackingVehicle)
         m_pJackingVehicle->SetJackingPed(this);
 }
+
+void CPed::SetHasJetPack(bool bHasJetPack)
+{
+    if (m_bHasJetPack == bHasJetPack)
+        return;
+
+    m_bHasJetPack = bHasJetPack;
+
+    if (!bHasJetPack)
+        return;
+
+    // Set weapon slot to 0 if weapon is disabled with jetpack to avoid HUD and audio bugs
+    eWeaponType weaponType = static_cast<eWeaponType>(GetWeaponType(GetWeaponSlot()));
+    if (weaponType <= WEAPONTYPE_UNARMED)
+        return;
+
+    bool weaponEnabled;
+    CStaticFunctionDefinitions::GetJetpackWeaponEnabled(weaponType, weaponEnabled);
+
+    if (!weaponEnabled)
+        CStaticFunctionDefinitions::SetPedWeaponSlot(this, 0);
+}

--- a/Server/mods/deathmatch/logic/CPed.h
+++ b/Server/mods/deathmatch/logic/CPed.h
@@ -188,7 +188,7 @@ public:
     static const char* GetBodyPartName(unsigned char ucID);
 
     bool HasJetPack() { return m_bHasJetPack; }
-    void SetHasJetPack(bool bHasJetPack) { m_bHasJetPack = bHasJetPack; }
+    void SetHasJetPack(bool bHasJetPack);
 
     bool IsInWater() { return m_bInWater; }
     void SetInWater(bool bInWater) { m_bInWater = bInWater; }


### PR DESCRIPTION
Fixed #3569 

Weapons can be switched even if they are not enabled by ``setJetpackWeaponEnabled``, but then they cannot be used, they are only held in the hand.

I encountered a bug where when putting on the jetpack, if the held weapon is not enabled by ``setJetpackWeaponEnabled``, it disappears from the hand, but its icon remains in the hud and its sound remains (chainsaw, molotov), ​​therefore the weapon slot must be set to 0 when the held weapon is not is enabled.