### PR TITLE
codemod: disable clang-format for `__asm` directives

### DIFF
--- a/Client/game_sa/C3DMarkersSA.cpp
+++ b/Client/game_sa/C3DMarkersSA.cpp
@@ -43,6 +43,7 @@ C3DMarker* C3DMarkersSA::CreateMarker(DWORD Identifier, T3DMarkerType dwType, CV
 
     DWORD dwFunc = FUNC_PlaceMarker;
     DWORD dwReturn = 0;
+    // clang-format off
     __asm
     {
         push    bZCheck     // zCheck  ##SA##
@@ -64,6 +65,7 @@ C3DMarker* C3DMarkersSA::CreateMarker(DWORD Identifier, T3DMarkerType dwType, CV
         mov     dwReturn, eax
         add     esp, 0x3C
     }
+    // clang-format on
 
     if (dwReturn)
     {

--- a/Client/game_sa/CAEAudioHardwareSA.cpp
+++ b/Client/game_sa/CAEAudioHardwareSA.cpp
@@ -24,6 +24,7 @@ bool CAEAudioHardwareSA::IsSoundBankLoaded(short wSoundBankID, short wSoundBankS
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAEAudioHardware__IsSoundBankLoaded;
     bool  bReturn = false;
+    // clang-format off
     __asm
     {
         push    dwSoundBankSlotID
@@ -32,6 +33,7 @@ bool CAEAudioHardwareSA::IsSoundBankLoaded(short wSoundBankID, short wSoundBankS
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -41,6 +43,7 @@ void CAEAudioHardwareSA::LoadSoundBank(short wSoundBankID, short wSoundBankSlotI
     DWORD dwSoundBankSlotID = wSoundBankSlotID;
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAEAudioHardware__LoadSoundBank;
+    // clang-format off
     __asm
     {
         push    dwSoundBankSlotID
@@ -48,4 +51,5 @@ void CAEAudioHardwareSA::LoadSoundBank(short wSoundBankID, short wSoundBankSlotI
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 }

--- a/Client/game_sa/CAERadioTrackManagerSA.cpp
+++ b/Client/game_sa/CAERadioTrackManagerSA.cpp
@@ -16,12 +16,14 @@ BYTE CAERadioTrackManagerSA::GetCurrentRadioStationID()
 {
     DWORD dwFunc = FUNC_GetCurrentRadioStationID;
     BYTE  bReturn = 0;
+    // clang-format off
     __asm
     {
         mov     ecx, CLASS_CAERadioTrackManager
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
 
     return bReturn;
 }
@@ -30,12 +32,14 @@ BYTE CAERadioTrackManagerSA::IsVehicleRadioActive()
 {
     DWORD dwFunc = FUNC_IsVehicleRadioActive;
     BYTE  bReturn = 0;
+    // clang-format off
     __asm
     {
         mov     ecx, CLASS_CAERadioTrackManager
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
 
     return bReturn;
 }
@@ -45,6 +49,7 @@ char* CAERadioTrackManagerSA::GetRadioStationName(BYTE bStationID)
     DWORD dwFunc = FUNC_GetRadioStationName;
     char* cReturn = 0;
     DWORD dwStationID = bStationID;
+    // clang-format off
     __asm
     {
         mov     ecx, CLASS_CAERadioTrackManager
@@ -52,6 +57,7 @@ char* CAERadioTrackManagerSA::GetRadioStationName(BYTE bStationID)
         call    dwFunc
         mov     cReturn, eax
     }
+    // clang-format on
 
     return cReturn;
 }
@@ -60,12 +66,14 @@ bool CAERadioTrackManagerSA::IsRadioOn()
 {
     DWORD dwFunc = FUNC_IsRadioOn;
     bool  bReturn = false;
+    // clang-format off
     __asm
     {
         mov     ecx, CLASS_CAERadioTrackManager
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
 
     return bReturn;
 }
@@ -73,6 +81,7 @@ bool CAERadioTrackManagerSA::IsRadioOn()
 void CAERadioTrackManagerSA::SetBassSetting(DWORD dwBass)
 {
     DWORD dwFunc = FUNC_SetBassSetting;
+    // clang-format off
     __asm
     {
         mov     ecx, CLASS_CAERadioTrackManager
@@ -80,16 +89,19 @@ void CAERadioTrackManagerSA::SetBassSetting(DWORD dwBass)
         push    dwBass
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CAERadioTrackManagerSA::Reset()
 {
     DWORD dwFunc = FUNC_Reset;
+    // clang-format off
     __asm
     {
         mov     ecx, CLASS_CAERadioTrackManager
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CAERadioTrackManagerSA::StartRadio(BYTE bStationID, BYTE bUnknown)
@@ -97,6 +109,7 @@ void CAERadioTrackManagerSA::StartRadio(BYTE bStationID, BYTE bUnknown)
     DWORD dwFunc = FUNC_StartRadio;
     DWORD dwStationID = bStationID;
     DWORD dwUnknown = bUnknown;
+    // clang-format off
     __asm
     {
         mov     ecx, CLASS_CAERadioTrackManager
@@ -106,6 +119,7 @@ void CAERadioTrackManagerSA::StartRadio(BYTE bStationID, BYTE bUnknown)
         push    dwStationID
         call    dwFunc
     }
+    // clang-format on
 }
 
 bool CAERadioTrackManagerSA::IsStationLoading() const

--- a/Client/game_sa/CAEVehicleAudioEntitySA.cpp
+++ b/Client/game_sa/CAEVehicleAudioEntitySA.cpp
@@ -22,11 +22,13 @@ void CAEVehicleAudioEntitySA::JustGotInVehicleAsDriver()
     m_pInterface->m_bPlayerDriver = true;
     DWORD dwFunc = FUNC_CAEVehicleAudioEntity__JustGotInVehicleAsDriver;
     DWORD dwThis = (DWORD)m_pInterface;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CAEVehicleAudioEntitySA::JustGotOutOfVehicleAsDriver()
@@ -34,22 +36,26 @@ void CAEVehicleAudioEntitySA::JustGotOutOfVehicleAsDriver()
     m_pInterface->m_bPlayerDriver = false;
     DWORD dwFunc = FUNC_CAEVehicleAudioEntity__JustGotOutOfVehicleAsDriver;
     DWORD dwThis = (DWORD)m_pInterface;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CAEVehicleAudioEntitySA::TurnOnRadioForVehicle()
 {
     DWORD dwFunc = FUNC_CAEVehicleAudioEntity__TurnOnRadioForVehicle;
     DWORD dwThis = (DWORD)m_pInterface;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CAEVehicleAudioEntitySA::StopVehicleEngineSound(unsigned char ucSlot)
@@ -59,10 +65,12 @@ void CAEVehicleAudioEntitySA::StopVehicleEngineSound(unsigned char ucSlot)
     if (pVehicleSound->m_pSound)
     {
         DWORD dwThis = (DWORD)pVehicleSound->m_pSound;
+        // clang-format off
         __asm
         {
             mov     ecx, dwThis
             call    dwFunc
         }
+        // clang-format on
     }
 }

--- a/Client/game_sa/CAnimBlendAssocGroupSA.cpp
+++ b/Client/game_sa/CAnimBlendAssocGroupSA.cpp
@@ -29,6 +29,7 @@ CAnimBlendAssociationSAInterface* CAnimBlendAssocGroupSA::CopyAnimation(unsigned
 
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendAssocGroup_CopyAnimation;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -36,6 +37,7 @@ CAnimBlendAssociationSAInterface* CAnimBlendAssocGroupSA::CopyAnimation(unsigned
         call    dwFunc
         mov     pAnimAssociationReturn, eax
     }
+    // clang-format on
     return pAnimAssociationReturn;
 }
 
@@ -43,12 +45,14 @@ void CAnimBlendAssocGroupSA::InitEmptyAssociations(RpClump* pClump)
 {
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendAssocGroup_InitEmptyAssociations;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         push    pClump
         call    dwFunc
     }
+    // clang-format on
 }
 
 bool CAnimBlendAssocGroupSA::IsCreated()
@@ -56,12 +60,14 @@ bool CAnimBlendAssocGroupSA::IsCreated()
     bool  bReturn;
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendAssocGroup_IsCreated;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -70,12 +76,14 @@ int CAnimBlendAssocGroupSA::GetNumAnimations()
     int   iReturn;
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendAssocGroup_GetNumAnimations;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         mov     iReturn, eax
     }
+    // clang-format on
     return iReturn;
 }
 
@@ -92,6 +100,7 @@ CAnimBlendStaticAssociation* CAnimBlendAssocGroupSA::GetAnimation(unsigned int I
     CAnimBlendStaticAssociation* pReturn;
     DWORD                        dwThis = (DWORD)m_pInterface;
     DWORD                        dwFunc = FUNC_CAnimBlendAssocGroup_GetAnimation;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -99,6 +108,7 @@ CAnimBlendStaticAssociation* CAnimBlendAssocGroupSA::GetAnimation(unsigned int I
         call    dwFunc
         mov     pReturn, eax
     }
+    // clang-format on
     return pReturn;
 }
 
@@ -124,12 +134,14 @@ void CAnimBlendAssocGroupSA::CreateAssociations(const char* szBlockName)
 {
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendAssocGroup_CreateAssociations;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         push    szBlockName
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CAnimBlendAssocGroupSA::SetupAnimBlock()

--- a/Client/game_sa/CAnimBlendAssociationSA.cpp
+++ b/Client/game_sa/CAnimBlendAssociationSA.cpp
@@ -32,25 +32,29 @@ CAnimBlendAssociationSAInterface* CAnimBlendAssociationSA::Constructor(CAnimBlen
 {
     DWORD DwFunc = 0x4CF080;
     DWORD DwThisInterface = reinterpret_cast<DWORD>(m_pInterface);
+    // clang-format off
     __asm
     {
         mov     ecx, DwThisInterface
         push    staticAssociationByReference
         call    DwFunc
-    };
+    }
+    // clang-format on;
 }
 
 CAnimBlendAssociationSAInterface* CAnimBlendAssociationSA::Constructor(RpClump* pClump, CAnimBlendHierarchySAInterface* pAnimHierarchy)
 {
     DWORD DwFunc = 0x4CEFC0;
     DWORD DwThisInterface = reinterpret_cast<DWORD>(m_pInterface);
+    // clang-format off
     __asm
     {
         mov     ecx, DwThisInterface
         push    pAnimHierarchy
         push    pClump
         call    DwFunc
-    };
+    }
+    // clang-format on;
 }
 
 CAnimBlendAssociationSAInterface* CAnimBlendAssociationSA::InitializeForCustomAnimation(RpClump* pClump, CAnimBlendHierarchySAInterface* pAnimHierarchy)
@@ -76,36 +80,42 @@ void CAnimBlendAssociationSA::Init(RpClump* pClump, CAnimBlendHierarchySAInterfa
 {
     DWORD DwFunc = 0x4CED50;
     DWORD DwThisInterface = reinterpret_cast<DWORD>(m_pInterface);
+    // clang-format off
     __asm
     {
         mov     ecx, DwThisInterface
         push    pAnimHierarchy
         push    pClump
         call    DwFunc
-    };
+    }
+    // clang-format on;
 }
 
 void CAnimBlendAssociationSA::AllocateAnimBlendNodeArray(int iCount)
 {
     DWORD DwFunc = 0x4CE9F0;
     DWORD DwThisInterface = reinterpret_cast<DWORD>(m_pInterface);
+    // clang-format off
     __asm
     {
         mov     ecx, DwThisInterface
         push    iCount
         call    DwFunc
-    };
+    }
+    // clang-format on;
 }
 
 void CAnimBlendAssociationSA::FreeAnimBlendNodeArray()
 {
     DWORD DwFunc = 0x4CEA40;
     DWORD DwThisInterface = reinterpret_cast<DWORD>(m_pInterface);
+    // clang-format off
     __asm
     {
         mov     ecx, DwThisInterface
         call    DwFunc
-    };
+    }
+    // clang-format on;
 }
 
 std::unique_ptr<CAnimBlendHierarchy> CAnimBlendAssociationSA::GetAnimHierarchy()
@@ -124,10 +134,12 @@ void CAnimBlendAssociationSA::SetCurrentProgress(float fProgress)
 
     DWORD DwFunc = 0x4CEA80;
     DWORD DwThisInterface = reinterpret_cast<DWORD>(m_pInterface);
+    // clang-format off
     __asm
     {
         mov     ecx, DwThisInterface
         push    fTime
         call    DwFunc
-    };
+    }
+    // clang-format on;
 }

--- a/Client/game_sa/CAnimBlendHierarchySA.cpp
+++ b/Client/game_sa/CAnimBlendHierarchySA.cpp
@@ -35,56 +35,66 @@ void CAnimBlendHierarchySA::SetName(const char* szName)
 {
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendHierarchy_SetName;
+    // clang-format off
     __asm
     {
         push    szName
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CAnimBlendHierarchySA::RemoveAnimSequences()
 {
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendHierarchy_RemoveAnimSequences;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CAnimBlendHierarchySA::RemoveFromUncompressedCache()
 {
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendHierarchy_RemoveFromUncompressedCache;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CAnimBlendHierarchySA::RemoveQuaternionFlips()
 {
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendHierarchy_RemoveQuaternionFlips;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CAnimBlendHierarchySA::CalculateTotalTime()
 {
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendHierarchy_CalculateTotalTime;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 }
 
 CAnimBlendSequenceSAInterface* CAnimBlendHierarchySA::GetSequence(DWORD dwIndex)

--- a/Client/game_sa/CAnimBlendSequenceSA.cpp
+++ b/Client/game_sa/CAnimBlendSequenceSA.cpp
@@ -24,30 +24,35 @@ void CAnimBlendSequenceSA::SetName(const char* szName)
 {
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendSequence_SetName;
+    // clang-format off
     __asm
     {
         push    szName
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CAnimBlendSequenceSA::SetBoneTag(int32_t i32BoneID)
 {
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendSequence_SetBoneTag;
+    // clang-format off
     __asm
     {
         push    i32BoneID
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CAnimBlendSequenceSA::SetKeyFrames(size_t cKeyFrames, bool bRoot, bool bCompressed, void* pKeyFrames)
 {
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendSequence_SetKeyFrames;
+    // clang-format off
     __asm
     {
         push    pKeyFrames
@@ -57,6 +62,7 @@ void CAnimBlendSequenceSA::SetKeyFrames(size_t cKeyFrames, bool bRoot, bool bCom
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CAnimBlendSequenceSA::CopySequenceProperties(CAnimBlendSequenceSAInterface* pAnimSequenceInterface)

--- a/Client/game_sa/CAnimBlendStaticAssociationSA.cpp
+++ b/Client/game_sa/CAnimBlendStaticAssociationSA.cpp
@@ -16,6 +16,7 @@ void CAnimBlendStaticAssociationSA::Initialize(RpClump* pClump, CAnimBlendHierar
 {
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendStaticAssociation_Initialize;
+    // clang-format off
     __asm
     {
         push    pAnimBlendHierarchyInterface
@@ -23,4 +24,5 @@ void CAnimBlendStaticAssociationSA::Initialize(RpClump* pClump, CAnimBlendHierar
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 }

--- a/Client/game_sa/CAnimManagerSA.cpp
+++ b/Client/game_sa/CAnimManagerSA.cpp
@@ -41,19 +41,23 @@ CAnimManagerSA::~CAnimManagerSA()
 void CAnimManagerSA::Initialize()
 {
     DWORD dwFunc = FUNC_CAnimManager_Initialize;
+    // clang-format off
     __asm
     {
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CAnimManagerSA::Shutdown()
 {
     DWORD dwFunc = FUNC_CAnimManager_Shutdown;
+    // clang-format off
     __asm
     {
         call    dwFunc
     }
+    // clang-format on
 }
 
 int CAnimManagerSA::GetNumAnimations()
@@ -76,6 +80,7 @@ std::unique_ptr<CAnimBlendHierarchy> CAnimManagerSA::GetAnimation(int ID)
 {
     CAnimBlendHierarchySAInterface* pInterface = nullptr;
     DWORD                           dwFunc = FUNC_CAnimManager_GetAnimation_int;
+    // clang-format off
     __asm
     {
         push    ID
@@ -83,6 +88,7 @@ std::unique_ptr<CAnimBlendHierarchy> CAnimManagerSA::GetAnimation(int ID)
         mov     pInterface, eax
         add     esp, 0x4
     }
+    // clang-format on
     if (pInterface)
     {
         return std::make_unique<CAnimBlendHierarchySA>(pInterface);
@@ -95,6 +101,7 @@ std::unique_ptr<CAnimBlendHierarchy> CAnimManagerSA::GetAnimation(const char* sz
     CAnimBlendHierarchySAInterface* pInterface = nullptr;
     DWORD                           dwFunc = FUNC_CAnimManager_GetAnimation_str_block;
     CAnimBlockSAInterface*          pBlockInterface = pBlock->GetInterface();
+    // clang-format off
     __asm
     {
         push    pBlockInterface
@@ -103,6 +110,7 @@ std::unique_ptr<CAnimBlendHierarchy> CAnimManagerSA::GetAnimation(const char* sz
         mov     pInterface, eax
         add     esp, 0x8
     }
+    // clang-format on
     if (pInterface)
     {
         return std::make_unique<CAnimBlendHierarchySA>(pInterface);
@@ -116,6 +124,7 @@ std::unique_ptr<CAnimBlendHierarchy> CAnimManagerSA::GetAnimation(unsigned int u
     ;
     DWORD                  dwFunc = FUNC_CAnimManager_GetAnimation_int_block;
     CAnimBlockSAInterface* pBlockInterface = pBlock->GetInterface();
+    // clang-format off
     __asm
     {
         push    pBlockInterface
@@ -124,6 +133,7 @@ std::unique_ptr<CAnimBlendHierarchy> CAnimManagerSA::GetAnimation(unsigned int u
         mov     pInterface, eax
         add     esp, 0x8
     }
+    // clang-format on
     if (pInterface)
     {
         return std::make_unique<CAnimBlendHierarchySA>(pInterface);
@@ -135,6 +145,7 @@ std::unique_ptr<CAnimBlock> CAnimManagerSA::GetAnimationBlock(int ID)
 {
     CAnimBlockSAInterface* pInterface = nullptr;
     DWORD                  dwFunc = FUNC_CAnimManager_GetAnimationBlock_int;
+    // clang-format off
     __asm
     {
         push    ID
@@ -142,6 +153,7 @@ std::unique_ptr<CAnimBlock> CAnimManagerSA::GetAnimationBlock(int ID)
         mov     pInterface, eax
         add     esp, 0x4
     }
+    // clang-format on
     if (pInterface)
     {
         return std::make_unique<CAnimBlockSA>(pInterface);
@@ -153,6 +165,7 @@ std::unique_ptr<CAnimBlock> CAnimManagerSA::GetAnimationBlock(const char* szName
 {
     CAnimBlockSAInterface* pInterface = nullptr;
     DWORD                  dwFunc = FUNC_CAnimManager_GetAnimationBlock_str;
+    // clang-format off
     __asm
     {
         push    szName
@@ -160,6 +173,7 @@ std::unique_ptr<CAnimBlock> CAnimManagerSA::GetAnimationBlock(const char* szName
         mov     pInterface, eax
         add     esp, 0x4
     }
+    // clang-format on
     if (pInterface)
     {
         return std::make_unique<CAnimBlockSA>(pInterface);
@@ -171,6 +185,7 @@ int CAnimManagerSA::GetAnimationBlockIndex(const char* szName)
 {
     int   iReturn;
     DWORD dwFunc = FUNC_CAnimManager_GetAnimationBlockIndex;
+    // clang-format off
     __asm
     {
         push    szName
@@ -178,6 +193,7 @@ int CAnimManagerSA::GetAnimationBlockIndex(const char* szName)
         mov     iReturn, eax
         add     esp, 0x4
     }
+    // clang-format on
     return iReturn;
 }
 
@@ -185,6 +201,7 @@ int CAnimManagerSA::RegisterAnimBlock(const char* szName)
 {
     int   iReturn;
     DWORD dwFunc = FUNC_CAnimManager_RegisterAnimBlock;
+    // clang-format off
     __asm
     {
         push    szName
@@ -192,6 +209,7 @@ int CAnimManagerSA::RegisterAnimBlock(const char* szName)
         mov     iReturn, eax
         add     esp, 0x4
     }
+    // clang-format on
     return iReturn;
 }
 
@@ -199,6 +217,7 @@ std::unique_ptr<CAnimBlendAssocGroup> CAnimManagerSA::GetAnimBlendAssoc(AssocGro
 {
     CAnimBlendAssocGroupSAInterface* pInterface = nullptr;
     DWORD                            dwFunc = FUNC_CAnimManager_GetAnimBlendAssoc;
+    // clang-format off
     __asm
     {
         push    groupID
@@ -206,6 +225,7 @@ std::unique_ptr<CAnimBlendAssocGroup> CAnimManagerSA::GetAnimBlendAssoc(AssocGro
         mov     pInterface, eax
         add     esp, 0x4
     }
+    // clang-format on
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssocGroupSA>(pInterface);
@@ -217,6 +237,7 @@ AssocGroupId CAnimManagerSA::GetFirstAssocGroup(const char* szName)
 {
     AssocGroupId groupReturn;
     DWORD        dwFunc = FUNC_CAnimManager_GetFirstAssocGroup;
+    // clang-format off
     __asm
     {
         push    szName
@@ -224,6 +245,7 @@ AssocGroupId CAnimManagerSA::GetFirstAssocGroup(const char* szName)
         mov     groupReturn, eax
         add     esp, 0x4
     }
+    // clang-format on
     return groupReturn;
 }
 
@@ -231,6 +253,7 @@ const char* CAnimManagerSA::GetAnimGroupName(AssocGroupId groupID)
 {
     const char* szReturn;
     DWORD       dwFunc = FUNC_CAnimManager_GetAnimGroupName;
+    // clang-format off
     __asm
     {
         push    groupID
@@ -238,6 +261,7 @@ const char* CAnimManagerSA::GetAnimGroupName(AssocGroupId groupID)
         mov     szReturn, eax
         add     esp, 0x4
     }
+    // clang-format on
     return szReturn;
 }
 
@@ -245,6 +269,7 @@ const char* CAnimManagerSA::GetAnimBlockName(AssocGroupId groupID)
 {
     const char* szReturn;
     DWORD       dwFunc = FUNC_CAnimManager_GetAnimBlockName;
+    // clang-format off
     __asm
     {
         push    groupID
@@ -252,6 +277,7 @@ const char* CAnimManagerSA::GetAnimBlockName(AssocGroupId groupID)
         mov     szReturn, eax
         add     esp, 0x4
     }
+    // clang-format on
     return szReturn;
 }
 
@@ -259,6 +285,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::CreateAnimAssociation(Ass
 {
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
     DWORD                             dwFunc = FUNC_CAnimManager_CreateAnimAssociation;
+    // clang-format off
     __asm
     {
         push    animID
@@ -267,6 +294,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::CreateAnimAssociation(Ass
         mov     pInterface, eax
         add     esp, 0x8
     }
+    // clang-format on
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -282,6 +310,7 @@ CAnimManagerSA::StaticAssocIntface_type CAnimManagerSA::GetAnimStaticAssociation
 
     CAnimBlendStaticAssociationSAInterface* pInterface = nullptr;
     DWORD                                   dwFunc = FUNC_CAnimManager_GetAnimAssociation;
+    // clang-format off
     __asm
     {
         push    animID
@@ -290,6 +319,7 @@ CAnimManagerSA::StaticAssocIntface_type CAnimManagerSA::GetAnimStaticAssociation
         mov     pInterface, eax
         add     esp, 0x8
     }
+    // clang-format on
     if (pInterface)
     {
         return std::make_unique<CAnimBlendStaticAssociationSA>(pInterface);
@@ -305,6 +335,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::GetAnimAssociation(AssocG
 
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
     DWORD                             dwFunc = FUNC_CAnimManager_GetAnimAssociation_str;
+    // clang-format off
     __asm
     {
         push    szAnimName
@@ -313,6 +344,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::GetAnimAssociation(AssocG
         mov     pInterface, eax
         add     esp, 0x8
     }
+    // clang-format on
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -327,6 +359,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::AddAnimation(RpClump* pCl
 
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
     DWORD                             dwFunc = FUNC_CAnimManager_AddAnimation;
+    // clang-format off
     __asm
     {
         push    animID
@@ -336,6 +369,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::AddAnimation(RpClump* pCl
         mov     pInterface, eax
         add     esp, 0xC
     }
+    // clang-format on
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -351,6 +385,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::AddAnimation(RpClump* pCl
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
     DWORD                             dwFunc = FUNC_CAnimManager_AddAnimation_hier;
     CAnimBlendHierarchySAInterface*   pHierarchyInterface = pHierarchy->GetInterface();
+    // clang-format off
     __asm
     {
         push    ID
@@ -360,6 +395,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::AddAnimation(RpClump* pCl
         mov     pInterface, eax
         add     esp, 0xC
     }
+    // clang-format on
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -376,6 +412,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::AddAnimationAndSync(RpClu
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
     DWORD                             dwFunc = FUNC_CAnimManager_AddAnimationAndSync;
     CAnimBlendAssociationSAInterface* pAssociationInterface = pAssociation->GetInterface();
+    // clang-format off
     __asm
     {
         push    animID
@@ -386,6 +423,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::AddAnimationAndSync(RpClu
         mov     pInterface, eax
         add     esp, 0x10
     }
+    // clang-format on
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -400,6 +438,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::BlendAnimation(RpClump* p
 
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
     DWORD                             dwFunc = FUNC_CAnimManager_BlendAnimation;
+    // clang-format off
     __asm
     {
         push    fBlendDelta
@@ -410,6 +449,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::BlendAnimation(RpClump* p
         mov     pInterface, eax
         add     esp, 0x10
     }
+    // clang-format on
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -425,6 +465,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::BlendAnimation(RpClump* p
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
     DWORD                             dwFunc = FUNC_CAnimManager_BlendAnimation_hier;
     CAnimBlendHierarchySAInterface*   pHierarchyInterface = pHierarchy->GetInterface();
+    // clang-format off
     __asm
     {
         push    fBlendDelta
@@ -435,6 +476,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::BlendAnimation(RpClump* p
         mov     pInterface, eax
         add     esp, 0x10
     }
+    // clang-format on
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -445,40 +487,47 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::BlendAnimation(RpClump* p
 void CAnimManagerSA::AddAnimBlockRef(int ID)
 {
     DWORD dwFunc = FUNC_CAnimManager_AddAnimBlockRef;
+    // clang-format off
     __asm
     {
         push    ID
         call    dwFunc
         add     esp, 0x4
     }
+    // clang-format on
 }
 
 void CAnimManagerSA::RemoveAnimBlockRef(int ID)
 {
     DWORD dwFunc = FUNC_CAnimManager_RemoveAnimBlockRef;
+    // clang-format off
     __asm
     {
         push    ID
         call    dwFunc
         add     esp, 0x4
     }
+    // clang-format on
 }
 
 void CAnimManagerSA::RemoveAnimBlockRefWithoutDelete(int ID)
 {
     DWORD dwFunc = FUNC_CAnimManager_RemoveAnimBlockRefWithoutDelete;
+    // clang-format off
     __asm
     {
         push    ID
         call    dwFunc
         add     esp, 0x4
     }
+    // clang-format on
 }
 
 int CAnimManagerSA::GetNumRefsToAnimBlock(int ID)
 {
     int   iReturn;
     DWORD dwFunc = FUNC_CAnimManager_GetNumRefsToAnimBlock;
+    // clang-format off
     __asm
     {
         push    ID
@@ -486,18 +535,21 @@ int CAnimManagerSA::GetNumRefsToAnimBlock(int ID)
         mov     iReturn, eax
         add     esp, 0x4
     }
+    // clang-format on
     return iReturn;
 }
 
 void CAnimManagerSA::RemoveAnimBlock(int ID)
 {
     DWORD dwFunc = FUNC_CAnimManager_RemoveAnimBlock;
+    // clang-format off
     __asm
     {
         push    ID
         call    dwFunc
         add     esp, 0x4
     }
+    // clang-format on
 }
 
 // Returns a pointer to GTA SA's internal animation association definition
@@ -509,6 +561,7 @@ AnimAssocDefinition* CAnimManagerSA::AddAnimAssocDefinition(const char* szBlockN
 
     AnimAssocDefinition* pReturn{};
     DWORD                dwFunc = FUNC_CAnimManager_AddAnimAssocDefinition;
+    // clang-format off
     __asm
     {
         push    pDescriptor
@@ -520,76 +573,90 @@ AnimAssocDefinition* CAnimManagerSA::AddAnimAssocDefinition(const char* szBlockN
         mov     pReturn, eax
         add     esp, 0x14
     }
+    // clang-format on
     return pReturn;
 }
 
 void CAnimManagerSA::ReadAnimAssociationDefinitions()
 {
     DWORD dwFunc = FUNC_CAnimManager_ReadAnimAssociationDefinitions;
+    // clang-format off
     __asm
     {
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CAnimManagerSA::CreateAnimAssocGroups()
 {
     DWORD dwFunc = FUNC_CAnimManager_CreateAnimAssocGroups;
+    // clang-format off
     __asm
     {
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CAnimManagerSA::UncompressAnimation(CAnimBlendHierarchy* pHierarchy)
 {
     DWORD                           dwFunc = FUNC_CAnimManager_UncompressAnimation;
     CAnimBlendHierarchySAInterface* pHierarchyInterface = pHierarchy->GetInterface();
+    // clang-format off
     __asm
     {
         push    pHierarchyInterface
         call    dwFunc
         add     esp, 0x4
     }
+    // clang-format on
 }
 
 void CAnimManagerSA::RemoveFromUncompressedCache(CAnimBlendHierarchy* pHierarchy)
 {
     DWORD                           dwFunc = FUNC_CAnimManager_RemoveFromUncompressedCache;
     CAnimBlendHierarchySAInterface* pHierarchyInterface = pHierarchy->GetInterface();
+    // clang-format off
     __asm
     {
         push    pHierarchyInterface
         call    dwFunc
         add     esp, 0x4
     }
+    // clang-format on
 }
 
 void CAnimManagerSA::RemoveFromUncompressedCache(CAnimBlendHierarchySAInterface* pHierarchyInterface)
 {
     DWORD dwFunc = FUNC_CAnimManager_RemoveFromUncompressedCache;
+    // clang-format off
     __asm
     {
         push    pHierarchyInterface
         call    dwFunc
         add     esp, 0x4
     }
+    // clang-format on
 }
 
 void CAnimManagerSA::LoadAnimFile(const char* szFile)
 {
     DWORD dwFunc = FUNC_CAnimManager_LoadAnimFile;
+    // clang-format off
     __asm
     {
         push    szFile
         call    dwFunc
         add     esp, 0x4
     }
+    // clang-format on
 }
 
 void CAnimManagerSA::LoadAnimFile(RwStream* pStream, bool b1, const char* sz1)
 {
     DWORD dwFunc = FUNC_CAnimManager_LoadAnimFile_stream;
+    // clang-format off
     __asm
     {
         push    sz1
@@ -598,30 +665,36 @@ void CAnimManagerSA::LoadAnimFile(RwStream* pStream, bool b1, const char* sz1)
         call    dwFunc
         add     esp, 0xC
     }
+    // clang-format on
 }
 
 void CAnimManagerSA::LoadAnimFiles()
 {
     DWORD dwFunc = FUNC_CAnimManager_LoadAnimFiles;
+    // clang-format off
     __asm
     {
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CAnimManagerSA::RemoveLastAnimFile()
 {
     DWORD dwFunc = FUNC_CAnimManager_RemoveLastAnimFile;
+    // clang-format off
     __asm
     {
         call    dwFunc
     }
+    // clang-format on
 }
 
 BYTE* CAnimManagerSA::AllocateKeyFramesMemory(uint32_t u32BytesToAllocate)
 {
     BYTE* pKeyFrames = nullptr;
     DWORD dwFunc = FUNC_CAnimManager_AllocateKeyFramesMemory;
+    // clang-format off
     __asm
     {
         push    u32BytesToAllocate
@@ -629,24 +702,28 @@ BYTE* CAnimManagerSA::AllocateKeyFramesMemory(uint32_t u32BytesToAllocate)
         add     esp, 0x4
         mov     pKeyFrames, eax
     }
+    // clang-format on
     return pKeyFrames;
 }
 
 void CAnimManagerSA::FreeKeyFramesMemory(void* pKeyFrames)
 {
     DWORD dwFunc = FUNC_CAnimManager_FreeKeyFramesMemory;
+    // clang-format off
     __asm
     {
         push    pKeyFrames
         call    dwFunc
         add     esp, 0x4
     }
+    // clang-format on
 }
 
 bool CAnimManagerSA::HasAnimGroupLoaded(AssocGroupId groupID)
 {
     bool  bReturn;
     DWORD dwFunc = FUNC_HasAnimGroupLoaded;
+    // clang-format off
     __asm
     {
         push    groupID
@@ -654,6 +731,7 @@ bool CAnimManagerSA::HasAnimGroupLoaded(AssocGroupId groupID)
         mov     bReturn, al
         add     esp, 0x4
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -664,6 +742,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::RpAnimBlendClumpGetFirstA
 
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
     DWORD                             dwFunc = FUNC_RpAnimBlendClumpGetFirstAssociation;
+    // clang-format off
     __asm
     {
         push    pClump
@@ -671,6 +750,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::RpAnimBlendClumpGetFirstA
         mov     pInterface, eax
         add     esp, 0x4
     }
+    // clang-format on
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -685,6 +765,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::RpAnimBlendClumpGetAssoci
 
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
     DWORD                             dwFunc = FUNC_RpAnimBlendClumpGetAssociation_str;
+    // clang-format off
     __asm
     {
         push    szAnimName
@@ -693,6 +774,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::RpAnimBlendClumpGetAssoci
         mov     pInterface, eax
         add     esp, 0x8
     }
+    // clang-format on
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -707,6 +789,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::RpAnimBlendClumpGetAssoci
 
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
     DWORD                             dwFunc = FUNC_RpAnimBlendClumpGetAssociation_int;
+    // clang-format off
     __asm
     {
         push    animID
@@ -715,6 +798,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::RpAnimBlendClumpGetAssoci
         mov     pInterface, eax
         add     esp, 0x8
     }
+    // clang-format on
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -727,6 +811,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::RpAnimBlendGetNextAssocia
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
     DWORD                             dwFunc = FUNC_RpAnimBlendGetNextAssociation;
     CAnimBlendAssociationSAInterface* pAssociationInterface = pAssociation->GetInterface();
+    // clang-format off
     __asm
     {
         push    pAssociationInterface
@@ -734,6 +819,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::RpAnimBlendGetNextAssocia
         mov     pInterface, eax
         add     esp, 0x4
     }
+    // clang-format on
     if (pInterface)
     {
         return std::make_unique<CAnimBlendAssociationSA>(pInterface);
@@ -748,6 +834,7 @@ int CAnimManagerSA::RpAnimBlendClumpGetNumAssociations(RpClump* pClump)
 
     int   iReturn;
     DWORD dwFunc = FUNC_RpAnimBlendClumpGetNumAssociations;
+    // clang-format off
     __asm
     {
         push    pClump
@@ -755,6 +842,7 @@ int CAnimManagerSA::RpAnimBlendClumpGetNumAssociations(RpClump* pClump)
         mov     iReturn, eax
         add     esp, 0x4
     }
+    // clang-format on
     return iReturn;
 }
 
@@ -764,6 +852,7 @@ void CAnimManagerSA::RpAnimBlendClumpUpdateAnimations(RpClump* pClump, float f1,
         return;
 
     DWORD dwFunc = FUNC_RpAnimBlendClumpUpdateAnimations;
+    // clang-format off
     __asm
     {
         push    b1
@@ -772,6 +861,7 @@ void CAnimManagerSA::RpAnimBlendClumpUpdateAnimations(RpClump* pClump, float f1,
         call    dwFunc
         add     esp, 0xC
     }
+    // clang-format on
 }
 
 std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::GetAnimBlendAssociation(CAnimBlendAssociationSAInterface* pInterface)

--- a/Client/game_sa/CAudioEngineSA.cpp
+++ b/Client/game_sa/CAudioEngineSA.cpp
@@ -62,7 +62,6 @@ void CAudioEngineSA::StopRadio()
     DWORD dwFunc = 0x4E9823;            // Some function CAudio::StopRadio jumps to immediately
 
     // clang-format off
-
     __asm
     {
         // This doesn't work anymore because we've
@@ -93,7 +92,6 @@ void CAudioEngineSA::StopRadio()
 
         retpoint:
     }
-
     // clang-format on
 }
 
@@ -458,7 +456,6 @@ static void __declspec(naked) HOOK_CAEAmbienceTrackManager_CheckForPause()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -473,7 +470,6 @@ static void __declspec(naked) HOOK_CAEAmbienceTrackManager_CheckForPause()
         xor     ecx, ecx
         jmp     RETURN_CAEAmbienceTrackManager_CheckForPause
     }
-
     // clang-format on
 }
 
@@ -552,7 +548,6 @@ static void __declspec(naked) HOOK_CAESoundManager_RequestNewSound()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -573,7 +568,6 @@ static void __declspec(naked) HOOK_CAESoundManager_RequestNewSound()
         xor     esi, esi
         jmp     RETURN_CAESoundManager_RequestNewSound
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CAudioEngineSA.cpp
+++ b/Client/game_sa/CAudioEngineSA.cpp
@@ -61,6 +61,8 @@ void CAudioEngineSA::StopRadio()
     // DWORD dwFunc = FUNC_StopRadio;
     DWORD dwFunc = 0x4E9823;            // Some function CAudio::StopRadio jumps to immediately
 
+    // clang-format off
+
     __asm
     {
         // This doesn't work anymore because we've
@@ -91,6 +93,8 @@ void CAudioEngineSA::StopRadio()
 
         retpoint:
     }
+
+    // clang-format on
 }
 
 void CAudioEngineSA::StartRadio(unsigned int station)
@@ -105,6 +109,7 @@ void CAudioEngineSA::StartRadio(unsigned int station)
 
     DWORD dwFunc = 0x4DBEC3;
     DWORD dwFunc2 = 0x4EB3C3;
+    // clang-format off
     __asm
     {
         // We can't do this anymore as we've returned out StartRadio
@@ -151,6 +156,7 @@ void CAudioEngineSA::StartRadio(unsigned int station)
 
         skip:
     }
+    // clang-format on
 }
 
 // 43 = race one
@@ -163,6 +169,7 @@ void CAudioEngineSA::PlayFrontEndSound(DWORD dwEventID)
         DWORD dwFunc = FUNC_ReportFrontendAudioEvent;
         float fSpeed = 1.0f;
         float fVolumeChange = 0.0f;
+        // clang-format off
         __asm
         {
             push    fSpeed
@@ -171,6 +178,7 @@ void CAudioEngineSA::PlayFrontEndSound(DWORD dwEventID)
             mov     ecx, CLASS_CAudioEngine
             call    dwFunc
         }
+        // clang-format on
     }
 }
 
@@ -178,24 +186,28 @@ void CAudioEngineSA::SetEffectsMasterVolume(BYTE bVolume)
 {
     DWORD dwFunc = FUNC_SetEffectsMasterVolume;
     DWORD dwVolume = bVolume;
+    // clang-format off
     __asm
     {
         mov     ecx, CLASS_CAudioEngine
         push    dwVolume
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CAudioEngineSA::SetMusicMasterVolume(BYTE bVolume)
 {
     DWORD dwFunc = FUNC_SetMusicMasterVolume;
     DWORD dwVolume = bVolume;
+    // clang-format off
     __asm
     {
         mov     ecx, CLASS_CAudioEngine
         push    dwVolume
         call    dwFunc
     }
+    // clang-format on
 
     //
     // See if radio stream should be stopped/started
@@ -228,38 +240,45 @@ void CAudioEngineSA::PlayBeatTrack(short iTrack)
     {
         DWORD dwFunc = FUNC_PreloadBeatTrack;
         DWORD dwTrack = iTrack;
+        // clang-format off
         __asm
         {
             mov     ecx, CLASS_CAudioEngine
             push    dwTrack
             call    dwFunc
         }
+        // clang-format on
 
         dwFunc = FUNC_PlayPreloadedBeatTrack;
+        // clang-format off
         __asm
         {
             mov     ecx, CLASS_CAudioEngine
             push    1
             call    dwFunc
         }
+        // clang-format on
     }
 }
 
 void CAudioEngineSA::ClearMissionAudio(int slot)
 {
     DWORD dwFunc = 0x5072F0;            // CAudioEngine::ClearMissionAudio(unsigned char)
+    // clang-format off
     __asm
     {
         mov     ecx, CLASS_CAudioEngine
         push    slot // sound bank slot?
         call    dwFunc
     }
+    // clang-format on
 }
 
 bool CAudioEngineSA::IsMissionAudioSampleFinished(int slot)
 {
     DWORD dwFunc = 0x5072C0;            // CAudioEngine::IsMissionAudioSampleFinished
     bool  cret = 0;
+    // clang-format off
     __asm
     {
         mov     ecx, CLASS_CAudioEngine
@@ -267,6 +286,7 @@ bool CAudioEngineSA::IsMissionAudioSampleFinished(int slot)
         call    dwFunc
         mov     cret, al
     }
+    // clang-format on
     return cret;
 }
 
@@ -274,6 +294,7 @@ void CAudioEngineSA::PreloadMissionAudio(unsigned short usAudioEvent, int slot)
 {
     DWORD dwFunc = 0x507290;            // CAudioEngine__PreloadMissionAudio
     DWORD AudioEvent = usAudioEvent;
+    // clang-format off
     __asm
     {
         mov     ecx, CLASS_CAudioEngine
@@ -281,12 +302,14 @@ void CAudioEngineSA::PreloadMissionAudio(unsigned short usAudioEvent, int slot)
         push    slot
         call    dwFunc
     }
+    // clang-format on
 }
 
 unsigned char CAudioEngineSA::GetMissionAudioLoadingStatus(int slot)
 {
     DWORD         dwFunc = 0x5072A0;            // get load status
     unsigned char cret = 0;
+    // clang-format off
     __asm
     {
         mov     ecx, CLASS_CAudioEngine
@@ -294,6 +317,7 @@ unsigned char CAudioEngineSA::GetMissionAudioLoadingStatus(int slot)
         call    dwFunc
         mov     cret, al
     }
+    // clang-format on
     return cret;
 }
 
@@ -308,6 +332,7 @@ void CAudioEngineSA::AttachMissionAudioToPhysical(CPhysical* physical, int slot)
     }
 
     DWORD dwFunc = 0x507330;            // AttachMissionAudioToPhysical
+    // clang-format off
     __asm
     {
         mov     ecx, CLASS_CAudioEngine
@@ -315,11 +340,13 @@ void CAudioEngineSA::AttachMissionAudioToPhysical(CPhysical* physical, int slot)
         push    slot
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CAudioEngineSA::SetMissionAudioPosition(CVector* position, int slot)
 {
     DWORD dwFunc = 0x507300;            // CAudioEngine__SetMissionAudioPosition
+    // clang-format off
     __asm
     {
         mov     ecx, CLASS_CAudioEngine
@@ -327,6 +354,7 @@ void CAudioEngineSA::SetMissionAudioPosition(CVector* position, int slot)
         push    slot
         call    dwFunc
     }
+    // clang-format on
 }
 
 bool CAudioEngineSA::PlayLoadedMissionAudio(int slot)
@@ -334,12 +362,14 @@ bool CAudioEngineSA::PlayLoadedMissionAudio(int slot)
     if (GetMissionAudioLoadingStatus(slot) == 1)
     {
         DWORD dwFunc = 0x5072B0;            // CAudioEngine::PlayLoadedMissionAudio(unsigned char)
+        // clang-format off
         __asm
         {
             mov     ecx, CLASS_CAudioEngine
             push    slot
             call    dwFunc
         }
+        // clang-format on
         return true;
     }
     return false;
@@ -350,20 +380,24 @@ void CAudioEngineSA::PauseAllSound(bool bPaused)
     if (bPaused)
     {
         DWORD dwFunc = FUNC_PauseAllSounds;
+        // clang-format off
         __asm
         {
             mov     ecx, CLASS_CAudioEngine
             call    dwFunc
         }
+        // clang-format on
     }
     else
     {
         DWORD dwFunc = FUNC_ResumeAllSounds;
+        // clang-format off
         __asm
         {
             mov     ecx, CLASS_CAudioEngine
             call    dwFunc
         }
+        // clang-format on
     }
 }
 
@@ -423,6 +457,8 @@ static void __declspec(naked) HOOK_CAEAmbienceTrackManager_CheckForPause()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -437,6 +473,8 @@ static void __declspec(naked) HOOK_CAEAmbienceTrackManager_CheckForPause()
         xor     ecx, ecx
         jmp     RETURN_CAEAmbienceTrackManager_CheckForPause
     }
+
+    // clang-format on
 }
 
 //
@@ -513,6 +551,8 @@ static void __declspec(naked) HOOK_CAESoundManager_RequestNewSound()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -533,6 +573,8 @@ static void __declspec(naked) HOOK_CAESoundManager_RequestNewSound()
         xor     esi, esi
         jmp     RETURN_CAESoundManager_RequestNewSound
     }
+
+    // clang-format on
 }
 
 void CAudioEngineSA::ReportBulletHit(CEntity* pEntity, unsigned char ucSurfaceType, CVector* pvecPosition, float f_2)
@@ -542,6 +584,7 @@ void CAudioEngineSA::ReportBulletHit(CEntity* pEntity, unsigned char ucSurfaceTy
         dwEntityInterface = (DWORD)pEntity->GetInterface();
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAudioEngine_ReportBulletHit;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -551,6 +594,7 @@ void CAudioEngineSA::ReportBulletHit(CEntity* pEntity, unsigned char ucSurfaceTy
         push    dwEntityInterface
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CAudioEngineSA::ReportWeaponEvent(int iEvent, eWeaponType weaponType, CPhysical* pPhysical)
@@ -560,6 +604,7 @@ void CAudioEngineSA::ReportWeaponEvent(int iEvent, eWeaponType weaponType, CPhys
         dwPhysicalInterface = (DWORD)pPhysical->GetInterface();
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAudioEngine_ReportWeaponEvent;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -568,4 +613,5 @@ void CAudioEngineSA::ReportWeaponEvent(int iEvent, eWeaponType weaponType, CPhys
         push    iEvent
         call    dwFunc
     }
+    // clang-format on
 }

--- a/Client/game_sa/CCameraSA.cpp
+++ b/Client/game_sa/CCameraSA.cpp
@@ -364,7 +364,6 @@ void CCameraSA::Find3rdPersonCamTargetVector(float fDistance, CVector* vecGunMuz
         return;
         
     // clang-format off
-        
     __asm
     {
         mov     ecx, cameraInterface
@@ -376,7 +375,6 @@ void CCameraSA::Find3rdPersonCamTargetVector(float fDistance, CVector* vecGunMuz
         push    fDistance
         call    dwFunc
     }
-        
     // clang-format on
 }
 
@@ -502,7 +500,6 @@ void CCameraSA::Fade(float fFadeOutTime, int iOutOrIn)
         return;
         
     // clang-format off
-        
     __asm
     {
         mov     ecx, cameraInterface
@@ -510,7 +507,6 @@ void CCameraSA::Fade(float fFadeOutTime, int iOutOrIn)
         push    fFadeOutTime
         call    dwFunc
     }
-        
     // clang-format on
 }
 
@@ -619,7 +615,6 @@ static void __declspec(naked) HOOK_Camera_CollisionDetection()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -631,7 +626,6 @@ static void __declspec(naked) HOOK_Camera_CollisionDetection()
         push    ebp
         jmp     RETURN_Camera_CollisionDetection
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CCameraSA.cpp
+++ b/Client/game_sa/CCameraSA.cpp
@@ -111,11 +111,13 @@ void CCameraSA::Restore()
         return;
 
     DWORD               dwFunc = FUNC_Restore;
+    // clang-format off
     __asm
     {
         mov     ecx, cameraInterface
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CCameraSA::RestoreWithJumpCut()
@@ -124,17 +126,21 @@ void CCameraSA::RestoreWithJumpCut()
     if (!cameraInterface)
         return;
     DWORD               dwFunc = 0x50BD40;
+    // clang-format off
     __asm
     {
         mov     ecx, cameraInterface
         call    dwFunc
     }
+    // clang-format on
     dwFunc = 0x50BAB0;
+    // clang-format off
     __asm
     {
         mov     ecx, cameraInterface
         call    dwFunc
     }
+    // clang-format on
 }
 
 /**
@@ -163,6 +169,7 @@ void CCameraSA::TakeControl(CEntity* entity, eCamMode CamMode, int CamSwitchStyl
         CamSwitchStyle = 10;
 
     DWORD CCamera__TakeControl = FUNC_TakeControl;
+    // clang-format off
     __asm
     {
         mov ecx, cameraInterface
@@ -172,6 +179,7 @@ void CCameraSA::TakeControl(CEntity* entity, eCamMode CamMode, int CamSwitchStyl
         push entityInterface
         call CCamera__TakeControl
     }
+    // clang-format on
 }
 
 void CCameraSA::TakeControl(CVector* position, int CamSwitchStyle)
@@ -193,6 +201,7 @@ void CCameraSA::TakeControl(CVector* position, int CamSwitchStyle)
         vecOffset.fY = 0.5f;
         vecOffset.fX = 0.5f;*/
     /*  DWORD dwFunc = 0x50BEC0;
+        // clang-format off
         __asm
         {
             mov ecx, cameraInterface
@@ -200,9 +209,11 @@ void CCameraSA::TakeControl(CVector* position, int CamSwitchStyle)
             push    eax
             push    position
             call    dwFunc
-        }*/
+        }
+        // clang-format on*/
 
     DWORD CCamera__TakeControlNoEntity = FUNC_TakeControlNoEntity;
+    // clang-format off
     __asm
         {
         mov ecx, cameraInterface
@@ -211,8 +222,10 @@ void CCameraSA::TakeControl(CVector* position, int CamSwitchStyle)
         push position
         call CCamera__TakeControlNoEntity
         }
+    // clang-format on
 
     DWORD dwFunc = 0x50BEC0;
+    // clang-format off
     __asm
     {
         mov ecx, cameraInterface
@@ -221,6 +234,7 @@ void CCameraSA::TakeControl(CVector* position, int CamSwitchStyle)
         push    position
         call    dwFunc
     }
+    // clang-format on
 }
 
 // LSOD recovery
@@ -349,6 +363,8 @@ void CCameraSA::Find3rdPersonCamTargetVector(float fDistance, CVector* vecGunMuz
     if (!cameraInterface)
         return;
         
+    // clang-format off
+        
     __asm
     {
         mov     ecx, cameraInterface
@@ -360,6 +376,8 @@ void CCameraSA::Find3rdPersonCamTargetVector(float fDistance, CVector* vecGunMuz
         push    fDistance
         call    dwFunc
     }
+        
+    // clang-format on
 }
 
 float CCameraSA::Find3rdPersonQuickAimPitch()
@@ -370,12 +388,14 @@ float CCameraSA::Find3rdPersonQuickAimPitch()
 
     float               fReturn;
     DWORD               dwFunc = FUNC_Find3rdPersonQuickAimPitch;
+    // clang-format off
     __asm
     {
         mov     ecx, cameraInterface
         call    dwFunc
         fstp    fReturn
     }
+    // clang-format on
     return fReturn;
 }
 
@@ -431,12 +451,14 @@ bool CCameraSA::IsFading()
     if (!cameraInterface)
         return false;
     bool                bRet = false;
+    // clang-format off
     __asm
     {
         mov     ecx, cameraInterface
         call    dwFunc
         mov     bRet, al
     }
+    // clang-format on
     return bRet;
 }
 
@@ -447,12 +469,14 @@ int CCameraSA::GetFadingDirection()
     if (!cameraInterface)
         return 0;
     int                 dwRet = false;
+    // clang-format off
     __asm
     {
         mov     ecx, cameraInterface
         call    dwFunc
         mov     dwRet, eax
     }
+    // clang-format on
     return dwRet;
 }
 
@@ -477,6 +501,8 @@ void CCameraSA::Fade(float fFadeOutTime, int iOutOrIn)
     if (!cameraInterface)
         return;
         
+    // clang-format off
+        
     __asm
     {
         mov     ecx, cameraInterface
@@ -484,6 +510,8 @@ void CCameraSA::Fade(float fFadeOutTime, int iOutOrIn)
         push    fFadeOutTime
         call    dwFunc
     }
+        
+    // clang-format on
 }
 
 void CCameraSA::SetFadeColor(unsigned char ucRed, unsigned char ucGreen, unsigned char ucBlue)
@@ -495,6 +523,7 @@ void CCameraSA::SetFadeColor(unsigned char ucRed, unsigned char ucGreen, unsigne
     DWORD               dwRed = ucRed;
     DWORD               dwGreen = ucGreen;
     DWORD               dwBlue = ucBlue;
+    // clang-format off
     __asm
     {
         mov     ecx, cameraInterface
@@ -503,6 +532,7 @@ void CCameraSA::SetFadeColor(unsigned char ucRed, unsigned char ucGreen, unsigne
         push    dwRed
         call    dwFunc
     }
+    // clang-format on
 }
 
 float CCameraSA::GetCameraRotation()
@@ -588,6 +618,8 @@ static void __declspec(naked) HOOK_Camera_CollisionDetection()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -599,6 +631,8 @@ static void __declspec(naked) HOOK_Camera_CollisionDetection()
         push    ebp
         jmp     RETURN_Camera_CollisionDetection
     }
+
+    // clang-format on
 }
 
 BYTE CCameraSA::GetCameraVehicleViewMode()

--- a/Client/game_sa/CCameraSA.cpp
+++ b/Client/game_sa/CCameraSA.cpp
@@ -201,7 +201,6 @@ void CCameraSA::TakeControl(CVector* position, int CamSwitchStyle)
         vecOffset.fY = 0.5f;
         vecOffset.fX = 0.5f;*/
     /*  DWORD dwFunc = 0x50BEC0;
-        // clang-format off
         __asm
         {
             mov ecx, cameraInterface
@@ -209,8 +208,7 @@ void CCameraSA::TakeControl(CVector* position, int CamSwitchStyle)
             push    eax
             push    position
             call    dwFunc
-        }
-        // clang-format on*/
+        }*/
 
     DWORD CCamera__TakeControlNoEntity = FUNC_TakeControlNoEntity;
     // clang-format off

--- a/Client/game_sa/CCarEnterExitSA.cpp
+++ b/Client/game_sa/CCarEnterExitSA.cpp
@@ -26,6 +26,7 @@ bool CCarEnterExitSA::GetNearestCarDoor(CPed* pPed, CVehicle* pVehicle, CVector*
     {
         CPedSAInterface*     pPedInterface = pPedSA->GetPedInterface();
         CVehicleSAInterface* pVehicleInterface = pVehicleSA->GetVehicleInterface();
+        // clang-format off
         __asm
         {
             push    pDoor
@@ -36,6 +37,7 @@ bool CCarEnterExitSA::GetNearestCarDoor(CPed* pPed, CVehicle* pVehicle, CVector*
             add     esp, 0x10
             mov     bReturn, al
         }
+        // clang-format on
     }
 
     return bReturn;
@@ -54,6 +56,7 @@ bool CCarEnterExitSA::GetNearestCarPassengerDoor(CPed* pPed, CVehicle* pVehicle,
     {
         CPedSAInterface*     pPedInterface = pPedSA->GetPedInterface();
         CVehicleSAInterface* pVehicleInterface = pVehicleSA->GetVehicleInterface();
+        // clang-format off
         __asm
         {
             push    ebx
@@ -73,6 +76,7 @@ bool CCarEnterExitSA::GetNearestCarPassengerDoor(CPed* pPed, CVehicle* pVehicle,
             mov     bReturn, al
             pop     ebx
         }
+        // clang-format on
     }
 
     return bReturn;
@@ -103,6 +107,7 @@ int CCarEnterExitSA::ComputeTargetDoorToExit(CPed* pPed, CVehicle* pVehicle)
     {
         CPedSAInterface*     pPedInterface = pPedSA->GetPedInterface();
         CVehicleSAInterface* pVehicleInterface = pVehicleSA->GetVehicleInterface();
+        // clang-format off
         __asm
         {
             push    pPedInterface
@@ -111,6 +116,7 @@ int CCarEnterExitSA::ComputeTargetDoorToExit(CPed* pPed, CVehicle* pVehicle)
             add     esp, 8
             mov     door, eax
         }
+        // clang-format on
 
         switch (door)
         {
@@ -185,6 +191,7 @@ bool CCarEnterExitSA::IsRoomForPedToLeaveCar(CVehicle* pVehicle, int iDoor, CVec
         if (pVehicleSA)
         {
             CVehicleSAInterface* pVehicleInterface = pVehicleSA->GetVehicleInterface();
+            // clang-format off
             __asm
             {
                 push    pUnknown
@@ -194,6 +201,7 @@ bool CCarEnterExitSA::IsRoomForPedToLeaveCar(CVehicle* pVehicle, int iDoor, CVec
                 add     esp, 12
                 mov     bRet, al
             }
+            // clang-format on
         }
     }
 

--- a/Client/game_sa/CCheckpointSA.cpp
+++ b/Client/game_sa/CCheckpointSA.cpp
@@ -163,6 +163,8 @@ static void __declspec(naked) HOOK_CCheckpoint__Render()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         push    esi
@@ -171,6 +173,8 @@ static void __declspec(naked) HOOK_CCheckpoint__Render()
 
         jmp RETURN_CCheckpoint__Render
     }
+
+    // clang-format on
 }
 
 void CCheckpointSA::StaticSetHooks()

--- a/Client/game_sa/CCheckpointSA.cpp
+++ b/Client/game_sa/CCheckpointSA.cpp
@@ -164,7 +164,6 @@ static void __declspec(naked) HOOK_CCheckpoint__Render()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push    esi
@@ -173,7 +172,6 @@ static void __declspec(naked) HOOK_CCheckpoint__Render()
 
         jmp RETURN_CCheckpoint__Render
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CColModelSA.cpp
+++ b/Client/game_sa/CColModelSA.cpp
@@ -20,11 +20,13 @@ CColModelSA::CColModelSA()
     
     try
     {
+        // clang-format off
         __asm
         {
             mov     ecx, dwThis
             call    dwFunc
         }
+        // clang-format on
     }
         catch (...)
         {
@@ -54,11 +56,13 @@ CColModelSA::~CColModelSA()
         
         try
         {
+            // clang-format off
             __asm
             {
                 mov     ecx, dwThis
                 call    dwFunc
             }
+            // clang-format on
         }
         catch (...)
         {

--- a/Client/game_sa/CControllerConfigManagerSA.cpp
+++ b/Client/game_sa/CControllerConfigManagerSA.cpp
@@ -35,6 +35,7 @@ CControllerConfigManagerSA::CControllerConfigManagerSA()
 void CControllerConfigManagerSA::SetControllerKeyAssociatedWithAction(eControllerAction action, int iKey, eControllerType controllerType)
 {
     DWORD dwFunc = FUNC_SetControllerKeyAssociatedWithAction;
+    // clang-format off
     __asm
     {
         mov     ecx, CLASS_CControllerConfigManager
@@ -43,12 +44,14 @@ void CControllerConfigManagerSA::SetControllerKeyAssociatedWithAction(eControlle
         push    action
         call    dwFunc
     }
+    // clang-format on
 }
 
 int CControllerConfigManagerSA::GetControllerKeyAssociatedWithAction(eControllerAction action, eControllerType controllerType)
 {
     int   iReturn = 0;
     DWORD dwFunc = FUNC_GetControllerKeyAssociatedWithAction;
+    // clang-format off
     __asm
     {
         mov     ecx, CLASS_CControllerConfigManager
@@ -57,6 +60,7 @@ int CControllerConfigManagerSA::GetControllerKeyAssociatedWithAction(eController
         call    dwFunc
         mov     iReturn, eax
     }
+    // clang-format on
     return iReturn;
 }
 
@@ -64,6 +68,7 @@ int CControllerConfigManagerSA::GetNumOfSettingsForAction(eControllerAction acti
 {
     int   iReturn = 0;
     DWORD dwFunc = FUNC_GetNumOfSettingsForAction;
+    // clang-format off
     __asm
     {
         mov     ecx, CLASS_CControllerConfigManager
@@ -71,12 +76,14 @@ int CControllerConfigManagerSA::GetNumOfSettingsForAction(eControllerAction acti
         call    dwFunc
         mov     iReturn, eax
     }
+    // clang-format on
     return iReturn;
 }
 
 void CControllerConfigManagerSA::ClearSettingsAssociatedWithAction(eControllerAction action, eControllerType controllerType)
 {
     DWORD dwFunc = FUNC_ClearSettingsAssociatedWithAction;
+    // clang-format off
     __asm
     {
         mov     ecx, CLASS_CControllerConfigManager
@@ -84,6 +91,7 @@ void CControllerConfigManagerSA::ClearSettingsAssociatedWithAction(eControllerAc
         push    action
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CControllerConfigManagerSA::SetClassicControls(bool bClassicControls)

--- a/Client/game_sa/CDamageManagerSA.cpp
+++ b/Client/game_sa/CDamageManagerSA.cpp
@@ -53,6 +53,7 @@ void CDamageManagerSA::SetDoorStatus(eDoors bDoor, BYTE bDoorStatus, bool spawnF
                 DWORD dwThis = (DWORD)internalEntityInterface;
                 int   iCarNodeIndex = s_iCarNodeIndexes[bDoor];
                 DWORD dwDoor = (DWORD)bDoor;
+                // clang-format off
                 __asm
                 {
                     mov     ecx, dwThis
@@ -60,6 +61,7 @@ void CDamageManagerSA::SetDoorStatus(eDoors bDoor, BYTE bDoorStatus, bool spawnF
                     push    iCarNodeIndex
                     call    dwFunc
                 }
+                // clang-format on
             }
             else
             {
@@ -68,6 +70,7 @@ void CDamageManagerSA::SetDoorStatus(eDoors bDoor, BYTE bDoorStatus, bool spawnF
                 DWORD dwThis = (DWORD)internalEntityInterface;
                 DWORD dwDoor = (DWORD)bDoor;
                 bool  bQuiet = !spawnFlyingComponent;
+                // clang-format off
                 __asm
                 {
                     mov     ecx, dwThis
@@ -75,6 +78,7 @@ void CDamageManagerSA::SetDoorStatus(eDoors bDoor, BYTE bDoorStatus, bool spawnF
                     push    dwDoor
                     call    dwFunc
                 }
+                // clang-format on
             }
         }
     }
@@ -112,6 +116,7 @@ void CDamageManagerSA::SetPanelStatus(BYTE bPanel, BYTE bPanelStatus, bool spawn
             DWORD dwThis = (DWORD)internalInterface;
             DWORD dwPanel = bPanel;
             DWORD dwStatus = bPanelStatus;
+            // clang-format off
             __asm
             {
                 mov     ecx, dwThis
@@ -119,6 +124,7 @@ void CDamageManagerSA::SetPanelStatus(BYTE bPanel, BYTE bPanelStatus, bool spawn
                 push    dwPanel
                 call    dwFunction
             }
+            // clang-format on
 
             // Intact?
             if (bPanelStatus == DT_PANEL_INTACT)
@@ -130,6 +136,8 @@ void CDamageManagerSA::SetPanelStatus(BYTE bPanel, BYTE bPanelStatus, bool spawn
                 if (carNodeIndex < 0)
                     return;
 
+                // clang-format off
+
                 __asm
                 {
                     mov     ecx, dwThis
@@ -137,6 +145,8 @@ void CDamageManagerSA::SetPanelStatus(BYTE bPanel, BYTE bPanelStatus, bool spawn
                     push    carNodeIndex
                     call    dwFunction
                 }
+
+                // clang-format on
             }
             else
                 reinterpret_cast<CAutomobileSAInterface*>(internalEntityInterface)->SetPanelDamage(bPanel, breakGlass, spawnFlyingComponent);
@@ -171,6 +181,7 @@ void CDamageManagerSA::SetLightStatus(BYTE bLight, BYTE bLightStatus)
     DWORD dwPointer = (DWORD)internalInterface;
     DWORD dwLight = bLight;
     DWORD dwStatus = bLightStatus;
+    // clang-format off
     __asm
     {
         mov     ecx, dwPointer
@@ -178,6 +189,7 @@ void CDamageManagerSA::SetLightStatus(BYTE bLight, BYTE bLightStatus)
         push    dwLight
         call    dwFunction
     }
+    // clang-format on
 }
 
 void CDamageManagerSA::SetLightStatus(unsigned char ucStatus)
@@ -191,6 +203,7 @@ BYTE CDamageManagerSA::GetLightStatus(BYTE bLight)
     DWORD dwPointer = (DWORD)internalInterface;
     BYTE  bReturn = 0;
     DWORD dwLight = bLight;
+    // clang-format off
     __asm
     {
         mov     ecx, dwPointer
@@ -198,6 +211,7 @@ BYTE CDamageManagerSA::GetLightStatus(BYTE bLight)
         call    dwFunction
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -211,6 +225,7 @@ void CDamageManagerSA::SetAeroplaneCompStatus(BYTE CompID, BYTE Status)
     DWORD dwFunction = FUNC_SetAeroplaneCompStatus;
     DWORD dwPointer = (DWORD)internalInterface;
     DWORD dwPannel = CompID;
+    // clang-format off
     __asm
     {
         mov     ecx, dwPointer
@@ -218,6 +233,7 @@ void CDamageManagerSA::SetAeroplaneCompStatus(BYTE CompID, BYTE Status)
         push    dwPannel
         call    dwFunction
     }
+    // clang-format on
 }
 
 BYTE CDamageManagerSA::GetAeroplaneCompStatus(BYTE CompID)
@@ -226,6 +242,7 @@ BYTE CDamageManagerSA::GetAeroplaneCompStatus(BYTE CompID)
     DWORD dwPointer = (DWORD)internalInterface;
     BYTE  bReturn = 0;
     DWORD dwPannel = CompID;
+    // clang-format off
     __asm
     {
         mov     ecx, dwPointer
@@ -233,6 +250,7 @@ BYTE CDamageManagerSA::GetAeroplaneCompStatus(BYTE CompID)
         call    dwFunction
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -240,12 +258,14 @@ void CDamageManagerSA::FuckCarCompletely(bool bKeepWheels)
 {
     DWORD dwFunc = FUNC_FuckCarCompletely;
     DWORD dwPointer = (DWORD)internalInterface;
+    // clang-format off
     __asm
     {
         mov     ecx, dwPointer
         push    bKeepWheels
         call    dwFunc
     }
+    // clang-format on
 }
 
 int CDamageManagerSA::GetCarNodeIndexFromPanel(std::uint8_t panelId) noexcept

--- a/Client/game_sa/CDamageManagerSA.cpp
+++ b/Client/game_sa/CDamageManagerSA.cpp
@@ -137,7 +137,6 @@ void CDamageManagerSA::SetPanelStatus(BYTE bPanel, BYTE bPanelStatus, bool spawn
                     return;
 
                 // clang-format off
-
                 __asm
                 {
                     mov     ecx, dwThis
@@ -145,7 +144,6 @@ void CDamageManagerSA::SetPanelStatus(BYTE bPanel, BYTE bPanelStatus, bool spawn
                     push    carNodeIndex
                     call    dwFunction
                 }
-
                 // clang-format on
             }
             else

--- a/Client/game_sa/CDoorSA.cpp
+++ b/Client/game_sa/CDoorSA.cpp
@@ -24,12 +24,14 @@ float CDoorSA::GetAngleOpenRatio()
 
     if (dwPointer != 0)
     {
+        // clang-format off
         __asm
         {
             mov     ecx, dwPointer
             call    dwFunction
             fstp    fReturn
         }
+        // clang-format on
     }
 
     return fReturn;
@@ -47,12 +49,14 @@ bool CDoorSA::IsClosed()
 
     if (dwPointer != 0)
     {
+        // clang-format off
         __asm
         {
             mov     ecx, dwPointer
             call    dwFunction
             mov     bReturn, al
         }
+        // clang-format on
     }
 
     return bReturn;
@@ -71,12 +75,14 @@ bool CDoorSA::IsFullyOpen()
 
     if (dwPointer != 0)
     {
+        // clang-format off
         __asm
         {
             mov     ecx, dwPointer
             call    dwFunction
             mov     bReturn, al
         }
+        // clang-format on
     }
 
     return bReturn;
@@ -94,11 +100,13 @@ void CDoorSA::Open(float fOpenRatio)
 
     if (dwPointer != 0)
     {
+        // clang-format off
         __asm
         {
             mov     ecx, dwPointer
             push    fOpenRatio
             call    dwFunction
         }
+        // clang-format on
     }
 }

--- a/Client/game_sa/CEntitySA.cpp
+++ b/Client/game_sa/CEntitySA.cpp
@@ -522,7 +522,6 @@ bool CEntitySA::IsPlayingAnimation(char* szAnimName)
     DWORD dwThis = (DWORD)m_pInterface->m_pRwObject;
 
     // clang-format off
-
     __asm
     {
         push    szAnimName
@@ -531,7 +530,6 @@ bool CEntitySA::IsPlayingAnimation(char* szAnimName)
         add     esp, 8
         mov     dwReturn, eax
     }
-
     // clang-format on
     if (dwReturn) return true;
     else return false;

--- a/Client/game_sa/CEntitySA.cpp
+++ b/Client/game_sa/CEntitySA.cpp
@@ -125,11 +125,13 @@ void CEntitySA::SetPosition(float fX, float fY, float fZ)
         // If it's a train, recalculate its rail position parameter (does not affect derailed state)
         DWORD dwThis = (DWORD)m_pInterface;
         DWORD dwFunc = FUNC_CTrain_FindPositionOnTrackFromCoors;
+        // clang-format off
         __asm
         {
             mov     ecx, dwThis
             call    dwFunc
         }
+        // clang-format on
     }
     if (m_pInterface->nType == ENTITY_TYPE_OBJECT)
     {
@@ -166,11 +168,13 @@ void CEntitySA::Render()
     // This function may use m_pInterface->Render()
     DWORD dwFunc = 0x59F180;            // m_pInterface->vtbl->Render;
     DWORD dwThis = (DWORD)m_pInterface;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CEntitySA::SetOrientation(float fX, float fY, float fZ)
@@ -181,18 +185,22 @@ void CEntitySA::SetOrientation(float fX, float fY, float fZ)
 
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = 0x446F90;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 
     dwFunc = 0x532B00;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 
     if (m_pInterface->nType == ENTITY_TYPE_OBJECT)
     {
@@ -207,18 +215,22 @@ void CEntitySA::FixBoatOrientation()
     pGame->GetWorld()->Remove(this, CEntity_FixBoatOrientation);
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = 0x446F90;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 
     dwFunc = 0x532B00;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 
     pGame->GetWorld()->Add(this, CEntity_FixBoatOrientation);
 }
@@ -318,11 +330,13 @@ void CEntitySA::SetMatrix(CMatrix* matrix)
         {
             DWORD dwThis = (DWORD) m_pInterface;
             DWORD dwFunc = 0x6F6CC0;
+            // clang-format off
             __asm
             {
                 mov     ecx, dwThis
                 call    dwFunc
             }
+            // clang-format on
 
             //OutputDebugString ( "Set train position on tracks (matrix)!\n" );
         }
@@ -331,18 +345,22 @@ void CEntitySA::SetMatrix(CMatrix* matrix)
         pGame->GetWorld()->Remove(this, CEntity_SetMatrix);
         DWORD dwThis = (DWORD)m_pInterface;
         DWORD dwFunc = 0x446F90;            // CEntity::UpdateRwMatrix
+        // clang-format off
         __asm
         {
             mov     ecx, dwThis
             call    dwFunc
         }
+        // clang-format on
 
         dwFunc = 0x532B00;            // CEntity::UpdateRwFrame
+        // clang-format off
         __asm
         {
             mov     ecx, dwThis
             call    dwFunc
         }
+        // clang-format on
 
         if (m_pInterface->nType == ENTITY_TYPE_OBJECT)
         {
@@ -368,12 +386,14 @@ float CEntitySA::GetDistanceFromCentreOfMassToBaseOfModel()
     DWORD dwFunc = FUNC_GetDistanceFromCentreOfMassToBaseOfModel;
     DWORD dwThis = (DWORD)m_pInterface;
     float fReturn;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         fstp    fReturn
     }
+    // clang-format on
     return fReturn;
 }
 
@@ -408,12 +428,14 @@ void CEntitySA::SetAlpha(DWORD dwAlpha)
 {
     DWORD dwFunc = FUNC_SetRwObjectAlpha;
     DWORD dwThis = (DWORD)m_pInterface;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         push    dwAlpha
         call    dwFunc
     }
+    // clang-format on
 }
 
 bool CEntitySA::IsOnScreen()
@@ -421,12 +443,14 @@ bool CEntitySA::IsOnScreen()
     DWORD dwFunc = FUNC_IsVisible;
     DWORD dwThis = (DWORD)m_pInterface;
     bool  bReturn = false;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -457,6 +481,7 @@ void CEntitySA::MatrixConvertFromEulerAngles(float fX, float fY, float fZ, int i
     if (matrixPadded)
     {
         DWORD dwFunc = FUNC_CMatrix__ConvertFromEulerAngles;
+        // clang-format off
         __asm
         {
             push    iUnknown
@@ -466,6 +491,7 @@ void CEntitySA::MatrixConvertFromEulerAngles(float fX, float fY, float fZ, int i
             mov     ecx, matrixPadded
             call    dwFunc
         }
+        // clang-format on
     }
 }
 
@@ -475,6 +501,7 @@ void CEntitySA::MatrixConvertToEulerAngles(float* fX, float* fY, float* fZ, int 
     if (matrixPadded)
     {
         DWORD dwFunc = FUNC_CMatrix__ConvertToEulerAngles;
+        // clang-format off
         __asm
         {
             push    iUnknown
@@ -484,6 +511,7 @@ void CEntitySA::MatrixConvertToEulerAngles(float* fX, float* fY, float* fZ, int 
             mov     ecx, matrixPadded
             call    dwFunc
         }
+        // clang-format on
     }
 }
 
@@ -493,6 +521,8 @@ bool CEntitySA::IsPlayingAnimation(char* szAnimName)
     DWORD dwFunc = FUNC_RpAnimBlendClumpGetAssociation;
     DWORD dwThis = (DWORD)m_pInterface->m_pRwObject;
 
+    // clang-format off
+
     __asm
     {
         push    szAnimName
@@ -501,6 +531,8 @@ bool CEntitySA::IsPlayingAnimation(char* szAnimName)
         add     esp, 8
         mov     dwReturn, eax
     }
+
+    // clang-format on
     if (dwReturn) return true;
     else return false;
 }

--- a/Client/game_sa/CEventDamageSA.cpp
+++ b/Client/game_sa/CEventDamageSA.cpp
@@ -27,6 +27,7 @@ CEventDamageSA::CEventDamageSA(CEntity* pEntity, unsigned int i_1, eWeaponType w
     DWORD dwEntityInterface = (DWORD)pEntity->GetInterface();
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CEventDamage_Constructor;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -39,6 +40,7 @@ CEventDamageSA::CEventDamageSA(CEntity* pEntity, unsigned int i_1, eWeaponType w
         push    dwEntityInterface
         call    dwFunc
     }
+    // clang-format on
 }
 
 CEventDamageSA::CEventDamageSA(CEventDamageSAInterface* pInterface)
@@ -57,11 +59,13 @@ CEventDamageSA::~CEventDamageSA()
     {
         DWORD dwThis = (DWORD)m_pInterface;
         DWORD dwFunc = FUNC_CEventDamage_Destructor;
+        // clang-format off
         __asm
         {
             mov     ecx, dwThis
             call    dwFunc
         }
+        // clang-format on
         delete m_pInterface;
     }
 }
@@ -83,12 +87,14 @@ bool CEventDamageSA::HasKilledPed()
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CEventDamage_HasKilledPed;
     bool  bReturn = false;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -97,12 +103,14 @@ float CEventDamageSA::GetDamageApplied()
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CEventDamage_GetDamageApplied;
     float fReturn = 0.0f;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         fstp    fReturn
     }
+    // clang-format on
     return fReturn;
 }
 
@@ -111,12 +119,14 @@ AssocGroupId CEventDamageSA::GetAnimGroup()
     DWORD        dwThis = (DWORD)m_pInterface;
     DWORD        dwFunc = FUNC_CEventDamage_GetAnimGroup;
     AssocGroupId animGroup = 0;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         mov     animGroup, eax
     }
+    // clang-format on
     return animGroup;
 }
 
@@ -125,12 +135,14 @@ AnimationId CEventDamageSA::GetAnimId()
     DWORD       dwThis = (DWORD)m_pInterface;
     DWORD       dwFunc = FUNC_CEventDamage_GetAnimId;
     AnimationId animID = 0;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         mov     animID, eax
     }
+    // clang-format on
     return animID;
 }
 
@@ -139,12 +151,14 @@ bool CEventDamageSA::GetAnimAdded()
     bool  bReturn;
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CEventDamage_GetAnimAdded;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -153,6 +167,7 @@ void CEventDamageSA::ComputeDeathAnim(CPed* pPed, bool bUnk)
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwPed = (DWORD)pPed->GetInterface();
     DWORD dwFunc = FUNC_CEventDamage_ComputeDeathAnim;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -160,6 +175,7 @@ void CEventDamageSA::ComputeDeathAnim(CPed* pPed, bool bUnk)
         push    dwPed
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CEventDamageSA::ComputeDamageAnim(CPed* pPed, bool bUnk)
@@ -167,6 +183,7 @@ void CEventDamageSA::ComputeDamageAnim(CPed* pPed, bool bUnk)
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwPed = (DWORD)pPed->GetInterface();
     DWORD dwFunc = FUNC_CEventDamage_ComputeDamageAnim;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -174,6 +191,7 @@ void CEventDamageSA::ComputeDamageAnim(CPed* pPed, bool bUnk)
         push    dwPed
         call    dwFunc
     }
+    // clang-format on
 }
 
 bool CEventDamageSA::AffectsPed(CPed* pPed)
@@ -182,6 +200,7 @@ bool CEventDamageSA::AffectsPed(CPed* pPed)
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CEventDamage_AffectsPed;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -189,5 +208,6 @@ bool CEventDamageSA::AffectsPed(CPed* pPed)
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }

--- a/Client/game_sa/CExplosionManagerSA.cpp
+++ b/Client/game_sa/CExplosionManagerSA.cpp
@@ -40,6 +40,7 @@ CExplosion* CExplosionManagerSA::AddExplosion(CEntity* pExplodingEntity, CEntity
     CExplosion* explosion = CExplosionManagerSA::FindFreeExplosion();
     bool        bReturn;
     DWORD       dwFunc = FUNC_CExplosion_AddExplosion;
+    // clang-format off
     __asm
     {
         push    bNoDamage
@@ -68,6 +69,7 @@ returnhere:
         add     esp, 0x28
         mov     bReturn, al
     }
+    // clang-format on
     if (bReturn) return explosion;
 
     return NULL;

--- a/Client/game_sa/CFireManagerSA.cpp
+++ b/Client/game_sa/CFireManagerSA.cpp
@@ -38,6 +38,8 @@ void CFireManagerSA::ExtinguishPoint(CVector& vecPosition, float fRadius)
     float fZ = vecPosition.fZ;
     DWORD dwFunction = FUNC_ExtinguishPoint;
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, CLASS_CFireManager
@@ -47,6 +49,8 @@ void CFireManagerSA::ExtinguishPoint(CVector& vecPosition, float fRadius)
         push    fX
         call    dwFunction
     }
+
+    // clang-format on
 }
 
 CFire* CFireManagerSA::StartFire(CEntity* entityTarget, CEntity* entityCreator, float fSize = DEFAULT_FIRE_PARTICLE_SIZE)

--- a/Client/game_sa/CFireManagerSA.cpp
+++ b/Client/game_sa/CFireManagerSA.cpp
@@ -39,7 +39,6 @@ void CFireManagerSA::ExtinguishPoint(CVector& vecPosition, float fRadius)
     DWORD dwFunction = FUNC_ExtinguishPoint;
 
     // clang-format off
-
     __asm
     {
         mov     ecx, CLASS_CFireManager
@@ -49,7 +48,6 @@ void CFireManagerSA::ExtinguishPoint(CVector& vecPosition, float fRadius)
         push    fX
         call    dwFunction
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CFireSA.cpp
+++ b/Client/game_sa/CFireSA.cpp
@@ -26,11 +26,13 @@ void CFireSA::Extinguish()
 {
     DWORD dwFunction = FUNC_Extinguish;
     DWORD dwPointer = (DWORD)internalInterface;
+    // clang-format off
     __asm
     {
         mov     ecx, dwPointer
         call    dwFunction
     }
+    // clang-format on
     internalInterface->bActive = false;
 }
 
@@ -184,6 +186,7 @@ void CFireSA::Ignite()
     CVector* vecPosition = GetPosition();
     DWORD    dwFunc = FUNC_CreateFxSysForStrength;
     DWORD    dwThis = (DWORD)internalInterface;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -191,6 +194,7 @@ void CFireSA::Ignite()
         push    vecPosition
         call    dwFunc
     }
+    // clang-format on
 
     internalInterface->bBeingExtinguished = 0;
     internalInterface->bFirstGeneration = 1;
@@ -241,6 +245,8 @@ static void __declspec(naked) HOOK_CFire_Extinguish()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     [eax+730h], edi
@@ -260,6 +266,8 @@ static void __declspec(naked) HOOK_CFire_Extinguish()
         pop     ebx
         jmp     CONTINUE_CFire_Extinguish
     }
+
+    // clang-format on
 }
 
 void CFireSA::StaticSetHooks()

--- a/Client/game_sa/CFireSA.cpp
+++ b/Client/game_sa/CFireSA.cpp
@@ -246,7 +246,6 @@ static void __declspec(naked) HOOK_CFire_Extinguish()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     [eax+730h], edi
@@ -266,7 +265,6 @@ static void __declspec(naked) HOOK_CFire_Extinguish()
         pop     ebx
         jmp     CONTINUE_CFire_Extinguish
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CFxManagerSA.cpp
+++ b/Client/game_sa/CFxManagerSA.cpp
@@ -21,6 +21,8 @@ CFxSystem* CFxManagerSA::CreateFxSystem(const char* szBlueprint, const CVector& 
     DWORD                 dwFunc = FUNC_FxManager_c__CreateFxSystem;
     CFxSystemSAInterface* pFxSystem;
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThis
@@ -31,6 +33,8 @@ CFxSystem* CFxManagerSA::CreateFxSystem(const char* szBlueprint, const CVector& 
         call    dwFunc
         mov     pFxSystem, eax
     }
+
+    // clang-format on
 
     if (pFxSystem)
     {
@@ -50,12 +54,16 @@ void CFxManagerSA::DestroyFxSystem(CFxSystem* pFxSystem)
 
     void* pFxSA = pFxSystem->GetInterface();
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThis
         push    pFxSA
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 //

--- a/Client/game_sa/CFxManagerSA.cpp
+++ b/Client/game_sa/CFxManagerSA.cpp
@@ -22,7 +22,6 @@ CFxSystem* CFxManagerSA::CreateFxSystem(const char* szBlueprint, const CVector& 
     CFxSystemSAInterface* pFxSystem;
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThis
@@ -33,7 +32,6 @@ CFxSystem* CFxManagerSA::CreateFxSystem(const char* szBlueprint, const CVector& 
         call    dwFunc
         mov     pFxSystem, eax
     }
-
     // clang-format on
 
     if (pFxSystem)
@@ -55,14 +53,12 @@ void CFxManagerSA::DestroyFxSystem(CFxSystem* pFxSystem)
     void* pFxSA = pFxSystem->GetInterface();
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThis
         push    pFxSA
         call    dwFunc
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CFxSA.cpp
+++ b/Client/game_sa/CFxSA.cpp
@@ -19,6 +19,7 @@ void CFxSA::AddBlood(CVector& vecPosition, CVector& vecDirection, int iCount, fl
     CVector* pvecDirection = &vecDirection;
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_AddBlood;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -28,6 +29,7 @@ void CFxSA::AddBlood(CVector& vecPosition, CVector& vecDirection, int iCount, fl
         push    pvecPosition
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CFxSA::AddWood(CVector& vecPosition, CVector& vecDirection, int iCount, float fBrightness)
@@ -36,6 +38,7 @@ void CFxSA::AddWood(CVector& vecPosition, CVector& vecDirection, int iCount, flo
     CVector* pvecDirection = &vecDirection;
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_AddWood;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -45,6 +48,7 @@ void CFxSA::AddWood(CVector& vecPosition, CVector& vecDirection, int iCount, flo
         push    pvecPosition
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CFxSA::AddSparks(CVector& vecPosition, CVector& vecDirection, float fForce, int iCount, CVector vecAcrossLine, unsigned char ucBlurIf0, float fSpread,
@@ -55,6 +59,7 @@ void CFxSA::AddSparks(CVector& vecPosition, CVector& vecDirection, float fForce,
     float    fX = vecAcrossLine.fX, fY = vecAcrossLine.fY, fZ = vecAcrossLine.fZ;
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_AddSparks;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -70,6 +75,7 @@ void CFxSA::AddSparks(CVector& vecPosition, CVector& vecDirection, float fForce,
         push    pvecPosition
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CFxSA::AddTyreBurst(CVector& vecPosition, CVector& vecDirection)
@@ -78,6 +84,7 @@ void CFxSA::AddTyreBurst(CVector& vecPosition, CVector& vecDirection)
     CVector* pvecDirection = &vecDirection;
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_AddTyreBurst;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -85,6 +92,7 @@ void CFxSA::AddTyreBurst(CVector& vecPosition, CVector& vecDirection)
         push    pvecPosition
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CFxSA::AddBulletImpact(CVector& vecPosition, CVector& vecDirection, int iSmokeSize, int iSparkCount, float fSmokeIntensity)
@@ -93,6 +101,7 @@ void CFxSA::AddBulletImpact(CVector& vecPosition, CVector& vecDirection, int iSm
     CVector* pvecDirection = &vecDirection;
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_AddBulletImpact;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -103,6 +112,7 @@ void CFxSA::AddBulletImpact(CVector& vecPosition, CVector& vecDirection, int iSm
         push    pvecPosition
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CFxSA::AddPunchImpact(CVector& vecPosition, CVector& vecDirection, int i)
@@ -111,6 +121,7 @@ void CFxSA::AddPunchImpact(CVector& vecPosition, CVector& vecDirection, int i)
     CVector* pvecDirection = &vecDirection;
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_AddPunchImpact;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -119,6 +130,7 @@ void CFxSA::AddPunchImpact(CVector& vecPosition, CVector& vecDirection, int i)
         push    pvecPosition
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CFxSA::AddDebris(CVector& vecPosition, RwColor& rwColor, float fDebrisScale, int iCount)
@@ -127,6 +139,7 @@ void CFxSA::AddDebris(CVector& vecPosition, RwColor& rwColor, float fDebrisScale
     RwColor* pColor = &rwColor;
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_AddDebris;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -136,6 +149,7 @@ void CFxSA::AddDebris(CVector& vecPosition, RwColor& rwColor, float fDebrisScale
         push    pvecPosition
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CFxSA::AddGlass(CVector& vecPosition, RwColor& rwColor, float fDebrisScale, int iCount)
@@ -144,6 +158,7 @@ void CFxSA::AddGlass(CVector& vecPosition, RwColor& rwColor, float fDebrisScale,
     RwColor* pColor = &rwColor;
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_AddGlass;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -153,6 +168,7 @@ void CFxSA::AddGlass(CVector& vecPosition, RwColor& rwColor, float fDebrisScale,
         push    pvecPosition
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CFxSA::TriggerWaterHydrant(CVector& vecPosition)
@@ -160,12 +176,14 @@ void CFxSA::TriggerWaterHydrant(CVector& vecPosition)
     CVector* pvecPosition = &vecPosition;
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_TriggerWaterHydrant;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         push    pvecPosition
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CFxSA::TriggerGunshot(CEntity* pEntity, CVector& vecPosition, CVector& vecDirection, bool bIncludeSparks)
@@ -175,6 +193,7 @@ void CFxSA::TriggerGunshot(CEntity* pEntity, CVector& vecPosition, CVector& vecD
     CVector* pvecDirection = &vecDirection;
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_TriggerGunshot;
+        // clang-format off
         __asm
     {
         mov     ecx, dwThis
@@ -184,6 +203,7 @@ void CFxSA::TriggerGunshot(CEntity* pEntity, CVector& vecPosition, CVector& vecD
         push    dwEntity
         call    dwFunc
     }
+        // clang-format on
 }
 
 void CFxSA::TriggerTankFire(CVector& vecPosition, CVector& vecDirection)
@@ -192,6 +212,7 @@ void CFxSA::TriggerTankFire(CVector& vecPosition, CVector& vecDirection)
     CVector* pvecDirection = &vecDirection;
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_TriggerTankFire;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -199,6 +220,7 @@ void CFxSA::TriggerTankFire(CVector& vecPosition, CVector& vecDirection)
         push    pvecPosition
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CFxSA::TriggerWaterSplash(CVector& vecPosition)
@@ -206,12 +228,14 @@ void CFxSA::TriggerWaterSplash(CVector& vecPosition)
     CVector* pvecPosition = &vecPosition;
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_TriggerWaterSplash;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         push    pvecPosition
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CFxSA::TriggerBulletSplash(CVector& vecPosition)
@@ -219,12 +243,14 @@ void CFxSA::TriggerBulletSplash(CVector& vecPosition)
     CVector* pvecPosition = &vecPosition;
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_TriggerBulletSplash;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         push    pvecPosition
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CFxSA::TriggerFootSplash(CVector& vecPosition)
@@ -232,12 +258,14 @@ void CFxSA::TriggerFootSplash(CVector& vecPosition)
     CVector* pvecPosition = &vecPosition;
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_TriggerFootSplash;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         push    pvecPosition
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CFxSA::AddParticle(FxParticleSystems eFxParticle, const CVector& vecPosition, const CVector& vecDirection, float fR, float fG, float fB, float fA, bool bRandomizeColors, std::uint32_t iCount, float fBrightness, float fSize, bool bRandomizeSizes, float fLife)

--- a/Client/game_sa/CFxSystemSA.cpp
+++ b/Client/game_sa/CFxSystemSA.cpp
@@ -173,7 +173,6 @@ static void __declspec(naked) HOOK_FxSystem_c_Update_MidA()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -197,7 +196,6 @@ inner:
         push    ebp
         jmp     RETURN_FxSystem_c_Update_MidA
     }
-
     // clang-format on
 }
 
@@ -247,7 +245,6 @@ static void __declspec(naked) HOOK_FxSystem_c_Update_MidB()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -266,7 +263,6 @@ static void __declspec(naked) HOOK_FxSystem_c_Update_MidB()
 
         jmp     RETURN_FxSystem_c_Update_MidB
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CFxSystemSA.cpp
+++ b/Client/game_sa/CFxSystemSA.cpp
@@ -43,11 +43,13 @@ void CFxSystemSA::PlayAndKill()
 {
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_FxSystem_c__PlayAndKill;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CFxSystemSA::GetMatrix(CMatrix& matrix)
@@ -170,6 +172,8 @@ static void __declspec(naked) HOOK_FxSystem_c_Update_MidA()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -193,6 +197,8 @@ inner:
         push    ebp
         jmp     RETURN_FxSystem_c_Update_MidA
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -240,6 +246,8 @@ static void __declspec(naked) HOOK_FxSystem_c_Update_MidB()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -258,6 +266,8 @@ static void __declspec(naked) HOOK_FxSystem_c_Update_MidB()
 
         jmp     RETURN_FxSystem_c_Update_MidB
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/game_sa/CHandlingManagerSA.cpp
+++ b/Client/game_sa/CHandlingManagerSA.cpp
@@ -109,6 +109,8 @@ static __declspec(naked) void Hook_Calculate()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     eax, [esp+4]
@@ -124,6 +126,8 @@ static __declspec(naked) void Hook_Calculate()
         mov     eax, 6F5085h
         jmp     eax
     }
+
+    // clang-format on
 }
 
 CHandlingManagerSA::CHandlingManagerSA()

--- a/Client/game_sa/CHandlingManagerSA.cpp
+++ b/Client/game_sa/CHandlingManagerSA.cpp
@@ -110,7 +110,6 @@ static __declspec(naked) void Hook_Calculate()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     eax, [esp+4]
@@ -126,7 +125,6 @@ static __declspec(naked) void Hook_Calculate()
         mov     eax, 6F5085h
         jmp     eax
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CHudSA.cpp
+++ b/Client/game_sa/CHudSA.cpp
@@ -902,7 +902,6 @@ static void __declspec(naked) HOOK_RenderWanted()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         cmp     ebp, edi
@@ -920,7 +919,6 @@ static void __declspec(naked) HOOK_RenderWanted()
 
         jmp     CONTINUE_RenderWanted
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CHudSA.cpp
+++ b/Client/game_sa/CHudSA.cpp
@@ -901,6 +901,8 @@ static void __declspec(naked) HOOK_RenderWanted()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         cmp     ebp, edi
@@ -918,6 +920,8 @@ static void __declspec(naked) HOOK_RenderWanted()
 
         jmp     CONTINUE_RenderWanted
     }
+
+    // clang-format on
 }
 
 static void HOOK_RenderHudBar(int playerId, int x, int y)

--- a/Client/game_sa/CKeyGenSA.cpp
+++ b/Client/game_sa/CKeyGenSA.cpp
@@ -16,6 +16,7 @@ unsigned int CKeyGenSA::GetKey(const char* szString, int iLength)
 {
     unsigned int uiReturn;
     DWORD        dwFunc = FUNC_CKeyGen_GetKey_len;
+    // clang-format off
     __asm
     {
         push    iLength
@@ -24,6 +25,7 @@ unsigned int CKeyGenSA::GetKey(const char* szString, int iLength)
         add     esp, 0x8
         mov     uiReturn, eax
     }
+    // clang-format on
     return uiReturn;
 }
 
@@ -31,6 +33,7 @@ unsigned int CKeyGenSA::GetKey(const char* szString)
 {
     unsigned int uiReturn;
     DWORD        dwFunc = FUNC_CKeyGen_GetKey;
+    // clang-format off
     __asm
     {
         push    szString
@@ -38,6 +41,7 @@ unsigned int CKeyGenSA::GetKey(const char* szString)
         add     esp, 0x4
         mov     uiReturn, eax
     }
+    // clang-format on
     return uiReturn;
 }
 
@@ -45,6 +49,7 @@ unsigned int CKeyGenSA::GetUppercaseKey(const char* szString)
 {
     unsigned int uiReturn;
     DWORD        dwFunc = FUNC_CKeyGen_GetUppercaseKey;
+    // clang-format off
     __asm
     {
         push    szString
@@ -52,6 +57,7 @@ unsigned int CKeyGenSA::GetUppercaseKey(const char* szString)
         add     esp, 0x4
         mov     uiReturn, eax
     }
+    // clang-format on
     return uiReturn;
 }
 
@@ -59,6 +65,7 @@ unsigned int CKeyGenSA::AppendStringToKey(unsigned int uiKey, const char* szStri
 {
     unsigned int uiReturn;
     DWORD        dwFunc = FUNC_CKeyGen_AppendStringToKey;
+    // clang-format off
     __asm
     {
         push    szString
@@ -67,5 +74,6 @@ unsigned int CKeyGenSA::AppendStringToKey(unsigned int uiKey, const char* szStri
         add     esp, 0x8
         mov     uiReturn, eax
     }
+    // clang-format on
     return uiReturn;
 }

--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -823,7 +823,8 @@ float CModelInfoSA::GetDistanceFromCentreOfMassToBaseOfModel()
     DWORD dwModelInfo = 0;
     DWORD ModelID = m_dwModelID;
     float fReturn = 0;
-    __asm {
+    __asm
+    {
         mov     eax, ModelID
 
         push    ecx

--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -112,6 +112,7 @@ bool CModelInfoSA::IsBoat()
     DWORD dwFunction = FUNC_IsBoatModel;
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
+    // clang-format off
     __asm
     {
         push    ModelID
@@ -119,6 +120,7 @@ bool CModelInfoSA::IsBoat()
         mov     bReturn, al
         add     esp, 4
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -127,6 +129,7 @@ bool CModelInfoSA::IsCar()
     DWORD dwFunction = FUNC_IsCarModel;
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
+    // clang-format off
     __asm
     {
         push    ModelID
@@ -134,6 +137,7 @@ bool CModelInfoSA::IsCar()
         mov     bReturn, al
         add     esp, 4
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -142,6 +146,7 @@ bool CModelInfoSA::IsTrain()
     DWORD dwFunction = FUNC_IsTrainModel;
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
+    // clang-format off
     __asm
     {
         push    ModelID
@@ -149,6 +154,7 @@ bool CModelInfoSA::IsTrain()
         mov     bReturn, al
         add     esp, 4
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -157,6 +163,7 @@ bool CModelInfoSA::IsHeli()
     DWORD dwFunction = FUNC_IsHeliModel;
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
+    // clang-format off
     __asm
     {
         push    ModelID
@@ -164,6 +171,7 @@ bool CModelInfoSA::IsHeli()
         mov     bReturn, al
         add     esp, 4
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -172,6 +180,7 @@ bool CModelInfoSA::IsPlane()
     DWORD dwFunction = FUNC_IsPlaneModel;
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
+    // clang-format off
     __asm
     {
         push    ModelID
@@ -179,6 +188,7 @@ bool CModelInfoSA::IsPlane()
         mov     bReturn, al
         add     esp, 4
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -187,6 +197,7 @@ bool CModelInfoSA::IsBike()
     DWORD dwFunction = FUNC_IsBikeModel;
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
+    // clang-format off
     __asm
     {
         push    ModelID
@@ -194,6 +205,7 @@ bool CModelInfoSA::IsBike()
         mov     bReturn, al
         add     esp, 4
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -202,6 +214,7 @@ bool CModelInfoSA::IsFakePlane()
     DWORD dwFunction = FUNC_IsFakePlaneModel;
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
+    // clang-format off
     __asm
     {
         push    ModelID
@@ -209,6 +222,7 @@ bool CModelInfoSA::IsFakePlane()
         mov     bReturn, al
         add     esp, 4
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -217,6 +231,7 @@ bool CModelInfoSA::IsMonsterTruck()
     DWORD dwFunction = FUNC_IsMonsterTruckModel;
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
+    // clang-format off
     __asm
     {
         push    ModelID
@@ -224,6 +239,7 @@ bool CModelInfoSA::IsMonsterTruck()
         mov     bReturn, al
         add     esp, 4
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -232,6 +248,7 @@ bool CModelInfoSA::IsQuadBike()
     DWORD dwFunction = FUNC_IsQuadBikeModel;
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
+    // clang-format off
     __asm
     {
         push    ModelID
@@ -239,6 +256,7 @@ bool CModelInfoSA::IsQuadBike()
         mov     bReturn, al
         add     esp, 4
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -247,6 +265,7 @@ bool CModelInfoSA::IsBmx()
     DWORD dwFunction = FUNC_IsBmxModel;
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
+    // clang-format off
     __asm
     {
         push    ModelID
@@ -254,6 +273,7 @@ bool CModelInfoSA::IsBmx()
         mov     bReturn, al
         add     esp, 4
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -262,6 +282,7 @@ bool CModelInfoSA::IsTrailer()
     DWORD dwFunction = FUNC_IsTrailerModel;
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
+    // clang-format off
     __asm
     {
         push    ModelID
@@ -269,6 +290,7 @@ bool CModelInfoSA::IsTrailer()
         mov     bReturn, al
         add     esp, 4
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -320,6 +342,8 @@ char* CModelInfoSA::GetNameIfVehicle()
     DWORD ModelID = m_dwModelID;
     DWORD dwReturn = 0;
 
+        // clang-format off
+
         __asm
         {
             push    eax
@@ -342,6 +366,8 @@ char* CModelInfoSA::GetNameIfVehicle()
             pop     ebx
             pop     eax
         }
+
+        // clang-format on
     return (char*)dwReturn;
 }
 
@@ -355,12 +381,14 @@ uint CModelInfoSA::GetAnimFileIndex()
     uint  uiReturn = 0;
     if (dwFunc)
     {
+        // clang-format off
         __asm
         {
             mov     ecx, dwThis
             call    dwFunc
             mov     uiReturn, eax
         }
+        // clang-format on
     }
     return uiReturn;
 }
@@ -756,6 +784,7 @@ CBoundingBox* CModelInfoSA::GetBoundingBox()
     DWORD         dwFunc = FUNC_GetBoundingBox;
     DWORD         ModelID = m_dwModelID;
     CBoundingBox* dwReturn = 0;
+    // clang-format off
     __asm
     {
         push    ModelID
@@ -763,6 +792,7 @@ CBoundingBox* CModelInfoSA::GetBoundingBox()
         add     esp, 4
         mov     dwReturn, eax
     }
+    // clang-format on
     return dwReturn;
 }
 
@@ -823,6 +853,7 @@ float CModelInfoSA::GetDistanceFromCentreOfMassToBaseOfModel()
     DWORD dwModelInfo = 0;
     DWORD ModelID = m_dwModelID;
     float fReturn = 0;
+    // clang-format off
     __asm
     {
         mov     eax, ModelID
@@ -840,6 +871,7 @@ float CModelInfoSA::GetDistanceFromCentreOfMassToBaseOfModel()
         fstp    fReturn
 skip:
     }
+    // clang-format on
     return fReturn;
 }
 
@@ -1320,11 +1352,13 @@ void CModelInfoSA::RemoveRef(bool bRemoveExtraGTARef)
         {
             DWORD                      dwFunction = FUNC_RemoveRef;
             CBaseModelInfoSAInterface* pInterface = m_pInterface;
+            // clang-format off
             __asm
             {
                 mov     ecx, pInterface
                 call    dwFunction
             }
+            // clang-format on
         }
     }
 
@@ -1393,6 +1427,7 @@ short CModelInfoSA::GetAvailableVehicleMod(unsigned short usUpgrade)
     if (usUpgrade >= 1000 && usUpgrade <= 1193)
     {
         DWORD ModelID = m_dwModelID;
+        // clang-format off
         __asm
         {
             mov     eax, ModelID
@@ -1407,6 +1442,7 @@ short CModelInfoSA::GetAvailableVehicleMod(unsigned short usUpgrade)
             mov     ax, [eax+edx*2+0x2D6]
             mov     sreturn, ax
         }
+        // clang-format on
     }
     return sreturn;
 }
@@ -1415,6 +1451,7 @@ bool CModelInfoSA::IsUpgradeAvailable(eVehicleUpgradePosn posn)
 {
     bool  bRet = false;
     DWORD ModelID = m_dwModelID;
+    // clang-format off
     __asm
     {
         mov     eax, ModelID
@@ -1434,6 +1471,7 @@ bool CModelInfoSA::IsUpgradeAvailable(eVehicleUpgradePosn posn)
 
         mov     bRet, al
     }
+    // clang-format on
     return bRet;
 }
 
@@ -1441,6 +1479,7 @@ void CModelInfoSA::SetCustomCarPlateText(const char* szText)
 {
     char* szStoredText;
     DWORD ModelID = m_dwModelID;
+    // clang-format off
     __asm
     {
         push    ecx
@@ -1455,6 +1494,7 @@ void CModelInfoSA::SetCustomCarPlateText(const char* szText)
         mov     szStoredText, ecx
         pop     ecx
     }
+    // clang-format on
 
     if (szText)
         strncpy(szStoredText, szText, 8);
@@ -1467,6 +1507,7 @@ unsigned int CModelInfoSA::GetNumRemaps()
     DWORD        dwFunc = FUNC_CVehicleModelInfo__GetNumRemaps;
     DWORD        ModelID = m_dwModelID;
     unsigned int uiReturn = 0;
+    // clang-format off
     __asm
     {
         mov     ecx, ModelID
@@ -1479,6 +1520,7 @@ unsigned int CModelInfoSA::GetNumRemaps()
         call    dwFunc
         mov     uiReturn, eax
     }
+    // clang-format on
     return uiReturn;
 }
 
@@ -2163,6 +2205,8 @@ static void __declspec(naked) HOOK_NodeNameStreamRead()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -2175,6 +2219,8 @@ static void __declspec(naked) HOOK_NodeNameStreamRead()
 
         jmp     RETURN_NodeNameStreamRead
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -343,7 +343,6 @@ char* CModelInfoSA::GetNameIfVehicle()
     DWORD dwReturn = 0;
 
         // clang-format off
-
         __asm
         {
             push    eax
@@ -366,7 +365,6 @@ char* CModelInfoSA::GetNameIfVehicle()
             pop     ebx
             pop     eax
         }
-
         // clang-format on
     return (char*)dwReturn;
 }
@@ -853,9 +851,7 @@ float CModelInfoSA::GetDistanceFromCentreOfMassToBaseOfModel()
     DWORD dwModelInfo = 0;
     DWORD ModelID = m_dwModelID;
     float fReturn = 0;
-    // clang-format off
-    __asm
-    {
+    __asm {
         mov     eax, ModelID
 
         push    ecx
@@ -871,7 +867,6 @@ float CModelInfoSA::GetDistanceFromCentreOfMassToBaseOfModel()
         fstp    fReturn
 skip:
     }
-    // clang-format on
     return fReturn;
 }
 
@@ -2206,7 +2201,6 @@ static void __declspec(naked) HOOK_NodeNameStreamRead()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -2219,7 +2213,6 @@ static void __declspec(naked) HOOK_NodeNameStreamRead()
 
         jmp     RETURN_NodeNameStreamRead
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CObjectSA.cpp
+++ b/Client/game_sa/CObjectSA.cpp
@@ -32,7 +32,6 @@ static void __declspec(naked) HOOK_CCObject_PreRender()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push    ecx
@@ -43,7 +42,6 @@ static void __declspec(naked) HOOK_CCObject_PreRender()
         mov     esi, ecx
         jmp     RETURN_CCObject_PreRender
     }
-
     // clang-format on
 }
 
@@ -174,13 +172,11 @@ void CObjectSA::Explode()
     DWORD dwThis = (DWORD)GetInterface();
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
-
     // clang-format on
 }
 
@@ -192,7 +188,6 @@ void CObjectSA::Break()
     float fHitVelocity = 1000.0f;            // has no direct influence, but should be high enough to trigger the break (effect)
 
     // clang-format off
-
     __asm
     {
         push    32h // most cases: between 30 and 37
@@ -203,7 +198,6 @@ void CObjectSA::Break()
         mov     ecx, dwThis
         call    dwFunc
     }
-
     // clang-format on
 
     if (IsGlass())
@@ -214,7 +208,6 @@ void CObjectSA::Break()
         dwFunc = FUNC_CGlass_WindowRespondsToCollision;
 
         // clang-format off
-
         __asm
         {
             push 0
@@ -229,7 +222,6 @@ void CObjectSA::Break()
             call dwFunc
             add esp, 24h
         }
-
         // clang-format on
     }
 }
@@ -282,7 +274,6 @@ bool CObjectSA::IsGlass()
     bool  bResult;
 
     // clang-format off
-
     __asm
     {
         push dwThis
@@ -290,7 +281,6 @@ bool CObjectSA::IsGlass()
         mov bResult, al
         add esp, 4
     }
-
     // clang-format on
     return bResult;
 }

--- a/Client/game_sa/CObjectSA.cpp
+++ b/Client/game_sa/CObjectSA.cpp
@@ -31,6 +31,8 @@ static void __declspec(naked) HOOK_CCObject_PreRender()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         push    ecx
@@ -41,6 +43,8 @@ static void __declspec(naked) HOOK_CCObject_PreRender()
         mov     esi, ecx
         jmp     RETURN_CCObject_PreRender
     }
+
+    // clang-format on
 }
 
 void CObjectSA::StaticSetHooks()
@@ -91,6 +95,7 @@ CObjectSA::CObjectSA(DWORD dwModel, bool bBreakingDisabled)
 {
     DWORD CObjectCreate = FUNC_CObject_Create;
     DWORD dwObjectPtr = 0;
+    // clang-format off
     __asm
     {
         push    1
@@ -99,6 +104,7 @@ CObjectSA::CObjectSA(DWORD dwModel, bool bBreakingDisabled)
         add     esp, 8
         mov     dwObjectPtr, eax
     }
+    // clang-format on
 
     if (dwObjectPtr)
     {
@@ -167,11 +173,15 @@ void CObjectSA::Explode()
     DWORD dwFunc = FUNC_CObject_Explode;
     DWORD dwThis = (DWORD)GetInterface();
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 void CObjectSA::Break()
@@ -180,6 +190,8 @@ void CObjectSA::Break()
     DWORD dwThis = (DWORD)GetInterface();
 
     float fHitVelocity = 1000.0f;            // has no direct influence, but should be high enough to trigger the break (effect)
+
+    // clang-format off
 
     __asm
     {
@@ -192,12 +204,16 @@ void CObjectSA::Break()
         call    dwFunc
     }
 
+    // clang-format on
+
     if (IsGlass())
     {
         float fX = 0.0f;
         float fY = 0.0f;
         float fZ = 0.0f;
         dwFunc = FUNC_CGlass_WindowRespondsToCollision;
+
+        // clang-format off
 
         __asm
         {
@@ -213,6 +229,8 @@ void CObjectSA::Break()
             call dwFunc
             add esp, 24h
         }
+
+        // clang-format on
     }
 }
 
@@ -263,6 +281,8 @@ bool CObjectSA::IsGlass()
     DWORD dwThis = (DWORD)GetInterface();
     bool  bResult;
 
+    // clang-format off
+
     __asm
     {
         push dwThis
@@ -270,6 +290,8 @@ bool CObjectSA::IsGlass()
         mov bResult, al
         add esp, 4
     }
+
+    // clang-format on
     return bResult;
 }
 

--- a/Client/game_sa/CPedDamageResponseCalculatorSA.cpp
+++ b/Client/game_sa/CPedDamageResponseCalculatorSA.cpp
@@ -23,6 +23,7 @@ CPedDamageResponseCalculatorSA::CPedDamageResponseCalculatorSA(CEntity* pEntity,
     DWORD dwEntityInterface = (DWORD)pEntity->GetInterface();
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CPedDamageResponseCalculator_Constructor;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -33,6 +34,7 @@ CPedDamageResponseCalculatorSA::CPedDamageResponseCalculatorSA(CEntity* pEntity,
         push    dwEntityInterface
         call    dwFunc
     }
+    // clang-format on
 }
 
 CPedDamageResponseCalculatorSA::CPedDamageResponseCalculatorSA(CPedDamageResponseCalculatorSAInterface* pInterface)
@@ -47,11 +49,13 @@ CPedDamageResponseCalculatorSA::~CPedDamageResponseCalculatorSA()
     {
         DWORD dwThis = (DWORD)m_pInterface;
         DWORD dwFunc = FUNC_CPedDamageResponseCalculator_Destructor;
+        // clang-format off
         __asm
         {
             mov     ecx, dwThis
             call    dwFunc
         }
+        // clang-format on
         delete m_pInterface;
     }
 }
@@ -62,6 +66,7 @@ void CPedDamageResponseCalculatorSA::ComputeDamageResponse(CPed* pPed, CPedDamag
     DWORD dwResponseInterface = (DWORD)pDamageResponse->GetInterface();
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CPedDamageResponseCalculator_ComputeDamageResponse;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -70,4 +75,5 @@ void CPedDamageResponseCalculatorSA::ComputeDamageResponse(CPed* pPed, CPedDamag
         push    dwPedInterface
         call    dwFunc
     }
+    // clang-format on
 }

--- a/Client/game_sa/CPedIntelligenceSA.cpp
+++ b/Client/game_sa/CPedIntelligenceSA.cpp
@@ -40,6 +40,7 @@ bool CPedIntelligenceSA::TestForStealthKill(CPed* pPed, bool bUnk)
     DWORD dwThis = (DWORD)internalInterface;
     DWORD dwPed = (DWORD)pPed->GetInterface();
     DWORD dwFunc = FUNC_CPedIntelligence_TestForStealthKill;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -48,6 +49,7 @@ bool CPedIntelligenceSA::TestForStealthKill(CPed* pPed, bool bUnk)
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 

--- a/Client/game_sa/CPedModelInfoSA.cpp
+++ b/Client/game_sa/CPedModelInfoSA.cpp
@@ -29,10 +29,12 @@ void CPedModelInfoSA::SetMotionAnimGroup(AssocGroupId animGroup)
 {
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = (DWORD)FUNC_SetMotionAnimGroup;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         push    animGroup
         call    dwFunc
     }
+    // clang-format on
 }

--- a/Client/game_sa/CPedSA.cpp
+++ b/Client/game_sa/CPedSA.cpp
@@ -604,6 +604,8 @@ static void __declspec(naked) HOOK_CPed_PreRenderAfterTest()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // Replaced code
@@ -627,6 +629,8 @@ static void __declspec(naked) HOOK_CPed_PreRenderAfterTest()
         // Skip code at start of CPed::PreRenderAfterTest
         jmp     RETURN_CPed_PreRenderAfterTestSkip
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////
@@ -645,6 +649,8 @@ static void __declspec(naked) HOOK_CPed_PreRenderAfterTest_Mid()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // Check what to do
@@ -661,6 +667,8 @@ static void __declspec(naked) HOOK_CPed_PreRenderAfterTest_Mid()
         // Skip code at mid of CPed::PreRenderAfterTest
         jmp     RETURN_CPed_PreRenderAfterTest_MidSkip
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////

--- a/Client/game_sa/CPedSA.cpp
+++ b/Client/game_sa/CPedSA.cpp
@@ -605,7 +605,6 @@ static void __declspec(naked) HOOK_CPed_PreRenderAfterTest()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Replaced code
@@ -629,7 +628,6 @@ static void __declspec(naked) HOOK_CPed_PreRenderAfterTest()
         // Skip code at start of CPed::PreRenderAfterTest
         jmp     RETURN_CPed_PreRenderAfterTestSkip
     }
-
     // clang-format on
 }
 
@@ -650,7 +648,6 @@ static void __declspec(naked) HOOK_CPed_PreRenderAfterTest_Mid()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Check what to do
@@ -667,7 +664,6 @@ static void __declspec(naked) HOOK_CPed_PreRenderAfterTest_Mid()
         // Skip code at mid of CPed::PreRenderAfterTest
         jmp     RETURN_CPed_PreRenderAfterTest_MidSkip
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CPedSoundSA.cpp
+++ b/Client/game_sa/CPedSoundSA.cpp
@@ -43,12 +43,14 @@ bool CPedSoundSA::IsSpeechDisabled()
     bool  bReturn;
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAEPedSound__IsSpeedDisabled;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -56,29 +58,35 @@ void CPedSoundSA::EnablePedSpeech()
 {
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAEPedSound__EnablePedSpeech;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CPedSoundSA::DisablePedSpeech(bool bStopCurrent)
 {
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAEPedSound__DisablePedSpeech;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         push    bStopCurrent
         call    dwFunc
     }
+    // clang-format on
 }
 
 short CPedSoundSA::GetVoiceTypeIDFromName(const char* szVoiceTypeName)
 {
     DWORD dwFunc = (DWORD)FUNC_CAEPedSound__GetAudioPedType;
     short sVoiceTypeID;
+
+    // clang-format off
 
     __asm
     {
@@ -87,6 +95,8 @@ short CPedSoundSA::GetVoiceTypeIDFromName(const char* szVoiceTypeName)
         add     esp, 4
         mov     sVoiceTypeID, ax
     }
+
+    // clang-format on
     return sVoiceTypeID;
 }
 
@@ -94,6 +104,8 @@ short CPedSoundSA::GetVoiceIDFromName(short sVoiceTypeID, const char* szVoiceNam
 {
     DWORD dwFunc = (DWORD)FUNC_CAEPedSound__GetVoice;
     short sVoiceID;
+
+    // clang-format off
 
     __asm
     {
@@ -104,6 +116,8 @@ short CPedSoundSA::GetVoiceIDFromName(short sVoiceTypeID, const char* szVoiceNam
         add     esp, 8
         mov     sVoiceID, ax
     }
+
+    // clang-format on
     return sVoiceID;
 }
 

--- a/Client/game_sa/CPedSoundSA.cpp
+++ b/Client/game_sa/CPedSoundSA.cpp
@@ -87,7 +87,6 @@ short CPedSoundSA::GetVoiceTypeIDFromName(const char* szVoiceTypeName)
     short sVoiceTypeID;
 
     // clang-format off
-
     __asm
     {
         push    szVoiceTypeName
@@ -95,7 +94,6 @@ short CPedSoundSA::GetVoiceTypeIDFromName(const char* szVoiceTypeName)
         add     esp, 4
         mov     sVoiceTypeID, ax
     }
-
     // clang-format on
     return sVoiceTypeID;
 }
@@ -106,7 +104,6 @@ short CPedSoundSA::GetVoiceIDFromName(short sVoiceTypeID, const char* szVoiceNam
     short sVoiceID;
 
     // clang-format off
-
     __asm
     {
         movzx eax, sVoiceTypeID
@@ -116,7 +113,6 @@ short CPedSoundSA::GetVoiceIDFromName(short sVoiceTypeID, const char* szVoiceNam
         add     esp, 8
         mov     sVoiceID, ax
     }
-
     // clang-format on
     return sVoiceID;
 }

--- a/Client/game_sa/CPhysicalSA.cpp
+++ b/Client/game_sa/CPhysicalSA.cpp
@@ -82,12 +82,14 @@ CVector* CPhysicalSA::GetMoveSpeedInternal(CVector* vecMoveSpeed)
     DWORD dwFunc = FUNC_GetMoveSpeed;
     DWORD dwThis = (DWORD)((CPhysicalSAInterface*)GetInterface());
     DWORD dwReturn = 0;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         mov     dwReturn, eax
     }
+    // clang-format on
     MemCpyFast(vecMoveSpeed, (void*)dwReturn, sizeof(CVector));
     return vecMoveSpeed;
 }
@@ -97,12 +99,14 @@ CVector* CPhysicalSA::GetTurnSpeedInternal(CVector* vecTurnSpeed)
     DWORD dwFunc = FUNC_GetTurnSpeed;
     DWORD dwThis = (DWORD)((CPhysicalSAInterface*)GetInterface());
     DWORD dwReturn = 0;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         mov     dwReturn, eax
     }
+    // clang-format on
     MemCpyFast(vecTurnSpeed, (void*)dwReturn, sizeof(CVector));
     return vecTurnSpeed;
 }
@@ -113,12 +117,16 @@ void CPhysicalSA::SetMoveSpeed(const CVector& vecMoveSpeed) noexcept
     DWORD dwThis = (DWORD)((CPhysicalSAInterface*)GetInterface());
     DWORD dwReturn = 0;
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         mov     dwReturn, eax
     }
+
+    // clang-format on
     MemCpyFast((void*)dwReturn, &vecMoveSpeed, sizeof(CVector));
 
     if (GetInterface()->nType == ENTITY_TYPE_OBJECT)
@@ -204,11 +212,15 @@ void CPhysicalSA::ProcessCollision()
     DWORD dwFunc = FUNC_ProcessCollision;
     DWORD dwThis = (DWORD)GetInterface();
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 void CPhysicalSA::AddToMovingList()
@@ -216,11 +228,15 @@ void CPhysicalSA::AddToMovingList()
     DWORD dwFunc = FUNC_CPhysical_AddToMovingList;
     DWORD dwThis = (DWORD)GetInterface();
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 float CPhysicalSA::GetDamageImpulseMagnitude()
@@ -289,6 +305,8 @@ void CPhysicalSA::DetachEntityFromEntity(float fUnkX, float fUnkY, float fUnkZ, 
     if (((CPhysicalSAInterface*)GetInterface())->m_pAttachedEntity == NULL)
         return;
 
+    // clang-format off
+
     __asm
     {
         push    bUnk
@@ -298,6 +316,8 @@ void CPhysicalSA::DetachEntityFromEntity(float fUnkX, float fUnkY, float fUnkZ, 
         mov     ecx, dwThis
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 bool CPhysicalSA::InternalAttachEntityToEntity(DWORD dwEntityInterface, const CVector* vecPosition, const CVector* vecRotation)
@@ -305,6 +325,7 @@ bool CPhysicalSA::InternalAttachEntityToEntity(DWORD dwEntityInterface, const CV
     DWORD dwFunc = FUNC_AttachEntityToEntity;
     DWORD dwThis = (DWORD)GetInterface();
     DWORD dwReturn = 0;
+    // clang-format off
     __asm
     {
         mov     ecx, vecRotation
@@ -320,6 +341,7 @@ bool CPhysicalSA::InternalAttachEntityToEntity(DWORD dwEntityInterface, const CV
         call    dwFunc
         mov     dwReturn, eax
     }
+    // clang-format on
     return (dwReturn != NULL);
 }
 

--- a/Client/game_sa/CPhysicalSA.cpp
+++ b/Client/game_sa/CPhysicalSA.cpp
@@ -118,14 +118,12 @@ void CPhysicalSA::SetMoveSpeed(const CVector& vecMoveSpeed) noexcept
     DWORD dwReturn = 0;
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         mov     dwReturn, eax
     }
-
     // clang-format on
     MemCpyFast((void*)dwReturn, &vecMoveSpeed, sizeof(CVector));
 
@@ -213,13 +211,11 @@ void CPhysicalSA::ProcessCollision()
     DWORD dwThis = (DWORD)GetInterface();
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
-
     // clang-format on
 }
 
@@ -229,13 +225,11 @@ void CPhysicalSA::AddToMovingList()
     DWORD dwThis = (DWORD)GetInterface();
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
-
     // clang-format on
 }
 
@@ -306,7 +300,6 @@ void CPhysicalSA::DetachEntityFromEntity(float fUnkX, float fUnkY, float fUnkZ, 
         return;
 
     // clang-format off
-
     __asm
     {
         push    bUnk
@@ -316,7 +309,6 @@ void CPhysicalSA::DetachEntityFromEntity(float fUnkX, float fUnkY, float fUnkZ, 
         mov     ecx, dwThis
         call    dwFunc
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CPickupSA.cpp
+++ b/Client/game_sa/CPickupSA.cpp
@@ -126,6 +126,7 @@ void CPickupSA::GiveUsAPickUpObject(int ForcedObjectIndex)
     DWORD GiveUsAPickUpObject = FUNC_GIVEUSAPICKUP;
     DWORD dwObject = (DWORD) & (GetInterface()->pObject);
     DWORD dwThis = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         push    ForcedObjectIndex
@@ -133,6 +134,7 @@ void CPickupSA::GiveUsAPickUpObject(int ForcedObjectIndex)
         mov     ecx, dwThis
         call    GiveUsAPickUpObject
     }
+    // clang-format on
     if (GetInterface()->pObject)
     {
         if (object)
@@ -162,11 +164,13 @@ void CPickupSA::Remove()
 {
     DWORD dwFunc = FUNC_CPickup_Remove;
     DWORD dwThis = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 
     // CPickup::Remove also destroys the owned object, so we need to delete our CObjectSA class
     if (object)

--- a/Client/game_sa/CPlayerPedSA.cpp
+++ b/Client/game_sa/CPlayerPedSA.cpp
@@ -36,6 +36,7 @@ CPlayerPedSA::CPlayerPedSA(unsigned int nModelIndex)
     DWORD CPlayerPedConstructor = FUNC_CPlayerPedConstructor;
 
     DWORD dwPedPointer = 0;
+    // clang-format off
     __asm
     {
         push    SIZEOF_CPLAYERPED
@@ -49,6 +50,7 @@ CPlayerPedSA::CPlayerPedSA(unsigned int nModelIndex)
         push    1
         call    CPlayerPedConstructor
     }
+    // clang-format on
 
     SetInterface((CEntitySAInterface*)dwPedPointer);
 
@@ -162,12 +164,14 @@ void CPlayerPedSA::SetInitialState()
     DWORD dwUnknown = 1;
     DWORD dwFunction = FUNC_SetInitialState;
     DWORD dwThis = (DWORD)m_pInterface;
+    // clang-format off
     __asm
     {
         push    dwUnknown
         mov     ecx, dwThis
         call    dwFunction
     }
+    // clang-format on
 
     // Avoid direction locks for respawning after a jump
     GetPlayerPedInterface()->pedFlags.bIsLanding = false;
@@ -293,11 +297,13 @@ void CPlayerPedSA::SetMoveAnim(eMoveAnim iAnimGroup)
 
     DWORD dwThis = (DWORD)pedInterface;
     DWORD dwFunc = FUNC_CPlayerPed_ReApplyMoveAnims;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
+    // clang-format on
 }
 
 CEntity* CPlayerPedSA::GetTargetedEntity() const
@@ -447,6 +453,8 @@ static void __declspec(naked) HOOK_CPlayerPed_ProcessAnimGroups_Mid()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -462,6 +470,8 @@ static void __declspec(naked) HOOK_CPlayerPed_ProcessAnimGroups_Mid()
 
         jmp     RETURN_CPlayerPed_ProcessAnimGroups_Mid
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////
@@ -501,6 +511,8 @@ static void __declspec(naked) HOOK_CClothes_GetDefaultPlayerMotionGroup()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     eax, 0x05A7FB0      // CClothes::GetPlayerMotionGroupToLoad
@@ -516,6 +528,8 @@ static void __declspec(naked) HOOK_CClothes_GetDefaultPlayerMotionGroup()
         mov     eax,[esp-32-4*1]    // Get temp
         jmp     RETURN_CClothes_GetDefaultPlayerMotionGroup
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/game_sa/CPlayerPedSA.cpp
+++ b/Client/game_sa/CPlayerPedSA.cpp
@@ -454,7 +454,6 @@ static void __declspec(naked) HOOK_CPlayerPed_ProcessAnimGroups_Mid()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -470,7 +469,6 @@ static void __declspec(naked) HOOK_CPlayerPed_ProcessAnimGroups_Mid()
 
         jmp     RETURN_CPlayerPed_ProcessAnimGroups_Mid
     }
-
     // clang-format on
 }
 
@@ -512,7 +510,6 @@ static void __declspec(naked) HOOK_CClothes_GetDefaultPlayerMotionGroup()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     eax, 0x05A7FB0      // CClothes::GetPlayerMotionGroupToLoad
@@ -528,7 +525,6 @@ static void __declspec(naked) HOOK_CClothes_GetDefaultPlayerMotionGroup()
         mov     eax,[esp-32-4*1]    // Get temp
         jmp     RETURN_CClothes_GetDefaultPlayerMotionGroup
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CPointLightsSA.cpp
+++ b/Client/game_sa/CPointLightsSA.cpp
@@ -28,6 +28,7 @@ void CPointLightsSA::AddLight(int iMode, const CVector vecPosition, CVector vecD
     float fPosX = vecPosition.fX, fPosY = vecPosition.fY, fPosZ = vecPosition.fZ;
     float fDirX = vecDirection.fX, fDirY = vecDirection.fY, fDirZ = vecDirection.fZ;
     float fRed = (float)color.R / 255, fGreen = (float)color.G / 255, fBlue = (float)color.B / 255;
+    // clang-format off
     __asm
     {
         push    dwEntityInterface
@@ -47,6 +48,7 @@ void CPointLightsSA::AddLight(int iMode, const CVector vecPosition, CVector vecD
         call    dwFunc
         add     esp, 56
     }
+    // clang-format on
 }
 
 void CPointLightsSA::PreRenderHeliLights()

--- a/Client/game_sa/CPoolsSA.cpp
+++ b/Client/game_sa/CPoolsSA.cpp
@@ -530,7 +530,8 @@ CPedSAInterface* CPoolsSA::GetPedInterface(DWORD dwGameRef)
     DWORD dwReturn;
     DWORD dwFunction = FUNC_GetPed;
 
-    __asm {
+    __asm
+    {
         mov     ecx, dword ptr ds : [CLASS_CPool_Ped]
         push    dwGameRef
         call    dwFunction

--- a/Client/game_sa/CPoolsSA.cpp
+++ b/Client/game_sa/CPoolsSA.cpp
@@ -530,18 +530,13 @@ CPedSAInterface* CPoolsSA::GetPedInterface(DWORD dwGameRef)
     DWORD dwReturn;
     DWORD dwFunction = FUNC_GetPed;
 
-    // clang-format off
-
-    __asm
-    {
+    __asm {
         mov     ecx, dword ptr ds : [CLASS_CPool_Ped]
         push    dwGameRef
         call    dwFunction
         add     esp, 0x4
         mov     dwReturn, eax
     }
-
-    // clang-format on
 
     CPedSAInterface* pInterface = (CPedSAInterface*)dwReturn;
     return pInterface;

--- a/Client/game_sa/CPoolsSA.cpp
+++ b/Client/game_sa/CPoolsSA.cpp
@@ -530,6 +530,8 @@ CPedSAInterface* CPoolsSA::GetPedInterface(DWORD dwGameRef)
     DWORD dwReturn;
     DWORD dwFunction = FUNC_GetPed;
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dword ptr ds : [CLASS_CPool_Ped]
@@ -538,6 +540,8 @@ CPedSAInterface* CPoolsSA::GetPedInterface(DWORD dwGameRef)
         add     esp, 0x4
         mov     dwReturn, eax
     }
+
+    // clang-format on
 
     CPedSAInterface* pInterface = (CPedSAInterface*)dwReturn;
     return pInterface;
@@ -1100,6 +1104,7 @@ int CPoolsSA::GetNumberOfUsedSpaces(ePools pool)
     int iOut = -2;
     if (*(DWORD*)dwThis != NULL)
     {
+        // clang-format off
         __asm
         {
             mov     ecx, dwThis
@@ -1108,6 +1113,7 @@ int CPoolsSA::GetNumberOfUsedSpaces(ePools pool)
             mov     iOut, eax
 
         }
+        // clang-format on
     }
 
     return iOut;

--- a/Client/game_sa/CProjectileInfoSA.cpp
+++ b/Client/game_sa/CProjectileInfoSA.cpp
@@ -49,6 +49,7 @@ void CProjectileInfoSA::RemoveProjectile(CProjectileInfo* pProjectileInfo, CProj
             if (bBlow)
             {
                 DWORD dwFunc = FUNC_RemoveProjectile;
+                // clang-format off
                 __asm
                 {
                     push    projectileInterface
@@ -56,16 +57,19 @@ void CProjectileInfoSA::RemoveProjectile(CProjectileInfo* pProjectileInfo, CProj
                     call    dwFunc
                     add     esp, 8
                 }
+                // clang-format on
             }
             else
             {
                 DWORD dwFunc = FUNC_RemoveIfThisIsAProjectile;
+                // clang-format off
                 __asm
                 {
                     push   projectileInterface
                     call   dwFunc
                     add    esp, 4
                 }
+                // clang-format on
             }
         }
     }
@@ -111,6 +115,8 @@ bool CProjectileInfoSA::AddProjectile(CEntity* creator, eWeaponType eWeapon, CVe
             targetVC = pTargetEntitySA->GetInterface();
     }
 
+    // clang-format off
+
     __asm
     {
         push    eax
@@ -130,6 +136,8 @@ bool CProjectileInfoSA::AddProjectile(CEntity* creator, eWeaponType eWeapon, CVe
 
         pop     eax
     }
+
+    // clang-format on
     pGame->GetWorld()->IgnoreEntity(nullptr);
     return dwReturn != 0;
 }

--- a/Client/game_sa/CProjectileInfoSA.cpp
+++ b/Client/game_sa/CProjectileInfoSA.cpp
@@ -116,7 +116,6 @@ bool CProjectileInfoSA::AddProjectile(CEntity* creator, eWeaponType eWeapon, CVe
     }
 
     // clang-format off
-
     __asm
     {
         push    eax
@@ -136,7 +135,6 @@ bool CProjectileInfoSA::AddProjectile(CEntity* creator, eWeaponType eWeapon, CVe
 
         pop     eax
     }
-
     // clang-format on
     pGame->GetWorld()->IgnoreEntity(nullptr);
     return dwReturn != 0;

--- a/Client/game_sa/CProjectileSA.cpp
+++ b/Client/game_sa/CProjectileSA.cpp
@@ -43,19 +43,23 @@ CProjectileSA::~CProjectileSA()
 
         DWORD dwThis = (DWORD)this->GetInterface();
         DWORD dwFunc = this->GetInterface()->vtbl->Remove;
+        // clang-format off
         __asm
         {
             mov     ecx, dwThis
             call    dwFunc
         }
+        // clang-format on
 
         dwFunc = this->GetInterface()->vtbl->SCALAR_DELETING_DESTRUCTOR; // we use the vtbl so we can be type independent
+        // clang-format off
         __asm
         {
             mov     ecx, dwThis
             push    1           //delete too
             call    dwFunc
         }
+        // clang-format on
 
         this->BeingDeleted = true;
         //((CPoolsSA *)pGame->GetPools())->RemoveObject((CObject *)(CObjectSA *)this);

--- a/Client/game_sa/CPtrNodeSingleLinkPoolSA.cpp
+++ b/Client/game_sa/CPtrNodeSingleLinkPoolSA.cpp
@@ -45,7 +45,6 @@ static void __declspec(naked) HOOK_CPtrListSingleLink_Flush()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     edi, ecx    // save register
@@ -58,7 +57,6 @@ static void __declspec(naked) HOOK_CPtrListSingleLink_Flush()
         mov     ecx, edi    // restore register
         jmp     CONTINUE_CPtrListSingleLink_Flush
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CPtrNodeSingleLinkPoolSA.cpp
+++ b/Client/game_sa/CPtrNodeSingleLinkPoolSA.cpp
@@ -44,6 +44,8 @@ static void __declspec(naked) HOOK_CPtrListSingleLink_Flush()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     edi, ecx    // save register
@@ -56,6 +58,8 @@ static void __declspec(naked) HOOK_CPtrListSingleLink_Flush()
         mov     ecx, edi    // restore register
         jmp     CONTINUE_CPtrListSingleLink_Flush
     }
+
+    // clang-format on
 }
 
 void CPtrNodeSingleLinkPoolSA::StaticSetHooks()

--- a/Client/game_sa/CRadarSA.cpp
+++ b/Client/game_sa/CRadarSA.cpp
@@ -63,6 +63,7 @@ void CRadarSA::DrawAreaOnRadar(float fX1, float fY1, float fX2, float fY2, const
     unsigned long abgr = color.A << 24 | color.B << 16 | color.G << 8 | color.R;
     CRect         myRect(fX1, fY2, fX2, fY1);
     DWORD         dwFunc = FUNC_DrawAreaOnRadar;
+    // clang-format off
     __asm
     {
         push    eax
@@ -77,4 +78,5 @@ void CRadarSA::DrawAreaOnRadar(float fX1, float fY1, float fX2, float fY2, const
 
         pop     eax
     }
+    // clang-format on
 }

--- a/Client/game_sa/CRenderWareSA.ClothesReplacing.cpp
+++ b/Client/game_sa/CRenderWareSA.ClothesReplacing.cpp
@@ -293,6 +293,8 @@ static void __declspec(naked) HOOK_CStreaming_RequestModel_Mid()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -323,6 +325,8 @@ static void __declspec(naked) HOOK_CStreaming_RequestModel_Mid()
         popad
         jmp     RETURN_CStreaming_RequestModel_MidB
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/game_sa/CRenderWareSA.ClothesReplacing.cpp
+++ b/Client/game_sa/CRenderWareSA.ClothesReplacing.cpp
@@ -294,7 +294,6 @@ static void __declspec(naked) HOOK_CStreaming_RequestModel_Mid()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -325,7 +324,6 @@ static void __declspec(naked) HOOK_CStreaming_RequestModel_Mid()
         popad
         jmp     RETURN_CStreaming_RequestModel_MidB
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CRenderWareSA.ShaderSupport.cpp
+++ b/Client/game_sa/CRenderWareSA.ShaderSupport.cpp
@@ -89,6 +89,8 @@ static void __declspec(naked) HOOK_CTxdStore_SetupTxdParent()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // Hooked from 731D55  6 bytes
@@ -104,6 +106,8 @@ static void __declspec(naked) HOOK_CTxdStore_SetupTxdParent()
         mov     esi, ds:00C8800Ch
         jmp     RETURN_CTxdStore_SetupTxdParent  // 731D5B
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////
@@ -124,6 +128,8 @@ static void __declspec(naked) HOOK_CTxdStore_RemoveTxd()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // Hooked from 731E90  6 bytes
@@ -139,6 +145,8 @@ static void __declspec(naked) HOOK_CTxdStore_RemoveTxd()
         mov     ecx, ds:00C8800Ch
         jmp     RETURN_CTxdStore_RemoveTxd      // 731E96
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////
@@ -881,6 +889,8 @@ static void __declspec(naked) HOOK_RwTextureSetName()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -895,6 +905,8 @@ static void __declspec(naked) HOOK_RwTextureSetName()
         mov     ecx, ds:0x0C97B24
         jmp     RETURN_RwTextureSetName
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -917,6 +929,8 @@ static void __declspec(naked) HOOK_RwTextureDestroy_Mid()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -928,6 +942,8 @@ static void __declspec(naked) HOOK_RwTextureDestroy_Mid()
         push    0x08E23CC
         jmp     RETURN_RwTextureDestroy_Mid
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -963,6 +979,8 @@ static void __declspec(naked) HOOK_RwIm3DRenderIndexedPrimitive()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -988,6 +1006,8 @@ static void __declspec(naked) HOOK_RwIm3DRenderIndexedPrimitive()
         mov     eax, ds:0x0C9C078
         jmp     RETURN_RwIm3DRenderIndexedPrimitive
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -1015,6 +1035,8 @@ static void __declspec(naked) HOOK_RwIm3DRenderPrimitive()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -1040,6 +1062,8 @@ static void __declspec(naked) HOOK_RwIm3DRenderPrimitive()
         mov     ecx, ds:0x0C97B24
         jmp     RETURN_RwIm3DRenderPrimitive
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -1067,6 +1091,8 @@ static void __declspec(naked) HOOK_RwIm2DRenderIndexedPrimitive()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -1093,6 +1119,8 @@ static void __declspec(naked) HOOK_RwIm2DRenderIndexedPrimitive()
         inner:
         jmp     RETURN_RwIm2DRenderIndexedPrimitive
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -1120,6 +1148,8 @@ static void __declspec(naked) HOOK_RwIm2DRenderPrimitive()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -1145,6 +1175,8 @@ static void __declspec(naked) HOOK_RwIm2DRenderPrimitive()
         mov     eax, ds:0x0C97B24
         jmp     RETURN_RwIm2DRenderPrimitive
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/game_sa/CRenderWareSA.ShaderSupport.cpp
+++ b/Client/game_sa/CRenderWareSA.ShaderSupport.cpp
@@ -90,7 +90,6 @@ static void __declspec(naked) HOOK_CTxdStore_SetupTxdParent()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Hooked from 731D55  6 bytes
@@ -106,7 +105,6 @@ static void __declspec(naked) HOOK_CTxdStore_SetupTxdParent()
         mov     esi, ds:00C8800Ch
         jmp     RETURN_CTxdStore_SetupTxdParent  // 731D5B
     }
-
     // clang-format on
 }
 
@@ -129,7 +127,6 @@ static void __declspec(naked) HOOK_CTxdStore_RemoveTxd()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Hooked from 731E90  6 bytes
@@ -145,7 +142,6 @@ static void __declspec(naked) HOOK_CTxdStore_RemoveTxd()
         mov     ecx, ds:00C8800Ch
         jmp     RETURN_CTxdStore_RemoveTxd      // 731E96
     }
-
     // clang-format on
 }
 
@@ -890,7 +886,6 @@ static void __declspec(naked) HOOK_RwTextureSetName()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -905,7 +900,6 @@ static void __declspec(naked) HOOK_RwTextureSetName()
         mov     ecx, ds:0x0C97B24
         jmp     RETURN_RwTextureSetName
     }
-
     // clang-format on
 }
 
@@ -930,7 +924,6 @@ static void __declspec(naked) HOOK_RwTextureDestroy_Mid()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -942,7 +935,6 @@ static void __declspec(naked) HOOK_RwTextureDestroy_Mid()
         push    0x08E23CC
         jmp     RETURN_RwTextureDestroy_Mid
     }
-
     // clang-format on
 }
 
@@ -980,7 +972,6 @@ static void __declspec(naked) HOOK_RwIm3DRenderIndexedPrimitive()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -1006,7 +997,6 @@ static void __declspec(naked) HOOK_RwIm3DRenderIndexedPrimitive()
         mov     eax, ds:0x0C9C078
         jmp     RETURN_RwIm3DRenderIndexedPrimitive
     }
-
     // clang-format on
 }
 
@@ -1036,7 +1026,6 @@ static void __declspec(naked) HOOK_RwIm3DRenderPrimitive()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -1062,7 +1051,6 @@ static void __declspec(naked) HOOK_RwIm3DRenderPrimitive()
         mov     ecx, ds:0x0C97B24
         jmp     RETURN_RwIm3DRenderPrimitive
     }
-
     // clang-format on
 }
 
@@ -1092,7 +1080,6 @@ static void __declspec(naked) HOOK_RwIm2DRenderIndexedPrimitive()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -1119,7 +1106,6 @@ static void __declspec(naked) HOOK_RwIm2DRenderIndexedPrimitive()
         inner:
         jmp     RETURN_RwIm2DRenderIndexedPrimitive
     }
-
     // clang-format on
 }
 
@@ -1149,7 +1135,6 @@ static void __declspec(naked) HOOK_RwIm2DRenderPrimitive()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -1175,7 +1160,6 @@ static void __declspec(naked) HOOK_RwIm2DRenderPrimitive()
         mov     eax, ds:0x0C97B24
         jmp     RETURN_RwIm2DRenderPrimitive
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CRopesSA.cpp
+++ b/Client/game_sa/CRopesSA.cpp
@@ -23,6 +23,7 @@ int CRopesSA::CreateRopeForSwatPed(const CVector& vecPosition, DWORD dwDuration)
     CVector* pvecPosition = const_cast<CVector*>(&vecPosition);
     // First Push @ 0x558D1D is the duration.
     MemPut((void*)(dwDurationAddress), dwDuration);
+    // clang-format off
     __asm
     {
         push    pvecPosition
@@ -30,6 +31,7 @@ int CRopesSA::CreateRopeForSwatPed(const CVector& vecPosition, DWORD dwDuration)
         add     esp, 0x4
         mov     iReturn, eax
     }
+    // clang-format on
     //   Set it back for SA in case we ever do some other implementation.
     MemPut((DWORD*)(dwDurationAddress), 4000);
     return iReturn;

--- a/Client/game_sa/CSettingsSA.cpp
+++ b/Client/game_sa/CSettingsSA.cpp
@@ -243,12 +243,14 @@ void CSettingsSA::SetAntiAliasing(unsigned int uiAntiAliasing, bool bOnRestart)
     if (!bOnRestart)
     {
         DWORD dwFunc = FUNC_SetAntiAliasing;
+        // clang-format off
         __asm
         {
             push    uiAntiAliasing
             call    dwFunc
             add     esp, 4
         }
+        // clang-format on
         SetCurrentVideoMode(m_pInterface->dwVideoMode, false);
     }
 
@@ -267,12 +269,14 @@ void CSettingsSA::SetMipMappingEnabled(bool bEnable)
 
 void CSettingsSA::Save()
 {
+    // clang-format off
     __asm
     {
         mov ecx, CLASS_CMenuManager
         mov eax, FUNC_CMenuManager_Save
         call eax
     }
+    // clang-format on
 }
 
 bool CSettingsSA::IsVolumetricShadowsEnabled() const noexcept
@@ -372,6 +376,8 @@ static void __declspec(naked) HOOK_GetFxQuality()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -387,12 +393,16 @@ static void __declspec(naked) HOOK_GetFxQuality()
         mov     eax, dwFxQualityValue
         retn
     }
+
+    // clang-format on
 }
 
 // Hook to discover what vehicle will be calling GetFxQuality
 static void __declspec(naked) HOOK_StoreShadowForVehicle()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -406,6 +416,8 @@ static void __declspec(naked) HOOK_StoreShadowForVehicle()
         call    eax
         jmp     RETURN_StoreShadowForVehicle
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////
@@ -977,6 +989,8 @@ static void __declspec(naked) HOOK_SelectDevice()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -997,6 +1011,8 @@ static void __declspec(naked) HOOK_SelectDevice()
         single:
         jmp     RETURN_SelectDeviceSingle
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////

--- a/Client/game_sa/CSettingsSA.cpp
+++ b/Client/game_sa/CSettingsSA.cpp
@@ -377,7 +377,6 @@ static void __declspec(naked) HOOK_GetFxQuality()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -393,7 +392,6 @@ static void __declspec(naked) HOOK_GetFxQuality()
         mov     eax, dwFxQualityValue
         retn
     }
-
     // clang-format on
 }
 
@@ -403,7 +401,6 @@ static void __declspec(naked) HOOK_StoreShadowForVehicle()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Hooked from 0x70BDA0  5 bytes
@@ -416,7 +413,6 @@ static void __declspec(naked) HOOK_StoreShadowForVehicle()
         call    eax
         jmp     RETURN_StoreShadowForVehicle
     }
-
     // clang-format on
 }
 
@@ -990,7 +986,6 @@ static void __declspec(naked) HOOK_SelectDevice()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -1011,7 +1006,6 @@ static void __declspec(naked) HOOK_SelectDevice()
         single:
         jmp     RETURN_SelectDeviceSingle
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CStatsSA.cpp
+++ b/Client/game_sa/CStatsSA.cpp
@@ -19,7 +19,6 @@ float CStatsSA::GetStatValue(unsigned short usIndex)
     DWORD dwStatIndex = usIndex;
 
     // clang-format off
-
     __asm
     {
         push    dwStatIndex
@@ -27,7 +26,6 @@ float CStatsSA::GetStatValue(unsigned short usIndex)
         add     esp, 4
         fstp    fReturn
     }
-
     // clang-format on
     return fReturn;
 }
@@ -38,7 +36,6 @@ void CStatsSA::ModifyStat(unsigned short usIndex, float fAmmount)
     DWORD dwStatIndex = usIndex;
 
     // clang-format off
-
     __asm
     {
         push    fAmmount
@@ -46,7 +43,6 @@ void CStatsSA::ModifyStat(unsigned short usIndex, float fAmmount)
         call    dwFunc
         add     esp, 8
     }
-
     // clang-format on
 }
 
@@ -56,7 +52,6 @@ void CStatsSA::SetStatValue(unsigned short usIndex, float fAmmount)
     DWORD dwStatIndex = usIndex;
 
     // clang-format off
-
     __asm
     {
         push    fAmmount
@@ -64,7 +59,6 @@ void CStatsSA::SetStatValue(unsigned short usIndex, float fAmmount)
         call    dwFunc
         add     esp, 8
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CStatsSA.cpp
+++ b/Client/game_sa/CStatsSA.cpp
@@ -18,6 +18,8 @@ float CStatsSA::GetStatValue(unsigned short usIndex)
     float fReturn = 0.0f;
     DWORD dwStatIndex = usIndex;
 
+    // clang-format off
+
     __asm
     {
         push    dwStatIndex
@@ -25,6 +27,8 @@ float CStatsSA::GetStatValue(unsigned short usIndex)
         add     esp, 4
         fstp    fReturn
     }
+
+    // clang-format on
     return fReturn;
 }
 
@@ -33,6 +37,8 @@ void CStatsSA::ModifyStat(unsigned short usIndex, float fAmmount)
     DWORD dwFunc = FUNC_ModifyStat;
     DWORD dwStatIndex = usIndex;
 
+    // clang-format off
+
     __asm
     {
         push    fAmmount
@@ -40,6 +46,8 @@ void CStatsSA::ModifyStat(unsigned short usIndex, float fAmmount)
         call    dwFunc
         add     esp, 8
     }
+
+    // clang-format on
 }
 
 void CStatsSA::SetStatValue(unsigned short usIndex, float fAmmount)
@@ -47,6 +55,8 @@ void CStatsSA::SetStatValue(unsigned short usIndex, float fAmmount)
     DWORD dwFunc = FUNC_SetStatValue;
     DWORD dwStatIndex = usIndex;
 
+    // clang-format off
+
     __asm
     {
         push    fAmmount
@@ -54,6 +64,8 @@ void CStatsSA::SetStatValue(unsigned short usIndex, float fAmmount)
         call    dwFunc
         add     esp, 8
     }
+
+    // clang-format on
 }
 
 unsigned short CStatsSA::GetSkillStatIndex(eWeaponType type)
@@ -61,6 +73,7 @@ unsigned short CStatsSA::GetSkillStatIndex(eWeaponType type)
     int   weaponType = (int)type;
     int   iIndex;
     DWORD dwFunc = FUNC_CWeaponInfo_GetSkillStatIndex;
+    // clang-format off
     __asm
     {
         push    weaponType
@@ -68,5 +81,6 @@ unsigned short CStatsSA::GetSkillStatIndex(eWeaponType type)
         add     esp, 0x4
         mov     iIndex, eax
     }
+    // clang-format on
     return (unsigned short)iIndex;
 }

--- a/Client/game_sa/CStreamingSA.cpp
+++ b/Client/game_sa/CStreamingSA.cpp
@@ -230,6 +230,7 @@ void CStreamingSA::RequestModel(DWORD dwModelID, DWORD dwFlags)
     if (IsUpgradeModelId(dwModelID))
     {
         DWORD dwFunc = FUNC_RequestVehicleUpgrade;
+        // clang-format off
         __asm
         {
             push    dwFlags
@@ -237,6 +238,7 @@ void CStreamingSA::RequestModel(DWORD dwModelID, DWORD dwFlags)
             call    dwFunc
             add     esp, 8
         }
+        // clang-format on
     }
     else
     {
@@ -245,6 +247,7 @@ void CStreamingSA::RequestModel(DWORD dwModelID, DWORD dwFlags)
             return;
 
         DWORD dwFunction = FUNC_CStreaming__RequestModel;
+        // clang-format off
         __asm
         {
             push    dwFlags
@@ -252,6 +255,7 @@ void CStreamingSA::RequestModel(DWORD dwModelID, DWORD dwFlags)
             call    dwFunction
             add     esp, 8
         }
+        // clang-format on
     }
 }
 
@@ -268,12 +272,14 @@ void CStreamingSA::LoadAllRequestedModels(bool bOnlyPriorityModels, const char* 
 
     DWORD dwFunction = FUNC_LoadAllRequestedModels;
     DWORD dwOnlyPriorityModels = bOnlyPriorityModels;
+    // clang-format off
     __asm
     {
         push    dwOnlyPriorityModels
         call    dwFunction
         add     esp, 4
     }
+    // clang-format on
 
     if (IS_TIMING_CHECKPOINTS())
     {
@@ -289,6 +295,7 @@ bool CStreamingSA::HasModelLoaded(DWORD dwModelID)
     {
         bool  bReturn;
         DWORD dwFunc = FUNC_CStreaming__HasVehicleUpgradeLoaded;
+        // clang-format off
         __asm
         {
             push    dwModelID
@@ -296,12 +303,14 @@ bool CStreamingSA::HasModelLoaded(DWORD dwModelID)
             add     esp, 0x4
             mov     bReturn, al
         }
+        // clang-format on
         return bReturn;
     }
     else
     {
         DWORD dwFunc = FUNC_CStreaming__HasModelLoaded;
         bool  bReturn = 0;
+        // clang-format off
         __asm
         {
             push    dwModelID
@@ -309,6 +318,7 @@ bool CStreamingSA::HasModelLoaded(DWORD dwModelID)
             mov     bReturn, al
             pop     eax
         }
+        // clang-format on
 
         return bReturn;
     }
@@ -317,6 +327,7 @@ bool CStreamingSA::HasModelLoaded(DWORD dwModelID)
 void CStreamingSA::RequestSpecialModel(DWORD model, const char* szTexture, DWORD channel)
 {
     DWORD dwFunc = FUNC_CStreaming_RequestSpecialModel;
+    // clang-format off
     __asm
     {
         push    channel
@@ -325,6 +336,7 @@ void CStreamingSA::RequestSpecialModel(DWORD model, const char* szTexture, DWORD
         call    dwFunc
         add     esp, 0xC
     }
+    // clang-format on
 }
 
 void CStreamingSA::ReinitStreaming()

--- a/Client/game_sa/CTaskManagementSystemSA.cpp
+++ b/Client/game_sa/CTaskManagementSystemSA.cpp
@@ -284,7 +284,6 @@ static void __declspec(naked) HOOK_CTask_Operator_Delete()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -299,6 +298,5 @@ static void __declspec(naked) HOOK_CTask_Operator_Delete()
         add     eax, 6
         jmp     eax
     }
-
     // clang-format on
 }

--- a/Client/game_sa/CTaskManagementSystemSA.cpp
+++ b/Client/game_sa/CTaskManagementSystemSA.cpp
@@ -138,12 +138,14 @@ CTaskSA* CTaskManagementSystemSA::GetTask(CTaskSAInterface* pTaskInterface)
     DWORD dwFunc = pVTBL->GetTaskType;
     if (dwFunc && dwFunc != 0x82263A)
     {
+        // clang-format off
         __asm
         {
             mov     ecx, pTaskInterface
             call    dwFunc
             mov     iTaskType, eax
         }
+        // clang-format on
     }
 
     // Create it and add it to our list
@@ -281,6 +283,8 @@ static void __declspec(naked) HOOK_CTask_Operator_Delete()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -295,4 +299,6 @@ static void __declspec(naked) HOOK_CTask_Operator_Delete()
         add     eax, 6
         jmp     eax
     }
+
+    // clang-format on
 }

--- a/Client/game_sa/CTaskManagerSA.cpp
+++ b/Client/game_sa/CTaskManagerSA.cpp
@@ -40,6 +40,7 @@ void CTaskManagerSA::SetTask(CTaskSA* pTaskPrimary, const int iTaskPriority, con
         taskInterface = pTaskPrimary->GetInterface();
 
     DWORD dwInterface = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         xor     eax, eax
@@ -50,6 +51,7 @@ void CTaskManagerSA::SetTask(CTaskSA* pTaskPrimary, const int iTaskPriority, con
         mov     ecx, dwInterface
         call    dwFunc
     }
+    // clang-format on
 }
 
 CTask* CTaskManagerSA::GetTask(const int iTaskPriority)
@@ -63,12 +65,14 @@ CTask* CTaskManagerSA::GetActiveTask()
     DWORD dwFunc = FUNC_GetActiveTask;
     DWORD dwReturn = 0;
     DWORD dwThis = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         mov     dwReturn, eax
     }
+    // clang-format on
 
     CTaskSAInterface* pActiveTask = (CTaskSAInterface*)dwReturn;
     if (dwReturn)
@@ -83,12 +87,16 @@ CTask* CTaskManagerSA::GetSimplestActiveTask()
     DWORD dwReturn = 0;
     DWORD dwThis = (DWORD)GetInterface();
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         mov     dwReturn, eax
     }
+
+    // clang-format on
 
     if (dwReturn) return m_pTaskManagementSystem->GetTask((CTaskSAInterface*)dwReturn);
     else return NULL;
@@ -99,6 +107,7 @@ CTask* CTaskManagerSA::GetSimplestTask(const int iPriority)
     DWORD dwFunc = FUNC_GetSimplestTask;
     DWORD dwReturn = 0;
     DWORD dwThis = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -106,6 +115,7 @@ CTask* CTaskManagerSA::GetSimplestTask(const int iPriority)
         call    dwFunc
         mov     dwReturn, eax
     }
+    // clang-format on
 
     if (dwReturn) return m_pTaskManagementSystem->GetTask((CTaskSAInterface*)dwReturn);
     else return NULL;
@@ -116,6 +126,7 @@ CTask* CTaskManagerSA::FindActiveTaskByType(const int iTaskType)
     DWORD dwFunc = FUNC_FindActiveTaskByType;
     DWORD dwReturn = 0;
     DWORD dwThis = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -123,6 +134,7 @@ CTask* CTaskManagerSA::FindActiveTaskByType(const int iTaskType)
         call    dwFunc
         mov     dwReturn, eax
     }
+    // clang-format on
 
     if (dwReturn) return m_pTaskManagementSystem->GetTask((CTaskSAInterface*)dwReturn);
     else return NULL;
@@ -133,6 +145,7 @@ CTask* CTaskManagerSA::FindTaskByType(const int iPriority, const int iTaskType)
     DWORD dwFunc = FUNC_FindTaskByType;
     DWORD dwReturn = 0;
     DWORD dwThis = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -141,6 +154,7 @@ CTask* CTaskManagerSA::FindTaskByType(const int iPriority, const int iTaskType)
         call    dwFunc
         mov     dwReturn, eax
     }
+    // clang-format on
 
     if (dwReturn) return m_pTaskManagementSystem->GetTask((CTaskSAInterface*)dwReturn);
     else return NULL;
@@ -170,6 +184,7 @@ void CTaskManagerSA::SetTaskSecondary(CTaskSA* pTaskSecondary, const int iType)
     if (pTaskSecondary)
         taskInterface = pTaskSecondary->GetInterface();
     DWORD dwInterface = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         push    iType
@@ -177,6 +192,7 @@ void CTaskManagerSA::SetTaskSecondary(CTaskSA* pTaskSecondary, const int iType)
         mov     ecx, dwInterface
         call    dwFunc
     }
+    // clang-format on
 }
 
 /**
@@ -194,22 +210,26 @@ bool CTaskManagerSA::HasTaskSecondary(const CTask* pTaskSecondary)
 {
     DWORD dwFunc = FUNC_HasTaskSecondary;
     bool  bReturn = false;
+    // clang-format off
     __asm
     {
         push    pTaskSecondary
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
 void CTaskManagerSA::ClearTaskEventResponse()
 {
     DWORD dwFunc = FUNC_ClearTaskEventResponse;
+    // clang-format off
     __asm
     {
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CTaskManagerSA::Flush(const int iPriority)

--- a/Client/game_sa/CTaskManagerSA.cpp
+++ b/Client/game_sa/CTaskManagerSA.cpp
@@ -88,14 +88,12 @@ CTask* CTaskManagerSA::GetSimplestActiveTask()
     DWORD dwThis = (DWORD)GetInterface();
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         mov     dwReturn, eax
     }
-
     // clang-format on
 
     if (dwReturn) return m_pTaskManagementSystem->GetTask((CTaskSAInterface*)dwReturn);

--- a/Client/game_sa/CTasksSA.cpp
+++ b/Client/game_sa/CTasksSA.cpp
@@ -287,7 +287,6 @@ static void __declspec(naked) HOOK_CEventHandler_ComputeDamageResponse_Mid()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -304,7 +303,6 @@ static void __declspec(naked) HOOK_CEventHandler_ComputeDamageResponse_Mid()
         call    CTaskSimpleBeHit_constructor
         jmp     RETURN_CEventHandler_ComputeDamageResponse_Mid
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CTasksSA.cpp
+++ b/Client/game_sa/CTasksSA.cpp
@@ -286,6 +286,8 @@ static void __declspec(naked) HOOK_CEventHandler_ComputeDamageResponse_Mid()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -302,6 +304,8 @@ static void __declspec(naked) HOOK_CEventHandler_ComputeDamageResponse_Mid()
         call    CTaskSimpleBeHit_constructor
         jmp     RETURN_CEventHandler_ComputeDamageResponse_Mid
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -42,7 +42,6 @@ static void __declspec(naked) HOOK_Vehicle_PreRender(void)
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     ecx, m_bVehicleSunGlare
@@ -57,7 +56,6 @@ static void __declspec(naked) HOOK_Vehicle_PreRender(void)
         push    6ABD04h
         retn
     }
-
     // clang-format on
 }
 
@@ -103,7 +101,6 @@ static void __declspec(naked) HOOK_CHeli_ProcessFlyingCarStuff()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     esi, ecx
@@ -120,7 +117,6 @@ static void __declspec(naked) HOOK_CHeli_ProcessFlyingCarStuff()
         skip:
         jmp     RETURN_CHeli_ProcessFlyingCarStuff
     }
-
     // clang-format on
 }
 
@@ -131,7 +127,6 @@ static void __declspec(naked) HOOK_CPlane_ProcessFlyingCarStuff()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push    esi
@@ -149,7 +144,6 @@ static void __declspec(naked) HOOK_CPlane_ProcessFlyingCarStuff()
         skip:
         jmp     RETURN_CPlane_ProcessFlyingCarStuff
     }
-
     // clang-format on
 }
 
@@ -809,14 +803,12 @@ void CVehicleSA::RemoveVehicleUpgrade(DWORD dwModelID)
     DWORD dwFunc = FUNC_CVehicle_RemoveVehicleUpgrade;
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThis
         push    dwModelID
         call    dwFunc
     }
-
     // clang-format on
 
     // GTA SA only does this when CVehicle::ClearVehicleUpgradeFlags returns false.
@@ -850,7 +842,6 @@ DWORD CVehicleSA::GetBaseVehicleType()
     DWORD dwReturn = 0;
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThis
@@ -858,7 +849,6 @@ DWORD CVehicleSA::GetBaseVehicleType()
         mov     dwReturn, eax
 
     }
-
     // clang-format on
 
     return dwReturn;
@@ -901,14 +891,12 @@ bool CVehicleSA::IsUpsideDown()
     bool  bReturn = false;
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         mov     bReturn, al
     }
-
     // clang-format on
 
     return bReturn;
@@ -921,14 +909,12 @@ void CVehicleSA::SetEngineOn(bool bEngineOn)
     DWORD dwFunc = FUNC_CVehicle_SetEngineOn;
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThis
         push    dwEngineOn
         call    dwFunc
     }
-
     // clang-format on
 }
 
@@ -982,13 +968,11 @@ void CVehicleSA::PlaceBikeOnRoadProperly()
     DWORD dwBike = (DWORD)GetInterface();
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwBike
         call    dwFunc
     }
-
     // clang-format on
 }
 
@@ -998,13 +982,11 @@ void CVehicleSA::PlaceAutomobileOnRoadProperly()
     DWORD dwAutomobile = (DWORD)GetInterface();
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwAutomobile
         call    dwFunc
     }
-
     // clang-format on
 }
 
@@ -1292,14 +1274,12 @@ void CVehicleSA::PickupEntityWithWinch(CEntity* pEntity)
         DWORD dwEntityInterface = (DWORD)pEntitySA->GetInterface();
 
         // clang-format off
-
         __asm
         {
             push    dwEntityInterface
             mov     ecx, dwThis
             call    dwFunc
         }
-
         // clang-format on
     }
 }
@@ -1310,13 +1290,11 @@ void CVehicleSA::ReleasePickedUpEntityWithWinch()
     DWORD dwThis = (DWORD)GetInterface();
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
-
     // clang-format on
 }
 
@@ -1326,14 +1304,12 @@ void CVehicleSA::SetRopeHeightForHeli(float fRopeHeight)
     DWORD dwThis = (DWORD)GetInterface();
 
     // clang-format off
-
     __asm
     {
         push    fRopeHeight
         mov     ecx, dwThis
         call    dwFunc
     }
-
     // clang-format on
 }
 
@@ -1555,14 +1531,12 @@ void CVehicleSA::SetTaxiLightOn(bool bLightOn)
     DWORD dwFunc = FUNC_CAutomobile_SetTaxiLight;
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThis
         push    dwState
         call    dwFunc
     }
-
     // clang-format on
 }
 
@@ -2529,7 +2503,6 @@ bool CVehicleSA::SetWindowOpenFlagState(unsigned char ucWindow, bool bState)
     bool bReturn = false;
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThis
@@ -2537,7 +2510,6 @@ bool CVehicleSA::SetWindowOpenFlagState(unsigned char ucWindow, bool bState)
         call    dwFunc
         mov     bReturn, al
     }
-
     // clang-format on
     return bReturn;
 }

--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -41,6 +41,8 @@ static void __declspec(naked) HOOK_Vehicle_PreRender(void)
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, m_bVehicleSunGlare
@@ -55,6 +57,8 @@ static void __declspec(naked) HOOK_Vehicle_PreRender(void)
         push    6ABD04h
         retn
     }
+
+    // clang-format on
 }
 
 static float& fTimeStep = *(float*)(0xB7CB5C);
@@ -98,6 +102,8 @@ static void __declspec(naked) HOOK_CHeli_ProcessFlyingCarStuff()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     esi, ecx
@@ -114,6 +120,8 @@ static void __declspec(naked) HOOK_CHeli_ProcessFlyingCarStuff()
         skip:
         jmp     RETURN_CHeli_ProcessFlyingCarStuff
     }
+
+    // clang-format on
 }
 
 static constexpr DWORD CONTINUE_CPlane_ProcessFlyingCarStuff = 0x6CB7D7;
@@ -121,6 +129,8 @@ static constexpr DWORD RETURN_CPlane_ProcessFlyingCarStuff = 0x6CC482;
 static void __declspec(naked) HOOK_CPlane_ProcessFlyingCarStuff()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -139,6 +149,8 @@ static void __declspec(naked) HOOK_CPlane_ProcessFlyingCarStuff()
         skip:
         jmp     RETURN_CPlane_ProcessFlyingCarStuff
     }
+
+    // clang-format on
 }
 
 namespace
@@ -321,11 +333,13 @@ CVehicleSA::~CVehicleSA()
 
             DWORD dwThis = (DWORD)m_pInterface;
             DWORD dwFunc = 0x6D2460;            // CVehicle::ExtinguishCarFire
+            // clang-format off
             __asm
             {
                 mov     ecx, dwThis
                 call    dwFunc
             }
+            // clang-format on
 
             CWorldSA* pWorld = (CWorldSA*)pGame->GetWorld();
             pGame->GetProjectileInfo()->RemoveEntityReferences(this);
@@ -344,12 +358,14 @@ void CVehicleSA::SetMoveSpeed(const CVector& vecMoveSpeed) noexcept
     DWORD dwFunc = FUNC_GetMoveSpeed;
     DWORD dwThis = (DWORD)GetInterface();
     DWORD dwReturn = 0;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         mov     dwReturn, eax
     }
+    // clang-format on
     MemCpyFast((void*)dwReturn, &vecMoveSpeed, sizeof(CVector));
 
     // INACCURATE. Use Get/SetTrainSpeed instead of Get/SetMoveSpeed. (Causes issue #4829).
@@ -558,11 +574,13 @@ void CVehicleSA::SetDerailed(bool bDerailed)
 
                 // Recalculate the on-rail distance from the start node (train position parameter, m_fTrainRailDistance)
                 DWORD dwFunc = FUNC_CTrain_FindPositionOnTrackFromCoors;
+                // clang-format off
                 __asm
                 {
                     mov     ecx, dwThis
                         call    dwFunc
                 }
+                // clang-format on
 
                 // Reset the speed
                 static_cast<CTrainSAInterface*>(GetVehicleInterface())->m_fTrainSpeed = 0.0f;
@@ -679,11 +697,13 @@ void CVehicleSA::SetRailTrack(BYTE ucTrackID)
         if (!IsDerailed())
         {
             DWORD dwFunc = FUNC_CTrain_FindPositionOnTrackFromCoors;
+            // clang-format off
             __asm
             {
                 mov ecx, pInterf
                 call dwFunc
             }
+            // clang-format on
         }
     }
 }
@@ -703,11 +723,13 @@ void CVehicleSA::SetTrainPosition(float fPosition, bool bRecalcOnRailDistance)
         if (bRecalcOnRailDistance && !IsDerailed())
         {
             DWORD dwFunc = FUNC_CTrain_FindPositionOnTrackFromCoors;
+            // clang-format off
             __asm
             {
                 mov ecx, pInterface
                 call dwFunc
             }
+            // clang-format on
         }
     }
 }
@@ -770,12 +792,14 @@ void CVehicleSA::AddVehicleUpgrade(DWORD dwModelID)
         DWORD dwThis = (DWORD)m_pInterface;
 
         DWORD dwFunc = FUNC_CVehicle_AddVehicleUpgrade;
+        // clang-format off
         __asm
         {
             mov     ecx, dwThis
             push    dwModelID
             call    dwFunc
         }
+        // clang-format on
     }
 }
 
@@ -784,12 +808,16 @@ void CVehicleSA::RemoveVehicleUpgrade(DWORD dwModelID)
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CVehicle_RemoveVehicleUpgrade;
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThis
         push    dwModelID
         call    dwFunc
     }
+
+    // clang-format on
 
     // GTA SA only does this when CVehicle::ClearVehicleUpgradeFlags returns false.
     // In the case of hydraulics and nitro, this function does not return false and the upgrade is never removed from the array
@@ -821,6 +849,8 @@ DWORD CVehicleSA::GetBaseVehicleType()
     DWORD dwFunc = FUNC_CVehicle_GetBaseVehicleType;
     DWORD dwReturn = 0;
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThis
@@ -828,6 +858,8 @@ DWORD CVehicleSA::GetBaseVehicleType()
         mov     dwReturn, eax
 
     }
+
+    // clang-format on
 
     return dwReturn;
 }
@@ -868,12 +900,16 @@ bool CVehicleSA::IsUpsideDown()
     DWORD dwFunc = FUNC_CVehicle_IsUpsideDown;
     bool  bReturn = false;
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         mov     bReturn, al
     }
+
+    // clang-format on
 
     return bReturn;
 }
@@ -884,12 +920,16 @@ void CVehicleSA::SetEngineOn(bool bEngineOn)
     DWORD dwEngineOn = (DWORD)bEngineOn;
     DWORD dwFunc = FUNC_CVehicle_SetEngineOn;
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThis
         push    dwEngineOn
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 CPed* CVehicleSA::GetDriver()
@@ -941,11 +981,15 @@ void CVehicleSA::PlaceBikeOnRoadProperly()
     DWORD dwFunc = FUNC_Bike_PlaceOnRoadProperly;
     DWORD dwBike = (DWORD)GetInterface();
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwBike
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 void CVehicleSA::PlaceAutomobileOnRoadProperly()
@@ -953,11 +997,15 @@ void CVehicleSA::PlaceAutomobileOnRoadProperly()
     DWORD dwFunc = FUNC_Automobile_PlaceOnRoadProperly;
     DWORD dwAutomobile = (DWORD)GetInterface();
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwAutomobile
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 void CVehicleSA::SetColor(SharedUtil::SColor color1, SharedUtil::SColor color2, SharedUtil::SColor color3, SharedUtil::SColor color4, int)
@@ -1010,6 +1058,7 @@ void CVehicleSA::GetTurretRotation(float* fHorizontal, float* fVertical)
     DWORD vehicleInterface = (DWORD)GetInterface();
     float fHoriz = 0.0f;
     float fVert = 0.0f;
+    // clang-format off
     __asm
     {
         mov     eax, vehicleInterface
@@ -1020,6 +1069,7 @@ void CVehicleSA::GetTurretRotation(float* fHorizontal, float* fVertical)
         fld     [eax]
         fstp    fVert
     }
+    // clang-format on
     *fHorizontal = fHoriz;
     *fVertical = fVert;
 }
@@ -1029,6 +1079,7 @@ void CVehicleSA::SetTurretRotation(float fHorizontal, float fVertical)
     //*(float *)(this->GetInterface() + 2380) = fHorizontal;
     //*(float *)(this->GetInterface() + 2384) = fVertical;
     DWORD vehicleInterface = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     eax, vehicleInterface
@@ -1039,6 +1090,7 @@ void CVehicleSA::SetTurretRotation(float fHorizontal, float fVertical)
         fld     fVertical
         fstp    [eax]
     }
+    // clang-format on
 }
 
 bool CVehicleSA::IsSirenOrAlarmActive()
@@ -1138,11 +1190,13 @@ void CVehicleSA::Fix()
 
         if (dwFunc)
         {
+            // clang-format off
             __asm
             {
                 mov     ecx, dwThis
                 call    dwFunc
             }
+            // clang-format on
         }
     }
 }
@@ -1237,12 +1291,16 @@ void CVehicleSA::PickupEntityWithWinch(CEntity* pEntity)
         DWORD dwThis = (DWORD)GetInterface();
         DWORD dwEntityInterface = (DWORD)pEntitySA->GetInterface();
 
+        // clang-format off
+
         __asm
         {
             push    dwEntityInterface
             mov     ecx, dwThis
             call    dwFunc
         }
+
+        // clang-format on
     }
 }
 
@@ -1251,11 +1309,15 @@ void CVehicleSA::ReleasePickedUpEntityWithWinch()
     DWORD dwFunc = FUNC_CVehicle_ReleasePickedUpEntityWithWinch;
     DWORD dwThis = (DWORD)GetInterface();
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 void CVehicleSA::SetRopeHeightForHeli(float fRopeHeight)
@@ -1263,12 +1325,16 @@ void CVehicleSA::SetRopeHeightForHeli(float fRopeHeight)
     DWORD dwFunc = FUNC_CVehicle_SetRopeHeightForHeli;
     DWORD dwThis = (DWORD)GetInterface();
 
+    // clang-format off
+
     __asm
     {
         push    fRopeHeight
         mov     ecx, dwThis
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 CPhysical* CVehicleSA::QueryPickedUpEntityWithWinch()
@@ -1277,12 +1343,14 @@ CPhysical* CVehicleSA::QueryPickedUpEntityWithWinch()
     DWORD dwThis = (DWORD)GetInterface();
 
     CPhysicalSAInterface* phys;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         mov     phys, eax
     }
+    // clang-format on
 
     if (phys)
     {
@@ -1296,12 +1364,14 @@ void CVehicleSA::SetRemap(int iRemap)
 {
     DWORD dwFunc = FUNC_CVehicle__SetRemap;
     DWORD dwThis = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         push    iRemap
         call    dwFunc
     }
+    // clang-format on
 }
 
 int CVehicleSA::GetRemapIndex()
@@ -1309,12 +1379,14 @@ int CVehicleSA::GetRemapIndex()
     DWORD dwFunc = FUNC_CVehicle__GetRemapIndex;
     DWORD dwThis = (DWORD)GetInterface();
     int   iReturn = 0;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         call    dwFunc
         mov     iReturn, eax
     }
+    // clang-format on
     return iReturn;
 }
 
@@ -1322,12 +1394,14 @@ void CVehicleSA::SetRemapTexDictionary(int iRemapTextureDictionary)
 {
     DWORD dwFunc = FUNC_CVehicle__SetRemapTexDictionary;
     DWORD dwThis = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         push    iRemapTextureDictionary
         call    dwFunc
     }
+    // clang-format on
 }
 
 bool CVehicleSA::IsSmokeTrailEnabled()
@@ -1480,12 +1554,16 @@ void CVehicleSA::SetTaxiLightOn(bool bLightOn)
     DWORD dwState = (DWORD)bLightOn;
     DWORD dwFunc = FUNC_CAutomobile_SetTaxiLight;
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThis
         push    dwState
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 void GetMatrixForGravity(const CVector& vecGravity, CMatrix& mat)
@@ -1741,6 +1819,7 @@ bool CVehicleSA::UpdateMovingCollision(float fAngle)
     bool  bReturn;
     DWORD dwThis = (DWORD)GetInterface();
     DWORD dwFunc = FUNC_CAutomobile__UpdateMovingCollision;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -1748,6 +1827,7 @@ bool CVehicleSA::UpdateMovingCollision(float fAngle)
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
 
     // Restore our driver
     vehicle->pDriver = pDriver;
@@ -1966,6 +2046,7 @@ namespace
         if (matrixPadded)
         {
             DWORD dwFunc = FUNC_CMatrix__ConvertFromEulerAngles;
+            // clang-format off
             __asm
             {
                 push    iUnknown
@@ -1975,6 +2056,7 @@ namespace
                 mov     ecx, matrixPadded
                 call    dwFunc
             }
+            // clang-format on
         }
     }
     void _MatrixConvertToEulerAngles(CMatrix_Padded* matrixPadded, float& fX, float& fY, float& fZ)
@@ -1983,6 +2065,7 @@ namespace
         if (matrixPadded)
         {
             DWORD dwFunc = FUNC_CMatrix__ConvertToEulerAngles;
+            // clang-format off
             __asm
             {
                 push    iUnknown
@@ -1992,6 +2075,7 @@ namespace
                 mov     ecx, matrixPadded
                 call    dwFunc
             }
+            // clang-format on
         }
     }
 }            // namespace
@@ -2413,6 +2497,7 @@ bool CVehicleSA::SetPlateText(const SString& strText)
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CVehicle_CustomCarPlate_TextureCreate;
     bool  bReturn = false;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
@@ -2420,6 +2505,7 @@ bool CVehicleSA::SetPlateText(const SString& strText)
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -2442,6 +2528,8 @@ bool CVehicleSA::SetWindowOpenFlagState(unsigned char ucWindow, bool bState)
     }
     bool bReturn = false;
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThis
@@ -2449,6 +2537,8 @@ bool CVehicleSA::SetWindowOpenFlagState(unsigned char ucWindow, bool bState)
         call    dwFunc
         mov     bReturn, al
     }
+
+    // clang-format on
     return bReturn;
 }
 

--- a/Client/game_sa/CVisibilityPluginsSA.cpp
+++ b/Client/game_sa/CVisibilityPluginsSA.cpp
@@ -17,6 +17,7 @@
 void CVisibilityPluginsSA::SetClumpAlpha(RpClump* pClump, int iAlpha)
 {
     DWORD dwFunc = FUNC_CVisiblityPlugins_SetClumpAlpha;
+    // clang-format off
     __asm
     {
         push    iAlpha
@@ -24,6 +25,7 @@ void CVisibilityPluginsSA::SetClumpAlpha(RpClump* pClump, int iAlpha)
         call    dwFunc
         add     esp, 0x8
     }
+    // clang-format on
 }
 
 // Some AtomicId bits are:
@@ -44,6 +46,7 @@ int CVisibilityPluginsSA::GetAtomicId(RwObject* pAtomic)
 {
     DWORD dwFunc = FUNC_CVisibilityPlugins_GetAtomicId;
     int   iResult = 0;
+    // clang-format off
     __asm
     {
         push    pAtomic
@@ -51,6 +54,7 @@ int CVisibilityPluginsSA::GetAtomicId(RwObject* pAtomic)
         add     esp, 0x4
         mov     iResult, eax
     }
+    // clang-format on
     return iResult;
 }
 

--- a/Client/game_sa/CWantedSA.cpp
+++ b/Client/game_sa/CWantedSA.cpp
@@ -42,12 +42,14 @@ void CWantedSA::SetWantedLevel(DWORD dwWantedLevel)
 {
     DWORD dwThis = (DWORD)GetInterface();
     DWORD dwFunc = FUNC_SetWantedLevel;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThis
         push    dwWantedLevel
         call    dwFunc
     }
+    // clang-format on
 }
 void CWantedSA::SetWantedLevelNoFlash(DWORD dwWantedLevel)
 {

--- a/Client/game_sa/CWaterManagerSA.cpp
+++ b/Client/game_sa/CWaterManagerSA.cpp
@@ -402,7 +402,6 @@ static void __declspec(naked) Hook6E9E23()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         check:
@@ -417,7 +416,6 @@ static void __declspec(naked) Hook6E9E23()
         lea     ebx, [eax+4*eax]
         jmp     dwHook6E9E23continue
     }
-
     // clang-format on
 }
 
@@ -428,7 +426,6 @@ static void __declspec(naked) Hook6EFCD7()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     eax, dword ptr [esi-4]
@@ -443,7 +440,6 @@ static void __declspec(naked) Hook6EFCD7()
         jz      check
         jmp     dwHook6EFCD7continue
     }
-
     // clang-format on
 }
 
@@ -453,7 +449,6 @@ static void __declspec(naked) Hook6EFBD8()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         check:
@@ -468,7 +463,6 @@ static void __declspec(naked) Hook6EFBD8()
         cont:
         jmp dwHook6EFBD8continue
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CWaterManagerSA.cpp
+++ b/Client/game_sa/CWaterManagerSA.cpp
@@ -401,6 +401,8 @@ static void __declspec(naked) Hook6E9E23()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         check:
@@ -415,6 +417,8 @@ static void __declspec(naked) Hook6E9E23()
         lea     ebx, [eax+4*eax]
         jmp     dwHook6E9E23continue
     }
+
+    // clang-format on
 }
 
 DWORD dwHook6EFCD7continue = 0x6EFCDD;
@@ -422,6 +426,8 @@ DWORD dwHook6EFCD7skip = 0x6EFE5E;
 static void __declspec(naked) Hook6EFCD7()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -437,12 +443,16 @@ static void __declspec(naked) Hook6EFCD7()
         jz      check
         jmp     dwHook6EFCD7continue
     }
+
+    // clang-format on
 }
 
 DWORD dwHook6EFBD8continue = 0x6EFBDE;
 static void __declspec(naked) Hook6EFBD8()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -458,6 +468,8 @@ static void __declspec(naked) Hook6EFBD8()
         cont:
         jmp dwHook6EFBD8continue
     }
+
+    // clang-format on
 }
 
 void CWaterManagerSA::InstallHooks()

--- a/Client/game_sa/CWorldSA.cpp
+++ b/Client/game_sa/CWorldSA.cpp
@@ -91,7 +91,6 @@ static void __declspec(naked) HOOK_FallenPeds()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         call    IsUnderWorldWarpEnabled
@@ -105,7 +104,6 @@ static void __declspec(naked) HOOK_FallenPeds()
         mov     ebx, ds:0B74490h
         jmp     CONTINUE_CWorld_FallenPeds
     }
-
     // clang-format on
 }
 
@@ -114,7 +112,6 @@ static void __declspec(naked) HOOK_FallenCars()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         call    IsUnderWorldWarpEnabled
@@ -128,7 +125,6 @@ static void __declspec(naked) HOOK_FallenCars()
         mov     ebx, ds:0B74494h
         jmp     CONTINUE_CWorld_FallenCars
     }
-
     // clang-format on
 }
 
@@ -453,7 +449,6 @@ bool CWorldSA::ProcessLineOfSight(const CVector* vecStart, const CVector* vecEnd
     MemPutFast<BYTE>(VAR_CWorld_bIncludeCarTires, flags.bCheckCarTires);
 
     // clang-format off
-
     __asm
     {
         push    flags.bShootThroughStuff
@@ -473,7 +468,6 @@ bool CWorldSA::ProcessLineOfSight(const CVector* vecStart, const CVector* vecEnd
         mov     bReturn, al
         add     esp, 0x30
     }
-
     // clang-format on
 
     MemPutFast<BYTE>(VAR_CWorld_bIncludeCarTires, 0);
@@ -631,7 +625,6 @@ bool CWorldSA::IsLineOfSightClear(const CVector* vecStart, const CVector* vecEnd
     // bool bIgnoreSomeObjectsForCamera = false
 
     // clang-format off
-
     __asm
     {
         push    flags.bIgnoreSomeObjectsForCamera
@@ -647,7 +640,6 @@ bool CWorldSA::IsLineOfSightClear(const CVector* vecStart, const CVector* vecEnd
         mov     bReturn, al
         add     esp, 0x24
     }
-
     // clang-format on
     return bReturn;
 }
@@ -746,7 +738,6 @@ void CWorldSA::FindWorldPositionForRailTrackPosition(float fRailTrackPosition, i
     DWORD dwFunc = FUNC_CWorld_FindPositionForTrackPosition;            // __cdecl
 
     // clang-format off
-
     __asm
     {
         push pOutVecPosition
@@ -755,7 +746,6 @@ void CWorldSA::FindWorldPositionForRailTrackPosition(float fRailTrackPosition, i
         call dwFunc
         add  esp, 3*4
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/CWorldSA.cpp
+++ b/Client/game_sa/CWorldSA.cpp
@@ -90,6 +90,8 @@ static void __declspec(naked) HOOK_FallenPeds()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         call    IsUnderWorldWarpEnabled
@@ -103,11 +105,15 @@ static void __declspec(naked) HOOK_FallenPeds()
         mov     ebx, ds:0B74490h
         jmp     CONTINUE_CWorld_FallenPeds
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_FallenCars()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -122,6 +128,8 @@ static void __declspec(naked) HOOK_FallenCars()
         mov     ebx, ds:0B74494h
         jmp     CONTINUE_CWorld_FallenCars
     }
+
+    // clang-format on
 }
 
 void CWorldSA::InstallHooks()
@@ -144,12 +152,14 @@ void CWorldSA::Add(CEntity* pEntity, eDebugCaller CallerId)
         }
         DWORD dwEntity = (DWORD)pEntitySA->GetInterface();
         DWORD dwFunction = FUNC_Add;
+        // clang-format off
         __asm
         {
             push    dwEntity
             call    dwFunction
             add     esp, 4
         }
+        // clang-format on
     }
 }
 
@@ -161,12 +171,14 @@ void CWorldSA::Add(CEntitySAInterface* entityInterface, eDebugCaller CallerId)
         SString strMessage("Caller: %i ", CallerId);
         LogEvent(506, "CWorld::Add ( CEntitySAInterface * ) Crash", "", strMessage);
     }
+    // clang-format off
     __asm
     {
         push    entityInterface
         call    dwFunction
         add     esp, 4
     }
+    // clang-format on
 }
 
 void CWorldSA::Remove(CEntity* pEntity, eDebugCaller CallerId)
@@ -183,12 +195,14 @@ void CWorldSA::Remove(CEntity* pEntity, eDebugCaller CallerId)
         }
         DWORD dwEntity = (DWORD)pInterface;
         DWORD dwFunction = FUNC_Remove;
+        // clang-format off
         __asm
         {
             push    dwEntity
             call    dwFunction
             add     esp, 4
         }
+        // clang-format on
     }
 }
 
@@ -200,6 +214,7 @@ void CWorldSA::Remove(CEntitySAInterface* entityInterface, eDebugCaller CallerId
         LogEvent(507, "CWorld::Remove ( CEntitySAInterface * ) Crash", "", strMessage);
     }
     DWORD dwFunction = FUNC_Remove;
+    // clang-format off
     __asm
     {
         push    entityInterface
@@ -211,18 +226,21 @@ void CWorldSA::Remove(CEntitySAInterface* entityInterface, eDebugCaller CallerId
         push    1
         call    dword ptr [esi+8]*/
     }
+    // clang-format on
 }
 
 void CWorldSA::RemoveReferencesToDeletedObject(CEntitySAInterface* entity)
 {
     DWORD dwFunc = FUNC_RemoveReferencesToDeletedObject;
     DWORD dwEntity = (DWORD)entity;
+    // clang-format off
     __asm
     {
         push    dwEntity
         call    dwFunc
         add     esp, 4
     }
+    // clang-format on
 }
 
 void ConvertMatrixToEulerAngles(const CMatrix_Padded& matrixPadded, float& fX, float& fY, float& fZ)
@@ -238,6 +256,7 @@ void ConvertMatrixToEulerAngles(const CMatrix_Padded& matrixPadded, float& fX, f
     float* pfY = &fY;
     float* pfZ = &fZ;
     int    iUnknown = 21;
+    // clang-format off
     __asm
     {
         push    iUnknown
@@ -247,6 +266,7 @@ void ConvertMatrixToEulerAngles(const CMatrix_Padded& matrixPadded, float& fX, f
             mov     ecx, pMatrixPadded
             call    dwFunc
     }
+    // clang-format on
 }
 
 
@@ -432,6 +452,8 @@ bool CWorldSA::ProcessLineOfSight(const CVector* vecStart, const CVector* vecEnd
     // bool bIgnoreSomeObjectsForCamera = false,    bool bShootThroughStuff = false
     MemPutFast<BYTE>(VAR_CWorld_bIncludeCarTires, flags.bCheckCarTires);
 
+    // clang-format off
+
     __asm
     {
         push    flags.bShootThroughStuff
@@ -451,6 +473,8 @@ bool CWorldSA::ProcessLineOfSight(const CVector* vecStart, const CVector* vecEnd
         mov     bReturn, al
         add     esp, 0x30
     }
+
+    // clang-format on
 
     MemPutFast<BYTE>(VAR_CWorld_bIncludeCarTires, 0);
 
@@ -576,6 +600,7 @@ float CWorldSA::FindGroundZFor3DPosition(CVector* vecPosition)
     float fX = vecPosition->fX;
     float fY = vecPosition->fY;
     float fZ = vecPosition->fZ;
+    // clang-format off
     __asm
     {
         push    0
@@ -587,6 +612,7 @@ float CWorldSA::FindGroundZFor3DPosition(CVector* vecPosition)
         fstp    fReturn
         add     esp, 0x14
     }
+    // clang-format on
     return fReturn;
 }
 
@@ -604,6 +630,8 @@ bool CWorldSA::IsLineOfSightClear(const CVector* vecStart, const CVector* vecEnd
     // bool bCheckObjects = true, bool bCheckDummies = true, bool bSeeThroughStuff = false,
     // bool bIgnoreSomeObjectsForCamera = false
 
+    // clang-format off
+
     __asm
     {
         push    flags.bIgnoreSomeObjectsForCamera
@@ -619,6 +647,8 @@ bool CWorldSA::IsLineOfSightClear(const CVector* vecStart, const CVector* vecEnd
         mov     bReturn, al
         add     esp, 0x24
     }
+
+    // clang-format on
     return bReturn;
 }
 
@@ -626,6 +656,7 @@ bool CWorldSA::HasCollisionBeenLoaded(CVector* vecPosition)
 {
     DWORD dwFunc = FUNC_HasCollisionBeenLoaded;
     bool  bRet = false;
+    // clang-format off
     __asm
     {
         push    0
@@ -634,6 +665,7 @@ bool CWorldSA::HasCollisionBeenLoaded(CVector* vecPosition)
         mov     bRet, al
         add     esp, 8
     }
+    // clang-format on
     return bRet;
 }
 
@@ -647,12 +679,14 @@ void CWorldSA::SetCurrentArea(DWORD dwArea)
     MemPutFast<DWORD>(VAR_currArea, dwArea);
 
     DWORD dwFunc = FUNC_RemoveBuildingsNotInArea;
+    // clang-format off
     __asm
     {
         push    dwArea
         call    dwFunc
         add     esp, 4
     }
+    // clang-format on
 }
 
 void CWorldSA::SetJetpackMaxHeight(float fHeight)
@@ -711,6 +745,8 @@ void CWorldSA::FindWorldPositionForRailTrackPosition(float fRailTrackPosition, i
 {
     DWORD dwFunc = FUNC_CWorld_FindPositionForTrackPosition;            // __cdecl
 
+    // clang-format off
+
     __asm
     {
         push pOutVecPosition
@@ -719,6 +755,8 @@ void CWorldSA::FindWorldPositionForRailTrackPosition(float fRailTrackPosition, i
         call dwFunc
         add  esp, 3*4
     }
+
+    // clang-format on
 }
 
 int CWorldSA::FindClosestRailTrackNode(const CVector& vecPosition, uchar& ucOutTrackId, float& fOutRailDistance)

--- a/Client/game_sa/HookSystem.h
+++ b/Client/game_sa/HookSystem.h
@@ -31,14 +31,12 @@
 // 
 // IMPORTANT: We can't use static_assert because __LOCAL_SIZE is not a compile-time constant.
 //            If you're going to change this macro, then copy your changes to the copy in multiplayer_sa.
-// clang-format off
 #define MTA_VERIFY_HOOK_LOCAL_SIZE                     \
 {                                                      \
     __asm {              push   eax                };  \
     __asm { _localSize:  mov    eax, __LOCAL_SIZE  };  \
     __asm {              pop    eax                };  \
 }
-// clang-format on
 
 template <typename T>
 void* FunctionPointerToVoidP(T func)

--- a/Client/game_sa/HookSystem.h
+++ b/Client/game_sa/HookSystem.h
@@ -31,12 +31,14 @@
 // 
 // IMPORTANT: We can't use static_assert because __LOCAL_SIZE is not a compile-time constant.
 //            If you're going to change this macro, then copy your changes to the copy in multiplayer_sa.
+// clang-format off
 #define MTA_VERIFY_HOOK_LOCAL_SIZE                     \
 {                                                      \
     __asm {              push   eax                };  \
     __asm { _localSize:  mov    eax, __LOCAL_SIZE  };  \
     __asm {              pop    eax                };  \
 }
+// clang-format on
 
 template <typename T>
 void* FunctionPointerToVoidP(T func)

--- a/Client/game_sa/TaskAttackSA.cpp
+++ b/Client/game_sa/TaskAttackSA.cpp
@@ -23,6 +23,7 @@ CTaskSimpleGangDriveBySA::CTaskSimpleGangDriveBySA(CEntity* pTargetEntity, const
     DWORD dwFunc = FUNC_CTaskSimpleGangDriveBy__Constructor;
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwTargetEntity = (pTargetEntity) ? (DWORD)pTargetEntity->GetInterface() : 0;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
@@ -34,6 +35,7 @@ CTaskSimpleGangDriveBySA::CTaskSimpleGangDriveBySA(CEntity* pTargetEntity, const
         push    dwTargetEntity
         call    dwFunc
     }
+    // clang-format on
 }
 
 CTaskSimpleUseGunSA::CTaskSimpleUseGunSA(CEntity* pTargetEntity, CVector vecTarget, char nCommand, short nBurstLength, unsigned char bAimImmediate)
@@ -46,6 +48,7 @@ CTaskSimpleUseGunSA::CTaskSimpleUseGunSA(CEntity* pTargetEntity, CVector vecTarg
     DWORD dwTargetEntity = (pTargetEntity) ? (DWORD)pTargetEntity->GetInterface() : 0;
     float fTargetX = vecTarget.fX, fTargetY = vecTarget.fY, fTargetZ = vecTarget.fZ;
     DWORD dwBurstLength = nBurstLength;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
@@ -58,6 +61,7 @@ CTaskSimpleUseGunSA::CTaskSimpleUseGunSA(CEntity* pTargetEntity, CVector vecTarg
         push    dwTargetEntity
         call    dwFunc
     }
+    // clang-format on
 }
 
 bool CTaskSimpleUseGunSA::SetPedPosition(CPed* pPed)
@@ -73,6 +77,8 @@ bool CTaskSimpleUseGunSA::SetPedPosition(CPed* pPed)
 
     BYTE currentWeaponSlot = dwPedInterface->bCurrentWeaponSlot;
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThisInterface
@@ -80,6 +86,8 @@ bool CTaskSimpleUseGunSA::SetPedPosition(CPed* pPed)
         call    dwFunc
         mov     bReturn, al
     }
+
+    // clang-format on
     return bReturn;
 }
 
@@ -88,6 +96,7 @@ void CTaskSimpleUseGunSA::FireGun(CPed* pPed, bool bFlag)
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_FireGun;
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
@@ -95,6 +104,7 @@ void CTaskSimpleUseGunSA::FireGun(CPed* pPed, bool bFlag)
         push    dwPedInterface
         call    dwFunc
     }
+    // clang-format on
 }
 
 bool CTaskSimpleUseGunSA::ControlGun(CPed* pPed, CEntity* pTargetEntity, char nCommand)
@@ -104,6 +114,7 @@ bool CTaskSimpleUseGunSA::ControlGun(CPed* pPed, CEntity* pTargetEntity, char nC
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
     DWORD dwTargetEntity = (pTargetEntity) ? (DWORD)pTargetEntity->GetInterface() : 0;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
@@ -113,6 +124,7 @@ bool CTaskSimpleUseGunSA::ControlGun(CPed* pPed, CEntity* pTargetEntity, char nC
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -121,6 +133,7 @@ bool CTaskSimpleUseGunSA::ControlGunMove(CVector2D* pMoveVec)
     bool  bReturn;
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_ControlGunMove;
     DWORD dwThisInterface = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
@@ -128,6 +141,7 @@ bool CTaskSimpleUseGunSA::ControlGunMove(CVector2D* pMoveVec)
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -139,6 +153,7 @@ void CTaskSimpleUseGunSA::Reset(CPed* pPed, CEntity* pTargetEntity, CVector vecT
     DWORD dwTargetEntity = (pTargetEntity) ? (DWORD)pTargetEntity->GetInterface() : 0;
     float fTargetX = vecTarget.fX, fTargetY = vecTarget.fY, fTargetZ = vecTarget.fZ;
     DWORD dwBurstLength = nBurstLength;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
@@ -151,6 +166,7 @@ void CTaskSimpleUseGunSA::Reset(CPed* pPed, CEntity* pTargetEntity, CVector vecT
         push    dwPedInterface
         call    dwFunc
     }
+    // clang-format on
 }
 
 int CTaskSimpleUseGunSA::GetTaskType()
@@ -158,12 +174,14 @@ int CTaskSimpleUseGunSA::GetTaskType()
     int   iReturn;
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_GetTaskType;
     DWORD dwThisInterface = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
         call    dwFunc
         mov     iReturn, eax
     }
+    // clang-format on
     return iReturn;
 }
 
@@ -175,6 +193,7 @@ bool CTaskSimpleUseGunSA::MakeAbortable(CPed* pPed, int iPriority, CEvent const*
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_MakeAbortable;
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
@@ -184,6 +203,7 @@ bool CTaskSimpleUseGunSA::MakeAbortable(CPed* pPed, int iPriority, CEvent const*
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -193,6 +213,7 @@ bool CTaskSimpleUseGunSA::ProcessPed(CPed* pPed)
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_ProcessPed;
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
@@ -200,6 +221,7 @@ bool CTaskSimpleUseGunSA::ProcessPed(CPed* pPed)
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -208,12 +230,14 @@ void CTaskSimpleUseGunSA::AbortIK(CPed* pPed)
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_AbortIK;
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
         push    dwPedInterface
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CTaskSimpleUseGunSA::AimGun(CPed* pPed)
@@ -221,12 +245,14 @@ void CTaskSimpleUseGunSA::AimGun(CPed* pPed)
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_AimGun;
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
         push    dwPedInterface
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CTaskSimpleUseGunSA::ClearAnim(CPed* pPed)
@@ -234,12 +260,14 @@ void CTaskSimpleUseGunSA::ClearAnim(CPed* pPed)
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_ClearAnim;
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
         push    dwPedInterface
         call    dwFunc
     }
+    // clang-format on
 }
 
 signed char CTaskSimpleUseGunSA::GetCurrentCommand()
@@ -247,12 +275,14 @@ signed char CTaskSimpleUseGunSA::GetCurrentCommand()
     signed char bReturn;
     DWORD       dwFunc = FUNC_CTaskSimpleUseGun_GetCurrentCommand;
     DWORD       dwThisInterface = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -261,12 +291,14 @@ bool CTaskSimpleUseGunSA::GetDoneFiring()
     bool  bReturn;
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_GetDoneFiring;
     DWORD dwThisInterface = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -275,12 +307,14 @@ bool CTaskSimpleUseGunSA::GetIsFinished()
     bool  bReturn;
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_GetIsFinished;
     DWORD dwThisInterface = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -289,12 +323,14 @@ bool CTaskSimpleUseGunSA::IsLineOfSightBlocked()
     bool  bReturn;
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_IsLineOfSightBlocked;
     DWORD dwThisInterface = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -303,12 +339,14 @@ bool CTaskSimpleUseGunSA::GetIsFiring()
     bool  bReturn;
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_GetIsFiring;
     DWORD dwThisInterface = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -317,12 +355,14 @@ bool CTaskSimpleUseGunSA::GetIsReloading()
     bool  bReturn;
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_GetIsReloading;
     DWORD dwThisInterface = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -331,12 +371,14 @@ bool CTaskSimpleUseGunSA::GetSkipAim()
     bool  bReturn;
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_GetSkipAim;
     DWORD dwThisInterface = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -345,12 +387,14 @@ bool CTaskSimpleUseGunSA::PlayerPassiveControlGun()
     bool  bReturn;
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_PlayerPassiveControlGun;
     DWORD dwThisInterface = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -359,6 +403,7 @@ void CTaskSimpleUseGunSA::RemoveStanceAnims(CPed* pPed, float f)
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_RemoveStanceAnims;
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
@@ -366,6 +411,7 @@ void CTaskSimpleUseGunSA::RemoveStanceAnims(CPed* pPed, float f)
         push    dwPedInterface
         call    dwFunc
     }
+    // clang-format on
 }
 
 bool CTaskSimpleUseGunSA::RequirePistolWhip(CPed* pPed, CEntity* pTargetEntity)
@@ -374,6 +420,7 @@ bool CTaskSimpleUseGunSA::RequirePistolWhip(CPed* pPed, CEntity* pTargetEntity)
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_ControlGun;
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
     DWORD dwTargetEntity = (pTargetEntity) ? (DWORD)pTargetEntity->GetInterface() : 0;
+    // clang-format off
     __asm
     {
         push    dwTargetEntity
@@ -381,6 +428,7 @@ bool CTaskSimpleUseGunSA::RequirePistolWhip(CPed* pPed, CEntity* pTargetEntity)
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -388,12 +436,14 @@ void CTaskSimpleUseGunSA::SetBurstLength(short a)
 {
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_SetBurstLength;
     DWORD dwThisInterface = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
         push    a
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CTaskSimpleUseGunSA::SetMoveAnim(CPed* pPed)
@@ -401,12 +451,14 @@ void CTaskSimpleUseGunSA::SetMoveAnim(CPed* pPed)
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_SetMoveAnim;
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
         push    dwPedInterface
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CTaskSimpleUseGunSA::StartAnim(class CPed* pPed)
@@ -414,18 +466,21 @@ void CTaskSimpleUseGunSA::StartAnim(class CPed* pPed)
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_StartAnim;
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
         push    dwPedInterface
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CTaskSimpleUseGunSA::StartCountDown(unsigned char a, bool b)
 {
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_StartCountDown;
     DWORD dwThisInterface = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
@@ -433,6 +488,7 @@ void CTaskSimpleUseGunSA::StartCountDown(unsigned char a, bool b)
         push    a
         call    dwFunc
     }
+    // clang-format on
 }
 
 CTaskSimpleFightSA::CTaskSimpleFightSA(CEntity* pTargetEntity, int nCommand, unsigned int nIdlePeriod)
@@ -443,6 +499,7 @@ CTaskSimpleFightSA::CTaskSimpleFightSA(CEntity* pTargetEntity, int nCommand, uns
     DWORD dwFunc = FUNC_CTaskSimpleFight__Constructor;
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwTargetEntity = (pTargetEntity) ? (DWORD)pTargetEntity->GetInterface() : 0;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
@@ -451,4 +508,5 @@ CTaskSimpleFightSA::CTaskSimpleFightSA(CEntity* pTargetEntity, int nCommand, uns
         push    dwTargetEntity
         call    dwFunc
     }
+    // clang-format on
 }

--- a/Client/game_sa/TaskAttackSA.cpp
+++ b/Client/game_sa/TaskAttackSA.cpp
@@ -78,7 +78,6 @@ bool CTaskSimpleUseGunSA::SetPedPosition(CPed* pPed)
     BYTE currentWeaponSlot = dwPedInterface->bCurrentWeaponSlot;
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThisInterface
@@ -86,7 +85,6 @@ bool CTaskSimpleUseGunSA::SetPedPosition(CPed* pPed)
         call    dwFunc
         mov     bReturn, al
     }
-
     // clang-format on
     return bReturn;
 }

--- a/Client/game_sa/TaskBasicSA.cpp
+++ b/Client/game_sa/TaskBasicSA.cpp
@@ -43,14 +43,12 @@ CTaskComplexUseMobilePhoneSA::CTaskComplexUseMobilePhoneSA(const int iDuration)
     DWORD dwThisInterface = (DWORD)GetInterface();
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThisInterface
         push    iDuration
         call    dwFunc
     }
-
     // clang-format on
 }
 
@@ -65,7 +63,6 @@ CTaskSimpleRunAnimSA::CTaskSimpleRunAnimSA(const AssocGroupId animGroup, const A
     DWORD dwThisInterface = (DWORD)GetInterface();
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThisInterface
@@ -77,7 +74,6 @@ CTaskSimpleRunAnimSA::CTaskSimpleRunAnimSA(const AssocGroupId animGroup, const A
         push    animGroup
         call    dwFunc
     }
-
     // clang-format on
 }
 
@@ -93,7 +89,6 @@ CTaskSimpleRunNamedAnimSA::CTaskSimpleRunNamedAnimSA(const char* pAnimName, cons
     DWORD dwThisInterface = (DWORD)GetInterface();
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThisInterface
@@ -108,7 +103,6 @@ CTaskSimpleRunNamedAnimSA::CTaskSimpleRunNamedAnimSA(const char* pAnimName, cons
         push    pAnimName
         call    dwFunc
     }
-
     // clang-format on
 }
 
@@ -124,7 +118,6 @@ CTaskComplexDieSA::CTaskComplexDieSA(const eWeaponType eMeansOfDeath, const Asso
     DWORD dwThisInterface = (DWORD)GetInterface();
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThisInterface
@@ -139,7 +132,6 @@ CTaskComplexDieSA::CTaskComplexDieSA(const eWeaponType eMeansOfDeath, const Asso
         push    eMeansOfDeath
         call    dwFunc
     }
-
     // clang-format on
 }
 
@@ -154,7 +146,6 @@ CTaskSimpleStealthKillSA::CTaskSimpleStealthKillSA(bool bKiller, CPed* pPed, con
     DWORD dwPedInterface = (DWORD)pPed->GetPedInterface();
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThisInterface
@@ -163,7 +154,6 @@ CTaskSimpleStealthKillSA::CTaskSimpleStealthKillSA(bool bKiller, CPed* pPed, con
         push    bKiller
         call    dwFunc
     }
-
     // clang-format on
 }
 
@@ -176,7 +166,6 @@ CTaskSimpleDeadSA::CTaskSimpleDeadSA(unsigned int uiDeathTimeMS, bool bUnk2)
     DWORD dwThisInterface = (DWORD)GetInterface();
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThisInterface
@@ -184,7 +173,6 @@ CTaskSimpleDeadSA::CTaskSimpleDeadSA(unsigned int uiDeathTimeMS, bool bUnk2)
         push    uiDeathTimeMS
         call    dwFunc
     }
-
     // clang-format on
 }
 
@@ -198,7 +186,6 @@ CTaskSimpleBeHitSA::CTaskSimpleBeHitSA(CPed* pPedAttacker, ePedPieceTypes hitBod
     DWORD dwPedInterface = (DWORD)pPedAttacker->GetPedInterface();
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThisInterface
@@ -208,7 +195,6 @@ CTaskSimpleBeHitSA::CTaskSimpleBeHitSA(CPed* pPedAttacker, ePedPieceTypes hitBod
         push    dwPedInterface
         call    dwFunc
     }
-
     // clang-format on
 }
 
@@ -225,7 +211,6 @@ CTaskComplexSunbatheSA::CTaskComplexSunbatheSA(CObject* pTowel, const bool bStar
         dwObjectInterface = (DWORD)pTowel->GetObjectInterface();
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThisInterface
@@ -233,7 +218,6 @@ CTaskComplexSunbatheSA::CTaskComplexSunbatheSA(CObject* pTowel, const bool bStar
         push    dwObjectInterface;
         call    dwFunc
     }
-
     // clang-format on
 }
 
@@ -255,13 +239,11 @@ CTaskSimplePlayerOnFootSA::CTaskSimplePlayerOnFootSA()
     DWORD dwThisInterface = (DWORD)GetInterface();
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThisInterface
         call    dwFunc
     }
-
     // clang-format on
 }
 
@@ -277,13 +259,11 @@ CTaskComplexFacialSA::CTaskComplexFacialSA()
     DWORD dwThisInterface = (DWORD)GetInterface();
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThisInterface
         call    dwFunc
     }
-
     // clang-format on
 }
 

--- a/Client/game_sa/TaskBasicSA.cpp
+++ b/Client/game_sa/TaskBasicSA.cpp
@@ -42,12 +42,16 @@ CTaskComplexUseMobilePhoneSA::CTaskComplexUseMobilePhoneSA(const int iDuration)
     DWORD dwFunc = FUNC_CTaskComplexUseMobilePhone__Constructor;
     DWORD dwThisInterface = (DWORD)GetInterface();
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThisInterface
         push    iDuration
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 CTaskSimpleRunAnimSA::CTaskSimpleRunAnimSA(const AssocGroupId animGroup, const AnimationId animID, const float fBlendDelta, const int iTaskType,
@@ -60,6 +64,8 @@ CTaskSimpleRunAnimSA::CTaskSimpleRunAnimSA(const AssocGroupId animGroup, const A
     DWORD dwFunc = FUNC_CTaskSimpleRunAnim__Constructor;
     DWORD dwThisInterface = (DWORD)GetInterface();
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThisInterface
@@ -71,6 +77,8 @@ CTaskSimpleRunAnimSA::CTaskSimpleRunAnimSA(const AssocGroupId animGroup, const A
         push    animGroup
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 CTaskSimpleRunNamedAnimSA::CTaskSimpleRunNamedAnimSA(const char* pAnimName, const char* pAnimGroupName, const int flags, const float fBlendDelta,
@@ -83,6 +91,8 @@ CTaskSimpleRunNamedAnimSA::CTaskSimpleRunNamedAnimSA(const char* pAnimName, cons
         return;
     DWORD dwFunc = FUNC_CTaskSimpleRunNamedAnim__Constructor;
     DWORD dwThisInterface = (DWORD)GetInterface();
+
+    // clang-format off
 
     __asm
     {
@@ -98,6 +108,8 @@ CTaskSimpleRunNamedAnimSA::CTaskSimpleRunNamedAnimSA(const char* pAnimName, cons
         push    pAnimName
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 CTaskComplexDieSA::CTaskComplexDieSA(const eWeaponType eMeansOfDeath, const AssocGroupId animGroup, const AnimationId anim, const float fBlendDelta,
@@ -110,6 +122,8 @@ CTaskComplexDieSA::CTaskComplexDieSA(const eWeaponType eMeansOfDeath, const Asso
         return;
     DWORD dwFunc = FUNC_CTaskComplexDie__Constructor;
     DWORD dwThisInterface = (DWORD)GetInterface();
+
+    // clang-format off
 
     __asm
     {
@@ -125,6 +139,8 @@ CTaskComplexDieSA::CTaskComplexDieSA(const eWeaponType eMeansOfDeath, const Asso
         push    eMeansOfDeath
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 CTaskSimpleStealthKillSA::CTaskSimpleStealthKillSA(bool bKiller, CPed* pPed, const AssocGroupId animGroup)
@@ -137,6 +153,8 @@ CTaskSimpleStealthKillSA::CTaskSimpleStealthKillSA(bool bKiller, CPed* pPed, con
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPed->GetPedInterface();
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThisInterface
@@ -145,6 +163,8 @@ CTaskSimpleStealthKillSA::CTaskSimpleStealthKillSA(bool bKiller, CPed* pPed, con
         push    bKiller
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 CTaskSimpleDeadSA::CTaskSimpleDeadSA(unsigned int uiDeathTimeMS, bool bUnk2)
@@ -155,6 +175,8 @@ CTaskSimpleDeadSA::CTaskSimpleDeadSA(unsigned int uiDeathTimeMS, bool bUnk2)
     DWORD dwFunc = FUNC_CTaskSimpleDead__Constructor;
     DWORD dwThisInterface = (DWORD)GetInterface();
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThisInterface
@@ -162,6 +184,8 @@ CTaskSimpleDeadSA::CTaskSimpleDeadSA(unsigned int uiDeathTimeMS, bool bUnk2)
         push    uiDeathTimeMS
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 CTaskSimpleBeHitSA::CTaskSimpleBeHitSA(CPed* pPedAttacker, ePedPieceTypes hitBodyPart, int hitBodySide, int weaponId)
@@ -173,6 +197,8 @@ CTaskSimpleBeHitSA::CTaskSimpleBeHitSA(CPed* pPedAttacker, ePedPieceTypes hitBod
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPedAttacker->GetPedInterface();
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThisInterface
@@ -182,6 +208,8 @@ CTaskSimpleBeHitSA::CTaskSimpleBeHitSA(CPed* pPedAttacker, ePedPieceTypes hitBod
         push    dwPedInterface
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 CTaskComplexSunbatheSA::CTaskComplexSunbatheSA(CObject* pTowel, const bool bStartStanding)
@@ -196,6 +224,8 @@ CTaskComplexSunbatheSA::CTaskComplexSunbatheSA(CObject* pTowel, const bool bStar
     if (pTowel)
         dwObjectInterface = (DWORD)pTowel->GetObjectInterface();
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThisInterface
@@ -203,6 +233,8 @@ CTaskComplexSunbatheSA::CTaskComplexSunbatheSA(CObject* pTowel, const bool bStar
         push    dwObjectInterface;
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 void CTaskComplexSunbatheSA::SetEndTime(DWORD dwTime)
@@ -222,11 +254,15 @@ CTaskSimplePlayerOnFootSA::CTaskSimplePlayerOnFootSA()
     DWORD dwFunc = (DWORD)FUNC_CTASKSimplePlayerOnFoot__Constructor;
     DWORD dwThisInterface = (DWORD)GetInterface();
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThisInterface
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 ////////////////////
@@ -240,11 +276,15 @@ CTaskComplexFacialSA::CTaskComplexFacialSA()
     DWORD dwFunc = (DWORD)FUNC_CTASKComplexFacial__Constructor;
     DWORD dwThisInterface = (DWORD)GetInterface();
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThisInterface
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 CTaskComplexInWaterSA::CTaskComplexInWaterSA()

--- a/Client/game_sa/TaskCarAccessoriesSA.cpp
+++ b/Client/game_sa/TaskCarAccessoriesSA.cpp
@@ -30,6 +30,8 @@ CTaskSimpleCarSetPedInAsDriverSA::CTaskSimpleCarSetPedInAsDriverSA(CVehicle* pTa
         DWORD dwVehiclePtr = (DWORD)pTargetVehicleSA->GetInterface();
         DWORD dwThisInterface = (DWORD)GetInterface();
 
+        // clang-format off
+
         __asm
         {
             mov     ecx, dwThisInterface
@@ -37,6 +39,8 @@ CTaskSimpleCarSetPedInAsDriverSA::CTaskSimpleCarSetPedInAsDriverSA(CVehicle* pTa
             push    dwVehiclePtr
             call    dwFunc
         }
+
+        // clang-format on
     }
 }
 
@@ -72,6 +76,7 @@ CTaskSimpleCarSetPedInAsPassengerSA::CTaskSimpleCarSetPedInAsPassengerSA(CVehicl
         DWORD dwFunc = FUNC_CTaskSimpleCarSetPedInAsPassenger__Constructor;
         DWORD dwVehiclePtr = (DWORD)pTargetVehicleSA->GetInterface();
         DWORD dwThisInterface = (DWORD)GetInterface();
+        // clang-format off
         __asm
         {
             mov     ecx, dwThisInterface
@@ -80,6 +85,7 @@ CTaskSimpleCarSetPedInAsPassengerSA::CTaskSimpleCarSetPedInAsPassengerSA(CVehicl
             push    dwVehiclePtr
             call    dwFunc
         }
+        // clang-format on
     }
 }
 
@@ -115,6 +121,7 @@ CTaskSimpleCarSetPedOutSA::CTaskSimpleCarSetPedOutSA(CVehicle* pTargetVehicle, i
         DWORD dwFunc = FUNC_CTaskSimpleCarSetPedOut__Constructor;
         DWORD dwVehiclePtr = (DWORD)pTargetVehicleSA->GetInterface();
         DWORD dwThisInterface = (DWORD)GetInterface();
+        // clang-format off
         __asm
         {
             mov     ecx, dwThisInterface
@@ -125,6 +132,7 @@ CTaskSimpleCarSetPedOutSA::CTaskSimpleCarSetPedOutSA(CVehicle* pTargetVehicle, i
             push    dwVehiclePtr
             call    dwFunc
         }
+        // clang-format on
     }
 }
 
@@ -154,6 +162,7 @@ void CTaskSimpleCarSetPedOutSA::PositionPedOutOfCollision(CPed* ped, CVehicle* v
     DWORD dwFunc = FUNC_CTaskSimpleCarSetPedOut__PositionPedOutOfCollision;
     DWORD dwVehiclePtr = (DWORD)((CEntitySA*)vehicle)->GetInterface();
     DWORD dwPedPtr = (DWORD)((CEntitySA*)ped)->GetInterface();
+    // clang-format off
     __asm
     {
         push    nDoor
@@ -161,4 +170,5 @@ void CTaskSimpleCarSetPedOutSA::PositionPedOutOfCollision(CPed* ped, CVehicle* v
         push    dwPedPtr
         call    dwFunc
     }
+    // clang-format on
 }

--- a/Client/game_sa/TaskCarAccessoriesSA.cpp
+++ b/Client/game_sa/TaskCarAccessoriesSA.cpp
@@ -31,7 +31,6 @@ CTaskSimpleCarSetPedInAsDriverSA::CTaskSimpleCarSetPedInAsDriverSA(CVehicle* pTa
         DWORD dwThisInterface = (DWORD)GetInterface();
 
         // clang-format off
-
         __asm
         {
             mov     ecx, dwThisInterface
@@ -39,7 +38,6 @@ CTaskSimpleCarSetPedInAsDriverSA::CTaskSimpleCarSetPedInAsDriverSA(CVehicle* pTa
             push    dwVehiclePtr
             call    dwFunc
         }
-
         // clang-format on
     }
 }

--- a/Client/game_sa/TaskCarSA.cpp
+++ b/Client/game_sa/TaskCarSA.cpp
@@ -44,14 +44,12 @@ CTaskComplexEnterCarAsDriverSA::CTaskComplexEnterCarAsDriverSA(CVehicle* pTarget
         DWORD dwThisInterface = (DWORD)GetInterface();
 
         // clang-format off
-
         __asm
         {
             mov     ecx, dwThisInterface
             push    dwVehiclePtr
             call    dwFunc
         }
-
         // clang-format on
     }
 }
@@ -76,7 +74,6 @@ CTaskComplexEnterCarAsPassengerSA::CTaskComplexEnterCarAsPassengerSA(CVehicle* p
         DWORD dwThisInterface = (DWORD)GetInterface();
 
         // clang-format off
-
         __asm
         {
             push    edx
@@ -89,7 +86,6 @@ CTaskComplexEnterCarAsPassengerSA::CTaskComplexEnterCarAsPassengerSA(CVehicle* p
             call    dwFunc
             pop     edx
         }
-
         // clang-format on
     }
 }
@@ -113,14 +109,12 @@ CTaskComplexEnterBoatAsDriverSA::CTaskComplexEnterBoatAsDriverSA(CVehicle* pTarg
         DWORD dwThisInterface = (DWORD)GetInterface();
 
         // clang-format off
-
         __asm
         {
             mov     ecx, dwThisInterface
             push    dwVehiclePtr
             call    dwFunc
         }
-
         // clang-format on
     }
 }
@@ -151,7 +145,6 @@ CTaskComplexLeaveCarSA::CTaskComplexLeaveCarSA(CVehicle* pTargetVehicle, const i
             dwDoorIdx = s_iCarNodeIndexes[iTargetDoor];
 
         // clang-format off
-
         __asm
         {
             mov     ecx, dwThisInterface
@@ -167,7 +160,6 @@ CTaskComplexLeaveCarSA::CTaskComplexLeaveCarSA(CVehicle* pTargetVehicle, const i
             call    dwFunc
             pop     ebx
         }
-
         // clang-format on
     }
 }

--- a/Client/game_sa/TaskCarSA.cpp
+++ b/Client/game_sa/TaskCarSA.cpp
@@ -43,12 +43,16 @@ CTaskComplexEnterCarAsDriverSA::CTaskComplexEnterCarAsDriverSA(CVehicle* pTarget
         DWORD dwVehiclePtr = (DWORD)pTargetVehicleSA->GetInterface();
         DWORD dwThisInterface = (DWORD)GetInterface();
 
+        // clang-format off
+
         __asm
         {
             mov     ecx, dwThisInterface
             push    dwVehiclePtr
             call    dwFunc
         }
+
+        // clang-format on
     }
 }
 
@@ -71,6 +75,8 @@ CTaskComplexEnterCarAsPassengerSA::CTaskComplexEnterCarAsPassengerSA(CVehicle* p
         DWORD dwVehiclePtr = (DWORD)pTargetVehicleSA->GetInterface();
         DWORD dwThisInterface = (DWORD)GetInterface();
 
+        // clang-format off
+
         __asm
         {
             push    edx
@@ -83,6 +89,8 @@ CTaskComplexEnterCarAsPassengerSA::CTaskComplexEnterCarAsPassengerSA(CVehicle* p
             call    dwFunc
             pop     edx
         }
+
+        // clang-format on
     }
 }
 
@@ -104,12 +112,16 @@ CTaskComplexEnterBoatAsDriverSA::CTaskComplexEnterBoatAsDriverSA(CVehicle* pTarg
         DWORD dwVehiclePtr = (DWORD)pTargetVehicleSA->GetInterface();
         DWORD dwThisInterface = (DWORD)GetInterface();
 
+        // clang-format off
+
         __asm
         {
             mov     ecx, dwThisInterface
             push    dwVehiclePtr
             call    dwFunc
         }
+
+        // clang-format on
     }
 }
 
@@ -138,6 +150,8 @@ CTaskComplexLeaveCarSA::CTaskComplexLeaveCarSA(CVehicle* pTargetVehicle, const i
         if (iTargetDoor >= 0 && iTargetDoor <= 5)
             dwDoorIdx = s_iCarNodeIndexes[iTargetDoor];
 
+        // clang-format off
+
         __asm
         {
             mov     ecx, dwThisInterface
@@ -153,5 +167,7 @@ CTaskComplexLeaveCarSA::CTaskComplexLeaveCarSA(CVehicle* pTargetVehicle, const i
             call    dwFunc
             pop     ebx
         }
+
+        // clang-format on
     }
 }

--- a/Client/game_sa/TaskGoToSA.cpp
+++ b/Client/game_sa/TaskGoToSA.cpp
@@ -26,12 +26,14 @@ int CTaskComplexWanderSA::GetWanderType()
 
     if (dwFunc && dwFunc != 0x82263A)            // some tasks have no wander type 0x82263A is purecal (assert?)
     {
+        // clang-format off
         __asm
         {
             mov     ecx, pTaskInterface
             call    dwFunc
             mov     iReturn, eax
         }
+        // clang-format on
     }
     return iReturn;
 }
@@ -58,6 +60,7 @@ CTaskComplexWanderStandardSA::CTaskComplexWanderStandardSA(const int iMoveState,
         return;
     DWORD dwFunc = FUNC_CTaskComplexWanderStandard__Constructor;
     DWORD dwThisInterface = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
@@ -66,4 +69,5 @@ CTaskComplexWanderStandardSA::CTaskComplexWanderStandardSA(const int iMoveState,
         push    iMoveState
         call    dwFunc
     }
+    // clang-format on
 }

--- a/Client/game_sa/TaskIKSA.cpp
+++ b/Client/game_sa/TaskIKSA.cpp
@@ -31,6 +31,7 @@ CTaskSimpleIKChainSA::CTaskSimpleIKChainSA(char* idString, int effectorBoneTag, 
         dwEntityInterface = (DWORD)pEntity->GetInterface();
     float fEffectorX = effectorVec.fX, fEffectorY = effectorVec.fY, fEffectorZ = effectorVec.fZ;
     float fX = offsetPos.fX, fY = offsetPos.fY, fZ = offsetPos.fZ;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
@@ -50,6 +51,7 @@ CTaskSimpleIKChainSA::CTaskSimpleIKChainSA(char* idString, int effectorBoneTag, 
         push    idString
         call    dwFunc
     }
+    // clang-format on
 }
 
 CTaskSimpleIKLookAtSA::CTaskSimpleIKLookAtSA(char* idString, CEntity* pEntity, int time, int offsetBoneTag, CVector offsetPos, unsigned char useTorso,
@@ -65,6 +67,7 @@ CTaskSimpleIKLookAtSA::CTaskSimpleIKLookAtSA(char* idString, CEntity* pEntity, i
     if (pEntity)
         dwEntityInterface = (DWORD)pEntity->GetInterface();
     float fX = offsetPos.fX, fY = offsetPos.fY, fZ = offsetPos.fZ;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
@@ -81,6 +84,7 @@ CTaskSimpleIKLookAtSA::CTaskSimpleIKLookAtSA(char* idString, CEntity* pEntity, i
         push    idString
         call    dwFunc
     }
+    // clang-format on
 }
 
 CTaskSimpleIKManagerSA::CTaskSimpleIKManagerSA()
@@ -157,6 +161,7 @@ CTaskSimpleTriggerLookAtSA::CTaskSimpleTriggerLookAtSA(CEntity* pEntity, int tim
     if (pEntity)
         dwEntityInterface = (DWORD)pEntity->GetInterface();
     float fX = offsetPos.fX, fY = offsetPos.fY, fZ = offsetPos.fZ;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
@@ -172,4 +177,5 @@ CTaskSimpleTriggerLookAtSA::CTaskSimpleTriggerLookAtSA(CEntity* pEntity, int tim
         push    dwEntityInterface
         call    dwFunc
     }
+    // clang-format on
 }

--- a/Client/game_sa/TaskJumpFallSA.cpp
+++ b/Client/game_sa/TaskJumpFallSA.cpp
@@ -22,7 +22,6 @@ CTaskSimpleClimbSA::CTaskSimpleClimbSA(CEntitySAInterface* pClimbEnt, const CVec
     DWORD dwThisInterface = (DWORD)GetInterface();
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThisInterface
@@ -34,7 +33,6 @@ CTaskSimpleClimbSA::CTaskSimpleClimbSA(CEntitySAInterface* pClimbEnt, const CVec
         push    pClimbEnt
         call    dwFunc
     }
-
     // clang-format on
 }
 
@@ -52,7 +50,6 @@ CTaskSimpleJetPackSA::CTaskSimpleJetPackSA(const CVector* pVecTargetPos, float f
     DWORD dwThisInterface = (DWORD)GetInterface();
 
     // clang-format off
-
     __asm
     {
         mov     ecx, dwThisInterface
@@ -62,6 +59,5 @@ CTaskSimpleJetPackSA::CTaskSimpleJetPackSA(const CVector* pVecTargetPos, float f
         push    pVecTargetPos
         call    dwFunc
     }
-
     // clang-format on
 }

--- a/Client/game_sa/TaskJumpFallSA.cpp
+++ b/Client/game_sa/TaskJumpFallSA.cpp
@@ -21,6 +21,8 @@ CTaskSimpleClimbSA::CTaskSimpleClimbSA(CEntitySAInterface* pClimbEnt, const CVec
     DWORD dwFunc = FUNC_CTaskSimpleClimb__Constructor;
     DWORD dwThisInterface = (DWORD)GetInterface();
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThisInterface
@@ -32,6 +34,8 @@ CTaskSimpleClimbSA::CTaskSimpleClimbSA(CEntitySAInterface* pClimbEnt, const CVec
         push    pClimbEnt
         call    dwFunc
     }
+
+    // clang-format on
 }
 
 // ##############################################################################
@@ -47,6 +51,8 @@ CTaskSimpleJetPackSA::CTaskSimpleJetPackSA(const CVector* pVecTargetPos, float f
     DWORD dwFunc = FUNC_CTaskSimpleJetPack__Constructor;
     DWORD dwThisInterface = (DWORD)GetInterface();
 
+    // clang-format off
+
     __asm
     {
         mov     ecx, dwThisInterface
@@ -56,4 +62,6 @@ CTaskSimpleJetPackSA::CTaskSimpleJetPackSA(const CVector* pVecTargetPos, float f
         push    pVecTargetPos
         call    dwFunc
     }
+
+    // clang-format on
 }

--- a/Client/game_sa/TaskPhysicalResponseSA.cpp
+++ b/Client/game_sa/TaskPhysicalResponseSA.cpp
@@ -37,6 +37,7 @@ CTaskSimpleChokingSA::CTaskSimpleChokingSA(CPed* pAttacker, bool bIsTearGas)
     if (!IsValid())
         return;
     DWORD dwThisInterface = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
@@ -46,6 +47,7 @@ CTaskSimpleChokingSA::CTaskSimpleChokingSA(CPed* pAttacker, bool bIsTearGas)
         call    dwFunc
         pop     ebx
     }
+    // clang-format on
 }
 
 CPed* CTaskSimpleChokingSA::GetAttacker()
@@ -99,6 +101,7 @@ void CTaskSimpleChokingSA::UpdateChoke(CPed* pPed, CPed* pAttacker, bool bIsTear
     // Call the func
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwFunc = FUNC_CTaskSimpleChoking__UpdateChoke;
+    // clang-format off
     __asm
     {
         mov         ecx, dwThisInterface
@@ -107,4 +110,5 @@ void CTaskSimpleChokingSA::UpdateChoke(CPed* pPed, CPed* pAttacker, bool bIsTear
         push        pPedInterface
         call        dwFunc
     }
+    // clang-format on
 }

--- a/Client/game_sa/TaskSA.cpp
+++ b/Client/game_sa/TaskSA.cpp
@@ -46,6 +46,7 @@ void CTaskSA::CreateTaskInterface(size_t nSize)
 
     DWORD dwFunc = FUNC_CTask__Operator_New;
     DWORD dwReturn = 0;
+    // clang-format off
     __asm
     {
         push    nSize
@@ -53,6 +54,7 @@ void CTaskSA::CreateTaskInterface(size_t nSize)
         add     esp, 4
         mov     dwReturn, eax
     }
+    // clang-format on
 
     TaskInterface = (CTaskSAInterface*)dwReturn;
     Parent = 0;
@@ -63,12 +65,14 @@ CTask* CTaskSA::Clone()
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwFunc = GetInterface()->VTBL->Clone;
     DWORD dwReturn = 0;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
         call    dwFunc
         mov     dwReturn, eax
     }
+    // clang-format on
     return (CTask*)dwReturn;
 }
 
@@ -93,12 +97,14 @@ CTask* CTaskSA::GetSubTask()
         return nullptr;
 
     DWORD dwReturn = 0;
+    // clang-format off
     __asm
     {
         mov     ecx, pTaskInterface
         call    dwFunc
         mov     dwReturn, eax
     }
+    // clang-format on
     return s_pTaskManagementSystem->GetTask((CTaskSAInterface*)dwReturn);
 }
 
@@ -107,12 +113,14 @@ bool CTaskSA::IsSimpleTask()
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwFunc = GetInterface()->VTBL->IsSimpleTask;
     bool  bReturn = 0;
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
         call    dwFunc
         mov     bReturn, al
     }
+    // clang-format on
     return bReturn;
 }
 
@@ -125,12 +133,14 @@ int CTaskSA::GetTaskType()
 
     if (dwFunc && dwFunc != 0x82263A)            // some functions have no task type 0x82263A is purecal (assert?)
     {
+        // clang-format off
         __asm
         {
             mov     ecx, pTaskInterface
             call    dwFunc
             mov     iReturn, eax
         }
+        // clang-format on
     }
     return iReturn;
 }
@@ -144,12 +154,14 @@ void CTaskSA::StopTimer(const CEvent* pEvent)
     DWORD dwFunc = GetInterface()->VTBL->StopTimer;
     if (dwFunc != 0x82263A && dwFunc)
     {
+        // clang-format off
         __asm
         {
             mov     ecx, dwThisInterface
             push    pEvent
             call    dwFunc
         }
+        // clang-format on
     }
 }
 
@@ -168,6 +180,7 @@ bool CTaskSA::MakeAbortable(CPed* pPed, const int iPriority, const CEvent* pEven
     bool  bReturn = 0;
     if (dwFunc != 0x82263A && dwFunc)            // 82263A = purecall
     {
+        // clang-format off
         __asm
         {
             mov     ecx, dwThisInterface
@@ -177,6 +190,7 @@ bool CTaskSA::MakeAbortable(CPed* pPed, const int iPriority, const CEvent* pEven
             call    dwFunc
             mov     bReturn, al
         }
+        // clang-format on
     }
     return bReturn;
 }
@@ -203,24 +217,28 @@ void CTaskSA::Destroy()
     DWORD dwFunc = GetInterface()->VTBL->DeletingDestructor;
     if (dwFunc)
     {
+        // clang-format off
         __asm
         {
             mov     ecx, dwThisInterface
             push    1           // delete the task too
             call    dwFunc
         }
+        // clang-format on
     }
 
     /*dwFunc = FUNC_CTask__Operator_Delete;
     DWORD thisInterface = (DWORD)GetInterface();
     if ( thisInterface )
     {
+        // clang-format off
         __asm
         {
             push    thisInterface
             call    dwFunc
             add     esp, 4
         }
+        // clang-format on
     }*/
 
     delete this;
@@ -261,6 +279,7 @@ bool CTaskSimpleSA::ProcessPed(CPed* pPed)
     bool  bReturn = 0;
     if (dwFunc != 0x82263A && dwFunc)
     {
+        // clang-format off
         __asm
         {
             mov     ecx, dwThisInterface
@@ -268,6 +287,7 @@ bool CTaskSimpleSA::ProcessPed(CPed* pPed)
             call    dwFunc
             mov     bReturn, al
         }
+        // clang-format on
     }
     return bReturn;
 }
@@ -284,6 +304,7 @@ bool CTaskSimpleSA::SetPedPosition(CPed* pPed)
     bool  bReturn = 0;
     if (dwFunc != 0x82263A && dwFunc)
     {
+        // clang-format off
         __asm
         {
             mov     ecx, dwThisInterface
@@ -291,6 +312,7 @@ bool CTaskSimpleSA::SetPedPosition(CPed* pPed)
             call    dwFunc
             mov     bReturn, al
         }
+        // clang-format on
     }
     return bReturn;
 }
@@ -319,12 +341,14 @@ void CTaskComplexSA::SetSubTask(CTask* pSubTask)
     DWORD dwFunc = ((TaskComplexVTBL*)GetInterface()->VTBL)->SetSubTask;
     if (dwFunc != 0x82263A && dwFunc)
     {
+        // clang-format off
         __asm
         {
             mov     ecx, dwThisInterface
             push    dwTaskInterface
             call    dwFunc
         }
+        // clang-format on
     }
 }
 
@@ -344,6 +368,7 @@ CTask* CTaskComplexSA::CreateNextSubTask(CPed* pPed)
 
     DWORD dwPedInterface = (DWORD)pPedSA->GetInterface();
     DWORD dwReturn = 0;
+    // clang-format off
     __asm
     {
         mov     ecx, pTaskInterface
@@ -351,6 +376,7 @@ CTask* CTaskComplexSA::CreateNextSubTask(CPed* pPed)
         call    dwFunc
         mov     dwReturn, eax
     }
+    // clang-format on
     return pGame->GetTaskManagementSystem()->GetTask((CTaskSAInterface*)dwReturn);
 }
 
@@ -370,6 +396,7 @@ CTask* CTaskComplexSA::CreateFirstSubTask(CPed* pPed)
 
     DWORD dwPedInterface = (DWORD)pPedSA->GetInterface();
     DWORD dwReturn = 0;
+    // clang-format off
     __asm
     {
         mov     ecx, pTaskInterface
@@ -377,6 +404,7 @@ CTask* CTaskComplexSA::CreateFirstSubTask(CPed* pPed)
         call    dwFunc
         mov     dwReturn, eax
     }
+    // clang-format on
     return pGame->GetTaskManagementSystem()->GetTask((CTaskSAInterface*)dwReturn);
 }
 
@@ -396,6 +424,7 @@ CTask* CTaskComplexSA::ControlSubTask(CPed* pPed)
 
     DWORD dwPedInterface = (DWORD)pPedSA->GetInterface();
     DWORD dwReturn = 0;
+    // clang-format off
     __asm
     {
         mov     ecx, pTaskInterface
@@ -403,5 +432,6 @@ CTask* CTaskComplexSA::ControlSubTask(CPed* pPed)
         call    dwFunc
         mov     dwReturn, eax
     }
+    // clang-format on
     return pGame->GetTaskManagementSystem()->GetTask((CTaskSAInterface*)dwReturn);
 }

--- a/Client/game_sa/TaskSecondarySA.cpp
+++ b/Client/game_sa/TaskSecondarySA.cpp
@@ -24,6 +24,7 @@ CTaskSimpleDuckSA::CTaskSimpleDuckSA(eDuckControlTypes nDuckControl, unsigned sh
     if (!IsValid())
         return;
     DWORD dwThisInterface = (DWORD)GetInterface();
+    // clang-format off
     __asm
     {
         mov     ecx, dwThisInterface
@@ -36,4 +37,5 @@ CTaskSimpleDuckSA::CTaskSimpleDuckSA(eDuckControlTypes nDuckControl, unsigned sh
         call    dwFunc
         pop     ebx
     }
+    // clang-format on
 }

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -2811,6 +2811,8 @@ static void __declspec(naked) HOOK_FindPlayerCoors()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // Only set our world of center if we have a center of world set
@@ -2843,6 +2845,8 @@ static void __declspec(naked) HOOK_FindPlayerCoors()
         add     ecx, 6
         jmp     ecx
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CStreaming_Update_Caller()
@@ -2854,11 +2858,15 @@ static void __declspec(naked) HOOK_CStreaming_Update_Caller()
     0053BF0B   E8 6027EDFF      CALL gta_sa.0040E670
     */
 
+    // clang-format off
+
     __asm
     {
         // Store all registers
         pushad
     }
+
+    // clang-format on
 
     // We're now in the streaming update
     bInStreamingUpdate = true;
@@ -2867,6 +2875,7 @@ static void __declspec(naked) HOOK_CStreaming_Update_Caller()
     if (activeEntityForStreaming)
     {
         // Do something...
+        // clang-format off
         __asm
         {
             mov     edi, FUNC_CPlayerInfoBase
@@ -2875,7 +2884,10 @@ static void __declspec(naked) HOOK_CStreaming_Update_Caller()
             mov     ebx, activeEntityForStreaming
             mov     [edi], ebx
         }
+        // clang-format on
     }
+
+    // clang-format off
 
     __asm
     {
@@ -2886,9 +2898,12 @@ static void __declspec(naked) HOOK_CStreaming_Update_Caller()
         call    eax
     }
 
+    // clang-format on
+
     // We have an entity for streaming?
     if (activeEntityForStreaming)
     {
+        // clang-format off
         __asm
         {
             // ...
@@ -2896,10 +2911,12 @@ static void __declspec(naked) HOOK_CStreaming_Update_Caller()
             mov     ebx, dwSavedPlayerPointer
             mov     [edi], ebx
         }
+        // clang-format on
     }
 
     // We're no longer in streaming update
     bInStreamingUpdate = false;
+    // clang-format off
     __asm
     {
         // Restore registers
@@ -2910,6 +2927,7 @@ static void __declspec(naked) HOOK_CStreaming_Update_Caller()
         add     eax, 7
         jmp     eax
     }
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CHud_Draw_Caller()
@@ -2920,6 +2938,7 @@ static void __declspec(naked) HOOK_CHud_Draw_Caller()
     0053E4FA   . E8 318BFCFF                          CALL gta_sa_u.00507030
     0053E4FF   . E8 DC150500                          CALL gta_sa_u.0058FAE0
     */
+    // clang-format off
     __asm
     {
         pushad
@@ -2927,19 +2946,23 @@ static void __declspec(naked) HOOK_CHud_Draw_Caller()
         mov     edx, FUNC_CAudioEngine__DisplayRadioStationName
         call    edx
     }
+    // clang-format on
 
     if (!bSetCenterOfWorld)
     {
+        // clang-format off
         __asm
         {
             mov     edx, FUNC_CHud_Draw
             call    edx
         }
+        // clang-format on
     }
     else
     {
         /*if ( activeEntityForStreaming )
         {
+            // clang-format off
             __asm
             {
                 mov     edi, FUNC_CPlayerInfoBase
@@ -2948,27 +2971,34 @@ static void __declspec(naked) HOOK_CHud_Draw_Caller()
                 mov     ebx, activeEntityForStreaming
                 mov     [edi], ebx
             }
+            // clang-format on
         }*/
 
         if (!bHideRadar)
         {
+            // clang-format off
             __asm
             {
                 mov     edx, 0x58A330
                 call    edx
             }
+            // clang-format on
         }
 
         /*if ( activeEntityForStreaming )
         {
+            // clang-format off
             __asm
             {
                 mov     edi, FUNC_CPlayerInfoBase
                 mov     ebx, dwSavedPlayerPointer
                 mov     [edi], ebx
             }
+            // clang-format on
         }*/
     }
+
+    // clang-format off
 
     __asm
     {
@@ -2978,6 +3008,8 @@ static void __declspec(naked) HOOK_CHud_Draw_Caller()
         add     eax, 10
         jmp     eax
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_FindPlayerCentreOfWorld()
@@ -2988,6 +3020,8 @@ static void __declspec(naked) HOOK_FindPlayerCentreOfWorld()
     0056E250  /$ 8B4424 04      MOV EAX,DWORD PTR SS:[ESP+4]
     0056E254  |. 85C0           TEST EAX,EAX
     */
+
+    // clang-format off
 
     __asm
     {
@@ -3007,6 +3041,8 @@ static void __declspec(naked) HOOK_FindPlayerCentreOfWorld()
         lea     eax, vecCenterOfWorld
         retn
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_FindPlayerHeading()
@@ -3017,6 +3053,8 @@ static void __declspec(naked) HOOK_FindPlayerHeading()
     0056E450  /$ 8B4C24 04      MOV ECX,DWORD PTR SS:[ESP+4]
     0056E454  |. 8BD1           MOV EDX,ECX
     */
+
+    // clang-format off
 
     __asm
     {
@@ -3040,12 +3078,16 @@ static void __declspec(naked) HOOK_FindPlayerHeading()
         fld     fFalseHeading
         retn
     }
+
+    // clang-format on
 }
 
 // this hook adds a null check to prevent the game crashing when objects are placed really high up (issue 517)
 static void __declspec(naked) HOOK_CCustomRoadsignMgr__RenderRoadsignAtomic()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -3062,6 +3104,8 @@ no_render:
         mov     edx, 0x6FF40B
         jmp     edx
     }
+
+    // clang-format on
 }
 
 bool CallBreakTowLinkHandler(CVehicleSAInterface* vehicle)
@@ -3079,18 +3123,26 @@ static void __declspec(naked) HOOK_CRadar__DrawRadarGangOverlay()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
 
+    // clang-format on
+
     if (m_pDrawRadarAreasHandler) m_pDrawRadarAreasHandler();
+
+    // clang-format off
 
     __asm
     {
         popad
         retn
     }
+
+    // clang-format on
 }
 
 CVehicleSAInterface* towingVehicle;
@@ -3099,27 +3151,37 @@ static void __declspec(naked) HOOK_Trailer_BreakTowLink()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     towingVehicle, ecx
         pushad
     }
 
+    // clang-format on
+
     if (CallBreakTowLinkHandler(towingVehicle))
     {
+        // clang-format off
         __asm
         {
             popad
             call    dword ptr [edx+0xF8]
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
         }
+        // clang-format on
     }
+
+    // clang-format off
 
     __asm
     {
@@ -3127,6 +3189,8 @@ static void __declspec(naked) HOOK_Trailer_BreakTowLink()
         add     ecx, 6
         jmp     ecx
     }
+
+    // clang-format on
 }
 
 eExplosionType explosionType;
@@ -3158,6 +3222,8 @@ bool CallExplosionHandler()
 static void __declspec(naked) HOOK_CExplosion_AddExplosion()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -3207,22 +3273,30 @@ static void __declspec(naked) HOOK_CExplosion_AddExplosion()
         pushad
     }
 
+    // clang-format on
+
     // Call the explosion handler
     if (!CallExplosionHandler())
     {
+        // clang-format off
         __asm
         {
             popad
             retn // if they return false from the handler, they don't want the explosion to show
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
         }
+        // clang-format on
     }
+
+    // clang-format off
 
     __asm
     {
@@ -3239,6 +3313,8 @@ static void __declspec(naked) HOOK_CExplosion_AddExplosion()
         add     edx, 6
         jmp     edx
     }
+
+    // clang-format on
 }
 
 CEntitySAInterface* entity;
@@ -3270,6 +3346,8 @@ static void __declspec(naked) HOOK_CTaskComplexJump__CreateSubTask()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     pedPosition, eax
@@ -3282,23 +3360,29 @@ static void __declspec(naked) HOOK_CTaskComplexJump__CreateSubTask()
         pushad
     }
 
+    // clang-format on
+
     if (processGrab())
     {
+        // clang-format off
         __asm
         {
             popad
             mov     eax, 0x67DAD6
             jmp     eax
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
             mov     eax, 0x67DAD1
             jmp     eax
         }
+        // clang-format on
     }
 }
 
@@ -3309,6 +3393,8 @@ DWORD* pNewCreateFxSystem_Matrix = 0;
 static void __declspec(naked) HOOK_FxManager_CreateFxSystem()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -3323,6 +3409,8 @@ static void __declspec(naked) HOOK_FxManager_CreateFxSystem()
         // Store all the registers on the stack
         pushad
     }
+
+    // clang-format on
 
     // If we got a matrix and it is an explosion type?
     if (pCreateFxSystem_Matrix != 0 && strncmp(szCreateFxSystem_ExplosionType, "explosion", 9) == 0)
@@ -3340,6 +3428,8 @@ static void __declspec(naked) HOOK_FxManager_CreateFxSystem()
         pNewCreateFxSystem_Matrix = pCreateFxSystem_Matrix;
     }
 
+    // clang-format off
+
     __asm
     {
         // Restore the registers
@@ -3356,6 +3446,8 @@ static void __declspec(naked) HOOK_FxManager_CreateFxSystem()
         // Jump back to the rest of the function we hooked
         jmp         RETURN_FxManager_CreateFxSystem
     }
+
+    // clang-format on
 }
 
 DWORD  dwDestroyFxSystem_Pointer = 0;
@@ -3364,6 +3456,8 @@ DWORD* pDestroyFxSystem_Matrix = 0;
 static void __declspec(naked) HOOK_FxManager_DestroyFxSystem()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -3375,11 +3469,15 @@ static void __declspec(naked) HOOK_FxManager_DestroyFxSystem()
         pushad
     }
 
+    // clang-format on
+
     // Grab the matrix pointer in it
     pDestroyFxSystem_Matrix = *((DWORD**)(dwDestroyFxSystem_Pointer + 12));
 
     // Delete it if it's in our list
     RemoveFxSystemPointer(pDestroyFxSystem_Matrix);
+
+    // clang-format off
 
     __asm
     {
@@ -3395,6 +3493,8 @@ static void __declspec(naked) HOOK_FxManager_DestroyFxSystem()
         // Jump back to the rest of the function we hooked
         jmp         RETURN_FxManager_DestroyFxSystem
     }
+
+    // clang-format on
 }
 
 bool CCam_ProcessFixed(class CCamSAInterface* pCamInterface)
@@ -3414,20 +3514,27 @@ static void __declspec(naked) HOOK_CCam_ProcessFixed()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov CCam_ProcessFixed_pCam, ecx
     }
 
+    // clang-format on
+
     if (CCam_ProcessFixed(CCam_ProcessFixed_pCam))
     {
+        // clang-format off
         __asm
         {
             ret 10h
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             mov ecx, CCam_ProcessFixed_pCam
@@ -3436,6 +3543,7 @@ static void __declspec(naked) HOOK_CCam_ProcessFixed()
             push ebp
             jmp RETURN_CCam_ProcessFixed
         }
+        // clang-format on
     }
 }
 
@@ -3443,11 +3551,17 @@ static void __declspec(naked) HOOK_Render3DStuff()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
+
+    // clang-format on
     if (m_pRender3DStuffHandler) m_pRender3DStuffHandler();
+
+    // clang-format off
 
     __asm
     {
@@ -3455,6 +3569,8 @@ static void __declspec(naked) HOOK_Render3DStuff()
         mov eax, FUNC_Render3DStuff
         jmp eax
     }
+
+    // clang-format on
 }
 
 CPedSAInterface* pProcessPlayerWeaponPed = NULL;
@@ -3488,14 +3604,17 @@ static void __declspec(naked) HOOK_CTaskSimplePlayerOnFoot_ProcessPlayerWeapon()
     006859A2  push        846BCEh                           <hook>
     006859A7  mov         eax,dword ptr fs:[00000000h]      <return>
     */
+    // clang-format off
     __asm
     {
         mov     eax, [esp+4]
         mov     pProcessPlayerWeaponPed, eax
         pushad
     }
+    // clang-format on
     if (ProcessPlayerWeapon())
     {
+        // clang-format off
         __asm
         {
             popad
@@ -3503,14 +3622,17 @@ static void __declspec(naked) HOOK_CTaskSimplePlayerOnFoot_ProcessPlayerWeapon()
             push    846BCEh
             jmp     RETURN_CTaskSimplePlayerOnFoot_ProcessPlayerWeapon
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
             ret 4
         }
+        // clang-format on
     }
 }
 
@@ -3528,28 +3650,34 @@ static void __declspec(naked) HOOK_CPed_IsPlayer()
     005DF8F0  mov         eax,dword ptr [ecx+598h]      <hook>
     005DF8F6  test        eax,eax                       <return>
     */
+    // clang-format off
     __asm
     {
         mov    pIsPlayerPed, ecx
         pushad
     }
+    // clang-format on
     if (IsPlayer())
     {
+        // clang-format off
         __asm
         {
             popad
             mov         eax,dword ptr [ecx+598h]
             jmp         RETURN_CPed_IsPlayer
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
             xor         al, al
             ret
         }
+        // clang-format on
     }
 }
 
@@ -3565,6 +3693,7 @@ void CRunningScript_Process()
 
         char szModelName[64];
         strcpy(szModelName, "player");
+        // clang-format off
         __asm
         {
             push    26
@@ -3574,24 +3703,30 @@ void CRunningScript_Process()
             call    dwFunc
             add     esp, 12
         }
+        // clang-format on
 
         dwFunc = 0x40EA10;            // load all requested models
+        // clang-format off
         __asm
         {
             push    1
             call    dwFunc
             add     esp, 4
         }
+        // clang-format on
 
         dwFunc = 0x60D790;            // setup player ped
+        // clang-format off
         __asm
         {
             push    0
             call    dwFunc
             add     esp, 4
         }
+        // clang-format on
 
         /*dwFunc = 0x05E47E0; // set created by
+        // clang-format off
         __asm
         {
             mov     edi, 0xB7CD98
@@ -3599,19 +3734,23 @@ void CRunningScript_Process()
             push    2
             call    dwFunc
         }
+        // clang-format on
 
         dwFunc = 0x609520; // deactivate player ped
+        // clang-format off
         __asm
         {
             push    0
             call    dwFunc
             add     esp, 4
         }
+        // clang-format on
 */
         dwFunc = 0x420B80;            // set position
         fX = 2488.562f;
         fY = -1666.864f;
         fZ = 12.8757f;
+        // clang-format off
         __asm
         {
             mov     edi, 0xB7CD98
@@ -3621,31 +3760,39 @@ void CRunningScript_Process()
             mov     ecx, [edi]
             call    dwFunc
         }
+        // clang-format on
         /*
         dwFunc = 0x609540; // reactivate player ped
+        // clang-format off
         __asm
         {
             push    0
             call    dwFunc
             add     esp, 4
         }
+        // clang-format on
 
         dwFunc = 0x61A5A0; // CTask::operator new
+        // clang-format off
         __asm
         {
             push    28
             call    dwFunc
             add     esp, 4
         }
+        // clang-format on
 
         dwFunc = 0x685750; // CTaskSimplePlayerOnFoot::CTaskSimplePlayerOnFoot
+        // clang-format off
         __asm
         {
             mov     ecx, eax
             call    dwFunc
         }
+        // clang-format on
 
         dwFunc = 0x681AF0; // set task
+        // clang-format off
         __asm
         {
             mov     edi, 0xB7CD98
@@ -3657,6 +3804,7 @@ void CRunningScript_Process()
             push    eax
             call    dwFunc
         }
+        // clang-format on
 */
 
         bHasProcessedScript = true;
@@ -3667,18 +3815,26 @@ static void __declspec(naked) HOOK_CRunningScript_Process()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
 
+    // clang-format on
+
     CRunningScript_Process();
+
+    // clang-format off
 
     __asm
     {
         popad
         retn
     }
+
+    // clang-format on
 }
 
 static CVehicleSAInterface* pDerailingTrain = NULL;
@@ -3687,6 +3843,7 @@ static void __declspec(naked) HOOK_CTrain_ProcessControl_Derail()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // If the train wouldn't derail, don't modify anything
+    // clang-format off
     __asm
     {
         jnp     train_would_derail
@@ -3696,26 +3853,31 @@ train_would_derail:
         pushad
         mov     pDerailingTrain, esi
     }
+    // clang-format on
 
     // At this point we know that GTA wants to derail the train
     if (pDerailingTrain->m_pVehicle->IsDerailable())
     {
         // Go back to the derailment code
+        // clang-format off
         __asm
         {
             popad
             mov     eax, 0x6F8DC0
             jmp     eax
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
             mov     eax, 0x6F8F89
             jmp     eax
         }
+        // clang-format on
     }
 }
 
@@ -3740,12 +3902,14 @@ static void SetEntityAlphaHooked(DWORD dwEntity, DWORD dwCallback, DWORD dwAlpha
 
         // Call SetRwObjectAlpha
         DWORD dwFunc = FUNC_SetRwObjectAlpha;
+        // clang-format off
         __asm
         {
             mov     ecx, dwEntity
             push    dwAlpha
             call    dwFunc
         }
+        // clang-format on
 
         // Restore the GTA callbacks
         MemPutFast<DWORD>(0x5332A2, (DWORD)(0x533280));
@@ -3815,13 +3979,19 @@ static void __declspec(naked) HOOK_CVehicle_SetupRender()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     dwAlphaEntity, esi
         pushad
     }
 
+    // clang-format on
+
     SetVehicleAlpha();
+
+    // clang-format off
 
     __asm
     {
@@ -3830,6 +4000,8 @@ static void __declspec(naked) HOOK_CVehicle_SetupRender()
         test    eax, eax
         jmp     dwCVehicle_SetupRender_ret
     }
+
+    // clang-format on
 }
 
 static DWORD dwCVehicle_ResetAfterRender_ret = 0x6D0E43;
@@ -3837,12 +4009,18 @@ static void __declspec(naked) HOOK_CVehicle_ResetAfterRender()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
 
+    // clang-format on
+
     RestoreAlphaValues();
+
+    // clang-format off
 
     __asm
     {
@@ -3851,6 +4029,8 @@ static void __declspec(naked) HOOK_CVehicle_ResetAfterRender()
         test    eax, eax
         jmp     dwCVehicle_ResetAfterRender_ret
     }
+
+    // clang-format on
 }
 
 /**
@@ -3908,6 +4088,8 @@ static void __declspec(naked) HOOK_CObject_Render()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         push    ecx
@@ -3915,6 +4097,8 @@ static void __declspec(naked) HOOK_CObject_Render()
         add     esp, 4
         retn
     }
+
+    // clang-format on
 }
 
 void _cdecl DoEndWorldColorsPokes()
@@ -3973,11 +4157,15 @@ static void __declspec(naked) HOOK_EndWorldColors()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+     // clang-format off
+
      __asm
     {
         call DoEndWorldColorsPokes
         ret
     }
+
+     // clang-format on
 }
 
 // This hook modifies the code in CWorld::ProcessVerticalLineSectorList to
@@ -3991,6 +4179,8 @@ static DWORD dwGlobalListOfObjects = 0xB9ACCC;
 static void __declspec(naked) HOOK_CWorld_ProcessVerticalLineSectorList()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -4013,6 +4203,8 @@ stop_looping:
         mov     dwObjectsChecked, 0
         jmp     dwProcessVerticalEndLooping
     }
+
+    // clang-format on
 }
 
 // Hook to detect when a player is choking
@@ -4022,6 +4214,8 @@ static unsigned char ucChokingWeaponType = 0;
 static void __declspec(naked) HOOK_ComputeDamageResponse_StartChoking()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -4052,6 +4246,8 @@ static void __declspec(naked) HOOK_ComputeDamageResponse_StartChoking()
         mov     eax, [ecx+0x47C]
         jmp     dwChokingChoke
     }
+
+    // clang-format on
 }
 
 void CMultiplayerSA::DisableEnterExitVehicleKey(bool bDisabled)
@@ -4233,6 +4429,7 @@ void CMultiplayerSA::ConvertEulerAnglesToMatrix(CMatrix& Matrix, float fX, float
     CMatrix_Padded* pMatrixPadded = &matrixPadded;
     DWORD           dwFunc = FUNC_CMatrix__ConvertFromEulerAngles;
     int             iUnknown = 21;
+    // clang-format off
     __asm
     {
         push    iUnknown
@@ -4242,6 +4439,7 @@ void CMultiplayerSA::ConvertEulerAnglesToMatrix(CMatrix& Matrix, float fX, float
         mov     ecx, pMatrixPadded
         call    dwFunc
     }
+    // clang-format on
 
     // Convert the result matrix to the CMatrix we know
     matrixPadded.ConvertToMatrix(Matrix);
@@ -4260,6 +4458,7 @@ void CMultiplayerSA::ConvertMatrixToEulerAngles(const CMatrix& Matrix, float& fX
     float* pfY = &fY;
     float* pfZ = &fZ;
     int    iUnknown = 21;
+    // clang-format off
     __asm
     {
         push    iUnknown
@@ -4269,6 +4468,7 @@ void CMultiplayerSA::ConvertMatrixToEulerAngles(const CMatrix& Matrix, float& fX
         mov     ecx, pMatrixPadded
         call    dwFunc
     }
+    // clang-format on
 }
 
 void CMultiplayerSA::RebuildMultiplayerPlayer(CPed* player)
@@ -4372,18 +4572,22 @@ static void __declspec(naked) HOOK_CollisionStreamRead()
 
     if (*(DWORD*)VAR_CollisionStreamRead_ModelInfo)
     {
+        // clang-format off
         __asm
         {
             mov eax, dword ptr fs:[0]
             jmp RETURN_CollisionStreamRead
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             ret
         }
+        // clang-format on
     }
 }
 
@@ -4392,10 +4596,14 @@ static void __declspec(naked) HOOK_CTrafficLights_GetPrimaryLightState()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
+
+    // clang-format on
 
     if (ucTrafficLightState == 0 || ucTrafficLightState == 5 || ucTrafficLightState == 8)
     {
@@ -4411,22 +4619,30 @@ static void __declspec(naked) HOOK_CTrafficLights_GetPrimaryLightState()
     }
     else ucDesignatedLightState = 2;            // Red
 
+    // clang-format off
+
     __asm
     {
         popad
         mov al, ucDesignatedLightState
         retn
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CTrafficLights_GetSecondaryLightState()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
+
+    // clang-format on
 
     if (ucTrafficLightState == 3 || ucTrafficLightState == 5 || ucTrafficLightState == 7)
     {
@@ -4442,22 +4658,30 @@ static void __declspec(naked) HOOK_CTrafficLights_GetSecondaryLightState()
     }
     else ucDesignatedLightState = 2;            // Red
 
+    // clang-format off
+
     __asm
     {
         popad
         mov al, ucDesignatedLightState
         retn
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CTrafficLights_DisplayActualLight()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
+
+    // clang-format on
 
     if (ucTrafficLightState == 2)
     {
@@ -4466,12 +4690,16 @@ static void __declspec(naked) HOOK_CTrafficLights_DisplayActualLight()
     else if (ucTrafficLightState == 9) { ucDesignatedLightState = 1; }
     else { ucDesignatedLightState = 2; }
 
+    // clang-format off
+
     __asm
     {
         popad
         movzx eax, ucDesignatedLightState
         jmp RETURN_CTrafficLights_DisplayActualLight
     }
+
+    // clang-format on
 }
 
 static CVehicleSAInterface* pHandlingDriveTypeVeh = NULL;
@@ -4497,6 +4725,8 @@ static void __declspec(naked) HOOK_Transmission_CalculateDriveAcceleration()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         push eax
@@ -4507,7 +4737,11 @@ static void __declspec(naked) HOOK_Transmission_CalculateDriveAcceleration()
         pushad
     }
 
+    // clang-format on
+
     CheckVehicleMaxGear();
+
+    // clang-format off
 
     __asm
     {
@@ -4516,6 +4750,8 @@ static void __declspec(naked) HOOK_Transmission_CalculateDriveAcceleration()
         mov edx, [eax]
         jmp RETURN_Transmission_CalculateDriveAcceleration
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_isVehDriveTypeNotRWD()
@@ -4523,19 +4759,23 @@ static void __declspec(naked) HOOK_isVehDriveTypeNotRWD()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // Get the Vehicle interface from esi
+    // clang-format off
     __asm
     {
          mov pHandlingDriveTypeVeh, esi
     }
+    // clang-format on
 
     GetVehicleDriveType();
 
     // push our drive type into bl :)
+    // clang-format off
     __asm
     {
         mov bl, ucDriveType
         jmp RETURN_CHandlingData_isNotRWD
     }
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_isVehDriveTypeNotFWD()
@@ -4543,19 +4783,23 @@ static void __declspec(naked) HOOK_isVehDriveTypeNotFWD()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // Get the Vehicle SA interface from esi
+    // clang-format off
     __asm
     {
          mov pHandlingDriveTypeVeh, esi
     }
+    // clang-format on
 
     GetVehicleDriveType();
 
     // push our drive type into bl :)
+    // clang-format off
     __asm
     {
         mov bl, ucDriveType
         jmp RETURN_CHandlingData_isNotFWD
     }
+    // clang-format on
 }
 
 unsigned char CMultiplayerSA::GetTrafficLightState()
@@ -4611,6 +4855,7 @@ void CMultiplayerSA::AllowCreatedObjectsInVerticalLineTest(bool bOn)
 void _cdecl CPhysical_ApplyGravity(DWORD dwThis)
 {
     DWORD dwType;
+    // clang-format off
     __asm
     {
         mov ecx, dwThis
@@ -4618,6 +4863,7 @@ void _cdecl CPhysical_ApplyGravity(DWORD dwThis)
         call eax
         mov dwType, eax
     }
+    // clang-format on
 
     float fTimeStep = *(float*)0xB7CB5C;
     float fGravity = *(float*)0x863984;
@@ -4647,6 +4893,8 @@ static void __declspec(naked) HOOK_CVehicle_ApplyBoatWaterResistance()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         fmul    ds : 0x871DDC   // Original constant used in code
@@ -4654,11 +4902,15 @@ static void __declspec(naked) HOOK_CVehicle_ApplyBoatWaterResistance()
         fdiv    kfTimeStepOrg   // Divide by desired timestep, used at 30fps
         jmp     RETURN_CVehicle_ApplyBoatWaterResistance
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CPhysical_ApplyGravity()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -4667,6 +4919,8 @@ static void __declspec(naked) HOOK_CPhysical_ApplyGravity()
         add esp, 4
         jmp RETURN_CPhysical_ApplyGravity
     }
+
+    // clang-format on
 }
 
 // ---------------------------------------------------
@@ -4742,6 +4996,8 @@ static void __declspec(naked) HOOK_VehicleCamStart()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         push edi
@@ -4758,6 +5014,8 @@ fail:
         add esp, 4
         jmp RETURN_VehicleCamStart_failure
     }
+
+    // clang-format on
 }
 
 // ---------------------------------------------------
@@ -4771,6 +5029,8 @@ void _cdecl VehicleCamTargetZTweak(CVector* pvecCamTarget, float fTargetZTweak)
 static void __declspec(naked) HOOK_VehicleCamTargetZTweak()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -4795,6 +5055,8 @@ static void __declspec(naked) HOOK_VehicleCamTargetZTweak()
         cmp eax, 1
         jmp RETURN_VehicleCamTargetZTweak
     }
+
+    // clang-format on
 }
 
 // ---------------------------------------------------
@@ -4811,6 +5073,8 @@ static void __declspec(naked) HOOK_VehicleCamLookDir1()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov eax, 0x59C910       // CVector::Normalise
@@ -4823,6 +5087,8 @@ static void __declspec(naked) HOOK_VehicleCamLookDir1()
 
         jmp RETURN_VehicleCamLookDir1
     }
+
+    // clang-format on
 }
 
 // ---------------------------------------------------
@@ -4846,6 +5112,8 @@ static void __declspec(naked) HOOK_VehicleCamLookDir2()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         push esi
@@ -4857,6 +5125,8 @@ static void __declspec(naked) HOOK_VehicleCamLookDir2()
         push 4
         jmp RETURN_VehicleCamLookDir2
     }
+
+    // clang-format on
 }
 
 // ---------------------------------------------------
@@ -4874,6 +5144,8 @@ static void __declspec(naked) HOOK_VehicleCamHistory()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         push [esp+0x0+0x7C]       // zoom
@@ -4888,6 +5160,8 @@ static void __declspec(naked) HOOK_VehicleCamHistory()
         mov eax, [esp+0x24]
         jmp RETURN_VehicleCamHistory
     }
+
+    // clang-format on
 }
 
 // ---------------------------------------------------
@@ -4909,6 +5183,8 @@ static void __declspec(naked) HOOK_VehicleCamUp()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov edx, ecx
@@ -4929,6 +5205,8 @@ docustom:
         add esp, 4
         ret
     }
+
+    // clang-format on
 }
 
 // ---------------------------------------------------
@@ -4949,6 +5227,8 @@ static void __declspec(naked) HOOK_VehicleCamEnd()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov ds:[0xB6F020], edx
@@ -4959,6 +5239,8 @@ static void __declspec(naked) HOOK_VehicleCamEnd()
 
         jmp RETURN_VehicleCamEnd
     }
+
+    // clang-format on
 }
 
 // ---------------------------------------------------
@@ -4973,6 +5255,8 @@ void _cdecl VehicleLookBehind(DWORD dwCam, CVector* pvecEntityPos, float fDistan
 static void __declspec(naked) HOOK_VehicleLookBehind()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -4996,6 +5280,8 @@ static void __declspec(naked) HOOK_VehicleLookBehind()
         mov eax, ebx            // pEntity
         jmp RETURN_VehicleLookBehind
     }
+
+    // clang-format on
 }
 
 // ---------------------------------------------------
@@ -5011,6 +5297,8 @@ static void __declspec(naked) HOOK_VehicleLookAside()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         push [esp+0x14]
@@ -5025,6 +5313,8 @@ static void __declspec(naked) HOOK_VehicleLookAside()
         mov ecx, [esi+0x21C]
         jmp RETURN_VehicleLookAside
     }
+
+    // clang-format on
 }
 
 // ---------------------------------------------------
@@ -5051,6 +5341,8 @@ static void __declspec(naked) HOOK_OccupiedVehicleBurnCheck()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         push eax
@@ -5058,11 +5350,15 @@ static void __declspec(naked) HOOK_OccupiedVehicleBurnCheck()
         add esp, 4
         jmp RETURN_OccupiedVehicleBurnCheck
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_UnoccupiedVehicleBurnCheck()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -5073,6 +5369,8 @@ static void __declspec(naked) HOOK_UnoccupiedVehicleBurnCheck()
         add esp, 4
         jmp RETURN_UnoccupiedVehicleBurnCheck
     }
+
+    // clang-format on
 }
 
 // ---------------------------------------------------
@@ -5097,6 +5395,8 @@ static void __declspec(naked) HOOK_ApplyCarBlowHop()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         push esi
@@ -5110,6 +5410,8 @@ static void __declspec(naked) HOOK_ApplyCarBlowHop()
         mov [esi+0x36], dl
         jmp RETURN_ApplyCarBlowHop
     }
+
+    // clang-format on
 }
 
 // ---------------------------------------------------
@@ -5135,6 +5437,8 @@ static void __declspec(naked) HOOK_CGame_Process()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -5147,6 +5451,8 @@ static void __declspec(naked) HOOK_CGame_Process()
         popad
         jmp     RETURN_CGame_Process;
     }
+
+    // clang-format on
 }
 
 void __cdecl HandleIdle()
@@ -5190,6 +5496,8 @@ static void __declspec(naked) HOOK_Idle()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -5200,12 +5508,16 @@ static void __declspec(naked) HOOK_Idle()
         mov     ecx, 0B6BC90h
         jmp     RETURN_Idle
     }
+
+    // clang-format on
 }
 
 // Hooked from 0049E650 5 bytes
 static void __declspec(naked) HOOK_PreFxRender()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -5215,7 +5527,11 @@ static void __declspec(naked) HOOK_PreFxRender()
         jne skip
     }
 
+    // clang-format on
+
     if (m_pPreFxRenderHandler) m_pPreFxRenderHandler();
+
+    // clang-format off
 
     __asm
     {
@@ -5223,6 +5539,8 @@ skip:
         popad
         jmp     RETURN_PreFxRender  // 00404D1E
     }
+
+    // clang-format on
 }
 
 // Hooked from 00705099  5 bytes
@@ -5230,12 +5548,18 @@ static void __declspec(naked) HOOK_PostColorFilterRender()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
 
+    // clang-format on
+
     if (m_pPostColorFilterRenderHandler) m_pPostColorFilterRenderHandler();
+
+    // clang-format off
 
     __asm
     {
@@ -5243,6 +5567,8 @@ static void __declspec(naked) HOOK_PostColorFilterRender()
         mov al, ds:0C402BAh
         jmp     RETURN_PostColorFilterRender  // 0070509E
     }
+
+    // clang-format on
 }
 
 // Hooked from 0053EAD8  5 bytes
@@ -5250,12 +5576,18 @@ static void __declspec(naked) HOOK_PreHUDRender()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
 
+    // clang-format on
+
     if (m_pPreHudRenderHandler) m_pPreHudRenderHandler();
+
+    // clang-format off
 
     __asm
     {
@@ -5263,6 +5595,8 @@ static void __declspec(naked) HOOK_PreHUDRender()
         mov     eax, ds:0B6F0B8h
         jmp     RETURN_PreHUDRender  // 0053EADD
     }
+
+    // clang-format on
 }
 
 // ---------------------------------------------------
@@ -5329,6 +5663,8 @@ static void __declspec(naked) HOOK_CVehicle_DoVehicleLights()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     pLightsVehicleInterface, ecx
@@ -5336,6 +5672,8 @@ static void __declspec(naked) HOOK_CVehicle_DoVehicleLights()
         sub     esp,3Ch
         jmp     RETURN_CVehicle_DoVehicleLights
     }
+
+    // clang-format on
 }
 
 unsigned long ulHeadLightR = 0, ulHeadLightG = 0, ulHeadLightB = 0;
@@ -5360,12 +5698,16 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightBeam_1()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     pHeadLightBeamVehicleInterface, ecx
         sub     esp, 94h
         jmp     RETURN_CVehicle_DoHeadLightBeam_1
     }
+
+    // clang-format on
 }
 
 RwVertex*    pHeadLightVerts = NULL;
@@ -5386,6 +5728,8 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightBeam_2()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     eax, [esp]
@@ -5395,7 +5739,11 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightBeam_2()
         pushad
     }
 
+    // clang-format on
+
     CVehicle_DoHeadLightBeam();
+
+    // clang-format off
 
     __asm
     {
@@ -5403,6 +5751,8 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightBeam_2()
         mov     dword ptr ds:[0C4B950h],5
         jmp     RETURN_CVehicle_DoHeadLightBeam_2
     }
+
+    // clang-format on
 }
 
 DWORD dwCCoronas_RegisterCorona = 0x6FC580;
@@ -5410,12 +5760,18 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightEffect_1()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
 
+    // clang-format on
+
     CVehicle_GetHeadLightColor(pLightsVehicleInterface, 160.0f, 160.0f, 140.0f);
+
+    // clang-format off
 
     __asm
     {
@@ -5433,18 +5789,26 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightEffect_1()
         add     esp,54h
         jmp     RETURN_CVehicle_DoHeadLightEffect_1
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CVehicle_DoHeadLightEffect_2()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
 
+    // clang-format on
+
     CVehicle_GetHeadLightColor(pLightsVehicleInterface, 160.0f, 160.0f, 140.0f);
+
+    // clang-format off
 
     __asm
     {
@@ -5462,6 +5826,8 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightEffect_2()
         add     esp, 54h
         jmp     RETURN_CVehicle_DoHeadLightEffect_2
     }
+
+    // clang-format on
 }
 
 DWORD dwCShadows_StoreCarLightShadow = 0x70C500;
@@ -5469,12 +5835,18 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightReflectionTwin()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
 
+    // clang-format on
+
     CVehicle_GetHeadLightColor(pLightsVehicleInterface, 45.0f, 45.0f, 45.0f);
+
+    // clang-format off
 
     __asm
     {
@@ -5490,18 +5862,26 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightReflectionTwin()
         add     esp, 4Ch
         jmp     RETURN_CVehicle_DoHeadLightReflectionTwin
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CVehicle_DoHeadLightReflectionSingle()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
 
+    // clang-format on
+
     CVehicle_GetHeadLightColor(pLightsVehicleInterface, 45.0f, 45.0f, 45.0f);
+
+    // clang-format off
 
     __asm
     {
@@ -5517,6 +5897,8 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightReflectionSingle()
         add     esp, 30h
         jmp     RETURN_CVehicle_DoHeadLightReflectionSingle
     }
+
+    // clang-format on
 }
 
 #endif  // ENABLE_VEHICLE_HEADLIGHT_COLOR
@@ -5531,12 +5913,14 @@ static void __declspec(naked) HOOK_CWorld_SetWorldOnFire()
 
     // Actually pass the pCreatorEntity parameter that this function receives to CFireManager::StartFire
     // (instead of a null pointer)
+    // clang-format off
     __asm
     {
         push 7000
         push [esp+0x18+0x14]
         jmp RETURN_CWorld_SetWorldOnFire
     }
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CTaskSimplePlayerOnFire_ProcessPed()
@@ -5544,6 +5928,7 @@ static void __declspec(naked) HOOK_CTaskSimplePlayerOnFire_ProcessPed()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // Actually pass the fire's pCreatorEntity to the damage event (instead of a null pointer)
+    // clang-format off
     __asm
     {
         push 3
@@ -5554,6 +5939,7 @@ static void __declspec(naked) HOOK_CTaskSimplePlayerOnFire_ProcessPed()
         push eax
         jmp RETURN_CTaskSimplePlayerOnFire_ProcessPed
     }
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CFire_ProcessFire()
@@ -5561,6 +5947,7 @@ static void __declspec(naked) HOOK_CFire_ProcessFire()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // Set the new fire's creator to the original fire's creator
+    // clang-format off
     __asm
     {
         mov eax, 0x53A450       // CCreepingFire::TryToStartFireAtCoors
@@ -5572,6 +5959,7 @@ static void __declspec(naked) HOOK_CFire_ProcessFire()
 fail:
         jmp RETURN_CFire_ProcessFire
     }
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CExplosion_Update()
@@ -5579,6 +5967,7 @@ static void __declspec(naked) HOOK_CExplosion_Update()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // Set the new fire's creator to the explosion's creator
+    // clang-format off
     __asm
     {
         mov eax, 0x53A450       // CCreepingFire::TryToStartFireAtCoors
@@ -5590,6 +5979,7 @@ static void __declspec(naked) HOOK_CExplosion_Update()
 fail:
         jmp RETURN_CExplosion_Update
     }
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CWeapon_FireAreaEffect()
@@ -5597,6 +5987,7 @@ static void __declspec(naked) HOOK_CWeapon_FireAreaEffect()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // Set the new fire's creator to the weapon's owner
+    // clang-format off
     __asm
     {
         mov eax, 0x53A450       // CCreepingFire::TryToStartFireAtCoors
@@ -5608,6 +5999,7 @@ static void __declspec(naked) HOOK_CWeapon_FireAreaEffect()
 fail:
         jmp RETURN_CWeapon_FireAreaEffect
     }
+    // clang-format on
 }
 
 // ---------------------------------------------------
@@ -5699,6 +6091,8 @@ static void __declspec(naked) HOOK_RenderScene_Plants()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -5717,11 +6111,15 @@ static void __declspec(naked) HOOK_RenderScene_Plants()
         popad
         ret
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_RenderScene_end()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -5745,6 +6143,8 @@ static void __declspec(naked) HOOK_RenderScene_end()
         mov eax, 0x7113B0
         jmp eax
     }
+
+    // clang-format on
 }
 
 bool _cdecl IsPlantBelowWater(float fPlantZ, float fWaterZ)
@@ -5757,6 +6157,7 @@ static void __declspec(naked) HOOK_CPlantMgr_Render()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // (bCamBelowWater, bRenderingBeforeWater)
+    // clang-format off
     __asm
     {
         sub esp, 4
@@ -5794,6 +6195,7 @@ rendercheck:
         fld ds:[0x8D12C0]
         jmp RETURN_CPlantMgr_Render_success
     }
+    // clang-format on
 }
 
 /* This hook called from CEventHandler::ComputeKnockOffBikeResponse makes sure the
@@ -5825,6 +6227,8 @@ static void __declspec(naked) HOOK_CEventHandler_ComputeKnockOffBikeResponse()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     pBikeDamageInterface, ecx
@@ -5834,7 +6238,11 @@ static void __declspec(naked) HOOK_CEventHandler_ComputeKnockOffBikeResponse()
 
         pushad
     }
+
+    // clang-format on
     CEventHandler_ComputeKnockOffBikeResponse();
+
+    // clang-format off
 
     __asm
     {
@@ -5842,6 +6250,8 @@ static void __declspec(naked) HOOK_CEventHandler_ComputeKnockOffBikeResponse()
         call    dw_CEventDamage_AffectsPed
         jmp     RETURN_CEventHandler_ComputeKnockOffBikeResponse
     }
+
+    // clang-format on
 }
 
 CPedSAInterface* weaponSkillPed;
@@ -5889,6 +6299,8 @@ static void __declspec(naked) HOOK_CPed_GetWeaponSkill()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     weaponSkillPed, ecx
@@ -5897,17 +6309,22 @@ static void __declspec(naked) HOOK_CPed_GetWeaponSkill()
         pushad
     }
 
+    // clang-format on
+
     if (CPed_GetWeaponSkill())
     {
+        // clang-format off
         __asm
         {
             popad
             mov     al, weaponSkill
             retn    4
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
@@ -5916,6 +6333,7 @@ static void __declspec(naked) HOOK_CPed_GetWeaponSkill()
             cmp     esi, 16h
             jmp     RETURN_CPed_GetWeaponSkill
         }
+        // clang-format on
     }
 }
 
@@ -5932,6 +6350,8 @@ static void __declspec(naked) HOOK_CPed_AddGogglesModel()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         push esi
@@ -5947,6 +6367,8 @@ static void __declspec(naked) HOOK_CPed_AddGogglesModel()
     skip:
         jmp RETURN_CPed_AddGogglesModel
     }
+
+    // clang-format on
 }
 
 void CMultiplayerSA::DeleteAndDisableGangTags()
@@ -5964,20 +6386,24 @@ void CMultiplayerSA::DeleteAndDisableGangTags()
             DWORD* pTagInterface = VAR_TagInfoArray[i << 1];
             if (pTagInterface)
             {
+                // clang-format off
                 __asm
                 {
                     push pTagInterface
                     call dwFunc
                     add esp, 4
                 }
+                // clang-format on
             }
         }
 
         dwFunc = FUNC_CTagManager_ShutdownForRestart;
+        // clang-format off
         __asm
         {
             call dwFunc
         }
+        // clang-format on
 
         // Disallow spraying gang tags
         // Nop the whole CTagManager::IsTag function and replace its body with:
@@ -6030,6 +6456,8 @@ static void __declspec(naked) HOOK_CPhysical_ProcessCollisionSectorList()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     pCollisionPhysicalThis, esi
@@ -6037,9 +6465,12 @@ static void __declspec(naked) HOOK_CPhysical_ProcessCollisionSectorList()
         pushad
     }
 
+    // clang-format on
+
     // Carry on with collision? (sets the CElement->bUsesCollision flag check)
     if (CPhysical_ProcessCollisionSectorList())
     {
+        // clang-format off
         __asm
         {
             popad
@@ -6047,9 +6478,11 @@ static void __declspec(naked) HOOK_CPhysical_ProcessCollisionSectorList()
             test    byte ptr [edi+1Ch], 1
             jmp     RETURN_CPhysical_ProcessCollisionSectorList
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
@@ -6059,6 +6492,7 @@ static void __declspec(naked) HOOK_CPhysical_ProcessCollisionSectorList()
             mov     edi, pCollisionPhysical
             jmp     RETURN_CPhysical_ProcessCollisionSectorList
         }
+        // clang-format on
     }
 }
 
@@ -6145,6 +6579,8 @@ static void __declspec(naked) HOOK_CheckAnimMatrix()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // Replaced code
@@ -6161,6 +6597,8 @@ static void __declspec(naked) HOOK_CheckAnimMatrix()
         push    eax
         jmp     RETURN_CheckAnimMatrix      // 7C5A61
     }
+
+    // clang-format on
 }
 
 static SColor vehColors[4];
@@ -6178,6 +6616,8 @@ void _cdecl SaveVehColors(DWORD dwThis)
 static void __declspec(naked) HOOK_VehCol()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -6199,11 +6639,15 @@ static void __declspec(naked) HOOK_VehCol()
 
         jmp     RETURN_VehCol  // 006D660C
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_VehColCB()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -6221,6 +6665,8 @@ static void __declspec(naked) HOOK_VehColCB()
 
         jmp     RETURN_VehColCB  // 004C83AA
     }
+
+    // clang-format on
 }
 
 // Check if this vehicle is allowed to process swinging doors.
@@ -6241,6 +6687,8 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessSwingingDoor()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     dwSwingingDoorAutomobile, esi
@@ -6248,21 +6696,27 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessSwingingDoor()
         pushad
     }
 
+    // clang-format on
+
     if (AllowSwingingDoors())
     {
+        // clang-format off
         __asm
         {
             popad
             jmp     dwSwingingRet1
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
             jmp     dwSwingingRet2
         }
+        // clang-format on
     }
 }
 
@@ -6308,17 +6762,22 @@ static void __declspec(naked) HOOK_ProcessVehicleCollision()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     pSuspensionInterface, esi
         pushad
     }
 
+    // clang-format on
+
     if (CheckHasSuspensionChanged())
     {
         // When the vehicle's collision is about to be processed, set its per-vehicle
         // suspension lines as the per-model suspension lines, and restore the per-model lines
         // afterwards
+        // clang-format off
         __asm
         {
             popad
@@ -6352,15 +6811,18 @@ static void __declspec(naked) HOOK_ProcessVehicleCollision()
             pop eax
             ret
         }
+        // clang-format on
     }
     else
     {
         // Skip our code in this case because they haven't changed anything so it'l just cause problems.
+        // clang-format off
         __asm
         {
             popad
             jmp dwSuspensionChangedJump
         }
+        // clang-format on
     }
 }
 
@@ -6416,21 +6878,27 @@ static void __declspec(naked) HOOK_LoadIPLInstance()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
         mov pEntityWorldAdd, ecx
     }
+
+    // clang-format on
     if (pEntityWorldAdd)
     {
         CheckRemovedModel();
     }
+    // clang-format off
     __asm
     {
         popad
         jmp CALL_LoadIPLInstance
         jmp RETURN_LoadIPLInstance
     }
+    // clang-format on
 }
 static bool bTest = false;
 // Binary
@@ -6477,17 +6945,23 @@ static void __declspec(naked) HOOK_CWorld_LOD_SETUP()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
         mov pLODInterface, esi
     }
+
+    // clang-format on
     HideEntitySomehow();
+    // clang-format off
     __asm
     {
         popad
         jmp CALL_CWorld_LODSETUP
     }
+    // clang-format on
 }
 
 CEntitySAInterface* pBuildingAdd = NULL;
@@ -6505,17 +6979,23 @@ static void __declspec(naked) Hook_AddBuildingInstancesToWorld()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
         mov pBuildingAdd, edx
     }
+
+    // clang-format on
     StorePointerToBuilding();
+    // clang-format off
     __asm
     {
         popad
         jmp JMP_CWorld_Add_AddBuildingInstancesToWorld_CALL_CWorldAdd
     }
+    // clang-format on
 }
 
 bool CheckForRemoval()
@@ -6539,19 +7019,25 @@ static void __declspec(naked) Hook_CWorld_ADD_CPopulation_ConvertToRealObject()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
         mov pBuildingAdd, esi
         mov pLODInterface, esi
     }
+
+    // clang-format on
     StorePointerToBuilding();
+    // clang-format off
     __asm
     {
         popad
         jmp JMP_CWorld_Add_CPopulation_ConvertToRealObject_CallCWorldAdd
         jmp JMP_CWorld_Add_CPopulation_ConvertToRealObject_Retn
     }
+    // clang-format on
 }
 
 void RemoveObjectIfNeeded()
@@ -6580,12 +7066,17 @@ static void __declspec(naked) HOOK_ConvertToObject_CPopulationManageDummy()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
         mov pBuildingAdd, edx
         mov pLODInterface, edx
     }
+
+    // clang-format on
+    // clang-format off
     __asm
     {
         popad
@@ -6595,12 +7086,15 @@ static void __declspec(naked) HOOK_ConvertToObject_CPopulationManageDummy()
         mov pLODInterface, ecx
         pushad
     }
+    // clang-format on
     RemoveObjectIfNeeded();
+    // clang-format off
     __asm
     {
         popad
         jmp JMP_RETN_Cancel_CPopulation_ManageDummy
     }
+    // clang-format on
 }
 
 CEntitySAInterface* pBuildingRemove = NULL;
@@ -6633,6 +7127,8 @@ static void __declspec(naked) HOOK_CWorld_Remove_CPopulation_ConvertToDummyObjec
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -6644,6 +7140,8 @@ static void __declspec(naked) HOOK_CWorld_Remove_CPopulation_ConvertToDummyObjec
 
         jmp     dwCWorldRemove
     }
+
+    // clang-format on
 }
 
 // if it's replaced get rid of it
@@ -6674,6 +7172,8 @@ static void __declspec(naked) HOOK_CWorld_Add_CPopulation_ConvertToDummyObject()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -6691,6 +7191,8 @@ static void __declspec(naked) HOOK_CWorld_Add_CPopulation_ConvertToDummyObject()
         call    CALL_CWorld_Add_CPopulation_ConvertToDummyObject
         jmp     JMP_RETN_Called_CPopulation_ConvertToDummyObject
     }
+
+    // clang-format on
 }
 
 // Destructors to catch element deletion so we can delete their entries
@@ -6698,34 +7200,46 @@ static void __declspec(naked) Hook_CBuilding_DTR()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
         mov pBuildingRemove, ecx
     }
+
+    // clang-format on
     RemovePointerToBuilding();
+    // clang-format off
     __asm
     {
         popad
         jmp JMP_CBuilding_DTR
     }
+    // clang-format on
 }
 
 static void __declspec(naked) Hook_CDummy_DTR()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
         mov pBuildingRemove, ecx
     }
+
+    // clang-format on
     RemovePointerToBuilding();
+    // clang-format off
     __asm
     {
         popad
         jmp JMP_CDummy_DTR
     }
+    // clang-format on
 }
 
 DWORD dwObjectVtbl = 0x866F60;
@@ -6733,18 +7247,24 @@ static void __declspec(naked) Hook_CObject_DTR()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
         mov pBuildingRemove, esi
     }
+
+    // clang-format on
     RemovePointerToBuilding();
+    // clang-format off
     __asm
     {
         popad
         mov dword ptr [esi], offset dwObjectVtbl
         jmp JMP_CObject_DTR
     }
+    // clang-format on
 }
 
 static DWORD dwEntityVtbl;
@@ -6752,6 +7272,8 @@ static DWORD dwMultResult;
 static void __declspec(naked) HOOK_CEntity_IsOnScreen_FixObjectScale()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -6762,7 +7284,11 @@ static void __declspec(naked) HOOK_CEntity_IsOnScreen_FixObjectScale()
         mov     dwEntityVtbl, eax
     }
 
+    // clang-format on
+
     if (dwEntityVtbl == 0x866F60) goto IsOnScreen_IsObject;
+
+    // clang-format off
 
     __asm
     {
@@ -6771,7 +7297,10 @@ static void __declspec(naked) HOOK_CEntity_IsOnScreen_FixObjectScale()
         jmp     JMP_CEntity_IsOnScreen_FixObjectsScale
     }
 
+    // clang-format on
+
 IsOnScreen_IsObject:
+    // clang-format off
     __asm
     {
         popad
@@ -6782,6 +7311,7 @@ IsOnScreen_IsObject:
         mov     esi, dwMultResult
         jmp     JMP_CEntity_IsOnScreen_FixObjectsScale
     }
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -6790,6 +7320,8 @@ IsOnScreen_IsObject:
 static void __declspec(naked) HOOK_CClothes_RebuildPlayer()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -6806,6 +7338,8 @@ static void __declspec(naked) HOOK_CClothes_RebuildPlayer()
     cont:
         jmp     RETURN_CClothes_RebuildPlayerb  // 005A837F
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CProjectileInfo_Update_FindLocalPlayer_FindLocalPlayerVehicle()
@@ -6816,11 +7350,13 @@ static void __declspec(naked) HOOK_CProjectileInfo_Update_FindLocalPlayer_FindLo
     // 00739570 E8 5B 4B E3 FF                          call    FindPlayerVehicle < HOOK >
     // Checks if the creator is the local player ped or the creator is the local player peds vehicle else decreases the velocity substantially.
     // We are forcing it to think the creator is not the local player ped or his vehicle for this specific check
+    // clang-format off
     __asm
     {
         xor eax, eax
         retn
     }
+    // clang-format on
 }
 
 void CMultiplayerSA::SetAutomaticVehicleStartupOnPedEnter(bool bSet)
@@ -6880,6 +7416,7 @@ static void __declspec(naked) HOOK_CHeli_ProcessHeliKill()
     // We hook just after the check if he's touched the blade as before that it's just got the results of if he's near enough the heli to hit the blades
     // esi = Heli
     // edi = ped
+    // clang-format off
     __asm
     {
         pushfd
@@ -6887,9 +7424,11 @@ static void __declspec(naked) HOOK_CHeli_ProcessHeliKill()
         mov pHeliKiller, esi
         mov pHitByHeli, edi
     }
+    // clang-format on
     //   Call our event
     if (CallHeliKillEvent() == false)
     {
+        // clang-format off
         __asm
         {
             popad
@@ -6897,9 +7436,11 @@ static void __declspec(naked) HOOK_CHeli_ProcessHeliKill()
             // Go to the end of the while loop and let it start again
             jmp RETURN_CHeli_ProcessHeliKill_RETN_Cancel
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
@@ -6911,6 +7452,7 @@ static void __declspec(naked) HOOK_CHeli_ProcessHeliKill()
 
 lp1:        jmp RETURN_CHeli_ProcessHeliKill_6DB437h
         }
+        // clang-format on
     }
 }
 
@@ -6941,6 +7483,8 @@ static void __declspec(naked) HOOK_CObject_ProcessDamage()
     // .text:005A0E07                 fsubr   dword ptr [esi+154h]
     // .text:005A0E0D                 fst     dword ptr [esi+154h]
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -6948,19 +7492,24 @@ static void __declspec(naked) HOOK_CObject_ProcessDamage()
         mov     pObjectAttacker, edi
         fst     dword ptr fNewObjectHealth
     }
+
+    // clang-format on
     if (TriggerObjectDamageEvent())
     {
         bObjectDamaged = true;
+        // clang-format off
         __asm
         {
             popad
             fst     dword ptr [esi+154h]
             jmp     RETURN_CObject_ProcessDamage
         }
+        // clang-format on
     }
     else
     {
         bObjectDamaged = false;
+        // clang-format off
         __asm
         {
             popad
@@ -6968,6 +7517,7 @@ static void __declspec(naked) HOOK_CObject_ProcessDamage()
             fdecstp
             jmp     RETURN_CObject_ProcessDamage_Cancel
         }
+        // clang-format on
     }
 }
 
@@ -6985,10 +7535,14 @@ static void __declspec(naked) HOOK_CObject_ProcessBreak()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
+
+    // clang-format on
     ucColDamageEffect = *(unsigned char*)((DWORD)pDamagedObject + 324);
 
     if (ucColDamageEffect != NULL)
@@ -6998,14 +7552,18 @@ static void __declspec(naked) HOOK_CObject_ProcessBreak()
             if (!TriggerObjectBreakEvent())
             {
                 bObjectDamaged = false;
+                // clang-format off
                 __asm
                 {
                     popad
                     jmp     RETURN_CObject_ProcessDamage_Cancel
                 }
+                // clang-format on
             }
         }
     }
+
+    // clang-format off
 
     __asm
     {
@@ -7013,6 +7571,8 @@ static void __declspec(naked) HOOK_CObject_ProcessBreak()
         cmp     eax, 0C9h
         jmp     RETURN_CObject_ProcessBreak
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CObject_ProcessCollision()
@@ -7021,6 +7581,7 @@ static void __declspec(naked) HOOK_CObject_ProcessCollision()
 
     if (bObjectDamaged)
     {
+        // clang-format off
         __asm
         {
             test    byte ptr [esi+1Ch], 1
@@ -7030,13 +7591,16 @@ static void __declspec(naked) HOOK_CObject_ProcessCollision()
         checkfordynamic:
             jmp     JMP_DynamicObject_Cond_Zero
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             jmp     RETURN_CObject_ProcessCollision
         }
+        // clang-format on
     }
 }
 
@@ -7044,6 +7608,8 @@ DWORD WindowRespondsToCollision_CalledFrom = 0;
 static void __declspec(naked) HOOK_CGlass_WindowRespondsToCollision()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -7053,14 +7619,18 @@ static void __declspec(naked) HOOK_CGlass_WindowRespondsToCollision()
         pop eax
     }
 
+    // clang-format on
+
     pObjectAttacker = nullptr;
 
     if (WindowRespondsToCollision_CalledFrom != CALL_FROM_CGlass_WindowRespondsToExplosion)
     {
+        // clang-format off
         __asm
         {
             mov pDamagedObject, esi
         }
+        // clang-format on
     }
 
     // Get attacker for the glass break
@@ -7068,21 +7638,26 @@ static void __declspec(naked) HOOK_CGlass_WindowRespondsToCollision()
         WindowRespondsToCollision_CalledFrom == CALL_FROM_CPhysical_ApplyCollision_2 ||
         WindowRespondsToCollision_CalledFrom == CALL_FROM_CPhysical_ApplySoftCollision)
     {
+        // clang-format off
         __asm
         {
             mov pObjectAttacker, edi
         }
+        // clang-format on
     }
 
     if (WindowRespondsToCollision_CalledFrom == CALL_FROM_CGlass_WasGlassHitByBullet)
     {
+        // clang-format off
         __asm
         {
             mov pObjectAttacker, ebx // WasGlassHitByBullet called from CWeapon::DoBulletImpact
         }
+        // clang-format on
 
         if (!pObjectAttacker || (pObjectAttacker && !pObjectAttacker->m_pRwObject)) // WasGlassHitByBullet called from CBulletInfo::Update
         {
+            // clang-format off
             __asm
             {
                 push ecx
@@ -7090,16 +7665,19 @@ static void __declspec(naked) HOOK_CGlass_WindowRespondsToCollision()
                 mov pObjectAttacker, ecx
                 pop ecx
             }
+            // clang-format on
         }
     }
 
     if (WindowRespondsToCollision_CalledFrom == CALL_FROM_CGlass_WindowRespondsToExplosion)
     {
+        // clang-format off
         __asm
         {
             mov pDamagedObject, edx
             mov pObjectAttacker, ebp
         }
+        // clang-format on
     }
 
     if (pObjectAttacker && !pObjectAttacker->m_pRwObject) // Still wrong?
@@ -7107,6 +7685,7 @@ static void __declspec(naked) HOOK_CGlass_WindowRespondsToCollision()
 
     if (TriggerObjectBreakEvent())
     {
+        // clang-format off
         __asm
         {
             sub esp, 68h
@@ -7114,13 +7693,16 @@ static void __declspec(naked) HOOK_CGlass_WindowRespondsToCollision()
             mov esi, [esp+6Ch+4]
             jmp RETURN_CGlass_WindowRespondsToCollision
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             retn
         }
+        // clang-format on
     }
 }
 
@@ -7129,6 +7711,8 @@ DWORD dummy_404350 = 0x404350;
 static void __declspec(naked) HOOK_CGlass__BreakGlassPhysically()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -7139,8 +7723,11 @@ static void __declspec(naked) HOOK_CGlass__BreakGlassPhysically()
         pop     ecx
     }
 
+    // clang-format on
+
     if (TriggerObjectBreakEvent())
     {
+        // clang-format off
         __asm
         {
             // restore replaced part
@@ -7148,9 +7735,11 @@ static void __declspec(naked) HOOK_CGlass__BreakGlassPhysically()
             // jump outside of the hook
             jmp     RETURN_CGlass__BreakGlassPhysically
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             pop     edi
@@ -7160,6 +7749,7 @@ static void __declspec(naked) HOOK_CGlass__BreakGlassPhysically()
             add     esp, 0BCh
             retn
         }
+        // clang-format on
     }
 }
 
@@ -7176,13 +7766,19 @@ static void __declspec(naked) HOOK_FxManager_c__DestroyFxSystem()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov pFxSystemToBeDestroyed, edi
         pushad
     }
 
+    // clang-format on
+
     FxManager_c__DestroyFxSystem();
+
+    // clang-format off
 
     __asm
     {
@@ -7195,6 +7791,8 @@ static void __declspec(naked) HOOK_FxManager_c__DestroyFxSystem()
         pop ecx
         retn 4
     }
+
+    // clang-format on
 }
 
 DWORD pProcessedGangDriveBySimpleTask;
@@ -7213,12 +7811,15 @@ static void __declspec(naked) HOOK_CTaskSimpleGangDriveBy__ProcessPed()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // esi contains 'this'
+    // clang-format off
     __asm
     {
         mov pProcessedGangDriveBySimpleTask, esi
         pushad
     }
+    // clang-format on
     CTaskSimpleGangDriveBy__ProcessPed();
+    // clang-format off
     __asm
     {
         popad
@@ -7231,6 +7832,7 @@ static void __declspec(naked) HOOK_CTaskSimpleGangDriveBy__ProcessPed()
     GangDriveBy_ProcessPed_Cancel:
         jmp RETURN_CTaskSimpleGangDriveBy_ProcessPed_Cancel
     }
+    // clang-format on
 }
 
 eRadioStationID dwStationID = UNKNOWN;
@@ -7409,6 +8011,8 @@ static void __declspec(naked) HOOK_CAERadioTrackManager__ChooseMusicTrackIndex()
     // esi is our station id
     // al has the random number picked (music id the game wants to play)
 
+    // clang-format off
+
     __asm
     {
         add esp, 8              // fix the stack from the function call above as we overrote this instruction
@@ -7417,9 +8021,12 @@ static void __declspec(naked) HOOK_CAERadioTrackManager__ChooseMusicTrackIndex()
         mov bTrackID, al        // save our track ID which we need to figure out if we can play it.
     }
 
+    // clang-format on
+
     // returns true if this is a restricted song
     if (ChooseMusicTrackIndex_SteamFix())
     {
+        // clang-format off
         __asm
         {
             // pop the stack
@@ -7429,8 +8036,10 @@ static void __declspec(naked) HOOK_CAERadioTrackManager__ChooseMusicTrackIndex()
             // as such generating a new ID is better than trying to fix it (this is how the game naturally works anyway)
             jmp RETURN_CAERadioTrackManager__ChooseMusicTrackIndex_Regenerate
         }
+        // clang-format on
     }
     // looks good, carry on
+    // clang-format off
     __asm
     {
         // pop the stack
@@ -7440,12 +8049,15 @@ static void __declspec(naked) HOOK_CAERadioTrackManager__ChooseMusicTrackIndex()
         // jump back to normal processing
         jmp RETURN_CAERadioTrackManager__ChooseMusicTrackIndex
     }
+    // clang-format on
 }
 
 // Use AI heli rotor sound if player sound bank is not loaded
 static void __declspec(naked) HOOK_CAEVehicleAudioEntity__ProcessDummyHeli()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -7457,12 +8069,16 @@ static void __declspec(naked) HOOK_CAEVehicleAudioEntity__ProcessDummyHeli()
         // go back
         jmp     RETURN_CAEVEhicleAudioEntity__ProcessDummyHeli
     }
+
+    // clang-format on
 }
 
 // Use AI plane propeller sound if player sound bank is not loaded
 static void __declspec(naked) HOOK_CAEVehicleAudioEntity__ProcessDummyProp()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -7474,12 +8090,16 @@ static void __declspec(naked) HOOK_CAEVehicleAudioEntity__ProcessDummyProp()
         // go back
         jmp     RETURN_CAEVEhicleAudioEntity__ProcessDummyProp
     }
+
+    // clang-format on
 }
 
 const float kfTimeStepOriginal = 1.66f;
 static void __declspec(naked) HOOK_CTaskSimpleSwim_ProcessSwimmingResistance()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -7509,6 +8129,8 @@ static void __declspec(naked) HOOK_CTaskSimpleSwim_ProcessSwimmingResistance()
 
         jmp     RETURN_CTaskSimpleSwim_ProcessSwimmingResistance
     }
+
+    // clang-format on
 }
 
 void PostCWorld_ProcessPedsAfterPreRender()
@@ -7544,12 +8166,16 @@ static void __declspec(naked) HOOK_Idle_CWorld_ProcessPedsAfterPreRender()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
        call CWorld_ProcessPedsAfterPreRender
        call PostCWorld_ProcessPedsAfterPreRender
        jmp RETURN_Idle_CWorld_ProcessPedsAfterPreRender
     }
+
+    // clang-format on
 }
 
 DWORD dwLastRequestedStation = -1;
@@ -7570,6 +8196,8 @@ static void __declspec(naked) HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackA
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         push    [esi+3]
@@ -7582,12 +8210,16 @@ static void __declspec(naked) HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackA
         add     esp, 36
         retn
     }
+
+    // clang-format on
 }
 
 // Stop radio after leaving audio zone
 static void __declspec(naked) HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StopRadio()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -7601,6 +8233,8 @@ static void __declspec(naked) HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackA
         add     esp, 36
         retn
     }
+
+    // clang-format on
 }
 
 static void AddVehicleColoredDebris(CAutomobileSAInterface* pVehicleInterface, CVector& vecPosition, int count)
@@ -7629,6 +8263,8 @@ static void __declspec(naked) HOOK_CAutomobile__dmgDrawCarCollidingParticles()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         lea eax, [esp + 0x1C]
@@ -7640,6 +8276,8 @@ static void __declspec(naked) HOOK_CAutomobile__dmgDrawCarCollidingParticles()
 
         jmp RETURN_CAutomobile__dmgDrawCarCollidingParticles
     }
+
+    // clang-format on
 }
 
 // Reimplement camera photo creation
@@ -7654,6 +8292,8 @@ static void __declspec(naked) HOOK_CWeapon__TakePhotograph()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // Restore instructions replaced by hook
@@ -7665,6 +8305,8 @@ static void __declspec(naked) HOOK_CWeapon__TakePhotograph()
         // Go back
         jmp     RETURN_CWeapon__TakePhotograph
     }
+
+    // clang-format on
 }
 
 // Disable camera collisions for projectiles and detached vehicle parts
@@ -7698,6 +8340,8 @@ static void __declspec(naked) HOOK_CCollision__CheckCameraCollisionObjects()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // Restore instructions replaced by hook
@@ -7722,4 +8366,6 @@ static void __declspec(naked) HOOK_CCollision__CheckCameraCollisionObjects()
     out1: jmp   RETURN_CCollision__CheckCameraCollisionObjects
     out2: jmp   RETURN_CCollision__CheckCameraCollisionObjects_2
     }
+
+    // clang-format on
 }

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -2812,7 +2812,6 @@ static void __declspec(naked) HOOK_FindPlayerCoors()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Only set our world of center if we have a center of world set
@@ -2845,7 +2844,6 @@ static void __declspec(naked) HOOK_FindPlayerCoors()
         add     ecx, 6
         jmp     ecx
     }
-
     // clang-format on
 }
 
@@ -2859,13 +2857,11 @@ static void __declspec(naked) HOOK_CStreaming_Update_Caller()
     */
 
     // clang-format off
-
     __asm
     {
         // Store all registers
         pushad
     }
-
     // clang-format on
 
     // We're now in the streaming update
@@ -2888,7 +2884,6 @@ static void __declspec(naked) HOOK_CStreaming_Update_Caller()
     }
 
     // clang-format off
-
     __asm
     {
         mov     edi, eax
@@ -2897,7 +2892,6 @@ static void __declspec(naked) HOOK_CStreaming_Update_Caller()
         mov     eax, FUNC_CStreaming_Update
         call    eax
     }
-
     // clang-format on
 
     // We have an entity for streaming?
@@ -2999,7 +2993,6 @@ static void __declspec(naked) HOOK_CHud_Draw_Caller()
     }
 
     // clang-format off
-
     __asm
     {
         popad
@@ -3008,7 +3001,6 @@ static void __declspec(naked) HOOK_CHud_Draw_Caller()
         add     eax, 10
         jmp     eax
     }
-
     // clang-format on
 }
 
@@ -3022,7 +3014,6 @@ static void __declspec(naked) HOOK_FindPlayerCentreOfWorld()
     */
 
     // clang-format off
-
     __asm
     {
         mov     al, bSetCenterOfWorld
@@ -3041,7 +3032,6 @@ static void __declspec(naked) HOOK_FindPlayerCentreOfWorld()
         lea     eax, vecCenterOfWorld
         retn
     }
-
     // clang-format on
 }
 
@@ -3055,7 +3045,6 @@ static void __declspec(naked) HOOK_FindPlayerHeading()
     */
 
     // clang-format off
-
     __asm
     {
         // Jump if bSetCenterOfWorld is true
@@ -3078,7 +3067,6 @@ static void __declspec(naked) HOOK_FindPlayerHeading()
         fld     fFalseHeading
         retn
     }
-
     // clang-format on
 }
 
@@ -3088,7 +3076,6 @@ static void __declspec(naked) HOOK_CCustomRoadsignMgr__RenderRoadsignAtomic()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         cmp     esi, 0
@@ -3104,7 +3091,6 @@ no_render:
         mov     edx, 0x6FF40B
         jmp     edx
     }
-
     // clang-format on
 }
 
@@ -3124,24 +3110,20 @@ static void __declspec(naked) HOOK_CRadar__DrawRadarGangOverlay()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     if (m_pDrawRadarAreasHandler) m_pDrawRadarAreasHandler();
 
     // clang-format off
-
     __asm
     {
         popad
         retn
     }
-
     // clang-format on
 }
 
@@ -3152,13 +3134,11 @@ static void __declspec(naked) HOOK_Trailer_BreakTowLink()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     towingVehicle, ecx
         pushad
     }
-
     // clang-format on
 
     if (CallBreakTowLinkHandler(towingVehicle))
@@ -3182,14 +3162,12 @@ static void __declspec(naked) HOOK_Trailer_BreakTowLink()
     }
 
     // clang-format off
-
     __asm
     {
         mov     ecx, HOOKPOS_Trailer_BreakTowLink
         add     ecx, 6
         jmp     ecx
     }
-
     // clang-format on
 }
 
@@ -3224,7 +3202,6 @@ static void __declspec(naked) HOOK_CExplosion_AddExplosion()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Check if explosions are disabled.
@@ -3272,7 +3249,6 @@ static void __declspec(naked) HOOK_CExplosion_AddExplosion()
         // Store registers for calling this handler
         pushad
     }
-
     // clang-format on
 
     // Call the explosion handler
@@ -3297,7 +3273,6 @@ static void __declspec(naked) HOOK_CExplosion_AddExplosion()
     }
 
     // clang-format off
-
     __asm
     {
         noexplosionhandler:
@@ -3313,7 +3288,6 @@ static void __declspec(naked) HOOK_CExplosion_AddExplosion()
         add     edx, 6
         jmp     edx
     }
-
     // clang-format on
 }
 
@@ -3347,7 +3321,6 @@ static void __declspec(naked) HOOK_CTaskComplexJump__CreateSubTask()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     pedPosition, eax
@@ -3359,7 +3332,6 @@ static void __declspec(naked) HOOK_CTaskComplexJump__CreateSubTask()
         mov     eax, pedPosition
         pushad
     }
-
     // clang-format on
 
     if (processGrab())
@@ -3395,7 +3367,6 @@ static void __declspec(naked) HOOK_FxManager_CreateFxSystem()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Store the explosion type
@@ -3409,7 +3380,6 @@ static void __declspec(naked) HOOK_FxManager_CreateFxSystem()
         // Store all the registers on the stack
         pushad
     }
-
     // clang-format on
 
     // If we got a matrix and it is an explosion type?
@@ -3429,7 +3399,6 @@ static void __declspec(naked) HOOK_FxManager_CreateFxSystem()
     }
 
     // clang-format off
-
     __asm
     {
         // Restore the registers
@@ -3446,7 +3415,6 @@ static void __declspec(naked) HOOK_FxManager_CreateFxSystem()
         // Jump back to the rest of the function we hooked
         jmp         RETURN_FxManager_CreateFxSystem
     }
-
     // clang-format on
 }
 
@@ -3458,7 +3426,6 @@ static void __declspec(naked) HOOK_FxManager_DestroyFxSystem()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Grab the FxSystem that's being destroyed
@@ -3468,7 +3435,6 @@ static void __declspec(naked) HOOK_FxManager_DestroyFxSystem()
         // Store all the registers on the stack
         pushad
     }
-
     // clang-format on
 
     // Grab the matrix pointer in it
@@ -3478,7 +3444,6 @@ static void __declspec(naked) HOOK_FxManager_DestroyFxSystem()
     RemoveFxSystemPointer(pDestroyFxSystem_Matrix);
 
     // clang-format off
-
     __asm
     {
         // Restore the registers
@@ -3493,7 +3458,6 @@ static void __declspec(naked) HOOK_FxManager_DestroyFxSystem()
         // Jump back to the rest of the function we hooked
         jmp         RETURN_FxManager_DestroyFxSystem
     }
-
     // clang-format on
 }
 
@@ -3515,12 +3479,10 @@ static void __declspec(naked) HOOK_CCam_ProcessFixed()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov CCam_ProcessFixed_pCam, ecx
     }
-
     // clang-format on
 
     if (CCam_ProcessFixed(CCam_ProcessFixed_pCam))
@@ -3552,24 +3514,20 @@ static void __declspec(naked) HOOK_Render3DStuff()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
     if (m_pRender3DStuffHandler) m_pRender3DStuffHandler();
 
     // clang-format off
-
     __asm
     {
         popad
         mov eax, FUNC_Render3DStuff
         jmp eax
     }
-
     // clang-format on
 }
 
@@ -3816,24 +3774,20 @@ static void __declspec(naked) HOOK_CRunningScript_Process()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     CRunningScript_Process();
 
     // clang-format off
-
     __asm
     {
         popad
         retn
     }
-
     // clang-format on
 }
 
@@ -3980,19 +3934,16 @@ static void __declspec(naked) HOOK_CVehicle_SetupRender()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     dwAlphaEntity, esi
         pushad
     }
-
     // clang-format on
 
     SetVehicleAlpha();
 
     // clang-format off
-
     __asm
     {
         popad
@@ -4000,7 +3951,6 @@ static void __declspec(naked) HOOK_CVehicle_SetupRender()
         test    eax, eax
         jmp     dwCVehicle_SetupRender_ret
     }
-
     // clang-format on
 }
 
@@ -4010,18 +3960,15 @@ static void __declspec(naked) HOOK_CVehicle_ResetAfterRender()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     RestoreAlphaValues();
 
     // clang-format off
-
     __asm
     {
         popad
@@ -4029,7 +3976,6 @@ static void __declspec(naked) HOOK_CVehicle_ResetAfterRender()
         test    eax, eax
         jmp     dwCVehicle_ResetAfterRender_ret
     }
-
     // clang-format on
 }
 
@@ -4089,7 +4035,6 @@ static void __declspec(naked) HOOK_CObject_Render()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push    ecx
@@ -4097,7 +4042,6 @@ static void __declspec(naked) HOOK_CObject_Render()
         add     esp, 4
         retn
     }
-
     // clang-format on
 }
 
@@ -4158,13 +4102,11 @@ static void __declspec(naked) HOOK_EndWorldColors()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
      // clang-format off
-
      __asm
     {
         call DoEndWorldColorsPokes
         ret
     }
-
      // clang-format on
 }
 
@@ -4181,7 +4123,6 @@ static void __declspec(naked) HOOK_CWorld_ProcessVerticalLineSectorList()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         test    ebp, ebp
@@ -4203,7 +4144,6 @@ stop_looping:
         mov     dwObjectsChecked, 0
         jmp     dwProcessVerticalEndLooping
     }
-
     // clang-format on
 }
 
@@ -4216,7 +4156,6 @@ static void __declspec(naked) HOOK_ComputeDamageResponse_StartChoking()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Get weapon type before pushad to avoid stack offset corruption
@@ -4246,7 +4185,6 @@ static void __declspec(naked) HOOK_ComputeDamageResponse_StartChoking()
         mov     eax, [ecx+0x47C]
         jmp     dwChokingChoke
     }
-
     // clang-format on
 }
 
@@ -4597,12 +4535,10 @@ static void __declspec(naked) HOOK_CTrafficLights_GetPrimaryLightState()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     if (ucTrafficLightState == 0 || ucTrafficLightState == 5 || ucTrafficLightState == 8)
@@ -4620,14 +4556,12 @@ static void __declspec(naked) HOOK_CTrafficLights_GetPrimaryLightState()
     else ucDesignatedLightState = 2;            // Red
 
     // clang-format off
-
     __asm
     {
         popad
         mov al, ucDesignatedLightState
         retn
     }
-
     // clang-format on
 }
 
@@ -4636,12 +4570,10 @@ static void __declspec(naked) HOOK_CTrafficLights_GetSecondaryLightState()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     if (ucTrafficLightState == 3 || ucTrafficLightState == 5 || ucTrafficLightState == 7)
@@ -4659,14 +4591,12 @@ static void __declspec(naked) HOOK_CTrafficLights_GetSecondaryLightState()
     else ucDesignatedLightState = 2;            // Red
 
     // clang-format off
-
     __asm
     {
         popad
         mov al, ucDesignatedLightState
         retn
     }
-
     // clang-format on
 }
 
@@ -4675,12 +4605,10 @@ static void __declspec(naked) HOOK_CTrafficLights_DisplayActualLight()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     if (ucTrafficLightState == 2)
@@ -4691,14 +4619,12 @@ static void __declspec(naked) HOOK_CTrafficLights_DisplayActualLight()
     else { ucDesignatedLightState = 2; }
 
     // clang-format off
-
     __asm
     {
         popad
         movzx eax, ucDesignatedLightState
         jmp RETURN_CTrafficLights_DisplayActualLight
     }
-
     // clang-format on
 }
 
@@ -4726,7 +4652,6 @@ static void __declspec(naked) HOOK_Transmission_CalculateDriveAcceleration()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push eax
@@ -4736,13 +4661,11 @@ static void __declspec(naked) HOOK_Transmission_CalculateDriveAcceleration()
         pop eax
         pushad
     }
-
     // clang-format on
 
     CheckVehicleMaxGear();
 
     // clang-format off
-
     __asm
     {
         popad
@@ -4750,7 +4673,6 @@ static void __declspec(naked) HOOK_Transmission_CalculateDriveAcceleration()
         mov edx, [eax]
         jmp RETURN_Transmission_CalculateDriveAcceleration
     }
-
     // clang-format on
 }
 
@@ -4894,7 +4816,6 @@ static void __declspec(naked) HOOK_CVehicle_ApplyBoatWaterResistance()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         fmul    ds : 0x871DDC   // Original constant used in code
@@ -4902,7 +4823,6 @@ static void __declspec(naked) HOOK_CVehicle_ApplyBoatWaterResistance()
         fdiv    kfTimeStepOrg   // Divide by desired timestep, used at 30fps
         jmp     RETURN_CVehicle_ApplyBoatWaterResistance
     }
-
     // clang-format on
 }
 
@@ -4911,7 +4831,6 @@ static void __declspec(naked) HOOK_CPhysical_ApplyGravity()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push esi
@@ -4919,7 +4838,6 @@ static void __declspec(naked) HOOK_CPhysical_ApplyGravity()
         add esp, 4
         jmp RETURN_CPhysical_ApplyGravity
     }
-
     // clang-format on
 }
 
@@ -4997,7 +4915,6 @@ static void __declspec(naked) HOOK_VehicleCamStart()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push edi
@@ -5014,7 +4931,6 @@ fail:
         add esp, 4
         jmp RETURN_VehicleCamStart_failure
     }
-
     // clang-format on
 }
 
@@ -5031,7 +4947,6 @@ static void __declspec(naked) HOOK_VehicleCamTargetZTweak()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         fstp st
@@ -5055,7 +4970,6 @@ static void __declspec(naked) HOOK_VehicleCamTargetZTweak()
         cmp eax, 1
         jmp RETURN_VehicleCamTargetZTweak
     }
-
     // clang-format on
 }
 
@@ -5074,7 +4988,6 @@ static void __declspec(naked) HOOK_VehicleCamLookDir1()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov eax, 0x59C910       // CVector::Normalise
@@ -5087,7 +5000,6 @@ static void __declspec(naked) HOOK_VehicleCamLookDir1()
 
         jmp RETURN_VehicleCamLookDir1
     }
-
     // clang-format on
 }
 
@@ -5113,7 +5025,6 @@ static void __declspec(naked) HOOK_VehicleCamLookDir2()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push esi
@@ -5125,7 +5036,6 @@ static void __declspec(naked) HOOK_VehicleCamLookDir2()
         push 4
         jmp RETURN_VehicleCamLookDir2
     }
-
     // clang-format on
 }
 
@@ -5145,7 +5055,6 @@ static void __declspec(naked) HOOK_VehicleCamHistory()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push [esp+0x0+0x7C]       // zoom
@@ -5160,7 +5069,6 @@ static void __declspec(naked) HOOK_VehicleCamHistory()
         mov eax, [esp+0x24]
         jmp RETURN_VehicleCamHistory
     }
-
     // clang-format on
 }
 
@@ -5184,7 +5092,6 @@ static void __declspec(naked) HOOK_VehicleCamUp()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov edx, ecx
@@ -5205,7 +5112,6 @@ docustom:
         add esp, 4
         ret
     }
-
     // clang-format on
 }
 
@@ -5228,7 +5134,6 @@ static void __declspec(naked) HOOK_VehicleCamEnd()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov ds:[0xB6F020], edx
@@ -5239,7 +5144,6 @@ static void __declspec(naked) HOOK_VehicleCamEnd()
 
         jmp RETURN_VehicleCamEnd
     }
-
     // clang-format on
 }
 
@@ -5257,7 +5161,6 @@ static void __declspec(naked) HOOK_VehicleLookBehind()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push [esp+0x14]
@@ -5280,7 +5183,6 @@ static void __declspec(naked) HOOK_VehicleLookBehind()
         mov eax, ebx            // pEntity
         jmp RETURN_VehicleLookBehind
     }
-
     // clang-format on
 }
 
@@ -5298,7 +5200,6 @@ static void __declspec(naked) HOOK_VehicleLookAside()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push [esp+0x14]
@@ -5313,7 +5214,6 @@ static void __declspec(naked) HOOK_VehicleLookAside()
         mov ecx, [esi+0x21C]
         jmp RETURN_VehicleLookAside
     }
-
     // clang-format on
 }
 
@@ -5342,7 +5242,6 @@ static void __declspec(naked) HOOK_OccupiedVehicleBurnCheck()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push eax
@@ -5350,7 +5249,6 @@ static void __declspec(naked) HOOK_OccupiedVehicleBurnCheck()
         add esp, 4
         jmp RETURN_OccupiedVehicleBurnCheck
     }
-
     // clang-format on
 }
 
@@ -5359,7 +5257,6 @@ static void __declspec(naked) HOOK_UnoccupiedVehicleBurnCheck()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov word ptr [esp+0x78], cx
@@ -5369,7 +5266,6 @@ static void __declspec(naked) HOOK_UnoccupiedVehicleBurnCheck()
         add esp, 4
         jmp RETURN_UnoccupiedVehicleBurnCheck
     }
-
     // clang-format on
 }
 
@@ -5396,7 +5292,6 @@ static void __declspec(naked) HOOK_ApplyCarBlowHop()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push esi
@@ -5410,7 +5305,6 @@ static void __declspec(naked) HOOK_ApplyCarBlowHop()
         mov [esi+0x36], dl
         jmp RETURN_ApplyCarBlowHop
     }
-
     // clang-format on
 }
 
@@ -5438,7 +5332,6 @@ static void __declspec(naked) HOOK_CGame_Process()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -5451,7 +5344,6 @@ static void __declspec(naked) HOOK_CGame_Process()
         popad
         jmp     RETURN_CGame_Process;
     }
-
     // clang-format on
 }
 
@@ -5497,7 +5389,6 @@ static void __declspec(naked) HOOK_Idle()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -5508,7 +5399,6 @@ static void __declspec(naked) HOOK_Idle()
         mov     ecx, 0B6BC90h
         jmp     RETURN_Idle
     }
-
     // clang-format on
 }
 
@@ -5518,7 +5408,6 @@ static void __declspec(naked) HOOK_PreFxRender()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -5526,20 +5415,17 @@ static void __declspec(naked) HOOK_PreFxRender()
         cmp     eax,0
         jne skip
     }
-
     // clang-format on
 
     if (m_pPreFxRenderHandler) m_pPreFxRenderHandler();
 
     // clang-format off
-
     __asm
     {
 skip:
         popad
         jmp     RETURN_PreFxRender  // 00404D1E
     }
-
     // clang-format on
 }
 
@@ -5549,25 +5435,21 @@ static void __declspec(naked) HOOK_PostColorFilterRender()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     if (m_pPostColorFilterRenderHandler) m_pPostColorFilterRenderHandler();
 
     // clang-format off
-
     __asm
     {
         popad
         mov al, ds:0C402BAh
         jmp     RETURN_PostColorFilterRender  // 0070509E
     }
-
     // clang-format on
 }
 
@@ -5577,25 +5459,21 @@ static void __declspec(naked) HOOK_PreHUDRender()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     if (m_pPreHudRenderHandler) m_pPreHudRenderHandler();
 
     // clang-format off
-
     __asm
     {
         popad
         mov     eax, ds:0B6F0B8h
         jmp     RETURN_PreHUDRender  // 0053EADD
     }
-
     // clang-format on
 }
 
@@ -5664,7 +5542,6 @@ static void __declspec(naked) HOOK_CVehicle_DoVehicleLights()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     pLightsVehicleInterface, ecx
@@ -5672,7 +5549,6 @@ static void __declspec(naked) HOOK_CVehicle_DoVehicleLights()
         sub     esp,3Ch
         jmp     RETURN_CVehicle_DoVehicleLights
     }
-
     // clang-format on
 }
 
@@ -5699,14 +5575,12 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightBeam_1()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     pHeadLightBeamVehicleInterface, ecx
         sub     esp, 94h
         jmp     RETURN_CVehicle_DoHeadLightBeam_1
     }
-
     // clang-format on
 }
 
@@ -5729,7 +5603,6 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightBeam_2()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     eax, [esp]
@@ -5738,20 +5611,17 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightBeam_2()
         mov     uiHeadLightNumVerts, eax
         pushad
     }
-
     // clang-format on
 
     CVehicle_DoHeadLightBeam();
 
     // clang-format off
-
     __asm
     {
         popad
         mov     dword ptr ds:[0C4B950h],5
         jmp     RETURN_CVehicle_DoHeadLightBeam_2
     }
-
     // clang-format on
 }
 
@@ -5761,18 +5631,15 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightEffect_1()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     CVehicle_GetHeadLightColor(pLightsVehicleInterface, 160.0f, 160.0f, 140.0f);
 
     // clang-format off
-
     __asm
     {
         popad
@@ -5789,7 +5656,6 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightEffect_1()
         add     esp,54h
         jmp     RETURN_CVehicle_DoHeadLightEffect_1
     }
-
     // clang-format on
 }
 
@@ -5798,18 +5664,15 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightEffect_2()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     CVehicle_GetHeadLightColor(pLightsVehicleInterface, 160.0f, 160.0f, 140.0f);
 
     // clang-format off
-
     __asm
     {
         popad
@@ -5826,7 +5689,6 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightEffect_2()
         add     esp, 54h
         jmp     RETURN_CVehicle_DoHeadLightEffect_2
     }
-
     // clang-format on
 }
 
@@ -5836,18 +5698,15 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightReflectionTwin()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     CVehicle_GetHeadLightColor(pLightsVehicleInterface, 45.0f, 45.0f, 45.0f);
 
     // clang-format off
-
     __asm
     {
         popad
@@ -5862,7 +5721,6 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightReflectionTwin()
         add     esp, 4Ch
         jmp     RETURN_CVehicle_DoHeadLightReflectionTwin
     }
-
     // clang-format on
 }
 
@@ -5871,18 +5729,15 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightReflectionSingle()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     CVehicle_GetHeadLightColor(pLightsVehicleInterface, 45.0f, 45.0f, 45.0f);
 
     // clang-format off
-
     __asm
     {
         popad
@@ -5897,7 +5752,6 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightReflectionSingle()
         add     esp, 30h
         jmp     RETURN_CVehicle_DoHeadLightReflectionSingle
     }
-
     // clang-format on
 }
 
@@ -6092,7 +5946,6 @@ static void __declspec(naked) HOOK_RenderScene_Plants()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -6111,7 +5964,6 @@ static void __declspec(naked) HOOK_RenderScene_Plants()
         popad
         ret
     }
-
     // clang-format on
 }
 
@@ -6120,7 +5972,6 @@ static void __declspec(naked) HOOK_RenderScene_end()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -6143,7 +5994,6 @@ static void __declspec(naked) HOOK_RenderScene_end()
         mov eax, 0x7113B0
         jmp eax
     }
-
     // clang-format on
 }
 
@@ -6228,7 +6078,6 @@ static void __declspec(naked) HOOK_CEventHandler_ComputeKnockOffBikeResponse()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     pBikeDamageInterface, ecx
@@ -6238,19 +6087,16 @@ static void __declspec(naked) HOOK_CEventHandler_ComputeKnockOffBikeResponse()
 
         pushad
     }
-
     // clang-format on
     CEventHandler_ComputeKnockOffBikeResponse();
 
     // clang-format off
-
     __asm
     {
         popad
         call    dw_CEventDamage_AffectsPed
         jmp     RETURN_CEventHandler_ComputeKnockOffBikeResponse
     }
-
     // clang-format on
 }
 
@@ -6300,7 +6146,6 @@ static void __declspec(naked) HOOK_CPed_GetWeaponSkill()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     weaponSkillPed, ecx
@@ -6308,7 +6153,6 @@ static void __declspec(naked) HOOK_CPed_GetWeaponSkill()
         mov     weaponSkillWeapon, eax
         pushad
     }
-
     // clang-format on
 
     if (CPed_GetWeaponSkill())
@@ -6351,7 +6195,6 @@ static void __declspec(naked) HOOK_CPed_AddGogglesModel()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push esi
@@ -6367,7 +6210,6 @@ static void __declspec(naked) HOOK_CPed_AddGogglesModel()
     skip:
         jmp RETURN_CPed_AddGogglesModel
     }
-
     // clang-format on
 }
 
@@ -6457,14 +6299,12 @@ static void __declspec(naked) HOOK_CPhysical_ProcessCollisionSectorList()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     pCollisionPhysicalThis, esi
         mov     pCollisionPhysical, edi
         pushad
     }
-
     // clang-format on
 
     // Carry on with collision? (sets the CElement->bUsesCollision flag check)
@@ -6580,7 +6420,6 @@ static void __declspec(naked) HOOK_CheckAnimMatrix()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Replaced code
@@ -6597,7 +6436,6 @@ static void __declspec(naked) HOOK_CheckAnimMatrix()
         push    eax
         jmp     RETURN_CheckAnimMatrix      // 7C5A61
     }
-
     // clang-format on
 }
 
@@ -6618,7 +6456,6 @@ static void __declspec(naked) HOOK_VehCol()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Get vehColors for this vehicle
@@ -6639,7 +6476,6 @@ static void __declspec(naked) HOOK_VehCol()
 
         jmp     RETURN_VehCol  // 006D660C
     }
-
     // clang-format on
 }
 
@@ -6648,7 +6484,6 @@ static void __declspec(naked) HOOK_VehColCB()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Hooked from 004C838D  29 bytes
@@ -6665,7 +6500,6 @@ static void __declspec(naked) HOOK_VehColCB()
 
         jmp     RETURN_VehColCB  // 004C83AA
     }
-
     // clang-format on
 }
 
@@ -6688,14 +6522,12 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessSwingingDoor()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     dwSwingingDoorAutomobile, esi
         mov     ecx, [esi+eax*4+0x648]
         pushad
     }
-
     // clang-format on
 
     if (AllowSwingingDoors())
@@ -6763,13 +6595,11 @@ static void __declspec(naked) HOOK_ProcessVehicleCollision()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     pSuspensionInterface, esi
         pushad
     }
-
     // clang-format on
 
     if (CheckHasSuspensionChanged())
@@ -6879,13 +6709,11 @@ static void __declspec(naked) HOOK_LoadIPLInstance()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
         mov pEntityWorldAdd, ecx
     }
-
     // clang-format on
     if (pEntityWorldAdd)
     {
@@ -6946,13 +6774,11 @@ static void __declspec(naked) HOOK_CWorld_LOD_SETUP()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
         mov pLODInterface, esi
     }
-
     // clang-format on
     HideEntitySomehow();
     // clang-format off
@@ -6980,13 +6806,11 @@ static void __declspec(naked) Hook_AddBuildingInstancesToWorld()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
         mov pBuildingAdd, edx
     }
-
     // clang-format on
     StorePointerToBuilding();
     // clang-format off
@@ -7020,14 +6844,12 @@ static void __declspec(naked) Hook_CWorld_ADD_CPopulation_ConvertToRealObject()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
         mov pBuildingAdd, esi
         mov pLODInterface, esi
     }
-
     // clang-format on
     StorePointerToBuilding();
     // clang-format off
@@ -7067,14 +6889,12 @@ static void __declspec(naked) HOOK_ConvertToObject_CPopulationManageDummy()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
         mov pBuildingAdd, edx
         mov pLODInterface, edx
     }
-
     // clang-format on
     // clang-format off
     __asm
@@ -7128,7 +6948,6 @@ static void __declspec(naked) HOOK_CWorld_Remove_CPopulation_ConvertToDummyObjec
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -7140,7 +6959,6 @@ static void __declspec(naked) HOOK_CWorld_Remove_CPopulation_ConvertToDummyObjec
 
         jmp     dwCWorldRemove
     }
-
     // clang-format on
 }
 
@@ -7173,7 +6991,6 @@ static void __declspec(naked) HOOK_CWorld_Add_CPopulation_ConvertToDummyObject()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -7191,7 +7008,6 @@ static void __declspec(naked) HOOK_CWorld_Add_CPopulation_ConvertToDummyObject()
         call    CALL_CWorld_Add_CPopulation_ConvertToDummyObject
         jmp     JMP_RETN_Called_CPopulation_ConvertToDummyObject
     }
-
     // clang-format on
 }
 
@@ -7201,13 +7017,11 @@ static void __declspec(naked) Hook_CBuilding_DTR()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
         mov pBuildingRemove, ecx
     }
-
     // clang-format on
     RemovePointerToBuilding();
     // clang-format off
@@ -7224,13 +7038,11 @@ static void __declspec(naked) Hook_CDummy_DTR()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
         mov pBuildingRemove, ecx
     }
-
     // clang-format on
     RemovePointerToBuilding();
     // clang-format off
@@ -7248,13 +7060,11 @@ static void __declspec(naked) Hook_CObject_DTR()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
         mov pBuildingRemove, esi
     }
-
     // clang-format on
     RemovePointerToBuilding();
     // clang-format off
@@ -7274,7 +7084,6 @@ static void __declspec(naked) HOOK_CEntity_IsOnScreen_FixObjectScale()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push    0xB6FA74
@@ -7283,20 +7092,17 @@ static void __declspec(naked) HOOK_CEntity_IsOnScreen_FixObjectScale()
         mov     eax, [esi]
         mov     dwEntityVtbl, eax
     }
-
     // clang-format on
 
     if (dwEntityVtbl == 0x866F60) goto IsOnScreen_IsObject;
 
     // clang-format off
-
     __asm
     {
         popad
         mov     esi, ecx
         jmp     JMP_CEntity_IsOnScreen_FixObjectsScale
     }
-
     // clang-format on
 
 IsOnScreen_IsObject:
@@ -7322,7 +7128,6 @@ static void __declspec(naked) HOOK_CClothes_RebuildPlayer()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push    esi
@@ -7338,7 +7143,6 @@ static void __declspec(naked) HOOK_CClothes_RebuildPlayer()
     cont:
         jmp     RETURN_CClothes_RebuildPlayerb  // 005A837F
     }
-
     // clang-format on
 }
 
@@ -7484,7 +7288,6 @@ static void __declspec(naked) HOOK_CObject_ProcessDamage()
     // .text:005A0E0D                 fst     dword ptr [esi+154h]
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -7492,7 +7295,6 @@ static void __declspec(naked) HOOK_CObject_ProcessDamage()
         mov     pObjectAttacker, edi
         fst     dword ptr fNewObjectHealth
     }
-
     // clang-format on
     if (TriggerObjectDamageEvent())
     {
@@ -7536,12 +7338,10 @@ static void __declspec(naked) HOOK_CObject_ProcessBreak()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
     ucColDamageEffect = *(unsigned char*)((DWORD)pDamagedObject + 324);
 
@@ -7564,14 +7364,12 @@ static void __declspec(naked) HOOK_CObject_ProcessBreak()
     }
 
     // clang-format off
-
     __asm
     {
         popad
         cmp     eax, 0C9h
         jmp     RETURN_CObject_ProcessBreak
     }
-
     // clang-format on
 }
 
@@ -7610,7 +7408,6 @@ static void __declspec(naked) HOOK_CGlass_WindowRespondsToCollision()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push eax
@@ -7618,7 +7415,6 @@ static void __declspec(naked) HOOK_CGlass_WindowRespondsToCollision()
         mov WindowRespondsToCollision_CalledFrom, eax
         pop eax
     }
-
     // clang-format on
 
     pObjectAttacker = nullptr;
@@ -7713,7 +7509,6 @@ static void __declspec(naked) HOOK_CGlass__BreakGlassPhysically()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     pDamagedObject, esi
@@ -7722,7 +7517,6 @@ static void __declspec(naked) HOOK_CGlass__BreakGlassPhysically()
         mov     pObjectAttacker, ecx
         pop     ecx
     }
-
     // clang-format on
 
     if (TriggerObjectBreakEvent())
@@ -7767,19 +7561,16 @@ static void __declspec(naked) HOOK_FxManager_c__DestroyFxSystem()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov pFxSystemToBeDestroyed, edi
         pushad
     }
-
     // clang-format on
 
     FxManager_c__DestroyFxSystem();
 
     // clang-format off
-
     __asm
     {
         popad
@@ -7791,7 +7582,6 @@ static void __declspec(naked) HOOK_FxManager_c__DestroyFxSystem()
         pop ecx
         retn 4
     }
-
     // clang-format on
 }
 
@@ -8012,7 +7802,6 @@ static void __declspec(naked) HOOK_CAERadioTrackManager__ChooseMusicTrackIndex()
     // al has the random number picked (music id the game wants to play)
 
     // clang-format off
-
     __asm
     {
         add esp, 8              // fix the stack from the function call above as we overrote this instruction
@@ -8020,7 +7809,6 @@ static void __declspec(naked) HOOK_CAERadioTrackManager__ChooseMusicTrackIndex()
         mov dwStationID, esi    // save esi, we need the station ID above
         mov bTrackID, al        // save our track ID which we need to figure out if we can play it.
     }
-
     // clang-format on
 
     // returns true if this is a restricted song
@@ -8058,7 +7846,6 @@ static void __declspec(naked) HOOK_CAEVehicleAudioEntity__ProcessDummyHeli()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // push our argument
@@ -8069,7 +7856,6 @@ static void __declspec(naked) HOOK_CAEVehicleAudioEntity__ProcessDummyHeli()
         // go back
         jmp     RETURN_CAEVEhicleAudioEntity__ProcessDummyHeli
     }
-
     // clang-format on
 }
 
@@ -8079,7 +7865,6 @@ static void __declspec(naked) HOOK_CAEVehicleAudioEntity__ProcessDummyProp()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // push our argument
@@ -8090,7 +7875,6 @@ static void __declspec(naked) HOOK_CAEVehicleAudioEntity__ProcessDummyProp()
         // go back
         jmp     RETURN_CAEVEhicleAudioEntity__ProcessDummyProp
     }
-
     // clang-format on
 }
 
@@ -8100,7 +7884,6 @@ static void __declspec(naked) HOOK_CTaskSimpleSwim_ProcessSwimmingResistance()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         fsub    st, st(1)
@@ -8129,7 +7912,6 @@ static void __declspec(naked) HOOK_CTaskSimpleSwim_ProcessSwimmingResistance()
 
         jmp     RETURN_CTaskSimpleSwim_ProcessSwimmingResistance
     }
-
     // clang-format on
 }
 
@@ -8167,14 +7949,12 @@ static void __declspec(naked) HOOK_Idle_CWorld_ProcessPedsAfterPreRender()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
        call CWorld_ProcessPedsAfterPreRender
        call PostCWorld_ProcessPedsAfterPreRender
        jmp RETURN_Idle_CWorld_ProcessPedsAfterPreRender
     }
-
     // clang-format on
 }
 
@@ -8197,7 +7977,6 @@ static void __declspec(naked) HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackA
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push    [esi+3]
@@ -8210,7 +7989,6 @@ static void __declspec(naked) HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackA
         add     esp, 36
         retn
     }
-
     // clang-format on
 }
 
@@ -8220,7 +7998,6 @@ static void __declspec(naked) HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackA
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push    0
@@ -8233,7 +8010,6 @@ static void __declspec(naked) HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackA
         add     esp, 36
         retn
     }
-
     // clang-format on
 }
 
@@ -8264,7 +8040,6 @@ static void __declspec(naked) HOOK_CAutomobile__dmgDrawCarCollidingParticles()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         lea eax, [esp + 0x1C]
@@ -8276,7 +8051,6 @@ static void __declspec(naked) HOOK_CAutomobile__dmgDrawCarCollidingParticles()
 
         jmp RETURN_CAutomobile__dmgDrawCarCollidingParticles
     }
-
     // clang-format on
 }
 
@@ -8293,7 +8067,6 @@ static void __declspec(naked) HOOK_CWeapon__TakePhotograph()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Restore instructions replaced by hook
@@ -8305,7 +8078,6 @@ static void __declspec(naked) HOOK_CWeapon__TakePhotograph()
         // Go back
         jmp     RETURN_CWeapon__TakePhotograph
     }
-
     // clang-format on
 }
 
@@ -8341,7 +8113,6 @@ static void __declspec(naked) HOOK_CCollision__CheckCameraCollisionObjects()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Restore instructions replaced by hook
@@ -8366,6 +8137,5 @@ static void __declspec(naked) HOOK_CCollision__CheckCameraCollisionObjects()
     out1: jmp   RETURN_CCollision__CheckCameraCollisionObjects
     out2: jmp   RETURN_CCollision__CheckCameraCollisionObjects_2
     }
-
     // clang-format on
 }

--- a/Client/multiplayer_sa/CMultiplayerSA_1.3.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_1.3.cpp
@@ -339,6 +339,8 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_TestSirenTypeSingle()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -349,8 +351,11 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_TestSirenTypeSingle()
         // Grab our siren vehicle
         mov pVehicleWithTheSiren, esi
     }
+
+    // clang-format on
     //   Call our Get siren type function which edits dwSirenType to our desired type
     GetVehicleSirenType();
+    // clang-format off
     __asm
     {
         popad
@@ -359,6 +364,7 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_TestSirenTypeSingle()
         // Jump back to the original code
         JMP RETN_CVehicle_ProcessStuff_TestSirenTypeSingle
     }
+    // clang-format on
 }
 
 void SetupSirenColour(CVehicle* pVehicle)
@@ -572,6 +578,8 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PostPushSirenPositionSi
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // Get our siren position into edx
@@ -582,10 +590,13 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PostPushSirenPositionSi
         // Put edx into our position variable
         mov vecRelativeSirenPosition, edx
     }
+
+    // clang-format on
     bPointLights = false;
     // Call our main siren Process function
     if (ProcessVehicleSirenPosition())
     {
+        // clang-format off
         __asm
         {
             popad
@@ -602,9 +613,11 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PostPushSirenPositionSi
             // return back to SA
             JMP RETN_CVehicle_ProcessStuff_PostPushSirenPositionSingle
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
@@ -617,6 +630,7 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PostPushSirenPositionSi
             // return back to SA
             JMP RETN_CVehicle_ProcessStuff_PostPushSirenPositionSingle
         }
+        // clang-format on
     }
 }
 
@@ -639,6 +653,8 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_TestSirenTypeDual()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // Grab our default siren type into edi
@@ -649,8 +665,11 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_TestSirenTypeDual()
         // Store our post hook default siren type
         mov dwSirenTypePostHook, edi
     }
+
+    // clang-format on
     //   Do our test and edit dwSirenType2 appropriately
     TestSirenTypeDualDefaultFix();
+    // clang-format off
     __asm
     {
         popad
@@ -659,11 +678,14 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_TestSirenTypeDual()
         // Return back to SA
         JMP RETN_CVehicle_ProcessStuff_TestSirenTypeDual
     }
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PostPushSirenPositionDualRed()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -679,11 +701,14 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PostPushSirenPositionDu
         mov dwGreen, edx
         mov dwBlue, ecx
     }
+
+    // clang-format on
     bPointLights = false;
 
     // Call our main process siren function
     if (ProcessVehicleSirenPosition())
     {
+        // clang-format off
         __asm
         {
             popad
@@ -701,9 +726,11 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PostPushSirenPositionDu
             // Return control
             JMP RETN_CVehicle_ProcessStuff_PostPushSirenPositionDual1
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
@@ -721,12 +748,15 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PostPushSirenPositionDu
             // Return control
             JMP RETN_CVehicle_ProcessStuff_PostPushSirenPositionDual1
         }
+        // clang-format on
     }
 }
 
 static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PostPushSirenPositionDualBlue()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -741,11 +771,14 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PostPushSirenPositionDu
         mov dwGreen, edx
         mov dwBlue, ecx
     }
+
+    // clang-format on
     bPointLights = false;
 
     // Call our main process siren function
     if (ProcessVehicleSirenPosition())
     {
+        // clang-format off
         __asm
         {
             popad
@@ -763,9 +796,11 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PostPushSirenPositionDu
             // Return control
             JMP RETN_CVehicle_ProcessStuff_PostPushSirenPositionDual2
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
@@ -783,6 +818,7 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PostPushSirenPositionDu
             // Return control
             JMP RETN_CVehicle_ProcessStuff_PostPushSirenPositionDual2
         }
+        // clang-format on
     }
 }
 
@@ -808,15 +844,20 @@ static void __declspec(naked) HOOK_CVehicle_DoesVehicleUseSiren()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
         // Grab our vehicle interface
         mov pVehicleWithTheSiren, ecx
     }
+
+    // clang-format on
     //   Test our vehicle for sirens
     if (TestVehicleForSiren())
     {
+        // clang-format off
         __asm
         {
             popad
@@ -825,9 +866,11 @@ static void __declspec(naked) HOOK_CVehicle_DoesVehicleUseSiren()
             // Return
             jmp RETN_CVehicleDoesVehicleUseSirenRetn
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
@@ -836,6 +879,7 @@ static void __declspec(naked) HOOK_CVehicle_DoesVehicleUseSiren()
             // Return
             jmp RETN_CVehicleDoesVehicleUseSirenRetn
         }
+        // clang-format on
     }
 }
 bool SirenCheckCameraPosition()
@@ -863,15 +907,20 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_TestCameraPosition()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
         // Grab our vehicle
         mov pVehicleWithTheSiren, esi
     }
+
+    // clang-format on
     //   Check if we disable or enable the 360 effect
     if (SirenCheckCameraPosition())
     {
+        // clang-format off
         __asm
         {
             popad
@@ -879,9 +928,11 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_TestCameraPosition()
             // Carry on
             jmp RETN_CVehicle_ProcessStuff_TestCameraPosition
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
@@ -892,6 +943,7 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_TestCameraPosition()
             // Carry on
             jmp RETN_CVehicle_ProcessStuff_TestCameraPosition2
         }
+        // clang-format on
     }
 }
 bool DisableVehicleSiren()
@@ -912,27 +964,35 @@ static void __declspec(naked) HOOK_CVehicleAudio_ProcessSirenSound()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
+
+    // clang-format on
     if (DisableVehicleSiren())
     {
+        // clang-format off
         __asm
         {
             popad
             mov dl, 0
             jmp RETN_CVehicleAudio_GetVehicleSirenType
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
             mov dl, [ecx+42Dh]
             jmp RETN_CVehicleAudio_GetVehicleSirenType
         }
+        // clang-format on
     }
 }
 DWORD CALL_CVehicleAudio_ProcessCarHorn = 0x5002C0;
@@ -940,11 +1000,17 @@ static void __declspec(naked) HOOK_CVehicleAudio_ProcessSirenSound1()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov pVehicleWithTheSiren, edi
         pushad
     }
+
+    // clang-format on
+
+    // clang-format off
 
     __asm
     {
@@ -952,17 +1018,25 @@ static void __declspec(naked) HOOK_CVehicleAudio_ProcessSirenSound1()
         call CALL_CVehicleAudio_ProcessCarHorn
         jmp RETN_CVehicleAudio_ProcessSirenSound1
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CVehicleAudio_ProcessSirenSound2()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov pVehicleWithTheSiren, edi
         pushad
     }
+
+    // clang-format on
+
+    // clang-format off
 
     __asm
     {
@@ -970,11 +1044,15 @@ static void __declspec(naked) HOOK_CVehicleAudio_ProcessSirenSound2()
         call CALL_CVehicleAudio_ProcessCarHorn
         jmp RETN_CVehicleAudio_ProcessSirenSound2
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CVehicleAudio_ProcessSirenSound3()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -982,12 +1060,18 @@ static void __declspec(naked) HOOK_CVehicleAudio_ProcessSirenSound3()
         pushad
     }
 
+    // clang-format on
+
+    // clang-format off
+
     __asm
     {
         popad
         call CALL_CVehicleAudio_ProcessCarHorn
         jmp RETN_CVehicleAudio_ProcessSirenSound3
     }
+
+    // clang-format on
 }
 
 DWORD RETN_CMotorbike_ProcessStuff_PostPushSirenPositionDual1 = 0x6BD4DB;
@@ -995,6 +1079,8 @@ DWORD RETN_CMotorbike_ProcessStuff_PostPushSirenPositionDual1 = 0x6BD4DB;
 static void __declspec(naked) HOOK_CMotorBike_ProcessStuff_PushSirenPositionBlue()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -1007,10 +1093,13 @@ static void __declspec(naked) HOOK_CMotorBike_ProcessStuff_PushSirenPositionBlue
         mov vecRelativeSirenPosition, eax
     }
 
+    // clang-format on
+
     bPointLights = false;
     // Call our main process siren function
     if (ProcessVehicleSirenPosition())
     {
+        // clang-format off
         __asm
         {
             popad
@@ -1028,9 +1117,11 @@ static void __declspec(naked) HOOK_CMotorBike_ProcessStuff_PushSirenPositionBlue
             // Return control
             JMP RETN_CMotorbike_ProcessStuff_PostPushSirenPositionDual1
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
@@ -1045,12 +1136,15 @@ static void __declspec(naked) HOOK_CMotorBike_ProcessStuff_PushSirenPositionBlue
             // Return control
             JMP RETN_CMotorbike_ProcessStuff_PostPushSirenPositionDual1
         }
+        // clang-format on
     }
 }
 
 static void __declspec(naked) HOOK_CMotorBike_ProcessStuff_PushSirenPositionRed()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -1061,10 +1155,13 @@ static void __declspec(naked) HOOK_CMotorBike_ProcessStuff_PushSirenPositionRed(
         mov vecRelativeSirenPosition, edx
     }
 
+    // clang-format on
+
     bPointLights = false;
     // Call our main process siren function
     if (ProcessVehicleSirenPosition())
     {
+        // clang-format off
         __asm
         {
             popad
@@ -1084,9 +1181,11 @@ static void __declspec(naked) HOOK_CMotorBike_ProcessStuff_PushSirenPositionRed(
             // Return control
             JMP RETN_CMotorBike_ProcessStuff_PushSirenPositionDualRed
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
@@ -1102,33 +1201,40 @@ static void __declspec(naked) HOOK_CMotorBike_ProcessStuff_PushSirenPositionRed(
             // Return control
             JMP RETN_CMotorBike_ProcessStuff_PushSirenPositionDualRed
         }
+        // clang-format on
     }
 }
 DWORD RETN_CMotorbike_ProcessStuff_TestVehicleModel2 = 0x6BD41B;
 static void __declspec(naked) HOOK_CMotorbike_ProcessStuff_TestVehicleModel()
 {
+    // clang-format off
     __asm
     {
         pushad
         mov pVehicleWithTheSiren, esi
     }
+    // clang-format on
     if (TestVehicleForSiren())
     {
+        // clang-format off
         __asm
         {
             popad
             cmp word ptr [esi+22h], 20Bh
             jmp RETN_CMotorbike_ProcessStuff_TestVehicleModel2
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
             cmp word ptr [esi+22h], 20Bh
             jmp RETN_CMotorbike_ProcessStuff_TestVehicleModel
         }
+        // clang-format on
     }
 }
 DWORD dwValue = 0x858B4C;
@@ -1136,14 +1242,19 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PushRGBPointLights()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
         mov esi, pVehicleWithTheSiren
     }
+
+    // clang-format on
     bPointLights = true;
     if (ProcessVehicleSirenPosition())
     {
+        // clang-format off
         __asm
         {
             popad
@@ -1164,9 +1275,11 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PushRGBPointLights()
             fild    dword ptr [esp+30h]
             JMP RETN_CVehicle_ProcessStuff_PushRGBPointLights
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
@@ -1183,6 +1296,7 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PushRGBPointLights()
             fild    dword ptr [esp+30h]
             JMP RETN_CVehicle_ProcessStuff_PushRGBPointLights
         }
+        // clang-format on
     }
 }
 
@@ -1190,13 +1304,18 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_StartPointLightCode()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
         mov pVehicleWithTheSiren, esi
     }
+
+    // clang-format on
     if (DoesVehicleHaveSiren())
     {
+        // clang-format off
         __asm
         {
             popad
@@ -1205,9 +1324,11 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_StartPointLightCode()
             fadd st, st
             jmp RETN_CVehicle_ProcessStuff_StartPointLightCode
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
@@ -1215,6 +1336,7 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_StartPointLightCode()
             mov     [esp+50h], eax
             jmp RETN_CVehicle_ProcessStuff_IgnorePointLightCode
         }
+        // clang-format on
     }
 }
 // Water Cannon Stuff
@@ -1241,6 +1363,8 @@ static void __declspec(naked) HOOK_CEventHitByWaterCannon()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -1251,17 +1375,22 @@ static void __declspec(naked) HOOK_CEventHitByWaterCannon()
         mov pPedHitByWaterCannonInterface, esi
         mov pVehicleWithTheCannonMounted, eax
     }
+
+    // clang-format on
     if (TriggerTheEvent())
     {
+        // clang-format off
         __asm
         {
             popad
             // Cancel.
             jmp RETURN_CWaterCannon_PushPeds_RETN_Cancel
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
@@ -1274,6 +1403,7 @@ static void __declspec(naked) HOOK_CEventHitByWaterCannon()
             // Go back to execution
             jmp RETURN_CWaterCannon_PushPeds_RETN
         }
+        // clang-format on
     }
 }
 CPedSAInterface* pPedUsingJetpack;
@@ -1287,12 +1417,14 @@ bool             IsUsingJetPack()
         {
             DWORD CPedIntelligence_FindJetpackTask = 0x601110;
             DWORD dwReturn = 0;
+            // clang-format off
             __asm
             {
                 mov ecx, dwJetpackPedIntelligence
                 call CPedIntelligence_FindJetpackTask
                 mov dwReturn, eax
             }
+            // clang-format on
             return dwReturn > 0;
         }
     }
@@ -1318,26 +1450,34 @@ static void __declspec(naked) HOOK_CTaskSimpleJetpack_ProcessInput()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov pPedUsingJetpack, edi
         pushad
     }
+
+    // clang-format on
     if (AllowJetPack())
     {
+        // clang-format off
         __asm
         {
             popad
             jmp RETN_CTaskSimpleJetpack_ProcessInputEnable
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
             jmp RETN_CTaskSimpleJetpack_ProcessInputDisabled
         }
+        // clang-format on
     }
 }
 
@@ -1345,28 +1485,36 @@ static void __declspec(naked) HOOK_CTaskSimplePlayerOnFoot_ProcessWeaponFire()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
         mov pPedUsingJetpack, esi
     }
+
+    // clang-format on
     if (AllowJetPack())
     {
+        // clang-format off
         __asm
         {
             popad
             xor al, al
             jmp RETN_CTaskSimplePlayerOnFoot_ProcessWeaponFire
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
             call RETN_CTaskSimplePlayerOnFoot_ProcessWeaponFire_Call
             jmp RETN_CTaskSimplePlayerOnFoot_ProcessWeaponFire
         }
+        // clang-format on
     }
 }
 
@@ -1390,6 +1538,7 @@ static void __declspec(naked) HOOK_CWorld_RemoveFallenPeds()
 
     // If it's going to skip the code anyway just do it otherwise check if he's in a vehicle as the vehicle will be respawned anyway and he will be warped with
     // it.
+    // clang-format off
     __asm
     {
         test ah, 5
@@ -1397,20 +1546,25 @@ static void __declspec(naked) HOOK_CWorld_RemoveFallenPeds()
         pushad
         mov pFallingPedInterface, esi
     }
+    // clang-format on
     if (CWorld_Remove_FallenPedsCheck())
     {
+        // clang-format off
         __asm
         {
             popad
 RemoveFallenPeds_Cancel:
             jmp RETURN_CWorld_RemoveFallenPeds_Cancel
         }
+        // clang-format on
     }
+    // clang-format off
     __asm
     {
         popad
         jmp RETURN_CWorld_RemoveFallenPeds_Cont
     }
+    // clang-format on
 }
 
 void CMultiplayerSA::SetVehicleFellThroughMapHandler(VehicleFellThroughMapHandler* pHandler)
@@ -1439,19 +1593,24 @@ static void __declspec(naked) HOOK_CWorld_RemoveFallenCars()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // If the vehicle fell through the map give it another try to respawn.
+    // clang-format off
     __asm
     {
         pushad
         mov pFallingVehicleInterface, esi
     }
+    // clang-format on
     if (CWorld_Remove_FallenVehiclesCheck())
     {
+        // clang-format off
         __asm
         {
             popad
             jmp RETURN_CWorld_RemoveFallenCars_Cancel
         }
+        // clang-format on
     }
+    // clang-format off
     __asm
     {
         popad
@@ -1463,6 +1622,7 @@ static void __declspec(naked) HOOK_CWorld_RemoveFallenCars()
      RemoveFallenCars_Cancel:
         jmp HOOK_CWorld_RemoveFallenCars_Cont1
     }
+    // clang-format on
 }
 
 void CMultiplayerSA::SetPedTargetingMarkerEnabled(bool bEnable)
@@ -1508,15 +1668,18 @@ static void __declspec(naked) HOOK_CVehicleModelInterface_SetClump()
 
     // Grab our currently loading clump
     // Get our Handling ID because that's all that's in the interface
+    // clang-format off
     __asm
     {
         pushad
         mov pLoadingClump, eax
         mov pLoadingModelInfo, esi
     }
+    // clang-format on
     //   Init our supported upgrades structure for this model info
     CVehicleModelInterface_SetClump();
     // Perform overwrite sequence and jump back
+    // clang-format off
     __asm
     {
         popad
@@ -1525,11 +1688,14 @@ static void __declspec(naked) HOOK_CVehicleModelInterface_SetClump()
         mov dword ptr [esp+14h], 0FFFFFFFFh
         jmp RETURN_CVehicleModelInterface_SetClump
     }
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CBoat_ApplyDamage()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -1541,18 +1707,24 @@ static void __declspec(naked) HOOK_CBoat_ApplyDamage()
         fst  dword ptr [esi+4C0h]
     }
 
+    // clang-format on
+
 boatCanBeDamaged:
+    // clang-format off
     __asm
     {
         pop eax
         jmp RETURN_CBoat_ApplyDamage
     }
+    // clang-format on
 }
 
 // fixes a crash where a vehicle is the source of a tear gas projectile.
 static void __declspec(naked) HOOK_CProjectile_FixTearGasCrash()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -1567,6 +1739,8 @@ static void __declspec(naked) HOOK_CProjectile_FixTearGasCrash()
         // dundundundundun
         // dundundundundun
     }
+
+    // clang-format on
 }
 
 void CMultiplayerSA::SetBoatWaterSplashEnabled(bool bEnabled)
@@ -1620,20 +1794,28 @@ static void __declspec(naked) HOOK_CMultiplayerSA_ToggleTyreSmoke()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
         mov pTyreSmokePed, ecx
     }
 
+    // clang-format on
+
     if (!IsPlayerPedLocal())
     {
+        // clang-format off
         __asm
         {
             popad
             jmp dwReturnIgnorePed
         }
+        // clang-format on
     }
+
+    // clang-format off
 
     __asm
     {
@@ -1645,6 +1827,8 @@ static void __declspec(naked) HOOK_CMultiplayerSA_ToggleTyreSmoke()
     ToggleTyreSmoke_Cancel:
         jmp dwReturnIgnorePed
     }
+
+    // clang-format on
 }
 
 void CMultiplayerSA::SetTyreSmokeEnabled(bool bEnabled)
@@ -1715,12 +1899,17 @@ static void __declspec(naked) HOOK_CProjectile_FixExplosionLocation()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov pExplosionEntity, esi
         pushad
     }
+
+    // clang-format on
     UpdateExplosionLocation();
+    // clang-format off
     __asm
     {
         popad
@@ -1733,12 +1922,15 @@ skip:
         lea eax, [esi+4]
         jmp RETURN_CProjectile_FixExplosionLocation
     }
+    // clang-format on
 }
 
 DWORD CPed_RemoveWeaponWhenEnteringVehicle_CalledFrom = 0;
 static void __declspec(naked) HOOK_CPed_RemoveWeaponWhenEnteringVehicle()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -1752,26 +1944,36 @@ static void __declspec(naked) HOOK_CPed_RemoveWeaponWhenEnteringVehicle()
         mov eax, [esi+480h]
     }
 
+    // clang-format on
+
     // Called from CTaskSimpleJetPack::ProcessPed
     if (CPed_RemoveWeaponWhenEnteringVehicle_CalledFrom == 0x68025F)
     {
+        // clang-format off
         __asm
         {
             mov pPedUsingJetpack, esi
         }
+        // clang-format on
 
         if (AllowJetPack())
         {
+            // clang-format off
             __asm
             {
                 pop esi
                 retn 4
             }
+            // clang-format on
         }
     }
+
+    // clang-format off
 
     __asm
     {
         jmp RETURN_CPed_RemoveWeaponWhenEnteringVehicle
     }
+
+    // clang-format on
 }

--- a/Client/multiplayer_sa/CMultiplayerSA_1.3.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_1.3.cpp
@@ -340,7 +340,6 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_TestSirenTypeSingle()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -351,7 +350,6 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_TestSirenTypeSingle()
         // Grab our siren vehicle
         mov pVehicleWithTheSiren, esi
     }
-
     // clang-format on
     //   Call our Get siren type function which edits dwSirenType to our desired type
     GetVehicleSirenType();
@@ -579,7 +577,6 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PostPushSirenPositionSi
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Get our siren position into edx
@@ -590,7 +587,6 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PostPushSirenPositionSi
         // Put edx into our position variable
         mov vecRelativeSirenPosition, edx
     }
-
     // clang-format on
     bPointLights = false;
     // Call our main siren Process function
@@ -654,7 +650,6 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_TestSirenTypeDual()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Grab our default siren type into edi
@@ -665,7 +660,6 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_TestSirenTypeDual()
         // Store our post hook default siren type
         mov dwSirenTypePostHook, edi
     }
-
     // clang-format on
     //   Do our test and edit dwSirenType2 appropriately
     TestSirenTypeDualDefaultFix();
@@ -686,7 +680,6 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PostPushSirenPositionDu
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Grab our siren position vector
@@ -701,7 +694,6 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PostPushSirenPositionDu
         mov dwGreen, edx
         mov dwBlue, ecx
     }
-
     // clang-format on
     bPointLights = false;
 
@@ -757,7 +749,6 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PostPushSirenPositionDu
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Grab our siren position vector
@@ -771,7 +762,6 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PostPushSirenPositionDu
         mov dwGreen, edx
         mov dwBlue, ecx
     }
-
     // clang-format on
     bPointLights = false;
 
@@ -845,14 +835,12 @@ static void __declspec(naked) HOOK_CVehicle_DoesVehicleUseSiren()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
         // Grab our vehicle interface
         mov pVehicleWithTheSiren, ecx
     }
-
     // clang-format on
     //   Test our vehicle for sirens
     if (TestVehicleForSiren())
@@ -908,14 +896,12 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_TestCameraPosition()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
         // Grab our vehicle
         mov pVehicleWithTheSiren, esi
     }
-
     // clang-format on
     //   Check if we disable or enable the 360 effect
     if (SirenCheckCameraPosition())
@@ -965,12 +951,10 @@ static void __declspec(naked) HOOK_CVehicleAudio_ProcessSirenSound()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
     if (DisableVehicleSiren())
     {
@@ -1001,24 +985,20 @@ static void __declspec(naked) HOOK_CVehicleAudio_ProcessSirenSound1()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov pVehicleWithTheSiren, edi
         pushad
     }
-
     // clang-format on
 
     // clang-format off
-
     __asm
     {
         popad
         call CALL_CVehicleAudio_ProcessCarHorn
         jmp RETN_CVehicleAudio_ProcessSirenSound1
     }
-
     // clang-format on
 }
 
@@ -1027,24 +1007,20 @@ static void __declspec(naked) HOOK_CVehicleAudio_ProcessSirenSound2()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov pVehicleWithTheSiren, edi
         pushad
     }
-
     // clang-format on
 
     // clang-format off
-
     __asm
     {
         popad
         call CALL_CVehicleAudio_ProcessCarHorn
         jmp RETN_CVehicleAudio_ProcessSirenSound2
     }
-
     // clang-format on
 }
 
@@ -1053,24 +1029,20 @@ static void __declspec(naked) HOOK_CVehicleAudio_ProcessSirenSound3()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov pVehicleWithTheSiren, edi
         pushad
     }
-
     // clang-format on
 
     // clang-format off
-
     __asm
     {
         popad
         call CALL_CVehicleAudio_ProcessCarHorn
         jmp RETN_CVehicleAudio_ProcessSirenSound3
     }
-
     // clang-format on
 }
 
@@ -1081,7 +1053,6 @@ static void __declspec(naked) HOOK_CMotorBike_ProcessStuff_PushSirenPositionBlue
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Grab our siren position vector
@@ -1092,7 +1063,6 @@ static void __declspec(naked) HOOK_CMotorBike_ProcessStuff_PushSirenPositionBlue
         // move our position vector pointer into our position variable
         mov vecRelativeSirenPosition, eax
     }
-
     // clang-format on
 
     bPointLights = false;
@@ -1145,7 +1115,6 @@ static void __declspec(naked) HOOK_CMotorBike_ProcessStuff_PushSirenPositionRed(
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -1154,7 +1123,6 @@ static void __declspec(naked) HOOK_CMotorBike_ProcessStuff_PushSirenPositionRed(
         // move our position vector pointer into our position variable
         mov vecRelativeSirenPosition, edx
     }
-
     // clang-format on
 
     bPointLights = false;
@@ -1243,13 +1211,11 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_PushRGBPointLights()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
         mov esi, pVehicleWithTheSiren
     }
-
     // clang-format on
     bPointLights = true;
     if (ProcessVehicleSirenPosition())
@@ -1305,13 +1271,11 @@ static void __declspec(naked) HOOK_CVehicle_ProcessStuff_StartPointLightCode()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
         mov pVehicleWithTheSiren, esi
     }
-
     // clang-format on
     if (DoesVehicleHaveSiren())
     {
@@ -1364,7 +1328,6 @@ static void __declspec(naked) HOOK_CEventHitByWaterCannon()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -1375,7 +1338,6 @@ static void __declspec(naked) HOOK_CEventHitByWaterCannon()
         mov pPedHitByWaterCannonInterface, esi
         mov pVehicleWithTheCannonMounted, eax
     }
-
     // clang-format on
     if (TriggerTheEvent())
     {
@@ -1451,13 +1413,11 @@ static void __declspec(naked) HOOK_CTaskSimpleJetpack_ProcessInput()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov pPedUsingJetpack, edi
         pushad
     }
-
     // clang-format on
     if (AllowJetPack())
     {
@@ -1486,13 +1446,11 @@ static void __declspec(naked) HOOK_CTaskSimplePlayerOnFoot_ProcessWeaponFire()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
         mov pPedUsingJetpack, esi
     }
-
     // clang-format on
     if (AllowJetPack())
     {
@@ -1696,7 +1654,6 @@ static void __declspec(naked) HOOK_CBoat_ApplyDamage()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push eax
@@ -1706,7 +1663,6 @@ static void __declspec(naked) HOOK_CBoat_ApplyDamage()
         jz   boatCanBeDamaged
         fst  dword ptr [esi+4C0h]
     }
-
     // clang-format on
 
 boatCanBeDamaged:
@@ -1725,7 +1681,6 @@ static void __declspec(naked) HOOK_CProjectile_FixTearGasCrash()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         cmp ebp, 0h
@@ -1739,7 +1694,6 @@ static void __declspec(naked) HOOK_CProjectile_FixTearGasCrash()
         // dundundundundun
         // dundundundundun
     }
-
     // clang-format on
 }
 
@@ -1795,13 +1749,11 @@ static void __declspec(naked) HOOK_CMultiplayerSA_ToggleTyreSmoke()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
         mov pTyreSmokePed, ecx
     }
-
     // clang-format on
 
     if (!IsPlayerPedLocal())
@@ -1816,7 +1768,6 @@ static void __declspec(naked) HOOK_CMultiplayerSA_ToggleTyreSmoke()
     }
 
     // clang-format off
-
     __asm
     {
         popad
@@ -1827,7 +1778,6 @@ static void __declspec(naked) HOOK_CMultiplayerSA_ToggleTyreSmoke()
     ToggleTyreSmoke_Cancel:
         jmp dwReturnIgnorePed
     }
-
     // clang-format on
 }
 
@@ -1900,13 +1850,11 @@ static void __declspec(naked) HOOK_CProjectile_FixExplosionLocation()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov pExplosionEntity, esi
         pushad
     }
-
     // clang-format on
     UpdateExplosionLocation();
     // clang-format off
@@ -1931,7 +1879,6 @@ static void __declspec(naked) HOOK_CPed_RemoveWeaponWhenEnteringVehicle()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push eax
@@ -1943,7 +1890,6 @@ static void __declspec(naked) HOOK_CPed_RemoveWeaponWhenEnteringVehicle()
         mov esi, ecx
         mov eax, [esi+480h]
     }
-
     // clang-format on
 
     // Called from CTaskSimpleJetPack::ProcessPed
@@ -1969,11 +1915,9 @@ static void __declspec(naked) HOOK_CPed_RemoveWeaponWhenEnteringVehicle()
     }
 
     // clang-format off
-
     __asm
     {
         jmp RETURN_CPed_RemoveWeaponWhenEnteringVehicle
     }
-
     // clang-format on
 }

--- a/Client/multiplayer_sa/CMultiplayerSA_ClothesCache.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_ClothesCache.cpp
@@ -381,6 +381,8 @@ static void __declspec(naked) HOOK_CClothesBuilderCreateSkinnedClump()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -424,6 +426,8 @@ inside:
         sub     esp, 0D4h
         jmp     RETURN_CClothesBuilderCreateSkinnedClump
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_ClothesCache.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_ClothesCache.cpp
@@ -382,7 +382,6 @@ static void __declspec(naked) HOOK_CClothesBuilderCreateSkinnedClump()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -426,7 +425,6 @@ inside:
         sub     esp, 0D4h
         jmp     RETURN_CClothesBuilderCreateSkinnedClump
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_ClothesMemFix.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_ClothesMemFix.cpp
@@ -23,23 +23,27 @@ void CPedModelInfo_DeleteRwObject(CBaseModelInfoSAInterface* pModelInfo)
 {
     DWORD                      dwFunction = FUNC_CPedModelInfo_DeleteRwObject;
     CBaseModelInfoSAInterface* pInterface = pModelInfo;
+    // clang-format off
     __asm
     {
         mov     ecx, pInterface
         call    dwFunction
     }
+    // clang-format on
 }
 
 void CPedModelInfo_SetClump(CBaseModelInfoSAInterface* pModelInfo, RwObject* pSavedRwObject)
 {
     DWORD                      dwFunction = FUNC_CPedModelInfo_SetClump;
     CBaseModelInfoSAInterface* pInterface = pModelInfo;
+    // clang-format off
     __asm
     {
         push    pSavedRwObject
         mov     ecx, pInterface
         call    dwFunction
     }
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -65,6 +69,8 @@ static void __declspec(naked) HOOK_CClothesDeleteRwObject()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -77,6 +83,8 @@ static void __declspec(naked) HOOK_CClothesDeleteRwObject()
         //call    dword ptr [edx+20h] //; 004C6C50 ; void CPedModelInfo::DeleteRwObject()
         jmp     RETURN_CClothesDeleteRwObject
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -104,6 +112,8 @@ static void __declspec(naked) HOOK_PostCPedDress()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -116,6 +126,8 @@ static void __declspec(naked) HOOK_PostCPedDress()
         push    eax
         jmp     RETURN_PostCPedDress
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_ClothesMemFix.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_ClothesMemFix.cpp
@@ -70,7 +70,6 @@ static void __declspec(naked) HOOK_CClothesDeleteRwObject()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -83,7 +82,6 @@ static void __declspec(naked) HOOK_CClothesDeleteRwObject()
         //call    dword ptr [edx+20h] //; 004C6C50 ; void CPedModelInfo::DeleteRwObject()
         jmp     RETURN_CClothesDeleteRwObject
     }
-
     // clang-format on
 }
 
@@ -113,7 +111,6 @@ static void __declspec(naked) HOOK_PostCPedDress()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -126,7 +123,6 @@ static void __declspec(naked) HOOK_PostCPedDress()
         push    eax
         jmp     RETURN_PostCPedDress
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_ClothesSpeedUp.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_ClothesSpeedUp.cpp
@@ -132,7 +132,6 @@ static void __declspec(naked) HOOK_CallCStreamingInfoAddToList()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -167,7 +166,6 @@ skip:
         add     esp, 4*1
         jmp     RETURN_CallCStreamingInfoAddToListB
     }
-
     // clang-format on
 }
 
@@ -198,7 +196,6 @@ static void __declspec(naked) HOOK_CStreamingLoadRequestedModels()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -218,7 +215,6 @@ skip:
         popad
         jmp     RETURN_CStreamingLoadRequestedModelsB
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_ClothesSpeedUp.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_ClothesSpeedUp.cpp
@@ -131,6 +131,8 @@ static void __declspec(naked) HOOK_CallCStreamingInfoAddToList()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -165,6 +167,8 @@ skip:
         add     esp, 4*1
         jmp     RETURN_CallCStreamingInfoAddToListB
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -193,6 +197,8 @@ static void __declspec(naked) HOOK_CStreamingLoadRequestedModels()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -212,6 +218,8 @@ skip:
         popad
         jmp     RETURN_CStreamingLoadRequestedModelsB
     }
+
+    // clang-format on
 }
 
 //
@@ -242,6 +250,7 @@ static void __declspec(naked) HOOK_LoadingPlayerImgDir()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // hook from 005A69E3 5 bytes
+    // clang-format off
     __asm
     {
         pushad
@@ -260,6 +269,7 @@ skip:
         popad
         jmp     RETURN_LoadingPlayerImgDirB
     }
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_CrashFixHacks.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_CrashFixHacks.cpp
@@ -33,7 +33,6 @@ static void __declspec(naked) CrashAverted()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
         {
         pushfd
@@ -45,7 +44,6 @@ static void __declspec(naked) CrashAverted()
         popfd
         retn    4
         }
-
     // clang-format on
 }
 
@@ -199,7 +197,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc1()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     eax,dword ptr [esp+18h]
@@ -216,7 +213,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc1()
     cont:
         jmp     RETURN_CrashFix_Misc1
     }
-
     // clang-format on
 }
 
@@ -234,7 +230,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc2()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         test    eax,eax
@@ -257,7 +252,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc2()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc2B
     }
-
     // clang-format on
 }
 
@@ -275,7 +269,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc4()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         test    ecx,ecx
@@ -290,7 +283,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc4()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc4B
     }
-
     // clang-format on
 }
 
@@ -307,10 +299,7 @@ static void __declspec(naked) HOOK_CrashFix_Misc5()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
-    // clang-format off
-
-    __asm
-    {
+    __asm {
         mov edi, dword ptr[ARRAY_ModelInfo]
         mov     edi, dword ptr [ecx*4+edi]
         mov     edi, dword ptr [edi+5Ch]
@@ -326,8 +315,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc5()
         pop edi
         jmp     RETURN_CrashFix_Misc5B
     }
-
-    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -346,7 +333,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc6()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         test    ecx, ecx
@@ -360,7 +346,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc6()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc6B
     }
-
     // clang-format on
 }
 
@@ -380,7 +365,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc7()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         test    ecx, ecx
@@ -394,7 +378,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc7()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc7B
     }
-
     // clang-format on
 }
 
@@ -414,7 +397,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc8()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         test    ecx, ecx
@@ -428,7 +410,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc8()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc8B
     }
-
     // clang-format on
 }
 
@@ -448,7 +429,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc9()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         test    esi, esi
@@ -462,7 +442,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc9()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc9B
     }
-
     // clang-format on
 }
 
@@ -482,7 +461,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc10()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         cmp     ecx, 0x80
@@ -500,7 +478,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc10()
         mov     dword ptr [ecx+8],0
         jmp     RETURN_CrashFix_Misc10B
     }
-
     // clang-format on
 }
 
@@ -520,7 +497,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc11()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         test    ecx, ecx
@@ -534,7 +510,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc11()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc11B
     }
-
     // clang-format on
 }
 
@@ -554,7 +529,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc12()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         test    edi, edi
@@ -568,7 +542,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc12()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc12B
     }
-
     // clang-format on
 }
 
@@ -586,7 +559,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc13()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         cmp     eax, 0x2480
@@ -600,7 +572,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc13()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc13B
     }
-
     // clang-format on
 }
 
@@ -617,7 +588,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc14()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
         {
         mov     eax, dword ptr ds:[0BD00F8h]
@@ -632,7 +602,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc14()
         add     esp, 12
         retn    12
         }
-
     // clang-format on
 }
 
@@ -668,7 +637,6 @@ static void __declspec(naked) HOOK_FreezeFix_Misc15()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pop eax
@@ -682,7 +650,6 @@ static void __declspec(naked) HOOK_FreezeFix_Misc15()
         popad
         jmp     RETURN_FreezeFix_Misc15
     }
-
     // clang-format on
 }
 
@@ -699,7 +666,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc16()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         cmp     eax, 0
@@ -716,7 +682,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc16()
         add     esp, 96
         retn
     }
-
     // clang-format on
 }
 
@@ -734,7 +699,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc17()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         cmp     eax, 0
@@ -749,7 +713,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc17()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc17B
     }
-
     // clang-format on
 }
 
@@ -766,7 +729,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc18()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
         {
         cmp     ebp, 0
@@ -789,7 +751,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc18()
         pop         ebp
         ret         0Ch
         }
-
     // clang-format on
 }
 
@@ -807,7 +768,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc19()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         cmp     esi, 0
@@ -824,7 +784,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc19()
         test    edx,edx
         jmp     RETURN_CrashFix_Misc19B
     }
-
     // clang-format on
 }
 
@@ -841,7 +800,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc20()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         cmp     ecx, 0
@@ -857,7 +815,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc20()
         call    CrashAverted
         retn
     }
-
     // clang-format on
 }
 
@@ -898,7 +855,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc21()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -920,7 +876,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc21()
         call    CrashAverted
         retn
     }
-
     // clang-format on
 }
 
@@ -937,7 +892,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc22()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov         edx,dword ptr [edi+0Ch]
@@ -975,7 +929,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc22()
         jl          altcode
         jmp     RETURN_CrashFix_Misc22
     }
-
     // clang-format on
 }
 
@@ -992,7 +945,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc23()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Ensure door index is reasonable
@@ -1012,7 +964,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc23()
         lea     eax, [edx+edx*2]
         jmp     RETURN_CrashFix_Misc23
     }
-
     // clang-format on
 }
 
@@ -1029,7 +980,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc24()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         cmp     ebp, 0x480
@@ -1046,7 +996,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc24()
         mov     eax, 0
         jmp     RETURN_CrashFix_Misc24
     }
-
     // clang-format on
 }
 
@@ -1063,7 +1012,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc25()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Check for zero pointer to vehicle
@@ -1084,7 +1032,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc25()
         pop     ecx
         retn
     }
-
     // clang-format on
 }
 
@@ -1101,7 +1048,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc26()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Check for incorrect pointer
@@ -1123,7 +1069,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc26()
         test    edi,edi
         jmp     RETURN_CrashFix_Misc26
     }
-
     // clang-format on
 }
 
@@ -1140,7 +1085,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc27()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Execute replaced code
@@ -1158,7 +1102,6 @@ cont:
         // Continue standard path
         jmp     RETURN_CrashFix_Misc27
     }
-
     // clang-format on
 }
 
@@ -1176,7 +1119,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc28()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Execute replaced code
@@ -1195,7 +1137,6 @@ cont:
         // Continue standard path
         jmp     RETURN_CrashFix_Misc28
     }
-
     // clang-format on
 }
 
@@ -1213,7 +1154,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc29()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Execute replaced code
@@ -1232,7 +1172,6 @@ cont:
             // Skip much code
         jmp     RETURN_CrashFix_Misc29B
     }
-
     // clang-format on
 }
 
@@ -1251,7 +1190,6 @@ static void __declspec(naked) HOOK_CrashFix_Misc30()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Check for incorrect pointer
@@ -1269,7 +1207,6 @@ cont:
             // Skip much code
         jmp     RETURN_CrashFix_Misc30B
     }
-
     // clang-format on
 }
 
@@ -1512,7 +1449,6 @@ static void _declspec(naked) HOOK_CrashFix_Misc36()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         cmp     ebx, 40000000h
@@ -1550,7 +1486,6 @@ static void _declspec(naked) HOOK_CrashFix_Misc36()
     ok:
         jmp     RETURN_CrashFix_Misc36
     }
-
     // clang-format on
 }
 
@@ -1631,7 +1566,6 @@ static void _declspec(naked) HOOK_CrashFix_Misc38()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     esi, [eax]
@@ -1649,7 +1583,6 @@ static void _declspec(naked) HOOK_CrashFix_Misc38()
         lea     ecx, [esp+ecx*4+18h]
         jmp     RETURN_CrashFix_Misc38
     }
-
     // clang-format on
 }
 
@@ -1737,7 +1670,6 @@ static void __declspec(naked) HOOK_CClumpModelInfo_GetFrameFromId()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push    [esp+4*2]
@@ -1765,7 +1697,6 @@ inner:
         mov     eax,dword ptr [esp+10h]
         jmp     RETURN_CClumpModelInfo_GetFrameFromId
     }
-
     // clang-format on
 }
 
@@ -1830,7 +1761,6 @@ static void __declspec(naked) HOOK_CEntity_GetBoundRect()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -1844,7 +1774,6 @@ static void __declspec(naked) HOOK_CEntity_GetBoundRect()
         mov     edx, [eax]
         jmp     RETURN_CEntity_GetBoundRect
     }
-
     // clang-format on
 }
 
@@ -1877,7 +1806,6 @@ static void __declspec(naked) HOOK_CVehicle_AddUpgrade()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -1902,7 +1830,6 @@ inner:
         mov     ebx, [esp+16]
         jmp     RETURN_CVehicle_AddUpgrade
     }
-
     // clang-format on
 }
 
@@ -1931,7 +1858,6 @@ static void __declspec(naked) HOOK_TrainCrossingBarrierCrashFix()
     TrainCrossingFix_InvalidReturnAddress = InvalidReturnAddress;
 
     // clang-format off
-
     __asm
     {
         test eax, eax            // Check if pLinkedBarrierPost exists
@@ -1943,7 +1869,6 @@ static void __declspec(naked) HOOK_TrainCrossingBarrierCrashFix()
 jmp_invalid:
         jmp TrainCrossingFix_InvalidReturnAddress
     }
-
     // clang-format on
 }
 
@@ -1962,14 +1887,12 @@ static void __declspec(naked) HOOK_ResetFurnitureObjectCounter()
     *(int*)0xBB3A18 = 0;            // InteriorManager_c::ms_objectCounter
 
     // clang-format off
-
     __asm
     {
         // original instruction
         mov eax, fs:[0]
         jmp RETURN_ResetFurnitureObjectCounter
     }
-
     // clang-format on
 }
 
@@ -1999,7 +1922,6 @@ static void __declspec(naked) HOOK_CVolumetricShadowMgr_Render()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -2019,7 +1941,6 @@ inner:
         mov     ecx, 0A9AE00h
         jmp     RETURN_CVolumetricShadowMgr_Render
     }
-
     // clang-format on
 }
 
@@ -2049,7 +1970,6 @@ static void __declspec(naked) HOOK_CVolumetricShadowMgr_Update()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -2070,7 +1990,6 @@ inner:
         mov     ecx, 0A9AE00h
         jmp     RETURN_CVolumetricShadowMgr_Update
     }
-
     // clang-format on
 }
 
@@ -2103,7 +2022,6 @@ static void __declspec(naked) HOOK_CAnimManager_CreateAnimAssocGroups()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -2120,7 +2038,6 @@ static void __declspec(naked) HOOK_CAnimManager_CreateAnimAssocGroups()
 
         jmp     RETURN_CAnimManager_CreateAnimAssocGroups
     }
-
     // clang-format on
 }
 
@@ -2144,7 +2061,6 @@ static void __declspec(naked) HOOK_CTaskComplexCarSlowBeDraggedOut_CreateFirstSu
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         test eax, eax
@@ -2159,7 +2075,6 @@ static void __declspec(naked) HOOK_CTaskComplexCarSlowBeDraggedOut_CreateFirstSu
         popad
         jmp RETURN_CTaskComplexCarSlowBeDraggedOut_CreateFirstSubTask_Invalid
     }
-
     // clang-format on
 }
 
@@ -2207,7 +2122,6 @@ static void __declspec(naked) HOOK_printf()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -2222,7 +2136,6 @@ static void __declspec(naked) HOOK_printf()
         push    887DC0h
         jmp     RETURN_printf
     }
-
     // clang-format on
 }
 
@@ -2240,7 +2153,6 @@ static void __declspec(naked) HOOK_RwMatrixMultiply()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     eax, [esp+0Ch]
@@ -2255,7 +2167,6 @@ cont:
         call    CrashAverted
         retn
     }
-
     // clang-format on
 }
 
@@ -2373,7 +2284,6 @@ static void __declspec(naked) HOOK_CStreaming_AreAnimsUsedByRequestedModels()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push    [esp + 4]
@@ -2381,7 +2291,6 @@ static void __declspec(naked) HOOK_CStreaming_AreAnimsUsedByRequestedModels()
         add     esp, 0x4
         retn
     }
-
     // clang-format on
 }
 
@@ -2444,7 +2353,6 @@ static void __declspec(naked) HOOK_CTrain__ProcessControl()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -2454,7 +2362,6 @@ static void __declspec(naked) HOOK_CTrain__ProcessControl()
         popad
         jmp     CONTINUE_CTrain__ProcessControl
     }
-
     // clang-format on
 }
 
@@ -2482,7 +2389,6 @@ static void __declspec(naked) HOOK_CTaskComplexCarSlowBeDraggedOutAndStandUp__Cr
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
         {
         test    eax, eax
@@ -2498,7 +2404,6 @@ static void __declspec(naked) HOOK_CTaskComplexCarSlowBeDraggedOutAndStandUp__Cr
         pop     esi
         retn    4
         }
-
     // clang-format on
 }
 
@@ -2529,7 +2434,6 @@ static void __declspec(naked) HOOK_CVehicleModelInfo__LoadVehicleColours_1()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         test    eax, eax
@@ -2551,7 +2455,6 @@ static void __declspec(naked) HOOK_CVehicleModelInfo__LoadVehicleColours_1()
         lea     eax, [edi - 1]
         jmp     CONTINUE_CVehicleModelInfo__LoadVehicleColours_1
     }
-
     // clang-format on
 }
 
@@ -2569,7 +2472,6 @@ static void __declspec(naked) HOOK_CVehicleModelInfo__LoadVehicleColours_2()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         test    eax, eax
@@ -2591,7 +2493,6 @@ static void __declspec(naked) HOOK_CVehicleModelInfo__LoadVehicleColours_2()
         lea     eax, [edi - 1]
         jmp     CONTINUE_CVehicleModelInfo__LoadVehicleColours_2
     }
-
     // clang-format on
 }
 
@@ -2614,7 +2515,6 @@ static void __declspec(naked) HOOK_CPlaceName__Process()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -2632,7 +2532,6 @@ static void __declspec(naked) HOOK_CPlaceName__Process()
         mov     ecx, [eax + 46Ch]
         jmp     CONTINUE_CPlaceName__Process
     }
-
     // clang-format on
 }
 
@@ -2665,7 +2564,6 @@ static void __declspec(naked) HOOK_CWorld__FindObjectsKindaCollidingSectorList()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov eax, [edx*4+0xA9B0C8]            // CModelInfo::ms_modelInfoPtrs
@@ -2687,7 +2585,6 @@ static void __declspec(naked) HOOK_CWorld__FindObjectsKindaCollidingSectorList()
 
         jmp RETURN_CWorld__FindObjectsKindaCollidingSectorList_SKIP
     }
-
     // clang-format on
 }
 
@@ -2710,7 +2607,6 @@ static void __declspec(naked) HOOK_RpClumpForAllAtomics()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     eax, [esp+4]            // RpClump* clump
@@ -2723,7 +2619,6 @@ static void __declspec(naked) HOOK_RpClumpForAllAtomics()
         push    ebp
         jmp     CONTINUE_RpClumpForAllAtomics
     }
-
     // clang-format on
 }
 
@@ -2744,7 +2639,6 @@ static void __declspec(naked) HOOK_RpAnimBlendClumpGetFirstAssociation()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     eax, [esp+4]            // RpClump* clump
@@ -2756,7 +2650,6 @@ static void __declspec(naked) HOOK_RpAnimBlendClumpGetFirstAssociation()
         mov     ecx, ds:[0xB5F878]
         jmp     CONTINUE_RpAnimBlendClumpGetFirstAssociation
     }
-
     // clang-format on
 }
 
@@ -2778,7 +2671,6 @@ static void __declspec(naked) HOOK_CAnimManager__BlendAnimation()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     eax, [esp+4]            // RpClump* clump
@@ -2791,7 +2683,6 @@ static void __declspec(naked) HOOK_CAnimManager__BlendAnimation()
         mov     ecx, [esp+18h]
         jmp     CONTINUE_CAnimManager__BlendAnimation
     }
-
     // clang-format on
 }
 
@@ -2847,7 +2738,6 @@ static void __declspec(naked) HOOK_FxSystemBP_c__Load()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
         {
         pushad
@@ -2863,7 +2753,6 @@ static void __declspec(naked) HOOK_FxSystemBP_c__Load()
         add     esp, 5E8h
         retn    0Ch
         }
-
     // clang-format on
 }
 
@@ -2885,7 +2774,6 @@ static void __declspec(naked) HOOK_FxPrim_c__Enable()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
         {
         test    ecx, ecx
@@ -2896,7 +2784,6 @@ static void __declspec(naked) HOOK_FxPrim_c__Enable()
         returnFromFunction:
         retn    4
         }
-
     // clang-format on
 }
 
@@ -2916,7 +2803,6 @@ static void __declspec(naked) HOOK_CFire_ProcessFire()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         test byte ptr [esi], 1            // If the "active" flag has been set to 0, we skip processing attached entities
@@ -2930,7 +2816,6 @@ static void __declspec(naked) HOOK_CFire_ProcessFire()
         mov ecx, esi
         jmp SKIP_CFire_ProcessFire
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_CrashFixHacks.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_CrashFixHacks.cpp
@@ -291,7 +291,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc5()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
-    __asm {
+    __asm
+    {
         mov edi, dword ptr[ARRAY_ModelInfo]
         mov     edi, dword ptr [ecx*4+edi]
         mov     edi, dword ptr [edi+5Ch]

--- a/Client/multiplayer_sa/CMultiplayerSA_CrashFixHacks.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_CrashFixHacks.cpp
@@ -32,6 +32,8 @@ static void __declspec(naked) CrashAverted()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
         {
         pushfd
@@ -43,6 +45,8 @@ static void __declspec(naked) CrashAverted()
         popfd
         retn    4
         }
+
+    // clang-format on
 }
 
 static bool HasReadAccess(DWORD dwProtect)
@@ -194,6 +198,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc1()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     eax,dword ptr [esp+18h]
@@ -210,6 +216,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc1()
     cont:
         jmp     RETURN_CrashFix_Misc1
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -224,6 +232,8 @@ DWORD                         RETURN_CrashFix_Misc2B = 0x6B3775;
 static void __declspec(naked) HOOK_CrashFix_Misc2()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -247,6 +257,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc2()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc2B
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -262,6 +274,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc4()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         test    ecx,ecx
@@ -276,6 +290,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc4()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc4B
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -290,6 +306,8 @@ DWORD                         RETURN_CrashFix_Misc5B = 0x5DFCC4;
 static void __declspec(naked) HOOK_CrashFix_Misc5()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -308,6 +326,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc5()
         pop edi
         jmp     RETURN_CrashFix_Misc5B
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -325,6 +345,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc6()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         test    ecx, ecx
@@ -338,6 +360,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc6()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc6B
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -355,6 +379,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc7()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         test    ecx, ecx
@@ -368,6 +394,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc7()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc7B
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -385,6 +413,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc8()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         test    ecx, ecx
@@ -398,6 +428,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc8()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc8B
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -415,6 +447,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc9()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         test    esi, esi
@@ -428,6 +462,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc9()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc9B
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -444,6 +480,8 @@ DWORD                         RETURN_CrashFix_Misc10B = 0x533539;
 static void __declspec(naked) HOOK_CrashFix_Misc10()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -462,6 +500,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc10()
         mov     dword ptr [ecx+8],0
         jmp     RETURN_CrashFix_Misc10B
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -479,6 +519,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc11()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         test    ecx, ecx
@@ -492,6 +534,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc11()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc11B
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -509,6 +553,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc12()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         test    edi, edi
@@ -522,6 +568,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc12()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc12B
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -537,6 +585,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc13()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         cmp     eax, 0x2480
@@ -550,6 +600,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc13()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc13B
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -563,6 +615,8 @@ DWORD                         RETURN_CrashFix_Misc14 = 0x4DD4BB;
 static void __declspec(naked) HOOK_CrashFix_Misc14()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
         {
@@ -578,6 +632,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc14()
         add     esp, 12
         retn    12
         }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -611,6 +667,8 @@ static void __declspec(naked) HOOK_FreezeFix_Misc15()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pop eax
@@ -624,6 +682,8 @@ static void __declspec(naked) HOOK_FreezeFix_Misc15()
         popad
         jmp     RETURN_FreezeFix_Misc15
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -637,6 +697,8 @@ DWORD                         RETURN_CrashFix_Misc16 = 0x5E581B;
 static void __declspec(naked) HOOK_CrashFix_Misc16()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -654,6 +716,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc16()
         add     esp, 96
         retn
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -669,6 +733,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc17()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         cmp     eax, 0
@@ -683,6 +749,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc17()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc17B
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -696,6 +764,8 @@ DWORD                         RETURN_CrashFix_Misc18 = 0x4C7DB4;
 static void __declspec(naked) HOOK_CrashFix_Misc18()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
         {
@@ -719,6 +789,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc18()
         pop         ebp
         ret         0Ch
         }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -733,6 +805,8 @@ DWORD                         RETURN_CrashFix_Misc19B = 0x7F0C20;
 static void __declspec(naked) HOOK_CrashFix_Misc19()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -750,6 +824,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc19()
         test    edx,edx
         jmp     RETURN_CrashFix_Misc19B
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -763,6 +839,8 @@ DWORD                         RETURN_CrashFix_Misc20 = 0x54F3B6;
 static void __declspec(naked) HOOK_CrashFix_Misc20()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -779,6 +857,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc20()
         call    CrashAverted
         retn
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -817,6 +897,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc21()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -838,6 +920,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc21()
         call    CrashAverted
         retn
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -851,6 +935,8 @@ DWORD                         RETURN_CrashFix_Misc22 = 0x4CEF25;
 static void __declspec(naked) HOOK_CrashFix_Misc22()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -889,6 +975,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc22()
         jl          altcode
         jmp     RETURN_CrashFix_Misc22
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -902,6 +990,8 @@ DWORD                         RETURN_CrashFix_Misc23 = 0x6E3D17;
 static void __declspec(naked) HOOK_CrashFix_Misc23()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -922,6 +1012,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc23()
         lea     eax, [edx+edx*2]
         jmp     RETURN_CrashFix_Misc23
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -935,6 +1027,8 @@ DWORD                         RETURN_CrashFix_Misc24 = 0x7F0DCE;
 static void __declspec(naked) HOOK_CrashFix_Misc24()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -952,6 +1046,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc24()
         mov     eax, 0
         jmp     RETURN_CrashFix_Misc24
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -965,6 +1061,8 @@ DWORD                         RETURN_CrashFix_Misc25 = 0x64602B;
 static void __declspec(naked) HOOK_CrashFix_Misc25()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -986,6 +1084,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc25()
         pop     ecx
         retn
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -999,6 +1099,8 @@ DWORD                         RETURN_CrashFix_Misc26 = 0x739FA6;
 static void __declspec(naked) HOOK_CrashFix_Misc26()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -1021,6 +1123,8 @@ static void __declspec(naked) HOOK_CrashFix_Misc26()
         test    edi,edi
         jmp     RETURN_CrashFix_Misc26
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1034,6 +1138,8 @@ DWORD                         RETURN_CrashFix_Misc27 = 0x637802;
 static void __declspec(naked) HOOK_CrashFix_Misc27()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -1052,6 +1158,8 @@ cont:
         // Continue standard path
         jmp     RETURN_CrashFix_Misc27
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1066,6 +1174,8 @@ DWORD                         RETURN_CrashFix_Misc28B = 0x44A650;
 static void __declspec(naked) HOOK_CrashFix_Misc28()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -1085,6 +1195,8 @@ cont:
         // Continue standard path
         jmp     RETURN_CrashFix_Misc28
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1099,6 +1211,8 @@ DWORD                         RETURN_CrashFix_Misc29B = 0x4E0227;
 static void __declspec(naked) HOOK_CrashFix_Misc29()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -1118,6 +1232,8 @@ cont:
             // Skip much code
         jmp     RETURN_CrashFix_Misc29B
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1133,6 +1249,8 @@ DWORD                         RETURN_CrashFix_Misc30B = 0x4CEBF5;
 static void __declspec(naked) HOOK_CrashFix_Misc30()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -1151,6 +1269,8 @@ cont:
             // Skip much code
         jmp     RETURN_CrashFix_Misc30B
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1165,6 +1285,7 @@ DWORD RETURN_CrashFix_Misc32 = 0x4CEA88;
 static void __declspec(naked) HOOK_CrashFix_Misc32()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+    // clang-format off
     __asm
         {
         test    ecx, ecx
@@ -1186,6 +1307,7 @@ static void __declspec(naked) HOOK_CrashFix_Misc32()
         call    CrashAverted
         retn    4
         }
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1203,17 +1325,20 @@ PFN_RwTexDictionaryGetCurrent pfnRwTexDictionaryGetCurrent = (PFN_RwTexDictionar
 static void __declspec(naked) CallOriginalFindNamedTexture()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+    // clang-format off
     __asm
     {
         mov     eax, [esp+4]
         push    ebx
         jmp     RETURN_CrashFix_Misc33
     }
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CrashFix_Misc33()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+    // clang-format off
     __asm
     {
         // Get first argument (dict)
@@ -1268,6 +1393,7 @@ static void __declspec(naked) HOOK_CrashFix_Misc33()
         xor     eax, eax            // Return NULL
         retn            // cdecl
     }
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1293,6 +1419,7 @@ DWORD                         RETURN_CrashFix_Misc34_Skip = 0x5D9E0D;           
 static void __declspec(naked) HOOK_CrashFix_Misc34()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+    // clang-format off
     __asm
     {
         // Replicate original flag check: ZF was set by previous "test al, al"
@@ -1320,6 +1447,7 @@ static void __declspec(naked) HOOK_CrashFix_Misc34()
         call    CrashAverted
         jmp     RETURN_CrashFix_Misc34_Skip
     }
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1336,6 +1464,7 @@ DWORD                 RETURN_CrashFix_Misc35_Abort = 0x7F3760;
 static void _declspec(naked) HOOK_CrashFix_Misc35()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+    // clang-format off
     __asm
     {
         pushad
@@ -1356,6 +1485,7 @@ static void _declspec(naked) HOOK_CrashFix_Misc35()
         add     eax, 0FFFFFFF8h
         jmp     RETURN_CrashFix_Misc35
     }
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1380,6 +1510,8 @@ DWORD RETURN_CrashFix_Misc36_Abort = 0x7F3A5C;
 static void _declspec(naked) HOOK_CrashFix_Misc36()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -1418,6 +1550,8 @@ static void _declspec(naked) HOOK_CrashFix_Misc36()
     ok:
         jmp     RETURN_CrashFix_Misc36
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1433,6 +1567,7 @@ DWORD RETURN_CrashFix_Misc37 = 0x7F39B8;
 static void _declspec(naked) HOOK_CrashFix_Misc37()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+    // clang-format off
     __asm
     {
         pushad
@@ -1461,6 +1596,7 @@ static void _declspec(naked) HOOK_CrashFix_Misc37()
         mov     [ecx], edx
         jmp     RETURN_CrashFix_Misc37
     }
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1494,6 +1630,8 @@ static void _declspec(naked) HOOK_CrashFix_Misc38()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     esi, [eax]
@@ -1511,6 +1649,8 @@ static void _declspec(naked) HOOK_CrashFix_Misc38()
         lea     ecx, [esp+ecx*4+18h]
         jmp     RETURN_CrashFix_Misc38
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1560,6 +1700,7 @@ RwFrame* OnMY_CClumpModelInfo_GetFrameFromId_Post(RwFrame* pFrameResult, DWORD _
         RwFrame* pNewFrameResult = NULL;
         uint     uiNewId = id + (i / 2) * ((i & 1) ? -1 : 1);
         DWORD    dwFunc = 0x4C53C0;            // CClumpModelInfo::GetFrameFromId
+        // clang-format off
         __asm
         {
             push    uiNewId
@@ -1568,6 +1709,7 @@ RwFrame* OnMY_CClumpModelInfo_GetFrameFromId_Post(RwFrame* pFrameResult, DWORD _
             add     esp, 8
             mov     pNewFrameResult,eax
         }
+        // clang-format on
 
         if (pNewFrameResult)
         {
@@ -1593,6 +1735,8 @@ DWORD                         RETURN_CClumpModelInfo_GetFrameFromId = 0x4C53C7;
 static void __declspec(naked) HOOK_CClumpModelInfo_GetFrameFromId()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -1621,6 +1765,8 @@ inner:
         mov     eax,dword ptr [esp+10h]
         jmp     RETURN_CClumpModelInfo_GetFrameFromId
     }
+
+    // clang-format on
 }
 
 CStreamingInfo* GetStreamingInfo(uint id)
@@ -1683,6 +1829,8 @@ static void __declspec(naked) HOOK_CEntity_GetBoundRect()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -1696,6 +1844,8 @@ static void __declspec(naked) HOOK_CEntity_GetBoundRect()
         mov     edx, [eax]
         jmp     RETURN_CEntity_GetBoundRect
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1726,6 +1876,8 @@ static void __declspec(naked) HOOK_CVehicle_AddUpgrade()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -1750,6 +1902,8 @@ inner:
         mov     ebx, [esp+16]
         jmp     RETURN_CVehicle_AddUpgrade
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1776,6 +1930,8 @@ static void __declspec(naked) HOOK_TrainCrossingBarrierCrashFix()
     TrainCrossingFix_ReturnAddress = ReturnAddress;
     TrainCrossingFix_InvalidReturnAddress = InvalidReturnAddress;
 
+    // clang-format off
+
     __asm
     {
         test eax, eax            // Check if pLinkedBarrierPost exists
@@ -1787,6 +1943,8 @@ static void __declspec(naked) HOOK_TrainCrossingBarrierCrashFix()
 jmp_invalid:
         jmp TrainCrossingFix_InvalidReturnAddress
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1803,12 +1961,16 @@ static void __declspec(naked) HOOK_ResetFurnitureObjectCounter()
 
     *(int*)0xBB3A18 = 0;            // InteriorManager_c::ms_objectCounter
 
+    // clang-format off
+
     __asm
     {
         // original instruction
         mov eax, fs:[0]
         jmp RETURN_ResetFurnitureObjectCounter
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1836,6 +1998,8 @@ static void __declspec(naked) HOOK_CVolumetricShadowMgr_Render()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -1855,6 +2019,8 @@ inner:
         mov     ecx, 0A9AE00h
         jmp     RETURN_CVolumetricShadowMgr_Render
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1882,6 +2048,8 @@ static void __declspec(naked) HOOK_CVolumetricShadowMgr_Update()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -1902,6 +2070,8 @@ inner:
         mov     ecx, 0A9AE00h
         jmp     RETURN_CVolumetricShadowMgr_Update
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1932,6 +2102,8 @@ static void __declspec(naked) HOOK_CAnimManager_CreateAnimAssocGroups()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -1948,6 +2120,8 @@ static void __declspec(naked) HOOK_CAnimManager_CreateAnimAssocGroups()
 
         jmp     RETURN_CAnimManager_CreateAnimAssocGroups
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -1969,6 +2143,8 @@ static void __declspec(naked) HOOK_CTaskComplexCarSlowBeDraggedOut_CreateFirstSu
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         test eax, eax
@@ -1983,6 +2159,8 @@ static void __declspec(naked) HOOK_CTaskComplexCarSlowBeDraggedOut_CreateFirstSu
         popad
         jmp RETURN_CTaskComplexCarSlowBeDraggedOut_CreateFirstSubTask_Invalid
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -2028,6 +2206,8 @@ static void __declspec(naked) HOOK_printf()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -2042,6 +2222,8 @@ static void __declspec(naked) HOOK_printf()
         push    887DC0h
         jmp     RETURN_printf
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -2057,6 +2239,8 @@ static void __declspec(naked) HOOK_RwMatrixMultiply()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     eax, [esp+0Ch]
@@ -2071,6 +2255,8 @@ cont:
         call    CrashAverted
         retn
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -2186,6 +2372,8 @@ static void __declspec(naked) HOOK_CStreaming_AreAnimsUsedByRequestedModels()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         push    [esp + 4]
@@ -2193,6 +2381,8 @@ static void __declspec(naked) HOOK_CStreaming_AreAnimsUsedByRequestedModels()
         add     esp, 0x4
         retn
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -2253,6 +2443,8 @@ static void __declspec(naked) HOOK_CTrain__ProcessControl()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -2262,6 +2454,8 @@ static void __declspec(naked) HOOK_CTrain__ProcessControl()
         popad
         jmp     CONTINUE_CTrain__ProcessControl
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -2287,6 +2481,8 @@ static void __declspec(naked) HOOK_CTaskComplexCarSlowBeDraggedOutAndStandUp__Cr
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
         {
         test    eax, eax
@@ -2302,6 +2498,8 @@ static void __declspec(naked) HOOK_CTaskComplexCarSlowBeDraggedOutAndStandUp__Cr
         pop     esi
         retn    4
         }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -2330,6 +2528,8 @@ static void __declspec(naked) HOOK_CVehicleModelInfo__LoadVehicleColours_1()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         test    eax, eax
@@ -2351,6 +2551,8 @@ static void __declspec(naked) HOOK_CVehicleModelInfo__LoadVehicleColours_1()
         lea     eax, [edi - 1]
         jmp     CONTINUE_CVehicleModelInfo__LoadVehicleColours_1
     }
+
+    // clang-format on
 }
 
 //     0x5B6CA5 | E8 96 EC F0 FF | call  CModelInfo::GetModelInfo
@@ -2365,6 +2567,8 @@ static DWORD SKIP_CVehicleModelInfo__LoadVehicleColours_2 = 0x5B6D04;
 static void __declspec(naked) HOOK_CVehicleModelInfo__LoadVehicleColours_2()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -2387,6 +2591,8 @@ static void __declspec(naked) HOOK_CVehicleModelInfo__LoadVehicleColours_2()
         lea     eax, [edi - 1]
         jmp     CONTINUE_CVehicleModelInfo__LoadVehicleColours_2
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -2407,6 +2613,8 @@ static void __declspec(naked) HOOK_CPlaceName__Process()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -2424,6 +2632,8 @@ static void __declspec(naked) HOOK_CPlaceName__Process()
         mov     ecx, [eax + 46Ch]
         jmp     CONTINUE_CPlaceName__Process
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -2454,6 +2664,8 @@ static void __declspec(naked) HOOK_CWorld__FindObjectsKindaCollidingSectorList()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov eax, [edx*4+0xA9B0C8]            // CModelInfo::ms_modelInfoPtrs
@@ -2475,6 +2687,8 @@ static void __declspec(naked) HOOK_CWorld__FindObjectsKindaCollidingSectorList()
 
         jmp RETURN_CWorld__FindObjectsKindaCollidingSectorList_SKIP
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -2495,6 +2709,8 @@ static void __declspec(naked) HOOK_RpClumpForAllAtomics()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     eax, [esp+4]            // RpClump* clump
@@ -2507,6 +2723,8 @@ static void __declspec(naked) HOOK_RpClumpForAllAtomics()
         push    ebp
         jmp     CONTINUE_RpClumpForAllAtomics
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -2525,6 +2743,8 @@ static void __declspec(naked) HOOK_RpAnimBlendClumpGetFirstAssociation()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     eax, [esp+4]            // RpClump* clump
@@ -2536,6 +2756,8 @@ static void __declspec(naked) HOOK_RpAnimBlendClumpGetFirstAssociation()
         mov     ecx, ds:[0xB5F878]
         jmp     CONTINUE_RpAnimBlendClumpGetFirstAssociation
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -2555,6 +2777,8 @@ static void __declspec(naked) HOOK_CAnimManager__BlendAnimation()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     eax, [esp+4]            // RpClump* clump
@@ -2567,6 +2791,8 @@ static void __declspec(naked) HOOK_CAnimManager__BlendAnimation()
         mov     ecx, [esp+18h]
         jmp     CONTINUE_CAnimManager__BlendAnimation
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -2620,6 +2846,8 @@ static void __declspec(naked) HOOK_FxSystemBP_c__Load()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
         {
         pushad
@@ -2635,6 +2863,8 @@ static void __declspec(naked) HOOK_FxSystemBP_c__Load()
         add     esp, 5E8h
         retn    0Ch
         }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -2654,6 +2884,8 @@ static void __declspec(naked) HOOK_FxPrim_c__Enable()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
         {
         test    ecx, ecx
@@ -2664,6 +2896,8 @@ static void __declspec(naked) HOOK_FxPrim_c__Enable()
         returnFromFunction:
         retn    4
         }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -2681,6 +2915,8 @@ static void __declspec(naked) HOOK_CFire_ProcessFire()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         test byte ptr [esi], 1            // If the "active" flag has been set to 0, we skip processing attached entities
@@ -2694,6 +2930,8 @@ static void __declspec(naked) HOOK_CFire_ProcessFire()
         mov ecx, esi
         jmp SKIP_CFire_ProcessFire
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_CustomAnimations.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_CustomAnimations.cpp
@@ -79,12 +79,10 @@ static void __declspec(naked) HOOK_CAnimBlendAssociation_SetCurrentTime()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     if (bDisableCallsToCAnimBlendNode)
@@ -99,7 +97,6 @@ static void __declspec(naked) HOOK_CAnimBlendAssociation_SetCurrentTime()
     }
 
     // clang-format off
-
     __asm
     {
         popad
@@ -107,7 +104,6 @@ static void __declspec(naked) HOOK_CAnimBlendAssociation_SetCurrentTime()
         fld     [esp+4]
         jmp     RETURN_CAnimBlendAssociation_SetCurrentTime_NORMALFLOW
     }
-
     // clang-format on
 }
 
@@ -117,12 +113,10 @@ static void __declspec(naked) HOOK_RpAnimBlendClumpUpdateAnimations()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     if (bDisableCallsToCAnimBlendNode)
@@ -137,7 +131,6 @@ static void __declspec(naked) HOOK_RpAnimBlendClumpUpdateAnimations()
     }
 
     // clang-format off
-
     __asm
     {
         popad
@@ -145,7 +138,6 @@ static void __declspec(naked) HOOK_RpAnimBlendClumpUpdateAnimations()
         mov     eax, ds:[0B5F878h]
         jmp     RETURN_RpAnimBlendClumpUpdateAnimations_NORMALFLOW
     }
-
     // clang-format on
 }
 
@@ -174,7 +166,6 @@ static void __declspec(naked) HOOK_CAnimManager_AddAnimation()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         lea     edx, [esp + 8]  // animationGroupID address
@@ -185,7 +176,6 @@ static void __declspec(naked) HOOK_CAnimManager_AddAnimation()
         add     esp, 8
         pushad
     }
-
     // clang-format on
 
     if (m_pAddAnimationHandler)
@@ -211,7 +201,6 @@ static void __declspec(naked) HOOK_CAnimManager_AddAnimation()
     }
 
     // clang-format off
-
     __asm
     {
         popad
@@ -219,7 +208,6 @@ static void __declspec(naked) HOOK_CAnimManager_AddAnimation()
         mov     edx, dword ptr ds : [0B4EA34h]
         jmp     RETURN_CAnimManager_AddAnimation_NORMAL_FLOW
     }
-
     // clang-format on
 }
 
@@ -229,7 +217,6 @@ static void __declspec(naked) HOOK_CAnimManager_AddAnimationAndSync()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
      // clang-format off
-
      __asm
      {
          lea     edx, [esp + 12] // animationGroup address
@@ -240,7 +227,6 @@ static void __declspec(naked) HOOK_CAnimManager_AddAnimationAndSync()
          add     esp, 8
          pushad
      }
-
      // clang-format on
 
     if (m_pAddAnimationAndSyncHandler)
@@ -265,7 +251,6 @@ static void __declspec(naked) HOOK_CAnimManager_AddAnimationAndSync()
     }
 
      // clang-format off
-
      __asm
      {
 
@@ -274,7 +259,6 @@ static void __declspec(naked) HOOK_CAnimManager_AddAnimationAndSync()
              mov     edx, dword ptr ds : [0B4EA34h]
              jmp     RETURN_CAnimManager_AddAnimationAndSync_NORMAL_FLOW
      }
-
      // clang-format on
 }
 
@@ -284,12 +268,10 @@ static void __declspec(naked) HOOK_CAnimManager_BlendAnimation_Hierarchy()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     if (m_pBlendAnimationHierarchyHandler)
@@ -341,7 +323,6 @@ static void __declspec(naked) HOOK_CAnimManager_BlendAnimation_Hierarchy()
     }
 
     // clang-format off
-
     __asm
     {
         NORMAL_FLOW_BlendAnimation_Hierarchy:
@@ -363,7 +344,6 @@ static void __declspec(naked) HOOK_CAnimManager_BlendAnimation_Hierarchy()
         call    FUNC_UncompressAnimation
         jmp    RETURN_CAnimManager_BlendAnimation_Hierarchy
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_CustomAnimations.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_CustomAnimations.cpp
@@ -78,19 +78,27 @@ static void __declspec(naked) HOOK_CAnimBlendAssociation_SetCurrentTime()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
 
+    // clang-format on
+
     if (bDisableCallsToCAnimBlendNode)
     {
+        // clang-format off
         __asm
         {
             popad
             retn 4
         }
+        // clang-format on
     }
+
+    // clang-format off
 
     __asm
     {
@@ -99,6 +107,8 @@ static void __declspec(naked) HOOK_CAnimBlendAssociation_SetCurrentTime()
         fld     [esp+4]
         jmp     RETURN_CAnimBlendAssociation_SetCurrentTime_NORMALFLOW
     }
+
+    // clang-format on
 }
 
 #define HOOKPOS_RpAnimBlendClumpUpdateAnimations            0x4D34F0
@@ -106,19 +116,27 @@ static void __declspec(naked) HOOK_RpAnimBlendClumpUpdateAnimations()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
 
+    // clang-format on
+
     if (bDisableCallsToCAnimBlendNode)
     {
+        // clang-format off
         __asm
         {
             popad
             retn
         }
+        // clang-format on
     }
+
+    // clang-format off
 
     __asm
     {
@@ -127,6 +145,8 @@ static void __declspec(naked) HOOK_RpAnimBlendClumpUpdateAnimations()
         mov     eax, ds:[0B5F878h]
         jmp     RETURN_RpAnimBlendClumpUpdateAnimations_NORMALFLOW
     }
+
+    // clang-format on
 }
 
 CAnimBlendAssociationSAInterface* __cdecl CAnimBlendAssocGroup_CopyAnimation(RpClump* pClump, eAnimGroup u32AnimGroupID, eAnimID animID)
@@ -153,6 +173,8 @@ static void __declspec(naked) HOOK_CAnimManager_AddAnimation()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         lea     edx, [esp + 8]  // animationGroupID address
@@ -164,8 +186,11 @@ static void __declspec(naked) HOOK_CAnimManager_AddAnimation()
         pushad
     }
 
+    // clang-format on
+
     if (m_pAddAnimationHandler)
     {
+        // clang-format off
         __asm
         {
             popad
@@ -182,7 +207,10 @@ static void __declspec(naked) HOOK_CAnimManager_AddAnimation()
             jmp     RETURN_CAnimManager_AddAnimation
 
         }
+        // clang-format on
     }
+
+    // clang-format off
 
     __asm
     {
@@ -191,12 +219,16 @@ static void __declspec(naked) HOOK_CAnimManager_AddAnimation()
         mov     edx, dword ptr ds : [0B4EA34h]
         jmp     RETURN_CAnimManager_AddAnimation_NORMAL_FLOW
     }
+
+    // clang-format on
 }
 
 #define HOOKPOS_CAnimManager_AddAnimationAndSync            0x4D3B30
 static void __declspec(naked) HOOK_CAnimManager_AddAnimationAndSync()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+     // clang-format off
 
      __asm
      {
@@ -209,8 +241,11 @@ static void __declspec(naked) HOOK_CAnimManager_AddAnimationAndSync()
          pushad
      }
 
+     // clang-format on
+
     if (m_pAddAnimationAndSyncHandler)
     {
+         // clang-format off
          __asm
          {
              popad
@@ -226,7 +261,10 @@ static void __declspec(naked) HOOK_CAnimManager_AddAnimationAndSync()
              push    edi
              jmp     RETURN_CAnimManager_AddAnimationAndSync
          }
+         // clang-format on
     }
+
+     // clang-format off
 
      __asm
      {
@@ -236,6 +274,8 @@ static void __declspec(naked) HOOK_CAnimManager_AddAnimationAndSync()
              mov     edx, dword ptr ds : [0B4EA34h]
              jmp     RETURN_CAnimManager_AddAnimationAndSync_NORMAL_FLOW
      }
+
+     // clang-format on
 }
 
 #define HOOKPOS_CAnimManager_BlendAnimation_Hierarchy       0x4D453E
@@ -243,13 +283,18 @@ static void __declspec(naked) HOOK_CAnimManager_BlendAnimation_Hierarchy()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
 
+    // clang-format on
+
     if (m_pBlendAnimationHierarchyHandler)
     {
+        // clang-format off
         __asm
         {
             popad
@@ -292,7 +337,10 @@ static void __declspec(naked) HOOK_CAnimManager_BlendAnimation_Hierarchy()
             pushad
             jmp NORMAL_FLOW_BlendAnimation_Hierarchy
         }
+        // clang-format on
     }
+
+    // clang-format off
 
     __asm
     {
@@ -315,6 +363,8 @@ static void __declspec(naked) HOOK_CAnimManager_BlendAnimation_Hierarchy()
         call    FUNC_UncompressAnimation
         jmp    RETURN_CAnimManager_BlendAnimation_Hierarchy
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_Direct3D.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Direct3D.cpp
@@ -75,7 +75,6 @@ static void __declspec(naked) HOOK_PreCreateDevice()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Run replaced code - these pushes create the original function parameters
@@ -118,7 +117,6 @@ static void __declspec(naked) HOOK_PreCreateDevice()
         // Continue
         jmp     RETURN_PreCreateDevice
     }
-
     // clang-format on
 }
 
@@ -179,7 +177,6 @@ static void __declspec(naked) HOOK_PostCreateDevice()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Replaced code
@@ -200,7 +197,6 @@ static void __declspec(naked) HOOK_PostCreateDevice()
 ok:
         jmp     RETURN_PostCreateDeviceB
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_Direct3D.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Direct3D.cpp
@@ -74,6 +74,8 @@ static void __declspec(naked) HOOK_PreCreateDevice()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // Run replaced code - these pushes create the original function parameters
@@ -116,6 +118,8 @@ static void __declspec(naked) HOOK_PreCreateDevice()
         // Continue
         jmp     RETURN_PreCreateDevice
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////
@@ -174,6 +178,8 @@ static void __declspec(naked) HOOK_PostCreateDevice()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // Replaced code
@@ -194,6 +200,8 @@ static void __declspec(naked) HOOK_PostCreateDevice()
 ok:
         jmp     RETURN_PostCreateDeviceB
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_Explosions.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Explosions.cpp
@@ -23,6 +23,8 @@ static void __declspec(naked) HOOK_CWorld_TriggerExplosion()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov [esp+1Ch-8h], eax
@@ -38,6 +40,8 @@ static void __declspec(naked) HOOK_CWorld_TriggerExplosion()
         cmp esi, eax
         jmp RETURN_CWorld_TriggerExplosion
     }
+
+    // clang-format on
 }
 
 #define HOOKPOS_CWorld_TriggerExplosionSectorList  0x5677F4
@@ -47,6 +51,8 @@ static constexpr std::uintptr_t SKIP_CWorld_TriggerExplosionSectorList = 0x56847
 static void __declspec(naked) HOOK_CWorld_TriggerExplosionSectorList()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -66,6 +72,8 @@ static void __declspec(naked) HOOK_CWorld_TriggerExplosionSectorList()
         skip:
         jmp SKIP_CWorld_TriggerExplosionSectorList
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_Explosions.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Explosions.cpp
@@ -24,7 +24,6 @@ static void __declspec(naked) HOOK_CWorld_TriggerExplosion()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov [esp+1Ch-8h], eax
@@ -40,7 +39,6 @@ static void __declspec(naked) HOOK_CWorld_TriggerExplosion()
         cmp esi, eax
         jmp RETURN_CWorld_TriggerExplosion
     }
-
     // clang-format on
 }
 
@@ -53,7 +51,6 @@ static void __declspec(naked) HOOK_CWorld_TriggerExplosionSectorList()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // check entity->m_nScanCode == CWorld::ms_nCurrentScanCode
@@ -72,7 +69,6 @@ static void __declspec(naked) HOOK_CWorld_TriggerExplosionSectorList()
         skip:
         jmp SKIP_CWorld_TriggerExplosionSectorList
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_Files.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Files.cpp
@@ -53,7 +53,6 @@ static void __declspec(naked) HOOK_Rtl_fopen()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push    [esp+4*3]
@@ -77,7 +76,6 @@ inner:
         push    [esp+0x0c]
         jmp     RETURN_Rtl_fopen
     }
-
     // clang-format on
 }
 
@@ -103,7 +101,6 @@ static void __declspec(naked) HOOK_Rtl_fclose()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -117,7 +114,6 @@ static void __declspec(naked) HOOK_Rtl_fclose()
         push    0x887EC8
         jmp     RETURN_Rtl_fclose
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_Files.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Files.cpp
@@ -52,6 +52,8 @@ static void __declspec(naked) HOOK_Rtl_fopen()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         push    [esp+4*3]
@@ -75,6 +77,8 @@ inner:
         push    [esp+0x0c]
         jmp     RETURN_Rtl_fopen
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -98,6 +102,8 @@ static void __declspec(naked) HOOK_Rtl_fclose()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -111,6 +117,8 @@ static void __declspec(naked) HOOK_Rtl_fclose()
         push    0x887EC8
         jmp     RETURN_Rtl_fclose
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_FixBadAnimId.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_FixBadAnimId.cpp
@@ -100,7 +100,6 @@ static void __declspec(naked) HOOK_GetAnimHierarchyFromSkinClump()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -114,7 +113,6 @@ static void __declspec(naked) HOOK_GetAnimHierarchyFromSkinClump()
         add     esp, 10h
         jmp     RETURN_GetAnimHierarchyFromSkinClump
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_FixBadAnimId.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_FixBadAnimId.cpp
@@ -99,6 +99,8 @@ static void __declspec(naked) HOOK_GetAnimHierarchyFromSkinClump()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -112,6 +114,8 @@ static void __declspec(naked) HOOK_GetAnimHierarchyFromSkinClump()
         add     esp, 10h
         jmp     RETURN_GetAnimHierarchyFromSkinClump
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_FixLineOfSightArgs.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_FixLineOfSightArgs.cpp
@@ -56,7 +56,6 @@ static void __declspec(naked) HOOK_CWorld_ProcessLineOfSight()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -70,7 +69,6 @@ static void __declspec(naked) HOOK_CWorld_ProcessLineOfSight()
         cmp     word ptr ds:[0B7CD78h], 0FFFFh
         jmp     RETURN_CWorld_ProcessLineOfSight
     }
-
     // clang-format on
 }
 
@@ -95,7 +93,6 @@ static void __declspec(naked) HOOK_CWorld_GetIsLineOfSightClear()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -109,7 +106,6 @@ static void __declspec(naked) HOOK_CWorld_GetIsLineOfSightClear()
         cmp     word ptr ds:[0B7CD78h], 0FFFFh
         jmp     RETURN_CWorld_GetIsLineOfSightClear
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_FixLineOfSightArgs.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_FixLineOfSightArgs.cpp
@@ -55,6 +55,8 @@ static void __declspec(naked) HOOK_CWorld_ProcessLineOfSight()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -68,6 +70,8 @@ static void __declspec(naked) HOOK_CWorld_ProcessLineOfSight()
         cmp     word ptr ds:[0B7CD78h], 0FFFFh
         jmp     RETURN_CWorld_ProcessLineOfSight
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////
@@ -90,6 +94,8 @@ static void __declspec(naked) HOOK_CWorld_GetIsLineOfSightClear()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -103,6 +109,8 @@ static void __declspec(naked) HOOK_CWorld_GetIsLineOfSightClear()
         cmp     word ptr ds:[0B7CD78h], 0FFFFh
         jmp     RETURN_CWorld_GetIsLineOfSightClear
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
@@ -23,6 +23,8 @@ static void __declspec(naked) HOOK_CTaskSimpleUseGun__SetMoveAnim()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         fld ds:[0xB7CB5C]           // CTimer::ms_fTimeStep
@@ -34,6 +36,8 @@ static void __declspec(naked) HOOK_CTaskSimpleUseGun__SetMoveAnim()
         fstp st(0)
         jmp RETURN_CTaskSimpleUseGun__SetMoveAnim
     }
+
+    // clang-format on
 }
 
 // Fixes excessively fast camera shaking with setCameraShakeLevel on high FPS.
@@ -44,6 +48,8 @@ static void __declspec(naked) HOOK_CCamera__Process()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         fld ds:[0x858C80]           // 5.0f
@@ -53,6 +59,8 @@ static void __declspec(naked) HOOK_CCamera__Process()
         fstp ds:[0xB6EC30]
         jmp RETURN_CCamera__Process
     }
+
+    // clang-format on
 }
 
 // Fixes helicopters accelerating excessively during takeoff at high FPS.
@@ -62,6 +70,8 @@ static const unsigned int RETURN_CHeli__ProcessFlyingCarStuff = 0x6C4F3D;
 static void __declspec(naked) HOOK_CHeli__ProcessFlyingCarStuff()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -83,6 +93,8 @@ static void __declspec(naked) HOOK_CHeli__ProcessFlyingCarStuff()
         fadd [esi+0x84C]
         jmp RETURN_CHeli__ProcessFlyingCarStuff
     }
+
+    // clang-format on
 }
 
 // Fixes excessively fast movement of fog on high FPS.
@@ -92,6 +104,8 @@ static const unsigned int RETURN_CClouds__MovingFog_Update = 0x716BBC;
 static void __declspec(naked) HOOK_CClouds__MovingFog_Update()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -106,6 +120,8 @@ static void __declspec(naked) HOOK_CClouds__MovingFog_Update()
         fdiv kOriginalTimeStep      // 1.666f
         jmp RETURN_CClouds__MovingFog_Update
     }
+
+    // clang-format on
 }
 
 // Fixes glass shards spinning and moving at excessive speeds on high FPS.
@@ -115,6 +131,8 @@ static const unsigned int RETURN_CFallingGlassPane__Update_A = 0x71AAC5;
 static void __declspec(naked) HOOK_CFallingGlassPane__Update_A()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -132,6 +150,8 @@ static void __declspec(naked) HOOK_CFallingGlassPane__Update_A()
         fadd [esi]
         jmp RETURN_CFallingGlassPane__Update_A
     }
+
+    // clang-format on
 }
 
 // Fixes glass shards spinning and moving at excessive speeds on high FPS.
@@ -141,6 +161,8 @@ static const unsigned int RETURN_CFallingGlassPane__Update_B = 0x71AAF0;
 static void __declspec(naked) HOOK_CFallingGlassPane__Update_B()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -160,6 +182,8 @@ static void __declspec(naked) HOOK_CFallingGlassPane__Update_B()
         mov [esp+0x2C], ecx
         jmp RETURN_CFallingGlassPane__Update_B
     }
+
+    // clang-format on
 }
 
 // Fixes glass shards spinning and moving at excessive speeds on high FPS.
@@ -169,6 +193,8 @@ static const unsigned int RETURN_CFallingGlassPane__Update_C = 0x71AB2F;
 static void __declspec(naked) HOOK_CFallingGlassPane__Update_C()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -188,6 +214,8 @@ static void __declspec(naked) HOOK_CFallingGlassPane__Update_C()
         mov [esp+0x38], edx
         jmp RETURN_CFallingGlassPane__Update_C
     }
+
+    // clang-format on
 }
 
 // Ensure that CTimer::CurrentFrame is updated only every 33+ milliseconds.
@@ -196,6 +224,8 @@ static void __declspec(naked) HOOK_CFallingGlassPane__Update_C()
 static void __declspec(naked) HOOK_CTimer__Update()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -218,6 +248,8 @@ static void __declspec(naked) HOOK_CTimer__Update()
         add esp, 0xC
         ret
     }
+
+    // clang-format on
 }
 
 // Fixes premature despawning of broken breakable objects on high FPS.
@@ -227,6 +259,8 @@ static const unsigned int RETURN_BreakObject_c__Update = 0x59E42B;
 static void __declspec(naked) HOOK_BreakObject_c__Update()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -242,6 +276,8 @@ static void __declspec(naked) HOOK_BreakObject_c__Update()
     skip:
         jmp RETURN_BreakObject_c__Update
     }
+
+    // clang-format on
 }
 
 // Fixes limited reach of the water cannon on high FPS.
@@ -253,6 +289,8 @@ static void __declspec(naked) HOOK_CWaterCannon__Update_OncePerFrame()
 {
 
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -267,6 +305,8 @@ static void __declspec(naked) HOOK_CWaterCannon__Update_OncePerFrame()
     skip:
         jmp RETURN_CWaterCannon__Update_OncePerFrame_SKIP
     }
+
+    // clang-format on
 }
 
 // Fixes money animation issues on high FPS.
@@ -277,6 +317,8 @@ static const unsigned int RETURN_CPlayerInfo__Process_SKIP = 0x57015B;
 static void __declspec(naked) HOOK_CPlayerInfo__Process()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -290,6 +332,8 @@ static void __declspec(naked) HOOK_CPlayerInfo__Process()
     skip:
         jmp RETURN_CPlayerInfo__Process_SKIP
     }
+
+    // clang-format on
 }
 
 // Fixes excessive effects spawning from rocket launchers on high FPS.
@@ -300,6 +344,8 @@ static const unsigned int RETURN_CProjectileInfo__Update_SKIP = 0x738F22;
 static void __declspec(naked) HOOK_CProjectileInfo__Update()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -314,6 +360,8 @@ static void __declspec(naked) HOOK_CProjectileInfo__Update()
     skip:
         jmp RETURN_CProjectileInfo__Update_SKIP
     }
+
+    // clang-format on
 }
 
 // Fixes excessive surface effects spawning from wheels on high FPS.
@@ -323,6 +371,8 @@ static const unsigned int RETURN_CVehicle__AddWheelDirtAndWater = 0x6D2D56;
 static void __declspec(naked) HOOK_CVehicle__AddWheelDirtAndWater()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -338,6 +388,8 @@ static void __declspec(naked) HOOK_CVehicle__AddWheelDirtAndWater()
         xor eax, eax
         retn 0x10
     }
+
+    // clang-format on
 }
 
 // Fixes excessive smoke trail particle spawning from stuntplanes and cropdusters on high FPS.
@@ -348,6 +400,8 @@ static const unsigned int RETURN_CPlane__PreRender_SKIP = 0x6CAA93;
 static void __declspec(naked) HOOK_CPlane__PreRender()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -361,6 +415,8 @@ static void __declspec(naked) HOOK_CPlane__PreRender()
     skip:
         jmp RETURN_CPlane__PreRender_SKIP
     }
+
+    // clang-format on
 }
 
 // Fixes increased frequency of water cannon pushing peds on high FPS.
@@ -371,6 +427,8 @@ static const unsigned int RETURN_CWaterCannon__Update_OncePerFrame_PushPedFix_SK
 static void __declspec(naked) HOOK_CWaterCannon__Update_OncePerFrame_PushPedFix()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -384,6 +442,8 @@ static void __declspec(naked) HOOK_CWaterCannon__Update_OncePerFrame_PushPedFix(
     skip:
         jmp RETURN_CWaterCannon__Update_OncePerFrame_PushPedFix_SKIP
     }
+
+    // clang-format on
 }
 
 // Fixes excessive particle spawning from water cannons on high FPS.
@@ -395,6 +455,8 @@ static void __declspec(naked) HOOK_CWaterCannon__Render_FxFix()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         movzx edx, bWouldBeNewFrame
@@ -405,6 +467,8 @@ static void __declspec(naked) HOOK_CWaterCannon__Render_FxFix()
     skip:
         jmp RETURN_CWaterCannon__Render_FxFix_SKIP
     }
+
+    // clang-format on
 }
 
 // Fixes excessive particle spawning with setPedHeadless on high FPS.
@@ -415,6 +479,8 @@ static const unsigned int RETURN_CPed__PreRenderAfterTest_SKIP = 0x5E722D;
 static void __declspec(naked) HOOK_CPed__PreRenderAfterTest()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -428,6 +494,8 @@ static void __declspec(naked) HOOK_CPed__PreRenderAfterTest()
     skip:
         jmp RETURN_CPed__PreRenderAfterTest_SKIP
     }
+
+    // clang-format on
 }
 
 // Fixes excessive particle spawning from boats on high FPS.
@@ -437,6 +505,8 @@ static const unsigned int RETURN_cBuoyancy__AddSplashParticles = 0x6C34E6;
 static void __declspec(naked) HOOK_cBuoyancy__AddSplashParticles()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -450,6 +520,8 @@ static void __declspec(naked) HOOK_cBuoyancy__AddSplashParticles()
     skip:
         retn 0x2C
     }
+
+    // clang-format on
 }
 
 // Fixes excessive weather particle spawning on high FPS.
@@ -459,6 +531,8 @@ static const unsigned int RETURN_CWeather__AddRain = 0x72AAAE;
 static void __declspec(naked) HOOK_CWeather__AddRain()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -474,6 +548,8 @@ static void __declspec(naked) HOOK_CWeather__AddRain()
         add esp, 0x84
         ret
     }
+
+    // clang-format on
 }
 
 // Fixes excessive damage particle spawning from airplanes on high FPS.
@@ -484,6 +560,8 @@ static const unsigned int RETURN_CPlane__ProcessFlyingCarStuff_SKIP = 0x6CC0D9;
 static void __declspec(naked) HOOK_CPlane__ProcessFlyingCarStuff()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -497,6 +575,8 @@ static void __declspec(naked) HOOK_CPlane__ProcessFlyingCarStuff()
     skip:
         jmp RETURN_CPlane__ProcessFlyingCarStuff_SKIP
     }
+
+    // clang-format on
 }
 
 // Fixes excessive spawning of sand and water particles from vehicles on high FPS.
@@ -507,6 +587,8 @@ static const unsigned int RETURN_CAutomobile__UpdateWheelMatrix_SKIP = 0x6AAAD0;
 static void __declspec(naked) HOOK_CAutomobile__UpdateWheelMatrix()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -520,6 +602,8 @@ static void __declspec(naked) HOOK_CAutomobile__UpdateWheelMatrix()
     skip:
         jmp RETURN_CAutomobile__UpdateWheelMatrix_SKIP
     }
+
+    // clang-format on
 }
 
 // Fixes excessive particle spawning from boats on high FPS.
@@ -529,6 +613,8 @@ static const unsigned int RETURN_CVehicle__DoBoatSplashes = 0x6DD136;
 static void __declspec(naked) HOOK_CVehicle__DoBoatSplashes()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -542,6 +628,8 @@ static void __declspec(naked) HOOK_CVehicle__DoBoatSplashes()
     skip:
         retn 4
     }
+
+    // clang-format on
 }
 
 // Fixes excessive rain particle spawning on vehicles on high FPS.
@@ -551,6 +639,8 @@ static const unsigned int RETURN_CVehicle__AddWaterSplashParticles = 0x6DDF66;
 static void __declspec(naked) HOOK_CVehicle__AddWaterSplashParticles()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -564,6 +654,8 @@ static void __declspec(naked) HOOK_CVehicle__AddWaterSplashParticles()
     skip:
         ret
     }
+
+    // clang-format on
 }
 
 // Fixes excessive particle spawning from airplanes when damaged on high FPS.
@@ -574,6 +666,8 @@ static const unsigned int RETURN_CPlane__ProcessControl_SKIP = 0x6C9463;
 static void __declspec(naked) HOOK_CPlane__ProcessControl()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -588,6 +682,8 @@ static void __declspec(naked) HOOK_CPlane__ProcessControl()
     skip:
         jmp RETURN_CPlane__ProcessControl_SKIP
     }
+
+    // clang-format on
 }
 
 // Fixes excessive exhaust particle spawning from vehicles on high FPS.
@@ -597,6 +693,8 @@ static const unsigned int RETURN_CVehicle__AddExhaustParticles = 0x6DE246;
 static void __declspec(naked) HOOK_CVehicle__AddExhaustParticles()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -610,6 +708,8 @@ static void __declspec(naked) HOOK_CVehicle__AddExhaustParticles()
     skip:
         ret
     }
+
+    // clang-format on
 }
 
 // Fixes excessive particle spawning while swimming on high FPS.
@@ -620,6 +720,8 @@ static const unsigned int RETURN_CTaskSimpleSwim__ProcessEffects_SKIP = 0x68AFDB
 static void __declspec(naked) HOOK_CTaskSimpleSwim__ProcessEffects()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -634,6 +736,8 @@ static void __declspec(naked) HOOK_CTaskSimpleSwim__ProcessEffects()
     skip:
         jmp RETURN_CTaskSimpleSwim__ProcessEffects_SKIP
     }
+
+    // clang-format on
 }
 
 // Fixes excessive particle spawning while swimming on high FPS.
@@ -644,6 +748,8 @@ static const unsigned int RETURN_CTaskSimpleSwim__ProcessEffectsBubbleFix_SKIP =
 static void __declspec(naked) HOOK_CTaskSimpleSwim__ProcessEffectsBubbleFix()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -658,6 +764,8 @@ static void __declspec(naked) HOOK_CTaskSimpleSwim__ProcessEffectsBubbleFix()
     skip:
         jmp RETURN_CTaskSimpleSwim__ProcessEffectsBubbleFix_SKIP
     }
+
+    // clang-format on
 }
 
 // Fixes invisible weapon particles (extinguisher, spraycan, flamethrower) at high FPS
@@ -667,6 +775,8 @@ static constexpr std::uintptr_t RETURN_CWeapon_Update = 0x073DC42;
 static void __declspec(naked) HOOK_CWeapon_Update()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -701,6 +811,8 @@ static void __declspec(naked) HOOK_CWeapon_Update()
         mov eax, ds:[0xB7CB84]
         jmp RETURN_CWeapon_Update
     }
+
+    // clang-format on
 }
 
 #define HOOKPOS_CPhysical__ApplyAirResistance  0x544D29
@@ -709,6 +821,8 @@ static const unsigned int    RETURN_CPhysical__ApplyAirResistance = 0x544D4D;
 static void __declspec(naked) HOOK_CPhysical__ApplyAirResistance()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -730,6 +844,8 @@ static void __declspec(naked) HOOK_CPhysical__ApplyAirResistance()
         fstp [esi+0x58]
         jmp RETURN_CPhysical__ApplyAirResistance
     }
+
+    // clang-format on
 }
 
 template <unsigned int returnAddress>
@@ -738,6 +854,7 @@ static void __declspec(naked) HOOK_VehicleRapidStopFix()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     static unsigned int RETURN_VehicleRapidStopFix = returnAddress;
+    // clang-format off
     __asm
     {
         fld ds:[0xC2B9CC]            // mod_HandlingManager.m_fWheelFriction
@@ -745,6 +862,7 @@ static void __declspec(naked) HOOK_VehicleRapidStopFix()
         fdiv kOriginalTimeStep            // 1.666f
         jmp RETURN_VehicleRapidStopFix
     }
+    // clang-format on
 }
 
 void CMultiplayerSA::SetRapidVehicleStopFixEnabled(bool enabled)

--- a/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
@@ -24,7 +24,6 @@ static void __declspec(naked) HOOK_CTaskSimpleUseGun__SetMoveAnim()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         fld ds:[0xB7CB5C]           // CTimer::ms_fTimeStep
@@ -36,7 +35,6 @@ static void __declspec(naked) HOOK_CTaskSimpleUseGun__SetMoveAnim()
         fstp st(0)
         jmp RETURN_CTaskSimpleUseGun__SetMoveAnim
     }
-
     // clang-format on
 }
 
@@ -49,7 +47,6 @@ static void __declspec(naked) HOOK_CCamera__Process()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         fld ds:[0x858C80]           // 5.0f
@@ -59,7 +56,6 @@ static void __declspec(naked) HOOK_CCamera__Process()
         fstp ds:[0xB6EC30]
         jmp RETURN_CCamera__Process
     }
-
     // clang-format on
 }
 
@@ -72,7 +68,6 @@ static void __declspec(naked) HOOK_CHeli__ProcessFlyingCarStuff()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov ax, [esi+0x22]
@@ -93,7 +88,6 @@ static void __declspec(naked) HOOK_CHeli__ProcessFlyingCarStuff()
         fadd [esi+0x84C]
         jmp RETURN_CHeli__ProcessFlyingCarStuff
     }
-
     // clang-format on
 }
 
@@ -106,7 +100,6 @@ static void __declspec(naked) HOOK_CClouds__MovingFog_Update()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         fmul [edi*4+0xC6E394]       // CClouds::ms_mf.fSpeedFactor
@@ -120,7 +113,6 @@ static void __declspec(naked) HOOK_CClouds__MovingFog_Update()
         fdiv kOriginalTimeStep      // 1.666f
         jmp RETURN_CClouds__MovingFog_Update
     }
-
     // clang-format on
 }
 
@@ -133,7 +125,6 @@ static void __declspec(naked) HOOK_CFallingGlassPane__Update_A()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         fld [esp+0x28]
@@ -150,7 +141,6 @@ static void __declspec(naked) HOOK_CFallingGlassPane__Update_A()
         fadd [esi]
         jmp RETURN_CFallingGlassPane__Update_A
     }
-
     // clang-format on
 }
 
@@ -163,7 +153,6 @@ static void __declspec(naked) HOOK_CFallingGlassPane__Update_B()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         fld [eax]
@@ -182,7 +171,6 @@ static void __declspec(naked) HOOK_CFallingGlassPane__Update_B()
         mov [esp+0x2C], ecx
         jmp RETURN_CFallingGlassPane__Update_B
     }
-
     // clang-format on
 }
 
@@ -195,7 +183,6 @@ static void __declspec(naked) HOOK_CFallingGlassPane__Update_C()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         fld [eax]
@@ -214,7 +201,6 @@ static void __declspec(naked) HOOK_CFallingGlassPane__Update_C()
         mov [esp+0x38], edx
         jmp RETURN_CFallingGlassPane__Update_C
     }
-
     // clang-format on
 }
 
@@ -226,7 +212,6 @@ static void __declspec(naked) HOOK_CTimer__Update()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         add esp, 0x4
@@ -248,7 +233,6 @@ static void __declspec(naked) HOOK_CTimer__Update()
         add esp, 0xC
         ret
     }
-
     // clang-format on
 }
 
@@ -261,7 +245,6 @@ static void __declspec(naked) HOOK_BreakObject_c__Update()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         movzx edx, bWouldBeNewFrame
@@ -276,7 +259,6 @@ static void __declspec(naked) HOOK_BreakObject_c__Update()
     skip:
         jmp RETURN_BreakObject_c__Update
     }
-
     // clang-format on
 }
 
@@ -291,7 +273,6 @@ static void __declspec(naked) HOOK_CWaterCannon__Update_OncePerFrame()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         movzx eax, bWouldBeNewFrame
@@ -305,7 +286,6 @@ static void __declspec(naked) HOOK_CWaterCannon__Update_OncePerFrame()
     skip:
         jmp RETURN_CWaterCannon__Update_OncePerFrame_SKIP
     }
-
     // clang-format on
 }
 
@@ -319,7 +299,6 @@ static void __declspec(naked) HOOK_CPlayerInfo__Process()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         movzx edx, bWouldBeNewFrame
@@ -332,7 +311,6 @@ static void __declspec(naked) HOOK_CPlayerInfo__Process()
     skip:
         jmp RETURN_CPlayerInfo__Process_SKIP
     }
-
     // clang-format on
 }
 
@@ -346,7 +324,6 @@ static void __declspec(naked) HOOK_CProjectileInfo__Update()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         movzx edx, bWouldBeNewFrame
@@ -360,7 +337,6 @@ static void __declspec(naked) HOOK_CProjectileInfo__Update()
     skip:
         jmp RETURN_CProjectileInfo__Update_SKIP
     }
-
     // clang-format on
 }
 
@@ -373,7 +349,6 @@ static void __declspec(naked) HOOK_CVehicle__AddWheelDirtAndWater()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         movzx edx, bWouldBeNewFrame
@@ -388,7 +363,6 @@ static void __declspec(naked) HOOK_CVehicle__AddWheelDirtAndWater()
         xor eax, eax
         retn 0x10
     }
-
     // clang-format on
 }
 
@@ -402,7 +376,6 @@ static void __declspec(naked) HOOK_CPlane__PreRender()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         movzx eax, bWouldBeNewFrame
@@ -415,7 +388,6 @@ static void __declspec(naked) HOOK_CPlane__PreRender()
     skip:
         jmp RETURN_CPlane__PreRender_SKIP
     }
-
     // clang-format on
 }
 
@@ -429,7 +401,6 @@ static void __declspec(naked) HOOK_CWaterCannon__Update_OncePerFrame_PushPedFix(
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         movzx edx, bWouldBeNewFrame
@@ -442,7 +413,6 @@ static void __declspec(naked) HOOK_CWaterCannon__Update_OncePerFrame_PushPedFix(
     skip:
         jmp RETURN_CWaterCannon__Update_OncePerFrame_PushPedFix_SKIP
     }
-
     // clang-format on
 }
 
@@ -456,7 +426,6 @@ static void __declspec(naked) HOOK_CWaterCannon__Render_FxFix()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         movzx edx, bWouldBeNewFrame
@@ -467,7 +436,6 @@ static void __declspec(naked) HOOK_CWaterCannon__Render_FxFix()
     skip:
         jmp RETURN_CWaterCannon__Render_FxFix_SKIP
     }
-
     // clang-format on
 }
 
@@ -481,7 +449,6 @@ static void __declspec(naked) HOOK_CPed__PreRenderAfterTest()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         movzx eax, bWouldBeNewFrame
@@ -494,7 +461,6 @@ static void __declspec(naked) HOOK_CPed__PreRenderAfterTest()
     skip:
         jmp RETURN_CPed__PreRenderAfterTest_SKIP
     }
-
     // clang-format on
 }
 
@@ -507,7 +473,6 @@ static void __declspec(naked) HOOK_cBuoyancy__AddSplashParticles()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         movzx eax, bWouldBeNewFrame
@@ -520,7 +485,6 @@ static void __declspec(naked) HOOK_cBuoyancy__AddSplashParticles()
     skip:
         retn 0x2C
     }
-
     // clang-format on
 }
 
@@ -533,7 +497,6 @@ static void __declspec(naked) HOOK_CWeather__AddRain()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         movzx eax, bWouldBeNewFrame
@@ -548,7 +511,6 @@ static void __declspec(naked) HOOK_CWeather__AddRain()
         add esp, 0x84
         ret
     }
-
     // clang-format on
 }
 
@@ -562,7 +524,6 @@ static void __declspec(naked) HOOK_CPlane__ProcessFlyingCarStuff()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         movzx eax, bWouldBeNewFrame
@@ -575,7 +536,6 @@ static void __declspec(naked) HOOK_CPlane__ProcessFlyingCarStuff()
     skip:
         jmp RETURN_CPlane__ProcessFlyingCarStuff_SKIP
     }
-
     // clang-format on
 }
 
@@ -589,7 +549,6 @@ static void __declspec(naked) HOOK_CAutomobile__UpdateWheelMatrix()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         movzx eax, bWouldBeNewFrame
@@ -602,7 +561,6 @@ static void __declspec(naked) HOOK_CAutomobile__UpdateWheelMatrix()
     skip:
         jmp RETURN_CAutomobile__UpdateWheelMatrix_SKIP
     }
-
     // clang-format on
 }
 
@@ -615,7 +573,6 @@ static void __declspec(naked) HOOK_CVehicle__DoBoatSplashes()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         movzx eax, bWouldBeNewFrame
@@ -628,7 +585,6 @@ static void __declspec(naked) HOOK_CVehicle__DoBoatSplashes()
     skip:
         retn 4
     }
-
     // clang-format on
 }
 
@@ -641,7 +597,6 @@ static void __declspec(naked) HOOK_CVehicle__AddWaterSplashParticles()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         movzx eax, bWouldBeNewFrame
@@ -654,7 +609,6 @@ static void __declspec(naked) HOOK_CVehicle__AddWaterSplashParticles()
     skip:
         ret
     }
-
     // clang-format on
 }
 
@@ -668,7 +622,6 @@ static void __declspec(naked) HOOK_CPlane__ProcessControl()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         movzx edx, bWouldBeNewFrame
@@ -682,7 +635,6 @@ static void __declspec(naked) HOOK_CPlane__ProcessControl()
     skip:
         jmp RETURN_CPlane__ProcessControl_SKIP
     }
-
     // clang-format on
 }
 
@@ -695,7 +647,6 @@ static void __declspec(naked) HOOK_CVehicle__AddExhaustParticles()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         movzx edx, bWouldBeNewFrame
@@ -708,7 +659,6 @@ static void __declspec(naked) HOOK_CVehicle__AddExhaustParticles()
     skip:
         ret
     }
-
     // clang-format on
 }
 
@@ -722,7 +672,6 @@ static void __declspec(naked) HOOK_CTaskSimpleSwim__ProcessEffects()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         movzx eax, bWouldBeNewFrame
@@ -736,7 +685,6 @@ static void __declspec(naked) HOOK_CTaskSimpleSwim__ProcessEffects()
     skip:
         jmp RETURN_CTaskSimpleSwim__ProcessEffects_SKIP
     }
-
     // clang-format on
 }
 
@@ -750,7 +698,6 @@ static void __declspec(naked) HOOK_CTaskSimpleSwim__ProcessEffectsBubbleFix()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         movzx eax, bWouldBeNewFrame
@@ -764,7 +711,6 @@ static void __declspec(naked) HOOK_CTaskSimpleSwim__ProcessEffectsBubbleFix()
     skip:
         jmp RETURN_CTaskSimpleSwim__ProcessEffectsBubbleFix_SKIP
     }
-
     // clang-format on
 }
 
@@ -777,7 +723,6 @@ static void __declspec(naked) HOOK_CWeapon_Update()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Temp fix for camera
@@ -811,7 +756,6 @@ static void __declspec(naked) HOOK_CWeapon_Update()
         mov eax, ds:[0xB7CB84]
         jmp RETURN_CWeapon_Update
     }
-
     // clang-format on
 }
 
@@ -823,7 +767,6 @@ static void __declspec(naked) HOOK_CPhysical__ApplyAirResistance()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         fld ds:[0x862CD0]            // 0.99000001f
@@ -844,7 +787,6 @@ static void __declspec(naked) HOOK_CPhysical__ApplyAirResistance()
         fstp [esi+0x58]
         jmp RETURN_CPhysical__ApplyAirResistance
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_HookDestructors.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_HookDestructors.cpp
@@ -185,7 +185,6 @@ static void __declspec(naked) HOOK_CAnimBlendAssoc_destructor()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Cache this pointer from ECX before pushad
@@ -210,7 +209,6 @@ static void __declspec(naked) HOOK_CAnimBlendAssoc_destructor()
         mov     eax, [esi + 10h]
         jmp     RETURN_CAnimBlendAssoc_destructor
     }
-
     // clang-format on
 }
 
@@ -232,7 +230,6 @@ static void __declspec(naked) HOOK_CObjectDestructor()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Cache parameters before pushad
@@ -259,7 +256,6 @@ static void __declspec(naked) HOOK_CObjectDestructor()
         push    0x83D228
         jmp     RETURN_CObjectDestructor
     }
-
     // clang-format on
 }
 
@@ -281,7 +277,6 @@ static void __declspec(naked) HOOK_CVehicleDestructor()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     eax, ecx
@@ -307,7 +302,6 @@ static void __declspec(naked) HOOK_CVehicleDestructor()
         push    0FFFFFFFFh      // SEH marker
         jmp     RETURN_CVehicleDestructor
     }
-
     // clang-format on
 }
 
@@ -329,7 +323,6 @@ static void __declspec(naked) HOOK_CPlayerPedDestructor()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     eax, ecx
@@ -350,7 +343,6 @@ static void __declspec(naked) HOOK_CPlayerPedDestructor()
         push    0x83EC18
         jmp     RETURN_CPlayerPedDestructor
     }
-
     // clang-format on
 }
 
@@ -374,7 +366,6 @@ static void __declspec(naked) HOOK_CProjectileDestructor()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     eax, ecx
@@ -394,7 +385,6 @@ static void __declspec(naked) HOOK_CProjectileDestructor()
         mov     dword ptr [ecx], 867030h
         jmp     RETURN_CProjectileDestructor
     }
-
     // clang-format on
 }
 
@@ -439,7 +429,6 @@ static void __declspec(naked) HOOK_CPhysicalDestructor()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     eax, ecx
@@ -460,7 +449,6 @@ static void __declspec(naked) HOOK_CPhysicalDestructor()
         push    0x83C996
         jmp     RETURN_CPhysicalDestructor
     }
-
     // clang-format on
 }
 
@@ -483,7 +471,6 @@ static void __declspec(naked) HOOK_CEntityDestructor()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     eax, ecx
@@ -503,7 +490,6 @@ static void __declspec(naked) HOOK_CEntityDestructor()
         mov     eax, dword ptr fs:[00000000h]
         jmp     RETURN_CEntityDestructor
     }
-
     // clang-format on
 }
 
@@ -548,7 +534,6 @@ static void __declspec(naked) HOOK_CEntityAddMid1()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // At hook entry: ECX = list pointer (thiscall this), [esp] = entity pointer (pushed arg)
@@ -572,7 +557,6 @@ static void __declspec(naked) HOOK_CEntityAddMid1()
         call    eax
         jmp     RETURN_CEntityAddMid1
     }
-
     // clang-format on
 }
 
@@ -619,7 +603,6 @@ static void __declspec(naked) HOOK_CEntityAddMid2()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // At hook entry: ECX = list pointer (thiscall this), [esp] = entity pointer (pushed arg)
@@ -643,7 +626,6 @@ static void __declspec(naked) HOOK_CEntityAddMid2()
         call    eax
         jmp     RETURN_CEntityAddMid2
     }
-
     // clang-format on
 }
 
@@ -690,7 +672,6 @@ static void __declspec(naked) HOOK_CEntityAddMid3()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // At hook entry: ECX = list pointer (thiscall this), [esp] = entity pointer (pushed arg)
@@ -714,7 +695,6 @@ static void __declspec(naked) HOOK_CEntityAddMid3()
         call    eax
         jmp     RETURN_CEntityAddMid3
     }
-
     // clang-format on
 }
 
@@ -738,7 +718,6 @@ static void __declspec(naked) HOOK_CEntityRemove()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Save original ESI (callee-saved)
@@ -771,7 +750,6 @@ inner:
         push    ebp
         jmp     RETURN_CEntityRemove
     }
-
     // clang-format on
 }
 
@@ -854,7 +832,6 @@ static void __declspec(naked) HOOK_CStreamingRemoveModel()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     eax, [esp+4]
@@ -876,7 +853,6 @@ static void __declspec(naked) HOOK_CStreamingRemoveModel()
         push    edi
         jmp     RETURN_CStreamingRemoveModel
     }
-
     // clang-format on
 }
 
@@ -900,7 +876,6 @@ static void __declspec(naked) HOOK_CTaskSimpleRunNamedAnimDestructor()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     eax, ecx
@@ -922,7 +897,6 @@ static void __declspec(naked) HOOK_CTaskSimpleRunNamedAnimDestructor()
         call    eax
         jmp     RETURN_CTaskSimpleRunNamedAnim
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_HookDestructors.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_HookDestructors.cpp
@@ -76,6 +76,7 @@ namespace
     void CPtrListSingleLink_Remove(SStreamSectorEntrySingle** ppStreamEntryList, CEntitySAInterface* pCheckEntity)
     {
         DWORD dwFunc = FUNC_CPtrListSingleLink_Remove;
+        // clang-format off
         __asm
         {
             pushfd                  // Preserve flags (including Direction Flag)
@@ -84,6 +85,7 @@ namespace
             call    dwFunc
             popfd                   // Restore flags
         }
+        // clang-format on
     }
 
     //
@@ -103,6 +105,7 @@ namespace
     void CPtrListDoubleLink_Remove(SStreamSectorEntryDouble** ppStreamEntryList, CEntitySAInterface* pCheckEntity)
     {
         DWORD dwFunc = FUNC_CPtrListDoubleLink_Remove;
+        // clang-format off
         __asm
         {
             pushfd                  // Preserve flags (including Direction Flag)
@@ -111,6 +114,7 @@ namespace
             call    dwFunc
             popfd                   // Restore flags
         }
+        // clang-format on
     }
 
     //
@@ -180,6 +184,8 @@ static void __declspec(naked) HOOK_CAnimBlendAssoc_destructor()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // Cache this pointer from ECX before pushad
@@ -204,6 +210,8 @@ static void __declspec(naked) HOOK_CAnimBlendAssoc_destructor()
         mov     eax, [esi + 10h]
         jmp     RETURN_CAnimBlendAssoc_destructor
     }
+
+    // clang-format on
 }
 
 void _cdecl OnCObjectDestructor(DWORD calledFrom, CObjectSAInterface* pObject)
@@ -222,6 +230,8 @@ DWORD RETURN_CObjectDestructor = 0x59F667;
 static void __declspec(naked) HOOK_CObjectDestructor()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -249,6 +259,8 @@ static void __declspec(naked) HOOK_CObjectDestructor()
         push    0x83D228
         jmp     RETURN_CObjectDestructor
     }
+
+    // clang-format on
 }
 
 void _cdecl OnVehicleDestructor(DWORD calledFrom, CVehicleSAInterface* pVehicle)
@@ -267,6 +279,8 @@ DWORD RETURN_CVehicleDestructor = 0x6E2B47;  // Avoid SA's anti-disasm obfuscati
 static void __declspec(naked) HOOK_CVehicleDestructor()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -293,6 +307,8 @@ static void __declspec(naked) HOOK_CVehicleDestructor()
         push    0FFFFFFFFh      // SEH marker
         jmp     RETURN_CVehicleDestructor
     }
+
+    // clang-format on
 }
 
 void _cdecl OnCPlayerPedDestructor(DWORD calledFrom, CPedSAInterface* pPlayerPed)
@@ -311,6 +327,8 @@ DWORD RETURN_CPlayerPedDestructor = 0x6093B7;
 static void __declspec(naked) HOOK_CPlayerPedDestructor()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -332,6 +350,8 @@ static void __declspec(naked) HOOK_CPlayerPedDestructor()
         push    0x83EC18
         jmp     RETURN_CPlayerPedDestructor
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -353,6 +373,8 @@ static void __declspec(naked) HOOK_CProjectileDestructor()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     eax, ecx
@@ -372,6 +394,8 @@ static void __declspec(naked) HOOK_CProjectileDestructor()
         mov     dword ptr [ecx], 867030h
         jmp     RETURN_CProjectileDestructor
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -396,11 +420,13 @@ void _cdecl OnCPhysicalDestructor(DWORD calledFrom, CPhysicalSAInterface* pEntit
         
         // Always perform the actual removal, even if logging failed
         DWORD dwFunc = FUNC_CPhysical_RemoveFromMovingList;
+        // clang-format off
         __asm
         {
             mov     ecx, pEntity
             call    dwFunc
         }
+        // clang-format on
     }
 }
 
@@ -411,6 +437,8 @@ DWORD RETURN_CPhysicalDestructor = 0x542457;
 static void __declspec(naked) HOOK_CPhysicalDestructor()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -432,6 +460,8 @@ static void __declspec(naked) HOOK_CPhysicalDestructor()
         push    0x83C996
         jmp     RETURN_CPhysicalDestructor
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -452,6 +482,8 @@ static void __declspec(naked) HOOK_CEntityDestructor()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     eax, ecx
@@ -471,6 +503,8 @@ static void __declspec(naked) HOOK_CEntityDestructor()
         mov     eax, dword ptr fs:[00000000h]
         jmp     RETURN_CEntityDestructor
     }
+
+    // clang-format on
 }
 
 void cdecl OnCEntityAddMid1(SStreamSectorEntrySingle** ppStreamEntryList, CEntitySAInterface* pEntitySAInterface) noexcept
@@ -513,6 +547,8 @@ static void __declspec(naked) HOOK_CEntityAddMid1()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // At hook entry: ECX = list pointer (thiscall this), [esp] = entity pointer (pushed arg)
@@ -536,6 +572,8 @@ static void __declspec(naked) HOOK_CEntityAddMid1()
         call    eax
         jmp     RETURN_CEntityAddMid1
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -580,6 +618,8 @@ static void __declspec(naked) HOOK_CEntityAddMid2()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // At hook entry: ECX = list pointer (thiscall this), [esp] = entity pointer (pushed arg)
@@ -603,6 +643,8 @@ static void __declspec(naked) HOOK_CEntityAddMid2()
         call    eax
         jmp     RETURN_CEntityAddMid2
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -647,6 +689,8 @@ static void __declspec(naked) HOOK_CEntityAddMid3()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // At hook entry: ECX = list pointer (thiscall this), [esp] = entity pointer (pushed arg)
@@ -670,6 +714,8 @@ static void __declspec(naked) HOOK_CEntityAddMid3()
         call    eax
         jmp     RETURN_CEntityAddMid3
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -690,6 +736,8 @@ DWORD RETURN_CEntityRemove = 0x534AE5;
 static void __declspec(naked) HOOK_CEntityRemove()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -723,6 +771,8 @@ inner:
         push    ebp
         jmp     RETURN_CEntityRemove
     }
+
+    // clang-format on
 }
 
 
@@ -803,6 +853,8 @@ static void __declspec(naked) HOOK_CStreamingRemoveModel()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     eax, [esp+4]
@@ -824,6 +876,8 @@ static void __declspec(naked) HOOK_CStreamingRemoveModel()
         push    edi
         jmp     RETURN_CStreamingRemoveModel
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -844,6 +898,8 @@ DWORD RETURN_CTaskSimpleRunNamedAnim = 0x61BEF8;
 static void __declspec(naked) HOOK_CTaskSimpleRunNamedAnimDestructor()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -866,6 +922,8 @@ static void __declspec(naked) HOOK_CTaskSimpleRunNamedAnimDestructor()
         call    eax
         jmp     RETURN_CTaskSimpleRunNamedAnim
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_LicensePlate.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_LicensePlate.cpp
@@ -66,7 +66,6 @@ static void __declspec(naked) HOOK_CAutomobile_CustomCarPlate_BeforeRenderingSta
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -80,7 +79,6 @@ static void __declspec(naked) HOOK_CAutomobile_CustomCarPlate_BeforeRenderingSta
         mov     eax, [eax+24h]
         jmp     RETURN_CAutomobile_CustomCarPlate_BeforeRenderingStart
     }
-
     // clang-format on
 }
 
@@ -127,7 +125,6 @@ static void __declspec(naked) HOOK_CAutomobile_CustomCarPlate_AfterRenderingStop
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -140,7 +137,6 @@ static void __declspec(naked) HOOK_CAutomobile_CustomCarPlate_AfterRenderingStop
         mov     eax, [eax+24h]
         jmp     RETURN_CAutomobile_CustomCarPlate_AfterRenderingStop
     }
-
     // clang-format on
 }
 
@@ -169,7 +165,6 @@ static void __declspec(naked) HOOK_CCustomCarPlateMgr_SetupMaterialPlateTexture(
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -184,7 +179,6 @@ static void __declspec(naked) HOOK_CCustomCarPlateMgr_SetupMaterialPlateTexture(
         mov     edi, [esp+8]
         jmp     RETURN_CCustomCarPlateMgr_SetupMaterialPlateTexture
     }
-
     // clang-format on
 }
 
@@ -219,7 +213,6 @@ static void __declspec(naked) HOOK_CVehicleModelInfo_SetCarCustomPlate()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -241,7 +234,6 @@ inner:
         mov     esi, ecx
         jmp     RETURN_CVehicleModelInfo_SetCarCustomPlate
     }
-
     // clang-format on
 }
 
@@ -261,7 +253,6 @@ static void __declspec(naked) HOOK_CCustomCarPlateMgr_CreatePlateTexture()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Skip our code if not processing a VehicleModelInfo
@@ -289,7 +280,6 @@ inner:
         mov     bl, [esp+0x0c]
         jmp     RETURN_CCustomCarPlateMgr_CreatePlateTexture
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_LicensePlate.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_LicensePlate.cpp
@@ -65,6 +65,8 @@ static void __declspec(naked) HOOK_CAutomobile_CustomCarPlate_BeforeRenderingSta
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -78,6 +80,8 @@ static void __declspec(naked) HOOK_CAutomobile_CustomCarPlate_BeforeRenderingSta
         mov     eax, [eax+24h]
         jmp     RETURN_CAutomobile_CustomCarPlate_BeforeRenderingStart
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -122,6 +126,8 @@ static void __declspec(naked) HOOK_CAutomobile_CustomCarPlate_AfterRenderingStop
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -134,6 +140,8 @@ static void __declspec(naked) HOOK_CAutomobile_CustomCarPlate_AfterRenderingStop
         mov     eax, [eax+24h]
         jmp     RETURN_CAutomobile_CustomCarPlate_AfterRenderingStop
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -160,6 +168,8 @@ static void __declspec(naked) HOOK_CCustomCarPlateMgr_SetupMaterialPlateTexture(
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -174,6 +184,8 @@ static void __declspec(naked) HOOK_CCustomCarPlateMgr_SetupMaterialPlateTexture(
         mov     edi, [esp+8]
         jmp     RETURN_CCustomCarPlateMgr_SetupMaterialPlateTexture
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -206,6 +218,8 @@ static void __declspec(naked) HOOK_CVehicleModelInfo_SetCarCustomPlate()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -227,6 +241,8 @@ inner:
         mov     esi, ecx
         jmp     RETURN_CVehicleModelInfo_SetCarCustomPlate
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -243,6 +259,8 @@ DWORD RETURN_CCustomCarPlateMgr_CreatePlateTexture = 0x006FDEA5;
 static void __declspec(naked) HOOK_CCustomCarPlateMgr_CreatePlateTexture()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -271,6 +289,8 @@ inner:
         mov     bl, [esp+0x0c]
         jmp     RETURN_CCustomCarPlateMgr_CreatePlateTexture
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_ObjectCollision.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_ObjectCollision.cpp
@@ -51,7 +51,6 @@ static void __declspec(naked) HOOK_CObject_Init()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -67,7 +66,6 @@ static void __declspec(naked) HOOK_CObject_Init()
 
         jmp     CONTINUE_CObject_Init
     }
-
     // clang-format on
 }
 
@@ -96,7 +94,6 @@ static void __declspec(naked) HOOK_CObject_Destructor()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -106,7 +103,6 @@ static void __declspec(naked) HOOK_CObject_Destructor()
         popad
         jmp     CONTINUE_CObject_Destructor
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_ObjectCollision.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_ObjectCollision.cpp
@@ -50,6 +50,8 @@ static void __declspec(naked) HOOK_CObject_Init()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -65,6 +67,8 @@ static void __declspec(naked) HOOK_CObject_Init()
 
         jmp     CONTINUE_CObject_Init
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -91,6 +95,8 @@ static void __declspec(naked) HOOK_CObject_Destructor()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -100,6 +106,8 @@ static void __declspec(naked) HOOK_CObject_Destructor()
         popad
         jmp     CONTINUE_CObject_Destructor
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_ObjectLODSystem.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_ObjectLODSystem.cpp
@@ -92,7 +92,6 @@ static void __declspec(naked) HOOK_CRenderer_SetupEntityVisibility()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
 ////////////////////
@@ -126,7 +125,6 @@ second:
         mov     esi,dword ptr [esp+1Ch]
         jmp     RETURN_CRenderer_SetupEntityVisibility   // 0x554238
     }
-
     // clang-format on
 }
 
@@ -158,7 +156,6 @@ static void __declspec(naked) HOOK_CWorldScan_ScanWorld()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         call    second
@@ -175,7 +172,6 @@ second:
 
         jmp     RETURN_CWorldScan_ScanWorldb   // 72CAE0
     }
-
     // clang-format on
 }
 
@@ -205,7 +201,6 @@ static void __declspec(naked) HOOK_CVisibilityPlugins_CalculateFadingAtomicAlpha
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -236,7 +231,6 @@ second:
         mov     ecx, [esp+8]
         jmp     RETURN_CVisibilityPlugins_CalculateFadingAtomicAlpha
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_ObjectLODSystem.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_ObjectLODSystem.cpp
@@ -91,6 +91,8 @@ static void __declspec(naked) HOOK_CRenderer_SetupEntityVisibility()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
 ////////////////////
@@ -124,6 +126,8 @@ second:
         mov     esi,dword ptr [esp+1Ch]
         jmp     RETURN_CRenderer_SetupEntityVisibility   // 0x554238
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////
@@ -153,6 +157,8 @@ static void __declspec(naked) HOOK_CWorldScan_ScanWorld()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         call    second
@@ -169,6 +175,8 @@ second:
 
         jmp     RETURN_CWorldScan_ScanWorldb   // 72CAE0
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////
@@ -195,6 +203,8 @@ DWORD RETURN_CVisibilityPlugins_CalculateFadingAtomicAlpha = 0x732505;
 static void __declspec(naked) HOOK_CVisibilityPlugins_CalculateFadingAtomicAlpha()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -226,6 +236,8 @@ second:
         mov     ecx, [esp+8]
         jmp     RETURN_CVisibilityPlugins_CalculateFadingAtomicAlpha
     }
+
+    // clang-format on
 }
 
 ////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_ObjectStreamerOptimization.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_ObjectStreamerOptimization.cpp
@@ -19,6 +19,8 @@ static void __declspec(naked) HOOK_CEntryInfoNodePool__New()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         inc CEntryInfoNodePool_UsedSpaces
@@ -27,6 +29,8 @@ static void __declspec(naked) HOOK_CEntryInfoNodePool__New()
         pop esi
         ret
     }
+
+    // clang-format on
 }
 
 #define HOOKPOS_CEntryInfoNode__operator_delete 0x536DF1
@@ -36,6 +40,8 @@ static void __declspec(naked) HOOK_CEntryInfoNode__operator_delete()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         dec CEntryInfoNodePool_UsedSpaces
@@ -44,6 +50,8 @@ static void __declspec(naked) HOOK_CEntryInfoNode__operator_delete()
         or byte ptr [eax], 0x80
         jmp RETURN_CEntryInfoNode__operator_delete
     }
+
+    // clang-format on
 }
 
 #define HOOKPOS_CEntryInfoList__Flush 0x536E6C
@@ -53,6 +61,8 @@ static void __declspec(naked) HOOK_CEntryInfoList__Flush()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         dec CEntryInfoNodePool_UsedSpaces
@@ -61,6 +71,8 @@ static void __declspec(naked) HOOK_CEntryInfoList__Flush()
         mov [eax], bl
         jmp RETURN_CEntryInfoList__Flush
     }
+
+    // clang-format on
 }
 
 #define HOOKPOS_CPtrNodeDoubleLinkPool__New 0x55233E
@@ -68,6 +80,8 @@ static void __declspec(naked) HOOK_CEntryInfoList__Flush()
 static void __declspec(naked) HOOK_CPtrNodeDoubleLinkPool__New()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -77,6 +91,8 @@ static void __declspec(naked) HOOK_CPtrNodeDoubleLinkPool__New()
         pop esi
         ret
     }
+
+    // clang-format on
 }
 
 #define HOOKPOS_CPtrNodeDoubleLink__operator_delete 0x5523F0
@@ -86,6 +102,8 @@ static void __declspec(naked) HOOK_CPtrNodeDoubleLink__operator_delete()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         dec CPtrNodeDoubleLinkPool_UsedSpaces
@@ -94,6 +112,8 @@ static void __declspec(naked) HOOK_CPtrNodeDoubleLink__operator_delete()
         or byte ptr [eax], 0x80
         jmp RETURN_CPtrNodeDoubleLink__operator_delete
     }
+
+    // clang-format on
 }
 
 #define HOOKPOS_CPtrListDoubleLink__Flush 0x5524CB
@@ -103,6 +123,8 @@ static void __declspec(naked) HOOK_CPtrListDoubleLink__Flush()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         dec CPtrNodeDoubleLinkPool_UsedSpaces
@@ -111,6 +133,8 @@ static void __declspec(naked) HOOK_CPtrListDoubleLink__Flush()
         mov [eax], bl
         jmp RETURN_CPtrListDoubleLink__Flush
     }
+
+    // clang-format on
 }
 
 void CMultiplayerSA::InitHooks_ObjectStreamerOptimization()

--- a/Client/multiplayer_sa/CMultiplayerSA_ObjectStreamerOptimization.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_ObjectStreamerOptimization.cpp
@@ -20,7 +20,6 @@ static void __declspec(naked) HOOK_CEntryInfoNodePool__New()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         inc CEntryInfoNodePool_UsedSpaces
@@ -29,7 +28,6 @@ static void __declspec(naked) HOOK_CEntryInfoNodePool__New()
         pop esi
         ret
     }
-
     // clang-format on
 }
 
@@ -41,7 +39,6 @@ static void __declspec(naked) HOOK_CEntryInfoNode__operator_delete()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         dec CEntryInfoNodePool_UsedSpaces
@@ -50,7 +47,6 @@ static void __declspec(naked) HOOK_CEntryInfoNode__operator_delete()
         or byte ptr [eax], 0x80
         jmp RETURN_CEntryInfoNode__operator_delete
     }
-
     // clang-format on
 }
 
@@ -62,7 +58,6 @@ static void __declspec(naked) HOOK_CEntryInfoList__Flush()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         dec CEntryInfoNodePool_UsedSpaces
@@ -71,7 +66,6 @@ static void __declspec(naked) HOOK_CEntryInfoList__Flush()
         mov [eax], bl
         jmp RETURN_CEntryInfoList__Flush
     }
-
     // clang-format on
 }
 
@@ -82,7 +76,6 @@ static void __declspec(naked) HOOK_CPtrNodeDoubleLinkPool__New()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         inc CPtrNodeDoubleLinkPool_UsedSpaces
@@ -91,7 +84,6 @@ static void __declspec(naked) HOOK_CPtrNodeDoubleLinkPool__New()
         pop esi
         ret
     }
-
     // clang-format on
 }
 
@@ -103,7 +95,6 @@ static void __declspec(naked) HOOK_CPtrNodeDoubleLink__operator_delete()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         dec CPtrNodeDoubleLinkPool_UsedSpaces
@@ -112,7 +103,6 @@ static void __declspec(naked) HOOK_CPtrNodeDoubleLink__operator_delete()
         or byte ptr [eax], 0x80
         jmp RETURN_CPtrNodeDoubleLink__operator_delete
     }
-
     // clang-format on
 }
 
@@ -124,7 +114,6 @@ static void __declspec(naked) HOOK_CPtrListDoubleLink__Flush()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         dec CPtrNodeDoubleLinkPool_UsedSpaces
@@ -133,7 +122,6 @@ static void __declspec(naked) HOOK_CPtrListDoubleLink__Flush()
         mov [eax], bl
         jmp RETURN_CPtrListDoubleLink__Flush
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_Peds.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Peds.cpp
@@ -38,7 +38,6 @@ static void __declspec(naked) HOOK_CPed_DoFootLanded()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -55,7 +54,6 @@ static void __declspec(naked) HOOK_CPed_DoFootLanded()
         mov     esi, ecx
         jmp     CONTINUE_CPed_DoFootLanded
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_Peds.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Peds.cpp
@@ -37,6 +37,8 @@ static void __declspec(naked) HOOK_CPed_DoFootLanded()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -53,6 +55,8 @@ static void __declspec(naked) HOOK_CPed_DoFootLanded()
         mov     esi, ecx
         jmp     CONTINUE_CPed_DoFootLanded
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_ProjectileCollisionFix.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_ProjectileCollisionFix.cpp
@@ -39,6 +39,8 @@ static void __declspec(naked) HOOK_CTempColModels__Initialise()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov ds:[0x968FE4], edx
@@ -47,6 +49,8 @@ static void __declspec(naked) HOOK_CTempColModels__Initialise()
 
         jmp RETURN_CTempColModels__Initialise
     }
+
+    // clang-format on
 }
 
 #define HOOKPOS_CFileLoader__LoadWeaponObject 0x5B401E
@@ -55,6 +59,8 @@ static const unsigned int RETURN_CFileLoader__LoadWeaponObject = 0x5B4023;
 static void __declspec(naked) HOOK_CFileLoader__LoadWeaponObject()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -75,6 +81,8 @@ static void __declspec(naked) HOOK_CFileLoader__LoadWeaponObject()
         push offset colModelGrenade
         jmp RETURN_CFileLoader__LoadWeaponObject
     }
+
+    // clang-format on
 }
 
 void CMultiplayerSA::InitHooks_ProjectileCollisionFix()

--- a/Client/multiplayer_sa/CMultiplayerSA_ProjectileCollisionFix.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_ProjectileCollisionFix.cpp
@@ -40,7 +40,6 @@ static void __declspec(naked) HOOK_CTempColModels__Initialise()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov ds:[0x968FE4], edx
@@ -49,7 +48,6 @@ static void __declspec(naked) HOOK_CTempColModels__Initialise()
 
         jmp RETURN_CTempColModels__Initialise
     }
-
     // clang-format on
 }
 
@@ -61,7 +59,6 @@ static void __declspec(naked) HOOK_CFileLoader__LoadWeaponObject()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov eax, [esp+0x8]
@@ -81,7 +78,6 @@ static void __declspec(naked) HOOK_CFileLoader__LoadWeaponObject()
         push offset colModelGrenade
         jmp RETURN_CFileLoader__LoadWeaponObject
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
@@ -53,7 +53,6 @@ static void __declspec(naked) HOOK_CallIdle()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -70,7 +69,6 @@ static void __declspec(naked) HOOK_CallIdle()
 
         jmp     RETURN_CallIdle
     }
-
     // clang-format on
 }
 
@@ -125,7 +123,6 @@ static void __declspec(naked) HOOK_CEntity_Render()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -148,7 +145,6 @@ inner:
         mov     eax,dword ptr [esi+18h]
         jmp     RETURN_CEntity_Render
     }
-
     // clang-format on
 }
 
@@ -184,7 +180,6 @@ static void __declspec(naked) HOOK_CEntity_RenderOneNonRoad()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -212,7 +207,6 @@ inner:
         mov     esi, [esp+08h]
         jmp     RETURN_CEntity_RenderOneNonRoad
     }
-
     // clang-format on
 }
 
@@ -237,7 +231,6 @@ static void __declspec(naked) HOOK_CVisibilityPlugins_RenderWeaponPedsForPC_Mid(
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -250,7 +243,6 @@ static void __declspec(naked) HOOK_CVisibilityPlugins_RenderWeaponPedsForPC_Mid(
         mov     ecx,dword ptr [ebx+4F4h]
         jmp     RETURN_CVisibilityPlugins_RenderWeaponPedsForPC_Mid
     }
-
     // clang-format on
 }
 
@@ -274,7 +266,6 @@ static void __declspec(naked) HOOK_CVisibilityPlugins_RenderWeaponPedsForPC_End(
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -286,7 +277,6 @@ static void __declspec(naked) HOOK_CVisibilityPlugins_RenderWeaponPedsForPC_End(
         add         esp,0Ch
         ret
     }
-
     // clang-format on
 }
 
@@ -306,7 +296,6 @@ static void __declspec(naked) HOOK_Check_NoOfVisibleLods()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         cmp     eax, 999            // Array limit is 1000
@@ -316,7 +305,6 @@ limit:
         mov     dword ptr ds:[00B76840h],eax        // NoOfVisibleLods
         jmp     RETURN_Check_NoOfVisibleLods
     }
-
     // clang-format on
 }
 
@@ -336,7 +324,6 @@ static void __declspec(naked) HOOK_Check_NoOfVisibleEntities()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         cmp     eax, 999        // Array limit is 1000
@@ -346,7 +333,6 @@ limit:
         mov     dword ptr ds:[00B76844h],eax        // NoOfVisibleEntities
         jmp     RETURN_Check_NoOfVisibleEntities
     }
-
     // clang-format on
 }
 
@@ -370,7 +356,6 @@ static void __declspec(naked) HOOK_WinLoop()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -380,7 +365,6 @@ static void __declspec(naked) HOOK_WinLoop()
         mov     eax, ds:0x0C8D4C0
         jmp     RETURN_WinLoop
     }
-
     // clang-format on
 }
 
@@ -399,18 +383,15 @@ static void __declspec(naked) HOOK_CTimer_Update()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     g_pCore->OnGameTimerUpdate();
 
     // clang-format off
-
     __asm
     {
         popad
@@ -419,7 +400,6 @@ static void __declspec(naked) HOOK_CTimer_Update()
         mov     ecx, dword ptr ds:[0B7CB28h]
         jmp     CONTINUE_CTimer_Update
     }
-
     // clang-format on
 }
 
@@ -525,7 +505,6 @@ static void __declspec(naked) HOOK_psGrabScreen()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -548,7 +527,6 @@ use_rect:
 
         jmp     RETURN_psGrabScreen_YesChange
     }
-
     // clang-format on
 }
 
@@ -575,7 +553,6 @@ static void __declspec(naked) HOOK_CClouds_RenderSkyPolys()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -585,7 +562,6 @@ static void __declspec(naked) HOOK_CClouds_RenderSkyPolys()
         mov     eax, ds:0x0B6F03C
         jmp     RETURN_CClouds_RenderSkyPolys
     }
-
     // clang-format on
 }
 
@@ -636,7 +612,6 @@ static void __declspec(naked) HOOK_RwCameraSetNearClipPlane()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -652,7 +627,6 @@ static void __declspec(naked) HOOK_RwCameraSetNearClipPlane()
         push    esi
         jmp     RETURN_RwCameraSetNearClipPlane
     }
-
     // clang-format on
 }
 
@@ -673,26 +647,22 @@ static void __declspec(naked) HOOK_RenderEffects_HeliLight()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     // Call render handler
     if (pRenderHeliLightHandler) pRenderHeliLightHandler();
 
     // clang-format off
-
     __asm
     {
         popad
         mov     eax, ds:[0xC1C96C]
         jmp     RETURN_RenderEffects_HeliLight
     }
-
     // clang-format on
 }
 
@@ -842,7 +812,6 @@ static void __declspec(naked) HOOK_CVisibilityPlugins_RenderPedCB()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push esi;
@@ -864,7 +833,6 @@ static void __declspec(naked) HOOK_CVisibilityPlugins_RenderPedCB()
         pop esi;
         retn;
     }
-
     // clang-format on
 }
 
@@ -878,19 +846,16 @@ static void __declspec(naked) HOOK_CRenderer_EverythingBarRoads()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     if (pRenderEverythingBarRoadsHandler)
         pRenderEverythingBarRoadsHandler();
 
     // clang-format off
-
     __asm
     {
         popad
@@ -898,7 +863,6 @@ static void __declspec(naked) HOOK_CRenderer_EverythingBarRoads()
         jmp RETURN_CRenderer_EverythingBarRoads
 
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
@@ -52,6 +52,8 @@ static void __declspec(naked) HOOK_CallIdle()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -68,6 +70,8 @@ static void __declspec(naked) HOOK_CallIdle()
 
         jmp     RETURN_CallIdle
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -120,6 +124,8 @@ static void __declspec(naked) HOOK_CEntity_Render()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -142,6 +148,8 @@ inner:
         mov     eax,dword ptr [esi+18h]
         jmp     RETURN_CEntity_Render
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -175,6 +183,8 @@ static void __declspec(naked) HOOK_CEntity_RenderOneNonRoad()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -202,6 +212,8 @@ inner:
         mov     esi, [esp+08h]
         jmp     RETURN_CEntity_RenderOneNonRoad
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -224,6 +236,8 @@ static void __declspec(naked) HOOK_CVisibilityPlugins_RenderWeaponPedsForPC_Mid(
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -236,6 +250,8 @@ static void __declspec(naked) HOOK_CVisibilityPlugins_RenderWeaponPedsForPC_Mid(
         mov     ecx,dword ptr [ebx+4F4h]
         jmp     RETURN_CVisibilityPlugins_RenderWeaponPedsForPC_Mid
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -257,6 +273,8 @@ static void __declspec(naked) HOOK_CVisibilityPlugins_RenderWeaponPedsForPC_End(
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -268,6 +286,8 @@ static void __declspec(naked) HOOK_CVisibilityPlugins_RenderWeaponPedsForPC_End(
         add         esp,0Ch
         ret
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -285,6 +305,8 @@ static void __declspec(naked) HOOK_Check_NoOfVisibleLods()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         cmp     eax, 999            // Array limit is 1000
@@ -294,6 +316,8 @@ limit:
         mov     dword ptr ds:[00B76840h],eax        // NoOfVisibleLods
         jmp     RETURN_Check_NoOfVisibleLods
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -311,6 +335,8 @@ static void __declspec(naked) HOOK_Check_NoOfVisibleEntities()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         cmp     eax, 999        // Array limit is 1000
@@ -320,6 +346,8 @@ limit:
         mov     dword ptr ds:[00B76844h],eax        // NoOfVisibleEntities
         jmp     RETURN_Check_NoOfVisibleEntities
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -341,6 +369,8 @@ static void __declspec(naked) HOOK_WinLoop()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -350,6 +380,8 @@ static void __declspec(naked) HOOK_WinLoop()
         mov     eax, ds:0x0C8D4C0
         jmp     RETURN_WinLoop
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -366,12 +398,18 @@ static void __declspec(naked) HOOK_CTimer_Update()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
 
+    // clang-format on
+
     g_pCore->OnGameTimerUpdate();
+
+    // clang-format off
 
     __asm
     {
@@ -381,6 +419,8 @@ static void __declspec(naked) HOOK_CTimer_Update()
         mov     ecx, dword ptr ds:[0B7CB28h]
         jmp     CONTINUE_CTimer_Update
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -484,6 +524,8 @@ static void __declspec(naked) HOOK_psGrabScreen()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -506,6 +548,8 @@ use_rect:
 
         jmp     RETURN_psGrabScreen_YesChange
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -530,6 +574,8 @@ static void __declspec(naked) HOOK_CClouds_RenderSkyPolys()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -539,6 +585,8 @@ static void __declspec(naked) HOOK_CClouds_RenderSkyPolys()
         mov     eax, ds:0x0B6F03C
         jmp     RETURN_CClouds_RenderSkyPolys
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -587,6 +635,8 @@ static void __declspec(naked) HOOK_RwCameraSetNearClipPlane()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -602,6 +652,8 @@ static void __declspec(naked) HOOK_RwCameraSetNearClipPlane()
         push    esi
         jmp     RETURN_RwCameraSetNearClipPlane
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -620,13 +672,19 @@ static void __declspec(naked) HOOK_RenderEffects_HeliLight()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
 
+    // clang-format on
+
     // Call render handler
     if (pRenderHeliLightHandler) pRenderHeliLightHandler();
+
+    // clang-format off
 
     __asm
     {
@@ -634,6 +692,8 @@ static void __declspec(naked) HOOK_RenderEffects_HeliLight()
         mov     eax, ds:[0xC1C96C]
         jmp     RETURN_RenderEffects_HeliLight
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -781,6 +841,8 @@ static void __declspec(naked) HOOK_CVisibilityPlugins_RenderPedCB()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         push esi;
@@ -802,6 +864,8 @@ static void __declspec(naked) HOOK_CVisibilityPlugins_RenderPedCB()
         pop esi;
         retn;
     }
+
+    // clang-format on
 }
 
 // Hook info
@@ -813,13 +877,19 @@ static void __declspec(naked) HOOK_CRenderer_EverythingBarRoads()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
 
+    // clang-format on
+
     if (pRenderEverythingBarRoadsHandler)
         pRenderEverythingBarRoadsHandler();
+
+    // clang-format off
 
     __asm
     {
@@ -828,6 +898,8 @@ static void __declspec(naked) HOOK_CRenderer_EverythingBarRoads()
         jmp RETURN_CRenderer_EverythingBarRoads
 
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_RwResources.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_RwResources.cpp
@@ -47,7 +47,6 @@ static void __declspec(naked) HOOK_RwTextureCreate()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -73,7 +72,6 @@ inner:
         mov     eax,dword ptr ds:[00C97B24h]
         jmp     RETURN_RwTextureCreate
     }
-
     // clang-format on
 }
 
@@ -107,7 +105,6 @@ static void __declspec(naked) HOOK_RwTextureDestroy()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push    esi
@@ -121,7 +118,6 @@ static void __declspec(naked) HOOK_RwTextureDestroy()
 
         jmp     RETURN_RwTextureDestroy
     }
-
     // clang-format on
 }
 
@@ -144,7 +140,6 @@ static void __declspec(naked) HOOK_RwRasterCreate()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov         eax,dword ptr ds:[00C97B24h]
@@ -157,7 +152,6 @@ static void __declspec(naked) HOOK_RwRasterCreate()
 
         jmp     RETURN_RwRasterCreate
     }
-
     // clang-format on
 }
 
@@ -180,7 +174,6 @@ static void __declspec(naked) HOOK_RwRasterDestroy()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push    esi
@@ -193,7 +186,6 @@ static void __declspec(naked) HOOK_RwRasterDestroy()
 
         jmp     RETURN_RwRasterDestroy
     }
-
     // clang-format on
 }
 
@@ -223,7 +215,6 @@ static void __declspec(naked) HOOK_RwGeometryCreate()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -252,7 +243,6 @@ inner:
         sub     esp, 8
         jmp     RETURN_RwGeometryCreate
     }
-
     // clang-format on
 }
 
@@ -286,7 +276,6 @@ static void __declspec(naked) HOOK_RwGeometryDestroy()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -300,7 +289,6 @@ static void __declspec(naked) HOOK_RwGeometryDestroy()
         mov         esi,dword ptr [esp+8]
         jmp     RETURN_RwGeometryDestroy
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_RwResources.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_RwResources.cpp
@@ -46,6 +46,8 @@ static void __declspec(naked) HOOK_RwTextureCreate()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -71,6 +73,8 @@ inner:
         mov     eax,dword ptr ds:[00C97B24h]
         jmp     RETURN_RwTextureCreate
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -102,6 +106,8 @@ static void __declspec(naked) HOOK_RwTextureDestroy()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         push    esi
@@ -115,6 +121,8 @@ static void __declspec(naked) HOOK_RwTextureDestroy()
 
         jmp     RETURN_RwTextureDestroy
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -135,6 +143,8 @@ static void __declspec(naked) HOOK_RwRasterCreate()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov         eax,dword ptr ds:[00C97B24h]
@@ -147,6 +157,8 @@ static void __declspec(naked) HOOK_RwRasterCreate()
 
         jmp     RETURN_RwRasterCreate
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -167,6 +179,8 @@ static void __declspec(naked) HOOK_RwRasterDestroy()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         push    esi
@@ -179,6 +193,8 @@ static void __declspec(naked) HOOK_RwRasterDestroy()
 
         jmp     RETURN_RwRasterDestroy
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -205,6 +221,8 @@ DWORD RETURN_RwGeometryCreate = 0x74CA97;
 static void __declspec(naked) HOOK_RwGeometryCreate()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -234,6 +252,8 @@ inner:
         sub     esp, 8
         jmp     RETURN_RwGeometryCreate
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -265,6 +285,8 @@ static void __declspec(naked) HOOK_RwGeometryDestroy()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -278,6 +300,8 @@ static void __declspec(naked) HOOK_RwGeometryDestroy()
         mov         esi,dword ptr [esp+8]
         jmp     RETURN_RwGeometryDestroy
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_Streaming.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Streaming.cpp
@@ -30,6 +30,8 @@ static void __declspec(naked) HOOK_CStreaming__ConvertBufferToObject()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         push    esi
@@ -44,6 +46,8 @@ static void __declspec(naked) HOOK_CStreaming__ConvertBufferToObject()
         add     esp, 20h
         retn
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_Streaming.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Streaming.cpp
@@ -31,7 +31,6 @@ static void __declspec(naked) HOOK_CStreaming__ConvertBufferToObject()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push    esi
@@ -46,7 +45,6 @@ static void __declspec(naked) HOOK_CStreaming__ConvertBufferToObject()
         add     esp, 20h
         retn
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_Tasks.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Tasks.cpp
@@ -30,6 +30,8 @@ static void __declspec(naked) HOOK_CTaskSimplePlayerOnFoot__MakeAbortable()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // return false and keep task alive
@@ -58,6 +60,8 @@ static void __declspec(naked) HOOK_CTaskSimplePlayerOnFoot__MakeAbortable()
         skip:
         jmp SKIP_CTaskSimplePlayerOnFoot__MakeAbortable
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_Tasks.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Tasks.cpp
@@ -31,7 +31,6 @@ static void __declspec(naked) HOOK_CTaskSimplePlayerOnFoot__MakeAbortable()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // return false and keep task alive
@@ -60,7 +59,6 @@ static void __declspec(naked) HOOK_CTaskSimplePlayerOnFoot__MakeAbortable()
         skip:
         jmp SKIP_CTaskSimplePlayerOnFoot__MakeAbortable
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_VehicleCollision.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_VehicleCollision.cpp
@@ -65,19 +65,16 @@ static void __declspec(naked) HOOK_CAutomobile_ProcessControl_VehicleDamage()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
         mov pCollisionVehicle, ecx
     }
-
     // clang-format on
 
     TriggerVehicleCollisionEvent();
 
     // clang-format off
-
     __asm
     {
         popad
@@ -87,7 +84,6 @@ static void __declspec(naked) HOOK_CAutomobile_ProcessControl_VehicleDamage()
         call    dword ptr[eax + 0E0h]
         jmp     CONTINUE_CAutomobile_ProcessControl_VehicleDamage
     }
-
     // clang-format on
 }
 
@@ -108,19 +104,16 @@ static void __declspec(naked) HOOK_CBike_ProcessControl_VehicleDamage()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
         mov pCollisionVehicle, ecx
     }
-
     // clang-format on
 
     TriggerVehicleCollisionEvent();
 
     // clang-format off
-
     __asm
     {
         popad
@@ -130,7 +123,6 @@ static void __declspec(naked) HOOK_CBike_ProcessControl_VehicleDamage()
         call    dword ptr[eax + 0E0h]
         jmp     CONTINUE_CBike_ProcessControl_VehicleDamage
     }
-
     // clang-format on
 }
 
@@ -152,19 +144,16 @@ static void __declspec(naked) HOOK_CBoat_ProcessControl_VehicleDamage()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
         mov pCollisionVehicle, ecx
     }
-
     // clang-format on
 
     TriggerVehicleCollisionEvent();
 
     // clang-format off
-
     __asm
     {
         popad
@@ -173,7 +162,6 @@ static void __declspec(naked) HOOK_CBoat_ProcessControl_VehicleDamage()
         call    FUNC_CVehicle_ProcessCarAlarm
         jmp     CONTINUE_CBoat_ProcessControl_VehicleDamage
     }
-
     // clang-format on
 }
 
@@ -194,19 +182,16 @@ static void __declspec(naked) HOOK_CTrain_ProcessControl_VehicleDamage()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
         mov pCollisionVehicle, esi
     }
-
     // clang-format on
 
     TriggerVehicleCollisionEvent();
 
     // clang-format off
-
     __asm
     {
         popad
@@ -214,7 +199,6 @@ static void __declspec(naked) HOOK_CTrain_ProcessControl_VehicleDamage()
         mov     al, ds:[0BA6728h]
         jmp     CONTINUE_CTrain_ProcessControl_VehicleDamage
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_VehicleCollision.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_VehicleCollision.cpp
@@ -64,13 +64,19 @@ static void __declspec(naked) HOOK_CAutomobile_ProcessControl_VehicleDamage()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
         mov pCollisionVehicle, ecx
     }
 
+    // clang-format on
+
     TriggerVehicleCollisionEvent();
+
+    // clang-format off
 
     __asm
     {
@@ -81,6 +87,8 @@ static void __declspec(naked) HOOK_CAutomobile_ProcessControl_VehicleDamage()
         call    dword ptr[eax + 0E0h]
         jmp     CONTINUE_CAutomobile_ProcessControl_VehicleDamage
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -99,13 +107,19 @@ static void __declspec(naked) HOOK_CBike_ProcessControl_VehicleDamage()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
         mov pCollisionVehicle, ecx
     }
 
+    // clang-format on
+
     TriggerVehicleCollisionEvent();
+
+    // clang-format off
 
     __asm
     {
@@ -116,6 +130,8 @@ static void __declspec(naked) HOOK_CBike_ProcessControl_VehicleDamage()
         call    dword ptr[eax + 0E0h]
         jmp     CONTINUE_CBike_ProcessControl_VehicleDamage
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -135,13 +151,19 @@ static void __declspec(naked) HOOK_CBoat_ProcessControl_VehicleDamage()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
         mov pCollisionVehicle, ecx
     }
 
+    // clang-format on
+
     TriggerVehicleCollisionEvent();
+
+    // clang-format off
 
     __asm
     {
@@ -151,6 +173,8 @@ static void __declspec(naked) HOOK_CBoat_ProcessControl_VehicleDamage()
         call    FUNC_CVehicle_ProcessCarAlarm
         jmp     CONTINUE_CBoat_ProcessControl_VehicleDamage
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -169,13 +193,19 @@ static void __declspec(naked) HOOK_CTrain_ProcessControl_VehicleDamage()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
         mov pCollisionVehicle, esi
     }
 
+    // clang-format on
+
     TriggerVehicleCollisionEvent();
+
+    // clang-format off
 
     __asm
     {
@@ -184,6 +214,8 @@ static void __declspec(naked) HOOK_CTrain_ProcessControl_VehicleDamage()
         mov     al, ds:[0BA6728h]
         jmp     CONTINUE_CTrain_ProcessControl_VehicleDamage
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_VehicleDamage.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_VehicleDamage.cpp
@@ -68,7 +68,6 @@ static void __declspec(naked) HOOK_CAutomobile_BurstTyre()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -90,7 +89,6 @@ cont:
         mov     ecx, ebx
         jmp     RETURN_CAutomobile_BurstTyre_A
     }
-
     // clang-format on
 }
 
@@ -111,7 +109,6 @@ static void __declspec(naked) HOOK_CBike_BurstTyre()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -134,7 +131,6 @@ cont:
         lea     ecx, [esi+138h]
         jmp     RETURN_CBike_BurstTyre_A
     }
-
     // clang-format on
 }
 
@@ -166,7 +162,6 @@ static void __declspec(naked) HOOK_CVehicle_InflictDamage()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -191,7 +186,6 @@ cont:
         push    0FFFFFFFFh
         jmp     RETURN_CVehicle_InflictDamage
     }
-
     // clang-format on
 }
 
@@ -226,7 +220,6 @@ static void __declspec(naked) HOOK_CAutomobile_VehicleDamage1()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -246,7 +239,6 @@ static void __declspec(naked) HOOK_CAutomobile_VehicleDamage1()
         push    [0x847FD8]
         jmp     RETURN_CAutomobile_VehicleDamage1
     }
-
     // clang-format on
 }
 
@@ -291,7 +283,6 @@ static void __declspec(naked) HOOK_CAutomobile_VehicleDamage2()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -307,7 +298,6 @@ static void __declspec(naked) HOOK_CAutomobile_VehicleDamage2()
         fsubr   dword ptr [esi+4C0h]
         jmp     RETURN_CAutomobile_VehicleDamage2
     }
-
     // clang-format on
 }
 
@@ -328,7 +318,6 @@ static void __declspec(naked) HOOK_CPlane_VehicleDamage1()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -348,7 +337,6 @@ static void __declspec(naked) HOOK_CPlane_VehicleDamage1()
         mov     eax, dword ptr ds:[0x08D33E4]
         jmp     RETURN_CPlane_VehicleDamage1
     }
-
     // clang-format on
 }
 
@@ -369,7 +357,6 @@ static void __declspec(naked) HOOK_CPlane_VehicleDamage2()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -385,7 +372,6 @@ static void __declspec(naked) HOOK_CPlane_VehicleDamage2()
         fsubr   dword ptr [esi+4C0h]
         jmp     RETURN_CPlane_VehicleDamage2
     }
-
     // clang-format on
 }
 
@@ -406,7 +392,6 @@ static void __declspec(naked) HOOK_CBike_VehicleDamage1()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -426,7 +411,6 @@ static void __declspec(naked) HOOK_CBike_VehicleDamage1()
         fld     [esp+8]
         jmp     RETURN_CBike_VehicleDamage1
     }
-
     // clang-format on
 }
 
@@ -447,7 +431,6 @@ static void __declspec(naked) HOOK_CBike_VehicleDamage2()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -463,7 +446,6 @@ static void __declspec(naked) HOOK_CBike_VehicleDamage2()
         fsubr   dword ptr [esi+4C0h]
         jmp     RETURN_CBike_VehicleDamage2
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_VehicleDamage.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_VehicleDamage.cpp
@@ -67,6 +67,8 @@ static void __declspec(naked) HOOK_CAutomobile_BurstTyre()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -88,6 +90,8 @@ cont:
         mov     ecx, ebx
         jmp     RETURN_CAutomobile_BurstTyre_A
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -105,6 +109,8 @@ DWORD RETURN_CBike_BurstTyre_B = 0x06BECA5;
 static void __declspec(naked) HOOK_CBike_BurstTyre()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -128,6 +134,8 @@ cont:
         lea     ecx, [esi+138h]
         jmp     RETURN_CBike_BurstTyre_A
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -157,6 +165,8 @@ static void __declspec(naked) HOOK_CVehicle_InflictDamage()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -181,6 +191,8 @@ cont:
         push    0FFFFFFFFh
         jmp     RETURN_CVehicle_InflictDamage
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -213,6 +225,8 @@ static void __declspec(naked) HOOK_CAutomobile_VehicleDamage1()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -232,6 +246,8 @@ static void __declspec(naked) HOOK_CAutomobile_VehicleDamage1()
         push    [0x847FD8]
         jmp     RETURN_CAutomobile_VehicleDamage1
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -274,6 +290,8 @@ static void __declspec(naked) HOOK_CAutomobile_VehicleDamage2()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -289,6 +307,8 @@ static void __declspec(naked) HOOK_CAutomobile_VehicleDamage2()
         fsubr   dword ptr [esi+4C0h]
         jmp     RETURN_CAutomobile_VehicleDamage2
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -306,6 +326,8 @@ DWORD RETURN_CPlane_VehicleDamage1 = 0x06CC4B8;
 static void __declspec(naked) HOOK_CPlane_VehicleDamage1()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -326,6 +348,8 @@ static void __declspec(naked) HOOK_CPlane_VehicleDamage1()
         mov     eax, dword ptr ds:[0x08D33E4]
         jmp     RETURN_CPlane_VehicleDamage1
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -344,6 +368,8 @@ static void __declspec(naked) HOOK_CPlane_VehicleDamage2()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -359,6 +385,8 @@ static void __declspec(naked) HOOK_CPlane_VehicleDamage2()
         fsubr   dword ptr [esi+4C0h]
         jmp     RETURN_CPlane_VehicleDamage2
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -376,6 +404,8 @@ DWORD RETURN_CBike_VehicleDamage1 = 0x06B8EC5;
 static void __declspec(naked) HOOK_CBike_VehicleDamage1()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -396,6 +426,8 @@ static void __declspec(naked) HOOK_CBike_VehicleDamage1()
         fld     [esp+8]
         jmp     RETURN_CBike_VehicleDamage1
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -414,6 +446,8 @@ static void __declspec(naked) HOOK_CBike_VehicleDamage2()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -429,6 +463,8 @@ static void __declspec(naked) HOOK_CBike_VehicleDamage2()
         fsubr   dword ptr [esi+4C0h]
         jmp     RETURN_CBike_VehicleDamage2
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_VehicleDummies.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_VehicleDummies.cpp
@@ -98,6 +98,8 @@ static void __declspec(naked) HOOK_CVehicle_AddExhaustParticles_1()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -119,6 +121,8 @@ static void __declspec(naked) HOOK_CVehicle_AddExhaustParticles_1()
         mov     [esp+0D4h-8Ch], edx
         jmp     CONTINUE_CVehicle_AddExhaustParticles_1
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -140,6 +144,8 @@ static void __declspec(naked) HOOK_CVehicle_AddExhaustParticles_2()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -158,6 +164,8 @@ static void __declspec(naked) HOOK_CVehicle_AddExhaustParticles_2()
         add     edx, 84h
         jmp     CONTINUE_CVehicle_AddExhaustParticles_2
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -178,6 +186,8 @@ static const DWORD CONTINUE_CVehicle_AddDamagedVehicleParticles = 0x6D2B0F;
 static void __declspec(naked) HOOK_CVehicle_AddDamagedVehicleParticles()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -201,6 +211,8 @@ static void __declspec(naked) HOOK_CVehicle_AddDamagedVehicleParticles()
         add     ecx, 54h
         jmp     CONTINUE_CVehicle_AddDamagedVehicleParticles
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -221,6 +233,8 @@ static const DWORD CONTINUE_CFire_ProcessFire = 0x53A719;
 static void __declspec(naked) HOOK_CFire_ProcessFire()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -244,6 +258,8 @@ static void __declspec(naked) HOOK_CFire_ProcessFire()
         mov     edx, [eax]
         jmp     CONTINUE_CFire_ProcessFire
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -264,6 +280,8 @@ static const DWORD CONTINUE_CAutomobile_DoNitroEffect_1 = 0x6A3BE8;
 static void __declspec(naked) HOOK_CAutomobile_DoNitroEffect_1()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -287,6 +305,8 @@ static void __declspec(naked) HOOK_CAutomobile_DoNitroEffect_1()
         add     ecx, 48h
         jmp     CONTINUE_CAutomobile_DoNitroEffect_1
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -338,6 +358,8 @@ static void __declspec(naked) HOOK_CAutomobile_DoNitroEffect_2()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -351,6 +373,8 @@ static void __declspec(naked) HOOK_CAutomobile_DoNitroEffect_2()
         test    [esi+40h], edi
         jmp     CONTINUE_CAutomobile_DoNitroEffect_2
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -375,6 +399,8 @@ static void __declspec(naked) HOOK_CVehicle_DoVehicleLights_1()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -397,6 +423,8 @@ static void __declspec(naked) HOOK_CVehicle_DoVehicleLights_1()
         add     eax, 18h
         jmp     CONTINUE_CVehicle_DoVehicleLights_1
     }
+
+    // clang-format on
 }
 
 //     0x6E22C6 | 8B 04 85 C8 B0 A9 00 | mov eax, CModelInfo::ms_modelInfoPtrs
@@ -410,6 +438,8 @@ static const DWORD CONTINUE_CVehicle_DoVehicleLights_2 = 0x6E22D3;
 static void __declspec(naked) HOOK_CVehicle_DoVehicleLights_2()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -433,6 +463,8 @@ static void __declspec(naked) HOOK_CVehicle_DoVehicleLights_2()
         add     ecx, 18h
         jmp     CONTINUE_CVehicle_DoVehicleLights_2
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -453,6 +485,8 @@ static const DWORD CONTINUE_CAutomobile_ProcessCarOnFireAndExplode = 0x6A7185;
 static void __declspec(naked) HOOK_CAutomobile_ProcessCarOnFireAndExplode()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -476,6 +510,8 @@ static void __declspec(naked) HOOK_CAutomobile_ProcessCarOnFireAndExplode()
         add     eax, 54h
         jmp     CONTINUE_CAutomobile_ProcessCarOnFireAndExplode
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -496,6 +532,8 @@ static const DWORD CONTINUE_CBike_FixHandsToBars = 0x6B8059;
 static void __declspec(naked) HOOK_CBike_FixHandsToBars()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -519,6 +557,8 @@ static void __declspec(naked) HOOK_CBike_FixHandsToBars()
         add     eax, 78h
         jmp     CONTINUE_CBike_FixHandsToBars
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -539,6 +579,8 @@ static const DWORD CONTINUE_CPed_SetPedPositionInCar_1 = 0x5DF992;
 static void __declspec(naked) HOOK_CPed_SetPedPositionInCar_1()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -563,6 +605,8 @@ static void __declspec(naked) HOOK_CPed_SetPedPositionInCar_1()
         mov     edi, [edi+5Ch]
         jmp     CONTINUE_CPed_SetPedPositionInCar_1
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -583,6 +627,8 @@ static const DWORD CONTINUE_CPed_SetPedPositionInCar_2 = 0x5DFA5C;
 static void __declspec(naked) HOOK_CPed_SetPedPositionInCar_2()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -607,6 +653,8 @@ static void __declspec(naked) HOOK_CPed_SetPedPositionInCar_2()
         add     eax, 3Ch
         jmp     CONTINUE_CPed_SetPedPositionInCar_2
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -627,6 +675,8 @@ static const DWORD CONTINUE_CPed_SetPedPositionInCar_3 = 0x5DFA0B;
 static void __declspec(naked) HOOK_CPed_SetPedPositionInCar_3()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -651,6 +701,8 @@ static void __declspec(naked) HOOK_CPed_SetPedPositionInCar_3()
         mov     edi, [edi+5Ch]
         jmp     CONTINUE_CPed_SetPedPositionInCar_3
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -671,6 +723,8 @@ static const DWORD CONTINUE_CPed_SetPedPositionInCar_4 = 0x5DFA86;
 static void __declspec(naked) HOOK_CPed_SetPedPositionInCar_4()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -695,6 +749,8 @@ static void __declspec(naked) HOOK_CPed_SetPedPositionInCar_4()
         add     edx, 3Ch
         jmp     CONTINUE_CPed_SetPedPositionInCar_4
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -715,6 +771,8 @@ static const DWORD CONTINUE_CVehicle_DoHeadLightEffect = 0x6E0A6F;
 static void __declspec(naked) HOOK_CVehicle_DoHeadLightEffect()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -738,6 +796,8 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightEffect()
         lea     ecx, [ebx+ebx*2]
         jmp     CONTINUE_CVehicle_DoHeadLightEffect
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -759,6 +819,8 @@ static const DWORD CONTINUE_CVehicle_DoTailLightEffect = 0x6E17C8;
 static void __declspec(naked) HOOK_CVehicle_DoTailLightEffect()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -784,6 +846,8 @@ static void __declspec(naked) HOOK_CVehicle_DoTailLightEffect()
         mov     ebx, [esp+4+30h]
         jmp     CONTINUE_CVehicle_DoTailLightEffect
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -805,6 +869,8 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightReflectionSingle()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -827,6 +893,8 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightReflectionSingle()
         mov     eax, [edx]
         jmp     CONTINUE_CVehicle_DoHeadLightReflectionSingle
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -848,6 +916,8 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightReflectionTwin()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -870,6 +940,8 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightReflectionTwin()
         mov     eax, [edx]
         jmp     CONTINUE_CVehicle_DoHeadLightReflectionTwin
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -892,6 +964,8 @@ static void __declspec(naked) HOOK_CVehicle_GetPlaneGunsPosition()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -916,6 +990,8 @@ static void __declspec(naked) HOOK_CVehicle_GetPlaneGunsPosition()
         mov     eax, [eax+5Ch]
         jmp     CONTINUE_CVehicle_GetPlaneGunsPosition
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -937,6 +1013,8 @@ static void __declspec(naked) HOOK_CVehicle_GetPlaneOrdnancePosition()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -959,6 +1037,8 @@ static void __declspec(naked) HOOK_CVehicle_GetPlaneOrdnancePosition()
         add     eax, 9Ch
         jmp     CONTINUE_CVehicle_GetPlaneOrdnancePosition
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -980,6 +1060,8 @@ static void __declspec(naked) HOOK_CVehicle_CanBeDriven()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -1002,6 +1084,8 @@ static void __declspec(naked) HOOK_CVehicle_CanBeDriven()
         mov     eax, [eax+5Ch]
         jmp     CONTINUE_CVehicle_CanBeDriven
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -1022,6 +1106,8 @@ static const DWORD CONTINUE_CPlane_PreRender_1 = 0x6C9724;
 static void __declspec(naked) HOOK_CPlane_PreRender_1()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -1045,6 +1131,8 @@ static void __declspec(naked) HOOK_CPlane_PreRender_1()
         add     ecx, 84h
         jmp     CONTINUE_CPlane_PreRender_1
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -1066,6 +1154,8 @@ static void __declspec(naked) HOOK_CPlane_PreRender_2()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -1088,6 +1178,8 @@ static void __declspec(naked) HOOK_CPlane_PreRender_2()
         add     eax, 6Ch
         jmp     CONTINUE_CPlane_PreRender_2
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -1109,6 +1201,8 @@ static void __declspec(naked) HOOK_CPlane_PreRender_3()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -1131,6 +1225,8 @@ static void __declspec(naked) HOOK_CPlane_PreRender_3()
         add     eax, 78h
         jmp     CONTINUE_CPlane_PreRender_3
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -1151,6 +1247,8 @@ static const DWORD CONTINUE_CVehicle_DoHeadLightBeam = 0x6E0E3E;
 static void __declspec(naked) HOOK_CVehicle_DoHeadLightBeam()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -1174,6 +1272,8 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightBeam()
         mov     eax, [esp+98h+4h]
         jmp     CONTINUE_CVehicle_DoHeadLightBeam
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_VehicleDummies.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_VehicleDummies.cpp
@@ -99,7 +99,6 @@ static void __declspec(naked) HOOK_CVehicle_AddExhaustParticles_1()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -121,7 +120,6 @@ static void __declspec(naked) HOOK_CVehicle_AddExhaustParticles_1()
         mov     [esp+0D4h-8Ch], edx
         jmp     CONTINUE_CVehicle_AddExhaustParticles_1
     }
-
     // clang-format on
 }
 
@@ -145,7 +143,6 @@ static void __declspec(naked) HOOK_CVehicle_AddExhaustParticles_2()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -164,7 +161,6 @@ static void __declspec(naked) HOOK_CVehicle_AddExhaustParticles_2()
         add     edx, 84h
         jmp     CONTINUE_CVehicle_AddExhaustParticles_2
     }
-
     // clang-format on
 }
 
@@ -188,7 +184,6 @@ static void __declspec(naked) HOOK_CVehicle_AddDamagedVehicleParticles()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -211,7 +206,6 @@ static void __declspec(naked) HOOK_CVehicle_AddDamagedVehicleParticles()
         add     ecx, 54h
         jmp     CONTINUE_CVehicle_AddDamagedVehicleParticles
     }
-
     // clang-format on
 }
 
@@ -235,7 +229,6 @@ static void __declspec(naked) HOOK_CFire_ProcessFire()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -258,7 +251,6 @@ static void __declspec(naked) HOOK_CFire_ProcessFire()
         mov     edx, [eax]
         jmp     CONTINUE_CFire_ProcessFire
     }
-
     // clang-format on
 }
 
@@ -282,7 +274,6 @@ static void __declspec(naked) HOOK_CAutomobile_DoNitroEffect_1()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -305,7 +296,6 @@ static void __declspec(naked) HOOK_CAutomobile_DoNitroEffect_1()
         add     ecx, 48h
         jmp     CONTINUE_CAutomobile_DoNitroEffect_1
     }
-
     // clang-format on
 }
 
@@ -359,7 +349,6 @@ static void __declspec(naked) HOOK_CAutomobile_DoNitroEffect_2()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -373,7 +362,6 @@ static void __declspec(naked) HOOK_CAutomobile_DoNitroEffect_2()
         test    [esi+40h], edi
         jmp     CONTINUE_CAutomobile_DoNitroEffect_2
     }
-
     // clang-format on
 }
 
@@ -400,7 +388,6 @@ static void __declspec(naked) HOOK_CVehicle_DoVehicleLights_1()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -423,7 +410,6 @@ static void __declspec(naked) HOOK_CVehicle_DoVehicleLights_1()
         add     eax, 18h
         jmp     CONTINUE_CVehicle_DoVehicleLights_1
     }
-
     // clang-format on
 }
 
@@ -440,7 +426,6 @@ static void __declspec(naked) HOOK_CVehicle_DoVehicleLights_2()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -463,7 +448,6 @@ static void __declspec(naked) HOOK_CVehicle_DoVehicleLights_2()
         add     ecx, 18h
         jmp     CONTINUE_CVehicle_DoVehicleLights_2
     }
-
     // clang-format on
 }
 
@@ -487,7 +471,6 @@ static void __declspec(naked) HOOK_CAutomobile_ProcessCarOnFireAndExplode()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -510,7 +493,6 @@ static void __declspec(naked) HOOK_CAutomobile_ProcessCarOnFireAndExplode()
         add     eax, 54h
         jmp     CONTINUE_CAutomobile_ProcessCarOnFireAndExplode
     }
-
     // clang-format on
 }
 
@@ -534,7 +516,6 @@ static void __declspec(naked) HOOK_CBike_FixHandsToBars()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -557,7 +538,6 @@ static void __declspec(naked) HOOK_CBike_FixHandsToBars()
         add     eax, 78h
         jmp     CONTINUE_CBike_FixHandsToBars
     }
-
     // clang-format on
 }
 
@@ -581,7 +561,6 @@ static void __declspec(naked) HOOK_CPed_SetPedPositionInCar_1()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -605,7 +584,6 @@ static void __declspec(naked) HOOK_CPed_SetPedPositionInCar_1()
         mov     edi, [edi+5Ch]
         jmp     CONTINUE_CPed_SetPedPositionInCar_1
     }
-
     // clang-format on
 }
 
@@ -629,7 +607,6 @@ static void __declspec(naked) HOOK_CPed_SetPedPositionInCar_2()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -653,7 +630,6 @@ static void __declspec(naked) HOOK_CPed_SetPedPositionInCar_2()
         add     eax, 3Ch
         jmp     CONTINUE_CPed_SetPedPositionInCar_2
     }
-
     // clang-format on
 }
 
@@ -677,7 +653,6 @@ static void __declspec(naked) HOOK_CPed_SetPedPositionInCar_3()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -701,7 +676,6 @@ static void __declspec(naked) HOOK_CPed_SetPedPositionInCar_3()
         mov     edi, [edi+5Ch]
         jmp     CONTINUE_CPed_SetPedPositionInCar_3
     }
-
     // clang-format on
 }
 
@@ -725,7 +699,6 @@ static void __declspec(naked) HOOK_CPed_SetPedPositionInCar_4()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -749,7 +722,6 @@ static void __declspec(naked) HOOK_CPed_SetPedPositionInCar_4()
         add     edx, 3Ch
         jmp     CONTINUE_CPed_SetPedPositionInCar_4
     }
-
     // clang-format on
 }
 
@@ -773,7 +745,6 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightEffect()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -796,7 +767,6 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightEffect()
         lea     ecx, [ebx+ebx*2]
         jmp     CONTINUE_CVehicle_DoHeadLightEffect
     }
-
     // clang-format on
 }
 
@@ -821,7 +791,6 @@ static void __declspec(naked) HOOK_CVehicle_DoTailLightEffect()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -846,7 +815,6 @@ static void __declspec(naked) HOOK_CVehicle_DoTailLightEffect()
         mov     ebx, [esp+4+30h]
         jmp     CONTINUE_CVehicle_DoTailLightEffect
     }
-
     // clang-format on
 }
 
@@ -870,7 +838,6 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightReflectionSingle()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -893,7 +860,6 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightReflectionSingle()
         mov     eax, [edx]
         jmp     CONTINUE_CVehicle_DoHeadLightReflectionSingle
     }
-
     // clang-format on
 }
 
@@ -917,7 +883,6 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightReflectionTwin()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -940,7 +905,6 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightReflectionTwin()
         mov     eax, [edx]
         jmp     CONTINUE_CVehicle_DoHeadLightReflectionTwin
     }
-
     // clang-format on
 }
 
@@ -965,7 +929,6 @@ static void __declspec(naked) HOOK_CVehicle_GetPlaneGunsPosition()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -990,7 +953,6 @@ static void __declspec(naked) HOOK_CVehicle_GetPlaneGunsPosition()
         mov     eax, [eax+5Ch]
         jmp     CONTINUE_CVehicle_GetPlaneGunsPosition
     }
-
     // clang-format on
 }
 
@@ -1014,7 +976,6 @@ static void __declspec(naked) HOOK_CVehicle_GetPlaneOrdnancePosition()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -1037,7 +998,6 @@ static void __declspec(naked) HOOK_CVehicle_GetPlaneOrdnancePosition()
         add     eax, 9Ch
         jmp     CONTINUE_CVehicle_GetPlaneOrdnancePosition
     }
-
     // clang-format on
 }
 
@@ -1061,7 +1021,6 @@ static void __declspec(naked) HOOK_CVehicle_CanBeDriven()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -1084,7 +1043,6 @@ static void __declspec(naked) HOOK_CVehicle_CanBeDriven()
         mov     eax, [eax+5Ch]
         jmp     CONTINUE_CVehicle_CanBeDriven
     }
-
     // clang-format on
 }
 
@@ -1108,7 +1066,6 @@ static void __declspec(naked) HOOK_CPlane_PreRender_1()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -1131,7 +1088,6 @@ static void __declspec(naked) HOOK_CPlane_PreRender_1()
         add     ecx, 84h
         jmp     CONTINUE_CPlane_PreRender_1
     }
-
     // clang-format on
 }
 
@@ -1155,7 +1111,6 @@ static void __declspec(naked) HOOK_CPlane_PreRender_2()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -1178,7 +1133,6 @@ static void __declspec(naked) HOOK_CPlane_PreRender_2()
         add     eax, 6Ch
         jmp     CONTINUE_CPlane_PreRender_2
     }
-
     // clang-format on
 }
 
@@ -1202,7 +1156,6 @@ static void __declspec(naked) HOOK_CPlane_PreRender_3()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -1225,7 +1178,6 @@ static void __declspec(naked) HOOK_CPlane_PreRender_3()
         add     eax, 78h
         jmp     CONTINUE_CPlane_PreRender_3
     }
-
     // clang-format on
 }
 
@@ -1249,7 +1201,6 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightBeam()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -1272,7 +1223,6 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightBeam()
         mov     eax, [esp+98h+4h]
         jmp     CONTINUE_CVehicle_DoHeadLightBeam
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_VehicleLights.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_VehicleLights.cpp
@@ -34,7 +34,6 @@ static void __declspec(naked) HOOK_CVehicle_DoTailLightEffect_Mid()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Save result of comparing camera and corona direction
@@ -46,7 +45,6 @@ behind_corona:
         mov     bCameraFacingCorona, eax
         jmp     RETURN_CVehicle_DoTailLightEffect_Mid
     }
-
     // clang-format on
 }
 
@@ -68,7 +66,6 @@ static void __declspec(naked) HOOK_CVehicle_DoTailLightEffect_Mid2()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         movzx   eax, byte ptr [esp+0Fh]
@@ -88,7 +85,6 @@ no_corona:
         sub     esp, 54h
         jmp     RETURN_CVehicle_DoTailLightEffect_Mid2_NoCorona
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_VehicleLights.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_VehicleLights.cpp
@@ -33,6 +33,8 @@ static void __declspec(naked) HOOK_CVehicle_DoTailLightEffect_Mid()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // Save result of comparing camera and corona direction
@@ -44,6 +46,8 @@ behind_corona:
         mov     bCameraFacingCorona, eax
         jmp     RETURN_CVehicle_DoTailLightEffect_Mid
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -62,6 +66,8 @@ DWORD RETURN_CVehicle_DoTailLightEffect_Mid2_NoCorona = 0x006E1A32;
 static void __declspec(naked) HOOK_CVehicle_DoTailLightEffect_Mid2()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -82,6 +88,8 @@ no_corona:
         sub     esp, 54h
         jmp     RETURN_CVehicle_DoTailLightEffect_Mid2_NoCorona
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_VehicleWeapons.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_VehicleWeapons.cpp
@@ -59,6 +59,8 @@ static void __declspec(naked) HOOK_CWaterCannon__Render()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -74,6 +76,8 @@ static void __declspec(naked) HOOK_CWaterCannon__Render()
         push    3E4CCCCDh
         jmp     CONTINUE_CWaterCannon__Render
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_VehicleWeapons.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_VehicleWeapons.cpp
@@ -60,7 +60,6 @@ static void __declspec(naked) HOOK_CWaterCannon__Render()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -76,7 +75,6 @@ static void __declspec(naked) HOOK_CWaterCannon__Render()
         push    3E4CCCCDh
         jmp     CONTINUE_CWaterCannon__Render
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -39,6 +39,8 @@ static void __declspec(naked) HOOK_CDamageManager__ProgressDoorDamage()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -58,6 +60,8 @@ static void __declspec(naked) HOOK_CDamageManager__ProgressDoorDamage()
         movzx   esi, [esp + 0Ch]
         jmp     CONTINUE_CDamageManager__ProgressDoorDamage
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -40,7 +40,6 @@ static void __declspec(naked) HOOK_CDamageManager__ProgressDoorDamage()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -60,7 +59,6 @@ static void __declspec(naked) HOOK_CDamageManager__ProgressDoorDamage()
         movzx   esi, [esp + 0Ch]
         jmp     CONTINUE_CDamageManager__ProgressDoorDamage
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/CMultiplayerSA_Weapons.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Weapons.cpp
@@ -58,6 +58,8 @@ static void __declspec(naked) HOOK_CWeapon_GenerateDamageEvent()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -76,6 +78,8 @@ static void __declspec(naked) HOOK_CWeapon_GenerateDamageEvent()
         push    848E10h
         jmp     RETURN_CWeapon_GenerateDamageEvent
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -107,6 +111,7 @@ void ResetShotInfoArray()
 
 void Call_CShotInfo_Update()
 {
+    // clang-format off
     __asm
     {
         call inner
@@ -118,6 +123,7 @@ void Call_CShotInfo_Update()
         jmp     RETURN_CShotInfo_Update
     done:
     }
+    // clang-format on
 }
 
 #pragma warning( pop )
@@ -148,6 +154,8 @@ static void __declspec(naked) HOOK_CShotInfo_Update()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -155,6 +163,8 @@ static void __declspec(naked) HOOK_CShotInfo_Update()
         popad
         retn
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -191,6 +201,8 @@ static void __declspec(naked) HOOK_Fx_AddBulletImpact()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -204,6 +216,8 @@ static void __declspec(naked) HOOK_Fx_AddBulletImpact()
         mov     eax, ds:0x0B6F03C
         jmp     RETURN_Fx_AddBulletImpact
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -220,6 +234,8 @@ static void __declspec(naked) HOOK_CVisibilityPlugins_RenderWeaponPedsForPC()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov eax, 5DF4E0h
@@ -233,6 +249,8 @@ static void __declspec(naked) HOOK_CVisibilityPlugins_RenderWeaponPedsForPC()
 
         jmp CONTINUE_CVisibilityPlugins_RenderWeaponPedsForPC
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -255,6 +273,8 @@ static void _declspec(naked) HOOK_CWaterLevel_TestLineAgainstWater()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // [esp+4]  from.x
@@ -274,6 +294,8 @@ static void _declspec(naked) HOOK_CWaterLevel_TestLineAgainstWater()
         sub     esp, 88h
         jmp CONTINUE_CWaterLevel_TestLineAgainstWater
     }
+
+    // clang-format on
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_Weapons.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Weapons.cpp
@@ -59,7 +59,6 @@ static void __declspec(naked) HOOK_CWeapon_GenerateDamageEvent()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -78,7 +77,6 @@ static void __declspec(naked) HOOK_CWeapon_GenerateDamageEvent()
         push    848E10h
         jmp     RETURN_CWeapon_GenerateDamageEvent
     }
-
     // clang-format on
 }
 
@@ -155,7 +153,6 @@ static void __declspec(naked) HOOK_CShotInfo_Update()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -163,7 +160,6 @@ static void __declspec(naked) HOOK_CShotInfo_Update()
         popad
         retn
     }
-
     // clang-format on
 }
 
@@ -202,7 +198,6 @@ static void __declspec(naked) HOOK_Fx_AddBulletImpact()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -216,7 +211,6 @@ static void __declspec(naked) HOOK_Fx_AddBulletImpact()
         mov     eax, ds:0x0B6F03C
         jmp     RETURN_Fx_AddBulletImpact
     }
-
     // clang-format on
 }
 
@@ -235,7 +229,6 @@ static void __declspec(naked) HOOK_CVisibilityPlugins_RenderWeaponPedsForPC()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov eax, 5DF4E0h
@@ -249,7 +242,6 @@ static void __declspec(naked) HOOK_CVisibilityPlugins_RenderWeaponPedsForPC()
 
         jmp CONTINUE_CVisibilityPlugins_RenderWeaponPedsForPC
     }
-
     // clang-format on
 }
 
@@ -274,7 +266,6 @@ static void _declspec(naked) HOOK_CWaterLevel_TestLineAgainstWater()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // [esp+4]  from.x
@@ -294,7 +285,6 @@ static void _declspec(naked) HOOK_CWaterLevel_TestLineAgainstWater()
         sub     esp, 88h
         jmp CONTINUE_CWaterLevel_TestLineAgainstWater
     }
-
     // clang-format on
 }
 

--- a/Client/multiplayer_sa/multiplayer_hooksystem.h
+++ b/Client/multiplayer_sa/multiplayer_hooksystem.h
@@ -20,12 +20,14 @@
 // compilation, and it must be zero.
 // 
 // NOTE: This was copied from game_sa. Check the comment there for more details.
+// clang-format off
 #define MTA_VERIFY_HOOK_LOCAL_SIZE                     \
 {                                                      \
     __asm {              push   eax                };  \
     __asm { _localSize:  mov    eax, __LOCAL_SIZE  };  \
     __asm {              pop    eax                };  \
 }
+// clang-format on
 
 VOID  HookInstallMethod(DWORD dwInstallAddress, DWORD dwHookFunction);
 VOID  HookInstallCall(DWORD dwInstallAddress, DWORD dwHookFunction);

--- a/Client/multiplayer_sa/multiplayer_hooksystem.h
+++ b/Client/multiplayer_sa/multiplayer_hooksystem.h
@@ -20,14 +20,12 @@
 // compilation, and it must be zero.
 // 
 // NOTE: This was copied from game_sa. Check the comment there for more details.
-// clang-format off
 #define MTA_VERIFY_HOOK_LOCAL_SIZE                     \
 {                                                      \
     __asm {              push   eax                };  \
     __asm { _localSize:  mov    eax, __LOCAL_SIZE  };  \
     __asm {              pop    eax                };  \
 }
-// clang-format on
 
 VOID  HookInstallMethod(DWORD dwInstallAddress, DWORD dwHookFunction);
 VOID  HookInstallCall(DWORD dwInstallAddress, DWORD dwHookFunction);

--- a/Client/multiplayer_sa/multiplayer_keysync.cpp
+++ b/Client/multiplayer_sa/multiplayer_keysync.cpp
@@ -514,6 +514,7 @@ static void __declspec(naked) HOOK_CPlayerPed__ProcessControl()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // Assumes no reentrancy
+    // clang-format off
     __asm
     {
         mov     dwCurrentPlayerPed, ecx
@@ -529,8 +530,11 @@ static void __declspec(naked) HOOK_CPlayerPed__ProcessControl()
         mov     PlayerPed__ProcessControl_Saved.edi, edi
         pushad
     }
+    // clang-format on
 
     SwitchContext((CPedSAInterface*)dwCurrentPlayerPed);
+
+    // clang-format off
 
     __asm
     {
@@ -540,18 +544,26 @@ static void __declspec(naked) HOOK_CPlayerPed__ProcessControl()
         pushad
     }
 
+    // clang-format on
+
     ReturnContextToLocalPlayer();
+
+    // clang-format off
 
     __asm
     {
         popad
         retn
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) CPlayerPed__ProcessControl_Abort()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -567,13 +579,19 @@ static void __declspec(naked) CPlayerPed__ProcessControl_Abort()
         pushad
     }
 
+    // clang-format on
+
     ReturnContextToLocalPlayer();
+
+    // clang-format off
 
     __asm
     {
         popad
         retn
     }
+
+    // clang-format on
 }
 
 //--------------------------------------------------------------------------------------------
@@ -582,13 +600,19 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessControl()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     dwCurrentVehicle, ecx
         pushad
     }
 
+    // clang-format on
+
     SwitchContext((CVehicleSAInterface*)dwCurrentVehicle);
+
+    // clang-format off
 
     __asm
     {
@@ -598,13 +622,19 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessControl()
         pushad
     }
 
+    // clang-format on
+
     ReturnContextToLocalPlayer();
+
+    // clang-format off
 
     __asm
     {
         popad
         retn
     }
+
+    // clang-format on
 }
 
 //--------------------------------------------------------------------------------------------
@@ -613,13 +643,19 @@ static void __declspec(naked) HOOK_CMonsterTruck__ProcessControl()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     dwCurrentVehicle, ecx
         pushad
     }
 
+    // clang-format on
+
     SwitchContext((CVehicleSAInterface*)dwCurrentVehicle);
+
+    // clang-format off
 
     __asm
     {
@@ -629,13 +665,19 @@ static void __declspec(naked) HOOK_CMonsterTruck__ProcessControl()
         pushad
     }
 
+    // clang-format on
+
     ReturnContextToLocalPlayer();
+
+    // clang-format off
 
     __asm
     {
         popad
         retn
     }
+
+    // clang-format on
 }
 
 //--------------------------------------------------------------------------------------------
@@ -644,13 +686,19 @@ static void __declspec(naked) HOOK_CTrailer__ProcessControl()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     dwCurrentVehicle, ecx
         pushad
     }
 
+    // clang-format on
+
     SwitchContext((CVehicleSAInterface*)dwCurrentVehicle);
+
+    // clang-format off
 
     __asm
     {
@@ -660,13 +708,19 @@ static void __declspec(naked) HOOK_CTrailer__ProcessControl()
         pushad
     }
 
+    // clang-format on
+
     ReturnContextToLocalPlayer();
+
+    // clang-format off
 
     __asm
     {
         popad
         retn
     }
+
+    // clang-format on
 }
 
 //--------------------------------------------------------------------------------------------
@@ -675,13 +729,19 @@ static void __declspec(naked) HOOK_CQuadBike__ProcessControl()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     dwCurrentVehicle, ecx
         pushad
     }
 
+    // clang-format on
+
     SwitchContext((CVehicleSAInterface*)dwCurrentVehicle);
+
+    // clang-format off
 
     __asm
     {
@@ -691,13 +751,19 @@ static void __declspec(naked) HOOK_CQuadBike__ProcessControl()
         pushad
     }
 
+    // clang-format on
+
     ReturnContextToLocalPlayer();
+
+    // clang-format off
 
     __asm
     {
         popad
         retn
     }
+
+    // clang-format on
 }
 
 //--------------------------------------------------------------------------------------------
@@ -706,13 +772,19 @@ static void __declspec(naked) HOOK_CPlane__ProcessControl()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     dwCurrentVehicle, ecx
         pushad
     }
 
+    // clang-format on
+
     SwitchContext((CVehicleSAInterface*)dwCurrentVehicle);
+
+    // clang-format off
 
     __asm
     {
@@ -722,13 +794,19 @@ static void __declspec(naked) HOOK_CPlane__ProcessControl()
         pushad
     }
 
+    // clang-format on
+
     ReturnContextToLocalPlayer();
+
+    // clang-format off
 
     __asm
     {
         popad
         retn
     }
+
+    // clang-format on
 }
 
 //--------------------------------------------------------------------------------------------
@@ -737,13 +815,19 @@ static void __declspec(naked) HOOK_CBmx__ProcessControl()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     dwCurrentVehicle, ecx
         pushad
     }
 
+    // clang-format on
+
     SwitchContext((CVehicleSAInterface*)dwCurrentVehicle);
+
+    // clang-format off
 
     __asm
     {
@@ -753,13 +837,19 @@ static void __declspec(naked) HOOK_CBmx__ProcessControl()
         pushad
     }
 
+    // clang-format on
+
     ReturnContextToLocalPlayer();
+
+    // clang-format off
 
     __asm
     {
         popad
         retn
     }
+
+    // clang-format on
 }
 
 //--------------------------------------------------------------------------------------------
@@ -768,13 +858,19 @@ static void __declspec(naked) HOOK_CTrain__ProcessControl()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     dwCurrentVehicle, ecx
         pushad
     }
 
+    // clang-format on
+
     SwitchContext((CVehicleSAInterface*)dwCurrentVehicle);
+
+    // clang-format off
 
     __asm
     {
@@ -784,13 +880,19 @@ static void __declspec(naked) HOOK_CTrain__ProcessControl()
         pushad
     }
 
+    // clang-format on
+
     ReturnContextToLocalPlayer();
+
+    // clang-format off
 
     __asm
     {
         popad
         retn
     }
+
+    // clang-format on
 }
 
 //--------------------------------------------------------------------------------------------
@@ -799,13 +901,19 @@ static void __declspec(naked) HOOK_CBoat__ProcessControl()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     dwCurrentVehicle, ecx
         pushad
     }
 
+    // clang-format on
+
     SwitchContext((CVehicleSAInterface*)dwCurrentVehicle);
+
+    // clang-format off
 
     __asm
     {
@@ -815,13 +923,19 @@ static void __declspec(naked) HOOK_CBoat__ProcessControl()
         pushad
     }
 
+    // clang-format on
+
     ReturnContextToLocalPlayer();
+
+    // clang-format off
 
     __asm
     {
         popad
         retn
     }
+
+    // clang-format on
 }
 
 //--------------------------------------------------------------------------------------------
@@ -830,13 +944,19 @@ static void __declspec(naked) HOOK_CBike__ProcessControl()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     dwCurrentVehicle, ecx
         pushad
     }
 
+    // clang-format on
+
     SwitchContext((CVehicleSAInterface*)dwCurrentVehicle);
+
+    // clang-format off
 
     __asm
     {
@@ -846,13 +966,19 @@ static void __declspec(naked) HOOK_CBike__ProcessControl()
         pushad
     }
 
+    // clang-format on
+
     ReturnContextToLocalPlayer();
+
+    // clang-format off
 
     __asm
     {
         popad
         retn
     }
+
+    // clang-format on
 }
 
 //--------------------------------------------------------------------------------------------
@@ -861,13 +987,19 @@ static void __declspec(naked) HOOK_CHeli__ProcessControl()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     dwCurrentVehicle, ecx
         pushad
     }
 
+    // clang-format on
+
     SwitchContext((CVehicleSAInterface*)dwCurrentVehicle);
+
+    // clang-format off
 
     __asm
     {
@@ -877,11 +1009,17 @@ static void __declspec(naked) HOOK_CHeli__ProcessControl()
         pushad
     }
 
+    // clang-format on
+
     ReturnContextToLocalPlayer();
+
+    // clang-format off
 
     __asm
     {
         popad
         retn
     }
+
+    // clang-format on
 }

--- a/Client/multiplayer_sa/multiplayer_keysync.cpp
+++ b/Client/multiplayer_sa/multiplayer_keysync.cpp
@@ -535,7 +535,6 @@ static void __declspec(naked) HOOK_CPlayerPed__ProcessControl()
     SwitchContext((CPedSAInterface*)dwCurrentPlayerPed);
 
     // clang-format off
-
     __asm
     {
         popad
@@ -543,19 +542,16 @@ static void __declspec(naked) HOOK_CPlayerPed__ProcessControl()
         call    edx
         pushad
     }
-
     // clang-format on
 
     ReturnContextToLocalPlayer();
 
     // clang-format off
-
     __asm
     {
         popad
         retn
     }
-
     // clang-format on
 }
 
@@ -564,7 +560,6 @@ static void __declspec(naked) CPlayerPed__ProcessControl_Abort()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // restore stuff
@@ -578,19 +573,16 @@ static void __declspec(naked) CPlayerPed__ProcessControl_Abort()
         mov     edi, PlayerPed__ProcessControl_Saved.edi
         pushad
     }
-
     // clang-format on
 
     ReturnContextToLocalPlayer();
 
     // clang-format off
-
     __asm
     {
         popad
         retn
     }
-
     // clang-format on
 }
 
@@ -601,19 +593,16 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessControl()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     dwCurrentVehicle, ecx
         pushad
     }
-
     // clang-format on
 
     SwitchContext((CVehicleSAInterface*)dwCurrentVehicle);
 
     // clang-format off
-
     __asm
     {
         popad
@@ -621,19 +610,16 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessControl()
         call    edx
         pushad
     }
-
     // clang-format on
 
     ReturnContextToLocalPlayer();
 
     // clang-format off
-
     __asm
     {
         popad
         retn
     }
-
     // clang-format on
 }
 
@@ -644,19 +630,16 @@ static void __declspec(naked) HOOK_CMonsterTruck__ProcessControl()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     dwCurrentVehicle, ecx
         pushad
     }
-
     // clang-format on
 
     SwitchContext((CVehicleSAInterface*)dwCurrentVehicle);
 
     // clang-format off
-
     __asm
     {
         popad
@@ -664,19 +647,16 @@ static void __declspec(naked) HOOK_CMonsterTruck__ProcessControl()
         call    edx
         pushad
     }
-
     // clang-format on
 
     ReturnContextToLocalPlayer();
 
     // clang-format off
-
     __asm
     {
         popad
         retn
     }
-
     // clang-format on
 }
 
@@ -687,19 +667,16 @@ static void __declspec(naked) HOOK_CTrailer__ProcessControl()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     dwCurrentVehicle, ecx
         pushad
     }
-
     // clang-format on
 
     SwitchContext((CVehicleSAInterface*)dwCurrentVehicle);
 
     // clang-format off
-
     __asm
     {
         popad
@@ -707,19 +684,16 @@ static void __declspec(naked) HOOK_CTrailer__ProcessControl()
         call    edx
         pushad
     }
-
     // clang-format on
 
     ReturnContextToLocalPlayer();
 
     // clang-format off
-
     __asm
     {
         popad
         retn
     }
-
     // clang-format on
 }
 
@@ -730,19 +704,16 @@ static void __declspec(naked) HOOK_CQuadBike__ProcessControl()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     dwCurrentVehicle, ecx
         pushad
     }
-
     // clang-format on
 
     SwitchContext((CVehicleSAInterface*)dwCurrentVehicle);
 
     // clang-format off
-
     __asm
     {
         popad
@@ -750,19 +721,16 @@ static void __declspec(naked) HOOK_CQuadBike__ProcessControl()
         call    edx
         pushad
     }
-
     // clang-format on
 
     ReturnContextToLocalPlayer();
 
     // clang-format off
-
     __asm
     {
         popad
         retn
     }
-
     // clang-format on
 }
 
@@ -773,19 +741,16 @@ static void __declspec(naked) HOOK_CPlane__ProcessControl()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     dwCurrentVehicle, ecx
         pushad
     }
-
     // clang-format on
 
     SwitchContext((CVehicleSAInterface*)dwCurrentVehicle);
 
     // clang-format off
-
     __asm
     {
         popad
@@ -793,19 +758,16 @@ static void __declspec(naked) HOOK_CPlane__ProcessControl()
         call    edx
         pushad
     }
-
     // clang-format on
 
     ReturnContextToLocalPlayer();
 
     // clang-format off
-
     __asm
     {
         popad
         retn
     }
-
     // clang-format on
 }
 
@@ -816,19 +778,16 @@ static void __declspec(naked) HOOK_CBmx__ProcessControl()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     dwCurrentVehicle, ecx
         pushad
     }
-
     // clang-format on
 
     SwitchContext((CVehicleSAInterface*)dwCurrentVehicle);
 
     // clang-format off
-
     __asm
     {
         popad
@@ -836,19 +795,16 @@ static void __declspec(naked) HOOK_CBmx__ProcessControl()
         call    edx
         pushad
     }
-
     // clang-format on
 
     ReturnContextToLocalPlayer();
 
     // clang-format off
-
     __asm
     {
         popad
         retn
     }
-
     // clang-format on
 }
 
@@ -859,19 +815,16 @@ static void __declspec(naked) HOOK_CTrain__ProcessControl()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     dwCurrentVehicle, ecx
         pushad
     }
-
     // clang-format on
 
     SwitchContext((CVehicleSAInterface*)dwCurrentVehicle);
 
     // clang-format off
-
     __asm
     {
         popad
@@ -879,19 +832,16 @@ static void __declspec(naked) HOOK_CTrain__ProcessControl()
         call    edx
         pushad
     }
-
     // clang-format on
 
     ReturnContextToLocalPlayer();
 
     // clang-format off
-
     __asm
     {
         popad
         retn
     }
-
     // clang-format on
 }
 
@@ -902,19 +852,16 @@ static void __declspec(naked) HOOK_CBoat__ProcessControl()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     dwCurrentVehicle, ecx
         pushad
     }
-
     // clang-format on
 
     SwitchContext((CVehicleSAInterface*)dwCurrentVehicle);
 
     // clang-format off
-
     __asm
     {
         popad
@@ -922,19 +869,16 @@ static void __declspec(naked) HOOK_CBoat__ProcessControl()
         call    edx
         pushad
     }
-
     // clang-format on
 
     ReturnContextToLocalPlayer();
 
     // clang-format off
-
     __asm
     {
         popad
         retn
     }
-
     // clang-format on
 }
 
@@ -945,19 +889,16 @@ static void __declspec(naked) HOOK_CBike__ProcessControl()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     dwCurrentVehicle, ecx
         pushad
     }
-
     // clang-format on
 
     SwitchContext((CVehicleSAInterface*)dwCurrentVehicle);
 
     // clang-format off
-
     __asm
     {
         popad
@@ -965,19 +906,16 @@ static void __declspec(naked) HOOK_CBike__ProcessControl()
         call    edx
         pushad
     }
-
     // clang-format on
 
     ReturnContextToLocalPlayer();
 
     // clang-format off
-
     __asm
     {
         popad
         retn
     }
-
     // clang-format on
 }
 
@@ -988,19 +926,16 @@ static void __declspec(naked) HOOK_CHeli__ProcessControl()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     dwCurrentVehicle, ecx
         pushad
     }
-
     // clang-format on
 
     SwitchContext((CVehicleSAInterface*)dwCurrentVehicle);
 
     // clang-format off
-
     __asm
     {
         popad
@@ -1008,18 +943,15 @@ static void __declspec(naked) HOOK_CHeli__ProcessControl()
         call    edx
         pushad
     }
-
     // clang-format on
 
     ReturnContextToLocalPlayer();
 
     // clang-format off
-
     __asm
     {
         popad
         retn
     }
-
     // clang-format on
 }

--- a/Client/multiplayer_sa/multiplayer_shotsync.cpp
+++ b/Client/multiplayer_sa/multiplayer_shotsync.cpp
@@ -323,6 +323,7 @@ static void __declspec(naked) HOOK_CTaskSimpleUsegun_ProcessPed()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // We can use EAX
+    // clang-format off
     __asm
     {
         // Store the ped pointer for our later hook (SkipAim)
@@ -338,6 +339,7 @@ static void __declspec(naked) HOOK_CTaskSimpleUsegun_ProcessPed()
         add         edx, 8
         jmp         edx
     }
+    // clang-format on
 }
 
 static CPed* GetTargetingPed()
@@ -353,6 +355,7 @@ static void __declspec(naked) HOOK_SkipAim()
     // We can use ECX
     // Return to 0x62AEED for normal aiming
     // Return to 0x62A565 for arms up. Should probably set [esi+0Eh] to 1 too.
+    // clang-format off
     __asm
     {
         // Store the pointer to the skipaim argument
@@ -363,6 +366,7 @@ static void __declspec(naked) HOOK_SkipAim()
         // Store all the registers
         pushad
     }
+    // clang-format on
 
     pATargetingPed = GetTargetingPed();
     if (pATargetingPed)
@@ -394,6 +398,7 @@ static void __declspec(naked) HOOK_SkipAim()
     // Return to the correct place wheter we put our arms up or not
     if (*pSkipAim)
     {
+        // clang-format off
         __asm
         {
             // Restore all registers
@@ -403,9 +408,11 @@ static void __declspec(naked) HOOK_SkipAim()
             mov         ecx, 0x62A565
             jmp         ecx
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             // Restore all registers
@@ -415,6 +422,7 @@ static void __declspec(naked) HOOK_SkipAim()
             mov         ecx, 0x62AEED
             jmp         ecx
         }
+        // clang-format on
     }
 }
 
@@ -425,6 +433,7 @@ static void __declspec(naked) HOOK_IKChainManager_PointArm()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // We can use edx
+    // clang-format off
     __asm
     {
         // Grab the ped whose aiming the gun and the pointer to the vector we aim at
@@ -436,6 +445,7 @@ static void __declspec(naked) HOOK_IKChainManager_PointArm()
         // Store all the registers on the stack
         pushad
     }
+    // clang-format on
 
     pATargetingPed = GetTargetingPed();
     if (pATargetingPed)
@@ -466,6 +476,8 @@ static void __declspec(naked) HOOK_IKChainManager_PointArm()
         }
     }
 
+    // clang-format off
+
     __asm
     {
         // Restore all the registers from the stack
@@ -480,6 +492,8 @@ static void __declspec(naked) HOOK_IKChainManager_PointArm()
         add     edx, 7
         jmp     edx
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_IKChainManager_LookAt()
@@ -487,6 +501,7 @@ static void __declspec(naked) HOOK_IKChainManager_LookAt()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // We can use eax
+    // clang-format off
     __asm
     {
         // Grab the player ped and the vector pointer from the stack
@@ -498,6 +513,7 @@ static void __declspec(naked) HOOK_IKChainManager_LookAt()
         // Store all the registers on the stack
         pushad
     }
+    // clang-format on
 
     // Jax: this gets called on vehicle collision and pTargetVector is null
     if (pTargetVector)
@@ -532,6 +548,8 @@ static void __declspec(naked) HOOK_IKChainManager_LookAt()
         }
     }
 
+    // clang-format off
+
     __asm
     {
         // Restore all the registers from the stack
@@ -546,11 +564,15 @@ static void __declspec(naked) HOOK_IKChainManager_LookAt()
         add     edx, 7
         jmp     edx
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CWeapon__Fire()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -569,19 +591,25 @@ static void __declspec(naked) HOOK_CWeapon__Fire()
         pushad
     }
 
+    // clang-format on
+
     // Weapon inaccuracy and animations problems may be fixed by blanking out the CWeapon variables nTimer and beyond.
 
     bWeaponFire = true;
     if (!WriteTargetDataForPed(pShootingPed, vecTargetPosition, vecOrigin))
     {
         // Don't fire shot
+         // clang-format off
          __asm
         {
             popad
             mov     al, 1
             retn    18h
         }
+         // clang-format on
     }
+
+     // clang-format off
 
      __asm
     {
@@ -593,24 +621,36 @@ static void __declspec(naked) HOOK_CWeapon__Fire()
         push    edi
     }
 
+     // clang-format on
+
+    // clang-format off
+
     __asm
     {
         mov     esi, HOOKPOS_CWeapon__Fire
         add     esi, 6
         jmp     esi
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CWeapon__PostFire()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
 
+    // clang-format on
+
     Event_PostFire();
+
+    // clang-format off
 
     __asm
     {
@@ -622,18 +662,26 @@ static void __declspec(naked) HOOK_CWeapon__PostFire()
         add     esp, 3Ch
         ret     18h
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CWeapon__PostFire2()            // handles the FALSE exit point at 0x074241E
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
 
+    // clang-format on
+
     Event_PostFire();
+
+    // clang-format off
 
     __asm
     {
@@ -642,12 +690,16 @@ static void __declspec(naked) HOOK_CWeapon__PostFire2()            // handles th
         add     esp, 3Ch
         ret     18h
     }
+
+    // clang-format on
 }
 
 static const DWORD CWeapon_DoBulletImpact_RET = 0x73B557;
 static void __declspec(naked) HOOK_CWeapon_DoBulletImpact()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -662,7 +714,11 @@ static void __declspec(naked) HOOK_CWeapon_DoBulletImpact()
         pushad
     }
 
+    // clang-format on
+
     Event_BulletImpact();
+
+    // clang-format off
 
     __asm
     {
@@ -671,6 +727,8 @@ static void __declspec(naked) HOOK_CWeapon_DoBulletImpact()
         push    0x00848E50
         jmp     CWeapon_DoBulletImpact_RET
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CTaskSimpleGangDriveBy__PlayerTarget()
@@ -678,17 +736,20 @@ static void __declspec(naked) HOOK_CTaskSimpleGangDriveBy__PlayerTarget()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // Replacement code
+    // clang-format off
     __asm
     {
         mov     cTempGunDirection, al
         mov     pPedInterfaceTemp, edi
         pushad
     }
+    // clang-format on
 
     // either store or change the data
     WriteGunDirectionDataForPed(pPedInterfaceTemp, 0, 0, &cTempGunDirection);
 
     // cTempGunDirection may be modified by the function, so write it back
+    // clang-format off
     __asm
     {
         popad
@@ -700,11 +761,14 @@ static void __declspec(naked) HOOK_CTaskSimpleGangDriveBy__PlayerTarget()
         jmp     edx
 
     }
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CPedIK__PointGunInDirection()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -717,10 +781,13 @@ static void __declspec(naked) HOOK_CPedIK__PointGunInDirection()
         pushad
     }
 
+    // clang-format on
+
     // either store or change the data
     WriteGunDirectionDataForPed((CPedSAInterface*)((DWORD)pPedIKInterface - 1292), fDirectionX, fDirectionY, 0);
 
     // replacement code
+    // clang-format off
     __asm
     {
         popad
@@ -734,6 +801,7 @@ static void __declspec(naked) HOOK_CPedIK__PointGunInDirection()
         add     edx, 7
         jmp     edx
     }
+    // clang-format on
 }
 
 // This hook prevents remote players always hitting local players if both players are targeting with sniper.
@@ -748,15 +816,20 @@ static void __declspec(naked) HOOK_CWeapon__Fire_Sniper()
     007424AA   85C0             TEST EAX,EAX
     */
 
+    // clang-format off
+
     __asm
     {
         mov     pPedInterfaceTemp, edi
         pushad
     }
 
+    // clang-format on
+
     if (IsLocalPlayer(pPedInterfaceTemp))
     {
         // use sniper (local players)
+        // clang-format off
         __asm
         {
             popad
@@ -768,16 +841,19 @@ static void __declspec(naked) HOOK_CWeapon__Fire_Sniper()
 
             jmp     ecx
         }
+        // clang-format on
     }
     else
     {
         // use instanthit (remote players)
+        // clang-format off
         __asm
         {
             popad
             mov     ecx, HOOKRET_CWeapon__Fire_Sniper
             jmp     ecx
         }
+        // clang-format on
     }
 }
 
@@ -818,6 +894,8 @@ static void __declspec(naked) HOOK_CEventDamage__AffectsPed()
     004B35A4   8BF1             MOV ESI,ECX
     */
 
+    // clang-format off
+
     __asm
     {
         push    esi
@@ -831,9 +909,12 @@ static void __declspec(naked) HOOK_CEventDamage__AffectsPed()
         pushad
     }
 
+    // clang-format on
+
     if (ProcessDamageEvent(event, affectsPed))
     {
         // they want the damage to happen!
+        // clang-format off
         __asm
         {
             popad
@@ -846,10 +927,13 @@ static void __declspec(naked) HOOK_CEventDamage__AffectsPed()
             add     ecx, 6
             jmp     ecx
         }
+        // clang-format on
     }
     else
     {
         // they want the player to escape unscathed
+
+        // clang-format off
 
         __asm
         {
@@ -857,6 +941,8 @@ static void __declspec(naked) HOOK_CEventDamage__AffectsPed()
             xor     eax, eax
             retn    4 // return from the function
         }
+
+        // clang-format on
     }
 }
 
@@ -868,6 +954,8 @@ static constexpr std::uintptr_t RETURN_CFireManager_StartFire = 0x53A056;
 static void __declspec(naked) HOOK_CFireManager__StartFire()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -897,6 +985,8 @@ static void __declspec(naked) HOOK_CFireManager__StartFire()
         abortCreatingFire:
         jmp SKIP_CFireManager_StartFire
     }
+
+    // clang-format on
 }
 
 static CEntity* GetProjectileOwner(CPools* pPools)
@@ -999,6 +1089,8 @@ static void __declspec(naked) HOOK_CProjectileInfo__AddProjectile()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         mov     edx, [esp+4]
@@ -1021,8 +1113,11 @@ static void __declspec(naked) HOOK_CProjectileInfo__AddProjectile()
 
         pushad
     }
+
+    // clang-format on
     if (ProcessProjectileAdd())
     {            // projectile should be created
+        // clang-format off
         __asm
         {
             popad
@@ -1030,21 +1125,26 @@ static void __declspec(naked) HOOK_CProjectileInfo__AddProjectile()
             mov     edx, RETURN_CProjectile__AddProjectile
             jmp     edx
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
             xor al, al
             retn
         }
+        // clang-format on
     }
 }
 
 static void __declspec(naked) HOOK_CProjectile__CProjectile()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
 
     __asm
     {
@@ -1053,7 +1153,11 @@ static void __declspec(naked) HOOK_CProjectile__CProjectile()
         pushad
     }
 
+    // clang-format on
+
     ProcessProjectile();
+
+    // clang-format off
 
     __asm
     {
@@ -1062,6 +1166,8 @@ static void __declspec(naked) HOOK_CProjectile__CProjectile()
         mov     edx, RETURN_CProjectile__CProjectile
         jmp     edx
     }
+
+    // clang-format on
 }
 
 static void CheckInVehicleDamage()
@@ -1080,6 +1186,8 @@ static void CheckInVehicleDamage()
                 eWeaponType weaponType = pWeapon->GetType();
                 DWORD       dwFunc = FUNC_CWeapon_CheckForShootingVehicleOccupant;
 
+                // clang-format off
+
                 __asm
                 {
                     push    pInstantHitStart
@@ -1090,6 +1198,8 @@ static void CheckInVehicleDamage()
                     call    dwFunc
                     add     esp, 0x14
                 }
+
+                // clang-format on
             }
         }
     }
@@ -1144,6 +1254,8 @@ static void __declspec(naked) HOOK_CWeapon_FireInstantHit_Mid()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         pushad
@@ -1175,6 +1287,8 @@ static void __declspec(naked) HOOK_CWeapon_FireInstantHit_Mid()
         push        eax
         jmp     RETURN_CWeapon_FireInstantHit_Mid
     }
+
+    // clang-format on
 }
 
 // Hook install
@@ -1227,6 +1341,8 @@ static void __declspec(naked) HOOK_CWeapon_FireSniper_Mid()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // Do original code
@@ -1262,6 +1378,8 @@ static void __declspec(naked) HOOK_CWeapon_FireSniper_Mid()
         // Continue
         jmp     RETURN_CWeapon_FireSniper_Mid
     }
+
+    // clang-format on
 }
 
 // Hook install
@@ -1333,6 +1451,7 @@ static void __declspec(naked) HOOK_CWeapon_FireInstantHit()
     00740B68  push        eax
     00740B69  call        0056BA00
     */
+    // clang-format off
     __asm
     {
         push        1
@@ -1357,14 +1476,19 @@ static void __declspec(naked) HOOK_CWeapon_FireInstantHit()
         push        eax
         pushad
     }
+    // clang-format on
 
     // Make sure we include car tyres in our ProcessLineOfSight check
+    // clang-format off
     __asm
     {
         call DoFireInstantHitPokes
     }
+    // clang-format on
 
     HandleRemoteInstantHit();
+
+    // clang-format off
 
     __asm
     {
@@ -1373,13 +1497,19 @@ static void __declspec(naked) HOOK_CWeapon_FireInstantHit()
         pushad
     }
 
+    // clang-format on
+
     CheckInVehicleDamage();
+
+    // clang-format off
 
     __asm
     {
         popad
         jmp         dwFunc_CWeapon_FireInstantHit_ret
     }
+
+    // clang-format on
 }
 
 bool FireInstantHit_CameraMode()
@@ -1415,37 +1545,45 @@ static void __declspec(naked) HOOK_CWeapon_FireInstantHit_CameraMode()
     0074037F  cmp         ax,31h (39)
     00740383  jne         007407C1
     */
+    // clang-format off
     __asm
     {
         mov     sFireInstantHit_CameraMode_camMode, ax
         pushad
     }
+    // clang-format on
 
     if (FireInstantHit_CameraMode())
     {
+        // clang-format off
         __asm
         {
             popad
             jmp          dwAddr_FireInstantHit_CameraMode
         }
+        // clang-format on
     }
     else
     {
         if (sFireInstantHit_CameraMode_camMode == 0x35)
         {
+            // clang-format off
             __asm
             {
                 popad
                 jmp dwAddr_FireInstantHit_CameraMode
             }
+            // clang-format on
         }
         else
         {
+            // clang-format off
             __asm
             {
                 popad
                 jmp         dwAddr_FireInstantHit_CameraMode_2
             }
+            // clang-format on
         }
     }
 }
@@ -1492,13 +1630,16 @@ static void __declspec(naked) HOOK_CWeapon_FireInstantHit_IsPlayer()
     00740E6B  test        al,al
     00740E6D  je          00740E7E
     */
+    // clang-format off
     __asm
     {
         mov     pFireInstantHit_IsPlayerPed, ecx
         pushad
     }
+    // clang-format on
     if (!FireInstantHit_IsPlayer())
     {
+        // clang-format off
         __asm
         {
             popad
@@ -1506,9 +1647,11 @@ static void __declspec(naked) HOOK_CWeapon_FireInstantHit_IsPlayer()
             test    al, al
             jmp     RETURN_CWeapon_FireInstantHit_IsPlayer
         }
+        // clang-format on
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
@@ -1516,6 +1659,7 @@ static void __declspec(naked) HOOK_CWeapon_FireInstantHit_IsPlayer()
             test    al,al
             jmp     RETURN_CWeapon_FireInstantHit_IsPlayer
         }
+        // clang-format on
     }
 }
 
@@ -1530,6 +1674,7 @@ static void __declspec(naked) HOOK_CCamera__Find3rdPersonCamTargetVector()
     0046FB38  |. 5B             POP EBX
     0046FB39  \. C2 1800        RETN 18
     */
+    // clang-format off
     __asm
     {
         mov     ebp, esp
@@ -1544,6 +1689,7 @@ static void __declspec(naked) HOOK_CCamera__Find3rdPersonCamTargetVector()
 
         pushad
     }
+    // clang-format on
 
     if(IsNotInLocalContext() && GetContextSwitchPedID())
     {
@@ -1590,6 +1736,8 @@ static void __declspec(naked) HOOK_CCamera__Find3rdPersonCamTargetVector()
         OutputDebugString(szDebug);*/
     }
 
+    // clang-format off
+
     __asm
     {
         popad
@@ -1599,6 +1747,8 @@ static void __declspec(naked) HOOK_CCamera__Find3rdPersonCamTargetVector()
         pop     ebx
         retn    0x18
     }
+
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_CWeapon__FireShotgun()
@@ -1616,13 +1766,18 @@ static void __declspec(naked) HOOK_CWeapon__FireShotgun()
     005CDAAA   . 83C4 0C                 ADD ESP,0C
     */
 
+    // clang-format off
+
     __asm
     {
         pushad
     }
 
+    // clang-format on
+
     if(IsNotInLocalContext() && GetContextSwitchPedID())
     {
+        // clang-format off
         __asm
         {
             popad
@@ -1634,6 +1789,7 @@ static void __declspec(naked) HOOK_CWeapon__FireShotgun()
 
             pushad
         }
+        // clang-format on
         sprintf(szDebug, "Switched Cross Products to %f  %f  %f (0x%X)",
             RemotePlayerCrossProducts[GetContextSwitchPedID()].fX,
             RemotePlayerCrossProducts[GetContextSwitchPedID()].fY,
@@ -1644,6 +1800,7 @@ static void __declspec(naked) HOOK_CWeapon__FireShotgun()
     }
     else
     {
+        // clang-format off
         __asm
         {
             popad
@@ -1660,6 +1817,7 @@ static void __declspec(naked) HOOK_CWeapon__FireShotgun()
 
             pushad
         }
+        // clang-format on
 
         MemCpy (&LocalPlayerCrossProduct, vecCrossProduct, sizeof(CVector));
         sprintf(szDebug, "SHOTGUN: Saved Local Cross Product  %f  %f  %f",
@@ -1669,6 +1827,8 @@ static void __declspec(naked) HOOK_CWeapon__FireShotgun()
         OutputDebugString(szDebug);
     }
 
+    // clang-format off
+
     __asm
     {
         popad
@@ -1677,6 +1837,8 @@ static void __declspec(naked) HOOK_CWeapon__FireShotgun()
         add     edx, 20
         jmp     edx
     }
+
+    // clang-format on
 }
 #endif
 
@@ -1701,6 +1863,8 @@ static void __declspec(naked) HOOK_CEventVehicleExplosion__AffectsPed()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // clang-format off
+
     __asm
     {
         // Save the ped
@@ -1721,8 +1885,12 @@ static void __declspec(naked) HOOK_CEventVehicleExplosion__AffectsPed()
         pushad
     }
 
+    // clang-format on
+
     // Notify Deathmatch about the death
     CEventVehicleExplosion_NotifyDeathmatch();
+
+    // clang-format off
 
     __asm
     {
@@ -1731,4 +1899,6 @@ static void __declspec(naked) HOOK_CEventVehicleExplosion__AffectsPed()
 return_from:
         retn 4
     }
+
+    // clang-format on
 }

--- a/Client/multiplayer_sa/multiplayer_shotsync.cpp
+++ b/Client/multiplayer_sa/multiplayer_shotsync.cpp
@@ -477,7 +477,6 @@ static void __declspec(naked) HOOK_IKChainManager_PointArm()
     }
 
     // clang-format off
-
     __asm
     {
         // Restore all the registers from the stack
@@ -492,7 +491,6 @@ static void __declspec(naked) HOOK_IKChainManager_PointArm()
         add     edx, 7
         jmp     edx
     }
-
     // clang-format on
 }
 
@@ -549,7 +547,6 @@ static void __declspec(naked) HOOK_IKChainManager_LookAt()
     }
 
     // clang-format off
-
     __asm
     {
         // Restore all the registers from the stack
@@ -564,7 +561,6 @@ static void __declspec(naked) HOOK_IKChainManager_LookAt()
         add     edx, 7
         jmp     edx
     }
-
     // clang-format on
 }
 
@@ -573,7 +569,6 @@ static void __declspec(naked) HOOK_CWeapon__Fire()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push    ebx
@@ -590,7 +585,6 @@ static void __declspec(naked) HOOK_CWeapon__Fire()
 
         pushad
     }
-
     // clang-format on
 
     // Weapon inaccuracy and animations problems may be fixed by blanking out the CWeapon variables nTimer and beyond.
@@ -610,7 +604,6 @@ static void __declspec(naked) HOOK_CWeapon__Fire()
     }
 
      // clang-format off
-
      __asm
     {
         popad
@@ -620,18 +613,15 @@ static void __declspec(naked) HOOK_CWeapon__Fire()
         push    esi
         push    edi
     }
-
      // clang-format on
 
     // clang-format off
-
     __asm
     {
         mov     esi, HOOKPOS_CWeapon__Fire
         add     esi, 6
         jmp     esi
     }
-
     // clang-format on
 }
 
@@ -640,18 +630,15 @@ static void __declspec(naked) HOOK_CWeapon__PostFire()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     Event_PostFire();
 
     // clang-format off
-
     __asm
     {
         popad
@@ -662,7 +649,6 @@ static void __declspec(naked) HOOK_CWeapon__PostFire()
         add     esp, 3Ch
         ret     18h
     }
-
     // clang-format on
 }
 
@@ -671,18 +657,15 @@ static void __declspec(naked) HOOK_CWeapon__PostFire2()            // handles th
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     Event_PostFire();
 
     // clang-format off
-
     __asm
     {
         popad
@@ -690,7 +673,6 @@ static void __declspec(naked) HOOK_CWeapon__PostFire2()            // handles th
         add     esp, 3Ch
         ret     18h
     }
-
     // clang-format on
 }
 
@@ -700,7 +682,6 @@ static void __declspec(naked) HOOK_CWeapon_DoBulletImpact()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     eax, [esp+4]
@@ -713,13 +694,11 @@ static void __declspec(naked) HOOK_CWeapon_DoBulletImpact()
         mov     pBulletImpactEndPosition, eax
         pushad
     }
-
     // clang-format on
 
     Event_BulletImpact();
 
     // clang-format off
-
     __asm
     {
         popad
@@ -727,7 +706,6 @@ static void __declspec(naked) HOOK_CWeapon_DoBulletImpact()
         push    0x00848E50
         jmp     CWeapon_DoBulletImpact_RET
     }
-
     // clang-format on
 }
 
@@ -769,7 +747,6 @@ static void __declspec(naked) HOOK_CPedIK__PointGunInDirection()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     pPedIKInterface, ecx
@@ -780,7 +757,6 @@ static void __declspec(naked) HOOK_CPedIK__PointGunInDirection()
         mov     fDirectionY, edx
         pushad
     }
-
     // clang-format on
 
     // either store or change the data
@@ -817,13 +793,11 @@ static void __declspec(naked) HOOK_CWeapon__Fire_Sniper()
     */
 
     // clang-format off
-
     __asm
     {
         mov     pPedInterfaceTemp, edi
         pushad
     }
-
     // clang-format on
 
     if (IsLocalPlayer(pPedInterfaceTemp))
@@ -895,7 +869,6 @@ static void __declspec(naked) HOOK_CEventDamage__AffectsPed()
     */
 
     // clang-format off
-
     __asm
     {
         push    esi
@@ -908,7 +881,6 @@ static void __declspec(naked) HOOK_CEventDamage__AffectsPed()
 
         pushad
     }
-
     // clang-format on
 
     if (ProcessDamageEvent(event, affectsPed))
@@ -934,14 +906,12 @@ static void __declspec(naked) HOOK_CEventDamage__AffectsPed()
         // they want the player to escape unscathed
 
         // clang-format off
-
         __asm
         {
             popad
             xor     eax, eax
             retn    4 // return from the function
         }
-
         // clang-format on
     }
 }
@@ -956,7 +926,6 @@ static void __declspec(naked) HOOK_CFireManager__StartFire()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         push esi
@@ -985,7 +954,6 @@ static void __declspec(naked) HOOK_CFireManager__StartFire()
         abortCreatingFire:
         jmp SKIP_CFireManager_StartFire
     }
-
     // clang-format on
 }
 
@@ -1090,7 +1058,6 @@ static void __declspec(naked) HOOK_CProjectileInfo__AddProjectile()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     edx, [esp+4]
@@ -1113,7 +1080,6 @@ static void __declspec(naked) HOOK_CProjectileInfo__AddProjectile()
 
         pushad
     }
-
     // clang-format on
     if (ProcessProjectileAdd())
     {            // projectile should be created
@@ -1145,20 +1111,17 @@ static void __declspec(naked) HOOK_CProjectile__CProjectile()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         mov     dwProjectileInfoIndex, ebx // it happens to be in here, luckily
         mov     pProjectile, ecx
         pushad
     }
-
     // clang-format on
 
     ProcessProjectile();
 
     // clang-format off
-
     __asm
     {
         popad
@@ -1166,7 +1129,6 @@ static void __declspec(naked) HOOK_CProjectile__CProjectile()
         mov     edx, RETURN_CProjectile__CProjectile
         jmp     edx
     }
-
     // clang-format on
 }
 
@@ -1187,7 +1149,6 @@ static void CheckInVehicleDamage()
                 DWORD       dwFunc = FUNC_CWeapon_CheckForShootingVehicleOccupant;
 
                 // clang-format off
-
                 __asm
                 {
                     push    pInstantHitStart
@@ -1198,7 +1159,6 @@ static void CheckInVehicleDamage()
                     call    dwFunc
                     add     esp, 0x14
                 }
-
                 // clang-format on
             }
         }
@@ -1255,7 +1215,6 @@ static void __declspec(naked) HOOK_CWeapon_FireInstantHit_Mid()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         pushad
@@ -1287,7 +1246,6 @@ static void __declspec(naked) HOOK_CWeapon_FireInstantHit_Mid()
         push        eax
         jmp     RETURN_CWeapon_FireInstantHit_Mid
     }
-
     // clang-format on
 }
 
@@ -1342,7 +1300,6 @@ static void __declspec(naked) HOOK_CWeapon_FireSniper_Mid()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Do original code
@@ -1378,7 +1335,6 @@ static void __declspec(naked) HOOK_CWeapon_FireSniper_Mid()
         // Continue
         jmp     RETURN_CWeapon_FireSniper_Mid
     }
-
     // clang-format on
 }
 
@@ -1489,26 +1445,22 @@ static void __declspec(naked) HOOK_CWeapon_FireInstantHit()
     HandleRemoteInstantHit();
 
     // clang-format off
-
     __asm
     {
         popad
         call        dwFunc_CWorld_ProcessLineOfSight
         pushad
     }
-
     // clang-format on
 
     CheckInVehicleDamage();
 
     // clang-format off
-
     __asm
     {
         popad
         jmp         dwFunc_CWeapon_FireInstantHit_ret
     }
-
     // clang-format on
 }
 
@@ -1737,7 +1689,6 @@ static void __declspec(naked) HOOK_CCamera__Find3rdPersonCamTargetVector()
     }
 
     // clang-format off
-
     __asm
     {
         popad
@@ -1747,7 +1698,6 @@ static void __declspec(naked) HOOK_CCamera__Find3rdPersonCamTargetVector()
         pop     ebx
         retn    0x18
     }
-
     // clang-format on
 }
 
@@ -1767,12 +1717,10 @@ static void __declspec(naked) HOOK_CWeapon__FireShotgun()
     */
 
     // clang-format off
-
     __asm
     {
         pushad
     }
-
     // clang-format on
 
     if(IsNotInLocalContext() && GetContextSwitchPedID())
@@ -1828,7 +1776,6 @@ static void __declspec(naked) HOOK_CWeapon__FireShotgun()
     }
 
     // clang-format off
-
     __asm
     {
         popad
@@ -1837,7 +1784,6 @@ static void __declspec(naked) HOOK_CWeapon__FireShotgun()
         add     edx, 20
         jmp     edx
     }
-
     // clang-format on
 }
 #endif
@@ -1864,7 +1810,6 @@ static void __declspec(naked) HOOK_CEventVehicleExplosion__AffectsPed()
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
     // clang-format off
-
     __asm
     {
         // Save the ped
@@ -1884,14 +1829,12 @@ static void __declspec(naked) HOOK_CEventVehicleExplosion__AffectsPed()
 
         pushad
     }
-
     // clang-format on
 
     // Notify Deathmatch about the death
     CEventVehicleExplosion_NotifyDeathmatch();
 
     // clang-format off
-
     __asm
     {
         popad
@@ -1899,6 +1842,5 @@ static void __declspec(naked) HOOK_CEventVehicleExplosion__AffectsPed()
 return_from:
         retn 4
     }
-
     // clang-format on
 }


### PR DESCRIPTION
Use [fastmod](https://github.com/facebookincubator/fastmod) to wrap `// clang-format off/on` around all our `__asm` directives:

```bash
$ fastmod '^( +?)(__asm$\n(?:\s+)\{$[^}]+})' '${1}// clang-format off
$1$2
${1}// clang-format on' --accept-all --print-changed-files | wc -l
102
```

I'm confident in this regex because VS Code showed it's selecting the right blocks of code:

<img width="311" height="335" alt="{FF157373-DA22-4BA0-BBEC-97883C25F7B5}" src="https://github.com/user-attachments/assets/9f983029-28be-4f43-ac5c-3405bef4d9a2" />

Additionally, fastmod says it changed 1021 instances, and VS Code reported the same number when I plugged in the regex.

Searching for "__asm" reports 1030 instances. The remaining 9 comes from inline `__asm {` (i.e. the open brace is on the same line), which I've manually changed.

This pull request essentially makes this change from the original clang-format script: https://github.com/multitheftauto/mtasa-blue/blob/81677d9e1a3632bd5e03b660c0bb37fe4234c7f8/utils/win-apply-clang-format.bat#L59-L60


**Motivation**

Unblocks https://github.com/multitheftauto/mtasa-blue/issues/2507 and possibly unblocks https://github.com/multitheftauto/mtasa-blue/issues/772.

Essentially, we can't currently enforce clang-tidy across our codebase because it doesn't work correctly with `__asm`. This addresses that problem by disabling clang-tidy for all `__asm`  directives.

**Does this make the codebase ugly?**

Maybe, but this is standard operating procedure for large codebases. This pull request allows people to enable format-on-save in their editors without having to manually undo uglification to `__asm` directives. I think it's an acceptable tradeoff.

**Test plan**

All changes are to comments, so they are safe. `fastmod`'s manual mode let me verify that this worked correctly.