### PR TITLE
Hide 'Limiter' from Frame Graph when not needed

### DIFF
--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -1869,6 +1869,13 @@ void CCore::RecalculateFrameRateLimit(uint uiServerFrameRateLimit, bool bLogToCo
     if ((m_uiFrameRateLimit == 0 || uiClientScriptRate < m_uiFrameRateLimit) && uiClientScriptRate > 0)
         m_uiFrameRateLimit = uiClientScriptRate;
 
+    // Removes Limiter from Frame Graph if limit is zero and skips frame limit
+    if (m_uiFrameRateLimit == 0)
+    {
+        m_bQueuedFrameRateValid = false;
+        GetGraphStats()->RemoveTimingPoint("Limiter");
+    }
+
     // Print new limits to the console
     if (bLogToConsole)
     {

--- a/Client/core/CGraphStats.cpp
+++ b/Client/core/CGraphStats.cpp
@@ -39,6 +39,7 @@ public:
     virtual void SetEnabled(bool bEnabled);
     virtual bool IsEnabled();
     virtual void AddTimingPoint(const char* szName);
+    virtual void RemoveTimingPoint(const char* szName);
 
 protected:
     bool                              m_bEnabled;
@@ -187,6 +188,21 @@ void CGraphStats::AddTimingPoint(const char* szName)
 
     // Insert data point
     pLine->dataHistory[pLine->iDataPos] = AvgData;
+}
+
+///////////////////////////////////////////////////////////////
+//
+// CGraphStats::RemoveTimingPoint
+//
+//
+//
+///////////////////////////////////////////////////////////////
+void CGraphStats::RemoveTimingPoint(const char* szName)
+{
+    if (!IsEnabled() || szName[0] == 0)
+        return;
+
+    MapRemove(m_LineList, szName);
 }
 
 ///////////////////////////////////////////////////////////////

--- a/Client/core/CGraphStats.h
+++ b/Client/core/CGraphStats.h
@@ -23,6 +23,7 @@ public:
     virtual void SetEnabled(bool bEnabled) = 0;
     virtual bool IsEnabled() = 0;
     virtual void AddTimingPoint(const char* szName) = 0;
+    virtual void RemoveTimingPoint(const char* szName) = 0;
 };
 
 CGraphStatsInterface* GetGraphStats();


### PR DESCRIPTION
Automatically removes 'Limiter' from Frame Graph (/showframegraph) when the FPS are unlimited.

This also skips the wait done in `ApplyQueuedFrameRateLimit` if its queued to happen that same frame.

Fixes #3718.