### PR TITLE
Fix #4482 (onPlayerWasted not trigerring with setElementHealth to 0)

### DIFF
--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1762,6 +1762,8 @@ bool CStaticFunctionDefinitions::SetElementHealth(CElement* pElement, float fHea
 
             if (pPed->IsDead() && fHealth > 0.0f)
                 pPed->SetIsDead(false);
+            else if (fHealth <= 0.0f && !pPed->IsDead())
+                KillPed(pElement, nullptr, 0xFF, 0xFF, false);
 
             break;
         }


### PR DESCRIPTION
Although I had a look at git blame to see which commit broke this, I didn't see one the closest commit that changed this function, but I can't see an explanation when looking at it, is: https://github.com/multitheftauto/mtasa-blue/commit/612f9a6715059baa43182e891258d9c3ceb19591

So just making a PR that fixes players not dying properly when setElementHealth(plr, 0) is used.