### PR TITLE
train-tracks: enable for custom builds only

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -64,7 +64,6 @@ void CLuaVehicleDefs::LoadFunctions()
         {"isTrainDerailable", IsTrainDerailable},
         {"getTrainDirection", GetTrainDirection},
         {"getTrainSpeed", GetTrainSpeed},
-        //{"getTrainTrack", ArgumentParser<GetTrainTrack>},
         {"getTrainPosition", GetTrainPosition},
         {"isTrainChainEngine", IsTrainChainEngine},
         {"getVehicleGravity", GetVehicleGravity},
@@ -136,7 +135,6 @@ void CLuaVehicleDefs::LoadFunctions()
         {"setTrainDerailable", SetTrainDerailable},
         {"setTrainDirection", SetTrainDirection},
         {"setTrainSpeed", SetTrainSpeed},
-        //{"setTrainTrack", ArgumentParser<SetTrainTrack>},
         {"setTrainPosition", SetTrainPosition},
         {"setVehicleTaxiLightOn", SetVehicleTaxiLightOn},
         {"setVehicleGravity", SetVehicleGravity},
@@ -177,6 +175,13 @@ void CLuaVehicleDefs::LoadFunctions()
     // Add functions
     for (const auto& [name, func] : functions)
         CLuaCFunctions::AddFunction(name, func);
+
+    // Add train track related functions
+    if (CLuaShared::CustomTrainTracks)
+    {
+        CLuaCFunctions::AddFunction("getTrainTrack", ArgumentParser<GetTrainTrack>);
+        CLuaCFunctions::AddFunction("setTrainTrack", ArgumentParser<SetTrainTrack>);
+    }
 }
 
 void CLuaVehicleDefs::AddClass(lua_State* luaVM)
@@ -206,7 +211,8 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getNitroLevel", "getVehicleNitroLevel");
     lua_classfunction(luaVM, "getDirection", "getTrainDirection");
     lua_classfunction(luaVM, "getTrainSpeed", "getTrainSpeed");
-    // lua_classfunction(luaVM, "getTrack", "getTrainTrack");
+    if (CLuaShared::CustomTrainTracks)
+        lua_classfunction(luaVM, "getTrainTrack", "getTrainTrack");
     lua_classfunction(luaVM, "getTrainPosition", "getTrainPosition");
     lua_classfunction(luaVM, "getName", "getVehicleName");
     lua_classfunction(luaVM, "getVehicleType", "getVehicleType");
@@ -295,7 +301,8 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setNitroLevel", "setVehicleNitroLevel");
     lua_classfunction(luaVM, "setDirection", "setTrainDirection");
     lua_classfunction(luaVM, "setTrainSpeed", "setTrainSpeed");
-    // lua_classfunction(luaVM, "setTrack", "setTrainTrack");
+    if (CLuaShared::CustomTrainTracks)
+        lua_classfunction(luaVM, "setTrainTrack", "setTrainTrack");
     lua_classfunction(luaVM, "setTrainPosition", "setTrainPosition");
     lua_classfunction(luaVM, "setDerailable", "setTrainDerailable");
     lua_classfunction(luaVM, "setDerailed", "setTrainDerailed");
@@ -360,7 +367,8 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "towedByVehicle", NULL, "getVehicleTowedByVehicle");
     lua_classvariable(luaVM, "direction", "setTrainDirection", "getTrainDirection");
     lua_classvariable(luaVM, "trainSpeed", "setTrainSpeed", "getTrainSpeed");
-    // lua_classvariable(luaVM, "track", "setTrainTrack", "getTrainTrack");
+    if (CLuaShared::CustomTrainTracks)
+        lua_classvariable(luaVM, "trainTrack", "setTrainTrack", "getTrainTrack");
     lua_classvariable(luaVM, "trainPosition", "setTrainPosition", "getTrainPosition");
     lua_classvariable(luaVM, "derailable", "setTrainDerailable", "isTrainDerailable");
     lua_classvariable(luaVM, "derailed", "setTrainDerailed", "isTrainDerailed");

--- a/Shared/mods/deathmatch/logic/lua/CLuaShared.cpp
+++ b/Shared/mods/deathmatch/logic/lua/CLuaShared.cpp
@@ -81,7 +81,7 @@ void CLuaShared::LoadFunctions()
     CLuaUTFDefs::LoadFunctions();
     CLuaUtilDefs::LoadFunctions();
 
-    if (m_CustomTrainTracks)
+    if (CustomTrainTracks)
         CLuaTrainTrackDefs::LoadFunctions();
 }
 
@@ -91,7 +91,7 @@ void CLuaShared::AddClasses(lua_State* luaVM)
     CLuaPathDefs::AddClass(luaVM);
     CLuaXMLDefs::AddClass(luaVM);
 
