### PR TITLE
Add vehicle model special ability API part1

### DIFF
--- a/Client/game_sa/CAEVehicleAudioEntitySA.h
+++ b/Client/game_sa/CAEVehicleAudioEntitySA.h
@@ -54,6 +54,12 @@ class CAEVehicleAudioEntitySAInterface : public CAEAudioEntity
 {
 public:
     void AddAudioEvent(int eventId, float volume) { ((void(__thiscall*)(CAEVehicleAudioEntitySAInterface*, int, float))0x4F6420)(this, eventId, volume); }
+    void UpdateGenericVehicleSound(int soundType, int bankSlot, int bank, int sfx, float speed, float volume, float rollOff)
+    {
+        ((void(__thiscall*)(CAEVehicleAudioEntitySAInterface*, int, int, int, int, float, float, float))0x4FAD40)(this, soundType, bankSlot, bank, sfx,
+                                                                                                                speed, volume, rollOff);
+    }
+    void StopGenericEngineSound(int soundType) { ((void(__thiscall*)(CAEVehicleAudioEntitySAInterface*, int))0x4F6320)(this, soundType); }
     bool TerminateAudio() { return ((bool(__thiscall*)(CAEVehicleAudioEntitySAInterface*))0x4FB8C0)(this); }
     bool SoundJoin() { return ((bool(__thiscall*)(CAEVehicleAudioEntitySAInterface*))0x4F5700)(this); }
 

--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -36,6 +36,49 @@ extern CGameSA*        pGame;
 
 static BOOL m_bVehicleSunGlare = false;
 
+static WORD GetRegisteredVehicleModelSpecialAbility(CVehicleSAInterface* vehicleInterface, WORD currentModel, int preRenderHook)
+{
+    if (!vehicleInterface)
+        return currentModel;
+
+    auto* const clientVehicle = pGame->GetPools()->GetVehicle(reinterpret_cast<DWORD*>(vehicleInterface));
+    auto* const vehicle = clientVehicle ? clientVehicle->pEntity : nullptr;
+    if (!vehicle)
+        return currentModel;
+
+    const WORD resolvedModel = vehicle->GetModelSpecialAbilityModel(currentModel);
+    if (auto* const vehicleSA = dynamic_cast<CVehicleSA*>(vehicle))
+        vehicleSA->NoteModelSpecialAbilityHookResolve(currentModel, resolvedModel, preRenderHook != 0);
+    return resolvedModel;
+}
+
+static WORD GetRegisteredVehicleProcessControlSpecialAbility(CVehicleSAInterface* vehicleInterface, WORD currentModel)
+{
+    if (!vehicleInterface)
+        return currentModel;
+
+    auto* const clientVehicle = pGame->GetPools()->GetVehicle(reinterpret_cast<DWORD*>(vehicleInterface));
+    auto* const vehicle = clientVehicle ? clientVehicle->pEntity : nullptr;
+    if (!vehicle)
+        return currentModel;
+
+    const WORD resolvedModel = vehicle->GetModelSpecialAbilityModel(currentModel);
+
+    // Custom packers keep GTA's native PreRender ramp rotation, but skip native
+    // UpdateMovingCollision. The generated moving collision can push the camera far above custom
+    // ramp meshes, so CClientVehicle updates only the misc angle for custom packers.
+    if (resolvedModel == 443 /* Packer */ && currentModel != resolvedModel)
+    {
+        if (auto* const vehicleSA = dynamic_cast<CVehicleSA*>(vehicle))
+            vehicleSA->NoteModelSpecialAbilityHookResolve(currentModel, currentModel, false);
+        return currentModel;
+    }
+
+    if (auto* const vehicleSA = dynamic_cast<CVehicleSA*>(vehicle))
+        vehicleSA->NoteModelSpecialAbilityHookResolve(currentModel, resolvedModel, false);
+    return resolvedModel;
+}
+
 // PreRender re-asserts rpATOMICRENDER on all wheel atomics every frame, which re-shows
 // the Rhino's middle wheels that SetupModelNodes hides at init. Re-clear the flag here so
 // it stays the last write of the frame and the wheels remain invisible like in vanilla.
@@ -55,6 +98,157 @@ static void __fastcall RehideRhinoMiddleWheels(CAutomobileSAInterface* vehicle)
         if (RwFrame* frame = vehicle->m_aCarNodes[static_cast<std::size_t>(comp)])
             RwFrameForAllObjects(frame, (void*)ClearAtomicRenderFlagCB, nullptr);
     }
+}
+
+static const DWORD HOOKPOS_CAutomobile_PreRender_MiscModelCheck = 0x6AC4D9;
+static const DWORD HOOKSIZE_CAutomobile_PreRender_MiscModelCheck = 6;
+static const DWORD RETURN_CAutomobile_PreRender_MiscModelCheckPacker = 0x6AC4DF;
+static const DWORD RETURN_CAutomobile_PreRender_MiscModelCheckNext = 0x6AC507;
+
+static const DWORD HOOKPOS_CAutomobile_ProcessControl_ModelSwitch = 0x6B1F77;
+static const DWORD HOOKSIZE_CAutomobile_ProcessControl_ModelSwitch = 8;
+static const DWORD RETURN_CAutomobile_ProcessControl_ModelSwitch = 0x6B1F7F;
+
+static const DWORD HOOKPOS_CAutomobile_GetTowBarPos_ModelCheck = 0x6AF250;
+static const DWORD HOOKSIZE_CAutomobile_GetTowBarPos_ModelCheck = 11;
+static const DWORD RETURN_CAutomobile_GetTowBarPos_ModelCheck = 0x6AF25B;
+
+static const DWORD HOOKPOS_CVehicle_UpdateTrailerLink_ModelCheck = 0x6DFDB2;
+static const DWORD HOOKSIZE_CVehicle_UpdateTrailerLink_ModelCheck = 8;
+static const DWORD RETURN_CVehicle_UpdateTrailerLink_ModelCheck = 0x6DFDBA;
+
+static const DWORD HOOKPOS_CVehicle_UpdateTractorLink_ModelCheck = 0x6E00D0;
+static const DWORD HOOKSIZE_CVehicle_UpdateTractorLink_ModelCheck = 8;
+static const DWORD RETURN_CVehicle_UpdateTractorLink_ModelCheck = 0x6E00D8;
+
+static void __declspec(naked) HOOK_CVehicle_UpdateTrailerLink_ModelCheck(void)
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // The tow line/drop physics path has its own towtruck/tractor model check. Resolve the
+        // transient comparison value here so custom towtrucks keep the original trailer-link logic.
+        pushad
+        movzx   eax, word ptr [ebx+22h]
+        push    0
+        push    eax
+        push    ebx
+        call    GetRegisteredVehicleModelSpecialAbility
+        add     esp, 12
+        mov     word ptr [esp+28], ax
+        popad
+
+        cmp     ax, 20Dh
+        jmp     RETURN_CVehicle_UpdateTrailerLink_ModelCheck
+    }
+    // clang-format on
+}
+
+static void __declspec(naked) HOOK_CVehicle_UpdateTractorLink_ModelCheck(void)
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // UpdateTractorLink repeats the same model-specific towtruck/tractor handling after
+        // computing link offsets. Keep that native branch available to configured custom models.
+        pushad
+        movzx   eax, word ptr [esi+22h]
+        push    eax
+        push    esi
+        call    GetRegisteredVehicleProcessControlSpecialAbility
+        add     esp, 8
+        mov     word ptr [esp+28], ax
+        popad
+
+        cmp     ax, 20Dh
+        jmp     RETURN_CVehicle_UpdateTractorLink_ModelCheck
+    }
+    // clang-format on
+}
+
+static void __declspec(naked) HOOK_CAutomobile_GetTowBarPos_ModelCheck(void)
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // Towbar lookup is also model-gated. Resolve the same ability model here so native
+        // TowTruckControl can find a towbar on resource-defined towtrucks.
+        pushad
+        movzx   eax, word ptr [ecx+22h]
+        push    0
+        push    eax
+        push    ecx
+        call    GetRegisteredVehicleModelSpecialAbility
+        add     esp, 12
+        mov     word ptr [esp+28], ax
+        popad
+
+        sub     esp, 0Ch
+        cmp     ax, 20Dh
+        jmp     RETURN_CAutomobile_GetTowBarPos_ModelCheck
+    }
+    // clang-format on
+}
+
+static void __declspec(naked) HOOK_CAutomobile_ProcessControl_ModelSwitch(void)
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // Original code loads m_nModelIndex into AX before the model switch that calls
+        // UpdateMovingCollision and TowTruckControl. Use a ProcessControl-specific resolver so
+        // custom packers can keep visual misc_a rotation without GTA's moving-collision camera push.
+        pushad
+        movzx   eax, word ptr [esi+22h]
+        push    eax
+        push    esi
+        call    GetRegisteredVehicleProcessControlSpecialAbility
+        add     esp, 8
+        mov     word ptr [esp+28], ax
+        popad
+
+        cmp     ax, 1B0h
+        jmp     RETURN_CAutomobile_ProcessControl_ModelSwitch
+    }
+    // clang-format on
+}
+
+static void __declspec(naked) HOOK_CAutomobile_PreRender_MiscModelCheck(void)
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // Original code checks AX against MODEL_PACKER, then falls through to MODEL_TOWTRUCK.
+        // Replace only that transient comparison value so the native misc_a rotation block can
+        // handle resource-defined special abilities without changing the vehicle's real model ID.
+        pushad
+        movzx   eax, word ptr [esp+28]
+        push    1
+        push    eax
+        push    esi
+        call    GetRegisteredVehicleModelSpecialAbility
+        add     esp, 12
+        mov     word ptr [esp+28], ax
+        popad
+
+        cmp     ax, 1BBh
+        jne     not_packer
+        jmp     RETURN_CAutomobile_PreRender_MiscModelCheckPacker
+
+not_packer:
+        jmp     RETURN_CAutomobile_PreRender_MiscModelCheckNext
+    }
+    // clang-format on
 }
 
 static void __declspec(naked) HOOK_Vehicle_PreRender(void)
