### PR TITLE
Add main menu setting for browser GPU rendering

### DIFF
--- a/Client/cefweb/CWebApp.cpp
+++ b/Client/cefweb/CWebApp.cpp
@@ -21,6 +21,16 @@ CefRefPtr<CefResourceHandler> CWebApp::HandleError(const SString& strError, unsi
 
 void CWebApp::OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefCommandLine> command_line)
 {
+    CWebCore* pWebCore = static_cast<CWebCore*>(g_pCore->GetWebCore());
+
+    if (!pWebCore->GetGPUEnabled()) // if GPU is disabled...
+    {
+        command_line->AppendSwitch("disable-gpu-compositing");
+        command_line->AppendSwitch("disable-gpu");
+    }  
+    else if (!pWebCore->GetGPUCompositingEnabled()) // if GPU is enabled, but compositing is disabled...
+        command_line->AppendSwitch("disable-gpu-compositing");
+
     // command_line->AppendSwitch("disable-d3d11");
     command_line->AppendSwitch("enable-begin-frame-scheduling");
 

--- a/Client/cefweb/CWebCore.cpp
+++ b/Client/cefweb/CWebCore.cpp
@@ -874,12 +874,12 @@ void CWebCore::StaticFetchBlacklistFinished(const SHttpDownloadResult& result)
 #endif
 }
 
-bool CWebCore::GetGPUEnabled()
+bool CWebCore::GetGPUEnabled() const noexcept
 {
     return m_bGPUEnabled;
 }
 
-bool CWebCore::GetGPUCompositingEnabled()
+bool CWebCore::GetGPUCompositingEnabled()  const noexcept
 {
     return m_bGPUCompositingEnabled;
 }

--- a/Client/cefweb/CWebCore.cpp
+++ b/Client/cefweb/CWebCore.cpp
@@ -49,10 +49,14 @@ CWebCore::~CWebCore()
     delete m_pXmlConfig;
 }
 
-bool CWebCore::Initialise()
+bool CWebCore::Initialise(bool gpuEnabled, bool gpuCompositingEnabled)
 {
     CefMainArgs        mainArgs;
     void*              sandboxInfo = nullptr;
+
+    m_bGPUEnabled = gpuEnabled;
+    m_bGPUCompositingEnabled = gpuCompositingEnabled;
+
     CefRefPtr<CWebApp> app(new CWebApp);
 
 #ifdef CEF_ENABLE_SANDBOX
@@ -868,4 +872,14 @@ void CWebCore::StaticFetchBlacklistFinished(const SHttpDownloadResult& result)
 #ifdef MTA_DEBUG
     OutputDebugLine("Updated browser blacklist!");
 #endif
+}
+
+bool CWebCore::GetGPUEnabled()
+{
+    return m_bGPUEnabled;
+}
+
+bool CWebCore::GetGPUCompositingEnabled()
+{
+    return m_bGPUCompositingEnabled;
 }

--- a/Client/cefweb/CWebCore.cpp
+++ b/Client/cefweb/CWebCore.cpp
@@ -879,7 +879,7 @@ bool CWebCore::GetGPUEnabled() const noexcept
     return m_bGPUEnabled;
 }
 
-bool CWebCore::GetGPUCompositingEnabled()  const noexcept
+bool CWebCore::GetGPUCompositingEnabled() const noexcept
 {
     return m_bGPUCompositingEnabled;
 }

--- a/Client/cefweb/CWebCore.h
+++ b/Client/cefweb/CWebCore.h
@@ -54,7 +54,7 @@ class CWebCore : public CWebCoreInterface
 public:
     CWebCore();
     ~CWebCore();
-    bool Initialise() override;
+    bool Initialise(bool gpuEnabled, bool gpuCompositingEnabled) override;
 
     CWebViewInterface* CreateWebView(unsigned int uiWidth, unsigned int uiHeight, bool bIsLocal, CWebBrowserItem* pWebBrowserRenderItem, bool bTransparent);
     void               DestroyWebView(CWebViewInterface* pWebViewInterface);
@@ -108,6 +108,9 @@ public:
     static void StaticFetchWhitelistFinished(const SHttpDownloadResult& result);
     static void StaticFetchBlacklistFinished(const SHttpDownloadResult& result);
 
+    bool GetGPUEnabled();
+    bool GetGPUCompositingEnabled();
+
 private:
     typedef std::pair<bool, eWebFilterType> WebFilterPair;
 
@@ -129,4 +132,8 @@ private:
     CXMLFile* m_pXmlConfig;
     int       m_iWhitelistRevision;
     int       m_iBlacklistRevision;
+
+    // Shouldn't be changed after init
+    bool m_bGPUEnabled;
+    bool m_bGPUCompositingEnabled;
 };

