### PR TITLE
Fix `processLineAgainstMesh` crashes when checking for colored meshes

### DIFF
--- a/Client/game_sa/CWorldSA.cpp
+++ b/Client/game_sa/CWorldSA.cpp
@@ -429,11 +429,11 @@ auto CWorldSA::ProcessLineAgainstMesh(CEntitySAInterface* targetEntity, CVector 
         if (c.hitGeo->materials.materials && c.hitGeo->materials.materials[c.hitTri->materialId])
         {
             RwTexture* const tex = c.hitGeo->materials.materials[c.hitTri->materialId]->texture;
-            ret.textureName = tex ? tex->name : "unknown";
+            ret.textureName = tex ? tex->name : nullptr;
         }
         else
         {
-            ret.textureName = "unknown";
+            ret.textureName = nullptr;
         }
 
         RwFrame* const hitFrame = RpAtomicGetFrame(c.hitAtomic);

--- a/Client/game_sa/CWorldSA.cpp
+++ b/Client/game_sa/CWorldSA.cpp
@@ -402,22 +402,39 @@ auto CWorldSA::ProcessLineAgainstMesh(CEntitySAInterface* targetEntity, CVector 
         // Now, calculate texture UV, etc based on the hit [if we've hit anything at all]
         // Since we have the barycentric coords of the hit, calculating it is easy
         ret.uv = {};
-        for (int i = 0; i < 3; i++)
+
+        // Index of the UV set to use
+        const int uvSetIdx = 0;
+
+        // Check if texcoords exist (some models only have colored mesh without textures)
+        if (c.hitGeo->texcoords[uvSetIdx])
         {
-            // UV set index - Usually models only use level 0 indices, so let's stick with that
-            const int uvSetIdx = 0;
+            for (int i = 0; i < 3; i++)
+            {
+                // Vertex's UV position
+                RwTextureCoordinates* const vtxUV = &c.hitGeo->texcoords[uvSetIdx][c.hitTri->verts[i]];
 
-            // Vertex's UV position
-            RwTextureCoordinates* const vtxUV = &c.hitGeo->texcoords[uvSetIdx][c.hitTri->verts[i]];
-
-            // Now, just interpolate
-            ret.uv += CVector2D{vtxUV->u, vtxUV->v} * c.hitBary[i];
+                // Now, just interpolate
+                ret.uv += CVector2D{vtxUV->u, vtxUV->v} * c.hitBary[i];
+            }
+        }
+        else
+        {
+            // No texture coords available, use barycentric coords as UV fallback
+            ret.uv = CVector2D{c.hitBary.fX, c.hitBary.fY};
         }
 
         // Find out material texture name
         // For some reason this is sometimes null
-        RwTexture* const tex = c.hitGeo->materials.materials[c.hitTri->materialId]->texture;
-        ret.textureName = tex ? tex->name : nullptr;
+        if (c.hitGeo->materials.materials && c.hitGeo->materials.materials[c.hitTri->materialId])
+        {
+            RwTexture* const tex = c.hitGeo->materials.materials[c.hitTri->materialId]->texture;
+            ret.textureName = tex ? tex->name : "unknown";
+        }
+        else
+        {
+            ret.textureName = "unknown";
+        }
 
         RwFrame* const hitFrame = RpAtomicGetFrame(c.hitAtomic);
         ret.frameName = hitFrame ? hitFrame->szName : nullptr;


### PR DESCRIPTION
#### Summary
Fixed crash in `processLineAgainstMesh` when processing models with colored meshes (no texture coordinates). The function now safely handles models without UV data by using barycentric coordinates as a fallback.
Fixes: #4632

#### Motivation
The function would crash with an access violation (0xC0000005) when called on certain models that only have vertex colors without texture coordinates (e.g., model IDs: 13656, 13606, 3081, 3060, 1784, 2070, 2077, 2122, 2742, 2772, 8146, 953, 1318, 2594, 2782, 2602, 2781).

#### Test plan
- Models with textures: Returns correct UV coordinates and texture names (existing behavior preserved)
- Models without textures (colored mesh only): Returns barycentric coordinates as UV
- Problematic model IDs from crash report (2781, 2782, etc.): All now work correctly

**Test script:** The attached resource spawns a test object at (0, 0, 3). You can change the model ID at the beginning of the script. (Shader won't apply on these object, thats a different issue)
[process_test.zip](https://github.com/user-attachments/files/24805437/process_test.zip)

https://github.com/user-attachments/assets/7608887b-e016-4ba3-8428-88f6c01e1ae0

#### Checklist
* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
