### PR TITLE
Add update server resources

### DIFF
--- a/Client/mods/deathmatch/logic/CLocalServer.cpp
+++ b/Client/mods/deathmatch/logic/CLocalServer.cpp
@@ -226,6 +226,8 @@ bool CLocalServer::OnUpdateResourcesButtonClick(CGUIElement* pElement)
                 if (unzOpenCurrentFile(zipFile) != UNZ_OK)
                     continue;
 
+                // Note: "wb" mode overwrites existing files if they have the same name
+                // Any other custom resources on disk that aren't in the zip are left untouched.
                 FILE* file = fopen(filePath.c_str(), "wb");
                 if (file)
                 {

--- a/Client/mods/deathmatch/logic/CLocalServer.cpp
+++ b/Client/mods/deathmatch/logic/CLocalServer.cpp
@@ -10,6 +10,10 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include "../../../vendor/zip/unzip.h"
+#include <urlmon.h>
+#pragma comment(lib, "urlmon.lib")
+#include "SharedUtil.AsyncTaskScheduler.h"
 
 using std::list;
 
@@ -91,6 +95,11 @@ CLocalServer::CLocalServer(const char* szConfig)
     m_pBroadcastInternet->SetPosition(CVector2D(0.4f, 0.38f), true);
     m_pBroadcastInternet->SetSize(CVector2D(0.45f, 0.08f), true);
 
+    m_pButtonUpdate = reinterpret_cast<CGUIButton*>(m_pGUI->CreateButton(m_pTabGeneral, _("Update server resources")));
+    m_pButtonUpdate->SetPosition(CVector2D(0.45f, 0.91f), true);
+    m_pButtonUpdate->SetSize(CVector2D(0.52f, 0.06f), true);
+    m_pButtonUpdate->SetZOrderingEnabled(false);
+
     m_pResourcesCur = reinterpret_cast<CGUIGridList*>(m_pGUI->CreateGridList(m_pTabResources, false));
     m_pResourcesCur->SetPosition(CVector2D(0.03f, 0.06f), true);
     m_pResourcesCur->SetSize(CVector2D(0.45f, 0.5f), true);
@@ -125,6 +134,7 @@ CLocalServer::CLocalServer(const char* szConfig)
     m_pButtonCancel->SetSize(CVector2D(0.3f, 0.05f), true);
     m_pButtonCancel->SetZOrderingEnabled(false);
 
+    m_pButtonUpdate->SetClickHandler(GUI_CALLBACK(&CLocalServer::OnUpdateResourcesButtonClick, this));
     m_pResourceAdd->SetClickHandler(GUI_CALLBACK(&CLocalServer::OnAddButtonClick, this));
     m_pResourceDel->SetClickHandler(GUI_CALLBACK(&CLocalServer::OnDelButtonClick, this));
     m_pButtonStart->SetClickHandler(GUI_CALLBACK(&CLocalServer::OnStartButtonClick, this));
@@ -159,6 +169,99 @@ bool CLocalServer::OnDelButtonClick(CGUIElement* pElement)
         m_pResourcesAll->SetItemText(m_pResourcesAll->AddRow(), m_hResourcesAll, &pItem->GetText().c_str()[3]);
         m_pResourcesCur->RemoveRow(m_pResourcesCur->GetItemRowIndex(pItem));
     }
+    return true;
+}
+
+bool CLocalServer::OnUpdateResourcesButtonClick(CGUIElement* pElement)
+{
+    SString url = "https://mirror-cdn.multitheftauto.com/mtasa/resources/mtasa-resources-latest.zip";
+    SString path = CalcMTASAPath(PathJoin("server", "mods", "deathmatch", "mtasa-resources-latest.zip"));
+    MakeSureDirExists(ExtractPath(path));
+
+    if (m_pButtonUpdate)
+    {
+        m_pButtonUpdate->SetText(_("Downloading..."));
+        m_pButtonUpdate->SetEnabled(false);
+    }
+
+    g_pClientGame->GetAsyncTaskScheduler()->PushTask(
+        [url, path]() -> bool
+        {
+            HRESULT result = URLDownloadToFileA(NULL, url.c_str(), path.c_str(), 0, NULL);
+            if (result != S_OK)
+                return false;
+
+            SString destPath = CalcMTASAPath(PathJoin("server", "mods", "deathmatch", "resources"));
+            unzFile zipFile = unzOpen(path.c_str());
+
+            if (!zipFile)
+            {
+                FileDelete(path);
+                return false;
+            }
+
+            if (unzGoToFirstFile(zipFile) != UNZ_OK)
+            {
+                unzClose(zipFile);
+                FileDelete(path);
+                return false;
+            }
+
+            do
+            {
+                char fileName[256];
+                unz_file_info fileInfo;
+
+                if (unzGetCurrentFileInfo(zipFile, &fileInfo, fileName, sizeof(fileName), nullptr, 0, nullptr, 0) != UNZ_OK)
+                    continue;
+
+                SString filePath = PathJoin(destPath, fileName);
+                if (fileName[fileInfo.size_filename - 1] == '/')
+                {
+                    MakeSureDirExists(filePath.c_str());
+                    continue;
+                }
+
+                MakeSureDirExists(ExtractPath(filePath).c_str());
+                if (unzOpenCurrentFile(zipFile) != UNZ_OK)
+                    continue;
+
+                FILE* file = fopen(filePath.c_str(), "wb");
+                if (file)
+                {
+                    char buffer[8192];
+                    int read = 0;
+
+                    while ((read = unzReadCurrentFile(zipFile, buffer, sizeof(buffer))) > 0)
+                    {
+                        fwrite(buffer, 1, read, file);
+                    }
+
+                    fclose(file);
+                }
+
+                unzCloseCurrentFile(zipFile);
+            } while (unzGoToNextFile(zipFile) != UNZ_END_OF_LIST_OF_FILE);
+
+            unzClose(zipFile);
+            FileDelete(path);
+
+            return true;
+        },
+        [this](bool success) {
+            if (m_pButtonUpdate)
+            {
+                m_pButtonUpdate->SetText(_("Update server resources"));
+                m_pButtonUpdate->SetEnabled(true);
+            }
+
+            Load();
+            g_pCore->ShowMessageBox(success ? _("Local Server") : _("Error") + _E("CC90"),
+                                    success ? _("Server resources updated successfully!") : _("Failed to download or extract resources."),
+                                    success ? MB_BUTTON_OK | MB_ICON_INFO : MB_BUTTON_OK | MB_ICON_ERROR);
+        }
+    );
+
     return true;
 }
 

