### PR TITLE
Fix chat scale loading and precision

### DIFF
--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -4165,9 +4165,10 @@ void CSettings::LoadData()
     {
         CVARS_GET("chat_scale", strVar);
         stringstream ss(strVar);
-        m_pChatScaleX->SetText(SString("%1.1f", atof(strVar.c_str())));
         ss >> strVar;
-        m_pChatScaleY->SetText(SString("%1.1f", atof(strVar.c_str())));
+        m_pChatScaleX->SetText(strVar.c_str());
+        ss >> strVar;
+        m_pChatScaleY->SetText(strVar.c_str());
     }
     catch (...)
     {


### PR DESCRIPTION
## **Summary**

Fixed Chat Scale loading the first stored value into both X and Y.

Both values now load independently and keep their saved precision.

## **Motivation**

The settings loader rounded the first scale value to one decimal place and used it for both fields. This changed non-uniform chat scales whenever the settings were loaded and saved.

For example, the bundled **Race Oversized** preset uses `1.65 × 1.17`. The old loader changed it to `1.6 × 1.6`, losing both the separate Y value and the original precision.

Fixes #5035.

## Test plan

**Runtime**

- Before Fix: A stored value of `1.65 1.17` loaded and saved as `1.6 × 1.6`.
- After Fix: The same value loaded as `1.65 × 1.17` and survived saving and restarting MTA.
- Presets: Confirmed **Race Oversized** and **iRace 2009** loaded their separate X and Y values.
- Valid Range: Confirmed both values still clamp independently to the existing `0.5` to `3` range.
- Defaults: Removing the setting recreated the default `1 × 1` scale.
- Live Update: Applied opposite non-uniform values and confirmed they changed the live chat immediately and remained saved.

**Builds and Tests**

- `Debug | Win32`: Client Core build passed, 304 client tests passed.
- `Release | Win32`: Client Core build passed, 304 client tests passed.

## Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.