### PR TITLE
`getElementDistanceFromCentreOfMassToBaseOfModel` add 'building'

### DIFF
--- a/Client/mods/deathmatch/logic/CClientBuilding.cpp
+++ b/Client/mods/deathmatch/logic/CClientBuilding.cpp
@@ -191,3 +191,8 @@ bool CClientBuilding::SetLowLodBuilding(CClientBuilding* pLod)
     }
     return true;
 }
+
+float CClientBuilding::GetDistanceFromCentreOfMassToBaseOfModel()
+{
+    return m_pBuilding ? m_pBuilding->GetDistanceFromCentreOfMassToBaseOfModel() : 0.0f;
+}

--- a/Client/mods/deathmatch/logic/CClientBuilding.h
+++ b/Client/mods/deathmatch/logic/CClientBuilding.h
@@ -55,6 +55,7 @@ public:
     bool SetLowLodBuilding(CClientBuilding* pLod = nullptr);
     bool IsLod() const noexcept { return m_pHighBuilding != nullptr; };
 
+    float GetDistanceFromCentreOfMassToBaseOfModel();
 
 private:
     CClientBuilding* GetHighLodBuilding() const { return m_pHighBuilding; }; 

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -675,6 +675,11 @@ bool CStaticFunctionDefinitions::GetElementDistanceFromCentreOfMassToBaseOfModel
             fDistance = static_cast<CClientObject&>(Entity).GetDistanceFromCentreOfMassToBaseOfModel();
             return true;
         }
+        case CCLIENTBUILDING:
+        {
+            fDistance = static_cast<CClientBuilding&>(Entity).GetDistanceFromCentreOfMassToBaseOfModel();
+            return true;
+        }
     }
 
     return false;


### PR DESCRIPTION
Fixes: #4495
This PR adds building element into [getElementDistanceFromCentreOfMassToBaseOfModel](https://wiki.multitheftauto.com/wiki/GetElementDistanceFromCentreOfMassToBaseOfModel) 