-    if (m_CustomTrainTracks)
+    if (CustomTrainTracks)
         CLuaTrainTrackDefs::AddClass(luaVM);
 }
 

--- a/Shared/mods/deathmatch/logic/lua/CLuaShared.cpp
+++ b/Shared/mods/deathmatch/logic/lua/CLuaShared.cpp
@@ -78,9 +78,11 @@ void CLuaShared::LoadFunctions()
     CLuaFileDefs::LoadFunctions();
     CLuaXMLDefs::LoadFunctions();
     CLuaPathDefs::LoadFunctions();
-    CLuaTrainTrackDefs::LoadFunctions();
     CLuaUTFDefs::LoadFunctions();
     CLuaUtilDefs::LoadFunctions();
+
+    if (m_CustomTrainTracks)
+        CLuaTrainTrackDefs::LoadFunctions();
 }
 
 void CLuaShared::AddClasses(lua_State* luaVM)
@@ -88,6 +90,9 @@ void CLuaShared::AddClasses(lua_State* luaVM)
     CLuaFileDefs::AddClass(luaVM);
     CLuaPathDefs::AddClass(luaVM);
     CLuaXMLDefs::AddClass(luaVM);
+
+    if (m_CustomTrainTracks)
+        CLuaTrainTrackDefs::AddClass(luaVM);
 }
 
 SharedUtil::CAsyncTaskScheduler* CLuaShared::GetAsyncTaskScheduler()

--- a/Shared/mods/deathmatch/logic/lua/CLuaShared.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaShared.h
@@ -34,4 +34,11 @@ public:
     // Shared scripting is the only place where we need the async task scheduler
     // so just go with a hack here
     static SharedUtil::CAsyncTaskScheduler* GetAsyncTaskScheduler();
+
+// Only enable train tracks for custom builds, as this is work in progress and the API may change
+#if MTASA_VERSION_TYPE == VERSION_TYPE_CUSTOM
+    const static bool m_CustomTrainTracks = true;
+#else
+    const static bool m_CustomTrainTracks = false;
+#endif
 };

--- a/Shared/mods/deathmatch/logic/lua/CLuaShared.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaShared.h
@@ -37,8 +37,8 @@ public:
 
 // Only enable train tracks for custom builds, as this is work in progress and the API may change
 #if MTASA_VERSION_TYPE == VERSION_TYPE_CUSTOM
-    const static bool m_CustomTrainTracks = true;
+    const static bool CustomTrainTracks = true;
 #else
-    const static bool m_CustomTrainTracks = false;
+    const static bool CustomTrainTracks = false;
 #endif
 };

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaTrainTrackDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaTrainTrackDefs.cpp
@@ -18,16 +18,16 @@
 
 void CLuaTrainTrackDefs::LoadFunctions()
 {
-    // CLuaCFunctions::AddFunction("getDefaultTrack", ArgumentParser<GetDefaultTrack>);
+    CLuaCFunctions::AddFunction("getDefaultTrack", ArgumentParser<GetDefaultTrack>);
 }
 
 void CLuaTrainTrackDefs::AddClass(lua_State* luaVM)
 {
-    // lua_newclass(luaVM);
+    lua_newclass(luaVM);
 
-    // lua_classfunction(luaVM, "getDefault", "getDefaultTrack");
+    lua_classfunction(luaVM, "getDefault", "getDefaultTrack");
 
-    // lua_registerclass(luaVM, "TrainTrack", "Element");
+    lua_registerclass(luaVM, "TrainTrack", "Element");
 }
 
 auto CLuaTrainTrackDefs::GetDefaultTrack(uchar trackID) -> CLuaTrainTrackDefs::TrainTrack

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaTrainTrackDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaTrainTrackDefs.cpp
@@ -30,7 +30,7 @@ void CLuaTrainTrackDefs::AddClass(lua_State* luaVM)
     lua_registerclass(luaVM, "TrainTrack", "Element");
 }
 
-auto CLuaTrainTrackDefs::GetDefaultTrack(uchar trackID) -> CLuaTrainTrackDefs::TrainTrack
+CLuaTrainTrackDefs::TrainTrack CLuaTrainTrackDefs::GetDefaultTrack(uchar trackID)
 {
     if (trackID > 3)
         throw std::invalid_argument("Bad default track ID (0-3)");


### PR DESCRIPTION
This puts the custom train tracks Lua definitions behind a poor man's feature flag, allowing us to develop train tracks incrementally (avoiding a gigantic branch).

I consider this change safe to merge during the feature freeze as it doesn't introduce new features into release builds.