### PR TITLE
Fix vehicle audio reinitialization churn

### DIFF
--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -11,6 +11,7 @@
 
 #include "StdInc.h"
 #include <core/CCoreInterface.h>
+#include <game/CAESoundManager.h>
 #include <multiplayer/CMultiplayer.h>
 #include "CAutomobileSA.h"
 #include "CBikeSA.h"
@@ -145,8 +146,29 @@ static void __declspec(naked) HOOK_CPlane_ProcessFlyingCarStuff()
     // clang-format on
 }
 
+#define NUM_FirstStreamEngineSlot    7
+#define NUM_LastStreamEngineSlot     16
+#define NUM_AllSoundIndices          0xFFFFFFFF
+#define NUM_ResidentEngineSlot       40
+#define NUM_LocalVehicleAudioContext 0x0
+#define VAR_VehicleAudioContext      0x50230C
+
 namespace
 {
+    void CancelVehicleAudioSlots(CAEVehicleAudioEntitySAInterface* pAudioInterface)
+    {
+        auto* pSoundManager = pGame ? pGame->GetAESoundManager() : nullptr;
+        if (!pAudioInterface || !pSoundManager)
+            return;
+
+        if (pAudioInterface->m_wEngineBankSlotId >= NUM_FirstStreamEngineSlot && pAudioInterface->m_wEngineBankSlotId <= NUM_LastStreamEngineSlot)
+            pSoundManager->CancelSoundsInBankSlot(pAudioInterface->m_wEngineBankSlotId, NUM_AllSoundIndices);
+
+        if (pAudioInterface->m_bPlayerDriver || pAudioInterface->m_bPlayerPassenger ||
+            *reinterpret_cast<const BYTE*>(VAR_VehicleAudioContext) == NUM_LocalVehicleAudioContext)
+            pSoundManager->CancelSoundsInBankSlot(NUM_ResidentEngineSlot, NUM_AllSoundIndices);
+    }
+
     bool ClumpDumpCB(RpAtomic* pAtomic, void* data)
     {
         CVehicleSA* pVehicleSA = (CVehicleSA*)data;
@@ -2582,7 +2604,14 @@ bool CVehicleSA::SetWindowOpenFlagState(unsigned char ucWindow, bool bState)
 
 void CVehicleSA::ReinitAudio()
 {
+    if (!m_pVehicleAudioEntity)
+        return;
+
     auto* audioInterface = m_pVehicleAudioEntity->GetInterface();
+    if (!audioInterface)
+        return;
+
+    CancelVehicleAudioSlots(audioInterface);
 
     audioInterface->TerminateAudio();
     audioInterface->InitAudio(GetVehicleInterface());

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -31,6 +31,27 @@ std::set<const CClientEntity*> ms_AttachedVehiclesToIgnore;
 
 namespace
 {
+    constexpr char RADIO_TYPE_RANDOM = 2;
+    constexpr char RADIO_NUM_RANDOM = 13;
+
+    tVehicleAudioSettings GetNormalizedAudioSettings(const CVehicleAudioSettingsEntry& settings)
+    {
+        auto normalizedSettings = static_cast<const CVehicleAudioSettingsEntrySA&>(settings).GetInterface();
+        if (normalizedSettings.m_nRadioType == RADIO_TYPE_RANDOM)
+            normalizedSettings.m_nRadioID = RADIO_NUM_RANDOM;
+
+        return normalizedSettings;
+    }
+
+    tVehicleAudioSettings GetNormalizedAudioSettings(const CAEVehicleAudioEntitySAInterface& audioInterface)
+    {
+        auto normalizedSettings = audioInterface.m_nSettings;
+        if (normalizedSettings.m_nRadioType == RADIO_TYPE_RANDOM)
+            normalizedSettings.m_nRadioID = RADIO_NUM_RANDOM;
+
+        return normalizedSettings;
+    }
+
     bool HasPendingAudioSettingsChange(CVehicle* pVehicle, const CVehicleAudioSettingsEntry& settings)
     {
         auto* pVehicleSA = dynamic_cast<CVehicleSA*>(pVehicle);
@@ -42,8 +63,9 @@ namespace
         if (!pAudioInterface)
             return true;
 
-        const auto& desiredSettings = static_cast<const CVehicleAudioSettingsEntrySA&>(settings).GetInterface();
-        return std::memcmp(&pAudioInterface->m_nSettings, &desiredSettings, sizeof(desiredSettings)) != 0;
+        const auto currentSettings = GetNormalizedAudioSettings(*pAudioInterface);
+        const auto desiredSettings = GetNormalizedAudioSettings(settings);
+        return std::memcmp(&currentSettings, &desiredSettings, sizeof(desiredSettings)) != 0;
     }
 }
 


### PR DESCRIPTION
#### Summary
Fix vehicle audio reinitialization churn when applying per-vehicle audio settings.

#### Motivation
Resolves #4314. Repeated `setVehicleAudioSetting` calls could reinit audio even when settings already matched, causing streamed vehicles to play only the high-speed engine layer.

#### Test plan
* Verify the comparison now accounts for GTA's radio setting normalization.
* Verify real audio reinitialization clears stale engine bank sounds first.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
