### PR TITLE
Fix broken CI by patching GitHub Actions back to vs2022

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,8 +30,13 @@ jobs:
         shell: powershell
 
       - name: Restore vs2022
-        run: git revert c757a89f7c92fa7c814572b28384ca5985fff5bb
-        shell: powershell
+        run: |
+          git fetch origin c757a89f7c92fa7c814572b28384ca5985fff5bb
+          git revert c757a89f7c92fa7c814572b28384ca5985fff5bb
+          git checkout $GITHUB_SHA -- README.md
+          git add README.md
+          git revert --continue
+        shell: bash
 
       - name: Install CEF
         run: utils\premake5 install_cef

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,6 +29,10 @@ jobs:
         run: Expand-Archive -Path utils/DXFiles.zip -DestinationPath utils/DXFiles
         shell: powershell
 
+      - name: Restore vs2022
+        run: git revert c757a89f7c92fa7c814572b28384ca5985fff5bb
+        shell: powershell
+
       - name: Install CEF
         run: utils\premake5 install_cef
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         platform: [win32, x64, arm64]
     name: windows-${{ matrix.platform }}
-    runs-on: windows-2022
+    runs-on: windows-2025
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         platform: [win32, x64, arm64]
     name: windows-${{ matrix.platform }}
-    runs-on: windows-2025
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,10 +32,8 @@ jobs:
       - name: Restore vs2022
         run: |
           git fetch origin c757a89f7c92fa7c814572b28384ca5985fff5bb
-          git revert c757a89f7c92fa7c814572b28384ca5985fff5bb
-          git checkout $GITHUB_SHA -- README.md
-          git add README.md
-          git revert --continue
+          git checkout c757a89f7c92fa7c814572b28384ca5985fff5bb -- README.md
+          git revert c757a89f7c92fa7c814572b28384ca5985fff5bb --no-commit
         shell: bash
 
       - name: Install CEF

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Our project's code repository can be found on the [multitheftauto/mtasa-blue](ht
 Prerequisites
 - [Visual Studio 2026](https://visualstudio.microsoft.com/vs/) with:
   - Desktop development with C++
-  - Optional component *C++ MFC for latest v145 build tools (x86 & x64)*
+  - Optional component *C++ MFC for latest v145 build tools (x86 & x64)* or if that's missing *C++ MFC for x64/x86 (Latest MSVC)*
 - [Microsoft DirectX SDK](https://wiki.multitheftauto.com/wiki/Compiling_MTASA#Microsoft_DirectX_SDK)
 - [Git for Windows](https://git-scm.com/download/win) (Optional)
 


### PR DESCRIPTION
Visual Studio 2026 isn't ready on GitHub Actions, so [the upgrade to 2026](https://github.com/multitheftauto/mtasa-blue/commit/c757a89f7c92fa7c814572b28384ca5985fff5bb) around [this time period](https://github.com/multitheftauto/mtasa-blue/commits/master/?after=1c590fbc46884bb25809d85d1017c08f779c6a28+104) causes GitHub Actions builds to stop succeeding.

Since we can't upgrade to Visual Studio 2026 yet (https://github.com/actions/runner-images/issues/13291), this change temporarily restores VS 2022 just for the purpose of CI.

Additionally this change clarifies how to install MFC v145, since the text has changed in the Visual Studio installer.

**Test plan**

CI should pass

**Safe to revert?**

Yes