### PR TITLE
Remove CEF GPU compositing

### DIFF
--- a/Client/cefweb/CWebApp.cpp
+++ b/Client/cefweb/CWebApp.cpp
@@ -23,13 +23,10 @@ void CWebApp::OnBeforeCommandLineProcessing(const CefString& process_type, CefRe
 {
     CWebCore* pWebCore = static_cast<CWebCore*>(g_pCore->GetWebCore());
 
-    if (!pWebCore->GetGPUEnabled()) // if GPU is disabled...
-    {
-        command_line->AppendSwitch("disable-gpu-compositing");
+    if (!pWebCore->GetGPUEnabled())
         command_line->AppendSwitch("disable-gpu");
-    }  
-    else if (!pWebCore->GetGPUCompositingEnabled()) // if GPU is enabled, but compositing is disabled...
-        command_line->AppendSwitch("disable-gpu-compositing");
+
+    command_line->AppendSwitch("disable-gpu-compositing"); // always disable this, causes issues with official builds
 
     // command_line->AppendSwitch("disable-d3d11");
     command_line->AppendSwitch("enable-begin-frame-scheduling");

--- a/Client/cefweb/CWebCore.cpp
+++ b/Client/cefweb/CWebCore.cpp
@@ -49,13 +49,12 @@ CWebCore::~CWebCore()
     delete m_pXmlConfig;
 }
 
-bool CWebCore::Initialise(bool gpuEnabled, bool gpuCompositingEnabled)
+bool CWebCore::Initialise(bool gpuEnabled)
 {
     CefMainArgs        mainArgs;
     void*              sandboxInfo = nullptr;
 
     m_bGPUEnabled = gpuEnabled;
-    m_bGPUCompositingEnabled = gpuCompositingEnabled;
 
     CefRefPtr<CWebApp> app(new CWebApp);
 
@@ -877,9 +876,4 @@ void CWebCore::StaticFetchBlacklistFinished(const SHttpDownloadResult& result)
 bool CWebCore::GetGPUEnabled() const noexcept
 {
     return m_bGPUEnabled;
-}
-
-bool CWebCore::GetGPUCompositingEnabled() const noexcept
-{
-    return m_bGPUCompositingEnabled;
 }

--- a/Client/cefweb/CWebCore.h
+++ b/Client/cefweb/CWebCore.h
@@ -54,7 +54,7 @@ class CWebCore : public CWebCoreInterface
 public:
     CWebCore();
     ~CWebCore();
-    bool Initialise(bool gpuEnabled, bool gpuCompositingEnabled) override;
+    bool Initialise(bool gpuEnabled) override;
 
     CWebViewInterface* CreateWebView(unsigned int uiWidth, unsigned int uiHeight, bool bIsLocal, CWebBrowserItem* pWebBrowserRenderItem, bool bTransparent);
     void               DestroyWebView(CWebViewInterface* pWebViewInterface);
@@ -109,7 +109,6 @@ public:
     static void StaticFetchBlacklistFinished(const SHttpDownloadResult& result);
 
     bool GetGPUEnabled() const noexcept;
-    bool GetGPUCompositingEnabled() const noexcept;
 
 private:
     typedef std::pair<bool, eWebFilterType> WebFilterPair;
@@ -135,5 +134,4 @@ private:
 
     // Shouldn't be changed after init
     bool m_bGPUEnabled;
-    bool m_bGPUCompositingEnabled;
 };

--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -359,7 +359,6 @@ void CClientVariables::LoadDefaults()
     DEFAULT("discord_rpc_share_data_firsttime", false);                               // Display the user data sharing consent dialog box - for the first time
     DEFAULT("_beta_qc_rightclick_command", _S("reconnect"));                          // Command to run when right clicking quick connect (beta - can be removed at any time)
     DEFAULT("browser_enable_gpu", true);                                              // Enable GPU in CEF? (allows stuff like WebGL to function)
-    DEFAULT("browser_enable_gpu_compositing", true);                                  // Enable GPU compositing in CEF? (required GPU enabled)
 
     if (!Exists("locale"))
     {

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -1156,13 +1156,11 @@ CWebCoreInterface* CCore::GetWebCore()
     if (m_pWebCore == nullptr)
     {
         bool gpuEnabled;
-        bool gpuCompositingEnabled;
         auto cvars = g_pCore->GetCVars();
         cvars->Get("browser_enable_gpu", gpuEnabled);
-        cvars->Get("browser_enable_gpu_compositing", gpuCompositingEnabled);
 
         m_pWebCore = CreateModule<CWebCoreInterface>(m_WebCoreModule, "CefWeb", "cefweb", "InitWebCoreInterface", this);
-        m_pWebCore->Initialise(gpuEnabled, gpuCompositingEnabled);
+        m_pWebCore->Initialise(gpuEnabled);
     }
     return m_pWebCore;
 }

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -918,14 +918,8 @@ void CSettings::CreateGUI()
     m_pCheckBoxRemoteJavascript->AutoSize(NULL, 20.0f);
 
     m_pCheckBoxBrowserGPUEnabled = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(m_pTabBrowser, _("Enable GPU rendering"), true));
-    m_pCheckBoxBrowserGPUEnabled->SetPosition(CVector2D(vecTemp.fX + 300.0f, vecTemp.fY - 20.0f));
+    m_pCheckBoxBrowserGPUEnabled->SetPosition(CVector2D(vecTemp.fX + 300.0f, vecTemp.fY - 25.0f));
     m_pCheckBoxBrowserGPUEnabled->AutoSize(NULL, 20.0f);
