### PR TITLE
Fix repeated aircraft wreck components when engine autostart is disabled

### DIFF
--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -95,6 +95,13 @@ static bool __fastcall CanProcessFlyingCarStuff(CAutomobileSAInterface* vehicleI
 
     if (vehicle->pEntity->GetVehicleRotorState())
     {
+        // Blown aircraft must not re-enter the custom rotor processing path. With
+        // vehicle_engine_autostart disabled this path moves unattended aircraft to
+        // STATUS_PHYSICS, which lets wreck contacts repeatedly create GTA flying
+        // components/explosions after the vehicle has already blown up.
+        if (vehicle->pEntity->GetHealth() <= 0.0f)
+            return false;
+
         if (g_pCore->GetMultiplayer()->IsVehicleEngineAutoStartEnabled())  // keep default behavior
             return true;
 

--- a/Client/mods/deathmatch/logic/CClientVehicleManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicleManager.cpp
@@ -824,7 +824,10 @@ void CClientVehicleManager::ResetNotControlledRotors(bool engineAutoStart)
     eEntityStatus status = engineAutoStart ? eEntityStatus::STATUS_ABANDONED : eEntityStatus::STATUS_PHYSICS;
     for (auto& pVehicle : m_List)
     {
-        if (pVehicle->GetGameEntity() && pVehicle->GetVehicleRotorState() && !pVehicle->IsDriven())
+        // Blown aircraft should stay out of the unattended rotor workaround. For
+        // engine autostart off, putting wrecks into STATUS_PHYSICS lets later
+        // contacts keep producing detached components and explosion effects.
+        if (pVehicle->GetGameEntity() && pVehicle->GetVehicleRotorState() && !pVehicle->IsDriven() && !pVehicle->IsBlown())
         {
             float speed = (!engineAutoStart && pVehicle->IsEngineOn()) ? 0.001f : 0.0f;
             pVehicle->GetGameEntity()->SetEntityStatus(status);


### PR DESCRIPTION
#### Summary

Prevents blown aircraft from re-entering the unattended rotor workaround when `vehicle_engine_autostart` is disabled.

This stops wrecked airplanes from repeatedly creating extra flying components and explosion effects after being touched.

#### Motivation

Fixes #4916.

When `vehicle_engine_autostart` is set to `false`, unattended aircraft can be moved into `STATUS_PHYSICS` so rotor behavior can be handled manually. For aircraft that have already blown up, that allowed later contacts with the wreck to keep producing detached components and explosion effects.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8e24905b-0aff-4b4a-a8d6-d977b9ff5cba" />


#### Test plan

Server-side test resource:

```lua
addEventHandler("onResourceStart", resourceRoot, function()
    setWorldSpecialPropertyEnabled("vehicle_engine_autostart", false)
end)
```

Manual test:

1. Start a server with the test resource enabled.
2. Spawn a Dodo or another airplane.
3. Blow up the airplane.
4. Touch/push the wreck.
5. Confirm it no longer creates repeated explosions or excessive flying components.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.