### PR TITLE
Add new Github types to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug report
 description: Create a report to help us improve
 labels: bug
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature request
 description: Suggest an idea for this project
 labels: enhancement
+type: Feature
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
This PR adds the new "Type" label for future issues, which can already be tested in Github Beta Issues.
https://github.com/orgs/community/discussions/139933