### PR TITLE
Allow changing client file cache path in Advanced Settings

### DIFF
--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -2466,7 +2466,19 @@ SString CCore::GetFileCachePath()
         {
             SString strPath = pFileCachePath->GetTagContent();
             if (!strPath.empty())
-                return strPath;
+            {
+                // Check if custom path still exists
+                if (DirectoryExists(strPath))
+                {
+                    return strPath;
+                }
+                else
+                {
+                    // Custom path was deleted, remove from config and fallback to registry
+                    pRoot->DeleteSubNode(pFileCachePath);
+                    SaveConfig();
+                }
+            }
         }
     }
 

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -2458,24 +2458,24 @@ std::shared_ptr<CDiscordInterface> CCore::GetDiscord()
 SString CCore::GetFileCachePath()
 {
     // First check coreconfig.xml
-    CXMLNode* pRoot = GetConfig();
-    if (pRoot)
+    CXMLNode* root = GetConfig();
+    if (root)
     {
-        CXMLNode* pFileCachePath = pRoot->FindSubNode("file_cache_path");
-        if (pFileCachePath)
+        CXMLNode* fileCachePath = root->FindSubNode("file_cache_path");
+        if (fileCachePath)
         {
-            SString strPath = pFileCachePath->GetTagContent();
-            if (!strPath.empty())
+            SString path = fileCachePath->GetTagContent();
+            if (!path.empty())
             {
                 // Check if custom path still exists
-                if (DirectoryExists(strPath))
+                if (DirectoryExists(path))
                 {
-                    return strPath;
+                    return path;
                 }
                 else
                 {
                     // Custom path was deleted, remove from config and fallback to registry
-                    pRoot->DeleteSubNode(pFileCachePath);
+                    root->DeleteSubNode(fileCachePath);
                     SaveConfig();
                 }
             }
@@ -2487,17 +2487,17 @@ SString CCore::GetFileCachePath()
 }
 
 // Set File Cache Path in coreconfig.xml
-bool CCore::SetFileCachePath(const SString& strPath)
+bool CCore::SetFileCachePath(const SString& path)
 {
-    CXMLNode* pRoot = GetConfig();
-    if (!pRoot)
+    CXMLNode* root = GetConfig();
+    if (!root)
         return false;
 
-    CXMLNode* pFileCachePath = pRoot->FindSubNode("file_cache_path");
-    if (!pFileCachePath)
-        pFileCachePath = pRoot->CreateSubNode("file_cache_path");
+    CXMLNode* fileCachePath = root->FindSubNode("file_cache_path");
+    if (!fileCachePath)
+        fileCachePath = root->CreateSubNode("file_cache_path");
 
-    pFileCachePath->SetTagContent(strPath);
+    fileCachePath->SetTagContent(path);
     SaveConfig();
     return true;
 }
@@ -2505,14 +2505,14 @@ bool CCore::SetFileCachePath(const SString& strPath)
 // Remove File Cache Path from coreconfig.xml to fallback to registry
 bool CCore::ResetFileCachePath()
 {
-    CXMLNode* pRoot = GetConfig();
-    if (!pRoot)
+    CXMLNode* root = GetConfig();
+    if (!root)
         return false;
 
-    CXMLNode* pFileCachePath = pRoot->FindSubNode("file_cache_path");
-    if (pFileCachePath)
+    CXMLNode* fileCachePath = root->FindSubNode("file_cache_path");
+    if (fileCachePath)
     {
-        pRoot->DeleteSubNode(pFileCachePath);
+        root->DeleteSubNode(fileCachePath);
         SaveConfig();
     }
 
@@ -2520,40 +2520,40 @@ bool CCore::ResetFileCachePath()
 }
 
 // Validate a file cache path
-bool CCore::ValidateFileCachePath(const SString& strPath, SString& strError)
+bool CCore::ValidateFileCachePath(const SString& path, SString& error)
 {
-    if (strPath.empty())
+    if (path.empty())
     {
-        strError = "Path cannot be empty";
+        error = "Path cannot be empty";
         return false;
     }
 
     // Check if directory exists
-    if (!DirectoryExists(strPath))
+    if (!DirectoryExists(path))
     {
-        strError = "Directory does not exist";
+        error = "Directory does not exist";
         return false;
     }
 
     // Check if path is not inside MTA directory to avoid conflicts
-    SString strMTAPath = GetMTADataPath();
-    SString strNormalizedPath = PathConform(strPath);
-    SString strNormalizedMTAPath = PathConform(strMTAPath);
+    SString mtaPath = GetMTADataPath();
+    SString normalizedPath = PathConform(path);
+    SString normalizedMTAPath = PathConform(mtaPath);
 
-    if (strNormalizedPath.BeginsWithI(strNormalizedMTAPath))
+    if (normalizedPath.BeginsWithI(normalizedMTAPath))
     {
-        strError = "Path cannot be inside MTA installation folder to avoid conflicts";
+        error = "Path cannot be inside MTA installation folder to avoid conflicts";
         return false;
     }
 
     // Check if writable
-    SString strTestFile = PathJoin(strPath, "_test_write.tmp");
-    if (!FileSave(strTestFile, "test"))
+    SString testFile = PathJoin(path, "_test_write.tmp");
+    if (!FileSave(testFile, "test"))
     {
-        strError = "Directory is not writable";
+        error = "Directory is not writable";
         return false;
     }
-    FileDelete(strTestFile);
+    FileDelete(testFile);
 
     return true;
 }

--- a/Client/core/CCore.h
+++ b/Client/core/CCore.h
@@ -115,9 +115,9 @@ public:
 
     // File Cache Path management
     SString GetFileCachePath();
-    bool    SetFileCachePath(const SString& strPath);
+    bool    SetFileCachePath(const SString& path);
     bool    ResetFileCachePath();
-    bool    ValidateFileCachePath(const SString& strPath, SString& strError);
+    bool    ValidateFileCachePath(const SString& path, SString& error);
 
     // Debug
     void DebugEcho(const char* szText);

--- a/Client/core/CCore.h
+++ b/Client/core/CCore.h
@@ -113,6 +113,12 @@ public:
 
     void SaveConfig(bool bWaitUntilFinished = false);
 
+    // File Cache Path management
+    SString GetFileCachePath();
+    bool    SetFileCachePath(const SString& strPath);
+    bool    ResetFileCachePath();
+    bool    ValidateFileCachePath(const SString& strPath, SString& strError);
+
     // Debug
     void DebugEcho(const char* szText);
     void DebugPrintf(const char* szFormat, ...);

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -5647,6 +5647,16 @@ bool CSettings::OnCachePathBrowseButtonClick(CGUIElement* pElement)
     SString strCurrentPath = CCore::GetSingleton().GetFileCachePath();
     HWND    hWnd = CCore::GetSingleton().GetHookedWindow();
 
+    bool bWasFullscreen = !GetVideoModeManager()->IsWindowed();
+    if (bWasFullscreen)
+    {
+        ShowWindow(hWnd, SW_MINIMIZE);
+    }
+
+    CGUI* pGUI = CCore::GetSingleton().GetGUI();
+    bool  wasCursorEnabled = pGUI->IsCursorEnabled();
+    pGUI->SetCursorEnabled(false);
+
     BrowseFolderThreadData threadData;
     threadData.strTitle = FromUTF8(_("Select a folder for Client resource files (must be outside MTA folder)"));
     threadData.szResult[0] = 0;
@@ -5674,6 +5684,14 @@ bool CSettings::OnCachePathBrowseButtonClick(CGUIElement* pElement)
 
     EnableWindow(hWnd, TRUE);
     SetForegroundWindow(hWnd);
+
+    if (wasCursorEnabled)
+        pGUI->SetCursorEnabled(true);
+
+    if (bWasFullscreen)
+    {
+        ShowWindow(hWnd, SW_RESTORE);
+    }
 
     if (threadData.bSuccess)
     {

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -307,6 +307,8 @@ void CSettings::ResetGuiPointers()
     m_pCachePathLabel = NULL;
     m_pCachePathValue = NULL;
     m_pCachePathShowButton = NULL;
+    m_pCachePathBrowseButton = NULL;
+    m_pCachePathResetButton = NULL;
 
     m_pLabelMasterVolume = NULL;
     m_pLabelRadioVolume = NULL;
@@ -1857,15 +1859,27 @@ void CSettings::CreateGUI()
     m_pCachePathLabel->AutoSize();
 
     m_pCachePathShowButton = reinterpret_cast<CGUIButton*>(pManager->CreateButton(pTabAdvanced, _("Show in Explorer")));
-    m_pCachePathShowButton->SetPosition(CVector2D(vecTemp.fX + fIndentX + 1, vecTemp.fY - 1));
-    m_pCachePathShowButton->AutoSize(NULL, 20.0f, 8.0f);
+    m_pCachePathShowButton->SetPosition(CVector2D(vecTemp.fX + fIndentX, vecTemp.fY));
+    m_pCachePathShowButton->SetSize(CVector2D(120.0f, 20.0f));
     m_pCachePathShowButton->SetClickHandler(GUI_CALLBACK(&CSettings::OnCachePathShowButtonClick, this));
     m_pCachePathShowButton->SetZOrderingEnabled(false);
-    m_pCachePathShowButton->GetSize(vecSize);
 
-    SString strFileCachePath = GetCommonRegistryValue("", "File Cache Path");
+    m_pCachePathBrowseButton = reinterpret_cast<CGUIButton*>(pManager->CreateButton(pTabAdvanced, _("Change Path")));
+    m_pCachePathBrowseButton->SetPosition(CVector2D(vecTemp.fX + fIndentX + 130, vecTemp.fY));
+    m_pCachePathBrowseButton->SetSize(CVector2D(120.0f, 20.0f));
+    m_pCachePathBrowseButton->SetClickHandler(GUI_CALLBACK(&CSettings::OnCachePathBrowseButtonClick, this));
+    m_pCachePathBrowseButton->SetZOrderingEnabled(false);
+
+    m_pCachePathResetButton = reinterpret_cast<CGUIButton*>(pManager->CreateButton(pTabAdvanced, _("Reset Path")));
+    m_pCachePathResetButton->SetPosition(CVector2D(vecTemp.fX + fIndentX + 260, vecTemp.fY));
+    m_pCachePathResetButton->SetSize(CVector2D(120.0f, 20.0f));
+    m_pCachePathResetButton->SetClickHandler(GUI_CALLBACK(&CSettings::OnCachePathResetButtonClick, this));
+    m_pCachePathResetButton->SetZOrderingEnabled(false);
+    vecTemp.fY += fLineHeight;
+
+    SString strFileCachePath = CCore::GetSingleton().GetFileCachePath();
     m_pCachePathValue = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabAdvanced, strFileCachePath));
-    m_pCachePathValue->SetPosition(CVector2D(vecTemp.fX + fIndentX + vecSize.fX + 10, vecTemp.fY + 3));
+    m_pCachePathValue->SetPosition(CVector2D(vecTemp.fX + fIndentX, vecTemp.fY));
     m_pCachePathValue->SetFont("default-small");
     m_pCachePathValue->AutoSize();
     vecTemp.fY += fLineHeight;
@@ -5586,9 +5600,182 @@ bool CSettings::OnUpdateButtonClick(CGUIElement* pElement)
 
 bool CSettings::OnCachePathShowButtonClick(CGUIElement* pElement)
 {
-    SString strFileCachePath = GetCommonRegistryValue("", "File Cache Path");
+    SString strFileCachePath = CCore::GetSingleton().GetFileCachePath();
     if (DirectoryExists(strFileCachePath))
         ShellExecuteNonBlocking("open", strFileCachePath);
+    return true;
+}
+
+struct BrowseFolderThreadData
+{
+    WString strTitle;
+    wchar_t szResult[MAX_PATH];
+    bool bSuccess;
+};
+
+DWORD WINAPI BrowseFolderThread(LPVOID lpParam)
+{
+    BrowseFolderThreadData* pData = (BrowseFolderThreadData*)lpParam;
+
+    CoInitialize(NULL);
+    ShowCursor(TRUE);
+    SetCursor(LoadCursor(NULL, IDC_ARROW));
+
+    BROWSEINFOW bi = {0};
+    bi.lpszTitle = pData->strTitle;
+    bi.ulFlags = BIF_RETURNONLYFSDIRS | BIF_NEWDIALOGSTYLE;
+    bi.hwndOwner = NULL;
+
+    LPITEMIDLIST pidl = SHBrowseForFolderW(&bi);
+
+    if (pidl != NULL)
+    {
+        if (SHGetPathFromIDListW(pidl, pData->szResult))
+        {
+            pData->bSuccess = true;
+        }
+        CoTaskMemFree(pidl);
+    }
+
+    CoUninitialize();
+    return 0;
+}
+
+bool CSettings::OnCachePathBrowseButtonClick(CGUIElement* pElement)
+{
+    SString strCurrentPath = CCore::GetSingleton().GetFileCachePath();
+
+    BrowseFolderThreadData threadData;
+    threadData.strTitle = FromUTF8(_("Select a folder for Client resource files (must be outside MTA folder)"));
+    threadData.szResult[0] = 0;
+    threadData.bSuccess = false;
+
+    HANDLE hThread = CreateThread(NULL, 0, BrowseFolderThread, &threadData, 0, NULL);
+    if (hThread)
+    {
+        WaitForSingleObject(hThread, INFINITE);
+        CloseHandle(hThread);
+    }
+
+    if (threadData.bSuccess)
+    {
+        SString strSelectedPath = ToUTF8(threadData.szResult);
+        SString strDefaultPath = GetCommonRegistryValue("", "File Cache Path");
+        SString strError;
+
+        if (!strDefaultPath.empty() && PathConform(strSelectedPath) == PathConform(strDefaultPath))
+        {
+            if (PathConform(strCurrentPath) != PathConform(strDefaultPath))
+            {
+                if (CCore::GetSingleton().ResetFileCachePath())
+                {
+                    m_pCachePathValue->SetText(strDefaultPath);
+                    m_pCachePathValue->AutoSize();
+
+                    CCore::GetSingleton().ShowMessageBox(
+                        _("File Cache Path Reset"),
+                        _("File cache path has been reset to default. Changes will take effect after restarting MTA."),
+                        MB_BUTTON_OK | MB_ICON_INFO
+                    );
+
+                    ShowRestartQuestion();
+                }
+            }
+            else
+            {
+                CCore::GetSingleton().ShowMessageBox(
+                    _("Info"),
+                    _("You are already using the default file cache path."),
+                    MB_BUTTON_OK | MB_ICON_INFO
+                );
+            }
+        }
+        else if (CCore::GetSingleton().ValidateFileCachePath(strSelectedPath, strError))
+        {
+            if (PathConform(strCurrentPath) != PathConform(strSelectedPath))
+            {
+                if (CCore::GetSingleton().SetFileCachePath(strSelectedPath))
+                {
+                    m_pCachePathValue->SetText(strSelectedPath);
+                    m_pCachePathValue->AutoSize();
+
+                    CCore::GetSingleton().ShowMessageBox(
+                        _("File Cache Path Changed"),
+                        _("The file cache path has been successfully changed. Changes will take effect after restarting MTA."),
+                        MB_BUTTON_OK | MB_ICON_INFO
+                    );
+
+                    ShowRestartQuestion();
+                }
+                else
+                {
+                    CCore::GetSingleton().ShowMessageBox(
+                        _("Error"),
+                        _("Failed to save the file cache path to configuration."),
+                        MB_BUTTON_OK | MB_ICON_ERROR
+                    );
+                }
+            }
+            else
+            {
+                CCore::GetSingleton().ShowMessageBox(
+                    _("Info"),
+                    _("The selected path is the same as the current file cache path."),
+                    MB_BUTTON_OK | MB_ICON_INFO
+                );
+            }
+        }
+        else
+        {
+            CCore::GetSingleton().ShowMessageBox(
+                _("Invalid Path"),
+                strError,
+                MB_BUTTON_OK | MB_ICON_ERROR
+            );
+        }
+    }
+
+    return true;
+}
+
+bool CSettings::OnCachePathResetButtonClick(CGUIElement* pElement)
+{
+    SString strCurrentPath = CCore::GetSingleton().GetFileCachePath();
+    SString strDefaultPath = GetCommonRegistryValue("", "File Cache Path");
+
+    if (!strDefaultPath.empty() && PathConform(strCurrentPath) == PathConform(strDefaultPath))
+    {
+        CCore::GetSingleton().ShowMessageBox(
+            _("Info"),
+            _("You are already using the default file cache path."),
+            MB_BUTTON_OK | MB_ICON_INFO
+        );
+        return true;
+    }
+
+    if (CCore::GetSingleton().ResetFileCachePath())
+    {
+        strDefaultPath = CCore::GetSingleton().GetFileCachePath();
+        m_pCachePathValue->SetText(strDefaultPath);
+        m_pCachePathValue->AutoSize();
+
+        CCore::GetSingleton().ShowMessageBox(
+            _("File Cache Path Reset"),
+            _("File cache path has been reset to default. Changes will take effect after restarting MTA."),
+            MB_BUTTON_OK | MB_ICON_INFO
+        );
+
+        ShowRestartQuestion();
+    }
+    else
+    {
+        CCore::GetSingleton().ShowMessageBox(
+            _("Error"),
+            _("Failed to reset the file cache path."),
+            MB_BUTTON_OK | MB_ICON_ERROR
+        );
+    }
+
     return true;
 }
 

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -256,6 +256,8 @@ protected:
     CGUILabel*     m_pCachePathLabel;
     CGUILabel*     m_pCachePathValue;
     CGUIButton*    m_pCachePathShowButton;
+    CGUIButton*    m_pCachePathBrowseButton;
+    CGUIButton*    m_pCachePathResetButton;
     CGUILabel*     m_pLabelMasterVolume;
     CGUILabel*     m_pLabelRadioVolume;
     CGUILabel*     m_pLabelSFXVolume;
@@ -419,6 +421,8 @@ protected:
     bool OnChatAlphaChanged(CGUIElement* pElement);
     bool OnUpdateButtonClick(CGUIElement* pElement);
     bool OnCachePathShowButtonClick(CGUIElement* pElement);
+    bool OnCachePathBrowseButtonClick(CGUIElement* pElement);
+    bool OnCachePathResetButtonClick(CGUIElement* pElement);
     bool OnMouseSensitivityChanged(CGUIElement* pElement);
     bool OnVerticalAimSensitivityChanged(CGUIElement* pElement);
     bool OnBrowserBlacklistAdd(CGUIElement* pElement);

--- a/Client/core/StdInc.h
+++ b/Client/core/StdInc.h
@@ -20,6 +20,7 @@
 #include <windowsx.h>
 #include <time.h>
 #include <shlwapi.h>
+#include <shlobj.h>
 #include <winsock.h>
 #include <conio.h>
 

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -6766,21 +6766,21 @@ void CClientGame::SetFileCacheRoot()
     else
     {
         // Get shared directory
-        SString strFileCachePath = g_pCore->GetFileCachePath();
+        SString fileCachePath = g_pCore->GetFileCachePath();
         // Check exists
-        if (!strFileCachePath.empty() && DirectoryExists(strFileCachePath))
+        if (!fileCachePath.empty() && DirectoryExists(fileCachePath))
         {
             // Check writable
-            SString strTestFileName = PathJoin(strFileCachePath, "resources", "_test.tmp");
-            if (FileSave(strTestFileName, "x"))
+            SString testFileName = PathJoin(fileCachePath, "resources", "_test.tmp");
+            if (FileSave(testFileName, "x"))
             {
-                FileDelete(strTestFileName);
-                strTestFileName = PathJoin(strFileCachePath, "priv", "_test.tmp");
-                if (FileSave(strTestFileName, "x"))
+                FileDelete(testFileName);
+                testFileName = PathJoin(fileCachePath, "priv", "_test.tmp");
+                if (FileSave(testFileName, "x"))
                 {
-                    FileDelete(strTestFileName);
+                    FileDelete(testFileName);
                     // Use shared directory
-                    m_strFileCacheRoot = strFileCachePath;
+                    m_strFileCacheRoot = fileCachePath;
                     AddReportLog(7411, SString("CClientGame::SetFileCacheRoot - Is shared '%s'", *m_strFileCacheRoot));
                     return;
                 }
@@ -6791,10 +6791,10 @@ void CClientGame::SetFileCacheRoot()
         m_strFileCacheRoot = GetModRoot();
         SetCommonRegistryValue("", "File Cache Path", m_strFileCacheRoot);
 
-        if (strFileCachePath.empty())
+        if (fileCachePath.empty())
             AddReportLog(7412, SString("CClientGame::SetFileCacheRoot - Initial setting '%s'", *m_strFileCacheRoot));
         else
-            AddReportLog(7413, SString("CClientGame::SetFileCacheRoot - Change shared from '%s' to '%s'", *strFileCachePath, *m_strFileCacheRoot));
+            AddReportLog(7413, SString("CClientGame::SetFileCacheRoot - Change shared from '%s' to '%s'", *fileCachePath, *m_strFileCacheRoot));
     }
 }
 

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -6766,7 +6766,7 @@ void CClientGame::SetFileCacheRoot()
     else
     {
         // Get shared directory
-        SString strFileCachePath = GetCommonRegistryValue("", "File Cache Path");
+        SString strFileCachePath = g_pCore->GetFileCachePath();
         // Check exists
         if (!strFileCachePath.empty() && DirectoryExists(strFileCachePath))
         {

--- a/Client/sdk/core/CCoreInterface.h
+++ b/Client/sdk/core/CCoreInterface.h
@@ -136,9 +136,9 @@ public:
     virtual void UpdateRecentlyPlayed() = 0;
 
     virtual SString GetFileCachePath() = 0;
-    virtual bool    SetFileCachePath(const SString& strPath) = 0;
+    virtual bool    SetFileCachePath(const SString& path) = 0;
     virtual bool    ResetFileCachePath() = 0;
-    virtual bool    ValidateFileCachePath(const SString& strPath, SString& strError) = 0;
+    virtual bool    ValidateFileCachePath(const SString& path, SString& error) = 0;
 
     virtual void SwitchRenderWindow(HWND hWnd, HWND hWndInput) = 0;
     virtual void SetCenterCursor(bool bEnabled) = 0;

--- a/Client/sdk/core/CCoreInterface.h
+++ b/Client/sdk/core/CCoreInterface.h
@@ -135,6 +135,11 @@ public:
     virtual void SaveConfig(bool bWaitUntilFinished = false) = 0;
     virtual void UpdateRecentlyPlayed() = 0;
 
+    virtual SString GetFileCachePath() = 0;
+    virtual bool    SetFileCachePath(const SString& strPath) = 0;
+    virtual bool    ResetFileCachePath() = 0;
+    virtual bool    ValidateFileCachePath(const SString& strPath, SString& strError) = 0;
+
     virtual void SwitchRenderWindow(HWND hWnd, HWND hWndInput) = 0;
     virtual void SetCenterCursor(bool bEnabled) = 0;
     virtual bool IsTimingCheckpoints() = 0;


### PR DESCRIPTION
#### Summary
Adds the ability to change the client-side file cache location from the Advanced Settings menu.
Two new buttons were introduced: **Change**, which allows the user to select a custom cache directory via a file explorer dialog, and **Reset**, which restores the default behavior.

By default, the client continues to use the cache path stored in the Windows Registry. If a custom cache path is defined in `coreconfig.xml`, it takes precedence. If the custom directory becomes unavailable or is deleted, the system automatically falls back to the default path.

<img width="583" height="67" alt="image" src="https://github.com/user-attachments/assets/3ec9341a-66fc-4eff-a193-92f844db838f" />

Closes #4655

#### Motivation
Currently, the cache path is only displayed in the UI and cannot be modified from within the client.
Changing it requires manually editing the Windows Registry.

This change makes cache path configuration accessible from the UI while keeping backward compatibility and safe fallback behavior.

#### Test plan
1. Open **Advanced Settings** and click **Change** to select a custom cache folder.
2. Restart the client and verify that the new cache path is in use.
3. Click **Reset**, restart again, and verify that the default cache path is restored.

#### Checklist
* [x] Code follows the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] The pull request is small, focused, and easy to review.