### PR TITLE
Crash handler polish

### DIFF
--- a/Client/core/CCrashDumpWriter.cpp
+++ b/Client/core/CCrashDumpWriter.cpp
@@ -282,61 +282,7 @@ static bool InvokeClientHandleExceptionSafe(CClientBase* pClient, CExceptionInfo
 
 namespace
 {
-    void ConfigureDbgHelpOptions()
-    {
-        static std::atomic_flag configured = ATOMIC_FLAG_INIT;
-        if (!configured.test_and_set(std::memory_order_acq_rel))
-        {
-            SymSetOptions(SYMOPT_LOAD_LINES | SYMOPT_UNDNAME | SYMOPT_FAIL_CRITICAL_ERRORS | SYMOPT_DEFERRED_LOADS);
-        }
-    }
-
-    std::mutex& GetSymInitMutex()
-    {
-        static std::mutex symMutex;
-        return symMutex;
-    }
 }  // namespace
-
-class SymbolHandlerGuard
-{
-public:
-    explicit SymbolHandlerGuard(HANDLE process, bool enableSymbols) : m_process(process), m_initialized(false)
-    {
-        if (!enableSymbols)
-            return;
-
-        if (m_process != nullptr)
-        {
-            std::lock_guard<std::mutex> lock{GetSymInitMutex()};
-
-            ConfigureDbgHelpOptions();
-
-            const SString& processDir = SharedUtil::GetMTAProcessBaseDir();
-            const char*    searchPath = processDir.empty() ? nullptr : processDir.c_str();
-
-            if (SymInitialize(m_process, searchPath, TRUE) != FALSE)
-                m_initialized = true;
-        }
-    }
-
-    ~SymbolHandlerGuard()
-    {
-        if (m_initialized)
-            SymCleanup(m_process);
-    }
-
-    SymbolHandlerGuard(const SymbolHandlerGuard&) = delete;
-    SymbolHandlerGuard& operator=(const SymbolHandlerGuard&) = delete;
-    SymbolHandlerGuard(SymbolHandlerGuard&&) = delete;
-    SymbolHandlerGuard& operator=(SymbolHandlerGuard&&) = delete;
-
-    bool IsInitialized() const { return m_initialized; }
-
-private:
-    HANDLE m_process;
-    bool   m_initialized;
-};
 
 [[nodiscard]] static bool NormalizePathForValidation(const SString& inputPath, SString& outputPath)
 {
@@ -767,9 +713,11 @@ static void AppendCrashDiagnostics(const SString& text)
     frame.AddrFrame.Mode = AddrModeFlat;
     frame.AddrStack.Mode = AddrModeFlat;
 
-    SymbolHandlerGuard symbolGuard(hProcess, hasSymbols);
-
-    const bool useDbgHelp = symbolGuard.IsInitialized();
+    bool useDbgHelp = false;
+    if (hasSymbols)
+    {
+        useDbgHelp = CrashHandler::InitializeSymbolHandler();
+    }
     const auto routines = useDbgHelp ? StackTraceHelpers::MakeStackWalkRoutines(true) : StackTraceHelpers::MakeStackWalkRoutines(false);
 
     static_assert(MAX_SYM_NAME > 1, "MAX_SYM_NAME must include room for a terminator");
@@ -1473,20 +1421,6 @@ long WINAPI CCrashDumpWriter::HandleExceptionGlobal(_EXCEPTION_POINTERS* pExcept
         SAFE_DEBUG_OUTPUT("CCrashDumpWriter::HandleExceptionGlobal - NULL or invalid exception\n");
         TerminateCurrentProcessWithExitCode(crashExitCode);
         return EXCEPTION_EXECUTE_HANDLER;
-    }
-
-    if (IsFatalException(exceptionCode) == FALSE)
-    {
-        std::array<char, DEBUG_BUFFER_SIZE> szDebug;
-        SAFE_DEBUG_PRINT_C(szDebug.data(), szDebug.size(), "CCrashDumpWriter: Non-fatal exception 0x%08X - ignoring\n", exceptionCode);
-        ms_bInCrashHandler.store(false, std::memory_order_release);
-        return EXCEPTION_CONTINUE_SEARCH;
-    }
-
-    const BOOL exceptionLogged = LogExceptionDetails(pException);
-    if (exceptionLogged == FALSE)
-    {
-        SAFE_DEBUG_OUTPUT("CCrashDumpWriter: WARNING - LogExceptionDetails failed\n");
     }
 
     SAFE_DEBUG_OUTPUT("CCrashDumpWriter: ======================================\n");

--- a/Client/core/CExceptionInformation_Impl.cpp
+++ b/Client/core/CExceptionInformation_Impl.cpp
@@ -129,59 +129,6 @@ struct StackFrameInfo
 };
 constexpr std::size_t MAX_FILE_NAME = 260;
 
-class SymbolHandlerGuard
-{
-public:
-    explicit SymbolHandlerGuard(HANDLE process, bool enableSymbols) : m_process(process), m_initialized(false), m_uncaughtExceptions(std::uncaught_exceptions())
-    {
-        if (!enableSymbols)
-        {
-            return;
-        }
-
-        if (m_process != nullptr)
-        {
-            SymSetOptions(SYMOPT_LOAD_LINES | SYMOPT_UNDNAME | SYMOPT_FAIL_CRITICAL_ERRORS);
-
-            if (SymInitialize(m_process, nullptr, TRUE) != FALSE)
-            {
-                m_initialized = true;
-            }
-            else
-            {
-                const DWORD dwError = GetLastError();
-                char        debugBuffer[DEBUG_BUFFER_SIZE] = {};
-                SAFE_DEBUG_PRINT_C(debugBuffer, DEBUG_BUFFER_SIZE, "%.*sSymbolHandlerGuard: SymInitialize failed, error: %u\n",
-                                   static_cast<int>(DEBUG_PREFIX_EXCEPTION_INFO.size()), DEBUG_PREFIX_EXCEPTION_INFO.data(), dwError);
-            }
-        }
-    }
-
-    ~SymbolHandlerGuard()
-    {
-        if (m_initialized)
-        {
-            if (std::uncaught_exceptions() <= m_uncaughtExceptions)
-            {
-                SymCleanup(m_process);
-            }
-            m_initialized = false;
-        }
-    }
-
-    SymbolHandlerGuard(const SymbolHandlerGuard&) = delete;
-    SymbolHandlerGuard& operator=(const SymbolHandlerGuard&) = delete;
-    SymbolHandlerGuard(SymbolHandlerGuard&&) = delete;
-    SymbolHandlerGuard& operator=(SymbolHandlerGuard&&) = delete;
-
-    bool IsInitialized() const { return m_initialized; }
-
-private:
-    HANDLE m_process;
-    bool   m_initialized;
-    int    m_uncaughtExceptions;
-};
-
 [[nodiscard]] static std::optional<std::vector<std::string>> CaptureEnhancedStackTrace(_EXCEPTION_POINTERS* pException)
 {
     if (pException == nullptr || pException->ContextRecord == nullptr)
@@ -214,9 +161,11 @@ private:
     frame.AddrFrame.Mode = AddrModeFlat;
     frame.AddrStack.Mode = AddrModeFlat;
 
-    SymbolHandlerGuard symbolGuard(hProcess, hasSymbols);
-
-    const bool useDbgHelp = symbolGuard.IsInitialized();
+    bool useDbgHelp = false;
+    if (hasSymbols)
+    {
+        useDbgHelp = CrashHandler::InitializeSymbolHandler();
+    }
 
     const auto                        routines = useDbgHelp ? StackTraceHelpers::MakeStackWalkRoutines(true) : StackTraceHelpers::MakeStackWalkRoutines(false);
     alignas(SYMBOL_INFO) std::uint8_t symbolBuffer[sizeof(SYMBOL_INFO) + MAX_SYMBOL_NAME];

--- a/Client/core/CrashHandler.cpp
+++ b/Client/core/CrashHandler.cpp
@@ -1303,7 +1303,7 @@ namespace CrashHandler
         return !GetPdbDirectories().empty();
     }
 
-    [[nodiscard]] static bool InitializeSymbolHandler()
+    [[nodiscard]] bool InitializeSymbolHandler()
     {
         std::scoped_lock lock{g_symbolMutex};
 
@@ -1789,93 +1789,21 @@ static bool ConfigureWerLocalDumps()
             }
 
             std::array<char, DEBUG_BUFFER_SIZE> debugBuffer{};
-            SAFE_DEBUG_PRINT_C(debugBuffer.data(), debugBuffer.size(), "CrashHandler: WerRegisterAppLocalDump failed with 0x%08X, trying registry fallback\n",
+            SAFE_DEBUG_PRINT_C(debugBuffer.data(), debugBuffer.size(),
+                               "CrashHandler: WerRegisterAppLocalDump failed with 0x%08X, registry fallback handled by loader\n",
                                static_cast<unsigned int>(hr));
         }
         else
         {
-            SafeDebugOutput("CrashHandler: WerRegisterAppLocalDump not available (Windows 10 1709+ required), trying registry fallback\n");
+            SafeDebugOutput("CrashHandler: WerRegisterAppLocalDump not available (Windows 10 1709+ required), registry fallback handled by loader\n");
         }
+        FreeLibrary(hWer);
     }
     else
     {
-        SafeDebugOutput("CrashHandler: Could not load wer.dll, trying registry fallback\n");
+        SafeDebugOutput("CrashHandler: Could not load wer.dll, registry fallback handled by loader\n");
     }
 