@@ -969,7 +1163,17 @@ float CVehicleSA::GetGasPedal()
 
 bool CVehicleSA::GetTowBarPos(CVector* pVector, CVehicle* pTrailer)
 {
-    return GetVehicleInterface()->GetTowbarPos(pVector, true, pTrailer ? pTrailer->GetVehicleInterface() : nullptr);
+    auto* const vehicleInterface = GetVehicleInterface();
+    const WORD  originalModel = vehicleInterface->m_nModelIndex;
+    const WORD  resolvedModel = GetModelSpecialAbilityModel(originalModel);
+
+    // GTA restricts towbar lookup for towtrucks/tractors by hard-coded model ID. Temporarily
+    // expose the configured ability model so native tow attachment uses the original towtruck
+    // geometry rules without permanently changing this custom model.
+    vehicleInterface->m_nModelIndex = resolvedModel;
+    const bool result = vehicleInterface->GetTowbarPos(pVector, true, pTrailer ? pTrailer->GetVehicleInterface() : nullptr);
+    vehicleInterface->m_nModelIndex = originalModel;
+    return result;
 }
 
 bool CVehicleSA::GetTowHitchPos(CVector* pVector)
@@ -1914,6 +2118,75 @@ bool CVehicleSA::UpdateMovingCollision(float fAngle)
     return bReturn;
 }
 
