### PR TITLE
Fix targeting marker staying on screen after death

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -1970,6 +1970,10 @@ void CClientPed::Kill(eWeaponType weaponType, unsigned char ucBodypart, bool bSt
     if (IsWearingGoggles())
         SetWearingGoggles(false, false);
 
+    // Clear the targeting marker so it doesn't stay on screen after death
+    if (m_pPlayerPed)
+        m_pPlayerPed->SetTargetedEntity(nullptr);
+
     m_bDead = true;
 }
 


### PR DESCRIPTION
#### Summary

Clears the player's aim target when they die, so the targeting marker over a ped/player doesn't stay on screen until you respawn.

#### Motivation

If you die while aiming at a ped or player, the targeting marker keeps being rendered even though you're dead, and it only goes away once you respawn. This happens because the engine hides the marker based on whether you still have an aim target set, and nothing was clearing that target when the player died.

Fixes #667

#### Test plan

```
stop play
```
```
run ped=Ped(19, 0, 0, 4) me:giveWeapon(23, 100, true) me.position=Vector3(0, -2, 4)
```
Aim at the ped, then kill yourself.
```
run me:kill()
```
Optionally set the camera to look straight at the ped so the marker is already visible when you die.
```
crun setCameraMatrix(-0.1896, -3.99, 3.83, -0.1480, -3, 3.75, 0, 70)
```
Before the fix, the marker stays on screen after death until you respawn. After the fix, it disappears the moment you die.

Also checked that the marker still shows up normally while aiming and alive.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.