### PR TITLE
Fix instant-respawn flows leaving player dead/stuck after setElementHealth(player, 0)

### DIFF
--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -5078,30 +5078,7 @@ bool CStaticFunctionDefinitions::SetCameraMatrix(const CVector& vecPosition, CVe
         return false;
 
     if (!m_pCamera->IsInFixedMode())
-    {
-        // Some scripts call setCameraMatrix(getCameraMatrix()) while dead to preserve the current frame.
-        // Treat this as a no-op so we don't switch into fixed mode and block later spectate target updates.
-        CMatrix currentMatrix;
-        if (m_pCamera->GetMatrix(currentMatrix))
-        {
-            const CVector currentLookAt = currentMatrix.vPos + currentMatrix.vFront;
-            const CVector requestedLookAt = pvecLookAt ? *pvecLookAt : currentLookAt;
-
-            constexpr float kCameraNoOpEpsilon = 0.01f;
-            const float     posDeltaSq = (currentMatrix.vPos - vecPosition).LengthSquared();
-            const float     lookDeltaSq = (currentLookAt - requestedLookAt).LengthSquared();
-            const float     epsilonSq = kCameraNoOpEpsilon * kCameraNoOpEpsilon;
-
-            if (posDeltaSq <= epsilonSq && lookDeltaSq <= epsilonSq)
-            {
-                if (std::isfinite(fFOV) && fFOV > 0.0f && fFOV < 180.0f)
-                    m_pCamera->SetFOV(fFOV);
-                return true;
-            }
-        }
-
         m_pCamera->ToggleCameraFixedMode(true);
-    }
 
     // Put the camera there
     m_pCamera->SetPosition(vecPosition);

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1788,7 +1788,25 @@ bool CStaticFunctionDefinitions::SetElementHealth(CElement* pElement, float fHea
             if (pPed->IsDead() && fHealth > 0.0f)
                 pPed->SetIsDead(false);
             else if (fHealth <= 0.0f && !pPed->IsDead())
-                KillPed(pElement, nullptr, 0xFF, 0xFF, false);
+            {
+                // Preserve #4482 (onPlayerWasted fires server-side from setElementHealth(p, 0)) without
+                // regressing instant-respawn flows (e.g. race respawntime=0). Two things matter:
+                //   1) Skip the WASTED broadcast to the dying player so the originator isn't forced into
+                //      CClientPed::Kill() / TaskComplexDie - that traps the camera in GTA's death cam
+                //      because the immediately-following PLAYER_SPAWN can't cleanly cancel the transition.
+                //   2) Send SET_ELEMENT_HEALTH=0 BEFORE KillPed and return early. KillPed fires
+                //      onPlayerWasted, whose handlers commonly call spawnPlayer; if the trailing health
+                //      RPC ran after that PLAYER_SPAWN, all clients would reset the freshly-spawned
+                //      player back to 0 health.
+                CBitStream BitStream;
+                BitStream.pBitStream->Write(fHealth);
+                BitStream.pBitStream->Write(pElement->GenerateSyncTimeContext());
+                m_pPlayerManager->BroadcastOnlyJoined(CElementRPCPacket(pElement, SET_ELEMENT_HEALTH, *BitStream.pBitStream));
+
+                CPlayer* pSkipBroadcastPlayer = IS_PLAYER(pPed) ? static_cast<CPlayer*>(pPed) : nullptr;
+                KillPed(pElement, nullptr, 0xFF, 0xFF, false, pSkipBroadcastPlayer);
+                return true;
+            }
 
             break;
         }
@@ -3808,9 +3826,13 @@ bool CStaticFunctionDefinitions::SetPedArmor(CElement* pElement, float armor)
     return true;
 }
 
