### PR TITLE
Fix object rotation desync after moveObject animation completes (#549)

### DIFF
--- a/Server/mods/deathmatch/logic/CObject.h
+++ b/Server/mods/deathmatch/logic/CObject.h
@@ -101,6 +101,8 @@ private:
     bool            m_bVisibleInAllDimensions = false;
     bool            m_bRespawnable;
 
+    void NotifyMovementComplete();
+
 protected:
     bool m_bCollisionsEnabled;
 


### PR DESCRIPTION
* Resolves **#549**

Object rotation wasn't properly updated in memory after moveObject animation completed.

**Solution**: Fixed method logic to always return current rotation state and notify clients when animation ends.

**Results** (Test script from #549):
```
fu gate created, rotation: 0, 90, 0
fu gate stopped, rotation: 0, 90, 180 -> Fixed
fu gate stopped, rotation: 0, 90, 180
```