### PR TITLE
Fix camera clipping through default GTA world objects at speed

### DIFF
--- a/Client/game_sa/CCameraSA.cpp
+++ b/Client/game_sa/CCameraSA.cpp
@@ -597,18 +597,24 @@ void CCameraSA::GetCameraClip(bool& bObjects, bool& bVehicles)
     bVehicles = (mask & static_cast<uint8_t>(CameraClipFlags::Vehicles)) != 0;
 }
 
-// Replicates GTA:SA's CCamera::CameraVehicleModeSpecialCases (0x50CDE0):
-// when the player's vehicle is moving faster than 0.2 speed units, camera
-// collision with objects/buildings is disabled so it doesn't jerk around
-// obstacles while driving.
+// At speed, relax camera collision against dynamic (script-created) objects only.
+// Static world geometry always keeps collision so default GTA world/buildings still block the camera.
 static void ApplyVehicleSpeedCameraClip()
 {
+    // Static-world clip stays on regardless of speed.
+    MemPutFast<char>(VAR_CameraClipStaticObjects, 1);
+
     using FindPlayerVehicle_t = void*(__cdecl*)(int playerId, bool bIncludeRemote);
     auto FindPlayerVehicle = reinterpret_cast<FindPlayerVehicle_t>(0x56E0D0);
 
     void* pVehicle = FindPlayerVehicle(-1, false);
     if (!pVehicle)
+    {
+        // No player vehicle: restore stock defaults.
+        MemPutFast<float>(VAR_RelVelCamCollisionVehSqr, 1.0f);
+        MemPutFast<char>(VAR_CameraClipDynamicObjects, 1);
         return;
+    }
 
     // CPhysicalSAInterface::m_vecLinearVelocity at offset 0x44 (CVector: 3 floats)
     float* pSpeed = reinterpret_cast<float*>(static_cast<char*>(pVehicle) + 0x44);
@@ -617,17 +623,13 @@ static void ApplyVehicleSpeedCameraClip()
 
     MemPutFast<float>(VAR_RelVelCamCollisionVehSqr, slow ? 0.1f : 1.0f);
     MemPutFast<char>(VAR_CameraClipDynamicObjects, slow ? 1 : 0);
-    MemPutFast<char>(VAR_CameraClipStaticObjects, slow ? 1 : 0);
 }
 
 static void _cdecl DoCameraCollisionDetectionPokes()
 {
     const uint8_t mask = s_cameraClipMask.load(std::memory_order_relaxed);
 
-    // Handle objects: when clip=true (the default), use GTA's native
-    // speed-dependent logic. When clip=false, force off unconditionally.
-    // This preserves backward compatibility: setCameraClip(true, false)
-    // means "objects = GTA default (speed-dependent), vehicles = off".
+    // Objects clip on = GTA default (speed-dependent dynamic, always-on static); off = force off.
     if (mask & static_cast<uint8_t>(CameraClipFlags::Objects))
         ApplyVehicleSpeedCameraClip();
     else
@@ -636,7 +638,7 @@ static void _cdecl DoCameraCollisionDetectionPokes()
         MemPutFast<char>(VAR_CameraClipStaticObjects, 0);
     }
 
-    // Handle vehicles: true = GTA default (always on), false = force off.
+    // Vehicles clip on = GTA default (always on); off = force off.
     if (mask & static_cast<uint8_t>(CameraClipFlags::Vehicles))
         MemPutFast<char>(VAR_CameraClipVehicles, 1);
     else


### PR DESCRIPTION
#### Summary
`ApplyVehicleSpeedCameraClip` now only toggles `VAR_CameraClipDynamicObjects` based on vehicle speed. 

`VAR_CameraClipStaticObjects` is forced on whenever camera-object clipping is enabled, so the camera always collides with default GTA world objects. Custom maps use dynamic objects (created via `createObject`), so they still benefit from the original "no collision at speed" fix. 

Also added a vehicle reset path so on-foot/cinematic cameras don't inherit a stale "driving" state from a previous frame; `setCameraClip(false, ...)` behaviour is unchanged.

#### Motivation
PR #4812 (commit fa8110e) restored GTA:SA's "relax camera collision while driving" behaviour to fix the camera colliding with dynamically created objects (i.e custom maps). However, it applied the 'fix' to *both* dynamic and static object clip flags, which means the camera now also clips through default GTA world geometry (buildings, ground, etc) when driving at speed. That is not how vanilla SA behaves, and users have reported this.

#### Test plan
- Drive around default GTA world, confirm the camera collides with buildings/objects as it does in vanilla SA (regardless of speed).
- Drive around a custom map made of script-created objects, confirm the camera still doesn't collide with the objects at speed.
- Verified `setCameraClip(false, true)` and `setCameraClip(true, false)` still behave as documented.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
