### PR TITLE
Remove unnecessary argument in engineRestreamWorld

### DIFF
--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -5589,7 +5589,7 @@ void CClientGame::ResetMapInfo()
     if (pPlayerInfo)
         pPlayerInfo->SetCamDrunkLevel(static_cast<byte>(0));
 
-    RestreamWorld(true);
+    RestreamWorld();
 
     ReinitMarkers();
 }
@@ -6812,7 +6812,7 @@ void CClientGame::RestreamModel(unsigned short usModel)
             m_pManager->GetVehicleManager()->RestreamVehicleUpgrades(usModel);
 }
 
-void CClientGame::RestreamWorld(bool removeBigBuildings)
+void CClientGame::RestreamWorld()
 {
     unsigned int numberOfFileIDs = g_pGame->GetCountOfAllFileIDs();
 
@@ -6825,9 +6825,7 @@ void CClientGame::RestreamWorld(bool removeBigBuildings)
     m_pManager->GetPedManager()->RestreamAllPeds();
     m_pManager->GetPickupManager()->RestreamAllPickups();
 
-    if (removeBigBuildings)
-        g_pGame->GetStreaming()->RemoveBigBuildings();
-
+    g_pGame->GetStreaming()->RemoveBigBuildings();
     g_pGame->GetStreaming()->ReinitStreaming();
 }
 

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -441,7 +441,7 @@ public:
 
     bool TriggerBrowserRequestResultEvent(const std::unordered_set<SString>& newPages);
     void RestreamModel(unsigned short usModel);
-    void RestreamWorld(bool removeBigBuildings);
+    void RestreamWorld();
     void ReinitMarkers();
 
     void OnWindowFocusChange(bool state);

--- a/Client/mods/deathmatch/logic/CClientIMG.cpp
+++ b/Client/mods/deathmatch/logic/CClientIMG.cpp
@@ -191,7 +191,7 @@ bool CClientIMG::StreamDisable()
 
     m_pImgManager->UpdateStreamerBufferSize();
 
-    g_pClientGame->RestreamWorld(true);
+    g_pClientGame->RestreamWorld();
     return true;
 }
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -2428,14 +2428,9 @@ bool CLuaEngineDefs::EngineResetModelFlags(uint uiModelID)
     return false;
 }
 
-bool CLuaEngineDefs::EngineRestreamWorld(lua_State* const luaVM)
+bool CLuaEngineDefs::EngineRestreamWorld()
 {
-    bool restreamLODs{};
-
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadBool(restreamLODs, false);
-
-    g_pClientGame->RestreamWorld(restreamLODs);
+    g_pClientGame->RestreamWorld();
     return true;
 }
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
@@ -76,7 +76,7 @@ public:
     static bool                                            EngineRestoreTXDImage(uint uiModelID);
     static std::vector<std::string_view>                   EngineImageGetFileList(CClientIMG* pImg);
     static std::string                                     EngineImageGetFile(CClientIMG* pImg, std::variant<size_t, std::string_view> file);
-    static bool                                            EngineRestreamWorld(lua_State* const luaVM);
+    static bool                                            EngineRestreamWorld();
     static bool                                            EngineSetModelVisibleTime(std::string strModelId, char cHourOn, char cHourOff);
     static std::variant<bool, CLuaMultiReturn<char, char>> EngineGetModelVisibleTime(std::string strModelId);
 


### PR DESCRIPTION
This PR removes `includeLODs` argument from `engineRestreamWorld`. Now `includeLODs` is false by default and it's always true in this PR.
1. This argument has very limited usage. It's better to use `engineRestreamWorld( true )` always
2. By default `engineRestreamWorld` reloads some LOD's. So `includeLODs` argument is frustrating.
3. This function doesn't use arguments for vehicles / peds / world models. So this argument is odd.
4. `engineRestreamWorld` uses old argument parser and new argument parser together.