### PR TITLE
Add setVehicleWheelAlignmentOnExitEnabled function

### DIFF
--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -1209,3 +1209,25 @@ CObjectGroupPhysicalProperties* CGameSA::GetObjectGroupPhysicalProperties(unsign
 
     return nullptr;
 }
+
+bool CGameSA::IsVehicleWheelAlignmentOnExitEnabled() const noexcept
+{
+    return *(std::uint8_t*)0x6B5579 == 0x89;
+}
+
+void CGameSA::SetVehicleWheelAlignmentOnExitEnabled(bool enabled) noexcept
+{
+    if (IsVehicleWheelAlignmentOnExitEnabled() == enabled)
+        return;
+
+    if (!enabled)
+    {
+        MemSet((void*)0x6B5579, 0x90, 6);
+        MemSet((void*)0x6B568A, 0x90, 6);
+    }
+    else
+    {
+        MemCpy((void*)0x6B5579, "\x89\xBE\x94\x04\x00\x00", 6);
+        MemCpy((void*)0x6B568A, "\x89\xBE\x94\x04\x00\x00", 6);
+    }
+}

--- a/Client/game_sa/CGameSA.h
+++ b/Client/game_sa/CGameSA.h
@@ -322,6 +322,9 @@ public:
 
     bool SetBuildingPoolSize(size_t size);
 
+    bool IsVehicleWheelAlignmentOnExitEnabled() const noexcept override;
+    void SetVehicleWheelAlignmentOnExitEnabled(bool enabled) noexcept override;
+
 private:
     std::unique_ptr<CPools>           m_Pools;
     CPlayerInfo*                      m_pPlayerInfo;

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -3466,6 +3466,8 @@ void CClientGame::Event_OnIngame()
     // Reset weapon render
     g_pGame->SetWeaponRenderEnabled(true);
 
+    g_pGame->SetVehicleWheelAlignmentOnExitEnabled(true);
+
     // Make sure we can access all areas
     g_pGame->GetStats()->ModifyStat(CITIES_PASSED, 2.0);
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -100,6 +100,7 @@ void CLuaVehicleDefs::LoadFunctions()
         {"getVehicleRotorState", ArgumentParser<GetVehicleRotorState>},
         {"getVehicleModelAudioSettings", ArgumentParser<GetVehicleModelAudioSettings>},
         {"getVehicleAudioSettings", ArgumentParser<GetVehicleAudioSettings>},
+        {"isVehicleWheelAlignmentOnExitEnabled", ArgumentParser<IsVehicleWheelAlignmentOnExitEnabled>},
 
         // Vehicle set funcs
         {"createVehicle", CreateVehicle},
@@ -172,6 +173,7 @@ void CLuaVehicleDefs::LoadFunctions()
         {"resetVehicleModelAudioSettings", ArgumentParser<ResetVehicleModelAudioSettings>},
         {"setVehicleAudioSetting", ArgumentParser<SetVehicleAudioSetting>},
         {"resetVehicleAudioSettings", ArgumentParser<ResetVehicleAudioSettings>},
+        {"setVehicleWheelAlignmentOnExitEnabled", ArgumentParser<SetVehicleWheelAlignmentOnExitEnabled>},
     };
 
     // Add functions
@@ -4700,5 +4702,15 @@ std::unordered_map<std::string, float> CLuaVehicleDefs::GetVehicleAudioSettings(
     output["horn-volume-delta"] = pEntry.GetHornVolumeDelta();
 
     return output;
+}
+
+bool CLuaVehicleDefs::IsVehicleWheelAlignmentOnExitEnabled() noexcept
+{
+    return g_pGame->IsVehicleWheelAlignmentOnExitEnabled();
+}
+
+void CLuaVehicleDefs::SetVehicleWheelAlignmentOnExitEnabled(bool enabled) noexcept
+{
+    g_pGame->SetVehicleWheelAlignmentOnExitEnabled(enabled);
 }
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -199,4 +199,7 @@ public:
 
     static bool SetSmokeTrailEnabled(CClientVehicle* vehicle, bool state);
     static bool IsSmokeTrailEnabled(CClientVehicle* vehicle) noexcept;
+
+    static bool IsVehicleWheelAlignmentOnExitEnabled() noexcept;
+    static void SetVehicleWheelAlignmentOnExitEnabled(bool enabled) noexcept;
 };

--- a/Client/sdk/game/CGame.h
+++ b/Client/sdk/game/CGame.h
@@ -287,5 +287,7 @@ public:
     virtual void RestoreGameWorld() = 0;
 
     virtual bool SetBuildingPoolSize(size_t size) = 0;
-
+    
+    virtual bool IsVehicleWheelAlignmentOnExitEnabled() const noexcept = 0;
+    virtual void SetVehicleWheelAlignmentOnExitEnabled(bool enabled) noexcept = 0;
 };


### PR DESCRIPTION
Add `setVehicleWheelAlignmentOnExitEnabled` and `isVehicleWheelAlignmentOnExitEnabled` functions

The value `false` prevents the wheels from returning to their original position after exiting the car

<img width="791" height="625" alt="image" src="https://github.com/user-attachments/assets/44acf609-ff30-4520-8934-2c921d5912aa" />
