### PR TITLE
Fix invalid ped skin IDs accepted by map/XML ped loading

### DIFF
--- a/Server/mods/deathmatch/logic/CPedManager.cpp
+++ b/Server/mods/deathmatch/logic/CPedManager.cpp
@@ -12,6 +12,7 @@
 #include "StdInc.h"
 #include "CPedManager.h"
 #include "CPed.h"
+#include "CPlayerManager.h"
 #include "Utils.h"
 
 CPedManager::CPedManager()
@@ -74,5 +75,7 @@ bool CPedManager::Exists(CPed* pPed)
 
 bool CPedManager::IsValidModel(unsigned short usModel)
 {
-    return true;
+    // Peds created from maps/XML also end up here, so keep this aligned with the
+    // script-facing validator and reject unused GTA skin IDs before they can be synced.
+    return CPlayerManager::IsValidPlayerModel(usModel);
 }


### PR DESCRIPTION
#### Summary
Map/XML ped loading validated models through `CPedManager::IsValidModel`, but that function accepted every ID.
This bypassed the existing player skin validation and allowed unused GTA skin IDs `74`, `149`, and `208` to be serialized to clients.
Clients then rejected those peds during entity add, which surfaced as protocol error `51`.


#### Motivation
Resolves #4848


#### Test plan
Used reproduction from #4848 - no longer recieve protocol error 51

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
