### PR TITLE
Fixes #4337 - Fix duplicate onClientExplosion events for satchel

### DIFF
--- a/Client/mods/deathmatch/logic/CClientExplosionManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientExplosionManager.cpp
@@ -58,7 +58,12 @@ bool CClientExplosionManager::Hook_ExplosionCreation(CEntity* pGameExplodingEnti
     // Determine the used weapon
     eWeaponType explosionWeaponType = WEAPONTYPE_EXPLOSION;
 
-    switch (explosionType)
+    // Use stored weapon type if available
+    if (m_LastWeaponType != WEAPONTYPE_UNARMED && m_pLastCreator == pResponsible)
+        explosionWeaponType = m_LastWeaponType;
+    else
+    {
+        switch (explosionType)
     {
         case EXP_TYPE_GRENADE:
         {
@@ -82,6 +87,7 @@ bool CClientExplosionManager::Hook_ExplosionCreation(CEntity* pGameExplodingEnti
             break;
         default:
             break;
+        }
     }
 
     // Handle this explosion client side only if entity is local or breakable (i.e. barrel)

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -4980,7 +4980,6 @@ void CClientPed::DestroySatchelCharges(bool bBlow, bool bDestroy)
             {
                 pProjectile->GetPosition(vecPosition);
                 m_pManager->GetExplosionManager()->Create(EXP_TYPE_GRENADE, vecPosition, this, true, -1.0f, false, WEAPONTYPE_REMOTE_SATCHEL_CHARGE);
-                g_pClientGame->SendExplosionSync(vecPosition, EXP_TYPE_GRENADE, this);
             }
             if (bDestroy)
             {

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -4979,18 +4979,8 @@ void CClientPed::DestroySatchelCharges(bool bBlow, bool bDestroy)
             if (bBlow)
             {
                 pProjectile->GetPosition(vecPosition);
-                CLuaArguments Arguments;
-                Arguments.PushNumber(vecPosition.fX);
-                Arguments.PushNumber(vecPosition.fY);
-                Arguments.PushNumber(vecPosition.fZ);
-                Arguments.PushNumber(EXP_TYPE_GRENADE);
-                bool bCancelExplosion = !CallEvent("onClientExplosion", Arguments, true);
-
-                if (!bCancelExplosion)
-                {
-                    m_pManager->GetExplosionManager()->Create(EXP_TYPE_GRENADE, vecPosition, this, true, -1.0f, false, WEAPONTYPE_REMOTE_SATCHEL_CHARGE);
-                    g_pClientGame->SendExplosionSync(vecPosition, EXP_TYPE_GRENADE, this);
-                }
+                m_pManager->GetExplosionManager()->Create(EXP_TYPE_GRENADE, vecPosition, this, true, -1.0f, false, WEAPONTYPE_REMOTE_SATCHEL_CHARGE);
+                g_pClientGame->SendExplosionSync(vecPosition, EXP_TYPE_GRENADE, this);
             }
             if (bDestroy)
             {


### PR DESCRIPTION
Fixes : #4337 , Tested.

I removed the manual event call from DestroySatchelCharges and let only the explosion manager handle the event firing, ensuring satchel explosions behave consistently with other explosives like grenades and eliminating the duplicate event triggers.

```lua
addEventHandler("onClientExplosion", root,
    function(x, y, z, theType, theVehicle)
        outputChatBox("Explosion detected at: " .. x .. ", " .. y .. ", " .. z, 255, 100, 100)
    end
)
```

Before:
❌ Event was being triggered twice due to both manual and automatic invocation.

After:
✅ Now triggered only once as expected, preventing duplicate event calls.

Also Tested all Explosion types : 
``` lua
local explosionTypes = {
    [0] = "Grenade",
    [1] = "Molotov",
    [2] = "Rocket",
    [3] = "Car",
    [4] = "Quick Car",
    [5] = "Boat",
    [6] = "Helicopter",
    [7] = "Mine",
    [8] = "Object",
    [9] = "Tank Grenade",
    [10] = "Small",
    [11] = "Tear Gas",
    [12] = "Fire",
    [13] = "Unknown"
}
```
