### PR TITLE
Revert "Fix dimension -1 after #4184"

### DIFF
--- a/Client/mods/deathmatch/logic/CClientStreamElement.cpp
+++ b/Client/mods/deathmatch/logic/CClientStreamElement.cpp
@@ -94,7 +94,7 @@ void CClientStreamElement::InternalStreamOut(bool ignoreSendingEvent)
 void CClientStreamElement::NotifyCreate()
 {
     // If the dimensions are different, stream out and do not continue
-    if (GetDimension() != -1 && GetDimension() != m_pStreamer->m_usDimension)
+    if (GetDimension() != m_pStreamer->m_usDimension)
     {
         m_bStreamedIn = true; // InternalStreamOut need it
         InternalStreamOut(true);


### PR DESCRIPTION
#4198 was merged by mistake. It should be reimplemented due to the invalid comparison between `unsigned short` and `signed integer`. `m_bVisibleInAllDimensions` value has to be taken into account instead.