### PR TITLE
Crashfix (uninitialized ptr)

### DIFF
--- a/Client/core/CLocalization.h
+++ b/Client/core/CLocalization.h
@@ -44,5 +44,5 @@ public:
 private:
     DictionaryManager             m_DictManager;
     std::map<SString, CLanguage*> m_LanguageMap;
-    CLanguage*                    m_pCurrentLang;
+    CLanguage*                    m_pCurrentLang{};
 };


### PR DESCRIPTION
`m_pCurrentLang` pointer is uninitialized currently which is UB and causes random crashes during a startup process. This PR fixes it.