### PR TITLE
Fix getPedTask crash with invalid primary task index

### DIFF
--- a/Client/game_sa/CTaskManagerSA.cpp
+++ b/Client/game_sa/CTaskManagerSA.cpp
@@ -56,8 +56,10 @@ void CTaskManagerSA::SetTask(CTaskSA* pTaskPrimary, const int iTaskPriority, con
 
 CTask* CTaskManagerSA::GetTask(const int iTaskPriority)
 {
-    CTaskManagerSAInterface* pTaskManagerInterface = GetInterface();
-    return m_pTaskManagementSystem->GetTask(pTaskManagerInterface->m_tasks[iTaskPriority]);
+    if (iTaskPriority >= 0 && iTaskPriority < TASK_PRIORITY_MAX)
+        return m_pTaskManagementSystem->GetTask(GetInterface()->m_tasks[iTaskPriority]);
+
+    return nullptr;
 }
 
 CTask* CTaskManagerSA::GetActiveTask()


### PR DESCRIPTION
## **Summary**

Added bounds validation to `CTaskManagerSA::GetTask`.

Primary task indices outside the valid `0` to `4` range now return `nullptr`, causing `getPedTask` to return `false` safely.

## **Motivation**

The primary task reader used the provided index directly on a five-entry native array. Larger values could read nearby fields and treat them as task pointers, eventually causing an access violation.

For example, a resource might loop through task slots to check what a ped is doing, but accidentally query slot `11`. Instead of returning `false`, the client could interpret the ped pointer stored after the task arrays as a task and crash.

<details>
<summary>Crash Stack</summary>

```text
Exception: Access violation
Module: client.dll
Module offset: 0x00107338
Requested primary task index: 11

CStaticFunctionDefinitions::GetPedTask (CStaticFunctionDefinitions.cpp:1732)
CLuaPedDefs::GetPedTask (CLuaPedDefs.cpp:555)
luaD_precall
luaV_execute
luaD_call
lua_pcall
```

<img width="950" height="1076" alt="Crash" src="https://github.com/user-attachments/assets/1a5d63a7-92cd-4b72-8640-a5a374f54cbf" />

</details>

## Test plan

**Runtime**

- Before Fix: Requesting primary task index `11` caused an access violation in `CStaticFunctionDefinitions::GetPedTask`.
- After Fix: The same index returned `false`, and the client stayed open.
- Valid Case: Primary task index `3` returned `false` for an empty valid slot.
- Invalid Cases: Primary task indices `5` and `10` returned `false` without an assertion or crash.

**Builds and Tests**

- `Debug | Win32`: Game SA project build passed.

## Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.