### PR TITLE
extend the per entity ref scaling to vehicles

### DIFF
--- a/Client/core/DXHook/CDirect3DEvents9.cpp
+++ b/Client/core/DXHook/CDirect3DEvents9.cpp
@@ -752,11 +752,16 @@ HRESULT CDirect3DEvents9::OnDrawPrimitive(IDirect3DDevice9* pDevice, IDirect3DDe
     if (!pLayers)
     {
         // No shaders for this texture.
-        // Apply dual-pass alpha rendering when the mesh has alpha blending with z-write enabled,
-        // but only for 3D world geometry (not pre-transformed 2D elements like the radar/HUD).
-        // This prevents transparent pixels (e.g. fence holes, vegetation cutouts) from writing to
-        // the z-buffer and blocking objects behind them — emulating PS2 per-pixel z-write behavior.
-        if (g_pDeviceState->RenderState.ALPHABLENDENABLE && g_pDeviceState->RenderState.ZWRITEENABLE && !g_pDeviceState->VertexDeclState.PositionT)
+        // Dual-pass alpha z-write emulation for blended 3D geometry (not pre-transformed 2D).
+        // Pass 1 z-writes pixels >= threshold, pass 2 blends the rest without z-write, so fence
+        // holes don't occlude what's behind them. only runs when the game has no meaningful alpha
+        // test of its own (ref at the DefinedState baseline of 2 or below): an active test at ref
+        // 100/140 already clips transparent pixels before z-write like vanilla, and forcing the
+        // dual pass over it draws the sub-ref gradient in pass 2, which is what kept the LV neon
+        // lines smeared no matter what the game side ALPHAREF was set to.
+        const bool bGameAlphaTestActive = g_pDeviceState->RenderState.ALPHATESTENABLE && g_pDeviceState->RenderState.ALPHAREF > 2;
+        if (!bGameAlphaTestActive && g_pDeviceState->RenderState.ALPHABLENDENABLE && g_pDeviceState->RenderState.ZWRITEENABLE &&
+            !g_pDeviceState->VertexDeclState.PositionT)
         {
             // Save current alpha test state
             const DWORD dwOrigAlphaTestEnable = g_pDeviceState->RenderState.ALPHATESTENABLE;
@@ -1003,11 +1008,12 @@ HRESULT CDirect3DEvents9::OnDrawIndexedPrimitive(IDirect3DDevice9* pDevice, IDir
     if (!pLayers)
     {
         // No shaders for this texture.
-        // Apply dual-pass alpha rendering when the mesh has alpha blending with z-write enabled,
-        // but only for 3D world geometry (not pre-transformed 2D elements like the radar/HUD).
-        // This prevents transparent pixels (e.g. fence holes, vegetation cutouts) from writing to
-        // the z-buffer and blocking objects behind them — emulating PS2 per-pixel z-write behavior.
-        if (g_pDeviceState->RenderState.ALPHABLENDENABLE && g_pDeviceState->RenderState.ZWRITEENABLE && !g_pDeviceState->VertexDeclState.PositionT)
+        // Dual-pass alpha z-write emulation, same rules as OnDrawPrimitive: skip when the game
+        // is already running a meaningful alpha test, it clips transparent pixels before z-write
+        // on its own and the dual pass would draw the sub-ref gradient in pass 2.
+        const bool bGameAlphaTestActive = g_pDeviceState->RenderState.ALPHATESTENABLE && g_pDeviceState->RenderState.ALPHAREF > 2;
+        if (!bGameAlphaTestActive && g_pDeviceState->RenderState.ALPHABLENDENABLE && g_pDeviceState->RenderState.ZWRITEENABLE &&
+            !g_pDeviceState->VertexDeclState.PositionT)
         {
             // Save current alpha test state
             const DWORD dwOrigAlphaTestEnable = g_pDeviceState->RenderState.ALPHATESTENABLE;

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1576,22 +1576,9 @@ void CMultiplayerSA::InitHooks()
     MemCpy((void*)0x53A23F, "\x33\xC0\x90\x90\x90", 5);
     MemCpy((void*)0x53A00A, "\x33\xC0\x90\x90\x90", 5);
 
-    // Fix objects with alpha below 141 are invisible (#425)
-    // Original SA values: 0x553AD9=140, 0x732C2F=100. These are passed to
-    // RwRenderStateSet(rwRENDERSTATEALPHATESTFUNCTIONREF, value).
-    //
-    // 0x553AD9 (RenderEverythingBarRoads initial ALPHAREF): set to 1 so
-    // fully-transparent pixels are rejected without breaking low-alpha objects
-    // that don't pass through RenderEntity's per-entity override.
-    //
-    // 0x732C2F (RenderEntity non-fading path): restored to SA's original 100.
-    // MTA's prior patch of 1 made neon light texture gradients (alpha 1-99) pass
-    // the test and render as a wide blurry band instead of a thin bright line.
-    // Entities with MTA custom material alpha < 100 (set via setElementAlpha) are
-    // handled per-entity in OnMY_CEntity_RenderOneNonRoad_Pre, which overrides
-    // ALPHAREF to 0 for those entities so they remain visible.
-    MemPut<BYTE>(0x553AD9, 1);
-    MemPut<BYTE>(0x732C2F, 100);
+    // SA alpha test refs (0x553AD9=140, 0x732C2F=100) stay at stock values, lowering them
+    // smears alpha gradient textures (LV neon, #4996). low alpha elements are handled per
+    // entity in OnMY_CEntity_RenderOneNonRoad_Pre (#425).
 
     InitHooks_CrashFixHacks();
     InitHooks_DeviceSelection();

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1576,10 +1576,6 @@ void CMultiplayerSA::InitHooks()
     MemCpy((void*)0x53A23F, "\x33\xC0\x90\x90\x90", 5);
     MemCpy((void*)0x53A00A, "\x33\xC0\x90\x90\x90", 5);
 
-    // SA alpha test refs (0x553AD9=140, 0x732C2F=100) stay at stock values, lowering them
-    // smears alpha gradient textures (LV neon, #4996). low alpha elements are handled per
-    // entity in OnMY_CEntity_RenderOneNonRoad_Pre (#425).
-
     InitHooks_CrashFixHacks();
     InitHooks_DeviceSelection();
 

--- a/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
@@ -157,32 +157,52 @@ inner:
 //
 //////////////////////////////////////////////////////////////////////////////////////////
 
-// Returns the alpha of the first material in the entity's first atomic geometry.
-// MTA's setElementAlpha (via FUNC_SetRwObjectAlpha) sets material alpha on all
-// materials. Checking just the first is sufficient to detect the low-alpha case.
-static BYTE GetEntityFirstMaterialAlpha(CEntitySAInterface* pEntity)
+// #425: the game sets ALPHAREF before the entity render call (140 in
+// RenderEverythingBarRoads, 100 in CVisibilityPlugins::RenderEntity), alpha func is
+// GREATER. MTA applies setElementAlpha by scaling material alpha during the render,
+// so at element alpha A every pixel lands at (texel * A / 255) and the object drops
+// below the ref once A <= 140 or A <= 100 depending on path. lowering the refs
+// globally is what smeared the LV neon textures (#4996), so scale the ref for this
+// entity only: ref' = ref * A / 255. both sides of the compare scale equally, cutouts
+// keep their shape and ref' < A so the object never fully vanishes. restored in the
+// Post handler. player peds, cars and bikes set ref 1 and restore it inside their
+// own Render fns, they were never affected by the world refs.
+static bool  ms_bAlphaTestRefOverridden = false;
+static DWORD ms_dwSavedAlphaTestRef = 0;
+
+static void OverrideAlphaTestRefForElementAlpha(CEntitySAInterface* pEntity)
 {
-    RwObject* pRwObj = reinterpret_cast<RwObject*>(pEntity->m_pRwObject);
-    if (!pRwObj)
-        return 255;
+    if (pEntity->nType != ENTITY_TYPE_OBJECT)
+        return;
 
-    RpAtomic* pAtomic = nullptr;
-    if (pRwObj->type == 1)  // rpATOMIC
-    {
-        pAtomic = reinterpret_cast<RpAtomic*>(pRwObj);
-    }
-    else if (pRwObj->type == 2)  // rpCLUMP
-    {
-        RpClump*     pClump = reinterpret_cast<RpClump*>(pRwObj);
-        RwListEntry* pEntry = pClump->atomics.root.next;
-        if (pEntry != &pClump->atomics.root)
-            pAtomic = reinterpret_cast<RpAtomic*>(reinterpret_cast<BYTE*>(pEntry) - offsetof(RpAtomic, globalClumps));
-    }
+    SClientEntity<CObjectSA>* pObjectClientEntity = pGameInterface->GetPools()->GetObject((DWORD*)pEntity);
+    CObject*                  pObject = pObjectClientEntity ? pObjectClientEntity->pEntity : nullptr;
+    if (!pObject)
+        return;
 
-    if (pAtomic && pAtomic->geometry && pAtomic->geometry->materials.entries > 0)
-        return pAtomic->geometry->materials.materials[0]->color.a;
+    unsigned char ucAlpha = pObject->GetAlpha();
+    if (ucAlpha == 255)
+        return;
 
-    return 255;
+    // RwEngineInstance->dOpenDevice.fpRenderStateGet/fpRenderStateSet
+    DWORD engine = *(DWORD*)0xC97B24;
+    auto  fpGet = reinterpret_cast<BOOL(__cdecl*)(DWORD, void*)>(*(DWORD*)(engine + 0x24));
+    auto  fpSet = reinterpret_cast<BOOL(__cdecl*)(DWORD, void*)>(*(DWORD*)(engine + 0x20));
+
+    fpGet(0x1e /*rwRENDERSTATEALPHATESTFUNCTIONREF*/, &ms_dwSavedAlphaTestRef);
+    fpSet(0x1e /*rwRENDERSTATEALPHATESTFUNCTIONREF*/, reinterpret_cast<void*>(ms_dwSavedAlphaTestRef * ucAlpha / 255));
+    ms_bAlphaTestRefOverridden = true;
+}
+
+static void RestoreAlphaTestRef()
+{
+    if (!ms_bAlphaTestRefOverridden)
+        return;
+    ms_bAlphaTestRefOverridden = false;
+
+    DWORD engine = *(DWORD*)0xC97B24;
+    auto  fpSet = reinterpret_cast<BOOL(__cdecl*)(DWORD, void*)>(*(DWORD*)(engine + 0x20));
+    fpSet(0x1e /*rwRENDERSTATEALPHATESTFUNCTIONREF*/, reinterpret_cast<void*>(ms_dwSavedAlphaTestRef));
 }
 
 bool OnMY_CEntity_RenderOneNonRoad_Pre(CEntitySAInterface* pEntity)
@@ -190,22 +210,15 @@ bool OnMY_CEntity_RenderOneNonRoad_Pre(CEntitySAInterface* pEntity)
     ms_RenderingOneNonRoad = pEntity;
     CallGameEntityRenderHandler(ms_RenderingOneNonRoad);
 
-    // CVisibilityPlugins::RenderEntity just set ALPHAREF=100 (SA's original value) for
-    // this non-fading entity. If MTA's setElementAlpha assigned material alpha < 100,
-    // the entity would be invisible with ALPHAREF=100. Override to 0 in that case so
-    // the entity renders normally under alpha blending.
-    if (GetEntityFirstMaterialAlpha(pEntity) < 100)
-    {
-        DWORD engine = *(DWORD*)0xC97B24;
-        auto  fpSet = reinterpret_cast<BOOL(__cdecl*)(DWORD, void*)>(*(DWORD*)(engine + 0x20));
-        fpSet(0x1e /*rwRENDERSTATEALPHATESTFUNCTIONREF*/, nullptr);
-    }
+    OverrideAlphaTestRefForElementAlpha(pEntity);
 
     return IsEntityRenderable(pEntity);
 }
 
 void OnMY_CEntity_RenderOneNonRoad_Post(CEntitySAInterface* pEntity)
 {
+    RestoreAlphaTestRef();
+
     if (ms_RenderingOneNonRoad)
     {
         ms_RenderingOneNonRoad = NULL;

--- a/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
@@ -166,21 +166,28 @@ inner:
 // entity only: ref' = ref * A / 255. both sides of the compare scale equally, cutouts
 // keep their shape and ref' < A so the object never fully vanishes. restored in the
 // Post handler. player peds, cars and bikes set ref 1 and restore it inside their
-// own Render fns, they were never affected by the world refs.
+// own Render fns. boats and trains never did, so vehicles get the same scaling,
+// for cars and bikes it's a no-op since their own ref write lands after ours.
 static bool  ms_bAlphaTestRefOverridden = false;
 static DWORD ms_dwSavedAlphaTestRef = 0;
 
 static void OverrideAlphaTestRefForElementAlpha(CEntitySAInterface* pEntity)
 {
-    if (pEntity->nType != ENTITY_TYPE_OBJECT)
-        return;
+    unsigned char ucAlpha = 255;
 
-    SClientEntity<CObjectSA>* pObjectClientEntity = pGameInterface->GetPools()->GetObject((DWORD*)pEntity);
-    CObject*                  pObject = pObjectClientEntity ? pObjectClientEntity->pEntity : nullptr;
-    if (!pObject)
-        return;
+    if (pEntity->nType == ENTITY_TYPE_OBJECT)
+    {
+        SClientEntity<CObjectSA>* pObjectClientEntity = pGameInterface->GetPools()->GetObject((DWORD*)pEntity);
+        if (pObjectClientEntity && pObjectClientEntity->pEntity)
+            ucAlpha = pObjectClientEntity->pEntity->GetAlpha();
+    }
+    else if (pEntity->nType == ENTITY_TYPE_VEHICLE)
+    {
+        SClientEntity<CVehicleSA>* pVehicleClientEntity = pGameInterface->GetPools()->GetVehicle((DWORD*)pEntity);
+        if (pVehicleClientEntity && pVehicleClientEntity->pEntity)
+            ucAlpha = pVehicleClientEntity->pEntity->GetAlpha();
+    }
 
-    unsigned char ucAlpha = pObject->GetAlpha();
     if (ucAlpha == 255)
         return;
 

--- a/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
@@ -205,6 +205,7 @@ static void RestoreAlphaTestRef()
 {
     if (!ms_bAlphaTestRefOverridden)
         return;
+
     ms_bAlphaTestRefOverridden = false;
 
     DWORD engine = *(DWORD*)0xC97B24;


### PR DESCRIPTION
#### Summary

builds on #5005. @dryxio asked whether setElementAlpha on a boat or train goes fully invisible which it does and is known behavior, it did on 1.6 and every release before it: cars and bikes set ALPHAREF 1 inside their own Render fns, boats and trains never touch it, so at stock refs the hull drops below the test once alpha goes under ~100. run vehicles through the same scaled ref as objects. cars and bikes are unaffected, their own ref write lands after ours and wins. boats and trains get working setElementAlpha out of it.

#### Test plan

1. setElementAlpha on a boat or train at any value, hull renders translucent instead of vanishing
2. cars and bikes unchanged

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
