### PR TITLE
WIP: Drop asm usages in game_sa

### DIFF
--- a/Client/game_sa/C3DMarkersSA.cpp
+++ b/Client/game_sa/C3DMarkersSA.cpp
@@ -48,27 +48,7 @@ C3DMarker* C3DMarkersSA::CreateMarker(DWORD Identifier, T3DMarkerType dwType, CV
     DWORD dwFunc = FUNC_PlaceMarker;
     DWORD dwReturn = 0;
     // clang-format off
-    __asm
-    {
-        push    bZCheck     // zCheck  ##SA##
-        push    0           // normalZ ##SA##
-        push    0           // normalY ##SA##
-        push    0           // normalX ##SA##
-        push    0           // rotate rate
-        push    fPulseFraction      // pulse
-        push    0           // period
-        push    a           // alpha
-        push    b           // blue
-        push    g           // green
-        push    r           // red
-        push    fSize       // size
-        push    pVecPosCopy // position (copy to prevent PlaceMarker from corrupting the caller's vector)
-        push    dwType      // type
-        push    Identifier  // identifier
-        call    dwFunc
-        mov     dwReturn, eax
-        add     esp, 0x3C
-    }
+    dwReturn = gta_call_address<decltype(dwReturn)>(dwFunc, Identifier, dwType, pVecPosCopy, fSize, r, g, b, a, 0, fPulseFraction, 0, 0, 0, 0, bZCheck);
     // clang-format on
 
     if (dwReturn)

--- a/Client/game_sa/CAEAudioHardwareSA.cpp
+++ b/Client/game_sa/CAEAudioHardwareSA.cpp
@@ -25,14 +25,7 @@ bool CAEAudioHardwareSA::IsSoundBankLoaded(short wSoundBankID, short wSoundBankS
     DWORD dwFunc = FUNC_CAEAudioHardware__IsSoundBankLoaded;
     bool  bReturn = false;
     // clang-format off
-    __asm
-    {
-        push    dwSoundBankSlotID
-        push    dwSoundBankID
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThis, dwSoundBankID, dwSoundBankSlotID);
     // clang-format on
     return bReturn;
 }
@@ -44,12 +37,6 @@ void CAEAudioHardwareSA::LoadSoundBank(short wSoundBankID, short wSoundBankSlotI
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAEAudioHardware__LoadSoundBank;
     // clang-format off
-    __asm
-    {
-        push    dwSoundBankSlotID
-        push    dwSoundBankID
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, dwSoundBankID, dwSoundBankSlotID);
     // clang-format on
 }

--- a/Client/game_sa/CAERadioTrackManagerSA.cpp
+++ b/Client/game_sa/CAERadioTrackManagerSA.cpp
@@ -17,12 +17,7 @@ BYTE CAERadioTrackManagerSA::GetCurrentRadioStationID()
     DWORD dwFunc = FUNC_GetCurrentRadioStationID;
     BYTE  bReturn = 0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, CLASS_CAERadioTrackManager
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, 0x8CB6F8);
     // clang-format on
 
     return bReturn;
@@ -33,12 +28,7 @@ BYTE CAERadioTrackManagerSA::IsVehicleRadioActive()
     DWORD dwFunc = FUNC_IsVehicleRadioActive;
     BYTE  bReturn = 0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, CLASS_CAERadioTrackManager
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, 0x8CB6F8);
     // clang-format on
 
     return bReturn;
@@ -50,13 +40,7 @@ char* CAERadioTrackManagerSA::GetRadioStationName(BYTE bStationID)
     char* cReturn = 0;
     DWORD dwStationID = bStationID;
     // clang-format off
-    __asm
-    {
-        mov     ecx, CLASS_CAERadioTrackManager
-        push    dwStationID
-        call    dwFunc
-        mov     cReturn, eax
-    }
+    cReturn = gta_thiscall_address<decltype(cReturn)>(dwFunc, 0x8CB6F8, dwStationID);
     // clang-format on
 
     return cReturn;
@@ -67,12 +51,7 @@ bool CAERadioTrackManagerSA::IsRadioOn()
     DWORD dwFunc = FUNC_IsRadioOn;
     bool  bReturn = false;
     // clang-format off
-    __asm
-    {
-        mov     ecx, CLASS_CAERadioTrackManager
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, 0x8CB6F8);
     // clang-format on
 
     return bReturn;
@@ -82,13 +61,7 @@ void CAERadioTrackManagerSA::SetBassSetting(DWORD dwBass)
 {
     DWORD dwFunc = FUNC_SetBassSetting;
     // clang-format off
-    __asm
-    {
-        mov     ecx, CLASS_CAERadioTrackManager
-        push    0x3F800000 // 1.0f
-        push    dwBass
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, 0x8CB6F8, dwBass, 0x3F800000);
     // clang-format on
 }
 
@@ -96,11 +69,7 @@ void CAERadioTrackManagerSA::Reset()
 {
     DWORD dwFunc = FUNC_Reset;
     // clang-format off
-    __asm
-    {
-        mov     ecx, CLASS_CAERadioTrackManager
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, 0x8CB6F8);
     // clang-format on
 }
 
@@ -110,15 +79,7 @@ void CAERadioTrackManagerSA::StartRadio(BYTE bStationID, BYTE bUnknown)
     DWORD dwStationID = bStationID;
     DWORD dwUnknown = bUnknown;
     // clang-format off
-    __asm
-    {
-        mov     ecx, CLASS_CAERadioTrackManager
-        push    0
-        push    0
-        push    dwUnknown
-        push    dwStationID
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, 0x8CB6F8, dwStationID, dwUnknown, 0, 0);
     // clang-format on
 }
 

--- a/Client/game_sa/CAEVehicleAudioEntitySA.cpp
+++ b/Client/game_sa/CAEVehicleAudioEntitySA.cpp
@@ -23,11 +23,7 @@ void CAEVehicleAudioEntitySA::JustGotInVehicleAsDriver()
     DWORD dwFunc = FUNC_CAEVehicleAudioEntity__JustGotInVehicleAsDriver;
     DWORD dwThis = (DWORD)m_pInterface;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis);
     // clang-format on
 }
 
@@ -37,11 +33,7 @@ void CAEVehicleAudioEntitySA::JustGotOutOfVehicleAsDriver()
     DWORD dwFunc = FUNC_CAEVehicleAudioEntity__JustGotOutOfVehicleAsDriver;
     DWORD dwThis = (DWORD)m_pInterface;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis);
     // clang-format on
 }
 
@@ -50,11 +42,7 @@ void CAEVehicleAudioEntitySA::TurnOnRadioForVehicle()
     DWORD dwFunc = FUNC_CAEVehicleAudioEntity__TurnOnRadioForVehicle;
     DWORD dwThis = (DWORD)m_pInterface;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis);
     // clang-format on
 }
 
@@ -66,11 +54,7 @@ void CAEVehicleAudioEntitySA::StopVehicleEngineSound(unsigned char ucSlot)
     {
         DWORD dwThis = (DWORD)pVehicleSound->m_pSound;
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwThis
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, dwThis);
         // clang-format on
     }
 }

--- a/Client/game_sa/CAnimBlendAssocGroupSA.cpp
+++ b/Client/game_sa/CAnimBlendAssocGroupSA.cpp
@@ -30,13 +30,7 @@ CAnimBlendAssociationSAInterface* CAnimBlendAssocGroupSA::CopyAnimation(unsigned
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendAssocGroup_CopyAnimation;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    AnimID
-        call    dwFunc
-        mov     pAnimAssociationReturn, eax
-    }
+    pAnimAssociationReturn = gta_thiscall_address<decltype(pAnimAssociationReturn)>(dwFunc, dwThis, AnimID);
     // clang-format on
     return pAnimAssociationReturn;
 }
@@ -46,12 +40,7 @@ void CAnimBlendAssocGroupSA::InitEmptyAssociations(RpClump* pClump)
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendAssocGroup_InitEmptyAssociations;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    pClump
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, pClump);
     // clang-format on
 }
 
@@ -61,12 +50,7 @@ bool CAnimBlendAssocGroupSA::IsCreated()
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendAssocGroup_IsCreated;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThis);
     // clang-format on
     return bReturn;
 }
@@ -77,12 +61,7 @@ int CAnimBlendAssocGroupSA::GetNumAnimations()
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendAssocGroup_GetNumAnimations;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     iReturn, eax
-    }
+    iReturn = gta_thiscall_address<decltype(iReturn)>(dwFunc, dwThis);
     // clang-format on
     return iReturn;
 }
@@ -101,13 +80,7 @@ CAnimBlendStaticAssociation* CAnimBlendAssocGroupSA::GetAnimation(unsigned int I
     DWORD                        dwThis = (DWORD)m_pInterface;
     DWORD                        dwFunc = FUNC_CAnimBlendAssocGroup_GetAnimation;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    ID
-        call    dwFunc
-        mov     pReturn, eax
-    }
+    pReturn = gta_thiscall_address<decltype(pReturn)>(dwFunc, dwThis, ID);
     // clang-format on
     return pReturn;
 }
@@ -135,12 +108,7 @@ void CAnimBlendAssocGroupSA::CreateAssociations(const char* szBlockName)
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendAssocGroup_CreateAssociations;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    szBlockName
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, szBlockName);
     // clang-format on
 }
 

--- a/Client/game_sa/CAnimBlendAssociationSA.cpp
+++ b/Client/game_sa/CAnimBlendAssociationSA.cpp
@@ -33,12 +33,7 @@ CAnimBlendAssociationSAInterface* CAnimBlendAssociationSA::Constructor(CAnimBlen
     DWORD DwFunc = 0x4CF080;
     DWORD DwThisInterface = reinterpret_cast<DWORD>(m_pInterface);
     // clang-format off
-    __asm
-    {
-        mov     ecx, DwThisInterface
-        push    staticAssociationByReference
-        call    DwFunc
-    }
+    gta_thiscall_address(DwFunc, DwThisInterface, staticAssociationByReference);
     // clang-format on;
 }
 
@@ -47,13 +42,7 @@ CAnimBlendAssociationSAInterface* CAnimBlendAssociationSA::Constructor(RpClump* 
     DWORD DwFunc = 0x4CEFC0;
     DWORD DwThisInterface = reinterpret_cast<DWORD>(m_pInterface);
     // clang-format off
-    __asm
-    {
-        mov     ecx, DwThisInterface
-        push    pAnimHierarchy
-        push    pClump
-        call    DwFunc
-    }
+    gta_thiscall_address(DwFunc, DwThisInterface, pClump, pAnimHierarchy);
     // clang-format on;
 }
 
@@ -81,13 +70,7 @@ void CAnimBlendAssociationSA::Init(RpClump* pClump, CAnimBlendHierarchySAInterfa
     DWORD DwFunc = 0x4CED50;
     DWORD DwThisInterface = reinterpret_cast<DWORD>(m_pInterface);
     // clang-format off
-    __asm
-    {
-        mov     ecx, DwThisInterface
-        push    pAnimHierarchy
-        push    pClump
-        call    DwFunc
-    }
+    gta_thiscall_address(DwFunc, DwThisInterface, pClump, pAnimHierarchy);
     // clang-format on;
 }
 
@@ -96,12 +79,7 @@ void CAnimBlendAssociationSA::AllocateAnimBlendNodeArray(int iCount)
     DWORD DwFunc = 0x4CE9F0;
     DWORD DwThisInterface = reinterpret_cast<DWORD>(m_pInterface);
     // clang-format off
-    __asm
-    {
-        mov     ecx, DwThisInterface
-        push    iCount
-        call    DwFunc
-    }
+    gta_thiscall_address(DwFunc, DwThisInterface, iCount);
     // clang-format on;
 }
 
@@ -110,11 +88,7 @@ void CAnimBlendAssociationSA::FreeAnimBlendNodeArray()
     DWORD DwFunc = 0x4CEA40;
     DWORD DwThisInterface = reinterpret_cast<DWORD>(m_pInterface);
     // clang-format off
-    __asm
-    {
-        mov     ecx, DwThisInterface
-        call    DwFunc
-    }
+    gta_thiscall_address(DwFunc, DwThisInterface);
     // clang-format on;
 }
 
@@ -135,11 +109,6 @@ void CAnimBlendAssociationSA::SetCurrentProgress(float fProgress)
     DWORD DwFunc = 0x4CEA80;
     DWORD DwThisInterface = reinterpret_cast<DWORD>(m_pInterface);
     // clang-format off
-    __asm
-    {
-        mov     ecx, DwThisInterface
-        push    fTime
-        call    DwFunc
-    }
+    gta_thiscall_address(DwFunc, DwThisInterface, fTime);
     // clang-format on;
 }

--- a/Client/game_sa/CAnimBlendHierarchySA.cpp
+++ b/Client/game_sa/CAnimBlendHierarchySA.cpp
@@ -36,12 +36,7 @@ void CAnimBlendHierarchySA::SetName(const char* szName)
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendHierarchy_SetName;
     // clang-format off
-    __asm
-    {
-        push    szName
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, szName);
     // clang-format on
 }
 
@@ -50,11 +45,7 @@ void CAnimBlendHierarchySA::RemoveAnimSequences()
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendHierarchy_RemoveAnimSequences;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis);
     // clang-format on
 }
 
@@ -63,11 +54,7 @@ void CAnimBlendHierarchySA::RemoveFromUncompressedCache()
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendHierarchy_RemoveFromUncompressedCache;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis);
     // clang-format on
 }
 
@@ -76,11 +63,7 @@ void CAnimBlendHierarchySA::RemoveQuaternionFlips()
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendHierarchy_RemoveQuaternionFlips;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis);
     // clang-format on
 }
 
@@ -89,11 +72,7 @@ void CAnimBlendHierarchySA::CalculateTotalTime()
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendHierarchy_CalculateTotalTime;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis);
     // clang-format on
 }
 

--- a/Client/game_sa/CAnimBlendSequenceSA.cpp
+++ b/Client/game_sa/CAnimBlendSequenceSA.cpp
@@ -25,12 +25,7 @@ void CAnimBlendSequenceSA::SetName(const char* szName)
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendSequence_SetName;
     // clang-format off
-    __asm
-    {
-        push    szName
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, szName);
     // clang-format on
 }
 
@@ -39,12 +34,7 @@ void CAnimBlendSequenceSA::SetBoneTag(int32_t i32BoneID)
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendSequence_SetBoneTag;
     // clang-format off
-    __asm
-    {
-        push    i32BoneID
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, i32BoneID);
     // clang-format on
 }
 
@@ -53,15 +43,7 @@ void CAnimBlendSequenceSA::SetKeyFrames(size_t cKeyFrames, bool bRoot, bool bCom
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendSequence_SetKeyFrames;
     // clang-format off
-    __asm
-    {
-        push    pKeyFrames
-        push    bCompressed
-        push    bRoot
-        push    cKeyFrames
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, cKeyFrames, bRoot, bCompressed, pKeyFrames);
     // clang-format on
 }
 

--- a/Client/game_sa/CAnimBlendStaticAssociationSA.cpp
+++ b/Client/game_sa/CAnimBlendStaticAssociationSA.cpp
@@ -17,12 +17,6 @@ void CAnimBlendStaticAssociationSA::Initialize(RpClump* pClump, CAnimBlendHierar
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAnimBlendStaticAssociation_Initialize;
     // clang-format off
-    __asm
-    {
-        push    pAnimBlendHierarchyInterface
-        push    pClump
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, pClump, pAnimBlendHierarchyInterface);
     // clang-format on
 }

--- a/Client/game_sa/CAnimManagerSA.cpp
+++ b/Client/game_sa/CAnimManagerSA.cpp
@@ -42,10 +42,7 @@ void CAnimManagerSA::Initialize()
 {
     DWORD dwFunc = FUNC_CAnimManager_Initialize;
     // clang-format off
-    __asm
-    {
-        call    dwFunc
-    }
+    gta_call_address(dwFunc);
     // clang-format on
 }
 
@@ -53,10 +50,7 @@ void CAnimManagerSA::Shutdown()
 {
     DWORD dwFunc = FUNC_CAnimManager_Shutdown;
     // clang-format off
-    __asm
-    {
-        call    dwFunc
-    }
+    gta_call_address(dwFunc);
     // clang-format on
 }
 
@@ -81,13 +75,7 @@ std::unique_ptr<CAnimBlendHierarchy> CAnimManagerSA::GetAnimation(int ID)
     CAnimBlendHierarchySAInterface* pInterface = nullptr;
     DWORD                           dwFunc = FUNC_CAnimManager_GetAnimation_int;
     // clang-format off
