### PR TITLE
Fix client crash when loading malformed ANPK IFP data

### DIFF
--- a/Client/mods/deathmatch/logic/CClientIFP.cpp
+++ b/Client/mods/deathmatch/logic/CClientIFP.cpp
@@ -90,18 +90,164 @@ bool CClientIFP::ReadIFPByVersion()
     else if (bAnpk)
     {
         m_bVersion1 = true;
-        ReadIFPVersion1();
-        return true;
+        if (!ValidateIFPVersion1())
+            return false;
+
+        return ReadIFPVersion1();
     }
     return false;
 }
 
-void CClientIFP::ReadIFPVersion1()
+bool CClientIFP::ValidateIFPVersion1() const
 {
-    SInfo Info;
+    const SString& buffer = GetBuffer();
+    size_t         offset = GetReadOffset();
+
+    const auto Read = [&buffer, &offset](void* destination, size_t size)
+    {
+        if (offset > buffer.size() || size > buffer.size() - offset)
+            return false;
+
+        std::memcpy(destination, buffer.data() + offset, size);
+        offset += size;
+        return true;
+    };
+
+    const auto ReadSpan = [&buffer, &offset](const char*& data, size_t size)
+    {
+        if (offset > buffer.size() || size > buffer.size() - offset)
+            return false;
+
+        data = buffer.data() + offset;
+        offset += size;
+        return true;
+    };
+
+    const auto GetPaddedSize = [](std::uint32_t size, size_t capacity, size_t& paddedSize)
+    {
+        const std::uint64_t paddedSize64 = (static_cast<std::uint64_t>(size) + 3u) & ~std::uint64_t{3u};
+        if (paddedSize64 > capacity)
+            return false;
+
+        paddedSize = static_cast<size_t>(paddedSize64);
+        return true;
+    };
+
+    std::uint32_t offsetEOF;
+    SBase         infoBase;
+    if (!Read(&offsetEOF, sizeof(offsetEOF)) || !Read(&infoBase, sizeof(infoBase)))
+        return false;
+
+    size_t infoSize;
+    if (!GetPaddedSize(infoBase.Size, sizeof(SInfo) - offsetof(SInfo, Entries), infoSize) || infoSize < sizeof(std::int32_t))
+        return false;
+
+    const char* infoData;
+    if (!ReadSpan(infoData, infoSize))
+        return false;
+
+    std::int32_t totalAnimations;
+    std::memcpy(&totalAnimations, infoData, sizeof(totalAnimations));
+    if (totalAnimations < 0)
+        return false;
+
+    for (std::int32_t animationIndex = 0; animationIndex < totalAnimations; ++animationIndex)
+    {
+        SBase nameBase;
+        if (!Read(&nameBase, sizeof(nameBase)))
+            return false;
+
+        size_t nameSize;
+        if (!GetPaddedSize(nameBase.Size, sizeof(SAnimationHeaderV2::Name), nameSize) || nameSize == 0)
+            return false;
+
+        const char* nameData;
+        if (!ReadSpan(nameData, nameSize))
+            return false;
+
+        SBase dganBase;
+        SBase dganInfoBase;
+        if (!Read(&dganBase, sizeof(dganBase)) || !Read(&dganInfoBase, sizeof(dganInfoBase)))
+            return false;
+
+        size_t dganInfoSize;
+        if (!GetPaddedSize(dganInfoBase.Size, sizeof(SInfo) - offsetof(SInfo, Entries), dganInfoSize) || dganInfoSize < sizeof(std::int32_t))
+            return false;
+
+        const char* dganInfoData;
+        if (!ReadSpan(dganInfoData, dganInfoSize))
+            return false;
+
+        std::int32_t totalSequences;
+        std::memcpy(&totalSequences, dganInfoData, sizeof(totalSequences));
+        if (totalSequences < 0 || totalSequences > std::numeric_limits<unsigned short>::max() - m_kcIFPSequences)
+            return false;
+
+        for (std::int32_t sequenceIndex = 0; sequenceIndex < totalSequences; ++sequenceIndex)
+        {
+            SBase cpanBase;
+            SBase animBase;
+            if (!Read(&cpanBase, sizeof(cpanBase)) || !Read(&animBase, sizeof(animBase)))
+                return false;
+
+            constexpr size_t animDataCapacity = sizeof(SAnim) - offsetof(SAnim, Name);
+            constexpr size_t framesOffset = offsetof(SAnim, Frames) - offsetof(SAnim, Name);
+
+            size_t animDataSize;
+            if (!GetPaddedSize(animBase.Size, animDataCapacity, animDataSize) || animDataSize < framesOffset + sizeof(std::int32_t))
+                return false;
+
+            const char* animData;
+            if (!ReadSpan(animData, animDataSize) || std::memchr(animData, '\0', sizeof(SAnim::Name)) == nullptr)
+                return false;
+
+            std::int32_t totalFrames;
+            std::memcpy(&totalFrames, animData + framesOffset, sizeof(totalFrames));
+            if (totalFrames < 0)
+                return false;
+            if (totalFrames == 0)
+                continue;
+
+            SBase kfrmBase;
+            if (!Read(&kfrmBase, sizeof(kfrmBase)))
+                return false;
+
+            size_t frameSize = 0;
+            if (std::memcmp(kfrmBase.FourCC, "KRTS", sizeof(kfrmBase.FourCC)) == 0)
+                frameSize = sizeof(SKrts);
+            else if (std::memcmp(kfrmBase.FourCC, "KRT0", sizeof(kfrmBase.FourCC)) == 0)
+                frameSize = sizeof(SKrt0);
+            else if (std::memcmp(kfrmBase.FourCC, "KR00", sizeof(kfrmBase.FourCC)) == 0)
+                frameSize = sizeof(SKr00);
+            else
+                return false;
+
+            const size_t frameCount = static_cast<size_t>(totalFrames);
+            if (offset > buffer.size() || frameCount > (buffer.size() - offset) / frameSize)
+                return false;
+
+            offset += frameCount * frameSize;
+        }
+    }
+
+    return true;
+}
+
+bool CClientIFP::ReadIFPVersion1()
+{
+    SInfo Info{};
     ReadHeaderVersion1(Info);
 
-    m_pVecAnimations->resize(Info.Entries);
+    try
+    {
+        m_pVecAnimations->resize(Info.Entries);
+    }
+    catch (const std::exception&)
+    {
+        // Allocation failures must not escape through the Lua C boundary.
+        return false;
+    }
+
     for (auto& Animation : m_pIFPAnimations->vecAnimations)
     {
         ReadAnimationNameVersion1(Animation);
@@ -117,6 +263,8 @@ void CClientIFP::ReadIFPVersion1()
         *(DWORD*)Animation.pSequencesMemory = ReadSequencesWithDummies(Animation.pHierarchy);
         PreProcessAnimationHierarchy(Animation.pHierarchy);
     }
+
+    return true;
 }
 
 void CClientIFP::ReadIFPVersion2(bool bAnp3)

