### PR TITLE
Add enginePreloadWorldArea function for preloading areas

### DIFF
--- a/Client/game_sa/CStreamingSA.cpp
+++ b/Client/game_sa/CStreamingSA.cpp
@@ -504,14 +504,14 @@ void CStreamingSA::RemoveBigBuildings()
     (reinterpret_cast<void(__cdecl*)()>(0x4093B0))();
 }
 
-void CStreamingSA::LoadScene(CVector* position)
+void CStreamingSA::LoadScene(const CVector* position)
 {
-    auto CStreaming_LoadScene = (void(__cdecl*)(CVector*))FUNC_CStreaming_LoadScene;
+    auto CStreaming_LoadScene = (void(__cdecl*)(const CVector*))FUNC_CStreaming_LoadScene;
     CStreaming_LoadScene(position);
 }
 
-void CStreamingSA::LoadSceneCollision(CVector* position)
+void CStreamingSA::LoadSceneCollision(const CVector* position)
 {
-    auto CStreaming_LoadSceneCollision = (void(__cdecl*)(CVector*))FUNC_CStreaming_LoadSceneCollision;
+    auto CStreaming_LoadSceneCollision = (void(__cdecl*)(const CVector*))FUNC_CStreaming_LoadSceneCollision;
     CStreaming_LoadSceneCollision(position);
 }

--- a/Client/game_sa/CStreamingSA.cpp
+++ b/Client/game_sa/CStreamingSA.cpp
@@ -503,3 +503,15 @@ void CStreamingSA::RemoveBigBuildings()
 {
     (reinterpret_cast<void(__cdecl*)()>(0x4093B0))();
 }
+
+void CStreamingSA::LoadScene(CVector* position)
+{
+    auto CStreaming_LoadScene = (void(__cdecl*)(CVector*))FUNC_CStreaming_LoadScene;
+    CStreaming_LoadScene(position);
+}
+
+void CStreamingSA::LoadSceneCollision(CVector* position)
+{
+    auto CStreaming_LoadSceneCollision = (void(__cdecl*)(CVector*))FUNC_CStreaming_LoadSceneCollision;
+    CStreaming_LoadSceneCollision(position);
+}

--- a/Client/game_sa/CStreamingSA.h
+++ b/Client/game_sa/CStreamingSA.h
@@ -20,6 +20,8 @@
 #define FUNC_LoadAllRequestedModels                  0x40EA10
 #define FUNC_CStreaming__HasVehicleUpgradeLoaded     0x407820
 #define FUNC_CStreaming_RequestSpecialModel          0x409d10
