### PR TITLE
Fix client crash from invalid sound FFT band counts

### DIFF
--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -8287,8 +8287,17 @@ bool CStaticFunctionDefinitions::GetSoundProperties(CClientSound& Sound, float& 
     return true;
 }
 
+static bool IsValidFFTBandCount(int iLength, int iBands)
+{
+    // BASS provides iLength / 2 spectrum values, so additional bands cannot be populated without reading beyond the FFT data.
+    return iBands >= 0 && iBands <= iLength / 2;
+}
+
 float* CStaticFunctionDefinitions::GetSoundFFTData(CClientSound& Sound, int iLength, int iBands)
 {
+    if (!IsValidFFTBandCount(iLength, iBands))
+        return nullptr;
+
     // Get our FFT Data
     float* fData = Sound.GetFFTData(iLength);
     if (iBands != 0 && fData != NULL)
@@ -8344,6 +8353,9 @@ float* CStaticFunctionDefinitions::GetSoundFFTData(CClientSound& Sound, int iLen
 
 float* CStaticFunctionDefinitions::GetSoundFFTData(CClientPlayer& Player, int iLength, int iBands)
 {
+    if (!IsValidFFTBandCount(iLength, iBands))
+        return nullptr;
+
     CClientPlayerVoice* pVoice = Player.GetVoice();
     if (pVoice != NULL && Player.GetVoice()->IsActive())
     {


### PR DESCRIPTION
## **Summary**

Added FFT band-count validation for sound elements and player voice.

Band counts from zero through half the requested FFT sample count remain valid. Negative values and values above the available half-spectrum now return `false` before FFT extraction or allocation.

## **Motivation**

`getSoundFFTData` accepted any signed band count. A value of `-1` reached `new float[iBands]` and became an extremely large allocation request, causing MTA's out-of-memory handler to terminate the client.

For example, a resource might use FFT data to draw a music visualizer and allow the number of bands to come from a setting. If that value becomes negative or exceeds the available spectrum, the old code could terminate the player's client or read beyond the FFT data.

The reported out-of-memory error was caused by the invalid allocation size. The machine had not actually run out of memory.

<details>
<summary>Crash Stack</summary>

```text
RaiseException
OutOfMemory
HandleMemoryAllocationFailure
_callnewh
operator new
CStaticFunctionDefinitions::GetSoundFFTData
CLuaAudioDefs::GetSoundFFTData
luaD_precall
luaV_execute
luaD_call
lua_pcall
CLuaMain::PCall
```

<img width="1042" height="1079" alt="Crash" src="https://github.com/user-attachments/assets/74a63502-ff53-4843-a93d-a6179056d628" />

<img width="301" height="149" alt="Out of memory dialog" src="https://github.com/user-attachments/assets/d0362b9b-5f1c-489d-a865-7f35c857407b" />

</details>

## Test plan

**Runtime**

- Valid Case: A 256-sample FFT with 16 bands returned a table containing 16 entries before and after the fix.
- Before Fix: Requesting `bands = -1` terminated the client through the out-of-memory handler.
- After Fix: The same negative band count returned `false`, and the client stayed open.
- Maximum Case: `bands = 128` returned a table containing 128 entries.
- Boundary Case: `bands = 129` returned `false`, and the client stayed open.

**Builds and Tests**

- `Debug | Win32`: Full build passed, 304 client tests passed.
- `Release | Win32`: Full build passed, 304 client tests passed.
- `Debug | x64`: Full build passed.
- `Release | x64`: Full build passed.
- Ran `clang-format`.

## Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.