### PR TITLE
Dark titlebar for dark windows mode

### DIFF
--- a/Client/core/DXHook/CProxyDirect3D9.cpp
+++ b/Client/core/DXHook/CProxyDirect3D9.cpp
@@ -10,6 +10,8 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include <dwmapi.h>
+
 HRESULT HandleCreateDeviceResult(HRESULT hResult, IDirect3D9* pDirect3D, UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD BehaviorFlags,
                                  D3DPRESENT_PARAMETERS* pPresentationParameters, IDirect3DDevice9** ppReturnedDeviceInterface);
 std::vector<IDirect3D9*> ms_CreatedDirect3D9List;
@@ -165,6 +167,20 @@ HRESULT CProxyDirect3D9::CreateDevice(UINT Adapter, D3DDEVTYPE DeviceType, HWND 
     #else
     SetWindowTextW(hFocusWindow, MbUTF8ToUTF16("MTA: San Andreas").c_str());
     #endif
+
+    // Set dark titlebar if needed
+    HKEY hKey;
+    DWORD systemThemeMode = 1;
+    DWORD dataSize = sizeof(systemThemeMode);
+
+    if (RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize", 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+    {
+        RegQueryValueExW(hKey, L"AppsUseLightTheme", nullptr, nullptr, reinterpret_cast<LPBYTE>(&systemThemeMode), &dataSize);
+        RegCloseKey(hKey);
+    }
+
+    BOOL darkTitleBar = systemThemeMode == 0;
+    DwmSetWindowAttribute(hFocusWindow, DWMWA_USE_IMMERSIVE_DARK_MODE, &darkTitleBar, sizeof(darkTitleBar));
 
     // Detect if second call to CreateDevice
     if (CreateDeviceSecondCallCheck(hResult, m_pDevice, Adapter, DeviceType, hFocusWindow, BehaviorFlags, pPresentationParameters, ppReturnedDeviceInterface))

--- a/Client/core/DXHook/CProxyDirect3D9.cpp
+++ b/Client/core/DXHook/CProxyDirect3D9.cpp
@@ -169,17 +169,7 @@ HRESULT CProxyDirect3D9::CreateDevice(UINT Adapter, D3DDEVTYPE DeviceType, HWND 
     #endif
 
     // Set dark titlebar if needed
-    HKEY hKey;
-    DWORD systemThemeMode = 1;
-    DWORD dataSize = sizeof(systemThemeMode);
-
-    if (RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize", 0, KEY_READ, &hKey) == ERROR_SUCCESS)
-    {
-        RegQueryValueExW(hKey, L"AppsUseLightTheme", nullptr, nullptr, reinterpret_cast<LPBYTE>(&systemThemeMode), &dataSize);
-        RegCloseKey(hKey);
-    }
-
-    BOOL darkTitleBar = systemThemeMode == 0;
+    BOOL darkTitleBar = GetSystemRegistryValue((uint)HKEY_CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize", "AppsUseLightTheme") == "\x0";
     DwmSetWindowAttribute(hFocusWindow, DWMWA_USE_IMMERSIVE_DARK_MODE, &darkTitleBar, sizeof(darkTitleBar));
 
     // Detect if second call to CreateDevice

--- a/Client/core/premake5.lua
+++ b/Client/core/premake5.lua
@@ -46,7 +46,7 @@ project "Client Core"
 
 	links {
 		"ws2_32", "d3dx9", "Userenv", "DbgHelp", "xinput", "Imagehlp", "dxguid", "dinput8",
-		"strmiids",	"odbc32", "odbccp32", "shlwapi", "winmm", "gdi32", "Imm32", "Psapi",
+		"strmiids",	"odbc32", "odbccp32", "shlwapi", "winmm", "gdi32", "Imm32", "Psapi", "dwmapi",
 		"pthread", "libpng", "jpeg", "zlib", "tinygettext", "discord-rpc",
 	}
 


### PR DESCRIPTION
Resolved #3859 

The title bar is set to dark if the Windows theme is dark or remains light for the light Windows theme.
![image](https://github.com/user-attachments/assets/343aca0f-6b0f-40bf-86a0-146da143b718)
