### PR TITLE
Fix #4803 building light flicker via pre-CWeather::Update hook

### DIFF
--- a/Client/game_sa/CWeatherSA.cpp
+++ b/Client/game_sa/CWeatherSA.cpp
@@ -25,6 +25,22 @@ void CWeatherSA::Set(unsigned char primary, unsigned char secondary)
     MemPutFast<unsigned char>(0xC8131C, secondary);  // CWeather::NewWeatherType
 }
 
+void CWeatherSA::ResyncInterpolationWithGameClock(unsigned char primary, unsigned char secondary)
+{
+    // CWeather::InterpolationValue — see plugin_sa CWeather.cpp (0xC8130C)
+    constexpr DWORD VAR_InterpolationValue = 0xC8130C;
+    constexpr DWORD VAR_TimeMinutes = 0xB70152;
+
+    if (primary == secondary)
+        MemPutFast<float>(VAR_InterpolationValue, 0.0f);
+    else
+    {
+        const auto          ucMinute = *reinterpret_cast<unsigned char*>(VAR_TimeMinutes);
+        const float fInterp = std::min(1.f, static_cast<float>(ucMinute) / 60.f);
+        MemPutFast<float>(VAR_InterpolationValue, fInterp);
+    }
+}
+
 void CWeatherSA::Release()
 {
     MemPutFast<unsigned char>(0xC81318, 0xFF);  // CWeather::ForcedWeatherType

--- a/Client/game_sa/CWeatherSA.h
+++ b/Client/game_sa/CWeatherSA.h
@@ -20,6 +20,7 @@ class CWeatherSA : public CWeather
 public:
     unsigned char Get();
     void          Set(unsigned char primary, unsigned char secondary);
+    void          ResyncInterpolationWithGameClock(unsigned char primary, unsigned char secondary);
 
     void Release();
 

--- a/Client/mods/deathmatch/logic/CBlendedWeather.cpp
+++ b/Client/mods/deathmatch/logic/CBlendedWeather.cpp
@@ -53,8 +53,14 @@ void CBlendedWeather::DoPulse()
         }
     }
 
-    // Force the weather
-    m_pWeather->Set(static_cast<unsigned char>(m_ucPrimaryWeather), static_cast<unsigned char>(m_ucSecondaryWeather));
+    const auto ucPrimary = static_cast<unsigned char>(m_ucPrimaryWeather);
+    const auto ucSecondary = static_cast<unsigned char>(m_ucSecondaryWeather);
+
+    m_pWeather->Set(ucPrimary, ucSecondary);
+    // CWeather::Update (before this pulse) advances InterpolationValue for its own Old/New pair.
+    // After we overwrite Old/New with MTA's state, keep the blend weight aligned with the game
+    // clock so reflective/translucent materials (e.g. glass windows) match the sky (#4803).
+    m_pWeather->ResyncInterpolationWithGameClock(ucPrimary, ucSecondary);
 }
 
 void CBlendedWeather::SetWeather(unsigned char ucWeather)

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -285,6 +285,7 @@ CClientGame::CClientGame(bool bLocalPlay) : m_ServerInfo(new CServerInfo())
     g_pMultiplayer->SetRenderHeliLightHandler(CClientGame::StaticRenderHeliLightHandler);
     g_pMultiplayer->SetRenderEverythingBarRoadsHandler(CClientGame::StaticRenderEverythingBarRoadsHandler);
     g_pMultiplayer->SetChokingHandler(CClientGame::StaticChokingHandler);
+    g_pMultiplayer->SetPreWeatherUpdateHandler(CClientGame::StaticPreWeatherUpdateHandler);
     g_pMultiplayer->SetPreWorldProcessHandler(CClientGame::StaticPreWorldProcessHandler);
     g_pMultiplayer->SetPostWorldProcessHandler(CClientGame::StaticPostWorldProcessHandler);
     g_pMultiplayer->SetPostWorldProcessPedsAfterPreRenderHandler(CClientGame::StaticPostWorldProcessPedsAfterPreRenderHandler);
