### PR TITLE
Fix OOP definitions to return vectors for listed APIs

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -252,8 +252,8 @@ void CLuaGUIDefs::AddGuiElementClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getEnabled", "guiGetEnabled");
     lua_classfunction(luaVM, "getVisible", "guiGetVisible");
     lua_classfunction(luaVM, "getText", "guiGetText");
-    lua_classfunction(luaVM, "getPosition", OOP_GUIGetPosition);
-    lua_classfunction(luaVM, "getSize", OOP_GUIGetSize);
+    lua_classfunction(luaVM, "getPosition", ArgumentParserWarn<false, OOP_GUIGetPosition>);
+    lua_classfunction(luaVM, "getSize", ArgumentParserWarn<false, OOP_GUIGetSize>);
     lua_classfunction(luaVM, "getProperty", "guiGetProperty");
 
     lua_classfunction(luaVM, "setInputEnabled", "guiSetInputEnabled");
@@ -283,8 +283,8 @@ void CLuaGUIDefs::AddGuiElementClass(lua_State* luaVM)
     lua_classvariable(luaVM, "alpha", "guiSetAlpha", "guiGetAlpha");
     lua_classvariable(luaVM, "enabled", "guiSetEnabled", "guiGetEnabled");
     lua_classvariable(luaVM, "text", "guiSetText", "guiGetText");
-    lua_classvariable(luaVM, "size", OOP_GUISetSize, OOP_GUIGetSize);
-    lua_classvariable(luaVM, "position", OOP_GUISetPosition, OOP_GUIGetPosition);
+    lua_classvariable(luaVM, "size", ArgumentParserWarn<false, OOP_GUISetSize>, ArgumentParserWarn<false, OOP_GUIGetSize>);
+    lua_classvariable(luaVM, "position", ArgumentParserWarn<false, OOP_GUISetPosition>, ArgumentParserWarn<false, OOP_GUIGetPosition>);
     lua_classvariable(luaVM, "chatboxCharacterLimit", "setChatboxCharacterLimit", "getChatboxCharacterLimit");
 
     lua_registerclass(luaVM, "GuiElement", "Element");
@@ -385,10 +385,10 @@ void CLuaGUIDefs::AddGuiImageClass(lua_State* luaVM)
 
     lua_classfunction(luaVM, "create", "guiCreateStaticImage");
     lua_classfunction(luaVM, "loadImage", "guiStaticImageLoadImage");
-    lua_classfunction(luaVM, "getNativeSize", OOP_GUIStaticImageGetNativeSize);
+    lua_classfunction(luaVM, "getNativeSize", ArgumentParserWarn<false, OOP_GUIStaticImageGetNativeSize>);
 
     lua_classvariable(luaVM, "image", "guiStaticImageLoadImage", NULL);
-    lua_classvariable(luaVM, "nativeSize", nullptr, OOP_GUIStaticImageGetNativeSize);
+    lua_classvariable(luaVM, "nativeSize", nullptr, ArgumentParserWarn<false, OOP_GUIStaticImageGetNativeSize>);
 
     lua_registerclass(luaVM, "GuiStaticImage", "GuiElement");
 }
@@ -1228,28 +1228,13 @@ int CLuaGUIDefs::GUIStaticImageGetNativeSize(lua_State* luaVM)
     return 1;
 }
 
-int CLuaGUIDefs::OOP_GUIStaticImageGetNativeSize(lua_State* luaVM)
+std::variant<bool, CVector2D> CLuaGUIDefs::OOP_GUIStaticImageGetNativeSize(CClientGUIElement* theElement)
 {
-    //  vector2 guiStaticImageGetNativeSize ( element theElement )
-    CClientGUIElement* theElement;
-    CVector2D          vecSize;
+    CVector2D vecSize;
+    if (!CStaticFunctionDefinitions::GUIStaticImageGetNativeSize(*theElement, vecSize))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(theElement);
-
-    if (!argStream.HasErrors())
-        if (CStaticFunctionDefinitions::GUIStaticImageGetNativeSize(*theElement, vecSize))
-        {
-            lua_pushvector(luaVM, vecSize);
-            return 1;
-        }
-
-    if (argStream.HasErrors())
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    // error: bad arguments
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecSize;
 }
 
 int CLuaGUIDefs::GUICreateTab(lua_State* luaVM)
@@ -1806,30 +1791,11 @@ int CLuaGUIDefs::GUIGetSize(lua_State* luaVM)
     return 1;
 }
 
-int CLuaGUIDefs::OOP_GUIGetSize(lua_State* luaVM)
+CVector2D CLuaGUIDefs::OOP_GUIGetSize(CClientGUIElement* theElement, std::optional<bool> relative)
 {
-    //  vector2 guiGetSize ( element theElement [, bool relative = false ] )
-    CClientGUIElement* theElement;
-    bool               relative;
-
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(theElement);
-    argStream.ReadBool(relative, false);
-
-    if (!argStream.HasErrors())
-    {
-        CVector2D Size;
-        theElement->GetCGUIElement()->GetSize(Size, relative);
-
-        lua_pushvector(luaVM, Size);
-        return 1;
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    // error: bad arguments
-    lua_pushboolean(luaVM, false);
-    return 1;
+    CVector2D size;
+    theElement->GetCGUIElement()->GetSize(size, relative.value_or(false));
+    return size;
 }
 
 int CLuaGUIDefs::GUIGetScreenSize(lua_State* luaVM)
@@ -1868,30 +1834,11 @@ int CLuaGUIDefs::GUIGetPosition(lua_State* luaVM)
     return 1;
 }
 
-int CLuaGUIDefs::OOP_GUIGetPosition(lua_State* luaVM)
+CVector2D CLuaGUIDefs::OOP_GUIGetPosition(CClientGUIElement* guiElement, std::optional<bool> relative)
 {
-    //  vector2 guiGetPosition ( element guiElement [, bool relative = false ] )
-    CClientGUIElement* guiElement;
-    bool               relative;
-
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(guiElement);
-    argStream.ReadBool(relative, false);
-
-    if (!argStream.HasErrors())
-    {
-        CVector2D Pos;
-        guiElement->GetCGUIElement()->GetPosition(Pos, relative);
-
-        lua_pushvector(luaVM, Pos);
-        return 1;
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    // error: bad arguments
-    lua_pushboolean(luaVM, false);
-    return 1;
+    CVector2D pos;
+    guiElement->GetCGUIElement()->GetPosition(pos, relative.value_or(false));
+    return pos;
 }
 
 int CLuaGUIDefs::GUISetAlpha(lua_State* luaVM)
@@ -2181,29 +2128,10 @@ int CLuaGUIDefs::GUISetSize(lua_State* luaVM)
     return 1;
 }
 
-int CLuaGUIDefs::OOP_GUISetSize(lua_State* luaVM)
+bool CLuaGUIDefs::OOP_GUISetSize(CClientGUIElement* guiElement, CVector2D vecSize, std::optional<bool> relative)
 {
-    //  bool guiSetSize ( element guiElement, vector2 size [, bool relative = false ] )
-    CClientGUIElement* guiElement;
-    CVector2D          vecSize;
-    bool               relative;
-
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(guiElement);
-    argStream.ReadVector2D(vecSize);
-    argStream.ReadBool(relative, false);
-
-    if (!argStream.HasErrors())
-    {
-        CStaticFunctionDefinitions::GUISetSize(*guiElement, vecSize, relative);
-        lua_pushboolean(luaVM, true);
-        return 1;
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    CStaticFunctionDefinitions::GUISetSize(*guiElement, vecSize, relative.value_or(false));
+    return true;
 }
 
 int CLuaGUIDefs::GUISetPosition(lua_State* luaVM)
@@ -2234,29 +2162,10 @@ int CLuaGUIDefs::GUISetPosition(lua_State* luaVM)
     return 1;
 }
 
-int CLuaGUIDefs::OOP_GUISetPosition(lua_State* luaVM)
+bool CLuaGUIDefs::OOP_GUISetPosition(CClientGUIElement* guiElement, CVector2D vecPosition, std::optional<bool> relative)
 {
-    //  bool guiSetPosition ( element guiElement, vector2 position [, bool relative = false ] )
-    CClientGUIElement* guiElement;
-    CVector2D          vecPosition;
-    bool               relative;
-
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(guiElement);
-    argStream.ReadVector2D(vecPosition);
-    argStream.ReadBool(relative, false);
-
-    if (!argStream.HasErrors())
-    {
-        CStaticFunctionDefinitions::GUISetPosition(*guiElement, vecPosition, relative);
-        lua_pushboolean(luaVM, true);
-        return 1;
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    CStaticFunctionDefinitions::GUISetPosition(*guiElement, vecPosition, relative.value_or(false));
+    return true;
 }
 
 int CLuaGUIDefs::GUIGridListSetSortingEnabled(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -223,7 +223,6 @@ void CLuaGUIDefs::AddClass(lua_State* luaVM)
     AddGuiTabClass(luaVM);
 }
 
-// TODO: vector class
 void CLuaGUIDefs::AddGuiElementClass(lua_State* luaVM)
 {
     lua_newclass(luaVM);
@@ -253,8 +252,8 @@ void CLuaGUIDefs::AddGuiElementClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getEnabled", "guiGetEnabled");
     lua_classfunction(luaVM, "getVisible", "guiGetVisible");
     lua_classfunction(luaVM, "getText", "guiGetText");
-    lua_classfunction(luaVM, "getPosition", "guiGetPosition");
-    lua_classfunction(luaVM, "getSize", "guiGetSize");
+    lua_classfunction(luaVM, "getPosition", OOP_GUIGetPosition);
+    lua_classfunction(luaVM, "getSize", OOP_GUIGetSize);
     lua_classfunction(luaVM, "getProperty", "guiGetProperty");
 
     lua_classfunction(luaVM, "setInputEnabled", "guiSetInputEnabled");
@@ -284,8 +283,8 @@ void CLuaGUIDefs::AddGuiElementClass(lua_State* luaVM)
     lua_classvariable(luaVM, "alpha", "guiSetAlpha", "guiGetAlpha");
     lua_classvariable(luaVM, "enabled", "guiSetEnabled", "guiGetEnabled");
     lua_classvariable(luaVM, "text", "guiSetText", "guiGetText");
-    lua_classvariable(luaVM, "size", "guiSetSize", "guiGetSize");
-    lua_classvariable(luaVM, "position", "guiSetPosition", "guiGetPosition");
+    lua_classvariable(luaVM, "size", OOP_GUISetSize, OOP_GUIGetSize);
+    lua_classvariable(luaVM, "position", OOP_GUISetPosition, OOP_GUIGetPosition);
     lua_classvariable(luaVM, "chatboxCharacterLimit", "setChatboxCharacterLimit", "getChatboxCharacterLimit");
 
     lua_registerclass(luaVM, "GuiElement", "Element");
@@ -386,9 +385,10 @@ void CLuaGUIDefs::AddGuiImageClass(lua_State* luaVM)
 
     lua_classfunction(luaVM, "create", "guiCreateStaticImage");
     lua_classfunction(luaVM, "loadImage", "guiStaticImageLoadImage");
-    lua_classfunction(luaVM, "getNativeSize", "guiStaticImageGetNativeSize");
+    lua_classfunction(luaVM, "getNativeSize", OOP_GUIStaticImageGetNativeSize);
 
     lua_classvariable(luaVM, "image", "guiStaticImageLoadImage", NULL);
+    lua_classvariable(luaVM, "nativeSize", nullptr, OOP_GUIStaticImageGetNativeSize);
 
     lua_registerclass(luaVM, "GuiStaticImage", "GuiElement");
 }
@@ -1228,6 +1228,30 @@ int CLuaGUIDefs::GUIStaticImageGetNativeSize(lua_State* luaVM)
     return 1;
 }
 
