### PR TITLE
Add element data client trust options.

### DIFF
--- a/Server/mods/deathmatch/local.conf
+++ b/Server/mods/deathmatch/local.conf
@@ -264,6 +264,12 @@
          Values: 0 - Off, 1 - Enabled.  Default - 1 -->
     <database_credentials_protection>1</database_credentials_protection>
 
+    <!-- Enables extra protection for element data.
+         When this option is enabled, the server ignores element data sync packets from the client,
+         except for allowed keys.
+         Values: 0 - Off, 1 - Enabled.  Default - 0 -->
+    <elementdata_whitelisted>0</elementdata_whitelisted>
+
     <!-- Specifies the module(s) which are loaded with the server. To load several modules, add more <module>
          parameter(s). Optional parameter. -->
     <!-- <module src="sample_win32.dll"/> -->

--- a/Server/mods/deathmatch/logic/CCustomData.cpp
+++ b/Server/mods/deathmatch/logic/CCustomData.cpp
@@ -121,15 +121,6 @@ bool CCustomData::Delete(const char* szName)
     return false;
 }
 
-bool CCustomData::IsClientChangesAllowed(const char* szName) const
-{
-    SCustomData* pData = Get(szName);
-    if (!pData || pData->clientChangesMode == ECustomDataClientTrust::UNSET)
-        return IsClientChangesAllowed();
-
-    return pData->clientChangesMode == ECustomDataClientTrust::ALLOW;
-}
-
 void CCustomData::SetClientChangesMode(const char* szName, ECustomDataClientTrust mode)
 {
     SCustomData& pData = m_Data[szName];

--- a/Server/mods/deathmatch/logic/CCustomData.cpp
+++ b/Server/mods/deathmatch/logic/CCustomData.cpp
@@ -21,7 +21,7 @@ void CCustomData::Copy(CCustomData* pCustomData)
     }
 }
 
-SCustomData* CCustomData::Get(const char* szName)
+SCustomData* CCustomData::Get(const char* szName) const
 {
     assert(szName);
 
@@ -100,6 +100,7 @@ void CCustomData::Set(const char* szName, const CLuaArgument& Variable, ESyncTyp
         SCustomData newData;
         newData.Variable = Variable;
         newData.syncType = syncType;
+        newData.allowClientChanges = true;
         m_Data[szName] = newData;
         UpdateSynced(szName, Variable, syncType);
     }
@@ -118,6 +119,18 @@ bool CCustomData::Delete(const char* szName)
 
     // Didn't exist
     return false;
+}
+
+bool CCustomData::IsClientChangesAllowed(const char* szName) const
+{
+    SCustomData* pData = Get(szName);
+    return pData ? pData->allowClientChanges : true;
+}
+
+void CCustomData::SetClientChangesAllowed(const char* szName, bool enabled)
+{
+    SCustomData& pData = m_Data[szName];
+    pData.allowClientChanges = enabled;
 }
 
 CXMLNode* CCustomData::OutputToXML(CXMLNode* pNode)

--- a/Server/mods/deathmatch/logic/CCustomData.cpp
+++ b/Server/mods/deathmatch/logic/CCustomData.cpp
@@ -100,7 +100,7 @@ void CCustomData::Set(const char* szName, const CLuaArgument& Variable, ESyncTyp
         SCustomData newData;
         newData.Variable = Variable;
         newData.syncType = syncType;
-        newData.clientChangesMode = ECustomDataClientTrust::UNSET;
+        newData.clientChangesMode = eCustomDataClientTrust::UNSET;
         m_Data[szName] = newData;
         UpdateSynced(szName, Variable, syncType);
     }
@@ -121,7 +121,7 @@ bool CCustomData::Delete(const char* szName)
     return false;
 }
 
-void CCustomData::SetClientChangesMode(const char* szName, ECustomDataClientTrust mode)
+void CCustomData::SetClientChangesMode(const char* szName, eCustomDataClientTrust mode)
 {
     SCustomData& pData = m_Data[szName];
     pData.clientChangesMode = mode;

--- a/Server/mods/deathmatch/logic/CCustomData.cpp
+++ b/Server/mods/deathmatch/logic/CCustomData.cpp
@@ -100,7 +100,7 @@ void CCustomData::Set(const char* szName, const CLuaArgument& Variable, ESyncTyp
         SCustomData newData;
         newData.Variable = Variable;
         newData.syncType = syncType;
-        newData.allowClientChanges = true;
+        newData.clientChangesMode = ECustomDataClientTrust::UNSET;
         m_Data[szName] = newData;
         UpdateSynced(szName, Variable, syncType);
     }
@@ -124,13 +124,16 @@ bool CCustomData::Delete(const char* szName)
 bool CCustomData::IsClientChangesAllowed(const char* szName) const
 {
     SCustomData* pData = Get(szName);
-    return pData ? pData->allowClientChanges : true;
+    if (!pData || pData->clientChangesMode == ECustomDataClientTrust::UNSET)
+        return IsClientChangesAllowed();
+
+    return pData->clientChangesMode == ECustomDataClientTrust::ALLOW;
 }
 
-void CCustomData::SetClientChangesAllowed(const char* szName, bool enabled)
+void CCustomData::SetClientChangesMode(const char* szName, ECustomDataClientTrust mode)
 {
     SCustomData& pData = m_Data[szName];
-    pData.allowClientChanges = enabled;
+    pData.clientChangesMode = mode;
 }
 
 CXMLNode* CCustomData::OutputToXML(CXMLNode* pNode)

--- a/Server/mods/deathmatch/logic/CCustomData.h
+++ b/Server/mods/deathmatch/logic/CCustomData.h
@@ -50,11 +50,7 @@ public:
 
     bool Delete(const char* szName);
 
-    bool IsClientChangesAllowed(const char* szName) const;
     void SetClientChangesMode(const char* szName, ECustomDataClientTrust mode);
-
-    bool IsClientChangesAllowed() const noexcept { return m_clientChangesAllowed; };
-    void SetClientChangesAllowed(bool enabled) noexcept { m_clientChangesAllowed = enabled; };
 
     unsigned short CountOnlySynchronized();
 
@@ -72,5 +68,4 @@ private:
 
     std::map<std::string, SCustomData> m_Data;
     std::map<std::string, SCustomData> m_SyncedData;
-    bool                               m_clientChangesAllowed{true};
 };

