### PR TITLE
Halve engineLoadTXD memory by moving textures to D3DPOOL_DEFAULT (#4062)

### DIFF
--- a/Client/core/Graphics/CGraphics.cpp
+++ b/Client/core/Graphics/CGraphics.cpp
@@ -11,6 +11,8 @@
 
 #include "StdInc.h"
 #include <game/CSettings.h>
+#include <game/CGame.h>
+#include <game/CRenderWare.h>
 #include <memory>
 #include "DXHook/CProxyDirect3DDevice9.h"
 #include "CTileBatcher.h"
@@ -1727,6 +1729,13 @@ void CGraphics::OnDeviceInvalidate(IDirect3DDevice9* pDevice)
     SAFE_RELEASE(m_pSavedFrontBufferData);
     SAFE_RELEASE(m_pTempBackBufferData);
 
+    // Release D3DPOOL_DEFAULT replacement textures owned by engineLoadTXD before
+    // IDirect3DDevice9::Reset is attempted; per the D3D9 contract, every DEFAULT-pool
+    // resource must be gone first. The game module rebuilds these in OnDeviceRestore.
+    if (CGame* pGame = g_pCore->GetGame())
+        if (CRenderWare* pRenderWare = pGame->GetRenderWare())
+            pRenderWare->OnDeviceLost();
+
     // Reset render zone tracking on device loss
     m_MTARenderZone = MTA_RZONE_NONE;
     m_iOutsideZoneCount = 0;
@@ -1756,6 +1765,13 @@ void CGraphics::OnDeviceRestore(IDirect3DDevice9* pDevice)
 
     m_pRenderItemManager->OnResetDevice();
     m_pScreenGrabber->OnResetDevice();
+
+    // Re-create the D3DPOOL_DEFAULT replacement textures we released in OnDeviceInvalidate.
+    // File-path TXDs re-read from disk; raw-data TXDs use the m_FileData buffer kept by
+    // CClientTXD since LoadFromBuffer.
+    if (CGame* pGame = g_pCore->GetGame())
+        if (CRenderWare* pRenderWare = pGame->GetRenderWare())
+            pRenderWare->OnDeviceReset();
 
     const uint uiViewportWidth = GetViewportWidth();
     const uint uiViewportHeight = GetViewportHeight();

--- a/Client/game_sa/CRenderWareSA.PoolMemorySaver.cpp
+++ b/Client/game_sa/CRenderWareSA.PoolMemorySaver.cpp
@@ -1,0 +1,607 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        game_sa/CRenderWareSA.PoolMemorySaver.cpp
+ *  PURPOSE:     Convert engineLoadTXD replacement textures from D3DPOOL_MANAGED
+ *               to D3DPOOL_DEFAULT to drop the system-memory shadow copy
+ *               (issue #4062). Handles device-lost/reset for those textures
+ *               since DEFAULT-pool resources do not auto-restore. Covers both
+ *               2D and cube-map rasters.
+ *
+ *  Multi Theft Auto is available from https://www.multitheftauto.com/
+ *  RenderWare is © Criterion Software
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+#include <core/CCoreInterface.h>
+#include <core/CGraphicsInterface.h>
+#include <game/RenderWareD3D.h>
+#include "CGameSA.h"
+#include "CRenderWareSA.h"
+#include "gamesa_renderware.h"
+
+extern CCoreInterface* g_pCore;
+
+namespace
+{
+    // GTA's RW raster type tag for a regular 2D texture raster (RwRaster::type field).
+    // 0 = normal, 1 = z-buffer, 2 = camera, 4 = texture, 5 = camera-texture.
+    // Replacement TXDs always produce type=4 entries (cube maps included; the
+    // distinction is in RwD3D9Raster::cubeTextureFlags, not RwRaster::type).
+    constexpr unsigned char kRwRasterTypeTexture = 4;
+
+    // RwRaster::flags bit 0x80 is rwRASTERDONTALLOCATE; if set the raster has no
+    // backing D3D resource yet and must be skipped.
+    constexpr unsigned char kRwRasterFlagDontAllocate = 0x80;
+
+    // RwD3D9Raster::cubeTextureFlags low bit marks the raster as a cube map.
+    // (The IDA struct calls this field cube_face; high nibble tracks the current
+    // face during stream-read iteration but is reset to 0 when decoding finishes.)
+    constexpr unsigned char kRwD3DRasterCubeMap = 0x01;
+
+    // RwD3D9Raster::textureFlags low nibble holds the D3DUSAGE_AUTOGENMIPMAP flag.
+    // Such textures are created with USAGE_AUTOGENMIPMAP, which is incompatible
+    // with D3DPOOL_SYSTEMMEM (per d3d9types.h table) so our SYSTEMMEM-staging
+    // path can't be used; we leave them MANAGED. They are uncommon in user TXDs.
+    constexpr unsigned char kRwD3DRasterAutoMipGenMask = 0x0F;
+
+    // Number of bytes in one row of a compressed-block surface, given the
+    // surface width in pixels and the per-block size.
+    UINT CompressedRowBytes(UINT widthPixels, UINT blockBytes)
+    {
+        const UINT widthBlocks = (widthPixels + 3u) / 4u;
+        return widthBlocks * blockBytes;
+    }
+
+    // Number of compressed-block rows for a surface height in pixels.
+    UINT CompressedRowCount(UINT heightPixels)
+    {
+        return (heightPixels + 3u) / 4u;
+    }
+
+    // Returns true and fills outPerRow / outRowCount with the actual data span
+    // on each mip level for the given format. Pitch reported by LockRect can be
+    // larger than this on some drivers; we always copy outPerRow bytes per row
+    // and step by the LockRect-reported pitch.
+    bool GetCopyParams(D3DFORMAT format, UINT widthPixels, UINT heightPixels, UINT& outPerRow, UINT& outRowCount)
+    {
+        switch (format)
+        {
+            case D3DFMT_DXT1:
+                outPerRow = CompressedRowBytes(widthPixels, 8);
+                outRowCount = CompressedRowCount(heightPixels);
+                return true;
+            case D3DFMT_DXT2:
+            case D3DFMT_DXT3:
+            case D3DFMT_DXT4:
+            case D3DFMT_DXT5:
+                outPerRow = CompressedRowBytes(widthPixels, 16);
+                outRowCount = CompressedRowCount(heightPixels);
+                return true;
+            case D3DFMT_A8R8G8B8:
+            case D3DFMT_X8R8G8B8:
+            case D3DFMT_A8B8G8R8:
+            case D3DFMT_X8B8G8R8:
+                outPerRow = widthPixels * 4u;
+                outRowCount = heightPixels;
+                return true;
+            case D3DFMT_R5G6B5:
+            case D3DFMT_X1R5G5B5:
+            case D3DFMT_A1R5G5B5:
+            case D3DFMT_A4R4G4B4:
+            case D3DFMT_X4R4G4B4:
+                outPerRow = widthPixels * 2u;
+                outRowCount = heightPixels;
+                return true;
+            case D3DFMT_R8G8B8:
+                outPerRow = widthPixels * 3u;
+                outRowCount = heightPixels;
+                return true;
+            case D3DFMT_L8:
+            case D3DFMT_A8:
+                outPerRow = widthPixels;
+                outRowCount = heightPixels;
+                return true;
+            case D3DFMT_A8L8:
+                outPerRow = widthPixels * 2u;
+                outRowCount = heightPixels;
+                return true;
+            default:
+                // Unknown format: refuse to convert. The caller will leave the
+                // texture in MANAGED, sacrificing memory savings for safety.
+                return false;
+        }
+    }
+
+    // Inner memcpy used by both 2D and cube paths. Locks are already held by
+    // the caller; we just copy bytes between two locked rects.
+    void CopyLockedRect(const D3DLOCKED_RECT& srcRect, const D3DLOCKED_RECT& dstRect, UINT perRow, UINT rowCount)
+    {
+        const std::uint8_t* pSrcBytes = static_cast<const std::uint8_t*>(srcRect.pBits);
+        std::uint8_t*       pDstBytes = static_cast<std::uint8_t*>(dstRect.pBits);
+        const UINT          srcPitch = static_cast<UINT>(srcRect.Pitch);
+        const UINT          dstPitch = static_cast<UINT>(dstRect.Pitch);
+        // min() guards against drivers reporting a smaller pitch than the data
+        // we computed (shouldn't happen, but cheap to clamp).
+        const UINT copyBytesPerRow = std::min(perRow, std::min(srcPitch, dstPitch));
+
+        for (UINT row = 0; row < rowCount; ++row)
+        {
+            std::memcpy(pDstBytes + row * dstPitch, pSrcBytes + row * srcPitch, copyBytesPerRow);
+        }
+    }
+
+    // Copy every mip level of a 2D pSrc (any pool) into a 2D pDst (must be
+    // SYSTEMMEM). Returns true on success; on failure the caller releases both
+    // textures and aborts the conversion.
+    bool CopyAllMipsToSystemMem(IDirect3DTexture9* pSrc, IDirect3DTexture9* pDst)
+    {
+        const UINT levelCount = pSrc->GetLevelCount();
+        if (levelCount == 0 || pDst->GetLevelCount() != levelCount)
+            return false;
+
+        for (UINT level = 0; level < levelCount; ++level)
+        {
+            D3DSURFACE_DESC desc{};
+            if (FAILED(pSrc->GetLevelDesc(level, &desc)))
+                return false;
+
+            UINT perRow = 0;
+            UINT rowCount = 0;
+            if (!GetCopyParams(desc.Format, desc.Width, desc.Height, perRow, rowCount))
+                return false;
+
+            D3DLOCKED_RECT srcRect{};
+            D3DLOCKED_RECT dstRect{};
+
+            // READONLY + NO_DIRTY_UPDATE keeps the source clean (we are not
+            // mutating it; we just want its bytes). NOSYSLOCK lets us run
+            // outside the global D3D9 lock when the driver allows it.
+            if (FAILED(pSrc->LockRect(level, &srcRect, nullptr, D3DLOCK_READONLY | D3DLOCK_NO_DIRTY_UPDATE | D3DLOCK_NOSYSLOCK)))
+                return false;
+
+            if (FAILED(pDst->LockRect(level, &dstRect, nullptr, 0)))
+            {
+                pSrc->UnlockRect(level);
+                return false;
+            }
+
+            CopyLockedRect(srcRect, dstRect, perRow, rowCount);
+
+            pDst->UnlockRect(level);
+            pSrc->UnlockRect(level);
+        }
+
+        return true;
+    }
+
+    // Copy every mip level of all 6 faces of a cube pSrc (any pool) into pDst
+    // (must be SYSTEMMEM cube). All 6 faces of a cube share the same mip
+    // dimensions and format so we re-derive perRow / rowCount per level only,
+    // not per face.
+    bool CopyAllCubeMipsToSystemMem(IDirect3DCubeTexture9* pSrc, IDirect3DCubeTexture9* pDst)
+    {
+        const UINT levelCount = pSrc->GetLevelCount();
+        if (levelCount == 0 || pDst->GetLevelCount() != levelCount)
+            return false;
+
+        for (UINT level = 0; level < levelCount; ++level)
+        {
+            D3DSURFACE_DESC desc{};
+            if (FAILED(pSrc->GetLevelDesc(level, &desc)))
+                return false;
+
+            UINT perRow = 0;
+            UINT rowCount = 0;
+            if (!GetCopyParams(desc.Format, desc.Width, desc.Height, perRow, rowCount))
+                return false;
+
+            for (UINT face = 0; face < 6; ++face)
+            {
+                const D3DCUBEMAP_FACES faceEnum = static_cast<D3DCUBEMAP_FACES>(face);
+
+                D3DLOCKED_RECT srcRect{};
+                D3DLOCKED_RECT dstRect{};
+
+                if (FAILED(pSrc->LockRect(faceEnum, level, &srcRect, nullptr, D3DLOCK_READONLY | D3DLOCK_NO_DIRTY_UPDATE | D3DLOCK_NOSYSLOCK)))
+                    return false;
+
+                if (FAILED(pDst->LockRect(faceEnum, level, &dstRect, nullptr, 0)))
+                {
+                    pSrc->UnlockRect(faceEnum, level);
+                    return false;
+                }
+
+                CopyLockedRect(srcRect, dstRect, perRow, rowCount);
+
+                pDst->UnlockRect(faceEnum, level);
+                pSrc->UnlockRect(faceEnum, level);
+            }
+        }
+
+        return true;
+    }
+
+    // After the OLD MANAGED texture is released and the NEW DEFAULT one is in
+    // place, scrub the cached lock-state fields on the rasterExt so any future
+    // code that consults them doesn't see a dangling pointer to a freed surface.
+    // Nothing on the replacement-texture path reads these today (RightSizeTexture
+    // only operates on freshly-decoded MANAGED textures, never on engineLoadTXD
+    // outputs), but leaving stale pointers behind is a cheap-to-eliminate footgun.
+    void ScrubLockStateAndSwapTexture(RwD3D9Raster* pD3DRaster, IDirect3DTexture9* pNewTexture)
+    {
+        pD3DRaster->lockedLevel = 0;
+        pD3DRaster->lockedSurface = nullptr;
+        pD3DRaster->lockedRect = D3DLOCKED_RECT{0, nullptr};
+        pD3DRaster->texture = pNewTexture;
+    }
+
+    // CreateTexture wrapper that mirrors CDirect3DEvents9::CreateTexture's
+    // retry-on-OOM behaviour without the proxy wrapping. Drops MANAGED resources
+    // from vram once on D3DERR_OUTOFVIDEOMEMORY before retrying; further failures
+    // propagate up.
+    HRESULT CreateTextureWithRetry(IDirect3DDevice9* pDevice, UINT width, UINT height, UINT levels, D3DFORMAT format, D3DPOOL pool, IDirect3DTexture9** ppOut)
+    {
+        HRESULT hr = pDevice->CreateTexture(width, height, levels, 0, format, pool, ppOut, nullptr);
+        if (hr != D3DERR_OUTOFVIDEOMEMORY)
+            return hr;
+        pDevice->EvictManagedResources();
+        return pDevice->CreateTexture(width, height, levels, 0, format, pool, ppOut, nullptr);
+    }
+
+    HRESULT CreateCubeTextureWithRetry(IDirect3DDevice9* pDevice, UINT edgeLength, UINT levels, D3DFORMAT format, D3DPOOL pool, IDirect3DCubeTexture9** ppOut)
+    {
+        HRESULT hr = pDevice->CreateCubeTexture(edgeLength, levels, 0, format, pool, ppOut, nullptr);
+        if (hr != D3DERR_OUTOFVIDEOMEMORY)
+            return hr;
+        pDevice->EvictManagedResources();
+        return pDevice->CreateCubeTexture(edgeLength, levels, 0, format, pool, ppOut, nullptr);
+    }
+
+    // Single 2D raster MANAGED -> DEFAULT conversion.
+    //
+    // Strategy:
+    //   1. Allocate the new D3DPOOL_DEFAULT texture (no system memory shadow).
+    //   2. Allocate a transient D3DPOOL_SYSTEMMEM scratch with the same layout.
+    //   3. Lock-and-memcpy each mip from MANAGED into SYSTEMMEM. The SYSTEMMEM
+    //      lock is taken with flags=0 so D3D records dirty regions; UpdateTexture
+    //      below uses those to drive the staging-to-DEFAULT copy.
+    //   4. UpdateTexture to push SYSTEMMEM into DEFAULT (canonical D3D9 path:
+    //      "the source must be in system memory, the destination in DEFAULT").
+    //   5. Release SYSTEMMEM, release MANAGED, swap in DEFAULT.
+    //
+    // We deliberately bypass D3DResourceSystem::DestroyTexture (gta_sa.exe @
+    // 0x730510 / 0x730B70) when releasing the original MANAGED texture: that
+    // function caches small (<= 256x256 square) textures in gD3DTextureBuffer
+    // for reuse, and the cache assumes everything in it is MANAGED.
+    bool Convert2DRaster(IDirect3DDevice9* pDevice, RwD3D9Raster* pD3DRaster, const D3DSURFACE_DESC& desc0, UINT levelCount)
+    {
+        // 1. Create the destination DEFAULT-pool texture (with one retry on
+        //    out-of-video-memory after evicting MANAGED resources).
+        IDirect3DTexture9* pDefault = nullptr;
+        if (FAILED(CreateTextureWithRetry(pDevice, desc0.Width, desc0.Height, levelCount, desc0.Format, D3DPOOL_DEFAULT, &pDefault)) || !pDefault)
+            return false;
+
+        // 2. Create a transient SYSTEMMEM scratch.
+        IDirect3DTexture9* pScratch = nullptr;
+        if (FAILED(pDevice->CreateTexture(desc0.Width, desc0.Height, levelCount, 0, desc0.Format, D3DPOOL_SYSTEMMEM, &pScratch, nullptr)) || !pScratch)
+        {
+            pDefault->Release();
+            return false;
+        }
+
+        // 3. Copy MANAGED -> SYSTEMMEM mip by mip.
+        IDirect3DTexture9* pManaged = pD3DRaster->texture;
+        if (!CopyAllMipsToSystemMem(pManaged, pScratch))
+        {
+            pScratch->Release();
+            pDefault->Release();
+            return false;
+        }
+
+        // 4. Push SYSTEMMEM contents to DEFAULT.
+        if (FAILED(pDevice->UpdateTexture(pScratch, pDefault)))
+        {
+            pScratch->Release();
+            pDefault->Release();
+            return false;
+        }
+
+        // 5. Drop originals; rasterExt now owns the DEFAULT texture.
+        pScratch->Release();
+        pManaged->Release();
+        ScrubLockStateAndSwapTexture(pD3DRaster, pDefault);
+        return true;
+    }
+
+    // Cube-map variant of Convert2DRaster. Differs only in:
+    //   - CreateCubeTexture (single EdgeLength param vs Width+Height)
+    //   - 6 faces per mip level (looped inside CopyAllCubeMipsToSystemMem)
+    //   - rasterExt->texture stores IDirect3DCubeTexture9* via the union; the
+    //     reinterpret_cast is well-defined because RwD3D9Raster::texture is a
+    //     union member that GTA already populates with cube pointers in
+    //     _rwD3D9NativeTextureRead at 0x4CD982.
+    //
+    // We keep the same SYSTEMMEM-staging + UpdateTexture pattern. UpdateTexture
+    // accepts cube-to-cube of identical type/format/level-count and copies all
+    // 6 faces in a single device call.
+    bool ConvertCubeRaster(IDirect3DDevice9* pDevice, RwD3D9Raster* pD3DRaster, const D3DSURFACE_DESC& desc0, UINT levelCount)
+    {
+        // For cubes EdgeLength = desc.Width (= desc.Height); D3D9 enforces
+        // square faces in CreateCubeTexture, so this is a no-op assertion.
+        if (desc0.Width != desc0.Height)
+            return false;
+
+        IDirect3DCubeTexture9* pManagedCube = reinterpret_cast<IDirect3DCubeTexture9*>(pD3DRaster->texture);
+
+        IDirect3DCubeTexture9* pDefault = nullptr;
+        if (FAILED(CreateCubeTextureWithRetry(pDevice, desc0.Width, levelCount, desc0.Format, D3DPOOL_DEFAULT, &pDefault)) || !pDefault)
+            return false;
+
+        IDirect3DCubeTexture9* pScratch = nullptr;
+        if (FAILED(pDevice->CreateCubeTexture(desc0.Width, levelCount, 0, desc0.Format, D3DPOOL_SYSTEMMEM, &pScratch, nullptr)) || !pScratch)
+        {
+            pDefault->Release();
+            return false;
+        }
+
+        if (!CopyAllCubeMipsToSystemMem(pManagedCube, pScratch))
+        {
+            pScratch->Release();
+            pDefault->Release();
+            return false;
+        }
+
+        if (FAILED(pDevice->UpdateTexture(pScratch, pDefault)))
+        {
+            pScratch->Release();
+            pDefault->Release();
+            return false;
+        }
+
+        pScratch->Release();
+        pManagedCube->Release();
+        // The union slot is typed IDirect3DTexture9* but actually stores a cube
+        // texture for cube rasters. GTA already does the same trick at
+        // 0x4CD982 (CreateCubeTexture writes into &v8->texture).
+        ScrubLockStateAndSwapTexture(pD3DRaster, reinterpret_cast<IDirect3DTexture9*>(pDefault));
+        return true;
+    }
+
+    // Top-level conversion dispatcher.
+    bool ConvertOneRaster(IDirect3DDevice9* pDevice, RwRaster* pRaster)
+    {
+        if (!pDevice || !pRaster)
+            return false;
+        if (pRaster->type != kRwRasterTypeTexture)
+            return false;
+        if ((pRaster->flags & kRwRasterFlagDontAllocate) != 0)
+            return false;
+
+        RwD3D9Raster* pD3DRaster = reinterpret_cast<RwD3D9Raster*>(&pRaster->renderResource);
+
+        // Palettised rasters carry an extra 1024-byte indexed palette buffer plus
+        // a D3DFMT_P8 texture; D3DPOOL_DEFAULT paletted textures are essentially
+        // unsupported on modern hardware (most drivers refuse the format and the
+        // ones that don't would still need explicit palette set-up post-Reset).
+        // These are vanishingly rare in user-supplied TXDs; leave them MANAGED.
+        if (pD3DRaster->palette != nullptr)
+            return false;
+
+        // D3DUSAGE_AUTOGENMIPMAP cannot coexist with D3DPOOL_SYSTEMMEM, which
+        // breaks our staging path; leave such rasters MANAGED.
+        if ((pD3DRaster->textureFlags & kRwD3DRasterAutoMipGenMask) != 0)
+            return false;
+
+        IDirect3DTexture9* pManaged = pD3DRaster->texture;
+        if (!pManaged)
+            return false;
+
+        // GetLevelDesc on a cube texture (called through the IDirect3DTexture9
+        // vtable) hits the cube vtable's GetLevelDesc at the same vtable slot
+        // and returns the level/face desc with the same struct layout, so this
+        // works for both 2D and cube rasters even before we know which it is.
+        D3DSURFACE_DESC desc0{};
+        if (FAILED(pManaged->GetLevelDesc(0, &desc0)))
+            return false;
+
+        // If GTA already gave us a non-MANAGED resource (e.g. driver fallback)
+        // there's nothing to optimise; leave it alone.
+        if (desc0.Pool != D3DPOOL_MANAGED)
+            return false;
+
+        const UINT levelCount = pManaged->GetLevelCount();
+        if (levelCount == 0)
+            return false;
+
+        // Refuse formats we don't have an explicit byte-count rule for. Keeps
+        // exotic FOURCC and proprietary formats on the original MANAGED path.
+        UINT perRow = 0;
+        UINT rowCount = 0;
+        if (!GetCopyParams(desc0.Format, desc0.Width, desc0.Height, perRow, rowCount))
+            return false;
+
+        const bool bIsCube = (pD3DRaster->cubeTextureFlags & kRwD3DRasterCubeMap) != 0;
+        if (bIsCube)
+            return ConvertCubeRaster(pDevice, pD3DRaster, desc0, levelCount);
+        return Convert2DRaster(pDevice, pD3DRaster, desc0, levelCount);
+    }
+}
+
+////////////////////////////////////////////////////////////////
+//
+// CRenderWareSA::ConvertScriptTxdToDefaultPool
+//
+// Walk a freshly-loaded RwTexDictionary and convert each texture's raster from
+// MANAGED to DEFAULT pool. Called from CRenderWareSA::ReadTXD after the GTA RW
+// loader has filled the textures and BEFORE ScriptAddedTxd, so the texinfo
+// shader-matching map is keyed against the new (DEFAULT) IDirect3DTexture9.
+//
+// Conversion is best-effort: any single texture that fails (out of vram,
+// unknown format) silently stays MANAGED. The caller does not branch on a
+// return value because there is no recovery to do beyond carrying on.
+//
+////////////////////////////////////////////////////////////////
+void CRenderWareSA::ConvertScriptTxdToDefaultPool(RwTexDictionary* pTxd)
+{
+    if (!pTxd || m_bDeviceLost)
+        return;
+
+    IDirect3DDevice9* pDevice = g_pCore->GetGraphics()->GetDevice();
+    if (!pDevice)
+        return;
+
+    std::vector<RwTexture*> textureList;
+    GetTxdTextures(textureList, pTxd);
+
+    for (RwTexture* pTexture : textureList)
+    {
+        if (!pTexture || !pTexture->raster)
+            continue;
+
+        // Already converted? Can happen when a script re-loads the same
+        // raster pointer; not expected in master but cheap to defend.
+        if (m_DefaultPoolRasters.count(pTexture->raster) != 0)
+            continue;
+
+        if (ConvertOneRaster(pDevice, pTexture->raster))
+            m_DefaultPoolRasters.insert(pTexture->raster);
+    }
+}
+
+////////////////////////////////////////////////////////////////
+//
+// CRenderWareSA::ReleaseTrackedDefaultPoolTexture
+//
+// Called from DestroyTexture before RwTextureDestroy. If the raster is one we
+// converted, release the IDirect3DTexture9 ourselves and NULL out
+// rasterExt->texture so _rwD3D9RasterDestroy hits its early-out and bypasses
+// D3DResourceSystem::DestroyTexture (the MANAGED-only cache).
+//
+// Returns true if the raster was tracked (so the caller knows we handled it).
+//
+////////////////////////////////////////////////////////////////
+bool CRenderWareSA::ReleaseTrackedDefaultPoolTexture(RwRaster* pRaster)
+{
+    if (!pRaster)
+        return false;
+
+    auto it = m_DefaultPoolRasters.find(pRaster);
+    if (it == m_DefaultPoolRasters.end())
+        return false;
+
+    RwD3D9Raster* pD3DRaster = reinterpret_cast<RwD3D9Raster*>(&pRaster->renderResource);
+    if (pD3DRaster->texture)
+    {
+        pD3DRaster->texture->Release();
+        pD3DRaster->texture = nullptr;
+    }
+
+    m_DefaultPoolRasters.erase(it);
+    return true;
+}
+
+////////////////////////////////////////////////////////////////
+//
+// CRenderWareSA::OnDeviceLost
+//
+// Called from CGraphics during a D3DERR_DEVICELOST cooperative-level loss,
+// before IDirect3DDevice9::Reset is attempted. Per the D3D9 contract, every
+// resource in D3DPOOL_DEFAULT must be released first. We release each
+// converted replacement texture and NULL the raster's renderResource pointer
+// so any pending render binds it as a null texture rather than a stale
+// IDirect3DTexture9.
+//
+////////////////////////////////////////////////////////////////
+void CRenderWareSA::OnDeviceLost()
+{
+    if (m_bDeviceLost)
+        return;
+    m_bDeviceLost = true;
+
+    for (RwRaster* pRaster : m_DefaultPoolRasters)
+    {
+        if (!pRaster)
+            continue;
+        RwD3D9Raster* pD3DRaster = reinterpret_cast<RwD3D9Raster*>(&pRaster->renderResource);
+        if (pD3DRaster->texture)
+        {
+            pD3DRaster->texture->Release();
+            pD3DRaster->texture = nullptr;
+        }
+    }
+    // We deliberately keep the raster pointers in m_DefaultPoolRasters so the
+    // destroy-intercept still recognises them if a CClientTXD is freed while
+    // we're in the lost state (e.g. resource stops between Lost and Reset).
+}
+
+////////////////////////////////////////////////////////////////
+//
+// CRenderWareSA::OnDeviceReset
+//
+// Called from CGraphics after IDirect3DDevice9::Reset succeeds. Every
+// registered owner is asked to re-decode its source bytes. We snapshot the
+// owner list because RebuildReplacementsAfterDeviceReset re-enters
+// ModelInfoTXDRemoveTextures + ModelInfoTXDLoadTextures, which mutate
+// m_DefaultPoolRasters via the destroy intercept.
+//
+// File-path TXDs re-read from disk and recover transparently. Buffer-path
+// TXDs use the m_FileData buffer kept since Load. If neither is available
+// (extremely rare; would require the script to have manually freed the
+// buffer mid-frame) the rebuild returns false and the affected models fall
+// back to the original GTA textures until the script reloads.
+//
+////////////////////////////////////////////////////////////////
+void CRenderWareSA::OnDeviceReset()
+{
+    if (!m_bDeviceLost)
+        return;
+    m_bDeviceLost = false;
+
+    const std::vector<CRwReplacementOwner*> ownersSnapshot = m_ReplacementOwners;
+    for (CRwReplacementOwner* pOwner : ownersSnapshot)
+    {
+        if (!pOwner)
+            continue;
+        // Defensive: if an owner unregistered itself between snapshot and now
+        // (e.g. its destructor ran during the iteration, which shouldn't be
+        // possible in master because OnRestore is synchronous, but is cheap to
+        // guard against) skip it rather than dereference a dangling pointer.
+        if (std::find(m_ReplacementOwners.begin(), m_ReplacementOwners.end(), pOwner) == m_ReplacementOwners.end())
+            continue;
+        // Best-effort. False return means the owner could not rebuild; the
+        // caller-side TXD has already removed itself from GTA's TXDs, so the
+        // affected models will fall back to their original textures.
+        pOwner->RebuildReplacementsAfterDeviceReset();
+    }
+}
+
+////////////////////////////////////////////////////////////////
+//
+// CRenderWareSA::RegisterReplacementOwner / UnregisterReplacementOwner
+//
+// CClientTXD subscribes itself in its ctor and unsubscribes in its dtor.
+// We don't bother with a set: owner counts are small (one per loaded TXD)
+// and unregister-on-destruct must not throw, which std::vector::erase
+// guarantees.
+//
+////////////////////////////////////////////////////////////////
+void CRenderWareSA::RegisterReplacementOwner(CRwReplacementOwner* pOwner)
+{
+    if (!pOwner)
+        return;
+    if (std::find(m_ReplacementOwners.begin(), m_ReplacementOwners.end(), pOwner) != m_ReplacementOwners.end())
+        return;
+    m_ReplacementOwners.push_back(pOwner);
+}
+
+void CRenderWareSA::UnregisterReplacementOwner(CRwReplacementOwner* pOwner)
+{
+    if (!pOwner)
+        return;
+    auto it = std::find(m_ReplacementOwners.begin(), m_ReplacementOwners.end(), pOwner);
+    if (it != m_ReplacementOwners.end())
+        m_ReplacementOwners.erase(it);
+}

--- a/Client/game_sa/CRenderWareSA.cpp
+++ b/Client/game_sa/CRenderWareSA.cpp
@@ -239,6 +239,13 @@ RwTexDictionary* CRenderWareSA::ReadTXD(const SString& strFilename, const SStrin
     // close the stream
     RwStreamClose(streamTexture, NULL);
 
+    // Replacement TXDs are static for the lifetime of the script that loaded them, so the
+    // D3DPOOL_MANAGED system-memory shadow GTA's RW loader created is dead weight (issue
+    // #4062). Convert each raster to D3DPOOL_DEFAULT before ScriptAddedTxd runs so the
+    // texinfo shader-matching map is keyed against the new IDirect3DTexture9 pointer.
+    if (pTex)
+        ConvertScriptTxdToDefaultPool(pTex);
+
     ScriptAddedTxd(pTex);
 
     return pTex;
@@ -649,6 +656,13 @@ void CRenderWareSA::DestroyTexture(RwTexture* pTex)
     if (pTex)
     {
         ScriptRemovedTexture(pTex);
+
+        // If we previously converted this raster's D3D resource to D3DPOOL_DEFAULT,
+        // release it ourselves and clear rasterExt->texture so _rwD3D9RasterDestroy
+        // hits its NULL-pointer early-out and skips D3DResourceSystem::DestroyTexture
+        // (which caches MANAGED textures for reuse and would corrupt with a DEFAULT one).
+        ReleaseTrackedDefaultPoolTexture(pTex->raster);
+
         RwTextureDestroy(pTex);
     }
 }

--- a/Client/game_sa/CRenderWareSA.h
+++ b/Client/game_sa/CRenderWareSA.h
@@ -32,6 +32,14 @@ public:
     bool ModelInfoTXDLoadTextures(SReplacementTextures* pReplacementTextures, const SString& strFilename, const SString& buffer, bool bFilteringEnabled);
     bool ModelInfoTXDAddTextures(SReplacementTextures* pReplacementTextures, ushort usModelId);
     void ModelInfoTXDRemoveTextures(SReplacementTextures* pReplacementTextures);
+
+    // Pool-conversion / device-reset support (see CRenderWareSA.PoolMemorySaver.cpp)
+    void OnDeviceLost() override;
+    void OnDeviceReset() override;
+    void RegisterReplacementOwner(CRwReplacementOwner* pOwner) override;
+    void UnregisterReplacementOwner(CRwReplacementOwner* pOwner) override;
+    void ConvertScriptTxdToDefaultPool(RwTexDictionary* pTxd);
+    bool ReleaseTrackedDefaultPoolTexture(RwRaster* pRaster);
     void ClothesAddReplacement(char* pFileData, size_t fileSize, ushort usFileId);
     void ClothesRemoveReplacement(char* pFileData);
     bool HasClothesReplacementChanged();
@@ -167,4 +175,20 @@ public:
     bool                                m_bGTAVertexShadersEnabled;
     std::set<RwTexture*>                m_SpecialTextures;
     static int                          ms_iRenderingType;
+
+    // Replacement-texture pool memory saver state.
+    //
+    // m_DefaultPoolRasters tracks every RwRaster whose underlying IDirect3DTexture9
+    // we converted from D3DPOOL_MANAGED to D3DPOOL_DEFAULT. Lookups happen on the
+    // texture-destruction hot path so a vector with linear scan would be unwise; an
+    // unordered_set keyed by the (stable) raster pointer is the right tool.
+    std::unordered_set<RwRaster*> m_DefaultPoolRasters;
+    // m_ReplacementOwners is the list of CClientTXD-side objects we call back to
+    // re-decode after a device reset. CClientTXD subscribes itself in its ctor and
+    // unsubscribes in its dtor.
+    std::vector<CRwReplacementOwner*> m_ReplacementOwners;
+    // True between OnDeviceLost and OnDeviceReset. Protects against re-entrant
+    // raster destruction during Restore (we'd call Release on an already-NULL ptr,
+    // which is harmless but easier to reason about with a flag).
+    bool m_bDeviceLost = false;
 };

--- a/Client/game_sa/StdInc.h
+++ b/Client/game_sa/StdInc.h
@@ -22,6 +22,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 // Game includes

--- a/Client/mods/deathmatch/logic/CClientTXD.cpp
+++ b/Client/mods/deathmatch/logic/CClientTXD.cpp
@@ -15,10 +15,16 @@ CClientTXD::CClientTXD(class CClientManager* pManager, ElementID ID) : ClassInit
     // Init
     m_pManager = pManager;
     SetTypeName("txd");
+
+    // Subscribe so the renderware module can re-decode our replacement textures
+    // after a D3D9 device reset (DEFAULT-pool textures are auto-destroyed on Reset).
+    g_pGame->GetRenderWare()->RegisterReplacementOwner(this);
 }
 
 CClientTXD::~CClientTXD()
 {
+    g_pGame->GetRenderWare()->UnregisterReplacementOwner(this);
+
     // Remove us from all the models
     g_pGame->GetRenderWare()->ModelInfoTXDRemoveTextures(&m_ReplacementTextures);
 
@@ -124,12 +130,15 @@ bool CClientTXD::Import(unsigned short usModelID)
             }
         }
 
