### PR TITLE
use correct map keys in SetResponseCookie

### DIFF
--- a/Server/mods/deathmatch/logic/CResourceHTMLItem.cpp
+++ b/Server/mods/deathmatch/logic/CResourceHTMLItem.cpp
@@ -219,7 +219,8 @@ void CResourceHTMLItem::SetResponseCookie(const char* szCookieName, const char* 
     CookieParameters params;
     Datum            data;
     data = szCookieValue;
-    params[szCookieName] = data;
+    params["name"] = szCookieName;
+    params["value"] = data;
     m_currentResponse->SetCookie(params);
 }
 


### PR DESCRIPTION
#### Summary

Fix httpSetResponseCookie so it actually sets cookies correctly.

CResourceHTMLItem::SetResponseCookie was building the CookieParameters map with the cookie name as the key (params[szCookieName] = data). But HttpResponse::SetCookie looks for two fixed keys "name" and "value" and skips the cookie if either is empty. So no Set-Cookie header was ever sent.

The fix puts the cookie name and value under the "name"` and "value" keys.

#### Motivation

Fixes #4806. httpSetResponseCookie is the only way for a resource to attach cookies to an HTTP response, so while it's broken there's no way to do anything cookie-based.

#### Test plan

Tested on a server build with:

1. The repro resource from #4806.
2. The example on https://wiki.multitheftauto.com/wiki/HttpSetResponseCookie

Before the fix neither sent a Set-Cookie header. After the fix the header shows up and the browser stores the cookie.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
