### PR TITLE
Fix missing states in getPedControlState

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPad.cpp
+++ b/Client/mods/deathmatch/logic/CClientPad.cpp
@@ -336,11 +336,9 @@ bool CClientPad::GetControlState(const char* szName, CControllerState& State, bo
                     return State.LeftShoulder2 == 255;
                     break;            // zoom out
                 case 9:
-                    return false;
-                    break;            // enter_exit
+                    return State.ButtonTriangle == 255; // enter_exit
                 case 10:
-                    return false;
-                    break;            // change_cam
+                    return State.Select == 255; // change_cam
                 case 11:
                     return State.ButtonSquare == 255;
                     break;            // jump
@@ -432,8 +430,7 @@ bool CClientPad::GetControlState(const char* szName, CControllerState& State, bo
                     return State.RightShoulder2 == 255;
                     break;            // look right
                 case 33:
-                    return false;
-                    break;            // look behind
+                    return State.LeftShoulder2 == 255 && State.RightShoulder2 == 255; // look behind
                 case 34:
                     return false;
                     break;            // mouse look


### PR DESCRIPTION
Fix #2327 

This PR fixes the following states:
- change_camera
- enter_exit
- vehicle_look_behind