### PR TITLE
Fix youtube embed not working on latest cef versions

### DIFF
--- a/Client/cefweb/CWebView.cpp
+++ b/Client/cefweb/CWebView.cpp
@@ -12,6 +12,7 @@
 #include "CAjaxResourceHandler.h"
 #include <cef3/cef/include/cef_parser.h>
 #include <cef3/cef/include/cef_task.h>
+#include <cef3/cef/include/cef_request.h>
 #include "CWebDevTools.h"
 
 namespace
@@ -897,6 +898,12 @@ CefResourceRequestHandler::ReturnValue CWebView::OnBeforeResourceLoad(CefRefPtr<
                 iter->second = iter->second.ToString() + "; SMART-TV; Tizen 4.0";
 
             request->SetHeaderMap(headerMap);
+        }
+
+        // Fix youtube embed (#4531)
+        if (domain == "www.youtube.com" && UTF16ToMbUTF8(urlParts.path.str).find("/embed") == 0)
+        {
+            request->SetReferrer("https://www.youtube-nocookie.com/", REFERRER_POLICY_ORIGIN);
         }
     }
 

--- a/Client/cefweb/CWebView.cpp
+++ b/Client/cefweb/CWebView.cpp
@@ -903,7 +903,7 @@ CefResourceRequestHandler::ReturnValue CWebView::OnBeforeResourceLoad(CefRefPtr<
         // Fix youtube embed (#4531)
         if (domain == "www.youtube.com" && UTF16ToMbUTF8(urlParts.path.str).find("/embed") == 0)
         {
-            request->SetReferrer("https://www.youtube-nocookie.com/", REFERRER_POLICY_ORIGIN);
+            request->SetReferrer("https://mtasa.com/", REFERRER_POLICY_ORIGIN);
         }
     }
 

--- a/Client/cefweb/CWebView.cpp
+++ b/Client/cefweb/CWebView.cpp
@@ -902,9 +902,7 @@ CefResourceRequestHandler::ReturnValue CWebView::OnBeforeResourceLoad(CefRefPtr<
 
         // Fix youtube embed (#4531)
         if (domain == "www.youtube.com" && UTF16ToMbUTF8(urlParts.path.str).find("/embed") == 0)
-        {
             request->SetReferrer("https://mtasa.com/", REFERRER_POLICY_ORIGIN);
-        }
     }
 
     WString scheme = urlParts.scheme.str;

--- a/Client/cefweb/CWebView.cpp
+++ b/Client/cefweb/CWebView.cpp
@@ -12,7 +12,6 @@
 #include "CAjaxResourceHandler.h"
 #include <cef3/cef/include/cef_parser.h>
 #include <cef3/cef/include/cef_task.h>
-#include <cef3/cef/include/cef_request.h>
 #include "CWebDevTools.h"
 
 namespace


### PR DESCRIPTION
This PR fixes the YouTube embedding, which broke completely after one of the CEF or YouTube updates.
It requires testing, but for me it has completely resolved all issues.

Fixes #4531