### PR TITLE
new "invert mouse horizontally" option in the controls settings tab.

### DIFF
--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -321,52 +321,52 @@ void CClientVariables::LoadDefaults()
     DEFAULT("server_can_flash_window", true);                               // allow server to flash the window
     DEFAULT("allow_tray_notifications", true);                              // allow scripts to create tray balloon notifications
     DEFAULT("text_scale", 1.0f);                                            // text scale
-    DEFAULT("invert_mouse", false);                                         // mouse inverting (vertical, kept the naming as it's due to backwards compatibility)
-    DEFAULT("invert_mouse_horizontal", true);                               // mouse inverting (horizontal)
-    DEFAULT("fly_with_mouse", false);                                       // flying with mouse controls
-    DEFAULT("steer_with_mouse", false);                                     // steering with mouse controls
-    DEFAULT("classic_controls", false);                                     // classic/standard controls
-    DEFAULT("mastervolume", 1.0f);                                          // master volume
-    DEFAULT("mtavolume", 1.0f);                                             // custom sound's volume
-    DEFAULT("voicevolume", 1.0f);                                           // voice chat output volume
-    DEFAULT("mapalpha", 155);                                               // player map alpha
-    DEFAULT("mapimage", 0);                                                 // player map image
-    DEFAULT("browser_speed", 1);                                            // Browser speed
-    DEFAULT("single_download", 0);                                          // Single connection for downloads
-    DEFAULT("packet_tag", 0);                                               // Tag network packets
-    DEFAULT("progress_animation", 1);                                       // Progress spinner at the bottom of the screen
-    DEFAULT("update_build_type", 0);                                        // 0-stable 1-test 2-nightly
-    DEFAULT("update_auto_install", 1);                                      // 0-off 1-on
-    DEFAULT("volumetric_shadows", 0);                                       // Enable volumetric shadows
-    DEFAULT("aspect_ratio", 0);                                             // Display aspect ratio
-    DEFAULT("hud_match_aspect_ratio", 1);                                   // GTA HUD should match the display aspect ratio
-    DEFAULT("anisotropic", 0);                                              // Anisotropic filtering
-    DEFAULT("grass", 1);                                                    // Enable grass
-    DEFAULT("heat_haze", 1);                                                // Enable heat haze
-    DEFAULT("tyre_smoke_enabled", 1);                                       // Enable tyre smoke
-    DEFAULT("high_detail_vehicles", 0);                                     // Disable rendering high detail vehicles all the time
-    DEFAULT("high_detail_peds", 0);                                         // Disable rendering high detail peds all the time
-    DEFAULT("blur", 1);                                                     // Enable blur
-    DEFAULT("corona_reflections", 0);                                       // Disable corona rain reflections
-    DEFAULT("dynamic_ped_shadows", 0);                                      // Disable dynamic ped shadows
-    DEFAULT("fast_clothes_loading", 1);                                     // 0-off 1-auto 2-on
-    DEFAULT("allow_screen_upload", 1);                                      // 0-off 1-on
-    DEFAULT("allow_external_sounds", 1);                                    // 0-off 1-on
-    DEFAULT("max_clientscript_log_kb", 5000);                               // Max size in KB (0-No limit)
-    DEFAULT("display_fullscreen_style", 0);                                 // 0-standard 1-borderless 2-borderless keep res 3-borderless stretch
-    DEFAULT("display_windowed", 0);                                         // 0-off 1-on
-    DEFAULT("multimon_fullscreen_minimize", 1);                             // 0-off 1-on
-    DEFAULT("borderless_gamma_power", 0.95f);                               // Gamma exponent applied to windowed gamma ramp (1.0 = unchanged)
-    DEFAULT("borderless_brightness_scale", 1.03f);                          // Brightness multiplier for windowed gamma ramp (1.0 = unchanged)
-    DEFAULT("borderless_contrast_scale", 1.0f);                             // Contrast multiplier for borderless presentation (1.0 = unchanged)
-    DEFAULT("borderless_saturation_scale", 1.0f);                           // Saturation multiplier for borderless presentation (1.0 = unchanged)
-    DEFAULT("borderless_enable_srgb", false);                               // Enable sRGB correction when running borderless
-    DEFAULT("borderless_gamma_enabled", false);                             // Apply gamma adjustment while borderless tuning active
-    DEFAULT("borderless_brightness_enabled", false);                        // Apply brightness adjustment while borderless tuning active
-    DEFAULT("borderless_contrast_enabled", false);                          // Apply contrast adjustment while borderless tuning active
-    DEFAULT("borderless_saturation_enabled", false);                        // Apply saturation adjustment while borderless tuning active
-    DEFAULT("borderless_apply_windowed", false);                            // Apply display adjustments while windowed/borderless
-    DEFAULT("borderless_apply_fullscreen", false);                          // Apply display adjustments while in exclusive fullscreen
+    DEFAULT("invert_mouse", false);                   // mouse inverting (vertical, kept the naming as it's due to backwards compatibility)
+    DEFAULT("invert_mouse_horizontal", true);         // mouse inverting (horizontal)
+    DEFAULT("fly_with_mouse", false);                 // flying with mouse controls
+    DEFAULT("steer_with_mouse", false);               // steering with mouse controls
+    DEFAULT("classic_controls", false);               // classic/standard controls
+    DEFAULT("mastervolume", 1.0f);                    // master volume
+    DEFAULT("mtavolume", 1.0f);                       // custom sound's volume
+    DEFAULT("voicevolume", 1.0f);                     // voice chat output volume
+    DEFAULT("mapalpha", 155);                         // player map alpha
+    DEFAULT("mapimage", 0);                           // player map image
+    DEFAULT("browser_speed", 1);                      // Browser speed
+    DEFAULT("single_download", 0);                    // Single connection for downloads
+    DEFAULT("packet_tag", 0);                         // Tag network packets
+    DEFAULT("progress_animation", 1);                 // Progress spinner at the bottom of the screen
+    DEFAULT("update_build_type", 0);                  // 0-stable 1-test 2-nightly
+    DEFAULT("update_auto_install", 1);                // 0-off 1-on
+    DEFAULT("volumetric_shadows", 0);                 // Enable volumetric shadows
+    DEFAULT("aspect_ratio", 0);                       // Display aspect ratio
+    DEFAULT("hud_match_aspect_ratio", 1);             // GTA HUD should match the display aspect ratio
+    DEFAULT("anisotropic", 0);                        // Anisotropic filtering
+    DEFAULT("grass", 1);                              // Enable grass
+    DEFAULT("heat_haze", 1);                          // Enable heat haze
+    DEFAULT("tyre_smoke_enabled", 1);                 // Enable tyre smoke
+    DEFAULT("high_detail_vehicles", 0);               // Disable rendering high detail vehicles all the time
+    DEFAULT("high_detail_peds", 0);                   // Disable rendering high detail peds all the time
+    DEFAULT("blur", 1);                               // Enable blur
+    DEFAULT("corona_reflections", 0);                 // Disable corona rain reflections
+    DEFAULT("dynamic_ped_shadows", 0);                // Disable dynamic ped shadows
+    DEFAULT("fast_clothes_loading", 1);               // 0-off 1-auto 2-on
+    DEFAULT("allow_screen_upload", 1);                // 0-off 1-on
+    DEFAULT("allow_external_sounds", 1);              // 0-off 1-on
+    DEFAULT("max_clientscript_log_kb", 5000);         // Max size in KB (0-No limit)
+    DEFAULT("display_fullscreen_style", 0);           // 0-standard 1-borderless 2-borderless keep res 3-borderless stretch
+    DEFAULT("display_windowed", 0);                   // 0-off 1-on
+    DEFAULT("multimon_fullscreen_minimize", 1);       // 0-off 1-on
+    DEFAULT("borderless_gamma_power", 0.95f);         // Gamma exponent applied to windowed gamma ramp (1.0 = unchanged)
+    DEFAULT("borderless_brightness_scale", 1.03f);    // Brightness multiplier for windowed gamma ramp (1.0 = unchanged)
+    DEFAULT("borderless_contrast_scale", 1.0f);       // Contrast multiplier for borderless presentation (1.0 = unchanged)
+    DEFAULT("borderless_saturation_scale", 1.0f);     // Saturation multiplier for borderless presentation (1.0 = unchanged)
+    DEFAULT("borderless_enable_srgb", false);         // Enable sRGB correction when running borderless
+    DEFAULT("borderless_gamma_enabled", false);       // Apply gamma adjustment while borderless tuning active
+    DEFAULT("borderless_brightness_enabled", false);  // Apply brightness adjustment while borderless tuning active
+    DEFAULT("borderless_contrast_enabled", false);    // Apply contrast adjustment while borderless tuning active
+    DEFAULT("borderless_saturation_enabled", false);  // Apply saturation adjustment while borderless tuning active
+    DEFAULT("borderless_apply_windowed", false);      // Apply display adjustments while windowed/borderless
+    DEFAULT("borderless_apply_fullscreen", false);    // Apply display adjustments while in exclusive fullscreen
 
     if (Exists("borderless_enable_srgb"))
     {

--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -321,7 +321,8 @@ void CClientVariables::LoadDefaults()
     DEFAULT("server_can_flash_window", true);                               // allow server to flash the window
     DEFAULT("allow_tray_notifications", true);                              // allow scripts to create tray balloon notifications
     DEFAULT("text_scale", 1.0f);                                            // text scale
-    DEFAULT("invert_mouse", false);                                         // mouse inverting
+    DEFAULT("invert_mouse", false);                                         // mouse inverting (vertical, kept the naming as it's due to backwards compatibility)
+    DEFAULT("invert_mouse_horizontal", true);                               // mouse inverting (horizontal)
     DEFAULT("fly_with_mouse", false);                                       // flying with mouse controls
     DEFAULT("steer_with_mouse", false);                                     // steering with mouse controls
     DEFAULT("classic_controls", false);                                     // classic/standard controls

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -681,7 +681,9 @@ void CCore::ApplyGameSettings()
     CGameSettings*            pGameSettings = m_pGame->GetSettings();
 
     CVARS_GET("invert_mouse", bVal);
-    pController->SetMouseInverted(bVal);
+    pController->SetMouseInvertedVertical(bVal);
+    CVARS_GET("invert_mouse_horizontal", bVal);
+    pController->SetMouseInvertedHorizontal(bVal);
     CVARS_GET("fly_with_mouse", bVal);
     pController->SetFlyWithMouse(bVal);
     CVARS_GET("steer_with_mouse", bVal);

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -350,6 +350,7 @@ void CSettings::ResetGuiPointers()
 
     m_pControlsMouseLabel = NULL;
     m_pInvertMouse = NULL;
+    m_pInvertMouseHorizontal = NULL;
     m_pSteerWithMouse = NULL;
     m_pFlyWithMouse = NULL;
     m_pLabelMouseSensitivity = NULL;
@@ -605,6 +606,10 @@ void CSettings::CreateGUI()
     m_pInvertMouse = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabControls, _("Invert mouse vertically"), true));
     m_pInvertMouse->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY));
     m_pInvertMouse->AutoSize(NULL, 20.0f);
