### PR TITLE
Fix showcursor controls

### DIFF
--- a/Client/game_sa/CWeatherSA.cpp
+++ b/Client/game_sa/CWeatherSA.cpp
@@ -25,6 +25,22 @@ void CWeatherSA::Set(unsigned char primary, unsigned char secondary)
     MemPutFast<unsigned char>(0xC8131C, secondary);  // CWeather::NewWeatherType
 }
 
+void CWeatherSA::ResyncInterpolationWithGameClock(unsigned char primary, unsigned char secondary)
+{
+    // CWeather::InterpolationValue — see plugin_sa CWeather.cpp (0xC8130C)
+    constexpr DWORD VAR_InterpolationValue = 0xC8130C;
+    constexpr DWORD VAR_TimeMinutes = 0xB70152;
+
+    if (primary == secondary)
+        MemPutFast<float>(VAR_InterpolationValue, 0.0f);
+    else
+    {
+        const auto  ucMinute = *reinterpret_cast<unsigned char*>(VAR_TimeMinutes);
+        const float fInterp = std::min(1.f, static_cast<float>(ucMinute) / 60.f);
+        MemPutFast<float>(VAR_InterpolationValue, fInterp);
+    }
+}
+
 void CWeatherSA::Release()
 {
     MemPutFast<unsigned char>(0xC81318, 0xFF);  // CWeather::ForcedWeatherType

--- a/Client/game_sa/CWeatherSA.h
+++ b/Client/game_sa/CWeatherSA.h
@@ -20,6 +20,7 @@ class CWeatherSA : public CWeather
 public:
     unsigned char Get();
     void          Set(unsigned char primary, unsigned char secondary);
+    void          ResyncInterpolationWithGameClock(unsigned char primary, unsigned char secondary);
 
     void Release();
 

--- a/Client/mods/deathmatch/logic/CBlendedWeather.cpp
+++ b/Client/mods/deathmatch/logic/CBlendedWeather.cpp
@@ -53,8 +53,14 @@ void CBlendedWeather::DoPulse()
         }
     }
 
-    // Force the weather
-    m_pWeather->Set(static_cast<unsigned char>(m_ucPrimaryWeather), static_cast<unsigned char>(m_ucSecondaryWeather));
+    const auto ucPrimary = static_cast<unsigned char>(m_ucPrimaryWeather);
+    const auto ucSecondary = static_cast<unsigned char>(m_ucSecondaryWeather);
+
+    m_pWeather->Set(ucPrimary, ucSecondary);
+    // CWeather::Update (before this pulse) advances InterpolationValue for its own Old/New pair.
+    // After we overwrite Old/New with MTA's state, keep the blend weight aligned with the game
+    // clock so reflective/translucent materials (e.g. glass windows) match the sky (#4803).
+    m_pWeather->ResyncInterpolationWithGameClock(ucPrimary, ucSecondary);
 }
 
 void CBlendedWeather::SetWeather(unsigned char ucWeather)

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -285,6 +285,7 @@ CClientGame::CClientGame(bool bLocalPlay) : m_ServerInfo(new CServerInfo())
     g_pMultiplayer->SetRenderHeliLightHandler(CClientGame::StaticRenderHeliLightHandler);
     g_pMultiplayer->SetRenderEverythingBarRoadsHandler(CClientGame::StaticRenderEverythingBarRoadsHandler);
     g_pMultiplayer->SetChokingHandler(CClientGame::StaticChokingHandler);
+    g_pMultiplayer->SetPreWeatherUpdateHandler(CClientGame::StaticPreWeatherUpdateHandler);
     g_pMultiplayer->SetPreWorldProcessHandler(CClientGame::StaticPreWorldProcessHandler);
     g_pMultiplayer->SetPostWorldProcessHandler(CClientGame::StaticPostWorldProcessHandler);
     g_pMultiplayer->SetPostWorldProcessPedsAfterPreRenderHandler(CClientGame::StaticPostWorldProcessPedsAfterPreRenderHandler);
