### PR TITLE
Disable warnings in vendor projects

### DIFF
--- a/vendor/bcrypt/premake5.lua
+++ b/vendor/bcrypt/premake5.lua
@@ -2,6 +2,7 @@ project "blowfish_bcrypt"
 	language "C++"
 	kind "StaticLib"
 	targetname "blowfish_bcrypt"
+	warnings "Off"
 
 	vpaths {
 		["Headers/*"] = "*.h",

--- a/vendor/cef3/premake5.lua
+++ b/vendor/cef3/premake5.lua
@@ -3,6 +3,7 @@ project "CEF"
 	language "C++"
 	kind "StaticLib"
 	targetdir(buildpath("lib"))
+	warnings "Off"
 
 	includedirs { "cef" }
 	-- Check this: https://bitbucket.org/chromiumembedded/cef/src/48908c919591afadac3383effbc5f21a2d40f637/cmake/cef_variables.cmake.in?at=master&fileviewer=file-view-default
@@ -27,6 +28,6 @@ project "CEF"
 
 	filter "architecture:not x86"
 		flags { "ExcludeFromBuild" }
-	
+
 	filter "system:not windows"
 		flags { "ExcludeFromBuild" }

--- a/vendor/cegui-0.4.0-custom/WidgetSets/Falagard/premake5.lua
+++ b/vendor/cegui-0.4.0-custom/WidgetSets/Falagard/premake5.lua
@@ -2,34 +2,35 @@ project "Falagard"
 	language "C++"
 	kind "StaticLib"
 	targetname "Falagard"
-	
+	warnings "Off"
+
 	pchheader "StdInc.h"
 	pchsource "src/StdInc.cpp"
-	
+
 	defines { "FALAGARDBASE_EXPORTS", "_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING" }
-	
-	includedirs { 
+
+	includedirs {
 		"include",
 		"../../include" -- CEGUI Includes
 	}
-	 
-	vpaths { 
+
+	vpaths {
 		["Headers/*"] = "**.h",
 		["Sources"] = "**.cpp",
 		["*"] = "premake5.lua"
 	}
-	
+
 	files {
 		"premake5.lua",
 		"src/**.cpp",
 		"include/**.h",
 	}
-	
+
 	filter "architecture:not x86"
-		flags { "ExcludeFromBuild" } 
-	
+		flags { "ExcludeFromBuild" }
+
 	filter "system:not windows"
-		flags { "ExcludeFromBuild" } 
-	
+		flags { "ExcludeFromBuild" }
+
 	filter {"system:windows"}
 		disablewarnings { "4297" }

--- a/vendor/cegui-0.4.0-custom/premake5.lua
+++ b/vendor/cegui-0.4.0-custom/premake5.lua
@@ -2,6 +2,7 @@ project "CEGUI"
 	language "C++"
 	kind "StaticLib"
 	targetname "CEGUI"
+	warnings "Off"
 
 	pchheader "StdInc.h"
 	pchsource "src/StdInc.cpp"
@@ -47,7 +48,7 @@ project "CEGUI"
 
 	filter "architecture:not x86"
 		flags { "ExcludeFromBuild" }
-	
+
 	filter "system:not windows"
 		flags { "ExcludeFromBuild" }
 

--- a/vendor/cegui-0.4.0-custom/src/renderers/directx9GUIRenderer/premake5.lua
+++ b/vendor/cegui-0.4.0-custom/src/renderers/directx9GUIRenderer/premake5.lua
@@ -2,20 +2,21 @@ project "DirectX9GUIRenderer"
 	language "C++"
 	kind "StaticLib"
 	targetname "DirectX9GUIRenderer"
+	warnings "Off"
 
 	defines { "_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING" }
-	
-	includedirs { 
+
+	includedirs {
 		"../sdk",
 		"../../../include"
-	 }
-	 
-	vpaths { 
+	}
+
+	vpaths {
 		["Headers/*"] = "**.h",
 		["Sources"] = "**.cpp",
 		["*"] = "premake5.lua"
 	}
-	
+
 	files {
 		"premake5.lua",
 		"d3d9renderer.cpp",
@@ -23,9 +24,9 @@ project "DirectX9GUIRenderer"
 		"../../../include/renderers/d3d9texture.h",
 		"../../../include/renderers/d3d9renderer.h"
 	}
-	
+
 	filter "architecture:not x86"
-		flags { "ExcludeFromBuild" } 
-	
+		flags { "ExcludeFromBuild" }
+
 	filter "system:not windows"
         flags { "ExcludeFromBuild" }

--- a/vendor/cryptopp/premake5.lua
+++ b/vendor/cryptopp/premake5.lua
@@ -2,6 +2,7 @@ project "cryptopp"
 	language "C++"
 	kind "StaticLib"
 	targetname "cryptopp"
+	warnings "Off"
 
 	vpaths {
 		["Headers/*"] = "**.h",

--- a/vendor/curl/premake5.lua
+++ b/vendor/curl/premake5.lua
@@ -3,6 +3,7 @@ project "curl"
 	language "C"
 	kind "StaticLib"
 	targetname "curl"
+	warnings "Off"
 
 	includedirs { "include", "lib", "../mbedtls/include", "../zlib" }
 	defines { "BUILDING_LIBCURL", "CURL_STATICLIB", "HTTP_ONLY", "USE_ZLIB", "HAVE_LIBZ", "HAVE_ZLIB_H", "HAVE_CONFIG_H", "CURL_DISABLE_LIBCURL_OPTION" }

--- a/vendor/detours/premake5.lua
+++ b/vendor/detours/premake5.lua
@@ -1,7 +1,8 @@
 project "detours"
     language "C++"
     kind "StaticLib"
-    
+	warnings "Off"
+
     defines {
         "WIN32_LEAN_AND_MEAN",
         -- "_WIN32_WINNT=0x501", Not necessary, predefined in root premake5.lua

--- a/vendor/discord-rpc/premake5.lua
+++ b/vendor/discord-rpc/premake5.lua
@@ -2,8 +2,9 @@ project "discord-rpc"
 	targetname "discord-rpc"
 	language "C++"
 	kind "StaticLib"
+	warnings "Off"
 
-	includedirs { 
+	includedirs {
 		"discord/include",
 		"discord/thirdparty/rapidjson/include"
 	}

--- a/vendor/ehs/premake5.lua
+++ b/vendor/ehs/premake5.lua
@@ -2,6 +2,7 @@ project "ehs"
 	language "C++"
 	kind "StaticLib"
 	targetname "ehs"
+	warnings "Off"
 
 	includedirs {
 		"../../Shared/sdk",

--- a/vendor/freetype/premake5.lua
+++ b/vendor/freetype/premake5.lua
@@ -3,6 +3,7 @@ project "freetype"
 	language "C"
 	kind "StaticLib"
 	targetname "freetype"
+	warnings "Off"
 
 	includedirs { "include", "src",  }
 	defines { "FT2_BUILD_LIBRARY=1", "_UNICODE", "UNICODE", "_LIB" }

--- a/vendor/glob/premake5.lua
+++ b/vendor/glob/premake5.lua
@@ -2,6 +2,7 @@ project "glob"
 	language "C++"
 	kind "StaticLib"
 	targetname "glob"
+	warnings "Off"
 
 	vpaths {
 		["Headers/*"] = "include/**.h",

--- a/vendor/google-breakpad/premake5.lua
+++ b/vendor/google-breakpad/premake5.lua
@@ -2,6 +2,7 @@ project "breakpad"
 	language "C++"
 	kind "StaticLib"
 	targetname "breakpad"
+	warnings "Off"
 
 	includedirs { "src", "src/third_party/glog/src" }
 	vpaths {

--- a/vendor/jpeg-9f/premake5.lua
+++ b/vendor/jpeg-9f/premake5.lua
@@ -2,6 +2,7 @@ project "jpeg"
 	language "C"
 	kind "StaticLib"
 	targetname "jpeg"
+	warnings "Off"
 
 	vpaths {
 		["Headers/*"] = "**.h",

--- a/vendor/json-c/premake5.lua
+++ b/vendor/json-c/premake5.lua
@@ -2,6 +2,7 @@ project "json-c"
 	language "C++"
 	kind "StaticLib"
 	targetname "json-c"
+	warnings "Off"
 
 	includedirs { "." }
 	defines { "_LIB" }

--- a/vendor/ksignals/premake5.lua
+++ b/vendor/ksignals/premake5.lua
@@ -2,6 +2,7 @@ project "ksignals"
 	language "C++"
 	kind "StaticLib"
 	targetname "ksignals"
+	warnings "Off"
 
 	vpaths {
 		["Headers/*"] = "**.h",

--- a/vendor/libpng/premake5.lua
+++ b/vendor/libpng/premake5.lua
@@ -3,6 +3,7 @@ project "libpng"
     language "C"
     architecture "x86"
     systemversion "latest"
+	warnings "Off"
 
     targetdir "bin"
     objdir "obj"

--- a/vendor/libspeex/premake5.lua
+++ b/vendor/libspeex/premake5.lua
@@ -2,6 +2,7 @@ project "libspeex"
 	language "C"
 	kind "StaticLib"
 	targetname "libspeex"
+	warnings "Off"
 
 	defines {
 		"HAVE_CONFIG_H"
@@ -44,6 +45,6 @@ project "libspeex"
 
 	filter "architecture:not x86"
 		flags { "ExcludeFromBuild" }
-	
+
 	filter "system:not windows"
 		flags { "ExcludeFromBuild" }

--- a/vendor/lua/premake5.lua
+++ b/vendor/lua/premake5.lua
@@ -1,13 +1,14 @@
 project "Lua_Server"
 	language "C++"
 	targetname "lua5.1"
+	warnings "Off"
 
-	vpaths { 
+	vpaths {
 		["Headers"] = "**.h",
 		["Sources"] = "**.c",
 		["*"] = "premake5.lua"
 	}
-	
+
 	files {
 		"premake5.lua",
 		"src/**.c",
@@ -40,23 +41,23 @@ if os.target() == "windows" then
 		targetname "lua5.1c"
 		targetdir(buildpath("mods/deathmatch"))
 
-		vpaths { 
+		vpaths {
 			["Headers"] = "**.h",
 			["Sources"] = "**.c",
 			["*"] = "premake5.lua"
 		}
-	
+
 		files {
 			"premake5.lua",
 			"src/**.c",
 			"src/**.h",
 		}
-	
+
 		defines {
 			"LUA_USE_APICHECK",
 			"LUA_BUILD_AS_DLL"
 		}
 
         filter "platforms:not x86"
-            flags { "ExcludeFromBuild" } 
+            flags { "ExcludeFromBuild" }
 end

--- a/vendor/lunasvg/premake5.lua
+++ b/vendor/lunasvg/premake5.lua
@@ -5,6 +5,7 @@ project "lunasvg"
 	targetdir(buildpath("mta"))
 	floatingpoint "Fast"
 	rtti "Off"
+	warnings "Off"
 
 	defines {
 		"PLUTOVG_BUILD",
@@ -44,6 +45,6 @@ project "lunasvg"
 
 	filter "architecture:not x86"
 		flags { "ExcludeFromBuild" }
-	
+
 	filter "system:not windows"
 		flags { "ExcludeFromBuild" }

--- a/vendor/mbedtls/premake5.lua
+++ b/vendor/mbedtls/premake5.lua
@@ -1,6 +1,7 @@
 project "mbedtls"
 	kind "StaticLib"
 	language "C"
+	warnings "Off"
 
 	includedirs {
 		"3rdparty",

--- a/vendor/pcre/premake5.lua
+++ b/vendor/pcre/premake5.lua
@@ -1,6 +1,7 @@
 project "pcre"
 	language "C++"
 	targetname "pcre3"
+	warnings "Off"
 
 	defines { "HAVE_CONFIG_H" }
 	includedirs { "." }

--- a/vendor/pme/premake5.lua
+++ b/vendor/pme/premake5.lua
@@ -2,6 +2,7 @@ project "pme"
 	language "C++"
 	kind "StaticLib"
 	targetname "pme"
+	warnings "Off"
 
 	includedirs { "../pcre" }
 

--- a/vendor/portaudio/premake5.lua
+++ b/vendor/portaudio/premake5.lua
@@ -2,6 +2,7 @@ project "portaudio"
 	language "C++"
 	kind "StaticLib"
 	targetname "portaudio"
+	warnings "Off"
 
 	vpaths {
 		["Headers/*"] = "**.h",
@@ -20,6 +21,6 @@ project "portaudio"
 
 	filter "architecture:not x86"
 		flags { "ExcludeFromBuild" }
-	
+
 	filter "system:not windows"
 		flags { "ExcludeFromBuild" }

--- a/vendor/pthreads/premake5.lua
+++ b/vendor/pthreads/premake5.lua
@@ -3,6 +3,7 @@ project "pthread"
 	kind "SharedLib"
 	targetname "pthread"
 	targetdir(buildpath("server"))
+	warnings "Off"
 
 	includedirs {
 		"include"

--- a/vendor/sqlite/premake5.lua
+++ b/vendor/sqlite/premake5.lua
@@ -2,6 +2,7 @@ project "sqlite"
 	language "C"
 	kind "StaticLib"
 	targetname "sqlite"
+	warnings "Off"
 
 	vpaths {
 		["Headers/*"] = "*.h",

--- a/vendor/tinygettext/premake5.lua
+++ b/vendor/tinygettext/premake5.lua
@@ -2,6 +2,7 @@ project "tinygettext"
 	language "C++"
 	kind "StaticLib"
 	targetname "tinygettext"
+	warnings "Off"
 
 	includedirs {
 		"../../Shared/sdk",

--- a/vendor/tinyxml/premake5.lua
+++ b/vendor/tinyxml/premake5.lua
@@ -2,6 +2,7 @@ project "tinyxml"
 	language "C++"
 	kind "StaticLib"
 	targetname "tinyxml"
+	warnings "Off"
 
 	includedirs {
 		"../../Shared/sdk",

--- a/vendor/unrar/premake5.lua
+++ b/vendor/unrar/premake5.lua
@@ -2,6 +2,7 @@ project "unrar"
 	language "C++"
 	kind "StaticLib"
 	targetname "unrar"
+	warnings "Off"
 
 	defines { "RARDLL" }
 

--- a/vendor/zip/premake5.lua
+++ b/vendor/zip/premake5.lua
@@ -2,6 +2,7 @@ project "zip"
 	language "C"
 	kind "StaticLib"
 	targetname "zip"
+	warnings "Off"
 
 	includedirs  { "../zlib" }
 

--- a/vendor/zlib/premake5.lua
+++ b/vendor/zlib/premake5.lua
@@ -2,6 +2,7 @@ project "zlib"
 	language "C"
 	kind "StaticLib"
 	targetname "zlib"
+	warnings "Off"
 
 	vpaths {
 		["Headers/*"] = "*.h",


### PR DESCRIPTION
#### Summary
<!-- What change are you making? -->
<!-- When changing Lua APIs, consider including code samples and documentation. -->

Add `warnings "Off"` to all vendor projects. We'll never address warnings in vendor projects because vendor projects should be kept in sync with upstream as much as possible.

#### Motivation
<!-- Why are you making this change? Which GitHub issue does this resolve, if any? Any additional context? -->

🧹 cleaning editor output

#### Test plan
<!-- How have you tested this change? This should give confidence to the reviewer  -->
<!-- If someone makes changes to this code in the future, what steps can they follow to check that it's still working correctly? -->

CI
