### PR TITLE
Fix onClientBrowserCreated never firing after lazy loading changes

### DIFF
--- a/Client/cefweb/CWebView.cpp
+++ b/Client/cefweb/CWebView.cpp
@@ -127,9 +127,10 @@ void CWebView::QueueBrowserEvent(const char* name, std::function<void(CWebBrowse
 
 void CWebView::Initialise()
 {
-    // Lazy browser creation: We don't create the CEF browser here.
-    // The browser will be created on first LoadURL() call via EnsureBrowserCreated().
-    // This saves memory and CPU for browsers that are created but never used.
+    // Create the CEF browser eagerly so onClientBrowserCreated fires
+    // even if loadBrowserURL hasn't been called yet.
+    // Scripts rely on this event to know when the browser is ready.
+    EnsureBrowserCreated();
 }
 
 bool CWebView::EnsureBrowserCreated()


### PR DESCRIPTION
Lazy loading (ab0bcbf9f) removed Initialise() to defer CefBrowserHost::CreateBrowser() until the first LoadURL() call. However, scripts universally wait for onClientBrowserCreated before calling loadBrowserURL - creating a deadlock: the event needs CreateBrowser, but CreateBrowser needs LoadURL, which scripts only call after the event.

Fix: restore eager browser creation in Initialise() by calling EnsureBrowserCreated(). The idempotency guard and pending URL mechanism from the lazy loading fixes (eefc173e7) are preserved for the race condition where LoadURL is called before OnAfterCreated fires.