### PR TITLE
Protocol error fixes

### DIFF
--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -4198,8 +4198,6 @@ retry:
                     if (!CClientBuildingManager::IsValidModel(modelId))
                         modelId = 1700;
 
-                    bitStream.ReadCompressed(ucInterior);
-
                     bitStream.Read(LowLodObjectID);
                     CClientBuilding* pBuilding = new CClientBuilding(g_pClientGame->m_pManager, EntityID, modelId, position.data.vecPosition,
                                                                      rotationRadians.data.vecRotation, ucInterior);

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -3221,16 +3221,16 @@ retry:
                         {
                             case CClientPickup::ARMOR:
                             {
-                                SPlayerHealthSync health;
-                                if (bitStream.Read(&health))
-                                    pPickup->m_fAmount = health.data.fValue;
+                                SPlayerArmorSync armor;
+                                if (bitStream.Read(&armor))
+                                    pPickup->m_fAmount = armor.data.fValue;
                                 break;
                             }
                             case CClientPickup::HEALTH:
                             {
-                                SPlayerArmorSync armor;
-                                if (bitStream.Read(&armor))
-                                    pPickup->m_fAmount = armor.data.fValue;
+                                SPlayerHealthSync health;
+                                if (bitStream.Read(&health))
+                                    pPickup->m_fAmount = health.data.fValue;
                                 break;
                             }
                             case CClientPickup::WEAPON:
@@ -3974,7 +3974,7 @@ retry:
                         int         time, blendTime;
                         bool        looped, updatePosition, interruptable, freezeLastFrame, taskRestore;
                         float       speed;
-                        double      startTime;
+                        float       elapsedTime;
 
                         // Read data
                         bitStream.ReadString(blockName);
@@ -3986,13 +3986,17 @@ retry:
                         bitStream.ReadBit(freezeLastFrame);
                         bitStream.Read(blendTime);
                         bitStream.ReadBit(taskRestore);
-                        bitStream.Read(startTime);
+                        bitStream.Read(elapsedTime);
                         bitStream.Read(speed);
+
+                        // Server sends elapsed time rather than start time due to bitstream limitations regarding 64 bit integers.
+                        const uint64_t nowTick = GetTickCount64_();
+                        const int64_t startTime = nowTick - elapsedTime;
 
                         // Run anim
                         CStaticFunctionDefinitions::SetPedAnimation(*pPed, blockName, animName.c_str(), time, blendTime, looped, updatePosition, interruptable,
                                                                     freezeLastFrame);
-                        pPed->m_AnimationCache.startTime = static_cast<std::int64_t>(startTime);
+                        pPed->m_AnimationCache.startTime = startTime;
                         pPed->m_AnimationCache.speed = speed;
                         pPed->m_AnimationCache.progress = 0.0f;
 
@@ -4193,6 +4197,8 @@ retry:
 
                     if (!CClientBuildingManager::IsValidModel(modelId))
                         modelId = 1700;
+
+                    bitStream.ReadCompressed(ucInterior);
 
                     bitStream.Read(LowLodObjectID);
                     CClientBuilding* pBuilding = new CClientBuilding(g_pClientGame->m_pManager, EntityID, modelId, position.data.vecPosition,

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -3991,7 +3991,7 @@ retry:
 
                         // Server sends elapsed time rather than start time due to bitstream limitations regarding 64 bit integers.
                         const uint64_t nowTick = GetTickCount64_();
-                        const int64_t startTime = nowTick - elapsedTime;
+                        const int64_t  startTime = nowTick - elapsedTime;
 
                         // Run anim
                         CStaticFunctionDefinitions::SetPedAnimation(*pPed, blockName, animName.c_str(), time, blendTime, looped, updatePosition, interruptable,

--- a/Server/mods/deathmatch/logic/CMapManager.cpp
+++ b/Server/mods/deathmatch/logic/CMapManager.cpp
@@ -282,7 +282,7 @@ void CMapManager::SendMapInformation(CPlayer& Player)
     marker.Set("Water");
 
     // Add the buildings to the packet
-    CBuildingManager*                pBuildingManager = g_pGame->GetBuildingManager();
+    CBuildingManager*                     pBuildingManager = g_pGame->GetBuildingManager();
     CFastList<CBuilding*>::const_iterator iterBuilding = pBuildingManager->IterBegin();
     for (; iterBuilding != pBuildingManager->IterEnd(); iterBuilding++)
     {

--- a/Server/mods/deathmatch/logic/CMapManager.cpp
+++ b/Server/mods/deathmatch/logic/CMapManager.cpp
@@ -15,6 +15,7 @@
 #include "CWaterManager.h"
 #include "CPlayerManager.h"
 #include "CMarkerManager.h"
+#include "CBuildingManager.h"
 #include "CWater.h"
 #include "CMarker.h"
 #include "CBlip.h"
@@ -279,6 +280,17 @@ void CMapManager::SendMapInformation(CPlayer& Player)
     }
 
     marker.Set("Water");
+
+    // Add the buildings to the packet
+    CBuildingManager*                pBuildingManager = g_pGame->GetBuildingManager();
+    CFastList<CBuilding*>::const_iterator iterBuilding = pBuildingManager->IterBegin();
+    for (; iterBuilding != pBuildingManager->IterEnd(); iterBuilding++)
+    {
+        CBuilding* pBuilding = *iterBuilding;
+        EntityPacket.Add(pBuilding);
+    }
+
+    marker.Set("Building");
 
     // Send it
     Player.Send(EntityPacket);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaBuildingDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaBuildingDefs.cpp
@@ -61,6 +61,12 @@ CBuilding* CLuaBuildingDefs::CreateBuilding(lua_State* const luaVM, std::uint16_
     if (!pBuilding)
         return nullptr;
 
+    CElementGroup* pGroup = pResource->GetElementGroup();
+    if (pGroup)
+    {
+        pGroup->Add(pBuilding);
+    }
+
     pBuilding->SetPosition(pos);
     pBuilding->SetRotation(rot.value());
     pBuilding->SetModel(modelId);

--- a/Server/mods/deathmatch/logic/packets/CEntityAddPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CEntityAddPacket.cpp
@@ -1129,9 +1129,6 @@ bool CEntityAddPacket::Write(NetBitStreamInterface& BitStream) const
                     // Model id
                     BitStream.WriteCompressed(pBuilding->GetModel());
 
-                    // Interior
-                    BitStream.WriteCompressed(pBuilding->GetInterior());
-
                     CBuilding* pLowLodBuilding = pBuilding->GetLowLodElement();
                     ElementID  lowLodBuildingID = pLowLodBuilding ? pLowLodBuilding->GetID() : INVALID_ELEMENT_ID;
                     BitStream.Write(lowLodBuildingID);


### PR DESCRIPTION
#### Summary
- Fix ped animation protocol error
  - Animation start time was changed to be sent as timedelta (to avoid casting uint64 to uint32), but the client side counterpart was never changed. (Fixes #4832)
- Fix picking health and armour
  - These were being sent with wrong precision, this wouldn't cause crashes but was a mismatch.
- Fix building protocol error
  - Interior was being sent a second time for buildings, but not being read.
- Fix building memory leak
  - Building would not be destroyed on resource end
- Fix buildings not appearing on startup
  - Buildings were not being sent in the initial entity add packet

