### PR TITLE
Fix physical objects rotation after restream

### DIFF
--- a/Client/mods/deathmatch/logic/CClientObject.cpp
+++ b/Client/mods/deathmatch/logic/CClientObject.cpp
@@ -136,10 +136,8 @@ void CClientObject::GetRotationDegrees(CVector& vecRotation) const
 
 void CClientObject::GetRotationRadians(CVector& vecRotation) const
 {
-    if (m_pObject && m_pAttachedToEntity)  // Temp fix for static objects->
+    if (m_pObject)
     {
-        // We've been returning the rotation that got set last so far (::m_vecRotation)..
-        //   but we need to get the real rotation for when the game moves the objects..
         CMatrix matTemp;
         m_pObject->GetMatrix(&matTemp);
         vecRotation = matTemp.GetRotation();
@@ -645,16 +643,28 @@ void CClientObject::StreamedInPulse()
     // Are we not frozen
     if (!m_bIsFrozen)
     {
-        // Grab our actual position (as GTA moves it too)
-        CVector vecPosition = *m_pObject->GetPosition();
-
-        // Has it moved without MTA knowing?
-        if (vecPosition != m_vecPosition)
+        // Model physics enabled?
+        if ((m_pModelInfo && m_pModelInfo->GetObjectPropertiesGroup() != -1) || !m_pModelInfo)
         {
-            m_vecPosition = vecPosition;
+            // Grab our actual position & rotation (as GTA moves it too)
+            CVector vecPosition = *m_pObject->GetPosition();
 
-            // Update our streaming position
-            UpdateStreamPosition(m_vecPosition);
+            CVector vecRot;
+            GetRotationRadians(vecRot);
+
+            // Has it moved without MTA knowing?
+            if (vecPosition != m_vecPosition)
+            {
+                m_vecPosition = vecPosition;
+
+                // Update our streaming position
+                UpdateStreamPosition(m_vecPosition);
+            }
+
+            if (vecRot != m_vecRotation)
+            {
+                m_vecRotation = vecRot;
+            }
         }
     }
 }


### PR DESCRIPTION
#### Summary
This PR fixes the rotation of non-static objects with physics enabled.

#### Motivation
Fixed #4706 


#### Test plan
1. Create dumpster (1344) object
2. Push it with vehicle
3. engineRestreamWorld()

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
