### PR TITLE
Temporary fix projectiles crash during disconnecting #3876

### DIFF
--- a/Client/game_sa/CProjectileInfoSA.cpp
+++ b/Client/game_sa/CProjectileInfoSA.cpp
@@ -46,6 +46,11 @@ void CProjectileInfoSA::RemoveProjectile(CProjectileInfo* pProjectileInfo, CProj
         // Has it not already been removed by GTA?
         if (pProjectileInfo->IsActive())
         {
+            // Fix crash when disconnecting
+            // GH #3876
+            if (!projectileInfoInterface->pEntProjectileOwner || projectileInfoInterface->pEntProjectileOwner->nType == ENTITY_TYPE_NOTHING || projectileInfoInterface->pEntProjectileOwner->pReferences == reinterpret_cast<void*>(0x80808080))
+                bBlow = false;
+
             if (bBlow)
             {
                 DWORD dwFunc = FUNC_RemoveProjectile;


### PR DESCRIPTION
Fixed #3876 

The crash occurs in the function ``CEntity::RegisterReference`` because, at the moment of creating an explosion for a projectile, for an unknown reason, the memory where the projectile's creator (the player disconnecting from the server) is located is freed and becomes ``0x80808080``. I haven’t investigated the cause of where and why the memory is being freed before the projectile is destroyed. In any case, removing projectiles without the explosion resolves the crash. Besides, the explosion during the server quit doesn’t make sense anyway because we can't see it