### PR TITLE
Fix ring markers rendering underground (#4792)

### DIFF
--- a/Client/game_sa/C3DMarkersSA.cpp
+++ b/Client/game_sa/C3DMarkersSA.cpp
@@ -41,6 +41,10 @@ C3DMarker* C3DMarkersSA::CreateMarker(DWORD Identifier, T3DMarkerType dwType, CV
     dwType = (T3DMarkerType)wType;
     bool bZCheck = true;
 
+    // Pass a copy of the position to PlaceMarker, not the original pointer.
+    CVector  vecPositionCopy = *vecPosition;
+    CVector* pVecPosCopy = &vecPositionCopy;
+
     DWORD dwFunc = FUNC_PlaceMarker;
     DWORD dwReturn = 0;
     // clang-format off
@@ -58,7 +62,7 @@ C3DMarker* C3DMarkersSA::CreateMarker(DWORD Identifier, T3DMarkerType dwType, CV
         push    g           // green
         push    r           // red
         push    fSize       // size
-        push    vecPosition // position
+        push    pVecPosCopy // position (copy to prevent PlaceMarker from corrupting the caller's vector)
         push    dwType      // type
         push    Identifier  // identifier
         call    dwFunc

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1590,14 +1590,6 @@ void CMultiplayerSA::InitHooks()
     MemSet((void*)0x6A2EAB, 0x90, 6);
     MemSet((void*)0x6ABC81, 0x90, 6);
 
-    // Disable Z position changes in the matrix in the C3dMarkers::PlaceMarker (#4000, #536)
-    // To prevent arrow-type markers from snapping to the ground
-    MemCpy((void*)0x725844, "\xDD\xD8\x90", 3);
-    MemCpy((void*)0x725619, "\xDD\xD8\x90", 3);
-    MemCpy((void*)0x72565A, "\xDD\xD8\x90", 3);
-    MemCpy((void*)0x7259B0, "\xDD\xD8\x90", 3);
-    MemSet((void*)0x7258B8, 0x90, 6);
-
     // Disable spreading fires (Moved from multiplayer_shotsync)
     MemCpy((void*)0x53A23F, "\x33\xC0\x90\x90\x90", 5);
     MemCpy((void*)0x53A00A, "\x33\xC0\x90\x90\x90", 5);


### PR DESCRIPTION
#### Summary

Pass a copy of the position vector to `C3dMarkers::PlaceMarker` instead of the original pointer, and remove the binary patches to `PlaceMarker` introduced in PR #4027.

Changes:
- **C3DMarkersSA.cpp**: Copy `vecPosition` before passing it to `PlaceMarker`'s inline asm call, so the game engine's Z-adjustment writes go to the copy instead of corrupting MTA's stored marker position.
- **CMultiplayerSA.cpp**: Remove the 5 `MemCpy`/`MemSet` patches at `0x725844`, `0x725619`, `0x72565A`, `0x7259B0`, `0x7258B8` that globally disabled Z logic inside `PlaceMarker`.

#### Motivation

Resolves #4792 - ring markers were "invisible" (rendering underground).

PR #4027 patched `PlaceMarker` globally to fix arrow markers snapping to the ground (#536, #4000). However, `CCheckpoints::Render` also calls `PlaceMarker` internally for torus/ring marker rendering and depends on the unmodified Z position logic. The global patches broke that path.

The actual root cause of #536 was that `PlaceMarker` takes `CVector&` (by reference) and internally modifies `pos.z` for roof/ground height checks on arrow/cone marker types. MTA was passing `&m_Matrix.vPos` directly from `CClient3DMarker::DoPulse`, so `PlaceMarker` permanently corrupted MTA's stored position every frame - the subsequent `SetMatrix` call used the already-corrupted data.

Passing a copy of the position isolates MTA's data from `PlaceMarker`'s internal modifications, fixing arrow ground-snapping without patching the engine.

#### Test plan

1. Create a ring marker (e.g. via map editor or `createMarker(x, y, z, "ring")`) - should be visible at the correct height, not underground.
2. Create an arrow marker near ground level (the script from #4000 works well) - should NOT snap to the ground.
3. Create cylinder and checkpoint markers - should render correctly.
4. Test markers at various Z heights and near roofs/overhangs.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.