### PR TITLE
New `abortDownload` function for `downloadFile` (#4157)

### DIFF
--- a/Client/mods/deathmatch/logic/CSingularFileDownload.cpp
+++ b/Client/mods/deathmatch/logic/CSingularFileDownload.cpp
@@ -96,11 +96,16 @@ bool CSingularFileDownload::Cancel()
     resource = nullptr;
     requestResource = nullptr;
 
-    // Cancel the actual HTTP download
     if (!httpManager || downloadMode == EDownloadMode::NONE)
-        return false;
+        return true;
 
-    return httpManager->CancelDownload(this, DownloadFinishedCallBack);
+    const bool httpCancelSuccess = httpManager->CancelDownload(this, DownloadFinishedCallBack);
+    return httpCancelSuccess;
+}
+
+void CSingularFileDownload::MarkForDeletion()
+{
+    beingDeleted = true;
 }
 
 bool CSingularFileDownload::DoesClientAndServerChecksumMatch()

--- a/Client/mods/deathmatch/logic/CSingularFileDownload.h
+++ b/Client/mods/deathmatch/logic/CSingularFileDownload.h
@@ -20,28 +20,32 @@
 
 #include <bochs_internal/bochs_crc32.h>
 #include "CChecksum.h"
+#include "net/CNetHTTPDownloadManagerInterface.h"
+#include <cstdint>
 
 class CSingularFileDownload
 {
 public:
     CSingularFileDownload(CResource* pResource, const char* szName, const char* szNameShort, SString strHTTPURL, CResource* pRequestResource,
-                          CChecksum serverChecksum);
+                          CChecksum serverChecksum, std::uint32_t handlerId);
     ~CSingularFileDownload();
 
     static void DownloadFinishedCallBack(const SHttpDownloadResult& result);
 
     bool DoesClientAndServerChecksumMatch();
 
-    const char* GetName() { return m_strName; };
-    const char* GetShortName() { return m_strNameShort; };
+    const char* GetName() const noexcept { return m_strName; }
+    const char* GetShortName() const noexcept { return m_strNameShort; }
 
-    CResource* GetResource() { return m_pResource; };
+    CResource* GetResource() const noexcept { return m_pResource; }
+    std::uint32_t GetHandlerId() const noexcept { return m_handlerId; }
 
-    void SetComplete() { m_bComplete = true; };
-    bool GetComplete() { return m_bComplete; };
+    void SetComplete() noexcept { m_bComplete = true; }
+    bool GetComplete() const noexcept { return m_bComplete; }
+    bool IsCancelled() const noexcept { return m_bCancelled; }
 
     void CallFinished(bool bSuccess);
-    void Cancel();
+    bool Cancel();
 
     CChecksum GenerateClientChecksum();
 
@@ -54,6 +58,11 @@ protected:
 
     bool m_bComplete;
     bool m_bBeingDeleted;
+    bool m_bCancelled;
+
+    std::uint32_t m_handlerId;
+    CNetHTTPDownloadManagerInterface* m_pHTTPManager;
+    EDownloadModeType m_downloadMode;
 
     CChecksum m_LastClientChecksum;
     CChecksum m_ServerChecksum;

--- a/Client/mods/deathmatch/logic/CSingularFileDownload.h
+++ b/Client/mods/deathmatch/logic/CSingularFileDownload.h
@@ -46,6 +46,7 @@ public:
 
     void CallFinished(bool bSuccess);
     bool Cancel();
+    void MarkForDeletion();
 
     CChecksum GenerateClientChecksum();
 

--- a/Client/mods/deathmatch/logic/CSingularFileDownload.h
+++ b/Client/mods/deathmatch/logic/CSingularFileDownload.h
@@ -37,12 +37,12 @@ public:
     const char* GetName() const noexcept { return m_strName; }
     const char* GetShortName() const noexcept { return m_strNameShort; }
 
-    CResource* GetResource() const noexcept { return m_pResource; }
-    std::uint32_t GetHandlerId() const noexcept { return m_handlerId; }
+    CResource* GetResource() const noexcept { return resource; }
+    std::uint32_t GetHandlerId() const noexcept { return handlerId; }
 
-    void SetComplete() noexcept { m_bComplete = true; }
-    bool GetComplete() const noexcept { return m_bComplete; }
-    bool IsCancelled() const noexcept { return m_bCancelled; }
+    void SetComplete() noexcept { complete = true; }
+    bool GetComplete() const noexcept { return complete; }
+    bool IsCancelled() const noexcept { return cancelled; }
 
     void CallFinished(bool bSuccess);
     bool Cancel();
