### PR TITLE
Use fail-safe ReadBit overload in join packet parser

### DIFF
--- a/Server/mods/deathmatch/logic/packets/CPlayerJoinDataPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerJoinDataPacket.cpp
@@ -24,7 +24,8 @@ bool CPlayerJoinDataPacket::Read(NetBitStreamInterface& BitStream)
     if (!BitStream.ReadString(m_strPlayerVersion))
         return false;
 
-    m_bOptionalUpdateInfoRequired = BitStream.ReadBit();
+    if (!BitStream.ReadBit(m_bOptionalUpdateInfoRequired))
+        return false;
 
     if (BitStream.Read(m_ucGameVersion) && BitStream.ReadStringCharacters(m_strNick, MAX_PLAYER_NICK_LENGTH) &&
         BitStream.Read(reinterpret_cast<char*>(&m_Password), 16))


### PR DESCRIPTION
Use fail-safe ReadBit overload in join packet parser

The no-arg ReadBit() returns the bit value, not a success indicator - on
bitstream exhaustion it silently returns false, not distinguishable from
reading a 0 bit. Switch to the ReadBit(bool&) overload from bitstream.h
which wraps ReadBits internally and properly returns false on exhaustion.

Now, the ReadBit is consistent with every other read in the function, (they all early-return on failure)


**Scenario where it (pre-PR) would be a problem, and how:**

If the bitstream is exhausted:
1) `ReadBit()` returns `false` - indistinguishable from "the bit was 0"
2) The parser continues with `m_bOptionalUpdateInfoRequired = false` instead of failing
3) Subsequent reads operate on garbage/out-of-bounds data, and that will cause unexpected behavior and real problems.