### PR TITLE
Fix/player damage event fix

### DIFF
--- a/Client/mods/deathmatch/logic/CNetAPI.cpp
+++ b/Client/mods/deathmatch/logic/CNetAPI.cpp
@@ -1687,7 +1687,6 @@ void CNetAPI::WriteVehiclePuresync(CClientPed* pPlayerModel, CClientVehicle* pVe
         BitStream.WriteBit(false);
     }
 
-
     if (!g_pClientGame->GetDamageSent())
     {
         g_pClientGame->SetDamageSent(true);

--- a/Client/mods/deathmatch/logic/CNetAPI.cpp
+++ b/Client/mods/deathmatch/logic/CNetAPI.cpp
@@ -1687,6 +1687,35 @@ void CNetAPI::WriteVehiclePuresync(CClientPed* pPlayerModel, CClientVehicle* pVe
         BitStream.WriteBit(false);
     }
 
+
+    if (!g_pClientGame->GetDamageSent())
+    {
+        g_pClientGame->SetDamageSent(true);
+
+        ElementID DamagerID = g_pClientGame->GetDamagerID();
+        if (DamagerID != RESERVED_ELEMENT_ID)
+        {
+            BitStream.WriteBit(true);
+            BitStream.Write(DamagerID);
+
+            SWeaponTypeSync weaponType;
+            weaponType.data.ucWeaponType = g_pClientGame->GetDamageWeapon();
+            BitStream.Write(&weaponType);
+
+            SBodypartSync bodypart;
+            bodypart.data.uiBodypart = g_pClientGame->GetDamageBodyPiece();
+            BitStream.Write(&bodypart);
+        }
+        else
+        {
+            BitStream.WriteBit(false);
+        }
+    }
+    else
+    {
+        BitStream.WriteBit(false);
+    }
+
     // Player health sync (scaled from 0.0f-200.0f to 0-255 to save three bytes).
     // Scale goes up to 200.0f because having max stats gives you the double of health.
     SPlayerHealthSync health;

--- a/Server/mods/deathmatch/logic/net/CSimVehiclePuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/net/CSimVehiclePuresyncPacket.cpp
@@ -163,7 +163,7 @@ bool CSimVehiclePuresyncPacket::Read(NetBitStreamInterface& BitStream)
             }
         }
 
-        if (BitStream.ReadBit() == true)
+        if (BitStream.ReadBit())
         {
             ElementID DamagerID;
             if (!BitStream.Read(DamagerID))

--- a/Server/mods/deathmatch/logic/net/CSimVehiclePuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/net/CSimVehiclePuresyncPacket.cpp
@@ -163,6 +163,21 @@ bool CSimVehiclePuresyncPacket::Read(NetBitStreamInterface& BitStream)
             }
         }
 
+        if (BitStream.ReadBit() == true)
+        {
+            ElementID DamagerID;
+            if (!BitStream.Read(DamagerID))
+                return false;
+
+            SWeaponTypeSync weaponType;
+            if (!BitStream.Read(&weaponType))
+                return false;
+
+            SBodypartSync bodyPart;
+            if (!BitStream.Read(&bodyPart))
+                return false;
+        }
+
         // Player health
         SPlayerHealthSync health;
         if (!BitStream.Read(&health))

--- a/Server/mods/deathmatch/logic/packets/CVehiclePuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CVehiclePuresyncPacket.cpp
@@ -275,25 +275,21 @@ bool CVehiclePuresyncPacket::Read(NetBitStreamInterface& BitStream)
                 }
             }
 
-            // Update Damage info
-            if (BitStream.Version() >= 0x047)
+            if (BitStream.ReadBit() == true)
             {
-                if (BitStream.ReadBit() == true)
-                {
-                    ElementID DamagerID;
-                    if (!BitStream.Read(DamagerID))
-                        return false;
+                ElementID DamagerID;
+                if (!BitStream.Read(DamagerID))
+                    return false;
 
-                    SWeaponTypeSync weaponType;
-                    if (!BitStream.Read(&weaponType))
-                        return false;
+                SWeaponTypeSync weaponType;
+                if (!BitStream.Read(&weaponType))
+                    return false;
 
-                    SBodypartSync bodyPart;
-                    if (!BitStream.Read(&bodyPart))
-                        return false;
+                SBodypartSync bodyPart;
+                if (!BitStream.Read(&bodyPart))
+                    return false;
 
-                    pSourcePlayer->SetDamageInfo(DamagerID, weaponType.data.ucWeaponType, static_cast<unsigned char>(bodyPart.data.uiBodypart));
-                }
+                pSourcePlayer->SetDamageInfo(DamagerID, weaponType.data.ucWeaponType, static_cast<unsigned char>(bodyPart.data.uiBodypart));
             }
 
             // Player health

--- a/Server/mods/deathmatch/logic/packets/CVehiclePuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CVehiclePuresyncPacket.cpp
@@ -275,7 +275,7 @@ bool CVehiclePuresyncPacket::Read(NetBitStreamInterface& BitStream)
                 }
             }
 
-            if (BitStream.ReadBit() == true)
+            if (BitStream.ReadBit())
             {
                 ElementID DamagerID;
                 if (!BitStream.Read(DamagerID))


### PR DESCRIPTION
#### Summary
The onPlayerDamage event was broken, attacker, bodypart and weapon info was no longer being sent. 
This seems to have been erroneously removed when resetting the bitstream version and getting rid of version checks.

The version check however was still present on the the VehiclePuresyncPacket (but not the CSim variant). This also would've caused vehicle sync to completely break some ~23 bitstream versions in the future.

This PR:
- Re-introduce sending of this data
- Modifies the puresync packet to read it again
- Removes the incorrect version check


#### Motivation
Otherwise stuff would break


#### Test plan
This simple script could reproduce the issue:
```lua
function onPlayerDamage(attacker, weapon, bodypart, loss)
    iprint({
        event = "onPlayerDamage", 
        source = source,
        attacker = attacker,
        weapon = weapon,
        bodypart = bodypart,
        loss = loss
    })
end
addEventHandler("onPlayerDamage", root, onPlayerDamage)
```

Before these fixes the output would be:
```cs
[22:43:28] INFO: {
  bodypart = 255,
  event = "onPlayerDamage",
  loss = 9,
  source = elem:player[SAES>NanoLaptop],
  weapon = 255
}
```
(Even though SAES>NanoBob shot SAES>NanoLaptop)

After the fix it looks like this:
```cs
[23:14:26] INFO: {
  attacker = elem:player[SAES>NanoBob],
  bodypart = 9,
  event = "onPlayerDamage",
  loss = 8,
  source = elem:player[SAES>NanoLaptop],
  weapon = 29
}
```


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
