### PR TITLE
Fix client-side createExplosion ignoring makeSound and camShake parameters

### DIFF
--- a/Client/mods/deathmatch/logic/CClientExplosionManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientExplosionManager.cpp
@@ -211,11 +211,20 @@ CExplosion* CClientExplosionManager::Create(eExplosionType explosionType, CVecto
     }
     else if (!pCreator)
     {
+        // Fire onClientExplosion for script-driven createExplosion() calls without a
+        // creator. We can't reuse Hook_ExplosionCreation here: when it sees the local
+        // player as responsible it routes the explosion through SendExplosionSync and
+        // the server-replayed copy uses default makeSound/camShake, ignoring the
+        // script's arguments (regression from PR #4341).
         CClientPlayer* localPlayer = m_pManager->GetPlayerManager()->GetLocalPlayer();
         if (localPlayer)
         {
-            bool allowExplosion = Hook_ExplosionCreation(nullptr, localPlayer->GetGameEntity(), vecPosition, explosionType);
-            if (!allowExplosion)
+            CLuaArguments arguments;
+            arguments.PushNumber(vecPosition.fX);
+            arguments.PushNumber(vecPosition.fY);
+            arguments.PushNumber(vecPosition.fZ);
+            arguments.PushNumber(m_LastWeaponType);
+            if (!localPlayer->CallEvent("onClientExplosion", arguments, true))
                 return nullptr;
         }
     }


### PR DESCRIPTION
#### Summary
Make client-side `createExplosion` honour the `makeSound` and `camShake` arguments again.

#### Motivation
User report: since 1.7, client `createExplosion(..., makeSound, camShake, ...)` ignores those parameters; explosions always play sound and shake the camera with default strength.

Caused by #4341, which routed script-driven explosions through a path that re-broadcasts them via the server and drops the script's arguments along the way.

#### Test plan
- `makeSound=false, camShake=0`: silent, no shake.
- `makeSound=true, camShake=1.5`: sound + brief shake.
- server API (no sound/shake params): unchanged -- still has sound + shake.

Engine-side explosions (grenades, rockets, vehicle blow-ups) behave unchanged.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.