### PR TITLE
Fix getVehicleDummyPosition returning 0,0,0 for the second exhaust

### DIFF
--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -5076,13 +5076,21 @@ CVehicleAudioSettingsEntry& CClientVehicle::GetOrCreateAudioSettings()
 
 bool CClientVehicle::GetDummyPosition(VehicleDummies dummy, CVector& position) const
 {
-    if (dummy >= VehicleDummies::LIGHT_FRONT_MAIN && dummy < VehicleDummies::VEHICLE_DUMMY_COUNT)
+    if (dummy < VehicleDummies::LIGHT_FRONT_MAIN || dummy >= VehicleDummies::VEHICLE_DUMMY_COUNT)
+        return false;
+
+    position = m_dummyPositions[(std::size_t)dummy];
+
+    // Most models have no second exhaust dummy, in which case the game mirrors the primary
+    // exhaust on the X axis (see ApplyExhaustParticlesPosition). Reflect that here, so the
+    // reported position matches where the effects actually appear
+    if (dummy == VehicleDummies::EXHAUST_SECONDARY && position == CVector())
     {
-        position = m_dummyPositions[(std::size_t)dummy];
-        return true;
+        position = m_dummyPositions[(std::size_t)VehicleDummies::EXHAUST];
+        position.fX = -position.fX;
     }
 
-    return false;
+    return true;
 }
 
 bool CClientVehicle::SetDummyPosition(VehicleDummies dummy, const CVector& position)


### PR DESCRIPTION
#### Summary

Most vehicle models don't have an `exhaust_second` dummy, so the game places the second exhaust by mirroring the primary exhaust on the X axis. However, `getVehicleDummyPosition(veh, "exhaust_second")` returned the raw stored value (`0, 0, 0` - the vehicle centre) instead of the mirrored position where the effects actually appear, e.g. after using `resetVehicleDummyPositions`.

The getter now applies the same mirroring fallback the game uses, so the reported position always matches the effective one. No visual or behavioural changes - only the returned value is fixed.

#### Motivation

Fixes #4761

#### Test plan

Using the script from the issue:

```lua
local veh = getPedOccupiedVehicle(localPlayer)
setVehicleDummyPosition(veh, "exhaust_second", 0, 0, -5000)
resetVehicleDummyPositions(veh)
print(getVehicleDummyPosition(veh, "exhaust_second"))
-- before: 0, 0, 0 | after: mirrored exhaust position (e.g. -0.39, -1.93, 0.15)
```

* Returns the mirrored primary exhaust position after a reset, matching where the exhaust/nitro effects render.
* Also works on freshly spawned vehicles without any set/reset.
* Vehicles whose model does define `exhaust_second` still return their real dummy position.
* Setting/resetting dummy positions and the effect rendering itself are unchanged.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.