### PR TITLE
Add new function getSystemInfo

### DIFF
--- a/Client/core/Graphics/CRenderItemManager.cpp
+++ b/Client/core/Graphics/CRenderItemManager.cpp
@@ -852,6 +852,19 @@ void CRenderItemManager::UpdateMemoryUsage()
 
 ////////////////////////////////////////////////////////////////
 //
+// CRenderItemManager::GetBasicGPUInfo
+//
+//
+//
+////////////////////////////////////////////////////////////////
+void CRenderItemManager::GetBasicGPUInfo(BasicGPUInfo& outInfo)
+{
+    outInfo.name = m_strVideoCardName;
+    outInfo.memoryKB = m_iVideoCardMemoryKBTotal;
+}
+
+////////////////////////////////////////////////////////////////
+//
 // CRenderItemManager::GetDxStatus
 //
 //

--- a/Client/core/Graphics/CRenderItemManager.h
+++ b/Client/core/Graphics/CRenderItemManager.h
@@ -58,6 +58,7 @@ public:
     virtual void           FlushNonAARenderTarget();
     virtual HRESULT        HandleStretchRect(IDirect3DSurface9* pSourceSurface, CONST RECT* pSourceRect, IDirect3DSurface9* pDestSurface,
                                              CONST RECT* pDestRect, int Filter);
+    virtual void           GetBasicGPUInfo(BasicGPUInfo& outInfo) override;
 
     // CRenderItemManager
     void NotifyContructRenderItem(CRenderItem* pItem);

--- a/Client/sdk/core/CRenderItemManagerInterface.h
+++ b/Client/sdk/core/CRenderItemManagerInterface.h
@@ -84,6 +84,12 @@ enum eDxTestMode
     DX_TEST_MODE_NO_SHADER,
 };
 
+struct BasicGPUInfo
+{
+    std::string     name;
+    std::uint32_t   memoryKB;
+};
+
 struct SDxStatus
 {
     eDxTestMode testMode;
@@ -187,6 +193,7 @@ public:
     virtual void     FlushNonAARenderTarget() = 0;
     virtual HRESULT  HandleStretchRect(IDirect3DSurface9* pSourceSurface, CONST RECT* pSourceRect, IDirect3DSurface9* pDestSurface,
                                        CONST RECT* pDestRect, int Filter) = 0;
+    virtual void    GetBasicGPUInfo(BasicGPUInfo& outInfo) = 0;
 };
 
 ////////////////////////////////////////////////////////////////

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.h
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.h
@@ -11,6 +11,9 @@
 #pragma once
 #include "luadefs/CLuaDefs.h"
 
+using DataSubTable = std::unordered_map<std::string, std::variant<std::string, lua_Number>>;
+using MainTable = std::unordered_map<std::string, std::variant<DataSubTable, lua_Number>>;
+
 class CLuaUtilDefs : public CLuaDefs
 {
 public:
@@ -52,4 +55,8 @@ public:
     // Utility functions
     LUA_DECLARE(GetTok);
     LUA_DECLARE(tocolor);
+
+    #ifdef MTA_CLIENT
+        static const MainTable& GetSystemInfo();
+    #endif
 };

--- a/Shared/sdk/SharedUtil.SysInfo.h
+++ b/Shared/sdk/SharedUtil.SysInfo.h
@@ -11,13 +11,27 @@
 #pragma once
 
 #ifdef WIN32
-#include <vector>
-#include "SString.h"
-#include <windows.h>
-#include "WinVer.h"
+    #include <vector>
+    #include "SString.h"
+    #include <windows.h>
+    #include "WinVer.h"
 
 namespace SharedUtil
 {
+    struct WMIProcessorInfo
+    {
+        std::uint32_t    MaxClockSpeed{0};
+        std::string      Name{};
+        std::uint32_t    NumberOfCores{0};
+        std::uint32_t    NumberOfLogicalProcessors{0};
+    };
+
+    struct WMISystemInfo
+    {
+        WMIProcessorInfo CPU{};
+        std::uint64_t    TotalPhysicalMemory{0};            // In KiB
+    };
+
     struct SQueryWMIResult : public std::vector<std::vector<SString> >
     {
     };
@@ -36,15 +50,16 @@ namespace SharedUtil
         SString strProductName;
     };
 
-    bool         QueryWMI(SQueryWMIResult& outResult, const SString& strQuery, const SString& strKeys, const SString& strNamespace = "CIMV2");
-    SString      GetWMIOSVersion();
-    unsigned int GetWMIVideoAdapterMemorySize(const unsigned long ulVen, const unsigned long ulDev);
-    long long    GetWMITotalPhysicalMemory();
-    void         GetWMIAntiVirusStatus(std::vector<SString>& outEnabledList, std::vector<SString>& outDisabledList);
-    void         GetInstalledHotFixList(std::vector<SString>& outInstalledList);
-    bool         IsHotFixInstalled(const SString& strHotFixId);
-    bool         GetLibVersionInfo(const SString& strLibName, SLibVersionInfo* pOutLibVersionInfo);
-    bool         Is64BitOS();
+    bool          QueryWMI(SQueryWMIResult& outResult, const SString& strQuery, const SString& strKeys, const SString& strNamespace = "CIMV2");
+    SString       GetWMIOSVersion();
+    unsigned int  GetWMIVideoAdapterMemorySize(const unsigned long ulVen, const unsigned long ulDev);
+    long long     GetWMITotalPhysicalMemory();
+    void          GetWMIAntiVirusStatus(std::vector<SString>& outEnabledList, std::vector<SString>& outDisabledList);
+    void          GetInstalledHotFixList(std::vector<SString>& outInstalledList);
+    bool          IsHotFixInstalled(const SString& strHotFixId);
+    bool          GetLibVersionInfo(const SString& strLibName, SLibVersionInfo* pOutLibVersionInfo);
+    bool          Is64BitOS();
+    WMISystemInfo GetWMISystemInfo();
 }            // namespace SharedUtil
 
 #endif


### PR DESCRIPTION
Original author @Pirulax (#2267)

> This function returns basic information about the client's system in a table.
> Example:
> 
> ```lua
> {
>     CPU = {
>         MaxClockSpeed = 3200,
>         NaNumberOfCores = 6,
>         Name = "AMD Ryzen 5 1600 Six-Core Processor",
>         NumberOfLogicalProcessors = 12
>     },
>     GPU = {
>         Name = "Radeon RX 570 Series",
>         RAM = 419328
>     },
>     TotalPhysicalMemory = 16727152 -- in bytes. I actually think it should be in MB (as the VRAM size)
> }
> ```
> Note: First call to this function is veeeeeery slow, as it has to query WMI.
> Subsequent calls are fast, as static variables are used to cache the data.
> 
> To clarify, this PR adds:
> 
> - CPU info (table under CPU key)
> - TotalPhysicalMemory
> - GPU info is just here for convenience (already available from dxGetStatus)

I’m not sure why the original PR was closed - probably due to being abandoned and not updated after review. As for the “privacy” aspect (though I don’t know if anyone still believes it actually exists), if it’s really necessary, we could add a checkbox in the settings. If someone wants to “maintain privacy,” they could simply uncheck it, and then ``getSystemInfo`` for that client would just return false. I’m waiting for feedback on whether this is actually needed.

This function will allow server owners to properly adjust their server for older computers, whose users experience FPS drops during rain, weapon/fx effects rendering. Without it, server creators cannot ensure smooth gameplay for everyone, even on a low-end PC.