### PR TITLE
Fix #4460 and #4675

### DIFF
--- a/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
@@ -81,6 +81,7 @@ bool CPlayerPuresyncPacket::Read(NetBitStreamInterface& BitStream)
         // Player position
         SPositionSync position(false);
         bool          positionRead = BitStream.Read(&position);
+        const CVector vecRelativePosition = position.data.vecPosition;
 
         if (positionRead && pContactElement != nullptr)
         {
@@ -204,7 +205,10 @@ bool CPlayerPuresyncPacket::Read(NetBitStreamInterface& BitStream)
 
         // Read the camera orientation
         CVector vecCamPosition, vecCamFwd;
-        ReadCameraOrientation(position.data.vecPosition, BitStream, vecCamPosition, vecCamFwd);
+        // Camera orientation is encoded against the same position basis the client wrote.
+        CVector vecCameraBasePosition = pContactElement ? vecRelativePosition : position.data.vecPosition;
+
+        ReadCameraOrientation(vecCameraBasePosition, BitStream, vecCamPosition, vecCamFwd);
         pSourcePlayer->SetCameraOrientation(vecCamPosition, vecCamFwd);
 
         if (flags.data.bHasAWeapon)


### PR DESCRIPTION
#### Summary
Fixes:
Bullet sync doesn't work when stood on a server side object #4675
and
Bandwidth reduction zones aren't accurate when stood on a mapped object. #4460

Which were both caused by the same issue. The problem was that when stood on a mapped object, MTA thought you were somewhere much further away at certain camera rotations which caused bandwidth reduction to not sync you as frequently as it should and bullets to not sync either.


#### Motivation
Both of these issues caused major player complaints which is why I eventually investigated them enough to have bugs to report and now thanks to help from codex investigated them further and developed a fix.



#### Test plan
I tested with 2 PCs, first of all verified that I could easily reproduce the bug.

Then codex added some debug outputs like so:

when shots sync:

[syncdbg] zone src=a **zone=0** route=sim dist=2999.2 dot=0.564 recvPos=(2484.81,-1665.73,15.74) cam=(4971.46,-3330.33,30.24) recvObj=130 recvRel=(0.81,-0.73,3.74) srcPos=(2477.54,-1664.47,13.33) srcObj=0 srcRel=(0.00,0.00,0.00)

when shots don't sync:

[syncdbg] zone src=a **zone=2** route=main dist=2997.2 dot=-0.122 recvPos=(2484.81,-1665.73,15.74) cam=(4970.46,-3328.33,30.24) recvObj=130 recvRel=(0.81,-0.73,3.74) srcPos=(2477.54,-1664.53,13.33) srcObj=0 srcRel=(0.00,0.00,0.00)

Then a bug fix was developed and I have tested it with 2 PCs and all bullets are syncing correctly regardless of camera rotation.

Also I tested just walking around the same as I did in the video on the bug reports and sync is now flawless with bandwidth reduction on maximum.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
