### PR TITLE
Fix client crash when firing at streamed-out vehicle wheels

### DIFF
--- a/Client/mods/deathmatch/logic/CClientWeapon.cpp
+++ b/Client/mods/deathmatch/logic/CClientWeapon.cpp
@@ -254,13 +254,12 @@ void CClientWeapon::Fire(bool bServerFire)
                     {
                         if (m_pTarget->GetType() == CCLIENTVEHICLE)
                         {
-                            if (m_itargetWheel <= MAX_WHEELS)
-                            {
-                                CClientVehicle* pTarget = (CClientVehicle*)(CClientEntity*)m_pTarget;
-                                vecTarget = pTarget->GetGameVehicle()->GetWheelPosition((eWheelPosition)m_itargetWheel);
-                            }
+                            CClientVehicle* pTarget = (CClientVehicle*)(CClientEntity*)m_pTarget;
+                            CVehicle*       pGameVehicle = pTarget->GetGameVehicle();
+                            if (m_itargetWheel >= 0 && m_itargetWheel < MAX_WHEELS && pGameVehicle)
+                                vecTarget = pGameVehicle->GetWheelPosition((eWheelPosition)m_itargetWheel);
                             else
-                                m_pTarget->GetPosition(vecTarget);
+                                pTarget->GetPosition(vecTarget);
                         }
                         else
                             m_pTarget->GetPosition(vecTarget);


### PR DESCRIPTION
## **Summary**

Added native vehicle and wheel index checks when custom weapons target vehicle wheels.
Streamed-out vehicles now use the vehicle element's cached position instead of trying to access missing wheel data.

## **Motivation**

A streamed-out vehicle can still be a valid Lua element, but it no longer has a native GTA vehicle. Firing a custom weapon at one of its wheels tried to read the wheel position from that missing object and caused an access violation.

For example, a remote turret resource might keep targeting a car wheel as it drives away. If the car streams out before the turret fires again, the next shot could crash the player's client.

<details>
<summary>Crash Stack</summary>

```text
Exception: Access violation (0xC0000005)

CClientWeapon::Fire (CClientWeapon.cpp:260)
CStaticFunctionDefinitions::FireWeapon (CStaticFunctionDefinitions.cpp:7718)
CLuaWeaponDefs::FireWeapon (CLuaWeaponDefs.cpp:195)
```

<img width="1036" height="1070" alt="image" src="https://github.com/user-attachments/assets/69e8b118-49b6-4ede-87ef-8bbee044ae2c" />

</details>

<details>
<summary>Reproduction</summary>

1. Created a client-side M4, a nearby control vehicle, and a vehicle far outside the streaming range.
2. Confirmed the weapon and control vehicle were streamed in while the far vehicle was a valid streamed-out element.
3. Targeted wheel 0 on the nearby vehicle and fired once. The client remained open.
4. Targeted wheel 0 on the streamed-out vehicle:

```lua
setWeaponTarget(weapon, streamedOutVehicle, 0)
fireWeapon(weapon)
```

Before the fix, `fireWeapon` immediately crashed the Debug client with the stack shown above.

</details>

## Test plan

**Runtime**

- Before Fix: Firing at wheel 0 on a valid streamed-out vehicle crashed the Debug client in `CClientWeapon::Fire`.
- After Fix: The same target and shot returned `true`, and the client stayed open. Repeated shots and cleanup/recreation also passed.
- Valid Case: Firing at wheel 0 on a streamed-in vehicle still returned `true`.

**Builds and Tests**

- `Debug | Win32`: Build passed, 304 client tests passed.
- `Release | Win32`: Build passed, 304 client tests passed.
- `Debug | x64`: Server build passed.
- Ran `clang-format`.

## Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.