### PR TITLE
Fix MinClientReqCheck and improve resource upgrade

### DIFF
--- a/Server/mods/deathmatch/StdInc.h
+++ b/Server/mods/deathmatch/StdInc.h
@@ -49,6 +49,7 @@
 #include <bochs_internal/bochs_crc32.h>
 #include <pcrecpp.h>
 #include <pthread.h>
+#include "version.h"
 
 extern class CNetServer* g_pRealNetServer;
 extern class CGame*      g_pGame;

--- a/Server/mods/deathmatch/logic/CResource.cpp
+++ b/Server/mods/deathmatch/logic/CResource.cpp
@@ -35,7 +35,6 @@
 #include <net/SimHeaders.h>
 #include <zip.h>
 #include <glob/glob.h>
-#include "version.h"
 #include "CStaticFunctionDefinitions.h"
 
 #ifdef WIN32

--- a/Server/mods/deathmatch/logic/CResourceChecker.Data.h
+++ b/Server/mods/deathmatch/logic/CResourceChecker.Data.h
@@ -167,8 +167,8 @@ namespace
         //{false, "doesPedHaveJetPack", "isPedWearingJetpack"},
 
         // Base Encoding & Decoding
-        {false, "base64Encode", "encodeString"},
-        {false, "base64Decode", "decodeString"},
+        {true, "base64Encode", "Please manually change this to encodeString (different syntax). Refer to the wiki for details"},
+        {true, "base64Decode", "Please manually change this to decodeString (different syntax). Refer to the wiki for details"},
 
         {false, "setHelicopterRotorSpeed", "setVehicleRotorSpeed"}
     };
@@ -271,7 +271,7 @@ namespace
         {true, "setPlayerDiscordJoinParams", "See GitHub PR #2499 for more details"},
 
         // Base Encoding & Decoding
-        {false, "base64Encode", "encodeString"},
-        {false, "base64Decode", "decodeString"}
+        {true, "base64Encode", "Please manually change this to encodeString (different syntax). Refer to the wiki for details"},
+        {true, "base64Decode", "Please manually change this to decodeString (different syntax). Refer to the wiki for details"}
     };
 }            // namespace

--- a/Server/mods/deathmatch/logic/CResourceChecker.cpp
+++ b/Server/mods/deathmatch/logic/CResourceChecker.cpp
@@ -367,16 +367,25 @@ void CResourceChecker::CheckMetaSourceForIssues(CXMLNode* pRootNode, const strin
             attributes.Delete("client");
             attributes.Delete("both");
 
-            if (!m_strReqServerVersion.empty())
+            // Use "both" if client and server versions are the same
+            if (!m_strReqServerVersion.empty() && !m_strReqClientVersion.empty() && m_strReqServerVersion == m_strReqClientVersion)
             {
-                CXMLAttribute* pAttr = attributes.Create("server");
+                CXMLAttribute* pAttr = attributes.Create("both");
                 pAttr->SetValue(m_strReqServerVersion);
             }
-
-            if (!m_strReqClientVersion.empty())
+            else
             {
-                CXMLAttribute* pAttr = attributes.Create("client");
-                pAttr->SetValue(m_strReqClientVersion);
+                if (!m_strReqServerVersion.empty())
+                {
+                    CXMLAttribute* pAttr = attributes.Create("server");
+                    pAttr->SetValue(m_strReqServerVersion);
+                }
+
+                if (!m_strReqClientVersion.empty())
+                {
+                    CXMLAttribute* pAttr = attributes.Create("client");
+                    pAttr->SetValue(m_strReqClientVersion);
+                }
             }
 
             if (pbOutHasChanged)

--- a/Server/mods/deathmatch/logic/CResourceChecker.h
+++ b/Server/mods/deathmatch/logic/CResourceChecker.h
@@ -2,7 +2,7 @@
  *
  *  PROJECT:     Multi Theft Auto v1.0
  *  LICENSE:     See LICENSE in the top level directory
- *  FILE:        mods/deathmatch/logic/CResourceChecker.cpp
+ *  FILE:        mods/deathmatch/logic/CResourceChecker.h
  *  PURPOSE:     Resource file content checker/validator/upgrader
  *
  *  Multi Theft Auto is available from http://www.multitheftauto.com/


### PR DESCRIPTION
## Details
- I found that `MinClientReqCheck` was not working on any builds because it was checking `MTASA_VERSION_TYPE`, which was not defined due to a missing `version.h` import. I have restored this include in server `StdInc.h`, as it was back in the day (before a big refactor that removed this by mistake, see https://github.com/multitheftauto/mtasa-blue/pull/3853#issuecomment-2472903077). This was resulting in clientside functions like fetchRemote which use old syntax not outputting any warnings.

- I changed the Resource Upgrade feature to set the `min_mta_version` meta.xml node with the `"both"` attribute when the client & server versions to set are the same (`CResourceChecker.cpp`). Attribute `"both"` is already correctly supported on resource parsing/loading.

- I changed the way base64Encode and base64Decode functions are detected by the resource checker (& upgrader). Previously, the upgrader would automatically rename these functions in your scripts to encodeString and decodeString, causing the scripts to break because these functions take different arguments (different syntaxes). Now, instead of doing that automatically, it warns you to manually update, like it does for other functions such as `givePlayerJetPack`.

## Tests

### `min_mta_version` attribute `"both"`
> [!NOTE]
> Tested by commenting the MTASA_VERSION_TYPE checks at MinServerReqCheck and MinClientReqCheck so this can run on custom builds:

Place this code on `client.lua` and `server.lua` script files in a new resource.
```lua
fileGetContents("doesnt_matter")
```

Start the server to load all resources or start the resource if the server was already running.

The resource upgrader will detect the missing `min_mta_version` information due to this new 1.6.0 function being used, which was added in 1.6.0-9.21938 for both client and server.

The upgrade command will result in the meta.xml being successfully updated with the new `"both"` `min_mta_version` required.

![image](https://github.com/user-attachments/assets/395f76ee-697a-45bb-a8f0-a075a56ff076)

### `base64Encode` and `base64Decode` detection

Place this code in a serverside script (taken from the wiki).
```lua
local k = base64Encode("Hello, world!")
outputServerLog(k)
--Output: SGVsbG8sIHdvcmxkIQ==
```

Start the resource. We now observe a warning asking you to update the function manually, where previously it would wrongfully replace the function name (base64Encode) with encodeString which has a different syntax.

```log
WARNING: testres/server.lua(Line 1) [Server] base64Encode no longer works. Please manually change this to encodeString (different syntax). Refer to the wiki for details
```