### PR TITLE
Fix uninitialized m_bDiscordRPCEnabled bypassing Discord RPC opt-out

### DIFF
--- a/Client/core/CDiscordRichPresence.cpp
+++ b/Client/core/CDiscordRichPresence.cpp
@@ -25,6 +25,7 @@ CDiscordRichPresence::CDiscordRichPresence() : m_uiDiscordAppStart(0), m_uiDisco
 
     m_strDiscordAppState.clear();
     m_strDiscordCustomResourceName.clear();
+    m_bDiscordRPCEnabled = false;
     m_bConnected = false;
 }
 


### PR DESCRIPTION
#### Summary

Initialize `m_bDiscordRPCEnabled` to `false` in the `CDiscordRichPresence` constructor. The member variable was previously left uninitialized.

#### Motivation

Resolves #4768. 

`m_bDiscordRPCEnabled` was never explicitly initialized. When a user opts out of Discord Rich Presence (`allow_discord_rpc = false`), neither `CMainMenu` nor `CCore::SetConnected()` call `SetDiscordRPCEnabled(false)` — they simply skip their Discord code blocks. This leaves the flag holding whatever garbage was in memory.

If that garbage value is truthy, server-side Lua scripts calling `setDiscordApplicationID(...)` see `IsDiscordRPCEnabled() == true`, proceed through `SetApplicationID()` → `RestartDiscord()` → `Discord_Initialize()`, and Discord connects - ignoring the user's opt-out preference.

This also explains the reporter's observation that toggling the setting off and back on "fixes" it: the explicit `SetDiscordRPCEnabled(false)` call properly zeroes the flag and calls `Discord_Shutdown()`.

#### Test plan

1. Set `allow_discord_rpc` to `false` in MTA settings.
2. Open Discord and connect to a server that uses `setDiscordApplicationID`.
3. Verify Discord does **not** show MTA game activity.
4. Enable Discord RPC in settings - verify it works.
5. Disable it again - verify Discord activity disappears and stays gone across reconnects.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.