### PR TITLE
Fix jetpack issues after #3511

### DIFF
--- a/Client/game_sa/TaskJumpFallSA.h
+++ b/Client/game_sa/TaskJumpFallSA.h
@@ -59,7 +59,7 @@ public:
 class CTaskSimpleJetPackSAInterface : public CTaskSimpleSAInterface
 {
 public:
-    unsigned char m_bIsFinished;
+    bool          m_bIsFinished;
     unsigned char m_bAddedIdleAnim;
     unsigned char m_bAnimsReferenced;
     unsigned char m_bAttackButtonPressed;
@@ -100,4 +100,6 @@ class CTaskSimpleJetPackSA : public virtual CTaskSimpleSA, public virtual CTaskS
 public:
     CTaskSimpleJetPackSA(){};
     CTaskSimpleJetPackSA(const CVector* pVecTargetPos, float fCruiseHeight = 10.0f, int nHoverTime = 0);
+
+    bool IsFinished() const override { return static_cast<const CTaskSimpleJetPackSAInterface*>(GetInterface())->m_bIsFinished; }
 };

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -4602,6 +4602,10 @@ bool CClientPed::HasJetPack()
         CTask* pPrimaryTask = m_pTaskManager->GetSimplestActiveTask();
         if (pPrimaryTask && pPrimaryTask->GetTaskType() == TASK_SIMPLE_JETPACK)
         {
+            auto* jetpackTask = dynamic_cast<CTaskSimpleJetPack*>(pPrimaryTask);
+            if (jetpackTask && jetpackTask->IsFinished())
+                return false;
+
             return true;
         }
         return false;

--- a/Client/sdk/game/TaskJumpFall.h
+++ b/Client/sdk/game/TaskJumpFall.h
@@ -23,4 +23,6 @@ class CTaskSimpleJetPack : public virtual CTaskSimple
 {
 public:
     virtual ~CTaskSimpleJetPack(){};
+
+    virtual bool IsFinished() const = 0;
 };


### PR DESCRIPTION
Fixed #4098

The bug is caused by the fact that after calling ``MakeAbortable``, the task still exists for some time, which causes ``HasJetpack`` to incorrectly return true. The solution is to check whether the task is finished. The task state is set to finished within the ``MakeAbortable`` function, so even if the task still exists, we know that it has already ended, and ``HasJetpack`` should return false.