### PR TITLE
Fast fix CModelInfoSA::IsValid

### DIFF
--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -751,6 +751,9 @@ bool CModelInfoSA::IsValid()
     if (!ppModelInfo[m_dwModelID])
         return false;
 
+    if (!IsAllocatedInArchive())
+        return false;
+    
     return true;
 }
 


### PR DESCRIPTION
Without this fix, corrupted models caused errors.