### PR TITLE
Fix isVehicleOnGround

### DIFF
--- a/Client/game_sa/CAutomobileSA.cpp
+++ b/Client/game_sa/CAutomobileSA.cpp
@@ -1,6 +1,6 @@
 /*****************************************************************************
  *
- *  PROJECT:     Multi Theft Auto v1.0
+ *  PROJECT:     Multi Theft Auto
  *  LICENSE:     See LICENSE in the top level directory
  *  FILE:        game_sa/CAutomobileSA.cpp
  *  PURPOSE:     Automobile vehicle entity
@@ -19,6 +19,16 @@ CAutomobileSA::CAutomobileSA(CAutomobileSAInterface* pInterface)
 {
     SetInterface(pInterface);
     Init();
+}
+
+bool CAutomobileSA::IsAnyWheelTouchingGround() const
+{
+    CAutomobileSAInterface* autoInterface = GetAutomobileInterface();
+    if (!autoInterface)
+        return false;
+
+    return autoInterface->m_wheelRatios[0] < 1.0f || autoInterface->m_wheelRatios[1] < 1.0f || autoInterface->m_wheelRatios[2] < 1.0f ||
+           autoInterface->m_wheelRatios[3] < 1.0f;
 }
 
 void CAutomobileSAInterface::SetPanelDamage(std::uint8_t panelId, bool breakGlass, bool spawnFlyingComponent)

--- a/Client/game_sa/CAutomobileSA.cpp
+++ b/Client/game_sa/CAutomobileSA.cpp
@@ -21,6 +21,7 @@ CAutomobileSA::CAutomobileSA(CAutomobileSAInterface* pInterface)
     Init();
 }
 
+// Returns true when any wheel is partially compressed (not fully relaxed)
 bool CAutomobileSA::IsAnyWheelTouchingGround() const
 {
     CAutomobileSAInterface* autoInterface = GetAutomobileInterface();

--- a/Client/game_sa/CAutomobileSA.h
+++ b/Client/game_sa/CAutomobileSA.h
@@ -53,7 +53,7 @@ public:
     CBouncingPanelSAInterface m_panels[3];
     CDoorSAInterface          m_swingingChassis;
     CColPointSAInterface      m_wheelColPoint[MAX_WHEELS];
-    float                     m_wheelRatios[4]; // supension compression, 0 = fully compressed, 1 = fully relaxed
+    float                     m_wheelRatios[4];  // supension compression, 0 = fully compressed, 1 = fully relaxed
     float                     m_prevWheelRatios[4];
     float                     m_wheelCollisionState[4];
     float                     field_800;

--- a/Client/game_sa/CAutomobileSA.h
+++ b/Client/game_sa/CAutomobileSA.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
  *
- *  PROJECT:     Multi Theft Auto v1.0
+ *  PROJECT:     Multi Theft Auto
  *  LICENSE:     See LICENSE in the top level directory
  *  FILE:        game_sa/CAutomobileSA.h
  *  PURPOSE:     Header file for automobile vehicle entity class
@@ -53,8 +53,8 @@ public:
     CBouncingPanelSAInterface m_panels[3];
     CDoorSAInterface          m_swingingChassis;
     CColPointSAInterface      m_wheelColPoint[MAX_WHEELS];
-    float                     m_wheelsDistancesToGround1[4];
-    float                     m_wheelsDistancesToGround2[4];
+    float                     m_wheelRatios[4]; // supension compression, 0 = fully compressed, 1 = fully relaxed
+    float                     m_prevWheelRatios[4];
     float                     m_wheelCollisionState[4];
     float                     field_800;
     float                     field_804;
@@ -123,8 +123,8 @@ public:
     float                     m_fForcedOrientation;
     float                     m_fUpDownLightAngle[2];
     unsigned char             m_nNumContactWheels;
-    unsigned char             m_nWheelsOnGround;
-    char                      field_962;
+    unsigned char             m_wheelsOnGround;
+    unsigned char             m_prevWheelsOnGround;
     char                      field_963;
     float                     field_964;
     int                       m_wheelFrictionState[4];
@@ -143,4 +143,7 @@ public:
     CAutomobileSA(CAutomobileSAInterface* pInterface);
 
     CAutomobileSAInterface* GetAutomobileInterface() { return reinterpret_cast<CAutomobileSAInterface*>(GetInterface()); }
+    CAutomobileSAInterface* GetAutomobileInterface() const { return reinterpret_cast<CAutomobileSAInterface*>(GetInterface()); }
+
+    bool IsAnyWheelTouchingGround() const override;
 };

--- a/Client/game_sa/CAutomobileSA.h
+++ b/Client/game_sa/CAutomobileSA.h
@@ -53,7 +53,7 @@ public:
     CBouncingPanelSAInterface m_panels[3];
     CDoorSAInterface          m_swingingChassis;
     CColPointSAInterface      m_wheelColPoint[MAX_WHEELS];
-    float                     m_wheelRatios[4];  // supension compression, 0 = fully compressed, 1 = fully relaxed
+    float                     m_wheelRatios[4];  // suspension compression, 0 = fully compressed, 1 = fully relaxed
     float                     m_prevWheelRatios[4];
     float                     m_wheelCollisionState[4];
     float                     field_800;

--- a/Client/game_sa/CBikeSA.cpp
+++ b/Client/game_sa/CBikeSA.cpp
@@ -44,5 +44,6 @@ bool CBikeSA::IsAnyWheelTouchingGround() const
     if (!bikeInterface)
         return false;
 
-    return bikeInterface->m_wheelRatios[0] < 1.0f || bikeInterface->m_wheelRatios[1] < 1.0f || bikeInterface->m_wheelRatios[2] < 1.0f || bikeInterface->m_wheelRatios[3] < 1.0f;
+    return bikeInterface->m_wheelRatios[0] < 1.0f || bikeInterface->m_wheelRatios[1] < 1.0f || bikeInterface->m_wheelRatios[2] < 1.0f ||
+           bikeInterface->m_wheelRatios[3] < 1.0f;
 }

--- a/Client/game_sa/CBikeSA.cpp
+++ b/Client/game_sa/CBikeSA.cpp
@@ -37,3 +37,12 @@ void CBikeSA::RecalculateBikeHandling()
     if (m_pBikeHandlingData)
         m_pBikeHandlingData->Recalculate();
 }
+
+bool CBikeSA::IsAnyWheelTouchingGround() const
+{
+    CBikeSAInterface* bikeInterface = GetBikeInterface();
+    if (!bikeInterface)
+        return false;
+
+    return bikeInterface->m_wheelRatios[0] < 1.0f || bikeInterface->m_wheelRatios[1] < 1.0f || bikeInterface->m_wheelRatios[2] < 1.0f || bikeInterface->m_wheelRatios[3] < 1.0f;
+}

--- a/Client/game_sa/CBikeSA.h
+++ b/Client/game_sa/CBikeSA.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
  *
- *  PROJECT:     Multi Theft Auto v1.0
+ *  PROJECT:     Multi Theft Auto
  *  LICENSE:     See LICENSE in the top level directory
  *  FILE:        game_sa/CBikeSA.h
  *  PURPOSE:     Header file for bike vehicle entity class
@@ -58,8 +58,8 @@ public:
     int8                 field_65E;
     int8                 field_65F;
     int8                 m_anWheelColPoint[176];
-    float                m_afWheelDistanceToGround[4];
-    int32                field_720[4];
+    float                m_wheelRatios[4];
+    float                m_prevWheelRatios[4];
     int32                field_730[4];
     int32                field_740;
     int32                m_aiWheelSurfaceType[2];
@@ -110,9 +110,11 @@ public:
     CBikeSA(CBikeSAInterface* pInterface);
 
     CBikeSAInterface* GetBikeInterface() { return reinterpret_cast<CBikeSAInterface*>(GetInterface()); }
+    CBikeSAInterface* GetBikeInterface() const { return reinterpret_cast<CBikeSAInterface*>(GetInterface()); }
 
     CBikeHandlingEntry* GetBikeHandlingData();
     void                SetBikeHandlingData(CBikeHandlingEntry* pHandling);
 
     void RecalculateBikeHandling();
+    bool IsAnyWheelTouchingGround() const override;
 };

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -3566,23 +3566,56 @@ float CClientVehicle::GetDistanceFromGround()
 
 bool CClientVehicle::IsOnGround()
 {
-    if (m_pModelInfo)
-    {
-        CBoundingBox* pBoundingBox = m_pModelInfo->GetBoundingBox();
-        if (pBoundingBox)
-        {
-            CVector vecMin = pBoundingBox->vecBoundMin;
-            CVector vecPosition;
-            GetPosition(vecPosition);
-            vecMin += vecPosition;
-            float fGroundLevel = static_cast<float>(g_pGame->GetWorld()->FindGroundZFor3DPosition(&vecPosition));
+    if (!m_pVehicle)
+        return m_bIsOnGround;
 
-            /* Is the lowest point of the bounding box lower than 0.5 above the floor,
-            or is the lowest point of the bounding box higher than 0.3 below the floor */
-            return ((fGroundLevel > vecMin.fZ && (fGroundLevel - vecMin.fZ) < 0.5f) || (vecMin.fZ > fGroundLevel && (vecMin.fZ - fGroundLevel) < 0.3f));
-        }
+    int type = m_pVehicle->GetBaseVehicleType();  // 0 = Automobile, 9 = Bike, 10 = BMX
+    if ((type == 0 && dynamic_cast<CAutomobile*>(m_pVehicle)->IsAnyWheelTouchingGround()) ||
+        ((type == 9 || type == 10) && dynamic_cast<CBike*>(m_pVehicle)->IsAnyWheelTouchingGround()))
+    {
+        return true;
     }
