### PR TITLE
Fix onMarkerHit not firing in interiors (#5018)

### DIFF
--- a/Client/mods/deathmatch/logic/CClientColCallback.h
+++ b/Client/mods/deathmatch/logic/CClientColCallback.h
@@ -15,6 +15,8 @@
 class CClientColCallback
 {
 public:
+    // Whether a geometric hit should be stored in collision state. Callbacks can defer
+    // tracking until interior/dimension checks pass, so stale hits are cleared. #5018
     virtual bool ShouldTrackCollision(CClientColShape& Shape, CClientEntity& Entity) = 0;
     virtual void Callback_OnCollision(CClientColShape& Shape, CClientEntity& Entity) = 0;
     virtual void Callback_OnLeave(CClientColShape& Shape, CClientEntity& Entity) = 0;

--- a/Client/mods/deathmatch/logic/CClientColCallback.h
+++ b/Client/mods/deathmatch/logic/CClientColCallback.h
@@ -16,7 +16,7 @@ class CClientColCallback
 {
 public:
     // Whether a geometric hit should be stored in collision state. Callbacks can defer
-    // tracking until interior/dimension checks pass, so stale hits are cleared. #5018
+    // tracking until interior/dimension checks pass, so stale hits are cleared.
     virtual bool ShouldTrackCollision(CClientColShape& Shape, CClientEntity& Entity) = 0;
     virtual void Callback_OnCollision(CClientColShape& Shape, CClientEntity& Entity) = 0;
     virtual void Callback_OnLeave(CClientColShape& Shape, CClientEntity& Entity) = 0;

--- a/Client/mods/deathmatch/logic/CClientColCallback.h
+++ b/Client/mods/deathmatch/logic/CClientColCallback.h
@@ -15,6 +15,7 @@
 class CClientColCallback
 {
 public:
+    virtual bool ShouldTrackCollision(CClientColShape& Shape, CClientEntity& Entity) = 0;
     virtual void Callback_OnCollision(CClientColShape& Shape, CClientEntity& Entity) = 0;
     virtual void Callback_OnLeave(CClientColShape& Shape, CClientEntity& Entity) = 0;
 };

--- a/Client/mods/deathmatch/logic/CClientColManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientColManager.cpp
@@ -137,7 +137,15 @@ void CClientColManager::DoHitDetectionForEntity(const CVector& vecNowPosition, f
 //
 void CClientColManager::HandleHitDetectionResult(bool bHit, CClientColShape* pShape, CClientEntity* pEntity)
 {
+    bool bShouldTrack = bHit;
     if (bHit)
+    {
+        CClientColCallback* pCallback = pShape->GetHitCallback();
+        if (pCallback)
+            bShouldTrack = pCallback->ShouldTrackCollision(*pShape, *pEntity);
+    }
+
+    if (bShouldTrack)
     {
         // If they havn't collided yet
         if (!pEntity->CollisionExists(pShape))
@@ -165,32 +173,28 @@ void CClientColManager::HandleHitDetectionResult(bool bHit, CClientColShape* pSh
             pShape->CallHitCallback(*pEntity);
         }
     }
-    else
+    else if (pEntity->CollisionExists(pShape))
     {
-        // If they collided before
-        if (pEntity->CollisionExists(pShape))
+        // Remove the collision and the collider
+        pShape->RemoveCollider(pEntity);
+        pEntity->RemoveCollision(pShape);
+
+        // Can we call the event?
+        if (!pEntity->IsBeingDeleted())
         {
-            // Remove the collision and the collider
-            pShape->RemoveCollider(pEntity);
-            pEntity->RemoveCollision(pShape);
+            // Call the event
+            CLuaArguments Arguments;
+            Arguments.PushElement(pEntity);
+            Arguments.PushBoolean((pShape->GetDimension() == pEntity->GetDimension()));
+            pShape->CallEvent("onClientColShapeLeave", Arguments, true);
 
-            // Can we call the event?
-            if (!pEntity->IsBeingDeleted())
-            {
-                // Call the event
-                CLuaArguments Arguments;
-                Arguments.PushElement(pEntity);
-                Arguments.PushBoolean((pShape->GetDimension() == pEntity->GetDimension()));
-                pShape->CallEvent("onClientColShapeLeave", Arguments, true);
-
-                CLuaArguments Arguments2;
-                Arguments2.PushElement(pShape);
-                Arguments2.PushBoolean((pShape->GetDimension() == pEntity->GetDimension()));
-                pEntity->CallEvent("onClientElementColShapeLeave", Arguments2, true);
-            }
-
-            pShape->CallLeaveCallback(*pEntity);
+            CLuaArguments Arguments2;
+            Arguments2.PushElement(pShape);
+            Arguments2.PushBoolean((pShape->GetDimension() == pEntity->GetDimension()));
+            pEntity->CallEvent("onClientElementColShapeLeave", Arguments2, true);
         }
+
+        pShape->CallLeaveCallback(*pEntity);
     }
 }
 

--- a/Client/mods/deathmatch/logic/CClientColManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientColManager.cpp
@@ -9,6 +9,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include "CClientColCallback.h"
 
 using std::list;
 using std::vector;

--- a/Client/mods/deathmatch/logic/CClientColShape.h
+++ b/Client/mods/deathmatch/logic/CClientColShape.h
@@ -57,6 +57,7 @@ public:
 
     void                CallHitCallback(CClientEntity& Entity);
     void                CallLeaveCallback(CClientEntity& Entity);
+    CClientColCallback* GetHitCallback() { return m_pCallback; };
     CClientColCallback* SetHitCallback(CClientColCallback* pCallback) { return (m_pCallback = pCallback); };
 
     bool GetAutoCallEvent() { return m_bAutoCallEvent; };

--- a/Client/mods/deathmatch/logic/CClientMarker.cpp
+++ b/Client/mods/deathmatch/logic/CClientMarker.cpp
@@ -423,9 +423,6 @@ void CClientMarker::StreamOut()
 
 void CClientMarker::Callback_OnCollision(CClientColShape& shape, CClientEntity& entity)
 {
-    if (GetInterior() != entity.GetInterior())
-        return;
-
     // Call the marker hit event
     CLuaArguments arguments;
     arguments.PushElement(&entity);                                  // Hit element
@@ -443,9 +440,6 @@ void CClientMarker::Callback_OnCollision(CClientColShape& shape, CClientEntity& 
 
 void CClientMarker::Callback_OnLeave(CClientColShape& shape, CClientEntity& entity)
 {
-    if (GetInterior() != entity.GetInterior())
-        return;
-
     // Call the marker leave event
     CLuaArguments arguments;
     arguments.PushElement(&entity);                                  // Hit element
@@ -459,6 +453,11 @@ void CClientMarker::Callback_OnLeave(CClientColShape& shape, CClientEntity& enti
     arguments2.PushElement(this);                                     // marker
     arguments2.PushBoolean(GetDimension() == entity.GetDimension());  // Matching dimension?
     entity.CallEvent("onPlayerMarkerLeave", arguments2, false);
+}
+
+bool CClientMarker::ShouldTrackCollision(CClientColShape& shape, CClientEntity& entity)
+{
+    return GetInterior() == entity.GetInterior();
 }
 
 void CClientMarker::CreateOfType(int iType)

--- a/Client/mods/deathmatch/logic/CClientMarker.h
+++ b/Client/mods/deathmatch/logic/CClientMarker.h
@@ -81,6 +81,7 @@ public:
 
     void Callback_OnCollision(CClientColShape& Shape, CClientEntity& Entity);
     void Callback_OnLeave(CClientColShape& Shape, CClientEntity& Entity);
+    bool ShouldTrackCollision(CClientColShape& Shape, CClientEntity& Entity);
 
     virtual CSphere GetWorldBoundingSphere();
 

--- a/Client/mods/deathmatch/logic/CClientPickup.cpp
+++ b/Client/mods/deathmatch/logic/CClientPickup.cpp
@@ -243,42 +243,44 @@ bool CClientPickup::ReCreate()
 
 void CClientPickup::Callback_OnCollision(CClientColShape& Shape, CClientEntity& Entity)
 {
-    if (IS_PLAYER(&Entity))
-    {
-        bool bMatchingDimensions = (GetDimension() == Entity.GetDimension());  // Matching dimensions?
+    bool bMatchingDimensions = (GetDimension() == Entity.GetDimension());  // Matching dimensions?
 
-        // Call the pickup hit event (source = pickup that was hit)
-        CLuaArguments Arguments;
-        Arguments.PushElement(&Entity);  // The element that hit the pickup
-        Arguments.PushBoolean(bMatchingDimensions);
-        CallEvent("onClientPickupHit", Arguments, true);
+    // Call the pickup hit event (source = pickup that was hit)
+    CLuaArguments Arguments;
+    Arguments.PushElement(&Entity);  // The element that hit the pickup
+    Arguments.PushBoolean(bMatchingDimensions);
+    CallEvent("onClientPickupHit", Arguments, true);
 
-        // Call the player pickup hit (source = player that hit the pickup)
-        CLuaArguments Arguments2;
-        Arguments2.PushElement(this);  // The pickup that was hit
-        Arguments2.PushBoolean(bMatchingDimensions);
-        Entity.CallEvent("onClientPlayerPickupHit", Arguments2, true);
-    }
+    // Call the player pickup hit (source = player that hit the pickup)
+    CLuaArguments Arguments2;
+    Arguments2.PushElement(this);  // The pickup that was hit
+    Arguments2.PushBoolean(bMatchingDimensions);
+    Entity.CallEvent("onClientPlayerPickupHit", Arguments2, true);
 }
 
 void CClientPickup::Callback_OnLeave(CClientColShape& Shape, CClientEntity& Entity)
 {
-    if (IS_PLAYER(&Entity))
-    {
-        bool bMatchingDimensions = (GetDimension() == Entity.GetDimension());  // Matching dimensions?
+    bool bMatchingDimensions = (GetDimension() == Entity.GetDimension());  // Matching dimensions?
 
-        // Call the pickup leave event (source = the pickup that was left)
-        CLuaArguments Arguments;
-        Arguments.PushElement(&Entity);  // The element that left the pickup
-        Arguments.PushBoolean(bMatchingDimensions);
-        CallEvent("onClientPickupLeave", Arguments, true);
+    // Call the pickup leave event (source = the pickup that was left)
+    CLuaArguments Arguments;
+    Arguments.PushElement(&Entity);  // The element that left the pickup
+    Arguments.PushBoolean(bMatchingDimensions);
+    CallEvent("onClientPickupLeave", Arguments, true);
 
-        // Call the player pickup leave event (source = the player that left the pickup)
-        CLuaArguments Arguments2;
-        Arguments2.PushElement(this);  // The pickup that was left (this)
-        Arguments2.PushBoolean(bMatchingDimensions);
-        Entity.CallEvent("onClientPlayerPickupLeave", Arguments2, true);
-    }
+    // Call the player pickup leave event (source = the player that left the pickup)
+    CLuaArguments Arguments2;
+    Arguments2.PushElement(this);  // The pickup that was left (this)
+    Arguments2.PushBoolean(bMatchingDimensions);
+    Entity.CallEvent("onClientPlayerPickupLeave", Arguments2, true);
+}
+
+bool CClientPickup::ShouldTrackCollision(CClientColShape& Shape, CClientEntity& Entity)
+{
+    if (!IS_PLAYER(&Entity))
+        return false;
+
+    return GetInterior() == Entity.GetInterior();
 }
 
 void CClientPickup::NotifyUnableToCreate()

--- a/Client/mods/deathmatch/logic/CClientPickup.h
+++ b/Client/mods/deathmatch/logic/CClientPickup.h
@@ -118,6 +118,7 @@ public:
 
     void Callback_OnCollision(CClientColShape& Shape, CClientEntity& Entity);
     void Callback_OnLeave(CClientColShape& Shape, CClientEntity& Entity);
+    bool ShouldTrackCollision(CClientColShape& Shape, CClientEntity& Entity);
 
 protected:
     void StreamIn(bool bInstantly);

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1313,6 +1313,29 @@ bool CStaticFunctionDefinitions::SetElementInterior(CClientEntity& Entity, unsig
         }
     }
 
+    switch (Entity.GetType())
+    {
+        case CCLIENTPLAYER:
+        case CCLIENTPED:
+        case CCLIENTVEHICLE:
+        {
+            CVector vecEntityPosition;
+            Entity.GetPosition(vecEntityPosition);
+            m_pColManager->DoHitDetection(vecEntityPosition, 0.0f, &Entity);
+            break;
+        }
+        case CCLIENTMARKER:
+        case CCLIENTPICKUP:
+        {
+            CClientColShape* pColShape = GetElementColShape(&Entity);
+            if (pColShape)
+                RefreshColShapeColliders(pColShape);
+            break;
+        }
+        default:
+            break;
+    }
+
     return true;
 }
 

--- a/Client/mods/deathmatch/logic/rpc/CElementRPCs.cpp
+++ b/Client/mods/deathmatch/logic/rpc/CElementRPCs.cpp
@@ -269,6 +269,35 @@ void CElementRPCs::SetElementInterior(CClientEntity* pSource, NetBitStreamInterf
                 pSource->SetPosition(vecPosition);
             }
         }
+
+        CClientColManager* pColManager = m_pClientGame->GetManager()->GetColManager();
+        switch (pSource->GetType())
+        {
+            case CCLIENTPLAYER:
+            case CCLIENTPED:
+            case CCLIENTVEHICLE:
+            {
+                CVector vecEntityPosition;
+                pSource->GetPosition(vecEntityPosition);
+                pColManager->DoHitDetection(vecEntityPosition, 0.0f, pSource);
+                break;
+            }
+            case CCLIENTMARKER:
+            case CCLIENTPICKUP:
+            {
+                CClientColShape* pColShape = NULL;
+                if (pSource->GetType() == CCLIENTMARKER)
+                    pColShape = static_cast<CClientMarker*>(pSource)->GetColShape();
+                else
+                    pColShape = static_cast<CClientPickup*>(pSource)->GetColShape();
+
+                if (pColShape)
+                    CStaticFunctionDefinitions::RefreshColShapeColliders(pColShape);
+                break;
+            }
+            default:
+                break;
+        }
     }
 }
 

--- a/Server/mods/deathmatch/logic/CColCallback.h
+++ b/Server/mods/deathmatch/logic/CColCallback.h
@@ -16,6 +16,8 @@
 class CColCallback
 {
 public:
+    // Whether a geometric hit should be stored in collision state. Callbacks can defer
+    // tracking until interior/dimension checks pass, so stale hits are cleared. #5018
     virtual bool ShouldTrackCollision(CColShape& Shape, CElement& Element) = 0;
     virtual void Callback_OnCollision(CColShape& Shape, CElement& Element) = 0;
     virtual void Callback_OnLeave(CColShape& Shape, CElement& Element) = 0;

--- a/Server/mods/deathmatch/logic/CColCallback.h
+++ b/Server/mods/deathmatch/logic/CColCallback.h
@@ -16,6 +16,7 @@
 class CColCallback
 {
 public:
+    virtual bool ShouldTrackCollision(CColShape& Shape, CElement& Element) = 0;
     virtual void Callback_OnCollision(CColShape& Shape, CElement& Element) = 0;
     virtual void Callback_OnLeave(CColShape& Shape, CElement& Element) = 0;
     virtual void Callback_OnCollisionDestroy(CColShape* pShape) = 0;

--- a/Server/mods/deathmatch/logic/CColCallback.h
+++ b/Server/mods/deathmatch/logic/CColCallback.h
@@ -17,7 +17,7 @@ class CColCallback
 {
 public:
     // Whether a geometric hit should be stored in collision state. Callbacks can defer
-    // tracking until interior/dimension checks pass, so stale hits are cleared. #5018
+    // tracking until interior/dimension checks pass, so stale hits are cleared.
     virtual bool ShouldTrackCollision(CColShape& Shape, CElement& Element) = 0;
     virtual void Callback_OnCollision(CColShape& Shape, CElement& Element) = 0;
     virtual void Callback_OnLeave(CColShape& Shape, CElement& Element) = 0;

--- a/Server/mods/deathmatch/logic/CColManager.cpp
+++ b/Server/mods/deathmatch/logic/CColManager.cpp
@@ -128,7 +128,15 @@ void CColManager::DoHitDetectionForEntity(const CVector& vecNowPosition, CElemen
 //
 void CColManager::HandleHitDetectionResult(bool bHit, CColShape* pShape, CElement* pEntity)
 {
+    bool bShouldTrack = bHit;
     if (bHit)
+    {
+        CColCallback* pCallback = pShape->GetCallback();
+        if (pCallback)
+            bShouldTrack = pCallback->ShouldTrackCollision(*pShape, *pEntity);
+    }
+
+    if (bShouldTrack)
     {
         // If they havn't collided yet
         if (!pEntity->CollisionExists(pShape))
@@ -156,32 +164,28 @@ void CColManager::HandleHitDetectionResult(bool bHit, CColShape* pShape, CElemen
             pShape->CallHitCallback(*pEntity);
         }
     }
-    else
+    else if (pEntity->CollisionExists(pShape))
     {
-        // If they collided before
-        if (pEntity->CollisionExists(pShape))
+        // Remove the collision and the collider
+        pShape->RemoveCollider(pEntity);
+        pEntity->RemoveCollision(pShape);
+
+        // Can we call the event?
+        if (!pEntity->IsBeingDeleted())
         {
-            // Remove the collision and the collider
-            pShape->RemoveCollider(pEntity);
-            pEntity->RemoveCollision(pShape);
+            // Call the event
+            CLuaArguments Arguments;
+            Arguments.PushElement(pEntity);
+            Arguments.PushBoolean((pShape->GetDimension() == pEntity->GetDimension()));
+            pShape->CallEvent("onColShapeLeave", Arguments);
 
-            // Can we call the event?
-            if (!pEntity->IsBeingDeleted())
-            {
-                // Call the event
-                CLuaArguments Arguments;
-                Arguments.PushElement(pEntity);
-                Arguments.PushBoolean((pShape->GetDimension() == pEntity->GetDimension()));
-                pShape->CallEvent("onColShapeLeave", Arguments);
-
-                CLuaArguments Arguments2;
-                Arguments2.PushElement(pShape);
-                Arguments2.PushBoolean((pShape->GetDimension() == pEntity->GetDimension()));
-                pEntity->CallEvent("onElementColShapeLeave", Arguments2);
-            }
-
-            pShape->CallLeaveCallback(*pEntity);
+            CLuaArguments Arguments2;
+            Arguments2.PushElement(pShape);
+            Arguments2.PushBoolean((pShape->GetDimension() == pEntity->GetDimension()));
+            pEntity->CallEvent("onElementColShapeLeave", Arguments2);
         }
+
+        pShape->CallLeaveCallback(*pEntity);
     }
 }
 

--- a/Server/mods/deathmatch/logic/CColManager.cpp
+++ b/Server/mods/deathmatch/logic/CColManager.cpp
@@ -10,6 +10,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include "CColCallback.h"
 #include "CColManager.h"
 #include "CSpatialDatabase.h"
 #include "Utils.h"

--- a/Server/mods/deathmatch/logic/CColShape.h
+++ b/Server/mods/deathmatch/logic/CColShape.h
@@ -45,6 +45,7 @@ public:
 
     void                CallHitCallback(CElement& Element);
     void                CallLeaveCallback(CElement& Element);
+    class CColCallback* GetCallback() { return m_pCallback; };
     class CColCallback* SetCallback(class CColCallback* pCallback) { return (m_pCallback = pCallback); };
 
     bool GetAutoCallEvent() { return m_bAutoCallEvent; };

--- a/Server/mods/deathmatch/logic/CMarker.cpp
+++ b/Server/mods/deathmatch/logic/CMarker.cpp
@@ -334,48 +334,45 @@ void CMarker::SetTargetArrowProperties(const SColor color, float size) noexcept
 
 void CMarker::Callback_OnCollision(CColShape& Shape, CElement& Element)
 {
-    // Do not call on ourselves #7359
-    if (this == &Element)
-        return;
+    // Call the marker hit event
+    CLuaArguments Arguments;
+    Arguments.PushElement(&Element);                                  // Hit element
+    Arguments.PushBoolean(GetDimension() == Element.GetDimension());  // Matching dimension?
+    CallEvent("onMarkerHit", Arguments);
 
-    // Matching interior?
-    if (GetInterior() == Element.GetInterior())
+    if (IS_PLAYER(&Element))
     {
-        // Call the marker hit event
-        CLuaArguments Arguments;
-        Arguments.PushElement(&Element);                                  // Hit element
-        Arguments.PushBoolean(GetDimension() == Element.GetDimension());  // Matching dimension?
-        CallEvent("onMarkerHit", Arguments);
-
-        if (IS_PLAYER(&Element))
-        {
-            CLuaArguments Arguments2;
-            Arguments2.PushElement(this);                                      // marker
-            Arguments2.PushBoolean(GetDimension() == Element.GetDimension());  // Matching dimension?
-            Element.CallEvent("onPlayerMarkerHit", Arguments2);
-        }
+        CLuaArguments Arguments2;
+        Arguments2.PushElement(this);                                      // marker
+        Arguments2.PushBoolean(GetDimension() == Element.GetDimension());  // Matching dimension?
+        Element.CallEvent("onPlayerMarkerHit", Arguments2);
     }
 }
 
 void CMarker::Callback_OnLeave(CColShape& Shape, CElement& Element)
 {
-    // Matching interior?
-    if (GetInterior() == Element.GetInterior())
-    {
-        // Call the marker hit event
-        CLuaArguments Arguments;
-        Arguments.PushElement(&Element);                                  // Hit element
-        Arguments.PushBoolean(GetDimension() == Element.GetDimension());  // Matching dimension?
-        CallEvent("onMarkerLeave", Arguments);
+    // Call the marker leave event
+    CLuaArguments Arguments;
+    Arguments.PushElement(&Element);                                  // Hit element
+    Arguments.PushBoolean(GetDimension() == Element.GetDimension());  // Matching dimension?
+    CallEvent("onMarkerLeave", Arguments);
 
-        if (IS_PLAYER(&Element))
-        {
-            CLuaArguments Arguments2;
-            Arguments2.PushElement(this);                                      // marker
-            Arguments2.PushBoolean(GetDimension() == Element.GetDimension());  // Matching dimension?
-            Element.CallEvent("onPlayerMarkerLeave", Arguments2);
-        }
+    if (IS_PLAYER(&Element))
+    {
+        CLuaArguments Arguments2;
+        Arguments2.PushElement(this);                                      // marker
+        Arguments2.PushBoolean(GetDimension() == Element.GetDimension());  // Matching dimension?
+        Element.CallEvent("onPlayerMarkerLeave", Arguments2);
     }
+}
+
+bool CMarker::ShouldTrackCollision(CColShape& Shape, CElement& Element)
+{
+    // Do not call on ourselves #7359
+    if (this == &Element)
+        return false;
+
+    return GetInterior() == Element.GetInterior();
 }
 
 void CMarker::Callback_OnCollisionDestroy(CColShape* pCollision)

--- a/Server/mods/deathmatch/logic/CMarker.h
+++ b/Server/mods/deathmatch/logic/CMarker.h
@@ -81,6 +81,7 @@ private:
     void Callback_OnCollision(CColShape& Shape, CElement& Element);
     void Callback_OnLeave(CColShape& Shape, CElement& Element);
     void Callback_OnCollisionDestroy(CColShape* pShape);
+    bool ShouldTrackCollision(CColShape& Shape, CElement& Element);
 
     void UpdateCollisionObject(unsigned char ucOldType);
 

--- a/Server/mods/deathmatch/logic/CPickup.cpp
+++ b/Server/mods/deathmatch/logic/CPickup.cpp
@@ -482,42 +482,27 @@ void CPickup::Use(CPlayer& Player)
 
 void CPickup::Callback_OnCollision(CColShape& Shape, CElement& Element)
 {
-    if (IS_PLAYER(&Element))
+    CPlayer& Player = static_cast<CPlayer&>(Element);
+
+    // Call the onPickupHit event
+    CLuaArguments Arguments;
+    Arguments.PushElement(&Player);
+    bool bContinue1 = CallEvent("onPickupHit", Arguments);
+
+    CLuaArguments Arguments2;
+    Arguments2.PushElement(this);  // pickup
+    bool bContinue2 = Element.CallEvent("onPlayerPickupHit", Arguments2);
+
+    if (bContinue1 && bContinue2)
     {
-        CPlayer& Player = static_cast<CPlayer&>(Element);
-
-        // Is he alive?
-        if (!Player.IsDead())
+        // Does it still exist?
+        if (!IsBeingDeleted())
         {
-            // Matching interior
-            if (GetInterior() == Element.GetInterior())
+            // Can we USE the pickup?
+            if (CanUse(Player))
             {
-                // Matching dimension
-                if (GetDimension() == Element.GetDimension())
-                {
-                    // Call the onPickupHit event
-                    CLuaArguments Arguments;
-                    Arguments.PushElement(&Player);
-                    bool bContinue1 = CallEvent("onPickupHit", Arguments);
-
-                    CLuaArguments Arguments2;
-                    Arguments2.PushElement(this);  // pickup
-                    bool bContinue2 = Element.CallEvent("onPlayerPickupHit", Arguments2);
-
-                    if (bContinue1 && bContinue2)
-                    {
-                        // Does it still exist?
-                        if (!IsBeingDeleted())
-                        {
-                            // Can we USE the pickup?
-                            if (CanUse(Player))
-                            {
-                                // USE the pickup
-                                Use(Player);
-                            }
-                        }
-                    }
-                }
+                // USE the pickup
+                Use(Player);
             }
         }
     }
@@ -525,31 +510,29 @@ void CPickup::Callback_OnCollision(CColShape& Shape, CElement& Element)
 
 void CPickup::Callback_OnLeave(CColShape& Shape, CElement& Element)
 {
-    if (IS_PLAYER(&Element))
-    {
-        CPlayer& Player = static_cast<CPlayer&>(Element);
+    CPlayer& Player = static_cast<CPlayer&>(Element);
 
-        // Matching interior
-        if (GetInterior() == Element.GetInterior())
-        {
-            // Matching dimension
-            if (GetDimension() == Element.GetDimension())
-            {
-                // Is he alive?
-                if (!Player.IsDead())
-                {
-                    // Call the onPickupLeave event
-                    CLuaArguments Arguments;
-                    Arguments.PushElement(&Player);
-                    CallEvent("onPickupLeave", Arguments);
+    // Call the onPickupLeave event
+    CLuaArguments Arguments;
+    Arguments.PushElement(&Player);
+    CallEvent("onPickupLeave", Arguments);
 
-                    CLuaArguments Arguments2;
-                    Arguments2.PushElement(this);  // pickup
-                    Element.CallEvent("onPlayerPickupLeave", Arguments2);
-                }
-            }
-        }
-    }
+    CLuaArguments Arguments2;
+    Arguments2.PushElement(this);  // pickup
+    Element.CallEvent("onPlayerPickupLeave", Arguments2);
+}
+
+bool CPickup::ShouldTrackCollision(CColShape& Shape, CElement& Element)
+{
+    if (!IS_PLAYER(&Element))
+        return false;
+
+    CPlayer& Player = static_cast<CPlayer&>(Element);
+
+    if (Player.IsDead())
+        return false;
+
+    return GetInterior() == Element.GetInterior() && GetDimension() == Element.GetDimension();
 }
 
 void CPickup::Callback_OnCollisionDestroy(CColShape* pCollision)

--- a/Server/mods/deathmatch/logic/CPickup.h
+++ b/Server/mods/deathmatch/logic/CPickup.h
@@ -152,6 +152,7 @@ private:
     void Callback_OnCollision(CColShape& Shape, CElement& Element);
     void Callback_OnLeave(CColShape& Shape, CElement& Element);
     void Callback_OnCollisionDestroy(CColShape* pShape);
+    bool ShouldTrackCollision(CColShape& Shape, CElement& Element);
 
     class CPickupManager* m_pPickupManager;
 

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1507,6 +1507,34 @@ bool CStaticFunctionDefinitions::SetElementInterior(CElement* pElement, unsigned
     {
         pElement->SetInterior(ucInterior);
 
+        // Re-evaluate marker/pickup collisions after interior changes
+        switch (pElement->GetType())
+        {
+            case CElement::PLAYER:
+            case CElement::PED:
+            case CElement::VEHICLE:
+                m_pColManager->DoHitDetection(pElement->GetPosition(), pElement);
+                break;
+            case CElement::MARKER:
+            {
+                CMarker*   pMarker = static_cast<CMarker*>(pElement);
+                CColShape* pColShape = pMarker->GetColShape();
+                if (pColShape)
+                    RefreshColShapeColliders(pColShape);
+                break;
+            }
+            case CElement::PICKUP:
+            {
+                CPickup*   pPickup = static_cast<CPickup*>(pElement);
+                CColShape* pColShape = pPickup->GetColShape();
+                if (pColShape)
+                    RefreshColShapeColliders(pColShape);
+                break;
+            }
+            default:
+                break;
+        }
+
         // Tell everyone
         CBitStream BitStream;
         BitStream.pBitStream->Write(ucInterior);
@@ -7910,6 +7938,10 @@ CMarker* CStaticFunctionDefinitions::CreateMarker(CResource* pResource, const CV
                 pMarker->RemoveVisibleToReference(m_pMapManager->GetRootElement());
                 pMarker->AddVisibleToReference(pVisibleTo);
             }
+
+            CColShape* pColShape = pMarker->GetColShape();
+            if (pColShape)
+                RefreshColShapeColliders(pColShape);
 
             // Tell everyone about it
             if (pResource->IsClientSynced())


### PR DESCRIPTION
#### Summary

Fixed `onMarkerHit` not firing in interiors when a geometric collision was recorded but the event was silently cancelled due to an interior mismatch. Interior (and dimension for pickups) checks were moved from callbacks into collision state management; hit detection is now refreshed after `setElementInterior` and `createMarker`.

Affected events:
- Server: `onMarkerHit`, `onMarkerLeave`, `onPickupHit`, `onPickupLeave`
- Client: `onClientMarkerHit`, `onClientMarkerLeave`, `onClientPickupHit`, `onClientPickupLeave`

#### Motivation

Fixes #5018 , #519

`CColManager::HandleHitDetectionResult` recorded collisions based on geometry only, while `CMarker::Callback_OnCollision` blocked the event entirely when interiors did not match. This mismatch created a stale collision state: even after the player later entered the correct interior, `CollisionExists` was already `true`, so `onMarkerHit` never fired again.

The same root cause also affected pickup and client-side marker/pickup events.

#### Test plan

Original repro (server console):

```lua
srun m = createMarker(me.position + Vector3(0,0,0.5), 'cylinder', 1.1, 255, 255, 255)
addEventHandler('onMarkerHit', m, function(he,md) outputChatBox('HIT '..tostring(he)..' md='..tostring(md)) end)
setElementInterior(m, 14)
setElementInterior(me, 14)
```

- `onMarkerHit` should fire.

Additional scenarios:

- Player passes through the marker area in interior 0 → event does not fire; then `setElementInterior(me, 14)` → `onMarkerHit` fires.
- Player is inside the marker and `setElementInterior(me, 0)` is called → `onMarkerLeave` fires.
- With a dimension mismatch, `onMarkerHit` still fires with `matchingDimension = false`.
- Same interior stale-state scenario verified for pickups via `onPickupHit`.
- Client-side `onClientMarkerHit` tested with the local player using the same scenarios.
- When interiors match, `isElementWithinMarker` returns `true` and `onMarkerHit` fires consistently.

#### Checklist

* [X] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [X] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.