### PR TITLE
Fix neon texture rendering regression

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1577,15 +1577,21 @@ void CMultiplayerSA::InitHooks()
     MemCpy((void*)0x53A00A, "\x33\xC0\x90\x90\x90", 5);
 
     // Fix objects with alpha below 141 are invisible (#425)
-    // Original values: 0x553AD9=140, 0x732C2F=100. These are passed to
+    // Original SA values: 0x553AD9=140, 0x732C2F=100. These are passed to
     // RwRenderStateSet(rwRENDERSTATEALPHATESTFUNCTIONREF, value).
-    // When value=0, RenderWare DISABLES alpha testing entirely, causing
-    // fully transparent pixels to write to the z-buffer and block objects
-    // behind transparent surfaces (fences, vegetation, etc).
-    // Using value=1 keeps alpha testing enabled (rejecting only alpha=0
-    // pixels) while preserving the fix for low-alpha entity visibility.
+    //
+    // 0x553AD9 (RenderEverythingBarRoads initial ALPHAREF): set to 1 so
+    // fully-transparent pixels are rejected without breaking low-alpha objects
+    // that don't pass through RenderEntity's per-entity override.
+    //
+    // 0x732C2F (RenderEntity non-fading path): restored to SA's original 100.
+    // MTA's prior patch of 1 made neon light texture gradients (alpha 1-99) pass
+    // the test and render as a wide blurry band instead of a thin bright line.
+    // Entities with MTA custom material alpha < 100 (set via setElementAlpha) are
+    // handled per-entity in OnMY_CEntity_RenderOneNonRoad_Pre, which overrides
+    // ALPHAREF to 0 for those entities so they remain visible.
     MemPut<BYTE>(0x553AD9, 1);
-    MemPut<BYTE>(0x732C2F, 1);
+    MemPut<BYTE>(0x732C2F, 100);
 
     InitHooks_CrashFixHacks();
     InitHooks_DeviceSelection();

--- a/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
@@ -9,6 +9,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include <game/RenderWare.h>
 extern CCoreInterface*           g_pCore;
 GameEntityRenderHandler*         pGameEntityRenderHandler = nullptr;
 PreRenderSkyHandler*             pPreRenderSkyHandlerHandler = nullptr;
@@ -155,10 +156,51 @@ inner:
 // Detect entity rendering
 //
 //////////////////////////////////////////////////////////////////////////////////////////
+
+// Returns the alpha of the first material in the entity's first atomic geometry.
+// MTA's setElementAlpha (via FUNC_SetRwObjectAlpha) sets material alpha on all
+// materials. Checking just the first is sufficient to detect the low-alpha case.
+static BYTE GetEntityFirstMaterialAlpha(CEntitySAInterface* pEntity)
+{
+    RwObject* pRwObj = reinterpret_cast<RwObject*>(pEntity->m_pRwObject);
+    if (!pRwObj)
+        return 255;
+
+    RpAtomic* pAtomic = nullptr;
+    if (pRwObj->type == 1)  // rpATOMIC
+    {
+        pAtomic = reinterpret_cast<RpAtomic*>(pRwObj);
+    }
+    else if (pRwObj->type == 2)  // rpCLUMP
+    {
+        RpClump*     pClump = reinterpret_cast<RpClump*>(pRwObj);
+        RwListEntry* pEntry = pClump->atomics.root.next;
+        if (pEntry != &pClump->atomics.root)
+            pAtomic = reinterpret_cast<RpAtomic*>(reinterpret_cast<BYTE*>(pEntry) - offsetof(RpAtomic, globalClumps));
+    }
+
+    if (pAtomic && pAtomic->geometry && pAtomic->geometry->materials.entries > 0)
+        return pAtomic->geometry->materials.materials[0]->color.a;
+
+    return 255;
+}
+
 bool OnMY_CEntity_RenderOneNonRoad_Pre(CEntitySAInterface* pEntity)
 {
     ms_RenderingOneNonRoad = pEntity;
     CallGameEntityRenderHandler(ms_RenderingOneNonRoad);
+
+    // CVisibilityPlugins::RenderEntity just set ALPHAREF=100 (SA's original value) for
+    // this non-fading entity. If MTA's setElementAlpha assigned material alpha < 100,
+    // the entity would be invisible with ALPHAREF=100. Override to 0 in that case so
+    // the entity renders normally under alpha blending.
+    if (GetEntityFirstMaterialAlpha(pEntity) < 100)
+    {
+        DWORD engine = *(DWORD*)0xC97B24;
+        auto  fpSet = reinterpret_cast<BOOL(__cdecl*)(DWORD, void*)>(*(DWORD*)(engine + 0x20));
+        fpSet(0x1e /*rwRENDERSTATEALPHATESTFUNCTIONREF*/, nullptr);
+    }
+
     return IsEntityRenderable(pEntity);
 }
 


### PR DESCRIPTION
#### Summary
Restores the original `ALPHAREF=100` value in `CVisibilityPlugins::RenderEntity` (byte at `0x732C2F`), which MTA had previously lowered to `1` to fix #425. To keep compatibility with that fix, this PR adds a per-entity override in `OnMY_CEntity_RenderOneNonRoad_Pre`: whenever an entity's material alpha is set below `100` via `setElementAlpha`, `ALPHAREF` is temporarily overridden to `0` for that specific entity before rendering.

<img width="1366" height="768" alt="mta-screen_2026-07-02_21-50-11" src="https://github.com/user-attachments/assets/b1a08d85-16ad-45ec-8d43-41a9b4254331" />


#### Motivation
Neon light textures on buildings were rendering incorrectly in MTA, appearing as wide, blurry color bands instead of the thin bright lines seen in vanilla GTA SA.

The issue comes from using `ALPHAREF=1`. With such a low threshold, gradient pixels in the neon textures with alpha values between `1` and `99` pass the alpha test and blend together into a diffuse glow. The original game uses `ALPHAREF=100`, which discards those low-alpha edge pixels and leaves only the bright center of the texture, producing the sharp neon line the game is supposed to display.

The fix for #425 lowered `ALPHAREF` globally so that objects with very low alpha values could still be rendered correctly. However, that change unintentionally affected neon rendering. This PR keeps the original threshold by default and only disables it for entities that actually need low-alpha rendering, handling both cases independently.

#### Test plan
1. Verify that neon light textures on buildings render as thin bright lines, matching vanilla GTA SA.
2. Verify that `setElementAlpha` values below `100` still make objects visible and correctly transparent.
3. Verify that `setElementAlpha` values between `100` and `255` continue to render normally.
4. Verify that fences, vegetation and other alpha-cutout world geometry render without z-buffer artifacts.

#### Checklist
* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.