### PR TITLE
Fix settings restart prompt lost after language/skin change

### DIFF
--- a/Client/core/CGUI.cpp
+++ b/Client/core/CGUI.cpp
@@ -45,6 +45,7 @@ CLocalGUI::CLocalGUI()
     m_LastSettingsRevision = -1;
     m_LocaleChangeCounter = 0;
     m_bHasQueuedLocaleChange = false;
+    m_bPendingRestartPrompt = false;
 }
 
 CLocalGUI::~CLocalGUI()
@@ -104,6 +105,8 @@ void CLocalGUI::SetSkin(const char* szName)
         CreateWindows(guiWasLoaded);
         m_pConsole->SetPosition(consolePos);
         m_pConsole->SetSize(consoleSize);
+        // QuestionBox was destroyed with MainMenu; re-show if settings still need a restart
+        TryShowRestartPrompt();
     }
 
     if (CCore::GetSingleton().GetConsole() && !error.empty())
@@ -143,6 +146,8 @@ void CLocalGUI::ChangeLocale(const char* szName)
         CreateWindows(guiWasLoaded);
         m_pConsole->SetPosition(consolePos);
         m_pConsole->SetSize(consoleSize);
+        // QuestionBox was destroyed with MainMenu; re-show if settings still need a restart
+        TryShowRestartPrompt();
     }
 }
 
@@ -247,6 +252,59 @@ void CLocalGUI::RequestLocaleChange(const SString& strLocale)
         CVARS_SET("locale", m_LastLocaleName);
 }
 
+void CLocalGUI::RequestRestartPrompt()
+{
+    m_bPendingRestartPrompt = true;
+    TryShowRestartPrompt();
+}
+
+void CLocalGUI::TryShowRestartPrompt()
+{
+    if (!m_bPendingRestartPrompt || !m_pMainMenu)
+        return;
+
+    // Wait until locale/skin rebuilds finish so the prompt is not destroyed with MainMenu
+    if (m_bHasQueuedLocaleChange)
+        return;
+
+    SString strCurrentSkinName;
+    CVARS_GET("current_skin", strCurrentSkinName);
+    if (!strCurrentSkinName.empty() && strCurrentSkinName != m_LastSkinName)
+        return;
+
+    CQuestionBox* pQuestionBox = m_pMainMenu->GetQuestionWindow();
+    if (pQuestionBox->IsVisible())
+        return;
+
+    SString strMessage = _("Some settings will be changed when you next start MTA");
+    strMessage += _("\n\nDo you want to restart now?");
+    pQuestionBox->Reset();
+    pQuestionBox->SetTitle(_("RESTART REQUIRED"));
+    pQuestionBox->SetMessage(strMessage);
+    pQuestionBox->SetButton(0, _("No"));
+    pQuestionBox->SetButton(1, _("Yes"));
+    pQuestionBox->SetCallback(RestartPromptCallBack);
+    pQuestionBox->Show();
+}
+
+void CLocalGUI::RestartPromptCallBack(void* pData, unsigned int uiButton)
+{
+    CLocalGUI* pLocalGUI = CLocalGUI::GetSingletonPtr();
+    if (!pLocalGUI)
+        return;
+
+    if (CMainMenu* pMainMenu = pLocalGUI->GetMainMenu())
+        pMainMenu->GetQuestionWindow()->Reset();
+
+    pLocalGUI->ClearRestartPrompt();
+
+    if (uiButton == 1)
+    {
+        SetOnQuitCommand("restart");
+        CCore::GetSingleton().Quit();
+    }
+}
+
 void CLocalGUI::ApplyQueuedLocale()
 {
     if (!m_bHasQueuedLocaleChange)
@@ -347,6 +405,9 @@ void CLocalGUI::DoPulse()
         if (m_LocaleChangeCounter >= 5)
             ApplyQueuedLocale();
     }
