### PR TITLE
Render dxDrawModel3D models after sun/moon flare pass

### DIFF
--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -3888,8 +3888,8 @@ void CClientGame::ProjectileInitiateHandler(CClientProjectile* pProjectile)
 void CClientGame::Render3DStuffHandler()
 {
     // Render models enqueued by scripts during the previous frame's
-    // onClientRender. This hook fires after GTA's full scene render,
-    // which is the earliest point where the queue is populated.
+    // onClientRender. This hook fires after GTA's Render3DStuff pass
+    // (sun/moon flare, coronas), so those don't bleed through our models.
     CModelRenderer* pModelRenderer = GetModelRenderer();
     pModelRenderer->Render();
     pModelRenderer->NotifyFrameEnd();

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -3512,20 +3512,25 @@ static void __declspec(naked) HOOK_Render3DStuff()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 
+    // Run GTA's Render3DStuff first (it draws sun/moon flare, coronas, etc.
+    // with loose depth testing). Invoking the handler afterwards lets it
+    // render on top, so script-drawn models aren't bled through by the moon.
     // clang-format off
     __asm
     {
         pushad
+        mov  eax, FUNC_Render3DStuff
+        call eax
     }
     // clang-format on
+
     if (m_pRender3DStuffHandler) m_pRender3DStuffHandler();
 
     // clang-format off
     __asm
     {
         popad
-        mov eax, FUNC_Render3DStuff
-        jmp eax
+        ret
     }
     // clang-format on
 }


### PR DESCRIPTION
#### Summary
Switch the `dxDrawModel3D` render queue to run **after** `CRenderer::Render3DStuff` instead of before.

#### Motivation
At night, the moon flare (drawn by `CCoronas::DoSunAndMoon` inside `Render3DStuff`) was visibly bleeding through models drawn with `dxDrawModel3D`.

Inverting the hook order makes the script-drawn models render on top of the flare pass, which is the expected behaviour.

Before:

<img width="1118" height="734" alt="image" src="https://github.com/user-attachments/assets/fcf7d253-630b-4c02-b578-4549ed0b861f" />

After: 

<img width="1096" height="783" alt="image" src="https://github.com/user-attachments/assets/c611ee0f-5f88-469d-842a-c2af3d26af91" />


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