+
+    m_pInvertMouseHorizontal = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabControls, _("Invert mouse horizontally"), true));
+    m_pInvertMouseHorizontal->SetPosition(CVector2D(vecTemp.fX + 170.0f, vecTemp.fY));
+    m_pInvertMouseHorizontal->AutoSize(NULL, 20.0f);
 
     m_pSteerWithMouse = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabControls, _("Steer with mouse"), true));
     m_pSteerWithMouse->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 16.0f));
@@ -2836,6 +2841,7 @@ bool CSettings::OnControlsDefaultClick(CGUIElement* pElement)
     // Load the default settings
     GetJoystickManager()->SetDefaults();
     CVARS_SET("invert_mouse", false);
+    CVARS_SET("invert_mouse_horizontal", false);
     CVARS_SET("fly_with_mouse", false);
     CVARS_SET("steer_with_mouse", false);
     CVARS_SET("classic_controls", false);
@@ -2844,7 +2850,8 @@ bool CSettings::OnControlsDefaultClick(CGUIElement* pElement)
     gameSettings->SetMouseSensitivity(0.5f);
 
     // Set game vars
-    pController->SetMouseInverted(CVARS_GET_VALUE<bool>("invert_mouse"));
+    pController->SetMouseInvertedVertical(CVARS_GET_VALUE<bool>("invert_mouse"));
+    pController->SetMouseInvertedHorizontal(CVARS_GET_VALUE<bool>("invert_mouse_horizontal"));
     pController->SetFlyWithMouse(CVARS_GET_VALUE<bool>("fly_with_mouse"));
     pController->SetSteerWithMouse(CVARS_GET_VALUE<bool>("steer_with_mouse"));
     pController->SetClassicControls(CVARS_GET_VALUE<bool>("classic_controls"));
