### PR TITLE
Colshape IDs fix

### DIFF
--- a/Client/mods/deathmatch/logic/CClientMarker.cpp
+++ b/Client/mods/deathmatch/logic/CClientMarker.cpp
@@ -447,7 +447,7 @@ void CClientMarker::CreateOfType(int iType)
             CClientCheckpoint* pCheckpoint = new CClientCheckpoint(this);
             pCheckpoint->SetCheckpointType(CClientCheckpoint::TYPE_NORMAL);
             m_pMarker = pCheckpoint;
-            m_pCollision = new CClientColCircle(g_pClientGame->GetManager(), NULL, vecOrigin, GetSize());
+            m_pCollision = new CClientColCircle(g_pClientGame->GetManager(), INVALID_ELEMENT_ID, vecOrigin, GetSize());
             m_pCollision->m_pOwningMarker = this;
             m_pCollision->SetHitCallback(this);
             break;
@@ -458,7 +458,7 @@ void CClientMarker::CreateOfType(int iType)
             CClientCheckpoint* pCheckpoint = new CClientCheckpoint(this);
             pCheckpoint->SetCheckpointType(CClientCheckpoint::TYPE_RING);
             m_pMarker = pCheckpoint;
-            m_pCollision = new CClientColSphere(g_pClientGame->GetManager(), NULL, vecOrigin, GetSize());
+            m_pCollision = new CClientColSphere(g_pClientGame->GetManager(), INVALID_ELEMENT_ID, vecOrigin, GetSize());
             m_pCollision->m_pOwningMarker = this;
             m_pCollision->SetHitCallback(this);
             break;
@@ -469,7 +469,7 @@ void CClientMarker::CreateOfType(int iType)
             CClient3DMarker* p3DMarker = new CClient3DMarker(this);
             p3DMarker->Set3DMarkerType(CClient3DMarker::TYPE_CYLINDER);
             m_pMarker = p3DMarker;
-            m_pCollision = new CClientColCircle(g_pClientGame->GetManager(), NULL, vecOrigin, GetSize());
+            m_pCollision = new CClientColCircle(g_pClientGame->GetManager(), INVALID_ELEMENT_ID, vecOrigin, GetSize());
             m_pCollision->m_pOwningMarker = this;
             m_pCollision->SetHitCallback(this);
             break;
@@ -480,7 +480,7 @@ void CClientMarker::CreateOfType(int iType)
             CClient3DMarker* p3DMarker = new CClient3DMarker(this);
             p3DMarker->Set3DMarkerType(CClient3DMarker::TYPE_ARROW);
             m_pMarker = p3DMarker;
-            m_pCollision = new CClientColSphere(g_pClientGame->GetManager(), NULL, vecOrigin, GetSize());
+            m_pCollision = new CClientColSphere(g_pClientGame->GetManager(), INVALID_ELEMENT_ID, vecOrigin, GetSize());
             m_pCollision->m_pOwningMarker = this;
             m_pCollision->SetHitCallback(this);
             break;
@@ -489,7 +489,7 @@ void CClientMarker::CreateOfType(int iType)
         case MARKER_CORONA:
         {
             m_pMarker = new CClientCorona(this);
-            m_pCollision = new CClientColSphere(g_pClientGame->GetManager(), NULL, vecOrigin, GetSize());
+            m_pCollision = new CClientColSphere(g_pClientGame->GetManager(), INVALID_ELEMENT_ID, vecOrigin, GetSize());
             m_pCollision->m_pOwningMarker = this;
             m_pCollision->SetHitCallback(this);
             break;


### PR DESCRIPTION
This PR is intended to fix the problem with the referring of several elements to one ID. Currently marker colshapes all reside on ID 0 which is erroneous and produces wrong results with functions like `getElementsWithinRange`.

Code for the reproducing:
```
addEventHandler( "onClientResourceStart", resourceRoot,
    function()
        local x, y, z = 0, 0, 4

        for i = 1, 2 do
            createMarker( x + i, y, z, "cylinder", 1 )
        end

        iprint( getElementsWithinRange( x, y, z, 10 ) )
    end
, false )
```

The output before PR:
`[2025-03-21 13:30:05] INFO: { elem:colshape0DDD87E0, elem:colshape0DDD87E0, elem:colshape0DDD87E0, false, false, elem:marker[cylinder]0DDD85D8, elem:marker[cylinder]0DDD8600, elem:colshape0DDD87E0 }`
**Four elem:colshape0DDD87E0 colshapes** and **falses**.

The output after PR:
`[2025-03-21 13:33:29] INFO: { elem:marker[cylinder]2C800980, elem:marker[cylinder]2C800CA0, elem:colshape2C800D68, elem:colshape2C800D90 }`
**Two different colshapes.**

**NOTE: This bug isn't stable and it may take several runs of the code above to notice the problem.**

