### PR TITLE
Fix jetpack behavior

### DIFF
--- a/Client/game_sa/CPedSA.cpp
+++ b/Client/game_sa/CPedSA.cpp
@@ -213,8 +213,8 @@ void CPedSA::ClearWeapons()
 
 void CPedSA::RemoveWeaponModel(std::uint32_t model)
 {
-    // void __thiscall CPed::RemoveWeaponModel(CPed *this, int modelID)
-    ((void(__thiscall*)(CEntitySAInterface*, std::uint32_t))FUNC_RemoveWeaponModel)(m_pInterface, model);
+    if (auto* pedInterface = GetPedInterface())
+        pedInterface->RemoveWeaponModel(model);
 }
 
 void CPedSA::ClearWeapon(eWeaponType weaponType)
@@ -598,6 +598,73 @@ void CPedSA::SetInWaterFlags(bool inWater)
     physicalInterface->bSubmergedInWater = inWater;
 }
 
+void __fastcall CPedSA::RemoveWeaponWhenEnteringVehicle(CPedSAInterface* pedInterface, void*, int jetpack)
+{
+    if (!pedInterface)
+        return;
+
+    pedInterface->RemoveWeaponWhenEnteringVehicle(jetpack == 1);
+}
+
+void CPedSAInterface::RemoveWeaponWhenEnteringVehicle(bool jetpack)
+{
+    // Bugfix #3659 (allow switch weapons while using jetpack - see PR #3573)
+    if (!jetpack)
+    {
+        if (auto* playerData = pPlayerData)
+            playerData->m_bInVehicleDontAllowWeaponChange = true;
+    }
+
+    if (savedWeapon != eWeaponType::WEAPONTYPE_UNIDENTIFIED)
+        return;
+
+    eWeaponSlot newSlot = WEAPONSLOT_MAX;
+
+    if (IsPlayer())
+    {
+        auto* playerInfo = pGame->GetPlayerInfo();
+        if (playerInfo && playerInfo->CanDoDriveBy())
+        {
+            const auto& smg = Weapons[WEAPONSLOT_TYPE_SMG];
+            const auto& shotgun = Weapons[WEAPONSLOT_TYPE_SHOTGUN];
+            const auto& pistol = Weapons[WEAPONSLOT_TYPE_HANDGUN];
+
+            const bool hasSMG = (smg.m_eWeaponType == eWeaponType::WEAPONTYPE_MICRO_UZI || smg.m_eWeaponType == eWeaponType::WEAPONTYPE_TEC9 ||
+                                 (jetpack && smg.m_eWeaponType == eWeaponType::WEAPONTYPE_MP5)) &&
+                                smg.m_ammoTotal > 0;
+
+            const bool hasSawnoff = jetpack && shotgun.m_eWeaponType == eWeaponType::WEAPONTYPE_SAWNOFF_SHOTGUN && shotgun.m_ammoTotal > 0;
+
+            const bool hasPistol = jetpack && pistol.m_eWeaponType == eWeaponType::WEAPONTYPE_PISTOL && pistol.m_ammoTotal > 0;
+
+            if (hasSMG)
+            {
+                newSlot = WEAPONSLOT_TYPE_SMG;
+            }
+            else if (hasSawnoff) // Bugfix - the default here was WEAPONSLOT_TYPE_HANDGUN
+            {
+                newSlot = WEAPONSLOT_TYPE_SHOTGUN;
+            }
+            else if (hasPistol)
+            {
+                newSlot = WEAPONSLOT_TYPE_HANDGUN;
+            }
+        }
+    }
+
+    if (newSlot != WEAPONSLOT_MAX)
+    {
+        savedWeapon = Weapons[bCurrentWeaponSlot].m_eWeaponType;
+        SetCurrentWeapon(newSlot);
+    }
+    else if (!jetpack) // Bugfix #508 (weapons are invisible when wearing jetpack - see PR #3559)
+    {
+        auto weaponType = Weapons[bCurrentWeaponSlot].m_eWeaponType;
+        auto model = pGame->GetWeaponInfo(weaponType, eWeaponSkill::WEAPONSKILL_STD)->GetModel();
+        RemoveWeaponModel(model);
+    }
+}
+
 ////////////////////////////////////////////////////////////////
 //
 // CPed_PreRenderAfterTest
