### PR TITLE
Fix ACL request detection when using refresh (#1824)

### DIFF
--- a/Server/mods/deathmatch/logic/CResource.AclRequest.cpp
+++ b/Server/mods/deathmatch/logic/CResource.AclRequest.cpp
@@ -379,13 +379,13 @@ std::string CResource::CalculateACLRequestFingerprint()
     std::unique_ptr<CXMLFile> metaFile(g_pServerInterface->GetXML()->CreateXML(strPath.c_str()));
     if (!metaFile || !metaFile->Parse())
     {
-        return "";
+        return {};
     }
 
     CXMLNode* root = metaFile->GetRootNode();
     if (!root)
     {
-        return "";
+        return {};
     }
 
     std::ostringstream fingerprint;
@@ -404,6 +404,7 @@ std::string CResource::CalculateACLRequestFingerprint()
 
             if (uiIndex > 0)
                 fingerprint << ";";
+                
             fingerprint << strName << ":" << strAccess;
         }
     }

--- a/Server/mods/deathmatch/logic/CResource.h
+++ b/Server/mods/deathmatch/logic/CResource.h
@@ -347,7 +347,7 @@ protected:
     void RefreshAutoPermissions(CXMLNode* pNodeAclRequest);
 
     void CommitAclRequest(const SAclRequest& request);
-    bool FindAclRequest(SAclRequest& request);
+    bool FindAclRequest(SAclRequest& result);
 
     std::string CalculateACLRequestFingerprint();
     bool        HasACLRequestsChanged();

--- a/Server/mods/deathmatch/logic/CResource.h
+++ b/Server/mods/deathmatch/logic/CResource.h
@@ -349,6 +349,9 @@ protected:
     void CommitAclRequest(const SAclRequest& request);
     bool FindAclRequest(SAclRequest& request);
 
+    std::string CalculateACLRequestFingerprint();
+    bool        HasACLRequestsChanged();
+
 private:
     bool CheckState();            // if the resource has no Dependents, stop it, if it has, start it. returns true if the resource is started.
     bool ReadIncludedResources(CXMLNode* pRoot);
@@ -450,6 +453,7 @@ private:
     SString     m_strMinServerReason;
 
     CChecksum m_metaChecksum;            // Checksum of meta.xml last time this was loaded, generated in GenerateChecksums()
+    std::string m_strACLRequestFingerprint;
 
     uint                              m_uiFunctionRightCacheRevision = 0;
     CFastHashMap<lua_CFunction, bool> m_FunctionRightCacheMap;

--- a/Server/mods/deathmatch/logic/CResourceManager.cpp
+++ b/Server/mods/deathmatch/logic/CResourceManager.cpp
@@ -184,6 +184,14 @@ bool CResourceManager::Refresh(bool bRefreshAll, const SString strJustThisResour
                 // Add the resource
                 Load(!info.bIsDir, info.strAbsPath, info.strName);
             }
+            else if (pResource && pResource->HasResourceChanged())
+            {
+                if (g_pServerInterface->IsRequestingExit())
+                    return false;
+                    
+                // Resource exists but has changed, reload it
+                Load(!info.bIsDir, info.strAbsPath, info.strName);
+            }
         }
     }
 


### PR DESCRIPTION
The issue occurred because the system skipped creating the necessary ACL structures when permissions already existed elsewhere. Additionally, it now ensures consistent cleanup of _temporary_ ACL entries and prevents any permission leakage.
Fixes #1824 