### PR TITLE
Fix swinging chassis handling flag not applying

### DIFF
--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -30,6 +30,7 @@
 #include "CWorldSA.h"
 #include "gamesa_renderware.h"
 #include "CFireManagerSA.h"
+#include "enums/VehicleType.h"
 
 extern CCoreInterface* g_pCore;
 extern CGameSA*        pGame;
@@ -1570,6 +1571,55 @@ void CVehicleSA::RecalculateHandling()
         GetVehicleInterface ()->fDragCoeff = pGame->GetHandlingManager()->GetBasicDragCoeff();
     else*/
     // pInt->fDragCoeff = m_pHandlingData->GetInterface()->fDragCoeff / 1000 * pGame->GetHandlingManager()->GetDragMultiplier();
+
+    // The swinging chassis flag is only applied once, inside the game's vehicle constructor.
+    // Redo that setup here so a live handling change actually takes effect.
+    RecalculateSwingingChassis();
+}
+
+void CVehicleSA::RecalculateSwingingChassis()
+{
+    if (GetVehicleInterface()->m_vehicleClass != VehicleClass::AUTOMOBILE)
+        return;
+
+    constexpr std::uint16_t axisZ = 2;
+    constexpr std::uint16_t axisNegY = 4;
+    constexpr std::uint16_t extraChassis = 0x40;
+    constexpr std::uint16_t extraFixedState = 0x80;
+    constexpr std::uint16_t extraFiretruck = 0x100;
+
+    auto&               chassis = static_cast<CAutomobileSAInterface*>(GetVehicleInterface())->m_swingingChassis;
+    const std::uint16_t modelID = GetModelIndex();
+
+    // The Firela's ladder reuses this same slot for its own animation, so it must never be overridden by the swinging chassis flag.
+    if (modelID == static_cast<std::uint16_t>(VehicleType::VT_FIRELA))
+    {
+        chassis.m_fOpenAngle = 0.1f * PI;
+        chassis.m_fClosedAngle = -0.1f * PI;
+        chassis.m_nAxis = axisZ;
+        chassis.m_nDirn = axisNegY | extraFixedState | extraFiretruck;
+        chassis.m_nDoorState = static_cast<std::uint8_t>(DoorState::DOOR_HIT_MAX_END);
+        return;
+    }
+
+    if (!(GetVehicleInterface()->dwHandlingFlags & HANDLING_SwingingChassis_Flag))
+    {
+        chassis = {};  // Flag off: reset so the chassis can't swing anymore
+        return;
+    }
+
+    // Same per-model angle multiplier the game's vehicle constructor uses
+    float angleMultiplier = 0.02f;
+    if (modelID == static_cast<std::uint16_t>(VehicleType::VT_COPCARVG) || modelID == static_cast<std::uint16_t>(VehicleType::VT_ESPERANT))
+        angleMultiplier = 0.03f;
+    else if (modelID == static_cast<std::uint16_t>(VehicleType::VT_STRETCH))
+        angleMultiplier = 0.01f;
+
+    chassis.m_fOpenAngle = angleMultiplier * PI;
+    chassis.m_fClosedAngle = -angleMultiplier * PI;
+    chassis.m_nAxis = axisZ;
+    chassis.m_nDirn = axisNegY | extraChassis | extraFixedState;
+    chassis.m_nDoorState = static_cast<std::uint8_t>(DoorState::DOOR_HIT_MAX_END);
 }
 
 void CVehicleSA::BurstTyre(BYTE bTyre)

--- a/Client/game_sa/CVehicleSA.h
+++ b/Client/game_sa/CVehicleSA.h
@@ -86,8 +86,9 @@ struct RwTexture;
 #define FUNC_CAutomobile__GetDoorAngleOpenRatio 0x6A2270
 #define FUNC_CTrain__GetDoorAngleOpenRatio      0x6F59C0
 
-#define HANDLING_NOS_Flag        0x00080000
-#define HANDLING_Hydraulics_Flag 0x00020000
+#define HANDLING_NOS_Flag             0x00080000
+#define HANDLING_Hydraulics_Flag      0x00020000
+#define HANDLING_SwingingChassis_Flag 0x10000000
 
 #define VAR_CVehicle_Variation1 0x8A6458
 #define VAR_CVehicle_Variation2 0x8A6459
@@ -721,6 +722,7 @@ private:
     static void SetAutomobileDummyPosition(CAutomobileSAInterface* automobile, VehicleDummies dummy, const CVector& position);
 
     void           RecalculateSuspensionLines();
+    void           RecalculateSwingingChassis();
     void           CopyGlobalSuspensionLinesToPrivate();
     SVehicleFrame* GetVehicleComponent(const SString& vehicleComponent);
     void           FinalizeFramesList();


### PR DESCRIPTION
#### Summary

Makes the swinging chassis handling flag actually apply when it's changed on a vehicle, instead of only doing something if the vehicle was created with that flag already set. Also makes sure turning the flag on for the Firela (ladder fire truck) doesn't break its ladder, since the game reuses the same internal slot for both.

#### Motivation

Fixes #1117. The game only reads the swinging chassis flag once, when the vehicle is actually constructed, to set up how much the chassis is allowed to wobble. Changing the handling afterwards (handling editor, setVehicleHandling, setModelHandling) updates the stored value but never redoes that setup, so the flag looked like it did nothing regardless of when you changed it.

#### Test plan

Spawn a Greenwood, disable the swinging chassis flag in hedit and confirm it stops wobbling right away, without having to respawn the vehicle. Enable it back and it will work.

Spawn a Firela (Firetruck with Ladder), force enable the swinging chassis flag on it in hedit and confirm the ladder still works normally instead of turning into a wobbling chassis.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.