### PR TITLE
Guard recursive Lua table bitstream reads

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaArgument.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaArgument.cpp
@@ -468,7 +468,7 @@ void CLuaArgument::Push(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKn
 }
 
 // Can't use bitStream.Version() here as it is sometimes not set
-bool CLuaArgument::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables)
+bool CLuaArgument::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables, unsigned int uiDepth)
 {
     DeleteTableData();
     m_iType = LUA_TNIL;
@@ -530,7 +530,7 @@ bool CLuaArgument::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vect
         case LUA_TTABLE:
         {
             m_pTableData = new CLuaArguments();
-            if (!m_pTableData->ReadFromBitStream(bitStream, pKnownTables))
+            if (!m_pTableData->ReadFromBitStream(bitStream, pKnownTables, uiDepth + 1))
             {
                 DeleteTableData();
                 return false;

--- a/Client/mods/deathmatch/logic/lua/CLuaArgument.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaArgument.h
@@ -62,7 +62,8 @@ public:
     CLuaArguments* GetTable() const { return m_pTableData; }
     CClientEntity* GetElement() const;
 
-    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL);
+    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL,
+                                   unsigned int uiDepth = 0);
     bool         WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL) const;
     json_object* WriteToJSONObject(bool bSerialize = false, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL);
     bool         ReadFromJSONObject(json_object* object, std::vector<CLuaArguments*>* pKnownTables = NULL);

--- a/Client/mods/deathmatch/logic/lua/CLuaArgument.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaArgument.h
@@ -62,8 +62,7 @@ public:
     CLuaArguments* GetTable() const { return m_pTableData; }
     CClientEntity* GetElement() const;
 
-    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL,
-                                   unsigned int uiDepth = 0);
+    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL, unsigned int uiDepth = 0);
     bool         WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL) const;
     json_object* WriteToJSONObject(bool bSerialize = false, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL);
     bool         ReadFromJSONObject(json_object* object, std::vector<CLuaArguments*>* pKnownTables = NULL);

--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
@@ -460,8 +460,11 @@ void CLuaArguments::ValidateTableKeys()
     }
 }
 
-bool CLuaArguments::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables)
+bool CLuaArguments::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables, unsigned int uiDepth)
 {
+    if (uiDepth > MaxBitStreamTableReadDepth)
+        return false;
+
     bool bKnownTablesCreated = false;
     if (!pKnownTables)
     {

--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -69,8 +69,7 @@ public:
     void DeleteArguments();
     void Pop();
 
-    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL,
-                                   unsigned int uiDepth = 0);
+    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL, unsigned int uiDepth = 0);
     bool         WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL) const;
     void         ValidateTableKeys();
     bool         ReadFromJSONString(const char* szJSON);

--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -32,6 +32,8 @@ class CLuaArguments;
 class CLuaArguments
 {
 public:
+    static constexpr unsigned int MaxBitStreamTableReadDepth = 64;
+
     CLuaArguments() {}
     CLuaArguments(const CLuaArguments& Arguments, CFastHashMap<CLuaArguments*, CLuaArguments*>* pKnownTables = NULL);
     CLuaArguments(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL);
@@ -67,7 +69,8 @@ public:
     void DeleteArguments();
     void Pop();
 
-    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL);
+    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL,
+                                   unsigned int uiDepth = 0);
     bool         WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL) const;
     void         ValidateTableKeys();
     bool         ReadFromJSONString(const char* szJSON);

--- a/Server/mods/deathmatch/logic/lua/CLuaArgument.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaArgument.cpp
@@ -435,7 +435,7 @@ bool CLuaArgument::GetAsString(SString& strBuffer)
 }
 
 // Can't use bitStream.Version() here as it is sometimes not set
