### PR TITLE
Make frame graph scale accordingly to resolution.

### DIFF
--- a/Client/core/CChat.cpp
+++ b/Client/core/CChat.cpp
@@ -1117,7 +1117,7 @@ void CChat::SetCharacterLimit(int charLimit)
     m_iCharacterLimit = charLimit;
 }
 
-float CChat::GetChatBottomPosition()
+float CChat::GetChatBottomPosition() const noexcept
 {
     return m_vecBackgroundSize.fY;
 }

--- a/Client/core/CChat.cpp
+++ b/Client/core/CChat.cpp
@@ -1117,6 +1117,11 @@ void CChat::SetCharacterLimit(int charLimit)
     m_iCharacterLimit = charLimit;
 }
 
+float CChat::GetChatBottomPosition()
+{
+    return m_vecBackgroundSize.fY;
+}
+
 CChatLine::CChatLine()
 {
     m_bActive = false;

--- a/Client/core/CChat.h
+++ b/Client/core/CChat.h
@@ -207,6 +207,8 @@ public:
     constexpr int GetDefaultCharacterLimit() const { return m_iDefaultCharacterLimit; }
     constexpr int GetMaxCharacterLimit() const { return m_iMaxCharacterLimit; }
 
+    float GetChatBottomPosition();
+
 private:
     void LoadCVars();
 

--- a/Client/core/CChat.h
+++ b/Client/core/CChat.h
@@ -207,7 +207,7 @@ public:
     constexpr int GetDefaultCharacterLimit() const { return m_iDefaultCharacterLimit; }
     constexpr int GetMaxCharacterLimit() const { return m_iMaxCharacterLimit; }
 
-    float GetChatBottomPosition();
+    float GetChatBottomPosition() const noexcept;
 
 private:
     void LoadCVars();

--- a/Client/core/CGUI.cpp
+++ b/Client/core/CGUI.cpp
@@ -449,7 +449,7 @@ CChat* CLocalGUI::GetChat()
     return m_pChat;
 }
 
-float CLocalGUI::GetChatBottomPosition()
+float CLocalGUI::GetChatBottomPosition() const noexcept
 {
     return m_pChat->GetChatBottomPosition();
 }

--- a/Client/core/CGUI.cpp
+++ b/Client/core/CGUI.cpp
@@ -449,6 +449,11 @@ CChat* CLocalGUI::GetChat()
     return m_pChat;
 }
 
