### PR TITLE
Fix objects with alpha below 141 are invisible

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1588,7 +1588,7 @@ void CMultiplayerSA::InitHooks()
 
     // Fix objects with alpha below 141 are invisible (#425)
     MemPut<BYTE>(0x553AD9, 0);
-    MemPut<BYTE>(0x732C2E, 0);
+    MemPut<BYTE>(0x732C2F, 0);
 
     InitHooks_CrashFixHacks();
     InitHooks_DeviceSelection();

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1586,6 +1586,10 @@ void CMultiplayerSA::InitHooks()
     MemCpy((void*)0x53A23F, "\x33\xC0\x90\x90\x90", 5);
     MemCpy((void*)0x53A00A, "\x33\xC0\x90\x90\x90", 5);
 
+    // Fix objects with alpha below 141 are invisible (#425)
+    MemPut<BYTE>(0x553AD9, 0);
+    MemPut<BYTE>(0x732C2E, 0);
+
     InitHooks_CrashFixHacks();
     InitHooks_DeviceSelection();
 


### PR DESCRIPTION
#### Summary
This PR fixes a bug where objects with alpha < 141 are not rendered.

This issue has two stages: the first is the alpha threshold (`rwRENDERSTATEALPHATESTFUNCTIONREF`) set to 140 in the function `CRenderer::RenderEverythingBarRoads` - this is the direct cause of #425. The next stage is in the function `CVisibilityPlugins::RenderEntity`, where the alpha threshold is set to 100, and then objects with alpha < 101 are not rendered.

## Is it safe to just set this to 0?
These settings were R*’s attempts to fix the halo effect around trees and bushes, which, as can be seen in the game, did not work. 
```cpp
            //!PC - required to minimize alpha halo problems outside (bushes & trees mainly)
            if ((CGame::currArea==AREA_MAIN_MAP) && (!pModelInfo->GetDontWriteZBuffer()))
            {
                RwRenderStateSet(rwRENDERSTATEALPHATESTFUNCTIONREF, (void*)100);
            }
            else
            {
                RwRenderStateSet(rwRENDERSTATEALPHATESTFUNCTIONREF, (void*)0);
            }
```
I did not observe any new or worse rendering bugs with plants after setting these values to 0.

Alpha halo bugs "fixed" by R*:
<img width="665" height="745" alt="image" src="https://github.com/user-attachments/assets/a3ff5d78-d197-4598-8c8a-d8be2acb8506" />
<img width="586" height="803" alt="image" src="https://github.com/user-attachments/assets/ac640406-92d7-40bc-b6e3-6009b1d18228" />
<img width="1183" height="859" alt="image" src="https://github.com/user-attachments/assets/a07f35ec-ebf6-4f39-8182-0304c91dd4e0" />


#### Motivation
Fixes #425


#### Test plan
1. ``crun o = createObject(1337, me.position)``
2. ``crun o.alpha = 140``


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