--- a/Server/mods/deathmatch/logic/CCustomData.h
+++ b/Server/mods/deathmatch/logic/CCustomData.h
@@ -25,11 +25,18 @@ enum class ESyncType
     SUBSCRIBE,
 };
 
+enum class ECustomDataClientTrust : std::uint8_t
+{
+    UNSET,
+    ALLOW,
+    DENY,
+};
+
 struct SCustomData
 {
-    CLuaArgument Variable;
-    ESyncType    syncType;
-    bool         allowClientChanges;
+    CLuaArgument           Variable;
+    ESyncType              syncType;
+    ECustomDataClientTrust clientChangesMode;
 };
 
 class CCustomData
@@ -42,8 +49,12 @@ public:
     void         Set(const char* szName, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST);
 
     bool Delete(const char* szName);
+
     bool IsClientChangesAllowed(const char* szName) const;
-    void SetClientChangesAllowed(const char* szName, bool enabled);
+    void SetClientChangesMode(const char* szName, ECustomDataClientTrust mode);
+
+    bool IsClientChangesAllowed() const noexcept { return m_clientChangesAllowed; };
+    void SetClientChangesAllowed(bool enabled) noexcept { m_clientChangesAllowed = enabled; };
 
     unsigned short CountOnlySynchronized();
 
@@ -61,4 +72,5 @@ private:
 
     std::map<std::string, SCustomData> m_Data;
     std::map<std::string, SCustomData> m_SyncedData;
+    bool                               m_clientChangesAllowed{true};
 };

--- a/Server/mods/deathmatch/logic/CCustomData.h
+++ b/Server/mods/deathmatch/logic/CCustomData.h
@@ -29,6 +29,7 @@ struct SCustomData
 {
     CLuaArgument Variable;
     ESyncType    syncType;
+    bool         allowClientChanges;
 };
 
 class CCustomData
@@ -36,11 +37,13 @@ class CCustomData
 public:
     void Copy(CCustomData* pCustomData);
 
-    SCustomData* Get(const char* szName);
+    SCustomData* Get(const char* szName) const;
     SCustomData* GetSynced(const char* szName);
     void         Set(const char* szName, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST);
 
     bool Delete(const char* szName);
+    bool IsClientChangesAllowed(const char* szName) const;
+    void SetClientChangesAllowed(const char* szName, bool enabled);
 
     unsigned short CountOnlySynchronized();
 

--- a/Server/mods/deathmatch/logic/CCustomData.h
+++ b/Server/mods/deathmatch/logic/CCustomData.h
@@ -25,7 +25,7 @@ enum class ESyncType
     SUBSCRIBE,
 };
 
-enum class ECustomDataClientTrust : std::uint8_t
+enum class eCustomDataClientTrust : std::uint8_t
 {
     UNSET,
     ALLOW,
@@ -36,7 +36,7 @@ struct SCustomData
 {
     CLuaArgument           Variable;
     ESyncType              syncType;
-    ECustomDataClientTrust clientChangesMode;
+    eCustomDataClientTrust clientChangesMode;
 };
 
 class CCustomData
@@ -50,7 +50,7 @@ public:
 
     bool Delete(const char* szName);
 
-    void SetClientChangesMode(const char* szName, ECustomDataClientTrust mode);
+    void SetClientChangesMode(const char* szName, eCustomDataClientTrust mode);
 
     unsigned short CountOnlySynchronized();
 

--- a/Server/mods/deathmatch/logic/CElement.cpp
+++ b/Server/mods/deathmatch/logic/CElement.cpp
@@ -508,7 +508,7 @@ void CElement::ReadCustomData(CEvents* pEvents, CXMLNode& Node)
     }
 }
 
-CLuaArgument* CElement::GetCustomData(const char* szName, bool bInheritData, ESyncType* pSyncType, ECustomDataClientTrust* clientChangesMode)
+CLuaArgument* CElement::GetCustomData(const char* szName, bool bInheritData, ESyncType* pSyncType, eCustomDataClientTrust* clientChangesMode)
 {
     assert(szName);
 

--- a/Server/mods/deathmatch/logic/CElement.cpp
+++ b/Server/mods/deathmatch/logic/CElement.cpp
@@ -508,7 +508,7 @@ void CElement::ReadCustomData(CEvents* pEvents, CXMLNode& Node)
     }
 }
 
