### PR TITLE
Make server components optional

### DIFF
--- a/Client/core/CMainMenu.cpp
+++ b/Client/core/CMainMenu.cpp
@@ -184,7 +184,7 @@ CMainMenu::CMainMenu(CGUI* pManager)
     m_menuItems.push_back(CreateItem(MENU_ITEM_BROWSE_SERVERS, "menu_browse_servers.png", CVector2D(0.168f, fBase + fGap * iMenuItemIndex++)));
 
     // Only add Host Game and Map Editor if server folder and MTA Server.exe exist
-    if (DirectoryExists(CalcMTASAPath("server")) && FileExists(CalcMTASAPath("server/MTA Server.exe")))
+    if (DirectoryExists(CalcMTASAPath("server")))
     {
         m_menuItems.push_back(CreateItem(MENU_ITEM_HOST_GAME, "menu_host_game.png", CVector2D(0.168f, fBase + fGap * iMenuItemIndex++)));
         m_menuItems.push_back(CreateItem(MENU_ITEM_MAP_EDITOR, "menu_map_editor.png", CVector2D(0.168f, fBase + fGap * iMenuItemIndex++)));

--- a/Client/core/CMainMenu.cpp
+++ b/Client/core/CMainMenu.cpp
@@ -179,13 +179,20 @@ CMainMenu::CMainMenu(CGUI* pManager)
     // Create the menu items
     // Filepath, Relative position, absolute native size
     // And the font for the graphics is ?
-    m_menuItems.push_back(CreateItem(MENU_ITEM_QUICK_CONNECT, "menu_quick_connect.png", CVector2D(0.168f, fBase + fGap * 0)));
-    m_menuItems.push_back(CreateItem(MENU_ITEM_BROWSE_SERVERS, "menu_browse_servers.png", CVector2D(0.168f, fBase + fGap * 1)));
-    m_menuItems.push_back(CreateItem(MENU_ITEM_HOST_GAME, "menu_host_game.png", CVector2D(0.168f, fBase + fGap * 2)));
-    m_menuItems.push_back(CreateItem(MENU_ITEM_MAP_EDITOR, "menu_map_editor.png", CVector2D(0.168f, fBase + fGap * 3)));
-    m_menuItems.push_back(CreateItem(MENU_ITEM_SETTINGS, "menu_settings.png", CVector2D(0.168f, fBase + fGap * 4)));
-    m_menuItems.push_back(CreateItem(MENU_ITEM_ABOUT, "menu_about.png", CVector2D(0.168f, fBase + fGap * 5)));
-    m_menuItems.push_back(CreateItem(MENU_ITEM_QUIT, "menu_quit.png", CVector2D(0.168f, fBase + fGap * 6)));
+    int iMenuItemIndex = 0;
+    m_menuItems.push_back(CreateItem(MENU_ITEM_QUICK_CONNECT, "menu_quick_connect.png", CVector2D(0.168f, fBase + fGap * iMenuItemIndex++)));
+    m_menuItems.push_back(CreateItem(MENU_ITEM_BROWSE_SERVERS, "menu_browse_servers.png", CVector2D(0.168f, fBase + fGap * iMenuItemIndex++)));
+
+    // Only add Host Game and Map Editor if server folder and MTA Server.exe exist
+    if (DirectoryExists(CalcMTASAPath("server")) && FileExists(CalcMTASAPath("server/MTA Server.exe")))
+    {
+        m_menuItems.push_back(CreateItem(MENU_ITEM_HOST_GAME, "menu_host_game.png", CVector2D(0.168f, fBase + fGap * iMenuItemIndex++)));
+        m_menuItems.push_back(CreateItem(MENU_ITEM_MAP_EDITOR, "menu_map_editor.png", CVector2D(0.168f, fBase + fGap * iMenuItemIndex++)));
+    }
+
+    m_menuItems.push_back(CreateItem(MENU_ITEM_SETTINGS, "menu_settings.png", CVector2D(0.168f, fBase + fGap * iMenuItemIndex++)));
+    m_menuItems.push_back(CreateItem(MENU_ITEM_ABOUT, "menu_about.png", CVector2D(0.168f, fBase + fGap * iMenuItemIndex++)));
+    m_menuItems.push_back(CreateItem(MENU_ITEM_QUIT, "menu_quit.png", CVector2D(0.168f, fBase + fGap * iMenuItemIndex++)));
 
     // We store the position of the top item, and the second item.  These will be useful later
     float fFirstItemSize = m_menuItems.front()->image->GetSize(false).fY;

--- a/Client/loader/Install.cpp
+++ b/Client/loader/Install.cpp
@@ -605,8 +605,7 @@ static int RunInstall()
         return 0;
 
     // Check if server is installed, if not, skip server files during update
-    const bool serverInstalled = DirectoryExists(PathJoin(targetRoot, "server")) && FileExists(PathJoin(targetRoot, "server/MTA Server.exe"));
-    if (!serverInstalled)
+    if (!DirectoryExists(CalcMTASAPath("server")) || !FileExists(CalcMTASAPath("server/MTA Server.exe")))
     {
         // Filter out server files
         size_t originalCount = archiveFiles.size();

--- a/Client/loader/Install.cpp
+++ b/Client/loader/Install.cpp
@@ -609,10 +609,9 @@ static int RunInstall()
     {
         // Filter out server files
         size_t originalCount = archiveFiles.size();
-        archiveFiles.erase(std::remove_if(archiveFiles.begin(), archiveFiles.end(),
-            [](const ManifestFile& file) {
-                return file.relativePath.compare(0, 7, "server/") == 0 || file.relativePath.compare(0, 7, "server\\") == 0;
-            }), archiveFiles.end());
+        archiveFiles.erase(std::remove_if(archiveFiles.begin(), archiveFiles.end(), [](const ManifestFile& file)
+                                          { return file.relativePath.compare(0, 7, "server/") == 0 || file.relativePath.compare(0, 7, "server\\") == 0; }),
+                           archiveFiles.end());
 
         size_t filteredCount = originalCount - archiveFiles.size();
         if (filteredCount > 0)

--- a/Client/loader/Install.cpp
+++ b/Client/loader/Install.cpp
@@ -604,6 +604,22 @@ static int RunInstall()
     if (archiveFiles.empty())
         return 0;
 
+    // Check if server is installed, if not, skip server files during update
+    const bool bServerInstalled = DirectoryExists(PathJoin(targetRoot, "server")) && FileExists(PathJoin(targetRoot, "server/MTA Server.exe"));
+    if (!bServerInstalled)
+    {
+        // Filter out server files
+        size_t originalCount = archiveFiles.size();
+        archiveFiles.erase(std::remove_if(archiveFiles.begin(), archiveFiles.end(),
+            [](const ManifestFile& file) {
+                return file.relativePath.compare(0, 7, "server/") == 0 || file.relativePath.compare(0, 7, "server\\") == 0;
+            }), archiveFiles.end());
+
+        size_t filteredCount = originalCount - archiveFiles.size();
+        if (filteredCount > 0)
+            OutputDebugLine(SString("RunInstall: Skipped %zu server files (server not installed)", filteredCount));
+    }
+
     // Create a backup directory for disaster recovery.
     const SString backupRoot = CreateWritableDirectory(sourceRoot + "_bak_");
 

--- a/Client/loader/Install.cpp
+++ b/Client/loader/Install.cpp
@@ -605,8 +605,8 @@ static int RunInstall()
         return 0;
 
     // Check if server is installed, if not, skip server files during update
-    const bool bServerInstalled = DirectoryExists(PathJoin(targetRoot, "server")) && FileExists(PathJoin(targetRoot, "server/MTA Server.exe"));
-    if (!bServerInstalled)
+    const bool serverInstalled = DirectoryExists(PathJoin(targetRoot, "server")) && FileExists(PathJoin(targetRoot, "server/MTA Server.exe"));
+    if (!serverInstalled)
     {
         // Filter out server files
         size_t originalCount = archiveFiles.size();

--- a/Client/loader/Install.cpp
+++ b/Client/loader/Install.cpp
@@ -605,7 +605,7 @@ static int RunInstall()
         return 0;
 
     // Check if server is installed, if not, skip server files during update
-    if (!DirectoryExists(CalcMTASAPath("server")) || !FileExists(CalcMTASAPath("server/MTA Server.exe")))
+    if (!DirectoryExists(CalcMTASAPath("server")))
     {
         // Filter out server files
         size_t originalCount = archiveFiles.size();

--- a/Shared/installer/nightly.nsi
+++ b/Shared/installer/nightly.nsi
@@ -225,7 +225,7 @@ LangString  DESC_Section2           ${LANG_ENGLISH} "The MTA:SA modification, al
 ;LangString DESC_Section3           ${LANG_ENGLISH} "The Multi Theft Auto:Editor for MTA:SA, allowing you to create and edit maps."
 ;LangString DESC_SectionGroupMods   ${LANG_ENGLISH} "Modifications for Multi Theft Auto. Without at least one of these, you cannot play Multi Theft Auto."
 LangString  DESC_SectionGroupServer  ${LANG_ENGLISH}    "The Multi Theft Auto Server. This allows you to host games from your computer. This requires a fast internet connection."
-LangString  DESC_Section4           ${LANG_ENGLISH} "The Multi Theft Auto server. This is an optional component."
+LangString  DESC_Section4           ${LANG_ENGLISH} "The Multi Theft Auto server. This is a required component."
 LangString  DESC_Section5           ${LANG_ENGLISH} "The MTA:SA modification for the server."
 LangString  DESC_Section6           ${LANG_ENGLISH} "This is a set of required resources for your server."
 LangString  DESC_Section7           ${LANG_ENGLISH} "This is an optional set of gamemodes and maps for your server."
@@ -877,7 +877,7 @@ SectionGroupEnd
 SectionGroup /e "$(INST_SEC_SERVER)" SECGSERVER
     Section "$(INST_SEC_CORE)" SEC04
         ${LogText} "+Section begin - SERVER CORE"
-        SectionIn 1 2 ; section is now optional
+        SectionIn 1 2 RO ; section is required
 
         SetOutPath "$INSTDIR\server"
         SetOverwrite on
@@ -891,7 +891,7 @@ SectionGroup /e "$(INST_SEC_SERVER)" SECGSERVER
 
     Section "$(INST_SEC_GAME)" SEC05
         ${LogText} "+Section begin - SERVER GAME"
-        SectionIn 1 2 ; section is now optional
+        SectionIn 1 2 RO ; section is required
         SetOutPath "$INSTDIR\server\mods\deathmatch"
 
         SetOverwrite on

--- a/Shared/installer/nightly.nsi
+++ b/Shared/installer/nightly.nsi
@@ -225,7 +225,7 @@ LangString  DESC_Section2           ${LANG_ENGLISH} "The MTA:SA modification, al
 ;LangString DESC_Section3           ${LANG_ENGLISH} "The Multi Theft Auto:Editor for MTA:SA, allowing you to create and edit maps."
 ;LangString DESC_SectionGroupMods   ${LANG_ENGLISH} "Modifications for Multi Theft Auto. Without at least one of these, you cannot play Multi Theft Auto."
 LangString  DESC_SectionGroupServer  ${LANG_ENGLISH}    "The Multi Theft Auto Server. This allows you to host games from your computer. This requires a fast internet connection."
-LangString  DESC_Section4           ${LANG_ENGLISH} "The Multi Theft Auto server. This is a required component."
+LangString  DESC_Section4           ${LANG_ENGLISH} "The Multi Theft Auto server. This is an optional component."
 LangString  DESC_Section5           ${LANG_ENGLISH} "The MTA:SA modification for the server."
 LangString  DESC_Section6           ${LANG_ENGLISH} "This is a set of required resources for your server."
 LangString  DESC_Section7           ${LANG_ENGLISH} "This is an optional set of gamemodes and maps for your server."
@@ -877,7 +877,7 @@ SectionGroupEnd
 SectionGroup /e "$(INST_SEC_SERVER)" SECGSERVER
     Section "$(INST_SEC_CORE)" SEC04
         ${LogText} "+Section begin - SERVER CORE"
-        SectionIn 1 2 RO ; section is required
+        SectionIn 1 2 ; section is now optional
 
         SetOutPath "$INSTDIR\server"
         SetOverwrite on
@@ -891,7 +891,7 @@ SectionGroup /e "$(INST_SEC_SERVER)" SECGSERVER
 
     Section "$(INST_SEC_GAME)" SEC05
         ${LogText} "+Section begin - SERVER GAME"
-        SectionIn 1 2 RO ; section is required
+        SectionIn 1 2 ; section is now optional
         SetOutPath "$INSTDIR\server\mods\deathmatch"
 
         SetOverwrite on


### PR DESCRIPTION
#### Summary
This PR hides server-dependent menu options when the MTA server component is not present.
Closes #4656

#### Motivation
Users who want to keep client and server installations separate (for example, running a dedicated server on a different drive) may manually remove the server component.

Currently, even if the `server` folder is deleted, the **Host Game** and **Map Editor** buttons remain visible. Clicking them fails because the MTA Server process cannot be created.

This change ensures that server-dependent UI elements are hidden when the server component is missing, the auto-updater does not restore the deleted server files, and the server can be restored later by running the MTA Installer to update existing files or by manually recreating the `server` folder with the required files.

#### Test plan
Delete the `server` folder and start MTA.

#### Checklist
- [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
- [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