@@ -2853,6 +2860,7 @@ bool CSettings::OnControlsDefaultClick(CGUIElement* pElement)
     // Update the GUI
     UpdateJoypadTab();
     m_pInvertMouse->SetSelected(CVARS_GET_VALUE<bool>("invert_mouse"));
+    m_pInvertMouseHorizontal->SetSelected(CVARS_GET_VALUE<bool>("invert_mouse_horizontal"));
     m_pFlyWithMouse->SetSelected(CVARS_GET_VALUE<bool>("fly_with_mouse"));
     m_pSteerWithMouse->SetSelected(CVARS_GET_VALUE<bool>("steer_with_mouse"));
     m_pStandardControls->SetSelected(!CVARS_GET_VALUE<bool>("classic_controls"));
@@ -3950,6 +3958,8 @@ void CSettings::LoadData()
     // Controls
     CVARS_GET("invert_mouse", bVar);
     m_pInvertMouse->SetSelected(bVar);
+    CVARS_GET("invert_mouse_horizontal", bVar);
+    m_pInvertMouseHorizontal->SetSelected(bVar);
     CVARS_GET("steer_with_mouse", bVar);
     m_pSteerWithMouse->SetSelected(bVar);
     CVARS_GET("fly_with_mouse", bVar);
@@ -4285,7 +4295,9 @@ void CSettings::SaveData()
     // Very hacky
     CControllerConfigManager* pController = g_pCore->GetGame()->GetControllerConfigManager();
     CVARS_SET("invert_mouse", m_pInvertMouse->GetSelected());
