### PR TITLE
Filter WER crash dialogs to fail-fast exceptions only

### DIFF
--- a/Client/loader/CInstallManager.cpp
+++ b/Client/loader/CInstallManager.cpp
@@ -650,6 +650,15 @@ SString CInstallManager::_CheckForWerCrash()
         {
             const auto  regs = WerCrash::ExtractRegistersFromMinidump(fullPath);
             const DWORD exceptionCode = regs.valid ? regs.exceptionCode : EXCEPTION_STACK_BUFFER_OVERRUN;
+
+            // Skip non-fail-fast dumps (e.g. 0xE06D7363 C++ exceptions) -
+            // those are handled by the normal crash handler, not the WER path.
+            if (regs.valid && exceptionCode != EXCEPTION_STACK_BUFFER_OVERRUN && exceptionCode != EXCEPTION_HEAP_CORRUPTION)
+            {
+                OutputDebugStringA(SString("_CheckForWerCrash: Skipping dump %s with non-fail-fast exception code 0x%08X\n", dumpFile.c_str(), exceptionCode));
+                continue;
+            }
+
             const char* exceptionName = (exceptionCode == EXCEPTION_STACK_BUFFER_OVERRUN) ? "Stack Buffer Overrun"
                                         : (exceptionCode == EXCEPTION_HEAP_CORRUPTION)    ? "Heap Corruption"
                                                                                           : "Security Exception";
@@ -796,6 +805,16 @@ SString CInstallManager::_CheckForWerCrash()
 
                 const auto  regs = WerCrash::ExtractRegistersFromMinidump(fullPath);
                 const DWORD exceptionCode = regs.valid ? regs.exceptionCode : EXCEPTION_STACK_BUFFER_OVERRUN;
+
+                // Skip non-fail-fast dumps (e.g. 0xE06D7363 C++ exceptions) -
+                // those are handled by the normal crash handler, not the WER path.
+                if (regs.valid && exceptionCode != EXCEPTION_STACK_BUFFER_OVERRUN && exceptionCode != EXCEPTION_HEAP_CORRUPTION)
+                {
+                    OutputDebugStringA(
+                        SString("_CheckForWerCrash: Skipping WER dump %s with non-fail-fast exception code 0x%08X\n", dumpFile.c_str(), exceptionCode));
+                    continue;
+                }
+
                 const char* exceptionName = (exceptionCode == EXCEPTION_STACK_BUFFER_OVERRUN) ? "Stack Buffer Overrun"
                                             : (exceptionCode == EXCEPTION_HEAP_CORRUPTION)    ? "Heap Corruption"
                                                                                               : "Security Exception";


### PR DESCRIPTION
_CheckForWerCrash picks up any .dmp file in the private dumps folder and shows a "Security Exception" crash dialog on the next launch. The problem is it doesn't check what kind of exception the dump actually contains - so a C++ exception (like a CEGUI texture load failure, 0xE06D7363) that got dumped by WER would show up as a delayed crash dialog on the next MTA launch, even though the game kept running fine as it wasn't a fatal exception at the time it happened.

Now it checks the exception code in the dump and skips anything that isn't a real fail-fast (0xC0000409 / 0xC0000374). This stops irrelevant crash dialogs from appearing on the next launch when no actual crash happened.