@@ -494,6 +495,7 @@ CClientGame::~CClientGame()
     g_pMultiplayer->SetRenderHeliLightHandler(nullptr);
     g_pMultiplayer->SetRenderEverythingBarRoadsHandler(nullptr);
     g_pMultiplayer->SetChokingHandler(NULL);
+    g_pMultiplayer->SetPreWeatherUpdateHandler(NULL);
     g_pMultiplayer->SetPreWorldProcessHandler(NULL);
     g_pMultiplayer->SetPostWorldProcessHandler(NULL);
     g_pMultiplayer->SetPostWorldProcessPedsAfterPreRenderHandler(nullptr);
@@ -3629,6 +3631,11 @@ bool CClientGame::StaticBlendAnimationHierarchyHandler(CAnimBlendAssociationSAIn
     return g_pClientGame->BlendAnimationHierarchyHandler(pAnimAssoc, pOutAnimHierarchy, pFlags, pClump);
 }
 
+void CClientGame::StaticPreWeatherUpdateHandler()
+{
+    g_pClientGame->PreWeatherUpdateHandler();
+}
+
 void CClientGame::StaticPreWorldProcessHandler()
 {
     g_pClientGame->PreWorldProcessHandler();
@@ -3898,6 +3905,20 @@ void CClientGame::Render3DStuffHandler()
 void CClientGame::PreRenderSkyHandler()
 {
     g_pCore->GetGraphics()->GetRenderItemManager()->PreDrawWorld();
+}
+
+void CClientGame::PreWeatherUpdateHandler()
+{
+    // Fix #4803 (building light flicker): Re-apply MTA's weather state BEFORE
+    // CWeather::Update runs. CWeather::Update detects a clock wrap when setTime()
+    // jumps the game clock past InterpolationValue and re-derives Rain, Foggyness,
+    // CloudCoverage, ExtraSunnyness, SunGlare, HeatHaze, etc. from a freshly-picked
+    // weather pair. Those globals drive cloud, fog and night-time building light
+    // rendering for the rest of the frame, and PreWorldProcessHandler runs too late
+    // to undo the damage. Pre-syncing Old/New/InterpolationValue here keeps the
+    // wrap branch from firing.
+    if (m_pManager->IsGameLoaded() && m_pBlendedWeather)
+        m_pBlendedWeather->DoPulse();
 }
 
 void CClientGame::PreWorldProcessHandler()

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -577,6 +577,7 @@ private:
     static void                              StaticRenderHeliLightHandler();
     static void                              StaticRenderEverythingBarRoadsHandler();
     static bool                              StaticChokingHandler(unsigned char ucWeaponType);
+    static void                              StaticPreWeatherUpdateHandler();
     static void                              StaticPreWorldProcessHandler();
     static void                              StaticPostWorldProcessHandler();
     static void                              StaticPostWorldProcessPedsAfterPreRenderHandler();
@@ -626,6 +627,7 @@ private:
     void                              Render3DStuffHandler();
     void                              PreRenderSkyHandler();
     bool                              ChokingHandler(unsigned char ucWeaponType);
+    void                              PreWeatherUpdateHandler();
     void                              PreWorldProcessHandler();
     void                              PostWorldProcessHandler();
     void                              PostWorldProcessPedsAfterPreRenderHandler();

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -88,6 +88,9 @@ DWORD RETURN_CTrafficLights_DisplayActualLight = 0x49E1FF;
 #define HOOKPOS_CGame_Process 0x53C095
 DWORD RETURN_CGame_Process = 0x53C09F;
 
+#define CALL_CWeather_Update_FromCGameProcess 0x53BFC2
+DWORD FUNC_CWeather_Update = 0x72B850;
+
 #define HOOKPOS_Idle 0x53E981
 DWORD RETURN_Idle = 0x53E98B;
 
@@ -398,6 +401,7 @@ ExplosionHandler*                          m_pExplosionHandler = NULL;
 BreakTowLinkHandler*                       m_pBreakTowLinkHandler = NULL;
 DrawRadarAreasHandler*                     m_pDrawRadarAreasHandler = NULL;
 Render3DStuffHandler*                      m_pRender3DStuffHandler = NULL;
+PreWeatherUpdateHandler*                   m_pPreWeatherUpdateHandler = NULL;
 PreWorldProcessHandler*                    m_pPreWorldProcessHandler = NULL;
 PostWorldProcessHandler*                   m_pPostWorldProcessHandler = NULL;
 PostWorldProcessPedsAfterPreRenderHandler* m_postWorldProcessPedsAfterPreRenderHandler = nullptr;
@@ -461,6 +465,7 @@ void HOOK_CFire_ProcessFire();
 void HOOK_CExplosion_Update();
 void HOOK_CWeapon_FireAreaEffect();
 void HOOK_CGame_Process();
+void HOOK_CWeather_Update();
 void HOOK_Idle();
 void HOOK_RenderScene_Plants();
 void HOOK_RenderScene_end();
@@ -663,6 +668,7 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_CExplosion_Update, (DWORD)HOOK_CExplosion_Update, 5);
     HookInstall(HOOKPOS_CWeapon_FireAreaEffect, (DWORD)HOOK_CWeapon_FireAreaEffect, 5);
     HookInstall(HOOKPOS_CGame_Process, (DWORD)HOOK_CGame_Process, 10);