-    return m_bIsOnGround;
+
+    CVector vehPos;
+    GetPosition(vehPos);
+    float groundZ = g_pGame->GetWorld()->FindGroundZFor3DPosition(&vehPos);
+
+    // Is vehicle under the ground?
+    if (DefinitelyLessThan(vehPos.fZ, groundZ, 1e-4f))
+        return false;
+
+    if (!m_pModelInfo)
+        return m_bIsOnGround;
+
+    CBoundingBox* bbox = m_pModelInfo->GetBoundingBox();
+    if (!bbox)
+        return m_bIsOnGround;
+
+    const CVector& min = bbox->vecBoundMin;
+    const CVector& max = bbox->vecBoundMax;
+
+    // Is vehicle too high above the ground?
+    float halfHeight = (max.fZ - min.fZ) * 0.5f;
+    if (DefinitelyGreaterThan(vehPos.fZ - halfHeight, groundZ + halfHeight + 0.3f, 1e-4f))
+        return false;
+
+    // OBB check
+    CMatrix mat;
+    GetMatrix(mat);
+
+    CVector localPoints[8] = {CVector(min.fX, min.fY, min.fZ), CVector(min.fX, min.fY, max.fZ), CVector(min.fX, max.fY, min.fZ),
+                              CVector(min.fX, max.fY, max.fZ), CVector(max.fX, min.fY, min.fZ), CVector(max.fX, min.fY, max.fZ),
+                              CVector(max.fX, max.fY, min.fZ), CVector(max.fX, max.fY, max.fZ)};
+
+    float lowestZ = FLT_MAX;
+    for (const auto& lp : localPoints)
+    {
+        float z = mat.TransformVector(lp).fZ;
+        if (z < lowestZ)
+            lowestZ = z;
+    }
+
+    return DefinitelyLessThan((lowestZ - groundZ), 0.3f, 1e-4f) || EssentiallyEqual((lowestZ - groundZ), 0.3f, 1e-4f);
 }
 
 void CClientVehicle::LockSteering(bool bLock)

