### PR TITLE
Add support for per-element RGB color code toggling in GUI elements

### DIFF
--- a/Client/gui/CGUIElement_Impl.cpp
+++ b/Client/gui/CGUIElement_Impl.cpp
@@ -734,14 +734,29 @@ inline void CGUIElement_Impl::ForceRedraw()
     m_pWindow->forceRedraw();
 }
 
+namespace {
+    void RecursivelyForceRedrawAutoWindows(CEGUI::Window* pWindow)
+    {
+        for (uint i = 0; i < pWindow->getChildCount(); ++i)
+        {
+            CEGUI::Window* pChild = pWindow->getChildAtIdx(i);
+            if (pChild->getName().find("__auto_") != CEGUI::String::npos)
+            {
+                pChild->forceRedraw();
+                RecursivelyForceRedrawAutoWindows(pChild);
+            }
+        }
+    }
+}
+
 void CGUIElement_Impl::SetColorCodesEnabled(bool bEnabled)
 {
     m_pWindow->setUserString("ColorCodesEnabled", bEnabled ? "True" : "False");
     m_pWindow->forceRedraw();
+    RecursivelyForceRedrawAutoWindows(m_pWindow);
 }
 
 bool CGUIElement_Impl::GetColorCodesEnabled()
 {
-    return m_pWindow->isUserStringDefined("ColorCodesEnabled") &&
-           m_pWindow->getUserString("ColorCodesEnabled") == "True";
+    return m_pWindow->isUserStringDefined("ColorCodesEnabled") && m_pWindow->getUserString("ColorCodesEnabled") == "True";
 }

--- a/Client/gui/CGUIElement_Impl.cpp
+++ b/Client/gui/CGUIElement_Impl.cpp
@@ -733,3 +733,15 @@ inline void CGUIElement_Impl::ForceRedraw()
 {
     m_pWindow->forceRedraw();
 }
+
+void CGUIElement_Impl::SetColorCodesEnabled(bool bEnabled)
+{
+    m_pWindow->setUserString("ColorCodesEnabled", bEnabled ? "True" : "False");
+    m_pWindow->forceRedraw();
+}
+
+bool CGUIElement_Impl::GetColorCodesEnabled()
+{
+    return m_pWindow->isUserStringDefined("ColorCodesEnabled") &&
+           m_pWindow->getUserString("ColorCodesEnabled") == "True";
+}

--- a/Client/gui/CGUIElement_Impl.h
+++ b/Client/gui/CGUIElement_Impl.h
@@ -100,6 +100,9 @@ public:
 
     void ForceRedraw();
 
+    void SetColorCodesEnabled(bool bEnabled);
+    bool GetColorCodesEnabled();
+
     void  SetUserData(void* pData) { m_pData = pData; }
     void* GetUserData() { return m_pData; }
 

--- a/Client/gui/CGUIElement_Inc.h
+++ b/Client/gui/CGUIElement_Inc.h
@@ -194,6 +194,19 @@ void ForceRedraw()
 {
     CGUIElement_Impl::ForceRedraw();
 };
+
+// Forwarding methods to the base CGUIElement_Impl implementation to resolve
+// diamond multiple-inheritance issues so subclasses aren't treated as abstract.
+#ifndef SETCOLORCODESENABLED_HACK
+void SetColorCodesEnabled(bool bEnabled)
+{
+    CGUIElement_Impl::SetColorCodesEnabled(bEnabled);
+};
+#endif
+bool GetColorCodesEnabled()
+{
+    return CGUIElement_Impl::GetColorCodesEnabled();
+};
 void SetAlwaysOnTop(bool bAlwaysOnTop)
 {
     CGUIElement_Impl::SetAlwaysOnTop(bAlwaysOnTop);

--- a/Client/gui/CGUITab_Impl.cpp
+++ b/Client/gui/CGUITab_Impl.cpp
@@ -87,3 +87,23 @@ bool CGUITab_Impl::IsEnabled()
     CEGUI::TabControl* pControl = reinterpret_cast<CEGUI::TabControl*>(((CGUITabPanel_Impl*)pParent)->m_pWindow);
     return !pControl->getButtonForTabContents(m_pWindow)->isDisabled();
 }
