### PR TITLE
train-tracks: fix track IDs shifting when you delete a default track

### DIFF
--- a/Server/mods/deathmatch/logic/CTrainTrack.cpp
+++ b/Server/mods/deathmatch/logic/CTrainTrack.cpp
@@ -19,8 +19,8 @@ CTrainTrack::CTrainTrack(CTrainTrackManager* pManager, const std::vector<STrackN
     m_iType = CElement::TRAIN_TRACK;
     SetTypeName("train-track");
 
-    m_LinkLastNodes = linkLastNodes;
     m_Nodes = nodes;
+    m_LinkLastNodes = linkLastNodes;
     m_DefaultTrackId = defaultTrackId;
 }
 

--- a/Server/mods/deathmatch/logic/CTrainTrack.h
+++ b/Server/mods/deathmatch/logic/CTrainTrack.h
@@ -57,6 +57,5 @@ private:
 
     std::vector<STrackNode> m_Nodes;
     bool                    m_LinkLastNodes;
-    bool                    m_Default;
     uchar                   m_DefaultTrackId;
 };

--- a/Server/mods/deathmatch/logic/CTrainTrackManager.cpp
+++ b/Server/mods/deathmatch/logic/CTrainTrackManager.cpp
@@ -18,8 +18,7 @@ CTrainTrackManager::CTrainTrackManager()
     // Create default tracks
     for (uchar i = 0; i < 4; ++i)
     {
-        // Create train tracks
-        CreateTrainTrack(OriginalTrackNodes[i], true, nullptr, i);
+        m_DefaultTracks[i] = CreateTrainTrack(OriginalTrackNodes[i], true, nullptr, i);
     }
 }
 
@@ -38,12 +37,16 @@ CTrainTrack* CTrainTrackManager::CreateTrainTrack(const std::vector<STrackNode>&
 void CTrainTrackManager::DestroyTrainTrack(CTrainTrack* pTrainTrack)
 {
     m_Tracks.erase(std::remove(m_Tracks.begin(), m_Tracks.end(), pTrainTrack));
+    if (pTrainTrack->IsDefault())
+    {
+        uchar defaultId = pTrainTrack->GetDefaultTrackId();
+        m_DefaultTracks[defaultId] = nullptr;
+    }
 }
 
-CTrainTrack* CTrainTrackManager::GetTrainTrackByIndex(unsigned int index)
+CTrainTrack* CTrainTrackManager::GetDefaultTrackByIndex(uchar index)
 {
-    if (index >= m_Tracks.size())
+    if (index >= MaxDefaultTracks)
         return nullptr;
-
-    return m_Tracks[index];
+    return m_DefaultTracks[index];
 }

--- a/Server/mods/deathmatch/logic/CTrainTrackManager.cpp
+++ b/Server/mods/deathmatch/logic/CTrainTrackManager.cpp
@@ -15,7 +15,12 @@
 
 CTrainTrackManager::CTrainTrackManager()
 {
-    Reset();
+    // Create default tracks
+    for (uchar i = 0; i < 4; ++i)
+    {
+        // Create train tracks
+        CreateTrainTrack(OriginalTrackNodes[i], true, nullptr, i);
+    }
 }
 
 CTrainTrack* CTrainTrackManager::CreateTrainTrack(const std::vector<STrackNode>& nodes, bool linkLastNodes, CElement* pParent, uchar defaultTrackId)
@@ -41,17 +46,4 @@ CTrainTrack* CTrainTrackManager::GetTrainTrackByIndex(unsigned int index)
         return nullptr;
 
     return m_Tracks[index];
-}
-
-void CTrainTrackManager::Reset()
-{
-    // Clear tracks
-    m_Tracks.clear();
-
-    // Create default tracks
-    for (uchar i = 0; i < 4; ++i)
-    {
-        // Create train tracks
-        CreateTrainTrack(OriginalTrackNodes[i], true, nullptr, i);
-    }
 }

