### PR TITLE
Fix & improvement getPedMoveState

### DIFF
--- a/Client/game_sa/CPedSA.h
+++ b/Client/game_sa/CPedSA.h
@@ -261,7 +261,7 @@ public:
     int                              unk_52C;
 
     int                              pedState;
-    int                              moveState;
+    PedMoveState::Enum               moveState;
     int                              swimmingMoveState;
 
     int                              unk_53C;
@@ -276,10 +276,10 @@ public:
     float                            fRotationSpeed;
     float                            fMoveAnim;
 
-    CEntitySAInterface*              pContactEntity;
+    CEntitySAInterface*              pContactEntity; // m_standingOnEntity
     CVector                          unk_56C;
     CVector                          unk_578;
-    CEntitySAInterface*              pLastContactEntity;
+    CEntitySAInterface*              pLastContactEntity; // m_contactEntity
 
     CVehicleSAInterface*             pLastVehicle;
     CVehicleSAInterface*             pVehicle;
@@ -421,8 +421,9 @@ public:
     void           SetFightingStyle(eFightingStyle style, std::uint8_t styleExtra = 6) override;
 
     CEntity* GetContactEntity() const override;
+    bool     IsStandingOnEntity() const override { return GetPedInterface()->pContactEntity != nullptr; };
 
-    int GetRunState() const override { return GetPedInterface()->moveState; }
+    PedMoveState::Enum GetMoveState() const override { return GetPedInterface()->moveState; }
 
     bool GetCanBeShotInVehicle() const override{ return GetPedInterface()->pedFlags.bCanBeShotInVehicle; }
     bool GetTestForShotInVehicle() const override { return GetPedInterface()->pedFlags.bTestForShotInVehicle; }

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -66,17 +66,22 @@ enum eBodyPart
 enum eMovementState
 {
     MOVEMENTSTATE_UNKNOWN,
-    MOVEMENTSTATE_STAND,                // Standing still
-    MOVEMENTSTATE_WALK,                 // Walking
-    MOVEMENTSTATE_POWERWALK,            // Walking quickly
-    MOVEMENTSTATE_JOG,                  // Jogging
-    MOVEMENTSTATE_SPRINT,               // Sprinting
-    MOVEMENTSTATE_CROUCH,               // Crouching still
-    MOVEMENTSTATE_CRAWL,                // Crouch-moving
-    MOVEMENTSTATE_ROLL,                 // Crouch-rolling (Needs adding)
-    MOVEMENTSTATE_JUMP,                 // Jumping
-    MOVEMENTSTATE_FALL,                 // Falling
-    MOVEMENTSTATE_CLIMB                 // Climbing
+    MOVEMENTSTATE_STAND,                      // Standing still
+    MOVEMENTSTATE_WALK,                       // Walking
+    MOVEMENTSTATE_POWERWALK,                  // Walking quickly
+    MOVEMENTSTATE_JOG,                        // Jogging (Unused)
+    MOVEMENTSTATE_SPRINT,                     // Sprinting
+    MOVEMENTSTATE_CROUCH,                     // Crouching still
+    MOVEMENTSTATE_CRAWL,                      // Crouch-moving
+    MOVEMENTSTATE_ROLL,                       // Crouch-rolling
+    MOVEMENTSTATE_JUMP,                       // Jumping
+    MOVEMENTSTATE_FALL,                       // Falling
+    MOVEMENTSTATE_CLIMB,                      // Climbing
+    MOVEMENTSTATE_SWIM,                       // Swimming
+    MOVEMENTSTATE_WALK_TO_POINT,              // Entering vehicle (walking to the door)
+    MOVEMENTSTATE_ASCENT_JETPACK,             // Ascending with jetpack
+    MOVEMENTSTATE_DESCENT_JETPACK,            // Descending with jetpack
+    MOVEMENTSTATE_JETPACK,                    // Jetpack flying
 };
 
 enum eDeathAnims

--- a/Client/sdk/game/CPed.h
+++ b/Client/sdk/game/CPed.h
@@ -14,6 +14,7 @@
 #include "CWeaponInfo.h"
 #include "CPedSound.h"
 #include "enums/PedState.h"
+#include "enums/PedMoveState.h"
 
 // To avoid VS intellisense highlight errors
 #include <memory>
@@ -253,8 +254,9 @@ public:
     virtual void           SetFightingStyle(eFightingStyle style, std::uint8_t styleExtra) = 0;
 
     virtual CEntity* GetContactEntity() const = 0;
+    virtual bool     IsStandingOnEntity() const = 0;
 
-    virtual int GetRunState() const = 0;
+    virtual PedMoveState::Enum GetMoveState() const = 0;
 
     virtual bool GetCanBeShotInVehicle() const = 0;
     virtual bool GetTestForShotInVehicle() const = 0;

--- a/Shared/sdk/enums/PedMoveState.h
+++ b/Shared/sdk/enums/PedMoveState.h
@@ -1,0 +1,27 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        sdk/PedMoveState.h
+ *  PURPOSE:     Header for common definitions
+ *
+ *  Multi Theft Auto is available from https://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#pragma once
+
+namespace PedMoveState
+{
+    enum Enum
+    {
+        PEDMOVE_NONE = 0,
+        PEDMOVE_STILL,
+        PEDMOVE_TURN_L,
+        PEDMOVE_TURN_R,
+        PEDMOVE_WALK,
+        PEDMOVE_JOG,
+        PEDMOVE_RUN,
+        PEDMOVE_SPRINT,
+    };
+}


### PR DESCRIPTION
Fixed #1598 #1594 #1590 

The ``getPedMoveState`` function behaves somewhat unreliably. It often incorrectly returns fall, which is caused by the imprecise behavior of IsOnGround (in some areas of the map, the player's position might be, for example, z = 8.5, while the ground is z = 7.5).

This PR fixes the mentioned issues and adds new states (previously incorrectly labeled as fall):

- **swim**
- **walk_to_point** (when a ped is walking to a vehicle door to get in)
- **ascent_jetpack** – ascending with jetpack (space key)
- **descent_jetpack** – descending with jetpack (shift key)
- **jetpack_flying** – flying with jetpack
- **roll** - Added the previously planned `roll` state

Here is a screenshot of one of the reported issues I received:
<img width="985" height="116" alt="image" src="https://github.com/user-attachments/assets/91d46fab-4d47-46b1-89db-9d962f0c6738" />

Thanks to @sacr1ficez for reporting in DM