### PR TITLE
Fix crash from engineFreeModel racing destroyElement deferred deletion

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -983,6 +983,14 @@ int CLuaEngineDefs::EngineFreeModel(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
+        // destroyElement() only defers the actual native entity deletion to the next pulse
+        // (see CElementDeleter). If a script destroys an entity using this model and calls
+        // engineFreeModel in the same tick, the entity's native CEntity is still alive and
+        // can still be found by other entities' collision processing the moment this model's
+        // collision data is freed below, crashing the game. Flush pending deletions first so
+        // any such entity is fully gone from the game world before the model is freed.
+        g_pClientGame->GetElementDeleter()->DoDeleteAll();
+
         auto                          modelManager = m_pManager->GetModelManager();
         std::shared_ptr<CClientModel> pModel = modelManager->FindModelByID(iModelID);
         if (pModel && modelManager->Remove(pModel))


### PR DESCRIPTION
### Summary

`engineFreeModel` now flushes the deferred element-deletion queue before freeing a models collision/DFF data.

### Motivation

Calling `engineFreeModel` right after `destroyElement` on an entity using that model crashes the game. `destroyElement` only flags the element and defers the actual native entity deletion to the next pulse (see `CElementDeleter`). If a script frees the model in the same tick, the native entity is still alive in the game world, and another entity's collision processing (`CEntity::GetIsTouching`/`GetBoundRadius`, called from `CPhysical::ProcessCollisionSectorList`) can still find it and read its now-freed `CColModel`, crashing with an access violation.


Closes #3316

### Test plan

- Reproduced the crash using `engineFreeModel` called immediately after `destroyElement` on a vehicle using a custom-content model.
- Applied the fix and confirmed the same sequence no longer crashes.

### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.