### PR TITLE
Fix custom weapons keeping pointers to destroyed elements

### DIFF
--- a/Server/mods/deathmatch/logic/CCustomWeapon.cpp
+++ b/Server/mods/deathmatch/logic/CCustomWeapon.cpp
@@ -11,12 +11,16 @@
 #include "StdInc.h"
 #include "CCustomWeapon.h"
 #include "CObjectManager.h"
+#include "CElementRefManager.h"
 #include "CVehicle.h"
 #include "CPed.h"
 
 CCustomWeapon::CCustomWeapon(CElement* pParent, CObjectManager* pObjectManager, CCustomWeaponManager* pWeaponManager, eWeaponType weaponType)
     : CObject(pParent, pObjectManager, false)
 {
+    // Ensure m_pTarget and m_pOwner get nulled when the elements they point at are destroyed
+    CElementRefManager::AddElementRefs(ELEMENT_REF_DEBUG(this, "CCustomWeapon"), &m_pTarget, &m_pOwner, NULL);
+
     // Init
     m_iType = CElement::WEAPON;
     SetTypeName("weapon");
@@ -57,6 +61,8 @@ CCustomWeapon::CCustomWeapon(CElement* pParent, CObjectManager* pObjectManager, 
 
 CCustomWeapon::~CCustomWeapon()
 {
+    CElementRefManager::RemoveElementRefs(ELEMENT_REF_DEBUG(this, "CCustomWeapon"), &m_pTarget, &m_pOwner, NULL);
+
     m_pWeaponManager->RemoveFromList(this);
 }
 

--- a/Server/mods/deathmatch/logic/packets/CEntityAddPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CEntityAddPacket.cpp
@@ -300,7 +300,13 @@ bool CEntityAddPacket::Write(NetBitStreamInterface& BitStream) const
                     if (ucEntityTypeID == CElement::WEAPON)
                     {
                         CCustomWeapon* pWeapon = static_cast<CCustomWeapon*>(pElement);
+                        CElement*      pTarget = pWeapon->GetElementTarget();
                         unsigned char  targetType = pWeapon->GetTargetType();
+
+                        // The targeted element may have been destroyed since it was set
+                        if (targetType == TARGET_TYPE_ENTITY && !pTarget)
+                            targetType = TARGET_TYPE_FIXED;
+
                         BitStream.WriteBits(&targetType, 3);  // 3 bits = 4 possible values.
 
                         switch (targetType)
@@ -311,7 +317,6 @@ bool CEntityAddPacket::Write(NetBitStreamInterface& BitStream) const
                             }
                             case TARGET_TYPE_ENTITY:
                             {
-                                CElement* pTarget = pWeapon->GetElementTarget();
                                 ElementID targetID = pTarget->GetID();
 
                                 BitStream.Write(targetID);


### PR DESCRIPTION
## **Summary**

Fixed the server holding on to destroyed elements through `setWeaponTarget` and `setWeaponOwner`.

A custom weapon created with `createWeapon` can be pointed at another element with
`setWeaponTarget`, and can be given an owning player with `setWeaponOwner`. The weapon stored both
as plain pointers and never let go of them, so once the target element was destroyed or the owner
left the server, the weapon was still pointing at memory that had been freed and reused. Reading it
gave back whatever happened to be there. Now both are cleared the moment the element they point at
is destroyed, and a weapon whose target is gone simply reports no target.

Servers that never call `setWeaponTarget` or `setWeaponOwner`, or that never destroy the elements
they passed to them, behave exactly as before.

## **Motivation**

`CCustomWeapon` keeps `m_pTarget` (a `CElement*`) and `m_pOwner` (a `CPlayer*`). The server has a
mechanism for exactly this problem, `CElementRefManager`, which nulls registered pointers inside
`~CElement`, and `CVehicle` and `CPlayer` both use it. `CCustomWeapon` never registered either
pointer.

The client side of the same feature does it correctly. `Client/mods/deathmatch/logic/CClientWeapon.cpp:22`
registers both members with `CClientEntityRefManager` under the comment *"Ensure m_pTarget and
m_pOwner get NULLed when they are destroyed"*. Only the server copy was missed.

Two reads then hit freed memory:

- `getWeaponTarget` and `getWeaponOwner` return the stale pointer to the script.
- `CEntityAddPacket` reads the target when a player joins, at
  `Server/mods/deathmatch/logic/packets/CEntityAddPacket.cpp:314`, with no check at all. It takes
  the element's ID and its type off freed memory and writes them to the joining client.

That second one also affects what goes on the wire. The server decides whether to append a bone byte
or four wheel bits by looking at the *server-side* element's type, while the client decides how many
bits to read by looking up the ID it just received. If the freed memory happens to read back as a ped
or a vehicle, the server writes bits the client never reads, and the rest of that entity add packet
is parsed at the wrong offset.

For example, a resource creates a turret with `createWeapon`, aims it at a ped with
`setWeaponTarget`, and later destroys that ped when the round ends. Every player who joins after
that gets a weapon element built from freed memory.

<details><summary>Runtime evidence (temporary logging, not part of this PR)</summary>

Pointer values printed from `~CElement` and from each place the weapon's pointers are read. The same
address showing up first as a destructor line and later as a read is the use-after-free. `type=14` is
`CElement::PED`, `type=1` is `CElement::PLAYER`.

```
~CElement 000000800498E060 type=14                   <- setWeaponTarget'd ped is destroyed and freed
getWeaponTarget reads 000000800498E060               <- same address, two seconds later
CEntityAddPacket reads target 000000800498E060       <- same address, on player join
CEntityAddPacket target id=2e6f7475 type=1635018341  <- block already reused; both values are garbage

~CElement 0000008004E57F70 type=1                    <- setWeaponOwner'd player quits
getWeaponOwner reads 0000008004E57F70                <- same address, two seconds later
```

`0x2e6f7475` is ASCII text, not an element ID, and it was written to the joining client.

</details>

## Test plan

**Runtime**

- Before Fix: A resource created a weapon, targeted a ped, destroyed the ped, then a player joined. The destroyed ped's address was read again by both `getWeaponTarget` and the entity add packet, and the packet carried a garbage element ID.
- After Fix: The same run showed the pointer nulled. `getWeaponTarget` returned `nil` and the entity add packet wrote `TARGET_TYPE_FIXED` with no dereference.
- Owner: A player was set as weapon owner and then disconnected. Before the fix `getWeaponOwner` read the freed player's address; after the fix it read null and returned `false`.
- Live entity target: A weapon targeting a ped that was never destroyed still resolved to that ped, and the entity add packet still wrote `TARGET_TYPE_ENTITY`.
- Vector target: A weapon targeting a fixed position still returned that position, and the entity add packet still wrote `TARGET_TYPE_VECTOR`.

**Builds and Tests**

- `Debug | Win32`: Full build passed, 304 client tests passed.
- `Release | Win32`: Full build passed.
- `Debug | x64`: Full build passed.
- `Release | x64`: Full build passed.
- Ran `clang-format`.

## Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