+int CLuaGUIDefs::OOP_GUIStaticImageGetNativeSize(lua_State* luaVM)
+{
+    //  vector2 guiStaticImageGetNativeSize ( element theElement )
+    CClientGUIElement* theElement;
+    CVector2D          vecSize;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(theElement);
+
+    if (!argStream.HasErrors())
+        if (CStaticFunctionDefinitions::GUIStaticImageGetNativeSize(*theElement, vecSize))
+        {
+            lua_pushvector(luaVM, vecSize);
+            return 1;
+        }
+
+    if (argStream.HasErrors())
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    // error: bad arguments
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
 int CLuaGUIDefs::GUICreateTab(lua_State* luaVM)
 {
     //  element guiCreateTab ( string text, element parent )
@@ -1782,6 +1806,32 @@ int CLuaGUIDefs::GUIGetSize(lua_State* luaVM)
     return 1;
 }
 
+int CLuaGUIDefs::OOP_GUIGetSize(lua_State* luaVM)
+{
+    //  vector2 guiGetSize ( element theElement [, bool relative = false ] )
+    CClientGUIElement* theElement;
+    bool               relative;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(theElement);
+    argStream.ReadBool(relative, false);
+
+    if (!argStream.HasErrors())
+    {
+        CVector2D Size;
+        theElement->GetCGUIElement()->GetSize(Size, relative);
+
+        lua_pushvector(luaVM, Size);
+        return 1;
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    // error: bad arguments
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
 int CLuaGUIDefs::GUIGetScreenSize(lua_State* luaVM)
 {
     const CVector2D Size = CStaticFunctionDefinitions::GUIGetScreenSize();
@@ -1809,6 +1859,32 @@ int CLuaGUIDefs::GUIGetPosition(lua_State* luaVM)
         lua_pushnumber(luaVM, Pos.fX);
         lua_pushnumber(luaVM, Pos.fY);
         return 2;
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    // error: bad arguments
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaGUIDefs::OOP_GUIGetPosition(lua_State* luaVM)
+{
+    //  vector2 guiGetPosition ( element guiElement [, bool relative = false ] )
+    CClientGUIElement* guiElement;
+    bool               relative;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(guiElement);
+    argStream.ReadBool(relative, false);
+
+    if (!argStream.HasErrors())
+    {
+        CVector2D Pos;
+        guiElement->GetCGUIElement()->GetPosition(Pos, relative);
+
+        lua_pushvector(luaVM, Pos);
+        return 1;
     }
     else
         m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
@@ -2105,6 +2181,31 @@ int CLuaGUIDefs::GUISetSize(lua_State* luaVM)
     return 1;
 }
 
+int CLuaGUIDefs::OOP_GUISetSize(lua_State* luaVM)
+{
+    //  bool guiSetSize ( element guiElement, vector2 size [, bool relative = false ] )
+    CClientGUIElement* guiElement;
+    CVector2D          vecSize;
+    bool               relative;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(guiElement);
+    argStream.ReadVector2D(vecSize);
+    argStream.ReadBool(relative, false);
+
+    if (!argStream.HasErrors())
+    {
+        CStaticFunctionDefinitions::GUISetSize(*guiElement, vecSize, relative);
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
 int CLuaGUIDefs::GUISetPosition(lua_State* luaVM)
 {
     //  bool guiSetPosition ( element guiElement, float x, float y, bool relative )
@@ -2129,6 +2230,31 @@ int CLuaGUIDefs::GUISetPosition(lua_State* luaVM)
         m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
 
     // error: bad arguments
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaGUIDefs::OOP_GUISetPosition(lua_State* luaVM)
+{
+    //  bool guiSetPosition ( element guiElement, vector2 position [, bool relative = false ] )
+    CClientGUIElement* guiElement;
+    CVector2D          vecPosition;
+    bool               relative;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(guiElement);
+    argStream.ReadVector2D(vecPosition);
+    argStream.ReadBool(relative, false);
+
+    if (!argStream.HasErrors())
+    {
+        CStaticFunctionDefinitions::GUISetPosition(*guiElement, vecPosition, relative);
+        lua_pushboolean(luaVM, true);
+        return 1;
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
     lua_pushboolean(luaVM, false);
     return 1;
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -252,8 +252,8 @@ void CLuaGUIDefs::AddGuiElementClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getEnabled", "guiGetEnabled");
     lua_classfunction(luaVM, "getVisible", "guiGetVisible");
     lua_classfunction(luaVM, "getText", "guiGetText");
-    lua_classfunction(luaVM, "getPosition", ArgumentParserWarn<false, OOP_GUIGetPosition>);
-    lua_classfunction(luaVM, "getSize", ArgumentParserWarn<false, OOP_GUIGetSize>);
+    lua_classfunction(luaVM, "getPosition", OOP_GUIGetPosition);
+    lua_classfunction(luaVM, "getSize", OOP_GUIGetSize);
     lua_classfunction(luaVM, "getProperty", "guiGetProperty");
 
     lua_classfunction(luaVM, "setInputEnabled", "guiSetInputEnabled");
@@ -283,8 +283,8 @@ void CLuaGUIDefs::AddGuiElementClass(lua_State* luaVM)
     lua_classvariable(luaVM, "alpha", "guiSetAlpha", "guiGetAlpha");
     lua_classvariable(luaVM, "enabled", "guiSetEnabled", "guiGetEnabled");
     lua_classvariable(luaVM, "text", "guiSetText", "guiGetText");
-    lua_classvariable(luaVM, "size", ArgumentParserWarn<false, OOP_GUISetSize>, ArgumentParserWarn<false, OOP_GUIGetSize>);
-    lua_classvariable(luaVM, "position", ArgumentParserWarn<false, OOP_GUISetPosition>, ArgumentParserWarn<false, OOP_GUIGetPosition>);
+    lua_classvariable(luaVM, "size", ArgumentParserWarn<false, OOP_GUISetSize>, OOP_GUIGetSize);
+    lua_classvariable(luaVM, "position", ArgumentParserWarn<false, OOP_GUISetPosition>, OOP_GUIGetPosition);
     lua_classvariable(luaVM, "chatboxCharacterLimit", "setChatboxCharacterLimit", "getChatboxCharacterLimit");
 
     lua_registerclass(luaVM, "GuiElement", "Element");
@@ -385,10 +385,10 @@ void CLuaGUIDefs::AddGuiImageClass(lua_State* luaVM)
 
     lua_classfunction(luaVM, "create", "guiCreateStaticImage");
     lua_classfunction(luaVM, "loadImage", "guiStaticImageLoadImage");
-    lua_classfunction(luaVM, "getNativeSize", ArgumentParserWarn<false, OOP_GUIStaticImageGetNativeSize>);
+    lua_classfunction(luaVM, "getNativeSize", OOP_GUIStaticImageGetNativeSize);
 
     lua_classvariable(luaVM, "image", "guiStaticImageLoadImage", NULL);
-    lua_classvariable(luaVM, "nativeSize", nullptr, ArgumentParserWarn<false, OOP_GUIStaticImageGetNativeSize>);
+    lua_classvariable(luaVM, "nativeSize", nullptr, OOP_GUIStaticImageGetNativeSize);
 
     lua_registerclass(luaVM, "GuiStaticImage", "GuiElement");
 }
@@ -1228,13 +1228,36 @@ int CLuaGUIDefs::GUIStaticImageGetNativeSize(lua_State* luaVM)
     return 1;
 }
 
-std::variant<bool, CVector2D> CLuaGUIDefs::OOP_GUIStaticImageGetNativeSize(CClientGUIElement* theElement)
+int CLuaGUIDefs::OOP_GUIStaticImageGetNativeSize(lua_State* luaVM)
 {
-    CVector2D vecSize;
-    if (!CStaticFunctionDefinitions::GUIStaticImageGetNativeSize(*theElement, vecSize))
-        return false;
+    // vector2 guiStaticImageGetNativeSize ( element theElement ) — or 2 floats if the caller expects them
+    CClientGUIElement* theElement;
+    CVector2D          vecSize;
 
-    return vecSize;
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(theElement);
+
+    if (!argStream.HasErrors())
+    {
+        if (CStaticFunctionDefinitions::GUIStaticImageGetNativeSize(*theElement, vecSize))
+        {
+            int iExpected = lua_ncallresult(luaVM);
+            if (iExpected == 2)
+            {
+                lua_pushnumber(luaVM, vecSize.fX);
+                lua_pushnumber(luaVM, vecSize.fY);
+                return 2;
+            }
+
+            lua_pushvector(luaVM, vecSize);
+            return 1;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
 }
 
 int CLuaGUIDefs::GUICreateTab(lua_State* luaVM)
@@ -1791,11 +1814,37 @@ int CLuaGUIDefs::GUIGetSize(lua_State* luaVM)
     return 1;
 }
 
-CVector2D CLuaGUIDefs::OOP_GUIGetSize(CClientGUIElement* theElement, std::optional<bool> relative)
+int CLuaGUIDefs::OOP_GUIGetSize(lua_State* luaVM)
 {
-    CVector2D size;
-    theElement->GetCGUIElement()->GetSize(size, relative.value_or(false));
-    return size;
+    // vector2 guiGetSize ( element theElement [, bool relative = false ] ) — or 2 floats if the caller expects them
+    CClientGUIElement* theElement;
+    bool               relative;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(theElement);
+    argStream.ReadBool(relative, false);
+
+    if (!argStream.HasErrors())
+    {
+        CVector2D Size;
+        theElement->GetCGUIElement()->GetSize(Size, relative);
+
+        int iExpected = lua_ncallresult(luaVM);
+        if (iExpected == 2)
+        {
+            lua_pushnumber(luaVM, Size.fX);
+            lua_pushnumber(luaVM, Size.fY);
+            return 2;
+        }
+
+        lua_pushvector(luaVM, Size);
+        return 1;
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
 }
 
 int CLuaGUIDefs::GUIGetScreenSize(lua_State* luaVM)
@@ -1834,11 +1883,37 @@ int CLuaGUIDefs::GUIGetPosition(lua_State* luaVM)
     return 1;
 }
 
-CVector2D CLuaGUIDefs::OOP_GUIGetPosition(CClientGUIElement* guiElement, std::optional<bool> relative)
+int CLuaGUIDefs::OOP_GUIGetPosition(lua_State* luaVM)
 {
-    CVector2D pos;
-    guiElement->GetCGUIElement()->GetPosition(pos, relative.value_or(false));
-    return pos;
+    // vector2 guiGetPosition ( element guiElement [, bool relative = false ] ) — or 2 floats if the caller expects them
+    CClientGUIElement* guiElement;
+    bool               relative;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(guiElement);
+    argStream.ReadBool(relative, false);
+
+    if (!argStream.HasErrors())
+    {
+        CVector2D Pos;
+        guiElement->GetCGUIElement()->GetPosition(Pos, relative);
+
+        int iExpected = lua_ncallresult(luaVM);
+        if (iExpected == 2)
+        {
+            lua_pushnumber(luaVM, Pos.fX);
+            lua_pushnumber(luaVM, Pos.fY);
+            return 2;
+        }
+
+        lua_pushvector(luaVM, Pos);
+        return 1;
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
 }
 
 int CLuaGUIDefs::GUISetAlpha(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.cpp
@@ -252,8 +252,8 @@ void CLuaGUIDefs::AddGuiElementClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getEnabled", "guiGetEnabled");
     lua_classfunction(luaVM, "getVisible", "guiGetVisible");
     lua_classfunction(luaVM, "getText", "guiGetText");
-    lua_classfunction(luaVM, "getPosition", OOP_GUIGetPosition);
-    lua_classfunction(luaVM, "getSize", OOP_GUIGetSize);
+    lua_classfunction(luaVM, "getPosition", ArgumentParserWarn<false, OOP_GUIGetPosition>);
+    lua_classfunction(luaVM, "getSize", ArgumentParserWarn<false, OOP_GUIGetSize>);
     lua_classfunction(luaVM, "getProperty", "guiGetProperty");
 
     lua_classfunction(luaVM, "setInputEnabled", "guiSetInputEnabled");
@@ -283,8 +283,8 @@ void CLuaGUIDefs::AddGuiElementClass(lua_State* luaVM)
     lua_classvariable(luaVM, "alpha", "guiSetAlpha", "guiGetAlpha");
     lua_classvariable(luaVM, "enabled", "guiSetEnabled", "guiGetEnabled");
     lua_classvariable(luaVM, "text", "guiSetText", "guiGetText");
-    lua_classvariable(luaVM, "size", ArgumentParserWarn<false, OOP_GUISetSize>, OOP_GUIGetSize);
-    lua_classvariable(luaVM, "position", ArgumentParserWarn<false, OOP_GUISetPosition>, OOP_GUIGetPosition);
+    lua_classvariable(luaVM, "size", ArgumentParserWarn<false, OOP_GUISetSize>, ArgumentParserWarn<false, OOP_GUIGetSize>);
+    lua_classvariable(luaVM, "position", ArgumentParserWarn<false, OOP_GUISetPosition>, ArgumentParserWarn<false, OOP_GUIGetPosition>);
     lua_classvariable(luaVM, "chatboxCharacterLimit", "setChatboxCharacterLimit", "getChatboxCharacterLimit");
 
     lua_registerclass(luaVM, "GuiElement", "Element");
@@ -385,10 +385,10 @@ void CLuaGUIDefs::AddGuiImageClass(lua_State* luaVM)
 
     lua_classfunction(luaVM, "create", "guiCreateStaticImage");
     lua_classfunction(luaVM, "loadImage", "guiStaticImageLoadImage");
-    lua_classfunction(luaVM, "getNativeSize", OOP_GUIStaticImageGetNativeSize);
+    lua_classfunction(luaVM, "getNativeSize", ArgumentParserWarn<false, OOP_GUIStaticImageGetNativeSize>);
 
     lua_classvariable(luaVM, "image", "guiStaticImageLoadImage", NULL);
-    lua_classvariable(luaVM, "nativeSize", nullptr, OOP_GUIStaticImageGetNativeSize);
+    lua_classvariable(luaVM, "nativeSize", nullptr, ArgumentParserWarn<false, OOP_GUIStaticImageGetNativeSize>);
 
     lua_registerclass(luaVM, "GuiStaticImage", "GuiElement");
 }
@@ -1228,36 +1228,17 @@ int CLuaGUIDefs::GUIStaticImageGetNativeSize(lua_State* luaVM)
     return 1;
 }
 
-int CLuaGUIDefs::OOP_GUIStaticImageGetNativeSize(lua_State* luaVM)
+std::variant<CLuaMultiReturn<float, float>, CVector2D, bool> CLuaGUIDefs::OOP_GUIStaticImageGetNativeSize(lua_State* luaVM, CClientGUIElement* guiElement)
 {
-    // vector2 guiStaticImageGetNativeSize ( element theElement ) — or 2 floats if the caller expects them
-    CClientGUIElement* theElement;
-    CVector2D          vecSize;
+    CVector2D vecSize;
+    if (!CStaticFunctionDefinitions::GUIStaticImageGetNativeSize(*guiElement, vecSize))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(theElement);
+    // Keep returning two floats when the caller assigns two results
+    if (lua_ncallresult(luaVM) == 2)
+        return CLuaMultiReturn<float, float>(vecSize.fX, vecSize.fY);
 
-    if (!argStream.HasErrors())
-    {
-        if (CStaticFunctionDefinitions::GUIStaticImageGetNativeSize(*theElement, vecSize))
-        {
-            int iExpected = lua_ncallresult(luaVM);
-            if (iExpected == 2)
-            {
-                lua_pushnumber(luaVM, vecSize.fX);
-                lua_pushnumber(luaVM, vecSize.fY);
-                return 2;
-            }
-
-            lua_pushvector(luaVM, vecSize);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecSize;
 }
 
 int CLuaGUIDefs::GUICreateTab(lua_State* luaVM)
@@ -1814,37 +1795,17 @@ int CLuaGUIDefs::GUIGetSize(lua_State* luaVM)
     return 1;
 }
 
-int CLuaGUIDefs::OOP_GUIGetSize(lua_State* luaVM)
+std::variant<CLuaMultiReturn<float, float>, CVector2D> CLuaGUIDefs::OOP_GUIGetSize(lua_State* luaVM, CClientGUIElement* guiElement,
+                                                                                   std::optional<bool> relative)
 {
-    // vector2 guiGetSize ( element theElement [, bool relative = false ] ) — or 2 floats if the caller expects them
-    CClientGUIElement* theElement;
-    bool               relative;
+    CVector2D vecSize;
+    guiElement->GetCGUIElement()->GetSize(vecSize, relative.value_or(false));
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(theElement);
-    argStream.ReadBool(relative, false);
+    // Keep returning two floats when the caller assigns two results
+    if (lua_ncallresult(luaVM) == 2)
+        return CLuaMultiReturn<float, float>(vecSize.fX, vecSize.fY);
 
-    if (!argStream.HasErrors())
-    {
-        CVector2D Size;
-        theElement->GetCGUIElement()->GetSize(Size, relative);
-
-        int iExpected = lua_ncallresult(luaVM);
-        if (iExpected == 2)
-        {
-            lua_pushnumber(luaVM, Size.fX);
-            lua_pushnumber(luaVM, Size.fY);
-            return 2;
-        }
-
-        lua_pushvector(luaVM, Size);
-        return 1;
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecSize;
 }
 
 int CLuaGUIDefs::GUIGetScreenSize(lua_State* luaVM)
@@ -1883,37 +1844,17 @@ int CLuaGUIDefs::GUIGetPosition(lua_State* luaVM)
     return 1;
 }
 
-int CLuaGUIDefs::OOP_GUIGetPosition(lua_State* luaVM)
+std::variant<CLuaMultiReturn<float, float>, CVector2D> CLuaGUIDefs::OOP_GUIGetPosition(lua_State* luaVM, CClientGUIElement* guiElement,
+                                                                                       std::optional<bool> relative)
 {
-    // vector2 guiGetPosition ( element guiElement [, bool relative = false ] ) — or 2 floats if the caller expects them
-    CClientGUIElement* guiElement;
-    bool               relative;
+    CVector2D vecPosition;
+    guiElement->GetCGUIElement()->GetPosition(vecPosition, relative.value_or(false));
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(guiElement);
-    argStream.ReadBool(relative, false);
+    // Keep returning two floats when the caller assigns two results
+    if (lua_ncallresult(luaVM) == 2)
+        return CLuaMultiReturn<float, float>(vecPosition.fX, vecPosition.fY);
 
-    if (!argStream.HasErrors())
-    {
-        CVector2D Pos;
-        guiElement->GetCGUIElement()->GetPosition(Pos, relative);
-
-        int iExpected = lua_ncallresult(luaVM);
-        if (iExpected == 2)
-        {
-            lua_pushnumber(luaVM, Pos.fX);
-            lua_pushnumber(luaVM, Pos.fY);
-            return 2;
-        }
-
-        lua_pushvector(luaVM, Pos);
-        return 1;
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecPosition;
 }
 
 int CLuaGUIDefs::GUISetAlpha(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
@@ -47,7 +47,7 @@ public:
     LUA_DECLARE(GUICreateStaticImage);
     LUA_DECLARE(GUICreateFont);
     LUA_DECLARE(GUIStaticImageLoadImage);
-    LUA_DECLARE_OOP(GUIStaticImageGetNativeSize);
+    static std::variant<bool, CVector2D> OOP_GUIStaticImageGetNativeSize(CClientGUIElement* theElement);
     LUA_DECLARE(GUIGetSelectedTab);
     LUA_DECLARE(GUISetSelectedTab);
     LUA_DECLARE(GUIDeleteTab);
@@ -94,8 +94,8 @@ public:
     LUA_DECLARE(GUISetEnabled);
     LUA_DECLARE(GUISetText);
     LUA_DECLARE(GUISetFont);
-    LUA_DECLARE_OOP(GUISetSize);
-    LUA_DECLARE_OOP(GUISetPosition);
+    static bool OOP_GUISetSize(CClientGUIElement* guiElement, CVector2D vecSize, std::optional<bool> relative);
+    static bool OOP_GUISetPosition(CClientGUIElement* guiElement, CVector2D vecPosition, std::optional<bool> relative);
     LUA_DECLARE(GUISetVisible);
     LUA_DECLARE(GUISetAlpha);
     LUA_DECLARE(GUISetProperty);
@@ -108,8 +108,8 @@ public:
     LUA_DECLARE(GUIGetEnabled);
     LUA_DECLARE(GUIGetText);
     LUA_DECLARE(GUIGetFont);
-    LUA_DECLARE_OOP(GUIGetSize);
-    LUA_DECLARE_OOP(GUIGetPosition);
+    static CVector2D OOP_GUIGetSize(CClientGUIElement* theElement, std::optional<bool> relative);
+    static CVector2D OOP_GUIGetPosition(CClientGUIElement* guiElement, std::optional<bool> relative);
     LUA_DECLARE(GUIGetVisible);
     LUA_DECLARE(GUIGetAlpha);
     LUA_DECLARE(GUIGetProperty);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
@@ -47,7 +47,7 @@ public:
     LUA_DECLARE(GUICreateStaticImage);
     LUA_DECLARE(GUICreateFont);
     LUA_DECLARE(GUIStaticImageLoadImage);
-    LUA_DECLARE(GUIStaticImageGetNativeSize);
+    LUA_DECLARE_OOP(GUIStaticImageGetNativeSize);
     LUA_DECLARE(GUIGetSelectedTab);
     LUA_DECLARE(GUISetSelectedTab);
     LUA_DECLARE(GUIDeleteTab);
@@ -94,8 +94,8 @@ public:
     LUA_DECLARE(GUISetEnabled);
     LUA_DECLARE(GUISetText);
     LUA_DECLARE(GUISetFont);
-    LUA_DECLARE(GUISetSize);
-    LUA_DECLARE(GUISetPosition);
+    LUA_DECLARE_OOP(GUISetSize);
+    LUA_DECLARE_OOP(GUISetPosition);
     LUA_DECLARE(GUISetVisible);
     LUA_DECLARE(GUISetAlpha);
     LUA_DECLARE(GUISetProperty);
@@ -108,8 +108,8 @@ public:
     LUA_DECLARE(GUIGetEnabled);
     LUA_DECLARE(GUIGetText);
     LUA_DECLARE(GUIGetFont);
-    LUA_DECLARE(GUIGetSize);
-    LUA_DECLARE(GUIGetPosition);
+    LUA_DECLARE_OOP(GUIGetSize);
+    LUA_DECLARE_OOP(GUIGetPosition);
     LUA_DECLARE(GUIGetVisible);
     LUA_DECLARE(GUIGetAlpha);
     LUA_DECLARE(GUIGetProperty);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
@@ -47,6 +47,7 @@ public:
     LUA_DECLARE(GUICreateStaticImage);
     LUA_DECLARE(GUICreateFont);
     LUA_DECLARE(GUIStaticImageLoadImage);
+    LUA_DECLARE(GUIStaticImageGetNativeSize);
     static std::variant<bool, CVector2D> OOP_GUIStaticImageGetNativeSize(CClientGUIElement* theElement);
     LUA_DECLARE(GUIGetSelectedTab);
     LUA_DECLARE(GUISetSelectedTab);
@@ -94,7 +95,9 @@ public:
     LUA_DECLARE(GUISetEnabled);
     LUA_DECLARE(GUISetText);
     LUA_DECLARE(GUISetFont);
+    LUA_DECLARE(GUISetSize);
     static bool OOP_GUISetSize(CClientGUIElement* guiElement, CVector2D vecSize, std::optional<bool> relative);
+    LUA_DECLARE(GUISetPosition);
     static bool OOP_GUISetPosition(CClientGUIElement* guiElement, CVector2D vecPosition, std::optional<bool> relative);
     LUA_DECLARE(GUISetVisible);
     LUA_DECLARE(GUISetAlpha);
@@ -108,7 +111,9 @@ public:
     LUA_DECLARE(GUIGetEnabled);
     LUA_DECLARE(GUIGetText);
     LUA_DECLARE(GUIGetFont);
+    LUA_DECLARE(GUIGetSize);
     static CVector2D OOP_GUIGetSize(CClientGUIElement* theElement, std::optional<bool> relative);
+    LUA_DECLARE(GUIGetPosition);
     static CVector2D OOP_GUIGetPosition(CClientGUIElement* guiElement, std::optional<bool> relative);
     LUA_DECLARE(GUIGetVisible);
     LUA_DECLARE(GUIGetAlpha);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
@@ -12,6 +12,8 @@
 #pragma once
 #include "CLuaDefs.h"
 
+class CClientGUIElement;
+
 #define MAX_CHATBOX_LAYOUT_CVARS 21
 
 class CLuaGUIDefs : public CLuaDefs
@@ -47,7 +49,8 @@ public:
     LUA_DECLARE(GUICreateStaticImage);
     LUA_DECLARE(GUICreateFont);
     LUA_DECLARE(GUIStaticImageLoadImage);
-    LUA_DECLARE_OOP(GUIStaticImageGetNativeSize);
+    LUA_DECLARE(GUIStaticImageGetNativeSize);
+    static std::variant<CLuaMultiReturn<float, float>, CVector2D, bool> OOP_GUIStaticImageGetNativeSize(lua_State* luaVM, CClientGUIElement* guiElement);
     LUA_DECLARE(GUIGetSelectedTab);
     LUA_DECLARE(GUISetSelectedTab);
     LUA_DECLARE(GUIDeleteTab);
@@ -110,8 +113,11 @@ public:
     LUA_DECLARE(GUIGetEnabled);
     LUA_DECLARE(GUIGetText);
     LUA_DECLARE(GUIGetFont);
-    LUA_DECLARE_OOP(GUIGetSize);
-    LUA_DECLARE_OOP(GUIGetPosition);
+    LUA_DECLARE(GUIGetSize);
+    static std::variant<CLuaMultiReturn<float, float>, CVector2D> OOP_GUIGetSize(lua_State* luaVM, CClientGUIElement* guiElement, std::optional<bool> relative);
+    LUA_DECLARE(GUIGetPosition);
+    static std::variant<CLuaMultiReturn<float, float>, CVector2D> OOP_GUIGetPosition(lua_State* luaVM, CClientGUIElement* guiElement,
+                                                                                     std::optional<bool> relative);
     LUA_DECLARE(GUIGetVisible);
     LUA_DECLARE(GUIGetAlpha);
     LUA_DECLARE(GUIGetProperty);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaGUIDefs.h
@@ -47,8 +47,7 @@ public:
     LUA_DECLARE(GUICreateStaticImage);
     LUA_DECLARE(GUICreateFont);
     LUA_DECLARE(GUIStaticImageLoadImage);
-    LUA_DECLARE(GUIStaticImageGetNativeSize);
-    static std::variant<bool, CVector2D> OOP_GUIStaticImageGetNativeSize(CClientGUIElement* theElement);
+    LUA_DECLARE_OOP(GUIStaticImageGetNativeSize);
     LUA_DECLARE(GUIGetSelectedTab);
     LUA_DECLARE(GUISetSelectedTab);
     LUA_DECLARE(GUIDeleteTab);
@@ -111,10 +110,8 @@ public:
     LUA_DECLARE(GUIGetEnabled);
     LUA_DECLARE(GUIGetText);
     LUA_DECLARE(GUIGetFont);
-    LUA_DECLARE(GUIGetSize);
-    static CVector2D OOP_GUIGetSize(CClientGUIElement* theElement, std::optional<bool> relative);
-    LUA_DECLARE(GUIGetPosition);
-    static CVector2D OOP_GUIGetPosition(CClientGUIElement* guiElement, std::optional<bool> relative);
+    LUA_DECLARE_OOP(GUIGetSize);
+    LUA_DECLARE_OOP(GUIGetPosition);
     LUA_DECLARE(GUIGetVisible);
     LUA_DECLARE(GUIGetAlpha);
     LUA_DECLARE(GUIGetProperty);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
@@ -56,7 +56,7 @@ void CLuaObjectDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "respawn", "respawnObject");
     lua_classfunction(luaVM, "toggleRespawn", "toggleObjectRespawn");
 
-    lua_classfunction(luaVM, "getScale", OOP_GetObjectScale);
+    lua_classfunction(luaVM, "getScale", ArgumentParserWarn<false, OOP_GetObjectScale>);
     lua_classfunction(luaVM, "isBreakable", "isObjectBreakable");
     lua_classfunction(luaVM, "getMass", "getObjectMass");
     lua_classfunction(luaVM, "getProperties", GetObjectProperties);
@@ -70,7 +70,7 @@ void CLuaObjectDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setProperty", "setObjectProperty");
 
     lua_classvariable(luaVM, "moving", nullptr, "isObjectMoving");
-    lua_classvariable(luaVM, "scale", SetObjectScale, OOP_GetObjectScale);
+    lua_classvariable(luaVM, "scale", SetObjectScale, ArgumentParserWarn<false, OOP_GetObjectScale>);
     lua_classvariable(luaVM, "breakable", "setObjectBreakable", "isObjectBreakable");
     lua_classvariable(luaVM, "mass", "setObjectMass", "getObjectMass");
     lua_classvariable(luaVM, "properties", nullptr, GetObjectProperties);
@@ -180,28 +180,13 @@ int CLuaObjectDefs::GetObjectScale(lua_State* luaVM)
     return 1;
 }
 
-int CLuaObjectDefs::OOP_GetObjectScale(lua_State* luaVM)
+std::variant<bool, CVector> CLuaObjectDefs::OOP_GetObjectScale(CClientObject* pObject)
 {
-    //  vector getObjectScale ( object theObject )
-    CClientObject* pObject;
+    CVector vecScale;
+    if (!CStaticFunctionDefinitions::GetObjectScale(*pObject, vecScale))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pObject);
-
-    if (!argStream.HasErrors())
-    {
-        CVector vecScale;
-        if (CStaticFunctionDefinitions::GetObjectScale(*pObject, vecScale))
-        {
-            lua_pushvector(luaVM, vecScale);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecScale;
 }
 
 int CLuaObjectDefs::IsObjectBreakable(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
@@ -56,7 +56,7 @@ void CLuaObjectDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "respawn", "respawnObject");
     lua_classfunction(luaVM, "toggleRespawn", "toggleObjectRespawn");
 
-    lua_classfunction(luaVM, "getScale", "getObjectScale");
+    lua_classfunction(luaVM, "getScale", OOP_GetObjectScale);
     lua_classfunction(luaVM, "isBreakable", "isObjectBreakable");
     lua_classfunction(luaVM, "getMass", "getObjectMass");
     lua_classfunction(luaVM, "getProperties", GetObjectProperties);
@@ -70,7 +70,7 @@ void CLuaObjectDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setProperty", "setObjectProperty");
 
     lua_classvariable(luaVM, "moving", nullptr, "isObjectMoving");
-    lua_classvariable(luaVM, "scale", "setObjectScale", "getObjectScale");
+    lua_classvariable(luaVM, "scale", SetObjectScale, OOP_GetObjectScale);
     lua_classvariable(luaVM, "breakable", "setObjectBreakable", "isObjectBreakable");
     lua_classvariable(luaVM, "mass", "setObjectMass", "getObjectMass");
     lua_classvariable(luaVM, "properties", nullptr, GetObjectProperties);
@@ -171,6 +171,30 @@ int CLuaObjectDefs::GetObjectScale(lua_State* luaVM)
             lua_pushnumber(luaVM, vecScale.fY);
             lua_pushnumber(luaVM, vecScale.fZ);
             return 3;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaObjectDefs::OOP_GetObjectScale(lua_State* luaVM)
+{
+    //  vector getObjectScale ( object theObject )
+    CClientObject* pObject;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pObject);
+
+    if (!argStream.HasErrors())
+    {
+        CVector vecScale;
+        if (CStaticFunctionDefinitions::GetObjectScale(*pObject, vecScale))
+        {
+            lua_pushvector(luaVM, vecScale);
+            return 1;
         }
     }
     else

--- a/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
@@ -56,7 +56,7 @@ void CLuaObjectDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "respawn", "respawnObject");
     lua_classfunction(luaVM, "toggleRespawn", "toggleObjectRespawn");
 
-    lua_classfunction(luaVM, "getScale", ArgumentParserWarn<false, OOP_GetObjectScale>);
+    lua_classfunction(luaVM, "getScale", OOP_GetObjectScale);
     lua_classfunction(luaVM, "isBreakable", "isObjectBreakable");
     lua_classfunction(luaVM, "getMass", "getObjectMass");
     lua_classfunction(luaVM, "getProperties", GetObjectProperties);
@@ -70,7 +70,7 @@ void CLuaObjectDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setProperty", "setObjectProperty");
 
     lua_classvariable(luaVM, "moving", nullptr, "isObjectMoving");
-    lua_classvariable(luaVM, "scale", SetObjectScale, ArgumentParserWarn<false, OOP_GetObjectScale>);
+    lua_classvariable(luaVM, "scale", SetObjectScale, OOP_GetObjectScale);
     lua_classvariable(luaVM, "breakable", "setObjectBreakable", "isObjectBreakable");
     lua_classvariable(luaVM, "mass", "setObjectMass", "getObjectMass");
     lua_classvariable(luaVM, "properties", nullptr, GetObjectProperties);
@@ -180,13 +180,37 @@ int CLuaObjectDefs::GetObjectScale(lua_State* luaVM)
     return 1;
 }
 
-std::variant<bool, CVector> CLuaObjectDefs::OOP_GetObjectScale(CClientObject* pObject)
+int CLuaObjectDefs::OOP_GetObjectScale(lua_State* luaVM)
 {
-    CVector vecScale;
-    if (!CStaticFunctionDefinitions::GetObjectScale(*pObject, vecScale))
-        return false;
+    // vector3 getObjectScale ( object theObject ) — or 3 floats if the caller expects them
+    CClientObject* pObject;
 
-    return vecScale;
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pObject);
+
+    if (!argStream.HasErrors())
+    {
+        CVector vecScale;
+        if (CStaticFunctionDefinitions::GetObjectScale(*pObject, vecScale))
+        {
+            int iExpected = lua_ncallresult(luaVM);
+            if (iExpected == 3)
+            {
+                lua_pushnumber(luaVM, vecScale.fX);
+                lua_pushnumber(luaVM, vecScale.fY);
+                lua_pushnumber(luaVM, vecScale.fZ);
+                return 3;
+            }
+
+            lua_pushvector(luaVM, vecScale);
+            return 1;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
 }
 
 int CLuaObjectDefs::IsObjectBreakable(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.cpp
@@ -56,7 +56,7 @@ void CLuaObjectDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "respawn", "respawnObject");
     lua_classfunction(luaVM, "toggleRespawn", "toggleObjectRespawn");
 
-    lua_classfunction(luaVM, "getScale", OOP_GetObjectScale);
+    lua_classfunction(luaVM, "getScale", ArgumentParserWarn<false, OOP_GetObjectScale>);
     lua_classfunction(luaVM, "isBreakable", "isObjectBreakable");
     lua_classfunction(luaVM, "getMass", "getObjectMass");
     lua_classfunction(luaVM, "getProperties", GetObjectProperties);
@@ -70,7 +70,7 @@ void CLuaObjectDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setProperty", "setObjectProperty");
 
     lua_classvariable(luaVM, "moving", nullptr, "isObjectMoving");
-    lua_classvariable(luaVM, "scale", SetObjectScale, OOP_GetObjectScale);
+    lua_classvariable(luaVM, "scale", SetObjectScale, ArgumentParserWarn<false, OOP_GetObjectScale>);
     lua_classvariable(luaVM, "breakable", "setObjectBreakable", "isObjectBreakable");
     lua_classvariable(luaVM, "mass", "setObjectMass", "getObjectMass");
     lua_classvariable(luaVM, "properties", nullptr, GetObjectProperties);
@@ -180,37 +180,17 @@ int CLuaObjectDefs::GetObjectScale(lua_State* luaVM)
     return 1;
 }
 
-int CLuaObjectDefs::OOP_GetObjectScale(lua_State* luaVM)
+std::variant<CLuaMultiReturn<float, float, float>, CVector, bool> CLuaObjectDefs::OOP_GetObjectScale(lua_State* luaVM, CClientObject* object)
 {
-    // vector3 getObjectScale ( object theObject ) — or 3 floats if the caller expects them
-    CClientObject* pObject;
+    CVector vecScale;
+    if (!CStaticFunctionDefinitions::GetObjectScale(*object, vecScale))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pObject);
+    // Keep returning three floats when the caller assigns three results
+    if (lua_ncallresult(luaVM) == 3)
+        return CLuaMultiReturn<float, float, float>(vecScale.fX, vecScale.fY, vecScale.fZ);
 
-    if (!argStream.HasErrors())
-    {
-        CVector vecScale;
-        if (CStaticFunctionDefinitions::GetObjectScale(*pObject, vecScale))
-        {
-            int iExpected = lua_ncallresult(luaVM);
-            if (iExpected == 3)
-            {
-                lua_pushnumber(luaVM, vecScale.fX);
-                lua_pushnumber(luaVM, vecScale.fY);
-                lua_pushnumber(luaVM, vecScale.fZ);
-                return 3;
-            }
-
-            lua_pushvector(luaVM, vecScale);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecScale;
 }
 
 int CLuaObjectDefs::IsObjectBreakable(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.h
@@ -23,7 +23,8 @@ public:
 
     // Object get funcs
     LUA_DECLARE(IsObjectStatic);
-    static bool                        IsObjectMoving(CClientEntity* pEntity);
+    static bool IsObjectMoving(CClientEntity* pEntity);
+    LUA_DECLARE(GetObjectScale);
     static std::variant<bool, CVector> OOP_GetObjectScale(CClientObject* pObject);
     LUA_DECLARE(IsObjectBreakable);
     LUA_DECLARE(GetObjectMass);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.h
@@ -24,7 +24,7 @@ public:
     // Object get funcs
     LUA_DECLARE(IsObjectStatic);
     static bool IsObjectMoving(CClientEntity* pEntity);
-    LUA_DECLARE(GetObjectScale);
+    LUA_DECLARE_OOP(GetObjectScale);
     LUA_DECLARE(IsObjectBreakable);
     LUA_DECLARE(GetObjectMass);
     LUA_DECLARE(GetObjectProperty);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.h
@@ -23,8 +23,8 @@ public:
 
     // Object get funcs
     LUA_DECLARE(IsObjectStatic);
-    static bool IsObjectMoving(CClientEntity* pEntity);
-    LUA_DECLARE_OOP(GetObjectScale);
+    static bool                        IsObjectMoving(CClientEntity* pEntity);
+    static std::variant<bool, CVector> OOP_GetObjectScale(CClientObject* pObject);
     LUA_DECLARE(IsObjectBreakable);
     LUA_DECLARE(GetObjectMass);
     LUA_DECLARE(GetObjectProperty);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.h
@@ -12,6 +12,8 @@
 #pragma once
 #include "CLuaDefs.h"
 
+class CClientObject;
+
 class CLuaObjectDefs : public CLuaDefs
 {
 public:
@@ -24,7 +26,8 @@ public:
     // Object get funcs
     LUA_DECLARE(IsObjectStatic);
     static bool IsObjectMoving(CClientEntity* pEntity);
-    LUA_DECLARE_OOP(GetObjectScale);
+    LUA_DECLARE(GetObjectScale);
+    static std::variant<CLuaMultiReturn<float, float, float>, CVector, bool> OOP_GetObjectScale(lua_State* luaVM, CClientObject* object);
     LUA_DECLARE(IsObjectBreakable);
     LUA_DECLARE(GetObjectMass);
     LUA_DECLARE(GetObjectProperty);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaObjectDefs.h
@@ -24,8 +24,7 @@ public:
     // Object get funcs
     LUA_DECLARE(IsObjectStatic);
     static bool IsObjectMoving(CClientEntity* pEntity);
-    LUA_DECLARE(GetObjectScale);
-    static std::variant<bool, CVector> OOP_GetObjectScale(CClientObject* pObject);
+    LUA_DECLARE_OOP(GetObjectScale);
     LUA_DECLARE(IsObjectBreakable);
     LUA_DECLARE(GetObjectMass);
     LUA_DECLARE(GetObjectProperty);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -178,7 +178,7 @@ void CLuaPedDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setFootBloodEnabled", "setPedFootBloodEnabled");
     lua_classfunction(luaVM, "getTargetEnd", OOP_GetPedTargetEnd);
     lua_classfunction(luaVM, "getTargetStart", OOP_GetPedTargetStart);
-    lua_classfunction(luaVM, "getWeaponMuzzlePosition", OOP_GetPedWeaponMuzzlePosition);
+    lua_classfunction(luaVM, "getWeaponMuzzlePosition", ArgumentParserWarn<false, OOP_GetPedWeaponMuzzlePosition>);
     lua_classfunction(luaVM, "getBonePosition", OOP_GetPedBonePosition);
     lua_classfunction(luaVM, "getCameraRotation", "getPedCameraRotation");
     lua_classfunction(luaVM, "getWeaponSlot", "getPedWeaponSlot");
@@ -241,7 +241,7 @@ void CLuaPedDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "targetCollision", nullptr, OOP_GetPedTargetCollision);
     lua_classvariable(luaVM, "targetEnd", nullptr, OOP_GetPedTargetEnd);
     lua_classvariable(luaVM, "targetStart", nullptr, OOP_GetPedTargetStart);
-    lua_classvariable(luaVM, "muzzlePosition", nullptr, OOP_GetPedWeaponMuzzlePosition);
+    lua_classvariable(luaVM, "muzzlePosition", nullptr, ArgumentParserWarn<false, OOP_GetPedWeaponMuzzlePosition>);
     lua_classvariable(luaVM, "weaponSlot", "setPedWeaponSlot", "getPedWeaponSlot");
     lua_classvariable(luaVM, "walkingStyle", "setPedWalkingStyle", "getPedWalkingStyle");
     lua_classvariable(luaVM, "reloadingWeapon", nullptr, "isPedReloadingWeapon");
@@ -482,27 +482,13 @@ int CLuaPedDefs::GetPedWeaponMuzzlePosition(lua_State* luaVM)
     return 1;
 }
 
-int CLuaPedDefs::OOP_GetPedWeaponMuzzlePosition(lua_State* luaVM)
+std::variant<bool, CVector> CLuaPedDefs::OOP_GetPedWeaponMuzzlePosition(CClientPed* pPed)
 {
-    // Verify the argument
-    CClientPed*      pPed = NULL;
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pPed);
+    CVector vecMuzzlePos;
+    if (!CStaticFunctionDefinitions::GetPedWeaponMuzzlePosition(*pPed, vecMuzzlePos))
+        return false;
 
-    if (!argStream.HasErrors())
-    {
-        CVector vecMuzzlePos;
-        if (CStaticFunctionDefinitions::GetPedWeaponMuzzlePosition(*pPed, vecMuzzlePos))
-        {
-            lua_pushvector(luaVM, vecMuzzlePos);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecMuzzlePos;
 }
 
 int CLuaPedDefs::GetPedOccupiedVehicle(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -178,7 +178,7 @@ void CLuaPedDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setFootBloodEnabled", "setPedFootBloodEnabled");
     lua_classfunction(luaVM, "getTargetEnd", OOP_GetPedTargetEnd);
     lua_classfunction(luaVM, "getTargetStart", OOP_GetPedTargetStart);
-    lua_classfunction(luaVM, "getWeaponMuzzlePosition", "getPedWeaponMuzzlePosition");
+    lua_classfunction(luaVM, "getWeaponMuzzlePosition", OOP_GetPedWeaponMuzzlePosition);
     lua_classfunction(luaVM, "getBonePosition", OOP_GetPedBonePosition);
     lua_classfunction(luaVM, "getCameraRotation", "getPedCameraRotation");
     lua_classfunction(luaVM, "getWeaponSlot", "getPedWeaponSlot");
@@ -241,7 +241,7 @@ void CLuaPedDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "targetCollision", nullptr, OOP_GetPedTargetCollision);
     lua_classvariable(luaVM, "targetEnd", nullptr, OOP_GetPedTargetEnd);
     lua_classvariable(luaVM, "targetStart", nullptr, OOP_GetPedTargetStart);
-    // lua_classvariable ( luaVM, "muzzlePosition", NULL, "getPedWeaponMuzzlePosition" ); // TODO: needs to return a vector3 for oop
+    lua_classvariable(luaVM, "muzzlePosition", nullptr, OOP_GetPedWeaponMuzzlePosition);
     lua_classvariable(luaVM, "weaponSlot", "setPedWeaponSlot", "getPedWeaponSlot");
     lua_classvariable(luaVM, "walkingStyle", "setPedWalkingStyle", "getPedWalkingStyle");
     lua_classvariable(luaVM, "reloadingWeapon", nullptr, "isPedReloadingWeapon");
@@ -473,6 +473,29 @@ int CLuaPedDefs::GetPedWeaponMuzzlePosition(lua_State* luaVM)
             lua_pushnumber(luaVM, vecMuzzlePos.fY);
             lua_pushnumber(luaVM, vecMuzzlePos.fZ);
             return 3;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaPedDefs::OOP_GetPedWeaponMuzzlePosition(lua_State* luaVM)
+{
+    // Verify the argument
+    CClientPed*      pPed = NULL;
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pPed);
+
+    if (!argStream.HasErrors())
+    {
+        CVector vecMuzzlePos;
+        if (CStaticFunctionDefinitions::GetPedWeaponMuzzlePosition(*pPed, vecMuzzlePos))
+        {
+            lua_pushvector(luaVM, vecMuzzlePos);
+            return 1;
         }
     }
     else

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -178,7 +178,7 @@ void CLuaPedDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setFootBloodEnabled", "setPedFootBloodEnabled");
     lua_classfunction(luaVM, "getTargetEnd", OOP_GetPedTargetEnd);
     lua_classfunction(luaVM, "getTargetStart", OOP_GetPedTargetStart);
-    lua_classfunction(luaVM, "getWeaponMuzzlePosition", ArgumentParserWarn<false, OOP_GetPedWeaponMuzzlePosition>);
+    lua_classfunction(luaVM, "getWeaponMuzzlePosition", OOP_GetPedWeaponMuzzlePosition);
     lua_classfunction(luaVM, "getBonePosition", OOP_GetPedBonePosition);
     lua_classfunction(luaVM, "getCameraRotation", "getPedCameraRotation");
     lua_classfunction(luaVM, "getWeaponSlot", "getPedWeaponSlot");
@@ -241,7 +241,7 @@ void CLuaPedDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "targetCollision", nullptr, OOP_GetPedTargetCollision);
     lua_classvariable(luaVM, "targetEnd", nullptr, OOP_GetPedTargetEnd);
     lua_classvariable(luaVM, "targetStart", nullptr, OOP_GetPedTargetStart);
-    lua_classvariable(luaVM, "muzzlePosition", nullptr, ArgumentParserWarn<false, OOP_GetPedWeaponMuzzlePosition>);
+    lua_classvariable(luaVM, "muzzlePosition", nullptr, OOP_GetPedWeaponMuzzlePosition);
     lua_classvariable(luaVM, "weaponSlot", "setPedWeaponSlot", "getPedWeaponSlot");
     lua_classvariable(luaVM, "walkingStyle", "setPedWalkingStyle", "getPedWalkingStyle");
     lua_classvariable(luaVM, "reloadingWeapon", nullptr, "isPedReloadingWeapon");
@@ -482,13 +482,37 @@ int CLuaPedDefs::GetPedWeaponMuzzlePosition(lua_State* luaVM)
     return 1;
 }
 
-std::variant<bool, CVector> CLuaPedDefs::OOP_GetPedWeaponMuzzlePosition(CClientPed* pPed)
+int CLuaPedDefs::OOP_GetPedWeaponMuzzlePosition(lua_State* luaVM)
 {
-    CVector vecMuzzlePos;
-    if (!CStaticFunctionDefinitions::GetPedWeaponMuzzlePosition(*pPed, vecMuzzlePos))
-        return false;
+    // vector3 getPedWeaponMuzzlePosition ( ped thePed ) — or 3 floats if the caller expects them
+    CClientPed* pPed = NULL;
 
-    return vecMuzzlePos;
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pPed);
+
+    if (!argStream.HasErrors())
+    {
+        CVector vecMuzzlePos;
+        if (CStaticFunctionDefinitions::GetPedWeaponMuzzlePosition(*pPed, vecMuzzlePos))
+        {
+            int iExpected = lua_ncallresult(luaVM);
+            if (iExpected == 3)
+            {
+                lua_pushnumber(luaVM, vecMuzzlePos.fX);
+                lua_pushnumber(luaVM, vecMuzzlePos.fY);
+                lua_pushnumber(luaVM, vecMuzzlePos.fZ);
+                return 3;
+            }
+
+            lua_pushvector(luaVM, vecMuzzlePos);
+            return 1;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
 }
 
 int CLuaPedDefs::GetPedOccupiedVehicle(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -178,7 +178,7 @@ void CLuaPedDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setFootBloodEnabled", "setPedFootBloodEnabled");
     lua_classfunction(luaVM, "getTargetEnd", OOP_GetPedTargetEnd);
     lua_classfunction(luaVM, "getTargetStart", OOP_GetPedTargetStart);
-    lua_classfunction(luaVM, "getWeaponMuzzlePosition", OOP_GetPedWeaponMuzzlePosition);
+    lua_classfunction(luaVM, "getWeaponMuzzlePosition", ArgumentParserWarn<false, OOP_GetPedWeaponMuzzlePosition>);
     lua_classfunction(luaVM, "getBonePosition", OOP_GetPedBonePosition);
     lua_classfunction(luaVM, "getCameraRotation", "getPedCameraRotation");
     lua_classfunction(luaVM, "getWeaponSlot", "getPedWeaponSlot");
@@ -241,7 +241,7 @@ void CLuaPedDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "targetCollision", nullptr, OOP_GetPedTargetCollision);
     lua_classvariable(luaVM, "targetEnd", nullptr, OOP_GetPedTargetEnd);
     lua_classvariable(luaVM, "targetStart", nullptr, OOP_GetPedTargetStart);
-    lua_classvariable(luaVM, "muzzlePosition", nullptr, OOP_GetPedWeaponMuzzlePosition);
+    lua_classvariable(luaVM, "muzzlePosition", nullptr, ArgumentParserWarn<false, OOP_GetPedWeaponMuzzlePosition>);
     lua_classvariable(luaVM, "weaponSlot", "setPedWeaponSlot", "getPedWeaponSlot");
     lua_classvariable(luaVM, "walkingStyle", "setPedWalkingStyle", "getPedWalkingStyle");
     lua_classvariable(luaVM, "reloadingWeapon", nullptr, "isPedReloadingWeapon");
@@ -482,37 +482,17 @@ int CLuaPedDefs::GetPedWeaponMuzzlePosition(lua_State* luaVM)
     return 1;
 }
 
-int CLuaPedDefs::OOP_GetPedWeaponMuzzlePosition(lua_State* luaVM)
+std::variant<CLuaMultiReturn<float, float, float>, CVector, bool> CLuaPedDefs::OOP_GetPedWeaponMuzzlePosition(lua_State* luaVM, CClientPed* ped)
 {
-    // vector3 getPedWeaponMuzzlePosition ( ped thePed ) — or 3 floats if the caller expects them
-    CClientPed* pPed = NULL;
+    CVector vecMuzzlePosition;
+    if (!CStaticFunctionDefinitions::GetPedWeaponMuzzlePosition(*ped, vecMuzzlePosition))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pPed);
+    // Keep returning three floats when the caller assigns three results
+    if (lua_ncallresult(luaVM) == 3)
+        return CLuaMultiReturn<float, float, float>(vecMuzzlePosition.fX, vecMuzzlePosition.fY, vecMuzzlePosition.fZ);
 
-    if (!argStream.HasErrors())
-    {
-        CVector vecMuzzlePos;
-        if (CStaticFunctionDefinitions::GetPedWeaponMuzzlePosition(*pPed, vecMuzzlePos))
-        {
-            int iExpected = lua_ncallresult(luaVM);
-            if (iExpected == 3)
-            {
-                lua_pushnumber(luaVM, vecMuzzlePos.fX);
-                lua_pushnumber(luaVM, vecMuzzlePos.fY);
-                lua_pushnumber(luaVM, vecMuzzlePos.fZ);
-                return 3;
-            }
-
-            lua_pushvector(luaVM, vecMuzzlePos);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecMuzzlePosition;
 }
 
 int CLuaPedDefs::GetPedOccupiedVehicle(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
@@ -34,6 +34,7 @@ public:
     LUA_DECLARE(GetPedWeapon);
     LUA_DECLARE(GetPedAmmoInClip);
     LUA_DECLARE(GetPedTotalAmmo);
+    LUA_DECLARE(GetPedWeaponMuzzlePosition);
     static std::variant<bool, CVector> OOP_GetPedWeaponMuzzlePosition(CClientPed* pPed);
     LUA_DECLARE(GetPedStat);
     LUA_DECLARE(GetPedOccupiedVehicle);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
@@ -34,7 +34,7 @@ public:
     LUA_DECLARE(GetPedWeapon);
     LUA_DECLARE(GetPedAmmoInClip);
     LUA_DECLARE(GetPedTotalAmmo);
-    LUA_DECLARE_OOP(GetPedWeaponMuzzlePosition);
+    static std::variant<bool, CVector> OOP_GetPedWeaponMuzzlePosition(CClientPed* pPed);
     LUA_DECLARE(GetPedStat);
     LUA_DECLARE(GetPedOccupiedVehicle);
     LUA_DECLARE(GetPedOccupiedVehicleSeat);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
@@ -34,7 +34,7 @@ public:
     LUA_DECLARE(GetPedWeapon);
     LUA_DECLARE(GetPedAmmoInClip);
     LUA_DECLARE(GetPedTotalAmmo);
-    LUA_DECLARE(GetPedWeaponMuzzlePosition);
+    LUA_DECLARE_OOP(GetPedWeaponMuzzlePosition);
     LUA_DECLARE(GetPedStat);
     LUA_DECLARE(GetPedOccupiedVehicle);
     LUA_DECLARE(GetPedOccupiedVehicleSeat);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
@@ -34,8 +34,7 @@ public:
     LUA_DECLARE(GetPedWeapon);
     LUA_DECLARE(GetPedAmmoInClip);
     LUA_DECLARE(GetPedTotalAmmo);
-    LUA_DECLARE(GetPedWeaponMuzzlePosition);
-    static std::variant<bool, CVector> OOP_GetPedWeaponMuzzlePosition(CClientPed* pPed);
+    LUA_DECLARE_OOP(GetPedWeaponMuzzlePosition);
     LUA_DECLARE(GetPedStat);
     LUA_DECLARE(GetPedOccupiedVehicle);
     LUA_DECLARE(GetPedOccupiedVehicleSeat);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
@@ -34,7 +34,8 @@ public:
     LUA_DECLARE(GetPedWeapon);
     LUA_DECLARE(GetPedAmmoInClip);
     LUA_DECLARE(GetPedTotalAmmo);
-    LUA_DECLARE_OOP(GetPedWeaponMuzzlePosition);
+    LUA_DECLARE(GetPedWeaponMuzzlePosition);
+    static std::variant<CLuaMultiReturn<float, float, float>, CVector, bool> OOP_GetPedWeaponMuzzlePosition(lua_State* luaVM, CClientPed* ped);
     LUA_DECLARE(GetPedStat);
     LUA_DECLARE(GetPedOccupiedVehicle);
     LUA_DECLARE(GetPedOccupiedVehicleSeat);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.cpp
@@ -10,6 +10,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include <lua/CLuaFunctionParser.h>
 
 void CLuaPointLightDefs::LoadFunctions()
 {
@@ -32,7 +33,7 @@ void CLuaPointLightDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getType", "getLightType");
     lua_classfunction(luaVM, "getRadius", "getLightRadius");
     lua_classfunction(luaVM, "getColor", "getLightColor");
-    lua_classfunction(luaVM, "getDirection", OOP_GetLightDirection);
+    lua_classfunction(luaVM, "getDirection", ArgumentParserWarn<false, OOP_GetLightDirection>);
 
     lua_classfunction(luaVM, "setRadius", "setLightRadius");
     lua_classfunction(luaVM, "setColor", "setLightColor");
@@ -40,7 +41,7 @@ void CLuaPointLightDefs::AddClass(lua_State* luaVM)
 
     lua_classvariable(luaVM, "type", nullptr, "getLightType");
     lua_classvariable(luaVM, "radius", "setLightRadius", "getLightRadius");
-    lua_classvariable(luaVM, "direction", SetLightDirection, OOP_GetLightDirection);
+    lua_classvariable(luaVM, "direction", SetLightDirection, ArgumentParserWarn<false, OOP_GetLightDirection>);
 
     lua_registerclass(luaVM, "Light", "Element");
 }
@@ -193,28 +194,13 @@ int CLuaPointLightDefs::GetLightDirection(lua_State* luaVM)
     return 1;
 }
 
-int CLuaPointLightDefs::OOP_GetLightDirection(lua_State* luaVM)
+std::variant<bool, CVector> CLuaPointLightDefs::OOP_GetLightDirection(CClientPointLights* pLight)
 {
-    //  vector getLightDirection ( light theLight )
-    CClientPointLights* pLight;
+    CVector vecDirection;
+    if (!CStaticFunctionDefinitions::GetLightDirection(pLight, vecDirection))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pLight);
-
-    if (!argStream.HasErrors())
-    {
-        CVector vecDirection;
-        if (CStaticFunctionDefinitions::GetLightDirection(pLight, vecDirection))
-        {
-            lua_pushvector(luaVM, vecDirection);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, SString("Bad argument @ '%s' [%s]", lua_tostring(luaVM, lua_upvalueindex(1)), *argStream.GetErrorMessage()));
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecDirection;
 }
 
 int CLuaPointLightDefs::SetLightRadius(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.cpp
@@ -32,7 +32,7 @@ void CLuaPointLightDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getType", "getLightType");
     lua_classfunction(luaVM, "getRadius", "getLightRadius");
     lua_classfunction(luaVM, "getColor", "getLightColor");
-    lua_classfunction(luaVM, "getDirection", "getLightDirection");
+    lua_classfunction(luaVM, "getDirection", OOP_GetLightDirection);
 
     lua_classfunction(luaVM, "setRadius", "setLightRadius");
     lua_classfunction(luaVM, "setColor", "setLightColor");
@@ -40,7 +40,7 @@ void CLuaPointLightDefs::AddClass(lua_State* luaVM)
 
     lua_classvariable(luaVM, "type", nullptr, "getLightType");
     lua_classvariable(luaVM, "radius", "setLightRadius", "getLightRadius");
-    lua_classvariable(luaVM, "direction", "setLightDirection", "getLightDirection");
+    lua_classvariable(luaVM, "direction", SetLightDirection, OOP_GetLightDirection);
 
     lua_registerclass(luaVM, "Light", "Element");
 }
@@ -184,6 +184,30 @@ int CLuaPointLightDefs::GetLightDirection(lua_State* luaVM)
             lua_pushnumber(luaVM, static_cast<lua_Number>(vecDirection.fY));
             lua_pushnumber(luaVM, static_cast<lua_Number>(vecDirection.fZ));
             return 3;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, SString("Bad argument @ '%s' [%s]", lua_tostring(luaVM, lua_upvalueindex(1)), *argStream.GetErrorMessage()));
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaPointLightDefs::OOP_GetLightDirection(lua_State* luaVM)
+{
+    //  vector getLightDirection ( light theLight )
+    CClientPointLights* pLight;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pLight);
+
+    if (!argStream.HasErrors())
+    {
+        CVector vecDirection;
+        if (CStaticFunctionDefinitions::GetLightDirection(pLight, vecDirection))
+        {
+            lua_pushvector(luaVM, vecDirection);
+            return 1;
         }
     }
     else

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.cpp
@@ -33,7 +33,7 @@ void CLuaPointLightDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getType", "getLightType");
     lua_classfunction(luaVM, "getRadius", "getLightRadius");
     lua_classfunction(luaVM, "getColor", "getLightColor");
-    lua_classfunction(luaVM, "getDirection", OOP_GetLightDirection);
+    lua_classfunction(luaVM, "getDirection", ArgumentParserWarn<false, OOP_GetLightDirection>);
 
     lua_classfunction(luaVM, "setRadius", "setLightRadius");
     lua_classfunction(luaVM, "setColor", "setLightColor");
@@ -41,7 +41,7 @@ void CLuaPointLightDefs::AddClass(lua_State* luaVM)
 
     lua_classvariable(luaVM, "type", nullptr, "getLightType");
     lua_classvariable(luaVM, "radius", "setLightRadius", "getLightRadius");
-    lua_classvariable(luaVM, "direction", SetLightDirection, OOP_GetLightDirection);
+    lua_classvariable(luaVM, "direction", SetLightDirection, ArgumentParserWarn<false, OOP_GetLightDirection>);
 
     lua_registerclass(luaVM, "Light", "Element");
 }
@@ -194,37 +194,17 @@ int CLuaPointLightDefs::GetLightDirection(lua_State* luaVM)
     return 1;
 }
 
-int CLuaPointLightDefs::OOP_GetLightDirection(lua_State* luaVM)
+std::variant<CLuaMultiReturn<float, float, float>, CVector, bool> CLuaPointLightDefs::OOP_GetLightDirection(lua_State* luaVM, CClientPointLights* light)
 {
-    // vector3 getLightDirection ( light theLight ) — or 3 floats if the caller expects them
-    CClientPointLights* pLight;
+    CVector vecDirection;
+    if (!CStaticFunctionDefinitions::GetLightDirection(light, vecDirection))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pLight);
+    // Keep returning three floats when the caller assigns three results
+    if (lua_ncallresult(luaVM) == 3)
+        return CLuaMultiReturn<float, float, float>(vecDirection.fX, vecDirection.fY, vecDirection.fZ);
 
-    if (!argStream.HasErrors())
-    {
-        CVector vecDirection;
-        if (CStaticFunctionDefinitions::GetLightDirection(pLight, vecDirection))
-        {
-            int iExpected = lua_ncallresult(luaVM);
-            if (iExpected == 3)
-            {
-                lua_pushnumber(luaVM, static_cast<lua_Number>(vecDirection.fX));
-                lua_pushnumber(luaVM, static_cast<lua_Number>(vecDirection.fY));
-                lua_pushnumber(luaVM, static_cast<lua_Number>(vecDirection.fZ));
-                return 3;
-            }
-
-            lua_pushvector(luaVM, vecDirection);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, SString("Bad argument @ '%s' [%s]", lua_tostring(luaVM, lua_upvalueindex(1)), *argStream.GetErrorMessage()));
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecDirection;
 }
 
 int CLuaPointLightDefs::SetLightRadius(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.cpp
@@ -33,7 +33,7 @@ void CLuaPointLightDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getType", "getLightType");
     lua_classfunction(luaVM, "getRadius", "getLightRadius");
     lua_classfunction(luaVM, "getColor", "getLightColor");
-    lua_classfunction(luaVM, "getDirection", ArgumentParserWarn<false, OOP_GetLightDirection>);
+    lua_classfunction(luaVM, "getDirection", OOP_GetLightDirection);
 
     lua_classfunction(luaVM, "setRadius", "setLightRadius");
     lua_classfunction(luaVM, "setColor", "setLightColor");
@@ -41,7 +41,7 @@ void CLuaPointLightDefs::AddClass(lua_State* luaVM)
 
     lua_classvariable(luaVM, "type", nullptr, "getLightType");
     lua_classvariable(luaVM, "radius", "setLightRadius", "getLightRadius");
-    lua_classvariable(luaVM, "direction", SetLightDirection, ArgumentParserWarn<false, OOP_GetLightDirection>);
+    lua_classvariable(luaVM, "direction", SetLightDirection, OOP_GetLightDirection);
 
     lua_registerclass(luaVM, "Light", "Element");
 }
@@ -194,13 +194,37 @@ int CLuaPointLightDefs::GetLightDirection(lua_State* luaVM)
     return 1;
 }
 
-std::variant<bool, CVector> CLuaPointLightDefs::OOP_GetLightDirection(CClientPointLights* pLight)
+int CLuaPointLightDefs::OOP_GetLightDirection(lua_State* luaVM)
 {
-    CVector vecDirection;
-    if (!CStaticFunctionDefinitions::GetLightDirection(pLight, vecDirection))
-        return false;
+    // vector3 getLightDirection ( light theLight ) — or 3 floats if the caller expects them
+    CClientPointLights* pLight;
 
-    return vecDirection;
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pLight);
+
+    if (!argStream.HasErrors())
+    {
+        CVector vecDirection;
+        if (CStaticFunctionDefinitions::GetLightDirection(pLight, vecDirection))
+        {
+            int iExpected = lua_ncallresult(luaVM);
+            if (iExpected == 3)
+            {
+                lua_pushnumber(luaVM, static_cast<lua_Number>(vecDirection.fX));
+                lua_pushnumber(luaVM, static_cast<lua_Number>(vecDirection.fY));
+                lua_pushnumber(luaVM, static_cast<lua_Number>(vecDirection.fZ));
+                return 3;
+            }
+
+            lua_pushvector(luaVM, vecDirection);
+            return 1;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, SString("Bad argument @ '%s' [%s]", lua_tostring(luaVM, lua_upvalueindex(1)), *argStream.GetErrorMessage()));
+
+    lua_pushboolean(luaVM, false);
+    return 1;
 }
 
 int CLuaPointLightDefs::SetLightRadius(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.h
@@ -22,7 +22,7 @@ public:
     LUA_DECLARE(GetLightType);
     LUA_DECLARE(GetLightRadius);
     LUA_DECLARE(GetLightColor);
-    LUA_DECLARE_OOP(GetLightDirection);
+    static std::variant<bool, CVector> OOP_GetLightDirection(CClientPointLights* pLight);
     LUA_DECLARE(SetLightRadius);
     LUA_DECLARE(SetLightColor);
     LUA_DECLARE(SetLightDirection);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.h
@@ -22,6 +22,7 @@ public:
     LUA_DECLARE(GetLightType);
     LUA_DECLARE(GetLightRadius);
     LUA_DECLARE(GetLightColor);
+    LUA_DECLARE(GetLightDirection);
     static std::variant<bool, CVector> OOP_GetLightDirection(CClientPointLights* pLight);
     LUA_DECLARE(SetLightRadius);
     LUA_DECLARE(SetLightColor);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.h
@@ -22,7 +22,7 @@ public:
     LUA_DECLARE(GetLightType);
     LUA_DECLARE(GetLightRadius);
     LUA_DECLARE(GetLightColor);
-    LUA_DECLARE(GetLightDirection);
+    LUA_DECLARE_OOP(GetLightDirection);
     LUA_DECLARE(SetLightRadius);
     LUA_DECLARE(SetLightColor);
     LUA_DECLARE(SetLightDirection);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.h
@@ -22,8 +22,7 @@ public:
     LUA_DECLARE(GetLightType);
     LUA_DECLARE(GetLightRadius);
     LUA_DECLARE(GetLightColor);
-    LUA_DECLARE(GetLightDirection);
-    static std::variant<bool, CVector> OOP_GetLightDirection(CClientPointLights* pLight);
+    LUA_DECLARE_OOP(GetLightDirection);
     LUA_DECLARE(SetLightRadius);
     LUA_DECLARE(SetLightColor);
     LUA_DECLARE(SetLightDirection);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPointLightDefs.h
@@ -12,6 +12,8 @@
 #pragma once
 #include "CLuaDefs.h"
 
+class CClientPointLights;
+
 class CLuaPointLightDefs : public CLuaDefs
 {
 public:
@@ -22,7 +24,8 @@ public:
     LUA_DECLARE(GetLightType);
     LUA_DECLARE(GetLightRadius);
     LUA_DECLARE(GetLightColor);
-    LUA_DECLARE_OOP(GetLightDirection);
+    LUA_DECLARE(GetLightDirection);
+    static std::variant<CLuaMultiReturn<float, float, float>, CVector, bool> OOP_GetLightDirection(lua_State* luaVM, CClientPointLights* light);
     LUA_DECLARE(SetLightRadius);
     LUA_DECLARE(SetLightColor);
     LUA_DECLARE(SetLightDirection);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
@@ -11,6 +11,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include <lua/CLuaFunctionParser.h>
 
 void CLuaRadarAreaDefs::LoadFunctions()
 {
@@ -33,7 +34,7 @@ void CLuaRadarAreaDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "isInside", "isInsideRadarArea");
 
     lua_classfunction(luaVM, "isFlashing", "isRadarAreaFlashing");
-    lua_classfunction(luaVM, "getSize", OOP_GetRadarAreaSize);
+    lua_classfunction(luaVM, "getSize", ArgumentParserWarn<false, OOP_GetRadarAreaSize>);
     lua_classfunction(luaVM, "getColor", "getRadarAreaColor");
 
     lua_classfunction(luaVM, "setSize", "setRadarAreaSize");
@@ -41,7 +42,7 @@ void CLuaRadarAreaDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setColor", "setRadarAreaColor");
 
     lua_classvariable(luaVM, "flashing", "setRadarAreaFlashing", "isRadarAreaFlashing");
-    lua_classvariable(luaVM, "size", SetRadarAreaSize, OOP_GetRadarAreaSize);
+    lua_classvariable(luaVM, "size", SetRadarAreaSize, ArgumentParserWarn<false, OOP_GetRadarAreaSize>);
 
     lua_registerclass(luaVM, "RadarArea", "Element");
 }
@@ -146,28 +147,13 @@ int CLuaRadarAreaDefs::GetRadarAreaSize(lua_State* luaVM)
     return 1;
 }
 
-int CLuaRadarAreaDefs::OOP_GetRadarAreaSize(lua_State* luaVM)
+std::variant<bool, CVector2D> CLuaRadarAreaDefs::OOP_GetRadarAreaSize(CClientRadarArea* pRadarArea)
 {
-    //  vector2 getRadarAreaSize ( radararea theRadararea )
-    CClientRadarArea* pRadarArea;
+    CVector2D vecSize;
+    if (!CStaticFunctionDefinitions::GetRadarAreaSize(pRadarArea, vecSize))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pRadarArea);
-
-    if (!argStream.HasErrors())
-    {
-        CVector2D vecSize;
-        if (CStaticFunctionDefinitions::GetRadarAreaSize(pRadarArea, vecSize))
-        {
-            lua_pushvector(luaVM, vecSize);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecSize;
 }
 
 int CLuaRadarAreaDefs::IsRadarAreaFlashing(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
@@ -33,7 +33,7 @@ void CLuaRadarAreaDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "isInside", "isInsideRadarArea");
 
     lua_classfunction(luaVM, "isFlashing", "isRadarAreaFlashing");
-    lua_classfunction(luaVM, "getSize", "getRadarAreaSize");
+    lua_classfunction(luaVM, "getSize", OOP_GetRadarAreaSize);
     lua_classfunction(luaVM, "getColor", "getRadarAreaColor");
 
     lua_classfunction(luaVM, "setSize", "setRadarAreaSize");

--- a/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
@@ -34,7 +34,7 @@ void CLuaRadarAreaDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "isInside", "isInsideRadarArea");
 
     lua_classfunction(luaVM, "isFlashing", "isRadarAreaFlashing");
-    lua_classfunction(luaVM, "getSize", OOP_GetRadarAreaSize);
+    lua_classfunction(luaVM, "getSize", ArgumentParserWarn<false, OOP_GetRadarAreaSize>);
     lua_classfunction(luaVM, "getColor", "getRadarAreaColor");
 
     lua_classfunction(luaVM, "setSize", "setRadarAreaSize");
@@ -42,7 +42,7 @@ void CLuaRadarAreaDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setColor", "setRadarAreaColor");
 
     lua_classvariable(luaVM, "flashing", "setRadarAreaFlashing", "isRadarAreaFlashing");
-    lua_classvariable(luaVM, "size", SetRadarAreaSize, OOP_GetRadarAreaSize);
+    lua_classvariable(luaVM, "size", SetRadarAreaSize, ArgumentParserWarn<false, OOP_GetRadarAreaSize>);
 
     lua_registerclass(luaVM, "RadarArea", "Element");
 }
@@ -147,36 +147,17 @@ int CLuaRadarAreaDefs::GetRadarAreaSize(lua_State* luaVM)
     return 1;
 }
 
-int CLuaRadarAreaDefs::OOP_GetRadarAreaSize(lua_State* luaVM)
+std::variant<CLuaMultiReturn<float, float>, CVector2D, bool> CLuaRadarAreaDefs::OOP_GetRadarAreaSize(lua_State* luaVM, CClientRadarArea* radarArea)
 {
-    // vector2 getRadarAreaSize ( radararea theRadararea ) — or 2 floats if the caller expects them
-    CClientRadarArea* pRadarArea;
+    CVector2D vecSize;
+    if (!CStaticFunctionDefinitions::GetRadarAreaSize(radarArea, vecSize))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pRadarArea);
+    // Keep returning two floats when the caller assigns two results
+    if (lua_ncallresult(luaVM) == 2)
+        return CLuaMultiReturn<float, float>(vecSize.fX, vecSize.fY);
 
-    if (!argStream.HasErrors())
-    {
-        CVector2D vecSize;
-        if (CStaticFunctionDefinitions::GetRadarAreaSize(pRadarArea, vecSize))
-        {
-            int iExpected = lua_ncallresult(luaVM);
-            if (iExpected == 2)
-            {
-                lua_pushnumber(luaVM, static_cast<lua_Number>(vecSize.fX));
-                lua_pushnumber(luaVM, static_cast<lua_Number>(vecSize.fY));
-                return 2;
-            }
-
-            lua_pushvector(luaVM, vecSize);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecSize;
 }
 
 int CLuaRadarAreaDefs::IsRadarAreaFlashing(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
@@ -34,7 +34,7 @@ void CLuaRadarAreaDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "isInside", "isInsideRadarArea");
 
     lua_classfunction(luaVM, "isFlashing", "isRadarAreaFlashing");
-    lua_classfunction(luaVM, "getSize", ArgumentParserWarn<false, OOP_GetRadarAreaSize>);
+    lua_classfunction(luaVM, "getSize", OOP_GetRadarAreaSize);
     lua_classfunction(luaVM, "getColor", "getRadarAreaColor");
 
     lua_classfunction(luaVM, "setSize", "setRadarAreaSize");
@@ -42,7 +42,7 @@ void CLuaRadarAreaDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setColor", "setRadarAreaColor");
 
     lua_classvariable(luaVM, "flashing", "setRadarAreaFlashing", "isRadarAreaFlashing");
-    lua_classvariable(luaVM, "size", SetRadarAreaSize, ArgumentParserWarn<false, OOP_GetRadarAreaSize>);
+    lua_classvariable(luaVM, "size", SetRadarAreaSize, OOP_GetRadarAreaSize);
 
     lua_registerclass(luaVM, "RadarArea", "Element");
 }
@@ -147,13 +147,36 @@ int CLuaRadarAreaDefs::GetRadarAreaSize(lua_State* luaVM)
     return 1;
 }
 
-std::variant<bool, CVector2D> CLuaRadarAreaDefs::OOP_GetRadarAreaSize(CClientRadarArea* pRadarArea)
+int CLuaRadarAreaDefs::OOP_GetRadarAreaSize(lua_State* luaVM)
 {
-    CVector2D vecSize;
-    if (!CStaticFunctionDefinitions::GetRadarAreaSize(pRadarArea, vecSize))
-        return false;
+    // vector2 getRadarAreaSize ( radararea theRadararea ) — or 2 floats if the caller expects them
+    CClientRadarArea* pRadarArea;
 
-    return vecSize;
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pRadarArea);
+
+    if (!argStream.HasErrors())
+    {
+        CVector2D vecSize;
+        if (CStaticFunctionDefinitions::GetRadarAreaSize(pRadarArea, vecSize))
+        {
+            int iExpected = lua_ncallresult(luaVM);
+            if (iExpected == 2)
+            {
+                lua_pushnumber(luaVM, static_cast<lua_Number>(vecSize.fX));
+                lua_pushnumber(luaVM, static_cast<lua_Number>(vecSize.fY));
+                return 2;
+            }
+
+            lua_pushvector(luaVM, vecSize);
+            return 1;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
 }
 
 int CLuaRadarAreaDefs::IsRadarAreaFlashing(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.h
@@ -19,7 +19,7 @@ public:
 
     LUA_DECLARE(CreateRadarArea);
     LUA_DECLARE(GetRadarAreaColor);
-    LUA_DECLARE_OOP(GetRadarAreaSize);
+    static std::variant<bool, CVector2D> OOP_GetRadarAreaSize(CClientRadarArea* pRadarArea);
     LUA_DECLARE(IsRadarAreaFlashing);
     LUA_DECLARE(SetRadarAreaColor);
     LUA_DECLARE(SetRadarAreaFlashing);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.h
@@ -19,6 +19,7 @@ public:
 
     LUA_DECLARE(CreateRadarArea);
     LUA_DECLARE(GetRadarAreaColor);
+    LUA_DECLARE(GetRadarAreaSize);
     static std::variant<bool, CVector2D> OOP_GetRadarAreaSize(CClientRadarArea* pRadarArea);
     LUA_DECLARE(IsRadarAreaFlashing);
     LUA_DECLARE(SetRadarAreaColor);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.h
@@ -19,8 +19,7 @@ public:
 
     LUA_DECLARE(CreateRadarArea);
     LUA_DECLARE(GetRadarAreaColor);
-    LUA_DECLARE(GetRadarAreaSize);
-    static std::variant<bool, CVector2D> OOP_GetRadarAreaSize(CClientRadarArea* pRadarArea);
+    LUA_DECLARE_OOP(GetRadarAreaSize);
     LUA_DECLARE(IsRadarAreaFlashing);
     LUA_DECLARE(SetRadarAreaColor);
     LUA_DECLARE(SetRadarAreaFlashing);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.h
@@ -11,6 +11,8 @@
 #pragma once
 #include "CLuaDefs.h"
 
+class CClientRadarArea;
+
 class CLuaRadarAreaDefs : public CLuaDefs
 {
 public:
@@ -19,7 +21,8 @@ public:
 
     LUA_DECLARE(CreateRadarArea);
     LUA_DECLARE(GetRadarAreaColor);
-    LUA_DECLARE_OOP(GetRadarAreaSize);
+    LUA_DECLARE(GetRadarAreaSize);
+    static std::variant<CLuaMultiReturn<float, float>, CVector2D, bool> OOP_GetRadarAreaSize(lua_State* luaVM, CClientRadarArea* radarArea);
     LUA_DECLARE(IsRadarAreaFlashing);
     LUA_DECLARE(SetRadarAreaColor);
     LUA_DECLARE(SetRadarAreaFlashing);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -229,7 +229,8 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getHelicopterRotorSpeed", "getHelicopterRotorSpeed");
     lua_classfunction(luaVM, "areHeliBladeCollisionsEnabled", "getHeliBladeCollisionsEnabled");
     lua_classfunction(luaVM, "getPaintjob", "getVehiclePaintjob");
-    lua_classfunction(luaVM, "getTurretPosition", "getVehicleTurretPosition");
+    // OOP should return a vector2 (procedural getVehicleTurretPosition returns two floats)
+    lua_classfunction(luaVM, "getTurretPosition", OOP_GetVehicleTurretPosition);
     lua_classfunction(luaVM, "getWheelStates", "getVehicleWheelStates");
     lua_classfunction(luaVM, "isWheelOnGround", "isVehicleWheelOnGround");
     lua_classfunction(luaVM, "getDoorOpenRatio", "getVehicleDoorOpenRatio");
@@ -381,6 +382,7 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "nitroRecharging", NULL, "isVehicleNitroRecharging");
     lua_classvariable(luaVM, "gravity", SetVehicleGravity, OOP_GetVehicleGravity);
     lua_classvariable(luaVM, "turnVelocity", SetVehicleTurnVelocity, OOP_GetVehicleTurnVelocity);
+    lua_classvariable(luaVM, "turretPosition", nullptr, OOP_GetVehicleTurretPosition);
     lua_classvariable(luaVM, "wheelScale", "setVehicleWheelScale", "getVehicleWheelScale");
     lua_classvariable(luaVM, "rotorState", "setVehicleRotorState", "getVehicleRotorState");
     lua_classvariable(luaVM, "audioSettings", nullptr, "getVehicleAudioSettings");
@@ -789,6 +791,27 @@ int CLuaVehicleDefs::GetVehicleTurretPosition(lua_State* luaVM)
         lua_pushnumber(luaVM, vecPosition.fX);
         lua_pushnumber(luaVM, vecPosition.fY);
         return 2;
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaVehicleDefs::OOP_GetVehicleTurretPosition(lua_State* luaVM)
+{
+    CClientVehicle*  pVehicle = NULL;
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pVehicle);
+
+    if (!argStream.HasErrors())
+    {
+        CVector2D vecPosition;
+        pVehicle->GetTurretRotation(vecPosition.fX, vecPosition.fY);
+
+        lua_pushvector(luaVM, vecPosition);
+        return 1;
     }
     else
         m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -230,7 +230,7 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "areHeliBladeCollisionsEnabled", "getHeliBladeCollisionsEnabled");
     lua_classfunction(luaVM, "getPaintjob", "getVehiclePaintjob");
     // OOP should return a vector2 (procedural getVehicleTurretPosition returns two floats)
-    lua_classfunction(luaVM, "getTurretPosition", OOP_GetVehicleTurretPosition);
+    lua_classfunction(luaVM, "getTurretPosition", ArgumentParserWarn<false, OOP_GetVehicleTurretPosition>);
     lua_classfunction(luaVM, "getWheelStates", "getVehicleWheelStates");
     lua_classfunction(luaVM, "isWheelOnGround", "isVehicleWheelOnGround");
     lua_classfunction(luaVM, "getDoorOpenRatio", "getVehicleDoorOpenRatio");
@@ -382,7 +382,7 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "nitroRecharging", NULL, "isVehicleNitroRecharging");
     lua_classvariable(luaVM, "gravity", SetVehicleGravity, OOP_GetVehicleGravity);
     lua_classvariable(luaVM, "turnVelocity", SetVehicleTurnVelocity, OOP_GetVehicleTurnVelocity);
-    lua_classvariable(luaVM, "turretPosition", nullptr, OOP_GetVehicleTurretPosition);
+    lua_classvariable(luaVM, "turretPosition", nullptr, ArgumentParserWarn<false, OOP_GetVehicleTurretPosition>);
     lua_classvariable(luaVM, "wheelScale", "setVehicleWheelScale", "getVehicleWheelScale");
     lua_classvariable(luaVM, "rotorState", "setVehicleRotorState", "getVehicleRotorState");
     lua_classvariable(luaVM, "audioSettings", nullptr, "getVehicleAudioSettings");
@@ -799,25 +799,11 @@ int CLuaVehicleDefs::GetVehicleTurretPosition(lua_State* luaVM)
     return 1;
 }
 
-int CLuaVehicleDefs::OOP_GetVehicleTurretPosition(lua_State* luaVM)
+CVector2D CLuaVehicleDefs::OOP_GetVehicleTurretPosition(CClientVehicle* pVehicle)
 {
-    CClientVehicle*  pVehicle = NULL;
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pVehicle);
-
-    if (!argStream.HasErrors())
-    {
-        CVector2D vecPosition;
-        pVehicle->GetTurretRotation(vecPosition.fX, vecPosition.fY);
-
-        lua_pushvector(luaVM, vecPosition);
-        return 1;
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    CVector2D vecPosition;
+    pVehicle->GetTurretRotation(vecPosition.fX, vecPosition.fY);
+    return vecPosition;
 }
 
 int CLuaVehicleDefs::IsVehicleLocked(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -229,8 +229,7 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getHelicopterRotorSpeed", "getHelicopterRotorSpeed");
     lua_classfunction(luaVM, "areHeliBladeCollisionsEnabled", "getHeliBladeCollisionsEnabled");
     lua_classfunction(luaVM, "getPaintjob", "getVehiclePaintjob");
-    // OOP should return a vector2 (procedural getVehicleTurretPosition returns two floats)
-    lua_classfunction(luaVM, "getTurretPosition", OOP_GetVehicleTurretPosition);
+    lua_classfunction(luaVM, "getTurretPosition", ArgumentParserWarn<false, OOP_GetVehicleTurretPosition>);
     lua_classfunction(luaVM, "getWheelStates", "getVehicleWheelStates");
     lua_classfunction(luaVM, "isWheelOnGround", "isVehicleWheelOnGround");
     lua_classfunction(luaVM, "getDoorOpenRatio", "getVehicleDoorOpenRatio");
@@ -382,7 +381,7 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "nitroRecharging", NULL, "isVehicleNitroRecharging");
     lua_classvariable(luaVM, "gravity", SetVehicleGravity, OOP_GetVehicleGravity);
     lua_classvariable(luaVM, "turnVelocity", SetVehicleTurnVelocity, OOP_GetVehicleTurnVelocity);
-    lua_classvariable(luaVM, "turretPosition", nullptr, OOP_GetVehicleTurretPosition);
+    lua_classvariable(luaVM, "turretPosition", SetVehicleTurretPosition, ArgumentParserWarn<false, OOP_GetVehicleTurretPosition>);
     lua_classvariable(luaVM, "wheelScale", "setVehicleWheelScale", "getVehicleWheelScale");
     lua_classvariable(luaVM, "rotorState", "setVehicleRotorState", "getVehicleRotorState");
     lua_classvariable(luaVM, "audioSettings", nullptr, "getVehicleAudioSettings");
@@ -799,35 +798,16 @@ int CLuaVehicleDefs::GetVehicleTurretPosition(lua_State* luaVM)
     return 1;
 }
 
