### PR TITLE
Fix `CElement::GetAttachedPosition` to return correct positions for rotated parents

### DIFF
--- a/Server/mods/deathmatch/logic/CElement.cpp
+++ b/Server/mods/deathmatch/logic/CElement.cpp
@@ -1256,14 +1256,12 @@ void CElement::GetAttachedPosition(CVector& vecPosition)
 {
     if (m_pAttachedTo)
     {
-        CVector vecRotation;
-        vecPosition = m_pAttachedTo->GetPosition();
-        m_pAttachedTo->GetRotation(vecRotation);
+        // Get the parent's matrix
+        CMatrix parentMatrix;
+        m_pAttachedTo->GetMatrix(parentMatrix);
 
-        CVector vecPositionOffset = m_vecAttachedPosition;
-        // This works when rotating around z axis. Other axes need testing.
-        RotateVector(vecPositionOffset, CVector(vecRotation.fX, vecRotation.fY, -vecRotation.fZ));
-        vecPosition += vecPositionOffset;
+        // Transform the attached position by the parent's matrix
+        vecPosition = m_pAttachedTo->GetPosition() + parentMatrix.TransformVector(m_vecAttachedPosition);
     }
 }
 

--- a/Server/mods/deathmatch/logic/CElement.cpp
+++ b/Server/mods/deathmatch/logic/CElement.cpp
@@ -1256,12 +1256,15 @@ void CElement::GetAttachedPosition(CVector& vecPosition)
 {
     if (m_pAttachedTo)
     {
-        // Get the parent's matrix
-        CMatrix parentMatrix;
-        m_pAttachedTo->GetMatrix(parentMatrix);
+        // Get the position of the element we're attached to
+        vecPosition = m_pAttachedTo->GetPosition();
 
-        // Transform the attached position by the parent's matrix
-        vecPosition = m_pAttachedTo->GetPosition() + parentMatrix.TransformVector(m_vecAttachedPosition);
+        // Get the parent's matrix
+        CMatrix matParent;
+        m_pAttachedTo->GetMatrix(matParent);
+
+        // Apply the transformation
+        vecPosition += matParent.TransformVectorByRotation(m_vecAttachedPosition);
     }
 }
 

--- a/Shared/sdk/CMatrix.h
+++ b/Shared/sdk/CMatrix.h
@@ -173,6 +173,11 @@ public:
         return CVector(vec.fX * vRight.fX + vec.fY * vFront.fX + vec.fZ * vUp.fX + vPos.fX, vec.fX * vRight.fY + vec.fY * vFront.fY + vec.fZ * vUp.fY + vPos.fY,
                        vec.fX * vRight.fZ + vec.fY * vFront.fZ + vec.fZ * vUp.fZ + vPos.fZ);
     }
+    CVector TransformVectorByRotation(const CVector& vec) const
+    {
+        return CVector(vec.fX * vRight.fX + vec.fY * vFront.fX + vec.fZ * vUp.fX, vec.fX * vRight.fY + vec.fY * vFront.fY + vec.fZ * vUp.fY,
+                       vec.fX * vRight.fZ + vec.fY * vFront.fZ + vec.fZ * vUp.fZ);
+    }
 
     //
     // Ensure matrix component axes are normalized and orthogonal to each other.


### PR DESCRIPTION
#### Summary
Fixed `CElement::GetAttachedPosition` to correctly calculate attached element positions.
The previous implementation incorrectly calculated the element's current position, resulting in wrong world coordinates being returned.
It now appears correct from all angles, and the issue has been resolved. Further testing may still be required.
Fixes #4679 

#### Motivation
Attached elements returned incorrect positions when the parent was rotated.

#### Test plan
Use test code from #4679, now it will return the correct position.

<img width="1602" height="927" alt="image" src="https://github.com/user-attachments/assets/aefa5f7b-9b5f-438c-87bd-1cb611c7f28f" />
<img width="1602" height="927" alt="image" src="https://github.com/user-attachments/assets/cfddd926-ee81-4487-b132-67f9454e48af" />

#### Checklist
* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
