### PR TITLE
Fix missing DFT-30 middle wheel

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -10,6 +10,22 @@
 
 #include "StdInc.h"
 
+#define CALL_CClumpModelInfo_FindFrameFromName_Stricmp 0x4C5311
+
+static int __cdecl CompareVehicleComponentName(const char* expectedName, const char* frameName)
+{
+    const int result = _stricmp(expectedName, frameName);
+    if (result == 0)
+        return 0;
+
+    // The stock DFT-30 model names its left middle wheel "wheel_lm", while
+    // the vehicle hierarchy expects "wheel_lm_dummy".
+    if (_stricmp(expectedName, "wheel_lm_dummy") == 0 && _stricmp(frameName, "wheel_lm") == 0)
+        return 0;
+
+    return result;
+}
+
 static bool __fastcall AreVehicleDoorsUndamageable(CVehicleSAInterface* vehicle)
 {
     SClientEntity<CVehicleSA>* pair = pGameInterface->GetPools()->GetVehicle((DWORD*)vehicle);
@@ -72,4 +88,5 @@ static void __declspec(naked) HOOK_CDamageManager__ProgressDoorDamage()
 void CMultiplayerSA::InitHooks_Vehicles()
 {
     EZHookInstall(CDamageManager__ProgressDoorDamage);
+    HookInstallCall(CALL_CClumpModelInfo_FindFrameFromName_Stricmp, (DWORD)CompareVehicleComponentName);
 }


### PR DESCRIPTION
#### Summary
Fix the missing left middle wheel on DFT-30.

The model calls this component `wheel_lm`, but the game search for `wheel_lm_dummy`, so it is never found. The fix accepts `wheel_lm` when this component is searched.

Based on [SilentPatch hierarchy typo fix](https://github.com/CookiePLMonster/SilentPatch/blob/16731db9de6bd84d3ac9e84f6c6fefe3c2cb1f31/SilentPatchSA/SilentPatchSA.cpp#L1964-L2001).

PS: I planned to make one PR with all SilentPatch vehicle fixes but not sure if you prefer one fix per PR. This one only fixes DFT.

Screen before the fix : 
<img width="1920" height="1200" alt="mta-screen_2026-07-25_00-28-50" src="https://github.com/user-attachments/assets/bc87b1f6-29ba-4251-8790-aa408094170e" />

Screen after the fix :
<img width="1920" height="1200" alt="mta-screen_2026-07-25_00-53-01" src="https://github.com/user-attachments/assets/3c8b3d8d-87b6-405f-98a8-a8aac212d2cc" />


#### Motivation
DFT-30 has one missing middle wheel in GTA SA and MTA.

#### Test plan
Spawn DFT-30, the left middle wheel is now visible.

#### Checklist

* [x] Your code should follow the coding guidelines.
* [x] Smaller pull requests are easier to review.