### PR TITLE
Fix engineLoadDFF rejecting valid DFF files

### DIFF
--- a/Client/game_sa/CRenderWareSA.cpp
+++ b/Client/game_sa/CRenderWareSA.cpp
@@ -387,9 +387,6 @@ RpClump* CRenderWareSA::ReadDFF(const SString& strFilename, const SString& buffe
         std::memcpy(&chunkType, headerData.data(), sizeof(chunkType));
         std::memcpy(&chunkSize, headerData.data() + 4, sizeof(chunkSize));
 
-        if (chunkType != RW_CHUNK_TYPE_DFF)
-            return nullptr;
-
         if (chunkSize > MAX_SANE_CHUNK_SIZE)
             return nullptr;
 
@@ -404,9 +401,6 @@ RpClump* CRenderWareSA::ReadDFF(const SString& strFilename, const SString& buffe
 
         std::memcpy(&chunkType, buffer.data(), sizeof(chunkType));
         std::memcpy(&chunkSize, buffer.data() + 4, sizeof(chunkSize));
-
-        if (chunkType != RW_CHUNK_TYPE_DFF)
-            return nullptr;
 
         if (chunkSize > MAX_SANE_CHUNK_SIZE)
             return nullptr;


### PR DESCRIPTION
#### Summary

Remove two redundant `chunkType != RW_CHUNK_TYPE_DFF` early-out checks in `CRenderWareSA::ReadDFF` that reject valid DFF files starting with a UV Animation Dictionary chunk (`0x002B`) instead of a Clump (`0x10`). `RwStreamFindChunk` on line 445 already handles this correctly by scanning forward through the stream.

#### Motivation

Since 6ede47a, `engineReplaceModel` fails for any DFF containing a UV Anim Dictionary. These models worked fine in previous versions.

#### Test plan

1. Use a DFF with a leading UV Anim Dictionary chunk (predominantly some SAMP objects)
[models.zip](https://github.com/user-attachments/files/26166112/models.zip)
2. Test in versions after 6ede47a -> see `engineReplaceModel` failing
3. Test in this version `engineReplaceModel` now succeeds where it previously failed
4. Non-DFF files are still rejected by `RwStreamFindChunk`

https://github.com/multitheftauto/mtasa-blue/blob/487f10ab7e1bf62426d8b490c64894eb4bbcec67/Client/game_sa/CRenderWareSA.cpp#L445-L449

#### Checklist
* [x] Your code should follow the [[coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines)](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.