### PR TITLE
Correct spelling in comments across multiple files

### DIFF
--- a/Client/core/CChat.cpp
+++ b/Client/core/CChat.cpp
@@ -645,7 +645,7 @@ bool CChat::CharacterKeyHandler(CGUIKeyEventArgs KeyboardArgs)
         case VK_RETURN:
         {
             // Empty the chat and hide the input stuff
-            // If theres a command to call, call it
+            // If there's a command to call, call it
             if (!m_strCommand.empty() && !m_strInputText.empty())
                 CCommands::GetSingleton().Execute(m_strCommand.c_str(), m_strInputText.c_str());
 

--- a/Client/core/CCommands.cpp
+++ b/Client/core/CCommands.cpp
@@ -102,7 +102,7 @@ bool CCommands::Execute(const char* szCommand, const char* szParametersIn, bool 
             // His line starts with '/'?
             if (*szParameters == '/')
             {
-                // Copy the characters after the slash to the 0 terminator to a seperate buffer
+                // Copy the characters after the slash to the 0 terminator to a separate buffer
                 char szBuffer[256];
                 strncpy(szBuffer, szParameters + 1, 256);
                 szBuffer[255] = 0;

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -953,7 +953,7 @@ void LoadModule(CModuleLoader& m_Loader, const SString& strName, const SString& 
     // Save current directory (shouldn't change anyway)
     SString strSavedCwd = GetSystemCurrentDirectory();
 
-    // Load approrpiate compilation-specific library.
+    // Load appropriate compilation-specific library.
 #ifdef MTA_DEBUG
     SString strModuleFileName = strModuleName + "_d.dll";
 #else

--- a/Client/core/CCrashDumpWriter.cpp
+++ b/Client/core/CCrashDumpWriter.cpp
@@ -1387,7 +1387,7 @@ static void TryWriteReentrantFlag(DWORD exceptionCode)
     }
     else
     {
-        return;  // Cant proceed without path
+        return;  //Can't proceed without path
     }
 
     __try
@@ -1562,7 +1562,7 @@ long WINAPI CCrashDumpWriter::HandleExceptionGlobal(_EXCEPTION_POINTERS* pExcept
 
             if (!bHandledSafely)
             {
-                SAFE_DEBUG_OUTPUT("CCrashDumpWriter: Client exception handler failrd - forcing crash dump\n");
+                SAFE_DEBUG_OUTPUT("CCrashDumpWriter: Client exception handler failed - forcing crash dump\n");
             }
 
             bClientHandled = true;

--- a/Client/core/CCrashDumpWriter.cpp
+++ b/Client/core/CCrashDumpWriter.cpp
@@ -1387,7 +1387,7 @@ static void TryWriteReentrantFlag(DWORD exceptionCode)
     }
     else
     {
-        return;  //Can't proceed without path
+        return;  // Can't proceed without path
     }
 
     __try


### PR DESCRIPTION
### Summary
Fixed spelling errors in comments and one debug output string across multiple files (4 commits):

**Commit 1: Update CChat.cpp**
- Fixed comment: "theres" → "there's"

**Commit 2: Update CCommands.cpp**
- Fixed comment: "seperate" → "separate"

**Commit 3: Update CCore.cpp**
- Fixed comment: "approrpiate" → "appropriate"

**Commit 4: Update CCrashDumpWriter.cpp**
- Fixed comment: "Cant" → "Can't"
- Fixed debug output: "failrd" → "failed" (line 1565)

### Motivation
These typos were found while reading the code. Fixing them improves code readability and maintains professional standards. The debug output fix ensures error messages are correctly spelled.

### Test plan
- Changes are in comments and one debug message string
- No functional code changes were made
- The project compiles successfully with these changes
- The debug output now displays the correct spelling ("failed" instead of "failrd")

### Checklist
* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.