### PR TITLE
Add the ability to set the aiming sensitivity the same as the mouse sensitivity

### DIFF
--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -398,6 +398,7 @@ void CClientVariables::LoadDefaults()
     DEFAULT("process_cpu_affinity", true);                                            // Set CPU 0 affinity to improve game performance and fix the known issue in single-threaded games
     DEFAULT("ask_before_disconnect", true);                                           // Ask before disconnecting from a server
     DEFAULT("allow_steam_client", false);                                             // Allow connecting with the local Steam client (to set GTA:SA ingame status)
+    DEFAULT("use_mouse_sensitivity_for_aiming", false);                               // It uses the horizontal mouse sensitivity for aiming, making the Y-axis sensitivity the same as the X-axis
 
     if (!Exists("locale"))
     {

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -680,6 +680,7 @@ void CCore::ApplyGameSettings()
     CVARS_GET("dynamic_ped_shadows", bVal);
     pGameSettings->SetDynamicPedShadowsEnabled(bVal);
     pController->SetVerticalAimSensitivityRawValue(CVARS_GET_VALUE<float>("vertical_aim_sensitivity"));
+    pController->SetVerticalAimSensitivitySameAsHorizontal(CVARS_GET_VALUE<bool>("use_mouse_sensitivity_for_aiming"));
     CVARS_GET("mastervolume", fVal);
     pGameSettings->SetRadioVolume(pGameSettings->GetRadioVolume() * fVal);
     pGameSettings->SetSFXVolume(pGameSettings->GetSFXVolume() * fVal);

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -2852,6 +2852,7 @@ bool CSettings::OnControlsDefaultClick(CGUIElement* pElement)
     m_pMouseSensitivity->SetScrollPosition(gameSettings->GetMouseSensitivity());
     m_pVerticalAimSensitivity->SetScrollPosition(pController->GetVerticalAimSensitivity());
     m_pCheckboxVerticalAimSensitivity->SetSelected(CVARS_GET_VALUE<bool>("use_mouse_sensitivity_for_aiming"));
+    m_pVerticalAimSensitivity->SetEnabled(!m_pCheckboxVerticalAimSensitivity->GetSelected());
 
     return true;
 }
@@ -3957,6 +3958,7 @@ void CSettings::LoadData()
 
     CVARS_GET("use_mouse_sensitivity_for_aiming", bVar);
     m_pCheckboxVerticalAimSensitivity->SetSelected(bVar);
+    m_pVerticalAimSensitivity->SetEnabled(!m_pCheckboxVerticalAimSensitivity->GetSelected());
 
     // Audio
     m_pCheckBoxAudioEqualizer->SetSelected(gameSettings->IsRadioEqualizerEnabled());

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -363,6 +363,7 @@ void CSettings::ResetGuiPointers()
     m_pLabelVerticalAimSensitivity = NULL;
     m_pVerticalAimSensitivity = NULL;
     m_pLabelVerticalAimSensitivityValue = NULL;
+    m_pCheckboxVerticalAimSensitivity = nullptr;
 
     m_pControlsJoypadLabel = NULL;
     m_pControlsInputTypePane = NULL;
@@ -658,6 +659,10 @@ void CSettings::CreateGUI()
     m_pLabelVerticalAimSensitivityValue->AutoSize("100%");
     FinalizeSliderRow(tabPanelSize.fX, m_pVerticalAimSensitivity, m_pLabelVerticalAimSensitivityValue, 160.0f, kSliderLabelSpacing, m_pLabelVerticalAimSensitivity);
     vecTemp.fY += 30.f;
+
+    m_pCheckboxVerticalAimSensitivity = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabControls, _("Use mouse sensitivity for aiming"), false));
+    m_pCheckboxVerticalAimSensitivity->SetPosition(CVector2D(verticalSliderPos.fX, verticalSliderPos.fY + 20.0f));
+    m_pCheckboxVerticalAimSensitivity->AutoSize(nullptr, 20.0f);
 
     vecTemp.fX = 16;
     // Joypad options