-    pController->SetMouseInverted(m_pInvertMouse->GetSelected());
+    pController->SetMouseInvertedVertical(m_pInvertMouse->GetSelected());
+    CVARS_SET("invert_mouse_horizontal", m_pInvertMouseHorizontal->GetSelected());
+    pController->SetMouseInvertedHorizontal(m_pInvertMouseHorizontal->GetSelected());
     CVARS_SET("steer_with_mouse", m_pSteerWithMouse->GetSelected());
     pController->SetSteerWithMouse(m_pSteerWithMouse->GetSelected());
     CVARS_SET("fly_with_mouse", m_pFlyWithMouse->GetSelected());

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -297,6 +297,7 @@ protected:
 
     CGUILabel*     m_pControlsMouseLabel;
     CGUICheckBox*  m_pInvertMouse;
+    CGUICheckBox*  m_pInvertMouseHorizontal;
     CGUICheckBox*  m_pSteerWithMouse;
     CGUICheckBox*  m_pFlyWithMouse;
     CGUILabel*     m_pLabelMouseSensitivity;

--- a/Client/game_sa/CControllerConfigManagerSA.cpp
+++ b/Client/game_sa/CControllerConfigManagerSA.cpp
@@ -14,6 +14,7 @@
 
 #define VAR_InputType                  ((BYTE*)(0xB6EC2E))
 #define VAR_MouseInverted              ((BYTE*)(0xBA6745))
+#define VAR_MouseInvertedHorizontal    ((BYTE*)(0xBA6744))
 #define VAR_FlyWithMouse               ((BYTE*)(0xC1CC03))
 #define VAR_SteerWithMouse             ((BYTE*)(0xC1CC02))
 #define VAR_VerticalAimSensitivity     ((float*)(0xB6EC18))
@@ -99,9 +100,14 @@ void CControllerConfigManagerSA::SetClassicControls(bool bClassicControls)
     MemPutFast<unsigned char>(VAR_InputType, bClassicControls ? 0 : 1);
 }
 
-void CControllerConfigManagerSA::SetMouseInverted(bool bInverted)
+void CControllerConfigManagerSA::SetMouseInvertedVertical(bool bInverted)
 {
     MemPutFast<BYTE>(VAR_MouseInverted, (bInverted) ? 0 : 1);
+}
+
+void CControllerConfigManagerSA::SetMouseInvertedHorizontal(bool bInverted)
+{
+    MemPutFast<BYTE>(VAR_MouseInvertedHorizontal, (bInverted) ? 0 : 1);
 }
 
 void CControllerConfigManagerSA::SetFlyWithMouse(bool bFlyWithMouse)

