### PR TITLE
Add onElementPositionChange event to SetElementPosition for anti-cheat compatibility

### DIFF
--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -1672,6 +1672,7 @@ void CGame::AddBuiltInEvents()
     m_Events.AddEvent("onElementInteriorChange", "oldInterior, newInterior", nullptr, false);
     m_Events.AddEvent("onElementAttach", "attachSource, attachOffsetX, attachOffsetY, attachOffsetZ, attachOffsetRX, attachOffsetRY, attachOffsetRZ", nullptr, false);
     m_Events.AddEvent("onElementDetach", "detachSource, detachWorldX, detachWorldY, detachWorldZ, detachWorldRX, detachWorldRY, detachWorldRZ", nullptr, false);
+    m_Events.AddEvent("onElementPositionChange", "oldX, oldY, oldZ, newX, newY, newZ", nullptr, false);
 
     // Radar area events
 

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1340,6 +1340,24 @@ bool CStaticFunctionDefinitions::SetElementPosition(CElement* pElement, const CV
     if (ped && ped->HasJetPack())
         m_pPlayerManager->BroadcastOnlyJoined(CElementRPCPacket(ped, GIVE_PED_JETPACK, *BitStream.pBitStream));
 
+    // This event is triggered server-side to allow anti-cheat scripts to distinguish between
+    // position changes made by the server (e.g., elevators, scripted teleports) and those made by the client.
+    // Without this event, anti-cheat systems may falsely detect legitimate server-side teleports as cheats,
+    // since they only check the distance between old and new positions.
+    // By listening to this event, anti-cheat scripts can safely ignore server-initiated position changes.
+    CLuaArguments Arguments;
+    Arguments.PushElement(pElement);
+    Arguments.PushNumber(vecPosition.fX);
+    Arguments.PushNumber(vecPosition.fY);
+    Arguments.PushNumber(vecPosition.fZ);
+    Arguments.PushBool(bWarp);
+     
+
+    if (!pElement->CallEvent("onElementPositionChange", Arguments))
+    {
+       return false;
+    }
+
     return true;
 }
 

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1305,6 +1305,9 @@ bool CStaticFunctionDefinitions::SetElementPosition(CElement* pElement, const CV
         player->SetTeleported(true);
     }
 
+    // Get element old position
+    CVector elementOldPosition = pElement->GetPosition();
+
     // Update our position for that entity.
     pElement->SetPosition(vecPosition);
 
@@ -1347,6 +1350,9 @@ bool CStaticFunctionDefinitions::SetElementPosition(CElement* pElement, const CV
     // By listening to this event, anti-cheat scripts can safely ignore server-initiated position changes.
     CLuaArguments Arguments;
     Arguments.PushElement(pElement);
+    Arguments.PushNumber(elementOldPosition.fX);
+    Arguments.PushNumber(elementOldPosition.fY);
+    Arguments.PushNumber(elementOldPosition.fZ);
     Arguments.PushNumber(vecPosition.fX);
     Arguments.PushNumber(vecPosition.fY);
     Arguments.PushNumber(vecPosition.fZ);


### PR DESCRIPTION
This PR adds a server-side "onElementPositionChange" event to the SetElementPosition function.

**Reason:**
Some anti-cheat scripts detect large position changes as cheating, but do not distinguish between server-initiated and client-initiated changes. This causes false positives when the server teleports players (e.g., for elevators or scripted events).

**How it works:**
By triggering the "onElementPositionChange" event server-side, anti-cheat scripts can listen for this event and safely ignore position changes that originate from the server.

This improves compatibility with anti-cheat resources and prevents legitimate server-side teleports from being flagged as cheats.