### PR TITLE
Fix #4499: Controls toggling with showCursor being globally unlocked

### DIFF
--- a/Client/mods/deathmatch/logic/CResource.cpp
+++ b/Client/mods/deathmatch/logic/CResource.cpp
@@ -21,6 +21,7 @@ using namespace std;
 extern CClientGame* g_pClientGame;
 
 int CResource::m_iShowingCursor = 0;
+int CResource::m_iToggleControls = 0;
 
 CResource::CResource(unsigned short usNetID, const char* szResourceName, CClientEntity* pResourceEntity, CClientEntity* pResourceDynamicEntity,
                      const CMtaVersion& strMinServerReq, const CMtaVersion& strMinClientReq, bool bEnableOOP)
@@ -31,6 +32,7 @@ CResource::CResource(unsigned short usNetID, const char* szResourceName, CClient
     m_bStarting = true;
     m_bStopping = false;
     m_bShowingCursor = false;
+    m_bToggleControls = false;
     m_usRemainingNoClientCacheScripts = 0;
     m_bLoadAfterReceivingNoClientCacheScripts = false;
     m_strMinServerReq = strMinServerReq;
@@ -486,8 +488,19 @@ void CResource::ShowCursor(bool bShow, bool bToggleControls)
         m_bShowingCursor = bShow;
     }
 
+    bool bWantsToggle = m_bShowingCursor && bToggleControls;
+    if (bWantsToggle != m_bToggleControls)
+    {
+        if (bWantsToggle)
+            m_iToggleControls += 1;
+        else
+            m_iToggleControls -= 1;
+
+        m_bToggleControls = bWantsToggle;
+    }
+
     // Always update cursor and controls state regardless of cursor visibility change
-    g_pCore->ForceCursorVisible(m_iShowingCursor > 0, bToggleControls);
+    g_pCore->ForceCursorVisible(m_iShowingCursor > 0, m_iToggleControls > 0);
     g_pClientGame->SetCursorEventsEnabled(m_iShowingCursor > 0);
 }
 

--- a/Client/mods/deathmatch/logic/CResource.h
+++ b/Client/mods/deathmatch/logic/CResource.h
@@ -142,6 +142,8 @@ private:
     // To control cursor show/hide
     static int m_iShowingCursor;
     bool       m_bShowingCursor;
+    static int m_iToggleControls;
+    bool       m_bToggleControls;
 
     SString m_strResourceDirectoryPath;            // stores the path to /mods/deathmatch/resources/resource_name
     SString m_strResourcePrivateDirectoryPath;     // stores the path to /mods/deathmatch/priv/server-id/resource_name


### PR DESCRIPTION
#### Summary
Implements reference counting for `showCursor` control toggling (`bToggleControls`). This ensures control states are tracked per resource, preventing one script from inadvertently unlocking controls globally.

#### Motivation
Fixes #4499.
Previously, `showCursor` passed `bToggleControls` directly to `ForceCursorVisible`, causing the most recent call to override the global state. This broke scenarios where one script relied on controls being locked, but a secondary script calling `showCursor(false, false)` would globally unlock them.

#### Test plan
1. Resource A calls `showCursor(true, true)` (cursor visible, controls locked).
2. Resource B calls `showCursor(false, false)`.
3. Verify controls remain locked since Resource A still holds the active state.
4. Resource A calls `showCursor(false)`. Verify controls successfully unlock.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