-    m_pCheckBoxBrowserGPUEnabled->SetClickHandler(GUI_CALLBACK(&CSettings::OnGPUSettingChanged, this));
-
-    m_pCheckBoxBrowserGPUCompositingEnabled =
-        reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(m_pTabBrowser, _("Enable GPU compositing"), true));
-    m_pCheckBoxBrowserGPUCompositingEnabled->SetPosition(CVector2D(vecTemp.fX + 300.0f, vecTemp.fY));
-    m_pCheckBoxBrowserGPUCompositingEnabled->AutoSize(NULL, 20.0f);
 
     m_pLabelBrowserCustomBlacklist = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(m_pTabBrowser, _("Custom blacklist")));
     m_pLabelBrowserCustomBlacklist->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 30.0f));
@@ -3300,12 +3294,6 @@ void CSettings::LoadData()
     CVARS_GET("browser_enable_gpu", bVar);
     m_pCheckBoxBrowserGPUEnabled->SetSelected(bVar);
 
-    if (!bVar)
-        m_pCheckBoxBrowserGPUCompositingEnabled->SetEnabled(false);
-
-    CVARS_GET("browser_enable_gpu_compositing", bVar);
-    m_pCheckBoxBrowserGPUCompositingEnabled->SetSelected(bVar);
-
     ReloadBrowserLists();
 }
 
@@ -3736,13 +3724,6 @@ void CSettings::SaveData()
     bool bBrowserGPUSettingChanged = (bBrowserGPUSetting != bBrowserGPUEnabled);
     CVARS_SET("browser_enable_gpu", bBrowserGPUSetting);
 
-    bool bBrowserGPUCompositingEnabled = false;
-    CVARS_GET("browser_enable_gpu_compositing", bBrowserGPUCompositingEnabled);
-
-    bool bBrowserGPUCompositingSetting = m_pCheckBoxBrowserGPUCompositingEnabled->GetSelected();
-    bool bBrowserGPUCompositingSettingChanged = (bBrowserGPUCompositingSetting != bBrowserGPUCompositingEnabled);
-    CVARS_SET("browser_enable_gpu_compositing", bBrowserGPUCompositingSetting);
-
     // Ensure CVARS ranges ok
     CClientVariables::GetSingleton().ValidateValues();
 
@@ -3752,8 +3733,7 @@ void CSettings::SaveData()
     gameSettings->Save();
 
     // Ask to restart?
-    if (bIsVideoModeChanged || bIsAntiAliasingChanged || bIsCustomizedSAFilesChanged || processsDPIAwareChanged || bBrowserGPUSettingChanged ||
-        bBrowserGPUCompositingSettingChanged)
+    if (bIsVideoModeChanged || bIsAntiAliasingChanged || bIsCustomizedSAFilesChanged || processsDPIAwareChanged || bBrowserGPUSettingChanged)
         ShowRestartQuestion();
     else if (CModManager::GetSingleton().IsLoaded() && bBrowserSettingChanged)
         ShowDisconnectQuestion();
@@ -4905,10 +4885,4 @@ void CSettings::TabSkip(bool bBackwards)
 bool CSettings::IsActive()
 {
     return m_pWindow->IsActive();
-}
-
-bool CSettings::OnGPUSettingChanged(CGUIElement* pElement)
-{
-    m_pCheckBoxBrowserGPUCompositingEnabled->SetEnabled(m_pCheckBoxBrowserGPUEnabled->GetSelected());
-    return true;
 }

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -339,7 +339,6 @@ protected:
     CGUIGridList* m_pGridBrowserWhitelist;
     CGUIButton*   m_pButtonBrowserWhitelistRemove;
     CGUICheckBox* m_pCheckBoxBrowserGPUEnabled;
-    CGUICheckBox* m_pCheckBoxBrowserGPUCompositingEnabled;
     bool          m_bBrowserListsChanged;
     bool          m_bBrowserListsLoadEnabled;
 
@@ -384,7 +383,6 @@ protected:
     bool OnBrowserWhitelistRemove(CGUIElement* pElement);
     bool OnBrowserWhitelistDomainAddFocused(CGUIElement* pElement);
     bool OnBrowserWhitelistDomainAddDefocused(CGUIElement* pElement);
-    bool OnGPUSettingChanged(CGUIElement* pElement);
 
     bool OnMouseDoubleClick(CGUIMouseEventArgs Args);
 

--- a/Client/sdk/core/CWebCoreInterface.h
+++ b/Client/sdk/core/CWebCoreInterface.h
@@ -49,7 +49,7 @@ class CWebCoreInterface
 {
 public:
     virtual ~CWebCoreInterface() {}
-    virtual bool Initialise(bool gpuEnabled, bool gpuCompositingEnabled) = 0;
+    virtual bool Initialise(bool gpuEnabled) = 0;
 
     virtual CWebViewInterface* CreateWebView(unsigned int uiWidth, unsigned int uiHeight, bool bIsLocal, CWebBrowserItem* pWebBrowserRenderItem,
                                              bool bTransparent) = 0;
@@ -92,5 +92,4 @@ public:
                                         eWebFilterState state = eWebFilterState::WEBFILTER_ALL) = 0;
 
     virtual bool GetGPUEnabled() const noexcept = 0;
-    virtual bool GetGPUCompositingEnabled() const noexcept = 0;
 };


### PR DESCRIPTION
Disable GPU compositing due to lag/input delay and breaking devtools (only in official builds, no issues were identified in custom debug or release builds), as reported by multiple users. 

GPU rendering is still enabled by default.
