### PR TITLE
Fix getPedAnimation for short-lived partial anims

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -5897,8 +5897,6 @@ void CClientPed::RunNamedAnimation(std::unique_ptr<CAnimBlock>& pBlock, const ch
     m_AnimationCache.bUpdatePosition = bUpdatePosition;
     m_AnimationCache.bInterruptible = bInterruptible;
     m_AnimationCache.bFreezeLastFrame = bFreezeLastFrame;
-    // Local setPedAnimation did not set this (RPCs did); needed for IsAnimationInProgress.
-    m_AnimationCache.startTime = GetTimestamp();
 }
 
 void CClientPed::KillAnimation()

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -5784,7 +5784,6 @@ bool CClientPed::GetRunningAnimationName(SString& strBlockName, SString& strAnim
 
 bool CClientPed::IsRunningAnimation()
 {
-    // Prefer the live named-anim primary task when present.
     if (m_pPlayerPed)
     {
         CTask* pTask = m_pTaskManager->GetTask(TASK_PRIORITY_PRIMARY);
@@ -5792,10 +5791,8 @@ bool CClientPed::IsRunningAnimation()
             return true;
     }
 
-    // Why: partial anims with a short time (e.g. time=1 on crry_prtial) finish the
-    // TASK_SIMPLE_NAMED_ANIM almost immediately while loop/freezeLastFrame keeps the
-    // pose. getPedAnimation must still report the cached block/anim in that case —
-    // same rule already used for streamed-out peds.
+    // Short-lived partial anims end TASK_SIMPLE_NAMED_ANIM while loop/freezeLastFrame
+    // keeps the pose; fall back to cache (same as streamed-out peds).
     return (m_AnimationCache.bLoop || m_AnimationCache.bFreezeLastFrame) && m_pAnimationBlock;
 }
 
@@ -5900,8 +5897,7 @@ void CClientPed::RunNamedAnimation(std::unique_ptr<CAnimBlock>& pBlock, const ch
     m_AnimationCache.bUpdatePosition = bUpdatePosition;
     m_AnimationCache.bInterruptible = bInterruptible;
     m_AnimationCache.bFreezeLastFrame = bFreezeLastFrame;
-    // Local setPedAnimation previously left startTime unset (only RPCs set it), which
-    // broke time-based IsAnimationInProgress checks for client-applied anims.
+    // Local setPedAnimation did not set this (RPCs did); needed for IsAnimationInProgress.
     m_AnimationCache.startTime = GetTimestamp();
 }
 

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -5784,15 +5784,18 @@ bool CClientPed::GetRunningAnimationName(SString& strBlockName, SString& strAnim
 
 bool CClientPed::IsRunningAnimation()
 {
+    // Prefer the live named-anim primary task when present.
     if (m_pPlayerPed)
     {
         CTask* pTask = m_pTaskManager->GetTask(TASK_PRIORITY_PRIMARY);
         if (pTask && pTask->GetTaskType() == TASK_SIMPLE_NAMED_ANIM)
-        {
             return true;
-        }
-        return false;
     }
+
+    // Why: partial anims with a short time (e.g. time=1 on crry_prtial) finish the
+    // TASK_SIMPLE_NAMED_ANIM almost immediately while loop/freezeLastFrame keeps the
+    // pose. getPedAnimation must still report the cached block/anim in that case —
+    // same rule already used for streamed-out peds.
     return (m_AnimationCache.bLoop || m_AnimationCache.bFreezeLastFrame) && m_pAnimationBlock;
 }
 
@@ -5897,6 +5900,9 @@ void CClientPed::RunNamedAnimation(std::unique_ptr<CAnimBlock>& pBlock, const ch
     m_AnimationCache.bUpdatePosition = bUpdatePosition;
     m_AnimationCache.bInterruptible = bInterruptible;
     m_AnimationCache.bFreezeLastFrame = bFreezeLastFrame;
+    // Local setPedAnimation previously left startTime unset (only RPCs set it), which
+    // broke time-based IsAnimationInProgress checks for client-applied anims.
+    m_AnimationCache.startTime = GetTimestamp();
 }
 
 void CClientPed::KillAnimation()

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -2264,6 +2264,9 @@ bool CStaticFunctionDefinitions::SetPedAnimation(CClientEntity& Entity, const SS
                 Ped.SetCurrentAnimationCustom(false);
                 Ped.SetNextAnimationNormal();
                 Ped.RunNamedAnimation(pBlock, szAnimName, iTime, iBlend, bLoop, bUpdatePosition, bInterruptible, bFreezeLastFrame);
+                Ped.m_AnimationCache.startTime = GetTimestamp();
+                Ped.m_AnimationCache.speed = 1.0f;
+                Ped.m_AnimationCache.progress = 0.0f;
                 return true;
             }
             else
@@ -2283,12 +2286,13 @@ bool CStaticFunctionDefinitions::SetPedAnimation(CClientEntity& Entity, const SS
 
                         const char* szGateWayAnimationName = g_pGame->GetAnimManager()->GetGateWayAnimationName();
                         Ped.RunNamedAnimation(pBlock, szGateWayAnimationName, iTime, iBlend, bLoop, bUpdatePosition, bInterruptible, bFreezeLastFrame);
+                        Ped.m_AnimationCache.startTime = GetTimestamp();
+                        Ped.m_AnimationCache.speed = 1.0f;
+                        Ped.m_AnimationCache.progress = 0.0f;
                         return true;
                     }
                 }
             }
