### PR TITLE
Support building maetro installer from master branch

### DIFF
--- a/Shared/installer/nightly.nsi
+++ b/Shared/installer/nightly.nsi
@@ -203,7 +203,7 @@ VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductVersion" "${VI_PRODUCT_VERSION}"
 
 ;@INSERT_TRANSLATIONS@
 
-LangString	GET_XPVISTA_PLEASE	${LANG_ENGLISH} "The version of MTA:SA you've downloaded does not support Windows XP or Vista.  Please download an alternative version from www.multitheftauto.com."
+LangString	GET_XPVISTA_PLEASE	${LANG_ENGLISH} "Multi Theft Auto does not support Windows XP or Vista.  Please upgrade your computer."
 LangString	GET_WIN81_PLEASE	${LANG_ENGLISH} "The version of MTA:SA you've downloaded does not support Windows 7, 8 or 8.1.  Please download an alternative version from www.multitheftauto.com."
 LangString  GET_MASTER_PLEASE	${LANG_ENGLISH} "The version of MTA:SA you've downloaded is designed for old versions of Windows.  Please download an alternative version from www.multitheftauto.com."
 LangString  WELCOME_TEXT  ${LANG_ENGLISH}   "This wizard will guide you through the installation or update of $(^Name) ${REVISION_TAG}\n\n\
@@ -256,15 +256,26 @@ Function .onInit
         !insertmacro UAC_AsUser_GetGlobalVar $LANGUAGE # Copy our selected language from the outer to the inner instance
     ${EndIf}
 
+    # MTA isn't supported on XP/Vista
     ${If} ${AtMostWinVista}
         MessageBox MB_OK "$(GET_XPVISTA_PLEASE)"
         ExecShell "open" "https://multitheftauto.com"
         Quit
-    ${ElseIf} ${AtMostWin8.1}
-        MessageBox MB_OK "$(GET_WIN81_PLEASE)"
-        ExecShell "open" "https://multitheftauto.com"
-        Quit
     ${EndIf}
+
+    !ifdef MTA_MAETRO
+        ${If} ${AtLeastWin10}
+            MessageBox MB_OK "$(GET_MASTER_PLEASE)"
+            ExecShell "open" "https://multitheftauto.com"
+            Quit
+        ${EndIf}
+    !else
+        ${If} ${AtMostWin8.1}
+            MessageBox MB_OK "$(GET_WIN81_PLEASE)"
+            ExecShell "open" "https://multitheftauto.com"
+            Quit
+        ${EndIf}
+    !endif
 
     File /oname=$TEMP\image.bmp "connect.bmp"
 
@@ -727,7 +738,7 @@ SectionGroup /e "$(INST_SEC_CLIENT)" SECGCLIENT
         #File "${FILES_ROOT}\mta\CEF\cef_100_percent.pak"
         #File "${FILES_ROOT}\mta\CEF\cef_200_percent.pak"
         #File "${FILES_ROOT}\mta\CEF\devtools_resources.pak"
-		
+
 	# Below file was included in the deprecation referenced above, but already disabled in MTA beforehand
         #File "${FILES_ROOT}\mta\CEF\cef_extensions.pak"
 


### PR DESCRIPTION
#### Summary
<!-- What change are you making? -->
<!-- When changing Lua APIs, consider including code samples and documentation. -->

Implements https://github.com/multitheftauto/mtasa-blue/pull/4641 for the installer too, following the same approach as @darkdreamingdan in https://github.com/multitheftauto/mtasa-blue/commit/28da8089bb0ed9f0837d3929834ecf7dfc004a67.

Also had to update `args.nsis` on the build server to include `/DMTA_MAETRO`.

#### Motivation
<!-- Why are you making this change? Which GitHub issue does this resolve, if any? Any additional context? -->

Reduce drift between `master` and `release/maetro` branch as much as possible

#### Test plan
<!-- How have you tested this change? This should give confidence to the reviewer  -->
<!-- If someone makes changes to this code in the future, what steps can they follow to check that it's still working correctly? -->

~~Not tested. I'll generate a build on the build server after these changes sync to the maetro branch.~~
See https://github.com/multitheftauto/mtasa-blue/pull/4645