### PR TITLE
Fix unoccupied vehicle sync list growing unbounded during vehicle exit

### DIFF
--- a/Client/mods/deathmatch/logic/CUnoccupiedVehicleSync.cpp
+++ b/Client/mods/deathmatch/logic/CUnoccupiedVehicleSync.cpp
@@ -235,7 +235,8 @@ void CUnoccupiedVehicleSync::UpdateStates()
         !pPlayer->GetRealOccupiedVehicle())
     {
         // Make sure it's valid and add it to our list temporarily
-        if (auto* pVehicle = dynamic_cast<CDeathmatchVehicle*>(pPlayer->GetOccupiedVehicle()))
+        pVehicle = dynamic_cast<CDeathmatchVehicle*>(pPlayer->GetOccupiedVehicle());
+        if (pVehicle)
             m_List.push_front(pVehicle);
     }
 


### PR DESCRIPTION
#### Summary
Fix unoccupied vehicle sync list growing unbounded during vehicle exit

#### Motivation
After a player exits a vehicle, the server can spam "WARN: Received excess unoccupied vehicle sync data". This can be reproduced simply by exiting and re-entering a stationary vehicle, after which driving triggers the warning.  

<img width="521" height="340" alt="image" src="https://github.com/user-attachments/assets/7d04ffa9-9a2e-4d2e-86d1-7be7818ae50b" />   <!-- -->
  
  
  
In `CUnoccupiedVehicleSync::UpdateStates`, the exiting vehicle is meant to be temporarily added to `m_List` before sending a sync packet and then removed immediately after. The removal relies on the outer `pVehicle` pointer, but the inner if statement declares a new shadow variable, leaving the outer as `nullptr`.   

As a result the cleanup never ran and the vehicle was pushed into the list on every sync tick for the entire duration of the exit animation, producing packets with hundreds of duplicate entries.

The fix assigns to the outer pVehicle instead of shadowing it, so the existing removal code at the bottom of the function works as intended.

#### Test plan
Exit a vehicle, re-enter it, and drive. Confirm the server no longer logs the excess sync warning.

#### Checklist

* [x] Your code should follow the coding guidelines.
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.