--- a/Client/game_sa/CControllerConfigManagerSA.cpp
+++ b/Client/game_sa/CControllerConfigManagerSA.cpp
@@ -100,14 +100,14 @@ void CControllerConfigManagerSA::SetClassicControls(bool bClassicControls)
     MemPutFast<unsigned char>(VAR_InputType, bClassicControls ? 0 : 1);
 }
 
-void CControllerConfigManagerSA::SetMouseInvertedVertical(bool bInverted)
+void CControllerConfigManagerSA::SetMouseInvertedVertical(bool bInvertedVertical)
 {
-    MemPutFast<BYTE>(VAR_MouseInverted, (bInverted) ? 0 : 1);
+    MemPutFast<BYTE>(VAR_MouseInverted, (bInvertedVertical) ? 0 : 1);
 }
 
-void CControllerConfigManagerSA::SetMouseInvertedHorizontal(bool bInverted)
+void CControllerConfigManagerSA::SetMouseInvertedHorizontal(bool bInvertedHorizontal)
 {
-    MemPutFast<BYTE>(VAR_MouseInvertedHorizontal, (bInverted) ? 0 : 1);
+    MemPutFast<BYTE>(VAR_MouseInvertedHorizontal, (bInvertedHorizontal) ? 0 : 1);
 }
 
 void CControllerConfigManagerSA::SetFlyWithMouse(bool bFlyWithMouse)

--- a/Client/game_sa/CControllerConfigManagerSA.h
+++ b/Client/game_sa/CControllerConfigManagerSA.h
@@ -29,7 +29,8 @@ public:
     int   GetNumOfSettingsForAction(eControllerAction action);
     void  ClearSettingsAssociatedWithAction(eControllerAction action, eControllerType controllerType);
     void  SetClassicControls(bool bClassicControls);
-    void  SetMouseInverted(bool bInverted);
+    void  SetMouseInvertedVertical(bool bInvertedVertical);
+    void  SetMouseInvertedHorizontal(bool bInvertedHorizontal);
     void  SetFlyWithMouse(bool bFlyWithMouse);
     void  SetSteerWithMouse(bool bSteerWithMouse);
     void  SuspendSteerAndFlyWithMouse(bool bSuspend);

--- a/Client/sdk/game/CControllerConfigManager.h
+++ b/Client/sdk/game/CControllerConfigManager.h
@@ -198,7 +198,8 @@ public:
     virtual void  SetControllerKeyAssociatedWithAction(eControllerAction action, int iKey, eControllerType controllerType) = 0;
     virtual int   GetControllerKeyAssociatedWithAction(eControllerAction action, eControllerType controllerType) = 0;
     virtual void  SetClassicControls(bool bClassicControls) = 0;
-    virtual void  SetMouseInverted(bool bInverted) = 0;
+    virtual void  SetMouseInvertedVertical(bool bInvertedVertical) = 0;
+    virtual void  SetMouseInvertedHorizontal(bool bInvertedHorizontal) = 0;
     virtual void  SetFlyWithMouse(bool bFlyWithMouse) = 0;
     virtual void  SetSteerWithMouse(bool bSteerWithMouse) = 0;
     virtual void  SuspendSteerAndFlyWithMouse(bool bSuspend) = 0;


### PR DESCRIPTION
#### Summary
<!-- What change are you making? -->
added a new "invert mouse horizontally" option, ticked on by default (as it is the default behavior in vanilla SA).
<img width="893" height="603" alt="image" src="https://github.com/user-attachments/assets/c24855c3-61aa-4bca-84ab-00e55814b5a2" />


#### Motivation
was working on a resource to achieve the same behavior in the following video, apparently I would need to rewrite the camera system inside MTA's lua engine in order to achieve this, as I can simply invert the camera source instead of the world 3D space, achievable by reloading the world but it might but... not so easy. 
https://www.youtube.com/watch?v=C3N2VBdDisA&t 

#### Test plan
<!-- How have you tested this change? This should give confidence to the reviewer that your change is safe. -->
simply validate the "controls" options via settings, 

#### Checklist

* [X] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [X] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