+
+void CGUITab_Impl::SetColorCodesEnabled(bool bEnabled)
+{
+    CGUIElement_Impl::SetColorCodesEnabled(bEnabled);
+
+    if (m_pParent && m_pParent->GetType() == CGUI_TABPANEL)
+    {
+        CGUIElement_Impl*  pParent = static_cast<CGUIElement_Impl*>(m_pParent);
+        CEGUI::TabControl* pTabControl = reinterpret_cast<CEGUI::TabControl*>(((CGUITabPanel_Impl*)pParent)->m_pWindow);
+        if (pTabControl)
+        {
+            CEGUI::TabButton* pButton = pTabControl->getButtonForTabContents(m_pWindow);
+            if (pButton)
+            {
+                pButton->setUserString("ColorCodesEnabled", bEnabled ? "True" : "False");
+                pButton->forceRedraw();
+            }
+        }
+    }
+}

--- a/Client/gui/CGUITab_Impl.h
+++ b/Client/gui/CGUITab_Impl.h
@@ -26,7 +26,9 @@ public:
 
 #define SETVISIBLE_HACK
 #define SETENABLED_HACK
+#define SETCOLORCODESENABLED_HACK
 #include "CGUIElement_Inc.h"
+#undef SETCOLORCODESENABLED_HACK
 #undef SETENABLED_HACK
 #undef SETVISIBLE_HACK
 
@@ -34,4 +36,6 @@ public:
     bool IsVisible();
     void SetEnabled(bool bEnabled);
     bool IsEnabled();
+    
+    void SetColorCodesEnabled(bool bEnabled);
 };

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -1869,19 +1869,43 @@ int CLuaGUIDefs::GUIGetAlpha(lua_State* luaVM)
     return 1;
 }
 
