### PR TITLE
Make engineRestreamWorld more aggressive

### DIFF
--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -1053,6 +1053,21 @@ bool CGameSA::SetBuildingPoolSize(size_t size)
     return status;
 }
 
+void CGameSA::UnloadUnusedModels()
+{
+    for (size_t id = 0; id < GetBaseIDforCOL(); id++)
+    {
+        CStreamingInfo* streamingInfo = m_pStreaming->GetStreamingInfo(id);
+        if (streamingInfo->loadState != 0 && streamingInfo->sizeInBlocks > 0)
+        {
+            if (ModelInfo[id].GetRefCount() == 0)
+            {
+                m_pStreaming->RemoveModel(id);
+            }
+        };
+    }
+}
+
 // Ensure models have the default lod distances
 void CGameSA::ResetModelLodDistances()
 {

--- a/Client/game_sa/CGameSA.h
+++ b/Client/game_sa/CGameSA.h
@@ -308,6 +308,8 @@ public:
 
     bool SetBuildingPoolSize(size_t size);
 
+    void UnloadUnusedModels();
+
 private:
     CPools*                         m_pPools;
     CPlayerInfo*                    m_pPlayerInfo;

--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -1067,11 +1067,6 @@ void CModelInfoSA::ModelAddRef(EModelRequestType requestType, const char* szTag)
     m_dwReferences++;
 }
 
-int CModelInfoSA::GetRefCount()
-{
-    return static_cast<int>(m_dwReferences);
-}
-
 void CModelInfoSA::RemoveRef(bool bRemoveExtraGTARef)
 {
     // Decrement the references

--- a/Client/game_sa/CModelInfoSA.h
+++ b/Client/game_sa/CModelInfoSA.h
@@ -396,7 +396,7 @@ public:
     static void StaticResetAlphaTransparencies();
 
     void ModelAddRef(EModelRequestType requestType, const char* szTag);
-    int  GetRefCount();
+    int  GetRefCount() const override { return static_cast<int>(m_dwReferences); };
     void RemoveRef(bool bRemoveExtraGTARef = false);
     bool ForceUnload();
 

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -6829,6 +6829,8 @@ void CClientGame::RestreamWorld(bool removeBigBuildings)
         g_pGame->GetStreaming()->RemoveBigBuildings();
 
     g_pGame->GetStreaming()->ReinitStreaming();
+
+    g_pGame->UnloadUnusedModels();
 }
 
 void CClientGame::ReinitMarkers()

--- a/Client/sdk/game/CGame.h
+++ b/Client/sdk/game/CGame.h
@@ -273,4 +273,5 @@ public:
 
     virtual bool SetBuildingPoolSize(size_t size) = 0;
 
+    virtual void UnloadUnusedModels() = 0;
 };

--- a/Client/sdk/game/CModelInfo.h
+++ b/Client/sdk/game/CModelInfo.h
@@ -177,7 +177,7 @@ public:
 
     virtual void ModelAddRef(EModelRequestType requestType, const char* szTag /* = NULL*/) = 0;
     virtual void RemoveRef(bool bRemoveExtraGTARef = false) = 0;
-    virtual int  GetRefCount() = 0;
+    virtual int  GetRefCount() const = 0;
     virtual bool ForceUnload() = 0;
     virtual void DeallocateModel() = 0;
 


### PR DESCRIPTION
Fixes some cases when GTA doesn't unload unused models and textures.
Can be related to #3162 and #3032