### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/vendor/jpeg-9f/rdgif.c
+++ b/vendor/jpeg-9f/rdgif.c
@@ -413,6 +413,8 @@ start_input_gif (j_compress_ptr cinfo, cjpeg_source_ptr sinfo)
     ERREXIT(cinfo, JERR_INPUT_EOF);
   width = LM_to_uint(hdrbuf, 0);
   height = LM_to_uint(hdrbuf, 2);
+  if (width == 0 || height == 0)
+    ERREXIT(cinfo, JERR_GIF_OUTOFRANGE);
   /* we ignore the color resolution, sort flag, and background color index */
   aspectRatio = UCH(hdrbuf[6]);
   if (aspectRatio != 0 && aspectRatio != 49)


### PR DESCRIPTION
Hi Development Team,

I identified another potential vulnerability in a clone function start_input_gif() in `vendor/jpeg-9f/rdgif.c` sourced from [libjpeg-turbo/libjpeg-turbo](https://github.com/libjpeg-turbo/libjpeg-turbo). This issue, originally reported in [CVE-2021-20205](https://nvd.nist.gov/vuln/detail/https://github.com/advisories/CVE-2021-20205), was resolved in the repository via this commit https://github.com/libjpeg-turbo/libjpeg-turbo/commit/1719d12e51641cce5c77e259516649ba5ef6303c.

This PR applies the corresponding patch to fix the vulnerability in this codebase.

Please review at your convenience. Thank you!