### PR TITLE
Fix #4258 - Prevent random nickname prompt from hiding Discord RPC consent window

### DIFF
--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -1273,7 +1273,8 @@ void CCore::DoPostFramePulse()
             }
         }
 
-        if (m_menuFrame >= 75 && m_requestNewNickname && GetLocalGUI()->GetMainMenu()->IsVisible() && !GetLocalGUI()->GetMainMenu()->IsFading())
+        if (m_menuFrame >= 75 && m_requestNewNickname && GetLocalGUI()->GetMainMenu()->IsVisible() && !GetLocalGUI()->GetMainMenu()->IsFading() &&
+            !GetLocalGUI()->GetMainMenu()->GetQuestionWindow()->IsVisible())
         {
             // Request a new nickname if we're waiting for one
             GetLocalGUI()->GetMainMenu()->GetSettingsWindow()->RequestNewNickname();


### PR DESCRIPTION
Added a check so the random nickname prompt only opens when no other question window is visible, ensuring the Discord RPC consent dialog isn’t hidden.
Fixes #4258

Before you go ahead and create a pull request, please make sure:

* [x] [your code follows the coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines)
* [x] your commit messages are informative ("update file.cpp" is unhelpful. "fix missing model in getVehicleNameFromModel" is helpful)

If your work is incomplete, **do not prefix your pull request with "WIP"**, instead
create a _draft_ pull request: https://github.blog/2019-02-14-introducing-draft-pull-requests/

Thank you!
