### PR TITLE
Fix for an issue where voice rejected packets

### DIFF
--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -1539,6 +1539,8 @@ const std::vector<SIntSetting>& CMainConfig::GetIntSettingList()
          &CMainConfig::OnPlayerTriggeredEventIntervalChange},
         {true, true, 0, 1, 1, "resource_client_file_checks", &m_checkResourceClientFiles, nullptr},
         {true, true, 0, 1, 2, "allow_multi_command_handlers", &m_allowMultiCommandHandlers, &CMainConfig::OnAllowMultiCommandHandlersChange},
+        {true, true, 50, 100, 1000, "voice_packets_interval", &m_voicePacketsInterval, nullptr},
+        {true, true, 1, 32, 200, "max_voice_packets_per_interval", &m_maxVoicePacketsPerInterval, nullptr},
     };
 
     static std::vector<SIntSetting> settingsList;

--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -1541,6 +1541,7 @@ const std::vector<SIntSetting>& CMainConfig::GetIntSettingList()
         {true, true, 0, 1, 2, "allow_multi_command_handlers", &m_allowMultiCommandHandlers, &CMainConfig::OnAllowMultiCommandHandlersChange},
         {true, true, 50, 100, 1000, "voice_packets_interval", &m_voicePacketsInterval, nullptr},
         {true, true, 1, 32, 200, "max_voice_packets_per_interval", &m_maxVoicePacketsPerInterval, nullptr},
+        {true, true, 128, 512, 2048, "max_voice_buffer_size", &m_maxVoiceBufferSize, nullptr},
     };
 
     static std::vector<SIntSetting> settingsList;

--- a/Server/mods/deathmatch/logic/CMainConfig.h
+++ b/Server/mods/deathmatch/logic/CMainConfig.h
@@ -152,6 +152,8 @@ public:
     int GetPlayerTriggeredEventInterval() const { return m_iPlayerTriggeredEventIntervalMs; }
     int GetMaxPlayerTriggeredEventsPerInterval() const { return m_iMaxPlayerTriggeredEventsPerInterval; }
     int GetAllowMultiCommandHandlers() const noexcept { return m_allowMultiCommandHandlers; }
+    int GetVoicePacketsInterval() const noexcept { return m_voicePacketsInterval; }
+    int GetMaxVoicePacketsPerInterval() const noexcept { return m_maxVoicePacketsPerInterval; }
 
 private:
     void RegisterCommand(const char* szName, FCommandHandler* pFunction, bool bRestricted, const char* szConsoleHelpText);
@@ -238,4 +240,6 @@ private:
     bool                       m_checkDuplicateSerials;
     int                        m_checkResourceClientFiles;
     int                        m_allowMultiCommandHandlers;
+    int                        m_voicePacketsInterval{};
+    int                        m_maxVoicePacketsPerInterval{};
 };

--- a/Server/mods/deathmatch/logic/CMainConfig.h
+++ b/Server/mods/deathmatch/logic/CMainConfig.h
@@ -154,6 +154,7 @@ public:
     int GetAllowMultiCommandHandlers() const noexcept { return m_allowMultiCommandHandlers; }
     int GetVoicePacketsInterval() const noexcept { return m_voicePacketsInterval; }
     int GetMaxVoicePacketsPerInterval() const noexcept { return m_maxVoicePacketsPerInterval; }
+    int GetMaxVoiceBufferSize() const noexcept { return m_maxVoiceBufferSize; }
 
 private:
     void RegisterCommand(const char* szName, FCommandHandler* pFunction, bool bRestricted, const char* szConsoleHelpText);
@@ -242,4 +243,5 @@ private:
     int                        m_allowMultiCommandHandlers;
     int                        m_voicePacketsInterval{};
     int                        m_maxVoicePacketsPerInterval{};
+    int                        m_maxVoiceBufferSize{};
 };

--- a/Server/mods/deathmatch/logic/packets/CVoiceDataPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CVoiceDataPacket.cpp
@@ -12,6 +12,8 @@
 #include "StdInc.h"
 #include "CVoiceDataPacket.h"
 #include "CPlayer.h"