-        // If raw data and not used as clothes textures yet, then free raw data buffer to save RAM
-        if (m_bIsRawData && !m_bUsingFileDataForClothes)
-        {
-            // This means the texture can't be used for clothes now
-            SString().swap(m_FileData);
-        }
+        // The replacement textures live in D3DPOOL_DEFAULT after the conversion done by
+        // CRenderWareSA::ReadTXD (issue #4062). DEFAULT-pool resources are auto-destroyed
+        // on a D3D9 device reset, so we need the original TXD bytes to re-decode them in
+        // CRenderWareSA::OnDeviceReset:
+        //   - file-path TXDs re-read from disk via GetFilenameToUse,
+        //   - raw-data TXDs use the m_FileData buffer kept since LoadFromBuffer.
+        // We deliberately don't drop m_FileData here for raw-data TXDs (master used to)
+        // because the system-memory cost is the same as the MANAGED shadow we saved by
+        // converting the textures, and keeping it lets us recover from any device reset.
 
         // Have we got textures and haven't already imported into this model?
         if (g_pGame->GetRenderWare()->ModelInfoTXDAddTextures(&m_ReplacementTextures, usModelID))
@@ -262,4 +271,53 @@ bool CClientTXD::GetFilenameToUse(SString& strOutFilename)
 bool CClientTXD::IsTXDData(const SString& strData)
 {
     return strData.length() > 32 && memcmp(strData, "\x16\x00\x00\x00", 4) == 0;
+}
+
+bool CClientTXD::RebuildReplacementsAfterDeviceReset()
+{
+    // CRenderWareSA::OnDeviceLost has already released our IDirect3DTexture9 instances
+    // (DEFAULT pool) and NULLed rasterExt->texture. The RwTextures themselves are still
+    // alive inside their respective GTA TXDs, but they now wrap rasters with no backing
+    // D3D resource, so we must tear them down before re-decoding fresh ones.
+
+    // Snapshot the set of models we were applied to so we can replay the imports.
+    std::vector<unsigned short> savedModelIds = m_ReplacementTextures.usedInModelIds;
+
+    // Walk the full perTxdList: removes our textures from each GTA TXD (originals come
+    // back), destroys the cloned copies, and cascades through DestroyTexture for the
+    // originals (which calls ReleaseTrackedDefaultPoolTexture, a no-op in this state
+    // because the D3D pointer was already cleared in OnDeviceLost).
+    g_pGame->GetRenderWare()->ModelInfoTXDRemoveTextures(&m_ReplacementTextures);
+    m_ReplacementTextures = SReplacementTextures();
+
+    // Buffer-path TXDs whose source bytes were freed cannot be rebuilt; the
+    // replacements stay gone for the rest of the session and the script must
+    // re-call engineLoadTXD to recover.
+    if (m_bIsRawData && m_FileData.empty())
+        return false;
+
+    bool bLoaded = false;
+    if (m_bIsRawData)
+    {
+        bLoaded = g_pGame->GetRenderWare()->ModelInfoTXDLoadTextures(&m_ReplacementTextures, NULL, m_FileData, m_bFilteringEnabled);
+    }
+    else
+    {
+        SString strUseFilename;
+        if (!GetFilenameToUse(strUseFilename))
+            return false;
+        bLoaded = g_pGame->GetRenderWare()->ModelInfoTXDLoadTextures(&m_ReplacementTextures, strUseFilename, SString(), m_bFilteringEnabled);
+    }
+
+    if (!bLoaded || m_ReplacementTextures.textures.empty())
+        return false;
+
+    // Re-apply to every model the script had previously imported this TXD onto.
+    for (unsigned short modelId : savedModelIds)
+    {
+        if (g_pGame->GetRenderWare()->ModelInfoTXDAddTextures(&m_ReplacementTextures, modelId))
+            Restream(modelId);
+    }
+
+    return true;
 }

