### PR TITLE
Fix memory leak in engineImageLinkDFF

### DIFF
--- a/Client/game_sa/CStreamingSA.cpp
+++ b/Client/game_sa/CStreamingSA.cpp
@@ -336,9 +336,9 @@ void CStreamingSA::SetStreamingInfo(uint modelid, unsigned char usStreamID, uint
     CStreamingInfo* pItemInfo = GetStreamingInfo(modelid);
 
     // We remove the existing RwObject because, after switching the archive, the streamer will load a new one.
-    // ReInit doesn’t delete all RwObjects unless certain conditions are met.
+    // ReInit doesn't delete all RwObjects unless certain conditions are met.
     // In this case, we must force-remove the RwObject from memory, because it is no longer used,
-    // and due to the archive change the streamer no longer detects it and therefore won’t delete it.
+    // and due to the archive change the streamer no longer detects it and therefore won't delete it.
     // As a result, a memory leak occurs after every call to engineImageLinkDFF.
     if (CModelInfo* modelInfo = g_pCore->GetGame()->GetModelInfo(modelid); modelInfo->GetRwObject())
         RemoveModel(modelid);

--- a/Client/mods/deathmatch/logic/CClientIMG.cpp
+++ b/Client/mods/deathmatch/logic/CClientIMG.cpp
@@ -211,6 +211,11 @@ bool CClientIMG::LinkModel(unsigned int uiModelID, size_t uiFileID)
 
     m_restoreInfo.emplace_back(uiModelID, pCurrInfo->offsetInBlocks, pCurrInfo->sizeInBlocks, pCurrInfo->archiveId);
 
+    // Internally stream out the vehicle before calling CStreamingSA::RemoveModel
+    // otherwise a crash will occur if the player is inside a vehicle that gets unloaded by the streamer
+    if (CClientVehicleManager::IsValidModel(uiModelID))
+        g_pClientGame->GetVehicleManager()->RestreamVehicles(static_cast<unsigned short>(uiModelID));
+
     g_pGame->GetStreaming()->SetStreamingInfo(uiModelID, m_ucArchiveID, pFileInfo->uiOffset, pFileInfo->usSize);
 
     return true;


### PR DESCRIPTION
Fixed #4288 

After updating the archive information and then calling the streaming ``CStreamingSA::ReInit`` (``engineRestreamWorld``), the ``RwObject`` associated with the original archive was “lost”, and a new one was loaded for the new archive.

Sequence:
```
link dff -> restream -> keep old RwObject -> create RwObject for new archive

Restart resource:
restore dff (unlink) -> restream -> keep previously loaded new RwObjects -> create RwObject from original archive
```

With every subsequent call to ``engineImageLinkDFF``, new ``RwObjects`` were created without removing the previous ones. As a result, after each resource restart or reconnect, the number of ``RwObjects`` kept increasing, depending on how many models were inside the IMG. This is what caused the memory leak.