### PR TITLE
Avoid duplicate resource checksum refresh on start

### DIFF
--- a/Server/mods/deathmatch/logic/CResource.cpp
+++ b/Server/mods/deathmatch/logic/CResource.cpp
@@ -1069,9 +1069,6 @@ bool CResource::Start(std::list<CResource*>* pDependents, bool bManualStart, con
     SendNoClientCacheScripts();
     m_bClientSync = true;
 
-    // HACK?: stops resources getting loaded twice when you change them then manually restart
-    GenerateChecksums();
-
     // Add us to the running resources list
     m_StartedResources.push_back(this);
 


### PR DESCRIPTION
#### Summary
Avoid running a second full resource checksum refresh after successful resource start.

#### Motivation
Resolves #4151. PR #3924 made checksum/cache work disk-backed, but resource start still repeated `GenerateChecksums()` after `StartResource()` already checked for changes. This made restarts re-read resource and HTTP cache files unnecessarily.

#### Test plan
* Review console, Lua, refresh, and startup paths to confirm loaded resources already get checksums during load or reload.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
