### PR TITLE
Make objects respawnable by default

### DIFF
--- a/Server/mods/deathmatch/logic/CObject.cpp
+++ b/Server/mods/deathmatch/logic/CObject.cpp
@@ -33,7 +33,7 @@ CObject::CObject(CElement* pParent, CObjectManager* pObjectManager, bool bIsLowL
     m_bIsFrozen = false;
     m_bDoubleSided = false;
     m_bBreakable = false;
-    m_bRespawnable = false;
+    m_bRespawnable = true;
 
     m_bCollisionsEnabled = true;
 


### PR DESCRIPTION
Fixes missing objects and collisions on serverside objects after a player damage them.