### PR TITLE
Sort the screen resolutions in the in-game video settings

### DIFF
--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -1771,14 +1771,12 @@ void CSettings::PopulateResolutionComboBox()
     if (resolutions.empty())
         return;
 
-    // Sort resolutions by total pixels (descending), then by width, then by depth
+    // Sort resolutions by width (descending), then by height, then by depth
     std::sort(resolutions.begin(), resolutions.end(), [](const ResolutionData& a, const ResolutionData& b) {
-        int pixelCountA = a.getPixelCount();
-        int pixelCountB = b.getPixelCount();
-        if (pixelCountA != pixelCountB)
-            return pixelCountA > pixelCountB;
         if (a.width != b.width)
             return a.width > b.width;
+        if (a.height != b.height)
+            return a.height > b.height;
         return a.depth > b.depth;
     });
 

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -1692,16 +1692,6 @@ struct ResolutionData
     int depth;
     int vidMode;
     bool isWidescreen;
-    
-    bool operator==(const ResolutionData& other) const
-    {
-        return width == other.width && height == other.height && depth == other.depth;
-    }
-    
-    int getPixelCount() const
-    {
-        return width * height;
-    }
 };
 
 //
@@ -1757,7 +1747,7 @@ void CSettings::PopulateResolutionComboBox()
         bool bDuplicate = false;
         for (const auto& existing : resolutions)
         {
-            if (existing == resData)
+            if (existing.width == resData.width && existing.height == resData.height && existing.depth == resData.depth)
             {
                 bDuplicate = true;
                 break;

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -10,6 +10,8 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include <algorithm>
+#include <vector>
 #include <core/CClientCommands.h>
 #include <game/CGame.h>
 #include <game/CSettings.h>
@@ -1683,6 +1685,25 @@ void CSettings::UpdateVideoTab()
     m_pPlayerMapImageCombo->SetSelectedItemByIndex(iVar);
 }
 
+struct ResolutionData
+{
+    int width;
+    int height;
+    int depth;
+    int vidMode;
+    bool isWidescreen;
+    
+    bool operator==(const ResolutionData& other) const
+    {
+        return width == other.width && height == other.height && depth == other.depth;
+    }
+    
+    int getPixelCount() const
+    {
+        return width * height;
+    }
+};
+
 //
 // PopulateResolutionComboBox
 //
@@ -1696,47 +1717,88 @@ void CSettings::PopulateResolutionComboBox()
     bool bShowUnsafeResolutions = m_pCheckBoxShowUnsafeResolutions->GetSelected();
 
     CGameSettings* gameSettings = CCore::GetSingleton().GetGame()->GetSettings();
+    if (!gameSettings)
+        return;
 
     VideoMode vidModemInfo;
     int       vidMode, numVidModes;
+    std::vector<ResolutionData> resolutions;
 
+    if (!m_pComboResolution)
+        return;
+        
     m_pComboResolution->Clear();
     numVidModes = gameSettings->GetNumVideoModes();
 
     for (vidMode = 0; vidMode < numVidModes; vidMode++)
     {
-        gameSettings->GetVideoModeInfo(&vidModemInfo, vidMode);
+        if (!gameSettings->GetVideoModeInfo(&vidModemInfo, vidMode))
+            continue;
 
         // Remove resolutions that will make the gui unusable
         if (vidModemInfo.width < 640 || vidModemInfo.height < 480)
-            continue;
-
-        // Check resolution hasn't already been added
-        bool bDuplicate = false;
-        for (int i = 1; i < vidMode; i++)
-        {
-            VideoMode info;
-            gameSettings->GetVideoModeInfo(&info, i);
-            if (info.width == vidModemInfo.width && info.height == vidModemInfo.height && info.depth == vidModemInfo.depth)
-                bDuplicate = true;
-        }
-        if (bDuplicate)
             continue;
 
         // Check resolution is below desktop res unless that is allowed
         if (gameSettings->IsUnsafeResolution(vidModemInfo.width, vidModemInfo.height) && !bShowUnsafeResolutions)
             continue;
 
-        SString strMode("%lu x %lu x %lu", vidModemInfo.width, vidModemInfo.height, vidModemInfo.depth);
+        if (!(vidModemInfo.flags & rwVIDEOMODEEXCLUSIVE))
+            continue;
 
-        if (vidModemInfo.flags & rwVIDEOMODEEXCLUSIVE)
-            m_pComboResolution->AddItem(strMode)->SetData((void*)vidMode);
+        ResolutionData resData;
+        resData.width = vidModemInfo.width;
+        resData.height = vidModemInfo.height;
+        resData.depth = vidModemInfo.depth;
+        resData.vidMode = vidMode;
+        resData.isWidescreen = (vidModemInfo.flags & rwVIDEOMODE_XBOX_WIDESCREEN) != 0;
 
-        VideoMode currentInfo;
-        gameSettings->GetVideoModeInfo(&currentInfo, iNextVidMode);
+        // Check resolution hasn't already been added
+        bool bDuplicate = false;
+        for (const auto& existing : resolutions)
+        {
+            if (existing == resData)
+            {
+                bDuplicate = true;
+                break;
+            }
+        }
+        
+        if (!bDuplicate)
+            resolutions.push_back(resData);
+    }
 
-        if (currentInfo.width == vidModemInfo.width && currentInfo.height == vidModemInfo.height && currentInfo.depth == vidModemInfo.depth)
-            m_pComboResolution->SetText(strMode);
+    if (resolutions.empty())
+        return;
+
+    // Sort resolutions by total pixels (descending), then by width, then by depth
+    std::sort(resolutions.begin(), resolutions.end(), [](const ResolutionData& a, const ResolutionData& b) {
+        int pixelCountA = a.getPixelCount();
+        int pixelCountB = b.getPixelCount();
+        if (pixelCountA != pixelCountB)
+            return pixelCountA > pixelCountB;
+        if (a.width != b.width)
+            return a.width > b.width;
+        return a.depth > b.depth;
+    });
+
+    SString selectedText;
+    VideoMode currentInfo;
+    if (gameSettings->GetVideoModeInfo(&currentInfo, iNextVidMode))
+    {
+        for (const auto& res : resolutions)
+        {
+            SString strMode("%d x %d x %d", res.width, res.height, res.depth);
+            CGUIListItem* pItem = m_pComboResolution->AddItem(strMode);
+            if (pItem)
+                pItem->SetData((void*)res.vidMode);
+
+            if (currentInfo.width == res.width && currentInfo.height == res.height && currentInfo.depth == res.depth)
+                selectedText = strMode;
+        }
+
+        if (!selectedText.empty())
+            m_pComboResolution->SetText(selectedText);
     }
 }
 


### PR DESCRIPTION
This PR sorts screen resolutions in the video settings dialog by size (largest first, descending).
It collects all available resolutions, sorts them by ~total pixel count (width × height)~ width first approach, then height, in descending order

<img width="220" height="151" alt="image" src="https://github.com/user-attachments/assets/39e9c89d-7d1b-4ca4-a5cc-23043701067a" />


More time and effort are needed for external dialogue.

~It's ordered by total pixel, not **width first**, so i think i will change this to match other game patterns.~
