### PR TITLE
HUD component visibility state handling

### DIFF
--- a/Client/core/CCommandFuncs.cpp
+++ b/Client/core/CCommandFuncs.cpp
@@ -366,9 +366,10 @@ void CCommandFuncs::CopyGTAControls(const char* szParameters)
 
 void CCommandFuncs::HUD(const char* szParameters)
 {
-    int  iCmd = (szParameters && szParameters[0]) ? atoi(szParameters) : -1;
-    bool bShow = (iCmd == 1) ? true : (iCmd == 0) ? false : g_pCore->GetGame()->GetHud()->IsDisabled();
-    g_pCore->GetGame()->GetHud()->Disable(!bShow);
+    const int  command = (szParameters && szParameters[0]) ? atoi(szParameters) : -1;
+    auto*      hud = g_pCore->GetGame()->GetHud();
+    const bool show = (command == 1) ? true : (command == 0) ? false : !hud->IsEnabled();
+    hud->Disable(!show);
 }
 
 void CCommandFuncs::SaveConfig(const char* szParameters)

--- a/Client/core/CCommandFuncs.cpp
+++ b/Client/core/CCommandFuncs.cpp
@@ -368,7 +368,7 @@ void CCommandFuncs::HUD(const char* szParameters)
 {
     const int  command = (szParameters && szParameters[0]) ? atoi(szParameters) : -1;
     auto*      hud = g_pCore->GetGame()->GetHud();
-    const bool show = (command == 1) ? true : (command == 0) ? false : !hud->IsEnabled();
+    const bool show = (command == 1) ? true : (command == 0) ? false : !hud->IsRequestedEnabled();
     hud->Disable(!show);
 }
 

--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -453,8 +453,9 @@ void CGameSA::Reset()
 
         Pause(false);  // We don't have to pause as the fadeout will stop the sound. Pausing it will make the fadein next start ugly
 
-        // Restore the HUD
-        m_pHud->ResetVisibilityState();
+        // Reset the showhud preference and clear any temporary suppression left by the player map.
+        m_pHud->Disable(false);
+        m_pHud->SetSuppressed(false);
         m_pHud->SetComponentVisible(HUD_ALL, true);
 
         // Restore model dummies' positions

--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -452,10 +452,9 @@ void CGameSA::Reset()
         m_pCamera->Fade(0, FADE_OUT);
 
         Pause(false);  // We don't have to pause as the fadeout will stop the sound. Pausing it will make the fadein next start ugly
-        m_pHud->Disable(false);
 
         // Restore the HUD
-        m_pHud->Disable(false);
+        m_pHud->ResetVisibilityState();
         m_pHud->SetComponentVisible(HUD_ALL, true);
 
         // Restore model dummies' positions

--- a/Client/game_sa/CHudSA.cpp
+++ b/Client/game_sa/CHudSA.cpp
@@ -96,23 +96,57 @@ CHudSA::CHudSA()
     componentProperties.wanted = MapGet(defaultComponentProperties, HUD_WANTED);
 }
 
