### PR TITLE
Add configurable object streaming limits (engineSetObjectStreamingLimits)

### DIFF
--- a/Client/mods/deathmatch/logic/CClientObjectManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientObjectManager.cpp
@@ -36,8 +36,10 @@ CClientObjectManager::CClientObjectManager(CClientManager* pManager)
     // Initialize members
     m_pManager = pManager;
     m_bCanRemoveFromList = true;
-    m_uiMaxStreamedInCount = MAX_OBJECTS_MTA / 2;
-    m_uiMaxLowLodStreamedInCount = MAX_OBJECTS_MTA - m_uiMaxStreamedInCount;
+    // Default streaming caps = stock behaviour (500/500). Configurable at runtime via
+    // engineSetObjectStreamingLimits (raising trades FPS for density; draw-call bound).
+    m_uiMaxStreamedInCount = 500;
+    m_uiMaxLowLodStreamedInCount = 500;
 }
 
 CClientObjectManager::~CClientObjectManager()
@@ -291,6 +293,18 @@ bool CClientObjectManager::IsHardObjectLimitReached()
     }
 
     return g_pGame->GetPools()->GetObjectCount() >= MAX_OBJECTS_MTA;
+}
+
+bool CClientObjectManager::SetStreamingLimits(uint uiHighDetail, uint uiLowLod)
+{
+    if (uiHighDetail == 0 || uiLowLod == 0)
+        return false;
+    // High-detail and low-LOD objects share the same object pool, so the total must fit.
+    if (uiHighDetail + uiLowLod > MAX_OBJECTS_MTA)
+        return false;
+    m_uiMaxStreamedInCount = uiHighDetail;
+    m_uiMaxLowLodStreamedInCount = uiLowLod;
+    return true;
 }
 
 void CClientObjectManager::RestreamObjects(unsigned short usModel)

--- a/Client/mods/deathmatch/logic/CClientObjectManager.h
+++ b/Client/mods/deathmatch/logic/CClientObjectManager.h
@@ -43,6 +43,12 @@ public:
     bool        IsLowLodObjectLimitReached();
     bool        IsHardObjectLimitReached();
 
+    // Configurable object streaming limits (default = stock). Raising them trades FPS for
+    // density (draw-call bound). See engineSetObjectStreamingLimits.
+    bool SetStreamingLimits(uint uiHighDetail, uint uiLowLod);
+    uint GetMaxStreamedInCount() const { return m_uiMaxStreamedInCount; }
+    uint GetMaxLowLodStreamedInCount() const { return m_uiMaxLowLodStreamedInCount; }
+
     void RestreamObjects(unsigned short usModel);
     void RestreamAllObjects();
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -58,6 +58,21 @@ size_t EngineStreamingGetMemorySize()
     return g_pCore->GetStreamingMemory();
 }
 
+// Set how many objects can be streamed in at once: high-detail (near) and low-LOD (far).
+// Default is stock (500/500). Raising these lets dense maps load more decoration, but it
+// trades FPS for density (rendering is draw-call bound). Total must fit the object pool.
+bool EngineSetObjectStreamingLimits(unsigned int uiHighDetail, unsigned int uiLowLod)
+{
+    return g_pClientGame->GetObjectManager()->SetStreamingLimits(uiHighDetail, uiLowLod);
+}
+
+// Get the current object streaming limits -> highDetail, lowLod
+CLuaMultiReturn<unsigned int, unsigned int> EngineGetObjectStreamingLimits()
+{
+    CClientObjectManager* pManager = g_pClientGame->GetObjectManager();
+    return {pManager->GetMaxStreamedInCount(), pManager->GetMaxLowLodStreamedInCount()};
+}
+
 // Set streaming buffer size
 bool EngineStreamingSetBufferSize(size_t sizeBytes)
 {
@@ -146,6 +161,8 @@ void CLuaEngineDefs::LoadFunctions()
         {"engineStreamingGetUsedMemory", ArgumentParser<EngineStreamingGetUsedMemory>},
         {"engineStreamingSetMemorySize", ArgumentParser<EngineStreamingSetMemorySize>},
         {"engineStreamingGetMemorySize", ArgumentParser<EngineStreamingGetMemorySize>},
+        {"engineSetObjectStreamingLimits", ArgumentParser<EngineSetObjectStreamingLimits>},
+        {"engineGetObjectStreamingLimits", ArgumentParser<EngineGetObjectStreamingLimits>},
         {"engineStreamingSetModelCacheLimits", ArgumentParser<EngineStreamingSetModelCacheLimits>},
         {"engineStreamingRestoreMemorySize", ArgumentParser<EngineStreamingRestoreMemorySize>},
         {"engineStreamingSetBufferSize", ArgumentParser<EngineStreamingSetBufferSize>},

--- a/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
@@ -27,6 +27,20 @@ namespace
     int                 ms_iSavedNumMirrorZones = 0;
 }  // namespace
 
