### PR TITLE
Fix getElementBoneMatrix to return Matrix when OOP is enabled

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -1064,7 +1064,6 @@ std::variant<bool, CMatrix, std::array<std::array<float, 4>, 4>> CLuaPedDefs::Ge
 
     g_pGame->GetRenderWare()->RwMatrixToCMatrix(*rwmatrix, matrix);
 
-
     CLuaMain* pLuaMain = g_pClientGame->GetLuaManager()->GetVirtualMachine(luaVM);
     if (pLuaMain && pLuaMain->IsOOPEnabled())
         return matrix;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -180,6 +180,7 @@ void CLuaPedDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getTargetStart", OOP_GetPedTargetStart);
     lua_classfunction(luaVM, "getWeaponMuzzlePosition", "getPedWeaponMuzzlePosition");
     lua_classfunction(luaVM, "getBonePosition", OOP_GetPedBonePosition);
+    lua_classfunction(luaVM, "getBoneMatrix", ArgumentParserWarn<false, GetElementBoneMatrix>);
     lua_classfunction(luaVM, "getCameraRotation", "getPedCameraRotation");
     lua_classfunction(luaVM, "getWeaponSlot", "getPedWeaponSlot");
     lua_classfunction(luaVM, "getWalkingStyle", "getPedWalkingStyle");
@@ -1044,7 +1045,7 @@ std::variant<bool, CLuaMultiReturn<float, float, float, float>> CLuaPedDefs::Get
     return CLuaMultiReturn<float, float, float, float>(x, y, z, w);
 }
 
-std::variant<bool, std::array<std::array<float, 4>, 4>> CLuaPedDefs::GetElementBoneMatrix(CClientPed* ped, const std::uint16_t bone)
+std::variant<bool, CMatrix, std::array<std::array<float, 4>, 4>> CLuaPedDefs::GetElementBoneMatrix(lua_State* luaVM, CClientPed* ped, const std::uint16_t bone)
 {
     if (bone < BONE_ROOT || bone > BONE_LEFTBREAST)
         throw std::invalid_argument("Invalid bone: " + std::to_string(bone));
@@ -1062,6 +1063,11 @@ std::variant<bool, std::array<std::array<float, 4>, 4>> CLuaPedDefs::GetElementB
     CMatrix matrix;
 
     g_pGame->GetRenderWare()->RwMatrixToCMatrix(*rwmatrix, matrix);
+
+
+    CLuaMain* pLuaMain = g_pClientGame->GetLuaManager()->GetVirtualMachine(luaVM);
+    if (pLuaMain && pLuaMain->IsOOPEnabled())
+        return matrix;
 
     return matrix.To4x4Array();
 }

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -180,7 +180,7 @@ void CLuaPedDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getTargetStart", OOP_GetPedTargetStart);
     lua_classfunction(luaVM, "getWeaponMuzzlePosition", "getPedWeaponMuzzlePosition");
     lua_classfunction(luaVM, "getBonePosition", OOP_GetPedBonePosition);
-    lua_classfunction(luaVM, "getBoneMatrix", ArgumentParserWarn<false, GetElementBoneMatrix>);
+    lua_classfunction(luaVM, "getBoneMatrix", ArgumentParserWarn<false, OOP_GetElementBoneMatrix>);
     lua_classfunction(luaVM, "getCameraRotation", "getPedCameraRotation");
     lua_classfunction(luaVM, "getWeaponSlot", "getPedWeaponSlot");
     lua_classfunction(luaVM, "getWalkingStyle", "getPedWalkingStyle");
@@ -1045,7 +1045,7 @@ std::variant<bool, CLuaMultiReturn<float, float, float, float>> CLuaPedDefs::Get
     return CLuaMultiReturn<float, float, float, float>(x, y, z, w);
 }
 
-std::variant<bool, CMatrix, std::array<std::array<float, 4>, 4>> CLuaPedDefs::GetElementBoneMatrix(lua_State* luaVM, CClientPed* ped, const std::uint16_t bone)
+std::variant<bool, std::array<std::array<float, 4>, 4>> CLuaPedDefs::GetElementBoneMatrix(CClientPed* ped, const std::uint16_t bone)
 {
     if (bone < BONE_ROOT || bone > BONE_LEFTBREAST)
         throw std::invalid_argument("Invalid bone: " + std::to_string(bone));
@@ -1064,11 +1064,29 @@ std::variant<bool, CMatrix, std::array<std::array<float, 4>, 4>> CLuaPedDefs::Ge
 
     g_pGame->GetRenderWare()->RwMatrixToCMatrix(*rwmatrix, matrix);
 
-    CLuaMain* pLuaMain = g_pClientGame->GetLuaManager()->GetVirtualMachine(luaVM);
-    if (pLuaMain && pLuaMain->IsOOPEnabled())
-        return matrix;
-
     return matrix.To4x4Array();
+}
+
+std::variant<bool, CMatrix> CLuaPedDefs::OOP_GetElementBoneMatrix(CClientPed* ped, const std::uint16_t bone)
+{
+    if (bone < BONE_ROOT || bone > BONE_LEFTBREAST)
+        throw std::invalid_argument("Invalid bone: " + std::to_string(bone));
+
+    CEntity* entity = ped->GetGameEntity();
+
+    if (!entity)
+        return false;
+
+    RwMatrix* rwmatrix = entity->GetBoneRwMatrix(static_cast<eBone>(bone));
+
+    if (!rwmatrix)
+        return false;
+
+    CMatrix matrix;
+
+    g_pGame->GetRenderWare()->RwMatrixToCMatrix(*rwmatrix, matrix);
+
+    return matrix;
 }
 
 bool CLuaPedDefs::SetElementBonePosition(CClientPed* ped, const std::uint16_t bone, const CVector position)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