-    __asm
-    {
-        push    ID
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x4
-    }
+    pInterface = gta_call_address<decltype(pInterface)>(dwFunc, ID);
     // clang-format on
     if (pInterface)
     {
@@ -102,14 +90,7 @@ std::unique_ptr<CAnimBlendHierarchy> CAnimManagerSA::GetAnimation(const char* sz
     DWORD                           dwFunc = FUNC_CAnimManager_GetAnimation_str_block;
     CAnimBlockSAInterface*          pBlockInterface = pBlock->GetInterface();
     // clang-format off
-    __asm
-    {
-        push    pBlockInterface
-        push    szName
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x8
-    }
+    pInterface = gta_call_address<decltype(pInterface)>(dwFunc, szName, pBlockInterface);
     // clang-format on
     if (pInterface)
     {
@@ -125,14 +106,7 @@ std::unique_ptr<CAnimBlendHierarchy> CAnimManagerSA::GetAnimation(unsigned int u
     DWORD                  dwFunc = FUNC_CAnimManager_GetAnimation_int_block;
     CAnimBlockSAInterface* pBlockInterface = pBlock->GetInterface();
     // clang-format off
-    __asm
-    {
-        push    pBlockInterface
-        push    uiIndex
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x8
-    }
+    pInterface = gta_call_address<decltype(pInterface)>(dwFunc, uiIndex, pBlockInterface);
     // clang-format on
     if (pInterface)
     {
@@ -146,13 +120,7 @@ std::unique_ptr<CAnimBlock> CAnimManagerSA::GetAnimationBlock(int ID)
     CAnimBlockSAInterface* pInterface = nullptr;
     DWORD                  dwFunc = FUNC_CAnimManager_GetAnimationBlock_int;
     // clang-format off
-    __asm
-    {
-        push    ID
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x4
-    }
+    pInterface = gta_call_address<decltype(pInterface)>(dwFunc, ID);
     // clang-format on
     if (pInterface)
     {
@@ -166,13 +134,7 @@ std::unique_ptr<CAnimBlock> CAnimManagerSA::GetAnimationBlock(const char* szName
     CAnimBlockSAInterface* pInterface = nullptr;
     DWORD                  dwFunc = FUNC_CAnimManager_GetAnimationBlock_str;
     // clang-format off
-    __asm
-    {
-        push    szName
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x4
-    }
+    pInterface = gta_call_address<decltype(pInterface)>(dwFunc, szName);
     // clang-format on
     if (pInterface)
     {
@@ -186,13 +148,7 @@ int CAnimManagerSA::GetAnimationBlockIndex(const char* szName)
     int   iReturn;
     DWORD dwFunc = FUNC_CAnimManager_GetAnimationBlockIndex;
     // clang-format off
-    __asm
-    {
-        push    szName
-        call    dwFunc
-        mov     iReturn, eax
-        add     esp, 0x4
-    }
+    iReturn = gta_call_address<decltype(iReturn)>(dwFunc, szName);
     // clang-format on
     return iReturn;
 }
@@ -202,13 +158,7 @@ int CAnimManagerSA::RegisterAnimBlock(const char* szName)
     int   iReturn;
     DWORD dwFunc = FUNC_CAnimManager_RegisterAnimBlock;
     // clang-format off
-    __asm
-    {
-        push    szName
-        call    dwFunc
-        mov     iReturn, eax
-        add     esp, 0x4
-    }
+    iReturn = gta_call_address<decltype(iReturn)>(dwFunc, szName);
     // clang-format on
     return iReturn;
 }
@@ -218,13 +168,7 @@ std::unique_ptr<CAnimBlendAssocGroup> CAnimManagerSA::GetAnimBlendAssoc(AssocGro
     CAnimBlendAssocGroupSAInterface* pInterface = nullptr;
     DWORD                            dwFunc = FUNC_CAnimManager_GetAnimBlendAssoc;
     // clang-format off
-    __asm
-    {
-        push    groupID
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x4
-    }
+    pInterface = gta_call_address<decltype(pInterface)>(dwFunc, groupID);
     // clang-format on
     if (pInterface)
     {
@@ -238,13 +182,7 @@ AssocGroupId CAnimManagerSA::GetFirstAssocGroup(const char* szName)
     AssocGroupId groupReturn;
     DWORD        dwFunc = FUNC_CAnimManager_GetFirstAssocGroup;
     // clang-format off
-    __asm
-    {
-        push    szName
-        call    dwFunc
-        mov     groupReturn, eax
-        add     esp, 0x4
-    }
+    groupReturn = gta_call_address<decltype(groupReturn)>(dwFunc, szName);
     // clang-format on
     return groupReturn;
 }
@@ -254,13 +192,7 @@ const char* CAnimManagerSA::GetAnimGroupName(AssocGroupId groupID)
     const char* szReturn;
     DWORD       dwFunc = FUNC_CAnimManager_GetAnimGroupName;
     // clang-format off
-    __asm
-    {
-        push    groupID
-        call    dwFunc
-        mov     szReturn, eax
-        add     esp, 0x4
-    }
+    szReturn = gta_call_address<decltype(szReturn)>(dwFunc, groupID);
     // clang-format on
     return szReturn;
 }
@@ -270,13 +202,7 @@ const char* CAnimManagerSA::GetAnimBlockName(AssocGroupId groupID)
     const char* szReturn;
     DWORD       dwFunc = FUNC_CAnimManager_GetAnimBlockName;
     // clang-format off
-    __asm
-    {
-        push    groupID
-        call    dwFunc
-        mov     szReturn, eax
-        add     esp, 0x4
-    }
+    szReturn = gta_call_address<decltype(szReturn)>(dwFunc, groupID);
     // clang-format on
     return szReturn;
 }
@@ -286,14 +212,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::CreateAnimAssociation(Ass
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
     DWORD                             dwFunc = FUNC_CAnimManager_CreateAnimAssociation;
     // clang-format off
-    __asm
-    {
-        push    animID
-        push    animGroup
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x8
-    }
+    pInterface = gta_call_address<decltype(pInterface)>(dwFunc, animGroup, animID);
     // clang-format on
     if (pInterface)
     {
@@ -311,14 +230,7 @@ CAnimManagerSA::StaticAssocIntface_type CAnimManagerSA::GetAnimStaticAssociation
     CAnimBlendStaticAssociationSAInterface* pInterface = nullptr;
     DWORD                                   dwFunc = FUNC_CAnimManager_GetAnimAssociation;
     // clang-format off
-    __asm
-    {
-        push    animID
-        push    animGroup
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x8
-    }
+    pInterface = gta_call_address<decltype(pInterface)>(dwFunc, animGroup, animID);
     // clang-format on
     if (pInterface)
     {
@@ -336,14 +248,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::GetAnimAssociation(AssocG
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
     DWORD                             dwFunc = FUNC_CAnimManager_GetAnimAssociation_str;
     // clang-format off
-    __asm
-    {
-        push    szAnimName
-        push    animGroup
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x8
-    }
+    pInterface = gta_call_address<decltype(pInterface)>(dwFunc, animGroup, szAnimName);
     // clang-format on
     if (pInterface)
     {
@@ -360,15 +265,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::AddAnimation(RpClump* pCl
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
     DWORD                             dwFunc = FUNC_CAnimManager_AddAnimation;
     // clang-format off
-    __asm
-    {
-        push    animID
-        push    animGroup
-        push    pClump
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0xC
-    }
+    pInterface = gta_call_address<decltype(pInterface)>(dwFunc, pClump, animGroup, animID);
     // clang-format on
     if (pInterface)
     {
@@ -386,15 +283,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::AddAnimation(RpClump* pCl
     DWORD                             dwFunc = FUNC_CAnimManager_AddAnimation_hier;
     CAnimBlendHierarchySAInterface*   pHierarchyInterface = pHierarchy->GetInterface();
     // clang-format off
-    __asm
-    {
-        push    ID
-        push    pHierarchyInterface
-        push    pClump
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0xC
-    }
+    pInterface = gta_call_address<decltype(pInterface)>(dwFunc, pClump, pHierarchyInterface, ID);
     // clang-format on
     if (pInterface)
     {
@@ -413,16 +302,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::AddAnimationAndSync(RpClu
     DWORD                             dwFunc = FUNC_CAnimManager_AddAnimationAndSync;
     CAnimBlendAssociationSAInterface* pAssociationInterface = pAssociation->GetInterface();
     // clang-format off
-    __asm
-    {
-        push    animID
-        push    animGroup
-        push    pAssociationInterface
-        push    pClump
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x10
-    }
+    pInterface = gta_call_address<decltype(pInterface)>(dwFunc, pClump, pAssociationInterface, animGroup, animID);
     // clang-format on
     if (pInterface)
     {
@@ -439,16 +319,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::BlendAnimation(RpClump* p
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
     DWORD                             dwFunc = FUNC_CAnimManager_BlendAnimation;
     // clang-format off
-    __asm
-    {
-        push    fBlendDelta
-        push    animID
-        push    animGroup
-        push    pClump
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x10
-    }
+    pInterface = gta_call_address<decltype(pInterface)>(dwFunc, pClump, animGroup, animID, fBlendDelta);
     // clang-format on
     if (pInterface)
     {
@@ -466,16 +337,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::BlendAnimation(RpClump* p
     DWORD                             dwFunc = FUNC_CAnimManager_BlendAnimation_hier;
     CAnimBlendHierarchySAInterface*   pHierarchyInterface = pHierarchy->GetInterface();
     // clang-format off
-    __asm
-    {
-        push    fBlendDelta
-        push    ID
-        push    pHierarchyInterface
-        push    pClump
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x10
-    }
+    pInterface = gta_call_address<decltype(pInterface)>(dwFunc, pClump, pHierarchyInterface, ID, fBlendDelta);
     // clang-format on
     if (pInterface)
     {
@@ -488,12 +350,7 @@ void CAnimManagerSA::AddAnimBlockRef(int ID)
 {
     DWORD dwFunc = FUNC_CAnimManager_AddAnimBlockRef;
     // clang-format off
-    __asm
-    {
-        push    ID
-        call    dwFunc
-        add     esp, 0x4
-    }
+    gta_call_address(dwFunc, ID);
     // clang-format on
 }
 
@@ -501,12 +358,7 @@ void CAnimManagerSA::RemoveAnimBlockRef(int ID)
 {
     DWORD dwFunc = FUNC_CAnimManager_RemoveAnimBlockRef;
     // clang-format off
-    __asm
-    {
-        push    ID
-        call    dwFunc
-        add     esp, 0x4
-    }
+    gta_call_address(dwFunc, ID);
     // clang-format on
 }
 
@@ -514,12 +366,7 @@ void CAnimManagerSA::RemoveAnimBlockRefWithoutDelete(int ID)
 {
     DWORD dwFunc = FUNC_CAnimManager_RemoveAnimBlockRefWithoutDelete;
     // clang-format off
-    __asm
-    {
-        push    ID
-        call    dwFunc
-        add     esp, 0x4
-    }
+    gta_call_address(dwFunc, ID);
     // clang-format on
 }
 
@@ -528,13 +375,7 @@ int CAnimManagerSA::GetNumRefsToAnimBlock(int ID)
     int   iReturn;
     DWORD dwFunc = FUNC_CAnimManager_GetNumRefsToAnimBlock;
     // clang-format off
-    __asm
-    {
-        push    ID
-        call    dwFunc
-        mov     iReturn, eax
-        add     esp, 0x4
-    }
+    iReturn = gta_call_address<decltype(iReturn)>(dwFunc, ID);
     // clang-format on
     return iReturn;
 }
@@ -543,12 +384,7 @@ void CAnimManagerSA::RemoveAnimBlock(int ID)
 {
     DWORD dwFunc = FUNC_CAnimManager_RemoveAnimBlock;
     // clang-format off
-    __asm
-    {
-        push    ID
-        call    dwFunc
-        add     esp, 0x4
-    }
+    gta_call_address(dwFunc, ID);
     // clang-format on
 }
 
@@ -562,17 +398,7 @@ AnimAssocDefinition* CAnimManagerSA::AddAnimAssocDefinition(const char* szBlockN
     AnimAssocDefinition* pReturn{};
     DWORD                dwFunc = FUNC_CAnimManager_AddAnimAssocDefinition;
     // clang-format off
-    __asm
-    {
-        push    pDescriptor
-        push    animID
-        push    animGroup
-        push    szAnimName
-        push    szBlockName
-        call    dwFunc
-        mov     pReturn, eax
-        add     esp, 0x14
-    }
+    pReturn = gta_call_address<decltype(pReturn)>(dwFunc, szBlockName, szAnimName, animGroup, animID, pDescriptor);
     // clang-format on
     return pReturn;
 }
@@ -581,10 +407,7 @@ void CAnimManagerSA::ReadAnimAssociationDefinitions()
 {
     DWORD dwFunc = FUNC_CAnimManager_ReadAnimAssociationDefinitions;
     // clang-format off
-    __asm
-    {
-        call    dwFunc
-    }
+    gta_call_address(dwFunc);
     // clang-format on
 }
 
@@ -592,10 +415,7 @@ void CAnimManagerSA::CreateAnimAssocGroups()
 {
     DWORD dwFunc = FUNC_CAnimManager_CreateAnimAssocGroups;
     // clang-format off
-    __asm
-    {
-        call    dwFunc
-    }
+    gta_call_address(dwFunc);
     // clang-format on
 }
 
@@ -604,12 +424,7 @@ void CAnimManagerSA::UncompressAnimation(CAnimBlendHierarchy* pHierarchy)
     DWORD                           dwFunc = FUNC_CAnimManager_UncompressAnimation;
     CAnimBlendHierarchySAInterface* pHierarchyInterface = pHierarchy->GetInterface();
     // clang-format off
-    __asm
-    {
-        push    pHierarchyInterface
-        call    dwFunc
-        add     esp, 0x4
-    }
+    gta_call_address(dwFunc, pHierarchyInterface);
     // clang-format on
 }
 
@@ -618,12 +433,7 @@ void CAnimManagerSA::RemoveFromUncompressedCache(CAnimBlendHierarchy* pHierarchy
     DWORD                           dwFunc = FUNC_CAnimManager_RemoveFromUncompressedCache;
     CAnimBlendHierarchySAInterface* pHierarchyInterface = pHierarchy->GetInterface();
     // clang-format off
-    __asm
-    {
-        push    pHierarchyInterface
-        call    dwFunc
-        add     esp, 0x4
-    }
+    gta_call_address(dwFunc, pHierarchyInterface);
     // clang-format on
 }
 
@@ -631,12 +441,7 @@ void CAnimManagerSA::RemoveFromUncompressedCache(CAnimBlendHierarchySAInterface*
 {
     DWORD dwFunc = FUNC_CAnimManager_RemoveFromUncompressedCache;
     // clang-format off
-    __asm
-    {
-        push    pHierarchyInterface
-        call    dwFunc
-        add     esp, 0x4
-    }
+    gta_call_address(dwFunc, pHierarchyInterface);
     // clang-format on
 }
 
@@ -644,12 +449,7 @@ void CAnimManagerSA::LoadAnimFile(const char* szFile)
 {
     DWORD dwFunc = FUNC_CAnimManager_LoadAnimFile;
     // clang-format off
-    __asm
-    {
-        push    szFile
-        call    dwFunc
-        add     esp, 0x4
-    }
+    gta_call_address(dwFunc, szFile);
     // clang-format on
 }
 
@@ -657,14 +457,7 @@ void CAnimManagerSA::LoadAnimFile(RwStream* pStream, bool b1, const char* sz1)
 {
     DWORD dwFunc = FUNC_CAnimManager_LoadAnimFile_stream;
     // clang-format off
-    __asm
-    {
-        push    sz1
-        push    b1
-        push    pStream
-        call    dwFunc
-        add     esp, 0xC
-    }
+    gta_call_address(dwFunc, pStream, b1, sz1);
     // clang-format on
 }
 
@@ -672,10 +465,7 @@ void CAnimManagerSA::LoadAnimFiles()
 {
     DWORD dwFunc = FUNC_CAnimManager_LoadAnimFiles;
     // clang-format off
-    __asm
-    {
-        call    dwFunc
-    }
+    gta_call_address(dwFunc);
     // clang-format on
 }
 
@@ -683,10 +473,7 @@ void CAnimManagerSA::RemoveLastAnimFile()
 {
     DWORD dwFunc = FUNC_CAnimManager_RemoveLastAnimFile;
     // clang-format off
-    __asm
-    {
-        call    dwFunc
-    }
+    gta_call_address(dwFunc);
     // clang-format on
 }
 
@@ -695,13 +482,7 @@ BYTE* CAnimManagerSA::AllocateKeyFramesMemory(uint32_t u32BytesToAllocate)
     BYTE* pKeyFrames = nullptr;
     DWORD dwFunc = FUNC_CAnimManager_AllocateKeyFramesMemory;
     // clang-format off
-    __asm
-    {
-        push    u32BytesToAllocate
-        call    dwFunc
-        add     esp, 0x4
-        mov     pKeyFrames, eax
-    }
+    pKeyFrames = gta_call_address<decltype(pKeyFrames)>(dwFunc, u32BytesToAllocate);
     // clang-format on
     return pKeyFrames;
 }
@@ -710,12 +491,7 @@ void CAnimManagerSA::FreeKeyFramesMemory(void* pKeyFrames)
 {
     DWORD dwFunc = FUNC_CAnimManager_FreeKeyFramesMemory;
     // clang-format off
-    __asm
-    {
-        push    pKeyFrames
-        call    dwFunc
-        add     esp, 0x4
-    }
+    gta_call_address(dwFunc, pKeyFrames);
     // clang-format on
 }
 
@@ -724,13 +500,7 @@ bool CAnimManagerSA::HasAnimGroupLoaded(AssocGroupId groupID)
     bool  bReturn;
     DWORD dwFunc = FUNC_HasAnimGroupLoaded;
     // clang-format off
-    __asm
-    {
-        push    groupID
-        call    dwFunc
-        mov     bReturn, al
-        add     esp, 0x4
-    }
+    bReturn = gta_call_address<decltype(bReturn)>(dwFunc, groupID);
     // clang-format on
     return bReturn;
 }
@@ -743,13 +513,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::RpAnimBlendClumpGetFirstA
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
     DWORD                             dwFunc = FUNC_RpAnimBlendClumpGetFirstAssociation;
     // clang-format off
-    __asm
-    {
-        push    pClump
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x4
-    }
+    pInterface = gta_call_address<decltype(pInterface)>(dwFunc, pClump);
     // clang-format on
     if (pInterface)
     {
@@ -766,14 +530,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::RpAnimBlendClumpGetAssoci
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
     DWORD                             dwFunc = FUNC_RpAnimBlendClumpGetAssociation_str;
     // clang-format off
-    __asm
-    {
-        push    szAnimName
-        push    pClump
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x8
-    }
+    pInterface = gta_call_address<decltype(pInterface)>(dwFunc, pClump, szAnimName);
     // clang-format on
     if (pInterface)
     {
@@ -790,14 +547,7 @@ std::unique_ptr<CAnimBlendAssociation> CAnimManagerSA::RpAnimBlendClumpGetAssoci
     CAnimBlendAssociationSAInterface* pInterface = nullptr;
     DWORD                             dwFunc = FUNC_RpAnimBlendClumpGetAssociation_int;
     // clang-format off
-    __asm
-    {
-        push    animID
-        push    pClump
-        call    dwFunc
-        mov     pInterface, eax
-        add     esp, 0x8
-    }
+    pInterface = gta_call_address<decltype(pInterface)>(dwFunc, pClump, animID);
     // clang-format on
     if (pInterface)
     {
@@ -835,13 +585,7 @@ int CAnimManagerSA::RpAnimBlendClumpGetNumAssociations(RpClump* pClump)
     int   iReturn;
     DWORD dwFunc = FUNC_RpAnimBlendClumpGetNumAssociations;
     // clang-format off
-    __asm
-    {
-        push    pClump
-        call    dwFunc
-        mov     iReturn, eax
-        add     esp, 0x4
-    }
+    iReturn = gta_call_address<decltype(iReturn)>(dwFunc, pClump);
     // clang-format on
     return iReturn;
 }
@@ -853,14 +597,7 @@ void CAnimManagerSA::RpAnimBlendClumpUpdateAnimations(RpClump* pClump, float f1,
 
     DWORD dwFunc = FUNC_RpAnimBlendClumpUpdateAnimations;
     // clang-format off
-    __asm
-    {
-        push    b1
-        push    f1
-        push    pClump
-        call    dwFunc
-        add     esp, 0xC
-    }
+    gta_call_address(dwFunc, pClump, f1, b1);
     // clang-format on
 }
 

--- a/Client/game_sa/CAudioEngineSA.cpp
+++ b/Client/game_sa/CAudioEngineSA.cpp
@@ -196,14 +196,7 @@ void CAudioEngineSA::PlayFrontEndSound(DWORD dwEventID)
         float fSpeed = 1.0f;
         float fVolumeChange = 0.0f;
         // clang-format off
-        __asm
-        {
-            push    fSpeed
-            push    fVolumeChange
-            push    dwEventID
-            mov     ecx, CLASS_CAudioEngine
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, 0xB6BC90, dwEventID, fVolumeChange, fSpeed);
         // clang-format on
     }
 }
@@ -213,12 +206,7 @@ void CAudioEngineSA::SetEffectsMasterVolume(BYTE bVolume)
     DWORD dwFunc = FUNC_SetEffectsMasterVolume;
     DWORD dwVolume = bVolume;
     // clang-format off
-    __asm
-    {
-        mov     ecx, CLASS_CAudioEngine
-        push    dwVolume
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, 0xB6BC90, dwVolume);
     // clang-format on
 }
 
@@ -227,12 +215,7 @@ void CAudioEngineSA::SetMusicMasterVolume(BYTE bVolume)
     DWORD dwFunc = FUNC_SetMusicMasterVolume;
     DWORD dwVolume = bVolume;
     // clang-format off
-    __asm
-    {
-        mov     ecx, CLASS_CAudioEngine
-        push    dwVolume
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, 0xB6BC90, dwVolume);
     // clang-format on
 
     //
@@ -267,22 +250,12 @@ void CAudioEngineSA::PlayBeatTrack(short iTrack)
         DWORD dwFunc = FUNC_PreloadBeatTrack;
         DWORD dwTrack = iTrack;
         // clang-format off
-        __asm
-        {
-            mov     ecx, CLASS_CAudioEngine
-            push    dwTrack
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, 0xB6BC90, dwTrack);
         // clang-format on
 
         dwFunc = FUNC_PlayPreloadedBeatTrack;
         // clang-format off
-        __asm
-        {
-            mov     ecx, CLASS_CAudioEngine
-            push    1
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, 0xB6BC90, 1);
         // clang-format on
     }
 }
@@ -291,12 +264,7 @@ void CAudioEngineSA::ClearMissionAudio(int slot)
 {
     DWORD dwFunc = 0x5072F0;  // CAudioEngine::ClearMissionAudio(unsigned char)
     // clang-format off
-    __asm
-    {
-        mov     ecx, CLASS_CAudioEngine
-        push    slot // sound bank slot?
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, 0xB6BC90, slot);
     // clang-format on
 }
 
@@ -305,13 +273,7 @@ bool CAudioEngineSA::IsMissionAudioSampleFinished(int slot)
     DWORD dwFunc = 0x5072C0;  // CAudioEngine::IsMissionAudioSampleFinished
     bool  cret = 0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, CLASS_CAudioEngine
-        push    slot
-        call    dwFunc
-        mov     cret, al
-    }
+    cret = gta_thiscall_address<decltype(cret)>(dwFunc, 0xB6BC90, slot);
     // clang-format on
     return cret;
 }
@@ -321,13 +283,7 @@ void CAudioEngineSA::PreloadMissionAudio(unsigned short usAudioEvent, int slot)
     DWORD dwFunc = 0x507290;  // CAudioEngine__PreloadMissionAudio
     DWORD AudioEvent = usAudioEvent;
     // clang-format off
-    __asm
-    {
-        mov     ecx, CLASS_CAudioEngine
-        push    AudioEvent
-        push    slot
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, 0xB6BC90, slot, AudioEvent);
     // clang-format on
 }
 
@@ -336,13 +292,7 @@ unsigned char CAudioEngineSA::GetMissionAudioLoadingStatus(int slot)
     DWORD         dwFunc = 0x5072A0;  // get load status
     unsigned char cret = 0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, CLASS_CAudioEngine
-        push    slot
-        call    dwFunc
-        mov     cret, al
-    }
+    cret = gta_thiscall_address<decltype(cret)>(dwFunc, 0xB6BC90, slot);
     // clang-format on
     return cret;
 }
@@ -359,13 +309,7 @@ void CAudioEngineSA::AttachMissionAudioToPhysical(CPhysical* physical, int slot)
 
     DWORD dwFunc = 0x507330;  // AttachMissionAudioToPhysical
     // clang-format off
-    __asm
-    {
-        mov     ecx, CLASS_CAudioEngine
-        push    entity
-        push    slot
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, 0xB6BC90, slot, entity);
     // clang-format on
 }
 
@@ -373,13 +317,7 @@ void CAudioEngineSA::SetMissionAudioPosition(CVector* position, int slot)
 {
     DWORD dwFunc = 0x507300;  // CAudioEngine__SetMissionAudioPosition
     // clang-format off
-    __asm
-    {
-        mov     ecx, CLASS_CAudioEngine
-        push    position
-        push    slot
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, 0xB6BC90, slot, position);
     // clang-format on
 }
 
@@ -389,12 +327,7 @@ bool CAudioEngineSA::PlayLoadedMissionAudio(int slot)
     {
         DWORD dwFunc = 0x5072B0;  // CAudioEngine::PlayLoadedMissionAudio(unsigned char)
         // clang-format off
-        __asm
-        {
-            mov     ecx, CLASS_CAudioEngine
-            push    slot
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, 0xB6BC90, slot);
         // clang-format on
         return true;
     }
@@ -407,22 +340,14 @@ void CAudioEngineSA::PauseAllSound(bool bPaused)
     {
         DWORD dwFunc = FUNC_PauseAllSounds;
         // clang-format off
-        __asm
-        {
-            mov     ecx, CLASS_CAudioEngine
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, 0xB6BC90);
         // clang-format on
     }
     else
     {
         DWORD dwFunc = FUNC_ResumeAllSounds;
         // clang-format off
-        __asm
-        {
-            mov     ecx, CLASS_CAudioEngine
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, 0xB6BC90);
         // clang-format on
     }
 }
@@ -613,15 +538,7 @@ void CAudioEngineSA::ReportBulletHit(CEntity* pEntity, unsigned char ucSurfaceTy
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAudioEngine_ReportBulletHit;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    f_2
-        push    pvecPosition
-        push    ucSurfaceType
-        push    dwEntityInterface
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, dwEntityInterface, ucSurfaceType, pvecPosition, f_2);
     // clang-format on
 }
 
@@ -633,13 +550,6 @@ void CAudioEngineSA::ReportWeaponEvent(int iEvent, eWeaponType weaponType, CPhys
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAudioEngine_ReportWeaponEvent;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    dwPhysicalInterface
-        push    weaponType
-        push    iEvent
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, iEvent, weaponType, dwPhysicalInterface);
     // clang-format on
 }

--- a/Client/game_sa/CCameraSA.cpp
+++ b/Client/game_sa/CCameraSA.cpp
@@ -113,11 +113,7 @@ void CCameraSA::Restore()
 
     DWORD dwFunc = FUNC_Restore;
     // clang-format off
-    __asm
-    {
-        mov     ecx, cameraInterface
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, cameraInterface);
     // clang-format on
 }
 
@@ -128,19 +124,11 @@ void CCameraSA::RestoreWithJumpCut()
         return;
     DWORD dwFunc = 0x50BD40;
     // clang-format off
-    __asm
-    {
-        mov     ecx, cameraInterface
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, cameraInterface);
     // clang-format on
     dwFunc = 0x50BAB0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, cameraInterface
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, cameraInterface);
     // clang-format on
 }
 
@@ -171,15 +159,7 @@ void CCameraSA::TakeControl(CEntity* entity, eCamMode CamMode, int CamSwitchStyl
 
     DWORD CCamera__TakeControl = FUNC_TakeControl;
     // clang-format off
-    __asm
-    {
-        mov ecx, cameraInterface
-        push 1
-        push CamSwitchStyle
-        push CamMode
-        push entityInterface
-        call CCamera__TakeControl
-    }
+    gta_thiscall_address(CCamera__TakeControl, cameraInterface, entityInterface, CamMode, CamSwitchStyle, 1);
     // clang-format on
 }
 
@@ -213,14 +193,7 @@ void CCameraSA::TakeControl(CVector* position, int CamSwitchStyle)
 
     DWORD CCamera__TakeControlNoEntity = FUNC_TakeControlNoEntity;
     // clang-format off
-    __asm
-        {
-        mov ecx, cameraInterface
-        push 1
-        push CamSwitchStyle
-        push position
-        call CCamera__TakeControlNoEntity
-        }
+    gta_thiscall_address(CCamera__TakeControlNoEntity, cameraInterface, position, CamSwitchStyle, 1);
     // clang-format on
 
     DWORD dwFunc = 0x50BEC0;
@@ -363,17 +336,7 @@ void CCameraSA::Find3rdPersonCamTargetVector(float fDistance, CVector* vecGunMuz
         return;
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, cameraInterface
-        push    vecTarget
-        push    vecSource
-        push    fOriginZ
-        push    fOriginY
-        push    fOriginX
-        push    fDistance
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, cameraInterface, fDistance, fOriginX, fOriginY, fOriginZ, vecSource, vecTarget);
     // clang-format on
 }
 
@@ -386,12 +349,7 @@ float CCameraSA::Find3rdPersonQuickAimPitch()
     float fReturn;
     DWORD dwFunc = FUNC_Find3rdPersonQuickAimPitch;
     // clang-format off
-    __asm
-    {
-        mov     ecx, cameraInterface
-        call    dwFunc
-        fstp    fReturn
-    }
+    fReturn = gta_thiscall_address<decltype(fReturn)>(dwFunc, cameraInterface);
     // clang-format on
     return fReturn;
 }