--- a/Client/mods/deathmatch/logic/CClientIFP.h
+++ b/Client/mods/deathmatch/logic/CClientIFP.h
@@ -220,7 +220,8 @@ public:
 
 private:
     bool ReadIFPByVersion();
-    void ReadIFPVersion1();
+    bool ValidateIFPVersion1() const;
+    bool ReadIFPVersion1();
     void ReadIFPVersion2(bool bAnp3);
 
     WORD         ReadSequencesWithDummies(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy);

--- a/Client/mods/deathmatch/logic/CFileReader.h
+++ b/Client/mods/deathmatch/logic/CFileReader.h
@@ -48,6 +48,10 @@ public:
             return 0;
     }
 
+protected:
+    const SString& GetBuffer() const noexcept { return m_buffer; }
+    std::uint32_t  GetReadOffset() const noexcept { return m_u32BytesReadFromBuffer; }
+
 private:
     SString       m_buffer;
     std::uint32_t m_u32BytesReadFromBuffer;


### PR DESCRIPTION
## **Summary**

Added bounds and structure checks before parsing legacy `ANPK` IFP data.
Malformed chunk sizes, counts, names, and frame data are now rejected instead of being copied into fixed buffers or read past the input.

## **Motivation**

ANPK chunk sizes came directly from the file and were copied into fixed-size parser structures. An oversized INFO chunk could overwrite stack memory and terminate the client with a stack buffer overrun.

For example, a resource might include a custom animation pack and load it through `engineLoadIFP`. If that file is damaged or deliberately malformed, starting the resource could crash the player's client instead of returning a normal load failure.

<details>
<summary>Crash Information</summary>

```text
Exception: 0xC0000409 (Stack Buffer Overrun)
Module: client_d.dll
Offset: 0x0008B7D5
IDA Address: 0x1098B7D5
```

<img width="748" height="501" alt="Crash" src="https://github.com/user-attachments/assets/c39ab111-befe-4c5e-872b-7004b15c71ab" />

The crash was reproduced by loading an ANPK file with a declared and supplied 64-byte INFO payload. The client froze, closed, and displayed an integrity violation. The next launch reported the stack buffer overrun above.

</details>

## Test plan

**Runtime**

- Before Fix: Loading an ANPK with a 64-byte INFO payload through `engineLoadIFP` froze and terminated the Debug client.
- After Fix: Loading the same 80-byte ANPK returned `false`, and the client remained open.
- Valid Case: A normal empty ANPK and a nonempty ANPK with one named animation both loaded successfully.
- Invalid Cases: Truncated INFO and oversized NAME, DGAN INFO, and ANIM payloads returned `false` without crashing.

**Builds and Tests**

- `Debug | Win32`: Build passed, 304 client tests passed.
- `Release | Win32`: Build passed, 304 client tests passed.
- `Debug | x64`: Server build passed.
- Ran `clang-format`.

## Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.