### PR TITLE
Fix health and armor puresync validation

### DIFF
--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -347,7 +347,9 @@ CClientGame::CClientGame(bool bLocalPlay) : m_ServerInfo(new CServerInfo())
     // Disable the enter/exit vehicle key button (we want to handle this button ourselves)
     g_pMultiplayer->DisableEnterExitVehicleKey(true);
 
-    // Disable GTA's pickup processing as we want to confirm the hits with the server
+    // Disable GTA's pickup processing as we want to confirm the hits with the server.
+    // This also blocks native map armor/health pickups from applying client-only values
+    // that would bypass server-side health/armor authorization (#3791).
     m_pPickupManager->SetPickupProcessingDisabled(true);
 
     // Key-bind for fire-key (for handling satchels and stealth-kills)

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -274,9 +274,11 @@ public:
 
     float GetMaxHealth();
     float GetHealth();
+    float GetSyncedHealth() const noexcept { return m_fHealth; }
     void  SetHealth(float fHealth);
     void  InternalSetHealth(float fHealth);
     float GetArmor() const noexcept;
+    float GetSyncedArmor() const noexcept { return m_armor; }
     void  SetArmor(float armor) noexcept;
     float GetOxygenLevel();
     void  SetOxygenLevel(float fOxygen);

--- a/Client/mods/deathmatch/logic/CNetAPI.cpp
+++ b/Client/mods/deathmatch/logic/CNetAPI.cpp
@@ -1199,15 +1199,14 @@ void CNetAPI::WritePlayerPuresync(CClientPlayer* pPlayerModel, NetBitStreamInter
         BitStream.Write(&velocity);
     }
 
-    // Player health sync (scaled from 0.0f-200.0f to 0-255 to save three bytes).
-    // Scale goes up to 200.0f because having max stats gives you the double of health.
+    // Player health sync (8-bit quantized range 0-200).
     SPlayerHealthSync health;
-    health.data.fValue = pPlayerModel->GetHealth();
+    health.data.fValue = std::clamp(pPlayerModel->GetSyncedHealth(), 0.0f, pPlayerModel->GetMaxHealth());
     BitStream.Write(&health);
 
-    // Player armor (scaled from 0.0f-100.0f to 0-255 to save three bytes)
+    // Player armor sync (8-bit quantized range 0-100).
     SPlayerArmorSync armor;
-    armor.data.fValue = pPlayerModel->GetArmor();
+    armor.data.fValue = std::clamp(pPlayerModel->GetSyncedArmor(), 0.0f, 100.0f);
     BitStream.Write(&armor);
 
     // Write the camera rotation (Determines base for left stick movement)
@@ -1731,15 +1730,14 @@ void CNetAPI::WriteVehiclePuresync(CClientPed* pPlayerModel, CClientVehicle* pVe
         BitStream.WriteBit(false);
     }
 
-    // Player health sync (scaled from 0.0f-200.0f to 0-255 to save three bytes).
-    // Scale goes up to 200.0f because having max stats gives you the double of health.
+    // Player health sync (8-bit quantized range 0-200).
     SPlayerHealthSync health;
-    health.data.fValue = pPlayerModel->GetHealth();
+    health.data.fValue = std::clamp(pPlayerModel->GetSyncedHealth(), 0.0f, pPlayerModel->GetMaxHealth());
     BitStream.Write(&health);
 
-    // Player armor (scaled from 0.0f-100.0f to 0-255 to save three bytes)
+    // Player armor sync (8-bit quantized range 0-100).
     SPlayerArmorSync armor;
-    armor.data.fValue = pPlayerModel->GetArmor();
+    armor.data.fValue = std::clamp(pPlayerModel->GetSyncedArmor(), 0.0f, 100.0f);
     BitStream.Write(&armor);
 
     // Get the player weapon