@@ -1965,6 +1970,7 @@ void CSettings::CreateGUI()
     m_pEditBrowserWhitelistAdd->SetActivateHandler(GUI_CALLBACK(&CSettings::OnBrowserWhitelistDomainAddFocused, this));
     m_pEditBrowserWhitelistAdd->SetDeactivateHandler(GUI_CALLBACK(&CSettings::OnBrowserWhitelistDomainAddDefocused, this));
     m_pProcessAffinityCheckbox->SetClickHandler(GUI_CALLBACK(&CSettings::OnAffinityClick, this));
+    m_pCheckboxVerticalAimSensitivity->SetClickHandler(GUI_CALLBACK(&CSettings::OnMouseAimingClick, this));
 
     // Set up the events for advanced description
     m_pPriorityLabel->SetMouseEnterHandler(GUI_CALLBACK(&CSettings::OnShowAdvancedSettingDescription, this));
@@ -2845,6 +2851,7 @@ bool CSettings::OnControlsDefaultClick(CGUIElement* pElement)
     m_pClassicControls->SetSelected(CVARS_GET_VALUE<bool>("classic_controls"));
     m_pMouseSensitivity->SetScrollPosition(gameSettings->GetMouseSensitivity());
     m_pVerticalAimSensitivity->SetScrollPosition(pController->GetVerticalAimSensitivity());
+    m_pCheckboxVerticalAimSensitivity->SetSelected(CVARS_GET_VALUE<bool>("use_mouse_sensitivity_for_aiming"));
 
     return true;
 }
@@ -3948,6 +3955,9 @@ void CSettings::LoadData()
     pController->SetVerticalAimSensitivityRawValue(CVARS_GET_VALUE<float>("vertical_aim_sensitivity"));
     m_pVerticalAimSensitivity->SetScrollPosition(pController->GetVerticalAimSensitivity());
 
+    CVARS_GET("use_mouse_sensitivity_for_aiming", bVar);
+    m_pCheckboxVerticalAimSensitivity->SetSelected(bVar);
+
     // Audio
     m_pCheckBoxAudioEqualizer->SetSelected(gameSettings->IsRadioEqualizerEnabled());
     m_pCheckBoxAudioAutotune->SetSelected(gameSettings->IsRadioAutotuneEnabled());
@@ -4274,6 +4284,8 @@ void CSettings::SaveData()
     pController->SetClassicControls(m_pClassicControls->GetSelected());
     pController->SetVerticalAimSensitivity(m_pVerticalAimSensitivity->GetScrollPosition());
     CVARS_SET("vertical_aim_sensitivity", pController->GetVerticalAimSensitivityRawValue());
+    CVARS_SET("use_mouse_sensitivity_for_aiming", m_pCheckboxVerticalAimSensitivity->GetSelected());
+    pController->SetVerticalAimSensitivitySameAsHorizontal(m_pCheckboxVerticalAimSensitivity->GetSelected());
 
     // Video
     // get current
@@ -5818,6 +5830,12 @@ bool CSettings::OnAffinityClick(CGUIElement* pElement)
     pQuestionBox->SetCallback(CPUAffinityQuestionCallBack, m_pProcessAffinityCheckbox);
     pQuestionBox->Show();
 
+    return true;
+}
+
+bool CSettings::OnMouseAimingClick(CGUIElement* pElement)
+{
+    m_pVerticalAimSensitivity->SetEnabled(!m_pCheckboxVerticalAimSensitivity->GetSelected());
     return true;
 }
 

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -308,6 +308,7 @@ protected:
     CGUILabel*     m_pLabelVerticalAimSensitivity;
     CGUIScrollBar* m_pVerticalAimSensitivity;
     CGUILabel*     m_pLabelVerticalAimSensitivityValue;
