### PR TITLE
Crash handler fixes

### DIFF
--- a/Client/core/CCrashDumpWriter.cpp
+++ b/Client/core/CCrashDumpWriter.cpp
@@ -1479,6 +1479,7 @@ long WINAPI CCrashDumpWriter::HandleExceptionGlobal(_EXCEPTION_POINTERS* pExcept
     {
         std::array<char, DEBUG_BUFFER_SIZE> szDebug;
         SAFE_DEBUG_PRINT_C(szDebug.data(), szDebug.size(), "CCrashDumpWriter: Non-fatal exception 0x%08X - ignoring\n", exceptionCode);
+        ms_bInCrashHandler.store(false, std::memory_order_release);
         return EXCEPTION_CONTINUE_SEARCH;
     }
 
@@ -1557,6 +1558,7 @@ long WINAPI CCrashDumpWriter::HandleExceptionGlobal(_EXCEPTION_POINTERS* pExcept
             {
                 SAFE_DEBUG_OUTPUT("CCrashDumpWriter: Client handled exception - continuing execution\n");
                 delete pExceptionInformation;
+                ms_bInCrashHandler.store(false, std::memory_order_release);
                 return EXCEPTION_CONTINUE_SEARCH;
             }
 

--- a/Client/core/CrashHandler.cpp
+++ b/Client/core/CrashHandler.cpp
@@ -106,6 +106,15 @@ void OutputDebugStringSafeImpl(const char* message)
     if (message == nullptr)
         return;
 
+    // Skip OutputDebugStringA when no debugger is attached.
+    //
+    // OutputDebugStringA raises an exception under the hood so a debugger
+    // can read the message; with no debugger attached the call is just
+    // unnecessary work and an extra exception-dispatch site. Suppressing it
+    // here is a robustness improvement on a path that runs frequently.
+    if (!IsDebuggerPresent())
+        return;
+
     __try
     {
         OutputDebugStringA(message);
@@ -1173,11 +1182,16 @@ public:
     CleanUpCrashHandler() = default;
     ~CleanUpCrashHandler()
     {
-        std::scoped_lock lock{g_handlerStateMutex};
+        // Minimal teardown for process-exit/DLL-unload path.
+        // Avoid restoring detours/CRT handlers here: teardown order during
+        // shutdown is unstable, and touching patched global handler state
+        // late can itself fault. Keep SymCleanup for dbghelp resources, and
+        // avoid taking g_handlerStateMutex in this destructor.
 
         g_bStackCookieCaptureEnabled.store(false, std::memory_order_release);
         g_pfnCrashCallback.store(nullptr, std::memory_order_release);
 
+        // Release dbghelp symbol resources
         if (g_symbolsInitialized.exchange(false, std::memory_order_acq_rel))
         {
             if (HANDLE hProcess = g_symbolProcess.exchange(nullptr, std::memory_order_acq_rel); hProcess != nullptr)
@@ -1187,44 +1201,14 @@ public:
             }
         }
 
-        if (auto terminateHandler = g_pfnOrigTerminate.exchange(nullptr, std::memory_order_acq_rel); terminateHandler != nullptr)
-        {
-            std::set_terminate(terminateHandler);
-        }
-
-        if (auto newHandler = g_pfnOrigNewHandler.exchange(nullptr, std::memory_order_acq_rel); newHandler != nullptr)
-        {
-#if defined(_MSC_VER)
-            _set_new_handler(newHandler);
-#else
-            std::set_new_handler(newHandler);
-#endif
-        }
-
-        if (auto abortHandler = g_pfnOrigAbortHandler.exchange(nullptr, std::memory_order_acq_rel); abortHandler != nullptr)
-        {
-            signal(SIGABRT, abortHandler);
-        }
-
-        if (auto pureCallHandler = g_pfnOrigPureCall.exchange(nullptr, std::memory_order_acq_rel); pureCallHandler != nullptr)
-        {
-            _set_purecall_handler(pureCallHandler);
-        }
-
-        if (auto previousFilter = g_pfnOrigFilt.exchange(nullptr, std::memory_order_acq_rel); previousFilter != nullptr)
-        {
-            SetUnhandledExceptionFilter(previousFilter);
-        }
-
-        if (auto kernelSetUnhandled = g_pfnKernelSetUnhandledExceptionFilter.exchange(nullptr, std::memory_order_acq_rel); kernelSetUnhandled != nullptr)
-        {
-            g_kernelSetUnhandledExceptionFilterTrampoline = kernelSetUnhandled;
-            if (!SharedUtil::UndoFunctionDetour(g_kernelSetUnhandledExceptionFilterTrampoline, reinterpret_cast<void*>(RedirectedSetUnhandledExceptionFilter)))
-            {
-                SafeDebugOutput("CrashHandler: WARNING - Failed to undo SEH detour during cleanup\n");
-            }
-            g_kernelSetUnhandledExceptionFilterTrampoline = nullptr;
-        }
+        // Clear cached state without restoration in teardown path
+        g_pfnOrigTerminate.store(nullptr, std::memory_order_release);
+        g_pfnOrigNewHandler.store(nullptr, std::memory_order_release);
+        g_pfnOrigAbortHandler.store(nullptr, std::memory_order_release);
+        g_pfnOrigPureCall.store(nullptr, std::memory_order_release);
+        g_pfnOrigFilt.store(nullptr, std::memory_order_release);
+        g_pfnKernelSetUnhandledExceptionFilter.store(nullptr, std::memory_order_release);
+        g_kernelSetUnhandledExceptionFilterTrampoline = nullptr;
     }
 };
 
@@ -2818,6 +2802,7 @@ LONG __stdcall CrashHandlerExceptionFilter(EXCEPTION_POINTERS* pExPtrs)
             SafeDebugOutput("SEH: FATAL - Stack overflow detected - _resetstkoflw() failed\n");
             // If we can't reset the stack, we can't safely do anything else.
             // Attempting to log or call handlers will likely trigger another overflow immediately.
+            bHandlerActive.store(false, std::memory_order_release);
             return EXCEPTION_CONTINUE_SEARCH;
         }
     }

