### PR TITLE
Fix IsPedInVehicle synchronization issue between server and client

### DIFF
--- a/Server/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -781,7 +781,9 @@ int CLuaPedDefs::IsPedInVehicle(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        lua_pushboolean(luaVM, CStaticFunctionDefinitions::GetPedOccupiedVehicle(pPed) != NULL);
+        CVehicle* pVehicle = CStaticFunctionDefinitions::GetPedOccupiedVehicle(pPed);
+        bool bInVehicle = (pVehicle != NULL) && (pPed->GetVehicleAction() == CPed::VEHICLEACTION_NONE);
+        lua_pushboolean(luaVM, bInVehicle);
         return 1;
     }
     else

--- a/Server/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -781,9 +781,9 @@ int CLuaPedDefs::IsPedInVehicle(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        CVehicle* pVehicle = CStaticFunctionDefinitions::GetPedOccupiedVehicle(pPed);
-        bool bInVehicle = (pVehicle != NULL) && (pPed->GetVehicleAction() == CPed::VEHICLEACTION_NONE);
-        lua_pushboolean(luaVM, bInVehicle);
+        CVehicle* vehicle = CStaticFunctionDefinitions::GetPedOccupiedVehicle(pPed);
+        bool inVehicle = vehicle && pPed->GetVehicleAction() == CPed::VEHICLEACTION_NONE;
+        lua_pushboolean(luaVM, inVehicle);
         return 1;
     }
     else


### PR DESCRIPTION
Fix IsPedInVehicle synchronization issue between server and client

- Server was returning true for IsPedInVehicle when ped was only trying to enter vehicle
- Client correctly returned false until ped was actually in vehicle
- Added check for VEHICLEACTION_NONE to ensure ped is actually in vehicle
- Fixes desync where server reported ped as in vehicle during entry process

Fixes issue where setPedEnterVehicle would cause server-side IsPedInVehicle 
to return true before ped actually entered the vehicle, while client-side 
correctly returned false until ped was physically in the vehicle.


bug:
<img width="1920" height="1080" alt="11" src="https://github.com/user-attachments/assets/e685a0ac-5534-4658-b75d-d5cb8beb5ae7" />

fixed:
<img width="1920" height="1080" alt="22" src="https://github.com/user-attachments/assets/24115c67-9221-4a83-a15f-ca6908d49313" />


