### PR TITLE
Fix setVehicleComponentVisible always showing the _ok state component

### DIFF
--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -211,6 +211,41 @@ namespace
     {
         RwFrameForAllObjects(frame, (void*)GetAllAtomicObjectCB, &result);
     }
+
+    int GetComponentIDFromName(const SString& name)
+    {
+        if (name == "bonnet_dummy")
+            return eDoors::BONNET;
+        else if (name == "boot_dummy")
+            return eDoors::BOOT;
+        else if (name == "door_lf_dummy")
+            return eDoors::FRONT_LEFT_DOOR;
+        else if (name == "door_rf_dummy")
+            return eDoors::FRONT_RIGHT_DOOR;
+        else if (name == "door_lb_dummy")
+            return eDoors::REAR_LEFT_DOOR;
+        else if (name == "door_rb_dummy")
+            return eDoors::REAR_RIGHT_DOOR;
+        else if (name == "bump_front_dummy")
+            return ePanels::FRONT_BUMPER;
+        else if (name == "bump_rear_dummy")
+            return ePanels::REAR_BUMPER;
+        else if (name == "windscreen_dummy")
+            return ePanels::WINDSCREEN_PANEL;
+    }
+
+    VehicleComponentType GetComponentTypeFromName(const SString& name)
+    {
+        if (name == "bonnet_dummy" || name == "boot_dummy" || name == "door_lf_dummy" || name == "door_rf_dummy" || name == "door_lb_dummy" ||
+            name == "door_rb_dummy")
+            return VehicleComponentType::DOOR;
+        else if (name == "bump_front_dummy" || name == "bump_rear_dummy" || name == "windscreen_dummy")
+            return VehicleComponentType::PANEL;
+        else if (name == "wheel_lb_dummy" || name == "wheel_rb_dummy" || name == "wheel_lf_dummy" || name == "wheel_rf_dummy")
+            return VehicleComponentType::WHEEL;
+
+        return VehicleComponentType::NONE;
+    }
 }  // namespace
 
 void CVehicleSA::Init()
