### PR TITLE
Fix false positive in `onPlayerTeleport` event when using `spawnPlayer`

### DIFF
--- a/Server/mods/deathmatch/logic/CMapManager.cpp
+++ b/Server/mods/deathmatch/logic/CMapManager.cpp
@@ -593,6 +593,7 @@ void CMapManager::SpawnPlayer(CPlayer& Player, const CVector& vecPosition, float
 
     // Update the player data
     Player.SetSpawned(true);
+    Player.SetTeleported(true);
     Player.SetHealth(Player.GetMaxHealth());
     Player.SetIsDead(false);
     Player.SetWearingGoggles(false);

--- a/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
@@ -132,15 +132,20 @@ bool CPlayerPuresyncPacket::Read(NetBitStreamInterface& BitStream)
             position.data.vecPosition += vecTempPos;
         }
 
-        CVector playerPosition = pSourcePlayer->GetPosition();
-        float playerDistancePosition = DistanceBetweenPoints3D(playerPosition, position.data.vecPosition);
-        if (playerDistancePosition >= g_TickRateSettings.playerTeleportAlert) {
-            if (!pSourcePlayer->GetTeleported()) {
-                CLuaArguments arguments;
-                pSourcePlayer->CallEvent("onPlayerTeleport", arguments, nullptr);
-            }
+        if (position.data.vecPosition.fX != 0.0f && position.data.vecPosition.fY != 0.0f && position.data.vecPosition.fZ != 0.0f)
+        {
+            CVector playerPosition = pSourcePlayer->GetPosition();
+            float playerDistancePosition = DistanceBetweenPoints3D(playerPosition, position.data.vecPosition);
+            if (playerDistancePosition >= g_TickRateSettings.playerTeleportAlert)
+            {
+                if (!pSourcePlayer->GetTeleported())
+                {
+                    CLuaArguments arguments;
+                    pSourcePlayer->CallEvent("onPlayerTeleport", arguments, nullptr);
+                }
 
-            pSourcePlayer->SetTeleported(false);
+                pSourcePlayer->SetTeleported(false);
+            }
         }
 
         pSourcePlayer->SetPosition(position.data.vecPosition);


### PR DESCRIPTION
This PR fixes a false positive in the `onPlayerTeleport` event that occurred when using the `spawnPlayer` function. The issue happened because `spawnPlayer` internally teleports the player to the position `(0, 0, 0)` before setting the correct position specified in the arguments. With this fix, the event is no longer triggered incorrectly during this process.