--- a/Client/cefweb/CWebCore.h
+++ b/Client/cefweb/CWebCore.h
@@ -108,8 +108,8 @@ public:
     static void StaticFetchWhitelistFinished(const SHttpDownloadResult& result);
     static void StaticFetchBlacklistFinished(const SHttpDownloadResult& result);
 
-    bool GetGPUEnabled();
-    bool GetGPUCompositingEnabled();
+    bool GetGPUEnabled() const noexcept;
+    bool GetGPUCompositingEnabled() const noexcept;
 
 private:
     typedef std::pair<bool, eWebFilterType> WebFilterPair;

--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -358,6 +358,8 @@ void CClientVariables::LoadDefaults()
     DEFAULT("discord_rpc_share_data", false);                                         // Consistent Rich Presence data sharing
     DEFAULT("discord_rpc_share_data_firsttime", false);                               // Display the user data sharing consent dialog box - for the first time
     DEFAULT("_beta_qc_rightclick_command", _S("reconnect"));                          // Command to run when right clicking quick connect (beta - can be removed at any time)
+    DEFAULT("browser_enable_gpu", true);                                              // Enable GPU in CEF? (allows stuff like WebGL to function)
+    DEFAULT("browser_enable_gpu_compositing", true);                                  // Enable GPU compositing in CEF? (required GPU enabled)
 
     if (!Exists("locale"))
     {

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -1155,8 +1155,14 @@ CWebCoreInterface* CCore::GetWebCore()
 {
     if (m_pWebCore == nullptr)
     {
+        bool gpuEnabled;
+        bool gpuCompositingEnabled;
+        auto cvars = g_pCore->GetCVars();
+        cvars->Get("browser_enable_gpu", gpuEnabled);
+        cvars->Get("browser_enable_gpu_compositing", gpuCompositingEnabled);
+
         m_pWebCore = CreateModule<CWebCoreInterface>(m_WebCoreModule, "CefWeb", "cefweb", "InitWebCoreInterface", this);
-        m_pWebCore->Initialise();
+        m_pWebCore->Initialise(gpuEnabled, gpuCompositingEnabled);
     }
     return m_pWebCore;
 }

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -917,6 +917,15 @@ void CSettings::CreateGUI()
     m_pCheckBoxRemoteJavascript->GetPosition(vecTemp);
     m_pCheckBoxRemoteJavascript->AutoSize(NULL, 20.0f);
 
+    m_pCheckBoxBrowserGPUEnabled = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(m_pTabBrowser, _("Enable GPU rendering"), true));
+    m_pCheckBoxBrowserGPUEnabled->SetPosition(CVector2D(vecTemp.fX + 300.0f, vecTemp.fY - 20.0f));
+    m_pCheckBoxBrowserGPUEnabled->AutoSize(NULL, 20.0f);
+
+    m_pCheckBoxBrowserGPUCompositingEnabled =
+        reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(m_pTabBrowser, _("Enable GPU compositing (GPU required)"), true));
+    m_pCheckBoxBrowserGPUCompositingEnabled->SetPosition(CVector2D(vecTemp.fX + 300.0f, vecTemp.fY));
+    m_pCheckBoxBrowserGPUCompositingEnabled->AutoSize(NULL, 20.0f);
+
     m_pLabelBrowserCustomBlacklist = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(m_pTabBrowser, _("Custom blacklist")));
     m_pLabelBrowserCustomBlacklist->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 30.0f));
     m_pLabelBrowserCustomBlacklist->GetPosition(vecTemp);
@@ -3287,6 +3296,10 @@ void CSettings::LoadData()
     m_pCheckBoxRemoteBrowser->SetSelected(bVar);
     CVARS_GET("browser_remote_javascript", bVar);
     m_pCheckBoxRemoteJavascript->SetSelected(bVar);
+    CVARS_GET("browser_enable_gpu", bVar);
+    m_pCheckBoxBrowserGPUEnabled->SetSelected(bVar);
+    CVARS_GET("browser_enable_gpu_compositing", bVar);
+    m_pCheckBoxBrowserGPUCompositingEnabled->SetSelected(bVar);
 
     ReloadBrowserLists();
 }
@@ -3711,6 +3724,20 @@ void CSettings::SaveData()
             bBrowserSettingChanged = true;
     }
 
+    bool bBrowserGPUEnabled = false;
+    CVARS_GET("browser_enable_gpu", bBrowserGPUEnabled);
+
+    bool bBrowserGPUSetting = m_pCheckBoxBrowserGPUEnabled->GetSelected();
+    bool bBrowserGPUSettingChanged = (bBrowserGPUSetting != bBrowserGPUEnabled);
+    CVARS_SET("browser_enable_gpu", bBrowserGPUSetting);
+
+    bool bBrowserGPUCompositingEnabled = false;
+    CVARS_GET("browser_enable_gpu_compositing", bBrowserGPUCompositingEnabled);
+
+    bool bBrowserGPUCompositingSetting = m_pCheckBoxBrowserGPUCompositingEnabled->GetSelected();
+    bool bBrowserGPUCompositingSettingChanged = (bBrowserGPUCompositingSetting != bBrowserGPUCompositingEnabled);
+    CVARS_SET("browser_enable_gpu_compositing", bBrowserGPUCompositingSetting);
+
     // Ensure CVARS ranges ok
     CClientVariables::GetSingleton().ValidateValues();
 
