### PR TITLE
Fix missing mtaserver.conf setting added from template not receiving attributes

### DIFF
--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -916,7 +916,7 @@ bool CMainConfig::AddMissingSettings()
                 CXMLAttribute* templateAttribute = *it3;
                 const SString& attrName = templateAttribute->GetName();
 
-                // Don't check value attribute which is intended to be different
+                // Don't check value attribute which is intended to be customized by the server
                 if (attrName == "value")
                     continue;
                 
@@ -945,6 +945,12 @@ bool CMainConfig::AddMissingSettings()
             foundNode = m_pRootNode->CreateSubNode(templateNodeName.c_str(), previousNode);
             foundNode->SetTagContent(templateNodeValue.c_str());
             foundNode->SetCommentText(templateNodeComment.c_str(), true);
+
+            for (auto it3 = templateAttributes.ListBegin(); it3 != templateAttributes.ListEnd(); ++it3)
+            {
+                CXMLAttribute* templateAttribute = *it3;
+                foundNode->GetAttributes().Create(*templateAttribute);
+            }
 
             CLogger::LogPrintf("Added missing '%s' setting to mtaserver.conf\n", templateNodeName.c_str());
             configChanged = true;


### PR DESCRIPTION
Fixes #4444

Previously, when a missing config node was added from the template, only its tag name, content, and comment were copied, leaving out all attributes.

This fix ensures that all attributes from the template node are copied into the new node, so added settings fully match the template. Currently only used in the new <rule> nodes.