### PR TITLE
Fix FPS limiter console spam

### DIFF
--- a/Client/core/FPSLimiter.cpp
+++ b/Client/core/FPSLimiter.cpp
@@ -164,21 +164,21 @@ namespace FPSLimiter
             QueryPerformanceCounter(&m_lastFrameTime);
             m_appliedThisFrame = false;
             OnFPSLimitChange();
-        }
 
-        std::stringstream ss;
-        ss << "FPSLimiter: FPS limit changed to " << (m_fpsTarget == 0 ? "unlimited" : std::to_string(m_fpsTarget));
-        ss << " (Enforced by: " << EnumToString(GetEnforcer()) << ")";
+            std::stringstream ss;
+            ss << "FPSLimiter: FPS limit changed to " << (m_fpsTarget == 0 ? "unlimited" : std::to_string(m_fpsTarget));
+            ss << " (Enforced by: " << EnumToString(GetEnforcer()) << ")";
 #ifdef MTA_DEBUG
-        ss << " [Server: " << (m_serverEnforcedFps == 0 ? "unlimited" : std::to_string(m_serverEnforcedFps));
-        ss << ", Client: " << (m_clientEnforcedFps == 0 ? "unlimited" : std::to_string(m_clientEnforcedFps));
-        ss << ", User: " << (m_userDefinedFps == 0 ? "unlimited" : std::to_string(m_userDefinedFps));
-        ss << ", VSync: " << (m_displayRefreshRate == 0 ? "unlimited" : std::to_string(m_displayRefreshRate)) << "]";
+            ss << " [Server: " << (m_serverEnforcedFps == 0 ? "unlimited" : std::to_string(m_serverEnforcedFps));
+            ss << ", Client: " << (m_clientEnforcedFps == 0 ? "unlimited" : std::to_string(m_clientEnforcedFps));
+            ss << ", User: " << (m_userDefinedFps == 0 ? "unlimited" : std::to_string(m_userDefinedFps));
+            ss << ", VSync: " << (m_displayRefreshRate == 0 ? "unlimited" : std::to_string(m_displayRefreshRate)) << "]";
 #endif
-        auto* pConsole = CCore::GetSingleton().GetConsole();
-        if (pConsole)
-            CCore::GetSingleton().GetConsole()->Print(ss.str().c_str());
-        OutputDebugLine(ss.str().c_str());
+            auto* pConsole = CCore::GetSingleton().GetConsole();
+            if (pConsole)
+                CCore::GetSingleton().GetConsole()->Print(ss.str().c_str());
+            OutputDebugLine(ss.str().c_str());
+        }
     }
 
     void FPSLimiter::SetFrameRateThrottle()


### PR DESCRIPTION
#### Summary
Fixes #4839 
FPSLimiter console outputs are too spammy

#### Motivation
Console info is important and 4 duplicate messages is harmful to the important info.


#### Test plan
Connected and disconnected and observed only 1 message instead of 3 for a connect and 4 for a disconnect.


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
