### PR TITLE
Preserve vehicle component visibility

### DIFF
--- a/Client/mods/deathmatch/logic/CClientVehicle.h
+++ b/Client/mods/deathmatch/logic/CClientVehicle.h
@@ -754,6 +754,8 @@ public:
     SLastSyncedVehData*                      m_LastSyncedData;
     SSirenInfo                               m_tSirenBeaconInfo;
     std::map<SString, SVehicleComponentData> m_ComponentData;
+    // Store visibility state when the component map is regenerated
+    std::map<SString, bool>                  m_ComponentVisibilityBackup;
     bool                                     m_bAsyncLoadingDisabled;
 
     std::array<CVector, static_cast<std::size_t>(VehicleDummies::VEHICLE_DUMMY_COUNT)> m_dummyPositions;


### PR DESCRIPTION
Cached `m_bVisible` flags before `m_ComponentData` resets and restored them post-recreation to ensure `setVehicleComponentVisible` persists through model/variant changes.

Fixes #3888

Before you go ahead and create a pull request, please make sure:

* [ x] [your code follows the coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines)
* [ x] your commit messages are informative ("update file.cpp" is unhelpful. "fix missing model in getVehicleNameFromModel" is helpful)

If your work is incomplete, **do not prefix your pull request with "WIP"**, instead
create a _draft_ pull request: https://github.blog/2019-02-14-introducing-draft-pull-requests/

Thank you!
