### PR TITLE
Potential fix for #4209

### DIFF
--- a/vendor/lua/src/lstring.c
+++ b/vendor/lua/src/lstring.c
@@ -107,7 +107,7 @@ Udata *luaS_newudata (lua_State *L, size_t s, Table *e) {
 
 LUALIB_API unsigned int luaS_hash(const char *str, size_t l)
 {
-    if (!str || str[0] == '\0' || l == 0)
+    if (!str || l == 0)
         return 0;
 
     unsigned int h = cast(unsigned int, l);  /* seed */


### PR DESCRIPTION
Fixes the issue with string hash calculation that #4169 was brought. Lua relies on strings without a null terminator which had not been taken into account. This potentially can lead to non-uniform hashmap access which in turn leads to poor performance. Thanks to @samr46 for pointing it out.