### PR TITLE
minor organisational tweaks to CBulletsyncPacket

### DIFF
--- a/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.cpp
@@ -189,6 +189,9 @@ bool CBulletsyncPacket::Read(NetBitStreamInterface& stream)
 
     if (!ReadOptionalDamage(stream))
     {
+        // todo: do we really need to reset damage data when we're returning
+        // false? returning false deletes the packet, and other packets don't
+        // reset internal data based on validation failures.
         ResetDamageData();
         return false;
     }

--- a/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.cpp
@@ -141,6 +141,7 @@ bool CBulletsyncPacket::Read(NetBitStreamInterface& stream)
     if (!m_pSourceElement)
         return false;
 
+    // todo: is this condition always true?
     CPlayer* pPlayer = static_cast<CPlayer*>(m_pSourceElement);
     if (pPlayer)
     {
@@ -207,6 +208,7 @@ bool CBulletsyncPacket::Write(NetBitStreamInterface& stream) const
     if (id == INVALID_ELEMENT_ID)
         return false;
 
+    // why?
     if (id == 0)
         return false;
 

--- a/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.cpp
@@ -141,14 +141,10 @@ bool CBulletsyncPacket::Read(NetBitStreamInterface& stream)
     if (!m_pSourceElement)
         return false;
 
-    // todo: is this condition always true?
-    CPlayer* pPlayer = static_cast<CPlayer*>(m_pSourceElement);
-    if (pPlayer)
-    {
-        // Check if player is spawned and alive
-        if (!pPlayer->IsSpawned() || pPlayer->IsDead())
-            return false;
-    }
+    // Check if player is spawned and alive
+    CPlayer* pPlayer = GetSourcePlayer();
+    if (!pPlayer->IsSpawned() || pPlayer->IsDead())
+        return false;
 
     if (!ReadWeaponAndPositions(stream))
         return false;

--- a/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.cpp
@@ -18,7 +18,6 @@
 #include "CWeaponNames.h"
 
 CBulletsyncPacket::CBulletsyncPacket(CPlayer* player)
-    : m_weapon(WEAPONTYPE_UNARMED), m_start(), m_end(), m_order(0), m_damage(0.0f), m_zone(0), m_damaged(INVALID_ELEMENT_ID)
 {
     m_pSourceElement = player;
 }

--- a/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.cpp
@@ -100,41 +100,28 @@ bool CBulletsyncPacket::ReadWeaponAndPositions(NetBitStreamInterface& stream)
     return true;
 }
 
+// Returns false when there's a validation error.
+// Make sure to reset damage data to defaults when that happens.
 bool CBulletsyncPacket::ReadOptionalDamage(NetBitStreamInterface& stream)
 {
     if (!stream.ReadBit())
-    {
-        ResetDamageData();
         return true;
-    }
 
     stream.Read(m_damage);
     stream.Read(m_zone);
     stream.Read(m_damaged);
 
     if (IsNaN(m_damage))
-    {
-        ResetDamageData();
         return false;
-    }
 
     if (m_damage < 0.0f || m_damage > MAX_DAMAGE)
-    {
-        ResetDamageData();
         return false;
-    }
 
     if (m_zone > MAX_BODY_ZONE)
-    {
-        ResetDamageData();
         return false;
-    }
 
     if (m_damaged == 0)
-    {
-        ResetDamageData();
         return false;
-    }
 
     // Check that target element exists (if specified)
     // Note: m_damaged can be INVALID_ELEMENT_ID when shooting at ground/world
@@ -142,10 +129,7 @@ bool CBulletsyncPacket::ReadOptionalDamage(NetBitStreamInterface& stream)
     {
         CElement* pElement = CElementIDs::GetElement(m_damaged);
         if (!pElement)
-        {
-            ResetDamageData();
             return false;
-        }
         // Element exists
     }
 
@@ -204,7 +188,10 @@ bool CBulletsyncPacket::Read(NetBitStreamInterface& stream)
         return false;
 
     if (!ReadOptionalDamage(stream))
+    {
+        ResetDamageData();
         return false;
+    }
 
     return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.cpp
@@ -147,12 +147,6 @@ bool CBulletsyncPacket::Read(NetBitStreamInterface& stream)
         // Check if player is spawned and alive
         if (!pPlayer->IsSpawned() || pPlayer->IsDead())
             return false;
-
-        // Check player position is reasonable relative to bullet start
-        const CVector& playerPos = pPlayer->GetPosition();
-        const float    maxShootDistance = 50.0f;  // Max distance from player to bullet start
-
-        // This check will be done after we read positions
     }
 
     if (!ReadWeaponAndPositions(stream))

