### PR TITLE
Fix building light and corona flicker on non-fog to FOGGY_SF weather blend

### DIFF
--- a/Client/game_sa/CWeatherSA.cpp
+++ b/Client/game_sa/CWeatherSA.cpp
@@ -27,34 +27,13 @@ void CWeatherSA::Set(unsigned char primary, unsigned char secondary)
 
 void CWeatherSA::ResyncInterpolationWithGameClock(unsigned char primary, unsigned char secondary)
 {
-    // CWeather::InterpolationValue — see plugin_sa CWeather.cpp (0xC8130C)
+    // Set InterpolationValue to 0 so CWeather::Update's wrap branch never fires.
+    // The wrap condition is (engine_computed_interp < stored_InterpolationValue);
+    // since the engine's value is always >= 0, this is always false.
+    // CWeather::Update then computes its own InterpolationValue from the game clock
+    // and uses it consistently for all weather globals (Foggyness, Rain, etc.).
     constexpr DWORD VAR_InterpolationValue = 0xC8130C;
-    constexpr DWORD VAR_TimeMinutes = 0xB70152;
-    constexpr DWORD VAR_TimeSeconds = 0xB70150;
-
-    if (primary == secondary)
-        MemPutFast<float>(VAR_InterpolationValue, 0.0f);
-    else
-    {
-        // Match the value CWeather::Update derives at 0x72B897:
-        //   v0 = ((double)seconds * 0.016666668f + (double)minutes) * 0.016666668f
-        // The engine loads 0.016666668f as a 32-bit float (0x3C888889); using a
-        // double literal (0.016666668) produces a slightly larger constant, making
-        // our InterpolationValue exceed the engine's v0 and triggering the wrap
-        // branch that corrupts Foggyness and causes building-light flicker (#4803).
-        // Always round InterpolationValue down by one ULP so it is <= engine v0
-        // even when 64-bit double intermediates differ from the engine's 80-bit x87 path.
-        const auto   ucMinute = *reinterpret_cast<unsigned char*>(VAR_TimeMinutes);
-        const auto   ucSecond = *reinterpret_cast<unsigned char*>(VAR_TimeSeconds);
-        const double dInterp = std::min(1.0, (static_cast<double>(ucSecond) * 0.016666668f + static_cast<double>(ucMinute)) * 0.016666668f);
-        float        fInterp = static_cast<float>(dInterp);
-
-        // Round down unconditionally: ensures InterpolationValue <= engine v0
-        // regardless of whether float->double conversion rounded up or down.
-        fInterp = std::nextafterf(fInterp, 0.0f);
-
-        MemPutFast<float>(VAR_InterpolationValue, fInterp);
-    }
+    MemPutFast<float>(VAR_InterpolationValue, 0.0f);
 }
 
 void CWeatherSA::Release()

--- a/Client/mods/deathmatch/logic/CBlendedWeather.cpp
+++ b/Client/mods/deathmatch/logic/CBlendedWeather.cpp
@@ -57,11 +57,15 @@ void CBlendedWeather::DoPulse()
     const auto ucSecondary = static_cast<unsigned char>(m_ucSecondaryWeather);
 
     m_pWeather->Set(ucPrimary, ucSecondary);
-    // CWeather::Update (before this pulse) advances InterpolationValue for its own Old/New pair.
-    // After we overwrite Old/New with MTA's state, mirror the value CWeather::Update would derive
-    // (seconds/3600 + minutes/60) so CTimeCycle::CalcColoursForPoint blends m_CurrentColours
-    // smoothly per frame instead of stepping per game-minute (#4803).
+    // Set InterpolationValue to 0 so CWeather::Update's wrap branch cannot fire.
+    // The engine will compute its own InterpolationValue from the game clock and
+    // use it consistently for all weather globals.
     m_pWeather->ResyncInterpolationWithGameClock(ucPrimary, ucSecondary);
+}
+
+void CBlendedWeather::ReapplyWeatherTypes()
+{
+    m_pWeather->Set(static_cast<unsigned char>(m_ucPrimaryWeather), static_cast<unsigned char>(m_ucSecondaryWeather));
 }
 
 void CBlendedWeather::SetWeather(unsigned char ucWeather)

--- a/Client/mods/deathmatch/logic/CBlendedWeather.h
+++ b/Client/mods/deathmatch/logic/CBlendedWeather.h
@@ -17,6 +17,7 @@ public:
     CBlendedWeather();
 
     void DoPulse();