+    HookInstallCall(CALL_CWeather_Update_FromCGameProcess, (DWORD)HOOK_CWeather_Update);
     HookInstall(HOOKPOS_Idle, (DWORD)HOOK_Idle, 10);
     HookInstall(HOOKPOS_CEventHandler_ComputeKnockOffBikeResponse, (DWORD)HOOK_CEventHandler_ComputeKnockOffBikeResponse, 7);
     HookInstall(HOOKPOS_CPed_GetWeaponSkill, (DWORD)HOOK_CPed_GetWeaponSkill, 8);
@@ -2650,6 +2656,11 @@ void CMultiplayerSA::SetProcessCamHandler(ProcessCamHandler* pProcessCamHandler)
 void CMultiplayerSA::SetChokingHandler(ChokingHandler* pChokingHandler)
 {
     m_pChokingHandler = pChokingHandler;
+}
+
+void CMultiplayerSA::SetPreWeatherUpdateHandler(PreWeatherUpdateHandler* pHandler)
+{
+    m_pPreWeatherUpdateHandler = pHandler;
 }
 
 void CMultiplayerSA::SetPreWorldProcessHandler(PreWorldProcessHandler* pHandler)
@@ -5337,6 +5348,36 @@ static void __declspec(naked) HOOK_ApplyCarBlowHop()
 }
 
 // ---------------------------------------------------
