### PR TITLE
Add missing "down" state for onClientGUIClick

### DIFF
--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -5740,26 +5740,22 @@ bool CClientGame::OnKeyDown(CGUIKeyEventArgs Args)
     return true;
 }
 
-bool CClientGame::OnMouseClick(CGUIMouseEventArgs Args)
+void CClientGame::TriggerGUIClickEvent(CGUIMouseEventArgs Args, const char* szState)
 {
     if (!Args.pWindow)
-        return false;
+        return;
 
     const char* szButton = NULL;
-    const char* szState = NULL;
     switch (Args.button)
     {
         case CGUIMouse::LeftButton:
             szButton = "left";
-            szState = "up";
             break;
         case CGUIMouse::MiddleButton:
             szButton = "middle";
-            szState = "up";
             break;
         case CGUIMouse::RightButton:
             szButton = "right";
-            szState = "up";
             break;
     }
 
@@ -5777,7 +5773,11 @@ bool CClientGame::OnMouseClick(CGUIMouseEventArgs Args)
             pGUIElement->CallEvent("onClientGUIClick", Arguments, true);
         }
     }
+}
 
+bool CClientGame::OnMouseClick(CGUIMouseEventArgs Args)
+{
+    TriggerGUIClickEvent(Args, "up");
     return true;
 }
 
@@ -5843,17 +5843,20 @@ bool CClientGame::OnMouseButtonDown(CGUIMouseEventArgs Args)
 
     if (szButton)
     {
-        CLuaArguments Arguments;
-        Arguments.PushString(szButton);
-        Arguments.PushNumber(Args.position.fX);
-        Arguments.PushNumber(Args.position.fY);
-
         CClientGUIElement* pGUIElement = CGUI_GET_CCLIENTGUIELEMENT(Args.pWindow);
         if (GetGUIManager()->Exists(pGUIElement))
         {
+            // Fire onClientGUIMouseDown for backward compatibility
+            CLuaArguments Arguments;
+            Arguments.PushString(szButton);
+            Arguments.PushNumber(Args.position.fX);
+            Arguments.PushNumber(Args.position.fY);
             pGUIElement->CallEvent("onClientGUIMouseDown", Arguments, true);
         }
     }
+
+    // Fire onClientGUIClick with state="down"
+    TriggerGUIClickEvent(Args, "down");
 
     return true;
 }

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -527,6 +527,7 @@ private:
     bool OnMouseEnter(CGUIMouseEventArgs Args);
     bool OnMouseLeave(CGUIMouseEventArgs Args);
     bool OnMouseWheel(CGUIMouseEventArgs Args);
+    void TriggerGUIClickEvent(CGUIMouseEventArgs Args, const char* szState);
     bool OnMove(CGUIElement* pElement);
     bool OnSize(CGUIElement* pElement);
     bool OnFocusGain(CGUIFocusEventArgs Args);

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -527,11 +527,11 @@ private:
     bool OnMouseEnter(CGUIMouseEventArgs Args);
     bool OnMouseLeave(CGUIMouseEventArgs Args);
     bool OnMouseWheel(CGUIMouseEventArgs Args);
-    void TriggerGUIClickEvent(CGUIMouseEventArgs Args, const char* szState);
     bool OnMove(CGUIElement* pElement);
     bool OnSize(CGUIElement* pElement);
     bool OnFocusGain(CGUIFocusEventArgs Args);
     bool OnFocusLoss(CGUIFocusEventArgs Args);
+    void TriggerGUIClickEvent(CGUIMouseEventArgs Args, const char* szState);
 
     // Network update functions
     void DoVehicleInKeyCheck();


### PR DESCRIPTION
#### Summary
This PR adds missing "down" state for `onClientGUIClick` (whis was unsupported previously)
<img width="1072" height="48" alt="image" src="https://github.com/user-attachments/assets/c3713c21-5826-44ba-bf66-4c5d37763b6b" />

### **Maybe this will be backward incompatible with some scripts.**

#### Motivation
Fixes #4730

#### Test plan
```lua
addEventHandler( "onClientResourceStart", resourceRoot, function( )
    btnOutput = guiCreateButton(0.7, 0.1, 0.2, 0.1, "Output!", true)
    addEventHandler("onClientGUIClick", btnOutput, function(...)
        iprint(source, ...)
    end, false)

    editBox = guiCreateEdit(0.3, 0.1, 0.4, 0.1, "Type your message here!", true)
    guiEditSetMaxLength(editBox, 128)
    addEventHandler("onClientGUIClick", editBox, function(...)
        iprint(source, ...)
    end, false)
end)

bindKey("m", "down", function()
    showCursor(not isCursorShowing())
end)
```

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