+void CVehicleSA::SetModelSpecialAbilityModel(unsigned short model, bool enabled)
+{
+    const WORD previousModel = m_modelSpecialAbilityModel;
+
+    // Store this on the SA wrapper so native hooks can resolve the ability through
+    // CVehicleSAInterface::m_pVehicle even if the underlying game entity is recreated.
+    m_modelSpecialAbilityEnabled = enabled;
+    m_modelSpecialAbilityModel = model;
+
+    if (!enabled && previousModel == 544 /* Fire Truck Ladder */)
+    {
+        auto* const automobile = dynamic_cast<CAutomobileSA*>(this);
+        auto* const automobileInterface = automobile ? automobile->GetAutomobileInterface() : nullptr;
+        if (automobileInterface)
+            automobileInterface->m_swingingChassis = {};
+    }
+    else if (enabled && model == 525 /* Towtruck */)
+    {
+        auto* const automobile = dynamic_cast<CAutomobileSA*>(this);
+        auto* const automobileInterface = automobile ? automobile->GetAutomobileInterface() : nullptr;
+        if (automobileInterface && automobileInterface->m_aCarNodes[static_cast<std::size_t>(eCarNodes::MISC_B)])
+        {
+            auto& towHookPanel = automobileInterface->m_panels[FRONT_LEFT_PANEL];
+            if (towHookPanel.m_nFrameId == 0xFFFF)
+                towHookPanel.SetPanel(static_cast<std::int16_t>(eCarNodes::MISC_B), 2, 1.0f);
+        }
+    }
+    else if (enabled && model == 544 /* Fire Truck Ladder */)
+    {
+        auto* const automobile = dynamic_cast<CAutomobileSA*>(this);
+        auto* const automobileInterface = automobile ? automobile->GetAutomobileInterface() : nullptr;
+        if (automobileInterface)
+        {
+            // MODEL_FIRELA initializes this special chassis door in CAutomobile's constructor.
+            // Custom models skip that constructor branch, so mirror the native setup when a
+            // resource opts into ladder behavior.
+            auto& swingingChassis = automobileInterface->m_swingingChassis;
+            swingingChassis.m_fOpenAngle = 0.1f * 3.14159265358979323846f;
+            swingingChassis.m_fClosedAngle = -0.1f * 3.14159265358979323846f;
+            swingingChassis.m_nDirn = 0x184;      // DOOR_AXIS_NEG_Y | DOOR_EXTRA_FIXEDSTATE | DOOR_EXTRA_FIRETRUCK
+            swingingChassis.m_nAxis = 2;          // DOOR_AXIS_Z
+            swingingChassis.m_nDoorState = 1;     // DOOR_HIT_MAX_END
+        }
+    }
+}
+
+WORD CVehicleSA::GetModelSpecialAbilityModel(WORD currentModel) const
+{
+    return m_modelSpecialAbilityEnabled ? m_modelSpecialAbilityModel : currentModel;
+}
+
+void CVehicleSA::NoteModelSpecialAbilityHookResolve(WORD currentModel, WORD resolvedModel, bool preRenderHook)
+{
+    // Keep a tiny live trace for diagnosing custom models that do not enter GTA's native special
+    // vehicle branches. This records the hook input/output without changing the native path.
+    if (preRenderHook)
+    {
+        m_modelSpecialAbilityLastPreRenderCurrentModel = currentModel;
+        m_modelSpecialAbilityLastPreRenderResolvedModel = resolvedModel;
+        ++m_modelSpecialAbilityPreRenderResolveCount;
+    }
+    else
+    {
+        m_modelSpecialAbilityLastProcessCurrentModel = currentModel;
+        m_modelSpecialAbilityLastProcessResolvedModel = resolvedModel;
+        ++m_modelSpecialAbilityProcessResolveCount;
+    }
+}
+
 void* CVehicleSA::GetPrivateSuspensionLines()
 {
     if (m_pSuspensionLines == NULL)
@@ -2076,6 +2349,26 @@ bool CVehicleSA::SetOnFire(bool onFire)
 
 void CVehicleSA::StaticSetHooks()
 {
+    // Trailer-link updates use separate model checks for towtruck line physics and drop/release
+    // behavior, so extend those checks as well as TowTruckControl and towbar lookup.
+    HookInstall(HOOKPOS_CVehicle_UpdateTrailerLink_ModelCheck, (DWORD)HOOK_CVehicle_UpdateTrailerLink_ModelCheck,
+                HOOKSIZE_CVehicle_UpdateTrailerLink_ModelCheck);
+    HookInstall(HOOKPOS_CVehicle_UpdateTractorLink_ModelCheck, (DWORD)HOOK_CVehicle_UpdateTractorLink_ModelCheck,
+                HOOKSIZE_CVehicle_UpdateTractorLink_ModelCheck);
+
+    // Let GTA's own towbar lookup treat configured custom models as towtrucks/tractors.
+    HookInstall(HOOKPOS_CAutomobile_GetTowBarPos_ModelCheck, (DWORD)HOOK_CAutomobile_GetTowBarPos_ModelCheck,
+                HOOKSIZE_CAutomobile_GetTowBarPos_ModelCheck);
+
+    // Extend GTA's native ProcessControl model switch so custom models enter the original
+    // towtruck/packer logic instead of calling those routines from MTA's post-frame pulse.
+    HookInstall(HOOKPOS_CAutomobile_ProcessControl_ModelSwitch, (DWORD)HOOK_CAutomobile_ProcessControl_ModelSwitch,
+                HOOKSIZE_CAutomobile_ProcessControl_ModelSwitch);
+
+    // Extend GTA's native misc_a PreRender model checks for resource-defined vehicle abilities.
+    HookInstall(HOOKPOS_CAutomobile_PreRender_MiscModelCheck, (DWORD)HOOK_CAutomobile_PreRender_MiscModelCheck,
+                HOOKSIZE_CAutomobile_PreRender_MiscModelCheck);
+
     // Setup vehicle sun glare hook
     HookInstall(FUNC_CAutomobile_OnVehiclePreRender, (DWORD)HOOK_Vehicle_PreRender, 5);
 

--- a/Client/game_sa/CVehicleSA.h
+++ b/Client/game_sa/CVehicleSA.h
@@ -440,6 +440,14 @@ private:
     unsigned char                    m_ucVariantCount{0};
     bool                             m_doorsUndamageable{false};
     bool                             m_rotorState{true};
+    bool                             m_modelSpecialAbilityEnabled{false};
+    WORD                             m_modelSpecialAbilityModel{0};
+    WORD                             m_modelSpecialAbilityLastProcessCurrentModel{0};
+    WORD                             m_modelSpecialAbilityLastProcessResolvedModel{0};
+    WORD                             m_modelSpecialAbilityLastPreRenderCurrentModel{0};
+    WORD                             m_modelSpecialAbilityLastPreRenderResolvedModel{0};
+    unsigned int                     m_modelSpecialAbilityProcessResolveCount{0};
+    unsigned int                     m_modelSpecialAbilityPreRenderResolveCount{0};
 
     std::array<CVector, static_cast<std::size_t>(VehicleDummies::VEHICLE_DUMMY_COUNT)> m_dummyPositions;
 
@@ -646,6 +654,17 @@ public:
 
     CColModel* GetSpecialColModel();
     bool       UpdateMovingCollision(float fAngle);
+    void       SetModelSpecialAbilityModel(unsigned short model, bool enabled) override;
+    WORD       GetModelSpecialAbilityModel(WORD currentModel) const override;
+    void       NoteModelSpecialAbilityHookResolve(WORD currentModel, WORD resolvedModel, bool preRenderHook);
+    bool       IsModelSpecialAbilityEnabled() const { return m_modelSpecialAbilityEnabled; }
+    WORD       GetConfiguredModelSpecialAbilityModel() const { return m_modelSpecialAbilityModel; }
+    WORD       GetLastProcessSpecialAbilityCurrentModel() const { return m_modelSpecialAbilityLastProcessCurrentModel; }
+    WORD       GetLastProcessSpecialAbilityResolvedModel() const { return m_modelSpecialAbilityLastProcessResolvedModel; }
+    WORD       GetLastPreRenderSpecialAbilityCurrentModel() const { return m_modelSpecialAbilityLastPreRenderCurrentModel; }
+    WORD       GetLastPreRenderSpecialAbilityResolvedModel() const { return m_modelSpecialAbilityLastPreRenderResolvedModel; }
+    unsigned int GetProcessSpecialAbilityResolveCount() const { return m_modelSpecialAbilityProcessResolveCount; }
+    unsigned int GetPreRenderSpecialAbilityResolveCount() const { return m_modelSpecialAbilityPreRenderResolveCount; }
 
     void RecalculateHandling();
 

--- a/Client/mods/deathmatch/logic/CClientDFF.cpp
+++ b/Client/mods/deathmatch/logic/CClientDFF.cpp
@@ -178,7 +178,10 @@ bool CClientDFF::DoReplaceModel(unsigned short usModel, bool bAlphaTransparency)
         // Is this a vehicle ID?
         if (CClientVehicleManager::IsValidModel(usModel))
         {
-            return ReplaceVehicleModel(pClump, usModel, bAlphaTransparency);
+            const bool wasReplaced = ReplaceVehicleModel(pClump, usModel, bAlphaTransparency);
+            if (wasReplaced)
+                ResetVehicleModelSpecialAbilities(usModel);
+            return wasReplaced;
         }
         else if (CClientPlayerManager::IsValidModel(usModel))
         {
@@ -261,6 +264,8 @@ void CClientDFF::InternalRestoreModel(unsigned short usModel)
     // Is this a vehicle ID?
     if (CClientVehicleManager::IsValidModel(usModel))
     {
+        ResetVehicleModelSpecialAbilities(usModel);
+
         // Stream the vehicles of that model out so we have no
         // loaded when we do the restore. The streamer will
         // eventually stream them back in with async loading.
@@ -322,6 +327,20 @@ void CClientDFF::InternalRestoreModel(unsigned short usModel)
         if (pInfo->pClump)
             g_pGame->GetRenderWare()->DestroyDFF(pInfo->pClump);
         MapRemove(m_LoadedClumpInfoMap, usModel);
+    }
+}
+
+void CClientDFF::ResetVehicleModelSpecialAbilities(unsigned short usModel)
+{
+    // Model special abilities depend on the current DFF/COL component layout. Clear explicit
+    // overrides when that layout is replaced or restored so a reused model ID does not inherit
+    // towtruck/packer behavior from the previous asset.
+    CClientVehicleManager* vehicleManager = m_pManager->GetVehicleManager();
+    for (auto iter = vehicleManager->IterBegin(); iter != vehicleManager->IterEnd(); ++iter)
+    {
+        CClientVehicle* vehicle = *iter;
+        if (vehicle && vehicle->GetModel() == usModel)
+            vehicle->ResetModelSpecialAbility();
     }
 }
 

--- a/Client/mods/deathmatch/logic/CClientDFF.cpp
+++ b/Client/mods/deathmatch/logic/CClientDFF.cpp
@@ -335,6 +335,8 @@ void CClientDFF::ResetVehicleModelSpecialAbilities(unsigned short usModel)
     // Model special abilities depend on the current DFF/COL component layout. Clear explicit
     // overrides when that layout is replaced or restored so a reused model ID does not inherit
     // towtruck/packer behavior from the previous asset.
+    CClientVehicle::ResetModelSpecialAbilityDefault(usModel);
+
     CClientVehicleManager* vehicleManager = m_pManager->GetVehicleManager();
     for (auto iter = vehicleManager->IterBegin(); iter != vehicleManager->IterEnd(); ++iter)
     {

--- a/Client/mods/deathmatch/logic/CClientDFF.h
+++ b/Client/mods/deathmatch/logic/CClientDFF.h
@@ -59,6 +59,7 @@ private:
     bool DoReplaceModel(unsigned short usModel, bool bAlphaTransparency);
     void UnloadDFF();
     void InternalRestoreModel(unsigned short usModel);
+    void ResetVehicleModelSpecialAbilities(unsigned short usModel);
 
     bool ReplaceClothes(ushort usModel);
     bool ReplaceObjectModel(RpClump* pClump, ushort usModel, bool bAlphaTransparency);

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -50,6 +50,7 @@ namespace
     };
 
     std::unordered_map<CClientVehicle*, SCustomPackerRampAudioState> g_customPackerRampAudioStates;
+    std::unordered_map<WORD, std::optional<WORD>>                   g_modelSpecialAbilityOverrides;
 
     CVector DecompressCollisionVector(const CCompressedVectorSA& vector)
     {
@@ -81,6 +82,29 @@ namespace
         vehicle->SetModelSpecialAbilityModel(model.value_or(0), model.has_value());
     }
 
+    bool ResolveModelSpecialAbility(const SString& ability, std::optional<WORD>& model)
+    {
+        const SString normalizedAbility = ability.ToLower();
+        if (normalizedAbility.empty() || normalizedAbility == "none")
+        {
+            model = std::nullopt;
+            return true;
+        }
+
+        if (normalizedAbility == "towtruck")
+            model = static_cast<WORD>(VehicleType::VT_TOWTRUCK);
+        else if (normalizedAbility == "packer")
+            model = static_cast<WORD>(VehicleType::VT_PACKER);
+        else if (normalizedAbility == "firetruckwater")
+            model = static_cast<WORD>(VehicleType::VT_FIRETRUK);
+        else if (normalizedAbility == "firetruckladder")
+            model = static_cast<WORD>(VehicleType::VT_FIRELA);
+        else
+            return false;
+
+        return true;
+    }
+
     const char* GetModelSpecialAbilityName(WORD model)
     {
         switch (static_cast<VehicleType>(model))
@@ -96,6 +120,29 @@ namespace
             default:
                 return "none";
         }
+    }
+
+    std::optional<WORD> GetNativeModelSpecialAbility(WORD model)
+    {
+        switch (static_cast<VehicleType>(model))
+        {
+            case VehicleType::VT_TOWTRUCK:
+            case VehicleType::VT_PACKER:
+            case VehicleType::VT_FIRETRUK:
+            case VehicleType::VT_FIRELA:
+                return model;
+            default:
+                return std::nullopt;
+        }
+    }
+
+    std::optional<WORD> GetModelSpecialAbilityOverride(WORD model)
+    {
+        const auto iter = g_modelSpecialAbilityOverrides.find(model);
+        if (iter != g_modelSpecialAbilityOverrides.end())
+            return iter->second;
+
+        return GetNativeModelSpecialAbility(model);
     }
 
     void StopCustomPackerRampSound(CClientVehicle* clientVehicle, CVehicle* vehicle)
@@ -1723,7 +1770,7 @@ void CClientVehicle::_SetAdjustablePropertyValue(unsigned short usValue)
                 // Resource-defined model abilities enter GTA's native moving-collision path through
                 // the ProcessControl hook. Calling UpdateMovingCollision here during stream-in can
                 // run before the custom model has all native state ready.
-                if (!m_modelSpecialAbilityModel)
+                if (!GetEffectiveModelSpecialAbilityModel())
                 {
                     float fAngle = (float)usValue / 2499.0f;
                     m_pVehicle->UpdateMovingCollision(fAngle);
@@ -2742,10 +2789,11 @@ void CClientVehicle::StreamedInPulse()
 
         Interpolate();
         ProcessDoorInterpolation();
-        UpdateCustomPackerRampAngle(this, m_pVehicle, m_modelSpecialAbilityModel);
-        UpdateCustomFireTruckWaterCannon(m_pVehicle, m_modelSpecialAbilityModel);
-        UpdateCustomFireTruckLadder(m_pVehicle, m_modelSpecialAbilityModel);
-        DrawModelSpecialAbilityDebug(this, m_pVehicle, m_modelSpecialAbilityModel);
+        const auto effectiveModelSpecialAbility = GetEffectiveModelSpecialAbilityModel();
+        UpdateCustomPackerRampAngle(this, m_pVehicle, effectiveModelSpecialAbility);
+        UpdateCustomFireTruckWaterCannon(m_pVehicle, effectiveModelSpecialAbility);
+        UpdateCustomFireTruckLadder(m_pVehicle, effectiveModelSpecialAbility);
+        DrawModelSpecialAbilityDebug(this, m_pVehicle, effectiveModelSpecialAbility);
 
         // Grab our current position
         CVector vecPosition = *m_pVehicle->GetPosition();
@@ -2903,7 +2951,7 @@ void CClientVehicle::Create()
             m_pVehicle = g_pGame->GetPools()->AddVehicle(this, m_usModel, m_ucVariation, m_ucVariation2);
         }
 
-        UpdateModelSpecialAbilityRegistration(m_pVehicle, m_modelSpecialAbilityModel);
+        UpdateModelSpecialAbilityRegistration(m_pVehicle, GetEffectiveModelSpecialAbilityModel());
 
         // Failed. Remove our reference to the vehicle model and return
         if (!m_pVehicle)
@@ -4981,8 +5029,11 @@ void CClientVehicle::RemoveVehicleSirens()
 
 bool CClientVehicle::SetModelSpecialAbility(const SString& ability)
 {
-    const SString normalizedAbility = ability.ToLower();
-    if (normalizedAbility.empty() || normalizedAbility == "none")
+    std::optional<WORD> specialAbilityModel;
+    if (!ResolveModelSpecialAbility(ability, specialAbilityModel))
+        return false;
+
+    if (!specialAbilityModel)
     {
         StopCustomPackerRampSound(this, m_pVehicle);
         m_hasModelSpecialAbilityOverride = true;
@@ -4998,18 +5049,6 @@ bool CClientVehicle::SetModelSpecialAbility(const SString& ability)
         return true;
     }
 
-    std::optional<WORD> specialAbilityModel;
-    if (normalizedAbility == "towtruck")
-        specialAbilityModel = static_cast<WORD>(VehicleType::VT_TOWTRUCK);
-    else if (normalizedAbility == "packer")
-        specialAbilityModel = static_cast<WORD>(VehicleType::VT_PACKER);
-    else if (normalizedAbility == "firetruckwater")
-        specialAbilityModel = static_cast<WORD>(VehicleType::VT_FIRETRUK);
-    else if (normalizedAbility == "firetruckladder")
-        specialAbilityModel = static_cast<WORD>(VehicleType::VT_FIRELA);
-    else
-        return false;
-
     // GTA gates these special component behaviors behind hard-coded model checks. Store the
     // original model that should drive those native paths, while keeping this vehicle's real
     // model ID intact for rendering and streaming.
@@ -5018,7 +5057,7 @@ bool CClientVehicle::SetModelSpecialAbility(const SString& ability)
     // ramp that can push the follow camera far above custom meshes.
     m_hasModelSpecialAbilityOverride = true;
     m_modelSpecialAbilityModel = specialAbilityModel;
-    UpdateModelSpecialAbilityRegistration(m_pVehicle, m_modelSpecialAbilityModel);
+    UpdateModelSpecialAbilityRegistration(m_pVehicle, GetEffectiveModelSpecialAbilityModel());
     return true;
 }
 
@@ -5028,7 +5067,7 @@ void CClientVehicle::ResetModelSpecialAbility()
     m_hasModelSpecialAbilityOverride = false;
     m_modelSpecialAbilityModel = std::nullopt;
     m_bHasAdjustableProperty = CClientVehicleManager::HasAdjustableProperty(m_usModel);
-    UpdateModelSpecialAbilityRegistration(m_pVehicle, std::nullopt);
+    UpdateModelSpecialAbilityRegistration(m_pVehicle, GetEffectiveModelSpecialAbilityModel());
 
     if (m_pVehicle)
     {
@@ -5045,7 +5084,63 @@ SString CClientVehicle::GetModelSpecialAbility() const
     if (m_hasModelSpecialAbilityOverride && !m_modelSpecialAbilityModel)
         return "none";
 
-    return GetModelSpecialAbilityName(m_modelSpecialAbilityModel.value_or(m_usModel));
+    const auto model = GetEffectiveModelSpecialAbilityModel();
+    return model ? GetModelSpecialAbilityName(*model) : "none";
+}
+
+std::optional<WORD> CClientVehicle::GetEffectiveModelSpecialAbilityModel() const
+{
+    if (m_hasModelSpecialAbilityOverride)
+        return m_modelSpecialAbilityModel;
+
+    return GetModelSpecialAbilityOverride(m_usModel);
+}
+
+bool CClientVehicle::SetModelSpecialAbilityDefault(WORD model, const SString& ability)
+{
+    std::optional<WORD> specialAbilityModel;
+    if (!ResolveModelSpecialAbility(ability, specialAbilityModel))
+        return false;
+
+    // Model-level abilities work like model handling: they are the default for vehicles with
+    // this model ID. Per-vehicle overrides stay authoritative for vehicles that already opted
+    // into a different behavior explicitly.
+    g_modelSpecialAbilityOverrides[model] = specialAbilityModel;
+
+    CClientVehicleManager* vehicleManager = g_pClientGame->GetManager()->GetVehicleManager();
+    for (auto iter = vehicleManager->IterBegin(); iter != vehicleManager->IterEnd(); ++iter)
+    {
+        CClientVehicle* vehicle = *iter;
+        if (vehicle && vehicle->GetModel() == model && !vehicle->m_hasModelSpecialAbilityOverride)
+        {
+            StopCustomPackerRampSound(vehicle, vehicle->m_pVehicle);
+            UpdateModelSpecialAbilityRegistration(vehicle->m_pVehicle, vehicle->GetEffectiveModelSpecialAbilityModel());
+        }
+    }
+
+    return true;
+}
+
+void CClientVehicle::ResetModelSpecialAbilityDefault(WORD model)
+{
+    g_modelSpecialAbilityOverrides.erase(model);
+
+    CClientVehicleManager* vehicleManager = g_pClientGame->GetManager()->GetVehicleManager();
+    for (auto iter = vehicleManager->IterBegin(); iter != vehicleManager->IterEnd(); ++iter)
+    {
+        CClientVehicle* vehicle = *iter;
+        if (vehicle && vehicle->GetModel() == model && !vehicle->m_hasModelSpecialAbilityOverride)
+        {
+            StopCustomPackerRampSound(vehicle, vehicle->m_pVehicle);
+            UpdateModelSpecialAbilityRegistration(vehicle->m_pVehicle, vehicle->GetEffectiveModelSpecialAbilityModel());
+        }
+    }
+}
+
+SString CClientVehicle::GetModelSpecialAbilityDefault(WORD model)
+{
+    const auto specialAbilityModel = GetModelSpecialAbilityOverride(model);
+    return specialAbilityModel ? GetModelSpecialAbilityName(*specialAbilityModel) : "none";
 }
 
 bool CClientVehicle::SetComponentPosition(const SString& vehicleComponent, CVector vecPosition, EComponentBaseType inputBase)

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -21,8 +21,16 @@
 #include <game/CStreaming.h>
 #include <game/CVehicleAudioSettingsManager.h>
 #include <enums/VehicleType.h>
+#include <game_sa/CAutomobileSA.h>
+#include <game_sa/CColModelSA.h>
+#include <game_sa/CModelInfoSA.h>
 #include <game_sa/CVehicleSA.h>
 #include <game_sa/CVehicleAudioSettingsEntrySA.h>
+#include <enums/SurfaceType.h>
+
+#include <cmath>
+#include <optional>
+#include <unordered_map>
 
 using std::list;
 
@@ -33,6 +41,315 @@ namespace
 {
     constexpr char RADIO_TYPE_RANDOM = 2;
     constexpr char RADIO_NUM_RANDOM = 13;
+
+    struct SCustomPackerRampAudioState
+    {
+        unsigned short lastAngle{};
+        float          smoothedSpeed{};
+        bool           initialized{};
+    };
+
+    std::unordered_map<CClientVehicle*, SCustomPackerRampAudioState> g_customPackerRampAudioStates;
+
+    CVector DecompressCollisionVector(const CCompressedVectorSA& vector)
+    {
+        return CVector(static_cast<float>(vector.x) / 128.0f, static_cast<float>(vector.y) / 128.0f, static_cast<float>(vector.z) / 128.0f);
+    }
+
+    CCompressedVectorSA CompressCollisionVector(const CVector& vector)
+    {
+        return CCompressedVectorSA{static_cast<short>(Clamp<float>(-32768.0f, vector.fX * 128.0f, 32767.0f)),
+                                   static_cast<short>(Clamp<float>(-32768.0f, vector.fY * 128.0f, 32767.0f)),
+                                   static_cast<short>(Clamp<float>(-32768.0f, vector.fZ * 128.0f, 32767.0f))};
+    }
+
+    void SetCollisionTrianglePlane(CColTrianglePlaneSA& plane, CCompressedVectorSA* vertices, const CColTriangleSA& triangle)
+    {
+        ((void(__thiscall*)(CColTrianglePlaneSA*, CCompressedVectorSA*, const CColTriangleSA&))0x411660)(&plane, vertices, triangle);
+    }
+
+    bool EnsureSpecialCollisionModel(CVehicleSAInterface* vehicleInterface)
+    {
+        return ((bool(__thiscall*)(CVehicleSAInterface*))0x6DF3D0)(vehicleInterface);
+    }
+
+    void UpdateModelSpecialAbilityRegistration(CVehicle* vehicle, const std::optional<WORD>& model)
+    {
+        if (!vehicle)
+            return;
+
+        vehicle->SetModelSpecialAbilityModel(model.value_or(0), model.has_value());
+    }
+
+    const char* GetModelSpecialAbilityName(WORD model)
+    {
+        switch (static_cast<VehicleType>(model))
+        {
+            case VehicleType::VT_TOWTRUCK:
+                return "towtruck";
+            case VehicleType::VT_PACKER:
+                return "packer";
+            case VehicleType::VT_FIRETRUK:
+                return "fireTruckWater";
+            case VehicleType::VT_FIRELA:
+                return "fireTruckLadder";
+            default:
+                return "none";
+        }
+    }
+
+    void StopCustomPackerRampSound(CClientVehicle* clientVehicle, CVehicle* vehicle)
+    {
+        if (auto* const vehicleSA = dynamic_cast<CVehicleSA*>(vehicle))
+        {
+            if (auto* const audioEntity = vehicleSA->GetVehicleAudioEntity())
+                audioEntity->GetInterface()->StopGenericEngineSound(11 /* AE_SOUND_MOVING_PARTS */);
+        }
+
+        g_customPackerRampAudioStates.erase(clientVehicle);
+    }
+
+    void UpdateCustomPackerRampSound(CClientVehicle* clientVehicle, CVehicle* vehicle, unsigned short angle)
+    {
+        auto* const vehicleSA = dynamic_cast<CVehicleSA*>(vehicle);
+        auto* const audioEntity = vehicleSA ? vehicleSA->GetVehicleAudioEntity() : nullptr;
+        auto* const audioInterface = audioEntity ? audioEntity->GetInterface() : nullptr;
+        if (!audioInterface)
+            return;
+
+        auto& state = g_customPackerRampAudioStates[clientVehicle];
+        if (!state.initialized)
+        {
+            state.lastAngle = angle;
+            state.initialized = true;
+            return;
+        }
+
+        const float delta = (static_cast<float>(angle) - static_cast<float>(state.lastAngle)) / 30.0f;
+        state.lastAngle = angle;
+
+        const float targetSpeed = Clamp<float>(0.0f, std::fabs(delta), 1.0f);
+        if (targetSpeed > state.smoothedSpeed)
+            state.smoothedSpeed = Min(targetSpeed, state.smoothedSpeed + 0.2f);
+        else
+            state.smoothedSpeed = Max(targetSpeed, state.smoothedSpeed - 0.2f);
+
+        if (state.smoothedSpeed <= 0.0f)
+        {
+            audioInterface->StopGenericEngineSound(11 /* AE_SOUND_MOVING_PARTS */);
+            return;
+        }
+
+        // Native ProcessMovingParts is model-gated and also updates moving collision for packers.
+        // Recreate only the packer ramp sound parameters so custom packers keep the original audio
+        // feedback without re-entering the collision path that can push the camera away.
+        const float speed = delta <= 0.0f ? 0.8f : 1.0f;
+        const float baseVolume = delta <= 0.0f ? 3.0f : 9.0f;
+        const float volume = baseVolume + std::log10(state.smoothedSpeed) * 20.0f;
+        if (volume <= -100.0f)
+            audioInterface->StopGenericEngineSound(11 /* AE_SOUND_MOVING_PARTS */);
+        else
+            audioInterface->UpdateGenericVehicleSound(11 /* AE_SOUND_MOVING_PARTS */, 19 /* SND_BANK_SLOT_VEHICLE_GEN */,
+                                                      138 /* SND_BANK_GENRL_VEHICLE_GEN */, 15, speed, volume, 1.5f);
+    }
+
+    void UpdateCustomPackerMovingCollision(CVehicle* vehicle, CAutomobileSAInterface* automobileInterface, unsigned short angle)
+    {
+        auto* const vehicleSA = dynamic_cast<CVehicleSA*>(vehicle);
+        if (!vehicleSA || !automobileInterface || !automobileInterface->m_aCarNodes[static_cast<std::size_t>(eCarNodes::MISC_A)])
+            return;
+
+        auto* const vehicleInterface = vehicleSA->GetVehicleInterface();
+        if (!EnsureSpecialCollisionModel(vehicleInterface))
+            return;
+
+        auto* const modelInfo = g_pGame->GetModelInfo(vehicleSA->GetModelIndex());
+        auto* const baseModelInfo = modelInfo ? modelInfo->GetInterface() : nullptr;
+        auto* const colModel = baseModelInfo ? baseModelInfo->pColModel : nullptr;
+        auto* const colData = colModel ? colModel->m_data : nullptr;
+        if (!colModel || !colData)
+            return;
+
+        if (vehicleInterface->m_nSpecialColModel == 0xFF)
+            return;
+
+        auto* const specialColModels = reinterpret_cast<CColModelSAInterface*>(VAR_CVehicle_SpecialColModels);
+        auto&       specialColModel = specialColModels[vehicleInterface->m_nSpecialColModel];
+        auto* const specialColData = specialColModel.m_data;
+        if (!colData->m_vertices || !colData->m_triangles || !specialColData || !specialColData->m_vertices || !specialColData->m_triangles)
+            return;
+
+        const RwMatrix* miscMatrix = RwFrameGetMatrix(automobileInterface->m_aCarNodes[static_cast<std::size_t>(eCarNodes::MISC_A)]);
+        if (!miscMatrix)
+            return;
+
+        const CVector componentPos(miscMatrix->pos.x, miscMatrix->pos.y, miscMatrix->pos.z);
+        const float   angleRadians = static_cast<float>(angle) * -0.0001f;
+        const float   sinAngle = std::sin(angleRadians);
+        const float   cosAngle = std::cos(angleRadians);
+
+        auto transformPoint = [&](const CVector& point) {
+            const CVector distance = point - componentPos;
+            return CVector(distance.fX, distance.fY * cosAngle - distance.fZ * sinAngle, distance.fY * sinAngle + distance.fZ * cosAngle) + componentPos;
+        };
+
+        float minZ = 1000.0f;
+        float maxZ = -1000.0f;
+        const auto updateBounds = [&](float z) {
+            minZ = Min(minZ, z);
+            maxZ = Max(maxZ, z);
+        };
+
+        const std::uint16_t numTriangles = Min(colData->m_numTriangles, specialColData->m_numTriangles);
+        for (std::uint16_t triangleIndex = 0; triangleIndex < numTriangles; ++triangleIndex)
+        {
+            const CColTriangleSA& sourceTriangle = colData->m_triangles[triangleIndex];
+            CColTriangleSA&       specialTriangle = specialColData->m_triangles[triangleIndex];
+            if (specialTriangle.m_material != SurfaceTypes::SURFACE_CAR_MOVINGCOMPONENT)
+                continue;
+
+            for (int vertexIndex = 0; vertexIndex < 3; ++vertexIndex)
+            {
+                const CVector transformed = transformPoint(DecompressCollisionVector(colData->m_vertices[sourceTriangle.m_indices[vertexIndex]]));
+                specialColData->m_vertices[specialTriangle.m_indices[vertexIndex]] = CompressCollisionVector(transformed);
+                updateBounds(transformed.fZ);
+            }
+        }
+
+        if (specialColData->m_trianglePlanes)
+        {
+            for (std::uint16_t triangleIndex = 0; triangleIndex < specialColData->m_numTriangles; ++triangleIndex)
+                SetCollisionTrianglePlane(specialColData->m_trianglePlanes[triangleIndex], specialColData->m_vertices, specialColData->m_triangles[triangleIndex]);
+        }
+
+        const std::uint16_t numSpheres = Min(colData->m_numSpheres, specialColData->m_numSpheres);
+        for (std::uint16_t sphereIndex = 0; colData->m_spheres && specialColData->m_spheres && sphereIndex < numSpheres; ++sphereIndex)
+        {
+            const CColSphereSA& sourceSphere = colData->m_spheres[sphereIndex];
+            CColSphereSA&       specialSphere = specialColData->m_spheres[sphereIndex];
+            if (specialSphere.m_material != SurfaceTypes::SURFACE_CAR_MOVINGCOMPONENT)
+                continue;
+
+            specialSphere.m_center = transformPoint(sourceSphere.m_center);
+            updateBounds(specialSphere.m_center.fZ - specialSphere.m_radius);
+            updateBounds(specialSphere.m_center.fZ + specialSphere.m_radius);
+        }
+
+        if (maxZ > minZ)
+        {
+            if (colModel->m_bounds.m_vecMax.fZ < maxZ)
+                specialColModel.m_bounds.m_vecMax.fZ = maxZ;
+            if (colModel->m_bounds.m_vecMin.fZ > minZ)
+                specialColModel.m_bounds.m_vecMin.fZ = minZ;
+        }
+    }
+
+    void DrawModelSpecialAbilityDebug(CClientVehicle* clientVehicle, CVehicle* vehicle, const std::optional<WORD>& abilityModel)
+    {
+        if (!abilityModel || !vehicle)
+            return;
+
+        auto* const vehicleSA = dynamic_cast<CVehicleSA*>(vehicle);
+        if (!vehicleSA)
+            return;
+
+        auto* const graphics = g_pCore->GetGraphics();
+        if (!graphics)
+            return;
+
+        CVector screenPosition;
+        CVector worldPosition = *vehicle->GetPosition() + CVector(0.0f, 0.0f, 1.8f);
+        graphics->CalcScreenCoors(&worldPosition, &screenPosition);
+        if (screenPosition.fZ <= 0.0f)
+            return;
+
+        const WORD currentModel = vehicleSA->GetVehicleInterface()->m_nModelIndex;
+        const WORD resolvedModel = vehicleSA->GetModelSpecialAbilityModel(currentModel);
+        const SString text(
+            "specialAbility=%u real=%u iface=%u resolved=%u enabled=%u\n"
+            "process: %u -> %u (%u)\n"
+            "preRender: %u -> %u (%u)",
+            static_cast<unsigned int>(*abilityModel), static_cast<unsigned int>(clientVehicle->GetModel()), static_cast<unsigned int>(currentModel),
+            static_cast<unsigned int>(resolvedModel), vehicleSA->IsModelSpecialAbilityEnabled() ? 1u : 0u,
+            static_cast<unsigned int>(vehicleSA->GetLastProcessSpecialAbilityCurrentModel()),
+            static_cast<unsigned int>(vehicleSA->GetLastProcessSpecialAbilityResolvedModel()), vehicleSA->GetProcessSpecialAbilityResolveCount(),
+            static_cast<unsigned int>(vehicleSA->GetLastPreRenderSpecialAbilityCurrentModel()),
+            static_cast<unsigned int>(vehicleSA->GetLastPreRenderSpecialAbilityResolvedModel()), vehicleSA->GetPreRenderSpecialAbilityResolveCount());
+
+        const int x = static_cast<int>(screenPosition.fX);
+        const int y = static_cast<int>(screenPosition.fY);
+        graphics->DrawString(x + 1, y + 1, x + 1, y + 1, 0xCC000000, text, 1.0f, 1.0f, DT_NOCLIP | DT_CENTER);
+        graphics->DrawString(x, y, x, y, 0xFFFFFF00, text, 1.0f, 1.0f, DT_NOCLIP | DT_CENTER);
+    }
+
+    void UpdateCustomPackerRampAngle(CClientVehicle* clientVehicle, CVehicle* vehicle, const std::optional<WORD>& abilityModel)
+    {
+        if (!abilityModel || *abilityModel != static_cast<WORD>(VehicleType::VT_PACKER) || !vehicle)
+            return;
+
+        if (!clientVehicle->GetOccupant(0) || !clientVehicle->GetOccupant(0)->IsLocalPlayer())
+        {
+            StopCustomPackerRampSound(clientVehicle, vehicle);
+            return;
+        }
+
+        auto* const automobile = dynamic_cast<CAutomobileSA*>(vehicle);
+        auto* const automobileInterface = automobile ? automobile->GetAutomobileInterface() : nullptr;
+        if (!automobileInterface)
+            return;
+
+        CControllerState controllerState;
+        g_pGame->GetPad()->GetCurrentControllerState(&controllerState);
+
+        const float input = static_cast<float>(controllerState.RightStickY) / 128.0f;
+        if (std::fabs(input) > 0.08f)
+        {
+            // Custom packers use the original PreRender branch for misc_a rotation, but not GTA's
+            // moving-collision ramp because it can push the follow camera far above custom meshes.
+            const float nextAngle =
+                static_cast<float>(automobileInterface->m_wMiscComponentAngle) + input * 10.0f * g_pGame->GetTimeStep();
+            automobileInterface->m_wMiscComponentAngle = static_cast<unsigned short>(Clamp<float>(0.0f, nextAngle, 2500.0f));
+        }
+
+        UpdateCustomPackerMovingCollision(vehicle, automobileInterface, automobileInterface->m_wMiscComponentAngle);
+        UpdateCustomPackerRampSound(clientVehicle, vehicle, automobileInterface->m_wMiscComponentAngle);
+    }
+
+    void UpdateCustomFireTruckWaterCannon(CVehicle* vehicle, const std::optional<WORD>& abilityModel)
+    {
+        if (!abilityModel || *abilityModel != static_cast<WORD>(VehicleType::VT_FIRETRUK) || !vehicle)
+            return;
+
+        auto* const automobile = dynamic_cast<CAutomobileSA*>(vehicle);
+        auto* const automobileInterface = automobile ? automobile->GetAutomobileInterface() : nullptr;
+        if (!automobileInterface)
+            return;
+
+        // FireTruckControl owns the original water cannon aiming, water effects, hit events and
+        // audio. The game normally reaches it through a hard-coded firetruck/SWAT model check, so
+        // call that native routine directly for resource-defined water-cannon vehicles.
+        ((void(__thiscall*)(CAutomobileSAInterface*, void*))0x729B60)(automobileInterface, nullptr);
+    }
+
+    void UpdateCustomFireTruckLadder(CVehicle* vehicle, const std::optional<WORD>& abilityModel)
+    {
+        if (!abilityModel || *abilityModel != static_cast<WORD>(VehicleType::VT_FIRELA) || !vehicle)
+            return;
+
+        auto* const vehicleSA = dynamic_cast<CVehicleSA*>(vehicle);
+        if (!vehicleSA || vehicleSA->GetModelIndex() == static_cast<WORD>(VehicleType::VT_FIRELA))
+            return;
+
+        auto* const vehicleInterface = vehicleSA->GetVehicleInterface();
+        const WORD  originalModel = vehicleInterface->m_nModelIndex;
+
+        // Firetruck ladder movement lives inside CAutomobile::UpdateMovingCollision, guarded by a
+        // hard-coded MODEL_FIRELA check. Temporarily expose that model only for this native call so
+        // custom ladder vehicles use GTA's original input/angle path without permanently changing ID.
+        vehicleInterface->m_nModelIndex = static_cast<WORD>(VehicleType::VT_FIRELA);
+        vehicleSA->UpdateMovingCollision(-1.0f);
+        vehicleInterface->m_nModelIndex = originalModel;
+    }
 
     tVehicleAudioSettings GetNormalizedAudioSettings(const CVehicleAudioSettingsEntry& settings)
     {
@@ -211,6 +528,8 @@ CClientVehicle::CClientVehicle(CClientManager* pManager, ElementID ID, unsigned 
     m_ucVariation = ucVariation;
     m_ucVariation2 = ucVariation2;
     m_bEnableHeliBladeCollisions = true;
+    m_modelSpecialAbilityModel = std::nullopt;
+    m_hasModelSpecialAbilityOverride = false;
     m_fNitroLevel = 1.0f;
     m_cNitroCount = 0;
     m_fWheelScale = 1.0f;
@@ -1041,6 +1360,11 @@ void CClientVehicle::SetModelBlocking(unsigned short usModel, unsigned char ucVa
     // Different vehicle ID than we have now?
     if (m_usModel != usModel)
     {
+        // A model special ability is tied to the DFF/COL layout that was active when the resource
+        // set it. Clear explicit overrides before changing model IDs so the new model falls back
+        // to its own default behavior instead of inheriting towtruck/packer state.
+        ResetModelSpecialAbility();
+
         // Destroy the old vehicle if we have one
         if (m_pVehicle)
             Destroy();
@@ -1396,8 +1720,14 @@ void CClientVehicle::_SetAdjustablePropertyValue(unsigned short usValue)
             // Update our collision for this adjustable?
             if (HasMovingCollision())
             {
-                float fAngle = (float)usValue / 2499.0f;
-                m_pVehicle->UpdateMovingCollision(fAngle);
+                // Resource-defined model abilities enter GTA's native moving-collision path through
+                // the ProcessControl hook. Calling UpdateMovingCollision here during stream-in can
+                // run before the custom model has all native state ready.
+                if (!m_modelSpecialAbilityModel)
+                {
+                    float fAngle = (float)usValue / 2499.0f;
+                    m_pVehicle->UpdateMovingCollision(fAngle);
+                }
             }
         }
     }
@@ -2412,6 +2742,10 @@ void CClientVehicle::StreamedInPulse()
 
         Interpolate();
         ProcessDoorInterpolation();
+        UpdateCustomPackerRampAngle(this, m_pVehicle, m_modelSpecialAbilityModel);
+        UpdateCustomFireTruckWaterCannon(m_pVehicle, m_modelSpecialAbilityModel);
+        UpdateCustomFireTruckLadder(m_pVehicle, m_modelSpecialAbilityModel);
+        DrawModelSpecialAbilityDebug(this, m_pVehicle, m_modelSpecialAbilityModel);
 
         // Grab our current position
         CVector vecPosition = *m_pVehicle->GetPosition();
@@ -2568,6 +2902,8 @@ void CClientVehicle::Create()
         {
             m_pVehicle = g_pGame->GetPools()->AddVehicle(this, m_usModel, m_ucVariation, m_ucVariation2);
         }
+
+        UpdateModelSpecialAbilityRegistration(m_pVehicle, m_modelSpecialAbilityModel);
 
         // Failed. Remove our reference to the vehicle model and return
         if (!m_pVehicle)
@@ -3006,6 +3342,8 @@ void CClientVehicle::Destroy()
 #ifdef MTA_DEBUG
         g_pCore->GetConsole()->Printf("CClientVehicle::Destroy %d", GetModel());
 #endif
+        StopCustomPackerRampSound(this, m_pVehicle);
+        UpdateModelSpecialAbilityRegistration(m_pVehicle, std::nullopt);
 
         // Invalidate
         m_pManager->InvalidateEntity(this);
@@ -4639,6 +4977,75 @@ void CClientVehicle::RemoveVehicleSirens()
     }
 
     m_tSirenBeaconInfo.m_ucSirenCount = 0;
+}
+
+bool CClientVehicle::SetModelSpecialAbility(const SString& ability)
+{
+    const SString normalizedAbility = ability.ToLower();
+    if (normalizedAbility.empty() || normalizedAbility == "none")
+    {
+        StopCustomPackerRampSound(this, m_pVehicle);
+        m_hasModelSpecialAbilityOverride = true;
+        m_modelSpecialAbilityModel = std::nullopt;
+        m_bHasAdjustableProperty = CClientVehicleManager::HasAdjustableProperty(m_usModel);
+        UpdateModelSpecialAbilityRegistration(m_pVehicle, std::nullopt);
+
+        if (m_pVehicle)
+        {
+            if (auto* vehicleSA = dynamic_cast<CVehicleSA*>(m_pVehicle))
+                vehicleSA->GetVehicleInterface()->m_nModelIndex = m_usModel;
+        }
+        return true;
+    }
+
+    std::optional<WORD> specialAbilityModel;
+    if (normalizedAbility == "towtruck")
+        specialAbilityModel = static_cast<WORD>(VehicleType::VT_TOWTRUCK);
+    else if (normalizedAbility == "packer")
+        specialAbilityModel = static_cast<WORD>(VehicleType::VT_PACKER);
+    else if (normalizedAbility == "firetruckwater")
+        specialAbilityModel = static_cast<WORD>(VehicleType::VT_FIRETRUK);
+    else if (normalizedAbility == "firetruckladder")
+        specialAbilityModel = static_cast<WORD>(VehicleType::VT_FIRELA);
+    else
+        return false;
+
+    // GTA gates these special component behaviors behind hard-coded model checks. Store the
+    // original model that should drive those native paths, while keeping this vehicle's real
+    // model ID intact for rendering and streaming.
+    // Do not mark custom packers as MTA adjustable-property vehicles here. Their misc angle is
+    // updated locally for the native PreRender rotation path, without GTA's moving collision
+    // ramp that can push the follow camera far above custom meshes.
+    m_hasModelSpecialAbilityOverride = true;
+    m_modelSpecialAbilityModel = specialAbilityModel;
+    UpdateModelSpecialAbilityRegistration(m_pVehicle, m_modelSpecialAbilityModel);
+    return true;
+}
+
+void CClientVehicle::ResetModelSpecialAbility()
+{
+    StopCustomPackerRampSound(this, m_pVehicle);
+    m_hasModelSpecialAbilityOverride = false;
+    m_modelSpecialAbilityModel = std::nullopt;
+    m_bHasAdjustableProperty = CClientVehicleManager::HasAdjustableProperty(m_usModel);
+    UpdateModelSpecialAbilityRegistration(m_pVehicle, std::nullopt);
+
+    if (m_pVehicle)
+    {
+        if (auto* vehicleSA = dynamic_cast<CVehicleSA*>(m_pVehicle))
+            vehicleSA->GetVehicleInterface()->m_nModelIndex = m_usModel;
+    }
+}
+
+SString CClientVehicle::GetModelSpecialAbility() const
+{
+    // If a resource did not explicitly override the ability, report the GTA default for the
+    // current model so original towtrucks, packers, firetrucks and ladder trucks keep their
+    // native special-vehicle identity.
+    if (m_hasModelSpecialAbilityOverride && !m_modelSpecialAbilityModel)
+        return "none";
+
+    return GetModelSpecialAbilityName(m_modelSpecialAbilityModel.value_or(m_usModel));
 }
 
 bool CClientVehicle::SetComponentPosition(const SString& vehicleComponent, CVector vecPosition, EComponentBaseType inputBase)

--- a/Client/mods/deathmatch/logic/CClientVehicle.h
+++ b/Client/mods/deathmatch/logic/CClientVehicle.h
@@ -27,6 +27,8 @@ class CClientVehicle;
 #include "CVehicleUpgrades.h"
 #include "CClientModel.h"
 
+#include <optional>
+
 class CBikeHandlingEntry;
 class CBoatHandlingEntry;
 class CClientProjectile;
@@ -550,6 +552,10 @@ public:
     bool SetDummyPosition(VehicleDummies dummy, const CVector& position);
     bool ResetDummyPositions();
 
+    bool SetModelSpecialAbility(const SString& ability);
+    void ResetModelSpecialAbility();
+    SString GetModelSpecialAbility() const;
+
     bool SpawnFlyingComponent(const eCarNodes& nodeID, const eCarComponentCollisionTypes& collisionType, std::int32_t removalTime);
 
     CVector GetEntryPoint(std::uint32_t entryPointIndex);
@@ -743,6 +749,8 @@ protected:
     unsigned char                  m_ucFellThroughMapCount;
     SFixedArray<bool, MAX_WINDOWS> m_bWindowOpen;
     std::shared_ptr<CClientModel>  m_clientModel;
+    std::optional<WORD>            m_modelSpecialAbilityModel;
+    bool                           m_hasModelSpecialAbilityOverride = false;
 
 public:
 #ifdef MTA_DEBUG

--- a/Client/mods/deathmatch/logic/CClientVehicle.h
+++ b/Client/mods/deathmatch/logic/CClientVehicle.h
@@ -555,6 +555,11 @@ public:
     bool SetModelSpecialAbility(const SString& ability);
     void ResetModelSpecialAbility();
     SString GetModelSpecialAbility() const;
+    std::optional<WORD> GetEffectiveModelSpecialAbilityModel() const;
+
+    static bool    SetModelSpecialAbilityDefault(WORD model, const SString& ability);
+    static void    ResetModelSpecialAbilityDefault(WORD model);
+    static SString GetModelSpecialAbilityDefault(WORD model);
 
     bool SpawnFlyingComponent(const eCarNodes& nodeID, const eCarComponentCollisionTypes& collisionType, std::int32_t removalTime);
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -995,6 +995,7 @@ int CLuaEngineDefs::EngineFreeModel(lua_State* luaVM)
         std::shared_ptr<CClientModel> pModel = modelManager->FindModelByID(iModelID);
         if (pModel && modelManager->Remove(pModel))
         {
+            CClientVehicle::ResetModelSpecialAbilityDefault(static_cast<WORD>(iModelID));
             lua_pushboolean(luaVM, true);
             return 1;
         }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -326,9 +326,7 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setSmokeTrailEnabled", "setVehicleSmokeTrailEnabled");
     lua_classfunction(luaVM, "setRotorState", "setVehicleRotorState");
     lua_classfunction(luaVM, "setSpecialAbility", "setVehicleSpecialAbility");
-    lua_classfunction(luaVM, "setModelSpecialAbility", "setVehicleModelSpecialAbility");
     lua_classfunction(luaVM, "getSpecialAbility", "getVehicleSpecialAbility");
-    lua_classfunction(luaVM, "getModelSpecialAbility", "getVehicleModelSpecialAbility");
     lua_classfunction(luaVM, "resetAudioSettings", "resetVehicleAudioSettings");
     lua_classfunction(luaVM, "setAudioSetting", "setVehicleAudioSetting");
 
@@ -2280,22 +2278,22 @@ bool CLuaVehicleDefs::SetVehicleWheelsRotation(CClientVehicle* pVehicle, float f
 
 bool CLuaVehicleDefs::SetVehicleSpecialAbility(CClientVehicle* pVehicle, std::string ability)
 {
-    return SetVehicleModelSpecialAbility(pVehicle, ability);
+    return pVehicle->SetModelSpecialAbility(SString(ability));
 }
 
-bool CLuaVehicleDefs::SetVehicleModelSpecialAbility(CClientVehicle* pVehicle, std::string ability)
+bool CLuaVehicleDefs::SetVehicleModelSpecialAbility(unsigned short model, std::string ability)
 {
-    return pVehicle->SetModelSpecialAbility(SString(ability));
+    return CClientVehicle::SetModelSpecialAbilityDefault(model, SString(ability));
 }
 
 std::string CLuaVehicleDefs::GetVehicleSpecialAbility(CClientVehicle* pVehicle)
 {
-    return GetVehicleModelSpecialAbility(pVehicle);
+    return pVehicle->GetModelSpecialAbility().c_str();
 }
 
-std::string CLuaVehicleDefs::GetVehicleModelSpecialAbility(CClientVehicle* pVehicle)
+std::string CLuaVehicleDefs::GetVehicleModelSpecialAbility(unsigned short model)
 {
-    return pVehicle->GetModelSpecialAbility().c_str();
+    return CClientVehicle::GetModelSpecialAbilityDefault(model).c_str();
 }
 
 int CLuaVehicleDefs::SetTrainDerailed(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -133,6 +133,10 @@ void CLuaVehicleDefs::LoadFunctions()
         {"setHelicopterRotorSpeed", SetHelicopterRotorSpeed},
         {"setVehicleRotorSpeed", ArgumentParser<SetVehicleRotorSpeed>},
         {"setVehicleWheelsRotation", ArgumentParser<SetVehicleWheelsRotation>},
+        {"setVehicleSpecialAbility", ArgumentParser<SetVehicleSpecialAbility>},
+        {"setVehicleModelSpecialAbility", ArgumentParser<SetVehicleModelSpecialAbility>},
+        {"getVehicleSpecialAbility", ArgumentParser<GetVehicleSpecialAbility>},
+        {"getVehicleModelSpecialAbility", ArgumentParser<GetVehicleModelSpecialAbility>},
         {"setTrainDerailed", SetTrainDerailed},
         {"setTrainDerailable", SetTrainDerailable},
         {"setTrainDirection", SetTrainDirection},
@@ -321,6 +325,10 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setModelWheelSize", "setVehicleModelWheelSize");
     lua_classfunction(luaVM, "setSmokeTrailEnabled", "setVehicleSmokeTrailEnabled");
     lua_classfunction(luaVM, "setRotorState", "setVehicleRotorState");
+    lua_classfunction(luaVM, "setSpecialAbility", "setVehicleSpecialAbility");
+    lua_classfunction(luaVM, "setModelSpecialAbility", "setVehicleModelSpecialAbility");
+    lua_classfunction(luaVM, "getSpecialAbility", "getVehicleSpecialAbility");
+    lua_classfunction(luaVM, "getModelSpecialAbility", "getVehicleModelSpecialAbility");
     lua_classfunction(luaVM, "resetAudioSettings", "resetVehicleAudioSettings");
     lua_classfunction(luaVM, "setAudioSetting", "setVehicleAudioSetting");
 
@@ -2268,6 +2276,26 @@ bool CLuaVehicleDefs::SetVehicleRotorSpeed(CClientVehicle* pVehicle, float fSpee
 bool CLuaVehicleDefs::SetVehicleWheelsRotation(CClientVehicle* pVehicle, float fRotation) noexcept
 {
     return pVehicle->SetWheelsRotation(fRotation, fRotation, fRotation, fRotation);
+}
+
+bool CLuaVehicleDefs::SetVehicleSpecialAbility(CClientVehicle* pVehicle, std::string ability)
+{
+    return SetVehicleModelSpecialAbility(pVehicle, ability);
+}
+
+bool CLuaVehicleDefs::SetVehicleModelSpecialAbility(CClientVehicle* pVehicle, std::string ability)
+{
+    return pVehicle->SetModelSpecialAbility(SString(ability));
+}
+
+std::string CLuaVehicleDefs::GetVehicleSpecialAbility(CClientVehicle* pVehicle)
+{
+    return GetVehicleModelSpecialAbility(pVehicle);
+}
+
+std::string CLuaVehicleDefs::GetVehicleModelSpecialAbility(CClientVehicle* pVehicle)
+{
+    return pVehicle->GetModelSpecialAbility().c_str();
 }
 
 int CLuaVehicleDefs::SetTrainDerailed(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -122,6 +122,10 @@ public:
     LUA_DECLARE(SetHelicopterRotorSpeed);
     static bool SetVehicleRotorSpeed(CClientVehicle* pVehicle, float fSpeed);
     static bool SetVehicleWheelsRotation(CClientVehicle* pVehicle, float fRotation) noexcept;
+    static bool SetVehicleSpecialAbility(CClientVehicle* pVehicle, std::string ability);
+    static bool SetVehicleModelSpecialAbility(CClientVehicle* pVehicle, std::string ability);
+    static std::string GetVehicleSpecialAbility(CClientVehicle* pVehicle);
+    static std::string GetVehicleModelSpecialAbility(CClientVehicle* pVehicle);
     LUA_DECLARE(SetTrainDerailed);
     LUA_DECLARE(SetTrainDerailable);
     LUA_DECLARE(SetTrainDirection);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -123,9 +123,9 @@ public:
     static bool SetVehicleRotorSpeed(CClientVehicle* pVehicle, float fSpeed);
     static bool SetVehicleWheelsRotation(CClientVehicle* pVehicle, float fRotation) noexcept;
     static bool SetVehicleSpecialAbility(CClientVehicle* pVehicle, std::string ability);
-    static bool SetVehicleModelSpecialAbility(CClientVehicle* pVehicle, std::string ability);
+    static bool SetVehicleModelSpecialAbility(unsigned short model, std::string ability);
     static std::string GetVehicleSpecialAbility(CClientVehicle* pVehicle);
-    static std::string GetVehicleModelSpecialAbility(CClientVehicle* pVehicle);
+    static std::string GetVehicleModelSpecialAbility(unsigned short model);
     LUA_DECLARE(SetTrainDerailed);
     LUA_DECLARE(SetTrainDerailable);
     LUA_DECLARE(SetTrainDirection);

--- a/Client/sdk/game/CVehicle.h
+++ b/Client/sdk/game/CVehicle.h
@@ -340,4 +340,7 @@ public:
 
     virtual const CVector* GetDummyPositions() const = 0;
     virtual void           ReinitAudio() = 0;
+
+    virtual void SetModelSpecialAbilityModel(unsigned short model, bool enabled) = 0;
+    virtual unsigned short GetModelSpecialAbilityModel(unsigned short currentModel) const = 0;
 };


### PR DESCRIPTION
> [!IMPORTANT]
> Everything is a subject to change

#### Summary
<!-- What change are you making? -->
<!-- When changing Lua APIs, consider including code samples and documentation. -->

This pull request adds a client-side vehicle special ability API for applying selected GTA SA native vehicle behaviors to vehicles whose model ID would not normally receive those behaviors.

New Lua functions:

```lua
setVehicleModelSpecialAbility(vehicle, ability)
getVehicleModelSpecialAbility(vehicle)
```

Aliases are also available:

```lua
setVehicleSpecialAbility(vehicle, ability)
getVehicleSpecialAbility(vehicle)
```

Supported ability names:

```lua
"none"
"towtruck"
"packer"
"fireTruckWater"
"fireTruckLadder"
```

Example usage:

```lua
local model = engineRequestModel("vehicle", 525)
engineImportTXD(engineLoadTXD("custom_towtruck.txd"), model)
engineReplaceModel(engineLoadDFF("custom_towtruck.dff"), model)

local vehicle = createVehicle(model, x, y, z)
setVehicleModelSpecialAbility(vehicle, "towtruck")
```

```lua
local ability = getVehicleModelSpecialAbility(vehicle)
if ability == "towtruck" then
    outputDebugString("Vehicle has towtruck behavior")
end
```

The API currently exposes these native behavior paths:

* `towtruck`
  * Enables the original towtruck hook movement, towbar lookup, tow line physics, attach behavior, and detach/drop behavior.
  * The actual tow attach point still comes from the model data used by GTA's native towbar lookup.

* `packer`
  * Enables original packer-style `misc_a` ramp rotation.
  * Uses MTA-side handling for custom moving collision/audio where native paths were unsafe for custom model layouts.

* `fireTruckWater`
  * Enables original firetruck water cannon behavior from model `407`.
  * Uses GTA's native `FireTruckControl` path for aiming, effects, audio, and hit handling.

* `fireTruckLadder`
  * Enables original firetruck ladder movement behavior from model `544`.
  * Initializes the fire ladder chassis state that GTA normally sets only when constructing a real `MODEL_FIRELA` vehicle.

* `none`
  * Explicitly disables the special ability override for that vehicle.

Getter behavior:

```lua
getVehicleModelSpecialAbility(vehicle)
```

returns one of:

```lua
"none"
"towtruck"
"packer"
"fireTruckWater"
"fireTruckLadder"
```

If no override has been set, original GTA models report their native default ability:

```lua
-- model 525
getVehicleModelSpecialAbility(towtruck) -- "towtruck"

-- model 443
getVehicleModelSpecialAbility(packer) -- "packer"

-- model 407
getVehicleModelSpecialAbility(firetruck) -- "fireTruckWater"

-- model 544
getVehicleModelSpecialAbility(firetruckLadder) -- "fireTruckLadder"
```

Other models default to:

```lua
"none"
```

Special ability overrides are cleared when:

* the vehicle model is changed with `setElementModel`,
* the underlying DFF for that model ID is replaced,
* the underlying DFF for that model ID is restored,
* the engine-requested model is unloaded and requested again.

This prevents stale behavior state from carrying over to a different DFF/COL/component layout.

Implementation notes:

* The towtruck behavior is integrated by extending the native model checks used by towbar lookup, tow line/drop physics, and towtruck misc component behavior.
* The packer behavior preserves native visual rotation but avoids unsafe native moving-collision paths for custom packer meshes.
* The firetruck water cannon behavior calls the native firetruck control routine for vehicles configured with `fireTruckWater`.
* The firetruck ladder behavior mirrors native `MODEL_FIRELA` chassis setup and calls native moving-collision ladder logic for configured custom ladder models.
* Debug-only on-screen ability information is drawn for vehicles with a configured model ability to help diagnose hook resolution while testing.

#### Motivation
<!-- Why are you making this change? Which GitHub issue does this resolve, if any? Any additional context? -->

MTA can request new vehicle model IDs at runtime with `engineRequestModel`, but several GTA SA vehicle behaviors are hardcoded to original model IDs. This means a custom model that is visually and structurally built like a towtruck, packer, firetruck, or fire ladder cannot naturally use the original game behavior when it lives on a newly requested model ID.

This change allows resources to opt a vehicle into one of those native special behavior paths explicitly, without permanently spoofing the vehicle's real model ID.

The main goals are:

* Allow custom towtrucks to tow vehicles using the original towtruck mechanics.
* Allow custom packers to move their ramp like the original packer.
* Allow custom firetrucks to use the original water cannon behavior.
* Allow custom fire ladder trucks to use the original ladder movement behavior.
* Keep original GTA models reporting and using their native default behavior when no override was set.
* Avoid carrying special behavior state across model replacement, model restore, or model ID reuse.

This is especially useful for resources that use `engineRequestModel` to add new vehicle models while still expecting original GTA SA special vehicle functionality.

#### Test plan
<!-- How have you tested this change? This should give confidence to the reviewer that your change is safe. -->
<!-- If someone makes changes to this code in the future, what steps can they follow to check that it's still working correctly? -->

[towtruck1.zip](https://github.com/user-attachments/files/29680704/towtruck1.zip)
Testing was done with the local `towtruck1` test resource under:

```text
Bin/server/mods/deathmatch/resources/towtruck1
```

The test resource includes custom replacement assets for:

```text
towtruck.txd / towtruck.dff
towtruck2.txd / towtruck2.dff
packer.txd / packer.dff
firetruk.txd / firetruk.dff
firela.txd / firela.dff
```


A shareable copy of the test resource is prepared under:

```text
towtruck1_pr_test_resource/towtruck1
```

That copy intentionally contains 0-byte placeholder `.txd` and `.dff` files only, so third-party/proprietary model assets are not included in the PR. Before running that copy, replace the placeholders with valid vehicle model files using the same filenames listed above. If the placeholders are left in place, custom model import/replacement tests are expected to fail; this is intentional.

Manual commands:

```lua
/testtow
/testtow2
/testpacker
/testfire
/testladder
/testabilities
/testabilityreset
```

Expected behavior:

* `/testtow`
  * Spawns a custom towtruck model.
  * Applies `towtruck`.
  * Vehicle should rotate the tow hook, attach nearby towable vehicles, keep tow line physics, and detach/drop normally.

* `/testtow2`
  * Spawns the second custom towtruck model.
  * Applies `towtruck`.
  * Used to verify behavior does not depend on a single custom DFF.

* `/testpacker`
  * Spawns a custom packer model.
  * Applies `packer`.
  * Player is warped into the vehicle after spawn.
  * Ramp should move with original-style input and should not throw the camera upward.
  * Ramp moving sound should play while the ramp moves.
  * Moving collision should follow the custom ramp.

* `/testfire`
  * Spawns a custom firetruck model.
  * Applies `fireTruckWater`.
  * Water cannon should aim/fire using original firetruck controls and effects.

* `/testladder`
  * Spawns a custom fire ladder model.
  * Applies `fireTruckLadder`.
  * Ladder should respond to original ladder controls.

* `/testabilities`
  * Spawns a matrix of original and custom vehicles with all supported ability values:

```lua
default
none
towtruck
packer
fireTruckWater
fireTruckLadder
```

  * The resource prints each case to the F8 console.
  * Client-side checks print `PASS` or `FAIL` for both getter aliases:

```lua
getVehicleModelSpecialAbility(vehicle)
getVehicleSpecialAbility(vehicle)
```

* `/testabilityreset`
  * Runs client-side reset/replacement tests.
  * Covers:
    * custom-to-custom `setElementModel` reset,
    * custom-to-original `setElementModel` reset,
    * original default getter behavior,
    * explicit `"none"` behavior,
    * invalid ability rejection,
    * alias setter behavior,
    * `engineReplaceModel` reset,
    * `engineRestoreModel` reset,
    * `engineFreeModel` plus re-request behavior,
    * replacing `towtruck2` assets onto the same custom towtruck model ID.

Important F8 checks:

```text
[towtruck1] PASS [...]
[towtruck1] FAIL [...]
```

The expected result is no `FAIL` lines.

Specific reset cases that should pass:

```text
same-id-before-towtruck2-replace
same-id-after-towtruck2-replace
same-id-before-original-towtruck-replace
same-id-after-original-towtruck-replace
default-original-towtruck
default-original-packer
default-original-firetruck
default-original-firetruck-ladder
default-original-towtruck-explicit-none
default-original-packer-explicit-towtruck
default-original-firetruck-explicit-none
default-original-firetruck-ladder-explicit-none
```

Native behavior checks:

* Towtruck:
  * Hook rotates in the same direction/range as the original towtruck.
  * Towed vehicle attaches at the DFF-defined towbar/hook location.
  * Towed vehicle can be dropped/detached by lowering it to the ground.
  * Tow line retains original physics when no vehicle is attached.

* Packer:
  * Ramp moves with original-style controls.
  * Camera does not jump far above the vehicle when the ramp moves.
  * Moving collision follows the ramp.
  * Ramp sound plays while moving.

* Firetruck water:
  * Water cannon fires with original controls.
  * Water cannon audio/effects are present.
  * Water cannon hit events still flow through existing MTA event handling.

* Firetruck ladder:
  * Ladder movement responds to original controls.
  * Custom ladder model receives fire ladder chassis initialization.






#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
