### PR TITLE
Persist exact radio and SFX slider values across restarts

### DIFF
--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -258,6 +258,8 @@ void CClientVariables::ValidateValues()
     ClampValue("chat_text_alignment", Chat::Text::Align::LEFT, Chat::Text::Align::RIGHT);
     ClampValue("text_scale", 0.8f, 3.0f);
     ClampValue("mastervolume", 0.0f, 1.0f);
+    ClampValue("radiovolume", 0.0f, 1.0f);
+    ClampValue("sfxvolume", 0.0f, 1.0f);
     ClampValue("mtavolume", 0.0f, 1.0f);
     ClampValue("voicevolume", 0.0f, 1.0f);
     ClampValue("mapalpha", 0, 255);
@@ -326,6 +328,8 @@ void CClientVariables::LoadDefaults()
     DEFAULT("steer_with_mouse", false);                                     // steering with mouse controls
     DEFAULT("classic_controls", false);                                     // classic/standard controls
     DEFAULT("mastervolume", 1.0f);                                          // master volume
+    DEFAULT("radiovolume", 1.0f);                                           // radio volume (unscaled)
+    DEFAULT("sfxvolume", 1.0f);                                             // sfx volume (unscaled)
     DEFAULT("mtavolume", 1.0f);                                             // custom sound's volume
     DEFAULT("voicevolume", 1.0f);                                           // voice chat output volume
     DEFAULT("mapalpha", 155);                                               // player map alpha

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -104,6 +104,13 @@ namespace
         return width;
     }
 