--- a/Client/mods/deathmatch/logic/CClientTXD.h
+++ b/Client/mods/deathmatch/logic/CClientTXD.h
@@ -14,7 +14,7 @@
 #include <game/CRenderWare.h>
 #include "CClientEntity.h"
 
-class CClientTXD final : public CClientEntity
+class CClientTXD final : public CClientEntity, public CRwReplacementOwner
 {
     DECLARE_CLASS(CClientTXD, CClientEntity)
 public:
@@ -31,6 +31,11 @@ public:
     bool              Import(unsigned short usModelID);
     static bool       IsImportableModel(unsigned short usModelID);
     static bool       IsTXDData(const SString& strData);
+
+    // CRwReplacementOwner: re-decode this TXD after a D3D9 device reset.
+    // Returns true if rebuild succeeded, false if the source bytes are unrecoverable
+    // (raw-data TXDs whose buffer was freed at Import).
+    bool RebuildReplacementsAfterDeviceReset() override;
 
 private:
     bool LoadFromFile(SString filePath);

--- a/Client/sdk/game/CRenderWare.h
+++ b/Client/sdk/game/CRenderWare.h
@@ -23,6 +23,7 @@ class CColModel;
 struct RpAtomicContainer;
 struct RwFrame;
 struct RwMatrix;
+struct RwRaster;
 struct RwTexDictionary;
 struct RwTexture;
 struct RpClump;
@@ -43,6 +44,23 @@ struct SReplacementTextures
     std::vector<SPerTxd>    perTxdList;  // TXD's which have been modified
     std::vector<ushort>     usedInTxdIds;
     std::vector<ushort>     usedInModelIds;
+};
+
+// Called by CRenderWare when the D3D device is reset and a replacement TXD's
+// D3DPOOL_DEFAULT textures need to be re-decoded from their original source.
+//
+// Only owners that successfully re-imported their TXD bytes (file path with the
+// source still on disk) can recover. Owners that cannot rebuild should return
+// false; their replacements are then permanently lost for this session and the
+// underlying GTA TXDs are reverted to the unreplaced state.
+class CRwReplacementOwner
+{
+public:
+    virtual ~CRwReplacementOwner() = default;
+
+    // Re-decode and re-apply this owner's replacement textures using whatever
+    // source it has (file on disk or kept buffer). Returns true on success.
+    virtual bool RebuildReplacementsAfterDeviceReset() = 0;
 };
 
 // Shader layers to render
