### PR TITLE
Fix aim pose desync when a weapon is given while the aim/fire button is held

### DIFF
--- a/Client/mods/deathmatch/logic/CNetAPI.cpp
+++ b/Client/mods/deathmatch/logic/CNetAPI.cpp
@@ -14,6 +14,8 @@
 #include <game/CWeapon.h>
 #include <game/CWeaponStat.h>
 #include <game/CWeaponStatManager.h>
+#include <game/CTaskManager.h>
+#include <game/Task.h>
 #include <enums/VehicleType.h>
 
 extern CClientGame* g_pClientGame;
@@ -1112,6 +1114,20 @@ void CNetAPI::WritePlayerPuresync(CClientPlayer* pPlayerModel, NetBitStreamInter
     // Write the full player keys
     CControllerState ControllerState;
     pPlayerModel->GetControllerState(ControllerState);
+
+    // The aim/fire buttons may still be held from before we received our current weapon.
+    // GTA:SA only starts TASK_SIMPLE_USE_GUN on a fresh button press, so clear stale bits
+    // here to keep the aim sync below consistent with our own pose.
+    if (ControllerState.RightShoulder1 || ControllerState.ButtonCircle)
+    {
+        CTask* pAttackTask = pPlayerModel->GetTaskManager()->GetTaskSecondary(TASK_SECONDARY_ATTACK);
+        if (!pAttackTask || pAttackTask->GetTaskType() != TASK_SIMPLE_USE_GUN)
+        {
+            ControllerState.RightShoulder1 = 0;
+            ControllerState.ButtonCircle = 0;
+        }
+    }
+
     WriteFullKeysync(ControllerState, BitStream);
 
     // Get the contact entity


### PR DESCRIPTION
#### Summary
`CNetAPI::WritePlayerPuresync` now clears the aim/fire (`RightShoulder1`/`ButtonCircle`) keysync bits in the outgoing on-foot puresync packet when the local ped's secondary attack task isn't actually `TASK_SIMPLE_USE_GUN`, instead of blindly forwarding the raw button state.

#### Motivation
Fixes #518, an ancient bug open since 2018.

GTA:SA only starts `TASK_SIMPLE_USE_GUN` on a fresh button press, not while held. If a weapon is given while aim is already held from before, the local pose looks right but the puresync protocol has no explicit "is aiming" wire bit - every reader rederives it from the raw keysync bits, which were still "held", so everyone else saw the player stuck aiming/running-aiming.

<details>
<summary>Before</summary>
<img width="1920" height="1080" alt="mta-screen_2026-06-21_21-07-08" src="https://github.com/user-attachments/assets/c7552b67-88c6-4e37-8243-2d577840c0b0" />
<img width="1366" height="768" alt="8a8517b7-65f8-4a7c-9880-fa9aec3147a4" src="https://github.com/user-attachments/assets/04fc2333-6b26-4f5b-982e-02afe8c50b6d" />

</details>

#### Test plan
Reproduced locally with two clients:
- Held aim with no weapon, then ran `giveWeapon(player, 34, 30, true)` (sniper) via a server-side `bindKey` test script while still holding aim.
- Before the fix: the local client correctly showed no aim pose, but the second client watching remotely saw the player aiming and running in the aiming animation.
- After the fix: both clients show the same (correct, non-aiming) pose.
- Also confirmed the fix covers picking up a weapon from a ground pickup, since `CPickup.cpp` calls the same `CStaticFunctionDefinitions::GiveWeapon` path used by the scripted function.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.