### PR TITLE
Fix map editor bug

### DIFF
--- a/Client/core/CModManager.cpp
+++ b/Client/core/CModManager.cpp
@@ -122,6 +122,8 @@ void CModManager::Unload()
 
 bool CModManager::Start()
 {
+    if (m_library != nullptr || m_client != nullptr)
+        Stop();
     dassert(m_state == State::PendingStart);
     dassert(m_library == nullptr);
     dassert(m_client == nullptr);


### PR DESCRIPTION
There was a bug when you join map editor and rejoin again game will crash
In this PR this bug got fixed

<img width="1281" height="789" alt="image" src="https://github.com/user-attachments/assets/3aa79cba-a361-4c12-aa24-53feebfd73a9" />