@@ -3720,7 +3747,8 @@ void CSettings::SaveData()
     gameSettings->Save();
 
     // Ask to restart?
-    if (bIsVideoModeChanged || bIsAntiAliasingChanged || bIsCustomizedSAFilesChanged || processsDPIAwareChanged)
+    if (bIsVideoModeChanged || bIsAntiAliasingChanged || bIsCustomizedSAFilesChanged || processsDPIAwareChanged || bBrowserGPUSettingChanged ||
+        bBrowserGPUCompositingSettingChanged)
         ShowRestartQuestion();
     else if (CModManager::GetSingleton().IsLoaded() && bBrowserSettingChanged)
         ShowDisconnectQuestion();

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -920,9 +920,10 @@ void CSettings::CreateGUI()
     m_pCheckBoxBrowserGPUEnabled = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(m_pTabBrowser, _("Enable GPU rendering"), true));
     m_pCheckBoxBrowserGPUEnabled->SetPosition(CVector2D(vecTemp.fX + 300.0f, vecTemp.fY - 20.0f));
     m_pCheckBoxBrowserGPUEnabled->AutoSize(NULL, 20.0f);
+    m_pCheckBoxBrowserGPUEnabled->SetClickHandler(GUI_CALLBACK(&CSettings::OnGPUSettingChanged, this));
 
     m_pCheckBoxBrowserGPUCompositingEnabled =
-        reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(m_pTabBrowser, _("Enable GPU compositing (GPU required)"), true));
+        reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(m_pTabBrowser, _("Enable GPU compositing"), true));
     m_pCheckBoxBrowserGPUCompositingEnabled->SetPosition(CVector2D(vecTemp.fX + 300.0f, vecTemp.fY));
     m_pCheckBoxBrowserGPUCompositingEnabled->AutoSize(NULL, 20.0f);
 
@@ -3298,6 +3299,10 @@ void CSettings::LoadData()
     m_pCheckBoxRemoteJavascript->SetSelected(bVar);
     CVARS_GET("browser_enable_gpu", bVar);
     m_pCheckBoxBrowserGPUEnabled->SetSelected(bVar);
+
+    if (!bVar)
+        m_pCheckBoxBrowserGPUCompositingEnabled->SetEnabled(false);
+
     CVARS_GET("browser_enable_gpu_compositing", bVar);
     m_pCheckBoxBrowserGPUCompositingEnabled->SetSelected(bVar);
 
@@ -4900,4 +4905,10 @@ void CSettings::TabSkip(bool bBackwards)
 bool CSettings::IsActive()
 {
     return m_pWindow->IsActive();
+}
+
+bool CSettings::OnGPUSettingChanged(CGUIElement* pElement)
+{
+    m_pCheckBoxBrowserGPUCompositingEnabled->SetEnabled(m_pCheckBoxBrowserGPUEnabled->GetSelected());
+    return true;
 }

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -384,6 +384,7 @@ protected:
     bool OnBrowserWhitelistRemove(CGUIElement* pElement);
     bool OnBrowserWhitelistDomainAddFocused(CGUIElement* pElement);
     bool OnBrowserWhitelistDomainAddDefocused(CGUIElement* pElement);
+    bool OnGPUSettingChanged(CGUIElement* pElement);
 
     bool OnMouseDoubleClick(CGUIMouseEventArgs Args);
 

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -338,6 +338,8 @@ protected:
     CGUIButton*   m_pButtonBrowserWhitelistAdd;
     CGUIGridList* m_pGridBrowserWhitelist;
     CGUIButton*   m_pButtonBrowserWhitelistRemove;
+    CGUICheckBox* m_pCheckBoxBrowserGPUEnabled;
+    CGUICheckBox* m_pCheckBoxBrowserGPUCompositingEnabled;
     bool          m_bBrowserListsChanged;
     bool          m_bBrowserListsLoadEnabled;
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.cpp
@@ -49,6 +49,7 @@ void CLuaBrowserDefs::LoadFunctions()
         {"resizeBrowser", ResizeBrowser},
         {"guiCreateBrowser", GUICreateBrowser},
         {"guiGetBrowser", GUIGetBrowser},
+        {"isBrowserGPUEnabled", ArgumentParser<IsBrowserGPUEnabled>},
     };
 
     // Add browser functions
