### PR TITLE
Fix createBuilding disable_backface_culling

### DIFF
--- a/Client/mods/deathmatch/logic/CClientBuilding.cpp
+++ b/Client/mods/deathmatch/logic/CClientBuilding.cpp
@@ -136,7 +136,8 @@ void CClientBuilding::Create()
     if (!m_pBuilding)
         return;
 
-    m_pBuilding->SetBackfaceCulled(!m_bDoubleSided);
+	if (m_bDoubleSidedInit)
+		m_pBuilding->SetBackfaceCulled(!m_bDoubleSided);
 
     if (!m_usesCollision)
     {


### PR DESCRIPTION
Fixes regression after #3976

MTA ignores the disable_backface_culling flags in createBuilding.
