### PR TITLE
add `.clang-tidy` for in-editor feedback

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,5 @@
+---
+Checks: 'readability-braces-around-statements,modernize-redundant-void-arg'
+CheckOptions:
+  - key: readability-braces-around-statements.ShortStatementLines
+    value: '2'

--- a/Client/ceflauncher/premake5.lua
+++ b/Client/ceflauncher/premake5.lua
@@ -5,6 +5,7 @@ project "CEFLauncher"
 	targetdir(buildpath("mta/cef"))
 	includedirs { "../sdk" }
 	links { "CEFLauncher DLL"}
+	clangtidy "On"
 
 	vpaths {
 		["Headers/*"] = "**.h",
@@ -21,7 +22,7 @@ project "CEFLauncher"
 	}
 
 	filter "system:windows"
-		buildoptions { 
+		buildoptions {
 			"/Zc:inline",
 			"/Zc:throwingNew",
 			"/diagnostics:caret",
@@ -45,6 +46,6 @@ project "CEFLauncher"
 
 	filter "architecture:not x86"
 		flags { "ExcludeFromBuild" }
-	
+
 	filter "system:not windows"
 		flags { "ExcludeFromBuild" }

--- a/Client/ceflauncher_DLL/premake5.lua
+++ b/Client/ceflauncher_DLL/premake5.lua
@@ -3,6 +3,7 @@ project "CEFLauncher DLL"
 	kind "SharedLib"
 	targetname "CEFLauncher_DLL"
 	targetdir(buildpath("mta/cef"))
+	clangtidy "On"
 
 	includedirs { "../../vendor/cef3/cef", "../../Shared/sdk" }
 	libdirs { "../../vendor/cef3/cef/Release" }

--- a/Client/cefweb/premake5.lua
+++ b/Client/cefweb/premake5.lua
@@ -3,6 +3,7 @@ project "Client Webbrowser"
 	kind "SharedLib"
 	targetname "cefweb"
 	targetdir(buildpath("mta"))
+	clangtidy "On"
 
 	filter "system:windows"
 		includedirs { "../../vendor/sparsehash/src/windows" }

--- a/Client/core/premake5.lua
+++ b/Client/core/premake5.lua
@@ -3,6 +3,7 @@ project "Client Core"
 	kind "SharedLib"
 	targetname "core"
 	targetdir(buildpath("mta"))
+	clangtidy "On"
 
 	filter "system:windows"
 		includedirs { "../../vendor/sparsehash/src/windows" }

--- a/Client/game_sa/premake5.lua
+++ b/Client/game_sa/premake5.lua
@@ -3,6 +3,7 @@ project "Game SA"
 	kind "SharedLib"
 	targetname "game_sa"
 	targetdir(buildpath("mta"))
+	clangtidy "On"
 
 	-- DO NOT REMOVE OR TURN THIS OPTION ON
 	-- By turning this feature off, our code will be compiled with '/Zi' instead of '/ZI'.

--- a/Client/gui/premake5.lua
+++ b/Client/gui/premake5.lua
@@ -3,6 +3,7 @@ project "GUI"
 	kind "SharedLib"
 	targetname "cgui"
 	targetdir(buildpath("mta"))
+	clangtidy "On"
 
 	filter "system:windows"
 		includedirs { "../../vendor/sparsehash/src/windows" }
@@ -39,7 +40,7 @@ project "GUI"
 		"*.h",
 		"*.cpp"
 	}
-	
+
 	filter "architecture:not x86"
 		flags { "ExcludeFromBuild" }
 

--- a/Client/launch/premake5.lua
+++ b/Client/launch/premake5.lua
@@ -4,6 +4,7 @@ project "Client Launcher"
 	targetname "Multi Theft Auto"
 	targetdir(buildpath("."))
 	debugdir(buildpath("."))
+	clangtidy "On"
 
 	includedirs {
 		"../../Shared/sdk",

--- a/Client/loader-proxy/premake5.lua
+++ b/Client/loader-proxy/premake5.lua
@@ -3,6 +3,7 @@ project "Loader Proxy"
 	kind "SharedLib"
 	targetname "mtasa"
 	targetdir(buildpath("mta"))
+	clangtidy "On"
 
 	filter "configurations:Debug"
 		targetsuffix "_d"

--- a/Client/loader/premake5.lua
+++ b/Client/loader/premake5.lua
@@ -6,6 +6,7 @@ project "Loader"
 	disablewarnings {
 		"4996", -- use of symbol with __declspec(deprecated)
 	}
+	clangtidy "On"
 
 	includedirs {
 		"../../Shared/sdk",

--- a/Client/mods/deathmatch/premake5.lua
+++ b/Client/mods/deathmatch/premake5.lua
@@ -3,6 +3,7 @@ project "Client Deathmatch"
 	kind "SharedLib"
 	targetname "client"
 	targetdir(buildpath("mods/deathmatch"))
+	clangtidy "On"
 
 	pchheader "StdInc.h"
 	pchsource "StdInc.cpp"

--- a/Client/multiplayer_sa/premake5.lua
+++ b/Client/multiplayer_sa/premake5.lua
@@ -3,6 +3,7 @@ project "Multiplayer SA"
 	kind "SharedLib"
 	targetname "multiplayer_sa"
 	targetdir(buildpath("mta"))
+	clangtidy "On"
 
 	-- DO NOT REMOVE OR TURN THIS OPTION ON
 	-- See details in game_sa/premake5.lua

--- a/Client/sdk/premake5.lua
+++ b/Client/sdk/premake5.lua
@@ -2,6 +2,7 @@ project "Client SDK"
 	language "C++"
 	kind "StaticLib"
 	targetname "sdk"
+	clangtidy "On"
 
 	vpaths {
 		["Headers/*"] = { "**.h", "**.hpp" },

--- a/Server/core/premake5.lua
+++ b/Server/core/premake5.lua
@@ -3,6 +3,7 @@ project "Core"
 	kind "SharedLib"
 	targetname "core"
 	targetdir(buildpath("server"))
+	clangtidy "On"
 
 	filter "system:windows"
 		includedirs { "../../vendor/sparsehash/current/src/windows" }

--- a/Server/dbconmy/premake5.lua
+++ b/Server/dbconmy/premake5.lua
@@ -3,6 +3,7 @@ project "Dbconmy"
 	kind "SharedLib"
 	targetname "dbconmy"
 	targetdir(buildpath("server/mods/deathmatch"))
+	clangtidy "On"
 
 	filter "system:windows"
 		includedirs {

--- a/Server/launcher/premake5.lua
+++ b/Server/launcher/premake5.lua
@@ -3,6 +3,7 @@ project "Launcher"
 	kind "ConsoleApp"
 	targetdir(buildpath("server"))
 	targetname "mta-server"
+	clangtidy "On"
 
 	includedirs {
 		"../../Shared/sdk",

--- a/Server/mods/deathmatch/premake5.lua
+++ b/Server/mods/deathmatch/premake5.lua
@@ -3,6 +3,7 @@ project "Deathmatch"
 	kind "SharedLib"
 	targetname "deathmatch"
 	targetdir(buildpath("server/mods/deathmatch"))
+	clangtidy "On"
 
 	pchheader "StdInc.h"
 	pchsource "StdInc.cpp"

--- a/Server/sdk/premake5.lua
+++ b/Server/sdk/premake5.lua
@@ -7,6 +7,7 @@ project "Server SDK"
 	language "C++"
 	kind "None"
 	targetname "sdk"
+	clangtidy "On"
 
 	vpaths {
 		["Headers/*"] = { "**.h", "**.hpp" },

--- a/Shared/XML/premake5.lua
+++ b/Shared/XML/premake5.lua
@@ -3,6 +3,7 @@ project "XML"
 	kind "SharedLib"
 	targetname "xmll"
 	targetdir(buildpath("server"))
+	clangtidy "On"
 
 	includedirs {
 		"../sdk",

--- a/Shared/premake5.lua
+++ b/Shared/premake5.lua
@@ -7,6 +7,7 @@ project "Shared"
 	language "C++"
 	kind "None"
 	targetname "shared"
+	clangtidy "On"
 
 	vpaths {
 		["Headers/*"] = { "**.h", "**.hpp" },


### PR DESCRIPTION
#### Summary
<!-- What change are you making? -->
<!-- When changing Lua APIs, consider including code samples and documentation. -->

Apparently [Visual Studio has native support for Clang-Tidy](https://learn.microsoft.com/en-us/cpp/code-quality/clang-tidy?view=msvc-170), and [so does Premake](https://premake.github.io/docs/clangtidy/).

This change makes it so that it's a linter warning when you:
- write methods like `bool foo(void);` (should be `bool foo():`)
- don't use braces with multiple lines of if statements

Note that this doesn't enforce anything in CI.

#### Motivation
<!-- Why are you making this change? Which GitHub issue does this resolve, if any? Any additional context? -->

https://github.com/multitheftauto/mtasa-blue/issues/772

#### Test plan for `readability-braces-around-statements`
<!-- How have you tested this change? This should give confidence to the reviewer  -->
<!-- If someone makes changes to this code in the future, what steps can they follow to check that it's still working correctly? -->

Only the first of the following code:

<img width="2436" height="404" alt="CleanShot 2026-01-25 at 17 18 41@2x" src="https://github.com/user-attachments/assets/8d69459a-93e4-49b1-8cd1-bc7c73eba1bb" />

Produces a lint like this:

<img width="948" height="172" alt="CleanShot 2026-01-25 at 17 19 06@2x" src="https://github.com/user-attachments/assets/9ad68ab4-f576-41d0-9777-1d2390d93783" />

(The second section isn't supposed to produce a lint, and correctly doesn't. The third section ideally would, but `clang-tidy` only lets you define number of statements not lines.)

#### Test plan for `modernize-redundant-void-arg`

<img width="1120" height="186" alt="CleanShot 2026-01-25 at 17 20 56@2x" src="https://github.com/user-attachments/assets/0f8872b2-dfcb-44f1-a283-8c917d40e0e0" />


