### PR TITLE
Fix precision mismatch in ResyncInterpolationWithGameClock

### DIFF
--- a/Client/game_sa/CWeatherSA.cpp
+++ b/Client/game_sa/CWeatherSA.cpp
@@ -37,15 +37,21 @@ void CWeatherSA::ResyncInterpolationWithGameClock(unsigned char primary, unsigne
     else
     {
         // Match the value CWeather::Update derives at 0x72B897:
-        //   v0 = ((double)seconds * 0.016666668 + (double)minutes) * 0.016666668
-        // Keep this <= engine v0 to avoid triggering the wrap branch on precision mismatches.
+        //   v0 = ((double)seconds * 0.016666668f + (double)minutes) * 0.016666668f
+        // The engine loads 0.016666668f as a 32-bit float (0x3C888889); using a
+        // double literal (0.016666668) produces a slightly larger constant, making
+        // our InterpolationValue exceed the engine's v0 and triggering the wrap
+        // branch that corrupts Foggyness and causes building-light flicker (#4803).
+        // Always round InterpolationValue down by one ULP so it is <= engine v0
+        // even when 64-bit double intermediates differ from the engine's 80-bit x87 path.
         const auto   ucMinute = *reinterpret_cast<unsigned char*>(VAR_TimeMinutes);
         const auto   ucSecond = *reinterpret_cast<unsigned char*>(VAR_TimeSeconds);
-        const double dInterp = std::min(1.0, (static_cast<double>(ucSecond) * 0.016666668 + static_cast<double>(ucMinute)) * 0.016666668);
+        const double dInterp = std::min(1.0, (static_cast<double>(ucSecond) * 0.016666668f + static_cast<double>(ucMinute)) * 0.016666668f);
         float        fInterp = static_cast<float>(dInterp);
 
-        if (static_cast<double>(fInterp) > dInterp)
-            fInterp = std::nextafterf(fInterp, 0.0f);
+        // Round down unconditionally: ensures InterpolationValue <= engine v0
+        // regardless of whether float->double conversion rounded up or down.
+        fInterp = std::nextafterf(fInterp, 0.0f);
 
         MemPutFast<float>(VAR_InterpolationValue, fInterp);
     }


### PR DESCRIPTION
#### Summary
Fix the final edge case of #4803 where blending from any non-fog weather into FOGGY_SF caused building lights and night windows to flicker every game-clock second. 

The root cause was a precision mismatch between the constant used in `CWeatherSA::ResyncInterpolationWithGameClock` and the one the engine's `CWeather::Update` loads from its binary data section.

#### Motivation
Three prior PRs (#4882, #4901, #4906) fixed most flicker cases by re-applying MTA's weather before `CWeather::Update` and adjusting `InterpolationValue` precision. 

However the interpolation formula still used a 64-bit double literal (`0.016666668`) while the engine loads a 32-bit float (`0x3C888889` = `0.016666668f`). The double literal is slightly larger, making MTA's `InterpolationValue` exceed the engine's `v0` and triggering the wrap branch that corrupts `Foggyness`. This only manifested visibly for FOGGY_SF because the `Foggyness` delta between non-fog and fog weathers is so large (~0 to ~1.0).

#### Test plan
1. Join a server, set time to night (22:00), position near buildings with visible night windows (e.g. San Fierro -2597 -156 4).
2. Run `setWeatherBlended(9)` from any non-fog weather (e.g. 5 SUNNY_SF).
3. Observe building lights and night windows during the 1-hour blend.
4. Expected: no per-second flicker, smooth fog transition.
5. Repeat with fast game clock to compress the blend and stress-test.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.