### PR TITLE
Fix `getVehiclePaintjob` returning -1 when the game engine hasn't applied a paintjob yet during stream-in

### DIFF
--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -3463,7 +3463,7 @@ unsigned char CClientVehicle::GetPaintjob()
     if (m_pVehicle)
     {
         int iRemap = m_pVehicle->GetRemapIndex();
-        return (iRemap == -1) ? 3 : iRemap;
+        return (iRemap == -1) ? m_ucPaintjob : iRemap;
     }
 
     return m_ucPaintjob;


### PR DESCRIPTION
Fixes #2227