-    std::array<char, DEBUG_BUFFER_SIZE> debugBuffer{};
-
-    HKEY           hKey = nullptr;
-    const wchar_t* exeName = wcsrchr(modulePath, L'\\');
-    exeName = exeName ? exeName + 1 : modulePath;
-
-    wchar_t regPath[512]{};
-    _snwprintf_s(regPath, _countof(regPath), _TRUNCATE, L"SOFTWARE\\Microsoft\\Windows\\Windows Error Reporting\\LocalDumps\\%s", exeName);
-
-    // LocalDumps registry settings are only supported in HKEY_LOCAL_MACHINE (requires admin to write)
-    // First try to create/open with write access - succeeds if running as admin
-    // Use KEY_WOW64_64KEY to write to the 64-bit registry view.
-    // WER is a 64-bit system service that reads from the native 64-bit registry,
-    // not the WOW6432Node that 32-bit apps normally access.
-    LONG result = RegCreateKeyExW(HKEY_LOCAL_MACHINE, regPath, 0, nullptr, REG_OPTION_NON_VOLATILE, KEY_SET_VALUE | KEY_WOW64_64KEY, nullptr, &hKey, nullptr);
-    if (result == ERROR_SUCCESS)
-    {
-        // We have write access (running as admin) - update values to ensure correct path
-        // DumpType: 0=Custom, 1=MiniDump, 2=FullDump - use 1 for smaller dumps
-        DWORD dumpType = 1;
-        RegSetValueExW(hKey, L"DumpType", 0, REG_DWORD, reinterpret_cast<const BYTE*>(&dumpType), sizeof(dumpType));
-
-        DWORD dumpCount = 10;
-        RegSetValueExW(hKey, L"DumpCount", 0, REG_DWORD, reinterpret_cast<const BYTE*>(&dumpCount), sizeof(dumpCount));
-
-        RegSetValueExW(hKey, L"DumpFolder", 0, REG_EXPAND_SZ, reinterpret_cast<const BYTE*>(dumpPathW.c_str()),
-                       static_cast<DWORD>((dumpPathW.length() + 1) * sizeof(wchar_t)));
-
-        RegCloseKey(hKey);
-
-        SafeDebugOutput("CrashHandler: WER LocalDumps configured via registry (admin access)\n");
-        SafeDebugOutput("CrashHandler: Fail-fast exceptions should now generate dumps in mta\\dumps\\private\n");
-        return true;
-    }
-
-    // Can't write - check if key already exists and has correct values
-    result = RegOpenKeyExW(HKEY_LOCAL_MACHINE, regPath, 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
-    if (result == ERROR_SUCCESS)
-    {
-        wchar_t existingPath[MAX_PATH]{};
-        DWORD   pathSize = sizeof(existingPath);
-        DWORD   pathType = 0;
-
-        bool pathCorrect = false;
-        if (RegQueryValueExW(hKey, L"DumpFolder", nullptr, &pathType, reinterpret_cast<BYTE*>(existingPath), &pathSize) == ERROR_SUCCESS)
-        {
-            if (pathType == REG_SZ || pathType == REG_EXPAND_SZ)
-            {
-                std::wstring existingPathStr(existingPath);
-                pathCorrect = (existingPathStr == dumpPathW);
-            }
-        }
-
-        RegCloseKey(hKey);
-
-        if (pathCorrect)
-        {
-            SafeDebugOutput("CrashHandler: WER LocalDumps registry key exists with correct path\n");
-            SafeDebugOutput("CrashHandler: Fail-fast exceptions should generate dumps in mta\\dumps\\private\n");
-            return true;
-        }
-        else
-        {
-            SAFE_DEBUG_PRINT_C(debugBuffer.data(), debugBuffer.size(), "CrashHandler: WARNING - WER LocalDumps exists but points to wrong path!\n");
-            SAFE_DEBUG_PRINT_C(debugBuffer.data(), debugBuffer.size(), "CrashHandler: Expected: %s\n", ToUTF8(dumpPathW).c_str());
-            SafeDebugOutput("CrashHandler: Run MTA as admin once OR reinstall to fix WER dump path\n");
-            return false;
-        }
-    }
-
-    // Neither write nor read succeeded - WER dumps won't work
-    SAFE_DEBUG_PRINT_C(debugBuffer.data(), debugBuffer.size(), "CrashHandler: Failed to access WER registry key in HKLM (error %ld)\n", result);
-    SafeDebugOutput("CrashHandler: WER LocalDumps requires either admin privileges or installer setup\n");
-    SafeDebugOutput("CrashHandler: NOTE: Reinstall MTA or run as admin once to enable WER crash dumps\n");
     return false;
 }
 
