### PR TITLE
Fix bullet synchronization by using total ammo instead of ammo in clip

### DIFF
--- a/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.cpp
@@ -15,6 +15,7 @@
 #include "CWeaponStatManager.h"
 #include "CElementIDs.h"
 #include "CElement.h"
+#include "CWeaponNames.h"
 
 CBulletsyncPacket::CBulletsyncPacket(CPlayer* player)
     : m_weapon(WEAPONTYPE_UNARMED)
@@ -222,10 +223,14 @@ bool CBulletsyncPacket::Read(NetBitStreamInterface& stream)
         if (!pPlayer->HasWeaponType(static_cast<unsigned char>(m_weapon)))
             return false;
             
+  
         // Check if weapon has ammo
-        if (pPlayer->GetWeaponAmmoInClip(static_cast<unsigned char>(m_weapon)) == 0)
+        unsigned char ucSlot = CWeaponNames::GetSlotFromWeapon(static_cast<unsigned char>(m_weapon));
+        CWeapon* pWeapon = pPlayer->GetWeapon(ucSlot);
+        if (!pWeapon || pWeapon->usAmmo <= 0)
             return false;
     }
+     
         
     if (!stream.Read(m_order))
         return false;

--- a/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.cpp
@@ -34,16 +34,16 @@ bool CBulletsyncPacket::IsValidVector(const CVector& vec) noexcept
 {
     if (!vec.IsValid())
         return false;
-
+        
     if (IsNaN(vec.fX))
         return false;
-
+        
     if (IsNaN(vec.fY))
         return false;
-
+        
     if (IsNaN(vec.fZ))
         return false;
-
+        
     return true;
 }
 
@@ -68,9 +68,9 @@ bool CBulletsyncPacket::ValidateTrajectory() const noexcept
     const float dx = m_end.fX - m_start.fX;
     const float dy = m_end.fY - m_start.fY;
     const float dz = m_end.fZ - m_start.fZ;
-
+    
     const float movementSq = (dx * dx) + (dy * dy) + (dz * dz);
-
+        
     if (IsNaN(movementSq))
         return false;
 
@@ -79,7 +79,7 @@ bool CBulletsyncPacket::ValidateTrajectory() const noexcept
 
     if (movementSq > MAX_DISTANCE_SQ)
         return false;
-
+        
     return true;
 }
 
@@ -103,25 +103,25 @@ bool CBulletsyncPacket::ReadWeaponAndPositions(NetBitStreamInterface& stream)
 
     if (!stream.Read(reinterpret_cast<char*>(&m_start), sizeof(CVector)))
         return false;
-
+        
     if (!stream.Read(reinterpret_cast<char*>(&m_end), sizeof(CVector)))
         return false;
-
+        
     if (!IsValidVector(m_start))
         return false;
 
     if (!IsValidVector(m_end))
         return false;
-
+        
     if (!ValidateVectorBounds(m_start))
         return false;
-
+        
     if (!ValidateVectorBounds(m_end))
         return false;
-
+        
     if (!ValidateTrajectory())
         return false;
-
+        
     return true;
 }
 
@@ -142,19 +142,19 @@ bool CBulletsyncPacket::ReadOptionalDamage(NetBitStreamInterface& stream)
         ResetDamageData();
         return false;
     }
-
+    
     if (m_damage < 0.0f || m_damage > MAX_DAMAGE)
     {
         ResetDamageData();
         return false;
     }
-
+    
     if (m_zone > MAX_BODY_ZONE)
     {
         ResetDamageData();
         return false;
     }
-
+    
     if (m_damaged == 0)
     {
         ResetDamageData();
@@ -170,7 +170,7 @@ bool CBulletsyncPacket::ReadOptionalDamage(NetBitStreamInterface& stream)
             ResetDamageData();
             return false;
         }
-
+        
         // Check element type is valid for damage
         auto elementType = pElement->GetType();
         if (elementType != CElement::PLAYER &&
@@ -181,7 +181,7 @@ bool CBulletsyncPacket::ReadOptionalDamage(NetBitStreamInterface& stream)
             return false;
         }
     }
-
+    
     return true;
 }
 
@@ -189,7 +189,7 @@ bool CBulletsyncPacket::Read(NetBitStreamInterface& stream)
 {
     if (!m_pSourceElement)
         return false;
-
+            
     CPlayer* pPlayer = static_cast<CPlayer*>(m_pSourceElement);
     if (pPlayer)
     {
@@ -200,10 +200,10 @@ bool CBulletsyncPacket::Read(NetBitStreamInterface& stream)
         // Check player position is reasonable relative to bullet start
         const CVector& playerPos = pPlayer->GetPosition();
         const float maxShootDistance = 50.0f; // Max distance from player to bullet start
-
+        
         // This check will be done after we read positions
     }
-
+        
     if (!ReadWeaponAndPositions(stream))
         return false;
 
@@ -215,23 +215,23 @@ bool CBulletsyncPacket::Read(NetBitStreamInterface& stream)
         float dy = m_start.fY - playerPos.fY;
         float dz = m_start.fZ - playerPos.fZ;
         float distSq = dx * dx + dy * dy + dz * dz;
-
+        
         const float maxShootDistanceSq = 50.0f * 50.0f;
         if (distSq > maxShootDistanceSq)
             return false;
-
+            
         // Check if player has this weapon
         if (!pPlayer->HasWeaponType(static_cast<std::uint8_t>(m_weapon)))
             return false;
-
+           
         // Check if weapon has ammo
         if (pPlayer->GetWeaponTotalAmmo(static_cast<std::uint8_t>(m_weapon)) <= 0)
             return false;
     }
