### PR TITLE
Fixing MTA library hashes for Windows 7/8.x

### DIFF
--- a/Client/loader/MainFunctions.cpp
+++ b/Client/loader/MainFunctions.cpp
@@ -863,15 +863,15 @@ void CheckDataFiles()
     {
         const char* expected;
         const char* fileName;
-    } integrityCheckList[] = {{"36CB1B284BC7CBB4F25CD00BBB044550", "bass.dll"},           {"1B909B47946167D153FB94020393E781", "bass_aac.dll"},
-                              {"E7E69A3B369F0ABA1A4A18C831BC4364", "bass_ac3.dll"},       {"E20A57EA7D845FADC9A48A0AA919121A", "bass_fx.dll"},
+    } integrityCheckList[] = {{"36CB1B284BC7CBB4F25CD00BBB044550", "bass.dll"},           {"80CDC5A50B27C47E53B99DE4D4523698", "bass_aac.dll"},
+                              {"2757D3E0F63C8C62DB32F90D776AB815", "bass_ac3.dll"},       {"539BE2B8762FF618C3BA04B638FD4A8B", "bass_fx.dll"},
                               {"F47DCE69DAFAA06A55A4BC1F07F80C8A", "bassflac.dll"},       {"F246D72BA73E9624FE8BE66E785FB5C5", "bassmidi.dll"},
                               {"5DEEC10A943E352EF7E0223327E8B48C", "bassmix.dll"},        {"2F87C5E0A1B7B28C8FC0D7E74116DDFC", "bassopus.dll"},
                               {"0F1B2FC6C0C703A43A24DC05352E7ADA", "basswebm.dll"},       {"893113C6C49DC1E1EF288310E68DB306", "basswma.dll"},
                               {"C6A44FC3CF2F5801561804272217B14D", "D3DX9_42.dll"},       {"D439E8EDD8C93D7ADE9C04BCFE9197C6", "sa.dat"},
-                              {"B33B21DB610116262D906305CE65C354", "D3DCompiler_42.dll"}, {"02ECD2919B3DAA59D6014EEFD29FC294", "tags.dll"},
+                              {"B33B21DB610116262D906305CE65C354", "D3DCompiler_42.dll"}, {"7A1665DD46726DA4592E77DC05D114F8", "tags.dll"},
                               {"0B3DD892007FB366D1F52F2247C046F5", "d3dcompiler_43.dll"}, {"D5D8C8561C6DDA7EF0D7D6ABB0D772F4", "xinput1_3_mta.dll"},
-                              {"E1677EC0E21E27405E65E31419980348", "d3dcompiler_47.dll"}, {"E2BAC93166B0C2AD4D83E97FC1E88F8F", "XInput9_1_0_mta.dll"}};
+                              {"E1677EC0E21E27405E65E31419980348", "d3dcompiler_47.dll"}, {"87F689D5636B6F31DBB4B9CBF56E17E3", "XInput9_1_0_mta.dll"}};
 
     for (const auto& item : integrityCheckList)
     {


### PR DESCRIPTION
Fixes a problem (https://github.com/multitheftauto/mtasa-blue/issues/3865) for the maetro version, when real file hashes did not match the hardcoded ones.