### PR TITLE
Fix unbounded virtual memory growth by switching textures to D3DPOOL_…

### DIFF
--- a/Client/core/Graphics/CRenderItem.FileTexture.cpp
+++ b/Client/core/Graphics/CRenderItem.FileTexture.cpp
@@ -25,13 +25,34 @@ void CFileTextureItem::PostConstruct(CRenderItemManager* pManager, const SString
     m_TextureType = textureType;
     m_TextureAddress = textureAddress;
 
+    // @ZeusHay - Store for recreation
+    m_bMipMaps = bMipMaps;
+    m_uiCreateSizeX = uiSizeX;
+    m_uiCreateSizeY = uiSizeY;
+    m_CreateFormat = format;
+
     // Initial creation of d3d data
     if (pPixels)
+    {
+        m_bIsFromFile = false;
+        m_bIsBlank = false;
+        m_PixelData.SetSize(pPixels->GetSize());
+        memcpy(m_PixelData.GetData(), pPixels->GetData(), pPixels->GetSize());
         CreateUnderlyingData(pPixels, bMipMaps, format);
+    }
     else if (!strFilename.empty())
+    {
+        m_bIsFromFile = true;
+        m_bIsBlank = false;
+        m_strFilename = strFilename;
         CreateUnderlyingData(strFilename, bMipMaps, uiSizeX, uiSizeY, format);
+    }
     else
+    {
+        m_bIsFromFile = false;
+        m_bIsBlank = true;
         CreateUnderlyingData(bMipMaps, uiSizeX, uiSizeY, format, textureType, uiVolumeDepth);
+    }
 }
 
 ////////////////////////////////////////////////////////////////
@@ -68,7 +89,8 @@ bool CFileTextureItem::IsValid()
 ////////////////////////////////////////////////////////////////
 void CFileTextureItem::OnLostDevice()
 {
-    // Nothing required for CFileTextureItem
+    // Release D3DPOOL_DEFAULT textures
+    ReleaseUnderlyingData();
 }
 
 ////////////////////////////////////////////////////////////////
@@ -80,7 +102,25 @@ void CFileTextureItem::OnLostDevice()
 ////////////////////////////////////////////////////////////////
 void CFileTextureItem::OnResetDevice()
 {
-    // Nothing required for CFileTextureItem
+    // Recreate D3DPOOL_DEFAULT textures
+    if (m_bIsFromFile)
+    {
+        CreateUnderlyingData(m_strFilename, m_bMipMaps, m_uiCreateSizeX, m_uiCreateSizeY, m_CreateFormat);
+    }
+    else if (!m_bIsBlank)
+    {
+        if (m_PixelData.GetSize() > 0)
+        {
+            CPixels pixels;
+            pixels.SetSize(m_PixelData.GetSize());
+            memcpy(pixels.GetData(), m_PixelData.GetData(), m_PixelData.GetSize());
+            CreateUnderlyingData(&pixels, m_bMipMaps, m_CreateFormat);
+        }
+    }
+    else
+    {
+        CreateUnderlyingData(m_bMipMaps, m_uiCreateSizeX, m_uiCreateSizeY, m_CreateFormat, m_TextureType, m_uiVolumeDepth);
+    }
 }
 
 ////////////////////////////////////////////////////////////////