@@ -2984,17 +2912,26 @@ namespace
         alignas(hardware_destructive_interference_size) std::atomic<DWORD> targetThreadId{0};
         alignas(hardware_destructive_interference_size) std::atomic<DWORD> timeoutSeconds{20};
 
-        // Non-atomic handle doesn't need cache-line alignment
+        // Non-atomic handles don't need cache-line alignment
         HANDLE watchdogThreadHandle{nullptr};
+        // Manual-reset event used to wake the watchdog from its check-interval wait so it can
+        // observe shouldStop immediately. Without this, the thread polls every 500 ms and
+        // shutdown could otherwise wait close to a full interval before the thread exits.
+        HANDLE stopEvent{nullptr};
 
         ~WatchdogState()
         {
-            // Note: watchdogThreadHandle should be closed by StopWatchdogThread,
-            // but we close it here as a safety measure in case of abnormal termination
+            // Note: handles should be closed by StopWatchdogThread,
+            // but we close them here as a safety measure in case of abnormal termination
             if (watchdogThreadHandle != nullptr && watchdogThreadHandle != INVALID_HANDLE_VALUE)
             {
                 CloseHandle(watchdogThreadHandle);
                 watchdogThreadHandle = nullptr;
+            }
+            if (stopEvent != nullptr && stopEvent != INVALID_HANDLE_VALUE)
+            {
+                CloseHandle(stopEvent);
+                stopEvent = nullptr;
             }
         }
     };
