### PR TITLE
Fix hpbar on hud is not compatible visually with MAX_HEALTH stat #3807

### DIFF
--- a/Client/game_sa/CHudSA.cpp
+++ b/Client/game_sa/CHudSA.cpp
@@ -89,8 +89,8 @@ CHudSA::CHudSA()
 
     // Change multiplier for STAT_10 and STAT_9 (MAX_HEALTH) from 176 to 200
     // Fix GH #3807
-    float* MAX_HEALTH = reinterpret_cast<float*>(0x8CDE78);
-    *MAX_HEALTH = 200.0f;
+    float* maxHealth = reinterpret_cast<float*>(0x8CDE78);
+    *maxHealth = 200.0f;
 }
 
 void CHudSA::Disable(bool bDisabled)

--- a/Client/game_sa/CHudSA.cpp
+++ b/Client/game_sa/CHudSA.cpp
@@ -641,7 +641,7 @@ void CHudSA::RenderHealthBar(int x, int y)
 
     // Calc bar width depending on MAX_HEALTH stat
     // We want to maintain the proportions of the bar and its width after changing MAX_HEALTH from 176 to 200
-    static const float baseWidth = barWidth * 100.0f / 176.0f; // 176 is default STAT_10 value
+    const float baseWidth = barWidth * 100.0f / 176.0f; // 176 is default STAT_10 value
     float totalWidth = baseWidth + (((barWidth - baseWidth) / 100.0f) * (maxHealth - 100.0f));
 
     float posX = useCustomPosition ? componentProperties.hpBar.placement.customX : (barWidth - totalWidth + x);


### PR DESCRIPTION
Fixed #3807

This PR modifies the calculations for the width and values of the health bar. By default, the maximum HP in SA is 176. However, based on experiences with other versions, players assume the maximum value is 200, and certain parts of the MTA code make the same assumption. Therefore, to avoid potential backward compatibility issues by limiting health to 176, a better solution is to extend the maximum value to the assumed 200