@@ -53,16 +53,16 @@ protected:
     SString m_strName;
     SString m_strNameShort;
 
-    CResource* m_pResource;
-    CResource* m_pRequestResource;
+    CResource* resource;
+    CResource* requestResource;
 
-    bool m_bComplete;
-    bool m_bBeingDeleted;
-    bool m_bCancelled;
+    bool complete;
+    bool beingDeleted;
+    bool cancelled;
 
-    std::uint32_t m_handlerId;
-    CNetHTTPDownloadManagerInterface* m_pHTTPManager;
-    EDownloadModeType m_downloadMode;
+    std::uint32_t handlerId;
+    CNetHTTPDownloadManagerInterface* httpManager;
+    EDownloadMode::EDownloadModeType downloadMode;
 
     CChecksum m_LastClientChecksum;
     CChecksum m_ServerChecksum;

--- a/Client/mods/deathmatch/logic/CSingularFileDownloadManager.cpp
+++ b/Client/mods/deathmatch/logic/CSingularFileDownloadManager.cpp
@@ -74,10 +74,8 @@ bool CSingularFileDownloadManager::AbortDownload(std::uint32_t handlerId)
         return false;
 
     const bool success = pDownload->Cancel();
-    if (success)
-    {
-        RemoveDownload(pDownload);
-    }
+    // Always remove from tracking, regardless of cancel success
+    RemoveDownload(pDownload);
     return success;
 }
 

--- a/Client/mods/deathmatch/logic/CSingularFileDownloadManager.cpp
+++ b/Client/mods/deathmatch/logic/CSingularFileDownloadManager.cpp
@@ -73,8 +73,10 @@ bool CSingularFileDownloadManager::AbortDownload(std::uint32_t handlerId)
     if (!pDownload)
         return false;
 
+    if (pDownload->GetComplete() || pDownload->IsCancelled())
+        return false;
+
     const bool success = pDownload->Cancel();
-    // Always remove from tracking, regardless of cancel success
     RemoveDownload(pDownload);
     return success;
 }
@@ -84,12 +86,7 @@ void CSingularFileDownloadManager::RemoveDownload(CSingularFileDownload* pDownlo
     if (!pDownload)
         return;
 
-    // Remove from handler map
     m_HandlerMap.erase(pDownload->GetHandlerId());
-
-    // Remove from downloads list
     m_Downloads.remove(pDownload);
-
-    // Delete the download object
-    delete pDownload;
+    pDownload->MarkForDeletion();
 }

--- a/Client/mods/deathmatch/logic/CSingularFileDownloadManager.h
+++ b/Client/mods/deathmatch/logic/CSingularFileDownloadManager.h
@@ -21,6 +21,8 @@
 #include <bochs_internal/bochs_crc32.h>
 #include "CChecksum.h"
 #include "CSingularFileDownload.h"
+#include <map>
+#include <cstdint>
 
 class CSingularFileDownloadManager
 {
@@ -36,6 +38,12 @@ public:
 
     bool AllComplete();
 
+    CSingularFileDownload* FindDownloadByHandler(std::uint32_t handlerId) const;
+    bool AbortDownload(std::uint32_t handlerId);
+    void RemoveDownload(CSingularFileDownload* pDownload);
+
 protected:
     std::list<CSingularFileDownload*> m_Downloads;
+    std::map<std::uint32_t, CSingularFileDownload*> m_HandlerMap;
+    std::uint32_t m_nextHandlerId;
 };

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -233,7 +233,7 @@ bool CStaticFunctionDefinitions::WasEventCancelled()
     return m_pEvents->WasEventCancelled();
 }
 
