### PR TITLE
Fix onPlayerTeleport

### DIFF
--- a/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
@@ -132,7 +132,7 @@ bool CPlayerPuresyncPacket::Read(NetBitStreamInterface& BitStream)
             position.data.vecPosition += vecTempPos;
         }
 
-        if (position.data.vecPosition.fX != 0.0f && position.data.vecPosition.fY != 0.0f && position.data.vecPosition.fZ != 0.0f)
+        // if (position.data.vecPosition.fX != 0.0f || position.data.vecPosition.fY != 0.0f || position.data.vecPosition.fZ != 0.0f)
         {
             CVector playerPosition = pSourcePlayer->GetPosition();
             float playerDistancePosition = DistanceBetweenPoints3D(playerPosition, position.data.vecPosition);


### PR DESCRIPTION
The event did not fire if one of the coordinates was zero, regardless of the distance.
```lua
setElementFrozen(localPlayer, true)
setElementPosition(localPlayer, 9999, 9999, 0)
```