### PR TITLE
Fix garages automatically closing/opening

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1029,8 +1029,8 @@ void CMultiplayerSA::InitHooks()
     MemPut<BYTE>(0x44C39A + 4, 0x00);
     MemPut<BYTE>(0x44C39A + 5, 0x00);
 
-    // Avoid garage doors closing when you change your model
-    MemSet((LPVOID)0x4486F7, 0x90, 4);
+    // Disable CGarages::PlayerArrestedOrDied to stop the game from automatically closing/opening garages
+    MemSet((void*)0x442303, 0x90, 5);
 
     // Disable CStats::IncrementStat (returns at start of function)
     MemPut<BYTE>(0x55C180, 0xC3);


### PR DESCRIPTION
#### Summary
When a ped model is being set (for example, the first time after joining the game, when changing a skin, or when calling engineRestreamWorld, stream-in etc), ``CPedSA::Respawn`` calls ``CGameLogic::RestorePlayerStuffDuringResurrection`` (it’s probably enough to call just ``CWorld::Remove`` and ``CWorld::Add``, since the rest of what this function does seems unnecessary but that’s not what this PR is about).

This function, among other things, calls ``CGarages::PlayerArrestedOrDied``, which can close garages that are currently open or open garages that should remain closed. This PR disables the call to that function.

#### Motivation
#4683 


#### Test plan
Works good.

```
crun me.position = Vector3(1843.37, -1856.32, 13.875) -- garage is closed now
```

Before
```
crun me.position = Vector3(1843.37, -1856.32, 13.875) -- garage is opened
crun isGarageOpen(3) -- true
srun isGarageOpen(3) -- false
crun setGarageOpen(3, false)
crun engineRestreamWorld()
-- garage opening again
```

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
