### PR TITLE
Fix #4029: Use shared pointer in CClientDisplay(Manager)

### DIFF
--- a/Client/mods/deathmatch/logic/CClientDisplay.cpp
+++ b/Client/mods/deathmatch/logic/CClientDisplay.cpp
@@ -10,22 +10,13 @@
 
 #include <StdInc.h>
 
-CClientDisplay::CClientDisplay(CClientDisplayManager* pDisplayManager, unsigned long ulID)
+CClientDisplay::CClientDisplay(unsigned long ulID)
 {
-    m_pDisplayManager = pDisplayManager;
     m_ulID = ulID;
 
     m_ulExpirationTime = 0;
     m_bVisible = true;
     m_Color = SColorRGBA(255, 255, 255, 255);
-
-    m_pDisplayManager->AddToList(this);
-}
-
-CClientDisplay::~CClientDisplay()
-{
-    // Remove us from the manager
-    m_pDisplayManager->RemoveFromList(this);
 }
 
 void CClientDisplay::SetColorAlpha(unsigned char ucAlpha)

--- a/Client/mods/deathmatch/logic/CClientDisplay.cpp
+++ b/Client/mods/deathmatch/logic/CClientDisplay.cpp
@@ -13,8 +13,6 @@
 CClientDisplay::CClientDisplay(unsigned long ulID)
 {
     m_ulID = ulID;
-
-    m_ulExpirationTime = 0;
     m_bVisible = true;
     m_Color = SColorRGBA(255, 255, 255, 255);
 }