+#define FUNC_CStreaming_LoadScene                    0x40EB70
+#define FUNC_CStreaming_LoadSceneCollision           0x40ED80
 
 struct CArchiveInfo
 {
@@ -76,6 +78,9 @@ public:
 
     void          MakeSpaceFor(std::uint32_t memoryToCleanInBytes) override;
     std::uint32_t GetMemoryUsed() const override;
+
+    void LoadScene(CVector* position);
+    void LoadSceneCollision(CVector* position);
 
 private:
     void AllocateArchive();

--- a/Client/game_sa/CStreamingSA.h
+++ b/Client/game_sa/CStreamingSA.h
@@ -79,8 +79,8 @@ public:
     void          MakeSpaceFor(std::uint32_t memoryToCleanInBytes) override;
     std::uint32_t GetMemoryUsed() const override;
 
-    void LoadScene(CVector* position);
-    void LoadSceneCollision(CVector* position);
+    void LoadScene(const CVector* position);
+    void LoadSceneCollision(const CVector* position);
 
 private:
     void AllocateArchive();

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
@@ -905,7 +905,7 @@ ADD_ENUM(eModelLoadState::LOADSTATE_FINISHING, "finishing")
 IMPLEMENT_ENUM_CLASS_END("model-load-state")
 
 IMPLEMENT_ENUM_CLASS_BEGIN(PreloadAreaOption)
-ADD_ENUM(PreloadAreaOption::WORLD_OBJECTS, "world_objects")
+ADD_ENUM(PreloadAreaOption::MODELS, "models")
 ADD_ENUM(PreloadAreaOption::COLLISIONS, "collisions")
 ADD_ENUM(PreloadAreaOption::ALL, "all")
 IMPLEMENT_ENUM_CLASS_END("preload-area-option")

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
@@ -904,6 +904,12 @@ ADD_ENUM(eModelLoadState::LOADSTATE_READING, "reading")
 ADD_ENUM(eModelLoadState::LOADSTATE_FINISHING, "finishing")
 IMPLEMENT_ENUM_CLASS_END("model-load-state")
 
+IMPLEMENT_ENUM_CLASS_BEGIN(PreloadAreaOption)
+ADD_ENUM(PreloadAreaOption::WORLD_OBJECTS, "world_objects")
+ADD_ENUM(PreloadAreaOption::COLLISIONS, "collisions")
+ADD_ENUM(PreloadAreaOption::ALL, "all")
+IMPLEMENT_ENUM_CLASS_END("preload-area-option")
+
 //
 // CResource from userdata
 //

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
@@ -87,6 +87,7 @@ DECLARE_ENUM_CLASS(eFxParticleSystems);
 DECLARE_ENUM(ePools);
 DECLARE_ENUM(eWorldProperty);
 DECLARE_ENUM_CLASS(eModelLoadState);
+DECLARE_ENUM_CLASS(PreloadAreaOption);
 
 class CRemoteCall;
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -2554,7 +2554,7 @@ void CLuaEngineDefs::EnginePreloadWorldArea(PreloadAreaOption option, CVector po
     switch (option)
     {
         case PreloadAreaOption::ALL:
-        case PreloadAreaOption::WORLD_OBJECTS:
+        case PreloadAreaOption::MODELS:
             g_pGame->GetStreaming()->LoadScene(&position);
 
             if (option != PreloadAreaOption::ALL)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -145,6 +145,7 @@ void CLuaEngineDefs::LoadFunctions()
         {"engineGetPoolDefaultCapacity", ArgumentParser<EngineGetPoolDefaultCapacity>},
         {"engineGetPoolUsedCapacity", ArgumentParser<EngineGetPoolUsedCapacity>},
         {"engineSetPoolCapacity", ArgumentParser<EngineSetPoolCapacity>},
+        {"enginePreloadWorldArea", ArgumentParser<EnginePreloadWorldArea>},
         
         // CLuaCFunctions::AddFunction ( "engineReplaceMatchingAtomics", EngineReplaceMatchingAtomics );
         // CLuaCFunctions::AddFunction ( "engineReplaceWheelAtomics", EngineReplaceWheelAtomics );
@@ -2546,4 +2547,24 @@ eModelLoadState CLuaEngineDefs::EngineStreamingGetModelLoadState(std::uint16_t m
         throw std::invalid_argument("Expected a valid model ID at argument 1");
 
     return g_pGame->GetStreaming()->GetStreamingInfo(modelId)->loadState;
+}
+
+void CLuaEngineDefs::EnginePreloadWorldArea(PreloadAreaOption option, CVector position)
+{
+    switch (option)
+    {
+        case PreloadAreaOption::ALL:
+        case PreloadAreaOption::WORLD_OBJECTS:
+            g_pGame->GetStreaming()->LoadScene(&position);
+
+            if (option != PreloadAreaOption::ALL)
+            {
+                break;
+            }
+        case PreloadAreaOption::COLLISIONS:
+            g_pGame->GetStreaming()->LoadSceneCollision(&position);
+            break;
+        default:
+            throw std::invalid_argument("Invalid option at argument 1");
+    }
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -2551,7 +2551,8 @@ eModelLoadState CLuaEngineDefs::EngineStreamingGetModelLoadState(std::uint16_t m
 
 void CLuaEngineDefs::EnginePreloadWorldArea(CVector position, std::optional<PreloadAreaOption> option)
 {
-    option = option.value_or(PreloadAreaOption::ALL);
+    if (!option.has_value())
+        option = PreloadAreaOption::ALL;
 
     if (option == PreloadAreaOption::ALL || option == PreloadAreaOption::MODELS)
         g_pGame->GetStreaming()->LoadScene(&position);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -2549,22 +2549,13 @@ eModelLoadState CLuaEngineDefs::EngineStreamingGetModelLoadState(std::uint16_t m
     return g_pGame->GetStreaming()->GetStreamingInfo(modelId)->loadState;
 }
 
-void CLuaEngineDefs::EnginePreloadWorldArea(PreloadAreaOption option, CVector position)
+void CLuaEngineDefs::EnginePreloadWorldArea(CVector position, std::optional<PreloadAreaOption> option)
 {
-    switch (option)
-    {
-        case PreloadAreaOption::ALL:
-        case PreloadAreaOption::MODELS:
-            g_pGame->GetStreaming()->LoadScene(&position);
+    option = option.value_or(PreloadAreaOption::ALL);
 
-            if (option != PreloadAreaOption::ALL)
-            {
-                break;
-            }
-        case PreloadAreaOption::COLLISIONS:
-            g_pGame->GetStreaming()->LoadSceneCollision(&position);
-            break;
-        default:
-            throw std::invalid_argument("Invalid option at argument 1");
-    }
+    if (option == PreloadAreaOption::ALL || option == PreloadAreaOption::MODELS)
+        g_pGame->GetStreaming()->LoadScene(&position);
+
+    if (option == PreloadAreaOption::ALL || option == PreloadAreaOption::COLLISIONS)
+        g_pGame->GetStreaming()->LoadSceneCollision(&position);
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
@@ -92,7 +92,7 @@ public:
     static bool EngineStreamingReleaseModel(lua_State* const luaVM, std::uint16_t modelId, std::optional<bool> removeReference);
     static eModelLoadState EngineStreamingGetModelLoadState(std::uint16_t modelId);
 
-    static void EnginePreloadWorldArea(PreloadAreaOption option, CVector position);
+    static void EnginePreloadWorldArea(CVector position, std::optional<PreloadAreaOption> option);
 
 private:
     static void AddEngineColClass(lua_State* luaVM);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
@@ -92,6 +92,8 @@ public:
     static bool EngineStreamingReleaseModel(lua_State* const luaVM, std::uint16_t modelId, std::optional<bool> removeReference);
     static eModelLoadState EngineStreamingGetModelLoadState(std::uint16_t modelId);
 
+    static void EnginePreloadWorldArea(PreloadAreaOption option, CVector position);
+
 private:
     static void AddEngineColClass(lua_State* luaVM);
     static void AddEngineTxdClass(lua_State* luaVM);

--- a/Client/sdk/game/CStreaming.h
+++ b/Client/sdk/game/CStreaming.h
@@ -37,6 +37,13 @@ enum class eModelLoadState : std::uint32_t
     LOADSTATE_FINISHING = 4
 };
 
+enum class PreloadAreaOption
+{
+    WORLD_OBJECTS = 0,
+    COLLISIONS,
+    ALL
+};
+
 struct CStreamingInfo
 {
     uint16_t prevId = (uint16_t)-1;
@@ -68,4 +75,6 @@ public:
     virtual void   MakeSpaceFor(std::uint32_t memoryToCleanInBytes) = 0;
     virtual std::uint32_t GetMemoryUsed() const = 0;
     virtual void          RemoveBigBuildings() = 0;
+    virtual void          LoadScene(CVector* position) = 0;
+    virtual void          LoadSceneCollision(CVector* position) = 0;
 };

--- a/Client/sdk/game/CStreaming.h
+++ b/Client/sdk/game/CStreaming.h
@@ -39,7 +39,7 @@ enum class eModelLoadState : std::uint32_t
 
 enum class PreloadAreaOption
 {
-    WORLD_OBJECTS = 0,
+    MODELS = 0,
     COLLISIONS,
     ALL
 };

--- a/Client/sdk/game/CStreaming.h
+++ b/Client/sdk/game/CStreaming.h
@@ -75,6 +75,6 @@ public:
     virtual void   MakeSpaceFor(std::uint32_t memoryToCleanInBytes) = 0;
     virtual std::uint32_t GetMemoryUsed() const = 0;
     virtual void          RemoveBigBuildings() = 0;
-    virtual void          LoadScene(CVector* position) = 0;
-    virtual void          LoadSceneCollision(CVector* position) = 0;
+    virtual void          LoadScene(const CVector* position) = 0;
+    virtual void          LoadSceneCollision(const CVector* position) = 0;
 };


### PR DESCRIPTION
Adds a new function **enginePreloadWorldArea**. This function takes in three required parameters, x, y and z for the position and a fourth optional parameter, option, which is a string (or actually an enum in the code) with the following valid values: 

- models (loads the models and their textures of everything in the area, but no collisions)
- collisions (loads all the collisions in the area, but not the models and textures)
- all (does all of the above - default value). 

The game determines the zone the given coordinates are in and loads everything in it. This function is not radius based (as the underlying game functions aren't either).

The game will automatically unload this area based on its own internal rule, often this can already happen the next frame. This functions loads in the area **immediately** so it's advisable to do the desired action, such as teleporting a player/ped/vehicle, or getting the position of the ground in the same frame.

Some use cases:
Load in the area, then retrieve the ground position at the desired location, then teleport the location to that location. The map will already be loaded, and the player is neatly put on the ground.
```lua
enginePreloadWorldArea(1000, 500, 0)   
local z = getGroundPosition(1000, 500, 100)   
setElementPosition(localPlayer, 1000, 500, z)
```  
Load in the area (collisions only), then retrieve the ground position at the desired location and output it.
```lua
enginePreloadWorldArea(1000, 500, 0, "collisions")   
local z = getGroundPosition(1000, 500, 100)   
iprint("The ground position is: "..z)
```  

NOTE: This function has been tested with the building removal functions and is not conflicting with them.