### PR TITLE
Fix client crash from DX primitive argument error leaks

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -599,38 +599,55 @@ int CLuaDrawingDefs::DxDrawPrimitive3D(lua_State* luaVM)
     D3DPRIMITIVETYPE ePrimitiveType;
     auto             pVecVertices = new std::vector<PrimitiveVertice>();
     eRenderStage     renderStage{eRenderStage::POST_FX};
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadEnumString(ePrimitiveType);
-    if (argStream.NextIsBool())
-        renderStage = argStream.ReadBool() ? eRenderStage::POST_GUI : eRenderStage::POST_FX;
-    else
-        argStream.ReadEnumString(renderStage, eRenderStage::POST_FX);
+    bool             bHasArgumentErrors{false};
 
-    std::vector<double> vecTableContent;
-
-    while (argStream.NextIsTable())
+    // Lua errors use longjmp, so leave this scope normally to release parser allocations before raising the error.
     {
-        vecTableContent.clear();
+        CScriptArgReader argStream(luaVM);
+        argStream.ReadEnumString(ePrimitiveType);
+        if (argStream.NextIsBool())
+            renderStage = argStream.ReadBool() ? eRenderStage::POST_GUI : eRenderStage::POST_FX;
+        else
+            argStream.ReadEnumString(renderStage, eRenderStage::POST_FX);
 
-        argStream.ReadNumberTable(vecTableContent);
-        switch (vecTableContent.size())
+        std::vector<double> vecTableContent;
+
+        while (argStream.NextIsTable())
         {
-            case Primitive3DVerticeSizes::VERT_XYZ:
-                pVecVertices->push_back(PrimitiveVertice{static_cast<float>(vecTableContent[0]), static_cast<float>(vecTableContent[1]),
-                                                         static_cast<float>(vecTableContent[2]), (DWORD)0xFFFFFFFF});
-                break;
-            case Primitive3DVerticeSizes::VERT_XYZ_COLOR:
-                pVecVertices->push_back(PrimitiveVertice{static_cast<float>(vecTableContent[0]), static_cast<float>(vecTableContent[1]),
-                                                         static_cast<float>(vecTableContent[2]), static_cast<DWORD>(static_cast<int64_t>(vecTableContent[3]))});
-                break;
-            default:
-                argStream.SetCustomError(SString("Expected table with 3 or 4 numbers, got %i numbers", vecTableContent.size()).c_str());
-                break;
+            vecTableContent.clear();
+
+            argStream.ReadNumberTable(vecTableContent);
+            switch (vecTableContent.size())
+            {
+                case Primitive3DVerticeSizes::VERT_XYZ:
+                    pVecVertices->push_back(PrimitiveVertice{static_cast<float>(vecTableContent[0]), static_cast<float>(vecTableContent[1]),
+                                                             static_cast<float>(vecTableContent[2]), (DWORD)0xFFFFFFFF});
+                    break;
+                case Primitive3DVerticeSizes::VERT_XYZ_COLOR:
+                    pVecVertices->push_back(PrimitiveVertice{static_cast<float>(vecTableContent[0]), static_cast<float>(vecTableContent[1]),
+                                                             static_cast<float>(vecTableContent[2]),
+                                                             static_cast<DWORD>(static_cast<int64_t>(vecTableContent[3]))});
+                    break;
+                default:
+                    argStream.SetCustomError(SString("Expected table with 3 or 4 numbers, got %i numbers", vecTableContent.size()).c_str());
+                    break;
+            }
+        }
+
+        bHasArgumentErrors = argStream.HasErrors();
+        if (bHasArgumentErrors)
+        {
+            luaL_where(luaVM, 1);
+            lua_pushstring(luaVM, argStream.GetFullErrorMessage());
+            lua_concat(luaVM, 2);
         }
     }
 
