### PR TITLE
Symmetry fix after 6c54a2d: Also update Utils.cpp "IsNickValid"

### DIFF
--- a/Shared/mods/deathmatch/logic/Utils.cpp
+++ b/Shared/mods/deathmatch/logic/Utils.cpp
@@ -931,6 +931,10 @@ bool IsNickValid(const char* szNick)
         {
             return false;
         }
+        if (ucTemp == '`')  // Backtick is rejected to match CheckNickProvided
+        {
+            return false;
+        }
     }
 
     // Nickname is valid, return true


### PR DESCRIPTION
PR #4909 (6c54a2d) forgot about Utils.cpp's IsNickValid and therefore, the use of setPlayerName can still lead to a protocol error.

This PR makes it symmetric.