### PR TITLE
Fix plain texture pixel size overflow

### DIFF
--- a/Client/core/Graphics/CPixelsManager.cpp
+++ b/Client/core/Graphics/CPixelsManager.cpp
@@ -740,7 +740,7 @@ bool CPixelsManager::GetPlainDimensions(const CPixels& pixels, uint& uiOutWidth,
         const ushort* pPlainTail = (const ushort*)(pData + uiDataSize - SIZEOF_PLAIN_TAIL);
         uiOutWidth = pPlainTail[0];
         uiOutHeight = pPlainTail[1];
-        uint uiPlainByteSize = uiOutWidth * uiOutHeight * 4 + SIZEOF_PLAIN_TAIL;
+        const uint64_t uiPlainByteSize = static_cast<uint64_t>(uiOutWidth) * static_cast<uint64_t>(uiOutHeight) * 4ULL + SIZEOF_PLAIN_TAIL;
         if (uiDataSize == uiPlainByteSize)
             return true;
     }


### PR DESCRIPTION
## **Summary**

Changed the plain-pixel size check in `CPixelsManager::GetPlainDimensions` to use 64-bit arithmetic.

Large width and height values can no longer wrap into a smaller buffer size and pass validation.

## **Motivation**

The expected plain-pixel size was calculated using 32-bit arithmetic. Dimensions of `32768 × 32769` require a little over 4 GiB, but the calculation wrapped to only `131076` bytes.

The undersized buffer was then accepted by `dxSetTexturePixels`. Its claimed width produced a source row pitch of `131072` bytes, causing later rows to be read beyond the supplied Lua string.

For example, a client resource might generate pixel data for a texture effect. If its width or height metadata becomes corrupted or is calculated incorrectly, the old validation could accept the buffer and crash the player's client during the copy.

<details>
<summary>Crash Stack</summary>

```text
Exception: Access violation

memcpy
CPixelsManager::SetSurfacePixels (CPixelsManager.cpp:443)
CPixelsManager::SetTexturePixels (CPixelsManager.cpp:214)
CLuaDrawingDefs::DxSetTexturePixels (CLuaDrawingDefs.cpp:1887)
```

<img width="1039" height="1071" alt="Crash" src="https://github.com/user-attachments/assets/bd12dd31-6474-4ab4-b003-0b850117ce05" />

</details>

## Test plan

**Runtime**

- Valid Case: A normal `64 × 64` plain-pixel buffer containing `16388` bytes returned `true` before and after the fix.
- Before Fix: A `131076`-byte buffer claiming dimensions of `32768 × 32769` caused an access violation in `CPixelsManager::SetSurfacePixels`.
- After Fix: The exact same malformed buffer returned `false`, and the client stayed open.

**Builds and Tests**

- `Debug | Win32`: Full rebuild passed.
- `Release | Win32`: Full rebuild passed.
- `Debug | x64`: Full rebuild passed.
- `Release | x64`: Full rebuild passed.
- Ran `clang-format`.

## Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.