### PR TITLE
clang-format.ps1: store tools in a config, for future clang-tidy support

### DIFF
--- a/utils/clang-format.ps1
+++ b/utils/clang-format.ps1
@@ -13,18 +13,18 @@ $ToolConfig = @{
             "hash" = "11defe615493876745f36fb77e9783e7eed03a7f800044ff58619d9293e79409"
         }
     }
-    "clang-tidy" = @{
-        "linux-amd64" = @{
-            "url" = "https://github.com/multitheftauto/clang-tools-static-binaries/releases/download/v21.1.7/clang-tidy-21_linux-amd64"
-            "filename" = "clang-tidy"
-            "hash" = "7b35986c04b7c4fc7040c254ac2b5eb0b01ece87c91cccb32e3a4d6ecfa9695f"
-        }
-        "windows-amd64" = @{
-            "url" = "https://github.com/multitheftauto/clang-tools-static-binaries/releases/download/v21.1.7/clang-tidy-21_windows-amd64.exe"
-            "filename" = "clang-tidy.exe"
-            "hash" = "e6afe42eb50ec9dcdf945d88b220b6b36971573cec7c5b6db22d3535c6cc61c4"
-        }
-    }
+    # "clang-tidy" = @{
+    #     "linux-amd64" = @{
+    #         "url" = "https://github.com/multitheftauto/clang-tools-static-binaries/releases/download/v21.1.7/clang-tidy-21_linux-amd64"
+    #         "filename" = "clang-tidy"
+    #         "hash" = "7b35986c04b7c4fc7040c254ac2b5eb0b01ece87c91cccb32e3a4d6ecfa9695f"
+    #     }
+    #     "windows-amd64" = @{
+    #         "url" = "https://github.com/multitheftauto/clang-tools-static-binaries/releases/download/v21.1.7/clang-tidy-21_windows-amd64.exe"
+    #         "filename" = "clang-tidy.exe"
+    #         "hash" = "e6afe42eb50ec9dcdf945d88b220b6b36971573cec7c5b6db22d3535c6cc61c4"
+    #     }
+    # }
 }
 
 function Get-ClangTool {
@@ -85,7 +85,7 @@ function Invoke-ClangFormat {
 
     try {
         $clangFormatPath = Get-ClangTool -RepoRoot $repoRoot -ToolName "clang-format"
-        $clangTidyPath = Get-ClangTool -RepoRoot $repoRoot -ToolName "clang-tidy"
+        # $clangTidyPath = Get-ClangTool -RepoRoot $repoRoot -ToolName "clang-tidy"
 
         Write-Verbose "Searching for source files to format..."
         $searchFolders = "Client", "Server", "Shared"

--- a/utils/clang-format.ps1
+++ b/utils/clang-format.ps1
@@ -13,6 +13,18 @@ $ToolConfig = @{
             "hash" = "11defe615493876745f36fb77e9783e7eed03a7f800044ff58619d9293e79409"
         }
     }
+    "clang-tidy" = @{
+        "linux-amd64" = @{
+            "url" = "https://github.com/multitheftauto/clang-tools-static-binaries/releases/download/v21.1.7/clang-tidy-21_linux-amd64"
+            "filename" = "clang-tidy"
+            "hash" = "7b35986c04b7c4fc7040c254ac2b5eb0b01ece87c91cccb32e3a4d6ecfa9695f"
+        }
+        "windows-amd64" = @{
+            "url" = "https://github.com/multitheftauto/clang-tools-static-binaries/releases/download/v21.1.7/clang-tidy-21_windows-amd64.exe"
+            "filename" = "clang-tidy.exe"
+            "hash" = "e6afe42eb50ec9dcdf945d88b220b6b36971573cec7c5b6db22d3535c6cc61c4"
+        }
+    }
 }
 
 function Get-ClangTool {
@@ -72,8 +84,10 @@ function Invoke-ClangFormat {
     Write-Verbose "Changed directory to repository root: $repoRoot"
 
     try {
-        Write-Verbose "Searching for source files to format..."
         $clangFormatPath = Get-ClangTool -RepoRoot $repoRoot -ToolName "clang-format"
+        $clangTidyPath = Get-ClangTool -RepoRoot $repoRoot -ToolName "clang-tidy"
+
+        Write-Verbose "Searching for source files to format..."
         $searchFolders = "Client", "Server", "Shared"
         $files = Get-ChildItem -Path $searchFolders -Include *.c, *.cc, *.cpp, *.h, *.hh, *.hpp -Recurse -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName
 


### PR DESCRIPTION
#### Summary
<!-- What change are you making? -->
<!-- When changing Lua APIs, consider including code samples and documentation. -->

Organise the `clang-format` tool into a hash so that we can add other clang tools to the list.

#### Motivation
<!-- Why are you making this change? Which GitHub issue does this resolve, if any? Any additional context? -->

https://github.com/multitheftauto/mtasa-blue/issues/772

#### Test plan
<!-- How have you tested this change? This should give confidence to the reviewer  -->
<!-- If someone makes changes to this code in the future, what steps can they follow to check that it's still working correctly? -->

Ran `./utils/clang-format.ps1` locally and it worked, even after deleting the pre-downloaded tool on disk