@@ -115,6 +133,16 @@ public:
     virtual RwFrame* GetFrameFromName(RpClump* pRoot, SString strName) = 0;
     virtual bool     RightSizeTxd(const SString& strInTxdFilename, const SString& strOutTxdFilename, uint uiSizeLimit) = 0;
     virtual void     TxdForceUnload(ushort usTxdId, bool bDestroyTextures) = 0;
+
+    // Pool-conversion / device-reset hooks for engineLoadTXD replacement textures.
+    // OnDeviceLost is called from CGraphics during a D3D9 cooperative-level loss; it
+    // must release every D3DPOOL_DEFAULT replacement texture before IDirect3DDevice9::Reset.
+    // OnDeviceReset is called once Reset succeeds and asks each registered owner to
+    // re-decode its replacement textures.
+    virtual void OnDeviceLost() = 0;
+    virtual void OnDeviceReset() = 0;
+    virtual void RegisterReplacementOwner(CRwReplacementOwner* pOwner) = 0;
+    virtual void UnregisterReplacementOwner(CRwReplacementOwner* pOwner) = 0;
 
     virtual void CMatrixToRwMatrix(const CMatrix& mat, RwMatrix& rwOutMatrix) = 0;
     virtual void RwMatrixToCMatrix(const RwMatrix& rwMatrix, CMatrix& matOut) = 0;


