### PR TITLE
Fix crash when assigning invalid model TXD IDs

### DIFF
--- a/Client/game_sa/CTxdPoolSA.cpp
+++ b/Client/game_sa/CTxdPoolSA.cpp
@@ -48,7 +48,10 @@ void CTxdPoolSA::RemoveTextureDictonarySlot(std::uint32_t uiTxdId)
 
 bool CTxdPoolSA::IsFreeTextureDictonarySlot(std::uint32_t uiTxdId)
 {
-    return (*m_ppTxdPoolInterface)->IsEmpty(uiTxdId);
+    CPoolSAInterface<CTextureDictonarySAInterface>* pTxdPool = *m_ppTxdPoolInterface;
+
+    // IsEmpty assumes the index is valid, while callers also use this method to validate script-provided IDs.
+    return !pTxdPool || !pTxdPool->IsContains(uiTxdId);
 }
 
 std::uint32_t CTxdPoolSA::GetFreeTextureDictonarySlot()

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -1370,6 +1370,9 @@ bool CLuaEngineDefs::EngineSetModelTXDID(uint uiModelID, unsigned short usTxdId)
     if (uiModelID >= g_pGame->GetBaseIDforTXD() || !pModelInfo)
         throw std::invalid_argument("Expected a valid model ID at argument 1");
 
+    if (g_pGame->GetPools()->GetTxdPool().IsFreeTextureDictonarySlot(usTxdId))
+        throw std::invalid_argument("Expected an allocated TXD ID at argument 2");
+
     pModelInfo->SetTextureDictionaryID(usTxdId);
     return true;
 }


### PR DESCRIPTION
## **Summary**

Added TXD slot validation to `engineSetModelTXDID` and made the pool availability check bounds safe.

Invalid or unallocated TXD IDs are now rejected before the model or its reference counts are changed.

## **Motivation**

`engineSetModelTXDID` checked the model ID but accepted any unsigned 16-bit TXD ID. This allowed an unavailable slot to remain stored on a loaded model. A later operation such as `engineGetModelTextureNames` could pass that ID into GTA's unchecked TXD lookup and crash the client.

For example, a resource might cache a TXD ID so it can update a player model later. If that slot was released during a resource restart, reusing the stale ID could leave the model pointing at missing TXD data. The next texture query could then crash the player.

Valid IDs returned by [`engineRequestTXD`](https://wiki.multitheftauto.com/wiki/EngineRequestTXD) are still accepted.

<details>
<summary>Crash Stack</summary>

```text
Exception: Access violation
Module: gta_sa.exe
Offset: 0x003F3737

CRenderWareSA::GetModelTextureNames (CRenderWareSA.cpp:786)
CLuaEngineDefs::EngineGetModelTextureNames (CLuaEngineDefs.cpp:1457)
```

<img width="1013" height="1104" alt="Crash" src="https://github.com/user-attachments/assets/8112fba0-3269-471e-a6b4-900d0bde1710" />

</details>

## Test plan

**Runtime**

- Before Fix: TXD ID `65535` was accepted for a loaded model, and querying its texture names caused an access violation in GTA's TXD lookup.
- After Fix: The invalid ID was rejected, the original TXD remained assigned, and texture names could still be queried safely.
- Valid Case: The model's existing TXD and a new slot returned by `engineRequestTXD` were both accepted.
- Stale Case: An allocated slot was released through resource teardown, and its old in-range ID was rejected without changing the model.

**Builds and Tests**

- `Debug | Win32`: Solution build passed, 304 client tests passed.
- `Release | Win32`: Solution build passed, 304 client tests passed.
- Ran `clang-format`.

## Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.