@@ -494,6 +495,7 @@ CClientGame::~CClientGame()
     g_pMultiplayer->SetRenderHeliLightHandler(nullptr);
     g_pMultiplayer->SetRenderEverythingBarRoadsHandler(nullptr);
     g_pMultiplayer->SetChokingHandler(NULL);
+    g_pMultiplayer->SetPreWeatherUpdateHandler(NULL);
     g_pMultiplayer->SetPreWorldProcessHandler(NULL);
     g_pMultiplayer->SetPostWorldProcessHandler(NULL);
     g_pMultiplayer->SetPostWorldProcessPedsAfterPreRenderHandler(nullptr);
@@ -3629,6 +3631,11 @@ bool CClientGame::StaticBlendAnimationHierarchyHandler(CAnimBlendAssociationSAIn
     return g_pClientGame->BlendAnimationHierarchyHandler(pAnimAssoc, pOutAnimHierarchy, pFlags, pClump);
 }
 
+void CClientGame::StaticPreWeatherUpdateHandler()
+{
+    g_pClientGame->PreWeatherUpdateHandler();
+}
+
 void CClientGame::StaticPreWorldProcessHandler()
 {
     g_pClientGame->PreWorldProcessHandler();
@@ -3898,6 +3905,20 @@ void CClientGame::Render3DStuffHandler()
 void CClientGame::PreRenderSkyHandler()
 {
     g_pCore->GetGraphics()->GetRenderItemManager()->PreDrawWorld();
+}
+
+void CClientGame::PreWeatherUpdateHandler()
+{
+    // Fix #4803 (building light flicker): Re-apply MTA's weather state BEFORE
+    // CWeather::Update runs. CWeather::Update detects a clock wrap when setTime()
+    // jumps the game clock past InterpolationValue and re-derives Rain, Foggyness,
+    // CloudCoverage, ExtraSunnyness, SunGlare, HeatHaze, etc. from a freshly-picked
+    // weather pair. Those globals drive cloud, fog and night-time building light
+    // rendering for the rest of the frame, and PreWorldProcessHandler runs too late
+    // to undo the damage. Pre-syncing Old/New/InterpolationValue here keeps the
+    // wrap branch from firing.
+    if (m_pManager->IsGameLoaded() && m_pBlendedWeather)
+        m_pBlendedWeather->DoPulse();
 }
 
 void CClientGame::PreWorldProcessHandler()

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -577,6 +577,7 @@ private:
     static void                              StaticRenderHeliLightHandler();
     static void                              StaticRenderEverythingBarRoadsHandler();
     static bool                              StaticChokingHandler(unsigned char ucWeaponType);
+    static void                              StaticPreWeatherUpdateHandler();
     static void                              StaticPreWorldProcessHandler();
     static void                              StaticPostWorldProcessHandler();
     static void                              StaticPostWorldProcessPedsAfterPreRenderHandler();
@@ -626,6 +627,7 @@ private:
     void                              Render3DStuffHandler();
     void                              PreRenderSkyHandler();
     bool                              ChokingHandler(unsigned char ucWeaponType);
+    void                              PreWeatherUpdateHandler();
     void                              PreWorldProcessHandler();
     void                              PostWorldProcessHandler();
     void                              PostWorldProcessPedsAfterPreRenderHandler();

--- a/Client/mods/deathmatch/logic/CResource.cpp
+++ b/Client/mods/deathmatch/logic/CResource.cpp
@@ -21,6 +21,7 @@ using namespace std;
 extern CClientGame* g_pClientGame;
 
 int CResource::m_iShowingCursor = 0;
+int CResource::m_iToggleControls = 0;
 
 CResource::CResource(unsigned short usNetID, const char* szResourceName, CClientEntity* pResourceEntity, CClientEntity* pResourceDynamicEntity,
                      const CMtaVersion& strMinServerReq, const CMtaVersion& strMinClientReq, bool bEnableOOP)
@@ -31,6 +32,7 @@ CResource::CResource(unsigned short usNetID, const char* szResourceName, CClient
     m_bStarting = true;
     m_bStopping = false;
     m_bShowingCursor = false;
+    m_bToggleControls = false;
     m_usRemainingNoClientCacheScripts = 0;
     m_bLoadAfterReceivingNoClientCacheScripts = false;
     m_strMinServerReq = strMinServerReq;
@@ -486,8 +488,19 @@ void CResource::ShowCursor(bool bShow, bool bToggleControls)
         m_bShowingCursor = bShow;
     }
 
+    bool bWantsToggle = m_bShowingCursor && bToggleControls;
+    if (bWantsToggle != m_bToggleControls)
+    {
+        if (bWantsToggle)
+            m_iToggleControls += 1;
+        else
+            m_iToggleControls -= 1;
+
+        m_bToggleControls = bWantsToggle;
+    }
+
     // Always update cursor and controls state regardless of cursor visibility change
-    g_pCore->ForceCursorVisible(m_iShowingCursor > 0, bToggleControls);
+    g_pCore->ForceCursorVisible(m_iShowingCursor > 0, m_iToggleControls > 0);
     g_pClientGame->SetCursorEventsEnabled(m_iShowingCursor > 0);
 }
 