-    if (argStream.HasErrors())
-        return luaL_error(luaVM, argStream.GetFullErrorMessage());
+    if (bHasArgumentErrors)
+    {
+        delete pVecVertices;
+        return lua_error(luaVM);
+    }
 
     if (g_pCore->GetGraphics()->IsValidPrimitiveSize(pVecVertices->size(), ePrimitiveType))
     {
@@ -652,43 +669,58 @@ int CLuaDrawingDefs::DxDrawMaterialPrimitive3D(lua_State* luaVM)
     auto             pVecVertices = new std::vector<PrimitiveMaterialVertice>();
     CClientMaterial* pMaterialElement;
     eRenderStage     renderStage{eRenderStage::POST_FX};
+    bool             bHasArgumentErrors{false};
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadEnumString(ePrimitiveType);
-    MixedReadMaterialString(argStream, pMaterialElement);
-    if (argStream.NextIsBool())
-        renderStage = argStream.ReadBool() ? eRenderStage::POST_GUI : eRenderStage::POST_FX;
-    else
-        argStream.ReadEnumString(renderStage, eRenderStage::POST_FX);
-
-    std::vector<double> vecTableContent;
-
-    while (argStream.NextIsTable())
+    // Lua errors use longjmp, so leave this scope normally to release parser allocations before raising the error.
     {
-        vecTableContent.clear();
+        CScriptArgReader argStream(luaVM);
+        argStream.ReadEnumString(ePrimitiveType);
+        MixedReadMaterialString(argStream, pMaterialElement);
+        if (argStream.NextIsBool())
+            renderStage = argStream.ReadBool() ? eRenderStage::POST_GUI : eRenderStage::POST_FX;
+        else
+            argStream.ReadEnumString(renderStage, eRenderStage::POST_FX);
 
-        argStream.ReadNumberTable(vecTableContent);
-        switch (vecTableContent.size())
+        std::vector<double> vecTableContent;
+
+        while (argStream.NextIsTable())
         {
-            case Primitive3DVerticeSizes::VERT_XYZ_UV:
-                pVecVertices->push_back(PrimitiveMaterialVertice{static_cast<float>(vecTableContent[0]), static_cast<float>(vecTableContent[1]),
-                                                                 static_cast<float>(vecTableContent[2]), (DWORD)0xFFFFFFFF,
-                                                                 static_cast<float>(vecTableContent[3]), static_cast<float>(vecTableContent[4])});
-                break;
-            case Primitive3DVerticeSizes::VERT_XYZ_COLOR_UV:
-                pVecVertices->push_back(PrimitiveMaterialVertice{static_cast<float>(vecTableContent[0]), static_cast<float>(vecTableContent[1]),
-                                                                 static_cast<float>(vecTableContent[2]),
-                                                                 static_cast<DWORD>(static_cast<int64_t>(vecTableContent[3])),
-                                                                 static_cast<float>(vecTableContent[4]), static_cast<float>(vecTableContent[5])});
-                break;
-            default:
-                argStream.SetCustomError(SString("Expected table with 5 or 6 numbers, got %i numbers", vecTableContent.size()).c_str());
-                break;
+            vecTableContent.clear();
+
+            argStream.ReadNumberTable(vecTableContent);
+            switch (vecTableContent.size())
+            {
+                case Primitive3DVerticeSizes::VERT_XYZ_UV:
+                    pVecVertices->push_back(PrimitiveMaterialVertice{static_cast<float>(vecTableContent[0]), static_cast<float>(vecTableContent[1]),
+                                                                     static_cast<float>(vecTableContent[2]), (DWORD)0xFFFFFFFF,
+                                                                     static_cast<float>(vecTableContent[3]), static_cast<float>(vecTableContent[4])});
+                    break;
+                case Primitive3DVerticeSizes::VERT_XYZ_COLOR_UV:
+                    pVecVertices->push_back(PrimitiveMaterialVertice{static_cast<float>(vecTableContent[0]), static_cast<float>(vecTableContent[1]),
+                                                                     static_cast<float>(vecTableContent[2]),
+                                                                     static_cast<DWORD>(static_cast<int64_t>(vecTableContent[3])),
+                                                                     static_cast<float>(vecTableContent[4]), static_cast<float>(vecTableContent[5])});
+                    break;
+                default:
+                    argStream.SetCustomError(SString("Expected table with 5 or 6 numbers, got %i numbers", vecTableContent.size()).c_str());
+                    break;
+            }
+        }
+
+        bHasArgumentErrors = argStream.HasErrors();
+        if (bHasArgumentErrors)
+        {
+            luaL_where(luaVM, 1);
+            lua_pushstring(luaVM, argStream.GetFullErrorMessage());
+            lua_concat(luaVM, 2);
         }
     }
 
-    if (argStream.HasErrors())
-        return luaL_error(luaVM, argStream.GetFullErrorMessage());
+    if (bHasArgumentErrors)
+    {
+        delete pVecVertices;
+        return lua_error(luaVM);
+    }
 
     if (g_pCore->GetGraphics()->IsValidPrimitiveSize(pVecVertices->size(), ePrimitiveType))
     {
@@ -709,35 +741,51 @@ int CLuaDrawingDefs::DxDrawPrimitive(lua_State* luaVM)
     D3DPRIMITIVETYPE ePrimitiveType;
     auto             pVecVertices = new std::vector<PrimitiveVertice>();
     bool             bPostGUI;
+    bool             bHasArgumentErrors{false};
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadEnumString(ePrimitiveType);
-    argStream.ReadBool(bPostGUI);
-
-    std::vector<double> vecTableContent;
-
-    while (argStream.NextIsTable())
+    // Lua errors use longjmp, so leave this scope normally to release parser allocations before raising the error.
     {
-        vecTableContent.clear();
+        CScriptArgReader argStream(luaVM);
+        argStream.ReadEnumString(ePrimitiveType);
+        argStream.ReadBool(bPostGUI);
 
-        argStream.ReadNumberTable(vecTableContent);
-        switch (vecTableContent.size())
+        std::vector<double> vecTableContent;
+
+        while (argStream.NextIsTable())
         {
-            case PrimitiveVerticeSizes::VERT_XY:
-                pVecVertices->push_back(PrimitiveVertice{static_cast<float>(vecTableContent[0]), static_cast<float>(vecTableContent[1]), 0, (DWORD)0xFFFFFFFF});
-                break;
-            case PrimitiveVerticeSizes::VERT_XY_COLOR:
-                pVecVertices->push_back(PrimitiveVertice{static_cast<float>(vecTableContent[0]), static_cast<float>(vecTableContent[1]), 0,
-                                                         static_cast<DWORD>(static_cast<int64_t>(vecTableContent[2]))});
-                break;
-            default:
-                argStream.SetCustomError(SString("Expected table with 2 or 3 numbers, got %i numbers", vecTableContent.size()).c_str());
-                break;
+            vecTableContent.clear();
+
+            argStream.ReadNumberTable(vecTableContent);
+            switch (vecTableContent.size())
+            {
+                case PrimitiveVerticeSizes::VERT_XY:
+                    pVecVertices->push_back(
+                        PrimitiveVertice{static_cast<float>(vecTableContent[0]), static_cast<float>(vecTableContent[1]), 0, (DWORD)0xFFFFFFFF});
+                    break;
+                case PrimitiveVerticeSizes::VERT_XY_COLOR:
+                    pVecVertices->push_back(PrimitiveVertice{static_cast<float>(vecTableContent[0]), static_cast<float>(vecTableContent[1]), 0,
+                                                             static_cast<DWORD>(static_cast<int64_t>(vecTableContent[2]))});
+                    break;
+                default:
+                    argStream.SetCustomError(SString("Expected table with 2 or 3 numbers, got %i numbers", vecTableContent.size()).c_str());
+                    break;
+            }
+        }
+
+        bHasArgumentErrors = argStream.HasErrors();
+        if (bHasArgumentErrors)
+        {
+            luaL_where(luaVM, 1);
+            lua_pushstring(luaVM, argStream.GetFullErrorMessage());
+            lua_concat(luaVM, 2);
         }
     }
 
-    if (argStream.HasErrors())
-        return luaL_error(luaVM, argStream.GetFullErrorMessage());
+    if (bHasArgumentErrors)
+    {
+        delete pVecVertices;
+        return lua_error(luaVM);
+    }
 
     if (g_pCore->GetGraphics()->IsValidPrimitiveSize(pVecVertices->size(), ePrimitiveType))
     {
@@ -759,39 +807,54 @@ int CLuaDrawingDefs::DxDrawMaterialPrimitive(lua_State* luaVM)
     auto             pVecVertices = new std::vector<PrimitiveMaterialVertice>();
     CClientMaterial* pMaterialElement;
     bool             bPostGUI;
+    bool             bHasArgumentErrors{false};
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadEnumString(ePrimitiveType);
-    MixedReadMaterialString(argStream, pMaterialElement);
-    argStream.ReadBool(bPostGUI);
-
-    std::vector<double> vecTableContent;
-
-    while (argStream.NextIsTable())
+    // Lua errors use longjmp, so leave this scope normally to release parser allocations before raising the error.
     {
-        vecTableContent.clear();
+        CScriptArgReader argStream(luaVM);
+        argStream.ReadEnumString(ePrimitiveType);
+        MixedReadMaterialString(argStream, pMaterialElement);
+        argStream.ReadBool(bPostGUI);
 
-        argStream.ReadNumberTable(vecTableContent);
-        switch (vecTableContent.size())
+        std::vector<double> vecTableContent;
+
+        while (argStream.NextIsTable())
         {
-            case PrimitiveVerticeSizes::VERT_XY_UV:
-                pVecVertices->push_back(PrimitiveMaterialVertice{static_cast<float>(vecTableContent[0]), static_cast<float>(vecTableContent[1]), 0,
-                                                                 (DWORD)0xFFFFFFFF, static_cast<float>(vecTableContent[2]),
-                                                                 static_cast<float>(vecTableContent[3])});
-                break;
-            case PrimitiveVerticeSizes::VERT_XY_COLOR_UV:
-                pVecVertices->push_back(PrimitiveMaterialVertice{static_cast<float>(vecTableContent[0]), static_cast<float>(vecTableContent[1]), 0,
-                                                                 static_cast<DWORD>(static_cast<int64_t>(vecTableContent[2])),
-                                                                 static_cast<float>(vecTableContent[3]), static_cast<float>(vecTableContent[4])});
-                break;
-            default:
-                argStream.SetCustomError(SString("Expected table with 4 or 5 numbers, got %i numbers", vecTableContent.size()).c_str());
-                break;
+            vecTableContent.clear();
+
+            argStream.ReadNumberTable(vecTableContent);
+            switch (vecTableContent.size())
+            {
+                case PrimitiveVerticeSizes::VERT_XY_UV:
+                    pVecVertices->push_back(PrimitiveMaterialVertice{static_cast<float>(vecTableContent[0]), static_cast<float>(vecTableContent[1]), 0,
+                                                                     (DWORD)0xFFFFFFFF, static_cast<float>(vecTableContent[2]),
+                                                                     static_cast<float>(vecTableContent[3])});
+                    break;
+                case PrimitiveVerticeSizes::VERT_XY_COLOR_UV:
+                    pVecVertices->push_back(PrimitiveMaterialVertice{static_cast<float>(vecTableContent[0]), static_cast<float>(vecTableContent[1]), 0,
+                                                                     static_cast<DWORD>(static_cast<int64_t>(vecTableContent[2])),
+                                                                     static_cast<float>(vecTableContent[3]), static_cast<float>(vecTableContent[4])});
+                    break;
+                default:
+                    argStream.SetCustomError(SString("Expected table with 4 or 5 numbers, got %i numbers", vecTableContent.size()).c_str());
+                    break;
+            }
+        }
+
+        bHasArgumentErrors = argStream.HasErrors();
+        if (bHasArgumentErrors)
+        {
+            luaL_where(luaVM, 1);
+            lua_pushstring(luaVM, argStream.GetFullErrorMessage());
+            lua_concat(luaVM, 2);
         }
     }
 
-    if (argStream.HasErrors())
-        return luaL_error(luaVM, argStream.GetFullErrorMessage());
+    if (bHasArgumentErrors)
+    {
+        delete pVecVertices;
+        return lua_error(luaVM);
+    }
 
     if (g_pCore->GetGraphics()->IsValidPrimitiveSize(pVecVertices->size(), ePrimitiveType))
     {


### PR DESCRIPTION
## **Summary**

Fixed native memory leaks on argument errors in:

- `dxDrawPrimitive`
- `dxDrawPrimitive3D`
- `dxDrawMaterialPrimitive`
- `dxDrawMaterialPrimitive3D`

Temporary parsing allocations and the heap-owned vertex vector are now released before the Lua error is raised. Valid drawing calls and their ownership flow remain unchanged.

## **Motivation**

Lua uses `longjmp` when raising errors, which skips C++ destructors. The primitive functions raised an error while their temporary number vector was still alive and without deleting the heap vertex vector.

For example, a resource might leave a malformed `dxDrawPrimitive` call inside `onClientRender`. MTA catches the Lua error, so the render handler continues running and repeats the same leaking call every frame. Over time, this could exhaust the 32-bit client's address space and terminate the player with an Out of Memory error.

<details>
<summary>Crash Stack</summary>

```text
Exception Type: User:OutOfMemory
Exception: Out of Memory - Allocation Failure
Fatal Exception: Yes
Reason: Out of Memory - Allocation Failure
Location: KERNELBASE.dll!RaiseException
```

<img width="2559" height="1424" alt="Crash" src="https://github.com/user-attachments/assets/57840b8d-da39-4c0b-b714-d3d3c4e4facb" />

<img width="298" height="152" alt="Out of memory dialog" src="https://github.com/user-attachments/assets/15778b71-2711-4167-9ce7-3c938a53f56b" />

</details>

## Test plan

**Runtime**

- Valid Case: A normal two-vertex `dxDrawPrimitive` call returned `true` before and after the fix.
- Error Case: The malformed call continued to report `Expected table with 2 or 3 numbers, got 4 numbers`.
- Before Fix: Private memory increased from about `503.1 MiB` to `540.1 MiB` after two batches of 512 malformed calls.
- Before Fix: One 65,536-call batch increased private memory to about `2953.3 MiB`. A second batch exhausted the client and caused the fatal out-of-memory crash.
- After Fix: Three 512-call batches completed while private memory remained around `515.2 MiB`.
- Stress Case: Ten 65,536-call batches completed all `655360` calls. The client stayed responsive and settled at about `521.2 MiB` private memory.

**Builds and Tests**

- `Debug | Win32`: `Client Deathmatch` build passed.
- `Release | Win32`: `Client Deathmatch` build passed.
- Ran `clang-format`.

## Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.