### PR TITLE
Add engineFramerateFixingSetProperty/GetProperty/ResetProperties

### DIFF
--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -3495,6 +3495,9 @@ void CClientGame::Event_OnIngame()
 
     g_pGame->GetVehicleAudioSettingsManager()->ResetAudioSettingsData();
 
+    // Reset framerate fixing property
+    g_pMultiplayer->FramerateFixingResetPhysicsTimeStep();
+
     // Tell doggy we got the game running
     WatchDogCompletedSection("L1");
 }

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
@@ -981,8 +981,8 @@ ADD_ENUM(VehicleAudioSettingProperty::VEHICLE_TYPE_FOR_AUDIO, "vehicle-type-for-
 IMPLEMENT_ENUM_CLASS_END("vehicle-audio-setting")
 
 
-IMPLEMENT_ENUM_CLASS_BEGIN(eFramerateFixingProperty)
-ADD_ENUM(eFramerateFixingProperty::FFP_VEHICLE_PHYSICS, "vehicle_physics")
+IMPLEMENT_ENUM_CLASS_BEGIN(FramerateFixingProperty)
+ADD_ENUM(FramerateFixingProperty::FFP_VEHICLE_PHYSICS, "vehicle_physics")
 IMPLEMENT_ENUM_END("framerate-fixing-property")
 
 //

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
@@ -981,6 +981,10 @@ ADD_ENUM(VehicleAudioSettingProperty::VEHICLE_TYPE_FOR_AUDIO, "vehicle-type-for-
 IMPLEMENT_ENUM_CLASS_END("vehicle-audio-setting")
 
 
+IMPLEMENT_ENUM_CLASS_BEGIN(eFramerateFixingProperty)
+ADD_ENUM(eFramerateFixingProperty::FFP_VEHICLE_PHYSICS, "vehicle_physics")
+IMPLEMENT_ENUM_END("framerate-fixing-property")
+
 //
 // CResource from userdata
 //

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
@@ -25,6 +25,7 @@
 #include "enums/SoundEffectParams.h"
 #include "enums/SoundEffectType.h"
 #include "enums/ObjectGroupPhysicalProperties.h"
+#include "enums/FramerateFixingProperty.h"
 
 enum eLuaType
 {
@@ -101,6 +102,7 @@ DECLARE_ENUM_CLASS(PreloadAreaOption);
 DECLARE_ENUM_CLASS(taskType);
 DECLARE_ENUM(eEntityType);
 DECLARE_ENUM_CLASS(VehicleAudioSettingProperty);
+DECLARE_ENUM_CLASS(eFramerateFixingProperty);
 
 class CRemoteCall;
 

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
@@ -102,7 +102,7 @@ DECLARE_ENUM_CLASS(PreloadAreaOption);
 DECLARE_ENUM_CLASS(taskType);
 DECLARE_ENUM(eEntityType);
 DECLARE_ENUM_CLASS(VehicleAudioSettingProperty);
-DECLARE_ENUM_CLASS(eFramerateFixingProperty);
+DECLARE_ENUM_CLASS(FramerateFixingProperty);
 
 class CRemoteCall;
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -15,6 +15,7 @@
 #include <game/CStreaming.h>
 #include <game/CPtrNodeSingleLinkPool.h>
 #include <lua/CLuaFunctionParser.h>
+#include <lua/CLuaFunctionParseHelpers.h>
 #include "CLuaEngineDefs.h"
 #include <enums/VehicleType.h>
 
@@ -2612,33 +2613,27 @@ void CLuaEngineDefs::EnginePreloadWorldArea(CVector position, std::optional<Prel
 }
 
 
-bool CLuaEngineDefs::EngineFramerateFixingResetProperties()
+void CLuaEngineDefs::EngineFramerateFixingResetProperties()
 {
     g_pMultiplayer->FramerateFixingSetPhysicsTimeStep(0);   //use default, Should we reset this when player disconnects?
-    return true;
 }
 
-bool CLuaEngineDefs::EngineFramerateFixingSetProperty(std::string strPropertyName, float timestep)
+void CLuaEngineDefs::EngineFramerateFixingSetProperty(eFramerateFixingProperty propertyName, float timestep)
 {
-    if (strPropertyName.compare("vehicle_physics") == 0)
+    switch (propertyName)
     {
-        g_pMultiplayer->FramerateFixingSetPhysicsTimeStep(timestep);
+        case eFramerateFixingProperty::FFP_VEHICLE_PHYSICS:
+            g_pMultiplayer->FramerateFixingSetPhysicsTimeStep(timestep);
+            break;
     }
-    else
-    {
-        throw std::invalid_argument("Unsupported property name at argument 1");
-    }
-    return true;
 }
 
-float CLuaEngineDefs::EngineFramerateFixingGetProperty(std::string strPropertyName)
+std::variant <bool, float> CLuaEngineDefs::EngineFramerateFixingGetProperty(eFramerateFixingProperty propertyName)
 {
-    if (strPropertyName.compare("vehicle_physics") == 0)
+    switch (propertyName)
     {
-        return g_pMultiplayer->FramerateFixingGetPhysicsTimeStep();
+        case eFramerateFixingProperty::FFP_VEHICLE_PHYSICS:
+            return g_pMultiplayer->FramerateFixingGetPhysicsTimeStep();
     }
-    else
-    {
-        throw std::invalid_argument("Unsupported property name at argument 1");
-    }
+    return false;
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -207,7 +207,6 @@ void CLuaEngineDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "framerateFixingGetProperty", "engineFramerateFixingGetProperty");
     lua_classfunction(luaVM, "framerateFixingResetProperties", "engineFramerateFixingResetProperties");
 
-
     lua_registerstaticclass(luaVM, "Engine");
 
     // `EngineStreaming` class
@@ -2618,21 +2617,21 @@ void CLuaEngineDefs::EngineFramerateFixingResetProperties()
     g_pMultiplayer->FramerateFixingSetPhysicsTimeStep(0);   //use default, Should we reset this when player disconnects?
 }
 
-void CLuaEngineDefs::EngineFramerateFixingSetProperty(eFramerateFixingProperty propertyName, float timestep)
+void CLuaEngineDefs::EngineFramerateFixingSetProperty(FramerateFixingProperty propertyName, float timestep)
 {
     switch (propertyName)
     {
-        case eFramerateFixingProperty::FFP_VEHICLE_PHYSICS:
+        case FramerateFixingProperty::FFP_VEHICLE_PHYSICS:
             g_pMultiplayer->FramerateFixingSetPhysicsTimeStep(timestep);
             break;
     }
 }
 
-std::variant <bool, float> CLuaEngineDefs::EngineFramerateFixingGetProperty(eFramerateFixingProperty propertyName)
+std::variant <bool, float> CLuaEngineDefs::EngineFramerateFixingGetProperty(FramerateFixingProperty propertyName)
 {
     switch (propertyName)
     {
-        case eFramerateFixingProperty::FFP_VEHICLE_PHYSICS:
+        case FramerateFixingProperty::FFP_VEHICLE_PHYSICS:
             return g_pMultiplayer->FramerateFixingGetPhysicsTimeStep();
     }
     return false;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -2611,7 +2611,6 @@ void CLuaEngineDefs::EnginePreloadWorldArea(CVector position, std::optional<Prel
         g_pGame->GetStreaming()->LoadSceneCollision(&position);
 }
 
-
 void CLuaEngineDefs::EngineFramerateFixingResetProperties()
 {
     g_pMultiplayer->FramerateFixingSetPhysicsTimeStep(0);   //use default, Should we reset this when player disconnects?

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -150,6 +150,9 @@ void CLuaEngineDefs::LoadFunctions()
         {"engineGetPoolUsedCapacity", ArgumentParser<EngineGetPoolUsedCapacity>},
         {"engineSetPoolCapacity", ArgumentParser<EngineSetPoolCapacity>},
         {"enginePreloadWorldArea", ArgumentParser<EnginePreloadWorldArea>},
+        {"engineFramerateFixingSetProperty", ArgumentParser<EngineFramerateFixingSetProperty>},
+        {"engineFramerateFixingGetProperty", ArgumentParser<EngineFramerateFixingGetProperty>},
+        {"engineFramerateFixingResetProperties", ArgumentParser<EngineFramerateFixingResetProperties>},
         
         // CLuaCFunctions::AddFunction ( "engineReplaceMatchingAtomics", EngineReplaceMatchingAtomics );
         // CLuaCFunctions::AddFunction ( "engineReplaceWheelAtomics", EngineReplaceWheelAtomics );
@@ -198,6 +201,11 @@ void CLuaEngineDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getModelTXDID", "engineGetModelTXDID");
     lua_classfunction(luaVM, "setModelTXDID", "engineSetModelTXDID");
     lua_classfunction(luaVM, "resetModelTXDID", "engineResetModelTXDID");
+
+    lua_classfunction(luaVM, "framerateFixingSetProperty", "engineFramerateFixingSetProperty");
+    lua_classfunction(luaVM, "framerateFixingGetProperty", "engineFramerateFixingGetProperty");
+    lua_classfunction(luaVM, "framerateFixingResetProperties", "engineFramerateFixingResetProperties");
+
 
     lua_registerstaticclass(luaVM, "Engine");
 
@@ -2601,4 +2609,36 @@ void CLuaEngineDefs::EnginePreloadWorldArea(CVector position, std::optional<Prel
 
     if (option == PreloadAreaOption::ALL || option == PreloadAreaOption::COLLISIONS)
         g_pGame->GetStreaming()->LoadSceneCollision(&position);
+}
+
+
+bool CLuaEngineDefs::EngineFramerateFixingResetProperties()
+{
+    g_pMultiplayer->FramerateFixingSetPhysicsTimeStep(0);   //use default, Should we reset this when player disconnects?
+    return true;
+}
+
+bool CLuaEngineDefs::EngineFramerateFixingSetProperty(std::string strPropertyName, float timestep)
+{
+    if (strPropertyName.compare("vehicle_physics") == 0)
+    {
+        g_pMultiplayer->FramerateFixingSetPhysicsTimeStep(timestep);
+    }
+    else
+    {
+        throw std::invalid_argument("Unsupported property name at argument 1");
+    }
+    return true;
+}
+
+float CLuaEngineDefs::EngineFramerateFixingGetProperty(std::string strPropertyName)
+{
+    if (strPropertyName.compare("vehicle_physics") == 0)
+    {
+        return g_pMultiplayer->FramerateFixingGetPhysicsTimeStep();
+    }
+    else
+    {
+        throw std::invalid_argument("Unsupported property name at argument 1");
+    }
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -2613,7 +2613,7 @@ void CLuaEngineDefs::EnginePreloadWorldArea(CVector position, std::optional<Prel
 
 void CLuaEngineDefs::EngineFramerateFixingResetProperties()
 {
-    g_pMultiplayer->FramerateFixingSetPhysicsTimeStep(0);   //use default, Should we reset this when player disconnects?
+    g_pMultiplayer->FramerateFixingResetPhysicsTimeStep();
 }
 
 void CLuaEngineDefs::EngineFramerateFixingSetProperty(FramerateFixingProperty propertyName, float timestep)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
@@ -98,8 +98,8 @@ public:
     static void EnginePreloadWorldArea(CVector position, std::optional<PreloadAreaOption> option);
 
     static void EngineFramerateFixingResetProperties();
-    static void  EngineFramerateFixingSetProperty(eFramerateFixingProperty propertyName, float timestep);
-    static std::variant<bool, float> EngineFramerateFixingGetProperty(eFramerateFixingProperty propertyName);
+    static void  EngineFramerateFixingSetProperty(FramerateFixingProperty propertyName, float timestep);
+    static std::variant<bool, float> EngineFramerateFixingGetProperty(FramerateFixingProperty propertyName);
 
 private:
     static void AddEngineColClass(lua_State* luaVM);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
@@ -97,6 +97,10 @@ public:
 
     static void EnginePreloadWorldArea(CVector position, std::optional<PreloadAreaOption> option);
 
+    static bool EngineFramerateFixingResetProperties();
+    static bool EngineFramerateFixingSetProperty(std::string strPropertyName, float timestep);
+    static float EngineFramerateFixingGetProperty(std::string strPropertyName);
+
 private:
     static void AddEngineColClass(lua_State* luaVM);
     static void AddEngineTxdClass(lua_State* luaVM);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
@@ -97,9 +97,9 @@ public:
 
     static void EnginePreloadWorldArea(CVector position, std::optional<PreloadAreaOption> option);
 
-    static bool EngineFramerateFixingResetProperties();
-    static bool EngineFramerateFixingSetProperty(std::string strPropertyName, float timestep);
-    static float EngineFramerateFixingGetProperty(std::string strPropertyName);
+    static void EngineFramerateFixingResetProperties();
+    static void  EngineFramerateFixingSetProperty(eFramerateFixingProperty propertyName, float timestep);
+    static std::variant<bool, float> EngineFramerateFixingGetProperty(eFramerateFixingProperty propertyName);
 
 private:
     static void AddEngineColClass(lua_State* luaVM);

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -367,7 +367,7 @@ public:
 
     //Framerate Fixing Property
     void  FramerateFixingSetPhysicsTimeStep(float timestep) override;
-    float FramerateFixingGetPhysicsTimeStep() override;
+    float FramerateFixingGetPhysicsTimeStep() const noexcept override;
 
 
     CVector      m_vecAkimboTarget;

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -366,6 +366,7 @@ public:
     unsigned int PtrNodeDoubleLinkPool_NoOfUsedSpaces() const noexcept override;
 
     //Framerate Fixing Property
+    void  FramerateFixingResetPhysicsTimeStep() override;
     void  FramerateFixingSetPhysicsTimeStep(float timestep) override;
     float FramerateFixingGetPhysicsTimeStep() const noexcept override;
 

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -365,6 +365,11 @@ public:
     unsigned int EntryInfoNodePool_NoOfUsedSpaces() const noexcept override;
     unsigned int PtrNodeDoubleLinkPool_NoOfUsedSpaces() const noexcept override;
 
+    //Framerate Fixing Property
+    void  FramerateFixingSetPhysicsTimeStep(float timestep) override;
+    float FramerateFixingGetPhysicsTimeStep() override;
+
+
     CVector      m_vecAkimboTarget;
     bool         m_bAkimboTargetUp;
     static char* ms_PlayerImgCachePtr;
@@ -390,7 +395,6 @@ private:
     float               m_fShadowsOffset;
 
     bool m_isRapidVehicleStopFixEnabled{false};
-
     /*  VOID                        SetPlayerShotVectors(CPlayerPed* player, Vector3D * vecTarget, Vector3D * vecStart);
         VOID                        SetPlayerCameraVectors(CPlayerPed* player, Vector3D * vecSource, Vector3D * vecFront);
         Vector3D                    * GetLocalShotOriginVector();*/

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -369,7 +369,6 @@ public:
     void  FramerateFixingSetPhysicsTimeStep(float timestep) override;
     float FramerateFixingGetPhysicsTimeStep() const noexcept override;
 
-
     CVector      m_vecAkimboTarget;
     bool         m_bAkimboTargetUp;
     static char* ms_PlayerImgCachePtr;

--- a/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
@@ -751,13 +751,14 @@ static void __declspec(naked) HOOK_VehicleRapidStopFix()
     }
 }
 
+void CMultiplayerSA::FramerateFixingResetPhysicsTimeStep()
+{
+    kPhysicTimeStep = kOriginalTimeStep;
+}
+
 void CMultiplayerSA::FramerateFixingSetPhysicsTimeStep(float timestep)
 {
     // Just change time step, will be automatically applied when related hook is installed
-    // If time step is not set, kOriginalTimeStep will be used as default;
-    if (timestep == 0)
-        timestep = kOriginalTimeStep;
-
     kPhysicTimeStep = timestep;
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
@@ -12,11 +12,12 @@
 
 static bool         bWouldBeNewFrame = false;
 static unsigned int nLastFrameTime = 0;
+
+// The global constant timestep for framerate fixing.
 constexpr float kOriginalTimeStep = 50.0f / 30.0f;
 
-//
+// The timestep for vehicle physics framerate fixing is adjustable by script.
 static float kPhysicTimeStep = kOriginalTimeStep;
-
 
 // Fixes player movement issue while aiming and walking on high FPS.
 #define HOOKPOS_CTaskSimpleUseGun__SetMoveAnim 0x61E4F2
@@ -756,6 +757,7 @@ void CMultiplayerSA::FramerateFixingSetPhysicsTimeStep(float timestep)
     // If time step is not set, kOriginalTimeStep will be used as default;
     if (timestep == 0)
         timestep = kOriginalTimeStep;
+
     kPhysicTimeStep = timestep;
 }
 
@@ -763,7 +765,6 @@ float CMultiplayerSA::FramerateFixingGetPhysicsTimeStep() const noexcept
 {
     return kPhysicTimeStep;
 }
-
 
 void CMultiplayerSA::SetRapidVehicleStopFixEnabled(bool enabled)
 {

--- a/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
@@ -717,7 +717,7 @@ static void __declspec(naked) HOOK_CPhysical__ApplyAirResistance()
     {
         fld ds:[0x862CD0]            // 0.99000001f
         fld ds:[0xB7CB5C]            // CTimer::ms_fTimeStep
-        fdiv kPhysicTimeStep            // 1.666f
+        fdiv kPhysicTimeStep  // 1.666f
         mov eax, 0x822130            // powf
         call eax
 
@@ -750,7 +750,8 @@ static void __declspec(naked) HOOK_VehicleRapidStopFix()
     }
 }
 
-void CMultiplayerSA::FramerateFixingSetPhysicsTimeStep(float timestep){
+void CMultiplayerSA::FramerateFixingSetPhysicsTimeStep(float timestep)
+{
     // Just change time step, will be automatically applied when related hook is installed
     // If time step is not set, kOriginalTimeStep will be used as default;
     if (timestep == 0)
@@ -758,9 +759,11 @@ void CMultiplayerSA::FramerateFixingSetPhysicsTimeStep(float timestep){
     kPhysicTimeStep = timestep;
 }
 
-float CMultiplayerSA::FramerateFixingGetPhysicsTimeStep(){
+float CMultiplayerSA::FramerateFixingGetPhysicsTimeStep() const noexcept
+{
     return kPhysicTimeStep;
 }
+
 
 void CMultiplayerSA::SetRapidVehicleStopFixEnabled(bool enabled)
 {

--- a/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
@@ -12,8 +12,11 @@
 
 static bool         bWouldBeNewFrame = false;
 static unsigned int nLastFrameTime = 0;
-
 constexpr float kOriginalTimeStep = 50.0f / 30.0f;
+
+//
+static float kPhysicTimeStep = kOriginalTimeStep;
+
 
 // Fixes player movement issue while aiming and walking on high FPS.
 #define HOOKPOS_CTaskSimpleUseGun__SetMoveAnim 0x61E4F2
@@ -714,7 +717,7 @@ static void __declspec(naked) HOOK_CPhysical__ApplyAirResistance()
     {
         fld ds:[0x862CD0]            // 0.99000001f
         fld ds:[0xB7CB5C]            // CTimer::ms_fTimeStep
-        fdiv kOriginalTimeStep            // 1.666f
+        fdiv kPhysicTimeStep            // 1.666f
         mov eax, 0x822130            // powf
         call eax
 
@@ -742,9 +745,21 @@ static void __declspec(naked) HOOK_VehicleRapidStopFix()
     {
         fld ds:[0xC2B9CC]            // mod_HandlingManager.m_fWheelFriction
         fmul ds:[0xB7CB5C]            // CTimer::ms_fTimeStep
-        fdiv kOriginalTimeStep            // 1.666f
+        fdiv kPhysicTimeStep            // 1.666f
         jmp RETURN_VehicleRapidStopFix
     }
+}
+
+void CMultiplayerSA::FramerateFixingSetPhysicsTimeStep(float timestep){
+    // Just change time step, will be automatically applied when related hook is installed
+    // If time step is not set, kOriginalTimeStep will be used as default;
+    if (timestep == 0)
+        timestep = kOriginalTimeStep;
+    kPhysicTimeStep = timestep;
+}
+
+float CMultiplayerSA::FramerateFixingGetPhysicsTimeStep(){
+    return kPhysicTimeStep;
 }
 
 void CMultiplayerSA::SetRapidVehicleStopFixEnabled(bool enabled)

--- a/Client/sdk/multiplayer/CMultiplayer.h
+++ b/Client/sdk/multiplayer/CMultiplayer.h
@@ -465,6 +465,7 @@ public:
     virtual eAnimID    GetLastStaticAnimationID() = 0;
     virtual DWORD      GetLastAnimArrayAddress() = 0;
 
+    virtual void        FramerateFixingResetPhysicsTimeStep() = 0;
     virtual void        FramerateFixingSetPhysicsTimeStep(float timestep) = 0;
     virtual float       FramerateFixingGetPhysicsTimeStep() const noexcept = 0;
 

--- a/Client/sdk/multiplayer/CMultiplayer.h
+++ b/Client/sdk/multiplayer/CMultiplayer.h
@@ -465,6 +465,10 @@ public:
     virtual eAnimID    GetLastStaticAnimationID() = 0;
     virtual DWORD      GetLastAnimArrayAddress() = 0;
 
+    virtual void        FramerateFixingSetPhysicsTimeStep(float timestep) = 0;
+    virtual float       FramerateFixingGetPhysicsTimeStep() = 0;
+
+
     virtual unsigned int EntryInfoNodePool_NoOfUsedSpaces() const noexcept = 0;
     virtual unsigned int PtrNodeDoubleLinkPool_NoOfUsedSpaces() const noexcept = 0;
 };

--- a/Client/sdk/multiplayer/CMultiplayer.h
+++ b/Client/sdk/multiplayer/CMultiplayer.h
@@ -466,7 +466,7 @@ public:
     virtual DWORD      GetLastAnimArrayAddress() = 0;
 
     virtual void        FramerateFixingSetPhysicsTimeStep(float timestep) = 0;
-    virtual float       FramerateFixingGetPhysicsTimeStep() = 0;
+    virtual float       FramerateFixingGetPhysicsTimeStep() const noexcept = 0;
 
 
     virtual unsigned int EntryInfoNodePool_NoOfUsedSpaces() const noexcept = 0;

--- a/Client/sdk/multiplayer/CMultiplayer.h
+++ b/Client/sdk/multiplayer/CMultiplayer.h
@@ -468,7 +468,6 @@ public:
     virtual void        FramerateFixingSetPhysicsTimeStep(float timestep) = 0;
     virtual float       FramerateFixingGetPhysicsTimeStep() const noexcept = 0;
 
-
     virtual unsigned int EntryInfoNodePool_NoOfUsedSpaces() const noexcept = 0;
     virtual unsigned int PtrNodeDoubleLinkPool_NoOfUsedSpaces() const noexcept = 0;
 };

--- a/Server/mods/deathmatch/logic/CCommon.h
+++ b/Server/mods/deathmatch/logic/CCommon.h
@@ -1068,6 +1068,11 @@ enum eStats
     STAT_MAYBE_WU_ZI_MEETING = 342
 };
 
+enum class eFramerateFixingProperty
+{
+    FFP_VEHICLE_PHYSICS = 0
+};
+
 #include "json.h"
 // Prettify toJSON (see mantis #9210)
 enum eJSONPrettyType

--- a/Server/mods/deathmatch/logic/CCommon.h
+++ b/Server/mods/deathmatch/logic/CCommon.h
@@ -1068,11 +1068,6 @@ enum eStats
     STAT_MAYBE_WU_ZI_MEETING = 342
 };
 
-enum class eFramerateFixingProperty
-{
-    FFP_VEHICLE_PHYSICS = 0
-};
-
 #include "json.h"
 // Prettify toJSON (see mantis #9210)
 enum eJSONPrettyType

--- a/Shared/sdk/enums/FramerateFixingProperty.h
+++ b/Shared/sdk/enums/FramerateFixingProperty.h
@@ -1,0 +1,17 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        sdk/FramerateFixingProperty.h
+ *  PURPOSE:     Header for common definitions
+ *
+ *  Multi Theft Auto is available from https://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#pragma once
+
+enum class eFramerateFixingProperty
+{
+    FFP_VEHICLE_PHYSICS
+};

--- a/Shared/sdk/enums/FramerateFixingProperty.h
+++ b/Shared/sdk/enums/FramerateFixingProperty.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-enum class eFramerateFixingProperty
+enum class FramerateFixingProperty
 {
     FFP_VEHICLE_PHYSICS
 };


### PR DESCRIPTION
For adjustable vehicle physics time step and air resistor physics when glitch "vehicle_rapid_stop" is disabled. In this way, DM players can play maps in any FPS.

Usage:
engineFramerateFixingSetProperty("vehicle_physics", 50.0/30.0) which is the default one.

Now we have only "vehicle_physics", but in future, there maybe more.

I notice that "vehicle_rapid_stop" acually includes vehicle turning (passive and active).
Passive turning includes terrain changing and colliding.
Active turning includes air control and normal on-road turning.
Thus, description of "vehicle_rapid_stop" should be "framerate_related_vehicle_physics" for better naming.

Maybe the name and usage of this function need to be discussed.