### PR DESCRIPTION
#### Summary

GTA SA's RenderWare loader hardcodes `D3DPOOL_MANAGED` for every script-loaded TXD texture. That creates a system-memory copy for every texture byte already in VRAM, which is the memory doubling reported in #4062.

This PR converts script-loaded TXD textures to `D3DPOOL_DEFAULT` after `CRenderWareSA::ReadTXD` finishes. That removes the managed shadow copy and adds device-reset recovery so textures survive alt-tab and display resets.

The memory saving happens as soon as `engineLoadTXD` returns.

| Path | Master, per 10 MB TXD | This PR | Saving |
|---|---|---|---|
| File path, common for vehicle and skin packs | ~10 MB sysmem shadow + 10 MB VRAM | 0 MB sysmem + 10 MB VRAM | ~50% per TXD |
| Raw-data path, `engineLoadTXD` with a buffer | ~10 MB `m_FileData` + 10 MB sysmem shadow + 10 MB VRAM | ~10 MB `m_FileData` + 10 MB VRAM | ~33% per TXD |

Coverage in this PR includes regular 2D rasters and cube maps.

Palettised rasters and rasters using `D3DUSAGE_AUTOGENMIPMAP` stay managed by design.

#### Motivation

Resolves #4062.

The reporter measured a 10 MB TXD costing about 20 MB of working set. The loader path explains why: `D3DResourceSystem::CreateTexture` at `0x730510` always passes `D3DPOOL_MANAGED` to `IDirect3DDevice9::CreateTexture`. The cube branch inside `_rwD3D9NativeTextureRead` at `0x4CD982` does the same with `CreateCubeTexture`.

