### PR TITLE
Remove redundant json-c rounding check in CLuaManager

### DIFF
--- a/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -67,14 +67,6 @@ CLuaManager::CLuaManager(CObjectManager* pObjectManager, CPlayerManager* pPlayer
     LoadCFunctions();
     lua_registerPreCallHook(CLuaDefs::CanUseFunction);
     lua_registerUndumpHook(CLuaMain::OnUndump);
-
-#ifdef MTA_DEBUG
-    // Check rounding in case json is updated
-    json_object* obj = json_object_new_double(5.1);
-    SString      strResult = json_object_to_json_string_ext(obj, JSON_C_TO_STRING_PLAIN);
-    assert(strResult == "5.1");
-    json_object_put(obj);
-#endif
 }
 
 CLuaManager::~CLuaManager()


### PR DESCRIPTION
We now enforce the %.16g rounding in CGame::Start and also verify there, oversight from #4948