### PR TITLE
Fix vehicle headlights not lighting other vehicles

### DIFF
--- a/Client/core/Graphics/CRenderItem.EffectParameters.cpp
+++ b/Client/core/Graphics/CRenderItem.EffectParameters.cpp
@@ -579,13 +579,17 @@ bool CEffectParameters::ApplyCommonHandles()
         D3DXCOLOR   strongestDiffuse(0, 0, 0, 0);
         D3DXCOLOR   strongestSpecular(0, 0, 0, 0);
         D3DXVECTOR3 strongestDirection(0, 0, -1);
-        for (uint i = 0; i < 4; i++)
+        // The vehicle pipeline reserves slot 7 for its specular directional
+        // light. Include it without broadening the existing selection of GTA's
+        // temporary world lights in slots 0 through 3.
+        constexpr DWORD COMMON_EFFECT_LIGHT_SLOTS[] = {0, 1, 2, 3, 7};
+        for (const DWORD lightSlot : COMMON_EFFECT_LIGHT_SLOTS)
         {
             BOOL bEnabled;
-            if (SUCCEEDED(pDevice->GetLightEnable(i, &bEnabled)) && bEnabled)
+            if (SUCCEEDED(pDevice->GetLightEnable(lightSlot, &bEnabled)) && bEnabled)
             {
                 D3DLIGHT9 D3DLight;
-                pDevice->GetLight(i, &D3DLight);
+                pDevice->GetLight(lightSlot, &D3DLight);
                 if (D3DLight.Type == D3DLIGHT_DIRECTIONAL)
                 {
                     totalAmbient += D3DLight.Ambient;

--- a/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
@@ -936,6 +936,15 @@ static void __declspec(naked) HOOK_CRenderer_EverythingBarRoads()
 //////////////////////////////////////////////////////////////////////////////////////////
 void CMultiplayerSA::InitHooks_Rendering()
 {
+    // GTA assigns main-world temporary directional lights to slots 1 through 6,
+    // but the vehicle env-map pipeline overwrites slot 1 with its specular light.
+    // Reserve slot 7 for the specular light so headlights can illuminate vehicle
+    // materials without being discarded immediately before the draw.
+    constexpr BYTE VEHICLE_SPECULAR_LIGHT_SLOT = 7;
+    MemPut<BYTE>(0x5D9A88, VEHICLE_SPECULAR_LIGHT_SLOT);  // RwD3D9SetLight
+    MemPut<BYTE>(0x5D9A91, VEHICLE_SPECULAR_LIGHT_SLOT);  // RwD3D9EnableLight(TRUE)
+    MemPut<BYTE>(0x5D9F1F, VEHICLE_SPECULAR_LIGHT_SLOT);  // RwD3D9EnableLight(FALSE)
+
     EZHookInstall(CallIdle);
     EZHookInstall(CEntity_Render);
     EZHookInstall(CEntity_RenderOneNonRoad);


### PR DESCRIPTION
#### Summary
Move the vehicle specular light from direct3d slot 1 to slot 7.

Slot 1 is also used for the first temporary directional light, so the vehicle pipeline was overwriting the incoming headlights before render the vehicle. Slot 7 is also added in common `LIGHT*` shader parameters to not break custom shaders.

#### Motivation
Fixes #4636.

#### Test plan
I reproduced the same scenario as in the issue video. The video below shows the result after the fix.


https://github.com/user-attachments/assets/01866dac-b1d3-43ee-b65c-5122e9c7f15b



#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