@@ -686,4 +753,9 @@ void CPedSA::StaticSetHooks()
 {
     EZHookInstall(CPed_PreRenderAfterTest);
     EZHookInstall(CPed_PreRenderAfterTest_Mid);
+
+    HookInstallCall(0x68025A, (DWORD)CPedSA::RemoveWeaponWhenEnteringVehicle); // CTaskSimpleJetPack::ProcessPed
+    HookInstallCall(0x64DB4D, (DWORD)CPedSA::RemoveWeaponWhenEnteringVehicle);  // CTaskSimpleCarGetIn::ProcessPed
+    HookInstallCall(0x64BCA3, (DWORD)CPedSA::RemoveWeaponWhenEnteringVehicle);  // CTaskSimpleCarSetPedInAsDriver::ProcessPed
+    HookInstallCall(0x64B876, (DWORD)CPedSA::RemoveWeaponWhenEnteringVehicle);  // CTaskSimpleCarSetPedInAsPassenger::ProcessPed
 }

--- a/Client/game_sa/CPedSA.cpp
+++ b/Client/game_sa/CPedSA.cpp
@@ -641,7 +641,7 @@ void CPedSAInterface::RemoveWeaponWhenEnteringVehicle(bool jetpack)
             {
                 newSlot = WEAPONSLOT_TYPE_SMG;
             }
-            else if (hasSawnoff) // Bugfix - the default here was WEAPONSLOT_TYPE_HANDGUN
+            else if (hasSawnoff)  // Bugfix - the default here was WEAPONSLOT_TYPE_HANDGUN
             {
                 newSlot = WEAPONSLOT_TYPE_SHOTGUN;
             }
@@ -657,7 +657,7 @@ void CPedSAInterface::RemoveWeaponWhenEnteringVehicle(bool jetpack)
         savedWeapon = Weapons[bCurrentWeaponSlot].m_eWeaponType;
         SetCurrentWeapon(newSlot);
     }