--- a/Client/sdk/game/CAutomobile.h
+++ b/Client/sdk/game/CAutomobile.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
  *
- *  PROJECT:     Multi Theft Auto v1.0
+ *  PROJECT:     Multi Theft Auto
  *  LICENSE:     See LICENSE in the top level directory
  *  FILE:        sdk/game/CAutomobile.h
  *  PURPOSE:     Automobile vehicle entity interface
@@ -21,4 +21,6 @@ class CAutomobile : public virtual CVehicle
 {
 public:
     virtual ~CAutomobile() {};
+
+    virtual bool IsAnyWheelTouchingGround() const = 0;
 };

--- a/Client/sdk/game/CBike.h
+++ b/Client/sdk/game/CBike.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
  *
- *  PROJECT:     Multi Theft Auto v1.0
+ *  PROJECT:     Multi Theft Auto
  *  LICENSE:     See LICENSE in the top level directory
  *  FILE:        sdk/game/CBike.h
  *  PURPOSE:     Bike vehicle entity interface
@@ -23,4 +23,5 @@ public:
     virtual CBikeHandlingEntry* GetBikeHandlingData() = 0;
     virtual void                SetBikeHandlingData(CBikeHandlingEntry* pHandling) = 0;
     virtual void                RecalculateBikeHandling() = 0;
+    virtual bool                IsAnyWheelTouchingGround() const = 0;
 };


### PR DESCRIPTION
#### Summary
This PR fixes the isVehicleOnGround function similarly to how #4317 fixed IsPedOnGround.

The current logic is very primitive. It simply checks the distance from the bottom of the bounding box to the ground. That’s why if a vehicle is, for example, lying on its roof, it returns false. It can also return false on slopes, and for a Monster Truck it always returns false, because its wheels aren’t included in the bounding box, which ends at the model’s edge.
<img width="936" height="554" alt="image" src="https://github.com/user-attachments/assets/e8d5fd41-1afa-42f1-b72e-fd2c715fba46" />

The fixed isVehicleOnGround function now first does a simple check to see if any wheel is touching the ground. If so, the vehicle is considered on the ground. If not, it performs a basic OOB check and measures the distance to the ground. During testing, I never received a false negative.

#### Motivation
Fixed #471 and #2093


#### Test plan
Tested.
```
Spawn Monster Truck
crun isVehicleOnGround(me.vehicle) -- always false
```

```
Spawn Beagle
crun setVehicleDamageProof(me.vehicle, true)
crun me.vehicle.rotation = Vector3(0, 180, 0)
crun isVehicleOnGround(me.vehicle) -- false
```

```
Spawn some car
crun setVehicleHandling(me.vehicle, 'suspensionLowerLimit', -1)
crun isVehicleOnGround(me.vehicle) -- false
```


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
