### PR TITLE
Fix #3588 Transparent Vehicles when turning lights ON & #1391 Backface culling occurs when vehicle light state is on

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1571,6 +1571,9 @@ void CMultiplayerSA::InitHooks()
     // Allow switch weapon during jetpack task (#3569)
     MemSetFast((void*)0x60D86F, 0x90, 19);
 
+    // Fix invisible vehicle windows when lights are on (#2936)
+    MemPut<BYTE>(0x6E1425, 0);
+
     InitHooks_CrashFixHacks();
 
     // Init our 1.3 hooks.

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1572,7 +1572,7 @@ void CMultiplayerSA::InitHooks()
     MemSetFast((void*)0x60D86F, 0x90, 19);
 
     // Fix invisible vehicle windows when lights are on (#2936)
-    MemPut<BYTE>(0x6E1425, 0);
+    MemPut<BYTE>(0x6E1425, 1);
 
     InitHooks_CrashFixHacks();
 


### PR DESCRIPTION
Fixed #3588 & #1391 

I made a mistake, it should be 1 and not 0, according to
```cpp
enum RwCullMode
{
    rwCULLMODENACULLMODE = 0,

    rwCULLMODECULLNONE, 
        /**<Both front and back-facing triangles are drawn. */
    rwCULLMODECULLBACK, 
        /**<Only front-facing triangles are drawn */
    rwCULLMODECULLFRONT,
        /**<Only back-facing triangles are drawn */

    rwCULLMODEFORCEENUMSIZEINT = RWFORCEENUMSIZEINT
};
```