### PR TITLE
Fix invisible weapon particles at high FPS

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
@@ -586,9 +586,6 @@ static void __declspec(naked) HOOK_CWeapon_Update()
 {
     _asm
     {
-        push esi
-        push ebp
-
         // timeStep / kOriginalTimeStep
         fld ds:[0xB7CB5C] // CTimer::ms_fTimeStep
         fdiv kOriginalTimeStep
@@ -609,8 +606,6 @@ static void __declspec(naked) HOOK_CWeapon_Update()
         mov eax, ebx
 
         xor ebx, ebx
-        pop ebp
-        pop esi
         jmp RETURN_CWeapon_Update
     }
 }

--- a/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
@@ -578,6 +578,43 @@ static void _declspec(naked) HOOK_CTaskSimpleSwim__ProcessEffectsBubbleFix()
     }
 }
 
+// Fixes invisible weapon particles (extinguisher, spraycan, flamethrower) at high FPS
+#define HOOKPOS_CWeapon_Update 0x73DC3D
+#define HOOKSIZE_CWeapon_Update 5
+static constexpr std::uintptr_t RETURN_CWeapon_Update = 0x073DC42;
+static void __declspec(naked) HOOK_CWeapon_Update()
+{
+    _asm
+    {
+        push esi
+        push ebp
+
+        // timeStep / kOriginalTimeStep
+        fld ds:[0xB7CB5C] // CTimer::ms_fTimeStep
+        fdiv kOriginalTimeStep
+
+        mov eax, [esi+10h] // m_timeToNextShootInMS
+        mov ebx, ds:[0xB7CB84] // CTimer::m_snTimeInMilliseconds
+
+        sub eax, ebx // m_timeToNextShootInMS - CTimer::m_snTimeInMilliseconds
+
+        push eax
+        fild dword ptr [esp]
+        add esp, 4
+
+        fmul st(0), st(1) // (m_timeToNextShootInMS - CTimer::m_snTimeInMilliseconds) * (timeStep / kOriginalTimeStep)
+        fadd st(0), ebx // + m_snTimeInMilliseconds
+        fistp [esi+10h]
+
+        mov eax, ebx
+
+        xor ebx, ebx
+        pop ebp
+        pop esi
+        jmp RETURN_CWeapon_Update
+    }
+}
+
 void CMultiplayerSA::InitHooks_FrameRateFixes()
 {
     EZHookInstall(CTaskSimpleUseGun__SetMoveAnim);
@@ -619,4 +656,6 @@ void CMultiplayerSA::InitHooks_FrameRateFixes()
     EZHookInstall(CVehicle__AddExhaustParticles);
     EZHookInstall(CTaskSimpleSwim__ProcessEffects);
     EZHookInstall(CTaskSimpleSwim__ProcessEffectsBubbleFix);
+
+    EZHookInstall(CWeapon_Update);
 }


### PR DESCRIPTION
This PR fixes the bug reported on the old (now unavailable) GitHub project called "Framerate issues." At high FPS (> 74), weapon particles such as the spraycan, fire extinguisher, or flamethrower were either invisible or very rare and sporadic.