### PR TITLE
Upgrade CEF to 147.0.10 (chromium 147.0.7727.118)

### DIFF
--- a/utils/buildactions/install_cef.lua
+++ b/utils/buildactions/install_cef.lua
@@ -9,8 +9,8 @@ local CEF_URL_PREFIX = "https://cef-builds.spotifycdn.com/cef_binary_"
 local CEF_URL_SUFFIX = "_windows32_minimal.tar.bz2"
 
 -- Change here to update CEF version
-local CEF_VERSION = "144.0.13+g9f739aa+chromium-144.0.7559.133"
-local CEF_HASH = "f39f2c31a2ac08f4e134b147072708468dc0861ca35ddcd333f4a8494beb3433"
+local CEF_VERSION = "147.0.10+gd58e84d+chromium-147.0.7727.118"
+local CEF_HASH = "b6574257645183fe948b2c9471e419a52505c4eb13593422aa25d7b826e8e4d5"
 
 -- Stuck in the past for maetro
 if os.getenv("MTA_MAETRO") == "true" then


### PR DESCRIPTION
#### Summary

Upgrades CEF from `144.0.13+g9f739aa+chromium-144.0.7559.133` to `147.0.10+gd58e84d+chromium-147.0.7727.118`.

Changes:
- `utils/buildactions/install_cef.lua`: bumped `CEF_VERSION` to `147.0.10+gd58e84d+chromium-147.0.7727.118` and updated `CEF_HASH` (`b6574257645183fe948b2c9471e419a52505c4eb13593422aa25d7b826e8e4d5`).

No mtasa-blue changes are required - CEF C++ API surface is unchanged between 144 and 147 for our usage.

#### Motivation

Keeping it fresh 🥦 

#### Test plan

1. Deleted `vendor/cef3/cef/` and the cached archive to force a clean download via the build action.
2. Ran `win-create-projects.bat`
3. Built `Release | Win32` and `Debug | Win32` - both configurations completed successfully.
4. Ran `win-install-data.bat`
5. Launched MTA (both Debug & Release) - CEF testing resources work as expected, no visible regression

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.