-void CHudSA::Disable(bool bDisabled)
+void CHudSA::Disable(bool disabled)
 {
-    if (bDisabled)
-        MemPut<BYTE>(FUNC_Draw, 0xC3);
-    else
-        MemPut<BYTE>(FUNC_Draw, 0x80);
+    const bool enabled = !disabled;
+    if (m_isEnabled == enabled)
+        return;
 
-    // Also disable the radar as the above code will not hide it before the local player has spawned
-    if (bDisabled)
-        MemPut<BYTE>(FUNC_DrawRadarPlanB, 0xC3);
-    else
-        MemPut<BYTE>(FUNC_DrawRadarPlanB, 0x83);
+    m_isEnabled = enabled;
+    ApplyVisibilityState();
 }
 
 bool CHudSA::IsDisabled()
 {
-    return *(BYTE*)FUNC_Draw == 0xC3;
+    return !m_isEnabled || m_suppressionReasons.any();
+}
+
+void CHudSA::SetSuppressed(eHudSuppressionReason reason, bool suppressed)
+{
+    const std::size_t index = static_cast<std::size_t>(reason);
+    if (index >= m_suppressionReasons.size() || m_suppressionReasons[index] == suppressed)
+        return;
+
+    m_suppressionReasons.set(index, suppressed);
+    ApplyVisibilityState();
+}
+
+void CHudSA::ResetVisibilityState()
+{
+    m_isEnabled = true;
+    m_suppressionReasons.reset();
+    ApplyVisibilityState();
+}
+
+void CHudSA::ApplyVisibilityState()
+{
+    const bool disabled = IsDisabled();
+    // Avoid rewriting GTA code when overlapping owners do not change the effective HUD state.
+    if (m_isAppliedDisabled == disabled)
+        return;
+
+    if (disabled)
+        MemPut<BYTE>(FUNC_Draw, 0xC3);
+    else
+        MemPut<BYTE>(FUNC_Draw, 0x80);
+
+    // The regular HUD draw patch does not cover the fallback radar path used before the local player spawns.
+    if (disabled)
+        MemPut<BYTE>(FUNC_DrawRadarPlanB, 0xC3);
+    else
+        MemPut<BYTE>(FUNC_DrawRadarPlanB, 0x83);
+
+    m_isAppliedDisabled = disabled;
 }
 
 //
@@ -130,9 +164,9 @@ void CHudSA::InitComponentList()
         {1, HUD_VEHICLE_NAME, 1, FUNC_DrawVehicleName, 1, 0xCC, 0xC3},
         {1, HUD_AREA_NAME, 1, FUNC_DrawAreaName, 1, 0xCC, 0xC3},
         {1, HUD_RADAR, 1, FUNC_DrawRadar, 1, 0xCC, 0xC3},
-        {1, HUD_RADAR_MAP, 1, FUNC_CRadar_DrawRadarMap, 1, 0xCC, 0xC3},
-        {1, HUD_RADAR_BLIPS, 1, FUNC_CRadar_DrawBlips, 1, 0xCC, 0xC3},
-        {1, HUD_RADAR_ALTIMETER, 1, CODE_ShowRadarAltimeter, 2, 0xCC, 0xEB30},
+        {1, HUD_RADAR_MAP, 1, FUNC_CRadar_DrawRadarMap, 1, 0xCC, 0xC3, HUD_RADAR},
+        {1, HUD_RADAR_BLIPS, 1, FUNC_CRadar_DrawBlips, 1, 0xCC, 0xC3, HUD_RADAR},
+        {1, HUD_RADAR_ALTIMETER, 1, CODE_ShowRadarAltimeter, 2, 0xCC, 0xEB30, HUD_RADAR},
         {1, HUD_CLOCK, 0, VAR_DisableClock, 1, 1, 0},
         {1, HUD_RADIO, 1, FUNC_DrawRadioName, 1, 0xCC, 0xC3},
         {1, HUD_WANTED, 1, FUNC_DrawWantedLevel, 1, 0xCC, 0xC3},
@@ -194,16 +228,25 @@ void CHudSA::SetComponentVisible(eHudComponent component, bool bVisible)
 //
 bool CHudSA::IsComponentVisible(eHudComponent component)
 {
-    SHudComponent* pComponent = MapFind(m_HudComponentMap, component);
-    if (pComponent)
+    if (IsDisabled())
+        return false;
+
+    // A child component cannot render when any containing component in its draw path is disabled.
+    auto* currentComponent = MapFind(m_HudComponentMap, component);
+    for (std::size_t depth = 0; currentComponent && depth < m_HudComponentMap.size(); ++depth)
     {
-        // Determine if invisible by matching data with disabled values
-        uchar* pSrc = (uchar*)(&pComponent->disabledData);
-        uchar* pDest = (uchar*)(pComponent->uiDataAddr);
-        if (memcmp(pDest, pSrc, pComponent->uiDataSize) == 0)
-            return false;  // Matches disabled bytes
-        return true;
+        const auto* disabledData = reinterpret_cast<const uchar*>(&currentComponent->disabledData);
+        const auto* currentData = reinterpret_cast<const uchar*>(currentComponent->uiDataAddr);
+        if (memcmp(currentData, disabledData, currentComponent->uiDataSize) == 0)
+            return false;
+
+        if (currentComponent->parent == HUD_ALL)
+            return true;
+
+        currentComponent = MapFind(m_HudComponentMap, currentComponent->parent);
     }
+
+    // Bound parent traversal so malformed component metadata cannot make a visibility query loop forever.
     return false;
 }
 