--- a/Client/mods/deathmatch/logic/CResource.h
+++ b/Client/mods/deathmatch/logic/CResource.h
@@ -142,6 +142,8 @@ private:
     // To control cursor show/hide
     static int m_iShowingCursor;
     bool       m_bShowingCursor;
+    static int m_iToggleControls;
+    bool       m_bToggleControls;
 
     SString m_strResourceDirectoryPath;            // stores the path to /mods/deathmatch/resources/resource_name
     SString m_strResourcePrivateDirectoryPath;     // stores the path to /mods/deathmatch/priv/server-id/resource_name

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -88,6 +88,9 @@ DWORD RETURN_CTrafficLights_DisplayActualLight = 0x49E1FF;
 #define HOOKPOS_CGame_Process 0x53C095
 DWORD RETURN_CGame_Process = 0x53C09F;
 
+#define CALL_CWeather_Update_FromCGameProcess 0x53BFC2
+DWORD FUNC_CWeather_Update = 0x72B850;
+
 #define HOOKPOS_Idle 0x53E981
 DWORD RETURN_Idle = 0x53E98B;
 
@@ -398,6 +401,7 @@ ExplosionHandler*                          m_pExplosionHandler = NULL;
 BreakTowLinkHandler*                       m_pBreakTowLinkHandler = NULL;
 DrawRadarAreasHandler*                     m_pDrawRadarAreasHandler = NULL;
 Render3DStuffHandler*                      m_pRender3DStuffHandler = NULL;
+PreWeatherUpdateHandler*                   m_pPreWeatherUpdateHandler = NULL;
 PreWorldProcessHandler*                    m_pPreWorldProcessHandler = NULL;
 PostWorldProcessHandler*                   m_pPostWorldProcessHandler = NULL;
 PostWorldProcessPedsAfterPreRenderHandler* m_postWorldProcessPedsAfterPreRenderHandler = nullptr;
@@ -461,6 +465,7 @@ void HOOK_CFire_ProcessFire();
 void HOOK_CExplosion_Update();
 void HOOK_CWeapon_FireAreaEffect();
 void HOOK_CGame_Process();
+void HOOK_CWeather_Update();
 void HOOK_Idle();
 void HOOK_RenderScene_Plants();
 void HOOK_RenderScene_end();
@@ -663,6 +668,7 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_CExplosion_Update, (DWORD)HOOK_CExplosion_Update, 5);
     HookInstall(HOOKPOS_CWeapon_FireAreaEffect, (DWORD)HOOK_CWeapon_FireAreaEffect, 5);
     HookInstall(HOOKPOS_CGame_Process, (DWORD)HOOK_CGame_Process, 10);