-    else if (!jetpack) // Bugfix #508 (weapons are invisible when wearing jetpack - see PR #3559)
+    else if (!jetpack)  // Bugfix #508 (weapons are invisible when wearing jetpack - see PR #3559)
     {
         auto weaponType = Weapons[bCurrentWeaponSlot].m_eWeaponType;
         auto model = pGame->GetWeaponInfo(weaponType, eWeaponSkill::WEAPONSKILL_STD)->GetModel();
@@ -754,7 +754,7 @@ void CPedSA::StaticSetHooks()
     EZHookInstall(CPed_PreRenderAfterTest);
     EZHookInstall(CPed_PreRenderAfterTest_Mid);
 
-    HookInstallCall(0x68025A, (DWORD)CPedSA::RemoveWeaponWhenEnteringVehicle); // CTaskSimpleJetPack::ProcessPed
+    HookInstallCall(0x68025A, (DWORD)CPedSA::RemoveWeaponWhenEnteringVehicle);  // CTaskSimpleJetPack::ProcessPed
     HookInstallCall(0x64DB4D, (DWORD)CPedSA::RemoveWeaponWhenEnteringVehicle);  // CTaskSimpleCarGetIn::ProcessPed
     HookInstallCall(0x64BCA3, (DWORD)CPedSA::RemoveWeaponWhenEnteringVehicle);  // CTaskSimpleCarSetPedInAsDriver::ProcessPed
     HookInstallCall(0x64B876, (DWORD)CPedSA::RemoveWeaponWhenEnteringVehicle);  // CTaskSimpleCarSetPedInAsPassenger::ProcessPed

--- a/Client/game_sa/CPedSA.h
+++ b/Client/game_sa/CPedSA.h
@@ -231,10 +231,7 @@ class CPedSAInterface : public CPhysicalSAInterface
 public:
     bool IsPlayer() const noexcept { return bPedType < 2; }
 
-    void SetCurrentWeapon(eWeaponSlot slot)
-    {
-        ((void(__thiscall*)(CPedSAInterface*, eWeaponSlot))FUNC_SetCurrentWeapon)(this, slot);
-    }
+    void SetCurrentWeapon(eWeaponSlot slot) { ((void(__thiscall*)(CPedSAInterface*, eWeaponSlot))FUNC_SetCurrentWeapon)(this, slot); }
 
     void RemoveWeaponModel(std::uint32_t model) { ((void(__thiscall*)(CEntitySAInterface*, std::uint32_t))FUNC_RemoveWeaponModel)(this, model); }
 
@@ -490,7 +487,7 @@ public:
     void SetInWaterFlags(bool inWater) override;
 
     static void __fastcall RemoveWeaponWhenEnteringVehicle(CPedSAInterface* pedInterface, void*, int jetpack);
-    static void StaticSetHooks();
+    static void            StaticSetHooks();
 
 private:
     void ApplySwimAndSlopeRotations();

--- a/Client/game_sa/CPedSA.h
+++ b/Client/game_sa/CPedSA.h
@@ -229,6 +229,18 @@ static_assert(sizeof(CPedStatSAInterface) == 0x34, "Invalid size for CPedStatSAI
 class CPedSAInterface : public CPhysicalSAInterface
 {
 public:
+    bool IsPlayer() const noexcept { return bPedType < 2; }
+
+    void SetCurrentWeapon(eWeaponSlot slot)
+    {
+        ((void(__thiscall*)(CPedSAInterface*, eWeaponSlot))FUNC_SetCurrentWeapon)(this, slot);
+    }
+
+    void RemoveWeaponModel(std::uint32_t model) { ((void(__thiscall*)(CEntitySAInterface*, std::uint32_t))FUNC_RemoveWeaponModel)(this, model); }
+
+    void RemoveWeaponWhenEnteringVehicle(bool jetpack);
+
+public:
     CPedSoundEntitySAInterface       pedAudio;           // CAEPedAudioEntity
     CPedSoundSAInterface             pedSound;           // CAEPedSpeechAudioEntity
     CPedWeaponAudioEntitySAInterface weaponAudioEntity;  // CAEPedWeaponAudioEntity
@@ -286,7 +298,7 @@ public:
     CVehicleSAInterface* vehicleDeadInFrontOf;
 
     int                  unk_594;
-    int                  bPedType;  // ped type? 0 = player, >1 = ped?
+    int                  bPedType;  // 0 = player, 1 = player2, > 1 = ped
     CPedStatSAInterface* pPedStats;
     CWeaponSAInterface   Weapons[WEAPONSLOT_MAX];
     eWeaponType          savedWeapon;
@@ -477,6 +489,7 @@ public:
 
     void SetInWaterFlags(bool inWater) override;
 
+    static void __fastcall RemoveWeaponWhenEnteringVehicle(CPedSAInterface* pedInterface, void*, int jetpack);
     static void StaticSetHooks();
 
 private:

--- a/Client/game_sa/CPlayerInfoSA.h
+++ b/Client/game_sa/CPlayerInfoSA.h
@@ -270,4 +270,6 @@ public:
     float        GetBikeFrontWheelDist() { return internalInterface->fBikeFrontWheelDist; }
     std::uint8_t GetMaxHealth() const { return internalInterface->MaxHealth; }
     std::uint8_t GetMaxArmor() const { return internalInterface->MaxArmour; }
+
+    bool CanDoDriveBy() const override { return internalInterface->bCanDoDriveBy; }
 };

--- a/Client/multiplayer_sa/CMultiplayerSA_1.3.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_1.3.cpp
@@ -111,9 +111,6 @@ DWORD RETURN_CProjectile_FixTearGasCrash_Cont = 0x4C0409;
 #define HOOKPOS_CProjectile_FixExplosionLocation 0x738A77
 DWORD RETURN_CProjectile_FixExplosionLocation = 0x738A86;
 
-#define HOOKPOS_CPed_RemoveWeaponWhenEnteringVehicle 0x5E6370
-DWORD RETURN_CPed_RemoveWeaponWhenEnteringVehicle = 0x5E6379;
-
 void          HOOK_CVehicle_ProcessStuff_TestSirenTypeSingle();
 void          HOOK_CVehicle_ProcessStuff_PostPushSirenPositionSingle();
 void          HOOK_CVehicle_ProcessStuff_TestSirenTypeDual();
@@ -140,7 +137,6 @@ void          HOOK_CVehicleModelInterface_SetClump();
 void          HOOK_CBoat_ApplyDamage();
 void          HOOK_CProjectile_FixTearGasCrash();
 void          HOOK_CProjectile_FixExplosionLocation();
-void          HOOK_CPed_RemoveWeaponWhenEnteringVehicle();
 void* __cdecl HOOK_CMemoryMgr_MallocAlign(int size, int alignment, int nHint);
 void __cdecl  HOOK_CMemoryMgr_FreeAlign(void* ptr);
 
@@ -197,9 +193,6 @@ void CMultiplayerSA::InitHooks_13()
     HookInstall(HOOKPOS_CProjectile_FixTearGasCrash, (DWORD)HOOK_CProjectile_FixTearGasCrash, 6);
 
     HookInstall(HOOKPOS_CProjectile_FixExplosionLocation, (DWORD)HOOK_CProjectile_FixExplosionLocation, 12);
-
-    // Fix invisible weapons during jetpack task
-    HookInstall(HOOKPOS_CPed_RemoveWeaponWhenEnteringVehicle, (DWORD)HOOK_CPed_RemoveWeaponWhenEnteringVehicle, 9);
 
     InitHooks_ClothesSpeedUp();
     EnableHooks_ClothesMemFix(true);
@@ -1869,55 +1862,6 @@ static void __declspec(naked) HOOK_CProjectile_FixExplosionLocation()
 skip:
         lea eax, [esi+4]
         jmp RETURN_CProjectile_FixExplosionLocation
-    }
-    // clang-format on
-}
-
-DWORD                         CPed_RemoveWeaponWhenEnteringVehicle_CalledFrom = 0;
-static void __declspec(naked) HOOK_CPed_RemoveWeaponWhenEnteringVehicle()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // clang-format off
-    __asm
-    {
-        push eax
-        mov eax, [esp+4]
-        mov CPed_RemoveWeaponWhenEnteringVehicle_CalledFrom, eax
-        pop eax
-
-        push esi
-        mov esi, ecx
-        mov eax, [esi+480h]
-    }
-    // clang-format on
-
-    // Called from CTaskSimpleJetPack::ProcessPed
-    if (CPed_RemoveWeaponWhenEnteringVehicle_CalledFrom == 0x68025F)
-    {
-        // clang-format off
-        __asm
-        {
-            mov pPedUsingJetpack, esi
-        }
-        // clang-format on
-
-        if (AllowJetPack())
-        {
-            // clang-format off
-            __asm
-            {
-                pop esi
-                retn 4
-            }
-            // clang-format on
-        }
-    }
-
-    // clang-format off
-    __asm
-    {
-        jmp RETURN_CPed_RemoveWeaponWhenEnteringVehicle
     }
     // clang-format on
 }