--- a/Client/game_sa/CHudSA.cpp
+++ b/Client/game_sa/CHudSA.cpp
@@ -17,6 +17,8 @@
 #include "TaskAttackSA.h"
 #include "CAERadioTrackManagerSA.h"
 
+#include <cstring>
+
 extern CGameSA* pGame;
 
 char szVehicleName[50] = {'\0'};
@@ -98,40 +100,32 @@ CHudSA::CHudSA()
 
 void CHudSA::Disable(bool disabled)
 {
-    const bool enabled = !disabled;
-    if (m_isEnabled == enabled)
+    const bool requestedEnabled = !disabled;
+    if (m_isRequestedEnabled == requestedEnabled)
         return;
 
-    m_isEnabled = enabled;
+    m_isRequestedEnabled = requestedEnabled;
     ApplyVisibilityState();
 }
 
-bool CHudSA::IsDisabled()
+bool CHudSA::IsDisabled() const noexcept
 {
-    return !m_isEnabled || m_suppressionReasons.any();
+    return !m_isRequestedEnabled || m_isSuppressed;
 }
 
-void CHudSA::SetSuppressed(eHudSuppressionReason reason, bool suppressed)
+void CHudSA::SetSuppressed(bool suppressed)
 {
-    const std::size_t index = static_cast<std::size_t>(reason);
-    if (index >= m_suppressionReasons.size() || m_suppressionReasons[index] == suppressed)
+    if (m_isSuppressed == suppressed)
         return;
 
-    m_suppressionReasons.set(index, suppressed);
-    ApplyVisibilityState();
-}
-
-void CHudSA::ResetVisibilityState()
-{
-    m_isEnabled = true;
-    m_suppressionReasons.reset();
+    m_isSuppressed = suppressed;
     ApplyVisibilityState();
 }
 
 void CHudSA::ApplyVisibilityState()
 {
     const bool disabled = IsDisabled();
-    // Avoid rewriting GTA code when overlapping owners do not change the effective HUD state.
+    // Only patch GTA's draw functions when the effective HUD state changes.
     if (m_isAppliedDisabled == disabled)
         return;
 
@@ -140,7 +134,7 @@ void CHudSA::ApplyVisibilityState()
     else
         MemPut<BYTE>(FUNC_Draw, 0x80);
 
-    // The regular HUD draw patch does not cover the fallback radar path used before the local player spawns.
+    // The fallback radar path can still draw before the local player has spawned.
     if (disabled)
         MemPut<BYTE>(FUNC_DrawRadarPlanB, 0xC3);
     else
@@ -228,16 +222,32 @@ void CHudSA::SetComponentVisible(eHudComponent component, bool bVisible)
 //
 bool CHudSA::IsComponentVisible(eHudComponent component)
 {
+    // Keep the old behaviour here: this only reports the value set through SetComponentVisible.
+    // Global HUD state and parent components are handled by IsComponentEffectivelyVisible instead.
+    const auto* hudComponent = MapFind(m_HudComponentMap, component);
+    if (!hudComponent)
+        return false;
+
+    const auto* disabledData = reinterpret_cast<const uchar*>(&hudComponent->disabledData);
+    const auto* currentData = reinterpret_cast<const uchar*>(hudComponent->uiDataAddr);
+    return std::memcmp(currentData, disabledData, hudComponent->uiDataSize) != 0;
+}
+
+//
+// CHudSA::IsComponentEffectivelyVisible
+//
+bool CHudSA::IsComponentEffectivelyVisible(eHudComponent component) const noexcept
+{
     if (IsDisabled())
         return false;
 
-    // A child component cannot render when any containing component in its draw path is disabled.
+    // A child keeps its own setting, but it still cannot draw while one of its parents is hidden.
     auto* currentComponent = MapFind(m_HudComponentMap, component);
     for (std::size_t depth = 0; currentComponent && depth < m_HudComponentMap.size(); ++depth)
     {
         const auto* disabledData = reinterpret_cast<const uchar*>(&currentComponent->disabledData);
         const auto* currentData = reinterpret_cast<const uchar*>(currentComponent->uiDataAddr);
-        if (memcmp(currentData, disabledData, currentComponent->uiDataSize) == 0)
+        if (std::memcmp(currentData, disabledData, currentComponent->uiDataSize) == 0)
             return false;
 
         if (currentComponent->parent == HUD_ALL)
@@ -246,7 +256,7 @@ bool CHudSA::IsComponentVisible(eHudComponent component)
         currentComponent = MapFind(m_HudComponentMap, currentComponent->parent);
     }
 
-    // Bound parent traversal so malformed component metadata cannot make a visibility query loop forever.
+    // Stop after one pass through the component map in case bad parent data ever creates a loop.
     return false;
 }
 

--- a/Client/game_sa/CHudSA.h
+++ b/Client/game_sa/CHudSA.h
@@ -11,7 +11,6 @@
 
 #pragma once
 
-#include <bitset>
 #include <game/CHud.h>
 #include <CVector.h>
 #include <game/RenderWare.h>
@@ -69,8 +68,8 @@ struct SHudComponent
     DWORD         uiDataSize;
     DWORD         origData;
     DWORD         disabledData;
-    // Components rendered inside another HUD component inherit their parent's visibility.
-    eHudComponent parent = HUD_ALL;
+    // A child keeps its own visibility setting, but it still depends on its parent.
+    eHudComponent parent{HUD_ALL};
 };
 
 enum class eHudColour
