### PR TITLE
Improve pulse sleep on busy servers (#4853)

### DIFF
--- a/Server/core/CServerImpl.cpp
+++ b/Server/core/CServerImpl.cpp
@@ -551,7 +551,7 @@ void CServerImpl::HandlePulseSleep()
     // regardless of how full the queue already was (#4853). busy_sleep_time
     // is no longer consulted on this path; server_logic_fps_limit is the
     // existing knob for a hard cap.
-    const int iSleepMs = Clamp(0, iSleepIdleMs, 50);
+    const int        iSleepMs = Clamp(0, iSleepIdleMs, 50);
     const CTickCount deadline = CTickCount::Now() + CTickCount((long long)iSleepMs);
     while (CTickCount::Now() < deadline)
     {

--- a/Server/core/CServerImpl.cpp
+++ b/Server/core/CServerImpl.cpp
@@ -544,21 +544,20 @@ void CServerImpl::HandlePulseSleep()
         return;
     }
 
-    CTickCount sleepLimit = CTickCount::Now() + CTickCount((long long)iSleepIdleMs);
-
-    // Initial sleep period
-    int iInitialMs = std::min(iSleepIdleMs, iSleepBusyMs);
-    Sleep(Clamp(1, iInitialMs, 50));
-
-    // Remaining idle sleep period
-    int iFinalMs = Clamp(1, iSleepIdleMs - iInitialMs, 50);
-    for (int i = 0; i < iFinalMs; i++)
+    // Sleep up to idle_sleep_time in 1ms ticks, exiting the moment the sync
+    // thread queues a packet. The previous code did a blind Sleep for
+    // busy_sleep_time at the top of every pulse before checking the inbound
+    // queue, which capped logic FPS near 1000/busy_sleep_time on busy servers
+    // regardless of how full the queue already was (#4853). busy_sleep_time
+    // is no longer consulted on this path; server_logic_fps_limit is the
+    // existing knob for a hard cap.
+    const int iSleepMs = Clamp(0, iSleepIdleMs, 50);
+    const CTickCount deadline = CTickCount::Now() + CTickCount((long long)iSleepMs);
+    while (CTickCount::Now() < deadline)
     {
         if (m_pModManager->PendingWorkToDo())
-            break;
+            return;
         Sleep(1);
-        if (CTickCount::Now() >= sleepLimit)
-            break;
     }
 }
 


### PR DESCRIPTION
#### Summary
Make HandlePulseSleep early-out as soon as the sync thread queues a packet, instead of doing a blind Sleep(busy_sleep_time) at the top of every pulse.

#### Motivation
Attempt at the regression in #4853, not a confirmed fix. With threadnet on, busy_sleep_time defaults to 20ms, and the old loop slept that 20ms before checking PendingWorkToDo. Once the sync thread fills m_InResultQueue faster than DoPulse can drain it under that cap (the issue reports this starting around 600 players), the queue grows every pulse and operators see chat lag and packet loss while total CPU stays under 40%, because the logic thread is sleeping most of every second.

#### Change
Replace the fixed Sleep + early-out tail loop with a single 1ms loop that exits the moment new work arrives.

* Quiet servers still sleep the full idle_sleep_time, no CPU change.
* Busy servers wake as soon as packets arrive. One main-thread core will run hot under steady inflow, which is what should happen. server_logic_fps_limit is still there for a hard cap.
* idle_sleep_time = 0 is honored as written; the previous Clamp(1, ..., 50) floor is well.. gone!

#### Note on busy_sleep_time
busy_sleep_time is no longer consulted by this loop. Its previous role was the unconditional Sleep at the top of every pulse, which is exactly the bottleneck this PR removes. Once early-out is in place, a separate "throttle while busy" knob is redundant. server_logic_fps_limit already provides a hard FPS cap when an operator wants one. The config option still parses and shows up in the perf info; it just has no effect on this code path.

#### Test plan
* Read HandlePulseSleep, PendingWorkToDo, GetSleepIntervals, CTickCount, and Clamp on Windows and Linux (Sleep(1) is usleep(1000)).
* Would benefit from someone with access to a 600+ player server confirming logic FPS scales past the previous ~50 Hz cap when the inbound queue is non-empty.

#### Checklist
* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review.
