### PR TITLE
Fix SVG texture color banding (#4891)

### DIFF
--- a/Client/core/Graphics/CGraphics.cpp
+++ b/Client/core/Graphics/CGraphics.cpp
@@ -27,6 +27,40 @@ extern std::atomic<bool> g_bInMTAScene;
 
 using namespace std;
 
+namespace
+{
+    // Convert a straight-alpha ARGB tint into its premultiplied form:
+    //
+    //     (R, G, B, A)  ->  (R*A/255, G*A/255, B*A/255, A)
+    //
+    // Needed when routing a translucent draw onto the (ONE, INVSRCALPHA)
+    // pipeline. That pipeline computes
+    //
+    //     out.rgb = src.rgb + dst.rgb * (1 - src.a)
+    //
+    // with src.rgb = tex.rgb * diff.rgb and src.a = tex.a * diff.a, so
+    // diff.a never enters the source rgb term. For a PM texel tex.rgb =
+    // R*A_tex, that leaves
+    //
+    //     out.rgb = R * A_tex * diff.rgb + dst.rgb * (1 - A_tex * diff.a)
+    //
+    // which is brighter than the correct PM composite by a factor of
+    // 1/diff.a during a fade. Premultiplying the diffuse here
+    // (diff.rgb *= diff.a) restores the missing factor and the equation
+    // reduces exactly to the PM "over" operator.
+    inline SColor PremultiplyAlpha(SColor c) noexcept
+    {
+        if (c.A == 0xFF)
+            return c;
+
+        const uint a = c.A;
+        c.R = static_cast<unsigned char>((c.R * a + 127) / 255);
+        c.G = static_cast<unsigned char>((c.G * a + 127) / 255);
+        c.B = static_cast<unsigned char>((c.B * a + 127) / 255);
+        return c;
+    }
+}  // namespace
+
 template <>
 CGraphics* CSingleton<CGraphics>::m_pSingleton = NULL;
 
@@ -1080,6 +1114,15 @@ void CGraphics::DrawMaterialPrimitiveQueued(std::vector<PrimitiveMaterialVertice
     sDrawQueueItem Item;
     Item.eType = QUEUE_PRIMITIVEMATERIAL;
     Item.blendMode = m_ActiveBlendMode;
+    // Same PM auto-route as DrawTextureQueued, so dxDrawMaterialPrimitive
+    // composites SVG (premultiplied) textures correctly under default blend.
+    if (Item.blendMode == EBlendMode::BLEND && pMaterial && pMaterial->m_bPremultipliedAlpha)
+    {
+        Item.blendMode = EBlendMode::ADD;
+        // See PremultiplyAlpha for the diffuse premultiply rationale (#3828).
+        for (auto& vert : *pVecVertices)
+            vert.Color = PremultiplyAlpha(vert.Color);
+    }
     Item.PrimitiveMaterial.eType = eType;
     Item.PrimitiveMaterial.pMaterial = pMaterial;
     Item.PrimitiveMaterial.pVecVertices = pVecVertices;
@@ -1134,6 +1177,16 @@ void CGraphics::DrawTextureQueued(float fX, float fY, float fWidth, float fHeigh
     // Set up a queue item
     sDrawQueueItem Item;
     Item.blendMode = m_ActiveBlendMode;
+    // Premultiplied-alpha textures (SVG) need the (ONE, INVSRCALPHA) pipeline,
+    // not the straight-alpha BLEND mode. Route the default blend to ADD when
+    // the script hasn't asked for a specific mode (issue #4891), and convert
+    // the diffuse tint to PM so a translucent dxDrawImage call still fades
+    // correctly through that pipeline (issue #3828).
+    if (Item.blendMode == EBlendMode::BLEND && pMaterial && pMaterial->m_bPremultipliedAlpha)
+    {
+        Item.blendMode = EBlendMode::ADD;
+        ulColor = PremultiplyAlpha(ulColor);
+    }
     Item.Texture.fX = fX;
     Item.Texture.fY = fY;
     Item.Texture.fWidth = fWidth;

--- a/Client/core/Graphics/CRenderItem.VectorGraphic.cpp
+++ b/Client/core/Graphics/CRenderItem.VectorGraphic.cpp
@@ -24,6 +24,9 @@ void CVectorGraphicItem::PostConstruct(CRenderItemManager* pManager, uint width,
     m_uiSizeY = height;
     m_uiSurfaceSizeX = width;
     m_uiSurfaceSizeY = height;
+    // lunasvg writes premultiplied ARGB into the surface; let the draw
+    // path use a PM-aware blend instead of unpremultiplying per pixel.
+    m_bPremultipliedAlpha = true;
 
     CreateUnderlyingData();
 }

--- a/Client/mods/deathmatch/logic/CClientVectorGraphicDisplay.cpp
+++ b/Client/mods/deathmatch/logic/CClientVectorGraphicDisplay.cpp
@@ -56,37 +56,6 @@ void CClientVectorGraphicDisplay::Render()
     }
 }
 
-void CClientVectorGraphicDisplay::UnpremultiplyBitmap(Bitmap& bitmap)
-{
-    auto width = bitmap.width();
-    auto height = bitmap.height();
-    auto stride = bitmap.stride();
-    auto rowData = bitmap.data();
-
-    for (decltype(height) y = 0; y < height; y++)
-    {
-        auto data = rowData;
-        for (decltype(width) x = 0; x < width; x++)
-        {
-            auto& b = data[0];
-            auto& g = data[1];
-            auto& r = data[2];
-            auto& a = data[3];
-
-            if (a != 0)
-            {
-                r = (r * 255) / a;
-                g = (g * 255) / a;
-                b = (b * 255) / a;
-            }
-
-            data += 4;
-        }
-
-        rowData += stride;
-    }
-}
-
 void CClientVectorGraphicDisplay::UpdateTexture()
 {
     if (!m_pVectorGraphic || m_pVectorGraphic->IsDestroyed())
@@ -144,7 +113,10 @@ void CClientVectorGraphicDisplay::UpdateTexture()
             return;
         }
 
-        UnpremultiplyBitmap(bitmap);
+        // The surface stays in lunasvg's native premultiplied ARGB layout.
+        // CGraphics::DrawTextureQueued routes the draw to a PM blend so we
+        // avoid the precision loss caused by an integer unpremultiply
+        // (see issue #4891 banding on translucent SVG gradients).
 
         // Unlock surface
         surface->UnlockRect();

--- a/Client/mods/deathmatch/logic/CClientVectorGraphicDisplay.h
+++ b/Client/mods/deathmatch/logic/CClientVectorGraphicDisplay.h
@@ -36,8 +36,6 @@ public:
     void Update();
 
 private:
-    void UnpremultiplyBitmap(lunasvg::Bitmap& bitmap);
-
     CClientVectorGraphic* m_pVectorGraphic;
 
     bool m_bIsCleared;

--- a/Client/sdk/core/CRenderItemManagerInterface.h
+++ b/Client/sdk/core/CRenderItemManagerInterface.h
@@ -351,12 +351,17 @@ class CEffectWrap : public CRenderItem
 class CMaterialItem : public CRenderItem
 {
     DECLARE_CLASS(CMaterialItem, CRenderItem)
-    CMaterialItem() : ClassInit(this), m_TextureAddress(TADDRESS_WRAP), m_uiBorderColor(0) {}
+    CMaterialItem() : ClassInit(this), m_TextureAddress(TADDRESS_WRAP), m_uiBorderColor(0), m_bPremultipliedAlpha(false) {}
 
     uint            m_uiSizeX;
     uint            m_uiSizeY;
     ETextureAddress m_TextureAddress;
     uint            m_uiBorderColor;
+    // True if the texture pixels are stored with premultiplied alpha. When set,
+    // the default dxDrawImage blend ("blend") is internally routed through the
+    // (ONE, INVSRCALPHA) pipeline so compositing is mathematically correct
+    // without losing precision to a per-pixel integer unpremultiply.
+    bool m_bPremultipliedAlpha;
 };
 
 ////////////////////////////////////////////////////////////////


### PR DESCRIPTION
#### Summary
SVG textures rendered with any opacity below 1.0 show visible color banding on smooth gradients. This PR keeps the lunasvg bitmap in its native premultiplied-alpha form and routes the default `dxDrawImage` blend through MTA's existing PM blend pipeline instead of unpremultiplying per pixel.

#### Motivation
Closes #4891.

The render path was doing `r = (r * 255) / a` per pixel after lunasvg wrote a premultiplied 8-bit ARGB bitmap. With alpha < 255 this is mathematically incapable of producing a smooth gradient: plutovg's gradient LUT is 8-bit per channel, so a translucent gradient (e.g. opacity 0.87, a=222) only takes ~11 distinct premul-R states across the whole gradient. The integer divide then stretches those 11 states across 0..255 and skips outputs (33 -> 37, 34 -> 39, 38 unreachable). Round-to-nearest does not help, it only shifts which output value is skipped.

PNG looks fine in the same scene because PNG stores straight alpha and never goes through the premul/unpremul roundtrip.

The fix is what every modern compositor does (Direct2D, Skia, WPF, browsers): keep the data premultiplied and use a (ONE, INVSRCALPHA) blend at draw time.

- Add `m_bPremultipliedAlpha` flag on `CMaterialItem`, default false.
- Set the flag in `CVectorGraphicItem::PostConstruct`. Drop the lossy `UnpremultiplyBitmap` pass.
- In `DrawTextureQueued` and `DrawMaterialPrimitiveQueued`, when the active blend is the default `BLEND` and the material is PM, route the queued item to `ADD`, which is the existing `(ONE, INVSRCALPHA)` mode in `CGraphics::SetBlendModeRenderStates`. Scripts that set a blend mode explicitly are not affected.

#### Test plan
- Reproduce #4891 with the SVG from the issue (rounded rect + linear gradient #2b3c4d -> #1f2326, opacity 0.87) via `svgCreate` and `dxDrawImage`. Before: visible bands. After: smooth gradient matching the PNG reference.
- Sanity check on opaque SVGs (no opacity, no gradient transparency): unchanged output, since `BLEND` and `ADD` agree when alpha is 255.
- Sanity check on `dxSetBlendMode("modulate_add")` and `dxSetBlendMode("add")` paths: untouched, the auto-route only fires when the active mode is `BLEND`.
- `dxDrawMaterialPrimitive` with an SVG texture under default blend: composites correctly (same auto-route applied).

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