-
+        
     if (!stream.Read(m_order))
         return false;
-
+        
     if (!ReadOptionalDamage(stream))
         return false;
 
@@ -248,7 +248,7 @@ bool CBulletsyncPacket::Write(NetBitStreamInterface& stream) const
         return false;
 
     const ElementID id = pPlayer->GetID();
-
+    
     if (id == INVALID_ELEMENT_ID)
         return false;
 
@@ -263,10 +263,10 @@ bool CBulletsyncPacket::Write(NetBitStreamInterface& stream) const
 
     if (!ValidateVectorBounds(m_start))
         return false;
-
+        
     if (!ValidateVectorBounds(m_end))
         return false;
-
+        
     if (!ValidateTrajectory())
         return false;
 
@@ -282,7 +282,7 @@ bool CBulletsyncPacket::Write(NetBitStreamInterface& stream) const
 
     const bool hasDamage = (m_damage > EPSILON) && (m_damaged != INVALID_ELEMENT_ID);
     stream.WriteBit(hasDamage);
-
+    
     if (hasDamage)
     {
         stream.Write(m_damage);

--- a/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.cpp
@@ -16,6 +16,7 @@
 #include "CElementIDs.h"
 #include "CElement.h"
 #include "CWeaponNames.h"
+#include <cstdint>
 
 CBulletsyncPacket::CBulletsyncPacket(CPlayer* player)
     : m_weapon(WEAPONTYPE_UNARMED)
@@ -33,16 +34,16 @@ bool CBulletsyncPacket::IsValidVector(const CVector& vec) noexcept
 {
     if (!vec.IsValid())
         return false;
-        
+
     if (IsNaN(vec.fX))
         return false;
-        
+
     if (IsNaN(vec.fY))
         return false;
-        
+
     if (IsNaN(vec.fZ))
         return false;
-        
+
     return true;
 }
 
@@ -67,18 +68,18 @@ bool CBulletsyncPacket::ValidateTrajectory() const noexcept
     const float dx = m_end.fX - m_start.fX;
     const float dy = m_end.fY - m_start.fY;
     const float dz = m_end.fZ - m_start.fZ;
-    
+
     const float movementSq = (dx * dx) + (dy * dy) + (dz * dz);
-    
+
     if (IsNaN(movementSq))
         return false;
-        
+
     if (movementSq < MIN_DISTANCE_SQ)
         return false;
-        
+
     if (movementSq > MAX_DISTANCE_SQ)
         return false;
-        
+
     return true;
 }
 
@@ -102,25 +103,25 @@ bool CBulletsyncPacket::ReadWeaponAndPositions(NetBitStreamInterface& stream)
 
     if (!stream.Read(reinterpret_cast<char*>(&m_start), sizeof(CVector)))
         return false;
-        
+
     if (!stream.Read(reinterpret_cast<char*>(&m_end), sizeof(CVector)))
         return false;
-    
+
     if (!IsValidVector(m_start))
         return false;
-        
+
     if (!IsValidVector(m_end))
         return false;
-    
+
     if (!ValidateVectorBounds(m_start))
         return false;
-        
+
     if (!ValidateVectorBounds(m_end))
         return false;
-        
+
     if (!ValidateTrajectory())
         return false;
-        
+
     return true;
 }
 
@@ -141,25 +142,25 @@ bool CBulletsyncPacket::ReadOptionalDamage(NetBitStreamInterface& stream)
         ResetDamageData();
         return false;
     }
-    
+
     if (m_damage < 0.0f || m_damage > MAX_DAMAGE)
     {
         ResetDamageData();
         return false;
     }
-    
+
     if (m_zone > MAX_BODY_ZONE)
     {
         ResetDamageData();
         return false;
     }
-    
+
     if (m_damaged == 0)
     {
         ResetDamageData();
         return false;
     }
-    
+
     // Validate that target element exists
     if (m_damaged != INVALID_ELEMENT_ID)
     {
@@ -169,18 +170,18 @@ bool CBulletsyncPacket::ReadOptionalDamage(NetBitStreamInterface& stream)
             ResetDamageData();
             return false;
         }
-        
+
         // Check element type is valid for damage
         auto elementType = pElement->GetType();