@@ -3182,6 +3119,19 @@ namespace
 
         constexpr auto kCheckInterval = std::chrono::milliseconds{500};
         static_assert(kCheckInterval.count() > 0, "Check interval must be positive");
+        constexpr DWORD kCheckIntervalMs = static_cast<DWORD>(kCheckInterval.count());
+
+        // Helper that sleeps for kCheckInterval but wakes immediately when StopWatchdogThread
+        // signals stopEvent. Returns true if the thread should exit (stop requested), false to continue.
+        const auto waitOrStop = [&]() -> bool
+        {
+            HANDLE ev = g_watchdogState.stopEvent;
+            if (ev != nullptr && ev != INVALID_HANDLE_VALUE)
+                return WaitForSingleObject(ev, kCheckIntervalMs) == WAIT_OBJECT_0;
+            // Fallback if the event somehow wasn't created: keep prior polling behavior
+            std::this_thread::sleep_for(kCheckInterval);
+            return g_watchdogState.shouldStop.load(std::memory_order_acquire);
+        };
 
         const auto targetThreadId = g_watchdogState.targetThreadId.load(std::memory_order_acquire);
 
@@ -3256,7 +3206,8 @@ namespace
                     TriggerWatchdogException(targetThread.get(), targetThreadId, true);
 
                     g_watchdogState.lastHeartbeat.store(std::chrono::steady_clock::now(), std::memory_order_release);
