### PR TITLE
Fix setElementDoubleSided resets after building manipulations

### DIFF
--- a/Client/mods/deathmatch/logic/CClientBuilding.cpp
+++ b/Client/mods/deathmatch/logic/CClientBuilding.cpp
@@ -132,6 +132,10 @@ void CClientBuilding::Create()
     ConvertZXYEulersToQuaternion(m_vRot, vRot4D);
 
     m_pBuilding = g_pGame->GetPools()->GetBuildingsPool().AddBuilding(this, m_usModelId, &m_vPos, &vRot4D, m_interior);
+
+    if (!m_pBuilding)
+        return;
+
     m_pBuilding->SetBackfaceCulled(!m_bDoubleSided);
 
     if (!m_usesCollision)

--- a/Client/mods/deathmatch/logic/CClientBuilding.cpp
+++ b/Client/mods/deathmatch/logic/CClientBuilding.cpp
@@ -132,6 +132,7 @@ void CClientBuilding::Create()
     ConvertZXYEulersToQuaternion(m_vRot, vRot4D);
 
     m_pBuilding = g_pGame->GetPools()->GetBuildingsPool().AddBuilding(this, m_usModelId, &m_vPos, &vRot4D, m_interior);
+    m_pBuilding->SetBackfaceCulled(!m_bDoubleSided);
 
     if (!m_usesCollision)
     {


### PR DESCRIPTION
WTR:
```lua
local building = createBuilding(1337, 0, 0, 3)
setElementDoubleSided(building, true)
setElementPosition(building, 1, 0, 3)
```