+#include "CGame.h"
+#include "CMainConfig.h"
 
 bool CVoiceDataPacket::Read(NetBitStreamInterface& BitStream)
 {
@@ -23,11 +25,12 @@ bool CVoiceDataPacket::Read(NetBitStreamInterface& BitStream)
     if (!BitStream.Read(voiceBufferLength) || voiceBufferLength == 0 || voiceBufferLength > MAX_VOICE_BUFFER_SIZE)
         return false;
 
+    const auto*         mainConfig = g_pGame->GetConfig();
     const long long     now = GetTickCount64_();
-    const bool          newInterval = pPlayer->GetLastVoiceDataTime() == 0 || now - pPlayer->GetLastVoiceDataTime() >= VOICE_PACKET_INTERVAL_MS;
+    const bool          newInterval = pPlayer->GetLastVoiceDataTime() == 0 || now - pPlayer->GetLastVoiceDataTime() >= mainConfig->GetVoicePacketsInterval();
     const unsigned char packetsInInterval = newInterval ? 0 : pPlayer->GetVoiceDataPacketsInInterval();
 
-    if (packetsInInterval >= MAX_VOICE_PACKETS_PER_INTERVAL)
+    if (packetsInInterval >= mainConfig->GetMaxVoicePacketsPerInterval())
         return false;
 
     std::vector<unsigned char> voiceBuffer(voiceBufferLength);

--- a/Server/mods/deathmatch/logic/packets/CVoiceDataPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CVoiceDataPacket.cpp
@@ -22,10 +22,10 @@ bool CVoiceDataPacket::Read(NetBitStreamInterface& BitStream)
         return false;
 
     unsigned short voiceBufferLength{};
-    if (!BitStream.Read(voiceBufferLength) || voiceBufferLength == 0 || voiceBufferLength > MAX_VOICE_BUFFER_SIZE)
+    const auto*    mainConfig = g_pGame->GetConfig();
+    if (!BitStream.Read(voiceBufferLength) || voiceBufferLength == 0 || voiceBufferLength > mainConfig->GetMaxVoiceBufferSize())
         return false;
 
-    const auto*         mainConfig = g_pGame->GetConfig();
     const long long     now = GetTickCount64_();
     const bool          newInterval = pPlayer->GetLastVoiceDataTime() == 0 || now - pPlayer->GetLastVoiceDataTime() >= mainConfig->GetVoicePacketsInterval();
     const unsigned char packetsInInterval = newInterval ? 0 : pPlayer->GetVoiceDataPacketsInInterval();

--- a/Server/mods/deathmatch/logic/packets/CVoiceDataPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CVoiceDataPacket.h
@@ -16,7 +16,7 @@
 
 constexpr unsigned short MAX_VOICE_BUFFER_SIZE = 2048;
 constexpr long long      VOICE_PACKET_INTERVAL_MS = 100;
-constexpr unsigned char  MAX_VOICE_PACKETS_PER_INTERVAL = 5;
+constexpr unsigned char  MAX_VOICE_PACKETS_PER_INTERVAL = 32;
 
 class CVoiceDataPacket final : public CPacket
 {

--- a/Server/mods/deathmatch/logic/packets/CVoiceDataPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CVoiceDataPacket.h
@@ -15,8 +15,6 @@
 #include <vector>
 
 constexpr unsigned short MAX_VOICE_BUFFER_SIZE = 2048;
-constexpr long long      VOICE_PACKET_INTERVAL_MS = 100;
-constexpr unsigned char  MAX_VOICE_PACKETS_PER_INTERVAL = 32;
 
 class CVoiceDataPacket final : public CPacket
 {

--- a/Server/mods/deathmatch/logic/packets/CVoiceDataPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CVoiceDataPacket.h
@@ -14,8 +14,6 @@
 #include "CPacket.h"
 #include <vector>
 
-constexpr unsigned short MAX_VOICE_BUFFER_SIZE = 2048;
-
 class CVoiceDataPacket final : public CPacket
 {
 public:

--- a/Server/mods/deathmatch/mtaserver.conf
+++ b/Server/mods/deathmatch/mtaserver.conf
@@ -243,6 +243,14 @@
          Available range: 0 to 10.  Default - 4 -->
     <voice_quality>4</voice_quality>
 
+    <!-- This parameter controls the interval between batches of voice packets.
+         The minimum value is 50, the maximum is 1000, and the default is 100 -->
+    <voice_packets_interval>100</voice_packets_interval>
+
+    <!-- The maximum number of voice packets per interval.
+         The minimum value is 1, the maximum is 200, and the default is 32 -->
+    <max_voice_packets_per_interval>32</max_voice_packets_per_interval>
+
     <!-- Specifies the voice bitrate, in bps. This optional parameter overrides the previous two settings.
          If not set, MTA handles this automatically.  Use with care. -->
     <!-- <voice_bitrate>24600</voice_bitrate> -->

--- a/Server/mods/deathmatch/mtaserver.conf
+++ b/Server/mods/deathmatch/mtaserver.conf
@@ -251,6 +251,10 @@
          The minimum value is 1, the maximum is 200, and the default is 32 -->
     <max_voice_packets_per_interval>32</max_voice_packets_per_interval>
 
+    <!-- The maximum size of a voice packet buffer in bytes.
+         The minimum value is 128, the maximum is 2048, and the default is 512 -->
+    <max_voice_buffer_size>512</max_voice_buffer_size>
+
     <!-- Specifies the voice bitrate, in bps. This optional parameter overrides the previous two settings.
          If not set, MTA handles this automatically.  Use with care. -->
     <!-- <voice_bitrate>24600</voice_bitrate> -->


### PR DESCRIPTION
Fix for an issue where `CVoiceDataPacket::Read` rejected packets and caused audio dropouts due to `while (uiSpeexFramesAvailable-- > 0)`.

~~Increased the `MAX_VOICE_PACKETS_PER_INTERVAL` limit from `5` to `32`.~~

Moved the `VOICE_PACKET_INTERVAL_MS` and `MAX_VOICE_PACKETS_PER_INTERVAL` limits to the server configuration as `voice_packets_interval` and `max_voice_packets_per_interval`.
Also increased the default value of `max_voice_packets_per_interval` from `5` to `32`.

Hopefully, there won't be any more issues.

@Lpsd 