+    int QuantizeVolumePercent(float& value)
+    {
+        const int iPercent = std::clamp(static_cast<int>(value * 100.0f + 0.5f), 0, 100);
+        value = iPercent / 100.0f;
+        return iPercent;
+    }
+
     void FinalizeSliderRow(float tabWidth, CGUIScrollBar* slider, CGUILabel* valueLabel, float preferredWidth, float labelSpacing = kSliderLabelSpacing,
                            CGUILabel* textLabel = nullptr)
     {
@@ -430,9 +437,48 @@ CSettings::CSettings()
 {
     ResetGuiPointers();
 
-    CGameSettings* gameSettings = CCore::GetSingleton().GetGame()->GetSettings();
-    m_fRadioVolume = (float)gameSettings->GetRadioVolume() / 64.0f;
-    m_fSFXVolume = (float)gameSettings->GetSFXVolume() / 64.0f;
+    CClientVariables& clientVars = CClientVariables::GetSingleton();
+    CGameSettings*    gameSettings = CCore::GetSingleton().GetGame()->GetSettings();
+
+    float fRadioVolume = 0.0f;
+    float fSFXVolume = 0.0f;
+
+    // Keep exact slider values in CVARs. Fall back to reconstructed values for
+    // one-time migration when those keys do not exist yet.
+    if (clientVars.Exists("radiovolume") && clientVars.Exists("sfxvolume"))
+    {
+        CVARS_GET("radiovolume", fRadioVolume);
+        CVARS_GET("sfxvolume", fSFXVolume);
+    }
+    else
+    {
+        // GTA stores radio/SFX as values already multiplied by master volume.
+        // The UI sliders represent the unscaled channel volumes, so recover them
+        // by dividing by the persisted master value during startup.
+        const float fMasterVolume = std::max(0.0f, std::min(CVARS_GET_VALUE<float>("mastervolume"), 1.0f));
+        const float fStoredRadioVolume = (float)gameSettings->GetRadioVolume() / 64.0f;
+        const float fStoredSFXVolume = (float)gameSettings->GetSFXVolume() / 64.0f;
+
+        if (fMasterVolume > 0.0001f)
+        {
+            fRadioVolume = fStoredRadioVolume / fMasterVolume;
+            fSFXVolume = fStoredSFXVolume / fMasterVolume;
+        }
+        else
+        {
+            // If master was zero we cannot recover hidden channel values.
+            fRadioVolume = fStoredRadioVolume;
+            fSFXVolume = fStoredSFXVolume;
+        }
+
+        CVARS_SET("radiovolume", fRadioVolume);
+        CVARS_SET("sfxvolume", fSFXVolume);
+    }
+
+    m_fRadioVolume = std::max(0.0f, std::min(fRadioVolume, 1.0f));
+    m_fSFXVolume = std::max(0.0f, std::min(fSFXVolume, 1.0f));
+    QuantizeVolumePercent(m_fRadioVolume);
+    QuantizeVolumePercent(m_fSFXVolume);
 
     m_iMaxAnisotropic = g_pDeviceState->AdapterState.MaxAnisotropicSetting;
     m_bBrowserListsChanged = false;
@@ -5446,20 +5492,30 @@ bool CSettings::OnMasterVolumeChanged(CGUIElement* pElement)
 
 bool CSettings::OnRadioVolumeChanged(CGUIElement* pElement)
 {
-    int iVolume = m_pAudioRadioVolume->GetScrollPosition() * 100.0f;
+    float fVolume = m_pAudioRadioVolume->GetScrollPosition();
+    int   iVolume = QuantizeVolumePercent(fVolume);
     m_pLabelRadioVolumeValue->SetText(SString("%i%%", iVolume).c_str());
 
-    SetRadioVolume(m_pAudioRadioVolume->GetScrollPosition());
+    if (std::abs(m_pAudioRadioVolume->GetScrollPosition() - fVolume) > 0.0001f)
+        m_pAudioRadioVolume->SetScrollPosition(fVolume);
+
+    CVARS_SET("radiovolume", fVolume);
+    SetRadioVolume(fVolume);
 
     return true;
 }
 
 bool CSettings::OnSFXVolumeChanged(CGUIElement* pElement)
 {
-    int iVolume = m_pAudioSFXVolume->GetScrollPosition() * 100.0f;
+    float fVolume = m_pAudioSFXVolume->GetScrollPosition();
+    int   iVolume = QuantizeVolumePercent(fVolume);
     m_pLabelSFXVolumeValue->SetText(SString("%i%%", iVolume).c_str());
 
-    SetSFXVolume(m_pAudioSFXVolume->GetScrollPosition());
+    if (std::abs(m_pAudioSFXVolume->GetScrollPosition() - fVolume) > 0.0001f)
+        m_pAudioSFXVolume->SetScrollPosition(fVolume);
+
+    CVARS_SET("sfxvolume", fVolume);
+    SetSFXVolume(fVolume);
 
     return true;
 }


### PR DESCRIPTION
#### Summary
This PR fixes Audio tab volume drift after restarting the client, especially for Radio and SFX sliders.

Changes made:
- Persist unscaled Radio and SFX slider values as dedicated client variables (`radiovolume`, `sfxvolume`) instead of reconstructing them only from GTA-stored values.
- Add defaults and range clamping for the new variables (`0.0` to `1.0`).
- Quantize Radio and SFX slider values to exact 1% steps when applying/storing, so displayed percentages and persisted values remain aligned.
- Keep a migration fallback for older configs that do not yet have the new variables.

This addresses cases where values like `69%` and `67%` could come back as nearby but different values after restart, while other audio settings remained stable.

#### Motivation
Audio settings persistence was inconsistent across restarts. Master, MTA, and Voice generally remained stable, but Radio and SFX could drift by 1-2% due to quantization and reconstruction behavior.
- GTA stores channel volumes in low-resolution integer form (0-64) and applies master-volume scaling.
- Reconstructing UI slider values from that path introduces rounding error.
- Slider float positions and displayed integer percentages were not always normalized to the same precision.

This PR makes restart behavior match the exact values selected in the UI.

#### Test plan
Manual test matrix:
- Set:
  - Master: 90%
  - Radio: 69%
  - SFX: 67%
  - MTA: 52%
  - Voice: 34%
- Click OK, close the game, relaunch, and reopen the Audio tab.
- Verify all five values match exactly, including Radio and SFX.

Additional checks:
- Repeat with multiple combinations, including edge cases: 0%, 1%, 99%, 100%.
- Verify changing Master still updates runtime Radio and SFX output correctly.
- Verify migration path:
  - Start with an existing config without `radiovolume` and `sfxvolume`.
  - Confirm first run migrates values and subsequent restarts stay stable.

Regression checks:
- Cancel still restores previous values.
- Audio defaults still set expected values.
- No regression for MTA and Voice volume persistence.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.