### PR TITLE
Fix setPedAnimation not initializing animation cache on success

### DIFF
--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -2264,6 +2264,9 @@ bool CStaticFunctionDefinitions::SetPedAnimation(CClientEntity& Entity, const SS
                 Ped.SetCurrentAnimationCustom(false);
                 Ped.SetNextAnimationNormal();
                 Ped.RunNamedAnimation(pBlock, szAnimName, iTime, iBlend, bLoop, bUpdatePosition, bInterruptible, bFreezeLastFrame);
+                Ped.m_AnimationCache.startTime = GetTimestamp();
+                Ped.m_AnimationCache.speed = 1.0f;
+                Ped.m_AnimationCache.progress = 0.0f;
                 return true;
             }
             else
@@ -2283,12 +2286,13 @@ bool CStaticFunctionDefinitions::SetPedAnimation(CClientEntity& Entity, const SS
 
                         const char* szGateWayAnimationName = g_pGame->GetAnimManager()->GetGateWayAnimationName();
                         Ped.RunNamedAnimation(pBlock, szGateWayAnimationName, iTime, iBlend, bLoop, bUpdatePosition, bInterruptible, bFreezeLastFrame);
+                        Ped.m_AnimationCache.startTime = GetTimestamp();
+                        Ped.m_AnimationCache.speed = 1.0f;
+                        Ped.m_AnimationCache.progress = 0.0f;
                         return true;
                     }
                 }
             }
-
-            Ped.m_AnimationCache.startTime = GetTimestamp();
         }
         else
         {


### PR DESCRIPTION
#### Summary
On successful local `setPedAnimation` paths, early `return true` skipped the trailing `m_AnimationCache.startTime = GetTimestamp()` assignment. Initialize `startTime`, `speed`, and `progress` before those returns (normal + IFP gateway paths), and remove the unreachable assignment after the branch.

#### Motivation
Client-local `setPedAnimation` never primed the animation cache on success (unlike RPC-driven setup). That breaks stream-in progress restore and time-based checks that depend on `startTime`. Split out from the `getPedAnimation` partial-anim PR so each change stays focused.

#### Test plan
1. Client: call `setPedAnimation(ped, block, anim, ...)` on a streamed-in ped, then stream the ped out and back in — timing/progress should resume from a sensible start, not look unset/stuck.
2. Client: exercise the custom IFP / gateway `setPedAnimation` path — same cache init, no regression.
3. Client: `setPedAnimation(ped, false)` / clear animation still works.
4. Compare with a server-synced animation (RPC path) — startTime/speed/progress priming should align.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.