### PR TITLE
Avoid throwing in CGUIElement::SetFont when the font name is unknown

### DIFF
--- a/Client/gui/CGUIElement_Impl.cpp
+++ b/Client/gui/CGUIElement_Impl.cpp
@@ -398,6 +398,12 @@ void CGUIElement_Impl::CorrectEdges()
 
 bool CGUIElement_Impl::SetFont(const char* szFontName)
 {
+    if (szFontName != nullptr && *szFontName != '\0')
+    {
+        if (!CEGUI::FontManager::getSingleton().isFontPresent(CEGUI::String(szFontName)))
+            return false;
+    }
+
     try
     {
         m_pWindow->setFont(CEGUI::String(szFontName));


### PR DESCRIPTION
#### Summary
Probe `CEGUI::FontManager::isFontPresent` before calling `setFont` in `CGUIElement_Impl::SetFont`, so unknown font names return `false` directly.

#### Motivation
Avoid an unnecessary throw on a hot path.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.