@@ -94,9 +134,44 @@ void CFileTextureItem::CreateUnderlyingData(const SString& strFilename, bool bMi
 {
     assert(!m_pD3DTexture);
 
-    D3DXIMAGE_INFO imageInfo;
-    if (FAILED(D3DXGetImageInfoFromFile(strFilename, &imageInfo)))
+    // Read file into VirtualAlloc memory to ensure it returns to OS
+    FILE* fh = File::Fopen(strFilename, "rb");
+    if (!fh)
         return;
+    
+    fseek(fh, 0, SEEK_END);
+    size_t fileSize = ftell(fh);
+    fseek(fh, 0, SEEK_SET);
+    
+    if (fileSize == 0 || fileSize > 1024 * 1024 * 512) // Limit 512MB
+    {
+        fclose(fh);
+        return;
+    }
+    
+    // VirtualAlloc with MEM_COMMIT | MEM_RESERVE
+    void* fileData = VirtualAlloc(NULL, fileSize, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+    if (!fileData)
+    {
+        fclose(fh);
+        return;
+    }
+    
+    size_t bytesRead = fread(fileData, 1, fileSize, fh);
+    fclose(fh);
+    
+    if (bytesRead != fileSize)
+    {
+        VirtualFree(fileData, 0, MEM_RELEASE);
+        return;
+    }
+
+    D3DXIMAGE_INFO imageInfo;
+    if (FAILED(D3DXGetImageInfoFromFileInMemory(fileData, fileSize, &imageInfo)))
+    {
+        VirtualFree(fileData, 0, MEM_RELEASE);
+        return;
+    }
 
     D3DFORMAT D3DFormat = (D3DFORMAT)format;
     int       iMipMaps = bMipMaps ? D3DX_DEFAULT : 1;
@@ -110,19 +185,20 @@ void CFileTextureItem::CreateUnderlyingData(const SString& strFilename, bool bMi
     m_uiSurfaceSizeX = imageInfo.Width;
     m_uiSurfaceSizeY = imageInfo.Height;
 
+    HRESULT hr = E_FAIL;
+    
+    // @ZeusHay - Changed D3DPOOL_MANAGED to D3DPOOL_DEFAULT to prevent system memory backup leak
     if (imageInfo.ResourceType == D3DRTYPE_VOLUMETEXTURE)
     {
         // It's a volume texture!
-        if (FAILED(D3DXCreateVolumeTextureFromFileEx(m_pDevice, strFilename, uiSizeX, uiSizeY, D3DX_DEFAULT, iMipMaps, 0, D3DFormat, D3DPOOL_MANAGED,
-                                                     D3DX_DEFAULT, D3DX_DEFAULT, 0, NULL, NULL, (IDirect3DVolumeTexture9**)&m_pD3DTexture)))
-            return;
+        hr = D3DXCreateVolumeTextureFromFileInMemoryEx(m_pDevice, fileData, fileSize, uiSizeX, uiSizeY, D3DX_DEFAULT, iMipMaps, 0, D3DFormat, D3DPOOL_DEFAULT,
+                                                     D3DX_DEFAULT, D3DX_DEFAULT, 0, NULL, NULL, (IDirect3DVolumeTexture9**)&m_pD3DTexture);
     }
     else if (imageInfo.ResourceType == D3DRTYPE_CUBETEXTURE)
     {
         // It's a cubemap texture!
-        if (FAILED(D3DXCreateCubeTextureFromFileEx(m_pDevice, strFilename, uiSizeX, iMipMaps, 0, D3DFormat, D3DPOOL_MANAGED, D3DX_DEFAULT, D3DX_DEFAULT, 0,
-                                                   NULL, NULL, (IDirect3DCubeTexture9**)&m_pD3DTexture)))
-            return;
+        hr = D3DXCreateCubeTextureFromFileInMemoryEx(m_pDevice, fileData, fileSize, uiSizeX, iMipMaps, 0, D3DFormat, D3DPOOL_DEFAULT, D3DX_DEFAULT, D3DX_DEFAULT, 0,
+                                                   NULL, NULL, (IDirect3DCubeTexture9**)&m_pD3DTexture);
     }
     else
     {
@@ -134,15 +210,31 @@ void CFileTextureItem::CreateUnderlyingData(const SString& strFilename, bool bMi
         if (uiSizeY == D3DX_DEFAULT)
             uiSizeY = D3DX_DEFAULT_NONPOW2;
 
-        if (FAILED(D3DXCreateTextureFromFileEx(m_pDevice, strFilename, uiSizeX, uiSizeY, iMipMaps, 0, D3DFormat, D3DPOOL_MANAGED, D3DX_DEFAULT, D3DX_DEFAULT, 0,
-                                               NULL, NULL, (IDirect3DTexture9**)&m_pD3DTexture)))
-            return;
+        hr = D3DXCreateTextureFromFileInMemoryEx(m_pDevice, fileData, fileSize, uiSizeX, uiSizeY, iMipMaps, 0, D3DFormat, D3DPOOL_DEFAULT, D3DX_DEFAULT, D3DX_DEFAULT, 0,
+                                               NULL, NULL, (IDirect3DTexture9**)&m_pD3DTexture);
 
-        // Update surface size if it's a normal texture
-        D3DSURFACE_DESC desc;
-        ((IDirect3DTexture9*)m_pD3DTexture)->GetLevelDesc(0, &desc);
-        m_uiSurfaceSizeX = desc.Width;
-        m_uiSurfaceSizeY = desc.Height;
+        if (SUCCEEDED(hr) && m_pD3DTexture)
+        {
+            // Update surface size if it's a normal texture
+            D3DSURFACE_DESC desc;
+            ((IDirect3DTexture9*)m_pD3DTexture)->GetLevelDesc(0, &desc);
+            m_uiSurfaceSizeX = desc.Width;
+            m_uiSurfaceSizeY = desc.Height;
+        }
+    }
+    
+    // Free file buffer
+    VirtualFree(fileData, 0, MEM_RELEASE);
+
+    if (FAILED(hr))
+    {
+        // Ensure m_pD3DTexture is null if failed
+        if (m_pD3DTexture)
+        {
+            m_pD3DTexture->Release();
+            m_pD3DTexture = nullptr;
+        }
+        return;
     }
 
     // Calc memory usage
@@ -175,6 +267,7 @@ void CFileTextureItem::CreateUnderlyingData(const CPixels* pInPixels, bool bMipM
     D3DFORMAT      D3DFormat = (D3DFORMAT)format;
     int            iMipMaps = bMipMaps ? D3DX_DEFAULT : 1;
 
+    // @ZeusHay - Changed D3DPOOL_MANAGED to D3DPOOL_DEFAULT
     if (FAILED(D3DXCreateTextureFromFileInMemoryEx(m_pDevice,                     //__in     LPDIRECT3DDEVICE9 pDevice,
                                                    pPixels->GetData(),            //__in     LPCVOID pSrcData,
                                                    pPixels->GetSize(),            //__in     UINT SrcDataSize,
@@ -183,7 +276,7 @@ void CFileTextureItem::CreateUnderlyingData(const CPixels* pInPixels, bool bMipM
                                                    iMipMaps,                      //__in     UINT MipLevels,
                                                    0,                             //__in     DWORD Usage,
                                                    D3DFormat,                     //__in     D3DFORMAT Format,
-                                                   D3DPOOL_MANAGED,               //__in     D3DPOOL Pool,
+                                                   D3DPOOL_DEFAULT,               //__in     D3DPOOL Pool,
                                                    D3DX_DEFAULT,                  //__in     DWORD Filter,
                                                    D3DX_DEFAULT,                  //__in     DWORD MipFilter,
                                                    0,                             //__in     D3DCOLOR ColorKey,
@@ -226,6 +319,7 @@ void CFileTextureItem::CreateUnderlyingData(bool bMipMaps, uint uiSizeX, uint ui
     m_uiSurfaceSizeX = uiSizeX;
     m_uiSurfaceSizeY = uiSizeY;
 
+    // @ZeusHay - Changed D3DPOOL_MANAGED to D3DPOOL_DEFAULT
     if (textureType == D3DRTYPE_VOLUMETEXTURE)
     {
         if (FAILED(D3DXCreateVolumeTexture(m_pDevice,                  //__in   LPDIRECT3DDEVICE9 pDevice,
@@ -235,7 +329,7 @@ void CFileTextureItem::CreateUnderlyingData(bool bMipMaps, uint uiSizeX, uint ui
                                            iMipMaps,                   //__in   UINT MipLevels,
                                            0,                          //__in   DWORD Usage,
                                            D3DFormat,                  //__in   D3DFORMAT Format,
-                                           D3DPOOL_MANAGED,            //__in   D3DPOOL Pool,
+                                           D3DPOOL_DEFAULT,            //__in   D3DPOOL Pool,
                                            (IDirect3DVolumeTexture9**)&m_pD3DTexture)))
             return;
     }
@@ -246,7 +340,7 @@ void CFileTextureItem::CreateUnderlyingData(bool bMipMaps, uint uiSizeX, uint ui
                                          iMipMaps,                   //__in   UINT MipLevels,
                                          0,                          //__in   DWORD Usage,
                                          D3DFormat,                  //__in   D3DFORMAT Format,
-                                         D3DPOOL_MANAGED,            //__in   D3DPOOL Pool,
+                                         D3DPOOL_DEFAULT,            //__in   D3DPOOL Pool,
                                          (IDirect3DCubeTexture9**)&m_pD3DTexture)))
             return;
     }
@@ -258,7 +352,7 @@ void CFileTextureItem::CreateUnderlyingData(bool bMipMaps, uint uiSizeX, uint ui
                                      iMipMaps,                   //__in   UINT MipLevels,
                                      0,                          //__in   DWORD Usage,
                                      D3DFormat,                  //__in   D3DFORMAT Format,
-                                     D3DPOOL_MANAGED,            //__in   D3DPOOL Pool,
+                                     D3DPOOL_DEFAULT,            //__in   D3DPOOL Pool,
                                      (IDirect3DTexture9**)&m_pD3DTexture)))
             return;
 
@@ -282,5 +376,22 @@ void CFileTextureItem::CreateUnderlyingData(bool bMipMaps, uint uiSizeX, uint ui
 ////////////////////////////////////////////////////////////////
 void CFileTextureItem::ReleaseUnderlyingData()
 {
+    if (m_pD3DTexture && m_pDevice)
+    {
+        // Force unbind from all stages to ensure immediate VRAM release
+        for (DWORD i = 0; i < 8; i++)
+        {
+            IDirect3DBaseTexture9* pCurTex = NULL;
+            if (SUCCEEDED(m_pDevice->GetTexture(i, &pCurTex)))
+            {
+                if (pCurTex == m_pD3DTexture)
+                {
+                    m_pDevice->SetTexture(i, NULL);
+                }
+                if (pCurTex)
+                    pCurTex->Release();
+            }
+        }
+    }
     SAFE_RELEASE(m_pD3DTexture);
 }

--- a/Client/core/Graphics/CRenderItem.FileTexture.cpp
+++ b/Client/core/Graphics/CRenderItem.FileTexture.cpp
@@ -25,7 +25,7 @@ void CFileTextureItem::PostConstruct(CRenderItemManager* pManager, const SString
     m_TextureType = textureType;
     m_TextureAddress = textureAddress;
 
-    // @ZeusHay - Store for recreation
+    // Store for recreation
     m_bMipMaps = bMipMaps;
     m_uiCreateSizeX = uiSizeX;
     m_uiCreateSizeY = uiSizeY;
@@ -187,7 +187,7 @@ void CFileTextureItem::CreateUnderlyingData(const SString& strFilename, bool bMi
 
     HRESULT hr = E_FAIL;
     
-    // @ZeusHay - Changed D3DPOOL_MANAGED to D3DPOOL_DEFAULT to prevent system memory backup leak
+    // Changed D3DPOOL_MANAGED to D3DPOOL_DEFAULT to prevent system memory backup leak
     if (imageInfo.ResourceType == D3DRTYPE_VOLUMETEXTURE)
     {
         // It's a volume texture!
@@ -267,7 +267,7 @@ void CFileTextureItem::CreateUnderlyingData(const CPixels* pInPixels, bool bMipM
     D3DFORMAT      D3DFormat = (D3DFORMAT)format;
     int            iMipMaps = bMipMaps ? D3DX_DEFAULT : 1;
 
-    // @ZeusHay - Changed D3DPOOL_MANAGED to D3DPOOL_DEFAULT
+    // Changed D3DPOOL_MANAGED to D3DPOOL_DEFAULT
     if (FAILED(D3DXCreateTextureFromFileInMemoryEx(m_pDevice,                     //__in     LPDIRECT3DDEVICE9 pDevice,
                                                    pPixels->GetData(),            //__in     LPCVOID pSrcData,
                                                    pPixels->GetSize(),            //__in     UINT SrcDataSize,
@@ -319,7 +319,7 @@ void CFileTextureItem::CreateUnderlyingData(bool bMipMaps, uint uiSizeX, uint ui
     m_uiSurfaceSizeX = uiSizeX;
     m_uiSurfaceSizeY = uiSizeY;
 
-    // @ZeusHay - Changed D3DPOOL_MANAGED to D3DPOOL_DEFAULT
+    // Changed D3DPOOL_MANAGED to D3DPOOL_DEFAULT
     if (textureType == D3DRTYPE_VOLUMETEXTURE)
     {
         if (FAILED(D3DXCreateVolumeTexture(m_pDevice,                  //__in   LPDIRECT3DDEVICE9 pDevice,

--- a/Client/sdk/core/CRenderItemManagerInterface.h
+++ b/Client/sdk/core/CRenderItemManagerInterface.h
@@ -472,6 +472,16 @@ class CFileTextureItem : public CTextureItem
 
     uint         m_uiVolumeDepth;
     ETextureType m_TextureType;
+
+    // @ZeusHay - Data for restoration
+    SString       m_strFilename;
+    CBuffer       m_PixelData;
+    bool          m_bMipMaps;
+    uint          m_uiCreateSizeX;
+    uint          m_uiCreateSizeY;
+    ERenderFormat m_CreateFormat;
+    bool          m_bIsFromFile;
+    bool          m_bIsBlank;
 };
 
 ////////////////////////////////////////////////////////////////

--- a/Client/sdk/core/CRenderItemManagerInterface.h
+++ b/Client/sdk/core/CRenderItemManagerInterface.h
@@ -473,7 +473,7 @@ class CFileTextureItem : public CTextureItem
     uint         m_uiVolumeDepth;
     ETextureType m_TextureType;
 
-    // @ZeusHay - Data for restoration
+    // Data for restoration
     SString       m_strFilename;
     CBuffer       m_PixelData;
     bool          m_bMipMaps;


### PR DESCRIPTION
Fixed a critical issue where loading textures, caused unbounded "virtual Memory" growth, leading to crashes.

I just replaced the D3DPOOL_MANAGED with D3DPOOL_DEFAULT for file-based textures, to avoid d3dx system memory retention.

I implemented OnLostDevice and OnResetDevice to handle texture restoration (when user use full screen) for ALT TAB Support.

I added forced texture unbinding too in ReleaseUnderlyingData to ensure the immediate VRAM cleanup on destruction

I updated file reading to use VirtualAlloc, verifying full memory release to the os.

Just a note:

if user load like, 30K textures (its a impratical situation, just example), it will took the time for reloading this textures, it's very lightweight and highly optimized.)

This Fixes: https://github.com/multitheftauto/mtasa-blue/issues/4554 & https://github.com/multitheftauto/mtasa-blue/issues/2869