-int CLuaVehicleDefs::OOP_GetVehicleTurretPosition(lua_State* luaVM)
+std::variant<CLuaMultiReturn<float, float>, CVector2D> CLuaVehicleDefs::OOP_GetVehicleTurretPosition(lua_State* luaVM, CClientVehicle* vehicle)
 {
-    // vector2 getVehicleTurretPosition ( vehicle theVehicle ) — or 2 floats if the caller expects them
-    CClientVehicle* pVehicle = NULL;
+    CVector2D vecPosition;
+    vehicle->GetTurretRotation(vecPosition.fX, vecPosition.fY);
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pVehicle);
+    // Keep returning two floats when the caller assigns two results
+    if (lua_ncallresult(luaVM) == 2)
+        return CLuaMultiReturn<float, float>(vecPosition.fX, vecPosition.fY);
 
-    if (!argStream.HasErrors())
-    {
-        CVector2D vecPosition;
-        pVehicle->GetTurretRotation(vecPosition.fX, vecPosition.fY);
-
-        int iExpected = lua_ncallresult(luaVM);
-        if (iExpected == 2)
-        {
-            lua_pushnumber(luaVM, vecPosition.fX);
-            lua_pushnumber(luaVM, vecPosition.fY);
-            return 2;
-        }
-
-        lua_pushvector(luaVM, vecPosition);
-        return 1;
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecPosition;
 }
 
 int CLuaVehicleDefs::IsVehicleLocked(lua_State* luaVM)
