### PR TITLE
Fix clang-format auto-fixes

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -23,7 +23,8 @@ jobs:
         if: |
           steps.clang_format.outcome == 'failure' &&
           github.ref == 'refs/heads/master' &&
-          github.event_name == 'push'
+          github.event_name == 'push' &&
+          !github.event.repository.fork
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ secrets.GH_APP_MTA_CLIENT_ID }}
@@ -36,7 +37,8 @@ jobs:
         if: |
           steps.clang_format.outcome == 'failure' &&
           github.ref == 'refs/heads/master' &&
-          github.event_name == 'push'
+          github.event_name == 'push' &&
+          !github.event.repository.fork
         shell: bash
         run: |
           # Stage the formatted files (clang-format.ps1 already ran in-place)

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -18,6 +18,20 @@ jobs:
         shell: pwsh
         run: ./utils/clang-format.ps1 -Verbose
 
+      - name: Generate GitHub App token
+        id: app-token
+        if: |
+          steps.clang_format.outcome == 'failure' &&
+          github.ref == 'refs/heads/master' &&
+          github.event_name == 'push'
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.GH_APP_MTA_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_MTA_PEM }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+
       - name: Auto-fix formatting issues
         if: |
           steps.clang_format.outcome == 'failure' &&
@@ -46,7 +60,8 @@ jobs:
 
           cc @${GITHUB_ACTOR} please make sure to run clang-format locally before pushing changes to avoid this in the future."
 
-          # And we're off to the races!
+          # Authenticate with the GitHub App token and push
+          git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}
           git push
 
       - name: Report formatting issues

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -52,8 +52,8 @@ jobs:
           fi
 
           # Allow commit to work
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "multitheftauto[bot]"
+          git config user.email "274826127+multitheftauto[bot]@users.noreply.github.com"
 
           # Append a commit with a fix applied
           git commit -m "Fix formatting issues introduced by ${GITHUB_SHA}

--- a/Client/loader/MainFunctions.cpp
+++ b/Client/loader/MainFunctions.cpp
@@ -45,11 +45,11 @@ namespace
 {
     constexpr DWORD kLegacyCrashExitCode = 3;
 
-    if (   exitCode    == kLegacyCrashExitCode    )
+    if (exitCode == kLegacyCrashExitCode)
         return true;
 
     if (exitCode == EXIT_OK || exitCode == EXIT_ERROR || exitCode == STILL_ACTIVE)
-        return false   ;
+        return false;
 
     const DWORD kInformationalCrashCodes[] = {
         0x40000015u,  // STATUS_FATAL_APP_EXIT

--- a/Client/loader/MainFunctions.cpp
+++ b/Client/loader/MainFunctions.cpp
@@ -45,11 +45,11 @@ namespace
 {
     constexpr DWORD kLegacyCrashExitCode = 3;
 
-    if (exitCode == kLegacyCrashExitCode)
+    if (   exitCode    == kLegacyCrashExitCode    )
         return true;
 
     if (exitCode == EXIT_OK || exitCode == EXIT_ERROR || exitCode == STILL_ACTIVE)
-        return false;
+        return false   ;
 
     const DWORD kInformationalCrashCodes[] = {
         0x40000015u,  // STATUS_FATAL_APP_EXIT


### PR DESCRIPTION
#### Summary and motivation

Branch protections were limiting the ability for GitHub Actions to push straight to master, so I created a GitHub App and granted that app the ability to bypass. Now the clang-format job will use the GitHub App for pushes to master.

Org owners can manage [the app](https://github.com/organizations/multitheftauto/settings/apps/multitheftauto) and separately manage [the app installation](https://github.com/organizations/multitheftauto/settings/installations/122647713) at those pages.

#### Test plan

See commit history of this branch 😀  My pull request is based on `master` on my branch, with the bot set up.

