### PR TITLE
Fix custom ped textures persisting after resource stop/disconnect

### DIFF
--- a/Client/game_sa/CRenderWareSA.TextureReplacing.cpp
+++ b/Client/game_sa/CRenderWareSA.TextureReplacing.cpp
@@ -213,6 +213,14 @@ bool CRenderWareSA::ModelInfoTXDAddTextures(SReplacementTextures* pReplacementTe
 ////////////////////////////////////////////////////////////////
 void CRenderWareSA::ModelInfoTXDRemoveTextures(SReplacementTextures* pReplacementTextures)
 {
+    // Force ped models to drop their loaded clump, mirroring the forced unload in GetModelTexturesInfo, so they pick up the restored textures below
+    for (ushort usModelId : pReplacementTextures->usedInModelIds)
+    {
+        CModelInfo* pModelInfo = pGame->GetModelInfo(usModelId);
+        if (pModelInfo && pModelInfo->GetModelType() == eModelInfoType::PED)
+            ((void(__cdecl*)(unsigned short))FUNC_RemoveModel)(usModelId);
+    }
+
     // For each using txd
     for (uint i = 0; i < pReplacementTextures->perTxdList.size(); i++)
     {

--- a/Client/mods/deathmatch/logic/CClientPedManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientPedManager.cpp
@@ -106,8 +106,8 @@ void CClientPedManager::RestreamPeds(unsigned short usModel)
     {
         pPed = *iter;
 
-        // Streamed in and same vehicle ID?
-        if (pPed->IsStreamedIn() && pPed->GetModel() == usModel)
+        // Streamed in (or the local player, whose m_bStreamedIn never gets set, see CLuaElementDefs::IsElementStreamedIn) and same model ID?
+        if ((pPed->IsStreamedIn() || pPed->IsLocalPlayer()) && pPed->GetModel() == usModel)
         {
             // Stream it out for a while until streamed decides to stream it
             // back in eventually
@@ -128,8 +128,8 @@ void CClientPedManager::RestreamAllPeds()
 {
     for (auto& pPed : m_List)
     {
-        // Streamed in and same vehicle ID?
-        if (pPed->IsStreamedIn())
+        // Streamed in (or the local player - see RestreamPeds above)?
+        if (pPed->IsStreamedIn() || pPed->IsLocalPlayer())
         {
             // Stream it out for a while until streamed decides to stream it
             // back in eventually


### PR DESCRIPTION
#### Summary
Fixes custom ped textures/skins applied via `engineImportTXD` not reverting to the original texture when the replacement is removed (resource stop, script `stopResource`, or disconnecting from the server).

Two issues in the ped texture-restream path, both specific to the local player:

- `CClientPedManager::RestreamPeds`/`RestreamAllPeds` gated the model-refresh hack behind `IsStreamedIn()`, which never becomes `true` for the local player (its ped is created via `_CreateLocalModel()`, which doesn't go through the normal `InternalStreamIn()` path that sets that flag). This meant the refresh never even attempted to run when you were wearing the modified skin yourself.
- `CRenderWareSA::ModelInfoTXDRemoveTextures` restored the original textures in the TXD dictionary, but never forced the ped model to drop its currently-loaded clump, unlike `GetModelTexturesInfo` which does this when the replacement is first applied. Without it, an already-rendered ped had no guarantee it would pick the restored textures back up.

#### Motivation
Fixes #1877.

#### Test plan

[zm-skin.zip](https://github.com/user-attachments/files/29677155/zm-skin.zip)

- Loaded a custom TXD onto a worn skin model via `engineLoadTXD` + `engineImportTXD` from a test resource.
- Confirmed the texture applies correctly (unaffected by this change).
- Stopped the resource while still connected: texture now reliably reverts to the original (previously it was inconsistent; sometimes reverted, sometimes stayed applied).
- Disconnected while the custom texture was active and reconnected to a server without the resource: skin now shows correctly instead of keeping the modified texture.
- Verified vehicles/objects are unaffected (they don't share the local-player streaming quirk that caused this).

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.