-
-            Ped.m_AnimationCache.startTime = GetTimestamp();
         }
         else
         {

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -2264,9 +2264,6 @@ bool CStaticFunctionDefinitions::SetPedAnimation(CClientEntity& Entity, const SS
                 Ped.SetCurrentAnimationCustom(false);
                 Ped.SetNextAnimationNormal();
                 Ped.RunNamedAnimation(pBlock, szAnimName, iTime, iBlend, bLoop, bUpdatePosition, bInterruptible, bFreezeLastFrame);
-                Ped.m_AnimationCache.startTime = GetTimestamp();
-                Ped.m_AnimationCache.speed = 1.0f;
-                Ped.m_AnimationCache.progress = 0.0f;
                 return true;
             }
             else
@@ -2286,13 +2283,12 @@ bool CStaticFunctionDefinitions::SetPedAnimation(CClientEntity& Entity, const SS
 
                         const char* szGateWayAnimationName = g_pGame->GetAnimManager()->GetGateWayAnimationName();
                         Ped.RunNamedAnimation(pBlock, szGateWayAnimationName, iTime, iBlend, bLoop, bUpdatePosition, bInterruptible, bFreezeLastFrame);
-                        Ped.m_AnimationCache.startTime = GetTimestamp();
-                        Ped.m_AnimationCache.speed = 1.0f;
-                        Ped.m_AnimationCache.progress = 0.0f;
                         return true;
                     }
                 }
             }
+
+            Ped.m_AnimationCache.startTime = GetTimestamp();
         }
         else
         {


### PR DESCRIPTION
#### Summary
Make `getPedAnimation` keep returning the cached block/anim when a short-lived partial animation has already ended its `TASK_SIMPLE_NAMED_ANIM` primary task but `loop` / `freezeLastFrame` still holds the pose.

Also set `m_AnimationCache.startTime` in `RunNamedAnimation` for locally applied animations (RPCs already set it).

```lua
setPedAnimation(localPlayer, "carry", "crry_prtial", 1, true, true, true, true, 0, false)
print(getPedAnimation(localPlayer)) -- expected: "carry", "crry_prtial", ...
```

#### Motivation
With a short but non-zero `time` (e.g. `1`), partial anims such as `carry` / `crry_prtial` finish the named-anim task almost immediately. The ped stays in the carry pose via loop/freeze, but `IsRunningAnimation` only checked `TASK_SIMPLE_NAMED_ANIM` for streamed-in peds, so `getPedAnimation` returned `false`. Using `time = -1` kept the task alive and appeared to work.

Fixes #5077.

#### Test plan
1. Build the client.
2. Run:
   `setPedAnimation(localPlayer, "carry", "crry_prtial", 1, true, true, true, true, 0, false)`
   then `getPedAnimation(localPlayer)` — expect `"carry"` / `"crry_prtial"` (not `false`).
3. Run the same with `time = -1` and confirm it still returns the correct values.
4. Clear with `setPedAnimation(localPlayer, false)` and confirm `getPedAnimation` returns `false`.

#### Checklist
* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
```