### PR TITLE
Add ability for the new parser to return nil on invalid arguments

### DIFF
--- a/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
@@ -797,6 +797,15 @@ struct CLuaFunctionParser<ErrorOnFailure, ReturnOnFailure, Func> : CLuaFunctionP
         return 1;
     }
 
+    // Special case for nullptr, as this is often used to indicate failure in lua functions
+    // Example: A function returns bool if element is found, and returns nil if the function fails e.g. because of invalid element argument
+    template <>
+    int PushResult(lua_State* L, const std::nullptr_t& value)
+    {
+        lua_pushnil(L);
+        return 1;
+    }
+
     int operator()(lua_State* L, CScriptDebugging* pScriptDebugging)
     {
         int  iResult = 0;

--- a/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
+++ b/Shared/mods/deathmatch/logic/lua/CLuaFunctionParser.h
@@ -799,7 +799,6 @@ struct CLuaFunctionParser<ErrorOnFailure, ReturnOnFailure, Func> : CLuaFunctionP
 
     // Special case for nullptr, as this is often used to indicate failure in lua functions
     // Example: A function returns bool if element is found, and returns nil if the function fails e.g. because of invalid element argument
-    template <>
     int PushResult(lua_State* L, const std::nullptr_t& value)
     {
         lua_pushnil(L);


### PR DESCRIPTION
#### Summary
This PR adds the ability for the new parser to return nil on invalid arguments.



#### Motivation
Some functions that return a boolean will return nil for invalid arguments. For example, `isElementOnScreen` returns false if the element is not on the screen, but if no argument is provided, it returns nil. The new parser also needs this ability in order to fully maintain backward compatibility with old functions.


#### Test plan
```cpp
        {"isElementOnScreen", ArgumentParserWarn<nullptr, IsElementOnScreen>},
```

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
