### PR TITLE
Fix setCameraTarget not syncing camera rotation to ped heading (#4915)

### DIFF
--- a/Client/mods/deathmatch/logic/CClientCamera.cpp
+++ b/Client/mods/deathmatch/logic/CClientCamera.cpp
@@ -628,6 +628,10 @@ void CClientCamera::SetFocusToLocalPlayerImpl()
     m_pCamera->RestoreWithJumpCut();
     SetCenterOfWorldCached(NULL, 0.0f);
     InvalidateCachedTransforms();
+
+    CClientPlayer* pLocalPlayer = m_pPlayerManager ? m_pPlayerManager->GetLocalPlayer() : nullptr;
+    if (pLocalPlayer && !pLocalPlayer->GetOccupiedVehicle())
+        pLocalPlayer->SetCameraRotation(pLocalPlayer->GetCurrentRotation());
 }
 
 void CClientCamera::UnreferenceEntity(CClientEntity* pEntity)

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -3376,6 +3376,13 @@ void CClientPed::SetCurrentRotation(float fRotation, bool bIncludeTarget)
     CVector vecRotation = m_Matrix.GetRotation();
     vecRotation.fZ = fRotation;
     m_Matrix.SetRotation(vecRotation);
+
+    if (IsFrozen() && !GetRealOccupiedVehicle())
+    {
+        CVector vecFrozenRot = m_matFrozen.GetRotation();
+        vecFrozenRot.fZ = fRotation;
+        m_matFrozen.SetRotation(vecFrozenRot);
+    }
 }
 
 void CClientPed::SetTargetRotation(float fRotation)

--- a/Client/mods/deathmatch/logic/rpc/CPedRPCs.cpp
+++ b/Client/mods/deathmatch/logic/rpc/CPedRPCs.cpp
@@ -79,7 +79,7 @@ void CPedRPCs::SetPedRotation(CClientEntity* pSource, NetBitStreamInterface& bit
 
             if (!IS_PLAYER(pPed))
                 pPed->SetCameraRotation(rotation.data.fRotation);
-            else if (pPed->IsLocalPlayer() && g_pClientGame && !g_pClientGame->GetCamera()->IsInFixedMode())
+            else if (pPed->IsLocalPlayer() && m_pCamera && !m_pCamera->IsInFixedMode())
                 pPed->SetCameraRotation(rotation.data.fRotation);
             pPed->SetSyncTimeContext(ucTimeContext);
         }

--- a/Client/mods/deathmatch/logic/rpc/CPedRPCs.cpp
+++ b/Client/mods/deathmatch/logic/rpc/CPedRPCs.cpp
@@ -79,6 +79,8 @@ void CPedRPCs::SetPedRotation(CClientEntity* pSource, NetBitStreamInterface& bit
 
             if (!IS_PLAYER(pPed))
                 pPed->SetCameraRotation(rotation.data.fRotation);
+            else if (pPed->IsLocalPlayer() && g_pClientGame && !g_pClientGame->GetCamera()->IsInFixedMode())
+                pPed->SetCameraRotation(rotation.data.fRotation);
             pPed->SetSyncTimeContext(ucTimeContext);
         }
     }


### PR DESCRIPTION
#### Summary
Fixes a 1.7 regression where `setCameraTarget(player)` does not reliably align the camera with the ped's rotation after a server-side rotation change, especially on a frozen local player.

Changes:
- Sync camera rotation to ped heading in `SetFocusToLocalPlayerImpl()` after `RestoreWithJumpCut()`
- Keep `m_matFrozen` rotation in sync when rotation is changed on a frozen ped
- Sync camera rotation for the local player on `SET_PED_ROTATION` when not in fixed camera mode

#### Motivation
Fixes #4915.

In MTA 1.6, `setCameraTarget(client)` consistently reset the camera to match the player's on-foot rotation. In 1.7 this became inconsistent; the camera often stayed wrong, commonly ~180° opposite to the ped.

The main causes were:
- `setCameraTarget` only restored camera focus via `RestoreWithJumpCut()` and did not sync camera rotation to ped heading
- Server-side `setElementRotation` did not update camera rotation for players
- On frozen players, `SetCurrentRotation()` updated `m_Matrix` but not `m_matFrozen`, so `StreamedInPulse()` could revert the ped to the old rotation on the next frame

#### Test plan
Reproduced the original report flow (frozen local player, server-side dimension/interior/rotation change, then `setCameraTarget`) and confirmed the camera now matches ped rotation instead of often ending up ~180° off. Also checked the same flow without freeze and after unfreeze.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.