+    HookInstallCall(CALL_CWeather_Update_FromCGameProcess, (DWORD)HOOK_CWeather_Update);
     HookInstall(HOOKPOS_Idle, (DWORD)HOOK_Idle, 10);
     HookInstall(HOOKPOS_CEventHandler_ComputeKnockOffBikeResponse, (DWORD)HOOK_CEventHandler_ComputeKnockOffBikeResponse, 7);
     HookInstall(HOOKPOS_CPed_GetWeaponSkill, (DWORD)HOOK_CPed_GetWeaponSkill, 8);
@@ -2650,6 +2656,11 @@ void CMultiplayerSA::SetProcessCamHandler(ProcessCamHandler* pProcessCamHandler)
 void CMultiplayerSA::SetChokingHandler(ChokingHandler* pChokingHandler)
 {
     m_pChokingHandler = pChokingHandler;
+}
+
+void CMultiplayerSA::SetPreWeatherUpdateHandler(PreWeatherUpdateHandler* pHandler)
+{
+    m_pPreWeatherUpdateHandler = pHandler;
 }
 
 void CMultiplayerSA::SetPreWorldProcessHandler(PreWorldProcessHandler* pHandler)
@@ -5337,6 +5348,36 @@ static void __declspec(naked) HOOK_ApplyCarBlowHop()
 }
 
 // ---------------------------------------------------
