### PR TITLE
fix(typo): correct spelling in CMainMenu.cpp comments

### DIFF
--- a/Client/core/CMainMenu.cpp
+++ b/Client/core/CMainMenu.cpp
@@ -172,7 +172,7 @@ CMainMenu::CMainMenu(CGUI* pManager)
 
     float fBase = 0.613f;
     float fGap = 0.043f;
-    // Our disconnect item is shown/hidden dynamically, so we store it seperately
+    // Our disconnect item is shown/hidden dynamically, so we store it separately
     m_pDisconnect = CreateItem(MENU_ITEM_DISCONNECT, "menu_disconnect.png", CVector2D(0.168f, fBase + fGap * 0));
     m_pDisconnect->image->SetVisible(false);
 
@@ -575,7 +575,7 @@ void CMainMenu::Update()
         while (it != m_unhoveredItems.end())
         {
             // Let's work out what the target progress should be by working out the time passed
-            // Min of 0.5 progress fixes occasional graphical glitchekal
+            // Min of 0.5 progress fixes occasional graphical glitches
             float newProgress =
                 (*it)->animProgress - std::min(0.5f, ((float)ulTimePassed / CORE_MTA_ANIMATION_TIME_OUT) * (CORE_MTA_HOVER_ALPHA - CORE_MTA_NORMAL_ALPHA));
             if (SetItemHoverProgress((*it), newProgress, false))


### PR DESCRIPTION
#### Summary
<!-- What change are you making? -->
Fixed typos in comments of CMainMenu.cpp:

glitchekal → glitches

seperately → separately


#### Motivation
<!-- Why are you making this change? Which GitHub issue does this resolve, if any? Any additional context? -->
These typos were found in code comments and corrected to improve codebase quality and readability. Fixing spelling errors helps maintain professional coding standards.



#### Test plan
<!-- How have you tested this change? This should give confidence to the reviewer  -->
Changes only affect comments, so code functionality remains unchanged

Verified that the project builds successfully after changes

Visually confirmed the corrected lines in the file




#### Checklist

* [*] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [*] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
