### PR TITLE
Fix #4233 isMTAWindowFocused() being unreliable

### DIFF
--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -6044,6 +6044,21 @@ bool CClientGame::OnFocusLoss(CGUIFocusEventArgs Args)
     return true;
 }
 
+bool CClientGame::IsWindowFocused() const
+{
+    HWND foregroundWindow = GetForegroundWindow();
+    if (!foregroundWindow)
+        return false;
+
+    HWND hookedWindow = g_pCore->GetHookedWindow();
+    if (foregroundWindow == hookedWindow || GetAncestor(foregroundWindow, GA_ROOTOWNER) == hookedWindow)
+        return true;
+
+    std::uint32_t processId = 0;
+    GetWindowThreadProcessId(foregroundWindow, &processId);
+    return processId == GetCurrentProcessId();
+}
+
 //
 // Display a progress dialog if a big packet is coming in
 //

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -272,7 +272,7 @@ public:
     void EnablePacketRecorder(const char* szFilename);
     void InitVoice(bool bEnabled, unsigned int uiServerSampleRate, unsigned char ucQuality, unsigned int uiBitrate);
 
-    bool IsWindowFocused() const { return m_bFocused; }
+    bool IsWindowFocused() const;
 
     // Accessors
 


### PR DESCRIPTION
#### Summary
If you launch MTA using the mtasa:// URI to automatically join a server, isMTAWindowFocused() returns false even when you're maximized, because m_bFocused can't be relied upon for this function.


#### Motivation
Because this bug affects me every day, because I launch MTA with mtasa:// so it's very annoying that once I login to the server I have to minimize and maximize my game to get this function to return the correct value, I use this function to save players CPU usage when they're minimized to not render stuff.



#### Test plan
Tested with and without launching via mtasa://
Made sure it does return false when minimized using a timer.


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
