### PR TITLE
Fix ArgumentParser not handling noexcept in GCC 13.1 upwards

### DIFF
--- a/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
@@ -744,7 +744,7 @@ struct CLuaFunctionParser
 {
 };
 
-template <bool ErrorOnFailure, auto ReturnOnFailure, typename Ret, typename... Args, auto (*Func)(Args...)->Ret>
+template <bool ErrorOnFailure, auto ReturnOnFailure, bool NoExcept, typename Ret, typename... Args, Ret (*Func)(Args...) noexcept(NoExcept)>
 struct CLuaFunctionParser<ErrorOnFailure, ReturnOnFailure, Func> : CLuaFunctionParserBase
 {
     template <typename... Params>
@@ -832,7 +832,7 @@ struct CLuaFunctionParser<ErrorOnFailure, ReturnOnFailure, Func> : CLuaFunctionP
 // Case where F is a class method pointer
 // Note: If you see weird compiler errors like: Undefined type, overload resolution failed, etc..
 // Ask on Dev Discord(#new-argument-parser), because rn this implementation is pretty beta. - 03/2021
-template <bool ErrorOnFailure, auto ReturnOnFailure, typename T, typename R, typename... Args, R(T::*F)(Args...)>
+template <bool ErrorOnFailure, auto ReturnOnFailure, typename T, bool NoExcept, typename R, typename... Args, R(T::*F)(Args...) noexcept(NoExcept)>
 struct CLuaFunctionParser<ErrorOnFailure, ReturnOnFailure, F>
 {
     // Remove constness here, because we must be able to std::move


### PR DESCRIPTION
I honestly have no idea why this is required, but apparently it works.