### PR TITLE
New functions setWeaponRenderEnabled & isWeaponRenderEnabled

### DIFF
--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -1143,6 +1143,9 @@ CWeaponStat* CGameSA::CreateWeaponStat(eWeaponType weaponType, eWeaponSkill weap
 
 void CGameSA::SetWeaponRenderEnabled(bool enabled)
 {
+    if (IsWeaponRenderEnabled() == enabled)
+        return;
+
     if (!enabled)
     {
         // Disable calls to CVisibilityPlugins::RenderWeaponPedsForPC

--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -1141,6 +1141,29 @@ CWeaponStat* CGameSA::CreateWeaponStat(eWeaponType weaponType, eWeaponSkill weap
     return m_pWeaponStatsManager->CreateWeaponStatUnlisted(weaponType, weaponSkill);
 }
 
+void CGameSA::SetWeaponRenderEnabled(bool enabled)
+{
+    if (!enabled)
+    {
+        // Disable calls to CVisibilityPlugins::RenderWeaponPedsForPC
+        MemSet((void*)0x53EAC4, 0x90, 5); // Idle
+        MemSet((void*)0x705322, 0x90, 5); // CPostEffects::Render
+        MemSet((void*)0x7271E3, 0x90, 5); // CMirrors::BeforeMainRender
+    }
+    else
+    {
+        // Restore original bytes
+        MemCpy((void*)0x53EAC4, "\xE8\x67\x44\x1F\x00", 5);
+        MemCpy((void*)0x705322, "\xE8\x09\xDC\x02\x00", 5);
+        MemCpy((void*)0x7271E3, "\xE8\x48\xBD\x00\x00", 5);
+    }
+}
+
+bool CGameSA::IsWeaponRenderEnabled() const
+{
+    return *(unsigned char*)0x53EAC4 == 0xE8;
+}
+
 void CGameSA::OnPedContextChange(CPed* pPedContext)
 {
     m_pPedContext = pPedContext;

--- a/Client/game_sa/CGameSA.h
+++ b/Client/game_sa/CGameSA.h
@@ -287,6 +287,8 @@ public:
     void         SetupBrokenModels();
     CWeapon*     CreateWeapon();
     CWeaponStat* CreateWeaponStat(eWeaponType weaponType, eWeaponSkill weaponSkill);
+    void         SetWeaponRenderEnabled(bool enabled) override;
+    bool         IsWeaponRenderEnabled() const override;
     void         FlushPendingRestreamIPL();
     void         ResetModelLodDistances();
     void         ResetModelFlags();

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -3428,9 +3428,6 @@ void CClientGame::Event_OnIngame()
     pHud->SetComponentVisible(HUD_VITAL_STATS, false);
     pHud->SetComponentVisible(HUD_AREA_NAME, false);
 
-    // Reset properties
-    CLuaPlayerDefs::ResetPlayerHudComponentProperty(HUD_ALL, eHudComponentProperty::ALL_PROPERTIES);
-
     g_pMultiplayer->DeleteAndDisableGangTags();
 
     g_pGame->GetBuildingRemoval()->ClearRemovedBuildingLists();
@@ -6112,6 +6109,16 @@ bool CClientGame::SetBirdsEnabled(bool bEnabled)
 bool CClientGame::GetBirdsEnabled()
 {
     return m_bBirdsEnabled;
+}
+
+void CClientGame::SetWeaponRenderEnabled(bool enabled)
+{
+    g_pGame->SetWeaponRenderEnabled(enabled);
+}
+
+bool CClientGame::IsWeaponRenderEnabled() const
+{
+    return g_pGame->IsWeaponRenderEnabled();
 }
 
 #pragma code_seg(".text")

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -3428,6 +3428,9 @@ void CClientGame::Event_OnIngame()
     pHud->SetComponentVisible(HUD_VITAL_STATS, false);
     pHud->SetComponentVisible(HUD_AREA_NAME, false);
 
+    // Reset properties
+    CLuaPlayerDefs::ResetPlayerHudComponentProperty(HUD_ALL, eHudComponentProperty::ALL_PROPERTIES);
+
     g_pMultiplayer->DeleteAndDisableGangTags();
 
     g_pGame->GetBuildingRemoval()->ClearRemovedBuildingLists();

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -3441,6 +3441,9 @@ void CClientGame::Event_OnIngame()
     g_pGame->ResetAlphaTransparencies();
     g_pGame->ResetModelTimes();
 
+    // Reset weapon render
+    g_pGame->SetWeaponRenderEnabled(true);
+
     // Make sure we can access all areas
     g_pGame->GetStats()->ModifyStat(CITIES_PASSED, 2.0);
 

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -419,6 +419,9 @@ public:
     bool SetBirdsEnabled(bool bEnabled);
     bool GetBirdsEnabled();
 
+    void SetWeaponRenderEnabled(bool enabled);
+    bool IsWeaponRenderEnabled() const;
+
     void ResetWorldProperties(const ResetWorldPropsInfo& resetPropsInfo);
 
     CTransferBox* GetTransferBox() { return m_pTransferBox; };

--- a/Client/mods/deathmatch/logic/luadefs/CLuaWeaponDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaWeaponDefs.cpp
@@ -39,6 +39,8 @@ void CLuaWeaponDefs::LoadFunctions()
         {"getWeaponClipAmmo", GetWeaponClipAmmo},
         {"setWeaponAmmo", SetWeaponAmmo},
         {"setWeaponClipAmmo", SetWeaponClipAmmo},
+        {"setWeaponRenderEnabled", ArgumentParser<SetWeaponRenderEnabled>},
+        {"isWeaponRenderEnabled", ArgumentParser<IsWeaponRenderEnabled>}
     };
 
     // Add functions
@@ -978,4 +980,15 @@ int CLuaWeaponDefs::GetOriginalWeaponProperty(lua_State* luaVM)
     // Failed
     lua_pushboolean(luaVM, false);
     return 1;
+}
+
+bool CLuaWeaponDefs::SetWeaponRenderEnabled(bool enabled)
+{
+    g_pClientGame->SetWeaponRenderEnabled(enabled);
+    return true;
+}
+
+bool CLuaWeaponDefs::IsWeaponRenderEnabled()
+{
+    return g_pClientGame->IsWeaponRenderEnabled();
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaWeaponDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaWeaponDefs.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "CLuaDefs.h"
+#include <lua/CLuaFunctionParser.h>
 
 class CLuaWeaponDefs : public CLuaDefs
 {
@@ -41,4 +42,6 @@ public:
     LUA_DECLARE(GetWeaponClipAmmo);
     LUA_DECLARE(SetWeaponAmmo);
     LUA_DECLARE(SetWeaponClipAmmo);
+    static bool SetWeaponRenderEnabled(bool enabled);
+    static bool IsWeaponRenderEnabled();
 };

--- a/Client/sdk/game/CGame.h
+++ b/Client/sdk/game/CGame.h
@@ -237,6 +237,9 @@ public:
     virtual CWeapon*     CreateWeapon() = 0;
     virtual CWeaponStat* CreateWeaponStat(eWeaponType weaponType, eWeaponSkill weaponSkill) = 0;
 
+    virtual void SetWeaponRenderEnabled(bool enabled) = 0;
+    virtual bool IsWeaponRenderEnabled() const = 0;
+
     virtual bool VerifySADataFileNames() = 0;
     virtual bool PerformChecks() = 0;
     virtual int& GetCheckStatus() = 0;


### PR DESCRIPTION
This PR adds functions that allow disabling the rendering of weapons. Some servers do not use the original weapons and replace them with their own system. To remove the original weapons, they need to replace the model with an empty one or manipulate the weapon model's LOD distance. The function only toggles the rendering of the weapon object, so shooting, aiming, etc., can still be done

```lua
bool setWeaponRenderEnabled(bool enabled)
bool isWeaponRenderEnabled()
```

Thanks to @ds1-e for idea