### PR TITLE
Avoid fixed camera mode on no-op setCameraMatrix calls

### DIFF
--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -5079,6 +5079,27 @@ bool CStaticFunctionDefinitions::SetCameraMatrix(const CVector& vecPosition, CVe
 
     if (!m_pCamera->IsInFixedMode())
     {
+        // Some scripts call setCameraMatrix(getCameraMatrix()) while dead to preserve the current frame.
+        // Treat this as a no-op so we don't switch into fixed mode and block later spectate target updates.
+        CMatrix currentMatrix;
+        if (m_pCamera->GetMatrix(currentMatrix))
+        {
+            const CVector currentLookAt = currentMatrix.vPos + currentMatrix.vFront;
+            const CVector requestedLookAt = pvecLookAt ? *pvecLookAt : currentLookAt;
+
+            constexpr float kCameraNoOpEpsilon = 0.01f;
+            const float     posDeltaSq = (currentMatrix.vPos - vecPosition).LengthSquared();
+            const float     lookDeltaSq = (currentLookAt - requestedLookAt).LengthSquared();
+            const float     epsilonSq = kCameraNoOpEpsilon * kCameraNoOpEpsilon;
+
+            if (posDeltaSq <= epsilonSq && lookDeltaSq <= epsilonSq)
+            {
+                if (std::isfinite(fFOV) && fFOV > 0.0f && fFOV < 180.0f)
+                    m_pCamera->SetFOV(fFOV);
+                return true;
+            }
+        }
+
         m_pCamera->ToggleCameraFixedMode(true);
     }
 


### PR DESCRIPTION
#### Summary
Prevent setCameraMatrix calls that request the camera's current position and look-at from switching the client into fixed camera mode. This keeps no-op camera preservation calls from pinning the camera at the local player's death frame and allows later setCameraTarget calls to correctly move the camera to the spectated player (setCameraTarget already handles fixed camera mode).

#### Motivation
Race calls setCameraMatrix(getCameraMatrix()) while the local player is dead to preserve the current frame. SetCameraMatrix always entered fixed camera mode even when the requested matrix was effectively identical to the current camera state. That caused the spectate UI to update while the actual camera remained stuck at the death position. This change treats unchanged camera matrix requests as no-ops unless a real camera move is being requested.

#### Test plan
Built the client with the SetCameraMatrix change and tested the race spectate flow on a live server. 

Repro before the fix: join a race in progress or spawn into an active session, die, enter spectate mode, observe that the UI reports a valid spectate target while the camera stays at the death location. 

Result after the fix: after dying, spectate correctly follows the selected player instead of remaining pinned to the death frame. 

Regression check: normal SetCameraMatrix behavior still applies when scripts request an actual camera move.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.