@@ -2531,16 +2511,16 @@ int CLuaVehicleDefs::SetVehicleHeadLightColor(lua_State* luaVM)
 
 int CLuaVehicleDefs::SetVehicleTurretPosition(lua_State* luaVM)
 {
+    // Accept Vector2 as well so vehicle.turretPosition = Vector2(...) works via the OOP property
     CClientVehicle*  pVehicle = NULL;
-    float            fHorizontal = 0.0f, fVertical = 0.0f;
+    CVector2D        vecPosition;
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pVehicle);
-    argStream.ReadNumber(fHorizontal);
-    argStream.ReadNumber(fVertical);
+    argStream.ReadVector2D(vecPosition);
 
     if (!argStream.HasErrors())
     {
-        pVehicle->SetTurretRotation(fHorizontal, fVertical);
+        pVehicle->SetTurretRotation(vecPosition.fX, vecPosition.fY);
         lua_pushboolean(luaVM, true);
         return 1;
     }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -230,7 +230,7 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "areHeliBladeCollisionsEnabled", "getHeliBladeCollisionsEnabled");
     lua_classfunction(luaVM, "getPaintjob", "getVehiclePaintjob");
     // OOP should return a vector2 (procedural getVehicleTurretPosition returns two floats)
-    lua_classfunction(luaVM, "getTurretPosition", ArgumentParserWarn<false, OOP_GetVehicleTurretPosition>);
+    lua_classfunction(luaVM, "getTurretPosition", OOP_GetVehicleTurretPosition);
     lua_classfunction(luaVM, "getWheelStates", "getVehicleWheelStates");
     lua_classfunction(luaVM, "isWheelOnGround", "isVehicleWheelOnGround");
     lua_classfunction(luaVM, "getDoorOpenRatio", "getVehicleDoorOpenRatio");
