### PR TITLE
Fix attached entities staying too bright

### DIFF
--- a/Client/mods/deathmatch/logic/CClientEntity.cpp
+++ b/Client/mods/deathmatch/logic/CClientEntity.cpp
@@ -1192,6 +1192,16 @@ void CClientEntity::DoAttaching()
 
         if (!SetMatrix(returnMatrix))
             SetPosition(returnMatrix.vPos);
+
+        // The game only recalculates an entity's surface brightness from its surroundings
+        // while it's not attached to anything (see CObject::PreRender), so an attached
+        // entity would otherwise stay stuck at its default (too bright) value forever.
+        // Keep it in sync with whatever it's attached to every frame, same as vanilla
+        // hand-held objects already do with their owning ped.
+        CPhysical* pThisPhysical = dynamic_cast<CPhysical*>(GetGameEntity());
+        CPhysical* pAttachedToPhysical = dynamic_cast<CPhysical*>(m_pAttachedToEntity->GetGameEntity());
+        if (pThisPhysical && pAttachedToPhysical)
+            pThisPhysical->SetLighting(pAttachedToPhysical->GetLighting());
     }
 }
 


### PR DESCRIPTION
#### Summary

`CObject::PreRender` only recalculates an entity's contact-surface brightness ("lighting") while it isn't attached to anything, so an attached entity keeps whatever value it had at attach time (the constructor default, which renders much too bright) forever.

`CClientEntity::DoAttaching` now copies the lighting value from whatever the entity is attached to, every frame, mirroring what vanilla hand-held objects already do with their owning ped.

Any entity attached to another (e.g. via `attachElements`) renders visibly too bright/washed-out compared to its surroundings, because it's stuck with its default lighting value instead of picking up the lighting of whatever it's attached to.

<img width="787" height="756" alt="mta-screen_2026-06-26_19-18-27" src="https://github.com/user-attachments/assets/cc363519-b082-4c16-ac64-2493652adf67" />


#### Motivation

Fixes #2203.

#### Test plan

- Attached an object to a vehicle/ped in a dark area and confirmed it now matches the lighting of the entity it's attached to, instead of rendering at the default (too bright) value.
- Moved the attached entity between differently-lit areas and confirmed the brightness keeps updating every frame instead of getting stuck at the value from attach time.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.