@@ -449,12 +407,7 @@ bool CCameraSA::IsFading()
         return false;
     bool bRet = false;
     // clang-format off
-    __asm
-    {
-        mov     ecx, cameraInterface
-        call    dwFunc
-        mov     bRet, al
-    }
+    bRet = gta_thiscall_address<decltype(bRet)>(dwFunc, cameraInterface);
     // clang-format on
     return bRet;
 }
@@ -467,12 +420,7 @@ int CCameraSA::GetFadingDirection()
         return 0;
     int dwRet = false;
     // clang-format off
-    __asm
-    {
-        mov     ecx, cameraInterface
-        call    dwFunc
-        mov     dwRet, eax
-    }
+    dwRet = gta_thiscall_address<decltype(dwRet)>(dwFunc, cameraInterface);
     // clang-format on
     return dwRet;
 }
@@ -499,13 +447,7 @@ void CCameraSA::Fade(float fFadeOutTime, int iOutOrIn)
         return;
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, cameraInterface
-        push    iOutOrIn
-        push    fFadeOutTime
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, cameraInterface, fFadeOutTime, iOutOrIn);
     // clang-format on
 }
 
@@ -519,14 +461,7 @@ void CCameraSA::SetFadeColor(unsigned char ucRed, unsigned char ucGreen, unsigne
     DWORD dwGreen = ucGreen;
     DWORD dwBlue = ucBlue;
     // clang-format off
-    __asm
-    {
-        mov     ecx, cameraInterface
-        push    dwBlue
-        push    dwGreen
-        push    dwRed
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, cameraInterface, dwRed, dwGreen, dwBlue);
     // clang-format on
 }
 

--- a/Client/game_sa/CCarEnterExitSA.cpp
+++ b/Client/game_sa/CCarEnterExitSA.cpp
@@ -27,16 +27,7 @@ bool CCarEnterExitSA::GetNearestCarDoor(CPed* pPed, CVehicle* pVehicle, CVector*
         CPedSAInterface*     pPedInterface = pPedSA->GetPedInterface();
         CVehicleSAInterface* pVehicleInterface = pVehicleSA->GetVehicleInterface();
         // clang-format off
-        __asm
-        {
-            push    pDoor
-            push    pVector
-            push    pVehicleInterface
-            push    pPedInterface
-            call    dwFunc
-            add     esp, 0x10
-            mov     bReturn, al
-        }
+        bReturn = gta_call_address<decltype(bReturn)>(dwFunc, pPedInterface, pVehicleInterface, pVector, pDoor);
         // clang-format on
     }
 
@@ -108,14 +99,7 @@ int CCarEnterExitSA::ComputeTargetDoorToExit(CPed* pPed, CVehicle* pVehicle)
         CPedSAInterface*     pPedInterface = pPedSA->GetPedInterface();
         CVehicleSAInterface* pVehicleInterface = pVehicleSA->GetVehicleInterface();
         // clang-format off
-        __asm
-        {
-            push    pPedInterface
-            push    pVehicleInterface
-            call    dwFunc
-            add     esp, 8
-            mov     door, eax
-        }
+        door = gta_call_address<decltype(door)>(dwFunc, pVehicleInterface, pPedInterface);
         // clang-format on
 
         switch (door)
@@ -192,15 +176,7 @@ bool CCarEnterExitSA::IsRoomForPedToLeaveCar(CVehicle* pVehicle, int iDoor, CVec
         {
             CVehicleSAInterface* pVehicleInterface = pVehicleSA->GetVehicleInterface();
             // clang-format off
-            __asm
-            {
-                push    pUnknown
-                push    dwIdx
-                push    pVehicleInterface
-                call    dwFunc
-                add     esp, 12
-                mov     bRet, al
-            }
+            bRet = gta_call_address<decltype(bRet)>(dwFunc, pVehicleInterface, dwIdx, pUnknown);
             // clang-format on
         }
     }

--- a/Client/game_sa/CControllerConfigManagerSA.cpp
+++ b/Client/game_sa/CControllerConfigManagerSA.cpp
@@ -36,14 +36,7 @@ void CControllerConfigManagerSA::SetControllerKeyAssociatedWithAction(eControlle
 {
     DWORD dwFunc = FUNC_SetControllerKeyAssociatedWithAction;
     // clang-format off
-    __asm
-    {
-        mov     ecx, CLASS_CControllerConfigManager
-        push    controllerType
-        push    iKey
-        push    action
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, 0xB70198, action, iKey, controllerType);
     // clang-format on
 }
 
@@ -52,14 +45,7 @@ int CControllerConfigManagerSA::GetControllerKeyAssociatedWithAction(eController
     int   iReturn = 0;
     DWORD dwFunc = FUNC_GetControllerKeyAssociatedWithAction;
     // clang-format off
-    __asm
-    {
-        mov     ecx, CLASS_CControllerConfigManager
-        push    controllerType
-        push    action
-        call    dwFunc
-        mov     iReturn, eax
-    }
+    iReturn = gta_thiscall_address<decltype(iReturn)>(dwFunc, 0xB70198, action, controllerType);
     // clang-format on
     return iReturn;
 }
@@ -69,13 +55,7 @@ int CControllerConfigManagerSA::GetNumOfSettingsForAction(eControllerAction acti
     int   iReturn = 0;
     DWORD dwFunc = FUNC_GetNumOfSettingsForAction;
     // clang-format off
-    __asm
-    {
-        mov     ecx, CLASS_CControllerConfigManager
-        push    action
-        call    dwFunc
-        mov     iReturn, eax
-    }
+    iReturn = gta_thiscall_address<decltype(iReturn)>(dwFunc, 0xB70198, action);
     // clang-format on
     return iReturn;
 }
@@ -84,13 +64,7 @@ void CControllerConfigManagerSA::ClearSettingsAssociatedWithAction(eControllerAc
 {
     DWORD dwFunc = FUNC_ClearSettingsAssociatedWithAction;
     // clang-format off
-    __asm
-    {
-        mov     ecx, CLASS_CControllerConfigManager
-        push    controllerType
-        push    action
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, 0xB70198, action, controllerType);
     // clang-format on
 }
 

--- a/Client/game_sa/CDamageManagerSA.cpp
+++ b/Client/game_sa/CDamageManagerSA.cpp
@@ -54,13 +54,7 @@ void CDamageManagerSA::SetDoorStatus(eDoors bDoor, BYTE bDoorStatus, bool spawnF
                 int   iCarNodeIndex = s_iCarNodeIndexes[bDoor];
                 DWORD dwDoor = (DWORD)bDoor;
                 // clang-format off
-                __asm
-                {
-                    mov     ecx, dwThis
-                    push    dwDoor
-                    push    iCarNodeIndex
-                    call    dwFunc
-                }
+                gta_thiscall_address(dwFunc, dwThis, iCarNodeIndex, dwDoor);
                 // clang-format on
             }
             else
@@ -71,13 +65,7 @@ void CDamageManagerSA::SetDoorStatus(eDoors bDoor, BYTE bDoorStatus, bool spawnF
                 DWORD dwDoor = (DWORD)bDoor;
                 bool  bQuiet = !spawnFlyingComponent;
                 // clang-format off
-                __asm
-                {
-                    mov     ecx, dwThis
-                    push    bQuiet
-                    push    dwDoor
-                    call    dwFunc
-                }
+                gta_thiscall_address(dwFunc, dwThis, dwDoor, bQuiet);
                 // clang-format on
             }
         }
@@ -117,13 +105,7 @@ void CDamageManagerSA::SetPanelStatus(BYTE bPanel, BYTE bPanelStatus, bool spawn
             DWORD dwPanel = bPanel;
             DWORD dwStatus = bPanelStatus;
             // clang-format off
-            __asm
-            {
-                mov     ecx, dwThis
-                push    dwStatus
-                push    dwPanel
-                call    dwFunction
-            }
+            gta_thiscall_address(dwFunction, dwThis, dwPanel, dwStatus);
             // clang-format on
 
             // Intact?
@@ -137,16 +119,11 @@ void CDamageManagerSA::SetPanelStatus(BYTE bPanel, BYTE bPanelStatus, bool spawn
                     return;
 
                 // clang-format off
-                __asm
-                {
-                    mov     ecx, dwThis
-                    push    dwPanel
-                    push    carNodeIndex
-                    call    dwFunction
-                }
+                gta_thiscall_address(dwFunction, dwThis, carNodeIndex, dwPanel);
                 // clang-format on
             }
-            else reinterpret_cast<CAutomobileSAInterface*>(internalEntityInterface)->SetPanelDamage(bPanel, breakGlass, spawnFlyingComponent);
+            else
+                reinterpret_cast<CAutomobileSAInterface*>(internalEntityInterface)->SetPanelDamage(bPanel, breakGlass, spawnFlyingComponent);
         }
     }
 }
@@ -178,13 +155,7 @@ void CDamageManagerSA::SetLightStatus(BYTE bLight, BYTE bLightStatus)
     DWORD dwLight = bLight;
     DWORD dwStatus = bLightStatus;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwPointer
-        push    dwStatus
-        push    dwLight
-        call    dwFunction
-    }
+    gta_thiscall_address(dwFunction, dwPointer, dwLight, dwStatus);
     // clang-format on
 }
 
@@ -200,13 +171,7 @@ BYTE CDamageManagerSA::GetLightStatus(BYTE bLight)
     BYTE  bReturn = 0;
     DWORD dwLight = bLight;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwPointer
-        push    dwLight
-        call    dwFunction
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunction, dwPointer, dwLight);
     // clang-format on
     return bReturn;
 }
@@ -222,13 +187,7 @@ void CDamageManagerSA::SetAeroplaneCompStatus(BYTE CompID, BYTE Status)
     DWORD dwPointer = (DWORD)internalInterface;
     DWORD dwPannel = CompID;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwPointer
