### PR TITLE
Fix `guiSetInputMode` cursor bug (#4015)

### DIFF
--- a/Client/core/CGUI.cpp
+++ b/Client/core/CGUI.cpp
@@ -700,9 +700,21 @@ bool CLocalGUI::InputGoesToGUI()
     if (!pGUI)
         return false;
 
-    // Here we're supposed to check if things like menues are up, console is up or the chatbox is expecting input
-    // If the console is visible OR the chat is expecting input OR the mainmenu is visible
-    return (IsConsoleVisible() || IsMainMenuVisible() || IsChatBoxInputEnabled() || m_bForceCursorVisible || pGUI->GetGUIInputEnabled() ||
+    bool shouldShowCursorForGUI = false;
+    if (pGUI->GetGUIInputEnabled())
+    {
+        eInputMode inputMode = pGUI->GetGUIInputMode();
+        if (inputMode == INPUTMODE_NO_BINDS_ON_EDIT)
+        {
+            shouldShowCursorForGUI = true;
+        }
+        else if (inputMode == INPUTMODE_NO_BINDS)
+        {
+            shouldShowCursorForGUI = false;
+        }
+    }
+    
+    return (IsConsoleVisible() || IsMainMenuVisible() || IsChatBoxInputEnabled() || m_bForceCursorVisible || shouldShowCursorForGUI ||
             !CCore::GetSingleton().IsFocused() || IsWebRequestGUIVisible());
 }
 


### PR DESCRIPTION
Fixes issue where `guiSetInputMode("no_binds")` forced cursor to show even when no GUI elements were visible.

* Resolves **#4015**

Tested.