### PR TITLE
Fix disabled server browser tabs being restored as enabled

### DIFF
--- a/Client/core/ServerBrowser/CServerBrowser.cpp
+++ b/Client/core/ServerBrowser/CServerBrowser.cpp
@@ -2276,12 +2276,7 @@ void CServerBrowser::LoadOptions(CXMLNode* pNode)
 
                     CXMLAttribute* pDisabled = pSubNode->GetAttributes().Find("disabled");
                     if (pDisabled)
-                    {
-                        const bool bDisabled = pDisabled->GetValue().compare("1") == 0;
-
-                        // The persisted attribute describes the disabled state, while the widget API expects the enabled state.
-                        m_pTab[listIndex]->SetEnabled(!bDisabled);
-                    }
+                        m_pTab[listIndex]->SetEnabled(pDisabled->GetValue().compare("1") != 0);
 
                     // restore the active tab
                     CXMLAttribute* pActiveTab = pSubNode->GetAttributes().Find("active");

--- a/Client/core/ServerBrowser/CServerBrowser.cpp
+++ b/Client/core/ServerBrowser/CServerBrowser.cpp
@@ -2276,7 +2276,12 @@ void CServerBrowser::LoadOptions(CXMLNode* pNode)
 
                     CXMLAttribute* pDisabled = pSubNode->GetAttributes().Find("disabled");
                     if (pDisabled)
-                        m_pTab[listIndex]->SetEnabled(pDisabled->GetValue().compare("1") == 0);
+                    {
+                        const bool bDisabled = pDisabled->GetValue().compare("1") == 0;
+
+                        // The persisted attribute describes the disabled state, while the widget API expects the enabled state.
+                        m_pTab[listIndex]->SetEnabled(!bDisabled);
+                    }
 
                     // restore the active tab
                     CXMLAttribute* pActiveTab = pSubNode->GetAttributes().Find("active");


### PR DESCRIPTION
## **Summary**

Fixed server browser tabs configured with `disabled="1"` being restored as enabled.

Tabs using `disabled="0"` or no `disabled` attribute remain enabled, and normal shutdown now preserves the intended state.

## **Motivation**

The saved value describes whether a tab is disabled, but it was passed directly to `SetEnabled`, which expects the opposite value. This inverted the tab state when MTA loaded its configuration.

For example, someone could disable the Local server browser tab in `coreconfig.xml`, launch MTA, and find that the tab was still usable. Closing MTA could then remove the original setting because the incorrect state was saved back.

Fixes #5031.

## Test plan

**Runtime**

- Before Fix: `disabled="1"` left the Local tab enabled, and normal shutdown removed the attribute.
- After Fix: `disabled="1"` disabled the Local tab and remained saved after shutdown.
- Inverse Control: `disabled="0"` previously disabled the tab but now leaves it enabled.
- Valid Case: A missing `disabled` attribute left all server browser tabs enabled.
- Other Tabs: Internet, Favourites, and Recent remained usable while Local was disabled.
- Persistence: Confirmed the redundant `disabled="0"` attribute was removed during normal shutdown without changing the enabled state.

**Builds and Tests**

- `Debug | Win32`: Client Core build passed, 304 client tests passed.
- `Release | Win32`: Full solution build passed, 304 client tests passed.

## Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.