### PR TITLE
Fix "Climbing over certain objects kills you"

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1584,10 +1584,10 @@ void CMultiplayerSA::InitHooks()
     MemCpy((void*)0x7259B0, "\xDD\xD8\x90", 3);
     MemSet((void*)0x7258B8, 0x90, 6);
 
-      // Disable spreading fires (Moved from multiplayer_shotsync)
+    // Disable spreading fires (Moved from multiplayer_shotsync)
     MemCpy((void*)0x53A23F, "\x33\xC0\x90\x90\x90", 5);
     MemCpy((void*)0x53A00A, "\x33\xC0\x90\x90\x90", 5);
-    
+
     InitHooks_CrashFixHacks();
     InitHooks_DeviceSelection();
 

--- a/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
@@ -708,6 +708,12 @@ void CMultiplayerSA::InitHooks_FrameRateFixes()
     // CVehicle::ProcessBoatControl
     MemPut(0x6DC23F, &kOriginalTimeStep);
 
+    // Fixes climbing over certain objects killing player on high FPS or low game speed.
+    // GitHub Issue #602
+    MemPut(0x6811E9, &kOriginalTimeStep);
+    MemPut(0x68128A, &kOriginalTimeStep);
+    MemPut(0x68131B, &kOriginalTimeStep);
+
     // CTimer::m_FrameCounter fixes
     EZHookInstall(CTimer__Update);
 


### PR DESCRIPTION
Fixed #602 

A ped is killed by excessive fall speed. CPed::ProcessEntityCollision applies damage when the ped’s Z-axis velocity is less than a defined value: -0.375. With high FPS (>74) or low game speed, this fall velocity becomes greater (the value becomes smaller) due to timeStep.

CTaskSimpleClimb sets the Z-axis velocity based on timeStep; specifically, it calculates a multiplier from 1 / timeStep, which produces high numbers for small values (e.g. 1 / 0.2 = 5). The solution is to set a fixed timeStep in this case.

I tested several locations on the map and did not observe the same issues as @lopezloo  reported in his PR.