-        push    Status
-        push    dwPannel
-        call    dwFunction
-    }
+    gta_thiscall_address(dwFunction, dwPointer, dwPannel, Status);
     // clang-format on
 }
 
@@ -239,13 +198,7 @@ BYTE CDamageManagerSA::GetAeroplaneCompStatus(BYTE CompID)
     BYTE  bReturn = 0;
     DWORD dwPannel = CompID;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwPointer
-        push    dwPannel
-        call    dwFunction
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunction, dwPointer, dwPannel);
     // clang-format on
     return bReturn;
 }
@@ -255,12 +208,7 @@ void CDamageManagerSA::FuckCarCompletely(bool bKeepWheels)
     DWORD dwFunc = FUNC_FuckCarCompletely;
     DWORD dwPointer = (DWORD)internalInterface;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwPointer
-        push    bKeepWheels
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwPointer, bKeepWheels);
     // clang-format on
 }
 

--- a/Client/game_sa/CDoorSA.cpp
+++ b/Client/game_sa/CDoorSA.cpp
@@ -25,12 +25,7 @@ float CDoorSA::GetAngleOpenRatio()
     if (dwPointer != 0)
     {
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwPointer
-            call    dwFunction
-            fstp    fReturn
-        }
+        fReturn = gta_thiscall_address<decltype(fReturn)>(dwFunction, dwPointer);
         // clang-format on
     }
 
@@ -50,12 +45,7 @@ bool CDoorSA::IsClosed()
     if (dwPointer != 0)
     {
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwPointer
-            call    dwFunction
-            mov     bReturn, al
-        }
+        bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunction, dwPointer);
         // clang-format on
     }
 
@@ -76,12 +66,7 @@ bool CDoorSA::IsFullyOpen()
     if (dwPointer != 0)
     {
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwPointer
-            call    dwFunction
-            mov     bReturn, al
-        }
+        bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunction, dwPointer);
         // clang-format on
     }
 
@@ -101,12 +86,7 @@ void CDoorSA::Open(float fOpenRatio)
     if (dwPointer != 0)
     {
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwPointer
-            push    fOpenRatio
-            call    dwFunction
-        }
+        gta_thiscall_address(dwFunction, dwPointer, fOpenRatio);
         // clang-format on
     }
 }

--- a/Client/game_sa/CEntitySA.cpp
+++ b/Client/game_sa/CEntitySA.cpp
@@ -153,11 +153,7 @@ void CEntitySA::SetPosition(float fX, float fY, float fZ)
         DWORD dwThis = (DWORD)m_pInterface;
         DWORD dwFunc = FUNC_CTrain_FindPositionOnTrackFromCoors;
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwThis
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, dwThis);
         // clang-format on
     }
     if (m_pInterface->nType == ENTITY_TYPE_OBJECT)
@@ -199,11 +195,7 @@ void CEntitySA::Render()
     DWORD dwFunc = 0x59F180;  // m_pInterface->vtbl->Render;
     DWORD dwThis = (DWORD)m_pInterface;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis);
     // clang-format on
 }
 
@@ -216,20 +208,12 @@ void CEntitySA::SetOrientation(float fX, float fY, float fZ)
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = 0x446F90;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis);
     // clang-format on
 
     dwFunc = 0x532B00;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis);
     // clang-format on
 
     if (m_pInterface->nType == ENTITY_TYPE_OBJECT)
@@ -246,20 +230,12 @@ void CEntitySA::FixBoatOrientation()
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = 0x446F90;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis);
     // clang-format on
 
     dwFunc = 0x532B00;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis);
     // clang-format on
 
     pGame->GetWorld()->Add(this, CEntity_FixBoatOrientation);
@@ -376,20 +352,12 @@ void CEntitySA::SetMatrix(CMatrix* matrix)
         DWORD dwThis = (DWORD)m_pInterface;
         DWORD dwFunc = 0x446F90;  // CEntity::UpdateRwMatrix
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwThis
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, dwThis);
         // clang-format on
 
         dwFunc = 0x532B00;  // CEntity::UpdateRwFrame
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwThis
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, dwThis);
         // clang-format on
 
         if (m_pInterface->nType == ENTITY_TYPE_OBJECT)
@@ -417,12 +385,7 @@ float CEntitySA::GetDistanceFromCentreOfMassToBaseOfModel()
     DWORD dwThis = (DWORD)m_pInterface;
     float fReturn;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        fstp    fReturn
-    }
+    fReturn = gta_thiscall_address<decltype(fReturn)>(dwFunc, dwThis);
     // clang-format on
     return fReturn;
 }
@@ -459,12 +422,7 @@ void CEntitySA::SetAlpha(DWORD dwAlpha)
     DWORD dwFunc = FUNC_SetRwObjectAlpha;
     DWORD dwThis = (DWORD)m_pInterface;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    dwAlpha
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, dwAlpha);
     // clang-format on
 }
 
@@ -474,12 +432,7 @@ bool CEntitySA::IsOnScreen()
     DWORD dwThis = (DWORD)m_pInterface;
     bool  bReturn = false;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThis);
     // clang-format on
     return bReturn;
 }
@@ -512,15 +465,7 @@ void CEntitySA::MatrixConvertFromEulerAngles(float fX, float fY, float fZ, int i
     {
         DWORD dwFunc = FUNC_CMatrix__ConvertFromEulerAngles;
         // clang-format off
-        __asm
-        {
-            push    iUnknown
-            push    fZ
-            push    fY
-            push    fX
-            mov     ecx, matrixPadded
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, matrixPadded, fX, fY, fZ, iUnknown);
         // clang-format on
     }
 }
@@ -532,15 +477,7 @@ void CEntitySA::MatrixConvertToEulerAngles(float* fX, float* fY, float* fZ, int 
     {
         DWORD dwFunc = FUNC_CMatrix__ConvertToEulerAngles;
         // clang-format off
-        __asm
-        {
-            push    iUnknown
-            push    fZ
-            push    fY
-            push    fX
-            mov     ecx, matrixPadded
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, matrixPadded, fX, fY, fZ, iUnknown);
         // clang-format on
     }
 }
@@ -552,17 +489,12 @@ bool CEntitySA::IsPlayingAnimation(char* szAnimName)
     DWORD dwThis = (DWORD)m_pInterface->m_pRwObject;
 
     // clang-format off
-    __asm
-    {
-        push    szAnimName
-        push    dwThis
-        call    dwFunc
-        add     esp, 8
-        mov     dwReturn, eax
-    }
+    dwReturn = gta_call_address<decltype(dwReturn)>(dwFunc, dwThis, szAnimName);
     // clang-format on
-    if (dwReturn) return true;
-    else return false;
+    if (dwReturn)
+        return true;
+    else
+        return false;
 }
 
 RwMatrix* CEntitySA::GetBoneRwMatrix(eBone boneId)

--- a/Client/game_sa/CEventDamageSA.cpp
+++ b/Client/game_sa/CEventDamageSA.cpp
@@ -28,18 +28,7 @@ CEventDamageSA::CEventDamageSA(CEntity* pEntity, unsigned int i_1, eWeaponType w
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CEventDamage_Constructor;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    b_4
-        push    b_3
-        push    uc_2
-        push    hitZone
-        push    weaponType
-        push    i_1
-        push    dwEntityInterface
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, dwEntityInterface, i_1, weaponType, hitZone, uc_2, b_3, b_4);
     // clang-format on
 }
 
@@ -60,11 +49,7 @@ CEventDamageSA::~CEventDamageSA()
         DWORD dwThis = (DWORD)m_pInterface;
         DWORD dwFunc = FUNC_CEventDamage_Destructor;
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwThis
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, dwThis);
         // clang-format on
         delete m_pInterface;
     }
@@ -88,12 +73,7 @@ bool CEventDamageSA::HasKilledPed()
     DWORD dwFunc = FUNC_CEventDamage_HasKilledPed;
     bool  bReturn = false;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThis);
     // clang-format on
     return bReturn;
 }
@@ -104,12 +84,7 @@ float CEventDamageSA::GetDamageApplied()
     DWORD dwFunc = FUNC_CEventDamage_GetDamageApplied;
     float fReturn = 0.0f;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        fstp    fReturn
-    }
+    fReturn = gta_thiscall_address<decltype(fReturn)>(dwFunc, dwThis);
     // clang-format on
     return fReturn;
 }
@@ -120,12 +95,7 @@ AssocGroupId CEventDamageSA::GetAnimGroup()
     DWORD        dwFunc = FUNC_CEventDamage_GetAnimGroup;
     AssocGroupId animGroup = 0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     animGroup, eax
-    }
+    animGroup = gta_thiscall_address<decltype(animGroup)>(dwFunc, dwThis);
     // clang-format on
     return animGroup;
 }
@@ -136,12 +106,7 @@ AnimationId CEventDamageSA::GetAnimId()
     DWORD       dwFunc = FUNC_CEventDamage_GetAnimId;
     AnimationId animID = 0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     animID, eax
-    }
+    animID = gta_thiscall_address<decltype(animID)>(dwFunc, dwThis);
     // clang-format on
     return animID;
 }
@@ -152,12 +117,7 @@ bool CEventDamageSA::GetAnimAdded()
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CEventDamage_GetAnimAdded;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThis);
     // clang-format on
     return bReturn;
 }
@@ -168,13 +128,7 @@ void CEventDamageSA::ComputeDeathAnim(CPed* pPed, bool bUnk)
     DWORD dwPed = (DWORD)pPed->GetInterface();
     DWORD dwFunc = FUNC_CEventDamage_ComputeDeathAnim;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    bUnk
-        push    dwPed
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, dwPed, bUnk);
     // clang-format on
 }
 
@@ -184,13 +138,7 @@ void CEventDamageSA::ComputeDamageAnim(CPed* pPed, bool bUnk)
     DWORD dwPed = (DWORD)pPed->GetInterface();
     DWORD dwFunc = FUNC_CEventDamage_ComputeDamageAnim;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    bUnk
-        push    dwPed
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, dwPed, bUnk);
     // clang-format on
 }
 
@@ -201,13 +149,7 @@ bool CEventDamageSA::AffectsPed(CPed* pPed)
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CEventDamage_AffectsPed;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    dwPedInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThis, dwPedInterface);
     // clang-format on
     return bReturn;
 }

--- a/Client/game_sa/CFireManagerSA.cpp
+++ b/Client/game_sa/CFireManagerSA.cpp
@@ -38,15 +38,7 @@ void CFireManagerSA::ExtinguishPoint(CVector& vecPosition, float fRadius)
     DWORD dwFunction = FUNC_ExtinguishPoint;
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, CLASS_CFireManager
-        push    fRadius
-        push    fZ
-        push    fY
-        push    fX
-        call    dwFunction
-    }
+    gta_thiscall_address(dwFunction, 0xB71F80, fX, fY, fZ, fRadius);
     // clang-format on
 }
 

--- a/Client/game_sa/CFireSA.cpp
+++ b/Client/game_sa/CFireSA.cpp
@@ -27,11 +27,7 @@ void CFireSA::Extinguish()
     DWORD dwFunction = FUNC_Extinguish;
     DWORD dwPointer = (DWORD)internalInterface;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwPointer
-        call    dwFunction
-    }
+    gta_thiscall_address(dwFunction, dwPointer);
     // clang-format on
     internalInterface->bActive = false;
 }
@@ -187,13 +183,7 @@ void CFireSA::Ignite()
     DWORD    dwFunc = FUNC_CreateFxSysForStrength;
     DWORD    dwThis = (DWORD)internalInterface;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    0
-        push    vecPosition
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, vecPosition, 0);
     // clang-format on
 
     internalInterface->bBeingExtinguished = 0;

--- a/Client/game_sa/CFxManagerSA.cpp
+++ b/Client/game_sa/CFxManagerSA.cpp
@@ -22,16 +22,7 @@ CFxSystem* CFxManagerSA::CreateFxSystem(const char* szBlueprint, const CVector& 
     CFxSystemSAInterface* pFxSystem;
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    bSkipCameraFrustumCheck
-        push    pRwMatrixTag
-        push    pvecPosition
-        push    szBlueprint
-        call    dwFunc
-        mov     pFxSystem, eax
-    }
+    pFxSystem = gta_thiscall_address<decltype(pFxSystem)>(dwFunc, dwThis, szBlueprint, pvecPosition, pRwMatrixTag, bSkipCameraFrustumCheck);
     // clang-format on
 
     if (pFxSystem)
@@ -53,12 +44,7 @@ void CFxManagerSA::DestroyFxSystem(CFxSystem* pFxSystem)
     void* pFxSA = pFxSystem->GetInterface();
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    pFxSA
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, pFxSA);
     // clang-format on
 }
 

--- a/Client/game_sa/CFxSA.cpp
+++ b/Client/game_sa/CFxSA.cpp
@@ -20,15 +20,7 @@ void CFxSA::AddBlood(CVector& vecPosition, CVector& vecDirection, int iCount, fl
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_AddBlood;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    fBrightness
-        push    iCount
-        push    pvecDirection
-        push    pvecPosition
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, pvecPosition, pvecDirection, iCount, fBrightness);
     // clang-format on
 }
 
@@ -39,15 +31,7 @@ void CFxSA::AddWood(CVector& vecPosition, CVector& vecDirection, int iCount, flo
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_AddWood;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    fBrightness
-        push    iCount
-        push    pvecDirection
-        push    pvecPosition
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, pvecPosition, pvecDirection, iCount, fBrightness);
     // clang-format on
 }
 
@@ -60,21 +44,7 @@ void CFxSA::AddSparks(CVector& vecPosition, CVector& vecDirection, float fForce,
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_AddSparks;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    fLife
-        push    fSpread
-        push    ucBlurIf0
-        push    fZ
-        push    fY
-        push    fX
-        push    iCount
-        push    fForce
-        push    pvecDirection
-        push    pvecPosition
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, pvecPosition, pvecDirection, fForce, iCount, fX, fY, fZ, ucBlurIf0, fSpread, fLife);
     // clang-format on
 }
 
@@ -85,13 +55,7 @@ void CFxSA::AddTyreBurst(CVector& vecPosition, CVector& vecDirection)
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_AddTyreBurst;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    pvecDirection
-        push    pvecPosition
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, pvecPosition, pvecDirection);
     // clang-format on
 }
 
@@ -102,16 +66,7 @@ void CFxSA::AddBulletImpact(CVector& vecPosition, CVector& vecDirection, int iSm
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_AddBulletImpact;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    fSmokeIntensity
-        push    iSparkCount
-        push    iSmokeSize
-        push    pvecDirection
-        push    pvecPosition
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, pvecPosition, pvecDirection, iSmokeSize, iSparkCount, fSmokeIntensity);
     // clang-format on
 }
 
@@ -122,14 +77,7 @@ void CFxSA::AddPunchImpact(CVector& vecPosition, CVector& vecDirection, int i)
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_AddPunchImpact;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    i
-        push    pvecDirection
-        push    pvecPosition
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, pvecPosition, pvecDirection, i);
     // clang-format on
 }
 
@@ -140,15 +88,7 @@ void CFxSA::AddDebris(CVector& vecPosition, RwColor& rwColor, float fDebrisScale
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_AddDebris;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    iCount
-        push    fDebrisScale
-        push    pColor
-        push    pvecPosition
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, pvecPosition, pColor, fDebrisScale, iCount);
     // clang-format on
 }
 
@@ -159,15 +99,7 @@ void CFxSA::AddGlass(CVector& vecPosition, RwColor& rwColor, float fDebrisScale,
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_AddGlass;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    iCount
-        push    fDebrisScale
-        push    pColor
-        push    pvecPosition
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, pvecPosition, pColor, fDebrisScale, iCount);
     // clang-format on
 }
 
@@ -177,12 +109,7 @@ void CFxSA::TriggerWaterHydrant(CVector& vecPosition)
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_TriggerWaterHydrant;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    pvecPosition
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, pvecPosition);
     // clang-format on
 }
 
@@ -194,15 +121,7 @@ void CFxSA::TriggerGunshot(CEntity* pEntity, CVector& vecPosition, CVector& vecD
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_TriggerGunshot;
     // clang-format off
-        __asm
-    {
-        mov     ecx, dwThis
-        push    bIncludeSparks
-        push    pvecDirection
-        push    pvecPosition
-        push    dwEntity
-        call    dwFunc
-    }
+        gta_thiscall_address(dwFunc, dwThis, dwEntity, pvecPosition, pvecDirection, bIncludeSparks);
     // clang-format on
 }
 
@@ -213,13 +132,7 @@ void CFxSA::TriggerTankFire(CVector& vecPosition, CVector& vecDirection)
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_TriggerTankFire;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    pvecDirection
-        push    pvecPosition
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, pvecPosition, pvecDirection);
     // clang-format on
 }
 
@@ -229,12 +142,7 @@ void CFxSA::TriggerWaterSplash(CVector& vecPosition)
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_TriggerWaterSplash;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    pvecPosition
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, pvecPosition);
     // clang-format on
 }
 
@@ -244,12 +152,7 @@ void CFxSA::TriggerBulletSplash(CVector& vecPosition)
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_TriggerBulletSplash;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    pvecPosition
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, pvecPosition);
     // clang-format on
 }
 
@@ -259,12 +162,7 @@ void CFxSA::TriggerFootSplash(CVector& vecPosition)
     DWORD    dwThis = (DWORD)m_pInterface;
     DWORD    dwFunc = FUNC_CFx_TriggerFootSplash;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    pvecPosition
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, pvecPosition);
     // clang-format on
 }
 

--- a/Client/game_sa/CFxSystemSA.cpp
+++ b/Client/game_sa/CFxSystemSA.cpp
@@ -44,11 +44,7 @@ void CFxSystemSA::PlayAndKill()
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_FxSystem_c__PlayAndKill;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis);
     // clang-format on
 }
 

--- a/Client/game_sa/CKeyGenSA.cpp
+++ b/Client/game_sa/CKeyGenSA.cpp
@@ -17,14 +17,7 @@ unsigned int CKeyGenSA::GetKey(const char* szString, int iLength)
     unsigned int uiReturn;
     DWORD        dwFunc = FUNC_CKeyGen_GetKey_len;
     // clang-format off
-    __asm
-    {
-        push    iLength
-        push    szString
-        call    dwFunc
-        add     esp, 0x8
-        mov     uiReturn, eax
-    }
+    uiReturn = gta_call_address<decltype(uiReturn)>(dwFunc, szString, iLength);
     // clang-format on
     return uiReturn;
 }
@@ -34,13 +27,7 @@ unsigned int CKeyGenSA::GetKey(const char* szString)
     unsigned int uiReturn;
     DWORD        dwFunc = FUNC_CKeyGen_GetKey;
     // clang-format off
