### PR TITLE
Fix server side peds death sync despite sync being disabled

### DIFF
--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -2088,14 +2088,8 @@ void CGame::Packet_PedWasted(CPedWastedPacket& Packet)
 
         // Non syncable peds should be fully ignored unless in vehicle (Fix for 3598)
         // We allow it only if the ped should die from their occupied vehicle exploding or drowning
-        if (!pPed->IsSyncable())
-        {
-            if (!pVehicle)
-                return;
-        
-            if (Packet.m_ucKillerWeapon != 51 && Packet.m_ucKillerWeapon != 53)
-                return;
-        }
+        if (!pPed->IsSyncable() && (!pVehicle || (Packet.m_ucKillerWeapon != 51 && Packet.m_ucKillerWeapon != 53)))
+            return;
 
         pPed->SetIsDead(true);
         pPed->SetHealth(0.0f);

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -2084,6 +2084,13 @@ void CGame::Packet_PedWasted(CPedWastedPacket& Packet)
     CPed* pPed = GetElementFromId<CPed>(Packet.m_PedID);
     if (pPed && !pPed->IsDead())
     {
+        CVehicle* pVehicle = pPed->GetOccupiedVehicle();
+
+        // Non syncable peds should be ignored unless in vehicle (Fix for 3598)
+        // We allow it when the ped is in the vehicle to avoid breaking a case where the ped should actually die (vehicle explosion)
+        if (!pPed->IsSyncable() && !pVehicle)
+            return;
+
         pPed->SetIsDead(true);
         pPed->SetHealth(0.0f);
         pPed->SetArmor(0.0f);
@@ -2096,7 +2103,6 @@ void CGame::Packet_PedWasted(CPedWastedPacket& Packet)
             pPed->SetVehicleAction(CPed::VEHICLEACTION_NONE);
 
         // Remove him from any occupied vehicle
-        CVehicle* pVehicle = pPed->GetOccupiedVehicle();
         if (pVehicle)
         {
             pVehicle->SetOccupant(NULL, pPed->GetOccupiedVehicleSeat());

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -2086,10 +2086,16 @@ void CGame::Packet_PedWasted(CPedWastedPacket& Packet)
     {
         CVehicle* pVehicle = pPed->GetOccupiedVehicle();
 
-        // Non syncable peds should be ignored unless in vehicle (Fix for 3598)
-        // We allow it when the ped is in the vehicle to avoid breaking a case where the ped should actually die (vehicle explosion)
-        if (!pPed->IsSyncable() && !pVehicle)
-            return;
+        // Non syncable peds should be fully ignored unless in vehicle (Fix for 3598)
+        // We allow it only if the ped should die from their occupied vehicle exploding or drowning
+        if (!pPed->IsSyncable())
+        {
+            if (!pVehicle)
+                return;
+        
+            if (Packet.m_ucKillerWeapon != 51 && Packet.m_ucKillerWeapon != 53)
+                return;
+        }
 
         pPed->SetIsDead(true);
         pPed->SetHealth(0.0f);


### PR DESCRIPTION
#### Summary
Peds which were created on the serverside with sync disabled still had their death synchronized to all players. 
This PR should resolve the issue

#### Motivation
#3598

#### Test plan
(Solo)
- Create a serversided ped with sync disabled
- Kill the ped on client
- Reconnect (Before this change, the ped will remain dead. After this change the ped is now alive as it should be)


(Multiple Clients)
- Create a serversided ped with sync disabled
- Have the ped in different positions on each client
- Kill the ped on client 1 (Before this change, the ped dies on all clients. After this change it only dies on client 1)
- Reconnect on any client (Before this change, the ped will remain dead. After this change the ped is now alive as it should be)