### PR TITLE
Fix inconsistent extra component names

### DIFF
--- a/Client/game_sa/CPoolsSA.cpp
+++ b/Client/game_sa/CPoolsSA.cpp
@@ -128,6 +128,8 @@ CVehicle* CPoolsSA::AddVehicle(CClientVehicle* pClientVehicle, eVehicleTypes eVe
         {
             pVehicle->m_ucVariant = ucVariation;
             pVehicle->m_ucVariant2 = ucVariation2;
+
+            pVehicle->DumpVehicleFrames();
         }
         else
         {

--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -1953,7 +1953,7 @@ void CVehicleSA::AddComponent(RwFrame* pFrame, bool bReadOnly)
     if (strName == "")
     {
         // In MTA variant 255 means no variant
-        if (m_ucVariantCount == 0 && m_ucVariant == 255 || m_ucVariantCount == 1 && m_ucVariant2 == 255)
+        if ((m_ucVariantCount == 0 && m_ucVariant == 255) || (m_ucVariantCount == 1 && m_ucVariant2 == 255))
             return;
 
         // name starts with extra

--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -186,12 +186,6 @@ void CVehicleSA::Init()
     }
 
     CopyGlobalSuspensionLinesToPrivate();
-
-    // clear our rw frames list
-    m_ExtraFrames.clear();
-    // dump the frames
-    VehicleDump(this);
-    FinalizeFramesList();
 }
 
 CVehicleSA::~CVehicleSA()
@@ -1949,6 +1943,7 @@ void CVehicleSA::AddComponent(RwFrame* pFrame, bool bReadOnly)
     // if the frame is invalid we don't want to be here
     if (!pFrame)
         return;
+
     // if the frame already exists ignore it
     if (IsComponentPresent(pFrame->szName) || pFrame->szName == "")
         return;
@@ -1957,23 +1952,22 @@ void CVehicleSA::AddComponent(RwFrame* pFrame, bool bReadOnly)
     // variants have no name field.
     if (strName == "")
     {
+        // In MTA variant 255 means no variant
+        if (m_ucVariantCount == 0 && m_ucVariant == 255 || m_ucVariantCount == 1 && m_ucVariant2 == 255)
+            return;
+
         // name starts with extra
         strName = "extra_";
-        if (m_ucVariantCount == 0)
-        {
-            // variants are extra_a, extra_b and so on
-            strName += ('a' - 1) + m_ucVariant;
-        }
-        if (m_ucVariantCount == 1)
-        {
-            // variants are extra_a, extra_b and so on
-            strName += ('a' - 1) + m_ucVariant2;
-        }
+
+        // variants are extra_a - extra_f
+        strName += 'a' + (m_ucVariantCount == 0 ? m_ucVariant : m_ucVariant2);
+
         // increment the variant count ( we assume that the first variant created is variant1 and the second is variant2 )
         m_ucVariantCount++;
     }
-    SVehicleFrame frame = SVehicleFrame(pFrame, bReadOnly);
+
     // insert our new frame
+    SVehicleFrame frame = SVehicleFrame(pFrame, bReadOnly);
     m_ExtraFrames.insert(std::pair<SString, SVehicleFrame>(strName, frame));
 }
 
@@ -1999,6 +1993,16 @@ void CVehicleSA::FinalizeFramesList()
             }
         }
     }
+}
+
+void CVehicleSA::DumpVehicleFrames()
+{
+    // clear our rw frames list
+    m_ExtraFrames.clear();
+
+    // dump the frames
+    VehicleDump(this);
+    FinalizeFramesList();
 }
 
 bool CVehicleSA::SetComponentVisible(const SString& vehicleComponent, bool bRequestVisible)

--- a/Client/game_sa/CVehicleSA.h
+++ b/Client/game_sa/CVehicleSA.h
@@ -687,4 +687,5 @@ private:
     void           CopyGlobalSuspensionLinesToPrivate();
     SVehicleFrame* GetVehicleComponent(const SString& vehicleComponent);
     void           FinalizeFramesList();
+    void           DumpVehicleFrames();
 };


### PR DESCRIPTION
Often when a vehicle has variants (extra components), their names are incorrect, such as ``'extra_`'`` or other strange characters

![image](https://github.com/user-attachments/assets/546e5fe0-84b4-46af-826f-da29fbfa678d)
![image](https://github.com/user-attachments/assets/37750540-381c-4a3b-beab-aa575425f838)

According to the specifications, they should be named extra_a, extra_b, and so on, up to extra_f.

The issue arises because the values of the current variant in the ``CPoolsSA::AddVehicle`` function are set after ``CVehicleSA::Init`` has already been called, which also triggers ``VehicleDump``. At the time this function is called, the variant values are incorrect, often random due to their type. This PR fixes the issue, restoring the correct behavior and proper names for the extra components, from extra_a to extra_f.

![image](https://github.com/user-attachments/assets/0a9fc13f-7895-4f72-a3e7-6122e5367e83)