-    __asm
-    {
-        push    szString
-        call    dwFunc
-        add     esp, 0x4
-        mov     uiReturn, eax
-    }
+    uiReturn = gta_call_address<decltype(uiReturn)>(dwFunc, szString);
     // clang-format on
     return uiReturn;
 }
@@ -50,13 +37,7 @@ unsigned int CKeyGenSA::GetUppercaseKey(const char* szString)
     unsigned int uiReturn;
     DWORD        dwFunc = FUNC_CKeyGen_GetUppercaseKey;
     // clang-format off
-    __asm
-    {
-        push    szString
-        call    dwFunc
-        add     esp, 0x4
-        mov     uiReturn, eax
-    }
+    uiReturn = gta_call_address<decltype(uiReturn)>(dwFunc, szString);
     // clang-format on
     return uiReturn;
 }
@@ -66,14 +47,7 @@ unsigned int CKeyGenSA::AppendStringToKey(unsigned int uiKey, const char* szStri
     unsigned int uiReturn;
     DWORD        dwFunc = FUNC_CKeyGen_AppendStringToKey;
     // clang-format off
-    __asm
-    {
-        push    szString
-        push    uiKey
-        call    dwFunc
-        add     esp, 0x8
-        mov     uiReturn, eax
-    }
+    uiReturn = gta_call_address<decltype(uiReturn)>(dwFunc, uiKey, szString);
     // clang-format on
     return uiReturn;
 }

--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -241,13 +241,7 @@ bool CModelInfoSA::IsBoat()
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
     // clang-format off
-    __asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
+    bReturn = gta_call_address<decltype(bReturn)>(dwFunction, ModelID);
     // clang-format on
     return bReturn;
 }
@@ -258,13 +252,7 @@ bool CModelInfoSA::IsCar()
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
     // clang-format off
-    __asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
+    bReturn = gta_call_address<decltype(bReturn)>(dwFunction, ModelID);
     // clang-format on
     return bReturn;
 }
@@ -275,13 +263,7 @@ bool CModelInfoSA::IsTrain()
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
     // clang-format off
-    __asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
+    bReturn = gta_call_address<decltype(bReturn)>(dwFunction, ModelID);
     // clang-format on
     return bReturn;
 }
@@ -292,13 +274,7 @@ bool CModelInfoSA::IsHeli()
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
     // clang-format off
-    __asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
+    bReturn = gta_call_address<decltype(bReturn)>(dwFunction, ModelID);
     // clang-format on
     return bReturn;
 }
@@ -309,13 +285,7 @@ bool CModelInfoSA::IsPlane()
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
     // clang-format off
-    __asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
+    bReturn = gta_call_address<decltype(bReturn)>(dwFunction, ModelID);
     // clang-format on
     return bReturn;
 }
@@ -326,13 +296,7 @@ bool CModelInfoSA::IsBike()
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
     // clang-format off
-    __asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
+    bReturn = gta_call_address<decltype(bReturn)>(dwFunction, ModelID);
     // clang-format on
     return bReturn;
 }
@@ -343,13 +307,7 @@ bool CModelInfoSA::IsFakePlane()
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
     // clang-format off
-    __asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
+    bReturn = gta_call_address<decltype(bReturn)>(dwFunction, ModelID);
     // clang-format on
     return bReturn;
 }
@@ -360,13 +318,7 @@ bool CModelInfoSA::IsMonsterTruck()
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
     // clang-format off
-    __asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
+    bReturn = gta_call_address<decltype(bReturn)>(dwFunction, ModelID);
     // clang-format on
     return bReturn;
 }
@@ -377,13 +329,7 @@ bool CModelInfoSA::IsQuadBike()
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
     // clang-format off
-    __asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
+    bReturn = gta_call_address<decltype(bReturn)>(dwFunction, ModelID);
     // clang-format on
     return bReturn;
 }
@@ -394,13 +340,7 @@ bool CModelInfoSA::IsBmx()
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
     // clang-format off
-    __asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
+    bReturn = gta_call_address<decltype(bReturn)>(dwFunction, ModelID);
     // clang-format on
     return bReturn;
 }
@@ -411,13 +351,7 @@ bool CModelInfoSA::IsTrailer()
     DWORD ModelID = m_dwModelID;
     bool  bReturn = false;
     // clang-format off
-    __asm
-    {
-        push    ModelID
-        call    dwFunction
-        mov     bReturn, al
-        add     esp, 4
-    }
+    bReturn = gta_call_address<decltype(bReturn)>(dwFunction, ModelID);
     // clang-format on
     return bReturn;
 }
@@ -511,12 +445,7 @@ uint CModelInfoSA::GetAnimFileIndex()
     DWORD dwThis = (DWORD)m_pInterface;
     uint  uiReturn = 0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     uiReturn, eax
-    }
+    uiReturn = gta_thiscall_address<decltype(uiReturn)>(dwFunc, dwThis);
     // clang-format on
     return uiReturn;
 }
@@ -976,13 +905,7 @@ CBoundingBox* CModelInfoSA::GetBoundingBox()
     DWORD         ModelID = m_dwModelID;
     CBoundingBox* dwReturn = 0;
     // clang-format off
-    __asm
-    {
-        push    ModelID
-        call    dwFunc
-        add     esp, 4
-        mov     dwReturn, eax
-    }
+    dwReturn = gta_call_address<decltype(dwReturn)>(dwFunc, ModelID);
     // clang-format on
     return dwReturn;
 }
@@ -1808,11 +1731,7 @@ void CModelInfoSA::RemoveRef(bool bRemoveExtraGTARef)
         if (pInterface && pInterface->usNumberOfRefs > 1)
         {
             DWORD dwFunction = FUNC_RemoveRef;
-            _asm
-            {
-                mov     ecx, pInterface
-                call    dwFunction
-            }
+            gta_thiscall_address(dwFunction, pInterface);
         }
     }
 
@@ -3484,11 +3403,7 @@ bool CModelInfoSA::ForceUnload()
     uint  uiLimit = 100;
     while (pInterface->usNumberOfRefs > 0 && uiLimit--)
     {
-        _asm
-        {
-            mov     ecx, pInterface
-            call    dwFunction
-        }
+        gta_thiscall_address(dwFunction, pInterface);
     }
 
     if (pInterface->usNumberOfRefs > 0 || pInterface->pRwObject != nullptr)

--- a/Client/game_sa/CObjectSA.cpp
+++ b/Client/game_sa/CObjectSA.cpp
@@ -94,14 +94,7 @@ CObjectSA::CObjectSA(DWORD dwModel, bool bBreakingDisabled)
     DWORD CObjectCreate = FUNC_CObject_Create;
     DWORD dwObjectPtr = 0;
     // clang-format off
-    __asm
-    {
-        push    1
-        push    dwModel
-        call    CObjectCreate
-        add     esp, 8
-        mov     dwObjectPtr, eax
-    }
+    dwObjectPtr = gta_call_address<decltype(dwObjectPtr)>(CObjectCreate, dwModel, 1);
     // clang-format on
 
     if (dwObjectPtr)
@@ -172,11 +165,7 @@ void CObjectSA::Explode()
     DWORD dwThis = (DWORD)GetInterface();
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis);
     // clang-format on
 }
 
@@ -188,16 +177,7 @@ void CObjectSA::Break()
     float fHitVelocity = 1000.0f;  // has no direct influence, but should be high enough to trigger the break (effect)
 
     // clang-format off
-    __asm
-    {
-        push    32h // most cases: between 30 and 37
-        push    0 // colliding entity. To ignore it, we can set it to 0
-        push    0B73710h // vecCollisionImpactVelocity
-        push    0 // vecCollisionLastPos
-        push    fHitVelocity
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, fHitVelocity, 0, 0x0B73710, 0, 0x32);
     // clang-format on
 
     if (IsGlass())
@@ -208,20 +188,7 @@ void CObjectSA::Break()
         dwFunc = FUNC_CGlass_WindowRespondsToCollision;
 
         // clang-format off
-        __asm
-        {
-            push 0
-            push fZ
-            push fY
-            push fX
-            push 0
-            push 0
-            push 0
-            push fHitVelocity
-            push dwThis
-            call dwFunc
-            add esp, 24h
-        }
+        gta_call_address(dwFunc, dwThis, fHitVelocity, 0, 0, 0, fX, fY, fZ, 0);
         // clang-format on
     }
 }
@@ -274,13 +241,7 @@ bool CObjectSA::IsGlass()
     bool  bResult;
 
     // clang-format off
-    __asm
-    {
-        push dwThis
-        call dwFunc
-        mov bResult, al
-        add esp, 4
-    }
+    bResult = gta_call_address<decltype(bResult)>(dwFunc, dwThis);
     // clang-format on
     return bResult;
 }

--- a/Client/game_sa/CPedDamageResponseCalculatorSA.cpp
+++ b/Client/game_sa/CPedDamageResponseCalculatorSA.cpp
@@ -24,16 +24,7 @@ CPedDamageResponseCalculatorSA::CPedDamageResponseCalculatorSA(CEntity* pEntity,
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CPedDamageResponseCalculator_Constructor;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    b_1
-        push    bodyPart
-        push    weaponType
-        push    fDamage
-        push    dwEntityInterface
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, dwEntityInterface, fDamage, weaponType, bodyPart, b_1);
     // clang-format on
 }
 
@@ -50,11 +41,7 @@ CPedDamageResponseCalculatorSA::~CPedDamageResponseCalculatorSA()
         DWORD dwThis = (DWORD)m_pInterface;
         DWORD dwFunc = FUNC_CPedDamageResponseCalculator_Destructor;
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwThis
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, dwThis);
         // clang-format on
         delete m_pInterface;
     }
@@ -67,13 +54,6 @@ void CPedDamageResponseCalculatorSA::ComputeDamageResponse(CPed* pPed, CPedDamag
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CPedDamageResponseCalculator_ComputeDamageResponse;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    bSpeak
-        push    dwResponseInterface
-        push    dwPedInterface
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, dwPedInterface, dwResponseInterface, bSpeak);
     // clang-format on
 }

--- a/Client/game_sa/CPedIntelligenceSA.cpp
+++ b/Client/game_sa/CPedIntelligenceSA.cpp
@@ -41,14 +41,7 @@ bool CPedIntelligenceSA::TestForStealthKill(CPed* pPed, bool bUnk)
     DWORD dwPed = (DWORD)pPed->GetInterface();
     DWORD dwFunc = FUNC_CPedIntelligence_TestForStealthKill;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    bUnk
-        push    dwPed
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThis, dwPed, bUnk);
     // clang-format on
     return bReturn;
 }

--- a/Client/game_sa/CPedModelInfoSA.cpp
+++ b/Client/game_sa/CPedModelInfoSA.cpp
@@ -30,11 +30,6 @@ void CPedModelInfoSA::SetMotionAnimGroup(AssocGroupId animGroup)
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = (DWORD)FUNC_SetMotionAnimGroup;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    animGroup
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, animGroup);
     // clang-format on
 }

--- a/Client/game_sa/CPedSoundSA.cpp
+++ b/Client/game_sa/CPedSoundSA.cpp
@@ -44,12 +44,7 @@ bool CPedSoundSA::IsSpeechDisabled()
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAEPedSound__IsSpeedDisabled;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThis);
     // clang-format on
     return bReturn;
 }
@@ -59,11 +54,7 @@ void CPedSoundSA::EnablePedSpeech()
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAEPedSound__EnablePedSpeech;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis);
     // clang-format on
 }
 
@@ -72,12 +63,7 @@ void CPedSoundSA::DisablePedSpeech(bool bStopCurrent)
     DWORD dwThis = (DWORD)m_pInterface;
     DWORD dwFunc = FUNC_CAEPedSound__DisablePedSpeech;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    bStopCurrent
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, bStopCurrent);
     // clang-format on
 }
 
@@ -87,13 +73,7 @@ short CPedSoundSA::GetVoiceTypeIDFromName(const char* szVoiceTypeName)
     short sVoiceTypeID;
 
     // clang-format off
-    __asm
-    {
-        push    szVoiceTypeName
-        call    dwFunc
-        add     esp, 4
-        mov     sVoiceTypeID, ax
-    }
+    sVoiceTypeID = gta_call_address<decltype(sVoiceTypeID)>(dwFunc, szVoiceTypeName);
     // clang-format on
     return sVoiceTypeID;
 }

--- a/Client/game_sa/CPhysicalSA.cpp
+++ b/Client/game_sa/CPhysicalSA.cpp
@@ -83,12 +83,7 @@ CVector* CPhysicalSA::GetMoveSpeedInternal(CVector* vecMoveSpeed)
     DWORD dwThis = (DWORD)((CPhysicalSAInterface*)GetInterface());
     DWORD dwReturn = 0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     dwReturn, eax
-    }
+    dwReturn = gta_thiscall_address<decltype(dwReturn)>(dwFunc, dwThis);
     // clang-format on
     MemCpyFast(vecMoveSpeed, (void*)dwReturn, sizeof(CVector));
     return vecMoveSpeed;
@@ -100,12 +95,7 @@ CVector* CPhysicalSA::GetTurnSpeedInternal(CVector* vecTurnSpeed)
     DWORD dwThis = (DWORD)((CPhysicalSAInterface*)GetInterface());
     DWORD dwReturn = 0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     dwReturn, eax
-    }
+    dwReturn = gta_thiscall_address<decltype(dwReturn)>(dwFunc, dwThis);
     // clang-format on
     MemCpyFast(vecTurnSpeed, (void*)dwReturn, sizeof(CVector));
     return vecTurnSpeed;
@@ -118,12 +108,7 @@ void CPhysicalSA::SetMoveSpeed(const CVector& vecMoveSpeed) noexcept
     DWORD dwReturn = 0;
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     dwReturn, eax
-    }
+    dwReturn = gta_thiscall_address<decltype(dwReturn)>(dwFunc, dwThis);
     // clang-format on
     MemCpyFast((void*)dwReturn, &vecMoveSpeed, sizeof(CVector));
 
@@ -211,11 +196,7 @@ void CPhysicalSA::ProcessCollision()
     DWORD dwThis = (DWORD)GetInterface();
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis);
     // clang-format on
 }
 
@@ -225,11 +206,7 @@ void CPhysicalSA::AddToMovingList()
     DWORD dwThis = (DWORD)GetInterface();
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis);
     // clang-format on
 }
 
@@ -300,15 +277,7 @@ void CPhysicalSA::DetachEntityFromEntity(float fUnkX, float fUnkY, float fUnkZ, 
         return;
 
     // clang-format off
-    __asm
-    {
-        push    bUnk
-        push    fUnkZ
-        push    fUnkY
-        push    fUnkX
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, fUnkX, fUnkY, fUnkZ, bUnk);
     // clang-format on
 }
 

--- a/Client/game_sa/CPickupSA.cpp
+++ b/Client/game_sa/CPickupSA.cpp
@@ -127,13 +127,7 @@ bool CPickupSA::GiveUsAPickUpObject(int ForcedObjectIndex)
     DWORD dwObject = (DWORD) & (GetInterface()->pObject);
     DWORD dwThis = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        push    ForcedObjectIndex
-        push    dwObject
-        mov     ecx, dwThis
-        call    GiveUsAPickUpObject
-    }
+    gta_thiscall_address(GiveUsAPickUpObject, dwThis, dwObject, ForcedObjectIndex);
     // clang-format on
 
     if (GetInterface()->pObject)
@@ -169,11 +163,7 @@ void CPickupSA::Remove()
     DWORD dwFunc = FUNC_CPickup_Remove;
     DWORD dwThis = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis);
     // clang-format on
 
     // CPickup::Remove also destroys the owned object, so we need to delete our CObjectSA class

--- a/Client/game_sa/CPlayerPedSA.cpp
+++ b/Client/game_sa/CPlayerPedSA.cpp
@@ -165,12 +165,7 @@ void CPlayerPedSA::SetInitialState()
     DWORD dwFunction = FUNC_SetInitialState;
     DWORD dwThis = (DWORD)m_pInterface;
     // clang-format off
-    __asm
-    {
-        push    dwUnknown
-        mov     ecx, dwThis
-        call    dwFunction
-    }
+    gta_thiscall_address(dwFunction, dwThis, dwUnknown);
     // clang-format on
 
     // Avoid direction locks for respawning after a jump
@@ -298,11 +293,7 @@ void CPlayerPedSA::SetMoveAnim(eMoveAnim iAnimGroup)
     DWORD dwThis = (DWORD)pedInterface;
     DWORD dwFunc = FUNC_CPlayerPed_ReApplyMoveAnims;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis);
     // clang-format on
 }
 

--- a/Client/game_sa/CPointLightsSA.cpp
+++ b/Client/game_sa/CPointLightsSA.cpp
@@ -32,25 +32,7 @@ void CPointLightsSA::AddLight(int iMode, const CVector vecPosition, CVector vecD
     float fDirX = vecDirection.fX, fDirY = vecDirection.fY, fDirZ = vecDirection.fZ;
     float fRed = (float)color.R / 255, fGreen = (float)color.G / 255, fBlue = (float)color.B / 255;
     // clang-format off
-    __asm
-    {
-        push    dwEntityInterface
-        push    bCreatesShadow
-        push    uc_8
-        push    fBlue
-        push    fGreen
-        push    fRed
-        push    fRadius
-        push    fDirZ
-        push    fDirY
-        push    fDirX
-        push    fPosZ
-        push    fPosY
-        push    fPosX
-        push    iMode
-        call    dwFunc
-        add     esp, 56
-    }
+    gta_call_address(dwFunc, iMode, fPosX, fPosY, fPosZ, fDirX, fDirY, fDirZ, fRadius, fRed, fGreen, fBlue, uc_8, bCreatesShadow, dwEntityInterface);
     // clang-format on
 }
 

--- a/Client/game_sa/CProjectileInfoSA.cpp
+++ b/Client/game_sa/CProjectileInfoSA.cpp
@@ -50,25 +50,14 @@ void CProjectileInfoSA::RemoveProjectile(CProjectileInfo* pProjectileInfo, CProj
             {
                 DWORD dwFunc = FUNC_RemoveProjectile;
                 // clang-format off
-                __asm
-                {
-                    push    projectileInterface
-                    push    projectileInfoInterface
-                    call    dwFunc
-                    add     esp, 8
-                }
+                gta_call_address(dwFunc, projectileInfoInterface, projectileInterface);
                 // clang-format on
             }
             else
             {
                 DWORD dwFunc = FUNC_RemoveIfThisIsAProjectile;
                 // clang-format off
-                __asm
-                {
-                    push   projectileInterface
-                    call   dwFunc
-                    add    esp, 4
-                }
+                gta_call_address(dwFunc, projectileInterface);
                 // clang-format on
             }
         }

--- a/Client/game_sa/CRopesSA.cpp
+++ b/Client/game_sa/CRopesSA.cpp
@@ -24,13 +24,7 @@ int CRopesSA::CreateRopeForSwatPed(const CVector& vecPosition, DWORD dwDuration)
     // First Push @ 0x558D1D is the duration.
     MemPut((void*)(dwDurationAddress), dwDuration);
     // clang-format off