--- a/Client/mods/deathmatch/logic/CClientDisplay.h
+++ b/Client/mods/deathmatch/logic/CClientDisplay.h
@@ -22,18 +22,16 @@ enum eDisplayType
 
 class CClientDisplay
 {
-    friend class CClientDisplayManager;
-
 public:
-    CClientDisplay(class CClientDisplayManager* pDisplayManager, unsigned long ulID);
-    virtual ~CClientDisplay();
+    CClientDisplay(unsigned long ulID);
+    virtual ~CClientDisplay() = default;
 
-    unsigned long        GetID() { return m_ulID; }
+    unsigned long        GetID() const { return m_ulID; }
     virtual eDisplayType GetType() = 0;
 
-    unsigned long GetExpirationTime() { return m_ulExpirationTime; };
+    unsigned long GetExpirationTime() const { return m_ulExpirationTime; };
     void          SetExpirationTime(unsigned long ulTime) { m_ulExpirationTime = ulTime; };
-    unsigned long GetTimeTillExpiration() { return m_ulExpirationTime - CClientTime::GetTime(); };
+    unsigned long GetTimeTillExpiration() const { return m_ulExpirationTime - CClientTime::GetTime(); };
     void          SetTimeTillExpiration(unsigned long ulMs) { m_ulExpirationTime = CClientTime::GetTime() + ulMs; };
 
     virtual const CVector& GetPosition() { return m_vecPosition; };
@@ -49,9 +47,7 @@ public:
     virtual void Render() = 0;
 
 protected:
-    bool IsExpired() { return (m_ulExpirationTime != 0 && (CClientTime::GetTime() > m_ulExpirationTime)); };
-
-    CClientDisplayManager* m_pDisplayManager;
+    bool IsExpired() const { return (m_ulExpirationTime != 0 && (CClientTime::GetTime() > m_ulExpirationTime)); };
 
     unsigned long m_ulID;
     unsigned long m_ulExpirationTime;

--- a/Client/mods/deathmatch/logic/CClientDisplay.h
+++ b/Client/mods/deathmatch/logic/CClientDisplay.h
@@ -29,11 +29,6 @@ public:
     unsigned long        GetID() const { return m_ulID; }
     virtual eDisplayType GetType() = 0;
 
-    unsigned long GetExpirationTime() const { return m_ulExpirationTime; };
-    void          SetExpirationTime(unsigned long ulTime) { m_ulExpirationTime = ulTime; };
-    unsigned long GetTimeTillExpiration() const { return m_ulExpirationTime - CClientTime::GetTime(); };
-    void          SetTimeTillExpiration(unsigned long ulMs) { m_ulExpirationTime = CClientTime::GetTime() + ulMs; };
-
     virtual const CVector& GetPosition() { return m_vecPosition; };
     virtual void           SetPosition(const CVector& vecPosition) { m_vecPosition = vecPosition; };
 
@@ -47,10 +42,7 @@ public:
     virtual void Render() = 0;
 
 protected:
-    bool IsExpired() const { return (m_ulExpirationTime != 0 && (CClientTime::GetTime() > m_ulExpirationTime)); };
-
     unsigned long m_ulID;
-    unsigned long m_ulExpirationTime;
     bool          m_bVisible;
     CVector       m_vecPosition;
     SColor        m_Color;

--- a/Client/mods/deathmatch/logic/CClientDisplayManager.h
+++ b/Client/mods/deathmatch/logic/CClientDisplayManager.h
@@ -13,9 +13,12 @@ class CClientDisplayManager;
 #pragma once
 
 #include "CClientManager.h"
-#include <list>
 
-class CClientDisplay;
+#include "CClientDisplay.h"
+#include "CClientVectorGraphicDisplay.h"
+#include "CClientTextDisplay.h"
+
+#include <list>
 
 class CClientDisplayManager
 {
@@ -23,21 +26,21 @@ class CClientDisplayManager
     friend class CClientDisplay;
 
 public:
-    CClientDisplayManager();
-    ~CClientDisplayManager();
+    CClientDisplayManager() = default;
+    ~CClientDisplayManager() = default;
 
     void DoPulse();
 
     unsigned int    Count() { return static_cast<unsigned int>(m_List.size()); };
-    CClientDisplay* Get(unsigned long ulID);
+    std::shared_ptr<CClientDisplay> Get(unsigned long ulID);
 
     void DrawText2D(const char* szCaption, const CVector& vecPosition, float fScale = 1.0f, RGBA rgbaColor = 0xFFFFFFFF);
 
-    void RemoveAll();
+    void AddToList(const std::shared_ptr<CClientDisplay>& display);
 
-    void AddToList(CClientDisplay* pDisplay);
-    void RemoveFromList(CClientDisplay* pDisplay);
+    std::shared_ptr<CClientVectorGraphicDisplay> CreateVectorGraphicDisplay(CClientVectorGraphic* svg);
+    std::shared_ptr<CClientTextDisplay>          CreateTextDisplay(int ID = 0xFFFFFFFF);
 
-    std::list<CClientDisplay*> m_List;
-    bool                       m_bCanRemoveFromList;
+    std::list<std::weak_ptr<CClientDisplay>> m_List;
 };
+

--- a/Client/mods/deathmatch/logic/CClientTextDisplay.cpp
+++ b/Client/mods/deathmatch/logic/CClientTextDisplay.cpp
@@ -14,16 +14,12 @@ using std::list;
 
 float CClientTextDisplay::m_fGlobalScale = 1.0f;
 
-CClientTextDisplay::CClientTextDisplay(CClientDisplayManager* pDisplayManager, int ID) : CClientDisplay(pDisplayManager, ID)
+CClientTextDisplay::CClientTextDisplay(int ID) : CClientDisplay(ID)
 {
     // Init
     m_fScale = 1;
     m_ulFormat = 0;
     m_bVisible = true;
-}
-
-CClientTextDisplay::~CClientTextDisplay()
-{
 }
 
 void CClientTextDisplay::SetCaption(const char* szCaption)

--- a/Client/mods/deathmatch/logic/CClientTextDisplay.h
+++ b/Client/mods/deathmatch/logic/CClientTextDisplay.h
@@ -16,13 +16,11 @@ class CClientTextDisplay;
 #include "CClientDisplayManager.h"
 #include <gui/CGUI.h>
 
-class CClientTextDisplay : public CClientDisplay
+class CClientTextDisplay final : public CClientDisplay
 {
-    friend class CClientDisplayManager;
-
 public:
-    CClientTextDisplay(CClientDisplayManager* pDisplayManager, int ID = 0xFFFFFFFF);
-    ~CClientTextDisplay();
+    CClientTextDisplay(int ID = 0xFFFFFFFF);
+    ~CClientTextDisplay() = default;
 
     eDisplayType GetType() { return DISPLAY_TEXT; }
 
@@ -34,24 +32,24 @@ public:
     void SetColorAlpha(unsigned char ucAlpha);
     void SetShadowAlpha(unsigned char ucShadowAlpha);
 
-    float GetScale() { return m_fScale; };
+    float GetScale() const { return m_fScale; };
     void  SetScale(float fScale);
 
-    unsigned long GetFormat() { return m_ulFormat; };
+    unsigned long GetFormat() const { return m_ulFormat; };
     void          SetFormat(unsigned long ulFormat);
 
     void SetVisible(bool bVisible);
 
     void Render();
 
-    static void SetGlobalScale(float fScale) { m_fGlobalScale = fScale; }
+    static void SetGlobalScale(float fScale) { m_fGlobalScale = fScale; };
 
 private:
     SString m_strCaption;
     float   m_fScale;
 
     unsigned long m_ulFormat;
-    unsigned char m_ucShadowAlpha;
+    unsigned char m_ucShadowAlpha{};
 
     static float m_fGlobalScale;
 };

--- a/Client/mods/deathmatch/logic/CClientVectorGraphic.cpp
+++ b/Client/mods/deathmatch/logic/CClientVectorGraphic.cpp
@@ -45,7 +45,7 @@ bool CClientVectorGraphic::LoadFromString(std::string strData)
 
 bool CClientVectorGraphic::SetDocument(CXMLNode* node)
 {
-    if (!m_pVectorGraphicDisplay || !node || !node->IsValid())
+    if (!node || !node->IsValid())
         return false;
 
     if (m_pXMLString && m_pXMLString->node != node)
@@ -79,9 +79,6 @@ bool CClientVectorGraphic::RemoveUpdateCallback()
 
 void CClientVectorGraphic::OnUpdate()
 {
-    if (!m_pVectorGraphicDisplay)
-        return;
-
     m_pVectorGraphicDisplay->UpdateTexture();
 
     if (std::holds_alternative<CLuaFunctionRef>(m_updateCallbackRef))

--- a/Client/mods/deathmatch/logic/CClientVectorGraphic.h
+++ b/Client/mods/deathmatch/logic/CClientVectorGraphic.h
@@ -57,7 +57,7 @@ private:
     std::unique_ptr<SXMLString>        m_pXMLString = nullptr;
     CXMLNode*                          m_pXMLDocument = nullptr;
 
-    std::unique_ptr<CClientVectorGraphicDisplay> m_pVectorGraphicDisplay;
+    std::shared_ptr<CClientVectorGraphicDisplay> m_pVectorGraphicDisplay;
 
     std::variant<CLuaFunctionRef, bool> m_updateCallbackRef = false;
 

--- a/Client/mods/deathmatch/logic/CClientVectorGraphicDisplay.cpp
+++ b/Client/mods/deathmatch/logic/CClientVectorGraphicDisplay.cpp
@@ -13,8 +13,8 @@
 
 using namespace lunasvg;
 
-CClientVectorGraphicDisplay::CClientVectorGraphicDisplay(CClientDisplayManager* pDisplayManager, CClientVectorGraphic* pVectorGraphic, int ID)
-    : CClientDisplay(pDisplayManager, ID)
+CClientVectorGraphicDisplay::CClientVectorGraphicDisplay(CClientVectorGraphic* pVectorGraphic, int ID)
+    : CClientDisplay(ID)
 {
     m_pVectorGraphic = pVectorGraphic;
     m_bVisible = true;
@@ -25,8 +25,11 @@ CClientVectorGraphicDisplay::CClientVectorGraphicDisplay(CClientDisplayManager* 
 
 void CClientVectorGraphicDisplay::Render()
 {
+    // When the underlying vector graphic is deleted, this display will be destroyed automatically by the manager.
+    // CClientVectorGraphicDisplay::Render should be called as long as the display manager is still alive.
+    // see CClientDisplayManager::DoPulse
     if (!m_pVectorGraphic || m_pVectorGraphic->IsDestroyed())
-        return;
+        return SetTimeTillExpiration(1);
 
     if (!m_bVisible)
     {

--- a/Client/mods/deathmatch/logic/CClientVectorGraphicDisplay.cpp
+++ b/Client/mods/deathmatch/logic/CClientVectorGraphicDisplay.cpp
@@ -25,11 +25,8 @@ CClientVectorGraphicDisplay::CClientVectorGraphicDisplay(CClientVectorGraphic* p
 
 void CClientVectorGraphicDisplay::Render()
 {
-    // When the underlying vector graphic is deleted, this display will be destroyed automatically by the manager.
-    // CClientVectorGraphicDisplay::Render should be called as long as the display manager is still alive.
-    // see CClientDisplayManager::DoPulse
     if (!m_pVectorGraphic || m_pVectorGraphic->IsDestroyed())
-        return SetTimeTillExpiration(1);
+        return;
 
     if (!m_bVisible)
     {

--- a/Client/mods/deathmatch/logic/CClientVectorGraphicDisplay.h
+++ b/Client/mods/deathmatch/logic/CClientVectorGraphicDisplay.h
@@ -20,7 +20,7 @@ class CClientVectorGraphicDisplay final : public CClientDisplay
     friend class CClientDisplayManager;
 
 public:
-    CClientVectorGraphicDisplay(CClientDisplayManager* pDisplayManager, CClientVectorGraphic* pVectorGraphic, int ID = DISPLAY_VECTORGRAPHIC);
+    CClientVectorGraphicDisplay(CClientVectorGraphic* pVectorGraphic, int ID = DISPLAY_VECTORGRAPHIC);
     ~CClientVectorGraphicDisplay() = default;
 
     eDisplayType GetType() { return DISPLAY_VECTORGRAPHIC; }
@@ -38,7 +38,6 @@ public:
 private:
     void UnpremultiplyBitmap(lunasvg::Bitmap& bitmap);
 
-private:
     CClientVectorGraphic* m_pVectorGraphic;
 
     bool m_bIsCleared;

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -4496,10 +4496,11 @@ void CPacketHandler::Packet_TextItem(NetBitStreamInterface& bitStream)
         if (bDelete)
         {
             // Grab it and delete it
-            CClientDisplay* pDisplay = g_pClientGame->m_pDisplayManager->Get(ulID);
+            std::shared_ptr<CClientDisplay> pDisplay = g_pClientGame->m_pDisplayManager->Get(ulID);
+
             if (pDisplay)
             {
-                delete pDisplay;
+                m_displayTextList.remove(std::static_pointer_cast<CClientTextDisplay>(pDisplay));
             }
         }
         else
@@ -4535,26 +4536,28 @@ void CPacketHandler::Packet_TextItem(NetBitStreamInterface& bitStream)
                 }
 
                 // Does the text not already exist? Create it
-                CClientTextDisplay* pTextDisplay = NULL;
-                CClientDisplay*     pDisplay = g_pClientGame->m_pDisplayManager->Get(ulID);
-                if (pDisplay && pDisplay->GetType() == DISPLAY_TEXT)
+                std::shared_ptr<CClientTextDisplay> textDisplay = nullptr;
+                std::shared_ptr<CClientDisplay> display = g_pClientGame->m_pDisplayManager->Get(ulID);
+
+                if (display && display->GetType() == DISPLAY_TEXT)
                 {
-                    pTextDisplay = static_cast<CClientTextDisplay*>(pDisplay);
+                    textDisplay = std::static_pointer_cast<CClientTextDisplay>(display);
                 }
 
-                if (!pTextDisplay)
+                if (!textDisplay)
                 {
                     // Create it
-                    pTextDisplay = new CClientTextDisplay(g_pClientGame->m_pDisplayManager, ulID);
+                    textDisplay = g_pClientGame->m_pDisplayManager->CreateTextDisplay(ulID);
+                    m_displayTextList.push_back(textDisplay);
                 }
 
                 // Set the text properties
-                pTextDisplay->SetCaption(szText);
-                pTextDisplay->SetPosition(CVector(fX, fY, 0));
-                pTextDisplay->SetColor(color);
-                pTextDisplay->SetScale(fScale);
-                pTextDisplay->SetFormat((unsigned long)ucFormat);
-                pTextDisplay->SetShadowAlpha(ucShadowAlpha);
+                textDisplay->SetCaption(szText);
+                textDisplay->SetPosition(CVector(fX, fY, 0));
+                textDisplay->SetColor(color);
+                textDisplay->SetScale(fScale);
+                textDisplay->SetFormat((unsigned long)ucFormat);
+                textDisplay->SetShadowAlpha(ucShadowAlpha);
 
                 delete[] szText;
             }

--- a/Client/mods/deathmatch/logic/CPacketHandler.h
+++ b/Client/mods/deathmatch/logic/CPacketHandler.h
@@ -16,6 +16,7 @@
 
 class CClientEntity;
 class CCustomData;
+class CClientTextDisplay;
 
 class CPacketHandler
 {
@@ -112,4 +113,6 @@ public:
     std::vector<int>       m_EntityAddReadOffsetStore;
     NetBitStreamInterface* m_pEntityAddBitStream;
     uint                   m_uiEntityAddNumEntities;
+
+    std::list<std::shared_ptr<CClientTextDisplay>> m_displayTextList;
 };

--- a/Client/mods/deathmatch/logic/CPlayerMap.cpp
+++ b/Client/mods/deathmatch/logic/CPlayerMap.cpp
@@ -87,7 +87,7 @@ CPlayerMap::CPlayerMap(CClientManager* pManager)
 
     for (uint i = 0; i < NUMELMS(messageList); i++)
     {
-        CClientTextDisplay* pTextDisplay = new CClientTextDisplay(m_pManager->GetDisplayManager());
+        auto pTextDisplay = m_pManager->GetDisplayManager()->CreateTextDisplay();
         pTextDisplay->SetCaption(messageList[i].strMessage);
         pTextDisplay->SetColor(messageList[i].color);
         pTextDisplay->SetPosition(CVector(0.50f, messageList[i].fPosY, 0));
@@ -112,8 +112,7 @@ CPlayerMap::~CPlayerMap()
     for (uint i = 0; i < m_markerTextureList.size(); i++)
         SAFE_RELEASE(m_markerTextureList[i]);
     m_markerTextureList.clear();
-
-    // Don't need to delete the help texts as those are destroyed by the display manager
+    m_HelpTextList.clear();
 }
 
 void CPlayerMap::CreateOrUpdateMapTexture()

--- a/Client/mods/deathmatch/logic/CPlayerMap.h
+++ b/Client/mods/deathmatch/logic/CPlayerMap.h
@@ -116,7 +116,7 @@ private:
 
     unsigned long m_ulUpdateTime;
 
-    std::vector<CClientTextDisplay*> m_HelpTextList;
+    std::vector<std::shared_ptr<CClientTextDisplay>> m_HelpTextList;
     bool                             m_bHideHelpText;
 
     bool m_bHudVisible;


### PR DESCRIPTION
A proper solution, where the CClientDisplayManager is used to create & return shared pointers which are also stored as weak pointers in a list.

Also removes the unused expiration functionality on display instances, which was part of the previous (crappy) solution.

Resolves #4029