### PR TITLE
remove duplicate Ryder skin 271 from player models

### DIFF
--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -1015,7 +1015,6 @@ void CGameSA::SetupSpecialCharacters()
     ModelInfo[268].MakePedModel("DWAYNE");
     ModelInfo[269].MakePedModel("SMOKE");
     ModelInfo[270].MakePedModel("SWEET");
-    ModelInfo[271].MakePedModel("RYDER");
     ModelInfo[272].MakePedModel("FORELLI");
     ModelInfo[273].MakePedModel("MEDIATR");
     ModelInfo[289].MakePedModel("SOMYAP");
@@ -1029,6 +1028,8 @@ void CGameSA::SetupSpecialCharacters()
     ModelInfo[297].MakePedModel("MADDOGG");
     ModelInfo[298].MakePedModel("CAT");
     ModelInfo[299].MakePedModel("CLAUDE");
+    // Keep Ryder available through the canonical 300 entry only so scripts and tools no longer
+    // see 271 as a separate selectable skin.
     ModelInfo[300].MakePedModel("RYDER2");
     ModelInfo[301].MakePedModel("RYDER3");
     ModelInfo[302].MakePedModel("EMMET");

--- a/Server/mods/deathmatch/logic/CPed.cpp
+++ b/Server/mods/deathmatch/logic/CPed.cpp
@@ -208,6 +208,14 @@ bool CPed::ReadSpecialData(const int iLine)
     {
         // Is it valid?
         unsigned short usModel = static_cast<unsigned short>(iTemp);
+        if (usModel == 271)
+        {
+            // Reject the duplicate Ryder entry at map-load time so map data cannot silently
+            // keep reviving a skin ID that was intentionally removed from the supported set.
+            CLogger::ErrorPrintf("Removed 'model' id 271 specified in <ped>; use 300 instead (line %d)\n", iLine);
+            return false;
+        }
+
         if (CPedManager::IsValidModel(usModel))
         {
             // Remember it and generate a new random color

--- a/Server/mods/deathmatch/logic/CPlayerManager.cpp
+++ b/Server/mods/deathmatch/logic/CPlayerManager.cpp
@@ -345,6 +345,7 @@ bool CPlayerManager::IsValidPlayerModel(unsigned short model)
         case 74:  // Missing skin
         case 149:
         case 208:
+        case 271:  // Removed duplicate Ryder skin, use 300 instead
             return false;
         default:
             return true;


### PR DESCRIPTION
This change removes support for the duplicate Ryder skin ID 271 and keeps 300 as the only supported Ryder entry.