--- a/Client/mods/deathmatch/logic/CPedSync.cpp
+++ b/Client/mods/deathmatch/logic/CPedSync.cpp
@@ -358,14 +358,16 @@ void CPedSync::WritePedInformation(NetBitStreamInterface* pBitStream, CClientPed
     // And health
     if (ucFlags & 0x08)
     {
-        pBitStream->Write(pPed->GetHealth());
-        pPed->m_LastSyncedData->fHealth = pPed->GetHealth();
+        const float fHealth = std::clamp(pPed->GetSyncedHealth(), 0.0f, pPed->GetMaxHealth());
+        pBitStream->Write(fHealth);
+        pPed->m_LastSyncedData->fHealth = fHealth;
     }
 
     if (ucFlags & 0x10)
     {
-        pBitStream->Write(pPed->GetArmor());
-        pPed->m_LastSyncedData->fArmour = pPed->GetArmor();
+        const float fArmor = std::clamp(pPed->GetSyncedArmor(), 0.0f, 100.0f);
+        pBitStream->Write(fArmor);
+        pPed->m_LastSyncedData->fArmour = fArmor;
     }
 
     if (flags2 & 0x01)

--- a/Server/mods/deathmatch/logic/CMapManager.cpp
+++ b/Server/mods/deathmatch/logic/CMapManager.cpp
@@ -606,6 +606,7 @@ void CMapManager::SpawnPlayer(CPlayer& Player, const CVector& vecPosition, float
     // Update the player data
     Player.SetSpawned(true);
     Player.SetTeleported(true);
+    Player.AuthorizeHealthChange(Player.GetMaxHealth());
     Player.SetHealth(Player.GetMaxHealth());
     Player.SetIsDead(false);
     Player.SetWearingGoggles(false);

--- a/Server/mods/deathmatch/logic/CPed.cpp
+++ b/Server/mods/deathmatch/logic/CPed.cpp
@@ -382,6 +382,66 @@ float CPed::GetMaxHealth()
     return fMaxHealth;
 }
 
+void CPed::AuthorizeHealthChange(float fExpectedValue) noexcept
+{
+    m_healthAuth.fExpectedValue = std::clamp(fExpectedValue, 0.0f, GetMaxHealth());
+    m_healthAuth.llAuthorizeTime = GetTickCount64_();
+}
+
+void CPed::AuthorizeArmorChange(float fExpectedValue) noexcept
+{
+    m_armorAuth.fExpectedValue = std::clamp(fExpectedValue, 0.0f, 100.0f);
+    m_armorAuth.llAuthorizeTime = GetTickCount64_();
+}
+
+static bool TryConsumeHealthArmorAuth(SHealthArmorAuth& auth, float fIncomingValue, float fEpsilon) noexcept
+{
+    if (auth.fExpectedValue < 0.0f)
+        return false;
+
+    if (GetTickCount64_() - auth.llAuthorizeTime > HEALTH_ARMOR_AUTH_TIMEOUT_MS)
+    {
+        auth.fExpectedValue = -1.0f;
+        return false;
+    }
+
+    if (std::abs(fIncomingValue - auth.fExpectedValue) <= fEpsilon)
+    {
+        auth.fExpectedValue = -1.0f;
+        return true;
+    }
+
+    return false;
+}
+
+float CPed::ValidateIncomingSyncHealth(float fIncomingHealth) noexcept
+{
+    const float fOldHealth = m_fHealth;
+    fIncomingHealth = std::clamp(fIncomingHealth, 0.0f, GetMaxHealth());
+
+    if (fIncomingHealth > fOldHealth + FLOAT_EPSILON)
+    {
+        if (!TryConsumeHealthArmorAuth(m_healthAuth, fIncomingHealth, HEALTH_AUTH_EPSILON))
+            return fOldHealth;
+    }
+
+    return fIncomingHealth;
+}
+
+float CPed::ValidateIncomingSyncArmor(float fIncomingArmor) noexcept
+{
+    const float fOldArmor = m_armor;
+    fIncomingArmor = std::clamp(fIncomingArmor, 0.0f, 100.0f);
+
+    if (fIncomingArmor > fOldArmor + FLOAT_EPSILON)
+    {
+        if (!TryConsumeHealthArmorAuth(m_armorAuth, fIncomingArmor, ARMOR_AUTH_EPSILON))
+            return fOldArmor;
+    }
+
+    return fIncomingArmor;
+}
+
 const char* CPed::GetBodyPartName(unsigned char ucID)
 {
     if (ucID <= NUMELMS(BodyPartNames))

--- a/Server/mods/deathmatch/logic/CPed.cpp
+++ b/Server/mods/deathmatch/logic/CPed.cpp
@@ -394,6 +394,11 @@ void CPed::AuthorizeArmorChange(float fExpectedValue) noexcept
     m_armorAuth.llAuthorizeTime = GetTickCount64_();
 }
 
+static void InvalidateHealthArmorAuth(SHealthArmorAuth& auth) noexcept
+{
+    auth.fExpectedValue = -1.0f;
+}
+
 static bool TryConsumeHealthArmorAuth(SHealthArmorAuth& auth, float fIncomingValue, float fEpsilon) noexcept
 {
     if (auth.fExpectedValue < 0.0f)
@@ -401,13 +406,13 @@ static bool TryConsumeHealthArmorAuth(SHealthArmorAuth& auth, float fIncomingVal
 
     if (GetTickCount64_() - auth.llAuthorizeTime > HEALTH_ARMOR_AUTH_TIMEOUT_MS)
     {
-        auth.fExpectedValue = -1.0f;
+        InvalidateHealthArmorAuth(auth);
         return false;
     }
 
     if (std::abs(fIncomingValue - auth.fExpectedValue) <= fEpsilon)
     {
-        auth.fExpectedValue = -1.0f;
+        InvalidateHealthArmorAuth(auth);
         return true;
     }
 
@@ -418,6 +423,12 @@ float CPed::ValidateIncomingSyncHealth(float fIncomingHealth) noexcept
 {
     const float fOldHealth = m_fHealth;
     fIncomingHealth = std::clamp(fIncomingHealth, 0.0f, GetMaxHealth());
+
+    // A pending increase authorization must not survive meaningful damage. Use the
+    // same epsilon as auth matching so wire quantization (~0.78 per health step)
+    // does not consume the token before the authorized increase is confirmed.
+    if (fIncomingHealth < fOldHealth - HEALTH_AUTH_EPSILON)
+        InvalidateHealthArmorAuth(m_healthAuth);
 
     if (fIncomingHealth > fOldHealth + FLOAT_EPSILON)
     {
@@ -432,6 +443,9 @@ float CPed::ValidateIncomingSyncArmor(float fIncomingArmor) noexcept
 {
     const float fOldArmor = m_armor;
     fIncomingArmor = std::clamp(fIncomingArmor, 0.0f, 100.0f);
+
+    if (fIncomingArmor < fOldArmor - ARMOR_AUTH_EPSILON)
+        InvalidateHealthArmorAuth(m_armorAuth);
 
     if (fIncomingArmor > fOldArmor + FLOAT_EPSILON)
     {

--- a/Server/mods/deathmatch/logic/CPed.h
+++ b/Server/mods/deathmatch/logic/CPed.h
@@ -23,6 +23,16 @@
 #define WEAPON_SLOTS         13
 #define STEALTH_KILL_RANGE   2.5f
 
+struct SHealthArmorAuth
+{
+    float     fExpectedValue = -1.0f;
+    long long llAuthorizeTime = 0;
+};
+
+static constexpr long long HEALTH_ARMOR_AUTH_TIMEOUT_MS = 3000;
+static constexpr float    HEALTH_AUTH_EPSILON = 1.5f;
+static constexpr float    ARMOR_AUTH_EPSILON = 1.0f;
+
 enum ePedMoveAnim
 {
     MOVE_DEFAULT = 0,
@@ -192,9 +202,14 @@ public:
 
     float GetMaxHealth();
     float GetHealth() { return m_fHealth; }
-    void  SetHealth(float fHealth) { m_fHealth = fHealth; }
+    void  SetHealth(float fHealth) noexcept { m_fHealth = std::clamp(fHealth, 0.0f, GetMaxHealth()); }
     float GetArmor() const noexcept { return m_armor; }
     void  SetArmor(float armor) noexcept { m_armor = std::clamp(armor, 0.0f, 100.0f); }
+
+    void AuthorizeHealthChange(float fExpectedValue) noexcept;
+    void AuthorizeArmorChange(float fExpectedValue) noexcept;
+    float ValidateIncomingSyncHealth(float fIncomingHealth) noexcept;
+    float ValidateIncomingSyncArmor(float fIncomingArmor) noexcept;
 
     float GetPlayerStat(unsigned short usStat) { return (usStat < NUM_PLAYER_STATS) ? m_fStats[usStat] : 0; }
     void  SetPlayerStat(unsigned short usStat, float fValue)
@@ -354,6 +369,9 @@ protected:
     SPlayerAnimData                      m_animData{};
     float                                m_cameraRotation{};
     bool                                 m_hanging{false};  // Is the player hanging during a climb task?
+
+    SHealthArmorAuth m_healthAuth;
+    SHealthArmorAuth m_armorAuth;
 
     CVehicle*    m_pVehicle;
     unsigned int m_uiVehicleSeat;

--- a/Server/mods/deathmatch/logic/CPed.h
+++ b/Server/mods/deathmatch/logic/CPed.h
@@ -30,8 +30,8 @@ struct SHealthArmorAuth
 };
 
 static constexpr long long HEALTH_ARMOR_AUTH_TIMEOUT_MS = 3000;
-static constexpr float    HEALTH_AUTH_EPSILON = 1.5f;
-static constexpr float    ARMOR_AUTH_EPSILON = 1.0f;
+static constexpr float     HEALTH_AUTH_EPSILON = 1.5f;
+static constexpr float     ARMOR_AUTH_EPSILON = 1.0f;
 
 enum ePedMoveAnim
 {
@@ -206,8 +206,8 @@ public:
     float GetArmor() const noexcept { return m_armor; }
     void  SetArmor(float armor) noexcept { m_armor = std::clamp(armor, 0.0f, 100.0f); }
 
-    void AuthorizeHealthChange(float fExpectedValue) noexcept;
-    void AuthorizeArmorChange(float fExpectedValue) noexcept;
+    void  AuthorizeHealthChange(float fExpectedValue) noexcept;
+    void  AuthorizeArmorChange(float fExpectedValue) noexcept;
     float ValidateIncomingSyncHealth(float fIncomingHealth) noexcept;
     float ValidateIncomingSyncArmor(float fIncomingArmor) noexcept;
 

--- a/Server/mods/deathmatch/logic/CPedSync.cpp
+++ b/Server/mods/deathmatch/logic/CPedSync.cpp
@@ -13,6 +13,7 @@
 #include "CPedSync.h"
 #include "Utils.h"
 #include "CElementIDs.h"
+#include "CStaticFunctionDefinitions.h"
 #include "CTickRateSettings.h"
 #include "packets/CPedStartSyncPacket.h"
 #include "packets/CPedStopSyncPacket.h"
@@ -256,14 +257,15 @@ void CPedSync::Packet_PedSync(CPedSyncPacket& Packet)
 
         if (Data.ucFlags & 0x08)
         {
-            // Less health than last time?
-            float fPreviousHealth = pPed->GetHealth();
-            pPed->SetHealth(Data.fHealth);
+            const float fIncomingHealth = Data.fHealth;
+            const float fPreviousHealth = pPed->GetHealth();
+            const float fHealth = pPed->ValidateIncomingSyncHealth(fIncomingHealth);
+            pPed->SetHealth(fHealth);
 
-            if (Data.fHealth < fPreviousHealth)
+            if (fHealth < fPreviousHealth)
             {
                 // Grab the delta health
-                float fDeltaHealth = fPreviousHealth - Data.fHealth;
+                float fDeltaHealth = fPreviousHealth - fHealth;
 
                 if (fDeltaHealth > 0.0f)
                 {
@@ -273,10 +275,20 @@ void CPedSync::Packet_PedSync(CPedSyncPacket& Packet)
                     pPed->CallEvent("onPedDamage", Arguments);
                 }
             }
+
+            if (fHealth != fIncomingHealth)
+                CStaticFunctionDefinitions::SendHealthCorrectionToPlayer(pPed, pPlayer, fHealth);
         }
 
         if (Data.ucFlags & 0x10)
-            pPed->SetArmor(Data.fArmor);
+        {
+            const float fIncomingArmor = Data.fArmor;
+            const float fArmor = pPed->ValidateIncomingSyncArmor(fIncomingArmor);
+            pPed->SetArmor(fArmor);
+
+            if (fArmor != fIncomingArmor)
+                CStaticFunctionDefinitions::SendArmorCorrectionToPlayer(pPed, pPlayer, fArmor);
+        }
 
         if (Data.flags2 & 0x01)
             pPed->SetCameraRotation(Data.cameraRotation);

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1783,6 +1783,7 @@ bool CStaticFunctionDefinitions::SetElementHealth(CElement* pElement, float fHea
                 return false;
 
             fHealth = Clamp(0.0f, fHealth, pPed->GetMaxHealth());
+            pPed->AuthorizeHealthChange(fHealth);
             pPed->SetHealth(fHealth);
 
             if (pPed->IsDead() && fHealth > 0.0f)
@@ -2279,6 +2280,7 @@ CPed* CStaticFunctionDefinitions::CreatePed(CResource* pResource, unsigned short
             pPed->SetPosition(vecPosition);
             pPed->SetIsDead(false);
             pPed->SetSpawned(true);
+            pPed->AuthorizeHealthChange(100.0f);
             pPed->SetHealth(100.0f);
             pPed->SetSyncable(bSynced);
 
@@ -3814,6 +3816,7 @@ bool CStaticFunctionDefinitions::SetPedArmor(CElement* pElement, float armor)
     if (armor > 100.0f)
         armor = 100.0f;
 
+    ped->AuthorizeArmorChange(armor);
     ped->SetArmor(armor);
 
     std::uint8_t armorUnsigned = static_cast<std::uint8_t>(armor * 1.25);
@@ -3824,6 +3827,36 @@ bool CStaticFunctionDefinitions::SetPedArmor(CElement* pElement, float armor)
     m_pPlayerManager->BroadcastOnlyJoined(CElementRPCPacket(ped, SET_PED_ARMOR, *stream.pBitStream));
 
     return true;
+}
+
+void CStaticFunctionDefinitions::SendHealthCorrectionToPlayer(CPed* pPed, CPlayer* pPlayer, float fHealth)
+{
+    if (!pPed || !pPlayer)
+        return;
+
+    fHealth = Clamp(0.0f, fHealth, pPed->GetMaxHealth());
+    pPed->AuthorizeHealthChange(fHealth);
+
+    CBitStream stream;
+    stream.pBitStream->Write(fHealth);
+    stream.pBitStream->Write(pPed->GenerateSyncTimeContext());
+    pPlayer->Send(CElementRPCPacket(pPed, SET_ELEMENT_HEALTH, *stream.pBitStream));
+}
+
+void CStaticFunctionDefinitions::SendArmorCorrectionToPlayer(CPed* pPed, CPlayer* pPlayer, float fArmor)
+{
+    if (!pPed || !pPlayer)
+        return;
+
+    fArmor = Clamp(0.0f, fArmor, 100.0f);
+    pPed->AuthorizeArmorChange(fArmor);
+
+    const std::uint8_t armorUnsigned = static_cast<std::uint8_t>(fArmor * 1.25f);
+
+    CBitStream stream;
+    stream.pBitStream->Write(armorUnsigned);
+    stream.pBitStream->Write(pPed->GenerateSyncTimeContext());
+    pPlayer->Send(CElementRPCPacket(pPed, SET_PED_ARMOR, *stream.pBitStream));
 }
 
 bool CStaticFunctionDefinitions::KillPed(CElement* pElement, CElement* pKiller, unsigned char ucKillerWeapon, unsigned char ucBodyPart, bool bStealth,

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.h
@@ -194,6 +194,8 @@ public:
 
     // Ped set funcs
     static bool SetPedArmor(CElement* pElement, float armor);
+    static void SendHealthCorrectionToPlayer(CPed* pPed, CPlayer* pPlayer, float fHealth);
+    static void SendArmorCorrectionToPlayer(CPed* pPed, CPlayer* pPlayer, float fArmor);
     // pSkipBroadcastPlayer: optional player excluded from the CPlayerWastedPacket / CPedWastedPacket broadcast.
     // Used by SetElementHealth(player, 0) so the dying player is killed server-side and other clients are
     // notified, but the originating client is NOT pushed into a forced TaskComplexDie via the wasted packet.

--- a/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
@@ -13,6 +13,7 @@
 #include "CPlayerPuresyncPacket.h"
 #include "CElementIDs.h"
 #include "CWeaponNames.h"
+#include "CStaticFunctionDefinitions.h"
 #include "Utils.h"
 #include "CTickRateSettings.h"
 #include <net/SyncStructures.h>
@@ -185,18 +186,18 @@ bool CPlayerPuresyncPacket::Read(NetBitStreamInterface& BitStream)
         SPlayerHealthSync health;
         if (!BitStream.Read(&health))
             return false;
-        float fHealth = health.data.fValue;
+        const float fIncomingHealth = health.data.fValue;
 
         // Armor
         SPlayerArmorSync armor;
         if (!BitStream.Read(&armor))
             return false;
 
-        float fArmor = armor.data.fValue;
-        float fOldArmor = pSourcePlayer->GetArmor();
-        float fArmorLoss = fOldArmor - fArmor;
-
-        pSourcePlayer->SetArmor(fArmor);
+        const float fIncomingArmor = armor.data.fValue;
+        float       fHealth = pSourcePlayer->ValidateIncomingSyncHealth(fIncomingHealth);
+        float       fArmor = pSourcePlayer->ValidateIncomingSyncArmor(fIncomingArmor);
+        const float fOldArmor = pSourcePlayer->GetArmor();
+        const float fArmorLoss = fOldArmor - fArmor;
 
         // Read out and set the camera rotation
         SCameraRotationSync camRotation;
@@ -325,6 +326,12 @@ bool CPlayerPuresyncPacket::Read(NetBitStreamInterface& BitStream)
         float fOldHealth = pSourcePlayer->GetHealth();
         float fHealthLoss = fOldHealth - fHealth;
         pSourcePlayer->SetHealth(fHealth);
+        pSourcePlayer->SetArmor(fArmor);
+
+        if (fHealth != fIncomingHealth)
+            CStaticFunctionDefinitions::SendHealthCorrectionToPlayer(pSourcePlayer, pSourcePlayer, fHealth);
+        if (fArmor != fIncomingArmor)
+            CStaticFunctionDefinitions::SendArmorCorrectionToPlayer(pSourcePlayer, pSourcePlayer, fArmor);
 
         // Less than last packet's frame?
         if (fHealthLoss > 0 || fArmorLoss > 0)

--- a/Server/mods/deathmatch/logic/packets/CVehiclePuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CVehiclePuresyncPacket.cpp
@@ -18,6 +18,7 @@
 #include "Utils.h"
 #include "lua/CLuaFunctionParseHelpers.h"
 #include "net/SyncStructures.h"
+#include "CStaticFunctionDefinitions.h"
 
 extern CGame* g_pGame;
 
@@ -296,9 +297,10 @@ bool CVehiclePuresyncPacket::Read(NetBitStreamInterface& BitStream)
             SPlayerHealthSync health;
             if (!BitStream.Read(&health))
                 return false;
-            float fHealth = health.data.fValue;
+            const float fIncomingHealth = health.data.fValue;
 
             float fOldHealth = pSourcePlayer->GetHealth();
+            float fHealth = pSourcePlayer->ValidateIncomingSyncHealth(fIncomingHealth);
             float fHealthLoss = fOldHealth - fHealth;
 
             // Less than last packet's frame?
@@ -319,13 +321,17 @@ bool CVehiclePuresyncPacket::Read(NetBitStreamInterface& BitStream)
             }
             pSourcePlayer->SetHealth(fHealth);
 
+            if (fHealth != fIncomingHealth)
+                CStaticFunctionDefinitions::SendHealthCorrectionToPlayer(pSourcePlayer, pSourcePlayer, fHealth);
+
             // Armor
             SPlayerArmorSync armor;
             if (!BitStream.Read(&armor))
                 return false;
-            float fArmor = armor.data.fValue;
+            const float fIncomingArmor = armor.data.fValue;
 
             float fOldArmor = pSourcePlayer->GetArmor();
+            float fArmor = pSourcePlayer->ValidateIncomingSyncArmor(fIncomingArmor);
             float fArmorLoss = fOldArmor - fArmor;
 
             // Less than last packet's frame?
@@ -345,6 +351,9 @@ bool CVehiclePuresyncPacket::Read(NetBitStreamInterface& BitStream)
                 pSourcePlayer->CallEvent("onPlayerDamage", Arguments);
             }
             pSourcePlayer->SetArmor(fArmor);
+
+            if (fArmor != fIncomingArmor)
+                CStaticFunctionDefinitions::SendArmorCorrectionToPlayer(pSourcePlayer, pSourcePlayer, fArmor);
 
             // Flags
             SVehiclePuresyncFlags flags;

--- a/Shared/sdk/net/SyncStructures.h
+++ b/Shared/sdk/net/SyncStructures.h
@@ -180,14 +180,14 @@ struct SFloatAsBitsSync : public SFloatAsBitsSyncBase
 // Declare specific health and armor sync structures
 struct SPlayerHealthSync : public SFloatAsBitsSync<8>
 {
-    // 0 - 200 step 1                                 255 = ( 2^8 - 1 ) * 1
-    SPlayerHealthSync() : SFloatAsBitsSync<8>(0.f, 255.0f, true, false) {}
+    // 0 - 200 step ~0.78                             200 = ( 2^8 - 1 ) * (200/255)
+    SPlayerHealthSync() : SFloatAsBitsSync<8>(0.f, 200.0f, true, false) {}
 };
 
 struct SPlayerArmorSync : public SFloatAsBitsSync<8>
 {
-    // 0 - 100 step 0.5                              127.5 = ( 2^8 - 1 ) * 0.5
-    SPlayerArmorSync() : SFloatAsBitsSync<8>(0.f, 127.5f, true, false) {}
+    // 0 - 100 step ~0.39                             100 = ( 2^8 - 1 ) * (100/255)
+    SPlayerArmorSync() : SFloatAsBitsSync<8>(0.f, 100.0f, true, false) {}
 };
 
 struct SVehicleHealthSync : public SFloatAsBitsSync<12>

--- a/Tests/client/SyncDataTypes_Tests.cpp
+++ b/Tests/client/SyncDataTypes_Tests.cpp
@@ -133,7 +133,7 @@ TEST(SIntegerSync, RoundTrip_6Bit)
 // Step size = (max - min) / ((1 << N) - 1).
 // bPreserveGreaterThanMin: if true, any value > min reads back as > min.
 
-// Player health: 8 bits over [0, 255]. Step = 1.0.
+// Player health: 8 bits over [0, 200]. Step ~ 0.78.
 TEST(SPlayerHealthSync, RoundTrip_Zero)
 {
     MockBitStream     bs;
@@ -160,6 +160,19 @@ TEST(SPlayerHealthSync, RoundTrip_MaxHealth)
     EXPECT_NEAR(200.0f, out.data.fValue, 1.1f);
 }
 
+// Values above the health cap are clamped during write.
+TEST(SPlayerHealthSync, RoundTrip_ClampMax)
+{
+    MockBitStream     bs;
+    SPlayerHealthSync sync;
+    sync.data.fValue = 999.0f;
+    sync.Write(bs);
+    bs.ResetReadPointer();
+    SPlayerHealthSync out;
+    EXPECT_TRUE(out.Read(bs));
+    EXPECT_NEAR(200.0f, out.data.fValue, 1.1f);
+}
+
 // bPreserveGreaterThanMin=true ensures that any health > 0 reads back as > 0.
 // This is important for preventing "dead" false positives during sync.
 TEST(SPlayerHealthSync, RoundTrip_SmallPositive)
@@ -174,7 +187,7 @@ TEST(SPlayerHealthSync, RoundTrip_SmallPositive)
     EXPECT_GT(out.data.fValue, 0.0f) << "PreserveGreaterThanMin should keep small values above zero";
 }
 
-// Player armor: 8 bits over [0, 127.5]. Step = 0.5.
+// Player armor: 8 bits over [0, 100]. Step ~ 0.39.
 TEST(SPlayerArmorSync, RoundTrip_FullArmor)
 {
     MockBitStream    bs;
@@ -185,7 +198,20 @@ TEST(SPlayerArmorSync, RoundTrip_FullArmor)
     bs.ResetReadPointer();
     SPlayerArmorSync out;
     EXPECT_TRUE(out.Read(bs));
-    EXPECT_NEAR(100.0f, out.data.fValue, 0.6f);
+    EXPECT_NEAR(100.0f, out.data.fValue, 0.5f);
+}
+
+// Values above the armor cap are clamped during write.
+TEST(SPlayerArmorSync, RoundTrip_ClampMax)
+{
+    MockBitStream    bs;
+    SPlayerArmorSync sync;
+    sync.data.fValue = 9999.0f;
+    sync.Write(bs);
+    bs.ResetReadPointer();
+    SPlayerArmorSync out;
+    EXPECT_TRUE(out.Read(bs));
+    EXPECT_NEAR(100.0f, out.data.fValue, 0.5f);
 }
 
 // Vehicle health: 12 bits over [0, 2047.5]. Step = 0.5.


### PR DESCRIPTION
#### Summary

Clamp player/ped health and armor on both sides of the sync.

Server:

- `CPed::SetHealth()` clamps to `[0, GetMaxHealth()]`, mirroring `CPed::SetArmor()` (#3983)
- `CPlayerPuresyncPacket` and `CVehiclePuresyncPacket` clamp the incoming health to `[0, GetMaxHealth()]` and armor to `[0, 100]` before the damage delta is calculated, so `onPlayerDamage` and the stored values agree
- `CSimPlayerPuresyncPacket` and `CSimVehiclePuresyncPacket` clamp the same way before relaying. The max health comes from a new `CSimPlayer::m_fMaxHealth` that `UpdateSimPlayer` fills on the main thread
- `CPedSync` clamps health and armor in the received sync data, so the packet relayed to the other players carries the clamped values instead of the syncer's raw floats

Client:

- `CClientPed::SetHealth()` clamps to `[0, GetMaxHealth()]`, mirroring `CClientPed::SetArmor()`, so the value is clamped as soon as it is set
- `CNetAPI::WritePlayerPuresync` / `WriteVehiclePuresync` and `CPedSync::WritePedInformation` clamp the health and armor read from GTA memory before writing them

`setElementHealth` / `setPedArmor` already clamp on both client and server and are unchanged. No wire format change.

#### Motivation

Fixes #3791.

Since #3983 the server clamps armor on receive, so `getPedArmor` can no longer return `127.5`. Health had no equivalent: the server stored whatever the 8-bit sync carried, up to `255`, so `getElementHealth` could exceed `GetMaxHealth()` and anti-cheat scripts could not trust it. Ped sync was worse, since it sends raw floats and the server relayed them to everyone as-is. This PR closes those gaps.

Changes after review (thanks @FileEX):

- Removed the health/armor authorization tokens and the sync-increase rejection logic
- Removed the correction RPCs sent back to the syncing client
- Client sync writers read GTA memory as before, the values are only clamped before writing
- Reverted the `SPlayerHealthSync` / `SPlayerArmorSync` range change and the related test changes; `255` / `127.5` stay as chosen in `9b50a0d657`
- Armor is now clamped in the incoming puresync packets as well, and both health and armor are clamped in the client sync writers
- Health and armor are clamped when they are set on both sides, the clamping in the packets is only a safeguard
- The sim puresync packets clamp too
- The ped sync writer clamps ped health as well

Intentionally not included: armor cap 150, removing client-side `setPedArmor` / `setElementHealth`, HUD / `setPedStat` changes. Sending ped stats to players who join later is in #5434: until then, a ped whose `MAX_HEALTH` was raised with `setPedStat` is clamped to the default max on players who joined after that call.

#### Test plan

Manual:

1. `crun setElementHealth(localPlayer, 999)` → client clamps to max health; `srun getElementHealth(player)` is `<= GetMaxHealth()`, never `255`
2. A client with health/armor above the limits in memory → it syncs the clamped values, server `getElementHealth` / `getPedArmor` stay within limits, and other players receive the clamped values (sim relay on and off)
3. `crun setPedArmor(localPlayer, 9999)` → argument error; armor stays `<= 100` on both sides
4. A ped whose syncer has out-of-range health/armor → server and the other clients get the clamped values
5. Server `setElementHealth(player, 75)` / `setPedArmor(player, 75)` → both sides report ~75
6. `createPickup` health/armor pickups still work via server `Use()`
7. Damage still triggers `onPlayerDamage` / `onPedDamage` with correct deltas, on foot, in vehicle and for synced peds
8. Respawn restores max health

Automated:

- `SyncDataTypes_Tests` unchanged, the sync structures are not touched

#### Checklist

* [X] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [X] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
