### PR TITLE
Fix vehicle corona/shadow flicker on fogless to foggy weather blend

### DIFF
--- a/Client/game_sa/CWeatherSA.cpp
+++ b/Client/game_sa/CWeatherSA.cpp
@@ -30,13 +30,20 @@ void CWeatherSA::ResyncInterpolationWithGameClock(unsigned char primary, unsigne
     // CWeather::InterpolationValue — see plugin_sa CWeather.cpp (0xC8130C)
     constexpr DWORD VAR_InterpolationValue = 0xC8130C;
     constexpr DWORD VAR_TimeMinutes = 0xB70152;
+    constexpr DWORD VAR_TimeSeconds = 0xB70150;
 
     if (primary == secondary)
         MemPutFast<float>(VAR_InterpolationValue, 0.0f);
     else
     {
+        // Match the value CWeather::Update derives at 0x72B897:
+        //   v0 = (seconds / 60 + minutes) / 60
+        // Snapping to minutes only would drop seconds and make CTimeCycle::CalcColoursForPoint
+        // step m_CurrentColours per game-minute, which surfaces as flicker on vehicle coronas
+        // (m_fSpriteBrightness) and shadows (m_wShadowStrength) when the clock runs fast.
         const auto  ucMinute = *reinterpret_cast<unsigned char*>(VAR_TimeMinutes);
-        const float fInterp = std::min(1.f, static_cast<float>(ucMinute) / 60.f);
+        const auto  ucSecond = *reinterpret_cast<unsigned char*>(VAR_TimeSeconds);
+        const float fInterp = std::min(1.f, static_cast<float>(ucMinute) / 60.f + static_cast<float>(ucSecond) / 3600.f);
         MemPutFast<float>(VAR_InterpolationValue, fInterp);
     }
 }

--- a/Client/mods/deathmatch/logic/CBlendedWeather.cpp
+++ b/Client/mods/deathmatch/logic/CBlendedWeather.cpp
@@ -58,8 +58,9 @@ void CBlendedWeather::DoPulse()
 
     m_pWeather->Set(ucPrimary, ucSecondary);
     // CWeather::Update (before this pulse) advances InterpolationValue for its own Old/New pair.
-    // After we overwrite Old/New with MTA's state, keep the blend weight aligned with the game
-    // clock so reflective/translucent materials (e.g. glass windows) match the sky (#4803).
+    // After we overwrite Old/New with MTA's state, mirror the value CWeather::Update would derive
+    // (seconds/3600 + minutes/60) so CTimeCycle::CalcColoursForPoint blends m_CurrentColours
+    // smoothly per frame instead of stepping per game-minute (#4803).
     m_pWeather->ResyncInterpolationWithGameClock(ucPrimary, ucSecondary);
 }
 


### PR DESCRIPTION
#### Summary

Include `CClock::ms_nGameClockSeconds` in `CWeatherSA::ResyncInterpolationWithGameClock` so `CWeather::InterpolationValue` matches the value `CWeather::Update` derives (`seconds/3600 + minutes/60`).

#### Motivation

Follow-up to #4882. Residual flicker on vehicle coronas and shadows during fogless to foggy weather blends (e.g. `SUNNY_COUNTRYSIDE` to `FOGGY_SF` reported by rx).

The previous resync snapped `InterpolationValue` to `minute/60` only. `CTimeCycle::CalcColoursForPoint` then blended `m_CurrentColours` between the weather pair using that snapped value, so:

- `m_CurrentColours.m_fSpriteBrightness` (read by `CEntity::ProcessLightsForEntity` at `0x6FCF83` for vehicle corona intensity)
- `m_CurrentColours.m_wShadowStrength` (read by `CShadows::StoreShadowForVehicle` at `0x70BDB9` for vehicle shadow intensity)

both updated in per-game-minute steps. With fast game clocks one game-minute is a fraction of a real second, so the steps surfaced as visible flicker on cars. `CWeather::Foggyness` itself was already smooth (it uses `v0`), which is why building lights and most other weather-driven values were fixed by #4882.

Adding seconds keeps the wrap-suppression intact (`v0 >= InterpolationValue` still holds, equal) and lets `m_CurrentColours` interpolate smoothly each frame.

#### Test plan

1. On a fast-clock server, set weather with `setWeatherBlended` from a fogless weather (e.g. `14` SUNNY_COUNTRYSIDE) to a foggy one (e.g. `9` FOGGY_SF).
2. Drive past a parked vehicle and watch its coronas and ground shadow during the blend hour.
3. Expected: brightness/shadow strength change smoothly, no per-tick flicker.
4. Confirm building lights, sky, and reflective surfaces from #4882 still behave correctly.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
