### PR TITLE
Fix some small problems with Device Selection Dialog

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1574,6 +1574,7 @@ void CMultiplayerSA::InitHooks()
     MemSet((void*)0x6C4453, 0x90, 0x68);
     
     InitHooks_CrashFixHacks();
+    InitHooks_DeviceSelection();
 
     // Init our 1.3 hooks.
     Init_13();

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -80,6 +80,7 @@ public:
     void                InitHooks_ProjectileCollisionFix();
     void                InitHooks_ObjectStreamerOptimization();
     void                InitHooks_Postprocess();
+    void                InitHooks_DeviceSelection();
     CRemoteDataStorage* CreateRemoteDataStorage();
     void                DestroyRemoteDataStorage(CRemoteDataStorage* pData);
     void                AddRemoteDataStorage(CPlayerPed* pPed, CRemoteDataStorage* pData);

--- a/Client/multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
@@ -94,7 +94,7 @@ struct RwSubSystemInfo
 
 #define FUNC_rwDeviceSystemRequest 0x7F2AB0
 using rwDeviceSystemRequest = RwSubSystemInfo*(__cdecl*)(RwDevice* device, std::int32_t requestId, RwSubSystemInfo* pOut, void* pInOut, std::int32_t numIn);
-static RwSubSystemInfo* RwEngineGetSubSystemInfo_Hooked(RwSubSystemInfo* subSystemInfo, int32_t subSystemIndex)
+static RwSubSystemInfo* RwEngineGetSubSystemInfo_Hooked(RwSubSystemInfo* subSystemInfo, std::int32_t subSystemIndex)
 {
     auto rwGlobals = *(RwGlobals**)(0xC97B24);
     auto rwDeviceSystemRequestFunc = (rwDeviceSystemRequest)(FUNC_rwDeviceSystemRequest);

--- a/Client/multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
@@ -18,9 +18,9 @@
 
 // This is copied from SilentPatch:
 // https://github.com/CookiePLMonster/SilentPatch/blob/dev/SilentPatch/FriendlyMonitorNames.cpp
-std::map<std::string, std::string, std::less<>> GetFriendlyMonitorNamesForDevicePaths()
+std::unordered_map<std::string, std::string> GetFriendlyMonitorNamesForDevicePaths()
 {
-    std::map<std::string, std::string, std::less<>> monitorNames;
+    std::unordered_map<std::string, std::string> monitorNames;
 
     HMODULE user32Lib = LoadLibrary(TEXT("user32"));
     if (!user32Lib)

--- a/Client/multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
@@ -2,7 +2,7 @@
  *
  *  PROJECT:     Multi Theft Auto v1.0
  *  LICENSE:     See LICENSE in the top level directory
- *  FILE:        multiplayer_sa/CMultiplayerSA_Weapons.cpp
+ *  FILE:        multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
  *
  *  Multi Theft Auto is available from http://www.multitheftauto.com/
  *

--- a/Client/multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
@@ -94,8 +94,7 @@ static RwSubSystemInfo* RwEngineGetSubSystemInfo_Hooked(RwSubSystemInfo* subSyst
 {
     auto rwGlobals = *(RwGlobals**)(0xC97B24);
     auto rwDeviceSystemRequestFunc = (rwDeviceSystemRequest)(FUNC_rwDeviceSystemRequest);
-    auto result = rwDeviceSystemRequestFunc(&rwGlobals->dOpenDevice, 14, subSystemInfo, nullptr, subSystemIndex);
-    if (!result)
+    if (!rwDeviceSystemRequestFunc(&rwGlobals->dOpenDevice, 14, subSystemInfo, nullptr, subSystemIndex))
         return nullptr;
 
     auto pDxDevice = *(IDirect3D9**)0xC97C20;

--- a/Client/multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
@@ -1,0 +1,157 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        multiplayer_sa/CMultiplayerSA_Weapons.cpp
+ *
+ *  Multi Theft Auto is available from http://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+
+#ifdef _WIN32
+    #ifndef NOMINMAX
+        #define NOMINMAX
+    #endif
+#endif
+
+// This is copied from SilentPatch:
+// https://github.com/CookiePLMonster/SilentPatch/blob/dev/SilentPatch/FriendlyMonitorNames.cpp
+std::map<std::string, std::string, std::less<>> GetFriendlyMonitorNamesForDevicePaths()
+{
+    std::map<std::string, std::string, std::less<>> monitorNames;
+
+#if WINVER < _WIN32_WINNT_WIN7
+    return monitorNames;
+#else
+    HMODULE user32Lib = LoadLibrary(TEXT("user32"));
+    if (user32Lib != nullptr)
+    {
+        auto getDisplayConfigBufferSizes = (decltype(GetDisplayConfigBufferSizes)*)GetProcAddress(user32Lib, "GetDisplayConfigBufferSizes");
+        auto queryDisplayConfig = (decltype(QueryDisplayConfig)*)GetProcAddress(user32Lib, "QueryDisplayConfig");
+        auto displayConfigGetDeviceInfo = (decltype(DisplayConfigGetDeviceInfo)*)GetProcAddress(user32Lib, "DisplayConfigGetDeviceInfo");
+        if (getDisplayConfigBufferSizes != nullptr && queryDisplayConfig != nullptr && displayConfigGetDeviceInfo != nullptr)
+        {
+            UINT32                                     pathCount, modeCount;
+            std::unique_ptr<DISPLAYCONFIG_PATH_INFO[]> paths;
+            std::unique_ptr<DISPLAYCONFIG_MODE_INFO[]> modes;
+
+            LONG result = ERROR_SUCCESS;
+            do
+            {
+                result = getDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &pathCount, &modeCount);
+                if (result != ERROR_SUCCESS)
+                {
+                    break;
+                }
+                paths = std::make_unique<DISPLAYCONFIG_PATH_INFO[]>(pathCount);
+                modes = std::make_unique<DISPLAYCONFIG_MODE_INFO[]>(modeCount);
+                result = queryDisplayConfig(QDC_ONLY_ACTIVE_PATHS, &pathCount, paths.get(), &modeCount, modes.get(), nullptr);
+            } while (result == ERROR_INSUFFICIENT_BUFFER);
+
+            if (result == ERROR_SUCCESS)
+            {
+                for (size_t i = 0; i < pathCount; i++)
+                {
+                    DISPLAYCONFIG_TARGET_DEVICE_NAME targetName = {};
+                    targetName.header.adapterId = paths[i].targetInfo.adapterId;
+                    targetName.header.id = paths[i].targetInfo.id;
+                    targetName.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME;
+                    targetName.header.size = sizeof(targetName);
+                    const LONG targetNameResult = DisplayConfigGetDeviceInfo(&targetName.header);
+
+                    DISPLAYCONFIG_SOURCE_DEVICE_NAME sourceName = {};
+                    sourceName.header.adapterId = paths[i].sourceInfo.adapterId;
+                    sourceName.header.id = paths[i].sourceInfo.id;
+                    sourceName.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME;
+                    sourceName.header.size = sizeof(sourceName);
+                    const LONG sourceNameResult = DisplayConfigGetDeviceInfo(&sourceName.header);
+                    if (targetNameResult == ERROR_SUCCESS && sourceNameResult == ERROR_SUCCESS && targetName.monitorFriendlyDeviceName[0] != '\0')
+                    {
+                        char gdiDeviceName[std::size(sourceName.viewGdiDeviceName)];
+                        char monitorFriendlyDeviceName[std::size(targetName.monitorFriendlyDeviceName)];
+                        WideCharToMultiByte(CP_ACP, 0, sourceName.viewGdiDeviceName, -1, gdiDeviceName, static_cast<int>(std::size(gdiDeviceName)), nullptr,
+                                            nullptr);
+                        WideCharToMultiByte(CP_ACP, 0, targetName.monitorFriendlyDeviceName, -1, monitorFriendlyDeviceName,
+                                            static_cast<int>(std::size(monitorFriendlyDeviceName)), nullptr, nullptr);
+
+                        monitorNames.try_emplace(gdiDeviceName, monitorFriendlyDeviceName);
+                    }
+                }
+            }
+        }
+        FreeLibrary(user32Lib);
+    }
+
+    return monitorNames;
+#endif
+}
+
+struct RwSubSystemInfo
+{
+    char name[80];
+};
+
+#define FUNC_rwDeviceSystemRequest 0x7F2AB0
+using rwDeviceSystemRequest = RwSubSystemInfo*(__cdecl*)(void* device, uint32_t requestId, RwSubSystemInfo* pOut, void* pInOut, uint32_t numIn);
+static RwSubSystemInfo* RwEngineGetSubSystemInfo_Hooked(RwSubSystemInfo* subSystemInfo, int32_t subSystemIndex)
+{
+    static auto rwDeviceSystemRequestFunc = (rwDeviceSystemRequest)(FUNC_rwDeviceSystemRequest);
+    auto        devicePointer = *(uint32_t*)(0xC97B24);
+    auto        result = rwDeviceSystemRequestFunc((void*)(devicePointer + 0x10), 14, subSystemInfo, nullptr, subSystemIndex);
+    if (result == nullptr)
+        return nullptr;
+
+    auto pDxDevice = *(IDirect3D9**)0xC97C20;
+    if (pDxDevice == nullptr)
+        return subSystemInfo;
+
+    D3DADAPTER_IDENTIFIER9 identifier;
+    if (FAILED(pDxDevice->GetAdapterIdentifier(subSystemIndex, 0, &identifier)))
+        return subSystemInfo;
+
+    static const auto friendlyNames = GetFriendlyMonitorNamesForDevicePaths();
+
+    // If we can't find the friendly name, either because it doesn't exist or we're on an ancient Windows, fall back to the device name
+    auto it = friendlyNames.find(identifier.DeviceName);
+    if (it != friendlyNames.end())
+    {
+        strncpy_s(subSystemInfo->name, it->second.c_str(), _TRUNCATE);
+    }
+    else
+    {
+        strncpy_s(subSystemInfo->name, identifier.Description, _TRUNCATE);
+    }
+
+    return subSystemInfo;
+}
+
+#define FUNC_DialogFunc 0x745E50
+static INT_PTR CALLBACK CustomDlgProc(HWND window, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    auto orgDialogFunc = (DLGPROC)FUNC_DialogFunc;
+    if (msg == WM_INITDIALOG)
+    {
+        orgDialogFunc(window, msg, wParam, lParam);
+
+        // Set Icon
+        HMODULE hGameModule = GetModuleHandle(nullptr);
+        SendMessage(window, WM_SETICON, ICON_SMALL, reinterpret_cast<LPARAM>(LoadIcon(hGameModule, MAKEINTRESOURCE(100))));
+
+        // Make the dialog visible in the task bar
+        // https://stackoverflow.com/a/1462811
+        SetWindowLongPtr(window, GWL_EXSTYLE, WS_EX_APPWINDOW);
+        ShowWindow(window, SW_HIDE);
+        ShowWindow(window, SW_SHOW);
+        return FALSE;
+    }
+
+    return orgDialogFunc(window, msg, wParam, lParam);
+}
+
+void CMultiplayerSA::InitHooks_DeviceSelection()
+{
+    MemPut<DLGPROC>(0x746239, (DLGPROC)&CustomDlgProc);
+    HookInstall(0x7F2C30, (DWORD)RwEngineGetSubSystemInfo_Hooked, 6);
+}

--- a/Client/multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
@@ -20,9 +20,9 @@ std::map<std::string, std::string, std::less<>> GetFriendlyMonitorNamesForDevice
     if (!user32Lib)
         return monitorNames;
 
-    auto getDisplayConfigBufferSizes = (decltype(GetDisplayConfigBufferSizes)*)GetProcAddress(user32Lib, "GetDisplayConfigBufferSizes");
-    auto queryDisplayConfig = (decltype(QueryDisplayConfig)*)GetProcAddress(user32Lib, "QueryDisplayConfig");
-    auto displayConfigGetDeviceInfo = (decltype(DisplayConfigGetDeviceInfo)*)GetProcAddress(user32Lib, "DisplayConfigGetDeviceInfo");
+    auto* getDisplayConfigBufferSizes = (decltype(GetDisplayConfigBufferSizes)*)GetProcAddress(user32Lib, "GetDisplayConfigBufferSizes");
+    auto* queryDisplayConfig = (decltype(QueryDisplayConfig)*)GetProcAddress(user32Lib, "QueryDisplayConfig");
+    auto* displayConfigGetDeviceInfo = (decltype(DisplayConfigGetDeviceInfo)*)GetProcAddress(user32Lib, "DisplayConfigGetDeviceInfo");
     if (!getDisplayConfigBufferSizes || !queryDisplayConfig || !displayConfigGetDeviceInfo)
     {
         FreeLibrary(user32Lib);
@@ -92,12 +92,12 @@ struct RwSubSystemInfo
 using rwDeviceSystemRequest = RwSubSystemInfo*(__cdecl*)(RwDevice* device, std::int32_t requestId, RwSubSystemInfo* pOut, void* pInOut, std::int32_t numIn);
 static RwSubSystemInfo* RwEngineGetSubSystemInfo_Hooked(RwSubSystemInfo* subSystemInfo, std::int32_t subSystemIndex)
 {
-    auto rwGlobals = *(RwGlobals**)(0xC97B24);
-    auto rwDeviceSystemRequestFunc = (rwDeviceSystemRequest)(FUNC_rwDeviceSystemRequest);
+    auto* rwGlobals = *(RwGlobals**)(0xC97B24);
+    auto* rwDeviceSystemRequestFunc = (rwDeviceSystemRequest)(FUNC_rwDeviceSystemRequest);
     if (!rwDeviceSystemRequestFunc(&rwGlobals->dOpenDevice, 14, subSystemInfo, nullptr, subSystemIndex))
         return nullptr;
 
-    auto pDxDevice = *(IDirect3D9**)0xC97C20;
+    auto* pDxDevice = *(IDirect3D9**)0xC97C20;
     if (!pDxDevice)
         return subSystemInfo;
 
@@ -124,7 +124,7 @@ static RwSubSystemInfo* RwEngineGetSubSystemInfo_Hooked(RwSubSystemInfo* subSyst
 #define FUNC_DialogFunc 0x745E50
 INT_PTR CALLBACK CustomDlgProc(HWND window, UINT msg, WPARAM wParam, LPARAM lParam)
 {
-    auto orgDialogFunc = (DLGPROC)FUNC_DialogFunc;
+    auto* orgDialogFunc = (DLGPROC)FUNC_DialogFunc;
     if (msg != WM_INITDIALOG)
         return orgDialogFunc(window, msg, wParam, lParam);
 

--- a/Client/multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
@@ -10,12 +10,6 @@
 
 #include "StdInc.h"
 
-#ifdef _WIN32
-    #ifndef NOMINMAX
-        #define NOMINMAX
-    #endif
-#endif
-
 // This is copied from SilentPatch:
 // https://github.com/CookiePLMonster/SilentPatch/blob/dev/SilentPatch/FriendlyMonitorNames.cpp
 std::map<std::string, std::string, std::less<>> GetFriendlyMonitorNamesForDevicePaths()

--- a/Client/multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
@@ -93,17 +93,17 @@ struct RwSubSystemInfo
 };
 
 #define FUNC_rwDeviceSystemRequest 0x7F2AB0
-using rwDeviceSystemRequest = RwSubSystemInfo*(__cdecl*)(void* device, uint32_t requestId, RwSubSystemInfo* pOut, void* pInOut, uint32_t numIn);
+using rwDeviceSystemRequest = RwSubSystemInfo*(__cdecl*)(RwDevice* device, std::int32_t requestId, RwSubSystemInfo* pOut, void* pInOut, std::int32_t numIn);
 static RwSubSystemInfo* RwEngineGetSubSystemInfo_Hooked(RwSubSystemInfo* subSystemInfo, int32_t subSystemIndex)
 {
-    static auto rwDeviceSystemRequestFunc = (rwDeviceSystemRequest)(FUNC_rwDeviceSystemRequest);
-    auto        devicePointer = *(uint32_t*)(0xC97B24);
-    auto        result = rwDeviceSystemRequestFunc((void*)(devicePointer + 0x10), 14, subSystemInfo, nullptr, subSystemIndex);
-    if (result == nullptr)
+    auto        rwGlobals = *(RwGlobals**)(0xC97B24);
+    auto rwDeviceSystemRequestFunc = (rwDeviceSystemRequest)(FUNC_rwDeviceSystemRequest);
+    auto        result = rwDeviceSystemRequestFunc(&rwGlobals->dOpenDevice, 14, subSystemInfo, nullptr, subSystemIndex);
+    if (!result)
         return nullptr;
 
     auto pDxDevice = *(IDirect3D9**)0xC97C20;
-    if (pDxDevice == nullptr)
+    if (!pDxDevice)
         return subSystemInfo;
 
     D3DADAPTER_IDENTIFIER9 identifier;

--- a/Client/multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
@@ -96,9 +96,9 @@ struct RwSubSystemInfo
 using rwDeviceSystemRequest = RwSubSystemInfo*(__cdecl*)(RwDevice* device, std::int32_t requestId, RwSubSystemInfo* pOut, void* pInOut, std::int32_t numIn);
 static RwSubSystemInfo* RwEngineGetSubSystemInfo_Hooked(RwSubSystemInfo* subSystemInfo, int32_t subSystemIndex)
 {
-    auto        rwGlobals = *(RwGlobals**)(0xC97B24);
+    auto rwGlobals = *(RwGlobals**)(0xC97B24);
     auto rwDeviceSystemRequestFunc = (rwDeviceSystemRequest)(FUNC_rwDeviceSystemRequest);
-    auto        result = rwDeviceSystemRequestFunc(&rwGlobals->dOpenDevice, 14, subSystemInfo, nullptr, subSystemIndex);
+    auto result = rwDeviceSystemRequestFunc(&rwGlobals->dOpenDevice, 14, subSystemInfo, nullptr, subSystemIndex);
     if (!result)
         return nullptr;
 
@@ -127,7 +127,7 @@ static RwSubSystemInfo* RwEngineGetSubSystemInfo_Hooked(RwSubSystemInfo* subSyst
 }
 
 #define FUNC_DialogFunc 0x745E50
-static INT_PTR CALLBACK CustomDlgProc(HWND window, UINT msg, WPARAM wParam, LPARAM lParam)
+INT_PTR CALLBACK CustomDlgProc(HWND window, UINT msg, WPARAM wParam, LPARAM lParam)
 {
     auto orgDialogFunc = (DLGPROC)FUNC_DialogFunc;
     if (msg != WM_INITDIALOG)
@@ -147,8 +147,11 @@ static INT_PTR CALLBACK CustomDlgProc(HWND window, UINT msg, WPARAM wParam, LPAR
     return FALSE;
 }
 
+#define FUNC_RwEngineGetSubSystemInfo 0x7F2C30
 void CMultiplayerSA::InitHooks_DeviceSelection()
 {
+    // 0x746239 -> Exact address where the original DialogFunc address is being pushed as an argument to DialogBoxParamA(),
+    // we're replacing it with out own proxy function
     MemPut<DLGPROC>(0x746239, (DLGPROC)&CustomDlgProc);
-    HookInstall(0x7F2C30, (DWORD)RwEngineGetSubSystemInfo_Hooked, 6);
+    HookInstall(FUNC_RwEngineGetSubSystemInfo, (DWORD)RwEngineGetSubSystemInfo_Hooked, 6);
 }

--- a/Client/multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_DeviceSelection.cpp
@@ -16,9 +16,6 @@ std::map<std::string, std::string, std::less<>> GetFriendlyMonitorNamesForDevice
 {
     std::map<std::string, std::string, std::less<>> monitorNames;
 
-#if WINVER < _WIN32_WINNT_WIN7
-    return monitorNames;
-#else
     HMODULE user32Lib = LoadLibrary(TEXT("user32"));
     if (!user32Lib)
         return monitorNames;
@@ -84,7 +81,6 @@ std::map<std::string, std::string, std::less<>> GetFriendlyMonitorNamesForDevice
 
     FreeLibrary(user32Lib);
     return monitorNames;
-#endif
 }
 
 struct RwSubSystemInfo

--- a/Client/sdk/game/RenderWare.h
+++ b/Client/sdk/game/RenderWare.h
@@ -549,7 +549,7 @@ struct RwDevice
     // RwIm3DRenderPrimitiveFunction        fpIm3DRenderPrimitive;
     // RwIm3DRenderIndexedPrimitiveFunction fpIm3DRenderIndexedPrimitive;
 };
-// static_assert(sizeof(RwDevice) == 0x38, "Incorrect class size: RwGlobals");
+// static_assert(sizeof(RwDevice) == 0x38, "Incorrect class size: RwDevice");
 
 typedef bool (*RwStandardFunc)(void*, void*, std::int32_t);
 struct RwGlobals

--- a/Client/sdk/game/RenderWare.h
+++ b/Client/sdk/game/RenderWare.h
@@ -526,3 +526,49 @@ struct RwError
 {
     int err1, err2;
 };
+
+/*****************************************************************************/
+/** RenderWare Globals                                                      **/
+/*****************************************************************************/
+
+typedef bool (*RwSystemFunc)(std::int32_t, void*, void*, std::int32_t);
+struct RwDevice
+{
+    float        gammaCorrection;
+    RwSystemFunc fpSystem;
+    float        zBufferNear;
+    float        zBufferFar;
+    // RwRenderStateSetFunction             fpRenderStateSet;
+    // RwRenderStateGetFunction             fpRenderStateGet;
+    // RwIm2DRenderLineFunction             fpIm2DRenderLine;
+    // RwIm2DRenderTriangleFunction         fpIm2DRenderTriangle;
+    // RwIm2DRenderPrimitiveFunction        fpIm2DRenderPrimitive;
+    // RwIm2DRenderIndexedPrimitiveFunction fpIm2DRenderIndexedPrimitive;
+    // RwIm3DRenderLineFunction             fpIm3DRenderLine;
+    // RwIm3DRenderTriangleFunction         fpIm3DRenderTriangle;
+    // RwIm3DRenderPrimitiveFunction        fpIm3DRenderPrimitive;
+    // RwIm3DRenderIndexedPrimitiveFunction fpIm3DRenderIndexedPrimitive;
+};
+// static_assert(sizeof(RwDevice) == 0x38, "Incorrect class size: RwGlobals");
+
+typedef bool (*RwStandardFunc)(void*, void*, std::int32_t);
+struct RwGlobals
+{
+    void*               curCamera;
+    void*               curWorld;
+    std::uint16_t       renderFrame;
+    std::uint16_t       lightFrame;
+    std::uint16_t       pad[2];
+    RwDevice            dOpenDevice;
+    RwStandardFunc      stdFunc[29];
+    // RwLinkList          dirtyFrameList;
+    // RwFileFunctions     fileFuncs;
+    // RwStringFunctions   stringFuncs;
+    // RwMemoryFunctions   memoryFuncs;
+    // RwMemoryAllocFn     memoryAlloc;
+    // RwMemoryFreeFn      memoryFree;
+    // RwMetrics*          metrics;
+    // RwEngineStatus      engineStatus;
+    // RwUInt32            resArenaInitSize;
+};
+//static_assert(sizeof(RwGlobals) == 0x158, "Incorrect class size: RwGlobals");


### PR DESCRIPTION
This aims to improve Device Selection dialog that shows on startup if more than one monitor is present. It's partially based on the changes introduced in SilentPatch, although the approach is a bit different.

Changes:
- The dialog is now visible in the taskbar
- The dialog now has an icon assigned to it
- The device selection drop down correctly displays the monitor names, instead of using the GPU model as all options (The name retrieval logic is copied from SilentPatch)

Here's how the dialog looked like before the changes:
![original_naming](https://github.com/user-attachments/assets/fcdaf864-62c4-4b99-9f7d-3b43912a4f16)

And here's the result after the changes:
![new_naming](https://github.com/user-attachments/assets/274da8ec-b3ff-4410-a824-d80579b68f48)
![obraz](https://github.com/user-attachments/assets/3b89eb59-d3bc-4820-9688-30cd6468ec08)

And here it is in the taskbar:
![Taskbar](https://github.com/user-attachments/assets/87056ac8-be40-434d-974c-8fa2d8ee1594)

The main reason for these change is that in most cases the device selection dialog is lost somewhere under all the windows, making it hard to find. I didn't port over all of the changes from SilentPatch, as i wanted to keep it simple for now.
