### PR TITLE
Fix sniper bullet sync on maximum bandwidth reduction

### DIFF
--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -2570,6 +2570,10 @@ void CGame::Packet_Bulletsync(CBulletsyncPacket& packet)
     args.PushNumber(packet.m_start.fZ);
 
     player->CallEvent("onPlayerWeaponFire", args);
+
+    // Sim sync only relays bullet packets to zone-0 viewers. Relay to the rest of the
+    // near list here so zone-1/2 observers still receive long-range bullet sync.
+    RelayNearbyPacket(packet);
 }
 
 void CGame::Packet_WeaponBulletsync(CCustomWeaponBulletSyncPacket& packet)


### PR DESCRIPTION
#### Summary
If a server has bandwidth reduction set to maximum, long distance shots do not sync, though actually doesn't even need to be that far, if the player is not looking in that direction.

Video of it not working and video of it working with PR: https://cit.gg/arran/vids/bsyncfix2.mp4

This is actually just re-adding what used to exist:

<img width="419" height="63" alt="image" src="https://github.com/user-attachments/assets/6c30c0a1-1a33-46e2-b250-37ccd4576fc0" />

This commit removed it: https://github.com/multitheftauto/mtasa-blue/commit/45d6996c965c72d2fb6c967b57d9b9b1351bd5d4#diff-3ca556956f6236bbcafbd7e847f5bda360c3db9fceea0c6b79ee4fb28bbcdb89

#### Motivation
Players get angry if bullets don't do any damage. Although I can work around it for now by using "medium" instead of "maximum" this will cause a lot of problems for servers using maximum that are unaware of this and have updated their server since bullet sync was refactored.

#### Test plan
I used 2 PCs, made sure the player being shot is looking away (changes their zone for bandwidth reduction) which causes the bullets to not sync as you can see in the above video. I then tested other guns with the PR and at different bandwidth reductions to make sure everything seemed normal.



#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