+
+    // Show after any deferred locale/skin work so a prior prompt is not lost
+    TryShowRestartPrompt();
 }
 
 void CLocalGUI::Draw()

--- a/Client/core/CGUI.h
+++ b/Client/core/CGUI.h
@@ -94,9 +94,17 @@ public:
 
     void RequestLocaleChange(const SString& strLocale);
 
+    // Locale/skin changes destroy MainMenu (and its QuestionBox). Keep the restart
+    // requirement across that rebuild so resolution/etc. prompts are not lost.
+    void RequestRestartPrompt();
+
 private:
     void UpdateCursor();
     void ApplyQueuedLocale();
+    void TryShowRestartPrompt();
+    void ClearRestartPrompt() { m_bPendingRestartPrompt = false; }
+
+    static void RestartPromptCallBack(void* pData, unsigned int uiButton);
 
     DWORD TranslateScanCodeToGUIKey(DWORD dwCharacter);
 
@@ -123,4 +131,5 @@ private:
     uint    m_LocaleChangeCounter;
     SString m_QueuedLocaleChange;
     bool    m_bHasQueuedLocaleChange;
+    bool    m_bPendingRestartPrompt;
 };

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -2096,29 +2096,10 @@ void CSettings::DestroyGUI()
     ResetGuiPointers();
 }
 
-void RestartCallBack(void* ptr, unsigned int uiButton)
-{
-    CCore::GetSingleton().GetLocalGUI()->GetMainMenu()->GetQuestionWindow()->Reset();
-
-    if (uiButton == 1)
-    {
-        SetOnQuitCommand("restart");
-        CCore::GetSingleton().Quit();
-    }
-}
-
 void CSettings::ShowRestartQuestion()
 {
-    SString strMessage = _("Some settings will be changed when you next start MTA");
-    strMessage += _("\n\nDo you want to restart now?");
-    CQuestionBox* pQuestionBox = CCore::GetSingleton().GetLocalGUI()->GetMainMenu()->GetQuestionWindow();
-    pQuestionBox->Reset();
-    pQuestionBox->SetTitle(_("RESTART REQUIRED"));
-    pQuestionBox->SetMessage(strMessage);
-    pQuestionBox->SetButton(0, _("No"));
-    pQuestionBox->SetButton(1, _("Yes"));
-    pQuestionBox->SetCallback(RestartCallBack);
-    pQuestionBox->Show();
+    // Persist across Interface locale/skin rebuilds (they destroy MainMenu's QuestionBox)
+    CLocalGUI::GetSingleton().RequestRestartPrompt();
 }
 
 void DisconnectCallback(void* ptr, unsigned int uiButton)


### PR DESCRIPTION
#### Summary
Persist the settings "restart required" prompt across Interface tab locale/skin rebuilds so changing resolution (or other restart-required options) still prompts after switching language/skin.

Previously `ShowRestartQuestion()` showed a `QuestionBox` owned by `MainMenu`. Changing language or skin destroys and recreates `MainMenu`, which dropped that prompt. The restart requirement is now tracked on `CLocalGUI` and re-shown after the UI rebuild.

#### Motivation
Fixes #5063 
When a user changed screen resolution in Video settings, then switched to the Interface tab and changed language (or skin), closing settings no longer asked to restart — even though the resolution change still required one.

Root cause: locale/skin changes call `DestroyWindows()` / `CreateWindows()`, which replaces `MainMenu` and its `QuestionBox`, so the restart dialog was lost and never restored.

#### Test plan
1. Open Settings → Video → change resolution only → OK → restart prompt appears.
2. Open Settings → Video → change resolution → Interface → change language → OK → after language reload, **RESTART REQUIRED** appears in the new language.
3. Repeat step 2 with a skin change instead of language → restart prompt appears after the UI rebuild.
4. Change language only (no restart-required setting) → no restart prompt.
5. On the restart prompt, choose **No** → client continues; choose **Yes** → client restarts.
6. Confirm dialog strings match the existing locale translations.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.