### PR TITLE
The second iteration of element data optimization

### DIFF
--- a/Client/mods/deathmatch/logic/CClientEntity.cpp
+++ b/Client/mods/deathmatch/logic/CClientEntity.cpp
@@ -279,7 +279,7 @@ void CClientEntity::SetID(ElementID ID)
     }
 }
 
-CLuaArgument* CClientEntity::GetCustomData(CStringName name, bool bInheritData, bool* pbIsSynced)
+CLuaArgument* CClientEntity::GetCustomData(const CStringName& name, bool bInheritData, bool* pbIsSynced)
 {
     assert(name);
 
@@ -315,7 +315,7 @@ CLuaArguments* CClientEntity::GetAllCustomData(CLuaArguments* table)
     return table;
 }
 
-bool CClientEntity::GetCustomDataString(CStringName name, SString& strOut, bool bInheritData)
+bool CClientEntity::GetCustomDataString(const CStringName& name, SString& strOut, bool bInheritData)
 {
     // Grab the custom data variable
     CLuaArgument* pData = GetCustomData(name, bInheritData);
@@ -350,7 +350,7 @@ bool CClientEntity::GetCustomDataString(CStringName name, SString& strOut, bool 
     return false;
 }
 
-bool CClientEntity::GetCustomDataInt(CStringName name, int& iOut, bool bInheritData)
+bool CClientEntity::GetCustomDataInt(const CStringName& name, int& iOut, bool bInheritData)
 {
     // Grab the custom data variable
     CLuaArgument* pData = GetCustomData(name, bInheritData);
@@ -388,7 +388,7 @@ bool CClientEntity::GetCustomDataInt(CStringName name, int& iOut, bool bInheritD
     return false;
 }
 
-bool CClientEntity::GetCustomDataFloat(CStringName name, float& fOut, bool bInheritData)
+bool CClientEntity::GetCustomDataFloat(const CStringName& name, float& fOut, bool bInheritData)
 {
     // Grab the custom data variable
     CLuaArgument* pData = GetCustomData(name, bInheritData);
@@ -415,7 +415,7 @@ bool CClientEntity::GetCustomDataFloat(CStringName name, float& fOut, bool bInhe
     return false;
 }
 
-bool CClientEntity::GetCustomDataBool(CStringName name, bool& bOut, bool bInheritData)
+bool CClientEntity::GetCustomDataBool(const CStringName& name, bool& bOut, bool bInheritData)
 {
     // Grab the custom data variable
     CLuaArgument* pData = GetCustomData(name, bInheritData);
@@ -470,7 +470,7 @@ bool CClientEntity::GetCustomDataBool(CStringName name, bool& bOut, bool bInheri
     return false;
 }
 
-void CClientEntity::SetCustomData(CStringName name, const CLuaArgument& Variable, bool bSynchronized)
+void CClientEntity::SetCustomData(const CStringName& name, const CLuaArgument& Variable, bool bSynchronized)
 {
     assert(name);
     if (name->length() > MAX_CUSTOMDATA_NAME_LENGTH)
@@ -499,7 +499,7 @@ void CClientEntity::SetCustomData(CStringName name, const CLuaArgument& Variable
     CallEvent("onClientElementDataChange", Arguments, true);
 }
 
-void CClientEntity::DeleteCustomData(CStringName name)
+void CClientEntity::DeleteCustomData(const CStringName& name)
 {
     // Grab the old variable
     SCustomData* pData = m_pCustomData->Get(name);

--- a/Client/mods/deathmatch/logic/CClientEntity.cpp
+++ b/Client/mods/deathmatch/logic/CClientEntity.cpp
@@ -279,12 +279,12 @@ void CClientEntity::SetID(ElementID ID)
     }
 }
 
-CLuaArgument* CClientEntity::GetCustomData(const char* szName, bool bInheritData, bool* pbIsSynced)
+CLuaArgument* CClientEntity::GetCustomData(CStringName name, bool bInheritData, bool* pbIsSynced)
 {
-    assert(szName);
+    assert(name);
 
     // Grab it and return a pointer to the variable
-    SCustomData* pData = m_pCustomData->Get(szName);
+    SCustomData* pData = m_pCustomData->Get(name);
     if (pData)
     {
         if (pbIsSynced)
@@ -295,7 +295,7 @@ CLuaArgument* CClientEntity::GetCustomData(const char* szName, bool bInheritData
     // If none, try returning parent's custom data
     if (bInheritData && m_pParent)
     {
-        return m_pParent->GetCustomData(szName, true, pbIsSynced);
+        return m_pParent->GetCustomData(name, true, pbIsSynced);
     }
 
     // None available
@@ -315,10 +315,10 @@ CLuaArguments* CClientEntity::GetAllCustomData(CLuaArguments* table)
     return table;
 }
 
-bool CClientEntity::GetCustomDataString(const char* szName, SString& strOut, bool bInheritData)
+bool CClientEntity::GetCustomDataString(CStringName name, SString& strOut, bool bInheritData)
 {
     // Grab the custom data variable
-    CLuaArgument* pData = GetCustomData(szName, bInheritData);
+    CLuaArgument* pData = GetCustomData(name, bInheritData);
     if (pData)
     {
         // Write the content depending on what type it is
@@ -350,10 +350,10 @@ bool CClientEntity::GetCustomDataString(const char* szName, SString& strOut, boo
     return false;
 }
 
-bool CClientEntity::GetCustomDataInt(const char* szName, int& iOut, bool bInheritData)
+bool CClientEntity::GetCustomDataInt(CStringName name, int& iOut, bool bInheritData)
 {
     // Grab the custom data variable
-    CLuaArgument* pData = GetCustomData(szName, bInheritData);
+    CLuaArgument* pData = GetCustomData(name, bInheritData);
     if (pData)
     {
         // Write the content depending on what type it is
@@ -388,10 +388,10 @@ bool CClientEntity::GetCustomDataInt(const char* szName, int& iOut, bool bInheri
     return false;
 }
 
-bool CClientEntity::GetCustomDataFloat(const char* szName, float& fOut, bool bInheritData)
+bool CClientEntity::GetCustomDataFloat(CStringName name, float& fOut, bool bInheritData)
 {
     // Grab the custom data variable
-    CLuaArgument* pData = GetCustomData(szName, bInheritData);
+    CLuaArgument* pData = GetCustomData(name, bInheritData);
     if (pData)
     {
         // Write the content depending on what type it is
@@ -415,10 +415,10 @@ bool CClientEntity::GetCustomDataFloat(const char* szName, float& fOut, bool bIn
     return false;
 }
 
-bool CClientEntity::GetCustomDataBool(const char* szName, bool& bOut, bool bInheritData)
+bool CClientEntity::GetCustomDataBool(CStringName name, bool& bOut, bool bInheritData)
 {
     // Grab the custom data variable
-    CLuaArgument* pData = GetCustomData(szName, bInheritData);
+    CLuaArgument* pData = GetCustomData(name, bInheritData);
     if (pData)
     {
         // Write the content depending on what type it is
@@ -470,50 +470,50 @@ bool CClientEntity::GetCustomDataBool(const char* szName, bool& bOut, bool bInhe
     return false;
 }
 
-void CClientEntity::SetCustomData(const char* szName, const CLuaArgument& Variable, bool bSynchronized)
+void CClientEntity::SetCustomData(CStringName name, const CLuaArgument& Variable, bool bSynchronized)
 {
-    assert(szName);
-    if (strlen(szName) > MAX_CUSTOMDATA_NAME_LENGTH)
+    assert(name);
+    if (name->length() > MAX_CUSTOMDATA_NAME_LENGTH)
     {
         // Don't allow it to be set if the name is too long
-        CLogger::ErrorPrintf("Custom data name too long (%s)", *SStringX(szName).Left(MAX_CUSTOMDATA_NAME_LENGTH + 1));
+        CLogger::ErrorPrintf("Custom data name too long (%s)", *SStringX(name.ToCString()).Left(MAX_CUSTOMDATA_NAME_LENGTH + 1));
         return;
     }
 
     // Grab the old variable
     CLuaArgument oldVariable;
-    SCustomData* pData = m_pCustomData->Get(szName);
+    SCustomData* pData = m_pCustomData->Get(name);
     if (pData)
     {
         oldVariable = pData->Variable;
     }
 
     // Set the new data
-    m_pCustomData->Set(szName, Variable, bSynchronized);
+    m_pCustomData->Set(name, Variable, bSynchronized);
 
     // Trigger the onClientElementDataChange event on us
     CLuaArguments Arguments;
-    Arguments.PushString(szName);
+    Arguments.PushString(name);
     Arguments.PushArgument(oldVariable);
     Arguments.PushArgument(Variable);
     CallEvent("onClientElementDataChange", Arguments, true);
 }
 
-void CClientEntity::DeleteCustomData(const char* szName)
+void CClientEntity::DeleteCustomData(CStringName name)
 {
     // Grab the old variable
-    SCustomData* pData = m_pCustomData->Get(szName);
+    SCustomData* pData = m_pCustomData->Get(name);
     if (pData)
     {
         CLuaArgument oldVariable;
         oldVariable = pData->Variable;
 
         // Delete the custom data
-        m_pCustomData->Delete(szName);
+        m_pCustomData->Delete(name);
 
         // Trigger the onClientElementDataChange event on us
         CLuaArguments Arguments;
-        Arguments.PushString(szName);
+        Arguments.PushString(name);
         Arguments.PushArgument(oldVariable);
         Arguments.PushArgument(CLuaArgument());            // Use nil as the new value to indicate the data has been removed
         CallEvent("onClientElementDataChange", Arguments, true);

--- a/Client/mods/deathmatch/logic/CClientEntity.h
+++ b/Client/mods/deathmatch/logic/CClientEntity.h
@@ -16,6 +16,7 @@ class CClientEntity;
 #include "CClientCommon.h"
 #include <core/CClientEntityBase.h>
 #include "logic/CClientEntityRefManager.h"
+#include "CStringName.h"
 class CLuaFunctionRef;
 
 // Used to check fast version of getElementsByType
@@ -201,14 +202,14 @@ public:
     void      SetID(ElementID ID);
 
     CCustomData*   GetCustomDataPointer() { return m_pCustomData; }
-    CLuaArgument*  GetCustomData(const char* szName, bool bInheritData, bool* pbIsSynced = nullptr);
+    CLuaArgument*  GetCustomData(CStringName name, bool bInheritData, bool* pbIsSynced = nullptr);
     CLuaArguments* GetAllCustomData(CLuaArguments* table);
-    bool           GetCustomDataString(const char* szKey, SString& strOut, bool bInheritData);
-    bool           GetCustomDataFloat(const char* szKey, float& fOut, bool bInheritData);
-    bool           GetCustomDataInt(const char* szKey, int& iOut, bool bInheritData);
-    bool           GetCustomDataBool(const char* szKey, bool& bOut, bool bInheritData);
-    void           SetCustomData(const char* szName, const CLuaArgument& Variable, bool bSynchronized = true);
-    void           DeleteCustomData(const char* szName);
+    bool           GetCustomDataString(CStringName name, SString& strOut, bool bInheritData);
+    bool           GetCustomDataFloat(CStringName name, float& fOut, bool bInheritData);
+    bool           GetCustomDataInt(CStringName name, int& iOut, bool bInheritData);
+    bool           GetCustomDataBool(CStringName name, bool& bOut, bool bInheritData);
+    void           SetCustomData(CStringName name, const CLuaArgument& Variable, bool bSynchronized = true);
+    void           DeleteCustomData(CStringName name);
 
     virtual bool GetMatrix(CMatrix& matrix) const;
     virtual bool SetMatrix(const CMatrix& matrix);

--- a/Client/mods/deathmatch/logic/CClientEntity.h
+++ b/Client/mods/deathmatch/logic/CClientEntity.h
@@ -202,14 +202,14 @@ public:
     void      SetID(ElementID ID);
 
     CCustomData*   GetCustomDataPointer() { return m_pCustomData; }
-    CLuaArgument*  GetCustomData(CStringName name, bool bInheritData, bool* pbIsSynced = nullptr);
+    CLuaArgument*  GetCustomData(const CStringName& name, bool bInheritData, bool* pbIsSynced = nullptr);
     CLuaArguments* GetAllCustomData(CLuaArguments* table);
-    bool           GetCustomDataString(CStringName name, SString& strOut, bool bInheritData);
-    bool           GetCustomDataFloat(CStringName name, float& fOut, bool bInheritData);
-    bool           GetCustomDataInt(CStringName name, int& iOut, bool bInheritData);
-    bool           GetCustomDataBool(CStringName name, bool& bOut, bool bInheritData);
-    void           SetCustomData(CStringName name, const CLuaArgument& Variable, bool bSynchronized = true);
-    void           DeleteCustomData(CStringName name);
+    bool           GetCustomDataString(const CStringName& name, SString& strOut, bool bInheritData);
+    bool           GetCustomDataFloat(const CStringName& name, float& fOut, bool bInheritData);
+    bool           GetCustomDataInt(const CStringName& name, int& iOut, bool bInheritData);
+    bool           GetCustomDataBool(const CStringName& name, bool& bOut, bool bInheritData);
+    void           SetCustomData(const CStringName& name, const CLuaArgument& Variable, bool bSynchronized = true);
+    void           DeleteCustomData(const CStringName& name);
 
     virtual bool GetMatrix(CMatrix& matrix) const;
     virtual bool SetMatrix(const CMatrix& matrix);

--- a/Client/mods/deathmatch/logic/CCustomData.cpp
+++ b/Client/mods/deathmatch/logic/CCustomData.cpp
@@ -21,7 +21,7 @@ void CCustomData::Copy(CCustomData* pCustomData)
     }
 }
 
-SCustomData* CCustomData::Get(CStringName name)
+SCustomData* CCustomData::Get(const CStringName& name)
 {
     assert(name);
 
@@ -32,7 +32,7 @@ SCustomData* CCustomData::Get(CStringName name)
     return NULL;
 }
 
-void CCustomData::Set(CStringName name, const CLuaArgument& Variable, bool bSynchronized)
+void CCustomData::Set(const CStringName& name, const CLuaArgument& Variable, bool bSynchronized)
 {
     assert(name);
 
@@ -54,7 +54,7 @@ void CCustomData::Set(CStringName name, const CLuaArgument& Variable, bool bSync
     }
 }
 
-bool CCustomData::Delete(CStringName name)
+bool CCustomData::Delete(const CStringName& name)
 {
     // Find the item and delete it
     auto it = m_Data.find(name);

--- a/Client/mods/deathmatch/logic/CCustomData.cpp
+++ b/Client/mods/deathmatch/logic/CCustomData.cpp
@@ -14,30 +14,30 @@
 
 void CCustomData::Copy(CCustomData* pCustomData)
 {
-    std::map<std::string, SCustomData>::const_iterator iter = pCustomData->IterBegin();
+    auto iter = pCustomData->IterBegin();
     for (; iter != pCustomData->IterEnd(); iter++)
     {
-        Set(iter->first.c_str(), iter->second.Variable);
+        Set(iter->first, iter->second.Variable);
     }
 }
 
-SCustomData* CCustomData::Get(const char* szName)
+SCustomData* CCustomData::Get(CStringName name)
 {
-    assert(szName);
+    assert(name);
 
-    std::map<std::string, SCustomData>::iterator it = m_Data.find(szName);
+    auto it = m_Data.find(name);
     if (it != m_Data.end())
         return &it->second;
 
     return NULL;
 }
 
-void CCustomData::Set(const char* szName, const CLuaArgument& Variable, bool bSynchronized)
+void CCustomData::Set(CStringName name, const CLuaArgument& Variable, bool bSynchronized)
 {
-    assert(szName);
+    assert(name);
 
     // Grab the item with the given name
-    SCustomData* pData = Get(szName);
+    SCustomData* pData = Get(name);
     if (pData)
     {
         // Update existing
@@ -50,14 +50,14 @@ void CCustomData::Set(const char* szName, const CLuaArgument& Variable, bool bSy
         SCustomData newData;
         newData.Variable = Variable;
         newData.bSynchronized = bSynchronized;
-        m_Data[szName] = newData;
+        m_Data[name] = newData;
     }
 }
 
-bool CCustomData::Delete(const char* szName)
+bool CCustomData::Delete(CStringName name)
 {
     // Find the item and delete it
-    std::map<std::string, SCustomData>::iterator it = m_Data.find(szName);
+    auto it = m_Data.find(name);
     if (it != m_Data.end())
     {
         m_Data.erase(it);

--- a/Client/mods/deathmatch/logic/CCustomData.h
+++ b/Client/mods/deathmatch/logic/CCustomData.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "lua/CLuaArgument.h"
+#include "CStringName.h"
 
 #define MAX_CUSTOMDATA_NAME_LENGTH 128
 
@@ -25,14 +26,14 @@ class CCustomData
 public:
     void Copy(CCustomData* pCustomData);
 
-    SCustomData* Get(const char* szName);
-    void         Set(const char* szName, const CLuaArgument& Variable, bool bSynchronized = true);
+    SCustomData* Get(CStringName name);
+    void         Set(CStringName name, const CLuaArgument& Variable, bool bSynchronized = true);
 
-    bool Delete(const char* szName);
+    bool Delete(CStringName name);
 
-    std::map<std::string, SCustomData>::const_iterator IterBegin() { return m_Data.begin(); }
-    std::map<std::string, SCustomData>::const_iterator IterEnd() { return m_Data.end(); }
+    std::unordered_map<CStringName, SCustomData>::const_iterator IterBegin() { return m_Data.begin(); }
+    std::unordered_map<CStringName, SCustomData>::const_iterator IterEnd() { return m_Data.end(); }
 
 private:
-    std::map<std::string, SCustomData> m_Data;
+    std::unordered_map<CStringName, SCustomData> m_Data;
 };

--- a/Client/mods/deathmatch/logic/CCustomData.h
+++ b/Client/mods/deathmatch/logic/CCustomData.h
@@ -26,10 +26,10 @@ class CCustomData
 public:
     void Copy(CCustomData* pCustomData);
 
-    SCustomData* Get(CStringName name);
-    void         Set(CStringName name, const CLuaArgument& Variable, bool bSynchronized = true);
+    SCustomData* Get(const CStringName& name);
+    void         Set(const CStringName& name, const CLuaArgument& Variable, bool bSynchronized = true);
 
-    bool Delete(CStringName name);
+    bool Delete(const CStringName& name);
 
     std::unordered_map<CStringName, SCustomData>::const_iterator IterBegin() { return m_Data.begin(); }
     std::unordered_map<CStringName, SCustomData>::const_iterator IterEnd() { return m_Data.end(); }

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -2885,7 +2885,7 @@ retry:
                         CLuaArgument Argument;
                         Argument.ReadFromBitStream(bitStream);
 
-                        pCustomData->Set(strName, Argument);
+                        pCustomData->Set(CStringName{strName}, Argument);
                     }
                     else
                     {

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1026,13 +1026,13 @@ bool CStaticFunctionDefinitions::SetElementID(CClientEntity& Entity, const char*
     return false;
 }
 
-bool CStaticFunctionDefinitions::SetElementData(CClientEntity& Entity, const char* szName, CLuaArgument& Variable, bool bSynchronize)
+bool CStaticFunctionDefinitions::SetElementData(CClientEntity& Entity, CStringName name, CLuaArgument& Variable, bool bSynchronize)
 {
-    assert(szName);
-    assert(strlen(szName) <= MAX_CUSTOMDATA_NAME_LENGTH);
+    assert(name);
+    assert(name->length() <= MAX_CUSTOMDATA_NAME_LENGTH);
 
     bool          bIsSynced;
-    CLuaArgument* pCurrentVariable = Entity.GetCustomData(szName, false, &bIsSynced);
+    CLuaArgument* pCurrentVariable = Entity.GetCustomData(name, false, &bIsSynced);
     if (!pCurrentVariable || Variable != *pCurrentVariable || bIsSynced != bSynchronize)
     {
         if (bSynchronize && !Entity.IsLocalEntity())
@@ -1040,9 +1040,9 @@ bool CStaticFunctionDefinitions::SetElementData(CClientEntity& Entity, const cha
             NetBitStreamInterface* pBitStream = g_pNet->AllocateNetBitStream();
             // Write element ID, name length and the name. Also write the variable.
             pBitStream->Write(Entity.GetID());
-            unsigned short usNameLength = static_cast<unsigned short>(strlen(szName));
+            unsigned short usNameLength = static_cast<unsigned short>(name->length());
             pBitStream->WriteCompressed(usNameLength);
-            pBitStream->Write(szName, usNameLength);
+            pBitStream->Write(name.ToCString(), usNameLength);
             Variable.WriteToBitStream(*pBitStream);
 
             // Send the packet and deallocate
@@ -1051,14 +1051,14 @@ bool CStaticFunctionDefinitions::SetElementData(CClientEntity& Entity, const cha
         }
 
         // Set its custom data
-        Entity.SetCustomData(szName, Variable, bSynchronize);
+        Entity.SetCustomData(name, Variable, bSynchronize);
         return true;
     }
 
     return false;
 }
 
-bool CStaticFunctionDefinitions::RemoveElementData(CClientEntity& Entity, const char* szName)
+bool CStaticFunctionDefinitions::RemoveElementData(CClientEntity& Entity, CStringName name)
 {
     // TODO
     return false;

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -85,8 +85,8 @@ public:
     static CClientDummy* CreateElement(CResource& Resource, const char* szTypeName, const char* szID);
     static bool          DestroyElement(CClientEntity& Entity);
     static bool          SetElementID(CClientEntity& Entity, const char* szID);
-    static bool          SetElementData(CClientEntity& Entity, const char* szName, CLuaArgument& Variable, bool bSynchronize);
-    static bool          RemoveElementData(CClientEntity& Entity, const char* szName);
+    static bool          SetElementData(CClientEntity& Entity, CStringName name, CLuaArgument& Variable, bool bSynchronize);
+    static bool          RemoveElementData(CClientEntity& Entity, CStringName name);
     static bool          SetElementMatrix(CClientEntity& Entity, const CMatrix& matrix);
     static bool          SetElementPosition(CClientEntity& Entity, const CVector& vecPosition, bool bWarp = true);
     static bool          SetElementRotation(CClientEntity& Entity, const CVector& vecRotation, eEulerRotationOrder rotationOrder, bool bNewWay);

--- a/Client/mods/deathmatch/logic/lua/CLuaArgument.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaArgument.cpp
@@ -334,6 +334,13 @@ void CLuaArgument::ReadString(const std::string_view& string)
     m_strString = std::string{string};
 }
 
+void CLuaArgument::ReadString(CStringName string)
+{
+    m_iType = LUA_TSTRING;
+    DeleteTableData();
+    m_strString = string.ToString();
+}
+
 void CLuaArgument::ReadString(const char* string)
 {
     m_iType = LUA_TSTRING;

--- a/Client/mods/deathmatch/logic/lua/CLuaArgument.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaArgument.cpp
@@ -334,7 +334,7 @@ void CLuaArgument::ReadString(const std::string_view& string)
     m_strString = std::string{string};
 }
 
-void CLuaArgument::ReadString(CStringName string)
+void CLuaArgument::ReadString(const CStringName& string)
 {
     m_iType = LUA_TSTRING;
     DeleteTableData();

--- a/Client/mods/deathmatch/logic/lua/CLuaArgument.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaArgument.h
@@ -43,7 +43,7 @@ public:
     void ReadNumber(double dNumber);
     void ReadString(const std::string& string);
     void ReadString(const std::string_view& string);
-    void ReadString(CStringName string);
+    void ReadString(const CStringName& string);
     void ReadString(const char* string);
     void ReadElement(CClientEntity* pElement);
     void ReadScriptID(uint uiScriptID);

--- a/Client/mods/deathmatch/logic/lua/CLuaArgument.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaArgument.h
@@ -17,6 +17,7 @@ extern "C"
 #include <net/bitstream.h>
 #include <string>
 #include "json.h"
+#include "CStringName.h"
 
 class CClientEntity;
 class CLuaArguments;
@@ -42,6 +43,7 @@ public:
     void ReadNumber(double dNumber);
     void ReadString(const std::string& string);
     void ReadString(const std::string_view& string);
+    void ReadString(CStringName string);
     void ReadString(const char* string);
     void ReadElement(CClientEntity* pElement);
     void ReadScriptID(uint uiScriptID);

--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
@@ -351,7 +351,7 @@ CLuaArgument* CLuaArguments::PushString(const std::string_view& string)
     return arg;
 }
 
-CLuaArgument* CLuaArguments::PushString(CStringName string)
+CLuaArgument* CLuaArguments::PushString(const CStringName& string)
 {
     CLuaArgument* arg = new CLuaArgument();
     arg->ReadString(string);

--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
@@ -351,6 +351,14 @@ CLuaArgument* CLuaArguments::PushString(const std::string_view& string)
     return arg;
 }
 
+CLuaArgument* CLuaArguments::PushString(CStringName string)
+{
+    CLuaArgument* arg = new CLuaArgument();
+    arg->ReadString(string);
+    m_Arguments.push_back(arg);
+    return arg;
+}
+
 CLuaArgument* CLuaArguments::PushString(const char* string)
 {
     CLuaArgument* arg = new CLuaArgument();

--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -57,7 +57,7 @@ public:
     CLuaArgument* PushNumber(double dNumber);
     CLuaArgument* PushString(const std::string& string);
     CLuaArgument* PushString(const std::string_view& string);
-    CLuaArgument* PushString(CStringName string);
+    CLuaArgument* PushString(const CStringName& string);
     CLuaArgument* PushString(const char* string);
     CLuaArgument* PushElement(CClientEntity* pElement);
     CLuaArgument* PushArgument(const CLuaArgument& argument);

--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -57,6 +57,7 @@ public:
     CLuaArgument* PushNumber(double dNumber);
     CLuaArgument* PushString(const std::string& string);
     CLuaArgument* PushString(const std::string_view& string);
+    CLuaArgument* PushString(CStringName string);
     CLuaArgument* PushString(const char* string);
     CLuaArgument* PushElement(CClientEntity* pElement);
     CLuaArgument* PushArgument(const CLuaArgument& argument);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -1789,7 +1789,7 @@ int CLuaElementDefs::SetElementData(lua_State* luaVM)
                 key = key->substr(0, MAX_CUSTOMDATA_NAME_LENGTH);
             }
 
-            if (CStaticFunctionDefinitions::SetElementData(*pEntity, key.ToCString(), value, bSynchronize))
+            if (CStaticFunctionDefinitions::SetElementData(*pEntity, key, value, bSynchronize))
             {
                 lua_pushboolean(luaVM, true);
                 return 1;
@@ -1828,7 +1828,7 @@ int CLuaElementDefs::RemoveElementData(lua_State* luaVM)
                 key = key->substr(0, MAX_CUSTOMDATA_NAME_LENGTH);
             }
 
-            if (CStaticFunctionDefinitions::RemoveElementData(*pEntity, key.ToCString()))
+            if (CStaticFunctionDefinitions::RemoveElementData(*pEntity, key))
             {
                 lua_pushboolean(luaVM, true);
                 return 1;

--- a/Client/mods/deathmatch/logic/rpc/CElementRPCs.cpp
+++ b/Client/mods/deathmatch/logic/rpc/CElementRPCs.cpp
@@ -96,7 +96,7 @@ void CElementRPCs::SetElementData(CClientEntity* pSource, NetBitStreamInterface&
         CLuaArgument Argument;
         if (bitStream.ReadStringCharacters(strName, usNameLength) && Argument.ReadFromBitStream(bitStream))
         {
-            pSource->SetCustomData(strName, Argument);
+            pSource->SetCustomData(CStringName{strName}, Argument);
         }
     }
 }
@@ -114,7 +114,7 @@ void CElementRPCs::RemoveElementData(CClientEntity* pSource, NetBitStreamInterfa
         if (bitStream.ReadStringCharacters(strName, usNameLength) && bitStream.ReadBit(bRecursive))
         {
             // Remove that name
-            pSource->DeleteCustomData(strName);
+            pSource->DeleteCustomData(CStringName{strName});
         }
     }
 }

--- a/Server/mods/deathmatch/logic/CCustomData.cpp
+++ b/Server/mods/deathmatch/logic/CCustomData.cpp
@@ -21,7 +21,7 @@ void CCustomData::Copy(CCustomData* pCustomData)
     }
 }
 
-SCustomData* CCustomData::Get(CStringName name) const
+SCustomData* CCustomData::Get(const CStringName& name) const
 {
     assert(name);
 
@@ -32,7 +32,7 @@ SCustomData* CCustomData::Get(CStringName name) const
     return NULL;
 }
 
-SCustomData* CCustomData::GetSynced(CStringName name)
+SCustomData* CCustomData::GetSynced(const CStringName& name)
 {
     assert(name);
 
@@ -43,7 +43,7 @@ SCustomData* CCustomData::GetSynced(CStringName name)
     return NULL;
 }
 
-bool CCustomData::DeleteSynced(CStringName name)
+bool CCustomData::DeleteSynced(const CStringName& name)
 {
     // Find the item and delete it
     auto iter = m_SyncedData.find(name);
@@ -57,7 +57,7 @@ bool CCustomData::DeleteSynced(CStringName name)
     return false;
 }
 
-void CCustomData::UpdateSynced(CStringName name, const CLuaArgument& Variable, ESyncType syncType)
+void CCustomData::UpdateSynced(const CStringName& name, const CLuaArgument& Variable, ESyncType syncType)
 {
     if (syncType == ESyncType::BROADCAST)
     {
@@ -81,7 +81,7 @@ void CCustomData::UpdateSynced(CStringName name, const CLuaArgument& Variable, E
     }
 }
 
-void CCustomData::Set(CStringName name, const CLuaArgument& Variable, ESyncType syncType)
+void CCustomData::Set(const CStringName& name, const CLuaArgument& Variable, ESyncType syncType)
 {
     assert(name);
 
@@ -106,7 +106,7 @@ void CCustomData::Set(CStringName name, const CLuaArgument& Variable, ESyncType 
     }
 }
 
-bool CCustomData::Delete(CStringName name)
+bool CCustomData::Delete(const CStringName& name)
 {
     // Find the item and delete it
     auto it = m_Data.find(name);
@@ -121,7 +121,7 @@ bool CCustomData::Delete(CStringName name)
     return false;
 }
 
-void CCustomData::SetClientChangesMode(CStringName name, eCustomDataClientTrust mode)
+void CCustomData::SetClientChangesMode(const CStringName& name, eCustomDataClientTrust mode)
 {
     SCustomData& pData = m_Data[name];
     pData.clientChangesMode = mode;

--- a/Server/mods/deathmatch/logic/CCustomData.cpp
+++ b/Server/mods/deathmatch/logic/CCustomData.cpp
@@ -14,39 +14,39 @@
 
 void CCustomData::Copy(CCustomData* pCustomData)
 {
-    std::map<std::string, SCustomData>::const_iterator iter = pCustomData->IterBegin();
+    auto iter = pCustomData->IterBegin();
     for (; iter != pCustomData->IterEnd(); iter++)
     {
-        Set(iter->first.c_str(), iter->second.Variable);
+        Set(iter->first, iter->second.Variable);
     }
 }
 
-SCustomData* CCustomData::Get(const char* szName) const
+SCustomData* CCustomData::Get(CStringName name) const
 {
-    assert(szName);
+    assert(name);
 
-    std::map<std::string, SCustomData>::const_iterator it = m_Data.find(szName);
+    auto it = m_Data.find(name);
     if (it != m_Data.end())
         return (SCustomData*)&it->second;
 
     return NULL;
 }
 
-SCustomData* CCustomData::GetSynced(const char* szName)
+SCustomData* CCustomData::GetSynced(CStringName name)
 {
-    assert(szName);
+    assert(name);
 
-    std::map<std::string, SCustomData>::const_iterator it = m_SyncedData.find(szName);
+    auto it = m_SyncedData.find(name);
     if (it != m_SyncedData.end())
         return (SCustomData*)&it->second;
 
     return NULL;
 }
 
-bool CCustomData::DeleteSynced(const char* szName)
+bool CCustomData::DeleteSynced(CStringName name)
 {
     // Find the item and delete it
-    std::map<std::string, SCustomData>::iterator iter = m_SyncedData.find(szName);
+    auto iter = m_SyncedData.find(name);
     if (iter != m_SyncedData.end())
     {
         m_SyncedData.erase(iter);
@@ -57,11 +57,11 @@ bool CCustomData::DeleteSynced(const char* szName)
     return false;
 }
 
-void CCustomData::UpdateSynced(const char* szName, const CLuaArgument& Variable, ESyncType syncType)
+void CCustomData::UpdateSynced(CStringName name, const CLuaArgument& Variable, ESyncType syncType)
 {
     if (syncType == ESyncType::BROADCAST)
     {
-        SCustomData* pDataSynced = GetSynced(szName);
+        SCustomData* pDataSynced = GetSynced(name);
         if (pDataSynced)
         {
             pDataSynced->Variable = Variable;
@@ -72,27 +72,27 @@ void CCustomData::UpdateSynced(const char* szName, const CLuaArgument& Variable,
             SCustomData newData;
             newData.Variable = Variable;
             newData.syncType = syncType;
-            m_SyncedData[szName] = newData;
+            m_SyncedData[name] = newData;
         }
     }
     else
     {
-        DeleteSynced(szName);
+        DeleteSynced(name);
     }
 }
 
-void CCustomData::Set(const char* szName, const CLuaArgument& Variable, ESyncType syncType)
+void CCustomData::Set(CStringName name, const CLuaArgument& Variable, ESyncType syncType)
 {
-    assert(szName);
+    assert(name);
 
     // Grab the item with the given name
-    SCustomData* pData = Get(szName);
+    SCustomData* pData = Get(name);
     if (pData)
     {
         // Update existing
         pData->Variable = Variable;
         pData->syncType = syncType;
-        UpdateSynced(szName, Variable, syncType);
+        UpdateSynced(name, Variable, syncType);
     }
     else
     {
@@ -101,18 +101,18 @@ void CCustomData::Set(const char* szName, const CLuaArgument& Variable, ESyncTyp
         newData.Variable = Variable;
         newData.syncType = syncType;
         newData.clientChangesMode = eCustomDataClientTrust::UNSET;
-        m_Data[szName] = newData;
-        UpdateSynced(szName, Variable, syncType);
+        m_Data[name] = newData;
+        UpdateSynced(name, Variable, syncType);
     }
 }
 
-bool CCustomData::Delete(const char* szName)
+bool CCustomData::Delete(CStringName name)
 {
     // Find the item and delete it
-    std::map<std::string, SCustomData>::iterator it = m_Data.find(szName);
+    auto it = m_Data.find(name);
     if (it != m_Data.end())
     {
-        DeleteSynced(szName);
+        DeleteSynced(name);
         m_Data.erase(it);
         return true;
     }
@@ -121,15 +121,15 @@ bool CCustomData::Delete(const char* szName)
     return false;
 }
 
-void CCustomData::SetClientChangesMode(const char* szName, eCustomDataClientTrust mode)
+void CCustomData::SetClientChangesMode(CStringName name, eCustomDataClientTrust mode)
 {
-    SCustomData& pData = m_Data[szName];
+    SCustomData& pData = m_Data[name];
     pData.clientChangesMode = mode;
 }
 
 CXMLNode* CCustomData::OutputToXML(CXMLNode* pNode)
 {
-    std::map<std::string, SCustomData>::const_iterator iter = m_Data.begin();
+    auto iter = m_Data.begin();
     for (; iter != m_Data.end(); iter++)
     {
         CLuaArgument* arg = (CLuaArgument*)&iter->second.Variable;
@@ -138,19 +138,19 @@ CXMLNode* CCustomData::OutputToXML(CXMLNode* pNode)
         {
             case LUA_TSTRING:
             {
-                CXMLAttribute* attr = pNode->GetAttributes().Create(iter->first.c_str());
+                CXMLAttribute* attr = pNode->GetAttributes().Create(iter->first.ToCString());
                 attr->SetValue(arg->GetString().c_str());
                 break;
             }
             case LUA_TNUMBER:
             {
-                CXMLAttribute* attr = pNode->GetAttributes().Create(iter->first.c_str());
+                CXMLAttribute* attr = pNode->GetAttributes().Create(iter->first.ToCString());
                 attr->SetValue((float)arg->GetNumber());
                 break;
             }
             case LUA_TBOOLEAN:
             {
-                CXMLAttribute* attr = pNode->GetAttributes().Create(iter->first.c_str());
+                CXMLAttribute* attr = pNode->GetAttributes().Create(iter->first.ToCString());
                 attr->SetValue(arg->GetBoolean());
                 break;
             }

--- a/Server/mods/deathmatch/logic/CCustomData.h
+++ b/Server/mods/deathmatch/logic/CCustomData.h
@@ -44,13 +44,13 @@ class CCustomData
 public:
     void Copy(CCustomData* pCustomData);
 
-    SCustomData* Get(CStringName name) const;
-    SCustomData* GetSynced(CStringName name);
-    void         Set(CStringName name, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST);
+    SCustomData* Get(const CStringName& name) const;
+    SCustomData* GetSynced(const CStringName& name);
+    void         Set(const CStringName& name, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST);
 
-    bool Delete(CStringName name);
+    bool Delete(const CStringName& name);
 
-    void SetClientChangesMode(CStringName name, eCustomDataClientTrust mode);
+    void SetClientChangesMode(const CStringName& name, eCustomDataClientTrust mode);
 
     unsigned short CountOnlySynchronized();
 
@@ -63,8 +63,8 @@ public:
     std::unordered_map<CStringName, SCustomData>::const_iterator SyncedIterEnd() { return m_SyncedData.end(); }
 
 private:
-    bool DeleteSynced(CStringName name);
-    void UpdateSynced(CStringName name, const CLuaArgument& Variable, ESyncType syncType);
+    bool DeleteSynced(const CStringName& name);
+    void UpdateSynced(const CStringName& name, const CLuaArgument& Variable, ESyncType syncType);
 
     std::unordered_map<CStringName, SCustomData> m_Data;
     std::unordered_map<CStringName, SCustomData> m_SyncedData;

--- a/Server/mods/deathmatch/logic/CCustomData.h
+++ b/Server/mods/deathmatch/logic/CCustomData.h
@@ -44,28 +44,28 @@ class CCustomData
 public:
     void Copy(CCustomData* pCustomData);
 
-    SCustomData* Get(const char* szName) const;
-    SCustomData* GetSynced(const char* szName);
-    void         Set(const char* szName, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST);
+    SCustomData* Get(CStringName name) const;
+    SCustomData* GetSynced(CStringName name);
+    void         Set(CStringName name, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST);
 
-    bool Delete(const char* szName);
+    bool Delete(CStringName name);
 
-    void SetClientChangesMode(const char* szName, eCustomDataClientTrust mode);
+    void SetClientChangesMode(CStringName name, eCustomDataClientTrust mode);
 
     unsigned short CountOnlySynchronized();
 
     CXMLNode* OutputToXML(CXMLNode* pNode);
 
-    std::map<std::string, SCustomData>::const_iterator IterBegin() { return m_Data.begin(); }
-    std::map<std::string, SCustomData>::const_iterator IterEnd() { return m_Data.end(); }
+    std::unordered_map<CStringName, SCustomData>::const_iterator IterBegin() { return m_Data.begin(); }
+    std::unordered_map<CStringName, SCustomData>::const_iterator IterEnd() { return m_Data.end(); }
 
-    std::map<std::string, SCustomData>::const_iterator SyncedIterBegin() { return m_SyncedData.begin(); }
-    std::map<std::string, SCustomData>::const_iterator SyncedIterEnd() { return m_SyncedData.end(); }
+    std::unordered_map<CStringName, SCustomData>::const_iterator SyncedIterBegin() { return m_SyncedData.begin(); }
+    std::unordered_map<CStringName, SCustomData>::const_iterator SyncedIterEnd() { return m_SyncedData.end(); }
 
 private:
-    bool DeleteSynced(const char* szName);
-    void UpdateSynced(const char* szName, const CLuaArgument& Variable, ESyncType syncType);
+    bool DeleteSynced(CStringName name);
+    void UpdateSynced(CStringName name, const CLuaArgument& Variable, ESyncType syncType);
 
-    std::map<std::string, SCustomData> m_Data;
-    std::map<std::string, SCustomData> m_SyncedData;
+    std::unordered_map<CStringName, SCustomData> m_Data;
+    std::unordered_map<CStringName, SCustomData> m_SyncedData;
 };

--- a/Server/mods/deathmatch/logic/CElement.cpp
+++ b/Server/mods/deathmatch/logic/CElement.cpp
@@ -508,7 +508,7 @@ void CElement::ReadCustomData(CEvents* pEvents, CXMLNode& Node)
     }
 }
 
-CLuaArgument* CElement::GetCustomData(CStringName name, bool bInheritData, ESyncType* pSyncType, eCustomDataClientTrust* clientChangesMode)
+CLuaArgument* CElement::GetCustomData(const CStringName& name, bool bInheritData, ESyncType* pSyncType, eCustomDataClientTrust* clientChangesMode)
 {
     assert(name);
 
@@ -550,7 +550,7 @@ CLuaArguments* CElement::GetAllCustomData(CLuaArguments* table)
     return table;
 }
 
-bool CElement::GetCustomDataString(CStringName name, char* pOut, size_t sizeBuffer, bool bInheritData)
+bool CElement::GetCustomDataString(const CStringName& name, char* pOut, size_t sizeBuffer, bool bInheritData)
 {
     // Grab the custom data variable
     CLuaArgument* pData = GetCustomData(name, bInheritData);
@@ -589,7 +589,7 @@ bool CElement::GetCustomDataString(CStringName name, char* pOut, size_t sizeBuff
     return false;
 }
 
-bool CElement::GetCustomDataInt(CStringName name, int& iOut, bool bInheritData)
+bool CElement::GetCustomDataInt(const CStringName& name, int& iOut, bool bInheritData)
 {
     // Grab the custom data variable
     CLuaArgument* pData = GetCustomData(name, bInheritData);
@@ -627,7 +627,7 @@ bool CElement::GetCustomDataInt(CStringName name, int& iOut, bool bInheritData)
     return false;
 }
 
-bool CElement::GetCustomDataFloat(CStringName name, float& fOut, bool bInheritData)
+bool CElement::GetCustomDataFloat(const CStringName& name, float& fOut, bool bInheritData)
 {
     // Grab the custom data variable
     CLuaArgument* pData = GetCustomData(name, bInheritData);
@@ -654,7 +654,7 @@ bool CElement::GetCustomDataFloat(CStringName name, float& fOut, bool bInheritDa
     return false;
 }
 
-bool CElement::GetCustomDataBool(CStringName name, bool& bOut, bool bInheritData)
+bool CElement::GetCustomDataBool(const CStringName& name, bool& bOut, bool bInheritData)
 {
     // Grab the custom data variable
     CLuaArgument* pData = GetCustomData(name, bInheritData);
@@ -709,7 +709,7 @@ bool CElement::GetCustomDataBool(CStringName name, bool& bOut, bool bInheritData
     return false;
 }
 
-void CElement::SetCustomData(CStringName name, const CLuaArgument& Variable, ESyncType syncType, CPlayer* pClient, bool bTriggerEvent)
+void CElement::SetCustomData(const CStringName& name, const CLuaArgument& Variable, ESyncType syncType, CPlayer* pClient, bool bTriggerEvent)
 {
     assert(name);
     if (name->length() > MAX_CUSTOMDATA_NAME_LENGTH)
@@ -741,7 +741,7 @@ void CElement::SetCustomData(CStringName name, const CLuaArgument& Variable, ESy
     }
 }
 
-void CElement::DeleteCustomData(CStringName name)
+void CElement::DeleteCustomData(const CStringName& name)
 {
     // Grab the old variable
     SCustomData* pData = m_CustomData.Get(name);

--- a/Server/mods/deathmatch/logic/CElement.cpp
+++ b/Server/mods/deathmatch/logic/CElement.cpp
@@ -508,12 +508,12 @@ void CElement::ReadCustomData(CEvents* pEvents, CXMLNode& Node)
     }
 }
 
-CLuaArgument* CElement::GetCustomData(const char* szName, bool bInheritData, ESyncType* pSyncType, eCustomDataClientTrust* clientChangesMode)
+CLuaArgument* CElement::GetCustomData(CStringName name, bool bInheritData, ESyncType* pSyncType, eCustomDataClientTrust* clientChangesMode)
 {
-    assert(szName);
+    assert(name);
 
     // Grab it and return a pointer to the variable
-    SCustomData* pData = m_CustomData.Get(szName);
+    SCustomData* pData = m_CustomData.Get(name);
     if (pData)
     {
         if (pSyncType)
@@ -528,7 +528,7 @@ CLuaArgument* CElement::GetCustomData(const char* szName, bool bInheritData, ESy
     // If none, try returning parent's custom data
     if (bInheritData && m_pParent)
     {
-        return m_pParent->GetCustomData(szName, true, pSyncType, clientChangesMode);
+        return m_pParent->GetCustomData(name, true, pSyncType, clientChangesMode);
     }
 
     // None available
@@ -540,20 +540,20 @@ CLuaArguments* CElement::GetAllCustomData(CLuaArguments* table)
     assert(table);
 
     // Grab it and return a pointer to the variable
-    map<string, SCustomData>::const_iterator iter = m_CustomData.IterBegin();
+    auto iter = m_CustomData.IterBegin();
     for (; iter != m_CustomData.IterEnd(); iter++)
     {
-        table->PushString(iter->first.c_str());                // key
+        table->PushString(iter->first);                        // key
         table->PushArgument(iter->second.Variable);            // value
     }
 
     return table;
 }
 
-bool CElement::GetCustomDataString(const char* szName, char* pOut, size_t sizeBuffer, bool bInheritData)
+bool CElement::GetCustomDataString(CStringName name, char* pOut, size_t sizeBuffer, bool bInheritData)
 {
     // Grab the custom data variable
-    CLuaArgument* pData = GetCustomData(szName, bInheritData);
+    CLuaArgument* pData = GetCustomData(name, bInheritData);
     if (pData)
     {
         // Make sure it gets 0 terminated
@@ -589,10 +589,10 @@ bool CElement::GetCustomDataString(const char* szName, char* pOut, size_t sizeBu
     return false;
 }
 
-bool CElement::GetCustomDataInt(const char* szName, int& iOut, bool bInheritData)
+bool CElement::GetCustomDataInt(CStringName name, int& iOut, bool bInheritData)
 {
     // Grab the custom data variable
-    CLuaArgument* pData = GetCustomData(szName, bInheritData);
+    CLuaArgument* pData = GetCustomData(name, bInheritData);
     if (pData)
     {
         // Write the content depending on what type it is
@@ -627,10 +627,10 @@ bool CElement::GetCustomDataInt(const char* szName, int& iOut, bool bInheritData
     return false;
 }
 
-bool CElement::GetCustomDataFloat(const char* szName, float& fOut, bool bInheritData)
+bool CElement::GetCustomDataFloat(CStringName name, float& fOut, bool bInheritData)
 {
     // Grab the custom data variable
-    CLuaArgument* pData = GetCustomData(szName, bInheritData);
+    CLuaArgument* pData = GetCustomData(name, bInheritData);
     if (pData)
     {
         // Write the content depending on what type it is
@@ -654,10 +654,10 @@ bool CElement::GetCustomDataFloat(const char* szName, float& fOut, bool bInherit
     return false;
 }
 
-bool CElement::GetCustomDataBool(const char* szName, bool& bOut, bool bInheritData)
+bool CElement::GetCustomDataBool(CStringName name, bool& bOut, bool bInheritData)
 {
     // Grab the custom data variable
-    CLuaArgument* pData = GetCustomData(szName, bInheritData);
+    CLuaArgument* pData = GetCustomData(name, bInheritData);
     if (pData)
     {
         // Write the content depending on what type it is
@@ -709,53 +709,53 @@ bool CElement::GetCustomDataBool(const char* szName, bool& bOut, bool bInheritDa
     return false;
 }
 
-void CElement::SetCustomData(const char* szName, const CLuaArgument& Variable, ESyncType syncType, CPlayer* pClient, bool bTriggerEvent)
+void CElement::SetCustomData(CStringName name, const CLuaArgument& Variable, ESyncType syncType, CPlayer* pClient, bool bTriggerEvent)
 {
-    assert(szName);
-    if (strlen(szName) > MAX_CUSTOMDATA_NAME_LENGTH)
+    assert(name);
+    if (name->length() > MAX_CUSTOMDATA_NAME_LENGTH)
     {
         // Don't allow it to be set if the name is too long
-        CLogger::ErrorPrintf("Custom data name too long (%s)\n", *SStringX(szName).Left(MAX_CUSTOMDATA_NAME_LENGTH + 1));
+        CLogger::ErrorPrintf("Custom data name too long (%s)\n", *SStringX(name.ToCString()).Left(MAX_CUSTOMDATA_NAME_LENGTH + 1));
         return;
     }
 
     // Grab the old variable
     CLuaArgument       oldVariable;
-    const SCustomData* pData = m_CustomData.Get(szName);
+    const SCustomData* pData = m_CustomData.Get(name);
     if (pData)
     {
         oldVariable = pData->Variable;
     }
 
     // Set the new data
-    m_CustomData.Set(szName, Variable, syncType);
+    m_CustomData.Set(name, Variable, syncType);
 
     if (bTriggerEvent)
     {
         // Trigger the onElementDataChange event on us
         CLuaArguments Arguments;
-        Arguments.PushString(szName);
+        Arguments.PushString(name);
         Arguments.PushArgument(oldVariable);
         Arguments.PushArgument(Variable);
         CallEvent("onElementDataChange", Arguments, pClient);
     }
 }
 
-void CElement::DeleteCustomData(const char* szName)
+void CElement::DeleteCustomData(CStringName name)
 {
     // Grab the old variable
-    SCustomData* pData = m_CustomData.Get(szName);
+    SCustomData* pData = m_CustomData.Get(name);
     if (pData)
     {
         CLuaArgument oldVariable;
         oldVariable = pData->Variable;
 
         // Delete the custom data
-        m_CustomData.Delete(szName);
+        m_CustomData.Delete(name);
 
         // Trigger the onElementDataChange event on us
         CLuaArguments Arguments;
-        Arguments.PushString(szName);
+        Arguments.PushString(name);
         Arguments.PushArgument(oldVariable);
         Arguments.PushArgument(CLuaArgument());            // Use nil as the new value to indicate the data has been removed
         CallEvent("onElementDataChange", Arguments);
@@ -765,22 +765,22 @@ void CElement::DeleteCustomData(const char* szName)
 // Used to send the root element data when a player joins
 void CElement::SendAllCustomData(CPlayer* pPlayer)
 {
-    for (map<std::string, SCustomData>::const_iterator iter = m_CustomData.SyncedIterBegin(); iter != m_CustomData.SyncedIterEnd(); ++iter)
+    for (auto iter = m_CustomData.SyncedIterBegin(); iter != m_CustomData.SyncedIterEnd(); ++iter)
     {
-        const std::string& strName = iter->first;
+        const CStringName& name = iter->first;
         const SCustomData& customData = iter->second;
 
         if (customData.syncType == ESyncType::LOCAL)
             continue;
 
         // Tell our clients to update their data
-        unsigned short usNameLength = static_cast<unsigned short>(strName.length());
+        unsigned short usNameLength = static_cast<unsigned short>(name->length());
         CBitStream     BitStream;
         BitStream.pBitStream->WriteCompressed(usNameLength);
-        BitStream.pBitStream->Write(strName.c_str(), usNameLength);
+        BitStream.pBitStream->Write(name.ToCString(), usNameLength);
         customData.Variable.WriteToBitStream(*BitStream.pBitStream);
 
-        if (customData.syncType == ESyncType::BROADCAST || pPlayer->IsSubscribed(this, strName))
+        if (customData.syncType == ESyncType::BROADCAST || pPlayer->IsSubscribed(this, name))
             pPlayer->Send(CElementRPCPacket(this, SET_ELEMENT_DATA, *BitStream.pBitStream));
     }
 }

--- a/Server/mods/deathmatch/logic/CElement.h
+++ b/Server/mods/deathmatch/logic/CElement.h
@@ -20,6 +20,7 @@
 #include <cstring>
 #include "Enums.h"
 #include "CElementGroup.h"
+#include "CStringName.h"
 
 // Used to check fast version of getElementsByType
 // #define CHECK_ENTITIES_FROM_ROOT  MTA_DEBUG
@@ -138,15 +139,15 @@ public:
 
     void           ReadCustomData(CEvents* pEvents, CXMLNode& Node);
     CCustomData&   GetCustomDataManager() { return m_CustomData; }
-    CLuaArgument*  GetCustomData(const char* szName, bool bInheritData, ESyncType* pSyncType = nullptr, eCustomDataClientTrust* clientChangesMode = nullptr);
+    CLuaArgument*  GetCustomData(CStringName name, bool bInheritData, ESyncType* pSyncType = nullptr, eCustomDataClientTrust* clientChangesMode = nullptr);
     CLuaArguments* GetAllCustomData(CLuaArguments* table);
-    bool           GetCustomDataString(const char* szName, char* pOut, size_t sizeBuffer, bool bInheritData);
-    bool           GetCustomDataInt(const char* szName, int& iOut, bool bInheritData);
-    bool           GetCustomDataFloat(const char* szName, float& fOut, bool bInheritData);
-    bool           GetCustomDataBool(const char* szName, bool& bOut, bool bInheritData);
-    void           SetCustomData(const char* szName, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST, CPlayer* pClient = NULL,
+    bool           GetCustomDataString(CStringName name, char* pOut, size_t sizeBuffer, bool bInheritData);
+    bool           GetCustomDataInt(CStringName name, int& iOut, bool bInheritData);
+    bool           GetCustomDataFloat(CStringName name, float& fOut, bool bInheritData);
+    bool           GetCustomDataBool(CStringName name, bool& bOut, bool bInheritData);
+    void           SetCustomData(CStringName name, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST, CPlayer* pClient = NULL,
                                  bool bTriggerEvent = true);
-    void           DeleteCustomData(const char* szName);
+    void           DeleteCustomData(CStringName name);
     void           SendAllCustomData(CPlayer* pPlayer);
 
     CXMLNode* OutputToXML(CXMLNode* pNode);

--- a/Server/mods/deathmatch/logic/CElement.h
+++ b/Server/mods/deathmatch/logic/CElement.h
@@ -139,15 +139,15 @@ public:
 
     void           ReadCustomData(CEvents* pEvents, CXMLNode& Node);
     CCustomData&   GetCustomDataManager() { return m_CustomData; }
-    CLuaArgument*  GetCustomData(CStringName name, bool bInheritData, ESyncType* pSyncType = nullptr, eCustomDataClientTrust* clientChangesMode = nullptr);
+    CLuaArgument*  GetCustomData(const CStringName& name, bool bInheritData, ESyncType* pSyncType = nullptr, eCustomDataClientTrust* clientChangesMode = nullptr);
     CLuaArguments* GetAllCustomData(CLuaArguments* table);
-    bool           GetCustomDataString(CStringName name, char* pOut, size_t sizeBuffer, bool bInheritData);
-    bool           GetCustomDataInt(CStringName name, int& iOut, bool bInheritData);
-    bool           GetCustomDataFloat(CStringName name, float& fOut, bool bInheritData);
-    bool           GetCustomDataBool(CStringName name, bool& bOut, bool bInheritData);
-    void           SetCustomData(CStringName name, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST, CPlayer* pClient = NULL,
+    bool           GetCustomDataString(const CStringName& name, char* pOut, size_t sizeBuffer, bool bInheritData);
+    bool           GetCustomDataInt(const CStringName& name, int& iOut, bool bInheritData);
+    bool           GetCustomDataFloat(const CStringName& name, float& fOut, bool bInheritData);
+    bool           GetCustomDataBool(const CStringName& name, bool& bOut, bool bInheritData);
+    void           SetCustomData(const CStringName& name, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST, CPlayer* pClient = NULL,
                                  bool bTriggerEvent = true);
-    void           DeleteCustomData(CStringName name);
+    void           DeleteCustomData(const CStringName& name);
     void           SendAllCustomData(CPlayer* pPlayer);
 
     CXMLNode* OutputToXML(CXMLNode* pNode);

--- a/Server/mods/deathmatch/logic/CPlayer.cpp
+++ b/Server/mods/deathmatch/logic/CPlayer.cpp
@@ -217,16 +217,16 @@ bool CPlayer::ShouldIgnoreMinClientVersionChecks()
     return false;
 }
 
-bool CPlayer::SubscribeElementData(CElement* pElement, const std::string& strName)
+bool CPlayer::SubscribeElementData(CElement* pElement, CStringName name)
 {
-    OutputDebugLine(SString("[Data] SubscribeElementData %s [%s]", GetNick(), strName.c_str()));
-    return m_DataSubscriptions.emplace(std::make_pair(pElement, strName)).second;
+    OutputDebugLine(SString("[Data] SubscribeElementData %s [%s]", GetNick(), name.ToCString()));
+    return m_DataSubscriptions.emplace(std::make_pair(pElement, name)).second;
 }
 
-bool CPlayer::UnsubscribeElementData(CElement* pElement, const std::string& strName)
+bool CPlayer::UnsubscribeElementData(CElement* pElement, CStringName name)
 {
-    OutputDebugLine(SString("[Data] UnsubscribeElementData %s [%s]", GetNick(), strName.c_str()));
-    return m_DataSubscriptions.erase(std::make_pair(pElement, strName)) > 0;
+    OutputDebugLine(SString("[Data] UnsubscribeElementData %s [%s]", GetNick(), name.ToCString()));
+    return m_DataSubscriptions.erase(std::make_pair(pElement, name)) > 0;
 }
 
 bool CPlayer::UnsubscribeElementData(CElement* pElement)
@@ -237,7 +237,7 @@ bool CPlayer::UnsubscribeElementData(CElement* pElement)
     {
         if (it->first == pElement)
         {
-            OutputDebugLine(SString("[Data] UnsubscribeElementData %s [%s]", GetNick(), it->second.c_str()));
+            OutputDebugLine(SString("[Data] UnsubscribeElementData %s [%s]", GetNick(), it->second.ToCString()));
             it = m_DataSubscriptions.erase(it);
             erased = true;
         }
@@ -248,9 +248,9 @@ bool CPlayer::UnsubscribeElementData(CElement* pElement)
     return erased;
 }
 
-bool CPlayer::IsSubscribed(CElement* pElement, const std::string& strName) const
+bool CPlayer::IsSubscribed(CElement* pElement, CStringName name) const
 {
-    return m_DataSubscriptions.find(std::make_pair(pElement, strName)) != m_DataSubscriptions.end();
+    return m_DataSubscriptions.find(std::make_pair(pElement, name)) != m_DataSubscriptions.end();
 }
 
 const char* CPlayer::GetSourceIP()

--- a/Server/mods/deathmatch/logic/CPlayer.h
+++ b/Server/mods/deathmatch/logic/CPlayer.h
@@ -23,6 +23,7 @@ class CPlayer;
 #include "CObject.h"
 #include "packets/CPacket.h"
 #include "packets/CPlayerStatsPacket.h"
+#include "CStringName.h"
 class CKeyBinds;
 class CPlayerCamera;
 enum class eVehicleAimDirection : unsigned char;
@@ -104,10 +105,10 @@ public:
     bool IsJoined() { return m_bIsJoined; }
     void SetJoined() { m_bIsJoined = true; }
 
-    bool SubscribeElementData(CElement* pElement, const std::string& strName);
-    bool UnsubscribeElementData(CElement* pElement, const std::string& strName);
+    bool SubscribeElementData(CElement* pElement, CStringName name);
+    bool UnsubscribeElementData(CElement* pElement, CStringName name);
     bool UnsubscribeElementData(CElement* pElement);
-    bool IsSubscribed(CElement* pElement, const std::string& strName) const;
+    bool IsSubscribed(CElement* pElement, CStringName name) const;
 
     float GetCameraRotation() { return m_fCameraRotation; };
     void  SetCameraRotation(float fRotation) { m_fCameraRotation = fRotation; };
@@ -432,7 +433,7 @@ private:
 
     std::map<std::string, std::string> m_AnnounceValues;
 
-    std::set<std::pair<CElement*, std::string>> m_DataSubscriptions;
+    std::set<std::pair<CElement*, CStringName>> m_DataSubscriptions;
 
     uint m_uiWeaponIncorrectCount;
 

--- a/Server/mods/deathmatch/logic/CPlayerManager.cpp
+++ b/Server/mods/deathmatch/logic/CPlayerManager.cpp
@@ -351,7 +351,7 @@ bool CPlayerManager::IsValidPlayerModel(unsigned short model)
     }
 }
 
-void CPlayerManager::ClearElementData(CElement* pElement, const std::string& name)
+void CPlayerManager::ClearElementData(CElement* pElement, CStringName name)
 {
     list<CPlayer*>::const_iterator iter = m_Players.begin();
     for (; iter != m_Players.end(); iter++)

--- a/Server/mods/deathmatch/logic/CPlayerManager.h
+++ b/Server/mods/deathmatch/logic/CPlayerManager.h
@@ -56,7 +56,7 @@ public:
 
     static bool IsValidPlayerModel(unsigned short model);
 
-    void ClearElementData(CElement* pElement, const std::string& name);
+    void ClearElementData(CElement* pElement, CStringName name);
     void ClearElementData(CElement* pElement);
 
     void               ResetAll();

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -51,7 +51,7 @@ public:
     static CElement*      GetElementByIndex(const char* szType, unsigned int uiIndex);
     static CElement*      GetElementChild(CElement* pElement, unsigned int uiIndex);
     static bool           GetElementChildrenCount(CElement* pElement, unsigned int& uiCount);
-    static CLuaArgument*  GetElementData(CElement* pElement, const char* szName, bool bInherit);
+    static CLuaArgument*  GetElementData(CElement* pElement, CStringName name, bool bInherit);
     static CLuaArguments* GetAllElementData(CElement* pElement, CLuaArguments* table);
     static CElement*      GetElementParent(CElement* pElement);
     static bool           GetElementMatrix(CElement* pElement, CMatrix& matrix);
@@ -83,12 +83,12 @@ public:
     // Element set funcs
     static bool ClearElementVisibleTo(CElement* pElement);
     static bool SetElementID(CElement* pElement, const char* szID);
-    static bool SetElementData(CElement* pElement, const char* szName, const CLuaArgument& Variable, ESyncType syncType,
+    static bool SetElementData(CElement* pElement, CStringName name, const CLuaArgument& Variable, ESyncType syncType,
                                std::optional<eCustomDataClientTrust> clientTrust);
-    static bool RemoveElementData(CElement* pElement, const char* szName);
-    static bool AddElementDataSubscriber(CElement* pElement, const char* szName, CPlayer* pPlayer);
-    static bool RemoveElementDataSubscriber(CElement* pElement, const char* szName, CPlayer* pPlayer);
-    static bool HasElementDataSubscriber(CElement* pElement, const char* szName, CPlayer* pPlayer);
+    static bool RemoveElementData(CElement* pElement, CStringName name);
+    static bool AddElementDataSubscriber(CElement* pElement, CStringName name, CPlayer* pPlayer);
+    static bool RemoveElementDataSubscriber(CElement* pElement, CStringName name, CPlayer* pPlayer);
+    static bool HasElementDataSubscriber(CElement* pElement, CStringName name, CPlayer* pPlayer);
     static bool SetElementParent(CElement* pElement, CElement* pParent);
     static bool SetElementMatrix(CElement* pElement, const CMatrix& matrix);
     static bool SetElementPosition(CElement* pElement, const CVector& vecPosition, bool bWarp = true);

--- a/Server/mods/deathmatch/logic/lua/CLuaArgument.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaArgument.cpp
@@ -339,6 +339,13 @@ void CLuaArgument::ReadString(const std::string_view& string)
     m_strString = string;
 }
 
+void CLuaArgument::ReadString(CStringName string)
+{
+    m_iType = LUA_TSTRING;
+    DeleteTableData();
+    m_strString = string.ToString();
+}
+
 void CLuaArgument::ReadString(const char* string)
 {
     m_iType = LUA_TSTRING;

--- a/Server/mods/deathmatch/logic/lua/CLuaArgument.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaArgument.cpp
@@ -339,7 +339,7 @@ void CLuaArgument::ReadString(const std::string_view& string)
     m_strString = string;
 }
 
-void CLuaArgument::ReadString(CStringName string)
+void CLuaArgument::ReadString(const CStringName& string)
 {
     m_iType = LUA_TSTRING;
     DeleteTableData();

--- a/Server/mods/deathmatch/logic/lua/CLuaArgument.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaArgument.h
@@ -45,6 +45,7 @@ public:
     void ReadNumber(double dNumber);
     void ReadString(const std::string& string);
     void ReadString(const std::string_view& string);
+    void ReadString(CStringName string);
     void ReadString(const char* string);
     void ReadElement(CElement* pElement);
     void ReadElementID(ElementID ID);

--- a/Server/mods/deathmatch/logic/lua/CLuaArgument.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaArgument.h
@@ -45,7 +45,7 @@ public:
     void ReadNumber(double dNumber);
     void ReadString(const std::string& string);
     void ReadString(const std::string_view& string);
-    void ReadString(CStringName string);
+    void ReadString(const CStringName& string);
     void ReadString(const char* string);
     void ReadElement(CElement* pElement);
     void ReadElementID(ElementID ID);

--- a/Server/mods/deathmatch/logic/lua/CLuaArguments.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaArguments.cpp
@@ -372,7 +372,7 @@ CLuaArgument* CLuaArguments::PushString(const std::string_view& string)
     return arg;
 }
 
-CLuaArgument* CLuaArguments::PushString(CStringName string)
+CLuaArgument* CLuaArguments::PushString(const CStringName& string)
 {
     CLuaArgument* arg = new CLuaArgument();
     arg->ReadString(string);

--- a/Server/mods/deathmatch/logic/lua/CLuaArguments.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaArguments.cpp
@@ -372,6 +372,14 @@ CLuaArgument* CLuaArguments::PushString(const std::string_view& string)
     return arg;
 }
 
+CLuaArgument* CLuaArguments::PushString(CStringName string)
+{
+    CLuaArgument* arg = new CLuaArgument();
+    arg->ReadString(string);
+    m_Arguments.push_back(arg);
+    return arg;
+}
+
 CLuaArgument* CLuaArguments::PushString(const char* string)
 {
     CLuaArgument* arg = new CLuaArgument();

--- a/Server/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -69,7 +69,7 @@ public:
     CLuaArgument* PushNumber(double dNumber);
     CLuaArgument* PushString(const std::string& string);
     CLuaArgument* PushString(const std::string_view& string);
-    CLuaArgument* PushString(CStringName string);
+    CLuaArgument* PushString(const CStringName& string);
     CLuaArgument* PushString(const char* string);
     CLuaArgument* PushElement(CElement* pElement);
     CLuaArgument* PushBan(CBan* pBan);

--- a/Server/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -69,6 +69,7 @@ public:
     CLuaArgument* PushNumber(double dNumber);
     CLuaArgument* PushString(const std::string& string);
     CLuaArgument* PushString(const std::string_view& string);
+    CLuaArgument* PushString(CStringName string);
     CLuaArgument* PushString(const char* string);
     CLuaArgument* PushElement(CElement* pElement);
     CLuaArgument* PushBan(CBan* pBan);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -1579,7 +1579,7 @@ int CLuaElementDefs::setElementData(lua_State* luaVM)
             key = key->substr(0, MAX_CUSTOMDATA_NAME_LENGTH);
         }
 
-        if (CStaticFunctionDefinitions::SetElementData(pElement, key.ToCString(), value, syncType, clientTrust))
+        if (CStaticFunctionDefinitions::SetElementData(pElement, key, value, syncType, clientTrust))
         {
             lua_pushboolean(luaVM, true);
             return 1;

--- a/Server/mods/deathmatch/logic/packets/CEntityAddPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CEntityAddPacket.cpp
@@ -177,15 +177,15 @@ bool CEntityAddPacket::Write(NetBitStreamInterface& BitStream) const
             // Write custom data
             CCustomData& pCustomData = pElement->GetCustomDataManager();
             BitStream.WriteCompressed(pCustomData.CountOnlySynchronized());
-            map<string, SCustomData>::const_iterator iter = pCustomData.SyncedIterBegin();
+            auto iter = pCustomData.SyncedIterBegin();
             for (; iter != pCustomData.SyncedIterEnd(); ++iter)
             {
-                const char*         szName = iter->first.c_str();
+                const CStringName   name = iter->first;
                 const CLuaArgument* pArgument = &iter->second.Variable;
 
-                unsigned char ucNameLength = static_cast<unsigned char>(strlen(szName));
+                unsigned char ucNameLength = static_cast<unsigned char>(name->length());
                 BitStream.Write(ucNameLength);
-                BitStream.Write(szName, ucNameLength);
+                BitStream.Write(name.ToCString(), ucNameLength);
                 pArgument->WriteToBitStream(BitStream);
             }
 

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaElementDefsShared.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaElementDefsShared.cpp
@@ -42,9 +42,9 @@ int CLuaElementDefs::GetElementData(lua_State* luaVM)
             }
 
 #ifdef MTA_CLIENT
-            CLuaArgument* pVariable = pElement->GetCustomData(key.ToCString(), bInherit);
+            CLuaArgument* pVariable = pElement->GetCustomData(key, bInherit);
 #else
-            CLuaArgument* pVariable = CStaticFunctionDefinitions::GetElementData(pElement, key.ToCString(), bInherit);
+            CLuaArgument* pVariable = CStaticFunctionDefinitions::GetElementData(pElement, key, bInherit);
 #endif
             if (pVariable)
             {


### PR DESCRIPTION
This is the second iteration of the element data optimization challenge. The first one see in there: #4169. This is a part of the reimplementation of #3287. This PR is aimed to eliminating unnessesary string copying. It also brings a faster element data lookup inside `std` containers.
