### PR TITLE
Fix lost onPlayerConnect cancel reason (#4963)

### DIFF
--- a/Server/mods/deathmatch/logic/CEvents.cpp
+++ b/Server/mods/deathmatch/logic/CEvents.cpp
@@ -141,7 +141,8 @@ void CEvents::PostEventPulse()
     m_bWasEventCancelled = m_bEventCancelled;
     m_bEventCancelled = m_CancelledList.back() ? true : false;
     m_CancelledList.pop_back();
-    // Restore the outer event's cancel reason that was active before this pulse.
+    // Mirrors m_bWasEventCancelled above, before restoring the outer reason.
+    m_strWasLastError = m_strLastError;
     m_strLastError = m_LastErrorList.back();
     m_LastErrorList.pop_back();
 }
@@ -165,4 +166,9 @@ bool CEvents::WasEventCancelled()
 const char* CEvents::GetLastError()
 {
     return m_strLastError;
+}
+
+const char* CEvents::WasLastError()
+{
+    return m_strWasLastError;
 }

--- a/Server/mods/deathmatch/logic/CEvents.h
+++ b/Server/mods/deathmatch/logic/CEvents.h
@@ -47,6 +47,7 @@ public:
     void        CancelEvent(bool bCancelled, const char* szReason);
     bool        WasEventCancelled();
     const char* GetLastError();
+    const char* WasLastError();
 
 private:
     void RemoveAllEvents();
@@ -61,4 +62,10 @@ private:
     bool m_bWasEventCancelled;
 
     SString m_strLastError;
+    SString m_strWasLastError;  // Mirrors m_bWasEventCancelled: captures the reason set via
+                                // cancelEvent() during the call, since m_strLastError itself
+                                // is restored to the outer event's reason once the call returns
+                                // (see issue #4963 - callers reading the reason after CallEvent()
+                                // returns, e.g. onPlayerConnect, must use this instead of
+                                // GetLastError()).
 };

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -4384,7 +4384,10 @@ void CGame::PlayerCompleteConnect(CPlayer* pPlayer)
     {
         // event cancelled, disconnect the player
         CLogger::LogPrintf("CONNECT: %s failed to connect. (onPlayerConnect event cancelled) (%s)\n", pPlayer->GetNick(), strIPAndSerial.c_str());
-        const char* szError = g_pGame->GetEvents()->GetLastError();
+        // Use WasLastError() rather than GetLastError(): CallEvent() above already restored
+        // m_strLastError to the outer (pre-call) value once it returned, so the reason set via
+        // cancelEvent() inside the onPlayerConnect handler is only available through this getter.
+        const char* szError = g_pGame->GetEvents()->WasLastError();
         if (szError && szError[0])
         {
             DisconnectPlayer(g_pGame, *pPlayer, szError);


### PR DESCRIPTION
#### Summary

Fixes the lost `onPlayerConnect` cancel reason by storing the reason captured during `CallEvent()` and using it when disconnecting the player.

#### Motivation

`CallEvent()` finishes by running `PostEventPulse()`, which restores `m_strLastError` to the value it had before the event call. Because `PlayerCompleteConnect()` reads the cancel reason after `CallEvent()` returns, it could no longer access the reason passed to `cancelEvent()`. This caused players cancelled from `onPlayerConnect` to receive the generic “Server refused the connection” message instead of the scripted reason.

Fixes #4963.

<img width="598" height="270" alt="image" src="https://github.com/user-attachments/assets/92d192fc-fd08-4a19-a0d0-7e91d2e5ef9e" />


#### Test plan

Tested by cancelling `onPlayerConnect` with a custom reason and confirming the disconnected player receives that reason instead of the generic fallback message.

Server-side test resource:

```lua
addEventHandler("onPlayerConnect", root, function()
    cancelEvent(true, "string reason 1.7")
end)
```

(Same as the issue)

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.