@@ -382,7 +382,7 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "nitroRecharging", NULL, "isVehicleNitroRecharging");
     lua_classvariable(luaVM, "gravity", SetVehicleGravity, OOP_GetVehicleGravity);
     lua_classvariable(luaVM, "turnVelocity", SetVehicleTurnVelocity, OOP_GetVehicleTurnVelocity);
-    lua_classvariable(luaVM, "turretPosition", nullptr, ArgumentParserWarn<false, OOP_GetVehicleTurretPosition>);
+    lua_classvariable(luaVM, "turretPosition", nullptr, OOP_GetVehicleTurretPosition);
     lua_classvariable(luaVM, "wheelScale", "setVehicleWheelScale", "getVehicleWheelScale");
     lua_classvariable(luaVM, "rotorState", "setVehicleRotorState", "getVehicleRotorState");
     lua_classvariable(luaVM, "audioSettings", nullptr, "getVehicleAudioSettings");
@@ -799,11 +799,35 @@ int CLuaVehicleDefs::GetVehicleTurretPosition(lua_State* luaVM)
     return 1;
 }
 
-CVector2D CLuaVehicleDefs::OOP_GetVehicleTurretPosition(CClientVehicle* pVehicle)
+int CLuaVehicleDefs::OOP_GetVehicleTurretPosition(lua_State* luaVM)
 {
-    CVector2D vecPosition;
-    pVehicle->GetTurretRotation(vecPosition.fX, vecPosition.fY);
-    return vecPosition;
+    // vector2 getVehicleTurretPosition ( vehicle theVehicle ) — or 2 floats if the caller expects them
+    CClientVehicle* pVehicle = NULL;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pVehicle);
+
+    if (!argStream.HasErrors())
+    {
+        CVector2D vecPosition;
+        pVehicle->GetTurretRotation(vecPosition.fX, vecPosition.fY);
+
+        int iExpected = lua_ncallresult(luaVM);
+        if (iExpected == 2)
+        {
+            lua_pushnumber(luaVM, vecPosition.fX);
+            lua_pushnumber(luaVM, vecPosition.fY);
+            return 2;
+        }
+
+        lua_pushvector(luaVM, vecPosition);
+        return 1;
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
 }
 
 int CLuaVehicleDefs::IsVehicleLocked(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -36,7 +36,7 @@ public:
     LUA_DECLARE(GetVehicleRotation);
     LUA_DECLARE(GetVehicleSirensOn);
     LUA_DECLARE_OOP(GetVehicleTurnVelocity);
-    LUA_DECLARE_OOP(GetVehicleTurretPosition);
+    static CVector2D OOP_GetVehicleTurretPosition(CClientVehicle* pVehicle);
     LUA_DECLARE(IsVehicleLocked);
     LUA_DECLARE(GetVehicleUpgradeOnSlot);
     LUA_DECLARE(GetVehicleUpgrades);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -36,6 +36,7 @@ public:
     LUA_DECLARE(GetVehicleRotation);
     LUA_DECLARE(GetVehicleSirensOn);
     LUA_DECLARE_OOP(GetVehicleTurnVelocity);
+    LUA_DECLARE(GetVehicleTurretPosition);
     static CVector2D OOP_GetVehicleTurretPosition(CClientVehicle* pVehicle);
     LUA_DECLARE(IsVehicleLocked);
     LUA_DECLARE(GetVehicleUpgradeOnSlot);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -36,7 +36,7 @@ public:
     LUA_DECLARE(GetVehicleRotation);
     LUA_DECLARE(GetVehicleSirensOn);
     LUA_DECLARE_OOP(GetVehicleTurnVelocity);
-    LUA_DECLARE(GetVehicleTurretPosition);
+    LUA_DECLARE_OOP(GetVehicleTurretPosition);
     LUA_DECLARE(IsVehicleLocked);
     LUA_DECLARE(GetVehicleUpgradeOnSlot);
     LUA_DECLARE(GetVehicleUpgrades);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -36,7 +36,8 @@ public:
     LUA_DECLARE(GetVehicleRotation);
     LUA_DECLARE(GetVehicleSirensOn);
     LUA_DECLARE_OOP(GetVehicleTurnVelocity);
-    LUA_DECLARE_OOP(GetVehicleTurretPosition);
+    LUA_DECLARE(GetVehicleTurretPosition);
+    static std::variant<CLuaMultiReturn<float, float>, CVector2D> OOP_GetVehicleTurretPosition(lua_State* luaVM, CClientVehicle* vehicle);
     LUA_DECLARE(IsVehicleLocked);
     LUA_DECLARE(GetVehicleUpgradeOnSlot);
     LUA_DECLARE(GetVehicleUpgrades);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -36,8 +36,7 @@ public:
     LUA_DECLARE(GetVehicleRotation);
     LUA_DECLARE(GetVehicleSirensOn);
     LUA_DECLARE_OOP(GetVehicleTurnVelocity);
-    LUA_DECLARE(GetVehicleTurretPosition);
-    static CVector2D OOP_GetVehicleTurretPosition(CClientVehicle* pVehicle);
+    LUA_DECLARE_OOP(GetVehicleTurretPosition);
     LUA_DECLARE(IsVehicleLocked);
     LUA_DECLARE(GetVehicleUpgradeOnSlot);
     LUA_DECLARE(GetVehicleUpgrades);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
@@ -10,6 +10,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include <lua/CLuaFunctionParser.h>
 
 void CLuaWaterDefs::LoadFunctions()
 {
@@ -48,7 +49,7 @@ void CLuaWaterDefs::AddClass(lua_State* luaVM)
     // lua_classvariable ( luaVM, "drawnLast", "setWaterDrawnLast", "isWaterDrawnLast" );
 
     lua_classfunction(luaVM, "getLevel", "getWaterLevel");
-    lua_classfunction(luaVM, "getVertexPosition", OOP_GetWaterVertexPosition);
+    lua_classfunction(luaVM, "getVertexPosition", ArgumentParserWarn<false, OOP_GetWaterVertexPosition>);
     lua_classfunction(luaVM, "getWaveHeight", "getWaveHeight");
     lua_classfunction(luaVM, "getColor", "getWaterColor");
 
@@ -429,28 +430,11 @@ int CLuaWaterDefs::GetWaterVertexPosition(lua_State* luaVM)
     return 1;
 }
 
-int CLuaWaterDefs::OOP_GetWaterVertexPosition(lua_State* luaVM)
+std::variant<bool, CVector> CLuaWaterDefs::OOP_GetWaterVertexPosition(CClientWater* pWater, int iVertexIndex)
 {
-    //  vector getWaterVertexPosition ( water theWater, int vertexIndex )
-    CClientWater* pWater;
-    int           iVertexIndex;
+    CVector vecPosition;
+    if (!CStaticFunctionDefinitions::GetWaterVertexPosition(pWater, iVertexIndex, vecPosition))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pWater);
-    argStream.ReadNumber(iVertexIndex);
-
-    if (!argStream.HasErrors())
-    {
-        CVector vecPosition;
-        if (CStaticFunctionDefinitions::GetWaterVertexPosition(pWater, iVertexIndex, vecPosition))
-        {
-            lua_pushvector(luaVM, vecPosition);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecPosition;
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
@@ -48,7 +48,7 @@ void CLuaWaterDefs::AddClass(lua_State* luaVM)
     // lua_classvariable ( luaVM, "drawnLast", "setWaterDrawnLast", "isWaterDrawnLast" );
 
     lua_classfunction(luaVM, "getLevel", "getWaterLevel");
-    lua_classfunction(luaVM, "getVertexPosition", "getWaterVertexPosition");
+    lua_classfunction(luaVM, "getVertexPosition", OOP_GetWaterVertexPosition);
     lua_classfunction(luaVM, "getWaveHeight", "getWaveHeight");
     lua_classfunction(luaVM, "getColor", "getWaterColor");
 
@@ -420,6 +420,32 @@ int CLuaWaterDefs::GetWaterVertexPosition(lua_State* luaVM)
             lua_pushnumber(luaVM, vecPosition.fY);
             lua_pushnumber(luaVM, vecPosition.fZ);
             return 3;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaWaterDefs::OOP_GetWaterVertexPosition(lua_State* luaVM)
+{
+    //  vector getWaterVertexPosition ( water theWater, int vertexIndex )
+    CClientWater* pWater;
+    int           iVertexIndex;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pWater);
+    argStream.ReadNumber(iVertexIndex);
+
+    if (!argStream.HasErrors())
+    {
+        CVector vecPosition;
+        if (CStaticFunctionDefinitions::GetWaterVertexPosition(pWater, iVertexIndex, vecPosition))
+        {
+            lua_pushvector(luaVM, vecPosition);
+            return 1;
         }
     }
     else

--- a/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
@@ -49,7 +49,7 @@ void CLuaWaterDefs::AddClass(lua_State* luaVM)
     // lua_classvariable ( luaVM, "drawnLast", "setWaterDrawnLast", "isWaterDrawnLast" );
 
     lua_classfunction(luaVM, "getLevel", "getWaterLevel");
-    lua_classfunction(luaVM, "getVertexPosition", ArgumentParserWarn<false, OOP_GetWaterVertexPosition>);
+    lua_classfunction(luaVM, "getVertexPosition", OOP_GetWaterVertexPosition);
     lua_classfunction(luaVM, "getWaveHeight", "getWaveHeight");
     lua_classfunction(luaVM, "getColor", "getWaterColor");
 
@@ -430,11 +430,37 @@ int CLuaWaterDefs::GetWaterVertexPosition(lua_State* luaVM)
     return 1;
 }
 
-std::variant<bool, CVector> CLuaWaterDefs::OOP_GetWaterVertexPosition(CClientWater* pWater, int iVertexIndex)
+int CLuaWaterDefs::OOP_GetWaterVertexPosition(lua_State* luaVM)
 {
-    CVector vecPosition;
-    if (!CStaticFunctionDefinitions::GetWaterVertexPosition(pWater, iVertexIndex, vecPosition))
-        return false;
+    // vector3 getWaterVertexPosition ( water theWater, int vertexIndex ) — or 3 floats if the caller expects them
+    CClientWater* pWater;
+    int           iVertexIndex;
 
-    return vecPosition;
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pWater);
+    argStream.ReadNumber(iVertexIndex);
+
+    if (!argStream.HasErrors())
+    {
+        CVector vecPosition;
+        if (CStaticFunctionDefinitions::GetWaterVertexPosition(pWater, iVertexIndex, vecPosition))
+        {
+            int iExpected = lua_ncallresult(luaVM);
+            if (iExpected == 3)
+            {
+                lua_pushnumber(luaVM, vecPosition.fX);
+                lua_pushnumber(luaVM, vecPosition.fY);
+                lua_pushnumber(luaVM, vecPosition.fZ);
+                return 3;
+            }
+
+            lua_pushvector(luaVM, vecPosition);
+            return 1;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
@@ -49,7 +49,7 @@ void CLuaWaterDefs::AddClass(lua_State* luaVM)
     // lua_classvariable ( luaVM, "drawnLast", "setWaterDrawnLast", "isWaterDrawnLast" );
 
     lua_classfunction(luaVM, "getLevel", "getWaterLevel");
-    lua_classfunction(luaVM, "getVertexPosition", OOP_GetWaterVertexPosition);
+    lua_classfunction(luaVM, "getVertexPosition", ArgumentParserWarn<false, OOP_GetWaterVertexPosition>);
     lua_classfunction(luaVM, "getWaveHeight", "getWaveHeight");
     lua_classfunction(luaVM, "getColor", "getWaterColor");
 
@@ -430,37 +430,16 @@ int CLuaWaterDefs::GetWaterVertexPosition(lua_State* luaVM)
     return 1;
 }
 
-int CLuaWaterDefs::OOP_GetWaterVertexPosition(lua_State* luaVM)
+std::variant<CLuaMultiReturn<float, float, float>, CVector, bool> CLuaWaterDefs::OOP_GetWaterVertexPosition(lua_State* luaVM, CClientWater* water,
+                                                                                                            int vertexIndex)
 {
-    // vector3 getWaterVertexPosition ( water theWater, int vertexIndex ) — or 3 floats if the caller expects them
-    CClientWater* pWater;
-    int           iVertexIndex;
+    CVector vecPosition;
+    if (!CStaticFunctionDefinitions::GetWaterVertexPosition(water, vertexIndex, vecPosition))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pWater);
-    argStream.ReadNumber(iVertexIndex);
+    // Keep returning three floats when the caller assigns three results
+    if (lua_ncallresult(luaVM) == 3)
+        return CLuaMultiReturn<float, float, float>(vecPosition.fX, vecPosition.fY, vecPosition.fZ);
 
-    if (!argStream.HasErrors())
-    {
-        CVector vecPosition;
-        if (CStaticFunctionDefinitions::GetWaterVertexPosition(pWater, iVertexIndex, vecPosition))
-        {
-            int iExpected = lua_ncallresult(luaVM);
-            if (iExpected == 3)
-            {
-                lua_pushnumber(luaVM, vecPosition.fX);
-                lua_pushnumber(luaVM, vecPosition.fY);
-                lua_pushnumber(luaVM, vecPosition.fZ);
-                return 3;
-            }
-
-            lua_pushvector(luaVM, vecPosition);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecPosition;
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.h
@@ -31,5 +31,6 @@ public:
     LUA_DECLARE(GetWaterColor);
     LUA_DECLARE(GetWaterLevel);
     LUA_DECLARE(IsWaterDrawnLast);
+    LUA_DECLARE(GetWaterVertexPosition);
     static std::variant<bool, CVector> OOP_GetWaterVertexPosition(CClientWater* pWater, int iVertexIndex);
 };

--- a/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.h
@@ -31,5 +31,5 @@ public:
     LUA_DECLARE(GetWaterColor);
     LUA_DECLARE(GetWaterLevel);
     LUA_DECLARE(IsWaterDrawnLast);
-    LUA_DECLARE(GetWaterVertexPosition);
+    LUA_DECLARE_OOP(GetWaterVertexPosition);
 };

--- a/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.h
@@ -31,5 +31,5 @@ public:
     LUA_DECLARE(GetWaterColor);
     LUA_DECLARE(GetWaterLevel);
     LUA_DECLARE(IsWaterDrawnLast);
-    LUA_DECLARE_OOP(GetWaterVertexPosition);
+    static std::variant<bool, CVector> OOP_GetWaterVertexPosition(CClientWater* pWater, int iVertexIndex);
 };

--- a/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.h
@@ -31,6 +31,5 @@ public:
     LUA_DECLARE(GetWaterColor);
     LUA_DECLARE(GetWaterLevel);
     LUA_DECLARE(IsWaterDrawnLast);
-    LUA_DECLARE(GetWaterVertexPosition);
-    static std::variant<bool, CVector> OOP_GetWaterVertexPosition(CClientWater* pWater, int iVertexIndex);
+    LUA_DECLARE_OOP(GetWaterVertexPosition);
 };

--- a/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaWaterDefs.h
@@ -12,6 +12,8 @@
 #pragma once
 #include "CLuaDefs.h"
 
+class CClientWater;
+
 class CLuaWaterDefs : public CLuaDefs
 {
 public:
@@ -31,5 +33,6 @@ public:
     LUA_DECLARE(GetWaterColor);
     LUA_DECLARE(GetWaterLevel);
     LUA_DECLARE(IsWaterDrawnLast);
-    LUA_DECLARE_OOP(GetWaterVertexPosition);
+    LUA_DECLARE(GetWaterVertexPosition);
+    static std::variant<CLuaMultiReturn<float, float, float>, CVector, bool> OOP_GetWaterVertexPosition(lua_State* luaVM, CClientWater* water, int vertexIndex);
 };

--- a/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
@@ -13,6 +13,7 @@
 #include "CLuaRadarAreaDefs.h"
 #include "CStaticFunctionDefinitions.h"
 #include "CScriptArgReader.h"
+#include <lua/CLuaFunctionParser.h>
 
 void CLuaRadarAreaDefs::LoadFunctions()
 {
@@ -45,7 +46,7 @@ void CLuaRadarAreaDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "isInside", "isInsideRadarArea");
 
     lua_classfunction(luaVM, "isFlashing", "isRadarAreaFlashing");
-    lua_classfunction(luaVM, "getSize", "getRadarAreaSize", OOP_GetRadarAreaSize);
+    lua_classfunction(luaVM, "getSize", "getRadarAreaSize", ArgumentParserWarn<false, OOP_GetRadarAreaSize>);
     lua_classfunction(luaVM, "getColor", "getRadarAreaColor");
 
     lua_classfunction(luaVM, "setSize", "setRadarAreaSize");
@@ -53,7 +54,7 @@ void CLuaRadarAreaDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setColor", "setRadarAreaColor");
 
     lua_classvariable(luaVM, "flashing", "setRadarAreaFlashing", "isRadarAreaFlashing");
-    lua_classvariable(luaVM, "size", "setRadarAreaSize", "getRadarAreaSize", SetRadarAreaSize, OOP_GetRadarAreaSize);
+    lua_classvariable(luaVM, "size", "setRadarAreaSize", "getRadarAreaSize", SetRadarAreaSize, ArgumentParserWarn<false, OOP_GetRadarAreaSize>);
 
     lua_registerclass(luaVM, "RadarArea", "Element");
 }
@@ -133,28 +134,13 @@ int CLuaRadarAreaDefs::GetRadarAreaSize(lua_State* luaVM)
     return 1;
 }
 
-int CLuaRadarAreaDefs::OOP_GetRadarAreaSize(lua_State* luaVM)
+std::variant<bool, CVector2D> CLuaRadarAreaDefs::OOP_GetRadarAreaSize(CRadarArea* pRadarArea)
 {
-    //  vector2 getRadarAreaSize ( radararea theRadararea )
-    CRadarArea* pRadarArea;
+    CVector2D vecSize;
+    if (!CStaticFunctionDefinitions::GetRadarAreaSize(pRadarArea, vecSize))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pRadarArea);
-
-    if (!argStream.HasErrors())
-    {
-        CVector2D vecSize;
-        if (CStaticFunctionDefinitions::GetRadarAreaSize(pRadarArea, vecSize))
-        {
-            lua_pushvector(luaVM, vecSize);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecSize;
 }
 
 int CLuaRadarAreaDefs::GetRadarAreaColor(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
@@ -45,7 +45,7 @@ void CLuaRadarAreaDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "isInside", "isInsideRadarArea");
 
     lua_classfunction(luaVM, "isFlashing", "isRadarAreaFlashing");
-    lua_classfunction(luaVM, "getSize", "getRadarAreaSize");
+    lua_classfunction(luaVM, "getSize", "getRadarAreaSize", OOP_GetRadarAreaSize);
     lua_classfunction(luaVM, "getColor", "getRadarAreaColor");
 
     lua_classfunction(luaVM, "setSize", "setRadarAreaSize");

--- a/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
@@ -46,7 +46,7 @@ void CLuaRadarAreaDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "isInside", "isInsideRadarArea");
 
     lua_classfunction(luaVM, "isFlashing", "isRadarAreaFlashing");
