### PR TITLE
Delete .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @multitheftauto/blue-collaborators


### PR DESCRIPTION
Causes GitHub notification spam whenever an open pull request is created
<img width="1415" height="197" alt="image" src="https://github.com/user-attachments/assets/3e464285-d189-4957-811a-a3c9b5e7ed94" />
