### PR TITLE
Fix OGG raw data in playSound3D and audible loop seam

### DIFF
--- a/Client/mods/deathmatch/logic/CBassAudio.cpp
+++ b/Client/mods/deathmatch/logic/CBassAudio.cpp
@@ -311,6 +311,14 @@ bool CBassAudio::BeginLoadingMedia()
         }
         m_pSound = pReversed;
         BASS_ChannelSetAttribute(m_pSound, BASS_ATTRIB_REVERSE_DIR, BASS_FX_RVS_FORWARD);
+
+        // Loop on the reverse (pre-tempo) stream so the time-stretch wrapper
+        // above sees a continuous source and never flushes its internal state
+        // at the loop boundary. Looping only on the outer tempo stream causes
+        // an audible seam for OGG iterations (#4084).
+        if (m_bLoop && BASS_ChannelFlags(m_pSound, BASS_SAMPLE_LOOP, BASS_SAMPLE_LOOP) == -1)
+            g_pCore->GetConsole()->Printf("BASS ERROR %d in LoadMedia ChannelFlags LOOP (reverse)  path:%s  3d:%d  loop:%d", BASS_ErrorGetCode(), *m_strPath,
+                                          m_b3D, m_bLoop);
         // Sucks.
         /*if ( BASS_FX_BPM_CallbackSet ( m_pSound, (BPMPROC*)&BPMCallback, 1, 0, 0, m_uiCallbackId ) == false )
         {
@@ -955,6 +963,11 @@ bool CBassAudio::SetLooped(bool bLoop)
         return false;
 
     m_bLoop = bLoop;
+
+    // Keep the reverse (pre-tempo) source in sync; the tempo wrapper relies on
+    // looping happening one layer below it to avoid an audible seam (#4084).
+    if (HSTREAM hSource = BASS_FX_TempoGetSource(m_pSound))
+        BASS_ChannelFlags(hSource, bLoop ? BASS_SAMPLE_LOOP : 0, BASS_SAMPLE_LOOP);
 
     return BASS_ChannelFlags(m_pSound, bLoop ? BASS_SAMPLE_LOOP : 0, BASS_SAMPLE_LOOP);
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
@@ -226,7 +226,7 @@ int CLuaAudioDefs::PlaySound3D(lua_State* luaVM)
                 SString strFilename;
                 bool    bIsURL = false;
                 bool    bIsRawData = false;
-                if (CResourceManager::ParseResourcePathInput(strSound, pResource, &strFilename))
+                if (CResourceManager::ParseResourcePathInput(strSound, pResource, &strFilename, nullptr, true))
                     strSound = strFilename;
                 else
                 {


### PR DESCRIPTION
#### Summary
- Fix `playSound3D` raw OGG detection to use the same length-aware `ParseResourcePathInput` path as `playSound` (#3495).
- Fix OGG loop seam by applying looping on the inner pre-tempo stream and keeping runtime loop toggles synced via `BASS_FX_TempoGetSource` (#4084).

#### Motivation
#3495 only patched `playSound`, leaving `playSound3D` on unsized `ParseResourcePathInput`.  
`IsValidFilePath` stopped at the embedded NUL after the `OggS` header, so raw OGG bytes could still be misclassified as a file path on the 3D entry point.

#4084 looped only the outer `BASS_FX_TempoCreate` stream.  
At wrap, the tempo stream reset internal time-stretch state, causing an audible click between OGG iterations.  
Looping the inner reverse source keeps playback continuous through the tempo layer.

Closes #3495  
Closes #4084

#### Test plan
- [x] Tested locally: `playSound3D` now correctly accepts raw OGG payloads.
- [x] Tested locally: looped OGG playback no longer clicks at loop boundary.
- [x] Verified `setSoundLooped` keeps both tempo and source loop flags in sync.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.