-CLuaArgument* CElement::GetCustomData(const char* szName, bool bInheritData, ESyncType* pSyncType)
+CLuaArgument* CElement::GetCustomData(const char* szName, bool bInheritData, ESyncType* pSyncType, bool* clientChangesAllowed)
 {
     assert(szName);
 
@@ -518,13 +518,17 @@ CLuaArgument* CElement::GetCustomData(const char* szName, bool bInheritData, ESy
     {
         if (pSyncType)
             *pSyncType = pData->syncType;
+
+        if (clientChangesAllowed)
+            *clientChangesAllowed = pData->allowClientChanges;
+
         return &pData->Variable;
     }
 
     // If none, try returning parent's custom data
     if (bInheritData && m_pParent)
     {
-        return m_pParent->GetCustomData(szName, true, pSyncType);
+        return m_pParent->GetCustomData(szName, true, pSyncType, clientChangesAllowed);
     }
 
     // None available

--- a/Server/mods/deathmatch/logic/CElement.cpp
+++ b/Server/mods/deathmatch/logic/CElement.cpp
@@ -508,7 +508,7 @@ void CElement::ReadCustomData(CEvents* pEvents, CXMLNode& Node)
     }
 }
 
-CLuaArgument* CElement::GetCustomData(const char* szName, bool bInheritData, ESyncType* pSyncType, bool* clientChangesAllowed)
+CLuaArgument* CElement::GetCustomData(const char* szName, bool bInheritData, ESyncType* pSyncType, ECustomDataClientTrust* clientChangesMode)
 {
     assert(szName);
 
@@ -519,8 +519,8 @@ CLuaArgument* CElement::GetCustomData(const char* szName, bool bInheritData, ESy
         if (pSyncType)
             *pSyncType = pData->syncType;
 
-        if (clientChangesAllowed)
-            *clientChangesAllowed = pData->allowClientChanges;
+        if (clientChangesMode)
+            *clientChangesMode = pData->clientChangesMode;
 
         return &pData->Variable;
     }
@@ -528,7 +528,7 @@ CLuaArgument* CElement::GetCustomData(const char* szName, bool bInheritData, ESy
     // If none, try returning parent's custom data
     if (bInheritData && m_pParent)
     {
-        return m_pParent->GetCustomData(szName, true, pSyncType, clientChangesAllowed);
+        return m_pParent->GetCustomData(szName, true, pSyncType, clientChangesMode);
     }
 
     // None available

--- a/Server/mods/deathmatch/logic/CElement.h
+++ b/Server/mods/deathmatch/logic/CElement.h
@@ -136,7 +136,7 @@ public:
 
     void           ReadCustomData(CEvents* pEvents, CXMLNode& Node);
     CCustomData&   GetCustomDataManager() { return m_CustomData; }
-    CLuaArgument*  GetCustomData(const char* szName, bool bInheritData, ESyncType* pSyncType = NULL);
+    CLuaArgument*  GetCustomData(const char* szName, bool bInheritData, ESyncType* pSyncType = nullptr, bool* clientChangesAllowed = nullptr);
     CLuaArguments* GetAllCustomData(CLuaArguments* table);
     bool           GetCustomDataString(const char* szName, char* pOut, size_t sizeBuffer, bool bInheritData);
     bool           GetCustomDataInt(const char* szName, int& iOut, bool bInheritData);

--- a/Server/mods/deathmatch/logic/CElement.h
+++ b/Server/mods/deathmatch/logic/CElement.h
@@ -136,7 +136,7 @@ public:
 
     void           ReadCustomData(CEvents* pEvents, CXMLNode& Node);
     CCustomData&   GetCustomDataManager() { return m_CustomData; }
-    CLuaArgument*  GetCustomData(const char* szName, bool bInheritData, ESyncType* pSyncType = nullptr, ECustomDataClientTrust* clientChangesMode = nullptr);
+    CLuaArgument*  GetCustomData(const char* szName, bool bInheritData, ESyncType* pSyncType = nullptr, eCustomDataClientTrust* clientChangesMode = nullptr);
     CLuaArguments* GetAllCustomData(CLuaArguments* table);
     bool           GetCustomDataString(const char* szName, char* pOut, size_t sizeBuffer, bool bInheritData);
     bool           GetCustomDataInt(const char* szName, int& iOut, bool bInheritData);

--- a/Server/mods/deathmatch/logic/CElement.h
+++ b/Server/mods/deathmatch/logic/CElement.h
@@ -136,7 +136,7 @@ public:
 
     void           ReadCustomData(CEvents* pEvents, CXMLNode& Node);
     CCustomData&   GetCustomDataManager() { return m_CustomData; }
-    CLuaArgument*  GetCustomData(const char* szName, bool bInheritData, ESyncType* pSyncType = nullptr, bool* clientChangesAllowed = nullptr);
+    CLuaArgument*  GetCustomData(const char* szName, bool bInheritData, ESyncType* pSyncType = nullptr, ECustomDataClientTrust* clientChangesMode = nullptr);
     CLuaArguments* GetAllCustomData(CLuaArguments* table);
     bool           GetCustomDataString(const char* szName, char* pOut, size_t sizeBuffer, bool bInheritData);
     bool           GetCustomDataInt(const char* szName, int& iOut, bool bInheritData);

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -2653,12 +2653,12 @@ void CGame::Packet_CustomData(CCustomDataPacket& Packet)
             }
 
             ESyncType lastSyncType = ESyncType::BROADCAST;
-            ECustomDataClientTrust clientChangesMode{};
+            eCustomDataClientTrust clientChangesMode{};
 
             pElement->GetCustomData(szName, false, &lastSyncType, &clientChangesMode);
 
-            const bool changesAllowed = clientChangesMode == ECustomDataClientTrust::UNSET ? !m_pMainConfig->IsElementDataWhitelisted()
-                                                                                           : clientChangesMode == ECustomDataClientTrust::ALLOW;
+            const bool changesAllowed = clientChangesMode == eCustomDataClientTrust::UNSET ? !m_pMainConfig->IsElementDataWhitelisted()
+                                                                                           : clientChangesMode == eCustomDataClientTrust::ALLOW;
             if (!changesAllowed)
             {
                 CLogger::ErrorPrintf("Client trying to change protected element data %s (%s)", Packet.GetSourcePlayer()->GetNick(),

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -2653,11 +2653,13 @@ void CGame::Packet_CustomData(CCustomDataPacket& Packet)
             }
 
             ESyncType lastSyncType = ESyncType::BROADCAST;
-            bool      clientChangesAllowed = true;
+            ECustomDataClientTrust clientChangesMode{};
 
-            pElement->GetCustomData(szName, false, &lastSyncType, &clientChangesAllowed);
+            pElement->GetCustomData(szName, false, &lastSyncType, &clientChangesMode);
 
-            if (!clientChangesAllowed)
+            const bool changesAllowed = clientChangesMode == ECustomDataClientTrust::UNSET ? pElement->GetCustomDataManager().IsClientChangesAllowed()
+                                                                                           : clientChangesMode == ECustomDataClientTrust::ALLOW;
+            if (!changesAllowed)
             {
                 CLogger::ErrorPrintf("Client trying to change protected element data %s (%s)", Packet.GetSourcePlayer()->GetNick(),
                                      szName);

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -2657,7 +2657,7 @@ void CGame::Packet_CustomData(CCustomDataPacket& Packet)
 
             pElement->GetCustomData(szName, false, &lastSyncType, &clientChangesMode);
 
-            const bool changesAllowed = clientChangesMode == ECustomDataClientTrust::UNSET ? pElement->GetCustomDataManager().IsClientChangesAllowed()
+            const bool changesAllowed = clientChangesMode == ECustomDataClientTrust::UNSET ? !m_pMainConfig->IsElementDataWhitelisted()
                                                                                            : clientChangesMode == ECustomDataClientTrust::ALLOW;
             if (!changesAllowed)
             {

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -1607,6 +1607,7 @@ void CGame::AddBuiltInEvents()
     m_Events.AddEvent("onPlayerTriggerEventThreshold", "", nullptr, false);
     m_Events.AddEvent("onPlayerTeamChange", "oldTeam, newTeam", nullptr, false);
     m_Events.AddEvent("onPlayerTriggerInvalidEvent", "eventName, isAdded, isRemote", nullptr, false);
+    m_Events.AddEvent("onPlayerChangesProtectedData", "element, key, value", nullptr, false);
 
     // Ped events
     m_Events.AddEvent("onPedVehicleEnter", "vehicle, seat, jacked", NULL, false);
@@ -2652,7 +2653,22 @@ void CGame::Packet_CustomData(CCustomDataPacket& Packet)
             }
 
             ESyncType lastSyncType = ESyncType::BROADCAST;
-            pElement->GetCustomData(szName, false, &lastSyncType);
+            bool      clientChangesAllowed = true;
+
+            pElement->GetCustomData(szName, false, &lastSyncType, &clientChangesAllowed);
+
+            if (!clientChangesAllowed)
+            {
+                CLogger::ErrorPrintf("Client trying to change protected element data %s (%s)", Packet.GetSourcePlayer()->GetNick(),
+                                     szName);
+
+                CLuaArguments arguments;
+                arguments.PushElement(pElement);
+                arguments.PushString(szName);
+                arguments.PushArgument(Value);
+                pSourcePlayer->CallEvent("onPlayerChangesProtectedData", arguments);
+                return;
+            }
 
             if (lastSyncType != ESyncType::LOCAL)
             {

--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -79,6 +79,7 @@ CMainConfig::CMainConfig(CConsole* pConsole) : CXMLConfig(NULL)
     m_iBackupInterval = 3;
     m_iBackupAmount = 5;
     m_bSyncMapElementData = true;
+    m_elementDataWhitelisted = false;
 }
 
 bool CMainConfig::Load()
@@ -525,6 +526,8 @@ bool CMainConfig::Load()
         GetInteger(m_pRootNode, "lightsync_rate", g_TickRateSettings.iLightSync);
         g_TickRateSettings.iLightSync = Clamp(200, g_TickRateSettings.iLightSync, 4000);
     }
+
+    GetBoolean(m_pRootNode, "elementdata_whitelisted", m_elementDataWhitelisted);
 
     ApplyNetOptions();
 

--- a/Server/mods/deathmatch/logic/CMainConfig.h
+++ b/Server/mods/deathmatch/logic/CMainConfig.h
@@ -126,6 +126,7 @@ public:
     const std::vector<SString>& GetOwnerEmailAddressList() const { return m_OwnerEmailAddressList; }
     bool                        IsDatabaseCredentialsProtectionEnabled() const { return m_bDatabaseCredentialsProtectionEnabled != 0; }
     bool                        IsFakeLagCommandEnabled() const { return m_bFakeLagCommandEnabled != 0; }
+    bool                        IsElementDataWhitelisted() const { return m_elementDataWhitelisted; };
 
     SString GetSetting(const SString& configSetting);
     bool    GetSetting(const SString& configSetting, SString& strValue);
@@ -227,4 +228,5 @@ private:
     int                        m_bFakeLagCommandEnabled;
     int                        m_iPlayerTriggeredEventIntervalMs;
     int                        m_iMaxPlayerTriggeredEventsPerInterval;
+    bool                       m_elementDataWhitelisted;
 };

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -989,6 +989,7 @@ bool CStaticFunctionDefinitions::SetElementData(CElement* pElement, const char* 
         // Unsubscribe all the players
         if (lastSyncType == ESyncType::SUBSCRIBE && syncType != ESyncType::SUBSCRIBE)
             m_pPlayerManager->ClearElementData(pElement, szName);
+
         // Set its custom data
         pElement->SetCustomData(szName, Variable, syncType);
         return true;

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -955,14 +955,14 @@ bool CStaticFunctionDefinitions::SetElementID(CElement* pElement, const char* sz
 }
 
 bool CStaticFunctionDefinitions::SetElementData(CElement* pElement, const char* szName, const CLuaArgument& Variable, ESyncType syncType,
-                                                std::optional<ECustomDataClientTrust> clientTrust)
+                                                std::optional<eCustomDataClientTrust> clientTrust)
 {
     assert(pElement);
     assert(szName);
     assert(strlen(szName) <= MAX_CUSTOMDATA_NAME_LENGTH);
 
     ESyncType              lastSyncType = ESyncType::BROADCAST;
-    ECustomDataClientTrust lastClientTrust{};
+    eCustomDataClientTrust lastClientTrust{};
     CLuaArgument*          pCurrentVariable = pElement->GetCustomData(szName, false, &lastSyncType, &lastClientTrust);
 
     if (clientTrust.has_value() && lastClientTrust != clientTrust.value())

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -954,14 +954,19 @@ bool CStaticFunctionDefinitions::SetElementID(CElement* pElement, const char* sz
     return true;
 }
 
-bool CStaticFunctionDefinitions::SetElementData(CElement* pElement, const char* szName, const CLuaArgument& Variable, ESyncType syncType)
+bool CStaticFunctionDefinitions::SetElementData(CElement* pElement, const char* szName, const CLuaArgument& Variable, ESyncType syncType,
+                                                std::optional<ECustomDataClientTrust> clientTrust)
 {
     assert(pElement);
     assert(szName);
     assert(strlen(szName) <= MAX_CUSTOMDATA_NAME_LENGTH);
 
-    ESyncType     lastSyncType = ESyncType::BROADCAST;
-    CLuaArgument* pCurrentVariable = pElement->GetCustomData(szName, false, &lastSyncType);
+    ESyncType              lastSyncType = ESyncType::BROADCAST;
+    ECustomDataClientTrust lastClientTrust{};
+    CLuaArgument*          pCurrentVariable = pElement->GetCustomData(szName, false, &lastSyncType, &lastClientTrust);
+
+    if (clientTrust.has_value() && lastClientTrust != clientTrust.value())
+        pElement->GetCustomDataManager().SetClientChangesMode(szName, clientTrust.value());
 
     if (!pCurrentVariable || *pCurrentVariable != Variable || lastSyncType != syncType)
     {
@@ -984,7 +989,7 @@ bool CStaticFunctionDefinitions::SetElementData(CElement* pElement, const char* 
         // Unsubscribe all the players
         if (lastSyncType == ESyncType::SUBSCRIBE && syncType != ESyncType::SUBSCRIBE)
             m_pPlayerManager->ClearElementData(pElement, szName);
-
+         
         // Set its custom data
         pElement->SetCustomData(szName, Variable, syncType);
         return true;

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -989,7 +989,6 @@ bool CStaticFunctionDefinitions::SetElementData(CElement* pElement, const char* 
         // Unsubscribe all the players
         if (lastSyncType == ESyncType::SUBSCRIBE && syncType != ESyncType::SUBSCRIBE)
             m_pPlayerManager->ClearElementData(pElement, szName);
-         
         // Set its custom data
         pElement->SetCustomData(szName, Variable, syncType);
         return true;

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -83,7 +83,8 @@ public:
     // Element set funcs
     static bool ClearElementVisibleTo(CElement* pElement);
     static bool SetElementID(CElement* pElement, const char* szID);
-    static bool SetElementData(CElement* pElement, const char* szName, const CLuaArgument& Variable, ESyncType syncType);
+    static bool SetElementData(CElement* pElement, const char* szName, const CLuaArgument& Variable, ESyncType syncType,
+                               std::optional<ECustomDataClientTrust> clientTrust);
     static bool RemoveElementData(CElement* pElement, const char* szName);
     static bool AddElementDataSubscriber(CElement* pElement, const char* szName, CPlayer* pPlayer);
     static bool RemoveElementDataSubscriber(CElement* pElement, const char* szName, CPlayer* pPlayer);

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -84,7 +84,7 @@ public:
     static bool ClearElementVisibleTo(CElement* pElement);
     static bool SetElementID(CElement* pElement, const char* szID);
     static bool SetElementData(CElement* pElement, const char* szName, const CLuaArgument& Variable, ESyncType syncType,
-                               std::optional<ECustomDataClientTrust> clientTrust);
+                               std::optional<eCustomDataClientTrust> clientTrust);
     static bool RemoveElementData(CElement* pElement, const char* szName);
     static bool AddElementDataSubscriber(CElement* pElement, const char* szName, CPlayer* pPlayer);
     static bool RemoveElementDataSubscriber(CElement* pElement, const char* szName, CPlayer* pPlayer);

--- a/Server/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
@@ -285,10 +285,10 @@ ADD_ENUM(ESyncType::LOCAL, "local")
 ADD_ENUM(ESyncType::SUBSCRIBE, "subscribe")
 IMPLEMENT_ENUM_CLASS_END("sync-mode")
 
-IMPLEMENT_ENUM_CLASS_BEGIN(ECustomDataClientTrust)
-ADD_ENUM(ECustomDataClientTrust::UNSET, "default")
-ADD_ENUM(ECustomDataClientTrust::ALLOW, "allow")
-ADD_ENUM(ECustomDataClientTrust::DENY, "deny")
+IMPLEMENT_ENUM_CLASS_BEGIN(eCustomDataClientTrust)
+ADD_ENUM(eCustomDataClientTrust::UNSET, "default")
+ADD_ENUM(eCustomDataClientTrust::ALLOW, "allow")
+ADD_ENUM(eCustomDataClientTrust::DENY, "deny")
 IMPLEMENT_ENUM_CLASS_END("client-trust-mode")
 
 //

--- a/Server/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
@@ -285,6 +285,12 @@ ADD_ENUM(ESyncType::LOCAL, "local")
 ADD_ENUM(ESyncType::SUBSCRIBE, "subscribe")
 IMPLEMENT_ENUM_CLASS_END("sync-mode")
 
+IMPLEMENT_ENUM_CLASS_BEGIN(ECustomDataClientTrust)
+ADD_ENUM(ECustomDataClientTrust::UNSET, "default")
+ADD_ENUM(ECustomDataClientTrust::ALLOW, "allow")
+ADD_ENUM(ECustomDataClientTrust::DENY, "deny")
+IMPLEMENT_ENUM_CLASS_END("client-trust-mode")
+
 //
 // CResource from userdata
 //

--- a/Server/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
@@ -38,7 +38,7 @@ DECLARE_ENUM(CAccessControlListRight::ERightType);
 DECLARE_ENUM(CElement::EElementType);
 DECLARE_ENUM(CAccountPassword::EAccountPasswordType);
 DECLARE_ENUM_CLASS(ESyncType);
-DECLARE_ENUM_CLASS(ECustomDataClientTrust)
+DECLARE_ENUM_CLASS(eCustomDataClientTrust)
 
 enum eHudComponent
 {

--- a/Server/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
@@ -38,6 +38,7 @@ DECLARE_ENUM(CAccessControlListRight::ERightType);
 DECLARE_ENUM(CElement::EElementType);
 DECLARE_ENUM(CAccountPassword::EAccountPasswordType);
 DECLARE_ENUM_CLASS(ESyncType);
+DECLARE_ENUM_CLASS(ECustomDataClientTrust)
 
 enum eHudComponent
 {

--- a/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -80,8 +80,9 @@ void CLuaElementDefs::LoadFunctions()
         {"addElementDataSubscriber", addElementDataSubscriber},
         {"removeElementDataSubscriber", removeElementDataSubscriber},
         {"hasElementDataSubscriber", hasElementDataSubscriber},
-        {"setElementDataClientTrustEnabled", ArgumentParser<SetElementDataClientTrustEnabled>},
-        {"isElementDataClientTrustEnabled", ArgumentParser<IsElementDataClientTrustEnabled>},
+        {"setElementDataClientTrust", ArgumentParser<SetElementDataClientTrust>},
+        {"isElementDataClientTrusted", ArgumentParser<IsElementDataClientTrusted>},
+        {"resetElementDataClientTrust", ArgumentParser<ResetElementDataClientTrust>},
 
         // Set
         {"setElementID", setElementID},
@@ -131,6 +132,7 @@ void CLuaElementDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "addDataSubscriber", "addElementDataSubscriber");
     lua_classfunction(luaVM, "removeDataSubscriber", "removeElementDataSubscriber");
     lua_classfunction(luaVM, "hasDataSubscriber", "hasElementDataSubscriber");
+    lua_classfunction(luaVM, "resetDataClientTrust", "resetElementDataClientTrust");
 
     lua_classfunction(luaVM, "setParent", "setElementParent");
     lua_classfunction(luaVM, "setFrozen", "setElementFrozen");
@@ -153,7 +155,7 @@ void CLuaElementDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setLowLOD", "setLowLODElement");
     lua_classfunction(luaVM, "setAttachedOffsets", "setElementAttachedOffsets");
     lua_classfunction(luaVM, "setCallPropagationEnabled", "setElementCallPropagationEnabled");
-    lua_classfunction(luaVM, "setDataClientTrustEnabled", "setElementDataClientTrustEnabled");
+    lua_classfunction(luaVM, "setDataClientTrust", "setElementDataClientTrust");
 
     lua_classfunction(luaVM, "getAttachedOffsets", "getElementAttachedOffsets");
     lua_classfunction(luaVM, "getChild", "getElementChild");
@@ -192,7 +194,7 @@ void CLuaElementDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "isVisibleTo", "isElementVisibleTo");
     lua_classfunction(luaVM, "isLowLOD", "isElementLowLOD");
     lua_classfunction(luaVM, "isAttached", "isElementAttached");
-    lua_classfunction(luaVM, "isDataClientTrustEnabled", "isElementDataClientTrustEnabled");
+    lua_classfunction(luaVM, "isDataClientTrusted", "isElementDataClientTrusted");
 
     lua_classvariable(luaVM, "id", "setElementID", "getElementID");
     lua_classvariable(luaVM, "callPropagationEnabled", "setElementCallPropagationEnabled", "isElementCallPropagationEnabled");
@@ -2442,12 +2444,26 @@ int CLuaElementDefs::isElementCallPropagationEnabled(lua_State* luaVM)
     return 1;
 }
 
-void CLuaElementDefs::SetElementDataClientTrustEnabled(CElement* pElement, std::string_view key, bool enabled)
+void CLuaElementDefs::SetElementDataClientTrust(CElement* pElement, bool enabled, std::optional<std::string_view> key)
 {
-    pElement->GetCustomDataManager().SetClientChangesAllowed(key.data(), enabled);
+    if (key.has_value())
+        pElement->GetCustomDataManager().SetClientChangesMode(key.value().data(), enabled ? ECustomDataClientTrust::ALLOW : ECustomDataClientTrust::DENY);
+    else
+        pElement->GetCustomDataManager().SetClientChangesAllowed(enabled);
 }
 
-bool CLuaElementDefs::IsElementDataClientTrustEnabled(CElement* pElement, std::string_view key)
+bool CLuaElementDefs::IsElementDataClientTrusted(CElement* pElement, std::optional<std::string_view> key)
 {
-    return pElement->GetCustomDataManager().IsClientChangesAllowed(key.data());
+    if (key.has_value())
+        return pElement->GetCustomDataManager().IsClientChangesAllowed(key.value().data());
+    else
+        return pElement->GetCustomDataManager().IsClientChangesAllowed();
+}
+
+void CLuaElementDefs::ResetElementDataClientTrust(CElement* pElement, std::optional<std::string_view> key)
+{
+    if (key.has_value())
+        pElement->GetCustomDataManager().SetClientChangesMode(key.value().data(), ECustomDataClientTrust::UNSET);
+    else
+        pElement->GetCustomDataManager().SetClientChangesAllowed(true);
 }

--- a/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -80,6 +80,8 @@ void CLuaElementDefs::LoadFunctions()
         {"addElementDataSubscriber", addElementDataSubscriber},
         {"removeElementDataSubscriber", removeElementDataSubscriber},
         {"hasElementDataSubscriber", hasElementDataSubscriber},
+        {"setElementDataClientTrustEnabled", ArgumentParser<SetElementDataClientTrustEnabled>},
+        {"isElementDataClientTrustEnabled", ArgumentParser<IsElementDataClientTrustEnabled>},
 
         // Set
         {"setElementID", setElementID},
@@ -151,6 +153,7 @@ void CLuaElementDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setLowLOD", "setLowLODElement");
     lua_classfunction(luaVM, "setAttachedOffsets", "setElementAttachedOffsets");
     lua_classfunction(luaVM, "setCallPropagationEnabled", "setElementCallPropagationEnabled");
+    lua_classfunction(luaVM, "setDataClientTrustEnabled", "setElementDataClientTrustEnabled");
 
     lua_classfunction(luaVM, "getAttachedOffsets", "getElementAttachedOffsets");
     lua_classfunction(luaVM, "getChild", "getElementChild");
@@ -189,6 +192,7 @@ void CLuaElementDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "isVisibleTo", "isElementVisibleTo");
     lua_classfunction(luaVM, "isLowLOD", "isElementLowLOD");
     lua_classfunction(luaVM, "isAttached", "isElementAttached");
+    lua_classfunction(luaVM, "isDataClientTrustEnabled", "isElementDataClientTrustEnabled");
 
     lua_classvariable(luaVM, "id", "setElementID", "getElementID");
     lua_classvariable(luaVM, "callPropagationEnabled", "setElementCallPropagationEnabled", "isElementCallPropagationEnabled");
@@ -2436,4 +2440,14 @@ int CLuaElementDefs::isElementCallPropagationEnabled(lua_State* luaVM)
 
     lua_pushboolean(luaVM, false);
     return 1;
+}
+
+void CLuaElementDefs::SetElementDataClientTrustEnabled(CElement* pElement, std::string_view key, bool enabled)
+{
+    pElement->GetCustomDataManager().SetClientChangesAllowed(key.data(), enabled);
+}
+
+bool CLuaElementDefs::IsElementDataClientTrustEnabled(CElement* pElement, std::string_view key)
+{
+    return pElement->GetCustomDataManager().IsClientChangesAllowed(key.data());
 }

--- a/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -1538,7 +1538,7 @@ int CLuaElementDefs::setElementData(lua_State* luaVM)
     SString      strKey;
     CLuaArgument value;
     ESyncType    syncType = ESyncType::BROADCAST;
-    std::optional<ECustomDataClientTrust> clientTrust{};
+    std::optional<eCustomDataClientTrust> clientTrust{};
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pElement);
@@ -1557,7 +1557,7 @@ int CLuaElementDefs::setElementData(lua_State* luaVM)
 
     if (!argStream.NextIsNone())
     {
-        ECustomDataClientTrust trustReaded;
+        eCustomDataClientTrust trustReaded;
         argStream.ReadEnumString(trustReaded);
         clientTrust = trustReaded;
     }

--- a/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
@@ -77,8 +77,9 @@ public:
     LUA_DECLARE(addElementDataSubscriber);
     LUA_DECLARE(removeElementDataSubscriber);
     LUA_DECLARE(hasElementDataSubscriber);
-    static void SetElementDataClientTrustEnabled(CElement* pElement, std::string_view key, bool enabled);
-    static bool IsElementDataClientTrustEnabled(CElement* pElement, std::string_view key);
+    static void SetElementDataClientTrust(CElement* pElement, bool enabled, std::optional<std::string_view> key);
+    static void ResetElementDataClientTrust(CElement* pElement, std::optional<std::string_view> key);
+    static bool IsElementDataClientTrusted(CElement* pElement, std::optional<std::string_view> key);
 
     // Attachement
     LUA_DECLARE(attachElements);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
@@ -77,9 +77,6 @@ public:
     LUA_DECLARE(addElementDataSubscriber);
     LUA_DECLARE(removeElementDataSubscriber);
     LUA_DECLARE(hasElementDataSubscriber);
-    static void SetElementDataClientTrust(CElement* pElement, bool enabled, std::optional<std::string_view> key);
-    static void ResetElementDataClientTrust(CElement* pElement, std::optional<std::string_view> key);
-    static bool IsElementDataClientTrusted(CElement* pElement, std::optional<std::string_view> key);
 
     // Attachement
     LUA_DECLARE(attachElements);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
@@ -77,6 +77,8 @@ public:
     LUA_DECLARE(addElementDataSubscriber);
     LUA_DECLARE(removeElementDataSubscriber);
     LUA_DECLARE(hasElementDataSubscriber);
+    static void SetElementDataClientTrustEnabled(CElement* pElement, std::string_view key, bool enabled);
+    static bool IsElementDataClientTrustEnabled(CElement* pElement, std::string_view key);
 
     // Attachement
     LUA_DECLARE(attachElements);

--- a/Server/mods/deathmatch/mtaserver.conf
+++ b/Server/mods/deathmatch/mtaserver.conf
@@ -268,6 +268,12 @@
          Values: 0 - Off, 1 - Enabled.  Default - 1 -->
     <database_credentials_protection>1</database_credentials_protection>
 
+     <!-- Enables extra protection for element data.
+         When this option is enabled, the server ignores element data sync packets from the client,
+         except for allowed keys.
+         Values: 0 - Off, 1 - Enabled.  Default - 0 -->
+    <elementdata_whitelisted>0</elementdata_whitelisted>
+
     <!-- These parameters specify the maximum amount of events that can be triggered by the client (via triggerServerEvent) within the given interval.
           Note: The interval is given in milliseconds
           Interval range: 50 to 5000. Default: 1000

--- a/Server/mods/deathmatch/mtaserver.conf.template
+++ b/Server/mods/deathmatch/mtaserver.conf.template
@@ -269,6 +269,12 @@
          Values: 0 - Off, 1 - Enabled.  Default - 1 -->
     <database_credentials_protection>1</database_credentials_protection>
 
+    <!-- Enables extra protection for element data.
+         When this option is enabled, the server ignores element data sync packets from the client,
+         except for allowed keys.
+         Values: 0 - Off, 1 - Enabled.  Default - 0 -->
+    <elementdata_whitelisted>0</elementdata_whitelisted>
+
     <!-- These parameters specify the maximum amount of events that can be triggered by the client (via triggerServerEvent) within the given interval.
           Note: The interval is given in milliseconds
           Interval range: 50 to 5000. Default: 1000


### PR DESCRIPTION
Added `elementdata_whitelisted` setting for `mtaserver.conf`
* Enabled: the client can't change element data on server, except allowed keys.
* Disabled: the client can change any element data. (default, unsafe)

Added `clientTrustMode` parameter for` setElementData`

```lua
-- Allow changes from the client
bool setElementData(root,  key, value, syncType, "allow" )

-- Deny changes from the client
bool setElementData(root,  key, value, syncType, "deny" )

-- Respect elementdata_whitelisted setting
bool setElementData(root,  key, value, syncType, "default" )
```

Added event `onPlayerChangesProtectedData`
source: player
arguments:
* element,
* key,
* value