-    __asm
-    {
-        push    pvecPosition
-        call    dwFunc
-        add     esp, 0x4
-        mov     iReturn, eax
-    }
+    iReturn = gta_call_address<decltype(iReturn)>(dwFunc, pvecPosition);
     // clang-format on
     //   Set it back for SA in case we ever do some other implementation.
     MemPut((DWORD*)(dwDurationAddress), 4000);

--- a/Client/game_sa/CSettingsSA.cpp
+++ b/Client/game_sa/CSettingsSA.cpp
@@ -247,12 +247,7 @@ void CSettingsSA::SetAntiAliasing(unsigned int uiAntiAliasing, bool bOnRestart)
     {
         DWORD dwFunc = FUNC_SetAntiAliasing;
         // clang-format off
-        __asm
-        {
-            push    uiAntiAliasing
-            call    dwFunc
-            add     esp, 4
-        }
+        gta_call_address(dwFunc, uiAntiAliasing);
         // clang-format on
         SetCurrentVideoMode(m_pInterface->dwVideoMode, false);
     }
@@ -273,12 +268,7 @@ void CSettingsSA::SetMipMappingEnabled(bool bEnable)
 void CSettingsSA::Save()
 {
     // clang-format off
-    __asm
-    {
-        mov ecx, CLASS_CMenuManager
-        mov eax, FUNC_CMenuManager_Save
-        call eax
-    }
+    gta_thiscall_address(0x57C660, 0xBA6748);
     // clang-format on
 }
 

--- a/Client/game_sa/CStatsSA.cpp
+++ b/Client/game_sa/CStatsSA.cpp
@@ -19,13 +19,7 @@ float CStatsSA::GetStatValue(unsigned short usIndex)
     DWORD dwStatIndex = usIndex;
 
     // clang-format off
-    __asm
-    {
-        push    dwStatIndex
-        call    dwFunc
-        add     esp, 4
-        fstp    fReturn
-    }
+    fReturn = gta_call_address<decltype(fReturn)>(dwFunc, dwStatIndex);
     // clang-format on
     return fReturn;
 }
@@ -36,13 +30,7 @@ void CStatsSA::ModifyStat(unsigned short usIndex, float fAmmount)
     DWORD dwStatIndex = usIndex;
 
     // clang-format off
-    __asm
-    {
-        push    fAmmount
-        push    dwStatIndex
-        call    dwFunc
-        add     esp, 8
-    }
+    gta_call_address(dwFunc, dwStatIndex, fAmmount);
     // clang-format on
 }
 
@@ -52,13 +40,7 @@ void CStatsSA::SetStatValue(unsigned short usIndex, float fAmmount)
     DWORD dwStatIndex = usIndex;
 
     // clang-format off
-    __asm
-    {
-        push    fAmmount
-        push    dwStatIndex
-        call    dwFunc
-        add     esp, 8
-    }
+    gta_call_address(dwFunc, dwStatIndex, fAmmount);
     // clang-format on
 }
 
@@ -68,13 +50,7 @@ unsigned short CStatsSA::GetSkillStatIndex(eWeaponType type)
     int   iIndex;
     DWORD dwFunc = FUNC_CWeaponInfo_GetSkillStatIndex;
     // clang-format off
-    __asm
-    {
-        push    weaponType
-        call    dwFunc
-        add     esp, 0x4
-        mov     iIndex, eax
-    }
+    iIndex = gta_call_address<decltype(iIndex)>(dwFunc, weaponType);
     // clang-format on
     return (unsigned short)iIndex;
 }

--- a/Client/game_sa/CStreamingSA.cpp
+++ b/Client/game_sa/CStreamingSA.cpp
@@ -474,13 +474,7 @@ void CStreamingSA::RequestModel(DWORD dwModelID, DWORD dwFlags)
     {
         DWORD dwFunc = FUNC_RequestVehicleUpgrade;
         // clang-format off
-        __asm
-        {
-            push    dwFlags
-            push    dwModelID
-            call    dwFunc
-            add     esp, 8
-        }
+        gta_call_address(dwFunc, dwModelID, dwFlags);
         // clang-format on
     }
     else
@@ -516,13 +510,7 @@ void CStreamingSA::RequestModel(DWORD dwModelID, DWORD dwFlags)
 
         DWORD dwFunction = FUNC_CStreaming__RequestModel;
         // clang-format off
-        __asm
-        {
-            push    dwFlags
-            push    dwModelID
-            call    dwFunction
-            add     esp, 8
-        }
+        gta_call_address(dwFunction, dwModelID, dwFlags);
         // clang-format on
     }
 }
@@ -547,12 +535,7 @@ void CStreamingSA::LoadAllRequestedModels(bool bOnlyPriorityModels, const char* 
     DWORD dwFunction = FUNC_LoadAllRequestedModels;
     DWORD dwOnlyPriorityModels = bOnlyPriorityModels;
     // clang-format off
-    __asm
-    {
-        push    dwOnlyPriorityModels
-        call    dwFunction
-        add     esp, 4
-    }
+    gta_call_address(dwFunction, dwOnlyPriorityModels);
     // clang-format on
 
     if (IS_TIMING_CHECKPOINTS())
@@ -570,13 +553,7 @@ bool CStreamingSA::HasModelLoaded(DWORD dwModelID)
         bool  bReturn;
         DWORD dwFunc = FUNC_CStreaming__HasVehicleUpgradeLoaded;
         // clang-format off
-        __asm
-        {
-            push    dwModelID
-            call    dwFunc
-            add     esp, 0x4
-            mov     bReturn, al
-        }
+        bReturn = gta_call_address<decltype(bReturn)>(dwFunc, dwModelID);
         // clang-format on
         return bReturn;
     }
@@ -602,14 +579,7 @@ void CStreamingSA::RequestSpecialModel(DWORD model, const char* szTexture, DWORD
 {
     DWORD dwFunc = FUNC_CStreaming_RequestSpecialModel;
     // clang-format off
-    __asm
-    {
-        push    channel
-        push    szTexture
-        push    model
-        call    dwFunc
-        add     esp, 0xC
-    }
+    gta_call_address(dwFunc, model, szTexture, channel);
     // clang-format on
 }
 

--- a/Client/game_sa/CTaskManagementSystemSA.cpp
+++ b/Client/game_sa/CTaskManagementSystemSA.cpp
@@ -139,12 +139,7 @@ CTaskSA* CTaskManagementSystemSA::GetTask(CTaskSAInterface* pTaskInterface)
     if (dwFunc && dwFunc != 0x82263A)
     {
         // clang-format off
-        __asm
-        {
-            mov     ecx, pTaskInterface
-            call    dwFunc
-            mov     iTaskType, eax
-        }
+        iTaskType = gta_thiscall_address<decltype(iTaskType)>(dwFunc, pTaskInterface);
         // clang-format on
     }
 

--- a/Client/game_sa/CTaskManagerSA.cpp
+++ b/Client/game_sa/CTaskManagerSA.cpp
@@ -66,12 +66,7 @@ CTask* CTaskManagerSA::GetActiveTask()
     DWORD dwReturn = 0;
     DWORD dwThis = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     dwReturn, eax
-    }
+    dwReturn = gta_thiscall_address<decltype(dwReturn)>(dwFunc, dwThis);
     // clang-format on
 
     CTaskSAInterface* pActiveTask = (CTaskSAInterface*)dwReturn;
@@ -88,16 +83,13 @@ CTask* CTaskManagerSA::GetSimplestActiveTask()
     DWORD dwThis = (DWORD)GetInterface();
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     dwReturn, eax
-    }
+    dwReturn = gta_thiscall_address<decltype(dwReturn)>(dwFunc, dwThis);
     // clang-format on
 
-    if (dwReturn) return m_pTaskManagementSystem->GetTask((CTaskSAInterface*)dwReturn);
-    else return NULL;
+    if (dwReturn)
+        return m_pTaskManagementSystem->GetTask((CTaskSAInterface*)dwReturn);
+    else
+        return NULL;
 }
 
 CTask* CTaskManagerSA::GetSimplestTask(const int iPriority)
@@ -106,17 +98,13 @@ CTask* CTaskManagerSA::GetSimplestTask(const int iPriority)
     DWORD dwReturn = 0;
     DWORD dwThis = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    iPriority
-        call    dwFunc
-        mov     dwReturn, eax
-    }
+    dwReturn = gta_thiscall_address<decltype(dwReturn)>(dwFunc, dwThis, iPriority);
     // clang-format on
 
-    if (dwReturn) return m_pTaskManagementSystem->GetTask((CTaskSAInterface*)dwReturn);
-    else return NULL;
+    if (dwReturn)
+        return m_pTaskManagementSystem->GetTask((CTaskSAInterface*)dwReturn);
+    else
+        return NULL;
 }
 
 CTask* CTaskManagerSA::FindActiveTaskByType(const int iTaskType)
@@ -125,17 +113,13 @@ CTask* CTaskManagerSA::FindActiveTaskByType(const int iTaskType)
     DWORD dwReturn = 0;
     DWORD dwThis = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    iTaskType
-        call    dwFunc
-        mov     dwReturn, eax
-    }
+    dwReturn = gta_thiscall_address<decltype(dwReturn)>(dwFunc, dwThis, iTaskType);
     // clang-format on
 
-    if (dwReturn) return m_pTaskManagementSystem->GetTask((CTaskSAInterface*)dwReturn);
-    else return NULL;
+    if (dwReturn)
+        return m_pTaskManagementSystem->GetTask((CTaskSAInterface*)dwReturn);
+    else
+        return NULL;
 }
 
 CTask* CTaskManagerSA::FindTaskByType(const int iPriority, const int iTaskType)
@@ -144,18 +128,13 @@ CTask* CTaskManagerSA::FindTaskByType(const int iPriority, const int iTaskType)
     DWORD dwReturn = 0;
     DWORD dwThis = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    iTaskType
-        push    iPriority
-        call    dwFunc
-        mov     dwReturn, eax
-    }
+    dwReturn = gta_thiscall_address<decltype(dwReturn)>(dwFunc, dwThis, iPriority, iTaskType);
     // clang-format on
 
-    if (dwReturn) return m_pTaskManagementSystem->GetTask((CTaskSAInterface*)dwReturn);
-    else return NULL;
+    if (dwReturn)
+        return m_pTaskManagementSystem->GetTask((CTaskSAInterface*)dwReturn);
+    else
+        return NULL;
 }
 
 void CTaskManagerSA::RemoveTaskSecondary(const int iTaskPriority)
@@ -183,13 +162,7 @@ void CTaskManagerSA::SetTaskSecondary(CTaskSA* pTaskSecondary, const int iType)
         taskInterface = pTaskSecondary->GetInterface();
     DWORD dwInterface = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        push    iType
-        push    taskInterface
-        mov     ecx, dwInterface
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwInterface, taskInterface, iType);
     // clang-format on
 }
 
@@ -209,12 +182,7 @@ bool CTaskManagerSA::HasTaskSecondary(const CTask* pTaskSecondary)
     DWORD dwFunc = FUNC_HasTaskSecondary;
     bool  bReturn = false;
     // clang-format off
-    __asm
-    {
-        push    pTaskSecondary
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_call_address<decltype(bReturn)>(dwFunc, pTaskSecondary);
     // clang-format on
     return bReturn;
 }
@@ -223,10 +191,7 @@ void CTaskManagerSA::ClearTaskEventResponse()
 {
     DWORD dwFunc = FUNC_ClearTaskEventResponse;
     // clang-format off
-    __asm
-    {
-        call    dwFunc
-    }
+    gta_call_address(dwFunc);
     // clang-format on
 }
 

--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -388,11 +388,7 @@ CVehicleSA::~CVehicleSA()
             DWORD dwThis = (DWORD)m_pInterface;
             DWORD dwFunc = 0x6D2460;  // CVehicle::ExtinguishCarFire
             // clang-format off
-            __asm
-            {
-                mov     ecx, dwThis
-                call    dwFunc
-            }
+            gta_thiscall_address(dwFunc, dwThis);
             // clang-format on
 
             CWorldSA* pWorld = (CWorldSA*)pGame->GetWorld();
@@ -413,12 +409,7 @@ void CVehicleSA::SetMoveSpeed(const CVector& vecMoveSpeed) noexcept
     DWORD dwThis = (DWORD)GetInterface();
     DWORD dwReturn = 0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     dwReturn, eax
-    }
+    dwReturn = gta_thiscall_address<decltype(dwReturn)>(dwFunc, dwThis);
     // clang-format on
     MemCpyFast((void*)dwReturn, &vecMoveSpeed, sizeof(CVector));
 
@@ -629,11 +620,7 @@ void CVehicleSA::SetDerailed(bool bDerailed)
                 // Recalculate the on-rail distance from the start node (train position parameter, m_fTrainRailDistance)
                 DWORD dwFunc = FUNC_CTrain_FindPositionOnTrackFromCoors;
                 // clang-format off
-                __asm
-                {
-                    mov     ecx, dwThis
-                        call    dwFunc
-                }
+                gta_thiscall_address(dwFunc, dwThis);
                 // clang-format on
 
                 // Reset the speed
@@ -752,11 +739,7 @@ void CVehicleSA::SetRailTrack(BYTE ucTrackID)
         {
             DWORD dwFunc = FUNC_CTrain_FindPositionOnTrackFromCoors;
             // clang-format off
-            __asm
-            {
-                mov ecx, pInterf
-                call dwFunc
-            }
+            gta_thiscall_address(dwFunc, pInterf);
             // clang-format on
         }
     }
@@ -778,11 +761,7 @@ void CVehicleSA::SetTrainPosition(float fPosition, bool bRecalcOnRailDistance)
         {
             DWORD dwFunc = FUNC_CTrain_FindPositionOnTrackFromCoors;
             // clang-format off
-            __asm
-            {
-                mov ecx, pInterface
-                call dwFunc
-            }
+            gta_thiscall_address(dwFunc, pInterface);
             // clang-format on
         }
     }
@@ -847,12 +826,7 @@ void CVehicleSA::AddVehicleUpgrade(DWORD dwModelID)
 
         DWORD dwFunc = FUNC_CVehicle_AddVehicleUpgrade;
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwThis
-            push    dwModelID
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, dwThis, dwModelID);
         // clang-format on
     }
 }
@@ -863,12 +837,7 @@ void CVehicleSA::RemoveVehicleUpgrade(DWORD dwModelID)
     DWORD dwFunc = FUNC_CVehicle_RemoveVehicleUpgrade;
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    dwModelID
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, dwModelID);
     // clang-format on
 
     // GTA SA only does this when CVehicle::ClearVehicleUpgradeFlags returns false.
@@ -902,13 +871,7 @@ DWORD CVehicleSA::GetBaseVehicleType()
     DWORD dwReturn = 0;
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     dwReturn, eax
-
-    }
+    dwReturn = gta_thiscall_address<decltype(dwReturn)>(dwFunc, dwThis);
     // clang-format on
 
     return dwReturn;
@@ -951,12 +914,7 @@ bool CVehicleSA::IsUpsideDown()
     bool  bReturn = false;
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThis);
     // clang-format on
 
     return bReturn;
@@ -969,12 +927,7 @@ void CVehicleSA::SetEngineOn(bool bEngineOn)
     DWORD dwFunc = FUNC_CVehicle_SetEngineOn;
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    dwEngineOn
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, dwEngineOn);
     // clang-format on
 }
 
@@ -1028,11 +981,7 @@ void CVehicleSA::PlaceBikeOnRoadProperly()
     DWORD dwBike = (DWORD)GetInterface();
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwBike
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwBike);
     // clang-format on
 }
 
@@ -1042,11 +991,7 @@ void CVehicleSA::PlaceAutomobileOnRoadProperly()
     DWORD dwAutomobile = (DWORD)GetInterface();
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwAutomobile
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwAutomobile);
     // clang-format on
 }
 
@@ -1233,11 +1178,7 @@ void CVehicleSA::Fix()
         if (dwFunc)
         {
             // clang-format off
-            __asm
-            {
-                mov     ecx, dwThis
-                call    dwFunc
-            }
+            gta_thiscall_address(dwFunc, dwThis);
             // clang-format on
         }
     }
@@ -1334,12 +1275,7 @@ void CVehicleSA::PickupEntityWithWinch(CEntity* pEntity)
         DWORD dwEntityInterface = (DWORD)pEntitySA->GetInterface();
 
         // clang-format off
-        __asm
-        {
-            push    dwEntityInterface
-            mov     ecx, dwThis
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, dwThis, dwEntityInterface);
         // clang-format on
     }
 }
@@ -1350,11 +1286,7 @@ void CVehicleSA::ReleasePickedUpEntityWithWinch()
     DWORD dwThis = (DWORD)GetInterface();
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis);
     // clang-format on
 }
 
@@ -1364,12 +1296,7 @@ void CVehicleSA::SetRopeHeightForHeli(float fRopeHeight)
     DWORD dwThis = (DWORD)GetInterface();
 
     // clang-format off
-    __asm
-    {
-        push    fRopeHeight
-        mov     ecx, dwThis
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, fRopeHeight);
     // clang-format on
 }
 
@@ -1380,12 +1307,7 @@ CPhysical* CVehicleSA::QueryPickedUpEntityWithWinch()
 
     CPhysicalSAInterface* phys;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     phys, eax
-    }
+    phys = gta_thiscall_address<decltype(phys)>(dwFunc, dwThis);
     // clang-format on
 
     if (phys)
@@ -1401,12 +1323,7 @@ void CVehicleSA::SetRemap(int iRemap)
     DWORD dwFunc = FUNC_CVehicle__SetRemap;
     DWORD dwThis = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    iRemap
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, iRemap);
     // clang-format on
 }
 
@@ -1416,12 +1333,7 @@ int CVehicleSA::GetRemapIndex()
     DWORD dwThis = (DWORD)GetInterface();
     int   iReturn = 0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     iReturn, eax
-    }
+    iReturn = gta_thiscall_address<decltype(iReturn)>(dwFunc, dwThis);
     // clang-format on
     return iReturn;
 }
@@ -1431,12 +1343,7 @@ void CVehicleSA::SetRemapTexDictionary(int iRemapTextureDictionary)
     DWORD dwFunc = FUNC_CVehicle__SetRemapTexDictionary;
     DWORD dwThis = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    iRemapTextureDictionary
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, iRemapTextureDictionary);
     // clang-format on
 }
 
@@ -1603,12 +1510,7 @@ void CVehicleSA::SetTaxiLightOn(bool bLightOn)
     DWORD dwFunc = FUNC_CAutomobile_SetTaxiLight;
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    dwState
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, dwState);
     // clang-format on
 }
 
