### PR TITLE
Fix elements sometimes being visible from other dimensions in the current dimension

### DIFF
--- a/Client/mods/deathmatch/logic/CClientStreamElement.cpp
+++ b/Client/mods/deathmatch/logic/CClientStreamElement.cpp
@@ -61,7 +61,7 @@ void CClientStreamElement::InternalStreamIn(bool bInstantly)
     }
 }
 
-void CClientStreamElement::InternalStreamOut()
+void CClientStreamElement::InternalStreamOut(bool ignoreSendingEvent)
 {
     if (m_bStreamedIn)
     {
@@ -83,13 +83,24 @@ void CClientStreamElement::InternalStreamOut()
             }
         }
 
-        CLuaArguments Arguments;
-        CallEvent("onClientElementStreamOut", Arguments, true);
+        if (!ignoreSendingEvent)
+        {
+            CLuaArguments Arguments;
+            CallEvent("onClientElementStreamOut", Arguments, true);
+        }
     }
 }
 
 void CClientStreamElement::NotifyCreate()
 {
+    // If the dimensions are different, stream out and do not continue
+    if (GetDimension() != m_pStreamer->m_usDimension)
+    {
+        m_bStreamedIn = true; // InternalStreamOut need it
+        InternalStreamOut(true);
+        return;
+    }
+
     // Update common atrributes
     if (!m_bDoubleSidedInit)
         m_bDoubleSided = IsDoubleSided();

--- a/Client/mods/deathmatch/logic/CClientStreamElement.h
+++ b/Client/mods/deathmatch/logic/CClientStreamElement.h
@@ -30,7 +30,7 @@ public:
     CClientStreamSector*    GetStreamSector() { return m_pStreamSector; }
     bool                    IsStreamedIn() { return m_bStreamedIn; }
     void                    InternalStreamIn(bool bInstantly);
-    void                    InternalStreamOut();
+    void                    InternalStreamOut(bool ignoreSendingEvent = false);
     virtual void            StreamIn(bool bInstantly) = 0;
     virtual void            StreamOut() = 0;
     virtual void            NotifyCreate();


### PR DESCRIPTION
Fixes #1245 (and maybe #4165?)

The bug is that the player's dimension changes after one second, but during that time not all vehicles have been streamed-in yet. As a result, some vehicles get streamed while the player is already in the new dimension. If for example, increase the delay in the test script attached to the mentioned issue, the problem no longer occurs because all vehicles have already been streamed.
The solution is to cancel the streaming of an element if the element's dimension is different from its streamer's dimension (e.g., vehicle streamer)