### PR TITLE
Fix bad streaming performance in some cases

### DIFF
--- a/Client/mods/deathmatch/logic/CClientStreamSector.h
+++ b/Client/mods/deathmatch/logic/CClientStreamSector.h
@@ -37,6 +37,7 @@ public:
     void                                       Remove(CClientStreamElement* pElement) { m_Elements.remove(pElement); }
     std::list<CClientStreamElement*>::iterator Begin() { return m_Elements.begin(); }
     std::list<CClientStreamElement*>::iterator End() { return m_Elements.end(); }
+    std::list<CClientStreamElement*>&          GetElements() { return m_Elements; }
 
     void         AddElements(std::list<CClientStreamElement*>* pList);
     void         RemoveElements(std::list<CClientStreamElement*>* pList);

--- a/Client/mods/deathmatch/logic/CClientStreamSectorRow.h
+++ b/Client/mods/deathmatch/logic/CClientStreamSectorRow.h
@@ -31,6 +31,7 @@ public:
     void                                      Add(CClientStreamSector* pSector);
     void                                      Remove(CClientStreamSector* pSector);
     unsigned int                              CountSectors() { return m_Sectors.size(); }
+    std::list<CClientStreamSector*>&          GetList() noexcept { return m_Sectors; }
 
     bool DoesContain(CVector& vecPosition);
     bool DoesContain(float fY);

--- a/Client/mods/deathmatch/logic/CClientStreamer.cpp
+++ b/Client/mods/deathmatch/logic/CClientStreamer.cpp
@@ -686,12 +686,8 @@ void CClientStreamer::OnElementEnterSector(CClientStreamElement* pElement, CClie
         // Is this new sector activated?
         if (pSector->IsActivated())
         {
-            // Was the previous sector not active?
-            if (!pPreviousSector || !pPreviousSector->IsActivated())
-            {
-                // Add this element to our active-elements list
-                AddToSortedList(&m_ActiveElements, pElement);
-            }
+            // Add this element to our active-elements list
+            AddToSortedList(&m_ActiveElements, pElement);
         }
         else
         {

--- a/Client/mods/deathmatch/logic/CClientStreamer.cpp
+++ b/Client/mods/deathmatch/logic/CClientStreamer.cpp
@@ -686,8 +686,12 @@ void CClientStreamer::OnElementEnterSector(CClientStreamElement* pElement, CClie
         // Is this new sector activated?
         if (pSector->IsActivated())
         {
-            // Add this element to our active-elements list
-            AddToSortedList(&m_ActiveElements, pElement);
+            // Was the previous sector not active?
+            if (!pPreviousSector || !pPreviousSector->IsActivated())
+            {
+                // Add this element to our active-elements list
+                AddToSortedList(&m_ActiveElements, pElement);
+            }
         }
         else
         {

--- a/Client/mods/deathmatch/logic/CClientStreamer.cpp
+++ b/Client/mods/deathmatch/logic/CClientStreamer.cpp
@@ -674,9 +674,6 @@ void CClientStreamer::OnElementEnterSector(CClientStreamElement* pElement, CClie
 
         // Remove the element from its old sector
         pPreviousSector->Remove(pElement);
-
-        if (pPreviousSector->IsActivated())
-            m_ActiveElements.remove(pElement);
     }
     if (pSector)
     {
@@ -695,6 +692,10 @@ void CClientStreamer::OnElementEnterSector(CClientStreamElement* pElement, CClie
         }
         else
         {
+            // Should we deactivate the element?
+            if (pPreviousSector && pPreviousSector->IsActivated())
+                m_ActiveElements.remove(pElement);
+
             // Should we activate this sector?
             if (pSector->IsExtra() && (m_pSector->IsMySurroundingSector(pSector) || m_pSector == pSector))
             {

--- a/Client/mods/deathmatch/logic/CClientStreamer.cpp
+++ b/Client/mods/deathmatch/logic/CClientStreamer.cpp
@@ -674,6 +674,9 @@ void CClientStreamer::OnElementEnterSector(CClientStreamElement* pElement, CClie
 
         // Remove the element from its old sector
         pPreviousSector->Remove(pElement);
+
+        if (pPreviousSector->IsActivated())
+            m_ActiveElements.remove(pElement);
     }
     if (pSector)
     {

--- a/Client/mods/deathmatch/logic/CClientStreamer.cpp
+++ b/Client/mods/deathmatch/logic/CClientStreamer.cpp
@@ -709,6 +709,12 @@ void CClientStreamer::OnElementEnterSector(CClientStreamElement* pElement, CClie
             }
         }
     }
+    else if (pPreviousSector && pPreviousSector->IsActivated())
+    {
+        // The element was removed from sectors.
+        // Remove it from active elements too.
+        m_ActiveElements.remove(pElement);
+    }
     pElement->SetStreamSector(pSector);
 }
 

--- a/Client/mods/deathmatch/logic/CClientStreamer.h
+++ b/Client/mods/deathmatch/logic/CClientStreamer.h
@@ -47,6 +47,14 @@ private:
     void AddElement(CClientStreamElement* pElement);
     void RemoveElement(CClientStreamElement* pElement);
 
+    void AddElementInSectors(CClientStreamElement* pElement);
+    void RemoveElementFromSectors(CClientStreamElement* pElement);
+
+    bool IsElementShouldVisibleInCurrentDimesnion(CClientStreamElement* pElement) const noexcept
+    {
+        return pElement->GetDimension() == m_usDimension || pElement->IsVisibleInAllDimensions();
+    }
+
     void SetExpDistances(std::list<CClientStreamElement*>* pList);
     void AddToSortedList(std::list<CClientStreamElement*>* pList, CClientStreamElement* pElement);
 
@@ -72,6 +80,7 @@ private:
     unsigned short                     m_usDimension;
     std::list<CClientStreamElement*>   m_ActiveElements;
     std::list<CClientStreamElement*>   m_ToStreamOut;
+    std::list<CClientStreamElement*>   m_outsideCurrentDimensionElements;
 
     static void* pAddingElement;
 };


### PR DESCRIPTION
Fixes [#813](https://github.com/multitheftauto/mtasa-blue/issues/813) and #3985

This PR disables streaming for elements that are outside of the current dimension. This increases performance for servers that have a lot of elements in different dimensions.

This PR fixes this bugged scenario too:
1. A player spawns at 0, 0, 3 position
2. The gamemode creates a lot of objects
3. The player has random fps drops on some map positions.

Why it happens:
MTA creates elements in 0, 0, 0 position by default. CClientStreamer adds these elements to the m_ActiveElements list.
MTA updates element positions BUT doesn't remove elements from the m_ActiveElements list.
This causes the situation when m_ActiveElements holds all possible elements and CClientStreamer requests huge O(N*M) operations.

This PR needs some testing.