### PR TITLE
Rebuild pots every week instead of every push

### DIFF
--- a/.github/workflows/rebuild-pots.yaml
+++ b/.github/workflows/rebuild-pots.yaml
@@ -1,6 +1,9 @@
 name: "Rebuild en_US pot files"
 
-on: [push, workflow_dispatch]
+on:
+  schedule:
+    - cron: '0 0 * * 1'  # Every Monday at 00:00 UTC
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
#### Motivation
<!-- Why are you making this change? Which GitHub issue does this resolve, if any? Any additional context? -->

Commits like https://github.com/multitheftauto/mtasa-blue/commit/f65294582dfb93ebe1f714b2f8344ffca30182e1 on a per-push basis are kind of spammy, as they just change line numbers. Given that strings don't change that frequently, I think we can reduce this to weekly.

#### Test plan
<!-- How have you tested this change? This should give confidence to the reviewer  -->
<!-- If someone makes changes to this code in the future, what steps can they follow to check that it's still working correctly? -->

GitHub Actions web editor has linting
