### PR TITLE
Fix button misalignments in the settings menu

### DIFF
--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -540,8 +540,8 @@ void CSettings::CreateGUI()
             return;
         CVector2D buttonSize;
         button->GetSize(buttonSize);
-        const float bottomPadding = 12.0f;
-        const float buttonY = std::max(0.0f, tabPanelSize.fY - buttonSize.fY - bottomPadding);
+        const float bottomPadding = 32.0f;
+        const float buttonY = std::max(0.0f, tabPanelSize.fY - buttonSize.fY - bottomPadding - 4.0f);
         button->SetPosition(CVector2D(std::max(0.0f, tabPanelSize.fX - buttonSize.fX - bottomPadding), buttonY));
     };
 
@@ -1586,7 +1586,7 @@ void CSettings::CreateGUI()
     m_pGridBrowserBlacklist->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 32.0f));
     m_pGridBrowserBlacklist->GetPosition(vecTemp);
     const CVector2D blacklistGridPos = vecTemp;
-    const float browserBottomPadding = 12.0f;
+    const float browserBottomPadding = 32.0f;
     const float browserButtonSpacing = 5.0f;
     const CVector2D blacklistRemoveSize(140.0f, 22.0f);
     const float blacklistHeightAvailable = tabPanelSize.fY - blacklistGridPos.fY - blacklistRemoveSize.fY - browserButtonSpacing - browserBottomPadding;


### PR DESCRIPTION
This PR fixes button misalignments in the settings menu that have been present for a while. The same issue currently exists in the 1.6 nightly as well.

Before:
<img width="606" height="114" alt="image" src="https://github.com/user-attachments/assets/935b3619-2970-4603-bcb2-38dba43e6d7c" />

<img width="722" height="139" alt="image" src="https://github.com/user-attachments/assets/5ac577fb-ac23-402c-ad2a-0b6d4b90a834" />

-----

After:
<img width="806" height="201" alt="image" src="https://github.com/user-attachments/assets/f480239b-1529-4379-9e14-1d88eb373ad1" />
<img width="794" height="204" alt="image" src="https://github.com/user-attachments/assets/11038d87-285c-4d8a-aa51-e22605c6c81b" />
