### PR TITLE
Fix CResourceModelStreamer::FullyReleaseModel crash

### DIFF
--- a/Client/mods/deathmatch/logic/CClientModel.cpp
+++ b/Client/mods/deathmatch/logic/CClientModel.cpp
@@ -84,9 +84,6 @@ bool CClientModel::Deallocate()
     if (!m_bAllocatedByUs)
         return false;
 
-    if (m_pParentResource)
-        m_pParentResource->GetResourceModelStreamer()->FullyReleaseModel(m_iModelID);
-
     SetParentResource(nullptr);
 
     CModelInfo* pModelInfo = g_pGame->GetModelInfo(m_iModelID, true);

--- a/Client/mods/deathmatch/logic/CClientModelManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientModelManager.cpp
@@ -49,6 +49,9 @@ bool CClientModelManager::Remove(const std::shared_ptr<CClientModel>& pModel)
     int modelId = pModel->GetModelID();
     if (m_Models[modelId] != nullptr)
     {
+        CResource* perentResource = m_Models[modelId]->GetParentResource();
+        if (perentResource)
+            perentResource->GetResourceModelStreamer()->FullyReleaseModel(modelId);
         m_Models[modelId]->RestoreEntitiesUsingThisModel();
         m_Models[modelId] = nullptr;
         m_modelCount--;

--- a/Client/mods/deathmatch/logic/CClientModelManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientModelManager.cpp
@@ -49,9 +49,9 @@ bool CClientModelManager::Remove(const std::shared_ptr<CClientModel>& pModel)
     int modelId = pModel->GetModelID();
     if (m_Models[modelId] != nullptr)
     {
-        CResource* perentResource = m_Models[modelId]->GetParentResource();
-        if (perentResource)
-            perentResource->GetResourceModelStreamer()->FullyReleaseModel(modelId);
+        CResource* parentResource = m_Models[modelId]->GetParentResource();
+        if (parentResource)
+            parentResource->GetResourceModelStreamer()->FullyReleaseModel(modelId);
         m_Models[modelId]->RestoreEntitiesUsingThisModel();
         m_Models[modelId] = nullptr;
         m_modelCount--;

--- a/Client/mods/deathmatch/logic/CResourceModelStreamer.h
+++ b/Client/mods/deathmatch/logic/CResourceModelStreamer.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <map>
+#include <unordered_map>
 
 class CResourceModelStreamer
 {
@@ -26,5 +26,5 @@ public:
     void FullyReleaseModel(std::uint16_t modelId);
 
 private:
-    std::map<std::uint16_t, std::uint16_t> m_requestedModels;
+    std::unordered_map<std::uint16_t, std::uint16_t> m_requestedModels;
 };

--- a/Client/mods/deathmatch/logic/CResourceModelStreamer.h
+++ b/Client/mods/deathmatch/logic/CResourceModelStreamer.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <unordered_map>
+#include <map>
 
 class CResourceModelStreamer
 {
@@ -26,5 +26,5 @@ public:
     void FullyReleaseModel(std::uint16_t modelId);
 
 private:
-    std::unordered_map<std::uint16_t, std::uint16_t> m_requestedModels;
+    std::map<std::uint16_t, std::uint16_t> m_requestedModels;
 };


### PR DESCRIPTION
Fixes #3710 and https://github.com/multitheftauto/mtasa-resources/issues/551

 CClientModelManager stores a pointer to a deleted CResource object. CClientModel::Deallocate uses dead pointer