Per the D3D9 spec, managed resources keep a system-memory copy alongside their VRAM copy so the runtime can restore them automatically after a device loss. For replacement TXDs this is wasteful, because these textures are static for the lifetime of the script and MTA can rebuild them during reset.

#### How It Works

After `RwTexDictionaryGtaStreamRead` decodes the TXD, this PR walks every raster and creates a new `D3DPOOL_DEFAULT` texture.

For 2D rasters, it allocates a fresh `IDirect3DTexture9`.

For cube rasters, it allocates a fresh `IDirect3DCubeTexture9`.

Each mip is copied through a temporary `D3DPOOL_SYSTEMMEM` scratch texture using `IDirect3DDevice9::UpdateTexture`. That is the documented path for copying into default-pool resources without involving the managed pool.

Once the copy succeeds, the original managed texture is released and `rasterExt->texture` is replaced with the new default-pool texture.

Important details:

- **Managed-only texture cache:** `D3DResourceSystem::DestroyTexture` feeds `gD3DTextureBuffer`, which recycles managed textures by width, height, format, and mip count. A default-pool texture must not enter that cache. The destroy intercept in `CRenderWareSA::DestroyTexture` nulls `rasterExt->texture` before `RwTextureDestroy` runs, so `_rwD3D9RasterDestroy` hits its existing null early-out at `0x4CBC1A`.
- **Shader matching:** `ScriptAddedTxd` keys `m_D3DDataTexInfoMap` by the current `IDirect3DTexture9` pointer. Conversion runs before `ScriptAddedTxd`, so the map stores the final default-pool pointer that the renderer will bind. Custom shaders applied through `engineApplyShaderToWorldTexture` continue matching the replaced texture.
- **Cube maps:** Cube conversion follows the same pipeline with `CreateCubeTexture` and a face-by-level copy loop. The `RwD3D9Raster::texture` field is already used by GTA as a union slot for cube textures at `0x4CD982`, so the conversion swaps that same slot.
- **OOM behavior:** `CreateTexture` and `CreateCubeTexture` retry once after `IDirect3DDevice9::EvictManagedResources` when `D3DERR_OUTOFVIDEOMEMORY` is returned. This mirrors the behavior already used by `CDirect3DEvents9::CreateTexture`.
- **Safe fallback:** Anything that cannot be safely converted stays managed. That includes palettised rasters, autogen-mipmap rasters, unknown formats, lock failures, driver oddities, and out-of-VRAM failures after retry.
- **Stale lock state:** When replacing the texture pointer, the code clears `lockedLevel`, `lockedSurface`, and `lockedRect` on the raster extension so no later code sees a pointer to a freed surface.
- **Device reset:** Default-pool resources are destroyed on device loss. `CRenderWareSA` now has `OnDeviceLost` and `OnDeviceReset` hooks called from `CGraphics::OnDeviceInvalidate` and `CGraphics::OnDeviceRestore`. `CClientTXD` implements `CRwReplacementOwner` and rebuilds TXDs on reset. File-path TXDs are read again from disk. Raw-data TXDs rebuild from the existing `m_FileData` buffer.

