### PR TITLE
Fix isPedDead returning true permanently after setElementHealth revival

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -1805,10 +1805,13 @@ int CLuaPedDefs::IsPedDead(lua_State* luaVM)
         // Grab his dead state and return it
         bool bDead = pPed->IsDead() || pPed->IsDying();
 
-        // Check player is already dead on network (#4147)
+        // Cover the window between network death and GTA processing it (#4147).
+        // Don't apply if GTA has already processed a revival (health > 0 and not
+        // in a death task) - IsDeadOnNetwork would be a stale server-side artifact.
         if (auto pPlayer = dynamic_cast<CClientPlayer*>(pPed))
         {
-            bDead = bDead || pPlayer->IsDeadOnNetwork();
+            if (pPlayer->IsDeadOnNetwork() && (pPed->GetHealth() <= 0.0f || bDead))
+                bDead = true;
         }
 
         lua_pushboolean(luaVM, bDead);


### PR DESCRIPTION
#### Summary

Narrow the `isPedDead` network-dead check so it only fires when GTA hasn't already processed a revival (health still <= 0 or death task still active).

#### Motivation

Three commits combined to break spectating in gamemodes that use `respawn=none`:

- **#4576** (`c2c62e14f`) - made `isPedDead()` check `IsDeadOnNetwork()` in addition to GTA's own dead state
- **#4862** (`560b53ddd`) - changed the server to skip sending `CPlayerWastedPacket` to the dying player on `setElementHealth(player, 0)`, sending `SET_ELEMENT_HEALTH=0` instead
- **#4969** (`0ab45c99d`) - made the client fire `onClientPlayerWasted` from the `SET_ELEMENT_HEALTH=0` RPC and call `SetDeadOnNetwork(true)` there

`IsDeadOnNetwork`  is only cleared by a `PLAYER_SPAWN` packet, so in `respawn=none` gamemodes it stays true permanently after death.

Scripts like the race gamemode call `setElementHealth(localPlayer, 90)` to locally revive the ped during spectating. This triggers `Respawn()` inside `InternalSetHealth`, clearing GTA's death task. 

Before #4576 that was enough to make `isPedDead()` return false and let the spectate camera follow an alive player. After it, `IsDeadOnNetwork` kept `isPedDead()` stuck as true, so the race gamemode's `onClientPreRender` hook kept calling `setCameraMatrix` every frame, freezing the camera at the death position.

The fix tightens the #4576 condition: `IsDeadOnNetwork` is only applied when health is still <= 0 or `IsDead()` is still true. Once GTA has processed a local revival, `IsDeadOnNetwork` is treated as stale and ignored.

#### Test plan

- Race map `respawn=none` with multiple players: die, confirm the spectate camera follows an alive player instead of freezing.
- Race map with `respawn=timelimit` & `respawntime > 0`: die, wait for respawn, confirm the respawn works as expected.
- Natural death: confirm `isPedDead` still returns true in the brief window between the server sending health=0 and GTA processing the death task (the original #4576 case).

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.