@@ -51,10 +51,11 @@ public:
     LUA_DECLARE(GetPedRotation);
     LUA_DECLARE(CanPedBeKnockedOffBike);
 
-    static std::variant<bool, CLuaMultiReturn<float, float, float>>         GetElementBonePosition(CClientPed* ped, const std::uint16_t bone);
-    static std::variant<bool, CLuaMultiReturn<float, float, float>>         GetElementBoneRotation(CClientPed* ped, const std::uint16_t bone);
-    static std::variant<bool, CLuaMultiReturn<float, float, float, float>>  GetElementBoneQuaternion(CClientPed* ped, const std::uint16_t bone);
-    static std::variant<bool, CMatrix, std::array<std::array<float, 4>, 4>> GetElementBoneMatrix(lua_State* luaVM, CClientPed* ped, const std::uint16_t bone);
+    static std::variant<bool, CLuaMultiReturn<float, float, float>>        GetElementBonePosition(CClientPed* ped, const std::uint16_t bone);
+    static std::variant<bool, CLuaMultiReturn<float, float, float>>        GetElementBoneRotation(CClientPed* ped, const std::uint16_t bone);
+    static std::variant<bool, CLuaMultiReturn<float, float, float, float>> GetElementBoneQuaternion(CClientPed* ped, const std::uint16_t bone);
+    static std::variant<bool, std::array<std::array<float, 4>, 4>>         GetElementBoneMatrix(CClientPed* ped, const std::uint16_t bone);
+    static std::variant<bool, CMatrix>                                     OOP_GetElementBoneMatrix(CClientPed* ped, const std::uint16_t bone);
 
     static bool SetElementBonePosition(CClientPed* ped, const std::uint16_t bone, const CVector position);
     static bool SetElementBoneRotation(CClientPed* ped, const std::uint16_t bone, const float yaw, const float pitch, const float roll);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
@@ -54,7 +54,7 @@ public:
     static std::variant<bool, CLuaMultiReturn<float, float, float>>        GetElementBonePosition(CClientPed* ped, const std::uint16_t bone);
     static std::variant<bool, CLuaMultiReturn<float, float, float>>        GetElementBoneRotation(CClientPed* ped, const std::uint16_t bone);
     static std::variant<bool, CLuaMultiReturn<float, float, float, float>> GetElementBoneQuaternion(CClientPed* ped, const std::uint16_t bone);
-    static std::variant<bool, std::array<std::array<float, 4>, 4>>         GetElementBoneMatrix(CClientPed* ped, const std::uint16_t bone);
+    static std::variant<bool, CMatrix, std::array<std::array<float, 4>, 4>> GetElementBoneMatrix(lua_State* luaVM, CClientPed* ped, const std::uint16_t bone);
 
     static bool SetElementBonePosition(CClientPed* ped, const std::uint16_t bone, const CVector position);
     static bool SetElementBoneRotation(CClientPed* ped, const std::uint16_t bone, const float yaw, const float pitch, const float roll);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.h
@@ -51,9 +51,9 @@ public:
     LUA_DECLARE(GetPedRotation);
     LUA_DECLARE(CanPedBeKnockedOffBike);
 
-    static std::variant<bool, CLuaMultiReturn<float, float, float>>        GetElementBonePosition(CClientPed* ped, const std::uint16_t bone);
-    static std::variant<bool, CLuaMultiReturn<float, float, float>>        GetElementBoneRotation(CClientPed* ped, const std::uint16_t bone);
-    static std::variant<bool, CLuaMultiReturn<float, float, float, float>> GetElementBoneQuaternion(CClientPed* ped, const std::uint16_t bone);
+    static std::variant<bool, CLuaMultiReturn<float, float, float>>         GetElementBonePosition(CClientPed* ped, const std::uint16_t bone);
+    static std::variant<bool, CLuaMultiReturn<float, float, float>>         GetElementBoneRotation(CClientPed* ped, const std::uint16_t bone);
+    static std::variant<bool, CLuaMultiReturn<float, float, float, float>>  GetElementBoneQuaternion(CClientPed* ped, const std::uint16_t bone);
     static std::variant<bool, CMatrix, std::array<std::array<float, 4>, 4>> GetElementBoneMatrix(lua_State* luaVM, CClientPed* ped, const std::uint16_t bone);
 
     static bool SetElementBonePosition(CClientPed* ped, const std::uint16_t bone, const CVector position);


### PR DESCRIPTION
#### Summary
Make `getElementBoneMatrix` return a `Matrix` userdata when the calling resource has OOP enabled, and keep returning a 4x4 Lua table otherwise. Also register `Ped:getBoneMatrix` for the OOP class API.

```lua
-- OOP disabled: table
local m = getElementBoneMatrix(localPlayer, 8)

-- OOP enabled: Matrix userdata
local m = getElementBoneMatrix(localPlayer, 8)
local m2 = localPlayer:getBoneMatrix(8)
```

#### Motivation
#1806 changed `getElementBoneMatrix` to always return a table for non-OOP compatibility, which also broke OOP callers that expect a `Matrix` (same split as `getElementMatrix` / `element:getMatrix`).

Fixes #2375.

#### Test plan
1. Build the client and confirm `CLuaPedDefs` compiles.
2. With OOP disabled, call `getElementBoneMatrix(localPlayer, 8)` and confirm the result is a table.
3. With `<oop>true</oop>`, call `getElementBoneMatrix(localPlayer, 8)` and `localPlayer:getBoneMatrix(8)` and confirm both return a Matrix userdata.

#### Checklist
* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.