+// === Raise the visible-entity / visible-LOD render list capacity =============
+// GTA's render lists (CRenderer::ms_aVisibleEntityPtrs @ 0xB75898,
+// ms_aVisibleLodPtrs @ 0xB748F8) are fixed 1000-entry arrays; the two
+// Check_NoOfVisible* hooks clamp the counters at 999. When more than ~1000
+// entities are visible (dense custom maps once the object streaming limits are
+// raised, see engineSetObjectStreamingLimits), the engine drops the excess and,
+// because which entities get dropped shifts per frame, the world flickers.
+// We relocate both arrays to larger buffers and raise the clamp. This is inert
+// with the default limits (a scene rarely exceeds 1000 visible entities), so it
+// does not change stock behaviour. Related: issues #869, #5054.
+#define RENDERLIST_LIMIT 10000           // capacity (stock game: 1000)
+static void* g_relocatedVisibleEntityPtrs[RENDERLIST_LIMIT] = {};
+static void* g_relocatedVisibleLodPtrs[RENDERLIST_LIMIT] = {};
+
 //////////////////////////////////////////////////////////////////////////////////////////
 //
 // CallIdle
@@ -361,7 +375,7 @@ static void __declspec(naked) HOOK_Check_NoOfVisibleLods()
     // clang-format off
     __asm
     {
-        cmp     eax, 999            // Array limit is 1000
+        cmp     eax, RENDERLIST_LIMIT - 1           // clamp to the render-list capacity
         jge     limit
         inc     eax
 limit:
@@ -389,7 +403,7 @@ static void __declspec(naked) HOOK_Check_NoOfVisibleEntities()
     // clang-format off
     __asm
     {
-        cmp     eax, 999        // Array limit is 1000
+        cmp     eax, RENDERLIST_LIMIT - 1           // clamp to the render-list capacity
         jge     limit
         inc     eax
 limit:
@@ -944,6 +958,18 @@ void CMultiplayerSA::InitHooks_Rendering()
     EZHookInstall(CVisibilityPlugins_RenderPedCB);
     EZHookInstall(Check_NoOfVisibleLods);
     EZHookInstall(Check_NoOfVisibleEntities);
+
+    // Relocate the two render-list arrays to our larger buffers (see RENDERLIST_LIMIT).
+    // Each site is a `[reg*4 + base]` access; we rewrite the 4-byte base immediate.
+    // ms_aVisibleLodPtrs (0xB748F8): 1 write + 2 reads
+    MemPut<DWORD>(0x5534F5, (DWORD)&g_relocatedVisibleLodPtrs[0]);
+    MemPut<DWORD>(0x553923, (DWORD)&g_relocatedVisibleLodPtrs[0]);
+    MemPut<DWORD>(0x553CB3, (DWORD)&g_relocatedVisibleLodPtrs[0]);
+    // ms_aVisibleEntityPtrs (0xB75898): 1 write + 3 reads
+    MemPut<DWORD>(0x553529, (DWORD)&g_relocatedVisibleEntityPtrs[0]);
+    MemPut<DWORD>(0x553944, (DWORD)&g_relocatedVisibleEntityPtrs[0]);
+    MemPut<DWORD>(0x553A53, (DWORD)&g_relocatedVisibleEntityPtrs[0]);
+    MemPut<DWORD>(0x553B03, (DWORD)&g_relocatedVisibleEntityPtrs[0]);
     EZHookInstall(WinLoop);
     EZHookInstall(CTimer_Update);
     EZHookInstall(CTimer_Suspend);

--- a/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
@@ -27,6 +27,20 @@ namespace
     int                 ms_iSavedNumMirrorZones = 0;
 }  // namespace
 
+// === Raise the visible-entity / visible-LOD render list capacity =============
+// GTA's render lists (CRenderer::ms_aVisibleEntityPtrs @ 0xB75898,
+// ms_aVisibleLodPtrs @ 0xB748F8) are fixed 1000-entry arrays; the two
+// Check_NoOfVisible* hooks clamp the counters at 999. When more than ~1000
+// entities are visible (dense custom maps once the object streaming limits are
+// raised, see engineSetObjectStreamingLimits), the engine drops the excess and,
+// because which entities get dropped shifts per frame, the world flickers.
+// We relocate both arrays to larger buffers and raise the clamp. This is inert
+// with the default limits (a scene rarely exceeds 1000 visible entities), so it
+// does not change stock behaviour. Related: issues #869, #5054.
+#define RENDERLIST_LIMIT 10000  // capacity (stock game: 1000)
+static void* g_relocatedVisibleEntityPtrs[RENDERLIST_LIMIT] = {};
+static void* g_relocatedVisibleLodPtrs[RENDERLIST_LIMIT] = {};
+
 //////////////////////////////////////////////////////////////////////////////////////////
 //
 // CallIdle
@@ -361,7 +375,7 @@ static void __declspec(naked) HOOK_Check_NoOfVisibleLods()
     // clang-format off
     __asm
     {
-        cmp     eax, 999            // Array limit is 1000
+        cmp     eax, RENDERLIST_LIMIT - 1           // clamp to the render-list capacity
         jge     limit
         inc     eax
 limit:
@@ -389,7 +403,7 @@ static void __declspec(naked) HOOK_Check_NoOfVisibleEntities()
     // clang-format off
     __asm
     {
-        cmp     eax, 999        // Array limit is 1000
+        cmp     eax, RENDERLIST_LIMIT - 1           // clamp to the render-list capacity
         jge     limit
         inc     eax
 limit:
@@ -953,6 +967,18 @@ void CMultiplayerSA::InitHooks_Rendering()
     EZHookInstall(CVisibilityPlugins_RenderPedCB);
     EZHookInstall(Check_NoOfVisibleLods);
     EZHookInstall(Check_NoOfVisibleEntities);
+
+    // Relocate the two render-list arrays to our larger buffers (see RENDERLIST_LIMIT).
+    // Each site is a `[reg*4 + base]` access; we rewrite the 4-byte base immediate.
+    // ms_aVisibleLodPtrs (0xB748F8): 1 write + 2 reads
+    MemPut<DWORD>(0x5534F5, (DWORD)&g_relocatedVisibleLodPtrs[0]);
+    MemPut<DWORD>(0x553923, (DWORD)&g_relocatedVisibleLodPtrs[0]);
+    MemPut<DWORD>(0x553CB3, (DWORD)&g_relocatedVisibleLodPtrs[0]);
+    // ms_aVisibleEntityPtrs (0xB75898): 1 write + 3 reads
+    MemPut<DWORD>(0x553529, (DWORD)&g_relocatedVisibleEntityPtrs[0]);
+    MemPut<DWORD>(0x553944, (DWORD)&g_relocatedVisibleEntityPtrs[0]);
+    MemPut<DWORD>(0x553A53, (DWORD)&g_relocatedVisibleEntityPtrs[0]);
+    MemPut<DWORD>(0x553B03, (DWORD)&g_relocatedVisibleEntityPtrs[0]);
     EZHookInstall(WinLoop);
     EZHookInstall(CTimer_Update);
     EZHookInstall(CTimer_Suspend);

--- a/Client/sdk/game/Common.h
+++ b/Client/sdk/game/Common.h
@@ -15,10 +15,12 @@
 // Limits for MTA
 #define MAX_VEHICLES_MTA             64     // Real limit is 110
 #define MAX_PEDS_MTA                 110    // Real limit is 140
-#define MAX_OBJECTS_MTA              1000   // Real limit is 1200
-#define MAX_ENTRY_INFO_NODES_MTA     72000  // Real limit is 72600  ( MAX_OBJECTS_MTA * 72 ) [Large col models are the cause of high usage]
-#define MAX_POINTER_SINGLE_LINKS_MTA 85000  // Real limit is 90000 [Large col models are the cause of high usage]
-#define MAX_POINTER_DOUBLE_LINKS_MTA 74000  // Real limit is 74800  ( MAX_OBJECTS_MTA * 72 + 2000 )
+// Object pool ceiling. Default streaming stays at stock (500/500, see CClientObjectManager);
+// this only sets how high engineSetObjectStreamingLimits may go. Node pools scale with it.
+#define MAX_OBJECTS_MTA              4000   // object pool ceiling for opt-in higher streaming limits
+#define MAX_ENTRY_INFO_NODES_MTA     (MAX_OBJECTS_MTA * 72)          // scales with objects (large col models drive usage)
+#define MAX_POINTER_SINGLE_LINKS_MTA (MAX_OBJECTS_MTA * 85)          // scales with objects
+#define MAX_POINTER_DOUBLE_LINKS_MTA (MAX_OBJECTS_MTA * 72 + 2000)   // scales with objects
 
 // Real limits for GTA
 #define MAX_VEHICLES             (MAX_VEHICLES_MTA + 46)  // 110

--- a/Client/sdk/game/Common.h
+++ b/Client/sdk/game/Common.h
@@ -13,12 +13,14 @@
 #include <stdint.h>
 
 // Limits for MTA
-#define MAX_VEHICLES_MTA             64     // Real limit is 110
-#define MAX_PEDS_MTA                 110    // Real limit is 140
-#define MAX_OBJECTS_MTA              1000   // Real limit is 1200
-#define MAX_ENTRY_INFO_NODES_MTA     72000  // Real limit is 72600  ( MAX_OBJECTS_MTA * 72 ) [Large col models are the cause of high usage]
-#define MAX_POINTER_SINGLE_LINKS_MTA 85000  // Real limit is 90000 [Large col models are the cause of high usage]
-#define MAX_POINTER_DOUBLE_LINKS_MTA 74000  // Real limit is 74800  ( MAX_OBJECTS_MTA * 72 + 2000 )
+#define MAX_VEHICLES_MTA 64   // Real limit is 110
+#define MAX_PEDS_MTA     110  // Real limit is 140
+// Object pool ceiling. Default streaming stays at stock (500/500, see CClientObjectManager);
+// this only sets how high engineSetObjectStreamingLimits may go. Node pools scale with it.
+#define MAX_OBJECTS_MTA              4000                           // object pool ceiling for opt-in higher streaming limits
+#define MAX_ENTRY_INFO_NODES_MTA     (MAX_OBJECTS_MTA * 72)         // scales with objects (large col models drive usage)
+#define MAX_POINTER_SINGLE_LINKS_MTA (MAX_OBJECTS_MTA * 85)         // scales with objects
+#define MAX_POINTER_DOUBLE_LINKS_MTA (MAX_OBJECTS_MTA * 72 + 2000)  // scales with objects
 
 // Real limits for GTA
 #define MAX_VEHICLES             (MAX_VEHICLES_MTA + 46)  // 110


### PR DESCRIPTION
## What this does

Implements the configurable limits discussed in #5054.

On maps with a lot of custom-object decoration (e.g. race maps placing thousands of `.map`
objects), decoration stops loading in dense areas and the world flickers. The cause is a
hard cap of **500 high-detail streamed-in objects** (`CClientObjectManager` sets
`m_uiMaxStreamedInCount = MAX_OBJECTS_MTA / 2`, with `MAX_OBJECTS_MTA = 1000`), combined
with the fixed **1000-entry render lists** that flicker when exceeded.

This PR makes those limits **opt-in and configurable**, with defaults equal to current
behaviour (fully backward compatible):

### New client functions
- `bool engineSetObjectStreamingLimits(int highDetail, int lowLod)` — how many high-detail
  (near) and low-LOD (far) objects may stream in at once. Returns `false` if invalid or the
  total exceeds the object pool.
- `int, int engineGetObjectStreamingLimits()` — current limits.

Defaults stay at **500 / 500** (stock), so servers that don't call these are unaffected.

### Supporting engine changes
- **Render list capacity**: relocate `CRenderer::ms_aVisibleEntityPtrs` (`0xB75898`) and
  `ms_aVisibleLodPtrs` (`0xB748F8`) to larger buffers and raise the `Check_NoOfVisible*`
  clamps. This lets the extra objects actually render instead of flickering (a long-standing
  ask, #869). It is inert with the default limits — a scene rarely exceeds 1000 visible
  entities — so it does not change stock behaviour.
- **Object pool ceiling**: `MAX_OBJECTS_MTA` raised to act as the maximum the runtime limits
  may reach; node pools scale with it.

## Why (draw-call trade-off)

Raising these trades FPS for density, so it must be the server/mapper's informed choice —
that's why it's opt-in rather than a global bump. I profiled FPS vs. rendered-object count
while driving a dense map (single machine, DX9, ~52 FPS frame limiter):

| Rendered objects (high + low-LOD) | FPS |
|---|---|
| 0 – 1500 | 52 |
| 1750 – 2000 | 46 |
| 2000 – 2250 | 43 |
| 2500 – 2750 | 33 |
| 3000+ | 30 |

Linear fit: **~9.4 FPS lost per 1000 rendered objects**, flat at 52 up to ~1800. Low-LOD
objects cost the same as high-detail ones despite far fewer polys, i.e. this is draw-call
bound (CPU/DX9), consistent with #905. On my content, `engineSetObjectStreamingLimits(1500, 800)`
gave a **flat ~52 FPS with ~2x the object density** of stock.

## Backward compatibility

- Defaults are identical to current behaviour (500 / 500).
- The render-array relocation and larger pools are inert unless the limits are raised.
- No new ACL rights; no server config changes.

## Testing

Built and tested locally on a dense custom race map: `/start`-ing a resource that calls
`engineSetObjectStreamingLimits(1500, 800)` visibly loads far more decoration; changing the
values at runtime updates streaming immediately; stopping it restores stock (500/500). No
crashes; FPS matches the table above.

## Open questions for reviewers

1. **Pool memory**: the object pool ceiling (`MAX_OBJECTS_MTA`) is compile-time, so raising
   it costs some memory for everyone even at default limits. Happy to tune the ceiling, make
   it configurable, or explore growing the pool on demand — guidance welcome.
2. **API surface**: free `engine*` functions here; would you also like OOP methods on an
   Engine class, and/or a getter for current streamed-in counts to help scripts auto-tune?
3. Wiki docs to follow once the API shape is agreed.
