### PR TITLE
Fix server build on RHEL/Fedora with `mysql-devel` package

### DIFF
--- a/Server/dbconmy/premake5.lua
+++ b/Server/dbconmy/premake5.lua
@@ -36,6 +36,15 @@ project "Dbconmy"
 
 	filter "system:linux"
 		includedirs { "/usr/include/mysql" }
+		libdirs {
+			-- RHEL/Fedora distributions put MySQL client libraries of their mysql-devel
+			-- package under a subdirectory not picked up by Premake's default library
+			-- search path
+			os.findlib("mysqlclient", {
+				"/usr/lib/mysql",
+				"/usr/lib64/mysql",
+			})
+		}
 		links { "rt" }
 
 	filter "system:macosx"


### PR DESCRIPTION
#### Summary

These changes improve the build experience of the MTA server in RHEL-like Linux distributions such as Fedora by tweaking a Premake recipe to additively take into account the idiosyncrasies of MySQL library placement in that distribution.

#### Motivation

A Discord user expressed interest in building the MTA server on Fedora Linux, mentioning that the server couldn't be compiled even after installing the corresponding build dependency packages.

Initially, the user's immediate need was addressed by building the server in a suitable Debian-like Docker container. However, I was curious whether there was indeed some shortcoming in our build pipeline that prevented server builds on that distribution.

After some experimentation with a clean, throwaway Fedora 44 container, I discovered that its `mysql-devel` package places MySQL client libraries in `/usr/lib(64)/mysql`, a location not covered by the [default Premake library search paths](https://github.com/premake/premake-core/blob/950cafb392358db3037d3d4ea9481689caa4a5bb/src/base/os.lua#L65). The alternative `mariadb-connector-c-devel` package places the library directly under `/usr/lib(64)`, but since all of our documentation and build scripts reference the `mysql`-named packages, it's only natural that Fedora users try `mysql-devel` instead of the more verbose alternative. The precise build error I could reproduce due to that was:

```
/usr/bin/ld.bfd: cannot find -lmysqlclient: No such file or directory
collect2: error: ld returned 1 exit status
make[1]: *** [Dbconmy.make:182: ../Bin/server/x64/dbconmy.so] Error 1
make: *** [Makefile:312: Dbconmy] Error 2
```

Of course, on Debian-based distributions, which are better tested in this project's CI, the default library search paths work fine.

Relevantly, both distribution families ship the MySQL development libraries with `pkgconfig` (.pc) files that abstract away these path differences, but using `pkgconfig` in Premake felt like overkill for this purpose. Instead, I opted to use `os.findlib` in a similar fashion to the macOS case, ensuring that Fedora's alternative MySQL library path is taken into account without imposing additional build dependencies. Similarly, I also felt it was overkill to add CI coverage for this distribution, since Fedora builds are, admittedly, a niche case that can be decently worked around by using Debian containers.

#### Test plan

I've tested these changes and confirmed that the server now builds successfully on both Fedora and Debian x64 containers. For Fedora specifically, installing `make`, `automake`, `gcc`, `gcc-c++`, `ncurses-devel`, and `mysql-devel` was all that was needed on top of a base system. More specifically, these commands now ran successfully on my end:

```
$ docker run --rm -it fedora:44
$ dnf install git make automake gcc gcc-c++ ncurses-devel mysql-devel
$ git clone https://github.com/multitheftauto/mtasa-blue.git
$ cd mtasa-blue
# Check out this PR
$ ./linux-build.sh
```
