### PR TITLE
Prevent blown-up vehicles from spawning excess flying components

### DIFF
--- a/Client/mods/deathmatch/logic/CDeathmatchVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CDeathmatchVehicle.cpp
@@ -42,6 +42,13 @@ void CDeathmatchVehicle::SetIsSyncing(bool bIsSyncing)
 
 bool CDeathmatchVehicle::SyncDamageModel()
 {
+    // Do not sync damage for blown vehicles. Once destroyed, further
+    // damage state changes (e.g. from physics collision or burn explosions)
+    // would only re-spawn flying components and excess explosions on all
+    // clients without meaningful effect.
+    if (IsBlown())
+        return false;
+
     SVehicleDamageSync damage(true, true, true, true, true);
     bool               bChanges = false;
 

--- a/Client/mods/deathmatch/logic/CNetAPI.cpp
+++ b/Client/mods/deathmatch/logic/CNetAPI.cpp
@@ -2255,7 +2255,12 @@ void CNetAPI::ReadVehiclePartsState(CClientVehicle* pVehicle, NetBitStreamInterf
 {
     SVehicleDamageSyncMethodeB damage;
     BitStream.Read(&damage);
-    bool flyingComponents = m_pVehicleManager->IsSpawnFlyingComponentEnabled();
+
+    // Do not spawn flying components when applying damage to already-blown
+    // vehicles. Physics collisions and burn explosions can trigger repeated
+    // damage syncs on destroyed vehicles, each of which would spawn new
+    // flying components even though the vehicle is already wrecked.
+    bool flyingComponents = m_pVehicleManager->IsSpawnFlyingComponentEnabled() && !pVehicle->IsBlown();
 
     if (damage.data.bSyncDoors)
         for (unsigned char i = 0; i < MAX_DOORS; ++i)

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -1659,7 +1659,11 @@ void CPacketHandler::Packet_VehicleDamageSync(NetBitStreamInterface& bitStream)
         CDeathmatchVehicle* pVehicle = static_cast<CDeathmatchVehicle*>(g_pClientGame->m_pVehicleManager->Get(ID));
         if (pVehicle)
         {
-            bool flyingComponents = g_pClientGame->IsWorldSpecialProperty(WorldSpecialProperty::FLYINGCOMPONENTS);
+            // Do not spawn flying components for already-blown vehicles.
+            // Physics collisions and burn explosions can trigger repeated
+            // damage syncs which would each spawn flying components on an
+            // already-destroyed vehicle.
+            bool flyingComponents = g_pClientGame->IsWorldSpecialProperty(WorldSpecialProperty::FLYINGCOMPONENTS) && !pVehicle->IsBlown();
 
             for (unsigned char i = 0; i < MAX_DOORS; ++i)
             {
@@ -3368,7 +3372,9 @@ retry:
                     pVehicle->SetPaintjob(paintjob.data.ucPaintjob);
                     pVehicle->SetColor(vehColor);
 
-                    bool flyingComponents = g_pClientGame->IsWorldSpecialProperty(WorldSpecialProperty::FLYINGCOMPONENTS);
+                    // Do not spawn flying components for already-blown vehicles
+                    // when applying damage states.
+                    bool flyingComponents = g_pClientGame->IsWorldSpecialProperty(WorldSpecialProperty::FLYINGCOMPONENTS) && !pVehicle->IsBlown();
                     // Setup our damage model
                     for (unsigned char i = 0; i < MAX_DOORS; i++)
                         pVehicle->SetDoorStatus(i, damage.data.ucDoorStates[i], flyingComponents);

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -2435,6 +2435,13 @@ void CGame::Packet_VehicleDamageSync(CVehicleDamageSyncPacket& Packet)
             // Is this guy the driver or syncer?
             if (pVehicle->GetSyncer() == pPlayer || pVehicle->GetOccupant(0) == pPlayer)
             {
+                // Ignore damage syncs for already-blown vehicles. Once a vehicle
+                // is destroyed, further damage changes (from physics collisions or
+                // burn explosions) only cause repeated flying component spawns and
+                // excess explosions on clients.
+                if (pVehicle->IsBlown())
+                    return;
+
                 // Set the new damage model
                 for (unsigned int i = 0; i < MAX_DOORS; ++i)
                 {


### PR DESCRIPTION
#### Summary
Prevent blown-up vehicles from spawning excess flying components through the damage sync layer, by adding `IsBlown` guards across all paths that propagate damage state changes.

This is a defense-in-depth fix. The triggering scenario for issue #4916 is resolved at the source by PR #4966 (which prevents blown aircraft from re-entering `STATUS_PHYSICS`). These sync-layer guards enforce that a destroyed vehicle should never spawn flying components or sync damage, protecting against any future path that might trigger damage on a wreck.

The initial blow damage reaches all clients through `PACKET_ID_EXPLOSION` or the `BLOW_VEHICLE` RPC - both call `FuckCarCompletely` locally on every client; `SyncDamageModel` is never involved in the initial state, so the `IsBlown` guard only blocks subsequent re-syncs.

#### Motivation
Fixes, in combination with #4966, issue #4916.

Without #4966: a blown plane stuck in `STATUS_PHYSICS` produces GTA-native flying components locally on contact. This PR ensures that even if those damage events occur, they are not propagated to other clients where they would cause additional spawns.

Without this PR: if any code path (a Lua event, a new special property, a GTA edge case) ever triggers panel damage on a blown vehicle, every client receives the sync and spawns a full set of flying components. These guards prevent that class of bug permanently.

Changes:
- `CDeathmatchVehicle::SyncDamageModel`: skip the entire sync if the vehicle is blown; no packet is sent
- Server `CGame::Packet_VehicleDamageSync`: ignore incoming damage syncs for blown vehicles; do not broadcast
- `CNetAPI::ReadVehiclePartsState`: suppress flying component spawns when applying damage to a blown vehicle
- `CPacketHandler` (two sites receiving damage syncs): same `IsBlown` guard on the `flyingComponents` flag

No bitstream format changes. The guards are purely behavioral.

#### Test plan
1. Start a server with `vehicle_engine_autostart` disabled
2. Spawn a Dodo, blow it up, walk into the wreckage
3. Verify no cascading flying components or explosions appear (requires #4966)
4
#### Checklist
* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.