### PR TITLE
Fix `showmemstat` crash when using in main menu

### DIFF
--- a/Client/core/CMemStats.cpp
+++ b/Client/core/CMemStats.cpp
@@ -988,7 +988,7 @@ void CMemStats::CreateTables()
             int     iDefCapacity = g_pCore->GetGame()->GetPools()->GetPoolDefaultCapacity((ePools)i);
             int     iCapacity = g_pCore->GetGame()->GetPools()->GetPoolCapacity((ePools)i);
             int     iUsedSpaces = g_pCore->GetGame()->GetPools()->GetNumberOfUsedSpaces((ePools)i);
-            int     iUsedPercent = iUsedSpaces * 100 / iCapacity;
+            int     iUsedPercent = iCapacity > 0 ? iUsedSpaces * 100 / iCapacity : 0;
             table.AddRow(SString("%s|%d|%d|%d%%", *strName, iCapacity, iUsedSpaces, iUsedPercent));
         }
     }

--- a/Client/core/CMemStats.cpp
+++ b/Client/core/CMemStats.cpp
@@ -988,7 +988,7 @@ void CMemStats::CreateTables()
             int     iDefCapacity = g_pCore->GetGame()->GetPools()->GetPoolDefaultCapacity((ePools)i);
             int     iCapacity = g_pCore->GetGame()->GetPools()->GetPoolCapacity((ePools)i);
             int     iUsedSpaces = g_pCore->GetGame()->GetPools()->GetNumberOfUsedSpaces((ePools)i);
-            int     iUsedPercent = iCapacity > 0 ? iUsedSpaces * 100 / iCapacity : 0;
+            int     iUsedPercent = iCapacity > 0 ? (iUsedSpaces * 100 / iCapacity) : 0;
             table.AddRow(SString("%s|%d|%d|%d%%", *strName, iCapacity, iUsedSpaces, iUsedPercent));
         }
     }

--- a/Client/game_sa/CBuildingsPoolSA.h
+++ b/Client/game_sa/CBuildingsPoolSA.h
@@ -29,7 +29,7 @@ public:
     void           RemoveAllWithBackup() override;
     void           RestoreBackup() override;
     bool           Resize(int size) override;
-    int            GetSize() const override { return (*m_ppBuildingPoolInterface)->m_nSize; };
+    int            GetSize() const override { return (m_ppBuildingPoolInterface && *m_ppBuildingPoolInterface) ? (*m_ppBuildingPoolInterface)->m_nSize : 0; };
     CClientEntity* GetClientBuilding(CBuildingSAInterface* pGameInterface) const noexcept;
 
 private:


### PR DESCRIPTION
#### Summary
Fixes #4676

#### Motivation
Fixing a bug

#### Test plan
Type `showmemstat` in main menu after MTA started and won't crash anymore

#### Checklist
* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
