### PR TITLE
Fix invalid references counter to TXD after engineSetModelTXDID

### DIFF
--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -806,7 +806,8 @@ void CModelInfoSA::SetTextureDictionaryID(unsigned short usID)
     size_t referencesCount = m_pInterface->usNumberOfRefs;
 
     // +1 reference for active rwObject
-    // TODO: pRwObject can have to unloaded TXD
+    // The current textures will be removed in RpAtomicDestroy
+    // RenderWare uses an additional reference counter per texture
     if (m_pInterface->pRwObject)
         referencesCount++;
 

--- a/Client/game_sa/CRenderWareSA.TextureReplacing.cpp
+++ b/Client/game_sa/CRenderWareSA.TextureReplacing.cpp
@@ -266,8 +266,10 @@ void CRenderWareSA::ModelInfoTXDRemoveTextures(SReplacementTextures* pReplacemen
                 ListRemove(currentTextures, pOriginalTexture);
             }
             assert(currentTextures.empty());
-        #endif
 
+            int32_t refsCount = CTxdStore_GetNumRefs(pInfo->usTxdId);
+            assert(refsCount > 0, "Should have at least one TXD reference here");
+        #endif
             // Remove info
             CTxdStore_RemoveRef(pInfo->usTxdId);
             MapRemove(ms_ModelTexturesInfoMap, usTxdId);


### PR DESCRIPTION
Could be related to #4028

I tested with this resource. Before the suggested changes i had an assertion window.
[crash_txd.zip](https://github.com/user-attachments/files/18892464/crash_txd.zip)
