### PR TITLE
Fix multiple damage instances in certain areas during explosions

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1595,6 +1595,7 @@ void CMultiplayerSA::InitHooks()
     InitHooks_ObjectStreamerOptimization();
 
     InitHooks_Postprocess();
+    InitHooks_Explosions();
 }
 
 // Used to store copied pointers for explosions in the FxSystem

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -81,6 +81,7 @@ public:
     void                InitHooks_ObjectStreamerOptimization();
     void                InitHooks_Postprocess();
     void                InitHooks_DeviceSelection();
+    void                InitHooks_Explosions();
     CRemoteDataStorage* CreateRemoteDataStorage();
     void                DestroyRemoteDataStorage(CRemoteDataStorage* pData);
     void                AddRemoteDataStorage(CPlayerPed* pPed, CRemoteDataStorage* pData);

--- a/Client/multiplayer_sa/CMultiplayerSA_Explosions.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Explosions.cpp
@@ -1,0 +1,78 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        multiplayer_sa/CMultiplayerSA_Explosions.cpp
+ *
+ *  Multi Theft Auto is available from https://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+#include "StdInc.h"
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CWorld::TriggerExplosion
+//
+// Fix for multiple damage instances in certain areas during explosions (GH #4125, #997)
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+#define HOOKPOS_CWorld_TriggerExplosion  0x56B82E
+#define HOOKSIZE_CWorld_TriggerExplosion 8
+static constexpr std::uintptr_t RETURN_CWorld_TriggerExplosion = 0x56B836;
+static void _declspec(naked) HOOK_CWorld_TriggerExplosion()
+{
+    _asm
+    {
+        mov [esp+1Ch-8h], eax
+        mov [esp+1Ch-10h], ecx
+
+        // Call SetNextScanCode
+        mov ecx, 0x4072E0
+        call ecx
+        mov ecx, esi
+
+        // SetNextScanCode overwrote the result of the cmp instruction at 0x56B82A
+        // so we call it again
+        cmp esi, eax
+        jmp RETURN_CWorld_TriggerExplosion
+    }
+}
+
+#define HOOKPOS_CWorld_TriggerExplosionSectorList  0x5677F4
+#define HOOKSIZE_CWorld_TriggerExplosionSectorList 7
+static constexpr std::uintptr_t RETURN_CWorld_TriggerExplosionSectorList = 0x5677FB;
+static constexpr std::uintptr_t SKIP_CWorld_TriggerExplosionSectorList = 0x568473;
+static void _declspec(naked) HOOK_CWorld_TriggerExplosionSectorList()
+{
+    _asm
+    {
+        // check entity->m_nScanCode == CWorld::ms_nCurrentScanCode
+        mov ecx, dword ptr ds:[0xB7CD78]
+        cmp [esi+2Ch], ecx
+        jz skip
+
+        // set entity current scan code
+        mov [esi+2Ch], ecx
+
+        mov al, [esi+36h]
+        and al, 7
+        cmp al, 4
+        jmp RETURN_CWorld_TriggerExplosionSectorList
+
+        skip:
+        jmp SKIP_CWorld_TriggerExplosionSectorList
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CMultiplayerSA::InitHooks_Explosions
+//
+// Setup hooks
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+void CMultiplayerSA::InitHooks_Explosions()
+{
+    EZHookInstall(CWorld_TriggerExplosion);
+    EZHookInstall(CWorld_TriggerExplosionSectorList);
+}


### PR DESCRIPTION
Fixes #997 and #4125 

The world in SA is divided into sectors for optimization purposes. Sectors are determined based on position, and it's possible for a single point to be located in multiple sectors simultaneously - for example, at the corner where four sectors meet. To prevent logic from being processed multiple times for the same entities, a mechanism called 'scan codes' was introduced. When scanning sectors, a new scan code is set, and each entity is assigned the current scan code during processing. Entities that already have the current scan code are skipped, as they've already been handled.

For some reason, R* likely forgot to include the scan code logic in the explosion-related functions, which caused the same entities to be processed (and receive damage) multiple times. This explains why the bug only occurred in specific areas - those happened to be at sector boundaries where a point was part of multiple sectors simultaneously