### PR TITLE
Fix crashes and TXD slot leaks in model cleanup

### DIFF
--- a/Client/mods/deathmatch/logic/CClientModelManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientModelManager.cpp
@@ -92,7 +92,8 @@ std::shared_ptr<CClientModel> CClientModelManager::FindModelByID(int iModelID)
 {
     int32_t iMaxModelId = g_pGame->GetBaseIDforCOL();
 
-    if (iModelID < iMaxModelId)
+    // Lua-facing callers can supply invalid IDs, so check both bounds before indexing the model array.
+    if (iModelID >= 0 && iModelID < iMaxModelId)
         return m_Models[iModelID];
 
     return nullptr;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -983,6 +983,12 @@ int CLuaEngineDefs::EngineFreeModel(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
+        if (iModelID < 0)
+        {
+            lua_pushboolean(luaVM, false);
+            return 1;
+        }
+
         // destroyElement() only defers the actual native entity deletion to the next pulse
         // (see CElementDeleter). If a script destroys an entity using this model and calls
         // engineFreeModel in the same tick, the entity's native CEntity is still alive and
@@ -2526,8 +2532,16 @@ uint CLuaEngineDefs::EngineRequestTXD(lua_State* const luaVM, std::string strTxd
 
 bool CLuaEngineDefs::EngineFreeTXD(uint txdID)
 {
-    std::shared_ptr<CClientModel> pModel = m_pManager->GetModelManager()->FindModelByID(MAX_MODEL_DFF_ID + txdID);
-    return pModel && pModel->Deallocate();
+    const std::uint32_t uiBaseIdForCol = g_pGame->GetBaseIDforCOL();
+
+    // Validate before adding the internal TXD offset so oversized script values cannot wrap to a negative model ID.
+    if (uiBaseIdForCol <= MAX_MODEL_DFF_ID || txdID >= uiBaseIdForCol - MAX_MODEL_DFF_ID)
+        return false;
+
+    const int                     iModelID = MAX_MODEL_DFF_ID + static_cast<int>(txdID);
+    auto                          modelManager = m_pManager->GetModelManager();
+    std::shared_ptr<CClientModel> pModel = modelManager->FindModelByID(iModelID);
+    return pModel && modelManager->Remove(pModel);
 }
 
 size_t CLuaEngineDefs::EngineGetPoolCapacity(ePools pool)


### PR DESCRIPTION
## **Summary**

Added lower-bound and overflow-safe ID checks to `engineFreeModel`, `engineFreeTXD`, and the shared model lookup.

Valid TXD cleanup now uses the model manager's removal path so affected models are reset, the allocation is removed, and the pool slot can be reused.

## **Motivation**

`CClientModelManager::FindModelByID` checked only the upper boundary. A negative model ID could therefore index memory before the model array. Large TXD IDs could also wrap into a negative internal model ID before reaching the same lookup.

For example, a resource might cache custom model and TXD IDs so it can free them during a restart. If an invalid model ID or wrapped TXD ID reaches cleanup, the old lookup could crash every player running that resource.

Valid `engineFreeTXD` calls also returned `true` without fully removing the allocation. The TXD slot remained occupied for the rest of the client session instead of becoming reusable.

<details>
<summary>engineFreeModel Crash Stack</summary>

```text
Exception: Access violation
Module: client_d.dll
Offset: 0x001CCADA

engineFreeModel(-1000000)
CClientModelManager::FindModelByID (CClientModelManager.cpp:95)
```

<img width="1055" height="1093" alt="Crash_01a" src="https://github.com/user-attachments/assets/8e004c33-233f-4e28-a984-dcedd6fbee5a" />

</details>

<details>
<summary>engineFreeTXD Crash Stack</summary>

```text
Exception: Access violation
Module: client_d.dll
Offset: 0x001CCADA

engineFreeTXD(4293947296)
CClientModelManager::FindModelByID (CClientModelManager.cpp:95)
```

<img width="1086" height="1074" alt="Crash_01b" src="https://github.com/user-attachments/assets/67e8c46d-eb66-4857-8f6d-67b3cf74bfd9" />

</details>

## Test plan

**Runtime**

- Before Fix: `engineFreeModel(-1000000)` caused an access violation in `CClientModelManager::FindModelByID`.
- Before Fix: `engineFreeTXD(4293947296)` wrapped into the same invalid lookup and crashed at the same client offset.
- After Fix: Both invalid calls returned `false`, and the client stayed open.
- Valid Case: Requested model ID `332` and TXD ID `3608` were freed successfully.
- TXD Cleanup: Freeing TXD `3608` reset the model using it, and the next TXD allocation reused slot `3608`.
- Repeated Free: Freeing the already released TXD returned `false`.

**Builds and Tests**

- `Debug | Win32`: Solution build passed, 304 client tests passed.
- `Release | Win32`: Solution build passed, 304 client tests passed.
- Ran `clang-format`.

## Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.