### PR TITLE
Fix missing onExplosion trigger for satchel charges

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -4970,7 +4970,10 @@ void CClientPed::DestroySatchelCharges(bool bBlow, bool bDestroy)
                 bool bCancelExplosion = !CallEvent("onClientExplosion", Arguments, true);
 
                 if (!bCancelExplosion)
+                {
                     m_pManager->GetExplosionManager()->Create(EXP_TYPE_GRENADE, vecPosition, this, true, -1.0f, false, WEAPONTYPE_REMOTE_SATCHEL_CHARGE);
+                    g_pClientGame->SendExplosionSync(vecPosition, EXP_TYPE_GRENADE, this);
+                }
             }
             if (bDestroy)
             {


### PR DESCRIPTION
(#3958)
Call to `SendExplosionSync()` added in `CClientPed::DestroySatchelCharges` to ensure satchel detonations trigger `onExplosion` on the server, like other explosives.

Before you go ahead and create a pull request, please make sure:

* [x] [your code follows the coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines)
* [x] your commit messages are informative ("update file.cpp" is unhelpful. "fix missing model in getVehicleNameFromModel" is helpful)

If your work is incomplete, **do not prefix your pull request with "WIP"**, instead
create a _draft_ pull request: https://github.blog/2019-02-14-introducing-draft-pull-requests/

Thank you!
