### PR TITLE
Fix #4259: report failed sound effects honestly on Windows 11 24H2

### DIFF
--- a/Client/mods/deathmatch/logic/CBassAudio.cpp
+++ b/Client/mods/deathmatch/logic/CBassAudio.cpp
@@ -311,6 +311,14 @@ bool CBassAudio::BeginLoadingMedia()
         }
         m_pSound = pReversed;
         BASS_ChannelSetAttribute(m_pSound, BASS_ATTRIB_REVERSE_DIR, BASS_FX_RVS_FORWARD);
+
+        // Loop on the reverse (pre-tempo) stream so the time-stretch wrapper
+        // above sees a continuous source and never flushes its internal state
+        // at the loop boundary. Looping only on the outer tempo stream causes
+        // an audible seam for OGG iterations (#4084).
+        if (m_bLoop && BASS_ChannelFlags(m_pSound, BASS_SAMPLE_LOOP, BASS_SAMPLE_LOOP) == -1)
+            g_pCore->GetConsole()->Printf("BASS ERROR %d in LoadMedia ChannelFlags LOOP (reverse)  path:%s  3d:%d  loop:%d", BASS_ErrorGetCode(), *m_strPath,
+                                          m_b3D, m_bLoop);
         // Sucks.
         /*if ( BASS_FX_BPM_CallbackSet ( m_pSound, (BPMPROC*)&BPMCallback, 1, 0, 0, m_uiCallbackId ) == false )
         {
@@ -955,6 +963,11 @@ bool CBassAudio::SetLooped(bool bLoop)
         return false;
 
     m_bLoop = bLoop;
+
+    // Keep the reverse (pre-tempo) source in sync; the tempo wrapper relies on
+    // looping happening one layer below it to avoid an audible seam (#4084).
+    if (HSTREAM hSource = BASS_FX_TempoGetSource(m_pSound))
+        BASS_ChannelFlags(hSource, bLoop ? BASS_SAMPLE_LOOP : 0, BASS_SAMPLE_LOOP);
 
     return BASS_ChannelFlags(m_pSound, bLoop ? BASS_SAMPLE_LOOP : 0, BASS_SAMPLE_LOOP);
 }

--- a/Client/mods/deathmatch/logic/CBassAudio.cpp
+++ b/Client/mods/deathmatch/logic/CBassAudio.cpp
@@ -1167,7 +1167,13 @@ void CBassAudio::ApplyFxEffects()
             // Switch on
             m_FxEffects[i] = BASS_ChannelSetFX(m_pSound, i, 0);
             if (!m_FxEffects[i])
+            {
+                // Effect could not be wired up by BASS. Notable case: Windows 11
+                // 24H2 removed BASS_FX_DX8_I3DL2REVERB at the OS level (#4259), so
+                // BASS_ChannelSetFX returns 0 with BASS_ERROR_NOFX.
+                g_pCore->GetConsole()->Printf("BASS ERROR %d in BASS_ChannelSetFX (effect %u)", BASS_ErrorGetCode(), i);
                 m_FxEffects[i] = INVALID_FX_HANDLE;
+            }
         }
         else if (!m_EnabledEffects[i] && m_FxEffects[i])
         {
@@ -1176,6 +1182,11 @@ void CBassAudio::ApplyFxEffects()
                 BASS_ChannelRemoveFX(m_pSound, m_FxEffects[i]);
             m_FxEffects[i] = 0;
         }
+
+        // Mirror failure into m_EnabledEffects so IsFxEffectEnabled() reports the
+        // truth and re-enable requests don't silently leave a dangling handle.
+        if (m_FxEffects[i] == INVALID_FX_HANDLE)
+            m_EnabledEffects[i] = 0;
     }
 }
 

--- a/Client/mods/deathmatch/logic/CBassAudio.h
+++ b/Client/mods/deathmatch/logic/CBassAudio.h
@@ -77,6 +77,7 @@ public:
     void    SetFxEffects(int* pEnabledEffects, uint iNumElements);
     BOOL    SetFxParameters(uint iFxEffect, void* params);
     BOOL    GetFxParameters(uint iFxEffect, void* params);
+    bool    IsFxEffectEnabled(uint iFxEffect) const { return iFxEffect < NUMELMS(m_EnabledEffects) && m_EnabledEffects[iFxEffect] != 0; }
     SString GetMetaTags(const SString& strFormat);
     uint    GetReachedEndCount();
     bool    IsFreed();

--- a/Client/mods/deathmatch/logic/CClientPlayerVoice.cpp
+++ b/Client/mods/deathmatch/logic/CClientPlayerVoice.cpp
@@ -361,7 +361,12 @@ bool CClientPlayerVoice::SetFxEffect(uint uiFxEffect, bool bEnable)
 
     // Apply if active
     if (m_pBassPlaybackStream)
+    {
         ApplyFxEffects();
+        // ApplyFxEffects clears m_EnabledEffects[i] when BASS rejects the effect
+        // (e.g. I3DL2REVERB on Windows 11 24H2, #4259), so report the truth.
+        return (m_EnabledEffects[uiFxEffect] != 0) == bEnable;
+    }
 
     return true;
 }
@@ -378,7 +383,12 @@ void CClientPlayerVoice::ApplyFxEffects()
             // Switch on
             m_FxEffects[i] = BASS_ChannelSetFX(m_pBassPlaybackStream, i, 0);
             if (!m_FxEffects[i])
+            {
+                // Effect could not be wired up by BASS (e.g. Windows 11 24H2
+                // removed BASS_FX_DX8_I3DL2REVERB at the OS level, #4259).
+                g_pCore->GetConsole()->Printf("BASS ERROR %d in BASS_ChannelSetFX (effect %u)", BASS_ErrorGetCode(), i);
                 m_FxEffects[i] = INVALID_FX_HANDLE;
+            }
         }
         else
         {
@@ -390,6 +400,11 @@ void CClientPlayerVoice::ApplyFxEffects()
                 m_FxEffects[i] = 0;
             }
         }
+
+        // Mirror failure into m_EnabledEffects so IsFxEffectEnabled() reports
+        // the truth and re-enable requests don't silently leave a dangling handle.
+        if (m_FxEffects[i] == INVALID_FX_HANDLE)
+            m_EnabledEffects[i] = 0;
     }
 }
 

--- a/Client/mods/deathmatch/logic/CClientSound.cpp
+++ b/Client/mods/deathmatch/logic/CClientSound.cpp
@@ -679,7 +679,12 @@ bool CClientSound::SetFxEffect(uint uiFxEffect, bool bEnable)
     m_EnabledEffects[uiFxEffect] = bEnable;
 
     if (m_pAudio)
+    {
         m_pAudio->SetFxEffects(&m_EnabledEffects[0], NUMELMS(m_EnabledEffects));
+        // Report the BASS-effective outcome: an effect the OS doesn't provide
+        // (e.g. I3DL2REVERB on Windows 11 24H2, #4259) won't actually engage.
+        return m_pAudio->IsFxEffectEnabled(uiFxEffect) == bEnable;
+    }
 
     return true;
 }
@@ -688,6 +693,8 @@ bool CClientSound::IsFxEffectEnabled(uint uiFxEffect)
 {
     if (uiFxEffect >= NUMELMS(m_EnabledEffects))
         return false;
+    if (m_pAudio)
+        return m_pAudio->IsFxEffectEnabled(uiFxEffect);
     return m_EnabledEffects[uiFxEffect] ? true : false;
 }
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
@@ -226,7 +226,7 @@ int CLuaAudioDefs::PlaySound3D(lua_State* luaVM)
                 SString strFilename;
                 bool    bIsURL = false;
                 bool    bIsRawData = false;
-                if (CResourceManager::ParseResourcePathInput(strSound, pResource, &strFilename))
+                if (CResourceManager::ParseResourcePathInput(strSound, pResource, &strFilename, nullptr, true))
                     strSound = strFilename;
                 else
                 {


### PR DESCRIPTION
#### Summary

On Windows 11 24H2, `BASS_ChannelSetFX(BASS_FX_DX8_I3DL2REVERB)` fails with `BASS_ERROR_NOFX` (41) because the OS dropped the I3DL2 DMO. `ApplyFxEffects` was swallowing the failure and storing `INVALID_FX_HANDLE`, so the next `BASS_FXSetParameters` rejected the bogus handle with `BASS_ERROR_HANDLE` (5). Scripts saw a misleading "BASS error 5" on `roomHF`.

`ApplyFxEffects` now logs the real BASS error and clears `m_EnabledEffects[i]` when the handle is `INVALID_FX_HANDLE`. `setSoundEffectEnabled` returns the BASS-effective outcome via `CBassAudio::IsFxEffectEnabled`, so `getSoundEffects` and the `setSoundEffectParameter` "must be enabled" gate report the truth. Same fix on `CClientPlayerVoice`.

#### Motivation

Fixes #4259.

`roomHF` is just the first I3DL2 parameter people try; any of the 12 errors identically. Code 5 (`BASS_ERROR_HANDLE`) was the latest BASS error from the failed `BASS_FXSetParameters`, not the underlying 41 (`BASS_ERROR_NOFX`) from the much earlier `BASS_ChannelSetFX`, which was never logged. Per [un4seen docs](https://www.un4seen.com/doc/bass/BASS_ChannelSetFX.html): *"Windows 11 24H2 removed the I3DL2REVERB effect, so it should be avoided if you need to run on the latest Windows."* BASS does not emulate it on Windows.

#### Test plan

- [x] Win 11 24H2: `setSoundEffectEnabled(s, "i3dl2reverb", true)` returns `false`; console logs `BASS ERROR 41 in BASS_ChannelSetFX (effect 6)`.
- [x] `setSoundEffectParameter(s, "i3dl2reverb", "roomHF", -100)` errors with `Effect's parameters can't be set unless it's enabled` instead of `BASS Error 5`.
- [x] `getSoundEffects(s).i3dl2reverb` returns `false` after the failed enable.
- [x] Other DX8 effects (chorus, echo, flanger, etc.) still enable, parameterise, and disable normally.
- [x] Re-enabling after a failed enable stays failed; no dangling handle.
- [x] Same scenarios pass on the player-voice path.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
