### PR TITLE
Add `resource_client_file_checks` setting to disable corrupt PNG/TXD/DFF warnings

### DIFF
--- a/Server/mods/deathmatch/editor.conf
+++ b/Server/mods/deathmatch/editor.conf
@@ -263,6 +263,10 @@
          *NOTE* This only protects resources which use dbConnect with mysql
          Values: 0 - Off, 1 - Enabled.  Default - 1 -->
     <database_credentials_protection>1</database_credentials_protection>
+	
+	<!-- This parameter determines if resource client files that end in PNG, DFF and TXD should be checked for errors;
+          Values: 0 - Off, 1 - Enabled.  Default - 1 -->
+    <resource_client_file_checks>1</resource_client_file_checks>
 
     <!-- Specifies the module(s) which are loaded with the server. To load several modules, add more <module>
          parameter(s). Optional parameter. -->

--- a/Server/mods/deathmatch/local.conf
+++ b/Server/mods/deathmatch/local.conf
@@ -263,6 +263,10 @@
          *NOTE* This only protects resources which use dbConnect with mysql
          Values: 0 - Off, 1 - Enabled.  Default - 1 -->
     <database_credentials_protection>1</database_credentials_protection>
+	
+	<!-- This parameter determines if resource files that end in PNG, DFF and TXD should be checked for errors;
+          Values: 0 - Off, 1 - Enabled.  Default - 1 -->
+    <resource_client_file_checks>1</resource_client_file_checks>
 
     <!-- Specifies the module(s) which are loaded with the server. To load several modules, add more <module>
          parameter(s). Optional parameter. -->

--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -1465,7 +1465,7 @@ const std::vector<SIntSetting>& CMainConfig::GetIntSettingList()
         {false, false, 0, 0, 1, "fakelag", &m_bFakeLagCommandEnabled, NULL},
         {true, true, 50, 1000, 5000, "player_triggered_event_interval", &m_iPlayerTriggeredEventIntervalMs, &CMainConfig::OnPlayerTriggeredEventIntervalChange},
         {true, true, 1, 100, 1000, "max_player_triggered_events_per_interval", &m_iMaxPlayerTriggeredEventsPerInterval, &CMainConfig::OnPlayerTriggeredEventIntervalChange},
-        {true, true, 0, 1, 1, "resource_client_file_checks", &m_bCheckResourceClientFilesEnabled, NULL},
+        {true, true, 0, 1, 1, "resource_client_file_checks", &m_checkResourceClientFiles, NULL},
     };
 
     static std::vector<SIntSetting> settingsList;

--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -1465,7 +1465,7 @@ const std::vector<SIntSetting>& CMainConfig::GetIntSettingList()
         {false, false, 0, 0, 1, "fakelag", &m_bFakeLagCommandEnabled, NULL},
         {true, true, 50, 1000, 5000, "player_triggered_event_interval", &m_iPlayerTriggeredEventIntervalMs, &CMainConfig::OnPlayerTriggeredEventIntervalChange},
         {true, true, 1, 100, 1000, "max_player_triggered_events_per_interval", &m_iMaxPlayerTriggeredEventsPerInterval, &CMainConfig::OnPlayerTriggeredEventIntervalChange},
-        {true, true, 0, 1, 1, "resource_client_file_checks", &m_checkResourceClientFiles, NULL},
+        {true, true, 0, 1, 1, "resource_client_file_checks", &m_checkResourceClientFiles, nullptr},
     };
 
     static std::vector<SIntSetting> settingsList;

--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -1465,6 +1465,7 @@ const std::vector<SIntSetting>& CMainConfig::GetIntSettingList()
         {false, false, 0, 0, 1, "fakelag", &m_bFakeLagCommandEnabled, NULL},
         {true, true, 50, 1000, 5000, "player_triggered_event_interval", &m_iPlayerTriggeredEventIntervalMs, &CMainConfig::OnPlayerTriggeredEventIntervalChange},
         {true, true, 1, 100, 1000, "max_player_triggered_events_per_interval", &m_iMaxPlayerTriggeredEventsPerInterval, &CMainConfig::OnPlayerTriggeredEventIntervalChange},
+        {true, true, 0, 1, 1, "resource_client_file_checks", &m_bCheckResourceClientFilesEnabled, NULL},
     };
 
     static std::vector<SIntSetting> settingsList;

--- a/Server/mods/deathmatch/logic/CMainConfig.h
+++ b/Server/mods/deathmatch/logic/CMainConfig.h
@@ -126,7 +126,7 @@ public:
     const std::vector<SString>& GetOwnerEmailAddressList() const { return m_OwnerEmailAddressList; }
     bool                        IsDatabaseCredentialsProtectionEnabled() const { return m_bDatabaseCredentialsProtectionEnabled != 0; }
     bool                        IsFakeLagCommandEnabled() const { return m_bFakeLagCommandEnabled != 0; }
-    bool                        IsCheckResourceClientFilesEnabled() const { return m_bCheckResourceClientFilesEnabled != 0; }
+    bool                        IsCheckResourceClientFilesEnabled() const noexcept { return m_checkResourceClientFiles != 0; }
 
     SString GetSetting(const SString& configSetting);
     bool    GetSetting(const SString& configSetting, SString& strValue);
