### PR TITLE
Fix wrong depth sorting and face culling behavior in mirrors

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -301,6 +301,8 @@ const DWORD RETURN_Idle_CWorld_ProcessPedsAfterPreRender = 0x53EA08;
 
 #define HOOKPOS_CCollision__CheckCameraCollisionObjects 0x41AB8E
 
+#define HOOKPOS_CMirrors__CreateBuffer 0x72701D
+
 CPed*         pContextSwitchedPed = 0;
 CVector       vecCenterOfWorld;
 FLOAT         fFalseHeading;
@@ -570,6 +572,8 @@ void HOOK_CWeapon__TakePhotograph();
 
 void HOOK_CCollision__CheckCameraCollisionObjects();
 
+void HOOK_CMirrors__CreateBuffer();
+
 CMultiplayerSA::CMultiplayerSA()
 {
     // Unprotect all of the GTASA code at once and leave it that way
@@ -769,6 +773,9 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_CWeapon__TakePhotograph, (DWORD)HOOK_CWeapon__TakePhotograph, 3 + 2);
 
     HookInstall(HOOKPOS_CCollision__CheckCameraCollisionObjects, (DWORD)HOOK_CCollision__CheckCameraCollisionObjects, 6 + 4);
+
+    // Fix mirror rendering when anti-aliasing is enabled
+    HookInstall(HOOKPOS_CMirrors__CreateBuffer, (DWORD)HOOK_CMirrors__CreateBuffer, 5);
 
     // Disable GTA setting g_bGotFocus to false when we minimize
     MemSet((void*)ADDR_GotFocus, 0x90, 10);
@@ -8200,4 +8207,38 @@ static void __declspec(naked) HOOK_CCollision__CheckCameraCollisionObjects()
     out2: jmp   RETURN_CCollision__CheckCameraCollisionObjects_2
     }
     // clang-format on
+}
+
+const DWORD RETURN_CMirrors__CreateBuffer = 0x727022;
+
+void CreateMirrorBuffer()
+{
+    // preserve the MSAA values
+    DWORD oldMSAAValues[2] = {*reinterpret_cast<DWORD*>(0xC9C050), *reinterpret_cast<DWORD*>(0xC9C054)};
+
+    // set them to 0 so that the Rw raster textures create correctly
+    MemPutFast<DWORD>(0xC9C050, 0);
+    MemPutFast<DWORD>(0xC9C054, 0);
+
+    // CMirrors::CreateBuffer
+    reinterpret_cast<void(__cdecl*)()>(0x7230A0)();
+
+    // restore the MSAA values
+    MemPutFast<DWORD>(0xC9C050, oldMSAAValues[0]);
+    MemPutFast<DWORD>(0xC9C054, oldMSAAValues[1]);
+}
+
+static void __declspec(naked) HOOK_CMirrors__CreateBuffer()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        pushad;
+        call CreateMirrorBuffer;
+        popad;
+
+        jmp RETURN_CMirrors__CreateBuffer;
+    }
 }

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -8241,4 +8241,5 @@ static void __declspec(naked) HOOK_CMirrors__CreateBuffer()
 
         jmp RETURN_CMirrors__CreateBuffer;
     }
+    // clang-format on
 }


### PR DESCRIPTION
#### Summary
<!-- What change are you making? -->
<!-- When changing Lua APIs, consider including code samples and documentation. -->
This PR ports SilentPatch's [depth and sorting behavior fix](https://github.com/CookiePLMonster/SilentPatch/blob/99b2feb66be5e02367dc3a196c6220b49ba5050f/SilentPatchSA/SilentPatchSA.cpp#L1281) for mirrors. Without this fix, having anti-aliasing enabled causes mirrors to render everything they see incorrectly as shown below.
<img width="619" height="693" alt="" src="https://github.com/user-attachments/assets/7eabd61e-193d-4c71-a67a-e2685c829c4a" />


With the patch, having anti-aliasing enabled results in working mirrors.
<img width="534" height="612" alt="" src="https://github.com/user-attachments/assets/8b50ddd9-faf4-4a95-b2ec-3ac24f843f5e" />

#### Motivation
<!-- Why are you making this change? Which GitHub issue does this resolve, if any? Any additional context? -->
I'm creating a character creator and the wardrobe interior I'm using looks terrible with the broken mirror rendering.

#### Test plan
<!-- How have you tested this change? This should give confidence to the reviewer that your change is safe. -->
<!-- If someone makes changes to this code in the future, what steps can they follow to check that it's still working correctly? -->
Standing near any mirror with anti-aliasing enabled should result in the mirror correctly sorting and rendering everything it sees. This can be tested at any clothes shop with a mirror, or the wardrobe room in interior 14.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
