### PR TITLE
Fix #4329: preserve plane rotor speed across vehicle recreation

### DIFF
--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -2673,6 +2673,10 @@ void CClientVehicle::Create()
             m_pVehicle->SetHeliRotorSpeed(m_fHeliRotorSpeed);
             m_pVehicle->SetHeliSearchLightVisible(m_bHeliSearchLightVisible);
         }
+        else if (m_eVehicleType == CLIENTVEHICLE_PLANE)
+        {
+            m_pVehicle->SetPlaneRotorSpeed(m_fPlaneRotorSpeed);
+        }
 
         m_pVehicle->SetUnderwater(IsBelowWater());
 
@@ -2995,6 +2999,7 @@ void CClientVehicle::Destroy()
         m_bEngineOn = m_pVehicle->IsEngineOn();
         m_bIsOnGround = IsOnGround();
         m_fHeliRotorSpeed = GetHeliRotorSpeed();
+        m_fPlaneRotorSpeed = GetPlaneRotorSpeed();
         m_bHeliSearchLightVisible = IsHeliSearchLightVisible();
         m_HandlingEntry->Assign(m_pVehicle->GetHandlingData());
         m_FlyingHandlingEntry->Assign(m_pVehicle->GetFlyingHandlingData());


### PR DESCRIPTION
#### Summary

Preserve plane rotor speed across vehicle recreation so that changing a plane's variant no longer causes a visible propeller stall.

Save `m_fPlaneRotorSpeed` in `Destroy()` and restore it in `Create()`, matching the existing heli rotor speed path.

#### Motivation

Fixes #4329. After #3486, calling `setVehicleVariant` on a plane (e.g. cropduster) causes the propeller to stop for about one second before ramping back up. `Destroy()` saved `m_fHeliRotorSpeed` but never saved `m_fPlaneRotorSpeed`, and `Create()` only restored rotor speed for `CLIENTVEHICLE_HELI`. Planes went through the recreate cycle with prop speed reset to zero.

#### Test plan

1. Spawn a cropduster with the engine on
2. Call `setVehicleVariant` repeatedly
3. Observe that the propeller maintains its speed with no interruption

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