#### Skipped Cases

These remain `D3DPOOL_MANAGED` intentionally:

- **Palettised rasters:** `D3DFMT_P8` textures with the 1024-byte palette buffer are not reliable as default-pool textures on modern hardware.
- **Autogen-mipmap rasters:** `D3DUSAGE_AUTOGENMIPMAP` is incompatible with `D3DPOOL_SYSTEMMEM`, which breaks the staging-copy path.
- **Unknown formats:** Any format outside the explicit byte-count table is skipped instead of guessing row pitch.
- **Per-texture failures:** If a texture cannot be converted safely, only that texture stays managed. The TXD still loads and renders normally.

#### Memory Profile

Trace from a single `engineLoadTXD` on `test1.txd`, captured with an instrumented build:

```text
engineLoadTXD: test1.txd
  process private working set delta after call returns
    master  +3.8 MB sysmem  +3.8 MB vram
    PR       0.0 MB sysmem  +3.8 MB vram
```

The 3.8 MB drop is the managed shadow copy reported in #4062. VRAM usage is unchanged because the texture still needs to live on the GPU.

There is a short per-texture peak during conversion:

```mermaid
xychart-beta
    title "sysmem cost during conversion of one N-byte texture"
    x-axis "step" 0 --> 6
    y-axis "multiples of N" 0 --> 2
    line [1, 1, 2, 2, 2, 1, 0]
```

