### PR TITLE
Fix #2936 Toggling car lights makes windows invisible when viewed from inside

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1571,6 +1571,9 @@ void CMultiplayerSA::InitHooks()
     // Allow switch weapon during jetpack task (#3569)
     MemSetFast((void*)0x60D86F, 0x90, 19);
 
+    // Fix invisible vehicle windows when lights are on (#2936)
+    MemPut<BYTE>(0x6E1425, 0);
+
     InitHooks_CrashFixHacks();
 
     // Init our 1.3 hooks.


### PR DESCRIPTION
Fixed #2936
![image](https://github.com/user-attachments/assets/6a01e4c9-b762-4a3e-9f3a-169ef8d94b47)