-    lua_classfunction(luaVM, "getSize", "getRadarAreaSize", OOP_GetRadarAreaSize);
+    lua_classfunction(luaVM, "getSize", "getRadarAreaSize", ArgumentParserWarn<false, OOP_GetRadarAreaSize>);
     lua_classfunction(luaVM, "getColor", "getRadarAreaColor");
 
     lua_classfunction(luaVM, "setSize", "setRadarAreaSize");
@@ -54,7 +54,7 @@ void CLuaRadarAreaDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setColor", "setRadarAreaColor");
 
     lua_classvariable(luaVM, "flashing", "setRadarAreaFlashing", "isRadarAreaFlashing");
-    lua_classvariable(luaVM, "size", "setRadarAreaSize", "getRadarAreaSize", SetRadarAreaSize, OOP_GetRadarAreaSize);
+    lua_classvariable(luaVM, "size", "setRadarAreaSize", "getRadarAreaSize", SetRadarAreaSize, ArgumentParserWarn<false, OOP_GetRadarAreaSize>);
 
     lua_registerclass(luaVM, "RadarArea", "Element");
 }
@@ -134,36 +134,17 @@ int CLuaRadarAreaDefs::GetRadarAreaSize(lua_State* luaVM)
     return 1;
 }
 
-int CLuaRadarAreaDefs::OOP_GetRadarAreaSize(lua_State* luaVM)
+std::variant<CLuaMultiReturn<float, float>, CVector2D, bool> CLuaRadarAreaDefs::OOP_GetRadarAreaSize(lua_State* luaVM, CRadarArea* radarArea)
 {
-    // vector2 getRadarAreaSize ( radararea theRadararea ) — or 2 floats if the caller expects them
-    CRadarArea* pRadarArea;
+    CVector2D vecSize;
+    if (!CStaticFunctionDefinitions::GetRadarAreaSize(radarArea, vecSize))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pRadarArea);
+    // Keep returning two floats when the caller assigns two results
+    if (lua_ncallresult(luaVM) == 2)
+        return CLuaMultiReturn<float, float>(vecSize.fX, vecSize.fY);
 
-    if (!argStream.HasErrors())
-    {
-        CVector2D vecSize;
-        if (CStaticFunctionDefinitions::GetRadarAreaSize(pRadarArea, vecSize))
-        {
-            int iExpected = lua_ncallresult(luaVM);
-            if (iExpected == 2)
-            {
-                lua_pushnumber(luaVM, static_cast<lua_Number>(vecSize.fX));
-                lua_pushnumber(luaVM, static_cast<lua_Number>(vecSize.fY));
-                return 2;
-            }
-
-            lua_pushvector(luaVM, vecSize);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecSize;
 }
 
 int CLuaRadarAreaDefs::GetRadarAreaColor(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.cpp
@@ -46,7 +46,7 @@ void CLuaRadarAreaDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "isInside", "isInsideRadarArea");
 
     lua_classfunction(luaVM, "isFlashing", "isRadarAreaFlashing");
-    lua_classfunction(luaVM, "getSize", "getRadarAreaSize", ArgumentParserWarn<false, OOP_GetRadarAreaSize>);
+    lua_classfunction(luaVM, "getSize", "getRadarAreaSize", OOP_GetRadarAreaSize);
     lua_classfunction(luaVM, "getColor", "getRadarAreaColor");
 
     lua_classfunction(luaVM, "setSize", "setRadarAreaSize");
@@ -54,7 +54,7 @@ void CLuaRadarAreaDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setColor", "setRadarAreaColor");
 
     lua_classvariable(luaVM, "flashing", "setRadarAreaFlashing", "isRadarAreaFlashing");
-    lua_classvariable(luaVM, "size", "setRadarAreaSize", "getRadarAreaSize", SetRadarAreaSize, ArgumentParserWarn<false, OOP_GetRadarAreaSize>);
+    lua_classvariable(luaVM, "size", "setRadarAreaSize", "getRadarAreaSize", SetRadarAreaSize, OOP_GetRadarAreaSize);
 
     lua_registerclass(luaVM, "RadarArea", "Element");
 }
@@ -134,13 +134,36 @@ int CLuaRadarAreaDefs::GetRadarAreaSize(lua_State* luaVM)
     return 1;
 }
 
-std::variant<bool, CVector2D> CLuaRadarAreaDefs::OOP_GetRadarAreaSize(CRadarArea* pRadarArea)
+int CLuaRadarAreaDefs::OOP_GetRadarAreaSize(lua_State* luaVM)
 {
-    CVector2D vecSize;
-    if (!CStaticFunctionDefinitions::GetRadarAreaSize(pRadarArea, vecSize))
-        return false;
+    // vector2 getRadarAreaSize ( radararea theRadararea ) — or 2 floats if the caller expects them
+    CRadarArea* pRadarArea;
 
-    return vecSize;
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pRadarArea);
+
+    if (!argStream.HasErrors())
+    {
+        CVector2D vecSize;
+        if (CStaticFunctionDefinitions::GetRadarAreaSize(pRadarArea, vecSize))
+        {
+            int iExpected = lua_ncallresult(luaVM);
+            if (iExpected == 2)
+            {
+                lua_pushnumber(luaVM, static_cast<lua_Number>(vecSize.fX));
+                lua_pushnumber(luaVM, static_cast<lua_Number>(vecSize.fY));
+                return 2;
+            }
+
+            lua_pushvector(luaVM, vecSize);
+            return 1;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
 }
 
 int CLuaRadarAreaDefs::GetRadarAreaColor(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.h
@@ -22,6 +22,7 @@ public:
     LUA_DECLARE(CreateRadarArea);
 
     // Radar area get funcs
+    LUA_DECLARE(GetRadarAreaSize);
     static std::variant<bool, CVector2D> OOP_GetRadarAreaSize(CRadarArea* pRadarArea);
     LUA_DECLARE(GetRadarAreaColor);
     LUA_DECLARE(IsRadarAreaFlashing);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.h
@@ -22,7 +22,7 @@ public:
     LUA_DECLARE(CreateRadarArea);
 
     // Radar area get funcs
-    LUA_DECLARE_OOP(GetRadarAreaSize);
+    static std::variant<bool, CVector2D> OOP_GetRadarAreaSize(CRadarArea* pRadarArea);
     LUA_DECLARE(GetRadarAreaColor);
     LUA_DECLARE(IsRadarAreaFlashing);
     LUA_DECLARE(IsInsideRadarArea);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.h
@@ -12,6 +12,8 @@
 #pragma once
 #include "CLuaDefs.h"
 
+class CRadarArea;
+
 class CLuaRadarAreaDefs : public CLuaDefs
 {
 public:
@@ -22,7 +24,8 @@ public:
     LUA_DECLARE(CreateRadarArea);
 
     // Radar area get funcs
-    LUA_DECLARE_OOP(GetRadarAreaSize);
+    LUA_DECLARE(GetRadarAreaSize);
+    static std::variant<CLuaMultiReturn<float, float>, CVector2D, bool> OOP_GetRadarAreaSize(lua_State* luaVM, CRadarArea* radarArea);
     LUA_DECLARE(GetRadarAreaColor);
     LUA_DECLARE(IsRadarAreaFlashing);
     LUA_DECLARE(IsInsideRadarArea);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaRadarAreaDefs.h
@@ -22,8 +22,7 @@ public:
     LUA_DECLARE(CreateRadarArea);
 
     // Radar area get funcs
-    LUA_DECLARE(GetRadarAreaSize);
-    static std::variant<bool, CVector2D> OOP_GetRadarAreaSize(CRadarArea* pRadarArea);
+    LUA_DECLARE_OOP(GetRadarAreaSize);
     LUA_DECLARE(GetRadarAreaColor);
     LUA_DECLARE(IsRadarAreaFlashing);
     LUA_DECLARE(IsInsideRadarArea);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.cpp
@@ -71,7 +71,7 @@ void CLuaTextDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "destroy", "textDestroyTextItem");
 
     lua_classfunction(luaVM, "getColor", "textItemGetColor");
-    lua_classfunction(luaVM, "getPosition", "textItemGetPosition");
+    lua_classfunction(luaVM, "getPosition", "textItemGetPosition", OOP_textItemGetPosition);
     lua_classfunction(luaVM, "getPriority", "textItemGetPriority");
     lua_classfunction(luaVM, "getScale", "textItemGetScale");
     lua_classfunction(luaVM, "getText", "textItemGetText");
@@ -85,7 +85,7 @@ void CLuaTextDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "priority", "textItemSetPriority", "textItemGetPriority");
     lua_classvariable(luaVM, "scale", "textItemSetScale", "textItemGetScale");
     lua_classvariable(luaVM, "text", "textItemSetText", "textItemGetText");
-    lua_classvariable(luaVM, "position", "textItemSetPosition", "textItemGetPosition");
+    lua_classvariable(luaVM, "position", "textItemSetPosition", "textItemGetPosition", textItemSetPosition, OOP_textItemGetPosition);
 
     lua_registerclass(luaVM, "TextItem");
 }
@@ -444,13 +444,13 @@ int CLuaTextDefs::textItemGetScale(lua_State* luaVM)
 
 int CLuaTextDefs::textItemSetPosition(lua_State* luaVM)
 {
+    // Accept Vector2 as well so textItem.position = Vector2(...) works via the OOP property
     CTextItem* pTextItem;
     CVector2D  vecPosition;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pTextItem);
-    argStream.ReadNumber(vecPosition.fX);
-    argStream.ReadNumber(vecPosition.fY);
+    argStream.ReadVector2D(vecPosition);
 
     if (!argStream.HasErrors())
     {
@@ -479,6 +479,26 @@ int CLuaTextDefs::textItemGetPosition(lua_State* luaVM)
         lua_pushnumber(luaVM, vecPosition.fX);
         lua_pushnumber(luaVM, vecPosition.fY);
         return 2;
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaTextDefs::OOP_textItemGetPosition(lua_State* luaVM)
+{
+    CTextItem* pTextItem;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pTextItem);
+
+    if (!argStream.HasErrors())
+    {
+        CVector2D vecPosition = pTextItem->GetPosition();
+        lua_pushvector(luaVM, vecPosition);
+        return 1;
     }
     else
         m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());

--- a/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.cpp
@@ -12,6 +12,7 @@
 #include "StdInc.h"
 #include "CLuaTextDefs.h"
 #include "CScriptArgReader.h"
+#include <lua/CLuaFunctionParser.h>
 
 void CLuaTextDefs::LoadFunctions()
 {
@@ -71,7 +72,7 @@ void CLuaTextDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "destroy", "textDestroyTextItem");
 
     lua_classfunction(luaVM, "getColor", "textItemGetColor");
-    lua_classfunction(luaVM, "getPosition", "textItemGetPosition", OOP_textItemGetPosition);
+    lua_classfunction(luaVM, "getPosition", "textItemGetPosition", ArgumentParserWarn<false, OOP_textItemGetPosition>);
     lua_classfunction(luaVM, "getPriority", "textItemGetPriority");
     lua_classfunction(luaVM, "getScale", "textItemGetScale");
     lua_classfunction(luaVM, "getText", "textItemGetText");
@@ -85,7 +86,7 @@ void CLuaTextDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "priority", "textItemSetPriority", "textItemGetPriority");
     lua_classvariable(luaVM, "scale", "textItemSetScale", "textItemGetScale");
     lua_classvariable(luaVM, "text", "textItemSetText", "textItemGetText");
-    lua_classvariable(luaVM, "position", "textItemSetPosition", "textItemGetPosition", textItemSetPosition, OOP_textItemGetPosition);
+    lua_classvariable(luaVM, "position", "textItemSetPosition", "textItemGetPosition", textItemSetPosition, ArgumentParserWarn<false, OOP_textItemGetPosition>);
 
     lua_registerclass(luaVM, "TextItem");
 }
@@ -487,24 +488,9 @@ int CLuaTextDefs::textItemGetPosition(lua_State* luaVM)
     return 1;
 }
 
-int CLuaTextDefs::OOP_textItemGetPosition(lua_State* luaVM)
+CVector2D CLuaTextDefs::OOP_textItemGetPosition(CTextItem* pTextItem)
 {
-    CTextItem* pTextItem;
-
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pTextItem);
-
-    if (!argStream.HasErrors())
-    {
-        CVector2D vecPosition = pTextItem->GetPosition();
-        lua_pushvector(luaVM, vecPosition);
-        return 1;
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return pTextItem->GetPosition();
 }
 
 int CLuaTextDefs::textItemSetColor(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.cpp
@@ -72,7 +72,7 @@ void CLuaTextDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "destroy", "textDestroyTextItem");
 
     lua_classfunction(luaVM, "getColor", "textItemGetColor");
-    lua_classfunction(luaVM, "getPosition", "textItemGetPosition", ArgumentParserWarn<false, OOP_textItemGetPosition>);
+    lua_classfunction(luaVM, "getPosition", "textItemGetPosition", OOP_textItemGetPosition);
     lua_classfunction(luaVM, "getPriority", "textItemGetPriority");
     lua_classfunction(luaVM, "getScale", "textItemGetScale");
     lua_classfunction(luaVM, "getText", "textItemGetText");
@@ -86,7 +86,7 @@ void CLuaTextDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "priority", "textItemSetPriority", "textItemGetPriority");
     lua_classvariable(luaVM, "scale", "textItemSetScale", "textItemGetScale");
     lua_classvariable(luaVM, "text", "textItemSetText", "textItemGetText");
-    lua_classvariable(luaVM, "position", "textItemSetPosition", "textItemGetPosition", textItemSetPosition, ArgumentParserWarn<false, OOP_textItemGetPosition>);
+    lua_classvariable(luaVM, "position", "textItemSetPosition", "textItemGetPosition", textItemSetPosition, OOP_textItemGetPosition);
 
     lua_registerclass(luaVM, "TextItem");
 }
@@ -488,9 +488,34 @@ int CLuaTextDefs::textItemGetPosition(lua_State* luaVM)
     return 1;
 }
 
-CVector2D CLuaTextDefs::OOP_textItemGetPosition(CTextItem* pTextItem)
+int CLuaTextDefs::OOP_textItemGetPosition(lua_State* luaVM)
 {
-    return pTextItem->GetPosition();
+    // vector2 textItemGetPosition ( textitem theTextItem ) — or 2 floats if the caller expects them
+    CTextItem* pTextItem;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pTextItem);
+
+    if (!argStream.HasErrors())
+    {
+        CVector2D vecPosition = pTextItem->GetPosition();
+
+        int iExpected = lua_ncallresult(luaVM);
+        if (iExpected == 2)
+        {
+            lua_pushnumber(luaVM, vecPosition.fX);
+            lua_pushnumber(luaVM, vecPosition.fY);
+            return 2;
+        }
+
+        lua_pushvector(luaVM, vecPosition);
+        return 1;
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
 }
 
 int CLuaTextDefs::textItemSetColor(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.cpp
@@ -86,8 +86,7 @@ void CLuaTextDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "priority", "textItemSetPriority", "textItemGetPriority");
     lua_classvariable(luaVM, "scale", "textItemSetScale", "textItemGetScale");
     lua_classvariable(luaVM, "text", "textItemSetText", "textItemGetText");
-    lua_classvariable(luaVM, "position", "textItemSetPosition", "textItemGetPosition", textItemSetPosition,
-                      ArgumentParserWarn<false, OOP_textItemGetPosition>);
+    lua_classvariable(luaVM, "position", "textItemSetPosition", "textItemGetPosition", textItemSetPosition, ArgumentParserWarn<false, OOP_textItemGetPosition>);
 
     lua_registerclass(luaVM, "TextItem");
 }

--- a/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.cpp
@@ -72,7 +72,7 @@ void CLuaTextDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "destroy", "textDestroyTextItem");
 
     lua_classfunction(luaVM, "getColor", "textItemGetColor");
-    lua_classfunction(luaVM, "getPosition", "textItemGetPosition", OOP_textItemGetPosition);
+    lua_classfunction(luaVM, "getPosition", "textItemGetPosition", ArgumentParserWarn<false, OOP_textItemGetPosition>);
     lua_classfunction(luaVM, "getPriority", "textItemGetPriority");
     lua_classfunction(luaVM, "getScale", "textItemGetScale");
     lua_classfunction(luaVM, "getText", "textItemGetText");
@@ -86,7 +86,8 @@ void CLuaTextDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "priority", "textItemSetPriority", "textItemGetPriority");
     lua_classvariable(luaVM, "scale", "textItemSetScale", "textItemGetScale");
     lua_classvariable(luaVM, "text", "textItemSetText", "textItemGetText");
-    lua_classvariable(luaVM, "position", "textItemSetPosition", "textItemGetPosition", textItemSetPosition, OOP_textItemGetPosition);
+    lua_classvariable(luaVM, "position", "textItemSetPosition", "textItemGetPosition", textItemSetPosition,
+                      ArgumentParserWarn<false, OOP_textItemGetPosition>);
 
     lua_registerclass(luaVM, "TextItem");
 }
@@ -488,34 +489,15 @@ int CLuaTextDefs::textItemGetPosition(lua_State* luaVM)
     return 1;
 }
 
-int CLuaTextDefs::OOP_textItemGetPosition(lua_State* luaVM)
+std::variant<CLuaMultiReturn<float, float>, CVector2D> CLuaTextDefs::OOP_textItemGetPosition(lua_State* luaVM, CTextItem* textItem)
 {
-    // vector2 textItemGetPosition ( textitem theTextItem ) — or 2 floats if the caller expects them
-    CTextItem* pTextItem;
+    const CVector2D& vecPosition = textItem->GetPosition();
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pTextItem);
+    // Keep returning two floats when the caller assigns two results
+    if (lua_ncallresult(luaVM) == 2)
+        return CLuaMultiReturn<float, float>(vecPosition.fX, vecPosition.fY);
 
