### PR TITLE
Reliability fixes for nickname valid-checks on client and server

### DIFF
--- a/Client/core/CConnectManager.cpp
+++ b/Client/core/CConnectManager.cpp
@@ -450,6 +450,8 @@ bool CConnectManager::CheckNickProvided(const char* szNick)
         return false;
     if (stricmp(szNick, "server") == 0)
         return false;
+    if (strchr(szNick, '`') != nullptr)
+        return false;
     return true;
 }
 

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -1627,6 +1627,10 @@ bool CClientGame::IsNickValid(const char* szNick)
         {
             return false;
         }
+        if (ucTemp == '`')  // Match server-side CheckNickProvided backtick rejection
+        {
+            return false;
+        }
     }
 
     // Nickname is valid, return true

--- a/Server/mods/deathmatch/logic/packets/CPlayerJoinDataPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerJoinDataPacket.cpp
@@ -21,7 +21,8 @@ bool CPlayerJoinDataPacket::Read(NetBitStreamInterface& BitStream)
     if (!BitStream.Read(m_usBitStreamVersion))
         return false;
 
-    BitStream.ReadString(m_strPlayerVersion);
+    if (!BitStream.ReadString(m_strPlayerVersion))
+        return false;
 
     m_bOptionalUpdateInfoRequired = BitStream.ReadBit();
 


### PR DESCRIPTION
Reliability fixes for nickname valid-checks on client and server

Fix 1: Backtick validation gap (client)
Added strchr(szNick, '') != nullptrcheck to the client's CheckNickProvided, matching the server's version in Shared/Utils.cpp. Previously, a nickname containing a backtick passed all client-side checks, was serialized correctly, and then got rejected server-side with INVALID_NICKNAME.

Fix 2: Unchecked ReadString (server)
Added return-value check on BitStream.ReadString(m_strPlayerVersion). If this read fails (corrupted length prefix from a shifted bitstream), it now returns false immediately instead of continung to parse the nickname and subsequent fields from a wrong offset. This prevents garbage data from being interpreted as the nickname and triggering an incorrect INVALID_NICKNAME.