--- a/Client/sdk/game/CPlayerInfo.h
+++ b/Client/sdk/game/CPlayerInfo.h
@@ -40,4 +40,6 @@ public:
     virtual float        GetBikeFrontWheelDist() = 0;
     virtual std::uint8_t GetMaxHealth() const = 0;
     virtual std::uint8_t GetMaxArmor() const = 0;
+
+    virtual bool CanDoDriveBy() const = 0;
 };

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -276,6 +276,7 @@ CGame::CGame() : m_FloodProtect(4, 30000, 30000)  // Max of 4 connections per 30
     m_JetpackWeapons[WEAPONTYPE_MICRO_UZI] = true;
     m_JetpackWeapons[WEAPONTYPE_TEC9] = true;
     m_JetpackWeapons[WEAPONTYPE_PISTOL] = true;
+    m_JetpackWeapons[WEAPONTYPE_SAWNOFF_SHOTGUN] = true;
     // Glitch names (for Lua interface)
     m_GlitchNames["quickreload"] = GLITCH_QUICKRELOAD;
     m_GlitchNames["fastfire"] = GLITCH_FASTFIRE;

--- a/Server/mods/deathmatch/logic/CPed.cpp
+++ b/Server/mods/deathmatch/logic/CPed.cpp
@@ -538,25 +538,3 @@ void CPed::SetJackingVehicle(CVehicle* pVehicle)
     if (m_pJackingVehicle)
         m_pJackingVehicle->SetJackingPed(this);
 }
