### PR TITLE
Fix animation query crash for streamed-out peds

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -2322,11 +2322,12 @@ int CLuaPedDefs::SetPedAnimationProgress(lua_State* luaVM)
 
 float CLuaPedDefs::GetPedAnimationProgress(CClientPed* ped)
 {
-    CTask*       currentTask = ped->GetTaskManager()->GetActiveTask();
-    std::int32_t type = currentTask->GetTaskType();
+    CTaskManager* taskManager = ped->GetTaskManager();
+    if (!taskManager)
+        return -1.0f;
 
-    // check if animation (task type is 401)
-    if (type != 401)
+    CTask* currentTask = taskManager->GetActiveTask();
+    if (!currentTask || currentTask->GetTaskType() != TASK_SIMPLE_NAMED_ANIM)
         return -1.0f;
 
     auto* animation = dynamic_cast<CTaskSimpleRunNamedAnim*>(currentTask);
@@ -2342,11 +2343,12 @@ float CLuaPedDefs::GetPedAnimationProgress(CClientPed* ped)
 
 float CLuaPedDefs::GetPedAnimationSpeed(CClientPed* ped)
 {
-    CTask*       currentTask = ped->GetTaskManager()->GetActiveTask();
-    std::int32_t type = currentTask->GetTaskType();
+    CTaskManager* taskManager = ped->GetTaskManager();
+    if (!taskManager)
+        return -1.0f;
 
-    // check if animation (task type is 401)
-    if (type != 401)
+    CTask* currentTask = taskManager->GetActiveTask();
+    if (!currentTask || currentTask->GetTaskType() != TASK_SIMPLE_NAMED_ANIM)
         return -1.0f;
 
     auto* animation = dynamic_cast<CTaskSimpleRunNamedAnim*>(currentTask);
@@ -2362,11 +2364,12 @@ float CLuaPedDefs::GetPedAnimationSpeed(CClientPed* ped)
 
 float CLuaPedDefs::GetPedAnimationLength(CClientPed* ped)
 {
-    CTask*       currentTask = ped->GetTaskManager()->GetActiveTask();
-    std::int32_t type = currentTask->GetTaskType();
+    CTaskManager* taskManager = ped->GetTaskManager();
+    if (!taskManager)
+        return -1.0f;
 
-    // check if animation (task type is 401)
-    if (type != 401)
+    CTask* currentTask = taskManager->GetActiveTask();
+    if (!currentTask || currentTask->GetTaskType() != TASK_SIMPLE_NAMED_ANIM)
         return -1.0f;
 
     auto* animation = dynamic_cast<CTaskSimpleRunNamedAnim*>(currentTask);


### PR DESCRIPTION
## **Summary**

Added missing task checks to `getPedAnimationProgress`, `getPedAnimationSpeed`, and `getPedAnimationLength`.
These functions now return `-1` when the ped has no task manager or active task.

## **Motivation**

A streamed-out ped can still be a valid Lua element, but it no longer has native task data. Querying its animation progress tried to access that missing data and caused an access violation. The speed and length functions had the same unchecked path.

For example, a server resource might track an NPC's animation to update a progress bar or other UI. If the player moves far enough away and the NPC streams out, the resource can still hold the ped element. The next animation query could crash the player's client.

<details>
<summary>Crash Stack</summary>

```text
Exception: Access violation

CLuaPedDefs::GetPedAnimationProgress (CLuaPedDefs.cpp:2325)
CLuaFunctionParser<...>::Call
CLuaFunctionParser<...>::operator()
CLuaMain::PCall
```

<img width="1149" height="1072" alt="image" src="https://github.com/user-attachments/assets/d62c656c-616e-439d-9b50-a5ade48d4e1d" />

</details>

## Test plan

**Runtime**

- Before Fix: Querying a valid streamed-out ped caused the Debug client to crash.
- After Fix: Progress, speed, and length returned `-1` for the same ped, and the client stayed open.
- Valid Case: A streamed-in ped with an active animation still returned normal progress, speed, and length values.

**Builds and Tests**

- `Debug | Win32`: Build passed, 304 client tests passed.
- `Release | Win32`: Build passed, 304 client tests passed.
- `Debug | x64`: Server build passed.
- Ran `clang-format`.

## Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.