### PR TITLE
Make some sync parameter configurable.

### DIFF
--- a/Server/mods/deathmatch/editor.conf
+++ b/Server/mods/deathmatch/editor.conf
@@ -126,6 +126,8 @@
     <ped_far_sync_interval>2000</ped_far_sync_interval>
     <!-- Unoccupied_vehicle sync interval. Default: 400 -->
     <unoccupied_vehicle_sync_interval>400</unoccupied_vehicle_sync_interval>
+    <!-- Object sync interval. Default: 500 -->
+    <object_sync_interval>500</object_sync_interval>
     <!-- Keysync mouse rotation sync interval. For limiting key sync packets due to mouse movement. Default: 100 -->
     <keysync_mouse_sync_interval>100</keysync_mouse_sync_interval>
     <!-- Keysync analog movement sync interval. For limiting key sync packets due to joystick movement. Default: 100 -->

--- a/Server/mods/deathmatch/local.conf
+++ b/Server/mods/deathmatch/local.conf
@@ -126,6 +126,8 @@
     <ped_far_sync_interval>2000</ped_far_sync_interval>
     <!-- Unoccupied_vehicle sync interval. Default: 400 -->
     <unoccupied_vehicle_sync_interval>400</unoccupied_vehicle_sync_interval>
+    <!-- Object sync interval. Default: 500 -->
+    <object_sync_interval>500</object_sync_interval>
     <!-- Keysync mouse rotation sync interval. For limiting key sync packets due to mouse movement. Default: 100 -->
     <keysync_mouse_sync_interval>100</keysync_mouse_sync_interval>
     <!-- Keysync analog movement sync interval. For limiting key sync packets due to joystick movement. Default: 100 -->

--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -1449,6 +1449,7 @@ const std::vector<SIntSetting>& CMainConfig::GetIntSettingList()
         {true, true, 50, 400, 4000, "ped_sync_interval", &g_TickRateSettings.iPedSync, &CMainConfig::OnTickRateChange},
         {true, true, 50, 2000, 4000, "ped_far_sync_interval", &g_TickRateSettings.iPedFarSync, NULL},
         {true, true, 50, 400, 4000, "unoccupied_vehicle_sync_interval", &g_TickRateSettings.iUnoccupiedVehicle, &CMainConfig::OnTickRateChange},
+        {true, true, 50, 500, 4000, "object_sync_interval", &g_TickRateSettings.iObjectSync, &CMainConfig::OnTickRateChange},
         {true, true, 50, 100, 4000, "keysync_mouse_sync_interval", &g_TickRateSettings.iKeySyncRotation, &CMainConfig::OnTickRateChange},
         {true, true, 50, 100, 4000, "keysync_analog_sync_interval", &g_TickRateSettings.iKeySyncAnalogMove, &CMainConfig::OnTickRateChange},
         {true, true, 50, 100, 4000, "donkey_work_interval", &g_TickRateSettings.iNearListUpdate, &CMainConfig::OnTickRateChange},

--- a/Server/mods/deathmatch/mtaserver.conf
+++ b/Server/mods/deathmatch/mtaserver.conf
@@ -126,6 +126,8 @@
     <ped_far_sync_interval>2000</ped_far_sync_interval>
     <!-- Unoccupied_vehicle sync interval. Default: 400 -->
     <unoccupied_vehicle_sync_interval>400</unoccupied_vehicle_sync_interval>
+    <!-- Object sync interval. Default: 500 -->
+    <object_sync_interval>500</object_sync_interval>
     <!-- Keysync mouse rotation sync interval. For limiting key sync packets due to mouse movement. Default: 100 -->
     <keysync_mouse_sync_interval>100</keysync_mouse_sync_interval>
     <!-- Keysync analog movement sync interval. For limiting key sync packets due to joystick movement. Default: 100 -->

--- a/Server/mods/deathmatch/mtaserver.conf.template
+++ b/Server/mods/deathmatch/mtaserver.conf.template
@@ -127,6 +127,8 @@
     <ped_far_sync_interval>2000</ped_far_sync_interval>
     <!-- Unoccupied_vehicle sync interval. Default: 400 -->
     <unoccupied_vehicle_sync_interval>400</unoccupied_vehicle_sync_interval>
+    <!-- Object sync interval. Default: 500 -->
+    <object_sync_interval>500</object_sync_interval>
     <!-- Keysync mouse rotation sync interval. For limiting key sync packets due to mouse movement. Default: 100 -->
     <keysync_mouse_sync_interval>100</keysync_mouse_sync_interval>
     <!-- Keysync analog movement sync interval. For limiting key sync packets due to joystick movement. Default: 100 -->


### PR DESCRIPTION
Adds the object_sync_interval parameter to the server configuration file. It is already supported, but for some unknown reason it could not be configured.