--- a/Client/core/CrashHandler.h
+++ b/Client/core/CrashHandler.h
@@ -44,14 +44,8 @@ constexpr DWORD CPP_EXCEPTION_CODE = 0xE06D7363;
 constexpr DWORD STATUS_INVALID_CRUNTIME_PARAMETER_CODE = 0xC0000417;
 constexpr DWORD STATUS_STACK_BUFFER_OVERRUN_CODE = 0xC0000409;
 constexpr DWORD STATUS_HEAP_CORRUPTION_CODE = 0xC0000374;
-// STATUS_FATAL_USER_CALLBACK_EXCEPTION (0xC000041D):
-// This exception type occurs when an exception happens inside a Windows system callback
-// (e.g., window procedures, DLL callbacks, kernel-to-user transitions) and cannot be
-// properly unwound. Special handling is required as:
-// - The stack may be corrupted or incomplete
-// - Context may not have full information
-// - Stack walking may fail or cause secondary exceptions
-// - Module resolution may point to trampolines instead of actual code
+// STATUS_FATAL_USER_CALLBACK_EXCEPTION (0xC000041D) can occur in Windows callback
+// transitions with unreliable unwind/context data, so crash handling treats it as fatal.
 constexpr DWORD STATUS_FATAL_USER_CALLBACK_EXCEPTION = 0xC000041D;
 constexpr DWORD CUSTOM_EXCEPTION_CODE_WATCHDOG_TIMEOUT = 0xE0000001;
 
@@ -62,23 +56,6 @@ constexpr DWORD INIT_PHASE_POST_D3D = 2;
 constexpr int EXIT_CODE_CRASH = 3;
 
 constexpr std::size_t DEBUG_BUFFER_SIZE_LARGE = 512;
-
-constexpr DWORD EXCEPTION_BREAKPOINT_NONFATAL = 0x80000003;
-constexpr DWORD EXCEPTION_SINGLE_STEP_NONFATAL = 0x80000004;
-constexpr DWORD EXCEPTION_GUARD_PAGE_NONFATAL = 0x80000001;
-constexpr DWORD EXCEPTION_INVALID_HANDLE_NONFATAL = 0xC0000008;
-constexpr DWORD EXCEPTION_ARRAY_BOUNDS_EXCEEDED_NONFATAL = 0xC000008C;
-constexpr DWORD EXCEPTION_FLT_DENORMAL_OPERAND_NONFATAL = 0xC000008D;
-constexpr DWORD EXCEPTION_FLT_DIVIDE_BY_ZERO_NONFATAL = 0xC000008E;
-constexpr DWORD EXCEPTION_FLT_INEXACT_RESULT_NONFATAL = 0xC000008F;
-constexpr DWORD EXCEPTION_FLT_INVALID_OPERATION_NONFATAL = 0xC0000090;
-constexpr DWORD EXCEPTION_FLT_OVERFLOW_NONFATAL = 0xC0000091;
-constexpr DWORD EXCEPTION_FLT_STACK_CHECK_NONFATAL = 0xC0000092;
-constexpr DWORD EXCEPTION_FLT_UNDERFLOW_NONFATAL = 0xC0000093;
-constexpr DWORD EXCEPTION_INT_DIVIDE_BY_ZERO_NONFATAL = 0xC0000094;
-constexpr DWORD EXCEPTION_INT_OVERFLOW_NONFATAL = 0xC0000095;
-constexpr DWORD EXCEPTION_PRIV_INSTRUCTION_NONFATAL = 0xC0000096;
-constexpr DWORD EXCEPTION_NONCONTINUABLE_EXCEPTION_NONFATAL = 0xC0000025;
 
 inline constexpr std::string_view DEBUG_PREFIX_CRASH = "CrashHandler: ";
 inline constexpr std::string_view DEBUG_PREFIX_SEH = "SEH: ";


### PR DESCRIPTION
#### Summary
* Skip `OutputDebugStringA` when no debugger is attached.
* Minimal teardown in `~CleanUpCrashHandler` to avoid touching global handler state late in process exit / DLL unload.
* Reset the in-handler guards on early-return paths so they don't stay stuck after benign exceptions or stack-overflow recovery.
* Drop unused exception-code constants from the header.

#### Motivation
Defensive cleanups around the crash-handling path.

#### Test plan
Launch / quit cycles on a local build; no regressions observed in normal exit, stack-overflow recovery, or benign-exception paths.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.