### PR TITLE
Simplify CODEOWNERS to only include blue-collaborators

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @multitheftauto/mta-team @multitheftauto/blue-collaborators
+* @multitheftauto/blue-collaborators


### PR DESCRIPTION
I don't like how the reviewers section mentions multiple teams:

<img width="237" height="100" alt="{CFFB510F-5922-45A5-BCA7-803673A0BB61}" src="https://github.com/user-attachments/assets/b6e33441-bac4-4617-9973-835ef1a03b0c" />

Since everyone in MTA Team is a member of Blue Collaborators, we don't need both entries, so this should simplify the UI a little bit.