### PR TITLE
Add arguments to `onPlayerTeleport` and fix the false positive caused by `setElementInterior` using x, y, z parameters.

### DIFF
--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -1641,7 +1641,7 @@ void CGame::AddBuiltInEvents()
     m_Events.AddEvent("onPlayerTriggerInvalidEvent", "eventName, isAdded, isRemote", nullptr, false);
     m_Events.AddEvent("onPlayerChangesProtectedData", "element, key, value", nullptr, false);
     m_Events.AddEvent("onPlayerChangesWorldSpecialProperty", "property, enabled", nullptr, false);
-    m_Events.AddEvent("onPlayerTeleport", "", nullptr, false);
+    m_Events.AddEvent("onPlayerTeleport", "previousX, previousY, previousZ, currentX, currentY, currentZ", nullptr, false);
 
     // Ped events
     m_Events.AddEvent("onPedVehicleEnter", "vehicle, seat, jacked", NULL, false);

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1477,6 +1477,12 @@ bool CStaticFunctionDefinitions::SetElementInterior(CElement* pElement, unsigned
         BitStream.pBitStream->Write(static_cast<unsigned char>((bSetPosition) ? 1 : 0));
         if (bSetPosition)
         {
+            if (IS_PLAYER(pElement))
+            {
+                CPlayer* player = static_cast<CPlayer*>(pElement);
+                player->SetTeleported(true);
+            }
+
             BitStream.pBitStream->Write(vecPosition.fX);
             BitStream.pBitStream->Write(vecPosition.fY);
             BitStream.pBitStream->Write(vecPosition.fZ);

--- a/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
@@ -141,6 +141,12 @@ bool CPlayerPuresyncPacket::Read(NetBitStreamInterface& BitStream)
                 if (!pSourcePlayer->GetTeleported())
                 {
                     CLuaArguments arguments;
+                    arguments.PushNumber(playerPosition.fX);
+                    arguments.PushNumber(playerPosition.fY);
+                    arguments.PushNumber(playerPosition.fZ);
+                    arguments.PushNumber(position.data.vecPosition.fX);
+                    arguments.PushNumber(position.data.vecPosition.fY);
+                    arguments.PushNumber(position.data.vecPosition.fZ);
                     pSourcePlayer->CallEvent("onPlayerTeleport", arguments, nullptr);
                 }
 


### PR DESCRIPTION
Suggested by [issue](https://github.com/multitheftauto/mtasa-blue/issues/3993)