### PR TITLE
Fix client crash from invalid COL header sizes

### DIFF
--- a/Client/game_sa/CRenderWareSA.cpp
+++ b/Client/game_sa/CRenderWareSA.cpp
@@ -461,6 +461,21 @@ CColModel* CRenderWareSA::ReadCOL(const SString& buffer)
     // Load the col model
     if (header.version[0] == 'C' && header.version[1] == 'O' && header.version[2] == 'L')
     {
+        constexpr DWORD COL_FILE_INFO_SIZE = sizeof(header.version) + sizeof(header.size);
+        constexpr DWORD COL_MODEL_NAME_SIZE = sizeof(header.name);
+        constexpr DWORD GTA_COL2_HEADER_SIZE = 0x4C;
+        constexpr DWORD GTA_COL3_HEADER_SIZE = 0x58;
+
+        // GTA trusts the declared size when reading its version header and copying data. COL archives can contain trailing entries, so require the first entry
+        // to fit rather than requiring it to consume the entire buffer.
+        const uint64_t totalSize = static_cast<uint64_t>(header.size) + COL_FILE_INFO_SIZE;
+        if (header.size < COL_MODEL_NAME_SIZE || totalSize > buffer.size())
+            return NULL;
+
+        const DWORD dataSize = header.size - COL_MODEL_NAME_SIZE;
+        if ((header.version[3] == '2' && dataSize < GTA_COL2_HEADER_SIZE) || (header.version[3] == '3' && dataSize < GTA_COL3_HEADER_SIZE))
+            return NULL;
+
         unsigned char* pModelData = (unsigned char*)buffer.data() + sizeof(ColModelFileHeader);
 
         // Create a new CColModel
@@ -472,11 +487,11 @@ CColModel* CRenderWareSA::ReadCOL(const SString& buffer)
         }
         else if (header.version[3] == '2')
         {
-            LoadCollisionModelVer2(pModelData, header.size - 0x18, pColModel->GetInterface(), NULL);
+            LoadCollisionModelVer2(pModelData, dataSize, pColModel->GetInterface(), NULL);
         }
         else if (header.version[3] == '3')
         {
-            LoadCollisionModelVer3(pModelData, header.size - 0x18, pColModel->GetInterface(), NULL);
+            LoadCollisionModelVer3(pModelData, dataSize, pColModel->GetInterface(), NULL);
         }
 
         // Return the collision model


### PR DESCRIPTION
## **Summary**

Added COL size validation to `CRenderWareSA::ReadCOL` before creating a collision model or calling GTA's parser.

Malformed entries are now rejected when the declared size is too small, extends beyond the supplied buffer, or cannot contain the required COL2 or COL3 header.

## **Motivation**

`CRenderWareSA::ReadCOL` subtracted the 24-byte model-name section from the declared COL size without checking it first. A declared size below 24 could underflow into a very large unsigned value and be passed to GTA.

For example, a resource might load custom collision data downloaded with a map. If that data is truncated or has a broken size field, calling `engineLoadCOL` could send the invalid length into GTA's collision parser and crash the player's client.

The validated size is now reused when calling GTA, while COL archives containing trailing entries remain supported.

<details>
<summary>Crash Stack</summary>

```text
Exception: Access violation
Code: 0xC0000005
Module: gta_sa.exe
Module offset: 0x00137F77
Address: 0x537F77

0x537F77 is inside LoadCollisionModelVer2
```

<img width="696" height="684" alt="Crash" src="https://github.com/user-attachments/assets/1af14893-88ee-412b-82bc-4477eeb1f85f" />

</details>

## Test plan

**Runtime**

- Valid Case: A known valid repository COL file returned a valid element before and after the fix.
- Before Fix: A 48-byte `COL2` buffer with a declared size of zero caused an access violation inside `LoadCollisionModelVer2`.
- After Fix: The exact same malformed buffer returned `false`, and the client stayed open.

**Builds and Tests**

- `Debug | Win32`: `Game SA` build passed.
- `Release | Win32`: `Game SA` build passed.
- Ran `clang-format`.

## Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.