-bool CStaticFunctionDefinitions::DownloadFile(CResource* pResource, const char* szFile, CResource* pRequestResource, CChecksum checksum)
+CSingularFileDownload* CStaticFunctionDefinitions::DownloadFile(CResource* pResource, const char* szFile, CResource* pRequestResource, CChecksum checksum)
 {
     SString strHTTPDownloadURLFull("%s/%s/%s", g_pClientGame->GetHTTPURL().c_str(), pResource->GetName(), szFile);
     SString strPath("%s\\resources\\%s\\%s", g_pClientGame->GetFileCacheRoot(), pResource->GetName(), szFile);
@@ -241,10 +241,9 @@ bool CStaticFunctionDefinitions::DownloadFile(CResource* pResource, const char* 
     // Call SingularFileDownloadManager
     if (g_pClientGame->GetSingularFileDownloadManager())
     {
-        g_pClientGame->GetSingularFileDownloadManager()->AddFile(pResource, strPath.c_str(), szFile, strHTTPDownloadURLFull, pRequestResource, checksum);
-        return true;
+        return g_pClientGame->GetSingularFileDownloadManager()->AddFile(pResource, strPath.c_str(), szFile, strHTTPDownloadURLFull, pRequestResource, checksum);
     }
-    return false;
+    return nullptr;
 }
 
 bool CStaticFunctionDefinitions::OutputConsole(const char* szText)

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -20,6 +20,9 @@ class CStaticFunctionDefinitions;
 #include "enums/WeaponProperty.h"
 #include "enums/ObjectProperty.h"
 
+// Forward declarations
+class CSingularFileDownload;
+
 class CStaticFunctionDefinitions
 {
 public:
@@ -39,7 +42,7 @@ public:
     static bool WasEventCancelled();
 
     // Misc funcs
-    static bool DownloadFile(CResource* pResource, const char* szFile, CResource* pRequestResource, CChecksum checksum = CChecksum());
+    static CSingularFileDownload* DownloadFile(CResource* pResource, const char* szFile, CResource* pRequestResource, CChecksum checksum = CChecksum());
 
     // Output funcs
     static bool OutputConsole(const char* szText);

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Util.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Util.cpp
@@ -372,6 +372,14 @@ int CLuaFunctionDefs::DownloadFile(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
+        // Validate that the file input is not empty
+        if (strFileInput.empty())
+        {
+            m_pScriptDebugging->LogCustom(luaVM, "Expected non-empty string, got empty string");
+            lua_pushboolean(luaVM, false);
+            return 1;
+        }
+
         // Grab our VM
         CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
         if (pLuaMain)
@@ -416,10 +424,27 @@ int CLuaFunctionDefs::AbortDownload(lua_State* luaVM)
     //  bool abortDownload(number handlerId)
     std::uint32_t handlerId = 0;
     CScriptArgReader argStream(luaVM);
+    
+    // Check if argument is a number first
+    if (!argStream.NextIsNumber())
+    {
+        m_pScriptDebugging->LogCustom(luaVM, SString("Expected number, got %s", lua_typename(luaVM, lua_type(luaVM, 1))));
+        lua_pushboolean(luaVM, false);
+        return 1;
+    }
+    
     argStream.ReadNumber(handlerId);
 
     if (!argStream.HasErrors())
     {
+        // Validate that handlerId is positive
+        if (handlerId <= 0)
+        {
+            m_pScriptDebugging->LogCustom(luaVM, SString("Expected positive value, got %d", handlerId));
+            lua_pushboolean(luaVM, false);
+            return 1;
+        }
+
         if (g_pClientGame->GetSingularFileDownloadManager())
         {
             const bool success = g_pClientGame->GetSingularFileDownloadManager()->AbortDownload(handlerId);

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.h
@@ -43,6 +43,7 @@ public:
 
     // Misc functions
     LUA_DECLARE(DownloadFile);
+    LUA_DECLARE(AbortDownload);
 
     // Output functions
     LUA_DECLARE(OutputConsole);

--- a/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -199,6 +199,7 @@ void CLuaManager::LoadCFunctions()
         // Util functions
         {"getValidPedModels", CLuaFunctionDefs::GetValidPedModels},
         {"downloadFile", CLuaFunctionDefs::DownloadFile},
+        {"abortDownload", CLuaFunctionDefs::AbortDownload},
 
         // Input functions
         {"bindKey", CLuaFunctionDefs::BindKey},


### PR DESCRIPTION
>[!WARNING]
**~This feature has not been fully tested. Please test thoroughly and report any issues or unexpected behaviors. Your feedback is highly appreciated~.**

> Sorry if I may have disappointed you, but this will take time and will need a different solution 🫠

### New Functionality

* **`abortDownload(handlerId)`**
  Cancels an ongoing download using a unique handler ID.

The function returns `false` in these cases:
- Invalid handler ID (download doesn't exist)
- Download already completed
- Download already cancelled
- HTTP cancellation failed
- It returns `true` when the download was successfully cancelled.

###  Usage Example

```lua
local download, handlerId = downloadFile("file.txt")
-- ... later ...
local success = abortDownload(handlerId)
```

### 🛠️ Changes

* Added download tracking using unique handler IDs.
* Integrated proper cancellation logic with the HTTP manager.
* Implemented input validation for both `downloadFile` and `abortDownload`.
* memory safety and error handling throughout.

###  Breaking Changes

* **`downloadFile()`** now returns **two values** (`download object`, `handler ID`) instead of a single boolean.

### 🔗 Resolves

* Issue **#4157**
