### PR TITLE
Fix double sided not syncing false

### DIFF
--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -3027,8 +3027,7 @@ retry:
                             return;
                         }
 
-                        if (bitStream.ReadBit())
-                            pObject->SetDoubleSided(true);
+                        pObject->SetDoubleSided(bitStream.ReadBit());
 
                         pObject->SetBreakable(bitStream.ReadBit());
 


### PR DESCRIPTION
Some objects are double sided by default, so SetDoubleSided must be called for them if you want it to be false.

Fixes: https://github.com/multitheftauto/mtasa-resources/issues/230

To reproduce:
start editor
Add object 3851
Make sure doublesided = false
Save the map
Open the map
Notice it now says doublesided = true

crun isElementDoubledSided(getElementsByType("object")[1]) -- returns true
srun isElementDoubledSided(getElementsByType("object")[1]) -- returns false

PR fixes this desync. I guess this object is doublesided by default, and the object sync would only set true, never false.