-
-void CPed::SetHasJetPack(bool bHasJetPack)
-{
-    if (m_bHasJetPack == bHasJetPack)
-        return;
-
-    m_bHasJetPack = bHasJetPack;
-
-    if (!bHasJetPack)
-        return;
-
-    // Set weapon slot to 0 if weapon is disabled with jetpack to avoid HUD and audio bugs
-    eWeaponType weaponType = static_cast<eWeaponType>(GetWeaponType(GetWeaponSlot()));
-    if (weaponType <= WEAPONTYPE_UNARMED)
-        return;
-
-    bool weaponEnabled;
-    CStaticFunctionDefinitions::GetJetpackWeaponEnabled(weaponType, weaponEnabled);
-
-    if (!weaponEnabled)
-        CStaticFunctionDefinitions::SetPedWeaponSlot(this, 0);
-}

--- a/Server/mods/deathmatch/logic/CPed.h
+++ b/Server/mods/deathmatch/logic/CPed.h
@@ -208,7 +208,7 @@ public:
     static const char* GetBodyPartName(unsigned char ucID);
 
     bool HasJetPack() { return m_bHasJetPack; }
-    void SetHasJetPack(bool bHasJetPack);
+    void SetHasJetPack(bool bHasJetPack) { m_bHasJetPack = bHasJetPack; }
 
     bool IsInWater() { return m_bInWater; }
     void SetInWater(bool bInWater) { m_bInWater = bInWater; }


### PR DESCRIPTION
#### Summary
In GTA, when you equip a jetpack, the weapon is automatically switched to a pistol, tec-9, or uzi if you have one of these weapons. Otherwise, the weapon is hidden from the player’s hands, but the slot remains unchanged, which causes two issues:
- Issue #508, where weapons are invisible
- The state described in PR #3573 - if you pick up a jetpack while holding a e.g chainsaw/molotov, the weapon model disappears, but the weapon sound and its HUD icon remain

In GTA, when you remove the jetpack, the slot is restored to the one you had before equipping it. For example, if you are holding an AK-47, then equip a jetpack and it switches to an uzi, after removing the jetpack you get the AK-47 back. PR #3573 changed this behavior so that after removing the jetpack, the slot is always reset to 0.

From the GTA code, it appears that Rockstar also intended to include the sawed-off shotgun for jetpack use, but a trivial mistake prevented it from working.
```cpp
			// this is to let the player use other 1 handed weapons when flying a jetpack!
			else if(nVehicleType==1 && m_WeaponSlots[WEAPONSLOT_TYPE_SHOTGUN].m_eWeaponType==WEAPONTYPE_SAWNOFF_SHOTGUN
			&& m_WeaponSlots[WEAPONSLOT_TYPE_SHOTGUN].m_nAmmoTotal>0)
			{
				nDoDrivebySlot = WEAPONSLOT_TYPE_HANDGUN;
			}
			else if(nVehicleType==1 && m_WeaponSlots[WEAPONSLOT_TYPE_HANDGUN].m_eWeaponType==WEAPONTYPE_PISTOL
			&& m_WeaponSlots[WEAPONSLOT_TYPE_HANDGUN].m_nAmmoTotal>0)
			{
				nDoDrivebySlot = WEAPONSLOT_TYPE_HANDGUN;
			}
```

This PR resolves the issues described above.

#### Motivation
https://github.com/multitheftauto/mtasa-blue/pull/3510#issuecomment-2573837673

#### Test plan
See issues: #508, #3569
1. Get chainsaw
2. Get jetpack
3. Remove jetpack
4. The slot should be reset to the chainsaw, but it is instead reset to 0.

**TL;DR**
- Removing the jetpack restores the previous slot, exactly like in GTA:SA
- While using a jetpack, you can now also use the sawed-off shotgun in addition to pistol, Uzi, and Tec-9

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
