### PR TITLE
Fix fake freeze crash when debugging

### DIFF
--- a/Client/core/CrashHandler.cpp
+++ b/Client/core/CrashHandler.cpp
@@ -956,7 +956,7 @@ static void CppNewHandlerBridge()
 LONG __stdcall CrashHandlerExceptionFilter(EXCEPTION_POINTERS* pExPtrs);
 
 [[noreturn]] void __cdecl CppTerminateHandler();
-void __cdecl AbortSignalHandler(int signal);
+void __cdecl              AbortSignalHandler(int signal);
 [[noreturn]] void __cdecl PureCallHandler();
 
 static void InstallCppHandlers();

--- a/Client/core/CrashHandler.cpp
+++ b/Client/core/CrashHandler.cpp
@@ -3167,6 +3167,15 @@ namespace
 
             if (elapsed.count() >= static_cast<std::chrono::seconds::rep>(timeoutSecs))
             {
+                #ifdef MTA_DEBUG
+                if (IsDebuggerPresent() == TRUE)
+                {
+                    g_watchdogState.lastHeartbeat.store(std::chrono::steady_clock::now(), std::memory_order_release);
+                    std::this_thread::sleep_for(kCheckInterval);
+                    continue;
+                }
+                #endif
+
                 AddReportLog(9311, SString("Watchdog detected freeze after %lld seconds (threshold %u)", static_cast<long long>(elapsed.count()), timeoutSecs));
 
                 const bool triggered = TriggerWatchdogException(targetThread.get(), targetThreadId);

--- a/Client/core/CrashHandler.cpp
+++ b/Client/core/CrashHandler.cpp
@@ -956,7 +956,7 @@ static void CppNewHandlerBridge()
 LONG __stdcall CrashHandlerExceptionFilter(EXCEPTION_POINTERS* pExPtrs);
 
 [[noreturn]] void __cdecl CppTerminateHandler();
-void __cdecl              AbortSignalHandler(int signal);
+void __cdecl AbortSignalHandler(int signal);
 [[noreturn]] void __cdecl PureCallHandler();
 
 static void InstallCppHandlers();
@@ -3167,14 +3167,14 @@ namespace
 
             if (elapsed.count() >= static_cast<std::chrono::seconds::rep>(timeoutSecs))
             {
-                #ifdef MTA_DEBUG
+#ifdef MTA_DEBUG
                 if (IsDebuggerPresent() == TRUE)
                 {
                     g_watchdogState.lastHeartbeat.store(std::chrono::steady_clock::now(), std::memory_order_release);
                     std::this_thread::sleep_for(kCheckInterval);
                     continue;
                 }
-                #endif
+#endif
 
                 AddReportLog(9311, SString("Watchdog detected freeze after %lld seconds (threshold %u)", static_cast<long long>(elapsed.count()), timeoutSecs));
 


### PR DESCRIPTION
#### Summary
During debugging, when a breakpoint is hit, a crash occurs shortly after resuming execution because the watchdog detects this as a freeze and forces a crash. This PR fixes that.


#### Motivation
https://discord.com/channels/801330706252038164/801411628600000522/1467514722965389536
<img width="753" height="813" alt="image" src="https://github.com/user-attachments/assets/b02ed886-1298-4a73-b600-3e100b042f9e" />


#### Test plan
N/A


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
