### PR TITLE
Fix client crash on invalid setTrainTrack track number

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -2366,7 +2366,7 @@ int CLuaVehicleDefs::SetTrainSpeed(lua_State* luaVM)
 bool CLuaVehicleDefs::SetTrainTrack(CClientVehicle* pVehicle, uchar ucTrack)
 {
     if (ucTrack > 3)
-        throw new std::invalid_argument("Invalid track number range (0-3)");
+        throw std::invalid_argument("Invalid track number range (0-3)");
 
     if (pVehicle->GetVehicleType() != CLIENTVEHICLE_TRAIN)
         return false;


### PR DESCRIPTION
## **Summary**

Changed `setTrainTrack` to throw `std::invalid_argument` by value.

Invalid track numbers are now caught by the existing Lua function parser and returned as a normal Lua error instead of terminating the client.

## **Motivation**

`setTrainTrack` previously used `throw new std::invalid_argument(...)`, which throws a pointer to an exception. The Lua function parser catches `std::logic_error&`, so the pointer escaped the handler and became a fatal C++ exception.

For example, a train resource might read the track number from a route configuration. If that value is `4` instead of the valid range from `0` through `3`, calling `setTrainTrack` could crash the player's client.

Throwing the exception object by value lets the existing handler report the invalid argument normally.

<details>
<summary>Crash Stack</summary>

```text
RaiseException
_CxxThrowException
CLuaVehicleDefs::SetTrainTrack (CLuaVehicleDefs.cpp:2369)
CLuaFunctionParser<..., &CLuaVehicleDefs::SetTrainTrack>::Call
CLuaFunctionParser<..., &CLuaVehicleDefs::SetTrainTrack>::operator()
CLuaDefs::ArgumentParser<&CLuaVehicleDefs::SetTrainTrack>
luaD_precall
luaV_execute
```

<img width="1168" height="1077" alt="Crash" src="https://github.com/user-attachments/assets/925f4544-057f-48e7-9c6c-7e976cafadf9" />

</details>

## Test plan

**Runtime**

- Setup: Created a local Freight train using model `537`.
- Valid Case: `setTrainTrack(train, 0)` returned `call=true result=true` before and after the fix.
- Before Fix: `setTrainTrack(train, 4)` caused a fatal C++ exception in `CLuaVehicleDefs::SetTrainTrack`.
- After Fix: The same call returned `call=false result=Invalid track number range (0-3)`, and the client stayed open.

**Builds and Tests**

- `Debug | Win32`: Full build passed, 304 client tests passed.
- `Release | Win32`: Full build passed, 304 client tests passed.
- `Debug | x64`: Full build passed.
- `Release | x64`: Full build passed.
- Ran `clang-format`.
## Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.