### PR TITLE
Apply element filter for buildings in engineApplyShaderToWorldTexture

### DIFF
--- a/Client/game_sa/CBuildingsPoolSA.cpp
+++ b/Client/game_sa/CBuildingsPoolSA.cpp
@@ -48,6 +48,16 @@ inline bool CBuildingsPoolSA::AddBuildingToPool(CClientBuilding* pClientBuilding
     return true;
 }
 
+CClientEntity* CBuildingsPoolSA::GetClientBuilding(CBuildingSAInterface* pGameInterface) const noexcept
+{
+    auto poolIndex = (*m_ppBuildingPoolInterface)->GetObjectIndex(pGameInterface);
+
+    if (poolIndex == -1)
+        return nullptr;
+
+    return m_buildingPool.entities[poolIndex].pClientEntity;
+}
+
 CBuilding* CBuildingsPoolSA::AddBuilding(CClientBuilding* pClientBuilding, uint16_t modelId, CVector* vPos, CVector4D* vRot, uint8_t interior)
 {
     if (!HasFreeBuildingSlot())

--- a/Client/game_sa/CBuildingsPoolSA.cpp
+++ b/Client/game_sa/CBuildingsPoolSA.cpp
@@ -52,7 +52,7 @@ CClientEntity* CBuildingsPoolSA::GetClientBuilding(CBuildingSAInterface* pGameIn
 {
     std::uint32_t poolIndex = (*m_ppBuildingPoolInterface)->GetObjectIndex(pGameInterface);
 
-    if (poolIndex == -1)
+    if (poolIndex == static_cast<std::uint32_t>(-1))
         return nullptr;
 
     return m_buildingPool.entities[poolIndex].pClientEntity;

--- a/Client/game_sa/CBuildingsPoolSA.cpp
+++ b/Client/game_sa/CBuildingsPoolSA.cpp
@@ -50,7 +50,7 @@ inline bool CBuildingsPoolSA::AddBuildingToPool(CClientBuilding* pClientBuilding
 
 CClientEntity* CBuildingsPoolSA::GetClientBuilding(CBuildingSAInterface* pGameInterface) const noexcept
 {
-    auto poolIndex = (*m_ppBuildingPoolInterface)->GetObjectIndex(pGameInterface);
+    std::uint32_t poolIndex = (*m_ppBuildingPoolInterface)->GetObjectIndex(pGameInterface);
 
     if (poolIndex == -1)
         return nullptr;

--- a/Client/game_sa/CBuildingsPoolSA.h
+++ b/Client/game_sa/CBuildingsPoolSA.h
@@ -30,6 +30,7 @@ public:
     void RestoreBackup() override;
     bool Resize(int size) override;
     int  GetSize() const override { return (*m_ppBuildingPoolInterface)->m_nSize; };
+    CClientEntity* GetClientBuilding(CBuildingSAInterface* pGameInterface) const noexcept;
 
 private:
     void RemoveBuildingFromWorld(CBuildingSAInterface* pBuilding);

--- a/Client/game_sa/CPoolsSA.cpp
+++ b/Client/game_sa/CPoolsSA.cpp
@@ -566,8 +566,12 @@ CClientEntity* CPoolsSA::GetClientEntity(DWORD* pGameInterface)
         {
             return pThePedEntity->pClientEntity;
         }
+
+        auto clientBuilding = m_BuildingsPool.GetClientBuilding(reinterpret_cast<CBuildingSAInterface*>(pGameInterface));
+        if (clientBuilding)
+            return clientBuilding;
     }
-    return NULL;
+    return nullptr;
 }
 
 static void CreateMissionTrain(const CVector& vecPos, bool bDirection, std::uint32_t uiTrainType, CTrainSAInterface** ppTrainBeginning,

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -3734,6 +3734,9 @@ void CClientGame::StaticGameEntityRenderHandler(CEntitySAInterface* pGameEntity)
                 case CCLIENTOBJECT:
                     iTypeMask = TYPE_MASK_OBJECT;
                     break;
+                case CCLIENTBUILDING:
+                    iTypeMask = TYPE_MASK_WORLD;
+                    break;
                 default:
                     iTypeMask = TYPE_MASK_OTHER;
                     break;

--- a/Client/multiplayer_sa/multiplayersa_init.cpp
+++ b/Client/multiplayer_sa/multiplayersa_init.cpp
@@ -82,8 +82,8 @@ void LogEvent(uint uiDebugId, const char* szType, const char* szContext, const c
 
 void CallGameEntityRenderHandler(CEntitySAInterface* pEntity)
 {
-    // Only call if not a building or a dummy
-    if (!pEntity || (pEntity->nType != ENTITY_TYPE_BUILDING && pEntity->nType != ENTITY_TYPE_DUMMY))
+    // Only call if not a dummy
+    if (!pEntity || pEntity->nType != ENTITY_TYPE_DUMMY)
         if (pGameEntityRenderHandler)
             pGameEntityRenderHandler(pEntity);
 }


### PR DESCRIPTION
Allows applying shaders to specific created building elements.

Example:
```lua
local building = createBuilding(8395, 100, 0, 3)
local buildingShader = dxCreateShader("building.fx",0,0 ,false,"world")
engineApplyShaderToWorldTexture(buildingShader, "luxorwindow01_128", building)
```