@@ -2273,17 +2308,48 @@ bool CVehicleSA::SetComponentVisible(const SString& vehicleComponent, bool bRequ
 
         if (bRequestVisible && uiNumAtomicsCurrentlyVisible == 0)
         {
-            // Make atomic (undamaged version) visible. TODO - Check if damaged version should be made visible instead
+            bool isComponentDamaged = false;
+            bool isComponentFallenOff = false;
+            int  componentID = GetComponentIDFromName(vehicleComponent);
+            auto damageManager = GetDamageManager();
+            auto type = static_cast<VehicleComponentType>(GetComponentTypeFromName(vehicleComponent));
+
+            switch (type)
+            {
+                case VehicleComponentType::DOOR:
+                {
+                    auto doorEnum = static_cast<eDoors>(componentID);
+                    int  doorStatus = damageManager->GetDoorStatus(doorEnum);
+
+                    isComponentDamaged = (doorStatus > 1);
+                    isComponentFallenOff = (doorStatus == 4);
+                    break;
+                }
+                case VehicleComponentType::PANEL:
+                {
+                    auto panelId = static_cast<std::uint8_t>(componentID);
+                    int  panelStatus = damageManager->GetPanelStatus(panelId);
+
+                    isComponentDamaged = (panelStatus > 0);
+                    isComponentFallenOff = (panelStatus == 3);
+                    break;
+                }
+                default:
+                    break;
+            }
+
+            // We don't want to show the component that fell off
+            if (isComponentFallenOff)
+                return false;
+
+            // Make atomic visible.
             for (uint i = 0; i < atomicList.size(); i++)
             {
                 RwObject* pAtomic = atomicList[i];
                 int       AtomicId = pGame->GetVisibilityPlugins()->GetAtomicId(pAtomic);
 
-                if (!(AtomicId & ATOMIC_ID_FLAG_TWO_VERSIONS_DAMAGED))
-                {
-                    // Either only one version, or two versions and this is the undamaged one
+                if ((isComponentDamaged && (AtomicId & ATOMIC_ID_FLAG_TWO_VERSIONS_DAMAGED)) || (!isComponentDamaged && (AtomicId & ATOMIC_ID_FLAG_TWO_VERSIONS_UNDAMAGED)))
                     pAtomic->flags |= 0x04;
-                }
             }
         }
         else if (!bRequestVisible && uiNumAtomicsCurrentlyVisible > 0)

--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -2312,14 +2312,12 @@ bool CVehicleSA::SetComponentVisible(const SString& vehicleComponent, bool bRequ
             bool isComponentFallenOff = false;
             int  componentID = GetComponentIDFromName(vehicleComponent);
             auto damageManager = GetDamageManager();
-            auto type = static_cast<VehicleComponentType>(GetComponentTypeFromName(vehicleComponent));
 
-            switch (type)
+            switch (GetComponentTypeFromName(vehicleComponent))
             {
                 case VehicleComponentType::DOOR:
                 {
-                    auto doorEnum = static_cast<eDoors>(componentID);
-                    int  doorStatus = damageManager->GetDoorStatus(doorEnum);
+                    std::uint8_t doorStatus = damageManager->GetDoorStatus(static_cast<eDoors>(componentID));
 
                     isComponentDamaged = (doorStatus > 1);
                     isComponentFallenOff = (doorStatus == 4);
@@ -2327,8 +2325,7 @@ bool CVehicleSA::SetComponentVisible(const SString& vehicleComponent, bool bRequ
                 }
                 case VehicleComponentType::PANEL:
                 {
-                    auto panelId = static_cast<std::uint8_t>(componentID);
-                    int  panelStatus = damageManager->GetPanelStatus(panelId);
+                    std::uint8_t panelStatus = damageManager->GetPanelStatus(static_cast<std::uint8_t>(componentID));
 
                     isComponentDamaged = (panelStatus > 0);
                     isComponentFallenOff = (panelStatus == 3);

--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -2345,7 +2345,8 @@ bool CVehicleSA::SetComponentVisible(const SString& vehicleComponent, bool bRequ
                 RwObject* pAtomic = atomicList[i];
                 int       AtomicId = pGame->GetVisibilityPlugins()->GetAtomicId(pAtomic);
 
-                if ((isComponentDamaged && (AtomicId & ATOMIC_ID_FLAG_TWO_VERSIONS_DAMAGED)) || (!isComponentDamaged && (AtomicId & ATOMIC_ID_FLAG_TWO_VERSIONS_UNDAMAGED)))
+                if ((isComponentDamaged && (AtomicId & ATOMIC_ID_FLAG_TWO_VERSIONS_DAMAGED)) ||
+                    (!isComponentDamaged && (AtomicId & ATOMIC_ID_FLAG_TWO_VERSIONS_UNDAMAGED)))
                     pAtomic->flags |= 0x04;
             }
         }

--- a/Client/sdk/game/CVehicle.h
+++ b/Client/sdk/game/CVehicle.h
@@ -91,6 +91,15 @@ struct SVehicleFrame
     std::vector<RwFrame*> frameList;  // Frames from root to parent
 };
 
+enum class VehicleComponentType
+{
+    NONE = -1,
+
+    DOOR,
+    PANEL,
+    WHEEL,
+};
+
 class CVehicle : public virtual CPhysical
 {
 public:


### PR DESCRIPTION
#### Summary
setVehicleComponentVisible always shows the undamaged atomic even if the component is damaged. This PR fixes that; now, the correct atomic is rendered depending on whether the component is damaged or not.


#### Motivation
#4687 


#### Test plan
1. Hit the vehicle against the wall to damage the hood.
2. ``crun setVehicleComponentVisible(me.vehicle, 'bonnet_dummy', false)``
3. ``crun setVehicleComponentVisible(me.vehicle, 'bonnet_dummy', true) -- the normal hood is shown instead of the damaged one, even though the hood is destroyed.``

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