@@ -180,16 +179,16 @@ class CHudSA : public CHud
 public:
     CHudSA();
     void Disable(bool disabled) override;
-    bool IsDisabled() override;
+    bool IsDisabled() const noexcept override;
     void SetComponentVisible(eHudComponent component, bool bVisible) override;
     bool IsComponentVisible(eHudComponent component) override;
     void AdjustComponents(float fAspectRatio);
     void ResetComponentAdjustment();
     bool IsCrosshairVisible();
 
-    bool IsEnabled() const noexcept override { return m_isEnabled; }
-    void SetSuppressed(eHudSuppressionReason reason, bool suppressed) override;
-    void ResetVisibilityState() override;
+    bool IsRequestedEnabled() const noexcept override { return m_isRequestedEnabled; }
+    void SetSuppressed(bool suppressed) override;
+    bool IsComponentEffectivelyVisible(eHudComponent component) const noexcept override;
 
     bool IsComponentBar(const eHudComponent& component) const noexcept override;
     bool IsComponentText(const eHudComponent& component) const noexcept override;
@@ -308,10 +307,10 @@ private:
 private:
     std::map<eHudComponent, SHudComponent> m_HudComponentMap;
 
-    bool m_isEnabled = true;
-    bool m_isAppliedDisabled = false;
-    // Each temporary owner releases only its own suppression, preserving the state requested through showhud.
-    std::bitset<static_cast<std::size_t>(eHudSuppressionReason::COUNT)> m_suppressionReasons;
+    bool m_isRequestedEnabled{true};
+    bool m_isAppliedDisabled{false};
+    // The player map hides the HUD temporarily, so keep this separate from the showhud preference.
+    bool m_isSuppressed{false};
 
     float* m_pfAspectRatioMultiplicator;
     float* m_pfCameraCrosshairScale;

