### PR TITLE
Fix onClientPlayerWasted not firing after e804d4d

### DIFF
--- a/Client/mods/deathmatch/logic/rpc/CElementRPCs.cpp
+++ b/Client/mods/deathmatch/logic/rpc/CElementRPCs.cpp
@@ -472,7 +472,25 @@ void CElementRPCs::SetElementHealth(CClientEntity* pSource, NetBitStreamInterfac
                     // to prevent DoWastedCheck from firing with stale local damage data
                     if (fHealth == 0.0f && pPed->IsLocalPlayer())
                     {
+                        CClientPlayer* pPlayer = static_cast<CClientPlayer*>(pPed);
+                        bool           bWasAlreadyDead = pPlayer->IsDeadOnNetwork();
+
                         g_pClientGame->ClearDamageData();
+                        pPlayer->SetDeadOnNetwork(true);
+
+                        // Fire onClientPlayerWasted to compensate for the server intentionally
+                        // skipping the CPlayerWastedPacket broadcast to the dying player.
+                        if (!bWasAlreadyDead)
+                        {
+                            CLuaArguments Arguments;
+                            Arguments.PushBoolean(false);  // killer = none
+                            Arguments.PushBoolean(false);  // weapon = unknown
+                            Arguments.PushBoolean(false);  // bodypart = unknown
+                            Arguments.PushBoolean(false);  // isStealth = false
+                            Arguments.PushNumber(0);       // animGroup
+                            Arguments.PushNumber(15);      // animID
+                            pPlayer->CallEvent("onClientPlayerWasted", Arguments, true);
+                        }
                     }
                 }
                 break;


### PR DESCRIPTION
#### Summary

PR #4862 fixed instant-respawn flows by skipping the CPlayerWastedPacket broadcast to the dying player in `SetElementHealth`. However the client-side `SET_ELEMENT_HEALTH=0` handler only called `ClearDamageData`, which sets `m_serverProcessedDeath=true`, blocking the local `DoWastedCheck` path too. With both paths blocked, `onClientPlayerWasted` never fired.

This change makes the client-side `SetElementHealth` RPC handler fire `onClientPlayerWasted` directly when the local player's health is set to 0, with the same arguments the skipped `CPlayerWastedPacket` would have delivered: `killer=false, weapon=false, bodypart=false, stealth=false, animGroup=0, animID=15`.

No behaviour change for remote players or `onPlayerWasted` (server-side), both of which were unaffected.

#### Motivation

After #4862, scripts relying on `onClientPlayerWasted` to detect scripted deaths via `setElementHealth(player, 0)` no longer receive the event. `onPlayerWasted` (server-side) still works, so the breakage is client-specific. Race and other gamemodes that listen on the client for death events are affected.

#### Test plan

Manually verify:
- `setElementHealth(player, 0)` from server: `onClientPlayerWasted` fires on the dying client, `onPlayerWasted` fires on server
- Race `respawntime=0` map: ENTER instantly respawns, no camera trap (original #4862 fix still holds)
- Race `respawntime=1` map: countdown then respawn, unchanged
- Natural death (drowning, fall damage): `onClientPlayerWasted` fires exactly once, no duplicate events
- Remote player killed via `setElementHealth`: their `onClientPlayerWasted` fires on other clients as before, unchanged

#### Checklist

* [x] Your code should follow the coding guidelines.
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.