### PR TITLE
Strip server name's spaces from beginning and end

### DIFF
--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -133,6 +133,20 @@ bool CMainConfig::Load()
         return false;
     }
 
+    // Strip spaces from beginning and end of server name
+    size_t snameStart = m_strServerName.find_first_not_of(" ");
+    if (snameStart != std::string::npos)
+    {
+        size_t snameEnd = m_strServerName.find_last_not_of(" ");
+        m_strServerName = m_strServerName.substr(snameStart, snameEnd - snameStart + 1);
+    }
+    else
+    {
+        // The string contains only spaces
+        CLogger::ErrorPrintf("Server name must contain at least one character other than a space\n");
+        return false;
+    }
+
     // Grab the forced server ip(s)
     GetString(m_pRootNode, "serverip", m_strServerIP);
     m_strServerIP = SString(m_strServerIP).Replace(" ", "");

--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -133,17 +133,8 @@ bool CMainConfig::Load()
         return false;
     }
 
-    // Cancel if the server name only contains spaces
-    const std::size_t snameStart = m_strServerName.find_first_not_of(" ");
-    if (snameStart == std::string::npos)
-    {
-        CLogger::ErrorPrintf("Server name must contain at least one character other than a space\n");
-        return false;
-    }
-
     // Strip spaces from beginning and end of server name
-    const std::size_t snameEnd = m_strServerName.find_last_not_of(" ");
-    m_strServerName = m_strServerName.substr(snameStart, snameEnd - snameStart + 1);
+    m_strServerName = SString(m_strServerName).TrimStart(" ").TrimEnd(" ");
 
     // Grab the forced server ip(s)
     GetString(m_pRootNode, "serverip", m_strServerIP);

--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -134,7 +134,7 @@ bool CMainConfig::Load()
     }
 
     // Cancel if the server name only contains spaces
-    const size_t snameStart = m_strServerName.find_first_not_of(" ");
+    const std::size_t snameStart = m_strServerName.find_first_not_of(" ");
     if (snameStart == std::string::npos)
     {
         CLogger::ErrorPrintf("Server name must contain at least one character other than a space\n");
@@ -142,7 +142,7 @@ bool CMainConfig::Load()
     }
 
     // Strip spaces from beginning and end of server name
-    const size_t snameEnd = m_strServerName.find_last_not_of(" ");
+    const std::size_t snameEnd = m_strServerName.find_last_not_of(" ");
     m_strServerName = m_strServerName.substr(snameStart, snameEnd - snameStart + 1);
 
     // Grab the forced server ip(s)

--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -134,10 +134,10 @@ bool CMainConfig::Load()
     }
 
     // Strip spaces from beginning and end of server name
-    size_t snameStart = m_strServerName.find_first_not_of(" ");
+    const size_t snameStart = m_strServerName.find_first_not_of(" ");
     if (snameStart != std::string::npos)
     {
-        size_t snameEnd = m_strServerName.find_last_not_of(" ");
+        const size_t snameEnd = m_strServerName.find_last_not_of(" ");
         m_strServerName = m_strServerName.substr(snameStart, snameEnd - snameStart + 1);
     }
     else

--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -133,19 +133,17 @@ bool CMainConfig::Load()
         return false;
     }
 
-    // Strip spaces from beginning and end of server name
+    // Cancel if the server name only contains spaces
     const size_t snameStart = m_strServerName.find_first_not_of(" ");
-    if (snameStart != std::string::npos)
+    if (snameStart == std::string::npos)
     {
-        const size_t snameEnd = m_strServerName.find_last_not_of(" ");
-        m_strServerName = m_strServerName.substr(snameStart, snameEnd - snameStart + 1);
-    }
-    else
-    {
-        // The string contains only spaces
         CLogger::ErrorPrintf("Server name must contain at least one character other than a space\n");
         return false;
     }
+
+    // Strip spaces from beginning and end of server name
+    const size_t snameEnd = m_strServerName.find_last_not_of(" ");
+    m_strServerName = m_strServerName.substr(snameStart, snameEnd - snameStart + 1);
 
     // Grab the forced server ip(s)
     GetString(m_pRootNode, "serverip", m_strServerIP);


### PR DESCRIPTION
Closes #402

Trims leading and trailing spaces from the server name on config load.

Btw, on the topic of #402, it's not a good idea to add an error if server name doesn't contain an alphanumeric character because some foreign languages might not need them at all.
