### PR TITLE
Show current and required versions in server update dialogs

### DIFF
--- a/Client/core/CVersionUpdater.cpp
+++ b/Client/core/CVersionUpdater.cpp
@@ -1914,10 +1914,12 @@ void CVersionUpdater::_DialogDownloading()
 ///////////////////////////////////////////////////////////////
 void CVersionUpdater::_DialogServerSaysUpdateQuestion()
 {
-    // Display message
+    // Include both versions so players can update manually if the auto-updater fails
+    // (e.g. blocked mirrors).
     GetQuestionBox().Reset();
     GetQuestionBox().SetTitle(_("MANDATORY UPDATE"));
-    GetQuestionBox().SetMessage(_("To join this server, you must update MTA.\n\n Do you want to update now ?"));
+    GetQuestionBox().SetMessage(SString(_("This server requires version %s.\nYou are currently running version %s.\n\nDo you want to update now?"),
+                                        *m_strServerSaysData, *GetProductVersion()));
     GetQuestionBox().SetButton(0, _("No"));
     GetQuestionBox().SetButton(1, _("Yes"));
     GetQuestionBox().Show();
@@ -1933,10 +1935,13 @@ void CVersionUpdater::_DialogServerSaysUpdateQuestion()
 ///////////////////////////////////////////////////////////////
 void CVersionUpdater::_DialogServerSaysRecommendQuestion()
 {
-    // Display message
+    // Include both versions so players can update manually if the auto-updater fails
+    // (e.g. blocked mirrors).
     GetQuestionBox().Reset();
     GetQuestionBox().SetTitle(_("OPTIONAL UPDATE"));
-    GetQuestionBox().SetMessage(_("Server says an update is recommended, but not essential.\n\n Do you want to update now ?"));
+    GetQuestionBox().SetMessage(
+        SString(_("This server recommends version %s, but it is not essential.\nYou are currently running version %s.\n\nDo you want to update now?"),
+                *m_strServerSaysData, *GetProductVersion()));
     GetQuestionBox().SetButton(0, _("No"));
     GetQuestionBox().SetButton(1, _("Yes"));
     GetQuestionBox().Show();


### PR DESCRIPTION
#### Summary
Show the server's required/recommended version and the client's current version in the mandatory and optional update dialogs (`CVersionUpdater`).

#### Motivation
The update dialogs only said "you must update" / "update is recommended" without showing which version the server needs or which version the client is running. This makes it hard to update manually when the auto-updater fails.

Fixes #4790.

#### Test plan
1. Build the client.
2. Connect to a server whose `minclientversion` is higher than the client and confirm the mandatory dialog shows both the required and current versions, and that Yes/No still starts or cancels the update flow.
3. Connect to a server whose `recommendedclientversion` is higher than the client and confirm the optional dialog shows both the recommended and current versions, and that Yes/No still starts or cancels the update flow.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.