### PR TITLE
Set main menu FPS limit to current display refresh rate

### DIFF
--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -156,6 +156,7 @@ CCore::CCore()
     m_bGettingIdleCallsFromMultiplayer = false;
     m_bWindowsTimerEnabled = false;
     m_timeDiscordAppLastUpdate = 0;
+    m_CurrentRefreshRate = 60;
 
     // Create tray icon
     m_pTrayIcon = new CTrayIcon();
@@ -1835,6 +1836,9 @@ void CCore::RecalculateFrameRateLimit(uint uiServerFrameRateLimit, bool bLogToCo
     if ((m_uiFrameRateLimit == 0 || uiClientScriptRate < m_uiFrameRateLimit) && uiClientScriptRate > 0)
         m_uiFrameRateLimit = uiClientScriptRate;
 
+    if (!IsConnected())
+        m_uiFrameRateLimit = m_CurrentRefreshRate;
+
     // Removes Limiter from Frame Graph if limit is zero and skips frame limit
     if (m_uiFrameRateLimit == 0)
     {
@@ -1858,6 +1862,12 @@ void CCore::RecalculateFrameRateLimit(uint uiServerFrameRateLimit, bool bLogToCo
 void CCore::SetClientScriptFrameRateLimit(uint uiClientScriptFrameRateLimit)
 {
     m_uiClientScriptFrameRateLimit = uiClientScriptFrameRateLimit;
+    RecalculateFrameRateLimit(-1, false);
+}
+
+void CCore::SetCurrentRefreshRate(uint value)
+{
+    m_CurrentRefreshRate = value;
     RecalculateFrameRateLimit(-1, false);
 }
 
@@ -1921,7 +1931,7 @@ void CCore::ApplyQueuedFrameRateLimit()
             double dSpare = dTargetTimeToUse - m_FrameRateTimer.Get();
             if (dSpare <= 0.0)
                 break;
-            if (dSpare >= 2.0)
+            if (dSpare >= 10.0)
                 Sleep(1);
         }
         m_FrameRateTimer.Reset();

--- a/Client/core/CCore.h
+++ b/Client/core/CCore.h
@@ -223,6 +223,7 @@ public:
     void ApplyQueuedFrameRateLimit();
     void EnsureFrameRateLimitApplied();
     void SetClientScriptFrameRateLimit(uint uiClientScriptFrameRateLimit);
+    void SetCurrentRefreshRate(uint value);
     void DoReliablePulse();
 
     bool IsTimingCheckpoints();
@@ -371,6 +372,7 @@ private:
     CElapsedTimeHD       m_FrameRateTimer;
     uint                 m_uiQueuedFrameRate;
     bool                 m_bQueuedFrameRateValid;
+    uint                 m_CurrentRefreshRate;
     bool                 m_requestNewNickname{false};
     EDiagnosticDebugType m_DiagnosticDebug;
 

--- a/Client/core/CMainMenu.cpp
+++ b/Client/core/CMainMenu.cpp
@@ -778,6 +778,9 @@ void CMainMenu::SetIsIngame(bool bIsIngame)
         m_bIsIngame = bIsIngame;
         m_Settings.SetIsModLoaded(bIsIngame);
 
+        // Reset frame rate limit
+        CCore::GetSingleton().RecalculateFrameRateLimit(-1, false);
+
         m_ulMoveStartTick = GetTickCount32();
         if (bIsIngame)
         {

--- a/Client/core/CModManager.cpp
+++ b/Client/core/CModManager.cpp
@@ -93,7 +93,7 @@ void CModManager::DoPulsePostFrame()
     if (m_client != nullptr)
         CCore::GetSingleton().EnsureFrameRateLimitApplied();            // Catch missed frames
     else
-        CCore::GetSingleton().ApplyFrameRateLimit(88);            // Limit when not connected
+        CCore::GetSingleton().ApplyFrameRateLimit();            // Limit when not connected
 
     if (m_state == State::PendingStart)
     {

--- a/Client/core/DXHook/CProxyDirect3D9.cpp
+++ b/Client/core/DXHook/CProxyDirect3D9.cpp
@@ -833,6 +833,13 @@ HRESULT HandleCreateDeviceResult(HRESULT hResult, IDirect3D9* pDirect3D, UINT Ad
         strMessage += SString("Direct3D CreateDevice error: %08x", hResult);
         BrowseToSolution("d3dcreatedevice-fail", EXIT_GAME_FIRST | ASK_GO_ONLINE, strMessage);
     }
+    else
+    {
+        // Get current refresh rate
+        D3DDISPLAYMODE DisplayMode;
+        if (pDirect3D->GetAdapterDisplayMode(Adapter, &DisplayMode) == D3D_OK)
+            CCore::GetSingleton().SetCurrentRefreshRate(DisplayMode.RefreshRate);
+    }
 
     return hResult;
 }


### PR DESCRIPTION
This small PR is aimed to provide smoother experience for high refresh monitors in main menu when player is not connected.
Current limit is below 88 and not stable because of how frame rate limiting is designed.

I had to change Sleep function call behavior to make frame limit work properly in main menu.
`Sleep(1)` freezes thread for at least 15ms (instead of 1) on average because of default timer resolution in Windows (64 times per second). And since thread isn't busy in main menu it prevented setting high refresh rate. So I changed Sleep call spare time from 2ms to 10ms (in my case 4ms was enough during testing but I decided to go with 10ms).

This also fixes bug with unlimited FPS if deathmatch mod is loaded when not connected (i.e. opening "host game" window).