### PR TITLE
Fix crash in CModelInfoSA::MakeObjectModel with weapon-based objects

### DIFF
--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -1859,14 +1859,19 @@ void CModelInfoSA::MakePedModel(const char* szTexture)
 
 void CModelInfoSA::MakeObjectModel(ushort usBaseID)
 {
-    CBaseModelInfoSAInterface* m_pInterface = new CBaseModelInfoSAInterface();
+    // Allocate at least a CClumpModelInfoSAInterface: the base model's vtable (copied below) may be a
+    // CClumpModelInfo-derived one (e.g. weapons), whose GetAnimFileIndex() reads m_nAnimFileIndex at
+    // offset sizeof(CBaseModelInfoSAInterface). Allocating only the base size would make that an
+    // out-of-bounds read/write.
+    CClumpModelInfoSAInterface* m_pInterface = new CClumpModelInfoSAInterface();
 
     CBaseModelInfoSAInterface* pBaseObjectInfo = ppModelInfo[usBaseID];
-    MemCpyFast(m_pInterface, pBaseObjectInfo, sizeof(CBaseModelInfoSAInterface));
+    MemCpyFast(m_pInterface, pBaseObjectInfo, sizeof(CClumpModelInfoSAInterface));
     m_pInterface->usNumberOfRefs = 0;
     m_pInterface->pRwObject = nullptr;
     m_pInterface->usUnknown = 65535;
     m_pInterface->usDynamicIndex = 65535;
+    m_pInterface->m_nAnimFileIndex = 0xFFFFFFFF;
 
     ppModelInfo[m_dwModelID] = m_pInterface;
 


### PR DESCRIPTION
#### Summary
<!-- What change are you making? -->
<!-- When changing Lua APIs, consider including code samples and documentation. -->
`CModelInfoSA::MakeObjectModel` now allocates and copies a `CClumpModelInfoSAInterface`-sized buffer (instead of `CBaseModelInfoSAInterface`) and resets `m_nAnimFileIndex` to `-1`, matching the existing pattern used by `MakeClumpModel`.

#### Motivation
<!-- Why are you making this change? Which GitHub issue does this resolve, if any? Any additional context? -->
Fixes #4241.

`MakeObjectModel` only allocated and copied `sizeof(CBaseModelInfoSAInterface)` bytes from the base model's interface, including its vtable pointer. When the base model is a weapon (`CClumpModelInfoSAInterface`-derived), the inherited vtable's `GetAnimFileIndex()` reads `m_nAnimFileIndex` at an offset past the allocated buffer. This out-of-bounds read returns garbage, which is then used as a model ID in a recursive `CStreaming::RequestModel` call, crashing the game (e.g. `engineRequestModel("object", 359)` followed by `engineReplaceModel`).

#### Test plan
<!-- How have you tested this change? This should give confidence to the reviewer that your change is safe. -->
<!-- If someone makes changes to this code in the future, what steps can they follow to check that it's still working correctly? -->
Reproduced the crash from #4241 using `engineRequestModel("object", 359)` + `engineLoadTXD`/`engineImportTXD`/`engineLoadDFF`/`engineReplaceModel` on an unpatched build. With this fix applied, the same script no longer crashes.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
