### PR TITLE
Fix client-sided animation progress

### DIFF
--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -2258,13 +2258,16 @@ bool CStaticFunctionDefinitions::SetPedAnimation(CClientEntity& Entity, const SS
         CClientPed& Ped = static_cast<CClientPed&>(Entity);
         if (strBlockName && szAnimName)
         {
+            bool success = false;
+
             std::unique_ptr<CAnimBlock> pBlock = g_pGame->GetAnimManager()->GetAnimationBlock(strBlockName);
             if (pBlock)
             {
                 Ped.SetCurrentAnimationCustom(false);
                 Ped.SetNextAnimationNormal();
                 Ped.RunNamedAnimation(pBlock, szAnimName, iTime, iBlend, bLoop, bUpdatePosition, bInterruptable, bFreezeLastFrame);
-                return true;
+
+                success = true;
             }
             else
             {
@@ -2283,12 +2286,16 @@ bool CStaticFunctionDefinitions::SetPedAnimation(CClientEntity& Entity, const SS
 
                         const char* szGateWayAnimationName = g_pGame->GetAnimManager()->GetGateWayAnimationName();
                         Ped.RunNamedAnimation(pBlock, szGateWayAnimationName, iTime, iBlend, bLoop, bUpdatePosition, bInterruptable, bFreezeLastFrame);
-                        return true;
+
+                        success = true;
                     }
                 }
             }
 
-            Ped.m_AnimationCache.startTime = GetTimestamp();
+            if (success)
+                Ped.m_AnimationCache.startTime = GetTimestamp();
+
+            return success;
         }
         else
         {


### PR DESCRIPTION
#### Summary
Because `CStaticFunctionDefinitions::SetPedAnimation` returned true immediately after setting the animation, startTime was never set to a timestamp. As a result, it always remained 0, and progress was calculated as timestamp / 1000, producing large values (clamped to 1).


#### Motivation


#### Test plan
```
crun ped = createPed(50, getElementPosition(me)) setPedAnimation(ped, "ped", "ko_shot_face", -1, false, false, false, true)
```

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
