### PR TITLE
Auto-fix clang-format issues on master pushes

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -37,9 +37,15 @@ jobs:
             exit 1
           fi
 
+          # Required, otherwise the push will squash the entire history
           git fetch --unshallow origin HEAD
+
+          # Allow commit to work
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Include a reference to the original commit in the commit message,
+          # so that we can view the actions results from the original commit
           git log -1 --format='%B' | \
             git interpret-trailers --trailer "Original-Commit: https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA" | \
             git commit --amend -F -

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -43,7 +43,7 @@ jobs:
           # Cancel other in-progress runs on master to free up minutes for the replacement push
           gh api "repos/$GITHUB_REPOSITORY/actions/runs" \
             -f head_sha="$GITHUB_SHA" -f status=in_progress \
-            --jq '.workflow_runs[].id' | \
+            --jq '.workflow_runs[].id' | tr -d '\r' | grep -E '^[0-9]+$' | \
           while read run_id; do
             if [ "$run_id" != "$GITHUB_RUN_ID" ]; then
               gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/cancel" --method POST || true

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -24,8 +24,7 @@ jobs:
         if: |
           steps.clang_format.outcome == 'failure' &&
           github.ref == 'refs/heads/master' &&
-          github.event_name == 'push' &&
-          github.event.repository.fork == false
+          github.event_name == 'push'
         shell: bash
         run: |
           # Stage the formatted files (clang-format.ps1 already ran in-place)
@@ -49,6 +48,6 @@ jobs:
       - name: Report formatting issues
         if: |
           steps.clang_format.outcome == 'failure' &&
-          !(github.ref == 'refs/heads/master' && github.event_name == 'push' && github.event.repository.fork == false)
+          !(github.ref == 'refs/heads/master' && github.event_name == 'push')
         shell: bash
         run: exit 1

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Run clang-format
         id: clang_format

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -24,6 +24,8 @@ jobs:
           steps.clang_format.outcome == 'failure' &&
           github.ref == 'refs/heads/master' &&
           github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           # Stage the formatted files (clang-format.ps1 already ran in-place)

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.POT_CI_PAT || github.token }}
 
       - name: Run clang-format
         id: clang_format

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      actions: write
 
     steps:
       - name: Checkout code
@@ -36,6 +37,16 @@ jobs:
             echo "::error::clang-format is not idempotent - cannot auto-fix"
             exit 1
           fi
+
+          # Cancel other in-progress runs on master to free up minutes for the replacement push
+          gh api "repos/$GITHUB_REPOSITORY/actions/runs" \
+            -f head_sha="$GITHUB_SHA" -f status=in_progress \
+            --jq '.workflow_runs[].id' | \
+          while read run_id; do
+            if [ "$run_id" != "$GITHUB_RUN_ID" ]; then
+              gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/cancel" --method POST || true
+            fi
+          done
 
           git fetch --unshallow
           git config user.name "github-actions[bot]"

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Run clang-format
         id: clang_format
@@ -39,6 +37,7 @@ jobs:
             exit 1
           fi
 
+          git fetch --unshallow
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git commit --amend --no-edit

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -37,19 +37,17 @@ jobs:
             exit 1
           fi
 
-          # Required, otherwise the push will squash the entire history
-          git fetch --unshallow origin HEAD
-
           # Allow commit to work
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Include a reference to the original commit in the commit message,
-          # so that we can view the actions results from the original commit
-          git log -1 --format='%B' | \
-            git interpret-trailers --trailer "Original-Commit: https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA" | \
-            git commit --amend -F -
-          git push --force-with-lease
+          # Append a commit with a fix applied
+          git commit -m "Fix formatting issues introduced by ${GITHUB_SHA}
+
+          cc @${GITHUB_ACTOR} please make sure to run clang-format locally before pushing changes to avoid this in the future."
+
+          # And we're off to the races!
+          git push
 
       - name: Report formatting issues
         if: |

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -7,7 +7,6 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
-      actions: write
 
     steps:
       - name: Checkout code
@@ -24,8 +23,6 @@ jobs:
           steps.clang_format.outcome == 'failure' &&
           github.ref == 'refs/heads/master' &&
           github.event_name == 'push'
-        env:
-          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           # Stage the formatted files (clang-format.ps1 already ran in-place)
@@ -40,20 +37,12 @@ jobs:
             exit 1
           fi
 
-          # Cancel other in-progress runs on master to free up minutes for the replacement push
-          gh api "repos/$GITHUB_REPOSITORY/actions/runs" \
-            -f head_sha="$GITHUB_SHA" -f status=in_progress \
-            --jq '.workflow_runs[].id' | tr -d '\r' | grep -E '^[0-9]+$' | \
-          while read run_id; do
-            if [ "$run_id" != "$GITHUB_RUN_ID" ]; then
-              gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/cancel" --method POST || true
-            fi
-          done || true
-
           git fetch --unshallow
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit --amend --no-edit
+          git log -1 --format='%B' | \
+            git interpret-trailers --trailer "Original-Commit: https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA" | \
+            git commit --amend -F -
           git push --force-with-lease
 
       - name: Report formatting issues

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -37,7 +37,7 @@ jobs:
             exit 1
           fi
 
