### PR TITLE
Use RtlGetVersion for Windows version checks

### DIFF
--- a/Shared/sdk/SharedUtil.Misc.hpp
+++ b/Shared/sdk/SharedUtil.Misc.hpp
@@ -2031,18 +2031,40 @@ bool SharedUtil::ShellExecuteNonBlocking(const SString& strAction, const SString
 // (Ignores compatibility mode)
 //
 ///////////////////////////////////////////////////////////////////////////
+// Use the extended structure which contains wServicePackMajor
+typedef NTSTATUS(WINAPI* RtlGetVersionPtr)(PRTL_OSVERSIONINFOEXW);
+
 bool SharedUtil::IsWindowsVersionOrGreater(WORD wMajorVersion, WORD wMinorVersion, WORD wServicePackMajor)
 {
-    OSVERSIONINFOEXW osvi = {sizeof(osvi), 0, 0, 0, 0, {0}, 0, 0};
-    DWORDLONG const  dwlConditionMask =
-        VerSetConditionMask(VerSetConditionMask(VerSetConditionMask(0, VER_MAJORVERSION, VER_GREATER_EQUAL), VER_MINORVERSION, VER_GREATER_EQUAL),
-                            VER_SERVICEPACKMAJOR, VER_GREATER_EQUAL);
+    HMODULE hMod = GetModuleHandleW(L"ntdll.dll");
+    if (hMod)
+    {
+        RtlGetVersionPtr pRtlGetVersion = (RtlGetVersionPtr)GetProcAddress(hMod, "RtlGetVersion");
+        if (pRtlGetVersion)
+        {
+            RTL_OSVERSIONINFOEXW rovi = {0};
+            rovi.dwOSVersionInfoSize = sizeof(rovi);
 
-    osvi.dwMajorVersion = wMajorVersion;
-    osvi.dwMinorVersion = wMinorVersion;
-    osvi.wServicePackMajor = wServicePackMajor;
+            // RtlGetVersion bypasses any compatibility shims and returns the true OS version
+            if (pRtlGetVersion(&rovi) == 0)  // STATUS_SUCCESS
+            {
+                if (rovi.dwMajorVersion > wMajorVersion)
+                    return true;
 
-    return VerifyVersionInfoW(&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR, dwlConditionMask) != FALSE;
+                if (rovi.dwMajorVersion == wMajorVersion)
+                {
+                    if (rovi.dwMinorVersion > wMinorVersion)
+                        return true;
+
+                    if (rovi.dwMinorVersion == wMinorVersion)
+                    {
+                        return rovi.wServicePackMajor >= wServicePackMajor;
+                    }
+                }
+            }
+        }
+    }
+    return false;
 }
 
 bool SharedUtil::IsWindowsXPSP3OrGreater()


### PR DESCRIPTION
#### Summary
Replaces the `VerifyVersionInfoW`-based Windows version check in `SharedUtil::IsWindowsVersionOrGreater` with `RtlGetVersion`.

This keeps the function aligned with its existing intent: return the real Windows version while ignoring compatibility mode shims.

VerifyVersionInfoW has also been deprecated by Microsoft all the way back in Windows 10.


#### Motivation
`VerifyVersionInfoW` can be affected by application compatibility/version manifest behavior, which can make OS version checks unreliable. `RtlGetVersion` returns the actual OS version from `ntdll.dll`, so this is a better fit for `IsWindowsVersionOrGreater`.

#### Test plan
Run on machines using Windows XP->Windows 7 SP-Whatever

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.