### PR TITLE
Fix the component list doesn't change after replacing the model

### DIFF
--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -3091,6 +3091,12 @@ void CClientVehicle::Destroy()
         g_pGame->GetPools()->RemoveVehicle(m_pVehicle);
         m_pVehicle = NULL;
 
+        // Clear our component data, but backup the visibility states so we can restore them on next create
+        m_ComponentVisibilityBackup.clear();
+        for (const auto& pair : m_ComponentData)
+            m_ComponentVisibilityBackup[pair.first] = pair.second.m_bVisible;
+        m_ComponentData.clear();
+
         // Remove reference to its model
         m_pModelInfo->RemoveRef();
 


### PR DESCRIPTION
#### Summary
Even though vehicles are restreamed after a model replacement, the component list is not cleared. As a result, an existing vehicle (CClientVehicle) retains an incorrect component list even after the restream.


#### Motivation
#4130 


#### Test plan
1. Create a vehicle next to you.
2. Replace the vehicle model with one that has a hidden component.
3. Check the vehicle’s component list (for example, using the /gvc command from the getVehicleComponents function example).
5. Notice that the list looks incorrect.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
