### PR TITLE
Fix dxGetTexturePixels/dxSetTexturePixels failing on browser elements

### DIFF
--- a/Client/core/Graphics/CPixelsManager.cpp
+++ b/Client/core/Graphics/CPixelsManager.cpp
@@ -126,7 +126,8 @@ bool CPixelsManager::GetTexturePixels(IDirect3DBaseTexture9* pD3DBaseTexture, CP
             bResult = SetPlainDimensions(outPixels, uiPixelsWidth, uiPixelsHeight);
         }
     }
-    else if (Desc.Usage == 0)
+    // Handle any non-rendertarget usage so D3DUSAGE_DYNAMIC textures (e.g. CEF browsers since PR #4634) go through the lockable path.
+    else if ((Desc.Usage & D3DUSAGE_RENDERTARGET) == 0)
     {
         if (pixelsFormat != EPixelsFormat::PLAIN)
             return D3DXGetSurfacePixels(pD3DSurface, outPixels, pixelsFormat, renderFormat, bMipMaps, pRect);
@@ -204,7 +205,8 @@ bool CPixelsManager::SetTexturePixels(IDirect3DBaseTexture9* pD3DBaseTexture, co
             if (FAILED(D3DXLoadSurfaceFromSurface(pD3DSurface, NULL, NULL, pLockableSurface, NULL, NULL, D3DX_FILTER_NONE, 0)))
                 return false;
     }
-    else if (Desc.Usage == 0)
+    // Handle any non-rendertarget usage so D3DUSAGE_DYNAMIC textures (e.g. CEF browsers since PR #4634) go through the lockable path.
+    else if ((Desc.Usage & D3DUSAGE_RENDERTARGET) == 0)
     {
         if (Desc.Format == D3DFMT_A8R8G8B8 || Desc.Format == D3DFMT_X8R8G8B8 || Desc.Format == D3DFMT_R5G6B5)
         {


### PR DESCRIPTION
#### Summary
Relax the non-rendertarget branch in `CPixelsManager::GetTexturePixels` and `CPixelsManager::SetTexturePixels` from `Desc.Usage == 0` to `(Desc.Usage & D3DUSAGE_RENDERTARGET) == 0`, so that `D3DUSAGE_DYNAMIC` textures are routed through the existing lockable-surface path instead of silently returning `false`.

#### Motivation
PR #4634 (CEF performance improvements, commit ddb924902) switched browser textures in `CWebBrowserItem::CreateUnderlyingData` from `D3DPOOL_MANAGED` (Usage == 0) to `D3DPOOL_DEFAULT + D3DUSAGE_DYNAMIC` in order to remove the duplicate system-RAM copy. 

As a side effect, `CPixelsManager` no longer recognised the browser texture's usage flag, so `dxGetTexturePixels(browser, ...)` and `dxSetTexturePixels(browser, ...)` started returning `false`.

This change is scoped narrowly: textures created with `Usage == 0` (e.g. `dxCreateTexture` from file/raw pixels, shader/RwTexture wrappers) and `D3DUSAGE_RENDERTARGET` (e.g. `dxCreateRenderTarget`, `dxCreateScreenSource`) continue to take exactly the same branches they did before. Only previously-unhandled non-rendertarget usages (notably `D3DUSAGE_DYNAMIC` browsers) now reach the lock path that was always intended to handle them.

#### Test plan
 **Before the fix:** all three image formats (jpg, png, plain) reported `false` / `len=nil` from `dxGetTexturePixels` against an actively-rendering browser
**After the fix:** all three formats return non-empty data with the expected dimensions.
Existing render-target and managed-texture callers (`dxCreateRenderTarget`, `dxCreateTexture` from file) were also smoke-tested via existing scripts to confirm no regression in those code paths.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.