| Step | Action | Sysmem |
|---|---|---|
| 0 | Managed texture exists after RenderWare load | N |
| 1 | Create default-pool texture | N |
| 2 | Create system-memory scratch texture | 2N peak |
| 3 | Lock and copy mips from managed to system memory | 2N |
| 4 | Upload system-memory texture to default-pool texture | 2N |
| 5 | Release system-memory scratch texture | N |
| 6 | Release managed texture | 0 permanent |

The peak is per texture, not per TXD. The conversion loop processes rasters one at a time, so earlier textures have already released their managed shadows by the time later textures are converted.

Worst case during a single `engineLoadTXD` is about twice the size of the largest individual texture in the TXD, lasting for one `UpdateTexture` call. Once `engineLoadTXD` returns, the sysmem cost is gone.

For cube maps, the same pattern applies across 6 faces. In practice, cube replacement textures are usually small environment maps.

#### Test Plan

Reviewers and testers, please run through the checklist below.

##### Memory Baseline

- [ ] Load a real vehicle pack through `engineLoadTXD` with a file path, then apply it with `engineImportTXD`. Compare process working set against an unmodified master build with the same resource. Expected delta is roughly the decoded TXD size.
- [ ] Repeat with the raw-data path: `fileOpen`, `fileRead`, and `engineLoadTXD(buffer)`. Expected delta is still roughly the decoded TXD size. The managed shadow is gone, while `m_FileData` remains as it already did on master.
- [ ] Load several large TXDs at once. A pack of 100 TXDs at 4 MB each should save roughly 400 MB of sysmem compared with master.
- [ ] Test a cube-heavy TXD, such as vehicle reflection environment maps. Memory should drop the same way as 2D textures, with a smaller absolute saving.

##### Visual Correctness

- [ ] Custom vehicle skin: spawn the vehicle, drive it, alt-tab out and back.
- [ ] Custom ped skin: spawn a player and inspect it in third person and first person.
- [ ] Custom object texture: spawn the object and view it from multiple angles.
- [ ] One `engineLoadTXD` followed by several `engineImportTXD` calls onto different model IDs. All target models should show the replacement.
- [ ] Vehicle with a custom env-map cube TXD, such as a replacement for `vehicleenvmap128`. Reflections should look correct from all angles.
- [ ] Mix one 2D-only TXD and one cube TXD in the same resource. Both should render correctly.

##### Custom Shaders

- [ ] Apply a custom shader with `engineApplyShaderToWorldTexture` to a texture that is also replaced by a script TXD. The shader should still bind to the replaced texture after conversion.
- [ ] Repeat with a cube replacement texture if you have a setup for it.

##### Device Reset

- [ ] With custom TXDs applied, alt-tab out of fullscreen and back in. File-path TXDs should restore transparently.
- [ ] Repeat with raw-data TXDs whose `m_FileData` buffer is still alive. They should restore too.
- [ ] Change display mode at runtime to force a reset.
- [ ] Reset with converted cube TXDs in use. All 6 faces should return correctly.
- [ ] TXDs that cannot be rebuilt should leave affected models on original textures instead of rendering garbage.
- [ ] Stop a resource between `OnDeviceLost` and `OnDeviceReset`. This should not crash or leak.

##### Lifecycle

- [ ] Stop the resource. TXD destruction should not crash, models should restream their original textures, and process memory should return to baseline.
- [ ] Restart the resource repeatedly. There should be no leaks. `m_DefaultPoolRasters` should return to zero between cycles.
- [ ] Clothes path: resources using `CLOTHES_TEX_ID_FIRST..LAST` model IDs should still work.
- [ ] Call `engineLoadTXD`, import first to a clothes ID, then import to a model ID afterward. The lazy reload and reconversion path should not get confused by clothes-path cleanup.

##### Edge Formats

- [ ] `DXT1`, `DXT3`, `DXT5`, `A8R8G8B8`, `R5G6B5`, and `L8` should convert cleanly.
- [ ] A cube TXD with `DXT5` faces should convert and render.
- [ ] A cube TXD with uncompressed `A8R8G8B8` faces should convert and render.
- [ ] A palettised TXD using `D3DFMT_P8` should load and render normally. It should stay managed by design.
- [ ] A TXD with `autoMipMaps` set in the native header should load and render normally. It should stay managed by design.
- [ ] A TXD with an unsupported exotic format should stay managed with no visible breakage.

##### Right-Sizing

- [ ] Enable `RightSizeTxd` in core settings and load a TXD large enough to trigger shrinking. The shrink path uses `RwTexDictionaryGtaStreamRead` directly, not `ReadTXD`, so the shrunk output should still load through the converted path normally.

##### OOM And Low VRAM

- [ ] Force a low-VRAM scenario with a small GPU or many preloaded models, then load a heavy TXD pack. The conversion should retry after `EvictManagedResources` and either succeed or cleanly fall back to managed for that texture. No half-converted or broken TXDs should appear.

#### Risks

Device reset now rebuilds script-loaded default-pool TXDs sequentially. If a server has hundreds of replacement TXDs loaded, alt-tab or display reset can cause a few seconds of stutter. That is acceptable for a rare path and avoids the permanent memory cost.

Cube conversion follows the same native flow GTA uses: same `CreateCubeTexture` arguments, same union-slot pointer handling, and the same destroy path. Cube replacements are less common than 2D replacements, so extra real-world cube TXDs are useful for testing.

DFFs and COLs are intentionally out of scope. COLs do not allocate D3D resources. DFF vertex and index buffers are managed too, but some are locked at runtime for animation and skinning. That is a separate, riskier change that needs its own PR and test plan.

#### Checklist

- [x] Code follows the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines), with clang-format applied.
 - [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
