### PR TITLE
Fix #3979: clear x87 stack after VehicleCamLookDir1 hook

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -5087,6 +5087,24 @@ static void __declspec(naked) HOOK_VehicleCamLookDir1()
         call VehicleCamLookDir1
         add esp, 8
 
+        // The lateral-velocity sqrt at 0x524F23/0x524F29 inside
+        // CCam::Process_FollowCar_SA peaks at depth 8 on the x87 stack with
+        // zero margin. If MSVC's codegen for the matInvertGravity * vec
+        // expression above leaves any tagged register behind, that block
+        // overflows and (with IM masked) writes the floating-point
+        // indefinite into the lateral magnitude, which then propagates
+        // through the NaN-blind fcom/jp/jnz clamps into m_fBetaSpeed and
+        // m_fHorizontalAngle. Empty the x87 stack here so vanilla SA
+        // resumes at depth 0 like it was authored to expect (#3979).
+        ffree st(0)
+        ffree st(1)
+        ffree st(2)
+        ffree st(3)
+        ffree st(4)
+        ffree st(5)
+        ffree st(6)
+        ffree st(7)
+
         jmp RETURN_VehicleCamLookDir1
     }
     // clang-format on


### PR DESCRIPTION
#### Summary

`ffree st(0)..st(7)` at the end of `HOOK_VehicleCamLookDir1`'s trampoline, before `jmp RETURN_VehicleCamLookDir1`. Vanilla SA resumes at x87 depth 0 instead of inheriting whatever MSVC left tagged.

`ffree` only flips tag bits. CW/SW/TOP/data are untouched. `fninit` would clobber CW from `0x007F` to `0x037F`, so it is not used.

#### Motivation

Fixes #3979.

`CCam::Process_FollowCar_SA`'s lateral velocity sqrt at `0x524F23` peaks the x87 stack at exactly depth 8 with no margin. If MSVC's codegen for the inline `gravcam_matInvertGravity * (*pvecLookDir)` in `VehicleCamLookDir1` leaves a single tagged register behind, the next `fld` overflows.

x87 CW is `0x007F` (IM masked) so overflow stores the indefinite (`0xFFC00000`) into the lateral magnitude. The beta clamps in this function all use the `fcom; fnstsw; test ah, X; jp/jnz` parity idiom, which is blind to unordered (`ah & 0x41 == 0x41`, `ah & 5 == 5`, both PF=1). NaN flows unclamped through `v73 -> v81 -> v82 -> v179 -> v120 -> v122 (m_fBetaSpeed) -> m_fHorizontalAngle`. The snap at `0x525B08` is skipped for the same reason.

`m_fVerticalAngle` is unaffected: its `asin` path uses a C-language clamp at `0x525030` that maps NaN to `-1.0`, and never reads the lateral magnitude. The beta-dies / alpha-fine selectivity in #3979 is the fingerprint.

#4818's recovery papers over the NaN after the fact; this removes the injection point.


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
