### PR TITLE
Appendum - CLuaFunctionParser refactor (#3494)

### DIFF
--- a/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
@@ -18,7 +18,6 @@ class CLuaArgument;
 #include "lua/CLuaStackChecker.h"
 #include "lua/LuaBasic.h"
 #include <lua/CLuaMultiReturn.h>
-#include <tuple>
 
 class LuaFunctionError
 {

--- a/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
@@ -18,6 +18,7 @@ class CLuaArgument;
 #include "lua/CLuaStackChecker.h"
 #include "lua/LuaBasic.h"
 #include <lua/CLuaMultiReturn.h>
+#include <tuple>
 
 class LuaFunctionError
 {
@@ -32,6 +33,8 @@ public:
     constexpr const char* what() const noexcept { return m_message; }
     constexpr bool        IsWarning() const noexcept { return m_bWarning; }
 };
+
+using LuaVarArgs = std::optional<CLuaArguments>;
 
 struct CLuaFunctionParserBase
 {
@@ -74,6 +77,8 @@ struct CLuaFunctionParserBase
         }
         else if constexpr (std::is_same_v<T, CLuaArgument>)
             return "value";
+        else if constexpr (std::is_same_v<T, CLuaArguments>)
+            return "values";
         else if constexpr (is_2specialization<T, std::vector>::value)
             return "table";
         else if constexpr (is_5specialization<T, std::unordered_map>::value)
@@ -217,6 +222,9 @@ struct CLuaFunctionParserBase
 
         // CLuaArgument can hold any value
         else if constexpr (std::is_same_v<T, CLuaArgument>)
+            return iArgument != LUA_TNONE;
+
+        else if constexpr (std::is_same_v<T, CLuaArguments>)
             return iArgument != LUA_TNONE;
 
         // All color classes are read as a single tocolor number
@@ -649,6 +657,12 @@ struct CLuaFunctionParserBase
         {
             CLuaArgument argument;
             argument.Read(L, index++);
+            return argument;
+        }
+        else if constexpr (std::is_same_v<T, CLuaArguments>)
+        {
+            CLuaArguments argument;
+            argument.ReadArguments(L, index);
             return argument;
         }
         else if constexpr (std::is_same_v<T, std::monostate>)


### PR DESCRIPTION
Appendum for #3494 
This PR will allow you to get variadic number of arguments via ArgumentParser.

Example:
```cpp
std::string SomeFunctionDefs::FunctionName(std::string arg1, LuaVarArgs args)
{
    DoSomethingWith(args.value_or(CLuaArguments())); // default args
}
```
`LuaVarArgs` is an alias to `std::optional<CLuaArguments>`.