### PR TITLE
Potential crash fix

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -6443,7 +6443,12 @@ void _declspec(naked) HOOK_CWorld_Remove_CPopulation_ConvertToDummyObject()
     TIMING_CHECKPOINT("+RemovePointerToBuilding");
     RemovePointerToBuilding();
     StorePointerToBuilding();
-    RemoveObjectIfNeeded();
+
+    // pLODInterface contains a dummy object's pointer
+    // And as follows from CPopulation::ConvertToDummyObject this pointer can be nullptr
+    if (pLODInterface)
+        RemoveObjectIfNeeded();
+
     TIMING_CHECKPOINT("-RemovePointerToBuilding");
     _asm
     {


### PR DESCRIPTION
According to provided crash reports there is an issue with the building removal system. It incorrectly handles dummy objects which are about to be streamed out.

Targets cases like #4202 (Technical details: [comment below](https://github.com/multitheftauto/mtasa-blue/pull/4206#issuecomment-2858003162)) where for any reason pLODInterface is passed as nullptr.
