### PR TITLE
Fix/restream streamout collision gap

### DIFF
--- a/Client/mods/deathmatch/logic/CClientStreamElement.cpp
+++ b/Client/mods/deathmatch/logic/CClientStreamElement.cpp
@@ -148,6 +148,15 @@ void CClientStreamElement::StreamOutForABit()
 {
     // Remove asap, very messy
     InternalStreamOut();
+
+    // This is a deliberate, temporary stream-out (e.g. engineReplaceModel / model restore
+    // via RestreamObjects/RestreamPeds/etc). Unlike a distance-based stream-out it must be
+    // allowed to stream back in immediately. Otherwise the anti-thrash cooldown added in #4744
+    // (minStreamInDelayAfterOutMs in CClientStreamer::Restream) keeps the element - and its
+    // collision - streamed out for >1s, which makes players fall through restreamed ground/objects.
+    // Clearing the timestamp restores the documented "stream back in next frame" behaviour without
+    // re-introducing the #4744 ping-pong (which only goes through the distance-based InternalStreamOut).
+    m_lastStreamOutTime = 0u;
 }
 
 void CClientStreamElement::SetDimension(unsigned short usDimension)


### PR DESCRIPTION
#### Summary

`StreamOutForABit` is used for deliberate restreams (engineReplaceModel, and
model restore via RestreamObjects / RestreamPeds / RestreamVehicles / etc).
It is documented to stream the element back in on the next frame.

Since #4744 added an anti-thrash cooldown (`minStreamInDelayAfterOutMs`, 1200ms)
before an element can stream back in after a stream-out, these deliberate
restreams were blocked for over a second too.

This clears `m_lastStreamOutTime` in `StreamOutForABit` so the restream path is
exempt from the cooldown and streams back in right away again. The distance
based stream-out keeps its timestamp, so the #4744 ping-pong fix stays intact.

#### Motivation

After #4744, replacing or restoring a model at runtime (for example
engineReplaceModel on a road/object, or destroyElement on a custom DFF) keeps
the affected objects streamed out for about 1.2 seconds. During that gap the
collision is gone, so any player standing on or driving over that model falls
through the world. It used to be instant before #4744.

This is a regression from #4744.

#### Test plan

1. Have the player stand on (or drive over) an object model, for example a road piece.
2. At runtime, call `engineReplaceModel` on that model id, then `destroyElement`
   the replacement DFF to restore the original.
3. Before this PR: the object stays streamed out for about 1.2s, and the player
   falls through the object during the gap.
4. After this PR: the object streams back in on the next frame, collision stays,
   no fall-through.

Before:
https://streamable.com/4gyu8i

After:
https://streamable.com/z3x3n4

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
