### PR TITLE
Fix client-side peds not being able to enter/exit local vehicles

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -6532,13 +6532,6 @@ bool CClientPed::EnterVehicle(CClientVehicle* pVehicle, bool bPassenger)
         return false;
     }
 
-    // Are we a clientside ped
-    // TODO: Add support for clientside peds
-    if (IsLocalEntity())
-    {
-        return false;
-    }
-
     // Are we already inside a vehicle
     if (GetOccupiedVehicle())
     {
@@ -6746,13 +6739,6 @@ bool CClientPed::ExitVehicle()
 {
     // Are we local player or ped we are syncing
     if (!IsSyncing() && !IsLocalPlayer() && !IsLocalEntity())
-    {
-        return false;
-    }
-
-    // Are we a clientside ped
-    // TODO: Add support for clientside peds
-    if (IsLocalEntity())
     {
         return false;
     }


### PR DESCRIPTION
A previous PR: https://github.com/multitheftauto/mtasa-blue/pull/3772 was found to not be working, due to leftover if-statements. This PR fixes that.