-                    std::this_thread::sleep_for(kCheckInterval);
+                    if (waitOrStop())
+                        break;
                     continue;
                 }
 #endif
@@ -3272,7 +3223,8 @@ namespace
                 break;
             }
 
-            std::this_thread::sleep_for(kCheckInterval);
+            if (waitOrStop())
+                break;
         }
 
         AddReportLog(9313, "Watchdog thread stopping");
@@ -3311,6 +3263,21 @@ namespace
     g_watchdogState.shouldStop.store(false, std::memory_order_release);
     g_watchdogState.lastHeartbeat.store(std::chrono::steady_clock::now(), std::memory_order_release);
 
+    // Create (or reset) the stop event used to wake the watchdog from its wait on shutdown.
+    // Manual-reset so all wait sites see the signal until the thread exits.
+    if (g_watchdogState.stopEvent == nullptr)
+    {
+        g_watchdogState.stopEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+        if (g_watchdogState.stopEvent == nullptr)
+        {
+            AddReportLog(9321, SString("Watchdog failed to create stop event (error %lu) - falling back to polling", GetLastError()));
+        }
+    }
+    else
+    {
+        ResetEvent(g_watchdogState.stopEvent);
+    }
+
     constexpr unsigned int kStackSize = 0;
     const auto             threadHandle{reinterpret_cast<HANDLE>(_beginthreadex(nullptr, kStackSize, WatchdogThreadProc, nullptr, 0, nullptr))};
 
@@ -3341,18 +3308,32 @@ void BUGSUTIL_DLLINTERFACE __stdcall StopWatchdogThread()
     AddReportLog(9318, "Stopping watchdog thread");
     g_watchdogState.shouldStop.store(true, std::memory_order_release);
 