@@ -228,5 +228,5 @@ private:
     int                        m_bFakeLagCommandEnabled;
     int                        m_iPlayerTriggeredEventIntervalMs;
     int                        m_iMaxPlayerTriggeredEventsPerInterval;
-    int                        m_bCheckResourceClientFilesEnabled;
+    int                        m_checkResourceClientFiles;
 };

--- a/Server/mods/deathmatch/logic/CMainConfig.h
+++ b/Server/mods/deathmatch/logic/CMainConfig.h
@@ -126,6 +126,7 @@ public:
     const std::vector<SString>& GetOwnerEmailAddressList() const { return m_OwnerEmailAddressList; }
     bool                        IsDatabaseCredentialsProtectionEnabled() const { return m_bDatabaseCredentialsProtectionEnabled != 0; }
     bool                        IsFakeLagCommandEnabled() const { return m_bFakeLagCommandEnabled != 0; }
+    bool                        IsCheckResourceClientFilesEnabled() const { return m_bCheckResourceClientFilesEnabled != 0; }
 
     SString GetSetting(const SString& configSetting);
     bool    GetSetting(const SString& configSetting, SString& strValue);
@@ -227,4 +228,5 @@ private:
     int                        m_bFakeLagCommandEnabled;
     int                        m_iPlayerTriggeredEventIntervalMs;
     int                        m_iMaxPlayerTriggeredEventsPerInterval;
+    int                        m_bCheckResourceClientFilesEnabled;
 };

--- a/Server/mods/deathmatch/logic/CResourceChecker.cpp
+++ b/Server/mods/deathmatch/logic/CResourceChecker.cpp
@@ -13,6 +13,8 @@
 #include "CResourceChecker.h"
 #include "CResourceChecker.Data.h"
 #include "CResource.h"
+#include "CMainConfig.h"
+#include "CGame.h"
 #include "CLogger.h"
 #include "CStaticFunctionDefinitions.h"
 #include <core/CServerInterface.h>
@@ -28,6 +30,7 @@
 
 extern CNetServer*       g_pRealNetServer;
 extern CServerInterface* g_pServerInterface;
+extern CGame*            g_pGame;
 
 ///////////////////////////////////////////////////////////////
 //
@@ -47,6 +50,9 @@ void CResourceChecker::CheckResourceForIssues(CResource* pResource, const string
 
     m_ulDeprecatedWarningCount = 0;
     m_upgradedFullPathList.clear();
+
+    // Checking certain resource client files is optional
+    bool checkResourceClientFiles = g_pGame->GetConfig()->IsCheckResourceClientFilesEnabled();
 
     // Check each file in the resource
     std::list<CResourceFile*>::iterator iterf = pResource->IterBegin();
@@ -73,7 +79,7 @@ void CResourceChecker::CheckResourceForIssues(CResource* pResource, const string
                     bScript = true;
                     bClient = true;
                 }
-                else if (type == CResourceFile::RESOURCE_FILE_TYPE_CLIENT_FILE)
+                else if (type == CResourceFile::RESOURCE_FILE_TYPE_CLIENT_FILE && checkResourceClientFiles)
                 {
                     bScript = false;
                     bClient = true;

--- a/Server/mods/deathmatch/mtaserver.conf
+++ b/Server/mods/deathmatch/mtaserver.conf
@@ -274,6 +274,10 @@
           Max events per interval range: 1 to 1000. Default: 100  -->
     <player_triggered_event_interval>1000</player_triggered_event_interval>
     <max_player_triggered_events_per_interval>100</max_player_triggered_events_per_interval>
+	
+	<!-- This parameter determines if resource client files that end in PNG, DFF and TXD should be checked for errors;
+          Values: 0 - Off, 1 - Enabled.  Default - 1 -->
+    <resource_client_file_checks>1</resource_client_file_checks>
 
     <!-- Specifies the module(s) which are loaded with the server. To load several modules, add more <module>
          parameter(s). Optional parameter. -->

--- a/Server/mods/deathmatch/mtaserver.conf.template
+++ b/Server/mods/deathmatch/mtaserver.conf.template
@@ -275,4 +275,8 @@
           Max events per interval range: 1 to 1000. Default: 100  -->
     <player_triggered_event_interval>1000</player_triggered_event_interval>
     <max_player_triggered_events_per_interval>100</max_player_triggered_events_per_interval>
+	
+	<!-- This parameter determines if resource client files that end in PNG, DFF and TXD should be checked for errors;
+          Values: 0 - Off, 1 - Enabled.  Default - 1 -->
+    <resource_client_file_checks>1</resource_client_file_checks>
 </config>


### PR DESCRIPTION
Fixes #2541 by adding a new mtaserver.conf setting `resource_client_file_checks` (enabled '1' by default), which allows the server to not check files in resources that end in PNG, DFF and TXD for errors. This would previously output a lot of unwanted annoying warnings for certain files, especially when they were encrypted.