### PR TITLE
Reimplement CPU Affinity

### DIFF
--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -357,7 +357,7 @@ void CClientVariables::LoadDefaults()
     DEFAULT("discord_rpc_share_data", false);                                         // Consistent Rich Presence data sharing
     DEFAULT("discord_rpc_share_data_firsttime", false);                               // Display the user data sharing consent dialog box - for the first time
     DEFAULT("browser_enable_gpu", true);                                              // Enable GPU in CEF? (allows stuff like WebGL to function)
-    DEFAULT("process_cpu_affinity", true);                                            // Set CPU 0 affinity to improve game performance and fix the known issue in single-threaded games
+    DEFAULT("process_cpu_affinity", false);                                            // Set CPU 0 affinity to improve game performance and fix the known issue in single-threaded games
 
     if (!Exists("locale"))
     {

--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -357,6 +357,7 @@ void CClientVariables::LoadDefaults()
     DEFAULT("discord_rpc_share_data", false);                                         // Consistent Rich Presence data sharing
     DEFAULT("discord_rpc_share_data_firsttime", false);                               // Display the user data sharing consent dialog box - for the first time
     DEFAULT("browser_enable_gpu", true);                                              // Enable GPU in CEF? (allows stuff like WebGL to function)
+    DEFAULT("process_cpu_affinity", true);                                            // Set CPU 0 affinity to improve game performance and fix the known issue in single-threaded games
 
     if (!Exists("locale"))
     {

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -1795,6 +1795,17 @@ void CCore::ApplyCoreInitSettings()
 
         SetApplicationSettingInt("reset-settings-revision", 21486);
     }
+
+    // Set process settings
+    HANDLE currProc = GetCurrentProcess();
+
+    // Process priority
+    int PriorityClassList[] = {NORMAL_PRIORITY_CLASS, ABOVE_NORMAL_PRIORITY_CLASS, HIGH_PRIORITY_CLASS};
+    SetPriorityClass(currProc, PriorityClassList[CVARS_GET_VALUE<int>("process_priority") % 3]);
+
+    // Process CPU affinity
+    if (CVARS_GET_VALUE<bool>("process_cpu_affinity"))
+        SetProcessAffinityMask(currProc, 1 << 0);
 }
 
 //

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -407,6 +407,7 @@ protected:
     bool OnShowAdvancedSettingDescription(CGUIElement* pElement);
     bool OnHideAdvancedSettingDescription(CGUIElement* pElement);
     bool OnTabChanged(CGUIElement* pElement);
+    bool OnAffinityClick(CGUIElement* pElement);
     void ReloadBrowserLists();
 
 private:

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -216,6 +216,7 @@ protected:
     CGUICheckBox*  m_pWin8ColorCheckBox;
     CGUICheckBox*  m_pWin8MouseCheckBox;
     CGUICheckBox*  m_pPhotoSavingCheckbox;
+    CGUICheckBox*  m_pProcessAffinityCheckbox;
     CGUILabel*     m_pUpdateBuildTypeLabel;
     CGUIComboBox*  m_pUpdateBuildTypeCombo;
     CGUILabel*     m_pUpdateAutoInstallLabel;


### PR DESCRIPTION
Better version of #4096 
Resolved #4088 

- Added information that the setting is experimental when hovering over it
![image](https://github.com/user-attachments/assets/d8ee88b6-c446-4854-b848-f4303c273c0e)

- Added a warning when enabling the setting, indicating that it is experimental
![image](https://github.com/user-attachments/assets/5ff178d9-177b-4c98-9c9d-99cd4589d208)

- The setting is now disabled by default

I moved the checkbox for saving screenshots in userfiles to the multiplayer tab (imo, this is a more appropriate place for this setting than the advanced tab). The advanced tab no longer has space, which caused the informational text at the bottom of the window (the one that appears when hovering over various elements) to be cut off and not visible.
