### PR TITLE
Fix cross-resource timer access (#827)

### DIFF
--- a/Server/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
@@ -316,12 +316,11 @@ CXMLNode* UserDataCast(CXMLNode* ptr, lua_State* luaState)
 //
 CLuaTimer* UserDataCast(CLuaTimer* ptr, lua_State* luaState)
 {
-    if (CLuaMain* luaMain = g_pGame->GetLuaManager()->GetVirtualMachine(luaState); luaMain != nullptr)
-    {
-        return luaMain->GetTimerManager()->GetTimerFromScriptID(reinterpret_cast<unsigned long>(ptr));
-    }
-
-    return nullptr;
+    CLuaManager* luaManager = g_pGame->GetLuaManager();
+    if (!luaManager)
+        return nullptr;
+        
+    return luaManager->FindTimerGlobally(reinterpret_cast<unsigned long>(ptr));
 }
 
 //

--- a/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -43,6 +43,7 @@
 #include "luadefs/CLuaVoiceDefs.h"
 #include "luadefs/CLuaWorldDefs.h"
 #include "luadefs/CLuaCompatibilityDefs.h"
+#include "CIdArray.h"
 
 extern CGame* g_pGame;
 
@@ -182,6 +183,35 @@ CResource* CLuaManager::GetVirtualMachineResource(lua_State* luaVM)
     if (pLuaMain)
         return pLuaMain->GetResource();
     return NULL;
+}
+
+CLuaTimer* CLuaManager::FindTimerGlobally(unsigned long scriptID) const noexcept
+{
+    // First check if timer exists in global ID system
+    CLuaTimer* luaTimer = static_cast<CLuaTimer*>(CIdArray::FindEntry(scriptID, EIdClass::TIMER));
+    if (!luaTimer)
+        return nullptr;
+        
+    // Verify timer exists in any resource manager (ensures it's still valid)
+    for (std::list<CLuaMain*>::const_iterator iter = m_virtualMachines.begin(); iter != m_virtualMachines.end(); ++iter)
+    {
+        CLuaMain* luaMain = *iter;
+        if (!luaMain)
+            continue;
+            
+        CLuaTimerManager* timerManager = luaMain->GetTimerManager();
+        if (!timerManager)
+            continue;
+            
+        if (timerManager->GetTimerFromScriptID(scriptID) == luaTimer)
+        {
+            return luaTimer;
+        }
+    }
+    
+    // Timer exists in global ID array but not in any resource manager
+    // This indicates the timer has been cleaned up
+    return nullptr;
 }
 
 void CLuaManager::LoadCFunctions()

--- a/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -185,7 +185,7 @@ CResource* CLuaManager::GetVirtualMachineResource(lua_State* luaVM)
     return NULL;
 }
 
-CLuaTimer* CLuaManager::FindTimerGlobally(unsigned long scriptID) const noexcept
+CLuaTimer* CLuaManager::FindTimerGlobally(unsigned long scriptID) const
 {
     // First check if timer exists in global ID system
     CLuaTimer* luaTimer = static_cast<CLuaTimer*>(CIdArray::FindEntry(scriptID, EIdClass::TIMER));

--- a/Server/mods/deathmatch/logic/lua/CLuaManager.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaManager.h
@@ -22,6 +22,7 @@ class CLuaManager;
 // Predeclarations
 class CBlipManager;
 class CEvents;
+class CLuaTimer;
 class CMapManager;
 class CObjectManager;
 class CPlayerManager;
@@ -51,6 +52,8 @@ public:
     void DoPulse();
 
     void LoadCFunctions();
+
+    CLuaTimer* FindTimerGlobally(unsigned long scriptID) const noexcept;
 
 private:
     CBlipManager*              m_pBlipManager;

--- a/Server/mods/deathmatch/logic/lua/CLuaManager.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaManager.h
@@ -53,7 +53,7 @@ public:
 
     void LoadCFunctions();
 
-    CLuaTimer* FindTimerGlobally(unsigned long scriptID) const noexcept;
+    CLuaTimer* FindTimerGlobally(unsigned long scriptID) const;
 
 private:
     CBlipManager*              m_pBlipManager;


### PR DESCRIPTION
Fixes issue #827 for timer functions (`getTimerDetails`, `setTimerPaused`, `resetTimer`, `killTimer`), matching the already working `isTimer`