### PR TITLE
Run clang-format on every push

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,19 +1,6 @@
 name: clang-format
 
-on:
-  push:
-    paths: &paths
-      - '**.c'
-      - '**.cc'
-      - '**.cpp'
-      - '**.h'
-      - '**.hh'
-      - '**.hpp'
-      - '.github/workflows/clang-format.yml'
-      - 'utils/clang-format.ps1'
-  pull_request:
-    paths: *paths
-  workflow_dispatch:
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   clang-format:


### PR DESCRIPTION
`clang-format` succeeding is required, and this was blocking pull requests to the build system from being merged without a bypass.