+    // Signal the stop event so the watchdog's interval-wait wakes immediately instead of
+    // sleeping up to kCheckInterval (~500 ms). Set after shouldStop so the wakeup observes it.
+    if (g_watchdogState.stopEvent != nullptr && g_watchdogState.stopEvent != INVALID_HANDLE_VALUE)
+    {
+        SetEvent(g_watchdogState.stopEvent);
+    }
+
     if (g_watchdogState.watchdogThreadHandle != nullptr && g_watchdogState.watchdogThreadHandle != INVALID_HANDLE_VALUE)
     {
-        constexpr DWORD kWaitTimeout = 5000;
+        // With the stop event the thread should exit within a single check cycle. Keep a 2 s
+        // safety cap to bound shutdown if the thread is genuinely wedged. We do not use
+        // TerminateThread here because it can leave CRT locks held, causing deadlocks during shutdown.
+        constexpr DWORD kWaitTimeout = 2000;
         if (const auto waitResult = WaitForSingleObject(g_watchdogState.watchdogThreadHandle, kWaitTimeout); waitResult != WAIT_OBJECT_0)
         {
-            AddReportLog(9319, "Watchdog thread forced termination");
-            TerminateThread(g_watchdogState.watchdogThreadHandle, 1);
-            WaitForSingleObject(g_watchdogState.watchdogThreadHandle, INFINITE);
+            AddReportLog(9319, "Watchdog thread did not exit in time, abandoning (no forced termination)");
         }
 
         CloseHandle(g_watchdogState.watchdogThreadHandle);
         g_watchdogState.watchdogThreadHandle = nullptr;
+    }
+
+    if (g_watchdogState.stopEvent != nullptr && g_watchdogState.stopEvent != INVALID_HANDLE_VALUE)
+    {
+        CloseHandle(g_watchdogState.stopEvent);
+        g_watchdogState.stopEvent = nullptr;
     }
 
     AddReportLog(9320, "Watchdog thread stopped");

--- a/Client/core/CrashHandler.cpp
+++ b/Client/core/CrashHandler.cpp
@@ -1183,10 +1183,9 @@ public:
     ~CleanUpCrashHandler()
     {
         // Minimal teardown for process-exit/DLL-unload path.
-        // Avoid restoring detours/CRT handlers here: teardown order during
-        // shutdown is unstable, and touching patched global handler state
-        // late can itself fault. Keep SymCleanup for dbghelp resources, and
-        // avoid taking g_handlerStateMutex in this destructor.
+        // Avoid restoring detours/CRT handlers here: teardown order is unstable, and touching
+        // patched/global handler state late can crash (including /GS 0xC0000409 on exit).
+        // Keep SymCleanup for dbghelp resources, and avoid g_handlerStateMutex in this destructor.
 
         g_bStackCookieCaptureEnabled.store(false, std::memory_order_release);
         g_pfnCrashCallback.store(nullptr, std::memory_order_release);

--- a/Client/core/CrashHandler.h
+++ b/Client/core/CrashHandler.h
@@ -255,4 +255,5 @@ extern "C"
 namespace CrashHandler
 {
     [[nodiscard]] bool ProcessHasLocalDebugSymbols();
+    [[nodiscard]] bool InitializeSymbolHandler();
 }


### PR DESCRIPTION
#### Summary
Architectural cleanup and hardening of the Crash Handler. 
* Unifies DbgHelp symbol lifecycle by replacing fragmented `SymInitialize`/`SymCleanup` calls with a shared `CrashHandler::InitializeSymbolHandler()`.
* Deduplicates WER (Windows Error Reporting) registry setup by moving canonical ownership entirely to the loader.
* Removes redundant classification and double-logging in `CCrashDumpWriter::HandleExceptionGlobal`.
* Replaces a dangerous `TerminateThread` call in the watchdog with clean abandonment to prevent CRT lock deadlocks during shutdown.

#### Motivation
This is a follow-up architectural polish to the recent crash handler fixes. It resolves technical debt around overlapping symbol management across `CrashHandler`, `CCrashDumpWriter`, and `CExceptionInformation_Impl`, centralizes WER setup, and hardens the shutdown sequence against deadlocks.

#### Test plan
1. Compiled and ran successfully.
2. Verified that MTA launches without regression. 
3. **To verify**: Trigger a crash and confirm that `mta/dumps/private` still correctly populates with dumps, and that `core.log` still successfully resolves symbols in the stack trace.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
