### PR TITLE
Fix voice packet spam and very FPS drop

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPlayerVoice.cpp
+++ b/Client/mods/deathmatch/logic/CClientPlayerVoice.cpp
@@ -147,7 +147,9 @@ void CClientPlayerVoice::DecodeAndBuffer(const unsigned char* voiceBuffer, unsig
     speex_bits_init(&speexBits);
 
     speex_bits_read_from(&speexBits, reinterpret_cast<const char*>(voiceBuffer), voiceBufferLength);
-    speex_decode_int(m_pSpeexDecoderState, &speexBits, (spx_int16_t*)pTempBuffer);
+    int result = speex_decode_int(m_pSpeexDecoderState, &speexBits, (spx_int16_t*)pTempBuffer);
+    if (result < 0)
+        return;
 
     speex_bits_destroy(&speexBits);
 

--- a/Server/mods/deathmatch/logic/CPlayer.h
+++ b/Server/mods/deathmatch/logic/CPlayer.h
@@ -263,6 +263,9 @@ public:
     bool GetTeleported() const noexcept { return m_teleported; }
     void SetTeleported(bool state) noexcept { m_teleported = state; }
 
+    std::time_t GetLastSendVoiceData() const noexcept { return m_lastSendVoiceData; }
+    void        SetLastSendVoiceData(std::time_t lastSendVoiceData) noexcept { m_lastSendVoiceData = lastSendVoiceData; }
+
 protected:
     bool ReadSpecialData(const int iLine) override { return true; }
 
@@ -463,4 +466,6 @@ private:
     SString m_strQuitReasonForLog;
 
     bool m_teleported = false;
+
+    std::time_t m_lastSendVoiceData{};
 };

--- a/Server/mods/deathmatch/logic/packets/CVoiceDataPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CVoiceDataPacket.cpp
@@ -13,49 +13,44 @@
 #include "CVoiceDataPacket.h"
 #include "CPlayer.h"
 
-CVoiceDataPacket::CVoiceDataPacket()
-{
-    m_voiceBuffer.reserve(2048);
-}
-
 bool CVoiceDataPacket::Read(NetBitStreamInterface& BitStream)
 {
+    if (!m_pSourceElement)
+        return false;
+
+    auto player = GetSourcePlayer();
+
+    auto now = GetTickCount64_(), last = player->GetLastSendVoiceData();
+    if (now - last < 100)
+        return false;
+
+    player->SetLastSendVoiceData(now);
+
     unsigned short voiceBufferLength{};
+    if (!BitStream.Read(voiceBufferLength))
+        return false;
+    
+    if (voiceBufferLength > MAX_VOICE_BUFFER)
+        return false;
 
-    if (BitStream.Read(voiceBufferLength) && voiceBufferLength <= m_voiceBuffer.capacity())
-    {
-        m_voiceBuffer.resize(voiceBufferLength);
-        return BitStream.Read(reinterpret_cast<char*>(m_voiceBuffer.data()), m_voiceBuffer.size());
-    }
-
-    return false;
+    m_voiceBuffer.resize(voiceBufferLength);
+    return BitStream.Read(reinterpret_cast<char*>(m_voiceBuffer.data()), m_voiceBuffer.size());
 }
 
 bool CVoiceDataPacket::Write(NetBitStreamInterface& BitStream) const
 {
-    if (!m_voiceBuffer.empty())
-    {
-        const auto voiceBuffer = reinterpret_cast<const char*>(m_voiceBuffer.data());
-        const auto voiceBufferLength = static_cast<uint16_t>(m_voiceBuffer.size());
+    if (m_voiceBuffer.empty())
+        return false;
 
-        // Write the source player
-        BitStream.Write(m_pSourceElement->GetID());
-        // Write the length as an unsigned short and then write the string
-        BitStream.Write(voiceBufferLength);
-        BitStream.Write(voiceBuffer, voiceBufferLength);
-        return true;
-    }
+    const auto voiceBuffer = reinterpret_cast<const char*>(m_voiceBuffer.data());
+    const auto voiceBufferLength = static_cast<uint16_t>(m_voiceBuffer.size());
 
-    return false;
-}
+    // Write the source player
+    BitStream.Write(m_pSourceElement->GetID());
 
-void CVoiceDataPacket::SetVoiceData(const unsigned char* voiceBuffer, unsigned short voiceBufferLength)
-{
-    m_voiceBuffer.clear();
+    // Write the length as an unsigned short and then write the string
+    BitStream.Write(voiceBufferLength);
+    BitStream.Write(voiceBuffer, voiceBufferLength);
 
-    if (!voiceBuffer || !voiceBufferLength || voiceBufferLength > m_voiceBuffer.capacity())
-        return;
-
-    m_voiceBuffer.resize(voiceBufferLength);
-    std::copy_n(voiceBuffer, voiceBufferLength, m_voiceBuffer.data());
+    return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CVoiceDataPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CVoiceDataPacket.h
@@ -14,19 +14,17 @@
 #include "CPacket.h"
 #include <vector>
 
+constexpr auto MAX_VOICE_BUFFER = 2048;
+
 class CVoiceDataPacket final : public CPacket
 {
 public:
-    CVoiceDataPacket();
-
     ePacketID               GetPacketID() const { return PACKET_ID_VOICE_DATA; }
     unsigned long           GetFlags() const { return PACKET_LOW_PRIORITY | PACKET_SEQUENCED; };
     virtual ePacketOrdering GetPacketOrdering() const { return PACKET_ORDERING_VOICE; }
 
     bool Read(NetBitStreamInterface& BitStream);
     bool Write(NetBitStreamInterface& BitStream) const;
-
-    void SetVoiceData(const unsigned char* voiceBuffer, unsigned short voiceBufferLength);
 
     bool IsEmpty() const noexcept { return m_voiceBuffer.empty(); }
 


### PR DESCRIPTION
Hello again!

You may choose not to pay attention to my PR, but I'd really appreciate it if you could review it because it fixes a vulnerability in the MTA client.

This fix addresses the FPS drops (up to the point where the client freezes) that occur when cheaters spam voice chat packets, causing nearby players' games to freeze or stutter due to `BASS_StreamPutData` slowing down execution.

I moved the `100 ms` cooldown check from the client, made a few adjustments to `CVoiceDataPacket`, and added a check for the return value of `speex_decode_int`.

I also removed the `reserve` call and the `CVoiceDataPacket` constructor so that memory is only allocated if the `100 ms` interval has elapsed.

This vulnerability has already been exploited by cheaters on NEXTRP and other projects, as I was told.

Thanks for taking the time to read this!😄