### PR TITLE
Fix login censor and add register censor in chatbox history

### DIFF
--- a/Client/core/CChat.cpp
+++ b/Client/core/CChat.cpp
@@ -657,9 +657,9 @@ bool CChat::CharacterKeyHandler(CGUIKeyEventArgs KeyboardArgs)
                     // If the input is not a command, store it
                     m_pInputHistory->Add(m_strInputText);
                 }
-                else if (m_strCommand.compare("login") != 0)
+                else
                 {
-                    // If the input is a command, check that it isn't the 'login' command, if it is censor it
+                    // If the input is a command, check that it isn't the 'login' or 'register' command, if it is censor it
                     char szInput[256];
                     unsigned int uiLength = sizeof(szInput) - 1;
 
@@ -667,11 +667,24 @@ bool CChat::CharacterKeyHandler(CGUIKeyEventArgs KeyboardArgs)
                     szInput[uiLength] = '\0';
 
                     const char* szCommand = strtok(szInput, " ");
-                    
-                    if (szCommand && (strcmp(szCommand, "login") != 0))
+
+                    if (szCommand && (strcmp(szCommand, "login") == 0))
+                    {
+                        // Censor the login command
+                        if (m_pInputHistory->Empty() || m_pInputHistory->GetLast() != std::string("/login"))
+                            m_pInputHistory->Add("/login");
+                    }
+                    else if (szCommand && (strcmp(szCommand, "register") == 0))
+                    {
+                        // Censor the register command
+                        if (m_pInputHistory->Empty() || m_pInputHistory->GetLast() != std::string("/register"))
+                            m_pInputHistory->Add("/register");
+                    }
+                    else
+                    {
+                        // Store the command as-is
                         m_pInputHistory->Add(m_strInputText);
-                    else if ((m_pInputHistory->Empty() || m_pInputHistory->GetLast() != std::string("/login")))
-                        m_pInputHistory->Add("/login");
+                    }
                 }
             }
 


### PR DESCRIPTION
This code fixes the unexpected behaviour of the [previously introduced](https://github.com/multitheftauto/mtasa-blue/pull/3725/files) `/login` censor in chatbox history, as the `/login` command was appearing in chatbox history even if it wasn't used, one of examples was to write `/` in chat.

\+ extend command censoring logic to also include the `/register` command, similar to `/login`.