-bool CLuaArgument::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables)
+bool CLuaArgument::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables, unsigned int uiDepth)
 {
     DeleteTableData();
     m_iType = LUA_TNIL;
@@ -494,7 +494,7 @@ bool CLuaArgument::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vect
             case LUA_TTABLE:
             {
                 m_pTableData = new CLuaArguments();
-                if (!m_pTableData->ReadFromBitStream(bitStream, pKnownTables))
+                if (!m_pTableData->ReadFromBitStream(bitStream, pKnownTables, uiDepth + 1))
                 {
                     DeleteTableData();
                     return false;

--- a/Server/mods/deathmatch/logic/lua/CLuaArgument.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaArgument.h
@@ -62,8 +62,7 @@ public:
     CElement*          GetElement() const;
     bool               GetAsString(SString& strBuffer);
 
-    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL,
-                                   unsigned int uiDepth = 0);
+    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL, unsigned int uiDepth = 0);
     bool         WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL) const;
     json_object* WriteToJSONObject(bool bSerialize = false, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL);
     bool         ReadFromJSONObject(json_object* object, std::vector<CLuaArguments*>* pKnownTables = NULL);

--- a/Server/mods/deathmatch/logic/lua/CLuaArgument.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaArgument.h
@@ -62,7 +62,8 @@ public:
     CElement*          GetElement() const;
     bool               GetAsString(SString& strBuffer);
 
-    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL);
+    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL,
+                                   unsigned int uiDepth = 0);
     bool         WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL) const;
     json_object* WriteToJSONObject(bool bSerialize = false, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL);
     bool         ReadFromJSONObject(json_object* object, std::vector<CLuaArguments*>* pKnownTables = NULL);

--- a/Server/mods/deathmatch/logic/lua/CLuaArguments.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaArguments.cpp
@@ -528,8 +528,11 @@ void CLuaArguments::ValidateTableKeys()
     }
 }
 
-bool CLuaArguments::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables)
+bool CLuaArguments::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables, unsigned int uiDepth)
 {
+    if (uiDepth > MaxBitStreamTableReadDepth)
+        return false;
+
     bool bKnownTablesCreated = false;
     if (!pKnownTables)
     {

--- a/Server/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -91,8 +91,7 @@ public:
     void ValidateTableKeys();
     void Pop();
 
-    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL,
-                                   unsigned int uiDepth = 0);
+    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL, unsigned int uiDepth = 0);
     bool         ReadFromJSONString(const char* szJSON);
     bool         WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL) const;
     bool         WriteToJSONString(std::string& strJSON, bool bSerialize = false, int flags = JSON_C_TO_STRING_PLAIN);

--- a/Server/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -44,6 +44,8 @@ class CLuaArguments;
 class CLuaArguments
 {
 public:
+    static constexpr unsigned int MaxBitStreamTableReadDepth = 64;
+
     CLuaArguments() {}
     CLuaArguments(const CLuaArguments& Arguments, CFastHashMap<CLuaArguments*, CLuaArguments*>* pKnownTables = NULL);
 
@@ -89,7 +91,8 @@ public:
     void ValidateTableKeys();
     void Pop();
 
-    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL);
+    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL,
+                                   unsigned int uiDepth = 0);
     bool         ReadFromJSONString(const char* szJSON);
     bool         WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL) const;
     bool         WriteToJSONString(std::string& strJSON, bool bSerialize = false, int flags = JSON_C_TO_STRING_PLAIN);


### PR DESCRIPTION
## Summary
- add a 64-level recursion limit when reading nested Lua tables from bitstreams
- apply the guard on both client and server deserialization paths
- preserve existing call sites by threading depth through defaulted parameters

## Why
The public source currently allows unbounded recursive LUA_TTABLE reads from the bitstream serializer. A crafted packet can drive recursive descent until deserialization fails from stack exhaustion or excessive recursion.

Current shipped binaries already enforce a 64-level limit in this path. This change brings the public source in line with that behavior so downstream forks and public builds do not keep the unbounded recursion path.

## Testing
- validated the touched files with editor diagnostics
- manually reviewed the nested-table bitstream read path to confirm inputs deeper than 64 levels now fail deserialization
- reviewed the patch scope to confirm it only changes the bitstream table read path