@@ -97,6 +98,7 @@ void CLuaBrowserDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "renderingPaused", "setBrowserRenderingPaused", "isBrowserRenderingPaused");
     lua_classvariable(luaVM, "volume", "setBrowserVolume", "getBrowserVolume");
     lua_classvariable(luaVM, "devTools", "toggleBrowserDevTools", nullptr);
+    lua_classvariable(luaVM, "gpuEnabled", nullptr, "isBrowserGPUEnabled");
 
     lua_registerclass(luaVM, "Browser", "DxTexture");
 
@@ -1053,4 +1055,9 @@ int CLuaBrowserDefs::SetBrowserAjaxHandler(lua_State* luaVM)
 
     lua_pushboolean(luaVM, false);
     return 1;
+}
+
+bool CLuaBrowserDefs::IsBrowserGPUEnabled()
+{
+    return g_pCore->GetWebCore()->GetGPUEnabled();
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.cpp
@@ -1057,7 +1057,7 @@ int CLuaBrowserDefs::SetBrowserAjaxHandler(lua_State* luaVM)
     return 1;
 }
 
-bool CLuaBrowserDefs::IsBrowserGPUEnabled()
+bool CLuaBrowserDefs::IsBrowserGPUEnabled() noexcept
 {
     return g_pCore->GetWebCore()->GetGPUEnabled();
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.h
@@ -51,4 +51,5 @@ public:
     LUA_DECLARE(ResizeBrowser);
     LUA_DECLARE(GUICreateBrowser);
     LUA_DECLARE(GUIGetBrowser);
+    static bool IsBrowserGPUEnabled();
 };

--- a/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.h
@@ -51,5 +51,5 @@ public:
     LUA_DECLARE(ResizeBrowser);
     LUA_DECLARE(GUICreateBrowser);
     LUA_DECLARE(GUIGetBrowser);
-    static bool IsBrowserGPUEnabled();
+    static bool IsBrowserGPUEnabled() noexcept;
 };

--- a/Client/sdk/core/CWebCoreInterface.h
+++ b/Client/sdk/core/CWebCoreInterface.h
@@ -91,6 +91,6 @@ public:
     virtual void GetFilterEntriesByType(std::vector<std::pair<SString, bool>>& outEntries, eWebFilterType filterType,
                                         eWebFilterState state = eWebFilterState::WEBFILTER_ALL) = 0;
 
-    virtual bool GetGPUEnabled() = 0;
-    virtual bool GetGPUCompositingEnabled() = 0;
+    virtual bool GetGPUEnabled() const noexcept = 0;
+    virtual bool GetGPUCompositingEnabled() const noexcept = 0;
 };

--- a/Client/sdk/core/CWebCoreInterface.h
+++ b/Client/sdk/core/CWebCoreInterface.h
@@ -49,7 +49,7 @@ class CWebCoreInterface
 {
 public:
     virtual ~CWebCoreInterface() {}
-    virtual bool Initialise() = 0;
+    virtual bool Initialise(bool gpuEnabled, bool gpuCompositingEnabled) = 0;
 
     virtual CWebViewInterface* CreateWebView(unsigned int uiWidth, unsigned int uiHeight, bool bIsLocal, CWebBrowserItem* pWebBrowserRenderItem,
                                              bool bTransparent) = 0;
@@ -90,4 +90,7 @@ public:
     virtual void WriteCustomList(const SString& strListName, const std::vector<SString>& customList, bool bReset = true) = 0;
     virtual void GetFilterEntriesByType(std::vector<std::pair<SString, bool>>& outEntries, eWebFilterType filterType,
                                         eWebFilterState state = eWebFilterState::WEBFILTER_ALL) = 0;
+
+    virtual bool GetGPUEnabled() = 0;
+    virtual bool GetGPUCompositingEnabled() = 0;
 };


### PR DESCRIPTION
Adds two options to "web browser" tab in the main menu settings:

- Enable GPU rendering (CVAR: `browser_enable_gpu=1`)
- Enable GPU compositing (CVAR: `browser_enable_gpu_compositing=1`)

![image](https://github.com/user-attachments/assets/3e3c065f-a1f9-4ed5-a757-6e75c8777d0d)


GPU rendering must be enabled for GPU compositing to be available. Both options require a restart upon change to take effect.

Adds a clientside Lua function to check if browser GPU is enabled:

```lua
bool isBrowserGPUEnabled()
```

Note: for some reason the GPU is not being disabled for me, even though I've debugged and can see the `disable-gpu` flag being applied (http://gta.rockstarvision.com/vehicleviewer still works for example, which relies on WebGL). Need others to test and see if they get the same results, as it doesn't make much sense 🤔 

GPU has always been disabled in MTA, until #2933 (merged 2 weeks ago)

Update: according to @theSarrum these changes work (both enabling and disabling), tested by attempting to load a page with WebGL content.