### PR TITLE
Fix #472 setElementHealth in onClientPedDamage can cause crash

### DIFF
--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -4394,12 +4394,10 @@ bool CClientGame::ApplyPedDamageFromGame(eWeaponType weaponUsed, float fDamage, 
             return false;
         }
 
-        if (pDamagedPed->IsLocalPlayer())
-        {
-            // Reget values in case they have been changed during onClientPlayerDamage event (Avoid AC#1 kick)
-            fCurrentHealth = pDamagedPed->GetGamePlayer()->GetHealth();
-            fCurrentArmor = pDamagedPed->GetGamePlayer()->GetArmor();
-        }
+        // Reget values in case they have been changed during onClientPlayerDamage event (Avoid AC#1 kick)
+        // (FileEX): We need to refresh the health value here because it may have been changed in the onClientPedDamage/onClientPlayerDamage event
+        fCurrentHealth = pDamagedPed->GetGamePlayer()->GetHealth();
+        fCurrentArmor = pDamagedPed->GetGamePlayer()->GetArmor();
 
         bool bIsBeingShotWhilstAiming = (weaponUsed >= WEAPONTYPE_PISTOL && weaponUsed <= WEAPONTYPE_MINIGUN && pDamagedPed->IsUsingGun());
         bool bOldBehaviour = !IsGlitchEnabled(GLITCH_HITANIM);


### PR DESCRIPTION
Fixes #472 

The crash was caused by the fact that for peds other than the local player, the current HP value wasn’t being updated. As a result, the code tried to kill a ped who still had 1 HP, which, due to an invalid pointer, caused a crash. However, this leads to another side effect: due to the ped being recreated, the ped pointer becomes invalid, so the ped never dies with such code.
```lua
addEventHandler('onClientPedDamage', root, function()
    setElementHealth(source, 1)
end)
```

For the local player, it works differently, and the player dies normally. For other players, they’re likely immortal in the same way as non-player peds but i'm not sure.

In any case, recreating the ped in setElementHealth causes a chain of additional bugs and unexpected behaviors. This PR aims to eliminate the crash but doesn’t address the underlying issue with ped recreation