+    CGUICheckBox*  m_pCheckboxVerticalAimSensitivity;
 
     CGUILabel*       m_pControlsJoypadLabel;
     CGUIScrollPane*  m_pControlsInputTypePane;
@@ -448,6 +449,7 @@ protected:
     bool OnHideAdvancedSettingDescription(CGUIElement* pElement);
     bool OnTabChanged(CGUIElement* pElement);
     bool OnAffinityClick(CGUIElement* pElement);
+    bool OnMouseAimingClick(CGUIElement* pElement);
     void ReloadBrowserLists();
 
 private:

--- a/Client/game_sa/CControllerConfigManagerSA.cpp
+++ b/Client/game_sa/CControllerConfigManagerSA.cpp
@@ -17,6 +17,7 @@
 #define VAR_FlyWithMouse    ( ( BYTE * ) ( 0xC1CC03 ) )
 #define VAR_SteerWithMouse  ( ( BYTE * ) ( 0xC1CC02 ) )
 #define VAR_VerticalAimSensitivity  ( ( float * ) ( 0xB6EC18 ) )
+#define VAR_HorizontalMouseSensitivity 0xB6EC1C
 
 static const float VERTICAL_AIM_SENSITIVITY_MIN = 0.000312f;
 static const float VERTICAL_AIM_SENSITIVITY_DEFAULT = 0.0015f;
@@ -148,4 +149,15 @@ float CControllerConfigManagerSA::GetVerticalAimSensitivityRawValue()
 void CControllerConfigManagerSA::SetVerticalAimSensitivityRawValue(float fRawValue)
 {
     MemPutFast<float>(VAR_VerticalAimSensitivity, fRawValue);
+}
+
+void CControllerConfigManagerSA::SetVerticalAimSensitivitySameAsHorizontal(bool enabled)
+{
+    std::uintptr_t varToUse = enabled ? VAR_HorizontalMouseSensitivity : reinterpret_cast<std::uintptr_t>(VAR_VerticalAimSensitivity);
+
+    MemPut<std::uintptr_t>(0x50F048, varToUse); // CCam::Process_1rstPersonPedOnPC
+    MemPut<std::uintptr_t>(0x50FB28, varToUse); // CCam::Process_FollowPedWithMouse
+    MemPut<std::uintptr_t>(0x510C28, varToUse); // CCam::Process_M16_1stPerson
+    MemPut<std::uintptr_t>(0x511E0A, varToUse); // CCam::Process_Rocket
+    MemPut<std::uintptr_t>(0x52228E, varToUse); // CCam::Process_AimWeapon
 }

--- a/Client/game_sa/CControllerConfigManagerSA.h
+++ b/Client/game_sa/CControllerConfigManagerSA.h
@@ -37,6 +37,7 @@ public:
     void  SetVerticalAimSensitivity(float fSensitivity);
     float GetVerticalAimSensitivityRawValue();
     void  SetVerticalAimSensitivityRawValue(float fRawValue);
+    void  SetVerticalAimSensitivitySameAsHorizontal(bool enabled) override;
 
     // CControllerConfigManagerSA
     void ApplySteerAndFlyWithMouseSettings();

--- a/Client/sdk/game/CControllerConfigManager.h
+++ b/Client/sdk/game/CControllerConfigManager.h
@@ -206,4 +206,5 @@ public:
     virtual void  SetVerticalAimSensitivity(float fSensitivity) = 0;
     virtual float GetVerticalAimSensitivityRawValue() = 0;
     virtual void  SetVerticalAimSensitivityRawValue(float fRawValue) = 0;
+    virtual void  SetVerticalAimSensitivitySameAsHorizontal(bool enable) = 0;
 };


### PR DESCRIPTION
Fixed #350

This PR allows setting the aiming sensitivity on the Y-axis to be the same as the mouse sensitivity. It does exactly the same thing as ThirteenAG’s patch.

<img width="406" height="98" alt="image" src="https://github.com/user-attachments/assets/3385f89d-a0d0-48c8-be25-e84db6f2693f" />