-          git fetch --unshallow
+          git fetch --unshallow origin HEAD
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git log -1 --format='%B' | \

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -48,7 +48,7 @@ jobs:
             if [ "$run_id" != "$GITHUB_RUN_ID" ]; then
               gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/cancel" --method POST || true
             fi
-          done
+          done || true
 
           git fetch --unshallow
           git config user.name "github-actions[bot]"

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -5,11 +5,50 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   clang-format:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.POT_CI_PAT || github.token }}
 
       - name: Run clang-format
+        id: clang_format
+        continue-on-error: true
         shell: pwsh
         run: ./utils/clang-format.ps1 -Verbose
+
+      - name: Auto-fix formatting issues
+        if: |
+          steps.clang_format.outcome == 'failure' &&
+          github.ref == 'refs/heads/master' &&
+          github.event_name == 'push' &&
+          github.event.repository.fork == false
+        shell: bash
+        run: |
+          # Stage the formatted files (clang-format.ps1 already ran in-place)
+          git add -u
+
+          # Verify idempotency: run clang-format again on the staged files
+          # and check that no further changes are produced
+          ./Build/tmp/clang-format -i $(git diff --name-only --cached)
+
+          if ! git diff --quiet; then
+            echo "::error::clang-format is not idempotent - cannot auto-fix"
+            exit 1
+          fi
+
+          # Commit and push; [ci skip] prevents triggering a new workflow run
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Run clang-format" -m "[ci skip]"
+          git push
+
+      - name: Report formatting issues
+        if: |
+          steps.clang_format.outcome == 'failure' &&
+          !(github.ref == 'refs/heads/master' && github.event_name == 'push' && github.event.repository.fork == false)
+        shell: bash
+        run: exit 1

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -37,11 +37,10 @@ jobs:
             exit 1
           fi
 
-          # Commit and push; [ci skip] prevents triggering a new workflow run
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "Run clang-format" -m "[ci skip]"
-          git push
+          git commit --amend --no-edit
+          git push --force-with-lease
 
       - name: Report formatting issues
         if: |

--- a/utils/clang-format.ps1
+++ b/utils/clang-format.ps1
@@ -119,8 +119,8 @@ function Invoke-ClangFormat {
         Remove-Item $tmp
         Write-Verbose "Successfully formatted $($files.Count) files."
 
-        # Check git diff only in CI (checkout starts off clean)
-        if ($env:CI) {
+        # Check git diff only on Linux (CI's checkout starts off clean)
+        if ($isLinux) {
             $diffOutput = git diff --name-only
             if ($diffOutput.Count -eq 0) {
                 Write-Host "No formatting changes detected." -ForegroundColor Green

--- a/utils/clang-format.ps1
+++ b/utils/clang-format.ps1
@@ -119,8 +119,8 @@ function Invoke-ClangFormat {
         Remove-Item $tmp
         Write-Verbose "Successfully formatted $($files.Count) files."
 
-        # Check git diff only on Linux (CI's checkout starts off clean)
-        if ($isLinux) {
+        # Check git diff only in CI (checkout starts off clean)
+        if ($env:CI) {
             $diffOutput = git diff --name-only
             if ($diffOutput.Count -eq 0) {
                 Write-Host "No formatting changes detected." -ForegroundColor Green


### PR DESCRIPTION
When a push to master contains formatting issues, append a new commit with the formatting fixed. 

**Motivation**

This should help reduce the impact of a master breakage, so that contributors aren't confused about why their branch builds are broken, and aren't blocked from merging changes.

<!--

**Why amend commit**

Amending the commit + force pushing master is atypical, but the alternative would be to append "fix code formatting" commits to master, which reduces the efficacy of `git blame`.

In practice, this shouldn't affect anyone's pull requests unless someone makes a PR within 1 minute of a new master commit.

-->

**Test plan**

I pushed a change with bad formatting: https://github.com/qaisjp/mtasa-blue/commit/61d3627aa88aa4e6d7c8f638eb9d99cd768d642c

And it pushed this extra commit: https://github.com/qaisjp/mtasa-blue/commit/5431b2df176dec2a6e022fbfe6ab2e616d3dda2b

<!--
I pushed a change with bad formatting: https://github.com/qaisjp/mtasa-blue/commit/109a904e27f8e407161430a220583afbc822bf4d

And it rewrote the commit to this: https://github.com/qaisjp/mtasa-blue/commit/f9d1082e13dc6baa79fdfa48004468452828c63c
-->