-bool CStaticFunctionDefinitions::KillPed(CElement* pElement, CElement* pKiller, unsigned char ucKillerWeapon, unsigned char ucBodyPart, bool bStealth)
+bool CStaticFunctionDefinitions::KillPed(CElement* pElement, CElement* pKiller, unsigned char ucKillerWeapon, unsigned char ucBodyPart, bool bStealth,
+                                         CPlayer* pSkipBroadcastPlayer)
 {
     assert(pElement);
+    // Note: pSkipBroadcastPlayer is intentionally NOT propagated through RUN_CHILDREN. It only ever applies
+    // to a single, specific player in the SetElementHealth auto-kill path, not to recursive kills on element
+    // hierarchies (which historically broadcast the wasted packet to everyone).
     RUN_CHILDREN(KillPed(*iter, pKiller, ucKillerWeapon, ucBodyPart))
 
     if (IS_PED(pElement))
@@ -3868,9 +3890,11 @@ bool CStaticFunctionDefinitions::KillPed(CElement* pElement, CElement* pKiller, 
             // TODO: change to onPedWasted
             if (IS_PLAYER(pPed))
             {
-                // Tell everyone to kill this player
+                // Tell everyone to kill this player. pSkipBroadcastPlayer (when set) is excluded so that
+                // server-initiated kills via SetElementHealth do not push the dying player into a forced
+                // client-side TaskComplexDie. See header comment on KillPed for the full rationale.
                 CPlayerWastedPacket WastedPacket(pPed, pKiller, ucKillerWeapon, ucBodyPart, bStealth);
-                m_pPlayerManager->BroadcastOnlyJoined(WastedPacket);
+                m_pPlayerManager->BroadcastOnlyJoined(WastedPacket, pSkipBroadcastPlayer);
                 pPed->CallEvent("onPlayerWasted", Arguments);
             }
             else

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -194,8 +194,13 @@ public:
 
     // Ped set funcs
     static bool SetPedArmor(CElement* pElement, float armor);
+    // pSkipBroadcastPlayer: optional player excluded from the CPlayerWastedPacket / CPedWastedPacket broadcast.
+    // Used by SetElementHealth(player, 0) so the dying player is killed server-side and other clients are
+    // notified, but the originating client is NOT pushed into a forced TaskComplexDie via the wasted packet.
+    // That keeps GTA's natural death path on the originator, which is required for instant-respawn flows
+    // (e.g. race maps with respawntime=0) to cancel cleanly. See PR #4486 / regression on race instant respawn.
     static bool KillPed(CElement* pElement, CElement* pKiller = NULL, unsigned char ucKillerWeapon = 0xFF, unsigned char ucBodyPart = 0xFF,
-                        bool bStealth = false);
+                        bool bStealth = false, CPlayer* pSkipBroadcastPlayer = nullptr);
     static bool SetPedRotation(CElement* pElement, float fRotation, bool bNewWay);
     static bool SetPedStat(CElement* pElement, unsigned short usStat, float fValue);
     static bool AddPedClothes(CElement* pElement, const char* szTexture, const char* szModel, unsigned char ucType);


### PR DESCRIPTION
#### Summary

Fixes a regression where `setElementHealth(player, 0)` followed by an immediate `spawnPlayer` (e.g. race maps with `respawntime=0`) left the originating client stuck in GTA's death camera.

Two changes in `CStaticFunctionDefinitions::SetElementHealth`:

1. The dying player is excluded from the `CPlayerWastedPacket` broadcast, so the originator isn't forced into a client-side death task. Other clients still see the death immediately.
2. The `SET_ELEMENT_HEALTH=0` RPC is sent before `KillPed` (with an early return), so it can't arrive after a `PLAYER_SPAWN` queued by an `onPlayerWasted` handler and clobber the respawned health back to 0.

`KillPed` gains an optional `CPlayer* pSkipBroadcastPlayer` parameter, used only by the auto-kill branch above. All other call sites are unchanged.

Also reverts #4833 (776f9b2c2). That change tried to work around the same symptom by making `setCameraMatrix(getCameraMatrix())` a no-op when not in fixed mode, but that pattern is widely used by scripts (including the default race gamemode) specifically to enter fixed mode and lock the camera. With the underlying issue fixed here, the workaround isn't needed and is reverted to restore the historical behaviour.

#### Motivation

After #4486, the default race gamemode broke on `respawntime=0` maps. Pressing ENTER to suicide no longer respawned the player cleanly. Maps with `respawntime > 0` and deaths from other causes (e.g. drowning) were unaffected.

#### Test plan

The broken flow was reproduced and verified manually: calling `setElementHealth(player, 0)` and then immediately calling `spawnPlayer` from inside `onPlayerWasted`. Around 1.5 seconds after the respawn, the following all hold:

- `onPlayerWasted` fired server-side from `setElementHealth(player, 0)` (the original condition from #4482).
- The local player is alive again and `isPedDead` is false.
- The camera is following the local player, its look direction is sane, and it stays near the player rather than drifting off.

Pre-fix: the alive/dead checks fail. Post-fix: all checks pass, including the explicit #4482 condition.

Also manually tested:
- Race `respawntime=0` map: ENTER instantly respawns into the vehicle.
- Race `respawntime=1` map: countdown then respawn — unchanged.
- Death by drowning: unchanged.
- `setCameraMatrix(getCameraMatrix())` once again enters fixed mode (verified after reverting #4833).

Pre-fix: health and dead-state checks fail. Post-fix: all checks pass, including the explicit #4482 condition.

Also manually tested:
- Race `respawntime=0` map: ENTER instantly respawns into the vehicle.
- Race `respawntime=1` map: countdown then respawn — unchanged.
- Death by drowning: unchanged.
- `setCameraMatrix(getCameraMatrix())` once again enters fixed mode (verified after reverting #4833).

#### Checklist

* [x] Your code follows the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.