### PR TITLE
Fix interiors bug introduced by #4187

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA_Explosions.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Explosions.cpp
@@ -48,7 +48,7 @@ static void _declspec(naked) HOOK_CWorld_TriggerExplosionSectorList()
     {
         // check entity->m_nScanCode == CWorld::ms_nCurrentScanCode
         mov ecx, dword ptr ds:[0xB7CD78]
-        cmp [esi+2Ch], ecx
+        cmp [esi+2Ch], cx
         jz skip
 
         // set entity current scan code

--- a/Client/multiplayer_sa/CMultiplayerSA_Explosions.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Explosions.cpp
@@ -52,7 +52,7 @@ static void _declspec(naked) HOOK_CWorld_TriggerExplosionSectorList()
         jz skip
 
         // set entity current scan code
-        mov [esi+2Ch], ecx
+        mov [esi+2Ch], cx
 
         mov al, [esi+36h]
         and al, 7


### PR DESCRIPTION
Fixes a crash and interior disappearing when throwing granades inside interiors.