### PR TITLE
Fix client spoiler upgrade placement on unsupported vehicle models

### DIFF
--- a/Client/mods/deathmatch/logic/CVehicleUpgrades.cpp
+++ b/Client/mods/deathmatch/logic/CVehicleUpgrades.cpp
@@ -610,6 +610,20 @@ void CVehicleUpgrades::ForceAddUpgrade(unsigned short usUpgrade)
         CVehicle* pVehicle = m_pVehicle->GetGameVehicle();
         if (pVehicle)
         {
+            // Spoiler upgrades (slot 2) must not be applied if the vehicle model
+            // doesn't have the "ug_spoiler" frame. Otherwise, SA's AddUpgrade will
+            // call GetFrameFromId and get NULL, triggering the crash-fix fallback
+            // that attaches the spoiler to the wrong frame.
+            if (ucSlot == 2)
+            {
+                CModelInfo* pVehicleModelInfo = g_pGame->GetModelInfo(m_pVehicle->GetModel());
+                if (!pVehicleModelInfo || !pVehicleModelInfo->GetVehicleSupportedUpgrades().m_bSpoiler)
+                {
+                    // Vehicle doesn't support this spoiler upgrade - skip it
+                    return;
+                }
+            }
+
             // Grab the upgrade model
             CModelInfo* pModelInfo = g_pGame->GetModelInfo(usUpgrade);
             if (pModelInfo)


### PR DESCRIPTION
Prevent slot-2 spoiler upgrades from being applied when the vehicle model lacks ug_spoiler support. This avoids SA fallback frame substitution that places spoilers inside the cabin or at incorrect offsets. Applied the check in ForceAddUpgrade before calling AddVehicleUpgrade. Tested with a resource: supported models still get spoilers (e.g via autopimp in race); unsupported models no longer get mispositioned spoilers.