### PR TITLE
Add new movement state to getPedMoveState

### DIFF
--- a/Client/game_sa/TaskJumpFallSA.h
+++ b/Client/game_sa/TaskJumpFallSA.h
@@ -31,8 +31,8 @@ public:
     bool          m_bChangePosition;
     bool          m_bForceClimb;
     bool          m_bInvalidClimb;
-    char          m_nHeightForAnim;
-    char          m_nHeightForPos;
+    eClimbHeights m_nHeightForAnim;
+    eClimbHeights m_nHeightForPos;
     unsigned char m_nSurfaceType;
     char          m_nFallAfterVault;
     float         m_fHandholdHeading;
@@ -49,6 +49,8 @@ public:
     CTaskSimpleClimbSA(){};
     CTaskSimpleClimbSA(CEntity* pClimbEnt, const CVector& vecTarget, float fHeading, unsigned char nSurfaceType, char nHeight = CLIMB_GRAB,
                        const bool bForceClimb = false);
+
+    eClimbHeights GetHeightForPos() const override { return static_cast<const CTaskSimpleClimbSAInterface*>(GetInterface())->m_nHeightForPos; }
 };
 
 // ##############################################################################

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -241,6 +241,7 @@ void CClientPed::Init(CClientManager* pManager, unsigned long ulModelID, bool bI
     m_MovementStateNames[MOVEMENTSTATE_ASCENT_JETPACK] = "ascent_jetpack";
     m_MovementStateNames[MOVEMENTSTATE_DESCENT_JETPACK] = "descent_jetpack";
     m_MovementStateNames[MOVEMENTSTATE_JETPACK] = "jetpack_flying";
+    m_MovementStateNames[MOVEMENTSTATE_HANGING] = "hanging";
 
     // Create the player model
     if (m_bIsLocalPlayer)
@@ -2426,7 +2427,13 @@ eMovementState CClientPed::GetMovementState()
 
         // Check tasks
         if (strcmp(szSimpleTaskName, "TASK_SIMPLE_CLIMB") == 0) // Is he climbing?
+        {
+            CTaskSimpleClimb* climbingTask = dynamic_cast<CTaskSimpleClimb*>(GetTaskManager()->GetSimplestActiveTask());
+            if (climbingTask && climbingTask->GetHeightForPos() == eClimbHeights::CLIMB_GRAB)
+                return MOVEMENTSTATE_HANGING;
+
             return MOVEMENTSTATE_CLIMB;
+        }
         else if (strcmp(szComplexTaskName, "TASK_COMPLEX_JUMP") == 0) // Is he jumping?
             return MOVEMENTSTATE_JUMP;
         else if (strcmp(szSimpleTaskName, "TASK_SIMPLE_GO_TO_POINT") == 0) // Entering vehicle (walking to the doors)?

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -82,6 +82,7 @@ enum eMovementState
     MOVEMENTSTATE_ASCENT_JETPACK,             // Ascending with jetpack
     MOVEMENTSTATE_DESCENT_JETPACK,            // Descending with jetpack
     MOVEMENTSTATE_JETPACK,                    // Jetpack flying
+    MOVEMENTSTATE_HANGING,                    // Hanging from the whall during climbing task
 };
 
 enum eDeathAnims

--- a/Client/sdk/game/CTasks.h
+++ b/Client/sdk/game/CTasks.h
@@ -52,7 +52,7 @@ class CVehicle;
 typedef unsigned long AssocGroupId;
 typedef unsigned long AnimationId;
 
-enum eClimbHeights
+enum eClimbHeights : std::int8_t
 {
     CLIMB_NOT_READY = 0,
     CLIMB_GRAB,

--- a/Client/sdk/game/TaskJumpFall.h
+++ b/Client/sdk/game/TaskJumpFall.h
@@ -13,10 +13,14 @@
 
 #include "Task.h"
 
+enum eClimbHeights : std::int8_t;
+
 class CTaskSimpleClimb : public virtual CTaskSimple
 {
 public:
     virtual ~CTaskSimpleClimb(){};
+
+    virtual eClimbHeights GetHeightForPos() const = 0;
 };
 
 class CTaskSimpleJetPack : public virtual CTaskSimple


### PR DESCRIPTION
This PR adds a new movement state to the ``getPedMoveState`` function:

**hanging** - means the ped is hanging during a climb task, for example, from a wall.

<img width="951" height="853" alt="image" src="https://github.com/user-attachments/assets/8f547fcc-a264-432e-8c0b-183da30c29e0" />

Currently, ``climb`` is returned regardless of whether the ped is hanging or actually climbing, so imo, a separate movement state better reflects the ped’s real movement.

At the same time, this means the change **breaks backward compatibility**, but since the new version hasn’t been officially released yet, I’m hoping this small PR can be quickly approved and merged.

Thanks to @sacr1ficez  for the idea.