### PR TITLE
Fix minor issues with vehicle audio settings

### DIFF
--- a/Client/game_sa/CVehicleSA.h
+++ b/Client/game_sa/CVehicleSA.h
@@ -284,7 +284,7 @@ public:
         ((void(__thiscall*)(CVehicleSAInterface*, RwFrame*, std::uint32_t))0x6D2700)(this, component, state);
     }
 
-    bool IsPassenger(CPedSAInterface* ped) const noexcept {
+    bool IsPassenger(CPedSAInterface* ped) const {
         return ((bool(__thiscall*)(CVehicleSAInterface const*, CPedSAInterface*))0x6D1BD0)(this, ped);
     }
 
@@ -483,7 +483,7 @@ public:
     void  SetRailTrack(BYTE ucTrackID);
     float GetTrainPosition();
     void  SetTrainPosition(float fPosition, bool bRecalcOnRailDistance = true);
-    bool  IsPassenger(CPed* pPed) noexcept { return GetVehicleInterface()->IsPassenger(pPed->GetPedInterface()); };
+    bool  IsPassenger(CPed* pPed) { return GetVehicleInterface()->IsPassenger(pPed->GetPedInterface()); };
 
     void AddVehicleUpgrade(DWORD dwModelID);
     void RemoveVehicleUpgrade(DWORD dwModelID);

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -2497,11 +2497,11 @@ void CClientVehicle::Create()
             g_pGame->GetVehicleAudioSettingsManager()->SetNextSettings(m_pSoundSettingsEntry.get());
         else
         {
-            uint32_t modelId = m_usModel;
+            std::uint32_t modelId = m_usModel;
             if (!CClientVehicleManager::IsStandardModel(modelId))
                 modelId = g_pGame->GetModelInfo(m_usModel)->GetParentID();
 
-            g_pGame->GetVehicleAudioSettingsManager()->SetNextSettings(m_usModel);
+            g_pGame->GetVehicleAudioSettingsManager()->SetNextSettings(modelId);
         }
 
         // Create the vehicle

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
@@ -967,7 +967,7 @@ ADD_ENUM(eVehicleAudioSettingProperty::ENGINE_ON_SOUND_BANK_ID, "engine-on-sound
 ADD_ENUM(eVehicleAudioSettingProperty::HORN_HIGH, "horn-high")
 ADD_ENUM(eVehicleAudioSettingProperty::HORN_TON, "horn-ton")
 ADD_ENUM(eVehicleAudioSettingProperty::HORN_VOLUME_DELTA, "horn-volume-delta")
-ADD_ENUM(eVehicleAudioSettingProperty::RADIO_NUM, "radion-num")
+ADD_ENUM(eVehicleAudioSettingProperty::RADIO_NUM, "radio-num")
 ADD_ENUM(eVehicleAudioSettingProperty::RADIO_TYPE, "radio-type")
 ADD_ENUM(eVehicleAudioSettingProperty::SOUND_TYPE, "sound-type")
 ADD_ENUM(eVehicleAudioSettingProperty::BASS_SETTING, "bass-setting")

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -4439,11 +4439,23 @@ bool CLuaVehicleDefs::SetVehicleModelAudioSetting(const uint32_t uiModel, const 
             pModelSettings.SetDoorSound(varValue);
             break;
         case eVehicleAudioSettingProperty::ENGINE_OFF_SOUND_BANK_ID:
+        {
+            // Using SPC_ sound banks in a language that isn't the one selected in the game causes a crash
+            if (varValue > 364)
+                throw std::invalid_argument("Invalid engine-off-sound-bank-id value");
+
             pModelSettings.SetEngineOffSoundBankID(varValue);
             break;
+        }
         case eVehicleAudioSettingProperty::ENGINE_ON_SOUND_BANK_ID:
+        {
+            // Using SPC_ sound banks in a language that isn't the one selected in the game causes a crash
+            if (varValue > 364)
+                throw std::invalid_argument("Invalid engine-on-sound-bank-id value");
+
             pModelSettings.SetEngineOnSoundBankID(varValue);
             break;
+        }
         case eVehicleAudioSettingProperty::HORN_HIGH:
             pModelSettings.SetHornHign(varValue);
             break;
@@ -4502,11 +4514,23 @@ bool CLuaVehicleDefs::SetVehicleAudioSetting(CClientVehicle* pVehicle, const eVe
             pModelSettings.SetDoorSound(varValue);
             break;
         case eVehicleAudioSettingProperty::ENGINE_OFF_SOUND_BANK_ID:
+        {
+            // Using SPC_ sound banks in a language that isn't the one selected in the game causes a crash
+            if (varValue > 364)
+                throw std::invalid_argument("Invalid engine-off-sound-bank-id value");
+
             pModelSettings.SetEngineOffSoundBankID(varValue);
             break;
+        }
         case eVehicleAudioSettingProperty::ENGINE_ON_SOUND_BANK_ID:
+        {
+            // Using SPC_ sound banks in a language that isn't the one selected in the game causes a crash
+            if (varValue > 364)
+                throw std::invalid_argument("Invalid engine-on-sound-bank-id value");
+
             pModelSettings.SetEngineOnSoundBankID(varValue);
             break;
+        }
         case eVehicleAudioSettingProperty::HORN_HIGH:
             pModelSettings.SetHornHign(varValue);
             break;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -4440,8 +4440,8 @@ bool CLuaVehicleDefs::SetVehicleModelAudioSetting(const uint32_t uiModel, const 
             break;
         case eVehicleAudioSettingProperty::ENGINE_OFF_SOUND_BANK_ID:
         {
-            // Using SPC_ sound banks in a language that isn't the one selected in the game causes a crash
-            if (varValue > 364)
+            // Using SPC_ sound banks other than SPC_EA causes a crash
+            if (varValue > 410)
                 throw std::invalid_argument("Invalid engine-off-sound-bank-id value");
 
             pModelSettings.SetEngineOffSoundBankID(varValue);
@@ -4449,8 +4449,8 @@ bool CLuaVehicleDefs::SetVehicleModelAudioSetting(const uint32_t uiModel, const 
         }
         case eVehicleAudioSettingProperty::ENGINE_ON_SOUND_BANK_ID:
         {
-            // Using SPC_ sound banks in a language that isn't the one selected in the game causes a crash
-            if (varValue > 364)
+            // Using SPC_ sound banks other than SPC_EA causes a crash
+            if (varValue > 410)
                 throw std::invalid_argument("Invalid engine-on-sound-bank-id value");
 
             pModelSettings.SetEngineOnSoundBankID(varValue);
@@ -4515,8 +4515,8 @@ bool CLuaVehicleDefs::SetVehicleAudioSetting(CClientVehicle* pVehicle, const eVe
             break;
         case eVehicleAudioSettingProperty::ENGINE_OFF_SOUND_BANK_ID:
         {
-            // Using SPC_ sound banks in a language that isn't the one selected in the game causes a crash
-            if (varValue > 364)
+            // Using SPC_ sound banks other than SPC_EA causes a crash
+            if (varValue > 410)
                 throw std::invalid_argument("Invalid engine-off-sound-bank-id value");
 
             pModelSettings.SetEngineOffSoundBankID(varValue);
@@ -4524,8 +4524,8 @@ bool CLuaVehicleDefs::SetVehicleAudioSetting(CClientVehicle* pVehicle, const eVe
         }
         case eVehicleAudioSettingProperty::ENGINE_ON_SOUND_BANK_ID:
         {
-            // Using SPC_ sound banks in a language that isn't the one selected in the game causes a crash
-            if (varValue > 364)
+            // Using SPC_ sound banks other than SPC_EA causes a crash
+            if (varValue > 410)
                 throw std::invalid_argument("Invalid engine-on-sound-bank-id value");
 
             pModelSettings.SetEngineOnSoundBankID(varValue);


### PR DESCRIPTION
Fixes minor issues with vehicle audio settings

- setVehicleAudioSetting/setVehicleModelAudioSetting expected radion_num instead of radio_num
- Passing a bank ID greater than SPC_EA (410) results in a crash. I'm not sure if this is related to languages, e.g loading a sound bank like GA without having German set as the in-game language causes a crash.