### PR TITLE
Fix timed-object collision crash

### DIFF
--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -2933,7 +2933,7 @@ void CModelInfoSA::MakeTimedObjectModel(ushort usBaseID)
     pNewInterface->pRwObject = nullptr;
     pNewInterface->usUnknown = 65535;
     pNewInterface->usDynamicIndex = 65535;
-    pNewInterface->timeInfo.m_wOtherTimeModel = 0;
+    pNewInterface->timeInfo.m_wOtherTimeModel = -1;
 
     ppModelInfo[m_dwModelID] = pNewInterface;
 


### PR DESCRIPTION
#### Summary
The crash was caused by the collision of model ID 0 being overwritten, which also made it impossible to set the CJ skin after running the script even once. After startup, the collision was set to the one from `engineReplaceCOL`, and after stopping the script, it was set to the collision of object 4715 (the parent ID for a timed object).

The collision for ID 0 was being replaced in `CBaseModelInfo::SetColModel`. The call replaced the collision for the given model (from `engineRequestModel`), and then it set the collision for m_wOtherTimeModel from CTimeInfo. MTA incorrectly sets the value of this field to 0, whereas the correct default value is -1.

```cpp
void CBaseModelInfo::SetColModel(CColModel* pColModel, bool bOwnColModel)
{	
	m_pColModel = pColModel; 
	SetOwnsColModel(bOwnColModel);
	
	if(bOwnColModel)
	{	
		// If found time model then attach collision to the other time model as well
		CTimeInfo* pTimeInfo = GetTimeInfo();
		if(pTimeInfo)
		{
			int32 otherModel = pTimeInfo->GetOtherTimeModel();
			
			if(otherModel != -1)
			{
				CBaseModelInfo* pOtherModel = CModelInfo::GetModelInfo(otherModel);
				ASSERT(pOtherModel);
				pOtherModel->SetColModel(pColModel, false);
			}	
		}
	}	
}
```


#### Motivation
Fixed #3342 


#### Test plan
```lua
local id = engineRequestModel('timed-object');

local col = engineLoadCOL('test.col');
engineReplaceCOL(col, id);

local txd = engineLoadTXD('test.txd');
engineImportTXD(txd, id);

local dff = engineLoadDFF('test.dff');
engineReplaceModel(dff, id, true);

engineSetModelVisibleTime(id, 23, 6);

local x,y,z = getElementPosition(localPlayer);
local obj = createObject(id, x,y,z + 1);
```
2. Run script
3. Stop script (optionally)
4. Disconnect / reconnect
5. Crash


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
