### PR TITLE
Fix std::format usage with .data() for error messages

### DIFF
--- a/Client/launch/Main.cpp
+++ b/Client/launch/Main.cpp
@@ -356,7 +356,7 @@ int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _
     if (!module_result) [[unlikely]]
     {
         DWORD   error = GetLastError();
-        SString msg   = std::format("Launcher Main: Failed to load: '{}'\n\n{}", dll_path, GetSystemErrorMessage(error));
+        SString msg = std::format("Launcher Main: Failed to load: '{}'\n\n{}", dll_path.data(), GetSystemErrorMessage(error).data());
         AddReportLog(5711, msg);
 
         // Pattern matching


### PR DESCRIPTION
#### Summary
<!-- What change are you making? -->
<!-- When changing Lua APIs, consider including code samples and documentation. -->
Explicitly use .data() on dll_path and error message strings in std::format to ensure correct formatting and type compatibility. This fixes bad output on launcher errors

Before
<img width="423" height="274" alt="image" src="https://github.com/user-attachments/assets/563cdbde-c43f-48e2-b072-1838ee4a031f" />

After
<img width="309" height="182" alt="{652503D7-D044-4EFB-8E0B-3BDB0A6D762D}" src="https://github.com/user-attachments/assets/13755149-d095-456e-b107-5186ac4f3ab7" />


#### Motivation
<!-- Why are you making this change? Which GitHub issue does this resolve, if any? Any additional context? -->
polish


#### Test plan
<!-- How have you tested this change? This should give confidence to the reviewer  -->
<!-- If someone makes changes to this code in the future, what steps can they follow to check that it's still working correctly? -->
delete loader_d.dll