+float CLocalGUI::GetChatBottomPosition()
+{
+    return m_pChat->GetChatBottomPosition();
+}
+
 CDebugView* CLocalGUI::GetDebugView()
 {
     return m_pDebugView;

--- a/Client/core/CGUI.h
+++ b/Client/core/CGUI.h
@@ -68,6 +68,7 @@ public:
     bool       IsMainMenuVisible();
 
     CChat* GetChat();
+    float  GetChatBottomPosition();
     void   SetChatBoxVisible(bool bVisible, bool bInputBlocked = true);
     bool   IsChatBoxVisible();
     bool   IsChatBoxInputBlocked();

--- a/Client/core/CGUI.h
+++ b/Client/core/CGUI.h
@@ -68,7 +68,7 @@ public:
     bool       IsMainMenuVisible();
 
     CChat* GetChat();
-    float  GetChatBottomPosition();
+    float  GetChatBottomPosition() const noexcept;
     void   SetChatBoxVisible(bool bVisible, bool bInputBlocked = true);
     bool   IsChatBoxVisible();
     bool   IsChatBoxInputBlocked();

--- a/Client/core/CGraphStats.cpp
+++ b/Client/core/CGraphStats.cpp
@@ -113,8 +113,8 @@ void CGraphStats::AddTimingPoint(const char* szName)
 
     CGraphicsInterface* pGraphics = g_pCore->GetGraphics();
 
-    uint uiViewportWidth = pGraphics->GetViewportWidth();
-    uint uiSizeX = uiViewportWidth / 4;
+    std::uint32_t viewportWidth = pGraphics->GetViewportWidth();
+    std::uint32_t sizeX = viewportWidth / 4;
 
     // Start of next frame?
     if (szName[0] == 0)
@@ -136,7 +136,7 @@ void CGraphStats::AddTimingPoint(const char* szName)
                 for (int i = 0; i < Dups; i++)
                 {
                     pLine->iDataPos++;
-                    if (pLine->iDataPos > uiSizeX - 1)
+                    if (pLine->iDataPos > sizeX - 1)
                         pLine->iDataPos = 0;
                     pLine->dataHistory[pLine->iDataPos] = Data;
                 }
@@ -156,7 +156,7 @@ void CGraphStats::AddTimingPoint(const char* szName)
         // Add new line
         MapSet(m_LineList, szName, SGraphStatLine());
         pLine = MapFind(m_LineList, szName);
-        pLine->dataHistory.resize(uiSizeX);
+        pLine->dataHistory.resize(sizeX);
         memset(&pLine->dataHistory[0], 0, pLine->dataHistory.size());
         pLine->iDataPos = 0;
         pLine->prevData = 0;
@@ -182,7 +182,7 @@ void CGraphStats::AddTimingPoint(const char* szName)
 
     // Inc position
     pLine->iDataPos++;
-    if (pLine->iDataPos > uiSizeX - 1)
+    if (pLine->iDataPos > sizeX - 1)
         pLine->iDataPos = 0;
 
     // Insert data point

--- a/Client/core/CGraphStats.cpp
+++ b/Client/core/CGraphStats.cpp
@@ -12,8 +12,6 @@
 
 namespace
 {
-    #define GRAPHSTAT_HISTORY_SIZE 256
-
     struct SGraphStatLine
     {
         TIMEUS              prevData;
@@ -113,6 +111,11 @@ void CGraphStats::AddTimingPoint(const char* szName)
     if (!IsEnabled())
         return;
 
+    CGraphicsInterface* pGraphics = g_pCore->GetGraphics();
+
+    uint uiViewportWidth = pGraphics->GetViewportWidth();
+    uint uiSizeX = uiViewportWidth / 4;
+
     // Start of next frame?
     if (szName[0] == 0)
     {
@@ -133,7 +136,7 @@ void CGraphStats::AddTimingPoint(const char* szName)
                 for (int i = 0; i < Dups; i++)
                 {
                     pLine->iDataPos++;
-                    if (pLine->iDataPos > GRAPHSTAT_HISTORY_SIZE - 1)
+                    if (pLine->iDataPos > uiSizeX - 1)
                         pLine->iDataPos = 0;
                     pLine->dataHistory[pLine->iDataPos] = Data;
                 }
@@ -153,7 +156,7 @@ void CGraphStats::AddTimingPoint(const char* szName)
         // Add new line
         MapSet(m_LineList, szName, SGraphStatLine());
         pLine = MapFind(m_LineList, szName);
-        pLine->dataHistory.resize(GRAPHSTAT_HISTORY_SIZE);
+        pLine->dataHistory.resize(uiSizeX);
         memset(&pLine->dataHistory[0], 0, pLine->dataHistory.size());
         pLine->iDataPos = 0;
         pLine->prevData = 0;
@@ -179,7 +182,7 @@ void CGraphStats::AddTimingPoint(const char* szName)
 
     // Inc position
     pLine->iDataPos++;
-    if (pLine->iDataPos > GRAPHSTAT_HISTORY_SIZE - 1)
+    if (pLine->iDataPos > uiSizeX - 1)
         pLine->iDataPos = 0;
 
     // Insert data point
@@ -200,11 +203,12 @@ void CGraphStats::Draw()
 
     CGraphicsInterface* pGraphics = g_pCore->GetGraphics();
 
+    uint  uiViewportWidth = pGraphics->GetViewportWidth();
     uint  uiViewportHeight = pGraphics->GetViewportHeight();
     uint  uiOriginX = 10;
-    uint  uiOriginY = std::min<int>(500, uiViewportHeight - 10);
-    uint  uiSizeX = GRAPHSTAT_HISTORY_SIZE;
-    uint  uiSizeY = 150;
+    uint  uiOriginY = uiViewportHeight / 2;
+    uint  uiSizeX = uiViewportWidth / 4;
+    uint  uiSizeY = uiViewportHeight / 4;
     uint  uiRangeY = 100;            // 100ms
     float fLineScale = 1 / 1000.f / uiRangeY * uiSizeY;
     float fLineHeight = pGraphics->GetDXFontHeight();
@@ -229,7 +233,7 @@ void CGraphStats::Draw()
             iDataPosPrev = iDataPos;
             iDataPos--;
             if (iDataPos == -1)
-                iDataPos = GRAPHSTAT_HISTORY_SIZE - 1;
+                iDataPos = uiSizeX - 1;
 
             pGraphics->DrawLineQueued(uiOriginX + i - 1, uiOriginY - fY0, uiOriginX + i, uiOriginY - fY1, 1, line.color, true);
 

--- a/Client/core/CGraphStats.cpp
+++ b/Client/core/CGraphStats.cpp
@@ -114,7 +114,7 @@ void CGraphStats::AddTimingPoint(const char* szName)
     CGraphicsInterface* pGraphics = g_pCore->GetGraphics();
 
     std::uint32_t viewportWidth = pGraphics->GetViewportWidth();
-    std::uint32_t sizeX = viewportWidth / 4;
+    std::uint32_t sizeX = viewportWidth / 4; // one quarter of screen width
 
     // Start of next frame?
     if (szName[0] == 0)
@@ -202,14 +202,18 @@ void CGraphStats::Draw()
         return;
 
     CGraphicsInterface* pGraphics = g_pCore->GetGraphics();
+    CLocalGUI*          pLocalGUI = g_pCore->GetLocalGUI();
 
-    uint  uiViewportWidth = pGraphics->GetViewportWidth();
-    uint  uiViewportHeight = pGraphics->GetViewportHeight();
-    uint  uiOriginX = 10;
-    uint  uiOriginY = uiViewportHeight / 2;
-    uint  uiSizeX = uiViewportWidth / 4;
-    uint  uiSizeY = uiViewportHeight / 4;
-    uint  uiRangeY = 100;            // 100ms
+    uint  uiViewportWidth = pGraphics->GetViewportWidth();      // get width of current resolution
+    uint  uiViewportHeight = pGraphics->GetViewportHeight();    // get height of current resolution
+    uint  uiOriginX = 10;                                       // offset the graph by 10 pixels from left side of screen
+    uint  uiOriginY = pLocalGUI->GetChatBottomPosition();       // get chat bottom screen position
+    uint  uiSizeX = uiViewportWidth / 4;                        // set the width of graph to 1/4 of current resolution
+    uint  uiSizeY = uiViewportHeight / 4;                       // set the height of graph to 1/4 of current resolution
+    uint  uiRangeY = 100;                                       // 100ms
+
+    uiOriginY = uiOriginY + uiSizeY + 30;                       // add graph height plus a little gap to the overall Y position
+
     float fLineScale = 1 / 1000.f / uiRangeY * uiSizeY;
     float fLineHeight = pGraphics->GetDXFontHeight();
 

--- a/Client/core/CGraphStats.cpp
+++ b/Client/core/CGraphStats.cpp
@@ -204,32 +204,32 @@ void CGraphStats::Draw()
     CGraphicsInterface* pGraphics = g_pCore->GetGraphics();
     CLocalGUI*          pLocalGUI = g_pCore->GetLocalGUI();
 
-    uint  uiViewportWidth = pGraphics->GetViewportWidth();      // get width of current resolution
-    uint  uiViewportHeight = pGraphics->GetViewportHeight();    // get height of current resolution
-    uint  uiOriginX = 10;                                       // offset the graph by 10 pixels from left side of screen
-    uint  uiOriginY = pLocalGUI->GetChatBottomPosition();       // get chat bottom screen position
-    uint  uiSizeX = uiViewportWidth / 4;                        // set the width of graph to 1/4 of current resolution
-    uint  uiSizeY = uiViewportHeight / 4;                       // set the height of graph to 1/4 of current resolution
-    uint  uiRangeY = 100;                                       // 100ms
+    std::uint32_t viewportWidth = pGraphics->GetViewportWidth();    // get width of current resolution
+    std::uint32_t viewportHeight = pGraphics->GetViewportHeight();  // get height of current resolution
+    std::uint32_t originX = 10;                                     // offset the graph by 10 pixels from left side of screen
+    std::uint32_t originY = pLocalGUI->GetChatBottomPosition();     // get chat bottom screen position
+    std::uint32_t sizeX = viewportWidth / 4;                        // set the width of graph to 1/4 of current resolution
+    std::uint32_t sizeY = viewportHeight / 4;                       // set the height of graph to 1/4 of current resolution
+    std::uint32_t rangeY = 100;                                     // 100ms
 
-    uiOriginY = uiOriginY + uiSizeY + 30;                       // add graph height plus a little gap to the overall Y position
+    originY = originY + sizeY + 30;  // add graph height plus a little gap to the overall Y position
 
-    float fLineScale = 1 / 1000.f / uiRangeY * uiSizeY;
+    float fLineScale = 1 / 1000.f / rangeY * sizeY;
     float fLineHeight = pGraphics->GetDXFontHeight();
 
     // Backgroung box
-    pGraphics->DrawRectQueued(uiOriginX, uiOriginY - uiSizeY, uiSizeX, uiSizeY, SColorRGBA(0, 0, 0, 128), true);
+    pGraphics->DrawRectQueued(originX, originY - sizeY, sizeX, sizeY, SColorRGBA(0, 0, 0, 128), true);
 
     // Draw data lines
-    float fLabelX = uiOriginX + uiSizeX + 22;
-    float fLabelY = uiOriginY - m_LineList.size() * fLineHeight;
+    float fLabelX = originX + sizeX + 22;
+    float fLabelY = originY - m_LineList.size() * fLineHeight;
     for (const auto& dataLine : m_LineList)
     {
         const SGraphStatLine& line = dataLine.second;
         int                   iDataPos = line.iDataPos;
         int                   iDataPosPrev = iDataPos;
 
-        for (int i = uiSizeX - 1; i > 0; i--)
+        for (int i = sizeX - 1; i > 0; i--)
         {
             float fY0 = line.dataHistory[iDataPos] * fLineScale;
             float fY1 = line.dataHistory[iDataPosPrev] * fLineScale;
@@ -237,14 +237,14 @@ void CGraphStats::Draw()
             iDataPosPrev = iDataPos;
             iDataPos--;
             if (iDataPos == -1)
-                iDataPos = uiSizeX - 1;
+                iDataPos = sizeX - 1;
 
-            pGraphics->DrawLineQueued(uiOriginX + i - 1, uiOriginY - fY0, uiOriginX + i, uiOriginY - fY1, 1, line.color, true);
+            pGraphics->DrawLineQueued(originX + i - 1, originY - fY0, originX + i, originY - fY1, 1, line.color, true);
 
-            if (i == uiSizeX - 1)
+            if (i == sizeX - 1)
             {
                 // Line from graph to label
-                pGraphics->DrawLineQueued(uiOriginX + i - 1, uiOriginY - fY0, fLabelX - 2, fLabelY + fLineHeight / 2, 1, line.color, true);
+                pGraphics->DrawLineQueued(originX + i - 1, originY - fY0, fLabelX - 2, fLabelY + fLineHeight / 2, 1, line.color, true);
             }
         }
 


### PR DESCRIPTION
Instead of hardcoding pixels to draw the frame graph, use screen resolution to adapt for dynamic sizes.
