### PR TITLE
Fix #3635 meta.xml file path patterns don't work on html files

### DIFF
--- a/Server/mods/deathmatch/logic/CResource.cpp
+++ b/Server/mods/deathmatch/logic/CResource.cpp
@@ -1462,43 +1462,54 @@ bool CResource::ReadIncludedHTML(CXMLNode* pRoot)
 
             if (!strFilename.empty())
             {
-                std::string strFullFilename;
                 ReplaceSlashes(strFilename);
 
-                if (IsFilenameUsed(strFilename, false))
-                {
-                    CLogger::LogPrintf("WARNING: Duplicate html file in resource '%s': '%s'\n", m_strResourceName.c_str(), strFilename.c_str());
-                }
-
-                // Try to find the file
-                if (IsValidFilePath(strFilename.c_str()) && GetFilePath(strFilename.c_str(), strFullFilename))
-                {
-                    // This one is supposed to be default, but there's already a default page
-                    if (bFoundDefault && bIsDefault)
-                    {
-                        CLogger::LogPrintf("Only one html item can be default per resource, ignoring %s in %s\n", strFilename.c_str(),
-                                           m_strResourceName.c_str());
-                        bIsDefault = false;
-                    }
-
-                    // If this is supposed to be default, we've now found our default page
-                    if (bIsDefault)
-                        bFoundDefault = true;
-
-                    // Create a new resource HTML file and add it to the list
-                    auto pResourceFile = new CResourceHTMLItem(this, strFilename.c_str(), strFullFilename.c_str(), &Attributes, bIsDefault, bIsRaw,
-                                                               bIsRestricted, m_bOOPEnabledInMetaXml);
-                    m_ResourceFiles.push_back(pResourceFile);
-
-                    // This is the first HTML file? Remember it
-                    if (!pFirstHTML)
-                        pFirstHTML = pResourceFile;
-                }
-                else
+                if (!IsValidFilePath(strFilename.c_str()))
                 {
                     m_strFailureReason = SString("Couldn't find html %s for resource %s\n", strFilename.c_str(), m_strResourceName.c_str());
                     CLogger::ErrorPrintf(m_strFailureReason);
                     return false;
+                }
+
+                std::vector<std::string> vecFiles = GetFilePaths(strFilename.c_str());
+                if (vecFiles.empty())
+                {
+                    if (glob::has_magic(strFilename))
+                    {
+                        m_ResourceFilesCountPerDir[strFilename] = vecFiles.size();
+                        continue;
+                    }
+
+                    m_strFailureReason = SString("Couldn't find html %s for resource %s\n", strFilename.c_str(), m_strResourceName.c_str());
+                    CLogger::ErrorPrintf(m_strFailureReason);
+                    return false;
+                }
+
+                for (const std::string& strFilePath : vecFiles)
+                {
+                    std::string strFullFilename;
+
+                    if (GetFilePath(strFilePath.c_str(), strFullFilename))
+                    {
+                        // This one is supposed to be default, but there's already a default page
+                        if (bFoundDefault && bIsDefault)
+                        {
+                            CLogger::LogPrintf("Only one html item can be default per resource, ignoring %s in %s\n", strFilename.c_str(), m_strResourceName.c_str());
+                            bIsDefault = false;
+                        }
+
+                        // If this is supposed to be default, we've now found our default page
+                        if (bIsDefault)
+                            bFoundDefault = true;
+
+                        // Create a new resource HTML file and add it to the list
+                        auto pResourceFile = new CResourceHTMLItem(this, strFilename.c_str(), strFullFilename.c_str(), &Attributes, bIsDefault, bIsRaw, bIsRestricted, m_bOOPEnabledInMetaXml);
+                        m_ResourceFiles.push_back(pResourceFile);
+
+                        // This is the first HTML file? Remember it
+                        if (!pFirstHTML)
+                            pFirstHTML = pResourceFile;
+                    }
                 }
             }
             else


### PR DESCRIPTION
Fix #3635 

```xml
	<html src="*.html" />
	<html src="*.png" raw="true" />
```