-    if (!argStream.HasErrors())
-    {
-        CVector2D vecPosition = pTextItem->GetPosition();
-
-        int iExpected = lua_ncallresult(luaVM);
-        if (iExpected == 2)
-        {
-            lua_pushnumber(luaVM, vecPosition.fX);
-            lua_pushnumber(luaVM, vecPosition.fY);
-            return 2;
-        }
-
-        lua_pushvector(luaVM, vecPosition);
-        return 1;
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecPosition;
 }
 
 int CLuaTextDefs::textItemSetColor(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.h
@@ -35,6 +35,7 @@ public:
     LUA_DECLARE(textItemSetScale);
     LUA_DECLARE(textItemGetScale);
     LUA_DECLARE(textItemSetPosition);
+    LUA_DECLARE(textItemGetPosition);
     static CVector2D OOP_textItemGetPosition(CTextItem* pTextItem);
     LUA_DECLARE(textItemSetColor);
     LUA_DECLARE(textItemGetColor);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.h
@@ -35,7 +35,7 @@ public:
     LUA_DECLARE(textItemSetScale);
     LUA_DECLARE(textItemGetScale);
     LUA_DECLARE(textItemSetPosition);
-    LUA_DECLARE(textItemGetPosition);
+    LUA_DECLARE_OOP(textItemGetPosition);
     LUA_DECLARE(textItemSetColor);
     LUA_DECLARE(textItemGetColor);
     LUA_DECLARE(textItemSetPriority);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.h
@@ -35,7 +35,7 @@ public:
     LUA_DECLARE(textItemSetScale);
     LUA_DECLARE(textItemGetScale);
     LUA_DECLARE(textItemSetPosition);
-    LUA_DECLARE_OOP(textItemGetPosition);
+    static CVector2D OOP_textItemGetPosition(CTextItem* pTextItem);
     LUA_DECLARE(textItemSetColor);
     LUA_DECLARE(textItemGetColor);
     LUA_DECLARE(textItemSetPriority);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.h
@@ -36,7 +36,7 @@ public:
     LUA_DECLARE(textItemGetScale);
     LUA_DECLARE(textItemSetPosition);
     LUA_DECLARE(textItemGetPosition);
-    static CVector2D OOP_textItemGetPosition(CTextItem* pTextItem);
+    LUA_DECLARE(OOP_textItemGetPosition);
     LUA_DECLARE(textItemSetColor);
     LUA_DECLARE(textItemGetColor);
     LUA_DECLARE(textItemSetPriority);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaTextDefs.h
@@ -12,6 +12,8 @@
 #pragma once
 #include "CLuaDefs.h"
 
+class CTextItem;
+
 class CLuaTextDefs : public CLuaDefs
 {
 public:
@@ -36,7 +38,7 @@ public:
     LUA_DECLARE(textItemGetScale);
     LUA_DECLARE(textItemSetPosition);
     LUA_DECLARE(textItemGetPosition);
-    LUA_DECLARE(OOP_textItemGetPosition);
+    static std::variant<CLuaMultiReturn<float, float>, CVector2D> OOP_textItemGetPosition(lua_State* luaVM, CTextItem* textItem);
     LUA_DECLARE(textItemSetColor);
     LUA_DECLARE(textItemGetColor);
     LUA_DECLARE(textItemSetPriority);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -205,15 +205,15 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getTowedByVehicle", "getVehicleTowedByVehicle");
     lua_classfunction(luaVM, "getTowingVehicle", "getVehicleTowingVehicle");
     lua_classfunction(luaVM, "getTurnVelocity", "getVehicleTurnVelocity", CLuaVehicleDefs::OOP_GetVehicleTurnVelocity);
-    lua_classfunction(luaVM, "getTurretPosition", "getVehicleTurretPosition");
+    lua_classfunction(luaVM, "getTurretPosition", "getVehicleTurretPosition", OOP_GetVehicleTurretPosition);
     lua_classfunction(luaVM, "getVehicleType", "getVehicleType");  // This isn't "getType" because it would overwrite Element.getType
     lua_classfunction(luaVM, "getUpgradeOnSlot", "getVehicleUpgradeOnSlot");
     lua_classfunction(luaVM, "getUpgrades", "getVehicleUpgrades");
     lua_classfunction(luaVM, "getWheelStates", "getVehicleWheelStates");
     lua_classfunction(luaVM, "getDoorOpenRatio", "getVehicleDoorOpenRatio");
     lua_classfunction(luaVM, "getHandling", "getVehicleHandling");
-    lua_classfunction(luaVM, "getRespawnPosition", "getVehicleRespawnPosition");
-    lua_classfunction(luaVM, "getRespawnRotation", "getVehicleRespawnRotation");
+    lua_classfunction(luaVM, "getRespawnPosition", "getVehicleRespawnPosition", OOP_GetVehicleRespawnPosition);
+    lua_classfunction(luaVM, "getRespawnRotation", "getVehicleRespawnRotation", OOP_GetVehicleRespawnRotation);
     lua_classfunction(luaVM, "isRespawnable", "isVehicleRespawnable");
     lua_classfunction(luaVM, "getRespawnDelay", "getVehicleRespawnDelay");
     lua_classfunction(luaVM, "getIdleRespawnDelay", "getVehicleIdleRespawnDelay");
@@ -280,7 +280,7 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "landingGearDown", "setVehicleLandingGearDown", "getVehicleLandingGearDown");
     lua_classvariable(luaVM, "maxPassengers", NULL, "getVehicleMaxPassengers");
     lua_classvariable(luaVM, "upgrades", NULL, "getVehicleUpgrades");
-    lua_classvariable(luaVM, "turretPosition", "setVehicleTurretPosition", "getVehicleTurretPosition");
+    lua_classvariable(luaVM, "turretPosition", "setVehicleTurretPosition", "getVehicleTurretPosition", SetVehicleTurretPosition, OOP_GetVehicleTurretPosition);
     lua_classvariable(luaVM, "turnVelocity", "setVehicleTurnVelocity", "getVehicleTurnVelocity", SetVehicleTurnVelocity, OOP_GetVehicleTurnVelocity);
     lua_classvariable(luaVM, "overrideLights", "setVehicleOverrideLights", "getVehicleOverrideLights");
     lua_classvariable(luaVM, "idleRespawnDelay", "setVehicleIdleRespawnDelay", "getVehicleIdleRespawnDelay");
@@ -1076,6 +1076,29 @@ int CLuaVehicleDefs::GetVehicleTurretPosition(lua_State* luaVM)
             lua_pushnumber(luaVM, vecPosition.fX);
             lua_pushnumber(luaVM, vecPosition.fY);
             return 2;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaVehicleDefs::OOP_GetVehicleTurretPosition(lua_State* luaVM)
+{
+    CVehicle* pVehicle;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pVehicle);
+
+    if (!argStream.HasErrors())
+    {
+        CVector2D vecPosition;
+        if (CStaticFunctionDefinitions::GetVehicleTurretPosition(pVehicle, vecPosition))
+        {
+            lua_pushvector(luaVM, vecPosition);
+            return 1;
         }
     }
     else
@@ -2895,18 +2918,17 @@ int CLuaVehicleDefs::SetVehicleHeadLightColor(lua_State* luaVM)
 
 int CLuaVehicleDefs::SetVehicleTurretPosition(lua_State* luaVM)
 {
+    // Accept Vector2 as well so vehicle.turretPosition = Vector2(...) works via the OOP property
     CVehicle* pVehicle;
-    float     fHorizontal;
-    float     fVertical;
+    CVector2D vecPosition;
 
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pVehicle);
-    argStream.ReadNumber(fHorizontal);
-    argStream.ReadNumber(fVertical);
+    argStream.ReadVector2D(vecPosition);
 
     if (!argStream.HasErrors())
     {
-        if (CStaticFunctionDefinitions::SetVehicleTurretPosition(pVehicle, fHorizontal, fVertical))
+        if (CStaticFunctionDefinitions::SetVehicleTurretPosition(pVehicle, vecPosition.fX, vecPosition.fY))
         {
             lua_pushboolean(luaVM, true);
             return 1;

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -205,15 +205,15 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getTowedByVehicle", "getVehicleTowedByVehicle");
     lua_classfunction(luaVM, "getTowingVehicle", "getVehicleTowingVehicle");
     lua_classfunction(luaVM, "getTurnVelocity", "getVehicleTurnVelocity", CLuaVehicleDefs::OOP_GetVehicleTurnVelocity);
-    lua_classfunction(luaVM, "getTurretPosition", "getVehicleTurretPosition", OOP_GetVehicleTurretPosition);
+    lua_classfunction(luaVM, "getTurretPosition", "getVehicleTurretPosition", ArgumentParserWarn<false, OOP_GetVehicleTurretPosition>);
     lua_classfunction(luaVM, "getVehicleType", "getVehicleType");  // This isn't "getType" because it would overwrite Element.getType
     lua_classfunction(luaVM, "getUpgradeOnSlot", "getVehicleUpgradeOnSlot");
     lua_classfunction(luaVM, "getUpgrades", "getVehicleUpgrades");
     lua_classfunction(luaVM, "getWheelStates", "getVehicleWheelStates");
     lua_classfunction(luaVM, "getDoorOpenRatio", "getVehicleDoorOpenRatio");
     lua_classfunction(luaVM, "getHandling", "getVehicleHandling");
-    lua_classfunction(luaVM, "getRespawnPosition", "getVehicleRespawnPosition", OOP_GetVehicleRespawnPosition);
-    lua_classfunction(luaVM, "getRespawnRotation", "getVehicleRespawnRotation", OOP_GetVehicleRespawnRotation);
+    lua_classfunction(luaVM, "getRespawnPosition", "getVehicleRespawnPosition", ArgumentParserWarn<false, OOP_GetVehicleRespawnPosition>);
+    lua_classfunction(luaVM, "getRespawnRotation", "getVehicleRespawnRotation", ArgumentParserWarn<false, OOP_GetVehicleRespawnRotation>);
     lua_classfunction(luaVM, "isRespawnable", "isVehicleRespawnable");
     lua_classfunction(luaVM, "getRespawnDelay", "getVehicleRespawnDelay");
     lua_classfunction(luaVM, "getIdleRespawnDelay", "getVehicleIdleRespawnDelay");
@@ -280,16 +280,17 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "landingGearDown", "setVehicleLandingGearDown", "getVehicleLandingGearDown");
     lua_classvariable(luaVM, "maxPassengers", NULL, "getVehicleMaxPassengers");
     lua_classvariable(luaVM, "upgrades", NULL, "getVehicleUpgrades");
-    lua_classvariable(luaVM, "turretPosition", "setVehicleTurretPosition", "getVehicleTurretPosition", SetVehicleTurretPosition, OOP_GetVehicleTurretPosition);
+    lua_classvariable(luaVM, "turretPosition", "setVehicleTurretPosition", "getVehicleTurretPosition", SetVehicleTurretPosition,
+                      ArgumentParserWarn<false, OOP_GetVehicleTurretPosition>);
     lua_classvariable(luaVM, "turnVelocity", "setVehicleTurnVelocity", "getVehicleTurnVelocity", SetVehicleTurnVelocity, OOP_GetVehicleTurnVelocity);
     lua_classvariable(luaVM, "overrideLights", "setVehicleOverrideLights", "getVehicleOverrideLights");
     lua_classvariable(luaVM, "idleRespawnDelay", "setVehicleIdleRespawnDelay", "getVehicleIdleRespawnDelay");
     lua_classvariable(luaVM, "respawnable", "toggleVehicleRespawn", "isVehicleRespawnable");
     lua_classvariable(luaVM, "respawnDelay", "setVehicleRespawnDelay", "getVehicleRespawnDelay");
     lua_classvariable(luaVM, "respawnPosition", "setVehicleRespawnPosition", "getVehicleRespawnPosition", SetVehicleRespawnPosition,
-                      OOP_GetVehicleRespawnPosition);
+                      ArgumentParserWarn<false, OOP_GetVehicleRespawnPosition>);
     lua_classvariable(luaVM, "respawnRotation", "setVehicleRespawnRotation", "getVehicleRespawnRotation", SetVehicleRespawnRotation,
-                      OOP_GetVehicleRespawnRotation);
+                      ArgumentParserWarn<false, OOP_GetVehicleRespawnRotation>);
     lua_classvariable(luaVM, "onGround", NULL, "isVehicleOnGround");
     lua_classvariable(luaVM, "name", NULL, "getVehicleName");
     lua_classvariable(luaVM, "vehicleType", NULL, "getVehicleType");
@@ -1085,27 +1086,13 @@ int CLuaVehicleDefs::GetVehicleTurretPosition(lua_State* luaVM)
     return 1;
 }
 
-int CLuaVehicleDefs::OOP_GetVehicleTurretPosition(lua_State* luaVM)
+std::variant<bool, CVector2D> CLuaVehicleDefs::OOP_GetVehicleTurretPosition(CVehicle* pVehicle)
 {
-    CVehicle* pVehicle;
+    CVector2D vecPosition;
+    if (!CStaticFunctionDefinitions::GetVehicleTurretPosition(pVehicle, vecPosition))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pVehicle);
-
-    if (!argStream.HasErrors())
-    {
-        CVector2D vecPosition;
-        if (CStaticFunctionDefinitions::GetVehicleTurretPosition(pVehicle, vecPosition))
-        {
-            lua_pushvector(luaVM, vecPosition);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecPosition;
 }
 
 int CLuaVehicleDefs::IsVehicleLocked(lua_State* luaVM)
@@ -2231,52 +2218,22 @@ int CLuaVehicleDefs::SetVehicleRespawnDelay(lua_State* luaVM)
     return 1;
 }
 
-int CLuaVehicleDefs::OOP_GetVehicleRespawnRotation(lua_State* luaVM)
+std::variant<bool, CVector> CLuaVehicleDefs::OOP_GetVehicleRespawnRotation(CElement* pElement)
 {
-    CElement* pElement = NULL;
+    CVector vecRotationDegress;
+    if (!CStaticFunctionDefinitions::GetVehicleRespawnRotation(pElement, vecRotationDegress))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pElement);
-
-    if (!argStream.HasErrors())
-    {
-        CVector vecRotationDegress;
-        if (CStaticFunctionDefinitions::GetVehicleRespawnRotation(pElement, vecRotationDegress))
-        {
-            lua_pushvector(luaVM, vecRotationDegress);
-
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecRotationDegress;
 }
 
-int CLuaVehicleDefs::OOP_GetVehicleRespawnPosition(lua_State* luaVM)
+std::variant<bool, CVector> CLuaVehicleDefs::OOP_GetVehicleRespawnPosition(CElement* pElement)
 {
-    CElement* pElement = NULL;
+    CVector vecPosition;
+    if (!CStaticFunctionDefinitions::GetVehicleRespawnPosition(pElement, vecPosition))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pElement);
-
-    if (!argStream.HasErrors())
-    {
-        CVector vecPosition;
-        if (CStaticFunctionDefinitions::GetVehicleRespawnPosition(pElement, vecPosition))
-        {
-            lua_pushvector(luaVM, vecPosition);
-
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecPosition;
 }
 
 int CLuaVehicleDefs::GetVehicleRespawnRotation(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -205,15 +205,15 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getTowedByVehicle", "getVehicleTowedByVehicle");
     lua_classfunction(luaVM, "getTowingVehicle", "getVehicleTowingVehicle");
     lua_classfunction(luaVM, "getTurnVelocity", "getVehicleTurnVelocity", CLuaVehicleDefs::OOP_GetVehicleTurnVelocity);
-    lua_classfunction(luaVM, "getTurretPosition", "getVehicleTurretPosition", ArgumentParserWarn<false, OOP_GetVehicleTurretPosition>);
+    lua_classfunction(luaVM, "getTurretPosition", "getVehicleTurretPosition", OOP_GetVehicleTurretPosition);
     lua_classfunction(luaVM, "getVehicleType", "getVehicleType");  // This isn't "getType" because it would overwrite Element.getType
     lua_classfunction(luaVM, "getUpgradeOnSlot", "getVehicleUpgradeOnSlot");
     lua_classfunction(luaVM, "getUpgrades", "getVehicleUpgrades");
     lua_classfunction(luaVM, "getWheelStates", "getVehicleWheelStates");
     lua_classfunction(luaVM, "getDoorOpenRatio", "getVehicleDoorOpenRatio");
     lua_classfunction(luaVM, "getHandling", "getVehicleHandling");
-    lua_classfunction(luaVM, "getRespawnPosition", "getVehicleRespawnPosition", ArgumentParserWarn<false, OOP_GetVehicleRespawnPosition>);
-    lua_classfunction(luaVM, "getRespawnRotation", "getVehicleRespawnRotation", ArgumentParserWarn<false, OOP_GetVehicleRespawnRotation>);
+    lua_classfunction(luaVM, "getRespawnPosition", "getVehicleRespawnPosition", OOP_GetVehicleRespawnPosition);
+    lua_classfunction(luaVM, "getRespawnRotation", "getVehicleRespawnRotation", OOP_GetVehicleRespawnRotation);
     lua_classfunction(luaVM, "isRespawnable", "isVehicleRespawnable");
     lua_classfunction(luaVM, "getRespawnDelay", "getVehicleRespawnDelay");
     lua_classfunction(luaVM, "getIdleRespawnDelay", "getVehicleIdleRespawnDelay");
@@ -280,17 +280,16 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "landingGearDown", "setVehicleLandingGearDown", "getVehicleLandingGearDown");
     lua_classvariable(luaVM, "maxPassengers", NULL, "getVehicleMaxPassengers");
     lua_classvariable(luaVM, "upgrades", NULL, "getVehicleUpgrades");
-    lua_classvariable(luaVM, "turretPosition", "setVehicleTurretPosition", "getVehicleTurretPosition", SetVehicleTurretPosition,
-                      ArgumentParserWarn<false, OOP_GetVehicleTurretPosition>);
+    lua_classvariable(luaVM, "turretPosition", "setVehicleTurretPosition", "getVehicleTurretPosition", SetVehicleTurretPosition, OOP_GetVehicleTurretPosition);
     lua_classvariable(luaVM, "turnVelocity", "setVehicleTurnVelocity", "getVehicleTurnVelocity", SetVehicleTurnVelocity, OOP_GetVehicleTurnVelocity);
     lua_classvariable(luaVM, "overrideLights", "setVehicleOverrideLights", "getVehicleOverrideLights");
     lua_classvariable(luaVM, "idleRespawnDelay", "setVehicleIdleRespawnDelay", "getVehicleIdleRespawnDelay");
     lua_classvariable(luaVM, "respawnable", "toggleVehicleRespawn", "isVehicleRespawnable");
     lua_classvariable(luaVM, "respawnDelay", "setVehicleRespawnDelay", "getVehicleRespawnDelay");
     lua_classvariable(luaVM, "respawnPosition", "setVehicleRespawnPosition", "getVehicleRespawnPosition", SetVehicleRespawnPosition,
-                      ArgumentParserWarn<false, OOP_GetVehicleRespawnPosition>);
+                      OOP_GetVehicleRespawnPosition);
     lua_classvariable(luaVM, "respawnRotation", "setVehicleRespawnRotation", "getVehicleRespawnRotation", SetVehicleRespawnRotation,
-                      ArgumentParserWarn<false, OOP_GetVehicleRespawnRotation>);
+                      OOP_GetVehicleRespawnRotation);
     lua_classvariable(luaVM, "onGround", NULL, "isVehicleOnGround");
     lua_classvariable(luaVM, "name", NULL, "getVehicleName");
     lua_classvariable(luaVM, "vehicleType", NULL, "getVehicleType");
@@ -1086,13 +1085,36 @@ int CLuaVehicleDefs::GetVehicleTurretPosition(lua_State* luaVM)
     return 1;
 }
 
-std::variant<bool, CVector2D> CLuaVehicleDefs::OOP_GetVehicleTurretPosition(CVehicle* pVehicle)
+int CLuaVehicleDefs::OOP_GetVehicleTurretPosition(lua_State* luaVM)
 {
-    CVector2D vecPosition;
-    if (!CStaticFunctionDefinitions::GetVehicleTurretPosition(pVehicle, vecPosition))
-        return false;
+    // vector2 getVehicleTurretPosition ( vehicle theVehicle ) — or 2 floats if the caller expects them
+    CVehicle* pVehicle;
 
-    return vecPosition;
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pVehicle);
+
+    if (!argStream.HasErrors())
+    {
+        CVector2D vecPosition;
+        if (CStaticFunctionDefinitions::GetVehicleTurretPosition(pVehicle, vecPosition))
+        {
+            int iExpected = lua_ncallresult(luaVM);
+            if (iExpected == 2)
+            {
+                lua_pushnumber(luaVM, vecPosition.fX);
+                lua_pushnumber(luaVM, vecPosition.fY);
+                return 2;
+            }
+
+            lua_pushvector(luaVM, vecPosition);
+            return 1;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
 }
 
 int CLuaVehicleDefs::IsVehicleLocked(lua_State* luaVM)
@@ -2218,22 +2240,70 @@ int CLuaVehicleDefs::SetVehicleRespawnDelay(lua_State* luaVM)
     return 1;
 }
 
-std::variant<bool, CVector> CLuaVehicleDefs::OOP_GetVehicleRespawnRotation(CElement* pElement)
+int CLuaVehicleDefs::OOP_GetVehicleRespawnRotation(lua_State* luaVM)
 {
-    CVector vecRotationDegress;
-    if (!CStaticFunctionDefinitions::GetVehicleRespawnRotation(pElement, vecRotationDegress))
-        return false;
+    // vector3 getVehicleRespawnRotation ( vehicle theVehicle ) — or 3 floats if the caller expects them
+    CElement* pElement = NULL;
 
-    return vecRotationDegress;
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pElement);
+
+    if (!argStream.HasErrors())
+    {
+        CVector vecRotationDegress;
+        if (CStaticFunctionDefinitions::GetVehicleRespawnRotation(pElement, vecRotationDegress))
+        {
+            int iExpected = lua_ncallresult(luaVM);
+            if (iExpected == 3)
+            {
+                lua_pushnumber(luaVM, vecRotationDegress.fX);
+                lua_pushnumber(luaVM, vecRotationDegress.fY);
+                lua_pushnumber(luaVM, vecRotationDegress.fZ);
+                return 3;
+            }
+
+            lua_pushvector(luaVM, vecRotationDegress);
+            return 1;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
 }
 
-std::variant<bool, CVector> CLuaVehicleDefs::OOP_GetVehicleRespawnPosition(CElement* pElement)
+int CLuaVehicleDefs::OOP_GetVehicleRespawnPosition(lua_State* luaVM)
 {
-    CVector vecPosition;
-    if (!CStaticFunctionDefinitions::GetVehicleRespawnPosition(pElement, vecPosition))
-        return false;
+    // vector3 getVehicleRespawnPosition ( vehicle theVehicle ) — or 3 floats if the caller expects them
+    CElement* pElement = NULL;
 
-    return vecPosition;
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pElement);
+
+    if (!argStream.HasErrors())
+    {
+        CVector vecPosition;
+        if (CStaticFunctionDefinitions::GetVehicleRespawnPosition(pElement, vecPosition))
+        {
+            int iExpected = lua_ncallresult(luaVM);
+            if (iExpected == 3)
+            {
+                lua_pushnumber(luaVM, vecPosition.fX);
+                lua_pushnumber(luaVM, vecPosition.fY);
+                lua_pushnumber(luaVM, vecPosition.fZ);
+                return 3;
+            }
+
+            lua_pushvector(luaVM, vecPosition);
+            return 1;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
 }
 
 int CLuaVehicleDefs::GetVehicleRespawnRotation(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -205,15 +205,15 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getTowedByVehicle", "getVehicleTowedByVehicle");
     lua_classfunction(luaVM, "getTowingVehicle", "getVehicleTowingVehicle");
     lua_classfunction(luaVM, "getTurnVelocity", "getVehicleTurnVelocity", CLuaVehicleDefs::OOP_GetVehicleTurnVelocity);
-    lua_classfunction(luaVM, "getTurretPosition", "getVehicleTurretPosition", OOP_GetVehicleTurretPosition);
+    lua_classfunction(luaVM, "getTurretPosition", "getVehicleTurretPosition", ArgumentParserWarn<false, OOP_GetVehicleTurretPosition>);
     lua_classfunction(luaVM, "getVehicleType", "getVehicleType");  // This isn't "getType" because it would overwrite Element.getType
     lua_classfunction(luaVM, "getUpgradeOnSlot", "getVehicleUpgradeOnSlot");
     lua_classfunction(luaVM, "getUpgrades", "getVehicleUpgrades");
     lua_classfunction(luaVM, "getWheelStates", "getVehicleWheelStates");
     lua_classfunction(luaVM, "getDoorOpenRatio", "getVehicleDoorOpenRatio");
     lua_classfunction(luaVM, "getHandling", "getVehicleHandling");
-    lua_classfunction(luaVM, "getRespawnPosition", "getVehicleRespawnPosition", OOP_GetVehicleRespawnPosition);
-    lua_classfunction(luaVM, "getRespawnRotation", "getVehicleRespawnRotation", OOP_GetVehicleRespawnRotation);
+    lua_classfunction(luaVM, "getRespawnPosition", "getVehicleRespawnPosition", ArgumentParserWarn<false, OOP_GetVehicleRespawnPosition>);
+    lua_classfunction(luaVM, "getRespawnRotation", "getVehicleRespawnRotation", ArgumentParserWarn<false, OOP_GetVehicleRespawnRotation>);
     lua_classfunction(luaVM, "isRespawnable", "isVehicleRespawnable");
     lua_classfunction(luaVM, "getRespawnDelay", "getVehicleRespawnDelay");
     lua_classfunction(luaVM, "getIdleRespawnDelay", "getVehicleIdleRespawnDelay");
@@ -280,16 +280,17 @@ void CLuaVehicleDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "landingGearDown", "setVehicleLandingGearDown", "getVehicleLandingGearDown");
     lua_classvariable(luaVM, "maxPassengers", NULL, "getVehicleMaxPassengers");
     lua_classvariable(luaVM, "upgrades", NULL, "getVehicleUpgrades");
-    lua_classvariable(luaVM, "turretPosition", "setVehicleTurretPosition", "getVehicleTurretPosition", SetVehicleTurretPosition, OOP_GetVehicleTurretPosition);
+    lua_classvariable(luaVM, "turretPosition", "setVehicleTurretPosition", "getVehicleTurretPosition", SetVehicleTurretPosition,
+                      ArgumentParserWarn<false, OOP_GetVehicleTurretPosition>);
     lua_classvariable(luaVM, "turnVelocity", "setVehicleTurnVelocity", "getVehicleTurnVelocity", SetVehicleTurnVelocity, OOP_GetVehicleTurnVelocity);
     lua_classvariable(luaVM, "overrideLights", "setVehicleOverrideLights", "getVehicleOverrideLights");
     lua_classvariable(luaVM, "idleRespawnDelay", "setVehicleIdleRespawnDelay", "getVehicleIdleRespawnDelay");
     lua_classvariable(luaVM, "respawnable", "toggleVehicleRespawn", "isVehicleRespawnable");
     lua_classvariable(luaVM, "respawnDelay", "setVehicleRespawnDelay", "getVehicleRespawnDelay");
     lua_classvariable(luaVM, "respawnPosition", "setVehicleRespawnPosition", "getVehicleRespawnPosition", SetVehicleRespawnPosition,
-                      OOP_GetVehicleRespawnPosition);
+                      ArgumentParserWarn<false, OOP_GetVehicleRespawnPosition>);
     lua_classvariable(luaVM, "respawnRotation", "setVehicleRespawnRotation", "getVehicleRespawnRotation", SetVehicleRespawnRotation,
-                      OOP_GetVehicleRespawnRotation);
+                      ArgumentParserWarn<false, OOP_GetVehicleRespawnRotation>);
     lua_classvariable(luaVM, "onGround", NULL, "isVehicleOnGround");
     lua_classvariable(luaVM, "name", NULL, "getVehicleName");
     lua_classvariable(luaVM, "vehicleType", NULL, "getVehicleType");
@@ -1085,36 +1086,17 @@ int CLuaVehicleDefs::GetVehicleTurretPosition(lua_State* luaVM)
     return 1;
 }
 
-int CLuaVehicleDefs::OOP_GetVehicleTurretPosition(lua_State* luaVM)
+std::variant<CLuaMultiReturn<float, float>, CVector2D, bool> CLuaVehicleDefs::OOP_GetVehicleTurretPosition(lua_State* luaVM, CVehicle* vehicle)
 {
-    // vector2 getVehicleTurretPosition ( vehicle theVehicle ) — or 2 floats if the caller expects them
-    CVehicle* pVehicle;
+    CVector2D vecPosition;
+    if (!CStaticFunctionDefinitions::GetVehicleTurretPosition(vehicle, vecPosition))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pVehicle);
+    // Keep returning two floats when the caller assigns two results
+    if (lua_ncallresult(luaVM) == 2)
+        return CLuaMultiReturn<float, float>(vecPosition.fX, vecPosition.fY);
 
-    if (!argStream.HasErrors())
-    {
-        CVector2D vecPosition;
-        if (CStaticFunctionDefinitions::GetVehicleTurretPosition(pVehicle, vecPosition))
-        {
-            int iExpected = lua_ncallresult(luaVM);
-            if (iExpected == 2)
-            {
-                lua_pushnumber(luaVM, vecPosition.fX);
-                lua_pushnumber(luaVM, vecPosition.fY);
-                return 2;
-            }
-
-            lua_pushvector(luaVM, vecPosition);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecPosition;
 }
 
 int CLuaVehicleDefs::IsVehicleLocked(lua_State* luaVM)
@@ -2240,70 +2222,30 @@ int CLuaVehicleDefs::SetVehicleRespawnDelay(lua_State* luaVM)
     return 1;
 }
 
