### PR TITLE
Fix white flash when takePlayerScreenShot is used with CEF browsers

### DIFF
--- a/Client/cefweb/CWebCore.cpp
+++ b/Client/cefweb/CWebCore.cpp
@@ -776,21 +776,6 @@ bool CWebCore::GetRemoteJavascriptEnabled()
     return bIsRemoteJavascriptEnabled;
 }
 
-void CWebCore::OnPreScreenshot()
-{
-    // Clear all textures
-    ClearTextures();
-}
-
-void CWebCore::OnPostScreenshot()
-{
-    // Re-draw textures
-    for (auto& pWebView : m_WebViews)
-    {
-        pWebView->GetCefBrowser()->GetHost()->Invalidate(CefBrowserHost::PaintElementType::PET_VIEW);
-    }
-}
-
 void CWebCore::OnFPSLimitChange(std::uint16_t fps)
 {
     dassert(g_pCore->GetNetwork() != nullptr);  // Ensure network module is loaded
@@ -833,14 +818,6 @@ void CWebCore::ProcessInputMessage(UINT uMsg, WPARAM wParam, LPARAM lParam)
     }
 
     m_pFocusedWebView->InjectKeyboardEvent(keyEvent);
-}
-
-void CWebCore::ClearTextures()
-{
-    for (auto& pWebBrowser : m_WebViews)
-    {
-        pWebBrowser->ClearTexture();
-    }
 }
 
 bool CWebCore::SetGlobalAudioVolume(float fVolume)

--- a/Client/cefweb/CWebCore.h
+++ b/Client/cefweb/CWebCore.h
@@ -94,13 +94,9 @@ public:
     CWebViewInterface* GetFocusedWebView();
     void               SetFocusedWebView(CWebView* pWebView) { m_pFocusedWebView = pWebView; };
     void               ProcessInputMessage(UINT uMsg, WPARAM wParam, LPARAM lParam);
-    void               ClearTextures();
 
     bool GetRemotePagesEnabled();
     bool GetRemoteJavascriptEnabled();
-
-    void OnPreScreenshot();
-    void OnPostScreenshot();
 
     void OnFPSLimitChange(std::uint16_t fps) override;
 

--- a/Client/cefweb/CWebView.cpp
+++ b/Client/cefweb/CWebView.cpp
@@ -325,34 +325,6 @@ void CWebView::Focus(bool state)
         pWebCore->SetFocusedWebView(nullptr);
 }
 