--- a/Client/game_sa/CHudSA.h
+++ b/Client/game_sa/CHudSA.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <bitset>
 #include <game/CHud.h>
 #include <CVector.h>
 #include <game/RenderWare.h>
@@ -68,6 +69,8 @@ struct SHudComponent
     DWORD         uiDataSize;
     DWORD         origData;
     DWORD         disabledData;
+    // Components rendered inside another HUD component inherit their parent's visibility.
+    eHudComponent parent = HUD_ALL;
 };
 
 enum class eHudColour
@@ -176,13 +179,17 @@ class CHudSA : public CHud
 {
 public:
     CHudSA();
-    void Disable(bool bDisabled);
-    bool IsDisabled();
-    void SetComponentVisible(eHudComponent component, bool bVisible);
-    bool IsComponentVisible(eHudComponent component);
+    void Disable(bool disabled) override;
+    bool IsDisabled() override;
+    void SetComponentVisible(eHudComponent component, bool bVisible) override;
+    bool IsComponentVisible(eHudComponent component) override;
     void AdjustComponents(float fAspectRatio);
     void ResetComponentAdjustment();
     bool IsCrosshairVisible();
+
+    bool IsEnabled() const noexcept override { return m_isEnabled; }
+    void SetSuppressed(eHudSuppressionReason reason, bool suppressed) override;
+    void ResetVisibilityState() override;
 
     bool IsComponentBar(const eHudComponent& component) const noexcept override;
     bool IsComponentText(const eHudComponent& component) const noexcept override;
@@ -276,6 +283,7 @@ public:
 
 private:
     void InitComponentList();
+    void ApplyVisibilityState();
     void UpdateStreetchCalculations();
     void ResetComponent(SComponentPlacement& placement, bool resetSize) noexcept;
     void ResetComponentFontData(const eHudComponent& component, const eHudComponentProperty& property) noexcept;
@@ -299,6 +307,11 @@ private:
 
 private:
     std::map<eHudComponent, SHudComponent> m_HudComponentMap;
+
+    bool m_isEnabled = true;
+    bool m_isAppliedDisabled = false;
+    // Each temporary owner releases only its own suppression, preserving the state requested through showhud.
+    std::bitset<static_cast<std::size_t>(eHudSuppressionReason::COUNT)> m_suppressionReasons;
 
     float* m_pfAspectRatioMultiplicator;
     float* m_pfCameraCrosshairScale;

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -5523,6 +5523,7 @@ void CClientGame::ResetMapInfo()
 
     // Player map
     m_pPlayerMap->SetForcedState(false);
+    m_pPlayerMap->SetPlayerMapEnabled(false);
 
     // Camera
     m_pCamera->FadeOut(0.0f, 0, 0, 0);

--- a/Client/mods/deathmatch/logic/CPlayerMap.cpp
+++ b/Client/mods/deathmatch/logic/CPlayerMap.cpp
@@ -505,15 +505,15 @@ void CPlayerMap::InternalSetPlayerMapEnabled(bool enable)
         m_bChatInputBlocked = g_pCore->IsChatInputBlocked();
         m_bDebugVisible = g_pCore->IsDebugVisible();
 
-        // The map temporarily suppresses the HUD without replacing the state requested through showhud.
-        g_pGame->GetHud()->SetSuppressed(eHudSuppressionReason::PLAYER_MAP, true);
+        // Hide the HUD for the map without changing what was requested through showhud.
+        g_pGame->GetHud()->SetSuppressed(true);
         g_pMultiplayer->HideRadar(true);
         g_pCore->SetChatVisible(false);
         g_pCore->SetDebugVisible(false);
     }
     else
     {
-        g_pGame->GetHud()->SetSuppressed(eHudSuppressionReason::PLAYER_MAP, false);
+        g_pGame->GetHud()->SetSuppressed(false);
         g_pMultiplayer->HideRadar(false);
         g_pCore->SetChatVisible(m_bChatVisible, m_bChatInputBlocked);
         g_pCore->SetDebugVisible(m_bDebugVisible);

--- a/Client/mods/deathmatch/logic/CPlayerMap.cpp
+++ b/Client/mods/deathmatch/logic/CPlayerMap.cpp
@@ -505,14 +505,15 @@ void CPlayerMap::InternalSetPlayerMapEnabled(bool enable)
         m_bChatInputBlocked = g_pCore->IsChatInputBlocked();
         m_bDebugVisible = g_pCore->IsDebugVisible();
 
-        g_pGame->GetHud()->Disable(true);
+        // The map temporarily suppresses the HUD without replacing the state requested through showhud.
+        g_pGame->GetHud()->SetSuppressed(eHudSuppressionReason::PLAYER_MAP, true);
         g_pMultiplayer->HideRadar(true);
         g_pCore->SetChatVisible(false);
         g_pCore->SetDebugVisible(false);
     }
     else
     {
-        g_pGame->GetHud()->Disable(false);
+        g_pGame->GetHud()->SetSuppressed(eHudSuppressionReason::PLAYER_MAP, false);
         g_pMultiplayer->HideRadar(false);
         g_pCore->SetChatVisible(m_bChatVisible, m_bChatInputBlocked);
         g_pCore->SetDebugVisible(m_bDebugVisible);

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -2064,9 +2064,11 @@ bool CStaticFunctionDefinitions::ShowPlayerHudComponent(eHudComponent component,
     return true;
 }
 
-bool CStaticFunctionDefinitions::IsPlayerHudComponentVisible(eHudComponent component, bool& bOutIsVisible)
+bool CStaticFunctionDefinitions::IsPlayerHudComponentVisible(eHudComponent component, bool& bOutIsVisible, bool bCheckEnabled)
 {
-    bOutIsVisible = g_pGame->GetHud()->IsComponentVisible(component);
+    CHud* hud = g_pGame->GetHud();
+    // Keep the one-argument behaviour compatible with SetComponentVisible. Passing false asks what can actually draw right now.
+    bOutIsVisible = bCheckEnabled ? hud->IsComponentVisible(component) : hud->IsComponentEffectivelyVisible(component);
     return true;
 }
 

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -123,7 +123,7 @@ public:
 
     // Player set funcs
     static bool ShowPlayerHudComponent(eHudComponent component, bool bShow);
-    static bool IsPlayerHudComponentVisible(eHudComponent component, bool& bOutIsVisible);
+    static bool IsPlayerHudComponentVisible(eHudComponent component, bool& bOutIsVisible, bool bCheckEnabled = true);
     static bool SetPlayerMoney(long lMoney, bool bInstant);
     static bool GivePlayerMoney(long lMoney);
     static bool TakePlayerMoney(long lMoney);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
@@ -354,16 +354,18 @@ int CLuaPlayerDefs::ShowPlayerHudComponent(lua_State* luaVM)
 
 int CLuaPlayerDefs::IsPlayerHudComponentVisible(lua_State* luaVM)
 {
-    //  bool isPlayerHudComponentVisible ( string componen )
+    //  bool isPlayerHudComponentVisible ( string component [, bool checkEnabled = true ] )
     eHudComponent component;
+    bool          bCheckEnabled;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadEnumString(component);
+    argStream.ReadBool(bCheckEnabled, true);
 
     if (!argStream.HasErrors())
     {
         bool bIsVisible;
-        if (CStaticFunctionDefinitions::IsPlayerHudComponentVisible(component, bIsVisible))
+        if (CStaticFunctionDefinitions::IsPlayerHudComponentVisible(component, bIsVisible, bCheckEnabled))
         {
             lua_pushboolean(luaVM, bIsVisible);
             return 1;

--- a/Client/sdk/game/CHud.h
+++ b/Client/sdk/game/CHud.h
@@ -57,13 +57,6 @@ enum class eHudComponentProperty
     ALL_PROPERTIES,
 };
 
-enum class eHudSuppressionReason : std::uint8_t
-{
-    PLAYER_MAP,
-
-    COUNT,
-};
-
 enum class eFontStyle : std::uint8_t
 {
     FONT_GOTHIC,
@@ -83,7 +76,7 @@ class CHud
 {
 public:
     virtual void Disable(bool bDisabled) = 0;
-    virtual bool IsDisabled() = 0;
+    virtual bool IsDisabled() const noexcept = 0;
     virtual void SetComponentVisible(eHudComponent component, bool bVisible) = 0;
     virtual bool IsComponentVisible(eHudComponent component) = 0;
     virtual void AdjustComponents(float fAspectRatio) = 0;
@@ -141,8 +134,9 @@ public:
 
     virtual CVector2D GetComponentTextSize(const eHudComponent& component) const = 0;
 
-    // Keep new methods at the end so existing CHud virtual method positions remain stable across client modules.
-    virtual bool IsEnabled() const noexcept = 0;
-    virtual void SetSuppressed(eHudSuppressionReason reason, bool suppressed) = 0;
-    virtual void ResetVisibilityState() = 0;
+    // CHud is used across client modules, so new virtuals stay at the end to avoid moving existing vtable slots.
+    virtual bool IsRequestedEnabled() const noexcept = 0;
+    // The map only hides the HUD temporarily; it should not overwrite the state requested through Disable.
+    virtual void SetSuppressed(bool suppressed) = 0;
+    virtual bool IsComponentEffectivelyVisible(eHudComponent component) const noexcept = 0;
 };

--- a/Client/sdk/game/CHud.h
+++ b/Client/sdk/game/CHud.h
@@ -57,6 +57,13 @@ enum class eHudComponentProperty
     ALL_PROPERTIES,
 };
 
+enum class eHudSuppressionReason : std::uint8_t
+{
+    PLAYER_MAP,
+
+    COUNT,
+};
+
 enum class eFontStyle : std::uint8_t
 {
     FONT_GOTHIC,
@@ -133,4 +140,9 @@ public:
     virtual bool GetComponentUseCustomAlpha(const eHudComponent& component) const noexcept = 0;
 
     virtual CVector2D GetComponentTextSize(const eHudComponent& component) const = 0;
+
+    // Keep new methods at the end so existing CHud virtual method positions remain stable across client modules.
+    virtual bool IsEnabled() const noexcept = 0;
+    virtual void SetSuppressed(eHudSuppressionReason reason, bool suppressed) = 0;
+    virtual void ResetVisibilityState() = 0;
 };


### PR DESCRIPTION
## **Summary**

Updated `isPlayerHudComponentVisible` to report whether a HUD component can actually be drawn, including the global `showhud` state and fullscreen map suppression.

Radar child components now follow the parent radar state without losing their own visibility settings.

## **Motivation**

Previously, `isPlayerHudComponentVisible` only checked the state of the requested component. This meant the radar could be hidden by `showhud` while the function still returned `true`.

The fullscreen player map also used the same global HUD state. Closing the map could re-enable a HUD that the player had already hidden with `showhud`.

For example, a resource might display a custom minimap only while the GTA radar is hidden. If the API incorrectly reports that the radar is still visible, the resource cannot reliably decide when to show its replacement.

Fixes #5026.

## Test plan

**Runtime**

- Before Fix: Running `showhud` hid the radar, but `isPlayerHudComponentVisible("radar")` still returned `true`.
- After Fix: The function returned `false` while the HUD was hidden and returned `true` after restoring it.
- Valid Case: Hiding the radar directly, toggling `showhud`, and restoring the HUD kept the radar hidden until it was explicitly restored.
- Player Map: Opening the fullscreen map temporarily hid the HUD without replacing the state requested through `showhud`.
- Radar Children: `radar_map`, `radar_blips`, and `radar_altimeter` followed the parent radar state while keeping their own visibility settings.
- Reset: Reconnecting restored the global HUD and component visibility defaults.

**Builds and Tests**

- `Debug | Win32`: Client build passed.
- `Release | Win32`: Client build passed.
- Client tests: 304 tests passed.
- Ran `clang-format`.

## Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.