### PR TITLE
Resolve CLocalization / CGUI memory leaks

### DIFF
--- a/Client/core/CGUI.cpp
+++ b/Client/core/CGUI.cpp
@@ -134,6 +134,10 @@ void CLocalGUI::ChangeLocale(const char* szName)
 
     m_LastLocaleName = strCanonicalLocale;
 
+    // Attempt CEGUI cleanup
+    if (CGUI* pGUI = CCore::GetSingleton().GetGUI())
+        pGUI->Cleanup();
+
     if (guiWasLoaded)
     {
         CreateWindows(guiWasLoaded);

--- a/Client/core/CLocalization.cpp
+++ b/Client/core/CLocalization.cpp
@@ -41,7 +41,7 @@ CLocalization::CLocalization(const SString& strLocale, const SString& strLocaleP
 
 CLocalization::~CLocalization()
 {
-    // m_LanguageMap now uses unique_ptr so cleanup is automatic
+    m_pCurrentLang = nullptr;
 }
 
 //

--- a/Client/core/CLocalization.cpp
+++ b/Client/core/CLocalization.cpp
@@ -41,10 +41,7 @@ CLocalization::CLocalization(const SString& strLocale, const SString& strLocaleP
 
 CLocalization::~CLocalization()
 {
-    for (auto iter : m_LanguageMap)
-    {
-        delete iter.second;
-    }
+    // m_LanguageMap now uses unique_ptr so cleanup is automatic
 }
 
 //
@@ -99,29 +96,32 @@ void CLocalization::SetCurrentLanguage(SString strLocale)
 CLanguage* CLocalization::GetLanguage(SString strLocale)
 {
     strLocale = ValidateLocale(strLocale);
-    CLanguage* pLanguage = MapFindRef(m_LanguageMap, strLocale);
-    if (!pLanguage)
+    auto iter = m_LanguageMap.find(strLocale);
+    if (iter != m_LanguageMap.end())
     {
-        Language Lang = Language::from_name(strLocale);
-        Lang = Lang ? Lang : Language::from_name("en_US");
-
-        try
-        {
-            pLanguage = new CLanguage(m_DictManager.get_dictionary(Lang, MTA_LOCALE_TEXTDOMAIN), Lang.str(), Lang.get_name());
-            MapSet(m_LanguageMap, strLocale, pLanguage);
-        }
-        catch (const std::exception& ex)
-        {
-            WriteDebugEvent(SString("Localization failed to load dictionary for '%s': %s", strLocale.c_str(), ex.what()));
-            return (strLocale != "en_US") ? GetLanguage("en_US") : nullptr;
-        }
-        catch (...)
-        {
-            WriteDebugEvent(SString("Localization failed to load dictionary for '%s': unknown error", strLocale.c_str()));
-            return (strLocale != "en_US") ? GetLanguage("en_US") : nullptr;
-        }
+        return iter->second.get();
     }
-    return pLanguage;
+
+    Language Lang = Language::from_name(strLocale);
+    Lang = Lang ? Lang : Language::from_name("en_US");
+
+    try
+    {
+        std::unique_ptr<CLanguage> pLanguage = std::make_unique<CLanguage>(m_DictManager.get_dictionary(Lang, MTA_LOCALE_TEXTDOMAIN), Lang.str(), Lang.get_name());
+        CLanguage* pLanguagePtr = pLanguage.get();
+        m_LanguageMap.emplace(strLocale, std::move(pLanguage));
+        return pLanguagePtr;
+    }
+    catch (const std::exception& ex)
+    {
+        WriteDebugEvent(SString("Localization failed to load dictionary for '%s': %s", strLocale.c_str(), ex.what()));
+        return (strLocale != "en_US") ? GetLanguage("en_US") : nullptr;
+    }
+    catch (...)
+    {
+        WriteDebugEvent(SString("Localization failed to load dictionary for '%s': unknown error", strLocale.c_str()));
+        return (strLocale != "en_US") ? GetLanguage("en_US") : nullptr;
+    }
 }
 
 //

--- a/Client/core/CLocalization.h
+++ b/Client/core/CLocalization.h
@@ -13,6 +13,7 @@ using namespace tinygettext;
 
 #include <core/CLocalizationInterface.h>
 #include "CLanguage.h"
+#include <memory>
 #define MTA_LOCALE_DIR "MTA/locale/"
 
 #pragma once

--- a/Client/core/CLocalization.h
+++ b/Client/core/CLocalization.h
@@ -13,7 +13,7 @@ using namespace tinygettext;
 
 #include <core/CLocalizationInterface.h>
 #include "CLanguage.h"
-#define MTA_LOCALE_DIR  "MTA/locale/"
+#define MTA_LOCALE_DIR "MTA/locale/"
 
 #pragma once
 
@@ -42,7 +42,7 @@ public:
     static void LogCallback(const std::string& str);
 
 private:
-    DictionaryManager             m_DictManager;
-    std::map<SString, CLanguage*> m_LanguageMap;
-    CLanguage*                    m_pCurrentLang{};
+    DictionaryManager                             m_DictManager;
+    std::map<SString, std::unique_ptr<CLanguage>> m_LanguageMap;
+    CLanguage*                                    m_pCurrentLang{};
 };

--- a/Client/gui/CGUI_Impl.cpp
+++ b/Client/gui/CGUI_Impl.cpp
@@ -330,28 +330,31 @@ bool CGUI_Impl::GetGUIInputEnabled()
             break;
         case INPUTMODE_NO_BINDS_ON_EDIT:
         {
-            CEGUI::Window* pActiveWindow = m_pTop->getActiveChild();
-            if (!pActiveWindow || pActiveWindow == m_pTop || !pActiveWindow->isVisible())
+            if (m_pTop)
             {
-                return false;
-            }
-            if (pActiveWindow->getType() == "CGUI/Editbox")
-            {
-                CEGUI::Editbox* pEditBox = reinterpret_cast<CEGUI::Editbox*>(pActiveWindow);
-                return (!pEditBox->isReadOnly() && pEditBox->hasInputFocus());
-            }
-            else if (pActiveWindow->getType() == "CGUI/MultiLineEditbox")
-            {
-                CEGUI::MultiLineEditbox* pMultiLineEditBox = reinterpret_cast<CEGUI::MultiLineEditbox*>(pActiveWindow);
-                return (!pMultiLineEditBox->isReadOnly() && pMultiLineEditBox->hasInputFocus());
-            }
-            else if (pActiveWindow->getType() == CGUIWEBBROWSER_NAME)
-            {
-                auto pElement = reinterpret_cast<CGUIElement_Impl*>(pActiveWindow->getUserData());
-                if (pElement->GetType() == CGUI_WEBBROWSER)
+                CEGUI::Window* pActiveWindow = m_pTop->getActiveChild();
+                if (!pActiveWindow || pActiveWindow == m_pTop || !pActiveWindow->isVisible())
                 {
-                    auto pWebBrowser = reinterpret_cast<CGUIWebBrowser_Impl*>(pElement);
-                    return pWebBrowser->HasInputFocus();
+                    return false;
+                }
+                if (pActiveWindow->getType() == "CGUI/Editbox")
+                {
+                    CEGUI::Editbox* pEditBox = reinterpret_cast<CEGUI::Editbox*>(pActiveWindow);
+                    return (!pEditBox->isReadOnly() && pEditBox->hasInputFocus());
+                }
+                else if (pActiveWindow->getType() == "CGUI/MultiLineEditbox")
+                {
+                    CEGUI::MultiLineEditbox* pMultiLineEditBox = reinterpret_cast<CEGUI::MultiLineEditbox*>(pActiveWindow);
+                    return (!pMultiLineEditBox->isReadOnly() && pMultiLineEditBox->hasInputFocus());
+                }
+                else if (pActiveWindow->getType() == CGUIWEBBROWSER_NAME)
+                {
+                    auto pElement = reinterpret_cast<CGUIElement_Impl*>(pActiveWindow->getUserData());
+                    if (pElement->GetType() == CGUI_WEBBROWSER)
+                    {
+                        auto pWebBrowser = reinterpret_cast<CGUIWebBrowser_Impl*>(pElement);
+                        return pWebBrowser->HasInputFocus();
+                    }
                 }
             }
             return false;
@@ -583,6 +586,9 @@ eCursorType CGUI_Impl::GetCursorType()
 
 void CGUI_Impl::AddChild(CGUIElement_Impl* pChild)
 {
+    if (!m_pTop)
+        return;
+
     m_pTop->addChildWindow(pChild->GetWindow());
 }
 
@@ -1156,12 +1162,15 @@ bool CGUI_Impl::Event_MouseButtonDown(const CEGUI::EventArgs& Args)
         pElement->Event_OnMouseButtonDown();
     else
     {
-        // If there's no element, we're probably dealing with the root element
-        CEGUI::Window* pActiveWindow = m_pTop->getActiveChild();
-        if (m_pTop == wnd && pActiveWindow)
+        if (m_pTop)
         {
-            // Deactivate active window to trigger onClientGUIBlur
-            pActiveWindow->deactivate();
+            // If there's no element, we're probably dealing with the root element
+            CEGUI::Window* pActiveWindow = m_pTop->getActiveChild();
+            if (m_pTop == wnd && pActiveWindow)
+            {
+                // Deactivate active window to trigger onClientGUIBlur
+                pActiveWindow->deactivate();
+            }
         }
     }
 

--- a/Client/gui/CGUI_Impl.cpp
+++ b/Client/gui/CGUI_Impl.cpp
@@ -146,6 +146,9 @@ CGUI_Impl::~CGUI_Impl()
 
 void CGUI_Impl::CreateRootWindow()
 {
+    if (!m_pWindowManager || !m_pSystem)
+        return;
+
     // Create dummy GUI root
     m_pTop = reinterpret_cast<CEGUI::DefaultWindow*>(m_pWindowManager->createWindow("DefaultWindow", "guiroot"));
     m_pSystem->setGUISheet(m_pTop);
@@ -1828,8 +1831,14 @@ void CGUI_Impl::Cleanup()
         // Recreate the root window (destroyed above via destroyAllWindows)
         CreateRootWindow();
     }
-    catch (std::exception& e)
+    catch (const std::exception& e)
     {
         WriteDebugEvent(SString("CGUI_Impl::Cleanup - Exception: %s", e.what()));
+        m_pTop = nullptr;
+    }
+    catch (...)
+    {
+        WriteDebugEvent("CGUI_Impl::Cleanup() failed with unknown exception");
+        m_pTop = nullptr;
     }
 }

--- a/Client/gui/CGUI_Impl.cpp
+++ b/Client/gui/CGUI_Impl.cpp
@@ -153,8 +153,6 @@ void CGUI_Impl::CreateRootWindow()
 
 void CGUI_Impl::SetSkin(const char* szName)
 {
-    m_currentSkin = szName;
-
     if (m_HasSchemeLoaded)
     {
         CEGUI::GlobalEventSet::getSingletonPtr()->removeAllEvents();
@@ -170,9 +168,6 @@ void CGUI_Impl::SetSkin(const char* szName)
     PopGuiWorkingDirectory();
 
     CEGUI::System::getSingleton().setDefaultMouseCursor("CGUI-Images", "MouseArrow");
-
-    // Destroy any windows we already have
-    CEGUI::WindowManager::getSingleton().destroyAllWindows();
 
     // Clean up CEGUI - this also re-creates the root window
     Cleanup();

--- a/Client/gui/CGUI_Impl.cpp
+++ b/Client/gui/CGUI_Impl.cpp
@@ -1821,6 +1821,6 @@ void CGUI_Impl::Cleanup()
     }
     catch (std::exception& e)
     {
-        OutputDebugLine(SString("CGUI_Impl::Cleanup - Exception: %s", e.what()));
+        WriteDebugEvent(SString("CGUI_Impl::Cleanup - Exception: %s", e.what()));
     }
 }

--- a/Client/gui/CGUI_Impl.cpp
+++ b/Client/gui/CGUI_Impl.cpp
@@ -1807,6 +1807,8 @@ void CGUI_Impl::Cleanup()
     {
         CleanDeadPool();
 
+        m_pTop = nullptr;
+
         if (m_pWindowManager)
             m_pWindowManager->destroyAllWindows();
 
@@ -1817,5 +1819,8 @@ void CGUI_Impl::Cleanup()
         // Recreate the root window (destroyed above via destroyAllWindows)
         CreateRootWindow();
     }
-    catch (...) {}
+    catch (std::exception& e)
+    {
+        OutputDebugLine(SString("CGUI_Impl::Cleanup - Exception: %s", e.what()));
+    }
 }

--- a/Client/gui/CGUI_Impl.h
+++ b/Client/gui/CGUI_Impl.h
@@ -283,6 +283,9 @@ public:
     CGUIWindow* LoadLayout(CGUIElement* pParent, const SString& strFilename);
     bool        LoadImageset(const SString& strFilename);
 
+    // Cleanup CEGUI active resources (dead pool)
+    void Cleanup();
+
 private:
     friend class CGUIElement_Impl;
     CGUIButton*      _CreateButton(CGUIElement_Impl* pParent = NULL, const char* szCaption = "");
@@ -361,4 +364,7 @@ private:
     bool         m_HasSchemeLoaded;
     SString      m_CurrentSchemeName;
     CElapsedTime m_RenderOkTimer;
+    const char*  m_currentSkin;
+
+    void CreateRootWindow();
 };

--- a/Client/gui/CGUI_Impl.h
+++ b/Client/gui/CGUI_Impl.h
@@ -364,7 +364,6 @@ private:
     bool         m_HasSchemeLoaded;
     SString      m_CurrentSchemeName;
     CElapsedTime m_RenderOkTimer;
-    const char*  m_currentSkin;
 
     void CreateRootWindow();
 };

--- a/Client/sdk/gui/CGUI.h
+++ b/Client/sdk/gui/CGUI.h
@@ -170,4 +170,6 @@ public:
 
     virtual CGUIWindow* LoadLayout(CGUIElement* pParent, const SString& strFilename) = 0;
     virtual bool        LoadImageset(const SString& strFilename) = 0;
+
+    virtual void Cleanup() = 0;
 };


### PR DESCRIPTION
Raised in Discord https://canary.discord.com/channels/801330706252038164/801411628600000522/1436840277175308299

CEGUI wasn't being properly cleaned up when GUI recreated (on locale and skin change).
We also have no reason to store 'old locales' in the map in CLocalization, so these are cleared up automatically