### PR TITLE
Fix getObjectProperty "air_resistance" property

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
@@ -274,7 +274,7 @@ int CLuaObjectDefs::GetObjectProperty(lua_State* luaVM)
                 lua_setfield(luaVM, -2, EnumToString(eObjectProperty::OBJECT_PROPERTY_TURNMASS));
 
                 lua_pushnumber(luaVM, pObject->GetAirResistance());
-                lua_setfield(luaVM, -2, EnumToString(eObjectProperty::OBJECT_PROPERTY_TURNMASS));
+                lua_setfield(luaVM, -2, EnumToString(eObjectProperty::OBJECT_PROPERTY_AIRRESISTANCE));
 
                 lua_pushnumber(luaVM, pObject->GetElasticity());
                 lua_setfield(luaVM, -2, EnumToString(eObjectProperty::OBJECT_PROPERTY_ELASTICITY));


### PR DESCRIPTION
Fixed a minor bug where getObjectProperty does not return air_resistance and returns incorrect turn_mass when "all" is passed as property argument.

![image](https://github.com/user-attachments/assets/45c26be4-2a17-4a7f-a169-eca079fe1ee5)

This PR is part of #3405 