### PR TITLE
Fix restoreGameWorld and removeWorldModel conflict

### DIFF
--- a/Client/game_sa/CBuildingsPoolSA.cpp
+++ b/Client/game_sa/CBuildingsPoolSA.cpp
@@ -18,6 +18,7 @@
 #include "CPtrNodeSingleListSA.h"
 #include "MemSA.h"
 #include "CVehicleSA.h"
+#include "CBuildingRemovalSA.h"
 
 extern CGameSA* pGame;
 
@@ -174,6 +175,9 @@ void CBuildingsPoolSA::RestoreBackup()
     if (!m_pOriginalBuildingsBackup)
         return;
 
+    auto* worldSA = pGame->GetWorld();
+    auto* buildingRemovealSA = static_cast<CBuildingRemovalSA*>(pGame->GetBuildingRemoval());
+
     auto& originalData = *m_pOriginalBuildingsBackup;
     auto  pBuildsingsPool = (*m_ppBuildingPoolInterface);
     for (size_t i = 0; i < MAX_BUILDINGS; i++)
@@ -184,7 +188,8 @@ void CBuildingsPoolSA::RestoreBackup()
             auto pBuilding = pBuildsingsPool->GetObject(i);
             *pBuilding = originalData[i].second;
 
-            pGame->GetWorld()->Add(pBuilding, CBuildingPool_Constructor);
+            worldSA->Add(pBuilding, CBuildingPool_Constructor);
+            buildingRemovealSA->AddDataBuilding(pBuilding);
         }
     }
 


### PR DESCRIPTION
Fixes #3942

WTR:
```
crun removeGameWorld()
crun restoreGameWorld()
crun for i = 0, 19999, 1 do  removeWorldModel(i, 100000, 0, 0, 0) end
```
