### PR TITLE
Fix build errors due to deprecations in MSVC 14.51 (Build Tools 18.6.11806.211)

### DIFF
--- a/vendor/cryptopp/integer.cpp
+++ b/vendor/cryptopp/integer.cpp
@@ -3059,7 +3059,7 @@ Integer::Integer(const byte *encodedInteger, size_t byteCount, Signedness s, Byt
 	else
 	{
 		SecByteBlock block(byteCount);
-#if (CRYPTOPP_MSC_VERSION >= 1500)
+#if (CRYPTOPP_MSC_VERSION >= 1500) && defined(_STDEXT_BEGIN)
 		std::reverse_copy(encodedInteger, encodedInteger+byteCount,
 			stdext::make_checked_array_iterator(block.begin(), block.size()));
 #else

--- a/vendor/cryptopp/zdeflate.cpp
+++ b/vendor/cryptopp/zdeflate.cpp
@@ -418,7 +418,7 @@ unsigned int Deflator::LongestMatch(unsigned int &bestMatch) const
 #else
 				std::mismatch
 #endif
-#if CRYPTOPP_MSC_VERSION >= 1600
+#if defined(_STDEXT_BEGIN) && CRYPTOPP_MSC_VERSION >= 1600
 				(stdext::make_unchecked_array_iterator(scan)+3, stdext::make_unchecked_array_iterator(scanEnd), stdext::make_unchecked_array_iterator(match)+3).first - stdext::make_unchecked_array_iterator(scan));
 #else
 				(scan+3, scanEnd, match+3).first - scan);


### PR DESCRIPTION
Fix build errors due to deprecations in MSVC 14.51 (Build Tools 18.6.11806.211), which finally dropped the non-standard stdext namespace from the C++ standard library headers.

_Note: the below description is neatly written (high detail) as it may help other OSS projects facing sudden build errors._

MSVC Build Tools 14.51, shipped just now with Visual Studio 2026 18.6.0 on May 12, 2026, unconditionally removes the non-standard stdext namespace from the C++ standard library headers. This removal is documented in the [MSVC Build Tools 14.51 release notes](https://learn.microsoft.com/en-us/cpp/overview/what-s-new-for-msvc) under "Removed features". For our cryptopp, Windows build agents that upgraded its toolchain as per ccc5d7d, began failing with:

**error C2653: 'stdext': is not a class or namespace name
error C3861: 'make_checked_array_iterator': identifier not found**

Two sites in cryptopp use stdext::make_checked_array_iterator and stdext::make_unchecked_array_iterator behind version guards that were only checking a lower bound, with no upper bound keeping in mind a future removal in MSVC Build Tools 14.51.

Fix: guard both call sites on defined(_STDEXT_BEGIN), a macro the MSVC STL headers define when stdext is present and omit when it is absent. When the macro is not defined - as is the case with MSVC Build Tools 14.51 and later - both sites fall through to their existing raw-pointer else branches, which are functionally identical.