--- a/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CBulletsyncPacket.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
  *
- *  PROJECT:     Multi Theft Auto v1.0
+ *  PROJECT:     Multi Theft Auto
  *  LICENSE:     See LICENSE in the top level directory
  *  FILE:        mods/deathmatch/logic/packets/CBulletsyncPacket.h
  *  PURPOSE:     Bullet synchronization packet class
@@ -8,9 +8,6 @@
  *  Multi Theft Auto is available from https://www.multitheftauto.com/
  *
  *****************************************************************************/
-
-#ifndef __CBULLETSYNCPACKET_H
-#define __CBULLETSYNCPACKET_H
 
 #pragma once
 
@@ -48,13 +45,11 @@ private:
     static bool           IsValidWeaponId(unsigned char weaponId) noexcept;
 
 public:
-    eWeaponType  m_weapon{};
+    eWeaponType  m_weapon = WEAPONTYPE_UNARMED;
     CVector      m_start{};
     CVector      m_end{};
-    std::uint8_t m_order{};
-    float        m_damage{};
-    std::uint8_t m_zone{};
-    ElementID    m_damaged{INVALID_ELEMENT_ID};
+    std::uint8_t m_order = 0;
+    float        m_damage = 0.0f;
+    std::uint8_t m_zone = 0;
+    ElementID    m_damaged = INVALID_ELEMENT_ID;
 };
-
-#endif  // __CBULLETSYNCPACKET_H

--- a/Server/mods/deathmatch/logic/packets/CPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPacket.h
@@ -43,7 +43,22 @@ public:
     virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_DEFAULT; }
     virtual unsigned long   GetFlags() const = 0;
 
+    // Overridden when it's an incoming packet.
+    //
+    // Incoming packets always have CPlayer* as the source element.
+    //
+    // - Examples of incoming-only packets: CPlayerDiagnosticPacket, CCommandPacket
+    // - Examples of dual packets: CBulletsyncPacket, CVoiceDataPacket
     virtual bool Read(NetBitStreamInterface& BitStream) { return false; };
+
+    // Overridden when it's an outgoing packet.
+    //
+    // Outgoing packets may have any element type as the source element. As of
+    // 2026-01, CStaticFunctionDefinitions::SetPedStat is the caller of
+    // SetSourceElement with a non-player source.
+    //
+    // - Examples of outgoing-only packets: CPlayerStatsPacket, CDebugEchoPacket
+    // - Examples of dual packets: CBulletsyncPacket, CVoiceDataPacket
     virtual bool Write(NetBitStreamInterface& BitStream) const { return false; };
 
     void                     SetSourceElement(CElement* pSource) { m_pSourceElement = pSource; };


### PR DESCRIPTION
#### Summary (I recommend reading commit by commit)
<!-- What change are you making? -->
<!-- When changing Lua APIs, consider including code samples and documentation. -->

* Prefer member initializer over `ctor-initializer` (we should have one, not both)
* Instead of calling `ResetDamageData` before every `return false` in `ReadOptionalDamage`, just have the caller do it when `ReadOptionalDamage` returns false
* remove dead code

#### Motivation
<!-- Why are you making this change? Which GitHub issue does this resolve, if any? Any additional context? -->

We were talking about packet architecture in the dev Discord and noticed that there was some dead code, so I thought I'd fix it. While I was here, I noticed other minor improvements that could be made.

#### Test plan
<!-- How have you tested this change? This should give confidence to the reviewer  -->
<!-- If someone makes changes to this code in the future, what steps can they follow to check that it's still working correctly? -->

CI
