### PR TITLE
Fix refresh restarting resources

### DIFF
--- a/Server/mods/deathmatch/logic/CResourceManager.cpp
+++ b/Server/mods/deathmatch/logic/CResourceManager.cpp
@@ -184,7 +184,7 @@ bool CResourceManager::Refresh(bool bRefreshAll, const SString strJustThisResour
                 // Add the resource
                 Load(!info.bIsDir, info.strAbsPath, info.strName);
             }
-            else if (pResource && pResource->HasResourceChanged())
+            else if (bRefreshAll && pResource && pResource->HasResourceChanged())
             {
                 if (g_pServerInterface->IsRequestingExit())
                     return false;


### PR DESCRIPTION
refresh isn't meant to restart, just refreshall does that.

Bug introduced in: https://github.com/multitheftauto/mtasa-blue/pull/4409/files

Before and after this fix:

<img width="466" height="265" alt="image" src="https://github.com/user-attachments/assets/d4905324-a393-4019-b993-cda1a67c8785" />