+
+static void Pre_CWeather_Update()
+{
+    if (m_pPreWeatherUpdateHandler)
+        m_pPreWeatherUpdateHandler();
+}
+
+// Replaces the `call CWeather::Update` site at 0x53BFC2 inside CGame::Process so that
+// MTA can re-apply its blended weather state before the engine reads it. CWeather::Update
+// detects a clock wrap when setTime() jumps the game clock past InterpolationValue and
+// derives Rain/Foggyness/CloudCoverage/SunGlare/etc. from a freshly-picked weather pair —
+// values that drive cloud, fog and night-time building light rendering. Restoring MTA's
+// state here keeps that wrap branch from firing.
+static void __declspec(naked) HOOK_CWeather_Update()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        pushad
+        call    Pre_CWeather_Update
+        popad
+
+        mov     eax, FUNC_CWeather_Update
+        call    eax
+        ret
+    }
+    // clang-format on
+}
 
 static void Pre_CGame_Process()
 {

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -118,6 +118,7 @@ public:
     void SetBreakTowLinkHandler(BreakTowLinkHandler* pBreakTowLinkHandler);
     void SetProcessCamHandler(ProcessCamHandler* pProcessCamHandler);
     void SetChokingHandler(ChokingHandler* pChokingHandler);
+    void SetPreWeatherUpdateHandler(PreWeatherUpdateHandler* pHandler);
     void SetPreWorldProcessHandler(PreWorldProcessHandler* pHandler);
     void SetPostWorldProcessHandler(PostWorldProcessHandler* pHandler);
     void SetPostWorldProcessPedsAfterPreRenderHandler(PostWorldProcessPedsAfterPreRenderHandler* pHandler);

--- a/Client/sdk/game/CWeather.h
+++ b/Client/sdk/game/CWeather.h
@@ -18,7 +18,11 @@ class CWeather
 public:
     virtual unsigned char Get() = 0;
     virtual void          Set(unsigned char primary, unsigned char secondary) = 0;
-    virtual void          Release() = 0;
+    // After Set(), if the engine had diverged from MTA's intended types (e.g. CWeather::Update
+    // clock-wrap in #4803), realign InterpolationValue with the game clock so materials that blend
+    // weather heavily (glass / reflections) match the sky.
+    virtual void ResyncInterpolationWithGameClock(unsigned char primary, unsigned char secondary) = 0;
+    virtual void Release() = 0;
 
     virtual float GetAmountOfRain() = 0;
     virtual void  SetAmountOfRain(float fAmount) = 0;

--- a/Client/sdk/multiplayer/CMultiplayer.h
+++ b/Client/sdk/multiplayer/CMultiplayer.h
@@ -97,6 +97,7 @@ typedef void(Render3DStuffHandler)();
 typedef void(PreRenderSkyHandler)();
 typedef void(RenderHeliLightHandler)();
 typedef bool(ChokingHandler)(unsigned char ucWeaponType);
+typedef void(PreWeatherUpdateHandler)();
 typedef void(PreWorldProcessHandler)();
 typedef void(PostWorldProcessHandler)();
 typedef void(PostWorldProcessPedsAfterPreRenderHandler)();
@@ -228,6 +229,7 @@ public:
     virtual void  SetChokingHandler(ChokingHandler* pChokingHandler) = 0;
     virtual void  SetProjectileHandler(ProjectileHandler* pProjectileHandler) = 0;
     virtual void  SetProjectileStopHandler(ProjectileStopHandler* pProjectileHandler) = 0;
+    virtual void  SetPreWeatherUpdateHandler(PreWeatherUpdateHandler* pHandler) = 0;
     virtual void  SetPreWorldProcessHandler(PreWorldProcessHandler* pHandler) = 0;
     virtual void  SetPostWorldProcessHandler(PostWorldProcessHandler* pHandler) = 0;
     virtual void  SetPostWorldProcessPedsAfterPreRenderHandler(PostWorldProcessPedsAfterPreRenderHandler* pHandler) = 0;

--- a/PR_WEATHER_FLICKER_4803.md
+++ b/PR_WEATHER_FLICKER_4803.md
@@ -1,0 +1,24 @@
+#### Summary
+
+Follow-up to #4870. Move the weather re-apply earlier in `CGame::Process` so the engine's clock-wrap branch in `CWeather::Update` also runs against MTA's intended weather pair.
+
+#### Motivation
+
+#4870 fixed the sky/ambient flicker by re-applying MTA's weather in `PreWorldProcessHandler` (`0x53C095`), ahead of `CTimeCycle::CalcColoursForPoint` (`0x53C0DA`). Cloud cover, fog and night-time building lights still pop for the same frames, because `CWeather::Update` itself runs earlier (`0x53BFC2`) and on the wrap branch derives `Rain`, `Foggyness`, `CloudCoverage`, `ExtraSunnyness`, `SunGlare`, `HeatHaze`, `Sandstorm`, `WetRoads`, `Wind` and `Rainbow` from its own freshly-picked pair before `PreWorldProcessHandler` gets a chance to fix things.
+
+This PR adds a `HookInstallCall` over the `call CWeather::Update` site at `0x53BFC2` and a new `PreWeatherUpdateHandler` that runs `CBlendedWeather::DoPulse` before the engine update. With Old/New/`InterpolationValue` already aligned, `CWeather::Update` takes the non-wrap branch and derives every weather global from MTA's pair. The existing `PreWorldProcessHandler` re-apply from #4870 is kept as an idempotent safety net for the colour-set path.
+
+`CBlendedWeather::DoPulse` also calls `CWeather::ResyncInterpolationWithGameClock` after `Set`, so `InterpolationValue` matches the clock — fixes residual flicker on glass/reflective materials that #4870 left behind.
+
+#### Test plan
+
+1. Join a server running the default race resource
+2. Set fullscreen (any mode)
+3. Use `setWeatherBlended` + `setTime` via script, then restart the race resource to respawn
+4. Observe no sky/lighting flicker on respawn
+5. Repeat at night so building/streetlight glow and cloud cover are visible — they should not pop either
+
+#### Checklist
+
+* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
+* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.


### PR DESCRIPTION
#### Summary
Implements reference counting for `showCursor` control toggling (`bToggleControls`). This ensures control states are tracked per resource, preventing one script from inadvertently unlocking controls globally.

#### Motivation
Fixes #4499.
Previously, `showCursor` passed `bToggleControls` directly to `ForceCursorVisible`, causing the most recent call to override the global state. This broke scenarios where one script relied on controls being locked, but a secondary script calling `showCursor(false, false)` would globally unlock them.

#### Test plan
1. Resource A calls `showCursor(true, true)` (cursor visible, controls locked).
2. Resource B calls `showCursor(false, false)`.
3. Verify controls remain locked since Resource A still holds the active state.
4. Resource A calls `showCursor(false)`. Verify controls successfully unlock.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