+static void RecursivelySetColorCodesEnabled(CClientGUIElement* pElement, bool bEnabled)
+{
+    pElement->GetCGUIElement()->SetColorCodesEnabled(bEnabled);
+    CElementListSnapshotRef pSnapshot = pElement->GetChildrenListSnapshot();
+    for (CClientEntity* pChild : *pSnapshot)
+    {
+        if (pChild->GetType() == CCLIENTGUI)
+        {
+            RecursivelySetColorCodesEnabled(static_cast<CClientGUIElement*>(pChild), bEnabled);
+        }
+    }
+}
+
 int CLuaGUIDefs::GUISetColorCodesEnabled(lua_State* luaVM)
 {
-    //  bool guiSetColorCodesEnabled ( element guiElement, bool enabled )
+    //  bool guiSetColorCodesEnabled ( element guiElement, bool enabled [, bool includeChildren = false ] )
     CClientGUIElement* guiElement;
     bool               bEnabled;
+    bool               bIncludeChildren = false;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(guiElement);
     argStream.ReadBool(bEnabled);
+    if (argStream.NextIsBool())
+        argStream.ReadBool(bIncludeChildren);
 
     if (!argStream.HasErrors())
     {
-        guiElement->GetCGUIElement()->SetColorCodesEnabled(bEnabled);
+        if (bIncludeChildren)
+        {
+            RecursivelySetColorCodesEnabled(guiElement, bEnabled);
+        }
+        else
+        {
+            guiElement->GetCGUIElement()->SetColorCodesEnabled(bEnabled);
+        }
+        
         lua_pushboolean(luaVM, true);
         return 1;
     }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -139,6 +139,8 @@ void CLuaGUIDefs::LoadFunctions()
         {"guiGetProperty", GUIGetProperty},
         {"guiGetProperties", GUIGetProperties},
         {"guiGetAlpha", GUIGetAlpha},
+        {"guiSetColorCodesEnabled", GUISetColorCodesEnabled},
+        {"guiGetColorCodesEnabled", GUIGetColorCodesEnabled},
         {"guiGetText", GUIGetText},
         {"guiGetFont", GUIGetFont},
         {"guiGetSize", GUIGetSize},
@@ -249,6 +251,7 @@ void CLuaGUIDefs::AddGuiElementClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getScreenSize", "guiGetScreenSize");
     lua_classfunction(luaVM, "getProperties", "guiGetProperties");
     lua_classfunction(luaVM, "getAlpha", "guiGetAlpha");
+    lua_classfunction(luaVM, "getColorCodesEnabled", "guiGetColorCodesEnabled");
     lua_classfunction(luaVM, "getFont", "guiGetFont");
     lua_classfunction(luaVM, "getEnabled", "guiGetEnabled");
     lua_classfunction(luaVM, "getVisible", "guiGetVisible");
@@ -259,6 +262,7 @@ void CLuaGUIDefs::AddGuiElementClass(lua_State* luaVM)
 
     lua_classfunction(luaVM, "setInputEnabled", "guiSetInputEnabled");
     lua_classfunction(luaVM, "setAlpha", "guiSetAlpha");
+    lua_classfunction(luaVM, "setColorCodesEnabled", "guiSetColorCodesEnabled");
     lua_classfunction(luaVM, "setEnabled", "guiSetEnabled");
     lua_classfunction(luaVM, "setFont", "guiSetFont");
     lua_classfunction(luaVM, "setVisible", "guiSetVisible");
@@ -282,6 +286,7 @@ void CLuaGUIDefs::AddGuiElementClass(lua_State* luaVM)
     lua_classvariable(luaVM, "visible", "guiSetVisible", "guiGetVisible");
     lua_classvariable(luaVM, "properties", NULL, "guiGetProperties");
     lua_classvariable(luaVM, "alpha", "guiSetAlpha", "guiGetAlpha");
+    lua_classvariable(luaVM, "colorCodesEnabled", "guiSetColorCodesEnabled", "guiGetColorCodesEnabled");
     lua_classvariable(luaVM, "enabled", "guiSetEnabled", "guiGetEnabled");
     lua_classvariable(luaVM, "text", "guiSetText", "guiGetText");
     lua_classvariable(luaVM, "size", "guiSetSize", "guiGetSize");
@@ -1855,6 +1860,49 @@ int CLuaGUIDefs::GUIGetAlpha(lua_State* luaVM)
     {
         float fAlpha = !bEffectiveAlpha ? guiElement->GetCGUIElement()->GetAlpha() : guiElement->GetCGUIElement()->GetEffectiveAlpha();
         lua_pushnumber(luaVM, fAlpha);
+        return 1;
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaGUIDefs::GUISetColorCodesEnabled(lua_State* luaVM)
+{
+    //  bool guiSetColorCodesEnabled ( element guiElement, bool enabled )
+    CClientGUIElement* guiElement;
+    bool               bEnabled;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(guiElement);
+    argStream.ReadBool(bEnabled);
+
+    if (!argStream.HasErrors())
+    {
+        guiElement->GetCGUIElement()->SetColorCodesEnabled(bEnabled);
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaGUIDefs::GUIGetColorCodesEnabled(lua_State* luaVM)
+{
+    //  bool guiGetColorCodesEnabled ( element guiElement )
+    CClientGUIElement* guiElement;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(guiElement);
+
+    if (!argStream.HasErrors())
+    {
+        lua_pushboolean(luaVM, guiElement->GetCGUIElement()->GetColorCodesEnabled());
         return 1;
     }
     else

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
@@ -112,6 +112,8 @@ public:
     LUA_DECLARE(GUIGetPosition);
     LUA_DECLARE(GUIGetVisible);
     LUA_DECLARE(GUIGetAlpha);
+    LUA_DECLARE(GUISetColorCodesEnabled);
+    LUA_DECLARE(GUIGetColorCodesEnabled);
     LUA_DECLARE(GUIGetProperty);
     LUA_DECLARE(GUIGetProperties);
     LUA_DECLARE(GUICheckBoxGetSelected);

--- a/Client/sdk/gui/CGUIElement.h
+++ b/Client/sdk/gui/CGUIElement.h
@@ -105,6 +105,9 @@ public:
 
     virtual void ForceRedraw() = 0;
 
+    virtual void SetColorCodesEnabled(bool bEnabled) = 0;
+    virtual bool GetColorCodesEnabled() = 0;
+
     virtual CRect2D   AbsoluteToRelative(const CRect2D& Rect) = 0;
     virtual CVector2D AbsoluteToRelative(const CVector2D& Vector) = 0;
 

--- a/vendor/cegui-0.4.0-custom/include/CEGUIFont.h
+++ b/vendor/cegui-0.4.0-custom/include/CEGUIFont.h
@@ -107,6 +107,11 @@ public:
 	*************************************************************************/
 	static const argb_t		DefaultColour;			//!< Colour value used whenever a colour is not specified.
 
+	// When true, drawTextLine/drawTextLineJustified parse inline #RRGGBB color codes.
+	// CEGUIWindow::drawSelf() sets this per-window before populateRenderCache() and
+	// resets it to false afterwards, giving per-element opt-in behaviour.
+	static bool s_colorCodesEnabled;
+
 
 	/*************************************************************************
 		Text drawing methods

--- a/vendor/cegui-0.4.0-custom/include/CEGUIRenderCache.h
+++ b/vendor/cegui-0.4.0-custom/include/CEGUIRenderCache.h
@@ -188,6 +188,7 @@ namespace CEGUI
             Rect customClipper;
             bool usingCustomClipper;
             bool clipToDisplay;
+            bool colorCodesEnabled; // Stores whether inline color codes formatting should be parsed when rendering this text.
         };
 
         typedef std::vector<ImageInfo>  ImageryList;

--- a/vendor/cegui-0.4.0-custom/src/CEGUIFont.cpp
+++ b/vendor/cegui-0.4.0-custom/src/CEGUIFont.cpp
@@ -53,6 +53,9 @@
 // Start of CEGUI namespace section
 namespace CEGUI
 {
+// Forward declaration of ParseColorCode to allow calls in early member functions (e.g. getTextExtent, getCharAtPixel) before its definition.
+static bool ParseColorCode(const String& text, size_t c, float& r, float& g, float& b);
+
 /*************************************************************************
 	static data definitions
 *************************************************************************/

--- a/vendor/cegui-0.4.0-custom/src/CEGUIFont.cpp
+++ b/vendor/cegui-0.4.0-custom/src/CEGUIFont.cpp
@@ -57,6 +57,7 @@ namespace CEGUI
 	static data definitions
 *************************************************************************/
 const argb_t Font::DefaultColour					= 0xFFFFFFFF;
+bool         Font::s_colorCodesEnabled              = false;
 const uint	Font::InterGlyphPadSpace			= 2;
 
 // XML related strings
@@ -760,6 +761,8 @@ size_t Font::getNextWord(const String& in_string, size_t start_idx, String& out_
 // but the following chars are not all hex digits, the '#' is treated as a literal char.
 static bool ParseColorCode(const String& text, size_t c, float& r, float& g, float& b)
 {
+    if (!Font::s_colorCodesEnabled)
+        return false;
     if (text[c] != '#' || c + 7 > text.length())
         return false;
 

--- a/vendor/cegui-0.4.0-custom/src/CEGUIFont.cpp
+++ b/vendor/cegui-0.4.0-custom/src/CEGUIFont.cpp
@@ -223,6 +223,13 @@ float Font::getTextExtent(const String& text, float x_scale) const
 
     for (size_t c = 0; c < char_count; ++c)
     {
+        float cr, cg, cb;
+        if (ParseColorCode(text, c, cr, cg, cb))
+        {
+            c += 6;
+            continue;
+        }
+
         const SCharSize* pCharSize = MapFind ( d_sizes_map, text[c] ); // Ask sub font if not
         if ( !pCharSize && !d_is_subfont )
         {
@@ -284,6 +291,13 @@ size_t Font::getCharAtPixel(const String& text, size_t start_char, float pixel, 
 
 	for (size_t c = start_char; c < char_count; ++c)
 	{
+        float cr, cg, cb;
+        if (ParseColorCode(text, c, cr, cg, cb))
+        {
+            c += 6;
+            continue;
+        }
+
 		pos = d_cp_map.find(text[c]);
 
 		if (pos != end)
@@ -741,6 +755,30 @@ size_t Font::getNextWord(const String& in_string, size_t start_idx, String& out_
 /*************************************************************************
 	Draw a line of text.  No formatting is applied.
 *************************************************************************/
+// Returns true and fills r/g/b (0.0-1.0) if text[c] begins a valid #RRGGBB color code.
+// A color code is exactly 7 chars: '#' followed by 6 hex digits.  If text[c] is '#'
+// but the following chars are not all hex digits, the '#' is treated as a literal char.
+static bool ParseColorCode(const String& text, size_t c, float& r, float& g, float& b)
+{
+    if (text[c] != '#' || c + 7 > text.length())
+        return false;
+
+    int digits[6];
+    for (int k = 0; k < 6; ++k)
+    {
+        utf32 ch = text[c + 1 + k];
+        if      (ch >= '0' && ch <= '9') digits[k] = ch - '0';
+        else if (ch >= 'a' && ch <= 'f') digits[k] = ch - 'a' + 10;
+        else if (ch >= 'A' && ch <= 'F') digits[k] = ch - 'A' + 10;
+        else return false;
+    }
+
+    r = static_cast<float>((digits[0] << 4) | digits[1]) / 255.0f;
+    g = static_cast<float>((digits[2] << 4) | digits[3]) / 255.0f;
+    b = static_cast<float>((digits[4] << 4) | digits[5]) / 255.0f;
+    return true;
+}
+
 void Font::drawTextLine(const String& text, const Vector3& position, const Rect& clip_rect, const ColourRect& colours, float x_scale, float y_scale) const
 {
 	Vector3	cur_pos(position);
@@ -752,8 +790,19 @@ void Font::drawTextLine(const String& text, const Vector3& position, const Rect&
 
     const_cast < Font* > ( this )->refreshStringForGlyphs ( text ); // Refresh our glyph set if there are new characters
 
+    ColourRect current_colours = colours;
+
 	for (size_t c = 0; c < char_count; ++c)
 	{
+        // Handle inline #RRGGBB color codes — skip the 7-char sequence and update color.
+        float cr, cg, cb;
+        if (ParseColorCode(text, c, cr, cg, cb))
+        {
+            current_colours = ColourRect(colour(cr, cg, cb, colours.d_top_left.getAlpha()));
+            c += 6;
+            continue;
+        }
+
 		pos = d_cp_map.find(text[c]);
 
         const Image* img;
@@ -792,7 +841,7 @@ void Font::drawTextLine(const String& text, const Vector3& position, const Rect&
         }
 		cur_pos.d_y = base_y - (img->getOffsetY() - img->getOffsetY() * y_scale);
 		Size sz(img->getWidth() * x_scale, img->getHeight() * y_scale);
-		img->draw(cur_pos, sz, clip_rect, colours);
+		img->draw(cur_pos, sz, clip_rect, current_colours);
 		cur_pos.d_x += horz_advance * x_scale;
 
 	}
@@ -818,7 +867,11 @@ void Font::drawTextLineJustified(const String& text, const Rect& draw_area, cons
 	uint space_count = 0;
     size_t c;
 	for (c = 0; c < char_count; ++c)
+    {
+        float cr, cg, cb;
+        if (ParseColorCode(text, c, cr, cg, cb)) { c += 6; continue; }
 		if ((text[c] == ' ') || (text[c] == '\t')) ++space_count;
+    }
 
 	// The width that must be added to each space character in order to transform the left aligned text in justified text
 	float shared_lost_space = 0.0;
@@ -826,8 +879,18 @@ void Font::drawTextLineJustified(const String& text, const Rect& draw_area, cons
 
     const_cast < Font* > ( this )->refreshStringForGlyphs ( text ); // Refresh our glyph set if there are new characters
 
+    ColourRect current_colours = colours;
+
     for (c = 0; c < char_count; ++c)
 	{
+        float cr, cg, cb;
+        if (ParseColorCode(text, c, cr, cg, cb))
+        {
+            current_colours = ColourRect(colour(cr, cg, cb, colours.d_top_left.getAlpha()));
+            c += 6;
+            continue;
+        }
+
 		pos = d_cp_map.find(text[c]);
 
 		if (pos != end)
@@ -835,7 +898,7 @@ void Font::drawTextLineJustified(const String& text, const Rect& draw_area, cons
 			const Image* img = pos->second.d_image;
 			cur_pos.d_y = base_y - (img->getOffsetY() - img->getOffsetY() * y_scale);
 			Size sz(img->getWidth() * x_scale, img->getHeight() * y_scale);
-			img->draw(cur_pos, sz, clip_rect, colours);
+			img->draw(cur_pos, sz, clip_rect, current_colours);
 			cur_pos.d_x += (float)pos->second.d_horz_advance * x_scale;
 			// That's where we adjust the size of each space character
 			if ((text[c] == ' ') || (text[c] == '\t')) cur_pos.d_x += shared_lost_space;

--- a/vendor/cegui-0.4.0-custom/src/CEGUIRenderCache.cpp
+++ b/vendor/cegui-0.4.0-custom/src/CEGUIRenderCache.cpp
@@ -84,8 +84,10 @@ namespace CEGUI
 
             finalRect = (*text).target_area;
             finalRect.offset(basePos);
+            Font::s_colorCodesEnabled = (*text).colorCodesEnabled; // Temporarily restore the color codes toggle state for this text block
             (*text).source_font->drawText((*text).text, finalRect, baseZ + (*text).z_offset, *finalClipper, (*text).formatting, (*text).colours);
         }
+        Font::s_colorCodesEnabled = false; // Reset to default state
 
     }
 
@@ -127,6 +129,7 @@ namespace CEGUI
         txtinf.z_offset     = zOffset;
         txtinf.colours      = cols;
         txtinf.clipToDisplay = clipToDisplay;
+        txtinf.colorCodesEnabled = Font::s_colorCodesEnabled; // Cache the current color code formatting enablement status
 
         if (clipper)
         {

--- a/vendor/cegui-0.4.0-custom/src/CEGUIWindow.cpp
+++ b/vendor/cegui-0.4.0-custom/src/CEGUIWindow.cpp
@@ -43,6 +43,25 @@
 // Start of CEGUI namespace section
 namespace CEGUI
 {
+namespace {
+    bool getColorCodesEnabledForWindow(const CEGUI::Window* window)
+    {
+        const CEGUI::Window* curr = window;
+        while (curr)
+        {
+            if (curr->isUserStringDefined("ColorCodesEnabled"))
+                return curr->getUserString("ColorCodesEnabled") == "True";
+            
+            // Stop inheriting if the window is not an auto-window
+            if (curr->getName().find("__auto_") == CEGUI::String::npos)
+                break;
+                
+            curr = curr->getParent();
+        }
+        return false;
+    }
+}
+
 const String Window::EventNamespace("Window");
 
 /*************************************************************************
@@ -1974,7 +1993,15 @@ void Window::render(void)
 
 	// perform drawing for 'this' Window
 	Renderer* renderer = System::getSingleton().getRenderer();
+	
+	// Set per-window color codes flag before geometry is generated.
+	// We do this here so widgets that override drawSelf (like Falagard buttons) still respect it.
+	Font::s_colorCodesEnabled = getColorCodesEnabledForWindow(this);
+	
 	drawSelf(renderer->getCurrentZ());
+	
+	Font::s_colorCodesEnabled = false;
+	
 	renderer->advanceZValue();
 
 	// render any child windows
@@ -1999,13 +2026,8 @@ void Window::drawSelf(float z)
     {
         // dispose of already cached imagery.
         d_renderCache.clearCachedImagery();
-        // Set per-window color codes flag before text geometry is generated.
-        Font::s_colorCodesEnabled = isUserStringDefined("ColorCodesEnabled") &&
-                                    getUserString("ColorCodesEnabled") == "True";
         // get derived class to re-populate cache.
         populateRenderCache();
-        // Reset so other windows default to no color parsing.
-        Font::s_colorCodesEnabled = false;
         // mark ourselves as no longer needed a redraw.
         d_needsRedraw = false;
     }

--- a/vendor/cegui-0.4.0-custom/src/CEGUIWindow.cpp
+++ b/vendor/cegui-0.4.0-custom/src/CEGUIWindow.cpp
@@ -29,6 +29,7 @@
 #include "CEGUIWindowManager.h"
 #include "CEGUISystem.h"
 #include "CEGUIFontManager.h"
+#include "CEGUIFont.h"
 #include "CEGUIImagesetManager.h"
 #include "CEGUIImageset.h"
 #include "CEGUIMouseCursor.h"
@@ -1998,8 +1999,13 @@ void Window::drawSelf(float z)
     {
         // dispose of already cached imagery.
         d_renderCache.clearCachedImagery();
+        // Set per-window color codes flag before text geometry is generated.
+        Font::s_colorCodesEnabled = isUserStringDefined("ColorCodesEnabled") &&
+                                    getUserString("ColorCodesEnabled") == "True";
         // get derived class to re-populate cache.
         populateRenderCache();
+        // Reset so other windows default to no color parsing.
+        Font::s_colorCodesEnabled = false;
         // mark ourselves as no longer needed a redraw.
         d_needsRedraw = false;
     }


### PR DESCRIPTION
#### Summary

Added RGB color code support for GUI elements, allowing inline color formatting across all supported GUI controls.

`guiSetColorCodesEnabled(guiElement, enabled [, includeChilds = false])`

When includeChilds is true, the function recursively applies the color code state to all child GUI elements, making it easy to enable or disable RGB color codes for an entire GUI hierarchy with a single call.

<details>
<summary><strong>Screenshots</strong></summary>

<br>

<img width="1366" height="768" alt="mta-screen_2026-06-18_23-31-01" src="https://github.com/user-attachments/assets/bd6acee9-d618-44e8-a07c-820c2200e1f4" />

<img width="1366" height="768" alt="mta-screen_2026-06-18_23-31-16" src="https://github.com/user-attachments/assets/cfc79227-8ccb-4943-ab02-29ac95b40b6e" />

<img width="1366" height="768" alt="mta-screen_2026-06-18_23-31-24" src="https://github.com/user-attachments/assets/b9d099b6-956c-48e4-8da0-24c20b9e328a" />

</details>


#### Motivation

Finally, RGB color codes are supported in MTA GUI elements.

This change adds consistent inline color formatting across GUI components such as windows, labels, buttons, checkboxes, radio buttons, tabs, grid lists (headers and rows), edit boxes, memos, combo boxes, and title bars.

Closes #4433.

#### Test plan

<!-- How have you tested this change? This should give confidence to the reviewer that your change is safe. -->

<!-- If someone makes changes to this code in the future, what steps can they follow to check that it's still working correctly? -->

Tested client-side using the following script to verify that all supported GUI elements correctly render RGB color codes and update immediately when color codes are enabled or disabled recursively.

```lua
-- Client-side test script for MTA GUI RGB color codes.
-- Use the /testrgb command in the game chat to open or close the test window.

local demoWindow = nil
local colorCodesState = true

local function buildTestGUI()
    -- 1. Window & Titlebar
    demoWindow = guiCreateWindow(100, 100, 600, 450, "#FF0000M#00FF00T#0000FFA #FFFFFFColor Code Test Window", false)
    guiWindowSetSizable(demoWindow, true)

    -- 2. Label
    guiCreateLabel(20, 40, 560, 20, "Label: #FF3333R#33FF33G#3333FFB inline coloring #FFAA00Orange #00FFFFCyan", false, demoWindow)

    -- 3. Button
    guiCreateButton(20, 70, 150, 30, "#FF5555Click #55FF55Me", false, demoWindow)

    -- 4. CheckBox
    guiCreateCheckBox(190, 70, 150, 30, "#FFFF00Checked #FF00FFBox", true, false, demoWindow)

    -- 5. Radio Button
    guiCreateRadioButton(360, 70, 180, 30, "#00FFFFRadio #FFFFFFButton", false, demoWindow)

    -- 6. Tab Panel & Tabs
    local tabPanel = guiCreateTabPanel(20, 110, 560, 200, false, demoWindow)
    local tab1 = guiCreateTab("#FF5555Tab #55FF55One", tabPanel)
    local tab2 = guiCreateTab("#5555FFTab #FFFF55Two", tabPanel)

    -- 7. GridList (Rows & Headers)
    local gridList = guiCreateGridList(10, 10, 540, 150, false, tab1)
    local col1 = guiGridListAddColumn(gridList, "#FFAA00Column #FF00FFOne", 0.4)
    local col2 = guiGridListAddColumn(gridList, "#00FFAAColumn #00FFFFTwo", 0.5)

    for i = 1, 3 do
        local row = guiGridListAddRow(gridList)
        guiGridListSetItemText(gridList, row, col1, "#FF5555Row " .. i .. " #FFFFFFCol 1", false, false)
        guiGridListSetItemText(gridList, row, col2, "#55FF55Row " .. i .. " #FFFF55Col 2", false, false)
    end

    -- 8. Memo
    guiCreateMemo(10, 10, 260, 100, "Memo: #FF8888Line 1\n#88FF88Line 2\n#8888FFLine 3", false, tab2)

    -- 9. Edit
    guiCreateEdit(10, 120, 260, 30, "Edit: #FFBB00Yellow", false, tab2)

    -- 10. ComboBox
    local comboBox = guiCreateComboBox(280, 10, 260, 140, "#FFFFFFSelect #FF00FFan #00FFFFitem", false, tab2)
    guiComboBoxAddItem(comboBox, "#FF5555Red Item")
    guiComboBoxAddItem(comboBox, "#55FF55Green Item")
    guiComboBoxAddItem(comboBox, "#5555FFBlue Item")

    -- Toggle button
    local toggleBtn = guiCreateButton(20, 320, 560, 40, "TOGGLE COLOR CODES (Currently: ON)", false, demoWindow)

    -- Close button
    local closeBtn = guiCreateButton(20, 370, 560, 30, "CLOSE TEST WINDOW", false, demoWindow)

    local function applyColorCodesState()
        guiSetColorCodesEnabled(demoWindow, colorCodesState, true)

        guiSetText(
            toggleBtn,
            "TOGGLE COLOR CODES (Currently: " ..
                (colorCodesState and "#00FF00ON" or "#FF0000OFF") .. ")"
        )

        -- Keep the toggle button itself colored.
        guiSetColorCodesEnabled(toggleBtn, true)
    end

    applyColorCodesState()

    addEventHandler("onClientGUIClick", toggleBtn, function(btn, state)
        if btn == "left" and state == "up" then
            colorCodesState = not colorCodesState
            applyColorCodesState()
        end
    end, false)

    addEventHandler("onClientGUIClick", closeBtn, function(btn, state)
        if btn == "left" and state == "up" then
            destroyElement(demoWindow)
            showCursor(false)
        end
    end, false)

    showCursor(true)
end

addCommandHandler("testrgb", function()
    if isElement(demoWindow) then
        destroyElement(demoWindow)
        showCursor(false)
    else
        buildTestGUI()
    end
end)
```

The test verifies:

* Window title rendering.
* Labels.
* Buttons.
* Checkboxes.
* Radio buttons.
* Tab panel and tab captions.
* GridList headers and row items.
* Memo text.
* Edit box text.
* ComboBox caption and items.
* Recursive enable/disable behavior using `guiSetColorCodesEnabled(element, enabled, true)`.
* Instant visual updates after toggling color codes.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
