### PR TITLE
Fix chat priority starvation under high load

### DIFF
--- a/Server/mods/deathmatch/logic/packets/CChatClearPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CChatClearPacket.h
@@ -18,9 +18,9 @@ class CChatClearPacket final : public CPacket
 public:
     CChatClearPacket() {};
 
-    // Chat uses low priority channel to avoid getting queued behind large map downloads #6877
+    // Keep chat on its own ordered channel, but avoid low-priority starvation under heavy sync load.
     ePacketID               GetPacketID() const { return PACKET_ID_CHAT_CLEAR; };
-    unsigned long           GetFlags() const { return PACKET_LOW_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    unsigned long           GetFlags() const { return PACKET_MEDIUM_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
     virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_CHAT; }
 
     bool Write(NetBitStreamInterface& BitStream) const;

--- a/Server/mods/deathmatch/logic/packets/CChatEchoPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CChatEchoPacket.h
@@ -45,9 +45,9 @@ public:
         m_ucMessageType = ucMessageType;
     };
 
-    // Chat uses low priority channel to avoid getting queued behind large map downloads #6877
+    // Keep chat on its own ordered channel, but avoid low-priority starvation under heavy sync load.
     ePacketID               GetPacketID() const { return PACKET_ID_CHAT_ECHO; };
-    unsigned long           GetFlags() const { return PACKET_LOW_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
+    unsigned long           GetFlags() const { return PACKET_MEDIUM_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
     virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_CHAT; }
 
     bool Write(NetBitStreamInterface& BitStream) const;


### PR DESCRIPTION
#### Summary
Raise chat echo and clear packets from low to medium priority.

#### Motivation
Resolves #4872. At high player counts, low-priority reliable chat packets can be starved by constant sync traffic, while commands and client events remain responsive because they use higher priority packets.

#### Test plan

* Verify chat still uses `PACKET_ORDERING_CHAT` for ordered delivery.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
