### PR TITLE
onClientTrailerAttach rework

### DIFF
--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -545,6 +545,8 @@ private:
 
     static AnimationId StaticDrivebyAnimationHandler(AnimationId animGroup, AssocGroupId animId);
     static void        StaticAudioZoneRadioSwitchHandler(DWORD dwStationID);
+    static bool        StaticAttachTrailerHandler(CVehicleSAInterface* trailer, CVehicleSAInterface* truckVehicle);
+    static bool        StaticTowVehicleHandler(CVehicleSAInterface* target, CVehicleSAInterface* towtruck);
 
     bool                              DamageHandler(CPed* pDamagePed, CEventDamage* pEvent);
     void                              DeathHandler(CPed* pKilledPed, unsigned char ucDeathReason, unsigned char ucBodyPart);
@@ -585,6 +587,8 @@ private:
     void        TaskSimpleBeHitHandler(CPedSAInterface* pPedAttacker, ePedPieceTypes hitBodyPart, int hitBodySide, int weaponId);
     AnimationId DrivebyAnimationHandler(AnimationId animGroup, AssocGroupId animId);
     void        AudioZoneRadioSwitchHandler(DWORD dwStationID);
+    bool        AttachTrailerHandler(CVehicleSAInterface* trailer, CVehicleSAInterface* truckVehicle);
+    bool        TowVehicleHandler(CVehicleSAInterface* target, CVehicleSAInterface* towtruck);
 
     static bool StaticProcessMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
     bool        ProcessMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -2168,11 +2168,6 @@ void CPacketHandler::Packet_VehicleTrailer(NetBitStreamInterface& bitStream)
                 g_pCore->GetConsole()->Printf("Packet_VehicleTrailer: attaching trailer %d to vehicle %d", TrailerID, ID);
                 #endif
                 pVehicle->SetTowedVehicle(pTrailer);
-
-                // Call the onClientTrailerAttach
-                CLuaArguments Arguments;
-                Arguments.PushElement(pVehicle);
-                pTrailer->CallEvent("onClientTrailerAttach", Arguments, true);
             }
             else
             {

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -144,6 +144,8 @@ public:
     void SetPedStepHandler(PedStepHandler* pHandler);
     void SetVehicleWeaponHitHandler(VehicleWeaponHitHandler* pHandler) override;
     void SetAudioZoneRadioSwitchHandler(AudioZoneRadioSwitchHandler* pHandler);
+    void SetAttachTrailerHandler(AttachTrailerHandler* pHandler) override;
+    void SetTowVehicleHandler(TowVehicleHandler* pHandler) override;
 
     void  AllowMouseMovement(bool bAllow);
     void  DoSoundHacksOnLostFocus(bool bLostFocus);

--- a/Client/sdk/multiplayer/CMultiplayer.h
+++ b/Client/sdk/multiplayer/CMultiplayer.h
@@ -134,6 +134,8 @@ typedef void(FxSystemDestructionHandler)(void* pFxSA);
 typedef AnimationId(DrivebyAnimationHandler)(AnimationId animGroup, AssocGroupId animId);
 typedef void(PedStepHandler)(CPedSAInterface* pPed, bool bFoot);
 typedef void(AudioZoneRadioSwitchHandler)(DWORD dwStationID);
+typedef bool(AttachTrailerHandler)(CVehicleSAInterface* trailer, CVehicleSAInterface* truckVehicle);
+typedef bool(TowVehicleHandler)(CVehicleSAInterface* target, CVehicleSAInterface* towtruck);
 
 using VehicleWeaponHitHandler = void(SVehicleWeaponHitEvent& event);
 
@@ -260,6 +262,8 @@ public:
     virtual void  SetPedStepHandler(PedStepHandler* pHandler) = 0;
     virtual void  SetVehicleWeaponHitHandler(VehicleWeaponHitHandler* pHandler) = 0;
     virtual void  SetAudioZoneRadioSwitchHandler(AudioZoneRadioSwitchHandler* pHandler) = 0;
+    virtual void  SetAttachTrailerHandler(AttachTrailerHandler* pHandler) = 0;
+    virtual void  SetTowVehicleHandler(TowVehicleHandler* pHandler) = 0;
     virtual void  AllowMouseMovement(bool bAllow) = 0;
     virtual void  DoSoundHacksOnLostFocus(bool bLostFocus) = 0;
     virtual bool  HasSkyColor() = 0;


### PR DESCRIPTION
Fixed #2119 and probably #449

Now the ``onClientTrailerAttach`` event is not based on vehicle synchronization but on actual interactions with the trailer. The event can be canceled by preventing the trailer/vehicle from being attached.

I also tried the ``onClientTrailerDetach`` event to be able to cancel it but I encountered two problems

- Weird vehicle physics bugs (fixable)
- Event flood for trucks with trailers when they are in a position that detaches the trailer (in case with cancelEvent)
![Screenshot_8](https://github.com/user-attachments/assets/08a4d9fa-86e1-4449-b81a-c5781c8d4a1c)
