### PR TITLE
Fix install-root resolution failures that lead to U01 errors in updater

### DIFF
--- a/Client/loader/CInstallManager.cpp
+++ b/Client/loader/CInstallManager.cpp
@@ -304,17 +304,28 @@ void CInstallManager::InitSequencer()
 //////////////////////////////////////////////////////////
 void CInstallManager::SetMTASAPathSource(const SString& strCommandLineIn)
 {
-    // Update some settings which are used by ReportLog
-    UpdateSettingsForReportLog();
-
     InitSequencer();
     RestoreSequencerFromSnapshot(strCommandLineIn);
 
     // If command line says we're not running from the launch directory, get the launch directory location from the registry
     if (m_pSequencer->GetVariable(INSTALL_LOCATION) == "far")
+    {
+        // Process B carried the real install root through the sequencer state. Honor it here so this
+        // temp launcher process can resolve its base dir without depending only on the registry.
+        // The override must be installed before UpdateSettingsForReportLog runs, because that helper
+        // reaches GetInstallPathForLauncher / GetMTASAPath through UpdateMTAVersionApplicationSetting.
+        const SString strRealInstallRoot = m_pSequencer->GetVariable(INSTALL_ROOT);
+        if (!strRealInstallRoot.empty() && IsUsableMtasaInstallRoot(strRealInstallRoot) && !IsTemporaryUpdateLaunchPath(strRealInstallRoot))
+            SharedUtil::SetMTASABaseDirOverride(strRealInstallRoot);
+
         ::SetMTASAPathSource(true);
+    }
     else
         ::SetMTASAPathSource(false);
+
+    // Update some settings which are used by ReportLog. Must run after the path source is resolved
+    // so that report-log helpers see the real install root rather than a temp extraction directory.
+    UpdateSettingsForReportLog();
 }
 
 //////////////////////////////////////////////////////////
