### PR TITLE
Fix min_mta_version 'server' not working as expected

### DIFF
--- a/Server/mods/deathmatch/logic/CResource.cpp
+++ b/Server/mods/deathmatch/logic/CResource.cpp
@@ -35,6 +35,8 @@
 #include <net/SimHeaders.h>
 #include <zip.h>
 #include <glob/glob.h>
+#include "version.h"
+#include "CStaticFunctionDefinitions.h"
 
 #ifdef WIN32
     #include <zip/iowin32.h>


### PR DESCRIPTION
Fixes #3852
Caused by: https://github.com/multitheftauto/mtasa-blue/pull/3853#issuecomment-2472903077

I found that 2 missing includes were preventing the script from checking if a server's version is too low to start a certain resource that requires a higher version.

![image](https://github.com/user-attachments/assets/484eaa44-9e20-4543-a942-411a919de270)

![image](https://github.com/user-attachments/assets/79f7ef1e-77df-4883-8fd7-9dd805e1503e)
