### PR TITLE
Fix radar_map HUD component freezing blips

### DIFF
--- a/Client/game_sa/CHudSA.cpp
+++ b/Client/game_sa/CHudSA.cpp
@@ -130,7 +130,7 @@ void CHudSA::InitComponentList()
         {1, HUD_VEHICLE_NAME, 1, FUNC_DrawVehicleName, 1, 0xCC, 0xC3},
         {1, HUD_AREA_NAME, 1, FUNC_DrawAreaName, 1, 0xCC, 0xC3},
         {1, HUD_RADAR, 1, FUNC_DrawRadar, 1, 0xCC, 0xC3},
-        {1, HUD_RADAR_MAP, 1, FUNC_CRadar_DrawMap, 1, 0xCC, 0xC3},
+        {1, HUD_RADAR_MAP, 1, FUNC_CRadar_DrawRadarMap, 1, 0xCC, 0xC3},
         {1, HUD_RADAR_BLIPS, 1, FUNC_CRadar_DrawBlips, 1, 0xCC, 0xC3},
         {1, HUD_RADAR_ALTIMETER, 1, CODE_ShowRadarAltimeter, 2, 0xCC, 0xEB30},
         {1, HUD_CLOCK, 0, VAR_DisableClock, 1, 1, 0},

--- a/Client/game_sa/CHudSA.h
+++ b/Client/game_sa/CHudSA.h
@@ -49,8 +49,8 @@
 #define FUNC_CSprite2d_Draw                 0x728350
 #define FUNC_CSprite_RenderOneXLUSprite     0x70D000
 
-#define FUNC_CRadar_DrawMap   0x586B00
-#define FUNC_CRadar_DrawBlips 0x588050
+#define FUNC_CRadar_DrawRadarMap 0x586880
+#define FUNC_CRadar_DrawBlips    0x588050
 
 #define CODE_ShowMoney          0x58F47D
 #define CODE_ShowRadarAltimeter 0x58A5A6


### PR DESCRIPTION
#### Summary

Fix `setPlayerHudComponentVisible("radar_map", false)` freezing the blips and the north indicator.

#4331 patches `CRadar::DrawMap` to hide the map, but that function also runs state updates the rest of the radar depends on. Skipping it freezes the blips and the N marker.

Patching `CRadar::DrawRadarMap` (the inner draw call) instead hides the map and leaves the state updates running.

#### Motivation

Fixes #4849

#### Test plan

Tested with the repro from #4849

#### Checklist

- [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
- [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
