### PR TITLE
Fix crash from disabling driveby during weapon fire

### DIFF
--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -5272,6 +5272,8 @@ void CClientGame::PostWeaponFire()
                 }
                 else
                     pPed->CallEvent("onClientPedWeaponFire", Arguments, true);
+
+                // Make sure to reset the weapon fire event state
                 pPed->SetProcessingWeaponFireEvent(false);
             }
             pPed->PostWeaponFire();

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -5259,6 +5259,8 @@ void CClientGame::PostWeaponFire()
                 else
                     Arguments.PushNil();
 
+                // Lets SetDoingGangDriveby(false) defer the task abort instead of running it re-entrantly.
+                pPed->SetProcessingWeaponFireEvent(true);
                 if (IS_PLAYER(pPed))
                 {
                     CVector vecOrigin;
@@ -5270,6 +5272,7 @@ void CClientGame::PostWeaponFire()
                 }
                 else
                     pPed->CallEvent("onClientPedWeaponFire", Arguments, true);
+                pPed->SetProcessingWeaponFireEvent(false);
             }
             pPed->PostWeaponFire();
 #ifdef MTA_DEBUG

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -184,6 +184,8 @@ void CClientPed::Init(CClientManager* pManager, unsigned long ulModelID, bool bI
     m_bSunbathing = false;
     m_bDestroyingSatchels = false;
     m_bDoingGangDriveby = false;
+    m_bProcessingWeaponFireEvent = false;
+    m_bDeferredGangDrivebyAbort = false;
 
     m_pAnimationBlock = NULL;
     m_bRequestedAnimation = false;
@@ -2763,6 +2765,15 @@ void CClientPed::StreamedInPulse(bool bDoStandardPulses)
 
         if (m_bPendingRebuildPlayer)
             ProcessRebuildPlayer(true);
+
+        // Run any gang driveby abort deferred by SetDoingGangDriveby(false).
+        if (m_bDeferredGangDrivebyAbort)
+        {
+            m_bDeferredGangDrivebyAbort = false;
+            CTask* primaryTask = m_pTaskManager->GetTask(TASK_PRIORITY_PRIMARY);
+            if (primaryTask && primaryTask->GetTaskType() == TASK_SIMPLE_GANG_DRIVEBY)
+                primaryTask->MakeAbortable(m_pPlayerPed, ABORT_PRIORITY_URGENT, NULL);
+        }
 
         CControllerState Current;
         GetControllerState(Current);
@@ -5705,7 +5716,15 @@ void CClientPed::SetDoingGangDriveby(bool bDriveby)
     {
         if (!bDriveby)
         {
-            primaryTask->MakeAbortable(m_pPlayerPed, ABORT_PRIORITY_URGENT, NULL);
+            if (m_bProcessingWeaponFireEvent)
+            {
+                // Aborting now would re-enter the task's own native ProcessPed() and crash.
+                m_bDeferredGangDrivebyAbort = true;
+            }
+            else
+            {
+                primaryTask->MakeAbortable(m_pPlayerPed, ABORT_PRIORITY_URGENT, NULL);
+            }
         }
     }
     else if (bDriveby)

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -462,6 +462,9 @@ public:
     bool IsDoingGangDriveby();
     void SetDoingGangDriveby(bool bDriveby);
 
+    // Set while onClientPlayerWeaponFire/onClientPedWeaponFire is dispatched.
+    void SetProcessingWeaponFireEvent(bool bProcessing) noexcept { m_bProcessingWeaponFireEvent = bProcessing; }
+
     bool GetRunningAnimationName(SString& strBlockName, SString& strAnimName);
     bool IsRunningAnimation();
 
@@ -722,6 +725,8 @@ public:
     CClientPad                               m_Pad;
     bool                                     m_bDestroyingSatchels;
     bool                                     m_bDoingGangDriveby;
+    bool                                     m_bProcessingWeaponFireEvent;
+    bool                                     m_bDeferredGangDrivebyAbort;
     std::unique_ptr<CAnimBlock>              m_pAnimationBlock;
     bool                                     m_bRequestedAnimation;
     SAnimationCache                          m_AnimationCache;


### PR DESCRIPTION
### Summary

Defers the native `MakeAbortable()` call for the gang driveby task when `setPedDoingGangDriveby(ped, false)` is called from inside an `onClientPlayerWeaponFire`/`onClientPedWeaponFire` handler, instead of running it immediately.

### Motivation

Calling `setPedDoingGangDriveby(localPlayer, false)` from `onClientPlayerWeaponFire` crashes the game. The event fires synchronously from inside the native `CTaskSimpleGangDriveBy::ProcessPed()` call (itself on the stack of `CPlayerPed::ProcessControl`). `MakeAbortable()` frees/nulls a member of the task object; when execution returns into the still-running `ProcessPed()` higher up the stack, it dereferences that now-null pointer and the game crashes with an access violation.

Closes #1913 (Crash issues from 2020 lol)

### Test plan

- Reproduced the crash with the original repro script (toggling `setPedDoingGangDriveby(localPlayer, false)` from `onClientPlayerWeaponFire` while actively firing in driveby).
- Applied the fix and confirmed the same script no longer crashes; the driveby task is aborted on the next pulse instead, and the ped correctly stops doing the driveby animation.

### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.