### PR TITLE
Add eventName to onPlayerTriggerEventThreshold

### DIFF
--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -5017,7 +5017,7 @@ void CGame::ProcessClientTriggeredEventSpam()
                 if (data.m_uiCounter > m_iMaxClientTriggeredEventsPerInterval)
                 {
                     CLuaArguments args;
-                    args.PushString(data.m_strLastEventName.c_str());
+                    args.PushString(data.m_strLastEventName);
                     player->CallEvent("onPlayerTriggerEventThreshold", args);
                 }
 

--- a/Server/mods/deathmatch/logic/CGame.h
+++ b/Server/mods/deathmatch/logic/CGame.h
@@ -526,7 +526,7 @@ private:
     static void PlayerCompleteConnect(CPlayer* pPlayer);
 
     void ProcessClientTriggeredEventSpam();
-    void RegisterClientTriggeredEventUsage(CPlayer* pPlayer);
+    void RegisterClientTriggeredEventUsage(CPlayer* pPlayer, const char* szEventName);
 
     // Technically, this could be put somewhere else.  It's a callback function
     // which the voice server library will call to send out data.
@@ -687,6 +687,7 @@ private:
     {
         long long m_llTicks = 0;
         uint32_t  m_uiCounter = 0;
+        std::string m_strLastEventName;
     };
 
     std::map<CPlayer*, ClientTriggeredEventsInfo> m_mapClientTriggeredEvents;


### PR DESCRIPTION
(#4116)
Enhanced onPlayerTriggerEventThreshold to include the name of the last triggered client event

Before you go ahead and create a pull request, please make sure:

* [x] [your code follows the coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines)
* [x] your commit messages are informative ("update file.cpp" is unhelpful. "fix missing model in getVehicleNameFromModel" is helpful)

If your work is incomplete, **do not prefix your pull request with "WIP"**, instead
create a _draft_ pull request: https://github.blog/2019-02-14-introducing-draft-pull-requests/

Thank you!
