### PR TITLE
Fix for randomly bright objects after weapon change

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA_Weapons.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Weapons.cpp
@@ -220,10 +220,8 @@ static void _declspec(naked) HOOK_CVisibilityPlugins_RenderWeaponPedsForPC()
         mov eax, 5533B0h
         mov ecx, ebx
 
-        pushad
         push 0
         call eax // call CPed::RemoveLighting
-        popad
 
         jmp CONTINUE_CVisibilityPlugins_RenderWeaponPedsForPC
     }

--- a/Client/multiplayer_sa/CMultiplayerSA_Weapons.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Weapons.cpp
@@ -202,6 +202,35 @@ void _declspec(naked) HOOK_Fx_AddBulletImpact()
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
+// CVisibilityPlugins::RenderWeaponPedsForPC
+// 
+// Fix for the bright objects after weapon change sometimes
+// 
+//////////////////////////////////////////////////////////////////////////////////////////
+#define HOOKPOS_CVisibilityPlugins_RenderWeaponPedsForPC 0x733123
+#define HOOKSIZE_CVisibilityPlugins_RenderWeaponPedsForPC 5
+static constexpr DWORD CONTINUE_CVisibilityPlugins_RenderWeaponPedsForPC = 0x733128;
+static void _declspec(naked) HOOK_CVisibilityPlugins_RenderWeaponPedsForPC()
+{
+    _asm
+    {
+        mov eax, 5DF4E0h
+        call eax // call CPed::ResetGunFlashAlpha
+
+        mov eax, 5533B0h
+        mov ecx, ebx
+
+        pushad
+        push 0
+        call eax // call CPed::RemoveLighting
+        popad
+
+        jmp CONTINUE_CVisibilityPlugins_RenderWeaponPedsForPC
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
 // CMultiplayerSA::InitHooks_Weapons
 //
 // Setup hooks
@@ -212,4 +241,5 @@ void CMultiplayerSA::InitHooks_Weapons()
     EZHookInstall(CWeapon_GenerateDamageEvent);
     EZHookInstall(CShotInfo_Update);
     EZHookInstall(Fx_AddBulletImpact);
+    EZHookInstall(CVisibilityPlugins_RenderWeaponPedsForPC);
 }


### PR DESCRIPTION
This PR fixes an old bug where some objects randomly become bright when switching weapons from unarmed to any other

## Example
**Without weapon**
![image](https://github.com/user-attachments/assets/c7b85ead-6627-4ce2-8fc8-a01dd9bef7d4)

**With weapon**
![image](https://github.com/user-attachments/assets/5eefc9b4-3b29-42f4-b32c-800379bd54e5)