-int CLuaVehicleDefs::OOP_GetVehicleRespawnRotation(lua_State* luaVM)
+std::variant<CLuaMultiReturn<float, float, float>, CVector, bool> CLuaVehicleDefs::OOP_GetVehicleRespawnRotation(lua_State* luaVM, CElement* element)
 {
-    // vector3 getVehicleRespawnRotation ( vehicle theVehicle ) — or 3 floats if the caller expects them
-    CElement* pElement = NULL;
+    CVector vecRotationDegrees;
+    if (!CStaticFunctionDefinitions::GetVehicleRespawnRotation(element, vecRotationDegrees))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pElement);
+    // Keep returning three floats when the caller assigns three results
+    if (lua_ncallresult(luaVM) == 3)
+        return CLuaMultiReturn<float, float, float>(vecRotationDegrees.fX, vecRotationDegrees.fY, vecRotationDegrees.fZ);
 
-    if (!argStream.HasErrors())
-    {
-        CVector vecRotationDegress;
-        if (CStaticFunctionDefinitions::GetVehicleRespawnRotation(pElement, vecRotationDegress))
-        {
-            int iExpected = lua_ncallresult(luaVM);
-            if (iExpected == 3)
-            {
-                lua_pushnumber(luaVM, vecRotationDegress.fX);
-                lua_pushnumber(luaVM, vecRotationDegress.fY);
-                lua_pushnumber(luaVM, vecRotationDegress.fZ);
-                return 3;
-            }
-
-            lua_pushvector(luaVM, vecRotationDegress);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecRotationDegrees;
 }
 
-int CLuaVehicleDefs::OOP_GetVehicleRespawnPosition(lua_State* luaVM)
+std::variant<CLuaMultiReturn<float, float, float>, CVector, bool> CLuaVehicleDefs::OOP_GetVehicleRespawnPosition(lua_State* luaVM, CElement* element)
 {
-    // vector3 getVehicleRespawnPosition ( vehicle theVehicle ) — or 3 floats if the caller expects them
-    CElement* pElement = NULL;
+    CVector vecPosition;
+    if (!CStaticFunctionDefinitions::GetVehicleRespawnPosition(element, vecPosition))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pElement);
+    // Keep returning three floats when the caller assigns three results
+    if (lua_ncallresult(luaVM) == 3)
+        return CLuaMultiReturn<float, float, float>(vecPosition.fX, vecPosition.fY, vecPosition.fZ);
 
-    if (!argStream.HasErrors())
-    {
-        CVector vecPosition;
-        if (CStaticFunctionDefinitions::GetVehicleRespawnPosition(pElement, vecPosition))
-        {
-            int iExpected = lua_ncallresult(luaVM);
-            if (iExpected == 3)
-            {
-                lua_pushnumber(luaVM, vecPosition.fX);
-                lua_pushnumber(luaVM, vecPosition.fY);
-                lua_pushnumber(luaVM, vecPosition.fZ);
-                return 3;
-            }
-
-            lua_pushvector(luaVM, vecPosition);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecPosition;
 }
 
 int CLuaVehicleDefs::GetVehicleRespawnRotation(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -37,7 +37,7 @@ public:
     LUA_DECLARE(GetVehicleSirensOn);
     LUA_DECLARE(GetVehicleTurnVelocity);
     LUA_DECLARE(OOP_GetVehicleTurnVelocity);
-    LUA_DECLARE_OOP(GetVehicleTurretPosition);
+    static std::variant<bool, CVector2D> OOP_GetVehicleTurretPosition(CVehicle* pVehicle);
     LUA_DECLARE(IsVehicleLocked);
     LUA_DECLARE(GetVehiclesOfType);
     LUA_DECLARE(GetVehicleUpgradeOnSlot);
@@ -90,11 +90,11 @@ public:
     LUA_DECLARE(SetVehicleRespawnDelay);
     LUA_DECLARE(SetVehicleRespawnPosition);
     LUA_DECLARE(SetVehicleRespawnRotation);
-    LUA_DECLARE_OOP(GetVehicleRespawnPosition);
-    LUA_DECLARE_OOP(GetVehicleRespawnRotation);
-    static bool     IsVehicleRespawnable(CVehicle* vehicle) noexcept;
-    static uint32_t GetVehicleRespawnDelay(CVehicle* vehicle) noexcept;
-    static uint32_t GetVehicleIdleRespawnDelay(CVehicle* vehicle) noexcept;
+    static std::variant<bool, CVector> OOP_GetVehicleRespawnPosition(CElement* pElement);
+    static std::variant<bool, CVector> OOP_GetVehicleRespawnRotation(CElement* pElement);
+    static bool                        IsVehicleRespawnable(CVehicle* vehicle) noexcept;
+    static uint32_t                    GetVehicleRespawnDelay(CVehicle* vehicle) noexcept;
+    static uint32_t                    GetVehicleIdleRespawnDelay(CVehicle* vehicle) noexcept;
     LUA_DECLARE(ToggleVehicleRespawn);
     LUA_DECLARE(ResetVehicleExplosionTime);
     LUA_DECLARE(ResetVehicleIdleTime);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -37,6 +37,7 @@ public:
     LUA_DECLARE(GetVehicleSirensOn);
     LUA_DECLARE(GetVehicleTurnVelocity);
     LUA_DECLARE(OOP_GetVehicleTurnVelocity);
+    LUA_DECLARE(GetVehicleTurretPosition);
     static std::variant<bool, CVector2D> OOP_GetVehicleTurretPosition(CVehicle* pVehicle);
     LUA_DECLARE(IsVehicleLocked);
     LUA_DECLARE(GetVehiclesOfType);
@@ -90,7 +91,9 @@ public:
     LUA_DECLARE(SetVehicleRespawnDelay);
     LUA_DECLARE(SetVehicleRespawnPosition);
     LUA_DECLARE(SetVehicleRespawnRotation);
+    LUA_DECLARE(GetVehicleRespawnPosition);
     static std::variant<bool, CVector> OOP_GetVehicleRespawnPosition(CElement* pElement);
+    LUA_DECLARE(GetVehicleRespawnRotation);
     static std::variant<bool, CVector> OOP_GetVehicleRespawnRotation(CElement* pElement);
     static bool                        IsVehicleRespawnable(CVehicle* vehicle) noexcept;
     static uint32_t                    GetVehicleRespawnDelay(CVehicle* vehicle) noexcept;

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -37,7 +37,7 @@ public:
     LUA_DECLARE(GetVehicleSirensOn);
     LUA_DECLARE(GetVehicleTurnVelocity);
     LUA_DECLARE(OOP_GetVehicleTurnVelocity);
-    LUA_DECLARE(GetVehicleTurretPosition);
+    LUA_DECLARE_OOP(GetVehicleTurretPosition);
     LUA_DECLARE(IsVehicleLocked);
     LUA_DECLARE(GetVehiclesOfType);
     LUA_DECLARE(GetVehicleUpgradeOnSlot);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -37,8 +37,7 @@ public:
     LUA_DECLARE(GetVehicleSirensOn);
     LUA_DECLARE(GetVehicleTurnVelocity);
     LUA_DECLARE(OOP_GetVehicleTurnVelocity);
-    LUA_DECLARE(GetVehicleTurretPosition);
-    static std::variant<bool, CVector2D> OOP_GetVehicleTurretPosition(CVehicle* pVehicle);
+    LUA_DECLARE_OOP(GetVehicleTurretPosition);
     LUA_DECLARE(IsVehicleLocked);
     LUA_DECLARE(GetVehiclesOfType);
     LUA_DECLARE(GetVehicleUpgradeOnSlot);
@@ -91,13 +90,11 @@ public:
     LUA_DECLARE(SetVehicleRespawnDelay);
     LUA_DECLARE(SetVehicleRespawnPosition);
     LUA_DECLARE(SetVehicleRespawnRotation);
-    LUA_DECLARE(GetVehicleRespawnPosition);
-    static std::variant<bool, CVector> OOP_GetVehicleRespawnPosition(CElement* pElement);
-    LUA_DECLARE(GetVehicleRespawnRotation);
-    static std::variant<bool, CVector> OOP_GetVehicleRespawnRotation(CElement* pElement);
-    static bool                        IsVehicleRespawnable(CVehicle* vehicle) noexcept;
-    static uint32_t                    GetVehicleRespawnDelay(CVehicle* vehicle) noexcept;
-    static uint32_t                    GetVehicleIdleRespawnDelay(CVehicle* vehicle) noexcept;
+    LUA_DECLARE_OOP(GetVehicleRespawnPosition);
+    LUA_DECLARE_OOP(GetVehicleRespawnRotation);
+    static bool     IsVehicleRespawnable(CVehicle* vehicle) noexcept;
+    static uint32_t GetVehicleRespawnDelay(CVehicle* vehicle) noexcept;
+    static uint32_t GetVehicleIdleRespawnDelay(CVehicle* vehicle) noexcept;
     LUA_DECLARE(ToggleVehicleRespawn);
     LUA_DECLARE(ResetVehicleExplosionTime);
     LUA_DECLARE(ResetVehicleIdleTime);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -37,7 +37,8 @@ public:
     LUA_DECLARE(GetVehicleSirensOn);
     LUA_DECLARE(GetVehicleTurnVelocity);
     LUA_DECLARE(OOP_GetVehicleTurnVelocity);
-    LUA_DECLARE_OOP(GetVehicleTurretPosition);
+    LUA_DECLARE(GetVehicleTurretPosition);
+    static std::variant<CLuaMultiReturn<float, float>, CVector2D, bool> OOP_GetVehicleTurretPosition(lua_State* luaVM, CVehicle* vehicle);
     LUA_DECLARE(IsVehicleLocked);
     LUA_DECLARE(GetVehiclesOfType);
     LUA_DECLARE(GetVehicleUpgradeOnSlot);
@@ -90,8 +91,10 @@ public:
     LUA_DECLARE(SetVehicleRespawnDelay);
     LUA_DECLARE(SetVehicleRespawnPosition);
     LUA_DECLARE(SetVehicleRespawnRotation);
-    LUA_DECLARE_OOP(GetVehicleRespawnPosition);
-    LUA_DECLARE_OOP(GetVehicleRespawnRotation);
+    LUA_DECLARE(GetVehicleRespawnPosition);
+    static std::variant<CLuaMultiReturn<float, float, float>, CVector, bool> OOP_GetVehicleRespawnPosition(lua_State* luaVM, CElement* element);
+    LUA_DECLARE(GetVehicleRespawnRotation);
+    static std::variant<CLuaMultiReturn<float, float, float>, CVector, bool> OOP_GetVehicleRespawnRotation(lua_State* luaVM, CElement* element);
     static bool     IsVehicleRespawnable(CVehicle* vehicle) noexcept;
     static uint32_t GetVehicleRespawnDelay(CVehicle* vehicle) noexcept;
     static uint32_t GetVehicleIdleRespawnDelay(CVehicle* vehicle) noexcept;

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.h
@@ -95,6 +95,7 @@ public:
     static std::variant<CLuaMultiReturn<float, float, float>, CVector, bool> OOP_GetVehicleRespawnPosition(lua_State* luaVM, CElement* element);
     LUA_DECLARE(GetVehicleRespawnRotation);
     static std::variant<CLuaMultiReturn<float, float, float>, CVector, bool> OOP_GetVehicleRespawnRotation(lua_State* luaVM, CElement* element);
+
     static bool     IsVehicleRespawnable(CVehicle* vehicle) noexcept;
     static uint32_t GetVehicleRespawnDelay(CVehicle* vehicle) noexcept;
     static uint32_t GetVehicleIdleRespawnDelay(CVehicle* vehicle) noexcept;

--- a/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
@@ -13,6 +13,7 @@
 #include "CLuaWaterDefs.h"
 #include "CWater.h"
 #include "CStaticFunctionDefinitions.h"
+#include <lua/CLuaFunctionParser.h>
 #include "CScriptArgReader.h"
 
 void CLuaWaterDefs::LoadFunctions()
@@ -43,7 +44,7 @@ void CLuaWaterDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getWaveHeight", "getWaveHeight");
     lua_classfunction(luaVM, "setWaveHeight", "setWaveHeight");
 
-    lua_classfunction(luaVM, "getVertexPosition", "getWaterVertexPosition", OOP_GetWaterVertexPosition);
+    lua_classfunction(luaVM, "getVertexPosition", "getWaterVertexPosition", ArgumentParserWarn<false, OOP_GetWaterVertexPosition>);
     lua_classfunction(luaVM, "getColor", "getWaterColor");
 
     lua_classfunction(luaVM, "setColor", "setWaterColor");
@@ -201,29 +202,13 @@ int CLuaWaterDefs::GetWaterVertexPosition(lua_State* luaVM)
     return 1;
 }
 
-int CLuaWaterDefs::OOP_GetWaterVertexPosition(lua_State* luaVM)
+std::variant<bool, CVector> CLuaWaterDefs::OOP_GetWaterVertexPosition(CWater* pWater, int iVertexIndex)
 {
-    CWater* pWater;
-    int     iVertexIndex;
+    CVector vecPosition;
+    if (!CStaticFunctionDefinitions::GetWaterVertexPosition(pWater, iVertexIndex, vecPosition))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pWater);
-    argStream.ReadNumber(iVertexIndex);
-
-    if (!argStream.HasErrors())
-    {
-        CVector vecPosition;
-        if (CStaticFunctionDefinitions::GetWaterVertexPosition(pWater, iVertexIndex, vecPosition))
-        {
-            lua_pushvector(luaVM, vecPosition);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecPosition;
 }
 
 int CLuaWaterDefs::SetWaterVertexPosition(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
@@ -43,7 +43,7 @@ void CLuaWaterDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getWaveHeight", "getWaveHeight");
     lua_classfunction(luaVM, "setWaveHeight", "setWaveHeight");
 
-    lua_classfunction(luaVM, "getVertexPosition", "getWaterVertexPosition");
+    lua_classfunction(luaVM, "getVertexPosition", "getWaterVertexPosition", OOP_GetWaterVertexPosition);
     lua_classfunction(luaVM, "getColor", "getWaterColor");
 
     lua_classfunction(luaVM, "setColor", "setWaterColor");
@@ -192,6 +192,31 @@ int CLuaWaterDefs::GetWaterVertexPosition(lua_State* luaVM)
             lua_pushnumber(luaVM, vecPosition.fY);
             lua_pushnumber(luaVM, vecPosition.fZ);
             return 3;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
+}
+
+int CLuaWaterDefs::OOP_GetWaterVertexPosition(lua_State* luaVM)
+{
+    CWater* pWater;
+    int     iVertexIndex;
+
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pWater);
+    argStream.ReadNumber(iVertexIndex);
+
+    if (!argStream.HasErrors())
+    {
+        CVector vecPosition;
+        if (CStaticFunctionDefinitions::GetWaterVertexPosition(pWater, iVertexIndex, vecPosition))
+        {
+            lua_pushvector(luaVM, vecPosition);
+            return 1;
         }
     }
     else

--- a/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
@@ -44,7 +44,7 @@ void CLuaWaterDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getWaveHeight", "getWaveHeight");
     lua_classfunction(luaVM, "setWaveHeight", "setWaveHeight");
 
-    lua_classfunction(luaVM, "getVertexPosition", "getWaterVertexPosition", ArgumentParserWarn<false, OOP_GetWaterVertexPosition>);
+    lua_classfunction(luaVM, "getVertexPosition", "getWaterVertexPosition", OOP_GetWaterVertexPosition);
     lua_classfunction(luaVM, "getColor", "getWaterColor");
 
     lua_classfunction(luaVM, "setColor", "setWaterColor");
@@ -202,13 +202,39 @@ int CLuaWaterDefs::GetWaterVertexPosition(lua_State* luaVM)
     return 1;
 }
 
-std::variant<bool, CVector> CLuaWaterDefs::OOP_GetWaterVertexPosition(CWater* pWater, int iVertexIndex)
+int CLuaWaterDefs::OOP_GetWaterVertexPosition(lua_State* luaVM)
 {
-    CVector vecPosition;
-    if (!CStaticFunctionDefinitions::GetWaterVertexPosition(pWater, iVertexIndex, vecPosition))
-        return false;
+    // vector3 getWaterVertexPosition ( water theWater, int vertexIndex ) — or 3 floats if the caller expects them
+    CWater* pWater;
+    int     iVertexIndex;
 
-    return vecPosition;
+    CScriptArgReader argStream(luaVM);
+    argStream.ReadUserData(pWater);
+    argStream.ReadNumber(iVertexIndex);
+
+    if (!argStream.HasErrors())
+    {
+        CVector vecPosition;
+        if (CStaticFunctionDefinitions::GetWaterVertexPosition(pWater, iVertexIndex, vecPosition))
+        {
+            int iExpected = lua_ncallresult(luaVM);
+            if (iExpected == 3)
+            {
+                lua_pushnumber(luaVM, vecPosition.fX);
+                lua_pushnumber(luaVM, vecPosition.fY);
+                lua_pushnumber(luaVM, vecPosition.fZ);
+                return 3;
+            }
+
+            lua_pushvector(luaVM, vecPosition);
+            return 1;
+        }
+    }
+    else
+        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+
+    lua_pushboolean(luaVM, false);
+    return 1;
 }
 
 int CLuaWaterDefs::SetWaterVertexPosition(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.cpp
@@ -44,7 +44,7 @@ void CLuaWaterDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getWaveHeight", "getWaveHeight");
     lua_classfunction(luaVM, "setWaveHeight", "setWaveHeight");
 
-    lua_classfunction(luaVM, "getVertexPosition", "getWaterVertexPosition", OOP_GetWaterVertexPosition);
+    lua_classfunction(luaVM, "getVertexPosition", "getWaterVertexPosition", ArgumentParserWarn<false, OOP_GetWaterVertexPosition>);
     lua_classfunction(luaVM, "getColor", "getWaterColor");
 
     lua_classfunction(luaVM, "setColor", "setWaterColor");
@@ -202,39 +202,17 @@ int CLuaWaterDefs::GetWaterVertexPosition(lua_State* luaVM)
     return 1;
 }
 
-int CLuaWaterDefs::OOP_GetWaterVertexPosition(lua_State* luaVM)
+std::variant<CLuaMultiReturn<float, float, float>, CVector, bool> CLuaWaterDefs::OOP_GetWaterVertexPosition(lua_State* luaVM, CWater* water, int vertexIndex)
 {
-    // vector3 getWaterVertexPosition ( water theWater, int vertexIndex ) — or 3 floats if the caller expects them
-    CWater* pWater;
-    int     iVertexIndex;
+    CVector vecPosition;
+    if (!CStaticFunctionDefinitions::GetWaterVertexPosition(water, vertexIndex, vecPosition))
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadUserData(pWater);
-    argStream.ReadNumber(iVertexIndex);
+    // Keep returning three floats when the caller assigns three results
+    if (lua_ncallresult(luaVM) == 3)
+        return CLuaMultiReturn<float, float, float>(vecPosition.fX, vecPosition.fY, vecPosition.fZ);
 
-    if (!argStream.HasErrors())
-    {
-        CVector vecPosition;
-        if (CStaticFunctionDefinitions::GetWaterVertexPosition(pWater, iVertexIndex, vecPosition))
-        {
-            int iExpected = lua_ncallresult(luaVM);
-            if (iExpected == 3)
-            {
-                lua_pushnumber(luaVM, vecPosition.fX);
-                lua_pushnumber(luaVM, vecPosition.fY);
-                lua_pushnumber(luaVM, vecPosition.fZ);
-                return 3;
-            }
-
-            lua_pushvector(luaVM, vecPosition);
-            return 1;
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    return vecPosition;
 }
 
 int CLuaWaterDefs::SetWaterVertexPosition(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.h
@@ -21,7 +21,7 @@ public:
     LUA_DECLARE(CreateWater);
     LUA_DECLARE(SetWaterLevel);
     LUA_DECLARE(ResetWaterLevel);
-    LUA_DECLARE(GetWaterVertexPosition);
+    LUA_DECLARE_OOP(GetWaterVertexPosition);
     LUA_DECLARE(SetWaterVertexPosition);
     LUA_DECLARE(GetWaterColor);
     LUA_DECLARE(SetWaterColor);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.h
@@ -21,6 +21,7 @@ public:
     LUA_DECLARE(CreateWater);
     LUA_DECLARE(SetWaterLevel);
     LUA_DECLARE(ResetWaterLevel);
+    LUA_DECLARE(GetWaterVertexPosition);
     static std::variant<bool, CVector> OOP_GetWaterVertexPosition(CWater* pWater, int iVertexIndex);
     LUA_DECLARE(SetWaterVertexPosition);
     LUA_DECLARE(GetWaterColor);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.h
@@ -21,7 +21,7 @@ public:
     LUA_DECLARE(CreateWater);
     LUA_DECLARE(SetWaterLevel);
     LUA_DECLARE(ResetWaterLevel);
-    LUA_DECLARE_OOP(GetWaterVertexPosition);
+    static std::variant<bool, CVector> OOP_GetWaterVertexPosition(CWater* pWater, int iVertexIndex);
     LUA_DECLARE(SetWaterVertexPosition);
     LUA_DECLARE(GetWaterColor);
     LUA_DECLARE(SetWaterColor);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.h
@@ -12,6 +12,8 @@
 #pragma once
 #include "CLuaDefs.h"
 
+class CWater;
+
 class CLuaWaterDefs : public CLuaDefs
 {
 public:
@@ -21,7 +23,8 @@ public:
     LUA_DECLARE(CreateWater);
     LUA_DECLARE(SetWaterLevel);
     LUA_DECLARE(ResetWaterLevel);
-    LUA_DECLARE_OOP(GetWaterVertexPosition);
+    LUA_DECLARE(GetWaterVertexPosition);
+    static std::variant<CLuaMultiReturn<float, float, float>, CVector, bool> OOP_GetWaterVertexPosition(lua_State* luaVM, CWater* water, int vertexIndex);
     LUA_DECLARE(SetWaterVertexPosition);
     LUA_DECLARE(GetWaterColor);
     LUA_DECLARE(SetWaterColor);

--- a/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaWaterDefs.h
@@ -21,8 +21,7 @@ public:
     LUA_DECLARE(CreateWater);
     LUA_DECLARE(SetWaterLevel);
     LUA_DECLARE(ResetWaterLevel);
-    LUA_DECLARE(GetWaterVertexPosition);
-    static std::variant<bool, CVector> OOP_GetWaterVertexPosition(CWater* pWater, int iVertexIndex);
+    LUA_DECLARE_OOP(GetWaterVertexPosition);
     LUA_DECLARE(SetWaterVertexPosition);
     LUA_DECLARE(GetWaterColor);
     LUA_DECLARE(SetWaterColor);


### PR DESCRIPTION
#### Summary
Wire OOP method/property getters (and matching Vector setters where needed) so the APIs listed in #1583 return `Vector2`/`Vector3` instead of multiple floats.

Procedural functions (e.g. `getObjectScale`, `guiGetPosition`, `getRadarAreaSize`) are unchanged and still return floats.

Examples:
```lua
-- procedural (unchanged)
local x, y, z = getObjectScale(obj)

-- OOP (now returns a vector)
local scale = obj:getScale()
local scale2 = obj.scale
```

Covered (client/server as applicable): RadarArea size, Object scale, Ped muzzle position, Light direction, Vehicle turret/respawn, Water vertex position, GUI position/size/nativeSize, TextItem position.

Skipped: server `getCameraMatrix` (incomplete stub), server PointLight (does not exist).

#### Motivation
Several OOP definitions incorrectly returned multiple floats (or were missing vector OOP wiring), so `:getX()` / `.x` did not match the expected vector OOP semantics.

Fixes #1583.

#### Test plan
1. Build client and server; confirm the changed `luadefs` compile cleanly.
2. Client: for Object/Ped/Light/Vehicle/RadarArea/Water/GUI, verify procedural calls still return floats, while OOP `:get*()` / `.*` return Vector types; for GUI also verify `.position` / `.size` assign with `Vector2`.
3. Server: for Vehicle turret/respawn, RadarArea size, TextItem position, and Water vertex position, verify the same procedural-vs-OOP split.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
```