### PR TITLE
Allow the Rhino to render headlight cones and coronas

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1571,8 +1571,8 @@ void CMultiplayerSA::InitHooks()
     MemSet((void*)0x6C4453, 0x90, 0x68);
 
     // Allow model ID 432 (Rhino) to render headlight cones and coronas
-    MemSet((void*)0x6A2EAF, 0x90, 2);
-    MemSet((void*)0x6ABC85, 0x90, 2);
+    MemSet((void*)0x6A2EAB, 0x90, 6);
+    MemSet((void*)0x6ABC81, 0x90, 6);
 
     // Disable Z position changes in the matrix in the C3dMarkers::PlaceMarker (#4000, #536)
     // To prevent arrow-type markers from snapping to the ground

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1570,6 +1570,10 @@ void CMultiplayerSA::InitHooks()
     MemSet((void*)0x6C444B, 0x90, 6);
     MemSet((void*)0x6C4453, 0x90, 0x68);
 
+    // Allow model ID 432 (Rhino) to render headlight cones and coronas
+    MemSet((void*)0x6A2EAF, 0x90, 2);
+    MemSet((void*)0x6ABC85, 0x90, 2);
+
     // Disable Z position changes in the matrix in the C3dMarkers::PlaceMarker (#4000, #536)
     // To prevent arrow-type markers from snapping to the ground
     MemCpy((void*)0x725844, "\xDD\xD8\x90", 3);


### PR DESCRIPTION
#### Summary
This pull request allows the Rhino (model ID 432) to use its headlight and brakelight textures and dummies by patching `CAutomobile::Render` and `CAutomobile::PreRender`. The vanilla model already has markers in place for these lights, and they are roughly in the correct positions. No model changes or Lua API changes are required.

#### Motivation
The vanilla model already has markers in place for these lights, but they were disabled by code. This pull request makes it so the base model and any potential replacement models of the Rhino can use the lights like other vehicles.

#### Test plan
The change was tested locally by spawning a Rhino on a default server setup and observing that the lights now work.

<img width="1920" height="1080" alt="an9w84t" src="https://github.com/user-attachments/assets/0bff4be8-ad44-4f32-960b-41a76f486e6e" />

#### Checklist
* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
