### PR TITLE
Improve IplStoreSA validation to avoid crashes

### DIFF
--- a/Client/game_sa/CIplStoreSA.cpp
+++ b/Client/game_sa/CIplStoreSA.cpp
@@ -84,6 +84,8 @@ void CIplStoreSA::SetDynamicIplStreamingEnabled(bool state)
 
     // Collect all IPL ids
     std::vector<int> iplIds;
+    iplIds.reserve(pool->m_nSize);
+
     for (int i = 1; i < pool->m_nSize; i++)
     {
         if (pool->IsContains(i))
@@ -122,6 +124,8 @@ void CIplStoreSA::SetDynamicIplStreamingEnabled(bool state, std::function<bool(C
 
     // Collect IPL ids that match the filter
     std::vector<int> iplIds;
+    iplIds.reserve(pool->m_nSize);
+
     for (int i = 1; i < pool->m_nSize; i++)
     {
         auto ipl = pool->GetObject(i);


### PR DESCRIPTION
Fixes #4496 (maybe?)

The crash occurred because the code accessed null or invalid IPL pointers, causing an Access Violation.
Now i'm unable to reproduce crash reported in #4496 anymore with this fix. Tested with 5000 buildings without any issue.

<details><summary>Test code</summary>

```lua
local objects = {}
local buildings = {}
local buildingsAmount = 5000

local state = false
function createBuildings()
	local x, y, z = getElementPosition(localPlayer)
	local int, dim = getElementInterior(localPlayer), getElementDimension(localPlayer)
	for i=1,buildingsAmount do
		if i%4 == 0 then
			buildings[i] = createBuilding(1337, x, y+(i/4)+1, z+2)
			objects[i] = createObject(1337, x, y+(i/4)+1, z+3)
		elseif i%4 == 1 then
			buildings[i] = createBuilding(1337, x, y-(i/4)-1, z+2)
			objects[i] = createObject(1337, x, y+(i/4)+1, z+3)
		elseif i%4 == 2 then
			buildings[i] = createBuilding(1337, x+(i/4)+1, y, z+2)
			objects[i] = createObject(1337, x, y+(i/4)+1, z+3)
		else
			buildings[i] = createBuilding(1337, x-(i/4)-1, y, z+2)
			objects[i] = createObject(1337, x, y+(i/4)+1, z+3)
		end
		
		setElementData(buildings[i], "test", true, false)
		setElementData(buildings[i], "id", i)
		
		setElementFrozen(buildings[i], true)
		setElementDoubleSided(buildings[i], true)
		
		setElementInterior(buildings[i], int)
		setElementDimension(buildings[i], dim)
	end
	
	state = true
end

function destroyBuildings()
	for i=1,buildingsAmount do
		destroyElement(buildings[i])
		destroyElement(objects[i])
	end
	
	state = false
end

setTimer(function()
	if state then
		destroyBuildings()
	else
		createBuildings()
	end
end, 100, 0)
```

</details> 