### PR TITLE
Make cross compiling the project using msvc-wine on Linux possible

### DIFF
--- a/utils/buildactions/utils.lua
+++ b/utils/buildactions/utils.lua
@@ -96,7 +96,7 @@ function os.sha256_file(path)
 	local windows = os.host() == "windows"
 	local s, errc
 	if windows then
-		s, errc = os.outputof(string.format("utils\\7z\\7za.exe h -scrcSHA256 \"%s\"", path))
+		s, errc = os.outputof(string.format("call \"utils\\7z\\7za.exe\" h -scrcSHA256 \"%s\"", path))
 	else
 		s, errc = os.outputof(string.format("sha256sum \"%s\" | awk '{ print $1 }'", path))
 	end

--- a/utils/buildactions/utils.lua
+++ b/utils/buildactions/utils.lua
@@ -96,7 +96,7 @@ function os.sha256_file(path)
 	local windows = os.host() == "windows"
 	local s, errc
 	if windows then
-		s, errc = os.outputof(string.format("CertUtil -hashfile \"%s\" SHA256", path))
+		s, errc = os.outputof(string.format("utils\\7z\\7za.exe h -scrcSHA256 \"%s\"", path))
 	else
 		s, errc = os.outputof(string.format("sha256sum \"%s\" | awk '{ print $1 }'", path))
 	end
@@ -109,7 +109,7 @@ function os.sha256_file(path)
 
 	-- Clean windows output
 	if windows then
-		s = (s:match("\n(.*)\n(.*)") or ""):gsub(" ", "")
+		s = (s:match("SHA256 for data: +([^\n]*)") or "")
 	end
 
 	return s:lower()

--- a/win-build.bat
+++ b/win-build.bat
@@ -45,7 +45,7 @@ IF /i [%2] == [Win32] (
     set BUILD_PLATFORM=ARM64
 ) ELSE (
     IF not [%2] == [] (
-        echo Invalid first argument %2. Using default platform %BUILD_PLATFORM%.
+        echo Invalid second argument %2. Using default platform %BUILD_PLATFORM%.
     )
 )
 

--- a/wine-build.sh
+++ b/wine-build.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+if [ -z "$MSBUILDPATH" ]; then
+    echo "Could not find MSBuild. Make sure the MSBUILDPATH environment variable points"
+    echo "to either MSBuild.exe or a script that handles the invocation of MSBuild.exe."
+    exit 1
+fi
+echo "Found MSBuild at: $MSBUILDPATH"
+
+BUILD_CONFIGURATION=Release
+BUILD_PLATFORM=Win32
+
+# Read configuration (1st parameter)
+case ${1,,} in
+    debug)   BUILD_CONFIGURATION=Debug ;;
+    release) BUILD_CONFIGURATION=Release ;;
+    "") ;;
+    *) echo "Invalid first argument $1. Using default configuration $BUILD_CONFIGURATION." ;;
+esac
+
+# Read platform (2nd parameter)
+case ${2,,} in
+    win32) BUILD_PLATFORM=Win32 ;;
+    x64)   BUILD_PLATFORM=x64 ;;
+    arm)   BUILD_PLATFORM=ARM ;;
+    arm64) BUILD_PLATFORM=ARM64 ;;
+    "") ;;
+    *) echo "Invalid second argument $2. Using default platform $BUILD_PLATFORM." ;;
+esac
+
+echo "Build configuration:"
+echo "  BUILD_CONFIGURATION = $BUILD_CONFIGURATION"
+echo "  BUILD_PLATFORM = $BUILD_PLATFORM"
+
+# Create solution (ignoring pause)
+wine win-create-projects.bat < /dev/null
+echo ""
+
+# Start compiling
+"$MSBUILDPATH" Build/MTASA.sln -property:Configuration="$BUILD_CONFIGURATION" -property:Platform="$BUILD_PLATFORM" -maxCpuCount

--- a/wine-build.sh
+++ b/wine-build.sh
@@ -3,6 +3,8 @@
 if [ -z "$MSBUILDPATH" ]; then
     echo "Could not find MSBuild. Make sure the MSBUILDPATH environment variable points"
     echo "to either MSBuild.exe or a script that handles the invocation of MSBuild.exe."
+    echo ""
+    echo "If using msvc-wine, it should point to /path/to/msvc-wine-install-dir/bin/x64/msbuild"
     exit 1
 fi
 echo "Found MSBuild at: $MSBUILDPATH"


### PR DESCRIPTION
This PR aims to streamline compiling (mainly the Client) on Linux using msvc-wine. I plan on submitting a full write-up about the process to the wiki.

This PR replaces CertUtil with 7za.exe inside `utils/buildactions/utils.lua`. This is needed, because Wine (as of writing) doesn't implement CertUtil, hence `os.sha256_file` would fail otherwise. On Windows, this shouldn't break anything.

The PR also introduces a helper build script `./wine-build.sh`. `./win-build.bat` can't be used, since the `msbuild` wrapper script that's shipped by msvc-wine fails to correctly set the paths in the environment variables if it's invoked from withing Wine. Also, `vswhere.exe` would just never work on Wine. This script is not strictly necessary for things to work though, as the individual commands can be invoked directly:
```sh
wine win-create-projects.bat < /dev/null
/path/to/msvc-wine-install-dir/bin/x64/msbuild" Build/MTASA.sln -property:Configuration=Release -property:Platform=Win32 -maxCpuCount
```
Thus it can be removed from this PR, if requested.