### PR TITLE
Fix chat preset colors without an alpha value

### DIFF
--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -5026,22 +5026,22 @@ void CSettings::LoadSkins()
 
 void CSettings::LoadChatColorFromString(eChatColorType eType, const string& strColor)
 {
-    CColor       pColor;
     stringstream ss(strColor);
-    int          iR, iG, iB, iA;
 
-    try
-    {
-        ss >> iR >> iG >> iB >> iA;
-        pColor.R = static_cast<unsigned char>(iR);
-        pColor.G = static_cast<unsigned char>(iG);
-        pColor.B = static_cast<unsigned char>(iB);
-        pColor.A = static_cast<unsigned char>(iA);
-        SetChatColorValues(eType, pColor);
-    }
-    catch (...)
-    {
-    }
+    int iR, iG, iB;
+    if (!(ss >> iR >> iG >> iB))
+        return;
+
+    int iA;
+    if (!(ss >> iA))
+        iA = 255;
+
+    CColor pColor;
+    pColor.R = static_cast<unsigned char>(iR);
+    pColor.G = static_cast<unsigned char>(iG);
+    pColor.B = static_cast<unsigned char>(iB);
+    pColor.A = static_cast<unsigned char>(iA);
+    SetChatColorValues(eType, pColor);
 }
 
 int CSettings::GetMilliseconds(CGUIEdit* pEdit)


### PR DESCRIPTION
## **Summary**

Fixed chat preset colors without an alpha value loading as fully transparent.

RGB-only colors now default to an alpha value of `255`, while colors with an explicit alpha keep their saved value. Presets with invalid RGB values are ignored.

## **Motivation**

The preset loader always tried to read four color values. When a preset only contained RGB values, reading the missing alpha failed and the color was applied with a transparency value of `0`.

For example, loading the bundled **MTA Blue** preset changed Chat Text to `255 255 255 0`, making the preview fully transparent.

Fixes #5033.

## Test plan

**Runtime**

- Before Fix: Loading **MTA Blue** changed Chat Text to `255 255 255 0`.
- After Fix: The same preset loaded as `255 255 255 255`, and white chat text remained visible in-game.
- Valid Case: **Race Oversized** preserved its explicit `172 213 254 255` color.
- Invalid Input: A preset containing `10 invalid 30` left the existing color unchanged.
- Persistence: Reopened Settings and restarted MTA, then confirmed `255 255 255 255` remained saved.

**Builds and Tests**

- `Debug | Win32`: Client Core build passed, 304 client tests passed.
- `Release | Win32`: Full solution build passed, 304 client tests passed.

## Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.