### PR TITLE
Deprecate setHelicopterRotorSpeed

### DIFF
--- a/Server/mods/deathmatch/logic/CResourceChecker.Data.h
+++ b/Server/mods/deathmatch/logic/CResourceChecker.Data.h
@@ -168,7 +168,9 @@ namespace
 
         // Base Encoding & Decoding
         {false, "base64Encode", "encodeString"},
-        {false, "base64Decode", "decodeString"}
+        {false, "base64Decode", "decodeString"},
+
+        {false, "setHelicopterRotorSpeed", "setVehicleRotorSpeed"}
     };
 
     SDeprecatedItem serverDeprecatedList[] = {


### PR DESCRIPTION
Deprecate ``setHelicopterRotorSpeed`` in favor of ``setVehicleRotorSpeed``