@@ -1042,6 +1053,11 @@ SString CInstallManager::_MaybeSwitchToTempExe()
     // If a new "Multi Theft Auto.exe" exists, let that complete the install
     if (m_pSequencer->GetVariable(INSTALL_LOCATION) == "far")
     {
+        // Carry the current real install root forward to the temp launcher so it can set a base-dir
+        // override before reading the registry. Without this, the temp launcher has only Last Run
+        // Location to fall back on, which can be missing, stale, or denied by HKLM write failures.
+        m_pSequencer->SetVariable(INSTALL_ROOT, GetMTASAPath());
+
         ReleaseSingleInstanceMutex();
         if (ShellExecuteNonBlocking("open", GetLauncherPathFilename(), GetSequencerSnapshot()))
             ExitProcess(0);  // All done here
@@ -1065,8 +1081,13 @@ SString CInstallManager::_SwitchBackFromTempExe()
     {
         m_pSequencer->SetVariable(INSTALL_LOCATION, "near");
 
-        SString strLauncherPathFilename = PathJoin(GetInstallPathForLauncher(), MTA_EXE_NAME);
-        if (!FileExists(strLauncherPathFilename))
+        // GetInstallPathForLauncher returns empty when running from a temp update directory and no
+        // usable non-temp install root could be resolved. PathJoin would then produce a root-relative
+        // probe like "\Multi Theft Auto.exe", which could match an unrelated file on the current drive
+        // and cause us to launch the wrong executable. Skip straight to the GetMTASAPath() fallback.
+        const SString strRealInstallRoot = GetInstallPathForLauncher();
+        SString       strLauncherPathFilename = strRealInstallRoot.empty() ? SString() : PathJoin(strRealInstallRoot, MTA_EXE_NAME);
+        if (strLauncherPathFilename.empty() || !FileExists(strLauncherPathFilename))
         {
             strLauncherPathFilename = PathJoin(GetMTASAPath(), MTA_EXE_NAME);
             if (!FileExists(strLauncherPathFilename))
@@ -1729,7 +1750,10 @@ SString CInstallManager::_ProcessAppCompatChecks()
     IsWow64Process(GetCurrentProcess(), &bIsWOW64);
     uint    uiHKLMFlags = bIsWOW64 ? KEY_WOW64_64KEY : 0;
     WString strGTAExePathFilename = GetGameExecutablePath().wstring();
-    WString strMTAExePathFilename = FromUTF8(PathJoin(GetInstallPathForLauncher(), MTA_EXE_NAME));
+    SString strMTAInstallPath = GetInstallPathForLauncher();
+    if (strMTAInstallPath.empty())
+        strMTAInstallPath = GetMTASAPath();
+    WString strMTAExePathFilename = FromUTF8(PathJoin(strMTAInstallPath, MTA_EXE_NAME));
     WString strCompatModeRegKey = L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\Layers";
     int     bWin816BitColorOption = GetApplicationSettingInt("Win8Color16");
     int     bWin8MouseOption = GetApplicationSettingInt("Win8MouseFix");

--- a/Client/loader/CInstallManager.cpp
+++ b/Client/loader/CInstallManager.cpp
@@ -315,8 +315,20 @@ void CInstallManager::SetMTASAPathSource(const SString& strCommandLineIn)
         // The override must be installed before UpdateSettingsForReportLog runs, because that helper
         // reaches GetInstallPathForLauncher / GetMTASAPath through UpdateMTAVersionApplicationSetting.
         const SString strRealInstallRoot = m_pSequencer->GetVariable(INSTALL_ROOT);
-        if (!strRealInstallRoot.empty() && IsUsableMtasaInstallRoot(strRealInstallRoot) && !IsTemporaryUpdateLaunchPath(strRealInstallRoot))
+        if (strRealInstallRoot.empty())
+        {
+            AddReportLog(1063, "CInstallManager::SetMTASAPathSource: no sequencer install root, falling back to registry");
+        }
+        else if (SharedUtil::IsUsableMtasaInstallRoot(strRealInstallRoot) && !SharedUtil::IsTemporaryUpdateLaunchPath(strRealInstallRoot))
+        {
+            AddReportLog(1063, SString("CInstallManager::SetMTASAPathSource: honoring sequencer install root '%s'", strRealInstallRoot.c_str()));
             SharedUtil::SetMTASABaseDirOverride(strRealInstallRoot);
+        }
+        else
+        {
+            AddReportLog(1063, SString("CInstallManager::SetMTASAPathSource: rejecting unusable sequencer install root '%s', falling back to registry",
+                                       strRealInstallRoot.c_str()));
+        }
 
         ::SetMTASAPathSource(true);
     }

--- a/Client/loader/CInstallManager.h
+++ b/Client/loader/CInstallManager.h
@@ -15,6 +15,7 @@
 // Common command line keys
 #define INSTALL_STAGE    "install_stage"
 #define INSTALL_LOCATION "install_loc"
+#define INSTALL_ROOT     "install_root"
 #define HIDE_PROGRESS    "hide_prog"
 
 typedef CBadLang<class CInstallManager> CSequencerType;

--- a/Client/loader/Install.cpp
+++ b/Client/loader/Install.cpp
@@ -249,14 +249,16 @@ static bool TerminateFileLockingProcesses(const SString& absolutePath, const SSt
     std::vector<DWORD> processIds = GetProcessListUsingFile(filePath);
     const DWORD        currentProcessId = GetCurrentProcessId();
 
-    const auto RemoveCurrentProcessId = [&]() {
+    const auto RemoveCurrentProcessId = [&]()
+    {
         const auto newEnd = std::remove(processIds.begin(), processIds.end(), currentProcessId);
         const bool removedCurrentProcess = newEnd != processIds.end();
         processIds.erase(newEnd, processIds.end());
         return removedCurrentProcess;
     };
 
-    const auto FailOnCurrentProcessLock = [&]() {
+    const auto FailOnCurrentProcessLock = [&]()
+    {
         AddReportLog(5055, SString("TerminateFileLockingProcesses: current process %lu is locking '%s'", currentProcessId, absolutePath.c_str()));
         return false;
     };

--- a/Client/loader/Install.cpp
+++ b/Client/loader/Install.cpp
@@ -14,6 +14,7 @@
 #include "Dialogs.h"
 #include "Main.h"
 #include <unrar/dll.hpp>
+#include <algorithm>
 #include <optional>
 #include <memory>
 #include <filesystem>
@@ -237,7 +238,7 @@ static void GetArchiveFilesInDirectory(const SString& directory, std::vector<Man
 }
 
 /**
- * @brief Terminates every process locking a file with the user's consent.
+ * @brief Tries to clear file locks by terminating other processes with the user's consent.
  * @param absolutePath The path to the file to check
  * @param displayName Name of the file in the user prompt
  * @return True if the file is not locked (anymore), false otherwise
@@ -246,9 +247,27 @@ static bool TerminateFileLockingProcesses(const SString& absolutePath, const SSt
 {
     WString            filePath(absolutePath);
     std::vector<DWORD> processIds = GetProcessListUsingFile(filePath);
+    const DWORD        currentProcessId = GetCurrentProcessId();
+
+    const auto RemoveCurrentProcessId = [&]() {
+        const auto newEnd = std::remove(processIds.begin(), processIds.end(), currentProcessId);
+        const bool removedCurrentProcess = newEnd != processIds.end();
+        processIds.erase(newEnd, processIds.end());
+        return removedCurrentProcess;
+    };
+
+    const auto FailOnCurrentProcessLock = [&]() {
+        AddReportLog(5055, SString("TerminateFileLockingProcesses: current process %lu is locking '%s'", currentProcessId, absolutePath.c_str()));
+        return false;
+    };
 
     while (true)
     {
+        const bool currentProcessLocksFile = RemoveCurrentProcessId();
+
+        if (currentProcessLocksFile)
+            return FailOnCurrentProcessLock();
+
         if (processIds.empty())
             return true;
 
@@ -274,6 +293,10 @@ static bool TerminateFileLockingProcesses(const SString& absolutePath, const SSt
             "MTA: San Andreas", MB_CANCELTRYCONTINUE | MB_ICONQUESTION | MB_TOPMOST);
 
         processIds = GetProcessListUsingFile(filePath);
+        const bool currentProcessLocksFileAfterPrompt = RemoveCurrentProcessId();
+
+        if (currentProcessLocksFileAfterPrompt)
+            return FailOnCurrentProcessLock();
 
         if (processIds.empty())
             return true;
@@ -658,7 +681,8 @@ static int RunInstall()
     if (files.empty())
         return 0;
 
-    // Check if any executable or library is locked by any process and terminate it with the user's consent.
+    // Binary replacements can fail after backup work has started, so clear blocking locks before
+    // any file copy starts.
     for (const InstallableFile& file : files)
     {
         if (file.relativePath.EndsWithI(".exe") || file.relativePath.EndsWithI(".dll"))

--- a/Client/loader/Main.cpp
+++ b/Client/loader/Main.cpp
@@ -148,8 +148,10 @@ namespace
         // Start logging.....now
         BeginEventLog();
 
-        // Start localization if possible
-        InitLocalization(false);
+        // A temp updater shouldnt load the install root's core.dll before RunInstall;
+        // the localization module stays loaded and would block replacement.
+        if (!IsTemporaryUpdateLaunchPath(GetLaunchPath()))
+            InitLocalization(false);
 
         // Handle commands from the installer
         HandleSpecialLaunchOptions();

--- a/Client/loader/Main.cpp
+++ b/Client/loader/Main.cpp
@@ -150,7 +150,7 @@ namespace
 
         // A temp updater shouldnt load the install root's core.dll before RunInstall;
         // the localization module stays loaded and would block replacement.
-        if (!IsTemporaryUpdateLaunchPath(GetLaunchPath()))
+        if (!SharedUtil::IsTemporaryUpdateLaunchPath(GetLaunchPath()))
             InitLocalization(false);
 
         // Handle commands from the installer

--- a/Client/loader/Main.cpp
+++ b/Client/loader/Main.cpp
@@ -42,8 +42,12 @@ namespace
         ERROR_INSTALL_CONTINUE = -4
     };
 
-    // Command line constants
-    constexpr size_t MAX_CMD_LINE_LENGTH = 4096;
+    // Command line constants. Sized to hold the Windows command-line maximum (CreateProcess limit
+    // is 32767 wchar_t, see CreateProcessW docs). The auto-update flow serializes the sequencer
+    // snapshot through this buffer (CInstallManager::_MaybeSwitchToTempExe -> ShellExecuteNonBlocking
+    // -> Process C lpCmdLine), so a smaller cap silently truncates restored state and breaks the
+    // INSTALL_ROOT carry that prevents U01 in temp-launched processes.
+    constexpr size_t MAX_CMD_LINE_LENGTH = 32768;
 
     // Report log IDs
     constexpr int LOG_ID_END = 1044;

--- a/Client/loader/MainFunctions.cpp
+++ b/Client/loader/MainFunctions.cpp
@@ -464,9 +464,17 @@ void InitLocalization(bool bShowErrors)
         return;
 
     const SString strLaunchPath = GetLaunchPath();
+    const SString strMTASAPath = GetMTASAPath();
 
-    // Check for core.dll
-    const SString strCoreDLL = PathJoin(strLaunchPath, "mta", MTA_DLL_NAME);
+    // Probe the install root first and only fall back to the launch path. In the auto-update flow,
+    // Process C runs from a temp directory under \upcache\_*_tmp_*\ which does not contain mta\core.dll;
+    // the real install root is carried into g_strMTASAPath via the install manager's SetMTASABaseDirOverride
+    // path, so GetMTASAPath returns it even though GetLaunchPath still points at the temp tree. On a normal
+    // non-temp launch the two paths are equal and the first probe succeeds.
+    SString strCoreDLL = PathJoin(strMTASAPath, "mta", MTA_DLL_NAME);
+    if (!FileExists(strCoreDLL))
+        strCoreDLL = PathJoin(strLaunchPath, "mta", MTA_DLL_NAME);
+
     if (!FileExists(strCoreDLL))
     {
         if (!bShowErrors)
@@ -477,7 +485,6 @@ void InitLocalization(bool bShowErrors)
     }
 
     // Setup DLL search paths
-    const SString strMTASAPath = GetMTASAPath();
     SetDllDirectory(PathJoin(strMTASAPath, "mta"));
 
     // See if xinput is loadable (XInput9_1_0.dll or xinput1_3.dll)
@@ -820,7 +827,9 @@ void ConfigureWerDumpPath()
 {
     using WerRegisterAppLocalDumpFn = HRESULT(WINAPI*)(PCWSTR);
 
-    const SString strInstallPath = GetInstallPathForLauncher();
+    SString strInstallPath = GetInstallPathForLauncher();
+    if (strInstallPath.empty())
+        strInstallPath = GetMTASAPath();
     if (strInstallPath.empty())
         return;
 

--- a/Client/loader/Utils.cpp
+++ b/Client/loader/Utils.cpp
@@ -679,7 +679,10 @@ bool IsTemporaryUpdateLaunchPath(const SString& strLaunchPath)
     if (!strLaunchPath.ContainsI("\\upcache\\"))
         return false;
 
-    return ExtractFilename(strLaunchPath).ContainsI("_tmp_");
+    // The auto-update flow creates the extraction directory in Install.cpp::CheckOnRestartCommand
+    // as MakeUniquePath("...\\upcache\\_<archiveName>_tmp_"), so the leaf always begins with '_'.
+    const SString strLeaf = ExtractFilename(strLaunchPath);
+    return strLeaf.BeginsWith("_") && strLeaf.ContainsI("_tmp_");
 }
 
 void SetMTASAPathSource(bool bReadFromRegistry)

--- a/Client/loader/Utils.cpp
+++ b/Client/loader/Utils.cpp
@@ -466,27 +466,6 @@ namespace
         return PathJoin(GetProductRegistryPath(), GetMajorVersionString(), strPath).TrimEnd("\\");
     }
 
-    bool IsTemporaryUpdateLaunchPath(const SString& strLaunchPath)
-    {
-        if (strLaunchPath.empty())
-            return false;
-
-        if (!strLaunchPath.ContainsI("\\upcache\\"))
-            return false;
-
-        return ExtractFilename(strLaunchPath).ContainsI("_tmp_");
-    }
-
-    bool IsUsableMtasaInstallRoot(const SString& strPath)
-    {
-        if (strPath.empty())
-            return false;
-
-        return FileExists(PathJoin(strPath, "Multi Theft Auto.exe")) || FileExists(PathJoin(strPath, "Multi Theft Auto_d.exe")) ||
-               FileExists(PathJoin(strPath, "mta", "core.dll")) || FileExists(PathJoin(strPath, "MTA", "core.dll")) ||
-               FileExists(PathJoin(strPath, "mta", "core_d.dll")) || FileExists(PathJoin(strPath, "MTA", "core_d.dll"));
-    }
-
     bool HasDistinct64BitRegistryView()
     {
 #if defined(_WIN64)
@@ -580,6 +559,62 @@ namespace
                        static_cast<DWORD>((wstrValue.length() + 1) * sizeof(wchar_t)));
         RegCloseKey(hKey);
     }
+
+    // Read Last Run Location from a specific registry view. viewFlag should be one of
+    // KEY_WOW64_64KEY, KEY_WOW64_32KEY, or 0 (no view override). Returns empty string on any failure.
+    // Oversized values are rejected without allocation so a malformed registry entry on the U01
+    // recovery path cannot turn into a large allocation; the same 1 MB cap is used by the generic
+    // ReadRegistryStringValue helper in SharedUtil.Misc.hpp.
+    SString ReadInstallRootRegistryView(REGSAM viewFlag)
+    {
+        constexpr DWORD kMaxRegistryValueBytes = 1024u * 1024u;
+
+        const WString wstrSubKey = FromUTF8(MakeCurrentVersionRegistryPath(""));
+        const WString wstrValueName = FromUTF8("Last Run Location");
+
+        HKEY hKey = nullptr;
+        if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, wstrSubKey.c_str(), 0, KEY_READ | viewFlag, &hKey) != ERROR_SUCCESS || !hKey)
+            return "";
+
+        DWORD valueType = REG_SZ;
+        DWORD valueSize = 0;
+        LONG  result = RegQueryValueExW(hKey, wstrValueName.c_str(), nullptr, &valueType, nullptr, &valueSize);
+        if (result != ERROR_SUCCESS || (valueType != REG_SZ && valueType != REG_EXPAND_SZ) || valueSize == 0 || valueSize > kMaxRegistryValueBytes)
+        {
+            RegCloseKey(hKey);
+            return "";
+        }
+
+        std::vector<wchar_t> buffer((valueSize / sizeof(wchar_t)) + 1u, L'\0');
+        result = RegQueryValueExW(hKey, wstrValueName.c_str(), nullptr, &valueType, reinterpret_cast<LPBYTE>(buffer.data()), &valueSize);
+        RegCloseKey(hKey);
+
+        if (result != ERROR_SUCCESS || (valueType != REG_SZ && valueType != REG_EXPAND_SZ) || valueSize > kMaxRegistryValueBytes)
+            return "";
+
+        if (valueSize >= sizeof(wchar_t))
+            buffer[(valueSize / sizeof(wchar_t)) - 1u] = L'\0';
+        else
+            buffer[0] = L'\0';
+
+        // Expand environment variable references for REG_EXPAND_SZ values so callers see a real
+        // filesystem path. Without this, a value like "%ProgramFiles%\..." would fail validation.
+        // The expansion is bounded by the same 1 MB cap so a value containing a self-referential or
+        // explosive expansion cannot trigger a large allocation here.
+        if (valueType == REG_EXPAND_SZ)
+        {
+            constexpr DWORD kMaxExpandChars = kMaxRegistryValueBytes / sizeof(wchar_t);
+            const DWORD     expandedChars = ExpandEnvironmentStringsW(buffer.data(), nullptr, 0);
+            if (expandedChars > 0 && expandedChars <= kMaxExpandChars)
+            {
+                std::vector<wchar_t> expanded(expandedChars, L'\0');
+                if (ExpandEnvironmentStringsW(buffer.data(), expanded.data(), expandedChars))
+                    return ToUTF8(expanded.data());
+            }
+        }
+
+        return ToUTF8(buffer.data());
+    }
 }
 
 SString GetInstallPathForLauncher()
@@ -588,15 +623,63 @@ SString GetInstallPathForLauncher()
     if (!IsTemporaryUpdateLaunchPath(strLaunchPath))
         return strLaunchPath;
 
-    const SString strSavedInstallPath = GetRegistryValue("", "Last Run Location");
-    if (IsUsableMtasaInstallRoot(strSavedInstallPath) && !IsTemporaryUpdateLaunchPath(strSavedInstallPath))
-        return strSavedInstallPath;
+    // Prefer the resolved base dir over the registry when one was already established. In the
+    // far-update Process C, CInstallManager applies SetMTASABaseDirOverride from the sequencer
+    // carried INSTALL_ROOT and runs ::SetMTASAPathSource(true) before any consumer reaches here,
+    // so g_strMTASAPath holds the validated real install root that Process B was updating. A stale
+    // or differently-installed registry "Last Run Location" must not win over that carried root and
+    // aim consumers at a different MTA install. Read g_strMTASAPath directly rather than calling
+    // GetMTASAPath(), because GetMTASAPath() lazy-inits via SetMTASAPathSource(false), which calls
+    // back into GetInstallPathForLauncher() and would recurse for any temp launcher whose g_strMTASAPath
+    // has not yet been populated by the far-update sequencer path. Empty string falls through to the
+    // per-view registry loop below, preserving the temp-launcher-without-far-update fallback.
+    if (!g_strMTASAPath.empty() && IsUsableMtasaInstallRoot(g_strMTASAPath) && !IsTemporaryUpdateLaunchPath(g_strMTASAPath) &&
+        !g_strMTASAPath.CompareI(strLaunchPath))
+        return g_strMTASAPath;
 
-    const SString strSavedInstallPath64 = GetRegistryValue64("", "Last Run Location");
-    if (IsUsableMtasaInstallRoot(strSavedInstallPath64) && !IsTemporaryUpdateLaunchPath(strSavedInstallPath64))
-        return strSavedInstallPath64;
+    // Read each registry view independently so a stale value in one view cannot shadow a usable value in another.
+    REGSAM viewFlags[3] = {0, 0, 0};
+    int    viewCount = 0;
+#if defined(KEY_WOW64_64KEY)
+    viewFlags[viewCount++] = KEY_WOW64_64KEY;
+#endif
+#if defined(KEY_WOW64_32KEY)
+    viewFlags[viewCount++] = KEY_WOW64_32KEY;
+#endif
+    viewFlags[viewCount++] = 0;
 
-    return strLaunchPath;
+    for (int i = 0; i < viewCount; ++i)
+    {
+        const SString strSavedInstallPath = ReadInstallRootRegistryView(viewFlags[i]);
+        if (IsUsableMtasaInstallRoot(strSavedInstallPath) && !IsTemporaryUpdateLaunchPath(strSavedInstallPath))
+            return strSavedInstallPath;
+    }
+
+    // No usable non-temp install root resolved. Returning empty forces callers to use their own fallbacks
+    // (such as a base-dir override carried forward from the parent launcher) instead of treating a temp
+    // update directory as the real install location.
+    return SString();
+}
+
+bool IsUsableMtasaInstallRoot(const SString& strPath)
+{
+    if (strPath.empty())
+        return false;
+
+    return FileExists(PathJoin(strPath, "Multi Theft Auto.exe")) || FileExists(PathJoin(strPath, "Multi Theft Auto_d.exe")) ||
+           FileExists(PathJoin(strPath, "mta", "core.dll")) || FileExists(PathJoin(strPath, "MTA", "core.dll")) ||
+           FileExists(PathJoin(strPath, "mta", "core_d.dll")) || FileExists(PathJoin(strPath, "MTA", "core_d.dll"));
+}
+
+bool IsTemporaryUpdateLaunchPath(const SString& strLaunchPath)
+{
+    if (strLaunchPath.empty())
+        return false;
+
+    if (!strLaunchPath.ContainsI("\\upcache\\"))
+        return false;
+
+    return ExtractFilename(strLaunchPath).ContainsI("_tmp_");
 }
 
 void SetMTASAPathSource(bool bReadFromRegistry)
@@ -612,11 +695,30 @@ void SetMTASAPathSource(bool bReadFromRegistry)
         SString strLaunchPath = GetLaunchPath();
         SString strInstallPath = GetInstallPathForLauncher();
 
+        // GetInstallPathForLauncher returns empty when running from a temp update directory and no
+        // usable non-temp install root could be resolved. In that case the safest local fallback is
+        // the launch path itself, which preserves the prior behavior for non-update launches without
+        // contaminating the registry from the auto-update flow (Process C now goes through the far
+        // branch with a base-dir override carried forward by CInstallManager).
+        if (strInstallPath.empty())
+            strInstallPath = strLaunchPath;
+
         if (!strInstallPath.CompareI(strLaunchPath))
         {
             AddReportLog(1063, SString("SetMTASAPathSource: preserving install path '%s' for temp launcher '%s'", strInstallPath.c_str(),
                                        strLaunchPathFilename.c_str()));
             g_strMTASAPath = strInstallPath;
+            return;
+        }
+
+        // Refuse to write a temp update extraction directory into the install-location registry
+        // values. A temp launcher started without the far-update sequencer state would otherwise
+        // contaminate Last Run Location with an upcache\_*_tmp_* path that gets deleted later by
+        // CleanDownloadCache, leaving a stale registry pointer that produces U01 on the next launch.
+        if (IsTemporaryUpdateLaunchPath(strLaunchPath))
+        {
+            AddReportLog(1063, SString("SetMTASAPathSource: refusing to record temp launch path '%s' in registry", strLaunchPath.c_str()));
+            g_strMTASAPath = strLaunchPath;
             return;
         }
 
@@ -1290,6 +1392,20 @@ void UpdateMTAVersionApplicationSetting(bool bQuiet)
     {
         hModule = LoadVersionModule(strInstallPath, dwLastError);
         bFreeModule = hModule != NULL;
+    }
+
+    // GetInstallPathForLauncher returns empty when running from a temp update directory and no
+    // usable non-temp install root could be resolved. GetMTASAPath consults SetMTASABaseDirOverride
+    // (which the install manager populates from the sequencer-carried INSTALL_ROOT in the far branch),
+    // so this attempt covers the recovered far-update case before falling back to the launch dir.
+    if (!hModule)
+    {
+        const SString strBaseDirPath = GetMTASAPath();
+        if (IsUsableMtasaInstallRoot(strBaseDirPath) && !strBaseDirPath.CompareI(strInstallPath))
+        {
+            hModule = LoadVersionModule(strBaseDirPath, dwLastError);
+            bFreeModule = hModule != NULL;
+        }
     }
 
     if (!hModule)

--- a/Client/loader/Utils.cpp
+++ b/Client/loader/Utils.cpp
@@ -579,7 +579,8 @@ namespace
         DWORD valueType = REG_SZ;
         DWORD valueSize = 0;
         LONG  result = RegQueryValueExW(hKey, wstrValueName.c_str(), nullptr, &valueType, nullptr, &valueSize);
-        if (result != ERROR_SUCCESS || (valueType != REG_SZ && valueType != REG_EXPAND_SZ) || valueSize == 0 || valueSize > kMaxRegistryValueBytes)
+        if (result != ERROR_SUCCESS || (valueType != REG_SZ && valueType != REG_EXPAND_SZ) || valueSize == 0 || valueSize > kMaxRegistryValueBytes ||
+            (valueSize % sizeof(wchar_t)) != 0)
         {
             RegCloseKey(hKey);
             return "";
@@ -589,13 +590,11 @@ namespace
         result = RegQueryValueExW(hKey, wstrValueName.c_str(), nullptr, &valueType, reinterpret_cast<LPBYTE>(buffer.data()), &valueSize);
         RegCloseKey(hKey);
 
-        if (result != ERROR_SUCCESS || (valueType != REG_SZ && valueType != REG_EXPAND_SZ) || valueSize > kMaxRegistryValueBytes)
+        if (result != ERROR_SUCCESS || (valueType != REG_SZ && valueType != REG_EXPAND_SZ) || valueSize > kMaxRegistryValueBytes ||
+            (valueSize % sizeof(wchar_t)) != 0)
             return "";
 
-        if (valueSize >= sizeof(wchar_t))
-            buffer[(valueSize / sizeof(wchar_t)) - 1u] = L'\0';
-        else
-            buffer[0] = L'\0';
+        buffer[valueSize / sizeof(wchar_t)] = L'\0';
 
         // Expand environment variable references for REG_EXPAND_SZ values so callers see a real
         // filesystem path. Without this, a value like "%ProgramFiles%\..." would fail validation.
@@ -620,7 +619,7 @@ namespace
 SString GetInstallPathForLauncher()
 {
     const SString strLaunchPath = GetLaunchPath();
-    if (!IsTemporaryUpdateLaunchPath(strLaunchPath))
+    if (!SharedUtil::IsTemporaryUpdateLaunchPath(strLaunchPath))
         return strLaunchPath;
 
     // Prefer the resolved base dir over the registry when one was already established. In the
@@ -633,7 +632,7 @@ SString GetInstallPathForLauncher()
     // back into GetInstallPathForLauncher() and would recurse for any temp launcher whose g_strMTASAPath
     // has not yet been populated by the far-update sequencer path. Empty string falls through to the
     // per-view registry loop below, preserving the temp-launcher-without-far-update fallback.
-    if (!g_strMTASAPath.empty() && IsUsableMtasaInstallRoot(g_strMTASAPath) && !IsTemporaryUpdateLaunchPath(g_strMTASAPath) &&
+    if (!g_strMTASAPath.empty() && SharedUtil::IsUsableMtasaInstallRoot(g_strMTASAPath) && !SharedUtil::IsTemporaryUpdateLaunchPath(g_strMTASAPath) &&
         !g_strMTASAPath.CompareI(strLaunchPath))
         return g_strMTASAPath;
 
@@ -651,7 +650,7 @@ SString GetInstallPathForLauncher()
     for (int i = 0; i < viewCount; ++i)
     {
         const SString strSavedInstallPath = ReadInstallRootRegistryView(viewFlags[i]);
-        if (IsUsableMtasaInstallRoot(strSavedInstallPath) && !IsTemporaryUpdateLaunchPath(strSavedInstallPath))
+        if (SharedUtil::IsUsableMtasaInstallRoot(strSavedInstallPath) && !SharedUtil::IsTemporaryUpdateLaunchPath(strSavedInstallPath))
             return strSavedInstallPath;
     }
 
@@ -659,30 +658,6 @@ SString GetInstallPathForLauncher()
     // (such as a base-dir override carried forward from the parent launcher) instead of treating a temp
     // update directory as the real install location.
     return SString();
-}
-
-bool IsUsableMtasaInstallRoot(const SString& strPath)
-{
-    if (strPath.empty())
-        return false;
-
-    return FileExists(PathJoin(strPath, "Multi Theft Auto.exe")) || FileExists(PathJoin(strPath, "Multi Theft Auto_d.exe")) ||
-           FileExists(PathJoin(strPath, "mta", "core.dll")) || FileExists(PathJoin(strPath, "MTA", "core.dll")) ||
-           FileExists(PathJoin(strPath, "mta", "core_d.dll")) || FileExists(PathJoin(strPath, "MTA", "core_d.dll"));
-}
-
-bool IsTemporaryUpdateLaunchPath(const SString& strLaunchPath)
-{
-    if (strLaunchPath.empty())
-        return false;
-
-    if (!strLaunchPath.ContainsI("\\upcache\\"))
-        return false;
-
-    // The auto-update flow creates the extraction directory in Install.cpp::CheckOnRestartCommand
-    // as MakeUniquePath("...\\upcache\\_<archiveName>_tmp_"), so the leaf always begins with '_'.
-    const SString strLeaf = ExtractFilename(strLaunchPath);
-    return strLeaf.BeginsWith("_") && strLeaf.ContainsI("_tmp_");
 }
 
 void SetMTASAPathSource(bool bReadFromRegistry)
@@ -718,7 +693,7 @@ void SetMTASAPathSource(bool bReadFromRegistry)
         // values. A temp launcher started without the far-update sequencer state would otherwise
         // contaminate Last Run Location with an upcache\_*_tmp_* path that gets deleted later by
         // CleanDownloadCache, leaving a stale registry pointer that produces U01 on the next launch.
-        if (IsTemporaryUpdateLaunchPath(strLaunchPath))
+        if (SharedUtil::IsTemporaryUpdateLaunchPath(strLaunchPath))
         {
             AddReportLog(1063, SString("SetMTASAPathSource: refusing to record temp launch path '%s' in registry", strLaunchPath.c_str()));
             g_strMTASAPath = strLaunchPath;
@@ -1391,7 +1366,7 @@ void UpdateMTAVersionApplicationSetting(bool bQuiet)
     bool    bFreeModule = false;
 
     const SString strInstallPath = GetInstallPathForLauncher();
-    if (IsUsableMtasaInstallRoot(strInstallPath))
+    if (SharedUtil::IsUsableMtasaInstallRoot(strInstallPath))
     {
         hModule = LoadVersionModule(strInstallPath, dwLastError);
         bFreeModule = hModule != NULL;
@@ -1404,7 +1379,7 @@ void UpdateMTAVersionApplicationSetting(bool bQuiet)
     if (!hModule)
     {
         const SString strBaseDirPath = GetMTASAPath();
-        if (IsUsableMtasaInstallRoot(strBaseDirPath) && !strBaseDirPath.CompareI(strInstallPath))
+        if (SharedUtil::IsUsableMtasaInstallRoot(strBaseDirPath) && !strBaseDirPath.CompareI(strInstallPath))
         {
             hModule = LoadVersionModule(strBaseDirPath, dwLastError);
             bFreeModule = hModule != NULL;

--- a/Client/loader/Utils.h
+++ b/Client/loader/Utils.h
@@ -79,6 +79,8 @@ auto    GetGameBaseDirectory() -> std::filesystem::path;
 auto    GetGameLaunchDirectory() -> std::filesystem::path;
 auto    GetGameExecutablePath() -> std::filesystem::path;
 SString GetInstallPathForLauncher();
+bool    IsUsableMtasaInstallRoot(const SString& strPath);
+bool    IsTemporaryUpdateLaunchPath(const SString& strLaunchPath);
 
 void            SetMTASAPathSource(bool bReadFromRegistry);
 SString         GetMTASAPath();

--- a/Client/loader/Utils.h
+++ b/Client/loader/Utils.h
@@ -79,8 +79,6 @@ auto    GetGameBaseDirectory() -> std::filesystem::path;
 auto    GetGameLaunchDirectory() -> std::filesystem::path;
 auto    GetGameExecutablePath() -> std::filesystem::path;
 SString GetInstallPathForLauncher();
-bool    IsUsableMtasaInstallRoot(const SString& strPath);
-bool    IsTemporaryUpdateLaunchPath(const SString& strLaunchPath);
 
 void            SetMTASAPathSource(bool bReadFromRegistry);
 SString         GetMTASAPath();

--- a/Shared/sdk/SharedUtil.Misc.h
+++ b/Shared/sdk/SharedUtil.Misc.h
@@ -147,6 +147,9 @@ namespace SharedUtil
     //
     void SetMTASABaseDirOverride(const SString& strPath);
 
+    bool IsUsableMtasaInstallRoot(const SString& strPath);
+    bool IsTemporaryUpdateLaunchPath(const SString& strLaunchPath);
+
     //
     // Get startup directory as saved in the registry by the launcher
     // Used in the Win32 Client only

--- a/Shared/sdk/SharedUtil.Misc.hpp
+++ b/Shared/sdk/SharedUtil.Misc.hpp
@@ -383,7 +383,7 @@ void SharedUtil::SetMTASABaseDirOverride(const SString& strPath)
     strInstallRootOverride = strPath;
 }
 
-static bool IsUsableMtasaInstallRoot(const SString& strPath)
+bool SharedUtil::IsUsableMtasaInstallRoot(const SString& strPath)
 {
     if (strPath.empty())
         return false;
@@ -393,22 +393,23 @@ static bool IsUsableMtasaInstallRoot(const SString& strPath)
            FileExists(PathJoin(strPath, "mta", "core_d.dll")) || FileExists(PathJoin(strPath, "MTA", "core_d.dll"));
 }
 
-// A path inside upcache\_<archive>_tmp_<n> is a transient extraction directory used by the auto-update
-// flow. Such a path can satisfy IsUsableMtasaInstallRoot while it still exists, but it must never be
-// accepted as the durable MTA install root. The launcher-side helper in Client/loader/Utils.cpp uses
-// the same shape; if either copy changes, update both.
-static bool IsTemporaryUpdateLaunchPath(const SString& strLaunchPath)
+// A path inside upcache\_<archive>_tmp_<n> is an auto-update extraction directory.
+// It can look like a usable install root while it exists, but it must not be kept as the real install root.
+bool SharedUtil::IsTemporaryUpdateLaunchPath(const SString& strLaunchPath)
 {
     if (strLaunchPath.empty())
         return false;
 
-    if (!strLaunchPath.ContainsI("\\upcache\\"))
+    const SString strNormalizedLaunchPath = PathConform(strLaunchPath).TrimEnd("\\");
+    if (strNormalizedLaunchPath.empty())
         return false;
 
-    // The auto-update flow creates the extraction directory in Install.cpp::CheckOnRestartCommand
-    // as MakeUniquePath("...\\upcache\\_<archiveName>_tmp_"), so the leaf always begins with '_'.
-    const SString strLeaf = ExtractFilename(strLaunchPath);
-    return strLeaf.BeginsWith("_") && strLeaf.ContainsI("_tmp_");
+    const SString strLeaf = ExtractFilename(strNormalizedLaunchPath);
+    if (!strLeaf.BeginsWith("_") || !strLeaf.ContainsI("_tmp_"))
+        return false;
+
+    const SString strParent = ExtractFilename(ExtractPath(strNormalizedLaunchPath));
+    return strParent.CompareI("upcache");
 }
 
 // Read Last Run Location from a specific registry view. viewFlag should be one of
@@ -430,7 +431,8 @@ static SString ReadInstallRootRegistryValueView(REGSAM viewFlag)
     DWORD dwType = REG_SZ;
     DWORD dwSize = 0;
     LONG  result = RegQueryValueExW(hkTemp, wstrValue, NULL, &dwType, NULL, &dwSize);
-    if (result != ERROR_SUCCESS || (dwType != REG_SZ && dwType != REG_EXPAND_SZ) || dwSize == 0 || dwSize > kMaxRegistryValueBytes)
+    if (result != ERROR_SUCCESS || (dwType != REG_SZ && dwType != REG_EXPAND_SZ) || dwSize == 0 || dwSize > kMaxRegistryValueBytes ||
+        (dwSize % sizeof(wchar_t)) != 0)
     {
         RegCloseKey(hkTemp);
         return "";
@@ -440,13 +442,10 @@ static SString ReadInstallRootRegistryValueView(REGSAM viewFlag)
     result = RegQueryValueExW(hkTemp, wstrValue, NULL, &dwType, reinterpret_cast<LPBYTE>(buffer.data()), &dwSize);
     RegCloseKey(hkTemp);
 
-    if (result != ERROR_SUCCESS || (dwType != REG_SZ && dwType != REG_EXPAND_SZ) || dwSize > kMaxRegistryValueBytes)
+    if (result != ERROR_SUCCESS || (dwType != REG_SZ && dwType != REG_EXPAND_SZ) || dwSize > kMaxRegistryValueBytes || (dwSize % sizeof(wchar_t)) != 0)
         return "";
 
-    if (dwSize >= sizeof(wchar_t))
-        buffer[(dwSize / sizeof(wchar_t)) - 1u] = L'\0';
-    else
-        buffer[0] = L'\0';
+    buffer[dwSize / sizeof(wchar_t)] = L'\0';
 
     // Expand environment variable references for REG_EXPAND_SZ values so callers see a real
     // filesystem path. Without this, a value like "%ProgramFiles%\..." would fail validation.
@@ -486,7 +485,7 @@ SString SharedUtil::GetMTASABaseDir()
             // install-root checks used elsewhere and reject temp update paths so the parent-process
             // branch cannot point this process at a directory that is about to be deleted.
             SString strParentDir = ExtractPath(GetParentProcessPathFilename(GetCurrentProcessId()));
-            if (IsUsableMtasaInstallRoot(strParentDir) && !IsTemporaryUpdateLaunchPath(strParentDir))
+            if (SharedUtil::IsUsableMtasaInstallRoot(strParentDir) && !SharedUtil::IsTemporaryUpdateLaunchPath(strParentDir))
             {
                 strInstallRoot = strParentDir;
                 strInstallRootSource = "parent process";
@@ -530,7 +529,7 @@ SString SharedUtil::GetMTASABaseDir()
                     continue;
                 if (strFirstNonEmptyRegistryValue.empty())
                     strFirstNonEmptyRegistryValue = strCandidate;
-                if (IsUsableMtasaInstallRoot(strCandidate) && !IsTemporaryUpdateLaunchPath(strCandidate))
+                if (SharedUtil::IsUsableMtasaInstallRoot(strCandidate) && !SharedUtil::IsTemporaryUpdateLaunchPath(strCandidate))
                 {
                     strInstallRoot = strCandidate;
                     strInstallRootSource = (viewFlags[i] == 0) ? "registry" :

--- a/Shared/sdk/SharedUtil.Misc.hpp
+++ b/Shared/sdk/SharedUtil.Misc.hpp
@@ -393,20 +393,41 @@ static bool IsUsableMtasaInstallRoot(const SString& strPath)
            FileExists(PathJoin(strPath, "mta", "core_d.dll")) || FileExists(PathJoin(strPath, "MTA", "core_d.dll"));
 }
 
-static SString ReadInstallRootRegistryValue64()
+// A path inside upcache\_<archive>_tmp_<n> is a transient extraction directory used by the auto-update
+// flow. Such a path can satisfy IsUsableMtasaInstallRoot while it still exists, but it must never be
+// accepted as the durable MTA install root. The launcher-side helper in Client/loader/Utils.cpp uses
+// the same shape; if either copy changes, update both.
+static bool IsTemporaryUpdateLaunchPath(const SString& strLaunchPath)
 {
-    #if defined(KEY_WOW64_64KEY)
+    if (strLaunchPath.empty())
+        return false;
+
+    if (!strLaunchPath.ContainsI("\\upcache\\"))
+        return false;
+
+    return ExtractFilename(strLaunchPath).ContainsI("_tmp_");
+}
+
+// Read Last Run Location from a specific registry view. viewFlag should be one of
+// KEY_WOW64_64KEY, KEY_WOW64_32KEY, or 0 (no view override). Returns empty on any failure.
+// Oversized values are rejected without allocation so a malformed registry entry on the U01
+// recovery path cannot turn into a large allocation; the same 1 MB cap is used by the generic
+// ReadRegistryStringValue helper later in this file.
+static SString ReadInstallRootRegistryValueView(REGSAM viewFlag)
+{
+    constexpr DWORD kMaxRegistryValueBytes = 1024u * 1024u;
+
     const WString wstrSubKey = FromUTF8(PathJoin(GetProductRegistryPath(), GetMajorVersionString()).TrimEnd("\\"));
     const WString wstrValue = FromUTF8("Last Run Location");
 
     HKEY hkTemp = NULL;
-    if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, wstrSubKey, 0, KEY_READ | KEY_WOW64_64KEY, &hkTemp) != ERROR_SUCCESS || !hkTemp)
+    if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, wstrSubKey, 0, KEY_READ | viewFlag, &hkTemp) != ERROR_SUCCESS || !hkTemp)
         return "";
 
     DWORD dwType = REG_SZ;
     DWORD dwSize = 0;
     LONG  result = RegQueryValueExW(hkTemp, wstrValue, NULL, &dwType, NULL, &dwSize);
-    if (result != ERROR_SUCCESS || (dwType != REG_SZ && dwType != REG_EXPAND_SZ) || dwSize == 0)
+    if (result != ERROR_SUCCESS || (dwType != REG_SZ && dwType != REG_EXPAND_SZ) || dwSize == 0 || dwSize > kMaxRegistryValueBytes)
     {
         RegCloseKey(hkTemp);
         return "";
@@ -416,7 +437,7 @@ static SString ReadInstallRootRegistryValue64()
     result = RegQueryValueExW(hkTemp, wstrValue, NULL, &dwType, reinterpret_cast<LPBYTE>(buffer.data()), &dwSize);
     RegCloseKey(hkTemp);
 
-    if (result != ERROR_SUCCESS || (dwType != REG_SZ && dwType != REG_EXPAND_SZ))
+    if (result != ERROR_SUCCESS || (dwType != REG_SZ && dwType != REG_EXPAND_SZ) || dwSize > kMaxRegistryValueBytes)
         return "";
 
     if (dwSize >= sizeof(wchar_t))
@@ -424,10 +445,23 @@ static SString ReadInstallRootRegistryValue64()
     else
         buffer[0] = L'\0';
 
+    // Expand environment variable references for REG_EXPAND_SZ values so callers see a real
+    // filesystem path. Without this, a value like "%ProgramFiles%\..." would fail validation.
+    // The expansion is bounded by the same 1 MB cap so a value containing a self-referential or
+    // explosive expansion cannot trigger a large allocation here.
+    if (dwType == REG_EXPAND_SZ)
+    {
+        constexpr DWORD kMaxExpandChars = kMaxRegistryValueBytes / sizeof(wchar_t);
+        const DWORD     expandedChars = ExpandEnvironmentStringsW(buffer.data(), nullptr, 0);
+        if (expandedChars > 0 && expandedChars <= kMaxExpandChars)
+        {
+            std::vector<wchar_t> expanded(expandedChars, L'\0');
+            if (ExpandEnvironmentStringsW(buffer.data(), expanded.data(), expandedChars))
+                return ToUTF8(expanded.data());
+        }
+    }
+
     return ToUTF8(buffer.data());
-    #else
-    return "";
-    #endif
 }
 
 //
@@ -445,9 +479,11 @@ SString SharedUtil::GetMTASABaseDir()
     {
         if (IsGTAProcess())
         {
-            // Try to get base dir from parent process
+            // Try to get base dir from parent process. Validate the candidate against the same
+            // install-root checks used elsewhere and reject temp update paths so the parent-process
+            // branch cannot point this process at a directory that is about to be deleted.
             SString strParentDir = ExtractPath(GetParentProcessPathFilename(GetCurrentProcessId()));
-            if (FileExists(PathJoin(strParentDir, "mta", "core.dll")) || FileExists(PathJoin(strParentDir, "MTA", "core.dll")))
+            if (IsUsableMtasaInstallRoot(strParentDir) && !IsTemporaryUpdateLaunchPath(strParentDir))
             {
                 strInstallRoot = strParentDir;
                 strInstallRootSource = "parent process";
@@ -470,34 +506,49 @@ SString SharedUtil::GetMTASABaseDir()
         }
         if (strInstallRoot.empty())
         {
-            strInstallRoot = GetRegistryValue("", "Last Run Location");
-            if (!IsUsableMtasaInstallRoot(strInstallRoot))
+            // Read each registry view independently and apply install-root validation per view, so a
+            // stale or temp-path value in one view cannot shadow a usable real install root in
+            // another. Order: 64-bit view, 32-bit view, default view.
+            REGSAM viewFlags[3] = {0, 0, 0};
+            int    viewCount = 0;
+    #if defined(KEY_WOW64_64KEY)
+            viewFlags[viewCount++] = KEY_WOW64_64KEY;
+    #endif
+    #if defined(KEY_WOW64_32KEY)
+            viewFlags[viewCount++] = KEY_WOW64_32KEY;
+    #endif
+            viewFlags[viewCount++] = 0;
+
+            SString strFirstNonEmptyRegistryValue;
+            for (int i = 0; i < viewCount && strInstallRoot.empty(); ++i)
             {
-                const SString strRegistry32InstallRoot = strInstallRoot;
-                const SString strRegistry64InstallRoot = ReadInstallRootRegistryValue64();
-                if (IsUsableMtasaInstallRoot(strRegistry64InstallRoot))
+                const SString strCandidate = ReadInstallRootRegistryValueView(viewFlags[i]);
+                if (strCandidate.empty())
+                    continue;
+                if (strFirstNonEmptyRegistryValue.empty())
+                    strFirstNonEmptyRegistryValue = strCandidate;
+                if (IsUsableMtasaInstallRoot(strCandidate) && !IsTemporaryUpdateLaunchPath(strCandidate))
                 {
-                    strInstallRoot = strRegistry64InstallRoot;
-                    strInstallRootSource = "registry64";
-                }
-                else
-                {
-                    if (!strRegistry32InstallRoot.empty())
-                    {
-                        AddReportLog(1042, SString("GetMTASABaseDir: ignoring unusable registry path '%s'", strRegistry32InstallRoot.c_str()), 1);
-                    }
-                    strInstallRoot.clear();
+                    strInstallRoot = strCandidate;
+                    strInstallRootSource = (viewFlags[i] == 0) ? "registry" :
+    #if defined(KEY_WOW64_64KEY)
+                                           (viewFlags[i] == KEY_WOW64_64KEY) ? "registry64"
+                                                                             :
+    #endif
+                                                                             "registry32";
                 }
             }
             if (strInstallRoot.empty())
             {
+                if (!strFirstNonEmptyRegistryValue.empty())
+                {
+                    AddReportLog(1042, SString("GetMTASABaseDir: ignoring unusable registry path '%s'", strFirstNonEmptyRegistryValue.c_str()), 1);
+                }
                 AddReportLog(1042, "GetMTASABaseDir: unable to resolve install root", 1);
                 MessageBoxUTF8(0, _("Multi Theft Auto has not been installed properly, please reinstall."), _("Error") + _E("U01"),
                                MB_OK | MB_ICONERROR | MB_TOPMOST);
                 TerminateProcess(GetCurrentProcess(), 9);
             }
-            if (strInstallRootSource.empty())
-                strInstallRootSource = "registry";
         }
 
         if (!strInstallRoot.empty())

--- a/Shared/sdk/SharedUtil.Misc.hpp
+++ b/Shared/sdk/SharedUtil.Misc.hpp
@@ -405,7 +405,10 @@ static bool IsTemporaryUpdateLaunchPath(const SString& strLaunchPath)
     if (!strLaunchPath.ContainsI("\\upcache\\"))
         return false;
 
-    return ExtractFilename(strLaunchPath).ContainsI("_tmp_");
+    // The auto-update flow creates the extraction directory in Install.cpp::CheckOnRestartCommand
+    // as MakeUniquePath("...\\upcache\\_<archiveName>_tmp_"), so the leaf always begins with '_'.
+    const SString strLeaf = ExtractFilename(strLaunchPath);
+    return strLeaf.BeginsWith("_") && strLeaf.ContainsI("_tmp_");
 }
 
 // Read Last Run Location from a specific registry view. viewFlag should be one of


### PR DESCRIPTION
Commits 4200137 & c15736e fixed some cases, but not all. This should close the remaining gaps.

**Fix install-root resolution failures that lead to U01 errors in updater**

MTA's auto-update spawns multiple processes. Process B (the installed launcher) extracts the update archive into a transient directory under `\upcache\_<archive>_tmp_<n>\` and launches Process C from the new executable there. Process C runs entirely from that temp extraction directory, which doesnt contain mta\core.dll or most MTA files.

Previously, Process C had no reliable way to know where the real MTA installation lives. It fell back to reading Last Run Location from the registry - but that value can be missing, stale, or unwritable (HKLM write failures on non-admin installs). When the registry lookup failed, Process C silently degraded to treating its own temp extraction directory as the install root. This produced a domino of problems:

* InitLocalization failed to find core.dll and aborted with CL23
* UpdateMTAVersionApplicationSetting loaded the wrong (or no) version DLL, producing wrong version strings
* ConfigureWerDumpPath and _ProcessAppCompatChecks built paths against the temp dir, silently doing nothing or pointing at non-existent files
* _SwitchBackFromTempExe called PathJoin(GetInstallPathForLauncher(), MTA_EXE_NAME) with an empty install path, producing a root-relative path like \Multi Theft Auto.exe that could match an unrelated file on the current drive
SetMTASAPathSource wrote the temp directory path into Last Run Location in the registry. When CleanDownloadCache later deleted the temp dir, the registry pointed at nothing, causing U01 on the very next launch

**What this PR does**
1. Carry the install root across the process boundary via the sequencer.

In _MaybeSwitchToTempExe (Process B), before spawning Process C, we now write the current real install root into the sequencer state snapshot as INSTALL_ROOT. When Process C starts and calls CInstallManager::SetMTASAPathSource, it reads that key back, validates it with IsUsableMtasaInstallRoot and IsTemporaryUpdateLaunchPath, and immediately installs it as a SetMTASABaseDirOverride. This override is in place before UpdateSettingsForReportLog runs (which transitively calls GetMTASAPath through UpdateMTAVersionApplicationSetting), so all downstream path consumers in Process C see the real install root. The ordering of UpdateSettingsForReportLog is moved after the path source is resolved for exactly this reason.

2. Make GetInstallPathForLauncher return empty on unresolvable temp launches, and guard every caller.

Rather than silently returning the temp path as a fallback, GetInstallPathForLauncher now returns an empty string when it cannot find a usable non-temp install root. This is a cleaner contract: callers know to apply their own fallback (typically GetMTASAPath(), which consults the carried override). Every call site is updated with an explicit guard. SetMTASAPathSource additionally refuses to write any temp-directory path into the registry.

3. Add a g_strMTASAPath fast-path in GetInstallPathForLauncher.

When the far-update sequencer path has already populated g_strMTASAPath via the override, GetInstallPathForLauncher returns it directly without touching the registry. This avoids the GetMTASAPath → SetMTASAPathSource(false) → GetInstallPathForLauncher recursion that would occur if we called GetMTASAPath() from inside the function.

4. Read registry views independently with full validation.

Both GetInstallPathForLauncher (Utils.cpp) and GetMTASABaseDir (SharedUtil.Misc.hpp) now probe the 64-bit view, 32-bit view, and default view as separate candidates, each validated through IsUsableMtasaInstallRoot and IsTemporaryUpdateLaunchPath. A stale or temp-path value in one view no longer shadows a usable value in another.

5. Harden registry reads. A 1 MB size cap is applied before any allocation, preventing a malformed registry entry on the U01 recovery path from triggering a large allocation. REG_EXPAND_SZ values are now expanded so install paths containing environment variable references (e.g. %ProgramFiles%\...) pass the file-existence validation checks.

6. Promote IsUsableMtasaInstallRoot and IsTemporaryUpdateLaunchPath to public scope so CInstallManager can use them directly for sequencer-carried root validation without duplicating the logic.

7. Strengthen the parent-process check in GetMTASABaseDir to use IsUsableMtasaInstallRoot && !IsTemporaryUpdateLaunchPath instead of only checking for core.dll, preventing the parent-process branch from pointing a child process at a directory that is about to be deleted.

Impact on normal (non-update) launches:

None. When the launch path is not a temp update directory, GetInstallPathForLauncher returns it immediately as before. The g_strMTASAPath fast-path only activates when the override was explicitly set by the install manager. The registry write guard only fires when the launch path itself is a temp directory.