### PR TITLE
Move maetro patches to master behind MTA_MAETRO env var

### DIFF
--- a/.github/workflows/sync-master-to-maetro.yaml
+++ b/.github/workflows/sync-master-to-maetro.yaml
@@ -24,14 +24,10 @@ jobs:
 
           git checkout release/maetro
           git merge master --no-ff --no-edit --no-commit || true
-          
+
           # Discard locale conflicts
           git checkout --ours -- Shared/installer/locale "Shared/data/MTA San Andreas/MTA/locale"
           git add --verbose Shared/installer/locale "Shared/data/MTA San Andreas/MTA/locale"
-          
-          # Discard install_cef.lua conflicts
-          git checkout --ours -- utils/buildactions/install_cef.lua
-          git add --verbose utils/buildactions/install_cef.lua
 
           # Discard d3dcompiler_47.dll conflicts (Due to old CEF version on maetro)
           git checkout --ours -- "Shared/data/MTA San Andreas/MTA/d3dcompiler_47.dll"
@@ -40,7 +36,7 @@ jobs:
           # Discard cefweb conflicts
           git checkout --ours -- Client/cefweb/CWebView.cpp
           git add --verbose Client/cefweb/CWebView.cpp
-          
+
           # We should be done with the merge now
           printf "Synchronize changes from 1.6 master branch [ci skip]\n\n" > commit.txt
           git log --expand-tabs=4 --pretty=format:'%h %s' release/maetro..master >> commit.txt

--- a/.github/workflows/sync-master-to-maetro.yaml
+++ b/.github/workflows/sync-master-to-maetro.yaml
@@ -33,10 +33,6 @@ jobs:
           git checkout --ours -- "Shared/data/MTA San Andreas/MTA/d3dcompiler_47.dll"
           git add --verbose "Shared/data/MTA San Andreas/MTA/d3dcompiler_47.dll"
 
-          # Discard cefweb conflicts
-          git checkout --ours -- Client/cefweb/CWebView.cpp
-          git add --verbose Client/cefweb/CWebView.cpp
-
           # We should be done with the merge now
           printf "Synchronize changes from 1.6 master branch [ci skip]\n\n" > commit.txt
           git log --expand-tabs=4 --pretty=format:'%h %s' release/maetro..master >> commit.txt

--- a/Client/ceflauncher_DLL/CCefApp.h
+++ b/Client/ceflauncher_DLL/CCefApp.h
@@ -41,7 +41,11 @@ public:
             if (!node)
                 return;
 
+#ifdef MTA_MAETRO
+            if (node->GetType() == CefDOMNode::Type::DOM_NODE_TYPE_ELEMENT && !node->GetFormControlElementType().empty())
+#else
             if (node->GetType() == CefDOMNode::Type::DOM_NODE_TYPE_ELEMENT && node->GetFormControlElementType() != CefDOMNode::FormControlType::DOM_FORM_CONTROL_TYPE_UNSUPPORTED)