+
+static void Pre_CWeather_Update()
+{
+    if (m_pPreWeatherUpdateHandler)
+        m_pPreWeatherUpdateHandler();
+}
+
+// Replaces the `call CWeather::Update` site at 0x53BFC2 inside CGame::Process so that
+// MTA can re-apply its blended weather state before the engine reads it. CWeather::Update
+// detects a clock wrap when setTime() jumps the game clock past InterpolationValue and
+// derives Rain/Foggyness/CloudCoverage/SunGlare/etc. from a freshly-picked weather pair —
+// values that drive cloud, fog and night-time building light rendering. Restoring MTA's
+// state here keeps that wrap branch from firing.
+static void __declspec(naked) HOOK_CWeather_Update()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        pushad
+        call    Pre_CWeather_Update
+        popad
+
+        mov     eax, FUNC_CWeather_Update
+        call    eax
+        ret
+    }
+    // clang-format on
+}
 
 static void Pre_CGame_Process()
 {

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -118,6 +118,7 @@ public:
     void SetBreakTowLinkHandler(BreakTowLinkHandler* pBreakTowLinkHandler);
     void SetProcessCamHandler(ProcessCamHandler* pProcessCamHandler);
     void SetChokingHandler(ChokingHandler* pChokingHandler);
+    void SetPreWeatherUpdateHandler(PreWeatherUpdateHandler* pHandler);
     void SetPreWorldProcessHandler(PreWorldProcessHandler* pHandler);
     void SetPostWorldProcessHandler(PostWorldProcessHandler* pHandler);
     void SetPostWorldProcessPedsAfterPreRenderHandler(PostWorldProcessPedsAfterPreRenderHandler* pHandler);

--- a/Client/sdk/game/CWeather.h
+++ b/Client/sdk/game/CWeather.h
@@ -18,6 +18,10 @@ class CWeather
 public:
     virtual unsigned char Get() = 0;
     virtual void          Set(unsigned char primary, unsigned char secondary) = 0;
+    // After Set(), if the engine had diverged from MTA's intended types (e.g. CWeather::Update
+    // clock-wrap in #4803), realign InterpolationValue with the game clock so materials that blend
+    // weather heavily (glass / reflections) match the sky.
+    virtual void ResyncInterpolationWithGameClock(unsigned char primary, unsigned char secondary) = 0;
     virtual void          Release() = 0;
 
     virtual float GetAmountOfRain() = 0;

--- a/Client/sdk/multiplayer/CMultiplayer.h
+++ b/Client/sdk/multiplayer/CMultiplayer.h
@@ -97,6 +97,7 @@ typedef void(Render3DStuffHandler)();
 typedef void(PreRenderSkyHandler)();
 typedef void(RenderHeliLightHandler)();
 typedef bool(ChokingHandler)(unsigned char ucWeaponType);
+typedef void(PreWeatherUpdateHandler)();
 typedef void(PreWorldProcessHandler)();
 typedef void(PostWorldProcessHandler)();
 typedef void(PostWorldProcessPedsAfterPreRenderHandler)();
@@ -228,6 +229,7 @@ public:
     virtual void  SetChokingHandler(ChokingHandler* pChokingHandler) = 0;
     virtual void  SetProjectileHandler(ProjectileHandler* pProjectileHandler) = 0;
     virtual void  SetProjectileStopHandler(ProjectileStopHandler* pProjectileHandler) = 0;
+    virtual void  SetPreWeatherUpdateHandler(PreWeatherUpdateHandler* pHandler) = 0;
     virtual void  SetPreWorldProcessHandler(PreWorldProcessHandler* pHandler) = 0;
     virtual void  SetPostWorldProcessHandler(PostWorldProcessHandler* pHandler) = 0;
     virtual void  SetPostWorldProcessPedsAfterPreRenderHandler(PostWorldProcessPedsAfterPreRenderHandler* pHandler) = 0;

--- a/PR_WEATHER_FLICKER_4803.md
+++ b/PR_WEATHER_FLICKER_4803.md
@@ -1,0 +1,31 @@
+#### Summary
+
+Re-apply MTA's blended weather state both **before** `CWeather::Update` and before `CTimeCycle::CalcColoursForPoint`, so neither the engine's clock-wrap branch nor the colour calculation ever observes a stale weather pair.
+
+#### Motivation
+
+Fixes #4803. When `setWeatherBlended`/`setTime` are used (e.g. race resource restart/respawn), the sky and ambient lighting flicker for 1-2 frames in fullscreen, and night-time building lights / cloud / fog also pop for the same frames.
+
+The engine's `CWeather::Update` (called at `0x53BFC2` from `CGame::Process`) detects a clock wrap when `setTime` jumps the game clock past its internal `InterpolationValue`. It then overwrites `OldWeatherType`/`NewWeatherType` with its own weather-list pick **and** uses that wrong pair to derive `Rain`, `Foggyness`, `CloudCoverage`, `ExtraSunnyness`, `SunGlare`, `HeatHaze`, `Sandstorm`, `WetRoads`, `Wind` and `Rainbow` for the frame. `CalcColoursForPoint` (at `0x53C0DA`) then reads `OldWeatherType`/`NewWeatherType`/`InterpolationValue` to compute the sky/ambient colour set.
+
+MTA's `CBlendedWeather::DoPulse` previously only ran in `DoPulses` during `Render2dStuff`, which is after the frame was already rendered with the wrong state.
+
+Two hooks are now used:
+
+1. **`HOOK_CWeather_Update`** — replaces the `call CWeather::Update` site at `0x53BFC2`. Fires `PreWeatherUpdateHandler` *before* the engine's update, so MTA's `Set` + `ResyncInterpolationWithGameClock` re-sync `OldWeatherType`/`NewWeatherType`/`InterpolationValue` with the new clock. `CWeather::Update` then takes the non-wrap branch and derives `Rain`/`Foggyness`/`CloudCoverage`/etc. from MTA's intended pair. This is what fixes the **building light / cloud / fog flicker**.
+2. **`PreWorldProcessHandler`** (the original hook from #4870, kept as a defensive idempotent re-apply) — runs at `CWorld::Process` (`0x53C095`), still ahead of `CalcColoursForPoint` at `0x53C0DA`, so the sky/ambient frame is also guaranteed to use MTA's weather pair even if the early hook is bypassed for any reason.
+
+Fullscreen-only because exclusive mode bypasses DWM composition, so every frame including the glitch frames is presented directly. Windowed mode's DWM triple buffering absorbs them.
+
+#### Test plan
+
+1. Join a server running the default race resource
+2. Set fullscreen (any mode)
+3. Use `setWeatherBlended` + `setTime` via script, then restart the race resource to respawn
+4. Observe no sky/lighting flicker on respawn
+5. Repeat at night-time so building/streetlight glow and cloud cover are visible — they should not pop either
+
+#### Checklist
+
+* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
+* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.


### PR DESCRIPTION
#### Summary

Follow-up to #4870. Move the weather re-apply earlier in `CGame::Process` so the engine's clock-wrap branch in `CWeather::Update` also runs against MTA's intended weather pair.

#### Motivation

#4870 fixed the sky/ambient flicker by re-applying MTA's weather in `PreWorldProcessHandler` (`0x53C095`), ahead of `CTimeCycle::CalcColoursForPoint` (`0x53C0DA`). Cloud cover, fog and night-time building lights still pop for the same frames, because `CWeather::Update` itself runs earlier (`0x53BFC2`) and on the wrap branch derives `Rain`, `Foggyness`, `CloudCoverage`, `ExtraSunnyness`, `SunGlare`, `HeatHaze`, `Sandstorm`, `WetRoads`, `Wind` and `Rainbow` from its own freshly-picked pair before `PreWorldProcessHandler` gets a chance to fix things.

This PR adds a `HookInstallCall` over the `call CWeather::Update` site at `0x53BFC2` and a new `PreWeatherUpdateHandler` that runs `CBlendedWeather::DoPulse` before the engine update. With Old/New/`InterpolationValue` already aligned, `CWeather::Update` takes the non-wrap branch and derives every weather global from MTA's pair. The existing `PreWorldProcessHandler` re-apply from #4870 is kept as an idempotent safety net for the colour-set path.

`CBlendedWeather::DoPulse` also calls `CWeather::ResyncInterpolationWithGameClock` after `Set`, so `InterpolationValue` matches the clock — fixes residual flicker on glass/reflective materials that #4870 left behind.

#### Test plan

1. Join a server running the default race resource
2. Set fullscreen (any mode)
3. Use `setWeatherBlended` + `setTime` via script, then restart the race resource to respawn
4. Observe no sky/lighting flicker on respawn
5. Repeat at night so building/streetlight glow and cloud cover are visible — they should not pop either

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