-        if (elementType != CElement::PLAYER && 
-            elementType != CElement::PED && 
+        if (elementType != CElement::PLAYER &&
+            elementType != CElement::PED &&
             elementType != CElement::VEHICLE)
         {
             ResetDamageData();
             return false;
         }
     }
-    
+
     return true;
 }
 
@@ -195,17 +196,17 @@ bool CBulletsyncPacket::Read(NetBitStreamInterface& stream)
         // Check if player is spawned and alive
         if (!pPlayer->IsSpawned() || pPlayer->IsDead())
             return false;
-            
+
         // Check player position is reasonable relative to bullet start
         const CVector& playerPos = pPlayer->GetPosition();
         const float maxShootDistance = 50.0f; // Max distance from player to bullet start
-        
+
         // This check will be done after we read positions
     }
-        
+
     if (!ReadWeaponAndPositions(stream))
         return false;
-    
+
     // Now validate player position relative to shot origin
     if (pPlayer)
     {
@@ -213,30 +214,27 @@ bool CBulletsyncPacket::Read(NetBitStreamInterface& stream)
         float dx = m_start.fX - playerPos.fX;
         float dy = m_start.fY - playerPos.fY;
         float dz = m_start.fZ - playerPos.fZ;
-        float distSq = dx*dx + dy*dy + dz*dz;
-        
+        float distSq = dx * dx + dy * dy + dz * dz;
+
         const float maxShootDistanceSq = 50.0f * 50.0f;
         if (distSq > maxShootDistanceSq)
             return false;
-            
+
         // Check if player has this weapon
-        if (!pPlayer->HasWeaponType(static_cast<unsigned char>(m_weapon)))
+        if (!pPlayer->HasWeaponType(static_cast<std::uint8_t>(m_weapon)))
             return false;
-            
-  
+
         // Check if weapon has ammo
-        std::uint8_t weaponSlot = CWeaponNames::GetSlotFromWeapon(static_cast<std::uint8_t>(m_weapon));
-           if (pPlayer->GetWeaponTotalAmmo(static_cast<std::uint8_t>(m_weapon)) <= 0)
-           return false;
+        if (pPlayer->GetWeaponTotalAmmo(static_cast<std::uint8_t>(m_weapon)) <= 0)
+            return false;
     }
-     
-        
+
     if (!stream.Read(m_order))
         return false;
-        
+
     if (!ReadOptionalDamage(stream))
         return false;
-        
+
     return true;
 }
 
@@ -248,27 +246,27 @@ bool CBulletsyncPacket::Write(NetBitStreamInterface& stream) const
     const auto* pPlayer = static_cast<const CPlayer*>(m_pSourceElement);
     if (!pPlayer)
         return false;
-        
+
     const ElementID id = pPlayer->GetID();
-    
+
     if (id == INVALID_ELEMENT_ID)
         return false;
-        
+
     if (id == 0)
         return false;
 
     if (!IsValidVector(m_start))
         return false;
-        
+
     if (!IsValidVector(m_end))
         return false;
-        
+
     if (!ValidateVectorBounds(m_start))
         return false;
-        
+
     if (!ValidateVectorBounds(m_end))
         return false;
-        
+
     if (!ValidateTrajectory())
         return false;
 
@@ -284,7 +282,7 @@ bool CBulletsyncPacket::Write(NetBitStreamInterface& stream) const
 
     const bool hasDamage = (m_damage > EPSILON) && (m_damaged != INVALID_ELEMENT_ID);
     stream.WriteBit(hasDamage);
-    
+
     if (hasDamage)
     {
         stream.Write(m_damage);

--- a/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.cpp
@@ -225,10 +225,9 @@ bool CBulletsyncPacket::Read(NetBitStreamInterface& stream)
             
   
         // Check if weapon has ammo
-        unsigned char ucSlot = CWeaponNames::GetSlotFromWeapon(static_cast<unsigned char>(m_weapon));
-        CWeapon* pWeapon = pPlayer->GetWeapon(ucSlot);
-        if (!pWeapon || pWeapon->usAmmo <= 0)
-            return false;
+        std::uint8_t weaponSlot = CWeaponNames::GetSlotFromWeapon(static_cast<std::uint8_t>(m_weapon));
+           if (pPlayer->GetWeaponTotalAmmo(static_cast<std::uint8_t>(m_weapon)) <= 0)
+           return false;
     }
      
         


### PR DESCRIPTION
In the original code,
`if (pPlayer->GetWeaponAmmoInClip(static_cast<unsigned char>(m_weapon)) == 0)`

was checking the weapon’s clip ammo, but it always returned 0. Because of that, the function would return false and the event couldn’t communicate properly with the function it was supposed to trigger.

After changing it to check the total ammo instead, the issue was resolved.

and below you can see the results in the video clip : 

https://github.com/user-attachments/assets/ce74715c-5be9-4ff9-8835-dc74e49ff554