--- a/Client/mods/deathmatch/logic/CLocalServer.cpp
+++ b/Client/mods/deathmatch/logic/CLocalServer.cpp
@@ -257,10 +257,13 @@ bool CLocalServer::OnUpdateResourcesButtonClick(CGUIElement* pElement)
                 m_pButtonUpdate->SetEnabled(true);
             }
 
-            Load();
-            g_pCore->ShowMessageBox(success ? _("Local Server") : _("Error") + _E("CC90"),
-                                    success ? _("Server resources updated successfully!") : _("Failed to download or extract resources."),
-                                    success ? MB_BUTTON_OK | MB_ICON_INFO : MB_BUTTON_OK | MB_ICON_ERROR);
+            if (success)
+            {
+                Load();
+                g_pCore->ShowMessageBox(_("Local Server"), _("Server resources updated successfully!"), MB_BUTTON_OK | MB_ICON_INFO);
+            }
+            else
+                g_pCore->ShowMessageBox(_("Error") + _E("CC90"), _("Failed to download or extract resources."), MB_BUTTON_OK | MB_ICON_ERROR);
         }
     );
 

--- a/Client/mods/deathmatch/logic/CLocalServer.h
+++ b/Client/mods/deathmatch/logic/CLocalServer.h
@@ -25,6 +25,7 @@ protected:
     bool OnCancelButtonClick(CGUIElement* pElement);
     bool OnAddButtonClick(CGUIElement* pElement);
     bool OnDelButtonClick(CGUIElement* pElement);
+    bool OnUpdateResourcesButtonClick(CGUIElement* pElement);
 
     // Server config
     bool Load();
@@ -71,6 +72,7 @@ private:
     CGUIButton* m_pResourceAdd;
     CGUIButton* m_pResourceDel;
 
+    CGUIButton* m_pButtonUpdate;
     CGUIButton* m_pButtonStart;
     CGUIButton* m_pButtonCancel;
 };

--- a/Client/mods/deathmatch/premake5.lua
+++ b/Client/mods/deathmatch/premake5.lua
@@ -10,7 +10,7 @@ project "Client Deathmatch"
 
 	defines { "LUNASVG_BUILD", "LUA_USE_APICHECK", "SDK_WITH_BCRYPT" }
 	links {
-		"Lua_Client", "pcre", "json-c", "ws2_32", "portaudio", "zlib", "cryptopp", "libspeex", "blowfish_bcrypt", "lunasvg",
+		"Lua_Client", "pcre", "json-c", "ws2_32", "portaudio", "zlib", "cryptopp", "libspeex", "blowfish_bcrypt", "lunasvg", "zip",
 		"../../../vendor/bass/lib/bass",
 		"../../../vendor/bass/lib/bass_fx",
 		"../../../vendor/bass/lib/bassmix",
@@ -45,7 +45,8 @@ project "Client Deathmatch"
 			"../../../Shared/mods/deathmatch/logic",
 			"../../../Shared/animation",
 			"../../../vendor/sparsehash/src/",
-			"../../../vendor/lunasvg/include"
+			"../../../vendor/lunasvg/include",
+			"../../../vendor/zip"
 	}
 
 	files {


### PR DESCRIPTION
#### Summary
Added an "Update server resources" button to the Local Server (Host game) menu, This allows users to download and extract the latest official `mtasa-resources` archive directly into their local server folder, Added new error code `CC90`.

#### Motivation
Closes #2324

#### Test plan
1. Open the "Host game" menu from the main menu.
2. Go to the General tab and click the new "Update server resources" button.
3. The button should switch to "Downloading..."
4. Wait for the download to finish

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