+    void ReapplyWeatherTypes();
 
     void SetWeather(unsigned char ucWeather);
     void SetWeatherBlended(unsigned char ucWeather, unsigned char ucHour);

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -3922,28 +3922,22 @@ void CClientGame::PreRenderSkyHandler()
 
 void CClientGame::PreWeatherUpdateHandler()
 {
-    // Fix #4803 (building light flicker): Re-apply MTA's weather state BEFORE
-    // CWeather::Update runs. CWeather::Update detects a clock wrap when setTime()
-    // jumps the game clock past InterpolationValue and re-derives Rain, Foggyness,
-    // CloudCoverage, ExtraSunnyness, SunGlare, HeatHaze, etc. from a freshly-picked
-    // weather pair. Those globals drive cloud, fog and night-time building light
-    // rendering for the rest of the frame, and PreWorldProcessHandler runs too late
-    // to undo the damage. Pre-syncing Old/New/InterpolationValue here keeps the
-    // wrap branch from firing.
+    // Fix #4803: Set MTA's weather types and zero InterpolationValue BEFORE
+    // CWeather::Update runs. Zeroing InterpolationValue prevents the wrap branch
+    // from ever firing (engine_interp >= 0 is always true), so the engine computes
+    // all weather globals (Foggyness, Rain, etc.) from MTA's weather pair.
     if (m_pManager->IsGameLoaded() && m_pBlendedWeather)
         m_pBlendedWeather->DoPulse();
 }
 
 void CClientGame::PreWorldProcessHandler()
 {
-    // Fix #4803: Re-apply MTA's weather state before CTimeCycle::CalcColoursForPoint()
-    // reads the weather globals for rendering. The engine's CWeather::Update() (0x53BFC2)
-    // runs earlier in CGame::Process() and can overwrite OldWeatherType/NewWeatherType
-    // when setTime() causes a clock wrap. This hook (at CWorld::Process, 0x53C095) runs
-    // after that overwrite but before CalcColoursForPoint (0x53C0DA) consumes the values,
-    // ensuring the rendered frame always uses MTA's intended weather.
+    // Re-apply MTA's weather types before CTimeCycle::CalcColoursForPoint() (0x53C0DA).
+    // Only set OldWeatherType/NewWeatherType — do NOT touch InterpolationValue here,
+    // so CalcColoursForPoint uses the same engine-computed value that CWeather::Update
+    // used for weather globals (Foggyness, etc.), keeping everything consistent.
     if (m_pManager->IsGameLoaded() && m_pBlendedWeather)
-        m_pBlendedWeather->DoPulse();
+        m_pBlendedWeather->ReapplyWeatherTypes();
 }
 
 void CClientGame::PostWorldProcessHandler()

--- a/Client/sdk/game/CWeather.h
+++ b/Client/sdk/game/CWeather.h
@@ -18,9 +18,7 @@ class CWeather
 public:
     virtual unsigned char Get() = 0;
     virtual void          Set(unsigned char primary, unsigned char secondary) = 0;
-    // After Set(), if the engine had diverged from MTA's intended types (e.g. CWeather::Update
-    // clock-wrap in #4803), realign InterpolationValue with the game clock so materials that blend
-    // weather heavily (glass / reflections) match the sky.
+    // Zero InterpolationValue so CWeather::Update's wrap branch cannot fire (#4803).
     virtual void ResyncInterpolationWithGameClock(unsigned char primary, unsigned char secondary) = 0;
     virtual void Release() = 0;
 


### PR DESCRIPTION
#### Summary
Eliminates the remaining per-clock-second flicker of building lights, traffic light coronas and 2DFX when blending from any non-fog weather into FOGGY_SF. Instead of trying to match the engine's `InterpolationValue`, `DoPulse` now resets it to zero before `CWeather::Update` runs. `PreWorldProcessHandler` was also simplified and now only re-applies weather types without touching `InterpolationValue`.

#### Motivation
Follow-up to #4870, #4882, #4901, #4906 and #4971. Those PRs fixed most flicker cases by pre-syncing `InterpolationValue` to the engine's `((seconds * 1/60) + minutes) * 1/60` formula.

There was still one remaining issue when blending from any non-fog weather into `FOGGY_SF`. This happened for two reasons. First, the engine computes `InterpolationValue` using x87 80-bit arithmetic, while MTA replicates it with SSE2 64-bit arithmetic. After double rounding, both values can differ by more than one ULP, allowing the stored value to become slightly larger than the engine's value and trigger the wrap branch. Second, when the player alt-tabs, the game timer can freeze for a few milliseconds, desynchronizing the clock seconds from the stored `InterpolationValue` by an arbitrary amount and making an exact match impossible.

When the wrap branch is triggered, `CWeather::Update` recalculates `Foggyness`, `Rain`, `CloudCoverage` and other weather globals from its own weather pair instead of MTA's. Since `FOGGY_SF` transitions from approximately `0 → 1` fogginess, even a single corrupted frame becomes visible as a flash.

The new approach is to set `InterpolationValue = 0` before every `CWeather::Update` call. The wrap condition is `engine_computed_interp < stored`, and because the engine always computes a value greater than or equal to zero, storing `0` guarantees that the condition never becomes true.

`CWeather::Update` can then compute its own `InterpolationValue` directly from the game clock and use it consistently for all weather globals. `PreWorldProcessHandler` only restores `OldWeatherType` and `NewWeatherType`, allowing `CalcColoursForPoint` to blend using the same `InterpolationValue` that the engine already used for `Foggyness`, eliminating the inconsistency that caused the flicker.

#### Test plan
1. On a server with a fast game clock (`setMinuteDuration(100)`), set the time to `22:00` and position yourself near buildings with night windows and traffic lights.
2. Set a non-fog weather with `setWeather(5)` (`SUNNY_SF`).
3. Blend into `FOGGY_SF` using `setWeatherBlended(9)`.
4. Watch building lights, traffic light coronas and 2DFX lights during the entire blend hour.
5. Expected result: no per-second flicker and a smooth fog transition throughout.
6. Alt-tab several times during the blend. The lights should remain stable after resuming.
7. Repeat the test with other non-fog weathers such as `14` (`SUNNY_COUNTRYSIDE`) and `0` (`EXTRA_SUNNY_SA`).

#### Checklist
* [x] Your code should follow the coding guidelines.
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.