### PR TITLE
Fix building crash

### DIFF
--- a/Client/game_sa/CBuildingsPoolSA.cpp
+++ b/Client/game_sa/CBuildingsPoolSA.cpp
@@ -151,8 +151,8 @@ void CBuildingsPoolSA::RemoveAllBuildings()
 
             RemoveBuildingFromWorld(building);
 
-            if (building->Placeable.matrix)
-                ((void(__thiscall*)(void*))0x54F3B0)(building);
+            if (building->HasMatrix())
+                building->RemoveMatrix();
 
             pBuildsingsPool->Release(i);
 

--- a/Client/game_sa/CBuildingsPoolSA.cpp
+++ b/Client/game_sa/CBuildingsPoolSA.cpp
@@ -151,6 +151,9 @@ void CBuildingsPoolSA::RemoveAllBuildings()
 
             RemoveBuildingFromWorld(building);
 
+            if (building->Placeable.matrix)
+                ((void(__thiscall*)(void*))0x54F3B0)(building);
+
             pBuildsingsPool->Release(i);
 
             (*m_pOriginalBuildingsBackup)[i].first = true;

--- a/Client/game_sa/CEntitySA.h
+++ b/Client/game_sa/CEntitySA.h
@@ -243,7 +243,7 @@ public:
         ((vtbl_DeleteRwObject)this->vtbl->DeleteRwObject)(this);
     };
 
-    bool HasMatrix() const noexcept { return Placeable.matrix != nullptr; };
+    bool HasMatrix() const noexcept { return Placeable.matrix != nullptr; }
 
     void RemoveMatrix() { ((void(__thiscall*)(void*))0x54F3B0)(this); }
 };

--- a/Client/game_sa/CEntitySA.h
+++ b/Client/game_sa/CEntitySA.h
@@ -242,6 +242,10 @@ public:
         using vtbl_DeleteRwObject = void(__thiscall*)(CEntitySAInterface * pEntity);
         ((vtbl_DeleteRwObject)this->vtbl->DeleteRwObject)(this);
     };
+
+    bool HasMatrix() const noexcept { return Placeable.matrix != nullptr; };
+
+    void RemoveMatrix() { ((void(__thiscall*)(void*))0x54F3B0)(this); }
 };
 static_assert(sizeof(CEntitySAInterface) == 0x38, "Invalid size for CEntitySAInterface");
 


### PR DESCRIPTION
Fixes crash when `createBuilding` is used with `removeAllGameBuildings`