@@ -1866,13 +1768,7 @@ bool CVehicleSA::UpdateMovingCollision(float fAngle)
     DWORD dwThis = (DWORD)GetInterface();
     DWORD dwFunc = FUNC_CAutomobile__UpdateMovingCollision;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    fAngle
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThis, fAngle);
     // clang-format on
 
     // Restore our driver
@@ -2098,15 +1994,7 @@ namespace
         {
             DWORD dwFunc = FUNC_CMatrix__ConvertFromEulerAngles;
             // clang-format off
-            __asm
-            {
-                push    iUnknown
-                push    fZ
-                push    fY
-                push    fX
-                mov     ecx, matrixPadded
-                call    dwFunc
-            }
+            gta_thiscall_address(dwFunc, matrixPadded, fX, fY, fZ, iUnknown);
             // clang-format on
         }
     }
@@ -2117,15 +2005,7 @@ namespace
         {
             DWORD dwFunc = FUNC_CMatrix__ConvertToEulerAngles;
             // clang-format off
-            __asm
-            {
-                push    iUnknown
-                push    fZ
-                push    fY
-                push    fX
-                mov     ecx, matrixPadded
-                call    dwFunc
-            }
+            gta_thiscall_address(dwFunc, matrixPadded, fX, fY, fZ, iUnknown);
             // clang-format on
         }
     }
@@ -2586,13 +2466,7 @@ bool CVehicleSA::SetPlateText(const SString& strText)
     DWORD dwFunc = FUNC_CVehicle_CustomCarPlate_TextureCreate;
     bool  bReturn = false;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    pVehicleModelInfo
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThis, pVehicleModelInfo);
     // clang-format on
     return bReturn;
 }
@@ -2617,13 +2491,7 @@ bool CVehicleSA::SetWindowOpenFlagState(unsigned char ucWindow, bool bState)
     bool bReturn = false;
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    ucWindow
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThis, ucWindow);
     // clang-format on
     return bReturn;
 }

--- a/Client/game_sa/CVisibilityPluginsSA.cpp
+++ b/Client/game_sa/CVisibilityPluginsSA.cpp
@@ -18,13 +18,7 @@ void CVisibilityPluginsSA::SetClumpAlpha(RpClump* pClump, int iAlpha)
 {
     DWORD dwFunc = FUNC_CVisiblityPlugins_SetClumpAlpha;
     // clang-format off
-    __asm
-    {
-        push    iAlpha
-        push    pClump
-        call    dwFunc
-        add     esp, 0x8
-    }
+    gta_call_address(dwFunc, pClump, iAlpha);
     // clang-format on
 }
 
@@ -47,13 +41,7 @@ int CVisibilityPluginsSA::GetAtomicId(RwObject* pAtomic)
     DWORD dwFunc = FUNC_CVisibilityPlugins_GetAtomicId;
     int   iResult = 0;
     // clang-format off
-    __asm
-    {
-        push    pAtomic
-        call    dwFunc
-        add     esp, 0x4
-        mov     iResult, eax
-    }
+    iResult = gta_call_address<decltype(iResult)>(dwFunc, pAtomic);
     // clang-format on
     return iResult;
 }

--- a/Client/game_sa/CWantedSA.cpp
+++ b/Client/game_sa/CWantedSA.cpp
@@ -43,12 +43,7 @@ void CWantedSA::SetWantedLevel(DWORD dwWantedLevel)
     DWORD dwThis = (DWORD)GetInterface();
     DWORD dwFunc = FUNC_SetWantedLevel;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        push    dwWantedLevel
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThis, dwWantedLevel);
     // clang-format on
 }
 void CWantedSA::SetWantedLevelNoFlash(DWORD dwWantedLevel)

--- a/Client/game_sa/CWorldSA.cpp
+++ b/Client/game_sa/CWorldSA.cpp
@@ -149,12 +149,7 @@ void CWorldSA::Add(CEntity* pEntity, eDebugCaller CallerId)
         DWORD dwEntity = (DWORD)pEntitySA->GetInterface();
         DWORD dwFunction = FUNC_Add;
         // clang-format off
-        __asm
-        {
-            push    dwEntity
-            call    dwFunction
-            add     esp, 4
-        }
+        gta_call_address(dwFunction, dwEntity);
         // clang-format on
     }
 }
@@ -168,12 +163,7 @@ void CWorldSA::Add(CEntitySAInterface* entityInterface, eDebugCaller CallerId)
         LogEvent(506, "CWorld::Add ( CEntitySAInterface * ) Crash", "", strMessage);
     }
     // clang-format off
-    __asm
-    {
-        push    entityInterface
-        call    dwFunction
-        add     esp, 4
-    }
+    gta_call_address(dwFunction, entityInterface);
     // clang-format on
 }
 
@@ -192,12 +182,7 @@ void CWorldSA::Remove(CEntity* pEntity, eDebugCaller CallerId)
         DWORD dwEntity = (DWORD)pInterface;
         DWORD dwFunction = FUNC_Remove;
         // clang-format off
-        __asm
-        {
-            push    dwEntity
-            call    dwFunction
-            add     esp, 4
-        }
+        gta_call_address(dwFunction, dwEntity);
         // clang-format on
     }
 }
@@ -211,17 +196,7 @@ void CWorldSA::Remove(CEntitySAInterface* entityInterface, eDebugCaller CallerId
     }
     DWORD dwFunction = FUNC_Remove;
     // clang-format off
-    __asm
-    {
-        push    entityInterface
-        call    dwFunction
-        add     esp, 4
-
-    /*  mov     ecx, entityInterface
-        mov     esi, [ecx]
-        push    1
-        call    dword ptr [esi+8]*/
-    }
+    gta_call_address(dwFunction, entityInterface);
     // clang-format on
 }
 
@@ -230,12 +205,7 @@ void CWorldSA::RemoveReferencesToDeletedObject(CEntitySAInterface* entity)
     DWORD dwFunc = FUNC_RemoveReferencesToDeletedObject;
     DWORD dwEntity = (DWORD)entity;
     // clang-format off
-    __asm
-    {
-        push    dwEntity
-        call    dwFunc
-        add     esp, 4
-    }
+    gta_call_address(dwFunc, dwEntity);
     // clang-format on
 }
 
@@ -253,15 +223,7 @@ void ConvertMatrixToEulerAngles(const CMatrix_Padded& matrixPadded, float& fX, f
     float* pfZ = &fZ;
     int    iUnknown = 21;
     // clang-format off
-    __asm
-    {
-        push    iUnknown
-            push    pfZ
-            push    pfY
-            push    pfX
-            mov     ecx, pMatrixPadded
-            call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, pMatrixPadded, pfX, pfY, pfZ, iUnknown);
     // clang-format on
 }
 
@@ -615,17 +577,7 @@ float CWorldSA::FindGroundZFor3DPosition(CVector* vecPosition)
     float fY = vecPosition->fY;
     float fZ = vecPosition->fZ;
     // clang-format off
-    __asm
-    {
-        push    0
-        push    0
-        push    fZ
-        push    fY
-        push    fX
-        call    dwFunc
-        fstp    fReturn
-        add     esp, 0x14
-    }
+    fReturn = gta_call_address<decltype(fReturn)>(dwFunc, fX, fY, fZ, 0, 0);
     // clang-format on
     return fReturn;
 }
@@ -669,14 +621,7 @@ bool CWorldSA::HasCollisionBeenLoaded(CVector* vecPosition)
     DWORD dwFunc = FUNC_HasCollisionBeenLoaded;
     bool  bRet = false;
     // clang-format off
-    __asm
-    {
-        push    0
-        push    vecPosition
-        call    dwFunc
-        mov     bRet, al
-        add     esp, 8
-    }
+    bRet = gta_call_address<decltype(bRet)>(dwFunc, vecPosition, 0);
     // clang-format on
     return bRet;
 }
@@ -692,12 +637,7 @@ void CWorldSA::SetCurrentArea(DWORD dwArea)
 
     DWORD dwFunc = FUNC_RemoveBuildingsNotInArea;
     // clang-format off
-    __asm
-    {
-        push    dwArea
-        call    dwFunc
-        add     esp, 4
-    }
+    gta_call_address(dwFunc, dwArea);
     // clang-format on
 }
 
@@ -758,14 +698,7 @@ void CWorldSA::FindWorldPositionForRailTrackPosition(float fRailTrackPosition, i
     DWORD dwFunc = FUNC_CWorld_FindPositionForTrackPosition;  // __cdecl
 
     // clang-format off
-    __asm
-    {
-        push pOutVecPosition
-        push iTrackId
-        push fRailTrackPosition
-        call dwFunc
-        add  esp, 3*4
-    }
+    gta_call_address(dwFunc, fRailTrackPosition, iTrackId, pOutVecPosition);
     // clang-format on
 }
 

--- a/Client/game_sa/TaskAttackSA.cpp
+++ b/Client/game_sa/TaskAttackSA.cpp
@@ -24,17 +24,7 @@ CTaskSimpleGangDriveBySA::CTaskSimpleGangDriveBySA(CEntity* pTargetEntity, const
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwTargetEntity = (pTargetEntity) ? (DWORD)pTargetEntity->GetInterface() : 0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    bSeatRHS
-        push    nDrivebyStyle
-        push    FrequencyPercentage
-        push    fAbortRange
-        push    pVecTarget
-        push    dwTargetEntity
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, dwTargetEntity, pVecTarget, fAbortRange, FrequencyPercentage, nDrivebyStyle, bSeatRHS);
     // clang-format on
 }
 
@@ -49,18 +39,7 @@ CTaskSimpleUseGunSA::CTaskSimpleUseGunSA(CEntity* pTargetEntity, CVector vecTarg
     float fTargetX = vecTarget.fX, fTargetY = vecTarget.fY, fTargetZ = vecTarget.fZ;
     DWORD dwBurstLength = nBurstLength;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    bAimImmediate
-        push    dwBurstLength
-        push    nCommand
-        push    fTargetZ
-        push    fTargetY
-        push    fTargetX
-        push    dwTargetEntity
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, dwTargetEntity, fTargetX, fTargetY, fTargetZ, nCommand, dwBurstLength, bAimImmediate);
     // clang-format on
 }
 
@@ -78,13 +57,7 @@ bool CTaskSimpleUseGunSA::SetPedPosition(CPed* pPed)
     BYTE currentWeaponSlot = dwPedInterface->bCurrentWeaponSlot;
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    dwPedInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThisInterface, dwPedInterface);
     // clang-format on
     return bReturn;
 }
@@ -95,13 +68,7 @@ void CTaskSimpleUseGunSA::FireGun(CPed* pPed, bool bFlag)
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    bFlag
-        push    dwPedInterface
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, dwPedInterface, bFlag);
     // clang-format on
 }
 
@@ -113,15 +80,7 @@ bool CTaskSimpleUseGunSA::ControlGun(CPed* pPed, CEntity* pTargetEntity, char nC
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
     DWORD dwTargetEntity = (pTargetEntity) ? (DWORD)pTargetEntity->GetInterface() : 0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    nCommand
-        push    dwTargetEntity
-        push    dwPedInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThisInterface, dwPedInterface, dwTargetEntity, nCommand);
     // clang-format on
     return bReturn;
 }
@@ -132,13 +91,7 @@ bool CTaskSimpleUseGunSA::ControlGunMove(CVector2D* pMoveVec)
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_ControlGunMove;
     DWORD dwThisInterface = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    pMoveVec
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThisInterface, pMoveVec);
     // clang-format on
     return bReturn;
 }
@@ -152,18 +105,7 @@ void CTaskSimpleUseGunSA::Reset(CPed* pPed, CEntity* pTargetEntity, CVector vecT
     float fTargetX = vecTarget.fX, fTargetY = vecTarget.fY, fTargetZ = vecTarget.fZ;
     DWORD dwBurstLength = nBurstLength;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    dwBurstLength
-        push    nCommand
-        push    fTargetZ
-        push    fTargetY
-        push    fTargetX
-        push    dwTargetEntity
-        push    dwPedInterface
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, dwPedInterface, dwTargetEntity, fTargetX, fTargetY, fTargetZ, nCommand, dwBurstLength);
     // clang-format on
 }
 
@@ -173,12 +115,7 @@ int CTaskSimpleUseGunSA::GetTaskType()
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_GetTaskType;
     DWORD dwThisInterface = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-        mov     iReturn, eax
-    }
+    iReturn = gta_thiscall_address<decltype(iReturn)>(dwFunc, dwThisInterface);
     // clang-format on
     return iReturn;
 }
@@ -192,15 +129,7 @@ bool CTaskSimpleUseGunSA::MakeAbortable(CPed* pPed, int iPriority, CEvent const*
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    pEvent
-        push    iPriority
-        push    dwPedInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThisInterface, dwPedInterface, iPriority, pEvent);
     // clang-format on
     return bReturn;
 }
@@ -212,13 +141,7 @@ bool CTaskSimpleUseGunSA::ProcessPed(CPed* pPed)
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    dwPedInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThisInterface, dwPedInterface);
     // clang-format on
     return bReturn;
 }
@@ -229,12 +152,7 @@ void CTaskSimpleUseGunSA::AbortIK(CPed* pPed)
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    dwPedInterface
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, dwPedInterface);
     // clang-format on
 }
 
@@ -244,12 +162,7 @@ void CTaskSimpleUseGunSA::AimGun(CPed* pPed)
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    dwPedInterface
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, dwPedInterface);
     // clang-format on
 }
 
@@ -259,12 +172,7 @@ void CTaskSimpleUseGunSA::ClearAnim(CPed* pPed)
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    dwPedInterface
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, dwPedInterface);
     // clang-format on
 }
 
@@ -274,12 +182,7 @@ signed char CTaskSimpleUseGunSA::GetCurrentCommand()
     DWORD       dwFunc = FUNC_CTaskSimpleUseGun_GetCurrentCommand;
     DWORD       dwThisInterface = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThisInterface);
     // clang-format on
     return bReturn;
 }
@@ -290,12 +193,7 @@ bool CTaskSimpleUseGunSA::GetDoneFiring()
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_GetDoneFiring;
     DWORD dwThisInterface = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThisInterface);
     // clang-format on
     return bReturn;
 }
@@ -306,12 +204,7 @@ bool CTaskSimpleUseGunSA::GetIsFinished()
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_GetIsFinished;
     DWORD dwThisInterface = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThisInterface);
     // clang-format on
     return bReturn;
 }
@@ -322,12 +215,7 @@ bool CTaskSimpleUseGunSA::IsLineOfSightBlocked()
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_IsLineOfSightBlocked;
     DWORD dwThisInterface = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThisInterface);
     // clang-format on
     return bReturn;
 }
@@ -338,12 +226,7 @@ bool CTaskSimpleUseGunSA::GetIsFiring()
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_GetIsFiring;
     DWORD dwThisInterface = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThisInterface);
     // clang-format on
     return bReturn;
 }
@@ -354,12 +237,7 @@ bool CTaskSimpleUseGunSA::GetIsReloading()
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_GetIsReloading;
     DWORD dwThisInterface = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThisInterface);
     // clang-format on
     return bReturn;
 }
@@ -370,12 +248,7 @@ bool CTaskSimpleUseGunSA::GetSkipAim()
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_GetSkipAim;
     DWORD dwThisInterface = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThisInterface);
     // clang-format on
     return bReturn;
 }
@@ -386,12 +259,7 @@ bool CTaskSimpleUseGunSA::PlayerPassiveControlGun()
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_PlayerPassiveControlGun;
     DWORD dwThisInterface = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThisInterface);
     // clang-format on
     return bReturn;
 }
@@ -402,13 +270,7 @@ void CTaskSimpleUseGunSA::RemoveStanceAnims(CPed* pPed, float f)
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    f
-        push    dwPedInterface
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, dwPedInterface, f);
     // clang-format on
 }
 
@@ -419,13 +281,7 @@ bool CTaskSimpleUseGunSA::RequirePistolWhip(CPed* pPed, CEntity* pTargetEntity)
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
     DWORD dwTargetEntity = (pTargetEntity) ? (DWORD)pTargetEntity->GetInterface() : 0;
     // clang-format off
-    __asm
-    {
-        push    dwTargetEntity
-        push    dwPedInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_call_address<decltype(bReturn)>(dwFunc, dwPedInterface, dwTargetEntity);
     // clang-format on
     return bReturn;
 }
@@ -435,12 +291,7 @@ void CTaskSimpleUseGunSA::SetBurstLength(short a)
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_SetBurstLength;
     DWORD dwThisInterface = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    a
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, a);
     // clang-format on
 }
 
@@ -450,12 +301,7 @@ void CTaskSimpleUseGunSA::SetMoveAnim(CPed* pPed)
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    dwPedInterface
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, dwPedInterface);
     // clang-format on
 }
 
@@ -465,12 +311,7 @@ void CTaskSimpleUseGunSA::StartAnim(class CPed* pPed)
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwPedInterface = (DWORD)pPed->GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    dwPedInterface
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, dwPedInterface);
     // clang-format on
 }
 
@@ -479,13 +320,7 @@ void CTaskSimpleUseGunSA::StartCountDown(unsigned char a, bool b)
     DWORD dwFunc = FUNC_CTaskSimpleUseGun_StartCountDown;
     DWORD dwThisInterface = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    b
-        push    a
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, a, b);
     // clang-format on
 }
 
@@ -498,13 +333,6 @@ CTaskSimpleFightSA::CTaskSimpleFightSA(CEntity* pTargetEntity, int nCommand, uns
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwTargetEntity = (pTargetEntity) ? (DWORD)pTargetEntity->GetInterface() : 0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    nIdlePeriod
-        push    nCommand
-        push    dwTargetEntity
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, dwTargetEntity, nCommand, nIdlePeriod);
     // clang-format on
 }

--- a/Client/game_sa/TaskBasicSA.cpp
+++ b/Client/game_sa/TaskBasicSA.cpp
@@ -42,12 +42,7 @@ CTaskComplexUseMobilePhoneSA::CTaskComplexUseMobilePhoneSA(const int iDuration)
     DWORD dwThisInterface = (DWORD)GetInterface();
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    iDuration
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, iDuration);
     // clang-format on
 }
 
@@ -62,17 +57,7 @@ CTaskSimpleRunAnimSA::CTaskSimpleRunAnimSA(const AssocGroupId animGroup, const A
     DWORD dwThisInterface = (DWORD)GetInterface();
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    bHoldLastFrame
-        push    pTaskName
-        push    iTaskType
-        push    fBlendDelta
-        push    animID
-        push    animGroup
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, animGroup, animID, fBlendDelta, iTaskType, pTaskName, bHoldLastFrame);
     // clang-format on
 }
 
