### PR TITLE
Fixes #551 - `onMarkerHit` on attached elements 

### DIFF
--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1628,6 +1628,18 @@ bool CStaticFunctionDefinitions::AttachElements(CElement* pElement, CElement* pA
     pElement->SetAttachedOffsets(vecPosition, vecRotation);
     pElement->AttachTo(pAttachedToElement);
 
+    if (IS_MARKER(pElement))
+    {
+        CMarker* pMarker = static_cast<CMarker*>(pElement);
+        CVector attachedPosition;
+        pMarker->GetAttachedPosition(attachedPosition);
+        pMarker->SetPosition(attachedPosition);
+
+        CColShape* pColShape = pMarker->GetColShape();
+        if (pColShape)
+            RefreshColShapeColliders(pColShape);
+    }
+
     CBitStream BitStream;
     BitStream.pBitStream->Write(pAttachedToElement->GetID());
     BitStream.pBitStream->Write(vecPosition.fX);
@@ -1675,6 +1687,14 @@ bool CStaticFunctionDefinitions::DetachElements(CElement* pElement, CElement* pA
     // old packets arriving.
     pElement->AttachTo(NULL);
     pElement->GenerateSyncTimeContext();
+
+    if (IS_MARKER(pElement))
+    {
+        CMarker* pMarker = static_cast<CMarker*>(pElement);
+        CColShape* pColShape = pMarker->GetColShape();
+        if (pColShape)
+            RefreshColShapeColliders(pColShape);
+    }
 
     CBitStream BitStream;
     BitStream.pBitStream->Write(pElement->GetSyncTimeContext());


### PR DESCRIPTION
Fixes https://github.com/multitheftauto/mtasa-blue/issues/551

### Notes
observed the debug line `ERROR: FIXME: CRPCFunctions::ProcessPacket - Element doesn't exist on client (AttachElements)` when the attach RPC arrives on the client before the marker is fully created. This is just a timing/diagnostic warning and does not affect marker hits. It could be silenced by wrapping that log in an if that skips `ATTACH_ELEMENTS/DETACH_ELEMENTS`

You can just use a `Timer` : 
```lua
setTimer(function()
    if isElement(marker) and isElement(bank) then
        attachElements(marker, bank, 0, 0, -1)
    end
end, 50, 1)
```