--- a/Server/mods/deathmatch/logic/CTrainTrackManager.h
+++ b/Server/mods/deathmatch/logic/CTrainTrackManager.h
@@ -14,7 +14,6 @@ class CTrainTrackManager
 {
 public:
     CTrainTrackManager();
-    void Reset();
 
     CTrainTrack* CreateTrainTrack(const std::vector<STrackNode>& nodes, bool linkLastNodes, CElement* pParent, uchar defaultTrackId = 0xFF);
     void         DestroyTrainTrack(CTrainTrack* pTrainTrack);

--- a/Server/mods/deathmatch/logic/CTrainTrackManager.h
+++ b/Server/mods/deathmatch/logic/CTrainTrackManager.h
@@ -20,9 +20,13 @@ public:
 
     const std::vector<CTrainTrack*>& GetTracks() { return m_Tracks; }
 
-    CTrainTrack* GetTrainTrackByIndex(unsigned int index);
+    CTrainTrack* GetDefaultTrackByIndex(uchar index);
 
 private:
     constexpr static std::size_t MaxTracks = 255;
-    std::vector<CTrainTrack*>    m_Tracks;
+    constexpr static std::size_t MaxDefaultTracks = 4;
+
+    std::vector<CTrainTrack*> m_Tracks;
+
+    CTrainTrack* m_DefaultTracks[MaxDefaultTracks];
 };

--- a/Server/mods/deathmatch/logic/packets/CVehiclePuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CVehiclePuresyncPacket.cpp
@@ -87,7 +87,7 @@ bool CVehiclePuresyncPacket::Read(NetBitStreamInterface& BitStream)
                 // Note: here we use a uchar, in the CTT branch this is a uint. Just don't forget that, it might be important
                 uchar trackIndex;
                 BitStream.Read(trackIndex);
-                pTrainTrack = g_pGame->GetTrainTrackManager()->GetTrainTrackByIndex(trackIndex);
+                pTrainTrack = g_pGame->GetTrainTrackManager()->GetDefaultTrackByIndex(trackIndex);
 
                 // But we should only actually apply that train-specific data if that vehicle is train on our side
                 if (vehicleType == VEHICLE_TRAIN)

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaTrainTrackDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaTrainTrackDefs.cpp
@@ -38,6 +38,6 @@ auto CLuaTrainTrackDefs::GetDefaultTrack(uchar trackID) -> CLuaTrainTrackDefs::T
 #ifdef MTA_CLIENT
     return trackID;
 #else
-    return g_pGame->GetTrainTrackManager()->GetTrainTrackByIndex(trackID);
+    return g_pGame->GetTrainTrackManager()->GetDefaultTrackByIndex(trackID);
 #endif
 }


### PR DESCRIPTION
Fix an issue where if you use `destroyElement(getDefaultTrack(2))`, calling `getDefaultTrack(2)` again would return what should have been track 3.

This is because `m_Tracks` is a `std::vector`, and we shift the entire vector when we destroy a train track. This is resolved by storing the default tracks in a separate `m_DefaultTracks` array and _not_ doing any shifting.

I've also merged `Reset()` into the constructor, since `Reset` isn't safe to be called on demand. (It simply empties the list without deleting any objects, which is a memory leak.)
 
### Backwards compatibility

This change affects only unreleased Lua APIs.

### Test plan

#### Before

```lua
t2 = getDefaultTrack(2) -- userdata(0x002)
t3 = getDefaultTrack(3) -- userdata(0x003)
destroyElement(t2)
getDefaultTrack(2) == t3 -- true         !!!! incorrect, expected false
getDefaultTrack(2) -- userdata(0x003)    !!!! incorrect, expected nil
getDefaultTrack(3) -- nil                !!!! incorrect, expected 0x003
```

#### After

```lua
t2 = getDefaultTrack(2) -- userdata(0x002)
t3 = getDefaultTrack(3) -- userdata(0x003)
destroyElement(t2)
getDefaultTrack(2) -- nil
getDefaultTrack(3) -- userdata(0x003) 
```



i.e. getDefaultTrack(2):destroy() followed by getDefaultTrack(2) returns the original track 3.
