### PR TITLE
Fix argument parser not handling noexcept functions (MSVC-friendly)

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDefs.h
@@ -77,7 +77,7 @@ protected:
     template <auto ReturnOnError, auto T>
     static inline int ArgumentParserWarn(lua_State* L)
     {
-        return CLuaFunctionParser<false, ReturnOnError, T>()(L, m_pScriptDebugging);
+        return CLuaFunctionParser<false, ReturnOnError, remove_noexcept_fn_v<T>>()(L, m_pScriptDebugging);
     }
 
     // Special case for overloads
@@ -87,8 +87,8 @@ protected:
     {
         // Pad functions to have the same number of parameters by
         // filling both up to the larger number of parameters with dummy_type arguments
-        using PaddedFunctionA = pad_func_with_func<FunctionA, FunctionB>;
-        using PaddedFunctionB = pad_func_with_func<FunctionB, FunctionA>;
+        using PaddedFunctionA = pad_func_with_func<remove_noexcept_fn_v<FunctionA>, remove_noexcept_fn_v<FunctionB>>;
+        using PaddedFunctionB = pad_func_with_func<remove_noexcept_fn_v<FunctionB>, remove_noexcept_fn_v<FunctionA>>;
         // Combine functions
         using Overload = CLuaOverloadParser<PaddedFunctionA::Call, PaddedFunctionB::Call>;
 
@@ -99,7 +99,7 @@ protected:
     template <auto T>
     static inline int ArgumentParser(lua_State* L)
     {
-        return CLuaFunctionParser<true, nullptr, T>()(L, m_pScriptDebugging);
+        return CLuaFunctionParser<true, nullptr, remove_noexcept_fn_v<T>>()(L, m_pScriptDebugging);
     }
 
     // Special case for overloads
@@ -109,8 +109,8 @@ protected:
     {
         // Pad functions to have the same number of parameters by
         // filling both up to the larger number of parameters with dummy_type arguments
-        using PaddedFunctionA = pad_func_with_func<FunctionA, FunctionB>;
-        using PaddedFunctionB = pad_func_with_func<FunctionB, FunctionA>;
+        using PaddedFunctionA = pad_func_with_func<remove_noexcept_fn_v<FunctionA>, remove_noexcept_fn_v<FunctionB>>;
+        using PaddedFunctionB = pad_func_with_func<remove_noexcept_fn_v<FunctionB>, remove_noexcept_fn_v<FunctionA>>;
         // Combine functions
         using Overload = CLuaOverloadParser<PaddedFunctionA::Call, PaddedFunctionB::Call>;
 

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDefs.h
@@ -96,7 +96,7 @@ protected:
     template <auto ReturnOnError, auto T>
     static inline int ArgumentParserWarn(lua_State* L)
     {
-        return CLuaFunctionParser<false, ReturnOnError, T>()(L, m_pScriptDebugging);
+        return CLuaFunctionParser<false, ReturnOnError, remove_noexcept_fn_v<T>>()(L, m_pScriptDebugging);
     }
 
     // Special case for overloads
@@ -106,8 +106,8 @@ protected:
     {
         // Pad functions to have the same number of parameters by
         // filling both up to the larger number of parameters with dummy_type arguments
-        using PaddedFunctionA = pad_func_with_func<FunctionA, FunctionB>;
-        using PaddedFunctionB = pad_func_with_func<FunctionB, FunctionA>;
+        using PaddedFunctionA = pad_func_with_func<remove_noexcept_fn_v<FunctionA>, remove_noexcept_fn_v<FunctionB>>;
+        using PaddedFunctionB = pad_func_with_func<remove_noexcept_fn_v<FunctionB>, remove_noexcept_fn_v<FunctionA>>;
         // Combine functions
         using Overload = CLuaOverloadParser<PaddedFunctionA::Call, PaddedFunctionB::Call>;
 
@@ -118,7 +118,7 @@ protected:
     template <auto T>
     static inline int ArgumentParser(lua_State* L)
     {
-        return CLuaFunctionParser<true, nullptr, T>()(L, m_pScriptDebugging);
+        return CLuaFunctionParser<true, nullptr, remove_noexcept_fn_v<T>>()(L, m_pScriptDebugging);
     }
 
     // Special case for overloads
@@ -128,8 +128,8 @@ protected:
     {
         // Pad functions to have the same number of parameters by
         // filling both up to the larger number of parameters with dummy_type arguments
-        using PaddedFunctionA = pad_func_with_func<FunctionA, FunctionB>;
-        using PaddedFunctionB = pad_func_with_func<FunctionB, FunctionA>;
+        using PaddedFunctionA = pad_func_with_func<remove_noexcept_fn_v<FunctionA>, remove_noexcept_fn_v<FunctionB>>;
+        using PaddedFunctionB = pad_func_with_func<remove_noexcept_fn_v<FunctionB>, remove_noexcept_fn_v<FunctionA>>;
         // Combine functions
         using Overload = CLuaOverloadParser<PaddedFunctionA::Call, PaddedFunctionB::Call>;
 

--- a/Shared/sdk/SharedUtil.Template.h
+++ b/Shared/sdk/SharedUtil.Template.h
@@ -250,3 +250,38 @@ struct pad_func_with_func<Func, FuncB>
                                                      std::max(sizeof...(Args), sizeof...(ArgsB)) - sizeof...(Args) == 0>::type>
 {
 };
+
+// Removes noexcept(true) from a function type
+template <typename T>
+struct remove_noexcept
+{
+    using type = T;
+};
+
+template <typename R, typename... Args>
+struct remove_noexcept<R(Args...) noexcept>
+{
+    using type = R(Args...);
+};
+
+template <typename T>
+using remove_noexcept_t = typename remove_noexcept<T>::type;
+
+// Removes noexcept(true) from a function
+template <typename T>
+struct remove_noexcept_fn;
+
+template <typename R, typename... Args>
+struct remove_noexcept_fn<R (*)(Args...) noexcept>
+{
+    using type = R (*)(Args...);
+};
+
+template <typename R, typename... Args>
+struct remove_noexcept_fn<R (*)(Args...)>
+{
+    using type = R (*)(Args...);
+};
+
+template <auto Func>
+constexpr auto remove_noexcept_fn_v = static_cast<typename remove_noexcept_fn<decltype(Func)>::type>(Func);


### PR DESCRIPTION
Improved version of #4390, msvc-friendly.