### PR TITLE
Fix for players dropping while climbing on high FPS

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
@@ -802,7 +802,7 @@ void CMultiplayerSA::InitHooks_FrameRateFixes()
     // GitHub Issue #602
     MemPut(0x6811E9, &kOriginalTimeStep);
     MemPut(0x68128A, &kOriginalTimeStep);
-    MemPut(0x68131B, &kOriginalTimeStep);
+    // MemPut(0x68131B, &kOriginalTimeStep); // This will break climbing on high fps, keep it on default (m_nGetToPosCounter).
 
     // CTimer::m_FrameCounter fixes
     EZHookInstall(CTimer__Update);


### PR DESCRIPTION
This PR fixes #4577 by disabling the overriding of `m_nGetToPosCounter` in `CTaskSimpleClimb::ProcessPed`.
Originally, this was implemented to fix #602, but as i see it has no effect on it and causes additional issues.
I tested the #602 fix, and it still works, but further testing will be required.