### PR TITLE
Add weekly automated CEF updater workflow & update to 148.0.7778.180

### DIFF
--- a/.github/workflows/update-cef.yaml
+++ b/.github/workflows/update-cef.yaml
@@ -1,0 +1,86 @@
+name: Update CEF
+
+on:
+  schedule:
+    - cron: "0 8 * * 2"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-cef:
+    if: github.event.repository.fork == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve latest stable minimal build
+        id: cef
+        run: |
+          set -euo pipefail
+          INSTALL_CEF="utils/buildactions/install_cef.lua"
+          CURRENT=$(grep -m1 '^local CEF_VERSION = ' "$INSTALL_CEF" | sed -E 's/.*"(.*)".*/\1/')
+
+          # Stream-parse index.json (not saved); same stable channel as install_cef.lua upgrade
+          LATEST=$(curl -fsSL "https://cef-builds.spotifycdn.com/index.json" | jq -r '
+            [.windows32.versions[] | select(.channel == "stable")]
+            | max_by(.cef_version | capture("^(?<a>[0-9]+)\\.(?<b>[0-9]+)\\.(?<c>[0-9]+)") | [.a, .b, .c] | map(tonumber))
+            | .cef_version
+          ')
+
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
+
+          if [ "$CURRENT" = "$LATEST" ]; then
+            echo "needs_update=false" >> "$GITHUB_OUTPUT"
+            echo "CEF is already up to date ($CURRENT)"
+          else
+            echo "needs_update=true" >> "$GITHUB_OUTPUT"
+            echo "CEF update available: $CURRENT -> $LATEST"
+          fi
+
+      - name: Download minimal build and compute SHA-256
+        if: steps.cef.outputs.needs_update == 'true'
+        id: hash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.cef.outputs.latest }}"
+          URL="https://cef-builds.spotifycdn.com/cef_binary_${VERSION}_windows32_minimal.tar.bz2"
+          ARCHIVE="${{ runner.temp }}/cef_minimal.tar.bz2"
+          curl -fsSL "$URL" -o "$ARCHIVE"
+          echo "hash=$(sha256sum "$ARCHIVE" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
+      - name: Update install_cef.lua
+        if: steps.cef.outputs.needs_update == 'true'
+        run: |
+          set -euo pipefail
+          FILE="utils/buildactions/install_cef.lua"
+          VERSION="${{ steps.cef.outputs.latest }}"
+          HASH="${{ steps.hash.outputs.hash }}"
+          sed -i "s|^local CEF_VERSION = \".*\"|local CEF_VERSION = \"${VERSION}\"|" "$FILE"
+          sed -i "s|^local CEF_HASH = \".*\"|local CEF_HASH = \"${HASH}\"|" "$FILE"
+
+      - name: Open pull request
+        if: steps.cef.outputs.needs_update == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.cef.outputs.latest }}"
+          BRANCH="chore/cef-$(echo "$VERSION" | tr '+/' '-')"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add utils/buildactions/install_cef.lua
+          git commit -m "Update CEF to ${VERSION}" -m "Automated update (stable windows32_minimal)."
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "Update CEF to ${VERSION}" \
+            --body "" \
+            --base master \
+            --head "$BRANCH"

--- a/utils/buildactions/install_cef.lua
+++ b/utils/buildactions/install_cef.lua
@@ -9,8 +9,8 @@ local CEF_URL_PREFIX = "https://cef-builds.spotifycdn.com/cef_binary_"
 local CEF_URL_SUFFIX = "_windows32_minimal.tar.bz2"
 
 -- Change here to update CEF version
-local CEF_VERSION = "147.0.10+gd58e84d+chromium-147.0.7727.118"
-local CEF_HASH = "b6574257645183fe948b2c9471e419a52505c4eb13593422aa25d7b826e8e4d5"
+local CEF_VERSION = "148.0.9+g0d9d52a+chromium-148.0.7778.180"
+local CEF_HASH = "a829016021f92e3fec19e50eb889465919f7dcfe62e6e5355c76be16a24ae247"
 
 -- Stuck in the past for maetro
 if os.getenv("MTA_MAETRO") == "true" then


### PR DESCRIPTION
#### Summary
Added a GitHub Actions workflow that automatically updates CEF every Tuesday at 08:00 CET.
After updating, the workflow automatically creates a pull request containing the changes, allowing maintainers to review and merge it manually.

This makes keeping CEF up-to-date significantly more streamlined and removes the need for manual update handling (except for review and merge).

#### Motivation
Updating CEF manually is repetitive and easy to forget.
By automating the process with a scheduled workflow and automatic PR creation, updates can be delivered faster and more consistently while still preserving manual review before merging.

**Before using it, make sure to verify that `secrets.GITHUB_TOKEN` is configured correctly and working properly (it is already used by another workflow).**

#### Checklist
* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