-void CWebView::ClearTexture()
-{
-    if (!m_pWebBrowserRenderItem) [[unlikely]]
-        return;
-
-    auto* const pD3DSurface = m_pWebBrowserRenderItem->m_pD3DRenderTargetSurface;
-    if (!pD3DSurface) [[unlikely]]
-        return;
-
-    D3DSURFACE_DESC SurfaceDesc;
-    if (FAILED(pD3DSurface->GetDesc(&SurfaceDesc))) [[unlikely]]
-        return;
-
-    D3DLOCKED_RECT LockedRect;
-    if (SUCCEEDED(pD3DSurface->LockRect(&LockedRect, nullptr, D3DLOCK_DISCARD)))
-    {
-        // Check for integer overflow in size calculation: height * pitch must fit in size_t
-        // Ensure both are positive and that multiplication won't overflow
-        if (SurfaceDesc.Height > 0 && LockedRect.Pitch > 0 && static_cast<size_t>(SurfaceDesc.Height) <= SIZE_MAX / static_cast<size_t>(LockedRect.Pitch))
-            [[likely]]
-        {
-            const auto memsetSize = static_cast<size_t>(SurfaceDesc.Height) * static_cast<size_t>(LockedRect.Pitch);
-            std::memset(LockedRect.pBits, 0xFF, memsetSize);
-        }
-        pD3DSurface->UnlockRect();
-    }
-}
-
 void CWebView::UpdateTexture()
 {
     const std::scoped_lock lock(m_RenderData.dataMutex);

--- a/Client/cefweb/CWebView.h
+++ b/Client/cefweb/CWebView.h
@@ -80,7 +80,6 @@ public:
     const bool         GetRenderingPaused() const;
     void               Focus(bool state = true);
     IDirect3DTexture9* GetTexture() { return static_cast<IDirect3DTexture9*>(m_pWebBrowserRenderItem->m_pD3DTexture); }
-    void               ClearTexture();
 
     void UpdateTexture();
 

--- a/Client/core/DXHook/CDirect3DEvents9.cpp
+++ b/Client/core/DXHook/CDirect3DEvents9.cpp
@@ -648,23 +648,11 @@ void CDirect3DEvents9::OnPresent(IDirect3DDevice9* pDevice, IDirect3DDevice9* pS
     // Must do this before GUI draw to prevent NVidia performance problems
     CGraphics::GetSingleton().GetRenderItemManager()->FlushNonAARenderTarget();
 
-    bool bTookScreenShot = false;
-    if (!CGraphics::GetSingleton().GetScreenGrabber()->IsQueueEmpty())
-    {
-        if (g_pCore->IsWebCoreLoaded())
-            g_pCore->GetWebCore()->OnPreScreenshot();
-
-        bTookScreenShot = true;
-    }
-
     // Draw pre-GUI primitives
     CGraphics::GetSingleton().DrawPreGUIQueue();
 
     // Maybe grab screen for upload
     CGraphics::GetSingleton().GetScreenGrabber()->DoPulse();
-
-    if (bTookScreenShot && g_pCore->IsWebCoreLoaded())
-        g_pCore->GetWebCore()->OnPostScreenshot();
 
     // Draw the GUI
     CLocalGUI::GetSingleton().Draw();

--- a/Client/sdk/core/CWebCoreInterface.h
+++ b/Client/sdk/core/CWebCoreInterface.h
@@ -78,13 +78,9 @@ public:
     virtual CWebViewInterface* GetFocusedWebView() = 0;
     virtual void               SetFocusedWebView(CWebView* pWebView) = 0;
     virtual void               ProcessInputMessage(UINT uMsg, WPARAM wParam, LPARAM lParam) = 0;
-    virtual void               ClearTextures() = 0;
 
     virtual bool GetRemotePagesEnabled() = 0;
     virtual bool GetRemoteJavascriptEnabled() = 0;
-
-    virtual void OnPreScreenshot() = 0;
-    virtual void OnPostScreenshot() = 0;
 
     virtual void OnFPSLimitChange(std::uint16_t fps) = 0;
 


### PR DESCRIPTION
#### Summary

Remove the pre/post screenshot hooks that cleared live CEF render targets before `takePlayerScreenShot` capture. The back buffer is now grabbed as-is after `DrawPreGUIQueue`, eliminating the visible white flash when a CEF browser is on screen.

Also removes the now-unused `OnPreScreenshot`, `OnPostScreenshot`, `ClearTextures`, and `ClearTexture` code paths.

#### Motivation

When the server calls `takePlayerScreenShot` while a client has a CEF browser displayed via `createBrowser` + `dxDrawImage`, the player's screen briefly flashes white on every capture.

The old flow cleared live CEF textures to white (`0xFF`) before reading the back buffer, then triggered an async `Invalidate` to repaint them. That touched the same textures used for on-screen rendering in the same frame, so the flash was visible to the player.

This change captures the back buffer without modifying live CEF textures. Screenshot upload continues to work; only the visible flash is removed.

Fixes #4955

#### Test plan

Create a CEF browser on the client and draw it with `dxDrawImage`. Call `takePlayerScreenShot` from the server repeatedly and confirm no white flash appears on the client.

Confirm the server still receives the screenshot with correct game content.

Test downscaled capture with `takePlayerScreenShot(player, 320, 240, ...)`.

Regression: F12 local screenshot still works.

Regression: alt-tab / minimized client still returns `MINIMIZED` / `DISABLED` responses as before.

#### Checklist

* [X] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [X] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.