@@ -88,20 +73,7 @@ CTaskSimpleRunNamedAnimSA::CTaskSimpleRunNamedAnimSA(const char* pAnimName, cons
     DWORD dwThisInterface = (DWORD)GetInterface();
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    bHoldLastFrame
-        push    bOffsetPed
-        push    bRunInSequence
-        push    bDontInterrupt
-        push    iTime
-        push    fBlendDelta
-        push    flags
-        push    pAnimGroupName
-        push    pAnimName
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, pAnimName, pAnimGroupName, flags, fBlendDelta, iTime, bDontInterrupt, bRunInSequence, bOffsetPed, bHoldLastFrame);
     // clang-format on
 }
 
@@ -117,20 +89,7 @@ CTaskComplexDieSA::CTaskComplexDieSA(const eWeaponType eMeansOfDeath, const Asso
     DWORD dwThisInterface = (DWORD)GetInterface();
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    bFallToDeathOverRailing
-        push    iFallToDeathDir
-        push    bFallingToDeath
-        push    bBeingKilledByStealth
-        push    fAnimSpeed
-        push    fBlendDelta
-        push    anim
-        push    animGroup
-        push    eMeansOfDeath
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, eMeansOfDeath, animGroup, anim, fBlendDelta, fAnimSpeed, bBeingKilledByStealth, bFallingToDeath, iFallToDeathDir, bFallToDeathOverRailing);
     // clang-format on
 }
 
@@ -145,14 +104,7 @@ CTaskSimpleStealthKillSA::CTaskSimpleStealthKillSA(bool bKiller, CPed* pPed, con
     DWORD dwPedInterface = (DWORD)pPed->GetPedInterface();
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    animGroup
-        push    dwPedInterface
-        push    bKiller
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, bKiller, dwPedInterface, animGroup);
     // clang-format on
 }
 
@@ -165,13 +117,7 @@ CTaskSimpleDeadSA::CTaskSimpleDeadSA(unsigned int uiDeathTimeMS, bool bUnk2)
     DWORD dwThisInterface = (DWORD)GetInterface();
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    bUnk2
-        push    uiDeathTimeMS
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, uiDeathTimeMS, bUnk2);
     // clang-format on
 }
 
@@ -185,15 +131,7 @@ CTaskSimpleBeHitSA::CTaskSimpleBeHitSA(CPed* pPedAttacker, ePedPieceTypes hitBod
     DWORD dwPedInterface = (DWORD)pPedAttacker->GetPedInterface();
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    weaponId
-        push    hitBodySide
-        push    hitBodyPart
-        push    dwPedInterface
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, dwPedInterface, hitBodyPart, hitBodySide, weaponId);
     // clang-format on
 }
 
@@ -210,13 +148,7 @@ CTaskComplexSunbatheSA::CTaskComplexSunbatheSA(CObject* pTowel, const bool bStar
         dwObjectInterface = (DWORD)pTowel->GetObjectInterface();
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    bStartStanding
-        push    dwObjectInterface;
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, dwObjectInterface, bStartStanding);
     // clang-format on
 }
 
@@ -238,11 +170,7 @@ CTaskSimplePlayerOnFootSA::CTaskSimplePlayerOnFootSA()
     DWORD dwThisInterface = (DWORD)GetInterface();
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface);
     // clang-format on
 }
 
@@ -258,11 +186,7 @@ CTaskComplexFacialSA::CTaskComplexFacialSA()
     DWORD dwThisInterface = (DWORD)GetInterface();
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface);
     // clang-format on
 }
 

--- a/Client/game_sa/TaskCarAccessoriesSA.cpp
+++ b/Client/game_sa/TaskCarAccessoriesSA.cpp
@@ -31,13 +31,7 @@ CTaskSimpleCarSetPedInAsDriverSA::CTaskSimpleCarSetPedInAsDriverSA(CVehicle* pTa
         DWORD dwThisInterface = (DWORD)GetInterface();
 
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwThisInterface
-            push    pUtility
-            push    dwVehiclePtr
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, dwThisInterface, dwVehiclePtr, pUtility);
         // clang-format on
     }
 }
@@ -75,14 +69,7 @@ CTaskSimpleCarSetPedInAsPassengerSA::CTaskSimpleCarSetPedInAsPassengerSA(CVehicl
         DWORD dwVehiclePtr = (DWORD)pTargetVehicleSA->GetInterface();
         DWORD dwThisInterface = (DWORD)GetInterface();
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwThisInterface
-            push    pUtility
-            push    iTargetDoor
-            push    dwVehiclePtr
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, dwThisInterface, dwVehiclePtr, iTargetDoor, pUtility);
         // clang-format on
     }
 }
@@ -161,12 +148,6 @@ void CTaskSimpleCarSetPedOutSA::PositionPedOutOfCollision(CPed* ped, CVehicle* v
     DWORD dwVehiclePtr = (DWORD)((CEntitySA*)vehicle)->GetInterface();
     DWORD dwPedPtr = (DWORD)((CEntitySA*)ped)->GetInterface();
     // clang-format off
-    __asm
-    {
-        push    nDoor
-        push    dwVehiclePtr
-        push    dwPedPtr
-        call    dwFunc
-    }
+    gta_call_address(dwFunc, dwPedPtr, dwVehiclePtr, nDoor);
     // clang-format on
 }

--- a/Client/game_sa/TaskCarSA.cpp
+++ b/Client/game_sa/TaskCarSA.cpp
@@ -44,12 +44,7 @@ CTaskComplexEnterCarAsDriverSA::CTaskComplexEnterCarAsDriverSA(CVehicle* pTarget
         DWORD dwThisInterface = (DWORD)GetInterface();
 
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwThisInterface
-            push    dwVehiclePtr
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, dwThisInterface, dwVehiclePtr);
         // clang-format on
     }
 }
@@ -109,12 +104,7 @@ CTaskComplexEnterBoatAsDriverSA::CTaskComplexEnterBoatAsDriverSA(CVehicle* pTarg
         DWORD dwThisInterface = (DWORD)GetInterface();
 
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwThisInterface
-            push    dwVehiclePtr
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, dwThisInterface, dwVehiclePtr);
         // clang-format on
     }
 }

--- a/Client/game_sa/TaskGoToSA.cpp
+++ b/Client/game_sa/TaskGoToSA.cpp
@@ -27,12 +27,7 @@ int CTaskComplexWanderSA::GetWanderType()
     if (dwFunc && dwFunc != 0x82263A)  // some tasks have no wander type 0x82263A is purecal (assert?)
     {
         // clang-format off
-        __asm
-        {
-            mov     ecx, pTaskInterface
-            call    dwFunc
-            mov     iReturn, eax
-        }
+        iReturn = gta_thiscall_address<decltype(iReturn)>(dwFunc, pTaskInterface);
         // clang-format on
     }
     return iReturn;
@@ -61,13 +56,6 @@ CTaskComplexWanderStandardSA::CTaskComplexWanderStandardSA(const int iMoveState,
     DWORD dwFunc = FUNC_CTaskComplexWanderStandard__Constructor;
     DWORD dwThisInterface = (DWORD)GetInterface();
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    bWanderSensibly
-        push    iDir
-        push    iMoveState
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, iMoveState, iDir, bWanderSensibly);
     // clang-format on
 }

--- a/Client/game_sa/TaskIKSA.cpp
+++ b/Client/game_sa/TaskIKSA.cpp
@@ -32,25 +32,7 @@ CTaskSimpleIKChainSA::CTaskSimpleIKChainSA(char* idString, int effectorBoneTag, 
     float fEffectorX = effectorVec.fX, fEffectorY = effectorVec.fY, fEffectorZ = effectorVec.fZ;
     float fX = offsetPos.fX, fY = offsetPos.fY, fZ = offsetPos.fZ;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    blendTime
-        push    time
-        push    speed
-        push    fZ
-        push    fY
-        push    fX
-        push    offsetBoneTag
-        push    dwEntityInterface
-        push    pivotBoneTag
-        push    fEffectorZ
-        push    fEffectorY
-        push    fEffectorX
-        push    effectorBoneTag
-        push    idString
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, idString, effectorBoneTag, fEffectorX, fEffectorY, fEffectorZ, pivotBoneTag, dwEntityInterface, offsetBoneTag, fX, fY, fZ, speed, time, blendTime);
     // clang-format on
 }
 
@@ -68,22 +50,7 @@ CTaskSimpleIKLookAtSA::CTaskSimpleIKLookAtSA(char* idString, CEntity* pEntity, i
         dwEntityInterface = (DWORD)pEntity->GetInterface();
     float fX = offsetPos.fX, fY = offsetPos.fY, fZ = offsetPos.fZ;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    m_priority
-        push    blendTime
-        push    speed
-        push    useTorso
-        push    fZ
-        push    fY
-        push    fX
-        push    offsetBoneTag
-        push    time
-        push    dwEntityInterface
-        push    idString
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, idString, dwEntityInterface, time, offsetBoneTag, fX, fY, fZ, useTorso, speed, blendTime, m_priority);
     // clang-format on
 }
 
@@ -162,20 +129,6 @@ CTaskSimpleTriggerLookAtSA::CTaskSimpleTriggerLookAtSA(CEntity* pEntity, int tim
         dwEntityInterface = (DWORD)pEntity->GetInterface();
     float fX = offsetPos.fX, fY = offsetPos.fY, fZ = offsetPos.fZ;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    priority
-        push    blendTime
-        push    speed
-        push    useTorso
-        push    fZ
-        push    fY
-        push    fX
-        push    offsetBoneTag
-        push    time
-        push    dwEntityInterface
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, dwEntityInterface, time, offsetBoneTag, fX, fY, fZ, useTorso, speed, blendTime, priority);
     // clang-format on
 }

--- a/Client/game_sa/TaskJumpFallSA.cpp
+++ b/Client/game_sa/TaskJumpFallSA.cpp
@@ -22,17 +22,7 @@ CTaskSimpleClimbSA::CTaskSimpleClimbSA(CEntitySAInterface* pClimbEnt, const CVec
     DWORD dwThisInterface = (DWORD)GetInterface();
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    bForceClimb
-        push    nHeight
-        push    nSurfaceType
-        push    fHeading
-        push    vecTarget
-        push    pClimbEnt
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, pClimbEnt, vecTarget, fHeading, nSurfaceType, nHeight, bForceClimb);
     // clang-format on
 }
 
@@ -50,14 +40,6 @@ CTaskSimpleJetPackSA::CTaskSimpleJetPackSA(const CVector* pVecTargetPos, float f
     DWORD dwThisInterface = (DWORD)GetInterface();
 
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        push    0               // pTargetEnt - ignored for simplicity's sake (we really don't need it)
-        push    nHoverTime
-        push    fCruiseHeight
-        push    pVecTargetPos
-        call    dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, pVecTargetPos, fCruiseHeight, nHoverTime, 0);
     // clang-format on
 }

--- a/Client/game_sa/TaskPhysicalResponseSA.cpp
+++ b/Client/game_sa/TaskPhysicalResponseSA.cpp
@@ -102,13 +102,6 @@ void CTaskSimpleChokingSA::UpdateChoke(CPed* pPed, CPed* pAttacker, bool bIsTear
     DWORD dwThisInterface = (DWORD)GetInterface();
     DWORD dwFunc = FUNC_CTaskSimpleChoking__UpdateChoke;
     // clang-format off
-    __asm
-    {
-        mov         ecx, dwThisInterface
-        push        bIsTearGas
-        push        pAttackerInterface
-        push        pPedInterface
-        call        dwFunc
-    }
+    gta_thiscall_address(dwFunc, dwThisInterface, pPedInterface, pAttackerInterface, bIsTearGas);
     // clang-format on
 }

--- a/Client/game_sa/TaskSA.cpp
+++ b/Client/game_sa/TaskSA.cpp
@@ -47,13 +47,7 @@ void CTaskSA::CreateTaskInterface(size_t nSize)
     DWORD dwFunc = FUNC_CTask__Operator_New;
     DWORD dwReturn = 0;
     // clang-format off
-    __asm
-    {
-        push    nSize
-        call    dwFunc
-        add     esp, 4
-        mov     dwReturn, eax
-    }
+    dwReturn = gta_call_address<decltype(dwReturn)>(dwFunc, nSize);
     // clang-format on
 
     TaskInterface = (CTaskSAInterface*)dwReturn;
@@ -66,12 +60,7 @@ CTask* CTaskSA::Clone()
     DWORD dwFunc = GetInterface()->VTBL->Clone;
     DWORD dwReturn = 0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-        mov     dwReturn, eax
-    }
+    dwReturn = gta_thiscall_address<decltype(dwReturn)>(dwFunc, dwThisInterface);
     // clang-format on
     return (CTask*)dwReturn;
 }
@@ -98,12 +87,7 @@ CTask* CTaskSA::GetSubTask()
 
     DWORD dwReturn = 0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, pTaskInterface
-        call    dwFunc
-        mov     dwReturn, eax
-    }
+    dwReturn = gta_thiscall_address<decltype(dwReturn)>(dwFunc, pTaskInterface);
     // clang-format on
     return s_pTaskManagementSystem->GetTask((CTaskSAInterface*)dwReturn);
 }
@@ -114,12 +98,7 @@ bool CTaskSA::IsSimpleTask()
     DWORD dwFunc = GetInterface()->VTBL->IsSimpleTask;
     bool  bReturn = 0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, dwThisInterface
-        call    dwFunc
-        mov     bReturn, al
-    }
+    bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThisInterface);
     // clang-format on
     return bReturn;
 }
@@ -134,12 +113,7 @@ int CTaskSA::GetTaskType()
     if (dwFunc && dwFunc != 0x82263A)  // some functions have no task type 0x82263A is purecal (assert?)
     {
         // clang-format off
-        __asm
-        {
-            mov     ecx, pTaskInterface
-            call    dwFunc
-            mov     iReturn, eax
-        }
+        iReturn = gta_thiscall_address<decltype(iReturn)>(dwFunc, pTaskInterface);
         // clang-format on
     }
     return iReturn;
@@ -155,12 +129,7 @@ void CTaskSA::StopTimer(const CEvent* pEvent)
     if (dwFunc != 0x82263A && dwFunc)
     {
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwThisInterface
-            push    pEvent
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, dwThisInterface, pEvent);
         // clang-format on
     }
 }
@@ -181,15 +150,7 @@ bool CTaskSA::MakeAbortable(CPed* pPed, const int iPriority, const CEvent* pEven
     if (dwFunc != 0x82263A && dwFunc)  // 82263A = purecall
     {
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwThisInterface
-            push    pEvent
-            push    iPriority
-            push    dwPedInterface
-            call    dwFunc
-            mov     bReturn, al
-        }
+        bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThisInterface, dwPedInterface, iPriority, pEvent);
         // clang-format on
     }
     return bReturn;
@@ -218,12 +179,7 @@ void CTaskSA::Destroy()
     if (dwFunc)
     {
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwThisInterface
-            push    1           // delete the task too
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, dwThisInterface, 1);
         // clang-format on
     }
 
@@ -280,13 +236,7 @@ bool CTaskSimpleSA::ProcessPed(CPed* pPed)
     if (dwFunc != 0x82263A && dwFunc)
     {
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwThisInterface
-            push    dwPedInterface
-            call    dwFunc
-            mov     bReturn, al
-        }
+        bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThisInterface, dwPedInterface);
         // clang-format on
     }
     return bReturn;
@@ -305,13 +255,7 @@ bool CTaskSimpleSA::SetPedPosition(CPed* pPed)
     if (dwFunc != 0x82263A && dwFunc)
     {
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwThisInterface
-            push    dwPedInterface
-            call    dwFunc
-            mov     bReturn, al
-        }
+        bReturn = gta_thiscall_address<decltype(bReturn)>(dwFunc, dwThisInterface, dwPedInterface);
         // clang-format on
     }
     return bReturn;
@@ -342,12 +286,7 @@ void CTaskComplexSA::SetSubTask(CTask* pSubTask)
     if (dwFunc != 0x82263A && dwFunc)
     {
         // clang-format off
-        __asm
-        {
-            mov     ecx, dwThisInterface
-            push    dwTaskInterface
-            call    dwFunc
-        }
+        gta_thiscall_address(dwFunc, dwThisInterface, dwTaskInterface);
         // clang-format on
     }
 }
@@ -369,13 +308,7 @@ CTask* CTaskComplexSA::CreateNextSubTask(CPed* pPed)
     DWORD dwPedInterface = (DWORD)pPedSA->GetInterface();
     DWORD dwReturn = 0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, pTaskInterface
-        push    dwPedInterface
-        call    dwFunc
-        mov     dwReturn, eax
-    }
+    dwReturn = gta_thiscall_address<decltype(dwReturn)>(dwFunc, pTaskInterface, dwPedInterface);
     // clang-format on
     return pGame->GetTaskManagementSystem()->GetTask((CTaskSAInterface*)dwReturn);
 }
@@ -397,13 +330,7 @@ CTask* CTaskComplexSA::CreateFirstSubTask(CPed* pPed)
     DWORD dwPedInterface = (DWORD)pPedSA->GetInterface();
     DWORD dwReturn = 0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, pTaskInterface
-        push    dwPedInterface
-        call    dwFunc
-        mov     dwReturn, eax
-    }
+    dwReturn = gta_thiscall_address<decltype(dwReturn)>(dwFunc, pTaskInterface, dwPedInterface);
     // clang-format on
     return pGame->GetTaskManagementSystem()->GetTask((CTaskSAInterface*)dwReturn);
 }
@@ -425,13 +352,7 @@ CTask* CTaskComplexSA::ControlSubTask(CPed* pPed)
     DWORD dwPedInterface = (DWORD)pPedSA->GetInterface();
     DWORD dwReturn = 0;
     // clang-format off
-    __asm
-    {
-        mov     ecx, pTaskInterface
-        push    dwPedInterface
-        call    dwFunc
-        mov     dwReturn, eax
-    }
+    dwReturn = gta_thiscall_address<decltype(dwReturn)>(dwFunc, pTaskInterface, dwPedInterface);
     // clang-format on
     return pGame->GetTaskManagementSystem()->GetTask((CTaskSAInterface*)dwReturn);
 }


### PR DESCRIPTION
Some initial work on automatically rewriting game_sa's inline asm to proper C++ calls via a custom clang-tidy plugin. 

See https://github.com/sbx320/mtaasmrewriter for source

Rough approach is: 

- Find all `__asm` statements
- Collect all `push` instructions (arguments)
- Look for a `mov ecx, [something]` instruction (__thiscall indicator)
- Look for a `mov [something], [something]` instruction (return value)

Then rewrite the statement to a function type declaration and a function call. 

Current issues:

- Does not support other asm instructions (e.g. `lea` is used in some places)
- ~~Does not properly escape prefix-less hexadecimal numbers (e.g. `push 0B73710h` is mapped to a function argument `0B73710h` which is a base-2 number~~
- If multiple function calls are used, the type declaration collides due to duplicate names
- clang formatting is disabled
- ~~needs to be on master, not on 1.6.0~~

