### PR TITLE
Fix camera colliding against scripted objects while spectating

### DIFF
--- a/Client/game_sa/CCameraSA.cpp
+++ b/Client/game_sa/CCameraSA.cpp
@@ -599,6 +599,7 @@ void CCameraSA::GetCameraClip(bool& bObjects, bool& bVehicles)
 
 // At speed, relax camera collision against dynamic (script-created) objects only.
 // Static world geometry always keeps collision so default GTA world/buildings still block the camera.
+// When the camera target is another player's vehicle, use that vehicle's speed rather than the local player
 static void ApplyVehicleSpeedCameraClip()
 {
     // Static-world clip stays on regardless of speed.
@@ -607,15 +608,35 @@ static void ApplyVehicleSpeedCameraClip()
     using FindPlayerVehicle_t = void*(__cdecl*)(int playerId, bool bIncludeRemote);
     auto FindPlayerVehicle = reinterpret_cast<FindPlayerVehicle_t>(0x56E0D0);
 
-    void* pVehicle = FindPlayerVehicle(-1, false);
+    void* pVehicle = nullptr;
+
+    // Check the camera's actual target entity first: when spectating another player who is driving,
+    // the camera target is their vehicle, not the local player's.
+    CCamera* pCamera = pGame->GetCamera();
+    if (pCamera)
+    {
+        CEntity* pTargetEntity = pCamera->GetTargetEntity();
+        if (pTargetEntity && pTargetEntity->GetEntityType() == ENTITY_TYPE_VEHICLE)
+        {
+            pVehicle = pTargetEntity->GetInterface();
+        }
+    }
+
+    // Fall back to local player's vehicle if the camera isn't targeting a vehicle.
     if (!pVehicle)
     {
-        // No player vehicle: restore stock defaults.
+        pVehicle = FindPlayerVehicle(-1, false);
+    }
+
+    // No vehicle to derive speed from: restore stock defaults so the camera collides with everything.
+    if (!pVehicle)
+    {
         MemPutFast<float>(VAR_RelVelCamCollisionVehSqr, 1.0f);
         MemPutFast<char>(VAR_CameraClipDynamicObjects, 1);
         return;
     }
 
+    // Apply camera clipping for dynamic objects
     // CPhysicalSAInterface::m_vecLinearVelocity at offset 0x44 (CVector: 3 floats)
     float* pSpeed = reinterpret_cast<float*>(static_cast<char*>(pVehicle) + 0x44);
     float  speedSq = pSpeed[0] * pSpeed[0] + pSpeed[1] * pSpeed[1] + pSpeed[2] * pSpeed[2];

--- a/Client/game_sa/CCameraSA.cpp
+++ b/Client/game_sa/CCameraSA.cpp
@@ -612,7 +612,7 @@ static void ApplyVehicleSpeedCameraClip()
 
     // Check the camera's actual target entity first: when spectating another player who is driving,
     // the camera target is their vehicle, not the local player's.
-    CCamera* pCamera = pGame->GetCamera();
+    CCamera* pCamera = pGame ? pGame->GetCamera() : nullptr;
     if (pCamera)
     {
         CEntity* pTargetEntity = pCamera->GetTargetEntity();


### PR DESCRIPTION
#### Summary
ApplyVehicleSpeedCameraClip now checks the camera's actual target entity before falling back to the local player's vehicle. When spectating another player who is driving, the camera target is their vehicle, so the speed-based relaxation of dynamic object clipping now applies correctly.


#### Motivation
Oversight from #4861


#### Test plan
Tested locally with two devices.
Before the fix: when spectating a player, camera collides with dynamic objects at speed
After the fix: when spectating a player, camera no longer collides with dynamic objects at speed


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