+#endif
             {
                 auto message = CefProcessMessage::Create("InputFocus");
                 message->GetArgumentList()->SetBool(0, true);

--- a/Client/cefweb/CWebView.cpp
+++ b/Client/cefweb/CWebView.cpp
@@ -748,7 +748,11 @@ bool CWebView::SetAudioVolume(float fVolume)
 
     for (auto& name : frameNames)
     {
+#ifdef MTA_MAETRO
+        auto frame = m_pWebView->GetFrame(name);
+#else
         auto frame = m_pWebView->GetFrameByName(name);
+#endif
         if (frame)
             frame->ExecuteJavaScript(strJSCode, "", 0);
     }
@@ -1387,10 +1391,17 @@ void CWebView::OnBeforeClose(CefRefPtr<CefBrowser> browser)
 // //
 //                                                                //
 ////////////////////////////////////////////////////////////////////
+#ifdef MTA_MAETRO
+bool CWebView::OnBeforePopup(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const CefString& target_url, const CefString& target_frame_name,
+                             CefLifeSpanHandler::WindowOpenDisposition target_disposition, bool user_gesture, const CefPopupFeatures& popupFeatures,
+                             CefWindowInfo& windowInfo, CefRefPtr<CefClient>& client, CefBrowserSettings& settings, CefRefPtr<CefDictionaryValue>& extra_info,
+                             bool* no_javascript_access)
+#else
 bool CWebView::OnBeforePopup(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, int popup_id, const CefString& target_url,
                              const CefString& target_frame_name, CefLifeSpanHandler::WindowOpenDisposition target_disposition, bool user_gesture,
                              const CefPopupFeatures& popupFeatures, CefWindowInfo& windowInfo, CefRefPtr<CefClient>& client, CefBrowserSettings& settings,
                              CefRefPtr<CefDictionaryValue>& extra_info, bool* no_javascript_access)
+#endif
 {
     // ATTENTION: This method is called on the IO thread
 
@@ -1459,9 +1470,14 @@ bool CWebView::OnJSDialog(CefRefPtr<CefBrowser> browser, const CefString& origin
 // //
 //                                                                //
 ////////////////////////////////////////////////////////////////////
+#ifdef MTA_MAETRO
+bool CWebView::OnFileDialog(CefRefPtr<CefBrowser> browser, CefDialogHandler::FileDialogMode mode, const CefString& title, const CefString& default_file_path,
+                            const std::vector<CefString>& accept_filters, CefRefPtr<CefFileDialogCallback> callback)
+#else
 bool CWebView::OnFileDialog(CefRefPtr<CefBrowser> browser, FileDialogMode mode, const CefString& title, const CefString& default_file_path,
         const std::vector<CefString>& accept_filters, const std::vector<CefString>& accept_extensions, const std::vector<CefString>& accept_descriptions,
         CefRefPtr<CefFileDialogCallback> callback)
+#endif
 {
     // Don't show the dialog
     return true;

--- a/Client/cefweb/CWebView.h
+++ b/Client/cefweb/CWebView.h
@@ -171,10 +171,17 @@ public:
 
     // CefLifeSpawnHandler methods
     virtual void OnBeforeClose(CefRefPtr<CefBrowser> browser) override;
+#ifdef MTA_MAETRO
+    virtual bool OnBeforePopup(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const CefString& target_url, const CefString& target_frame_name,
+                               CefLifeSpanHandler::WindowOpenDisposition target_disposition, bool user_gesture, const CefPopupFeatures& popupFeatures,
+                               CefWindowInfo& windowInfo, CefRefPtr<CefClient>& client, CefBrowserSettings& settings, CefRefPtr<CefDictionaryValue>& extra_info,
+                               bool* no_javascript_access) override;
+#else
     virtual bool OnBeforePopup(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, int popup_id, const CefString& target_url,
                                const CefString& target_frame_name, CefLifeSpanHandler::WindowOpenDisposition target_disposition, bool user_gesture,
                                const CefPopupFeatures& popupFeatures, CefWindowInfo& windowInfo, CefRefPtr<CefClient>& client, CefBrowserSettings& settings,
                                CefRefPtr<CefDictionaryValue>& extra_info, bool* no_javascript_access) override;
+#endif
     virtual void OnAfterCreated(CefRefPtr<CefBrowser> browser) override;
 
     // CefJSDialogHandler methods
@@ -183,9 +190,14 @@ public:
                             bool& suppress_message) override;
 
     // CefDialogHandler methods
+#ifdef MTA_MAETRO
+    virtual bool OnFileDialog(CefRefPtr<CefBrowser> browser, CefDialogHandler::FileDialogMode mode, const CefString& title, const CefString& default_file_path,
+                              const std::vector<CefString>& accept_filters, CefRefPtr<CefFileDialogCallback> callback) override;
+#else
     virtual bool OnFileDialog(CefRefPtr<CefBrowser> browser, FileDialogMode mode, const CefString& title, const CefString& default_file_path,
         const std::vector<CefString>& accept_filters, const std::vector<CefString>& accept_extensions, const std::vector<CefString>& accept_descriptions,
         CefRefPtr<CefFileDialogCallback> callback) override;
+#endif
 
     // CefDisplayHandler methods
     virtual void OnTitleChange(CefRefPtr<CefBrowser> browser, const CefString& title) override;

--- a/Client/loader/MainFunctions.cpp
+++ b/Client/loader/MainFunctions.cpp
@@ -1605,7 +1605,11 @@ void CheckDataFiles()
         {"4B3932359373F11CBC542CC96D9A9285", "tags.dll"},
         {"0B3DD892007FB366D1F52F2247C046F5", "d3dcompiler_43.dll"},
         {"D5D8C8561C6DDA7EF0D7D6ABB0D772F4", "xinput1_3_mta.dll"},
+#ifdef MTA_MAETRO
+        {"E1677EC0E21E27405E65E31419980348", "d3dcompiler_47.dll"},
+#else
         {"2C0C596EE071B93CE15130BD5EE9CD31", "d3dcompiler_47.dll"},
+#endif
         {"F1CA5A1E77965777AC26A81EAF345A7A", "XInput9_1_0_mta.dll"}
     };
 

--- a/Shared/sdk/version.h
+++ b/Shared/sdk/version.h
@@ -64,6 +64,8 @@
 #define MTA_DM_FULL_STRING "MTA:SA Server"
 #endif
 
+// MTA_MAETRO is defined in premake5.lua
+
 // Compile types
 #define VERSION_TYPE_CUSTOM         0x01
 #define VERSION_TYPE_EXPERIMENTAL   0x03

--- a/premake5.lua
+++ b/premake5.lua
@@ -62,6 +62,10 @@ workspace "MTASA"
 		"_TIMESPEC_DEFINED"
 	}
 
+	if MTA_MAETRO then
+		defines { "MTA_MAETRO" }
+	end
+
 	-- Helper function for output path
 	buildpath = function(p) return "%{wks.location}/../Bin/"..p.."/" end
 	copy = function(p) return "{COPY} %{cfg.buildtarget.abspath} \"%{wks.location}../Bin/"..p.."/\"" end

--- a/premake5.lua
+++ b/premake5.lua
@@ -15,6 +15,7 @@ else
 	CI_BUILD = false
 end
 GLIBC_COMPAT = os.getenv("GLIBC_COMPAT") == "true"
+MAETRO_BUILD = os.getenv("MTA_MAETRO") == "true"
 
 newoption {
 	trigger     = "gccprefix",

--- a/premake5.lua
+++ b/premake5.lua
@@ -15,7 +15,7 @@ else
 	CI_BUILD = false
 end
 GLIBC_COMPAT = os.getenv("GLIBC_COMPAT") == "true"
-MAETRO_BUILD = os.getenv("MTA_MAETRO") == "true"
+MTA_MAETRO = os.getenv("MTA_MAETRO") == "true"
 
 newoption {
 	trigger     = "gccprefix",

--- a/utils/buildactions/install_cef.lua
+++ b/utils/buildactions/install_cef.lua
@@ -13,7 +13,7 @@ local CEF_VERSION = "143.0.14+gdd46a37+chromium-143.0.7499.193"
 local CEF_HASH = "b1a4e9649dc8aefedbf1aa5797376b1fe12ef29d14c7f722a3a58fa95150a496"
 
 -- Stuck in the past for maetro
-if MTA_MAETRO then
+if os.getenv("MTA_MAETRO") == "true" then
 	CEF_URL_PREFIX = "https://mirror-cdn.multitheftauto.com/vendor/cef/cef_binary_"
 	CEF_VERSION = "109.1.18+gf1c41e4+chromium-109.0.5414.120"
 	CEF_HASH = "ac78ea1e9f9d386130de16ca951acef1ba5a37ad9aef9d66f3d5f3529672c21c"

--- a/utils/buildactions/install_cef.lua
+++ b/utils/buildactions/install_cef.lua
@@ -13,7 +13,7 @@ local CEF_VERSION = "143.0.14+gdd46a37+chromium-143.0.7499.193"
 local CEF_HASH = "b1a4e9649dc8aefedbf1aa5797376b1fe12ef29d14c7f722a3a58fa95150a496"
 
 -- Stuck in the past for maetro
-if MAETRO_BUILD then
+if MTA_MAETRO then
 	CEF_URL_PREFIX = "https://mirror-cdn.multitheftauto.com/vendor/cef/cef_binary_"
 	CEF_VERSION = "109.1.18+gf1c41e4+chromium-109.0.5414.120"
 	CEF_HASH = "ac78ea1e9f9d386130de16ca951acef1ba5a37ad9aef9d66f3d5f3529672c21c"

--- a/utils/buildactions/install_cef.lua
+++ b/utils/buildactions/install_cef.lua
@@ -12,6 +12,13 @@ local CEF_URL_SUFFIX = "_windows32_minimal.tar.bz2"
 local CEF_VERSION = "143.0.14+gdd46a37+chromium-143.0.7499.193"
 local CEF_HASH = "b1a4e9649dc8aefedbf1aa5797376b1fe12ef29d14c7f722a3a58fa95150a496"
 
+-- Stuck in the past for maetro
+if MAETRO_BUILD then
+	CEF_URL_PREFIX = "https://mirror-cdn.multitheftauto.com/vendor/cef/cef_binary_"
+	CEF_VERSION = "109.1.18+gf1c41e4+chromium-109.0.5414.120"
+	CEF_HASH = "ac78ea1e9f9d386130de16ca951acef1ba5a37ad9aef9d66f3d5f3529672c21c"
+end
+
 function make_cef_download_url()
 	return CEF_URL_PREFIX..CEF_VERSION..CEF_URL_SUFFIX
 end

--- a/vendor/freetype/premake5.lua
+++ b/vendor/freetype/premake5.lua
@@ -9,7 +9,7 @@ project "freetype"
 	defines { "FT2_BUILD_LIBRARY=1", "_UNICODE", "UNICODE", "_LIB" }
 	removedefines { "DEBUG" }
 
-	if MAETRO_BUILD then
+	if MTA_MAETRO then
 		defines { "WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP" }
 	end
 

--- a/vendor/freetype/premake5.lua
+++ b/vendor/freetype/premake5.lua
@@ -9,6 +9,10 @@ project "freetype"
 	defines { "FT2_BUILD_LIBRARY=1", "_UNICODE", "UNICODE", "_LIB" }
 	removedefines { "DEBUG" }
 
+	if MAETRO_BUILD then
+		defines { "WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP" }
+	end
+
 	files {
 		"premake5.lua",
 		"include/**.h",

--- a/vendor/zip/premake5.lua
+++ b/vendor/zip/premake5.lua
@@ -6,6 +6,10 @@ project "zip"
 
 	includedirs  { "../zlib" }
 
+	if MAETRO_BUILD then
+		defines { "WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP" }
+	end
+
 	vpaths {
 		["Headers/*"] = "**.h",
 		["Sources"] = "*.c",

--- a/vendor/zip/premake5.lua
+++ b/vendor/zip/premake5.lua
@@ -6,7 +6,7 @@ project "zip"
 
 	includedirs  { "../zlib" }
 
-	if MAETRO_BUILD then
+	if MTA_MAETRO then
 		defines { "WINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP" }
 	end
 


### PR DESCRIPTION
#### Summary
<!-- What change are you making? -->
<!-- When changing Lua APIs, consider including code samples and documentation. -->

Instead of maintaining two branches that causes problems when they diverge, we incorporate maetro directly into the master branch behind the `MTA_MAETRO` environment variable.

Try it in powershell using:
```
$env:MTA_MAETRO="true"
.\win-create-projects.bat
```

#### Motivation
<!-- Why are you making this change? Which GitHub issue does this resolve, if any? Any additional context? -->

Reduces maintenance burden

#### Test plan
<!-- How have you tested this change? This should give confidence to the reviewer  -->
<!-- If someone makes changes to this code in the future, what steps can they follow to check that it's still working correctly? -->

created projects as above, old version of CEF was downloaded, confirmed that it shows up in preprocessor defs now:

<img width="1016" height="315" alt="image" src="https://github.com/user-attachments/assets/fcbdf8fa-2fbb-4d32-82ac-35ac252ec51e" />

builds on my machine ✔️ 


#### Build server

Added an env-based parameter to the maetro projects:

<img width="542" height="104" alt="{5FB2BEF7-E455-4040-8F86-B93416301528}" src="https://github.com/user-attachments/assets/d19db212-5cb3-40bd-94c2-3d79e258a17b" />
