### PR TITLE
Fixed a bug with desynchronization of the values of some fields of the CTickRateSettings structure.

### DIFF
--- a/Client/mods/deathmatch/logic/rpc/CWorldRPCs.cpp
+++ b/Client/mods/deathmatch/logic/rpc/CWorldRPCs.cpp
@@ -619,6 +619,8 @@ void CWorldRPCs::SetSyncIntervals(NetBitStreamInterface& bitStream)
     bitStream.Read(g_TickRateSettings.iObjectSync);
     bitStream.Read(g_TickRateSettings.iKeySyncRotation);
     bitStream.Read(g_TickRateSettings.iKeySyncAnalogMove);
+    bitStream.Read(g_TickRateSettings.iPedSyncerDistance);
+    bitStream.Read(g_TickRateSettings.iUnoccupiedVehicleSyncerDistance);
 }
 
 void CWorldRPCs::SetMoonSize(NetBitStreamInterface& bitStream)

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -10861,6 +10861,8 @@ bool CStaticFunctionDefinitions::SendSyncIntervals(CPlayer* pPlayer)
     BitStream.pBitStream->Write(g_TickRateSettings.iObjectSync);
     BitStream.pBitStream->Write(g_TickRateSettings.iKeySyncRotation);
     BitStream.pBitStream->Write(g_TickRateSettings.iKeySyncAnalogMove);
+    BitStream.pBitStream->Write(g_TickRateSettings.iPedSyncerDistance);
+    BitStream.pBitStream->Write(g_TickRateSettings.iUnoccupiedVehicleSyncerDistance);
     if (pPlayer)
         pPlayer->Send(CLuaPacket(SET_SYNC_INTERVALS, *BitStream.pBitStream));
     else


### PR DESCRIPTION
Fixes a bug where server configuration fields (ped_syncer_distance and unoccupied_vehicle_syncer_distance) did not affect the game in any way, i.e. the client side used its default values ​​(easy to check with the /sinfo command).