### PR TITLE
Add CPU affinity setting & fix process related settings

### DIFF
--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -357,6 +357,7 @@ void CClientVariables::LoadDefaults()
     DEFAULT("discord_rpc_share_data", false);                                         // Consistent Rich Presence data sharing
     DEFAULT("discord_rpc_share_data_firsttime", false);                               // Display the user data sharing consent dialog box - for the first time
     DEFAULT("browser_enable_gpu", true);                                              // Enable GPU in CEF? (allows stuff like WebGL to function)
+    DEFAULT("process_cpu_affinity", true);                                            // Set CPU 0 affinity to improve game performance and fix the known issue in single-threaded games
 
     if (!Exists("locale"))
     {

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -1795,6 +1795,17 @@ void CCore::ApplyCoreInitSettings()
 
         SetApplicationSettingInt("reset-settings-revision", 21486);
     }
+
+    // Set process settings
+    HANDLE currProc = GetCurrentProcess();
+
+    // Process priority
+    int PriorityClassList[] = {NORMAL_PRIORITY_CLASS, ABOVE_NORMAL_PRIORITY_CLASS, HIGH_PRIORITY_CLASS};
+    SetPriorityClass(currProc, PriorityClassList[CVARS_GET_VALUE<int>("process_priority") % 3]);
+
+    // Process CPU affinity
+    if (CVARS_GET_VALUE<bool>("process_cpu_affinity"))
+        SetProcessAffinityMask(currProc, 1 << 0);
 }
 
 //

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -216,6 +216,7 @@ protected:
     CGUICheckBox*  m_pWin8ColorCheckBox;
     CGUICheckBox*  m_pWin8MouseCheckBox;
     CGUICheckBox*  m_pPhotoSavingCheckbox;
+    CGUICheckBox*  m_pProcessAffinityCheckbox;
     CGUILabel*     m_pUpdateBuildTypeLabel;
     CGUIComboBox*  m_pUpdateBuildTypeCombo;
     CGUILabel*     m_pUpdateAutoInstallLabel;


### PR DESCRIPTION
Resolved #4088 

This PR adds a checkbox that allows setting CPU affinity to either CPU 0 or, by default, to all cores. By default, the checkbox is checked, meaning the affinity is set to CPU 0.

Additionally, this PR fixes a bug where process-related settings, such as process priority, were not applied upon starting MTA but only after entering the settings.

![image](https://github.com/user-attachments/assets/7feacca7-b65c-4a88-82ac-a9a584b79239)
