### PR TITLE
Fix client crash from out of range vehicle siren data

### DIFF
--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -4631,7 +4631,7 @@ void CClientVehicle::RemoveVehicleSirens()
     m_tSirenBeaconInfo.m_bOverrideSirens = false;
     SetSirenOrAlarmActive(false);
 
-    for (unsigned char i = 0; i < 7; i++)
+    for (unsigned char i = 0; i < SIREN_COUNT_MAX; i++)
     {
         SetVehicleSirenPosition(i, CVector(0, 0, 0));
         SetVehicleSirenMinimumAlpha(i, 0);

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -3575,11 +3575,20 @@ retry:
                         bitStream.Read(ucSirenCount);
                         bitStream.Read(ucSirenType);
 
-                        pVehicle->GiveVehicleSirens(ucSirenType, ucSirenCount);
+                        // The count comes straight off the wire and is used to index a fixed size array.
+                        // Keep reading the entries the packet claims to hold so the stream stays aligned,
+                        // but only store the ones that fit.
+                        unsigned char ucStoredSirenCount = std::min<unsigned char>(ucSirenCount, SIREN_COUNT_MAX);
+
+                        pVehicle->GiveVehicleSirens(ucSirenType, ucStoredSirenCount);
                         for (unsigned char i = 0; i < ucSirenCount; i++)
                         {
                             SVehicleSirenSync sirenData;
                             bitStream.Read(&sirenData);
+
+                            if (i >= ucStoredSirenCount)
+                                continue;
+
                             pVehicle->SetVehicleSirenPosition(i, sirenData.data.m_vecSirenPositions);
                             pVehicle->SetVehicleSirenColour(i, sirenData.data.m_colSirenColour);
                             pVehicle->SetVehicleSirenMinimumAlpha(i, sirenData.data.m_dwSirenMinAlpha);

--- a/Shared/sdk/net/SyncStructures.h
+++ b/Shared/sdk/net/SyncStructures.h
@@ -1812,7 +1812,10 @@ struct SVehicleSirenSync : public ISyncStructure
                 bitStream.ReadBit(data.m_bDoLOSCheck);
                 bitStream.ReadBit(data.m_bUseRandomiser);
                 bitStream.ReadBit(data.m_bEnableSilent);
-                return true;
+
+                // The id indexes a fixed size array, so reject it here rather than at the point of use.
+                // Everything is read first so the rest of the stream stays aligned.
+                return data.m_ucSirenID <= SIREN_ID_MAX;
             }
         }
 


### PR DESCRIPTION
## **Summary**

Added range checks to the two places where the client takes vehicle siren data off the network.

A vehicle with custom sirens stores them in a fixed array of eight entries. Which entry to write is decided by a number the server sends, and the client never checked that number against the size of the array. A server sending anything above eight made the client write past the end of it, which in practice ends the session for every player connecting to that server. The client now ignores siren data that does not fit instead of storing it.

Servers behave the same as before, because a stock server already range checks these values before sending them. This only changes what the client does when it receives values that cannot be right.

## **Motivation**

Both `CClientVehicle` and the game-side `CVehicleSA` hold sirens in an `SFixedArray<SSirenBeaconInfo, 8>`. Its `operator[]` guards with a plain `assert`, which is not a range check a shipped client can rely on.

Two paths write into it using an unchecked network value:

- **The vehicle block of the entity add packet.** `Client/mods/deathmatch/logic/CPacketHandler.cpp:3575` reads the siren count as a raw byte and loops that many times, writing entry `i` each iteration. There is no upper bound, so a count of 40 writes 40 entries into an array of 8.
- **`SVehicleSirenSync`**, which carries the siren id for the `SET_VEHICLE_SIRENS` RPC. `Shared/sdk/net/SyncStructures.h:1801` reads the id and returns it unvalidated, and `CVehicleRPCs::SetVehicleSirens` passes it straight to `CClientVehicle::SetVehicleSirenPosition`.

The structure directly above it in the same file, `SVehicleSirenAddSync`, does validate its type and count (`Shared/sdk/net/SyncStructures.h:1750`), which is the same check missing here. The entity add path also bypasses that existing validation, because it reads the count itself rather than going through that structure.

Both fixes read every field before rejecting anything, so a bad packet does not leave the rest of the bit stream misaligned.

A third, smaller problem in the same array: `CClientVehicle::RemoveVehicleSirens` looped over seven entries rather than eight, so the last slot was never reset. That function runs from the `CClientVehicle` constructor (`Client/mods/deathmatch/logic/CClientVehicle.cpp:245`), so it applies to every vehicle, not just ones that had sirens removed.

For example, a player joins a server whose vehicle sends a siren count above eight. The siren block is part of the packet that introduces the vehicle, so the player does not have to see, enter or go anywhere near it.

<details><summary>Runtime evidence</summary>

Reproduced by patching a local server's entity add packet to write a siren count of 40 and logging, from `CClientVehicle::SetVehicleSirenPosition`, the bounds of the array and the address each write lands on. Both the patch and the logging are temporary and are not part of this PR.

Before the fix, on joining:

```
[SIREN-INSTR] id=7 array=[2CB42618,2CB426B8) write=2CB426A4 in-bounds
[SIREN-INSTR] id=8 array=[2CB42618,2CB426B8) write=2CB426B8 OUT OF BOUNDS (+0 bytes past end)
```

The client then stopped on `SFixedArray::operator[]`'s `assert(uiIndex < SIZE)` (`Shared/sdk/SharedUtil.Misc.h:1906`) with a Visual C++ assertion dialog, on a `Release | Win32` build. It never reached the remaining 32 entries the packet claimed to hold.

After the fix, the same server and the same client: no out of bounds write, the highest index written is 7, and the client stays connected.

</details>

## Test plan

**Runtime**

- Before Fix: A local server patched to send a siren count of 40 in the vehicle entity add packet. The joining client wrote past the end of its eight entry siren array and stopped on the array bounds assertion.
- After Fix: Same patched server, same scenario. The count was clamped to eight, no write landed outside the array, and the client stayed connected and playable.
- Normal siren data: An unpatched server ran `addVehicleSirens(vehicle, 8, 1)` and set sirens 1 and 8. A client script read the values back with `getVehicleSirenParams` and `getVehicleSirens` and reported count 8, type 1, siren 1 at `1.00,0.00,0.50` coloured `255,0,0` and siren 8 at `-1.00,0.00,0.50` coloured `0,0,255`, all matching what the server set.
- Siren reset: The constructor's reset loop was observed clearing entries 0 to 6 before the change and 0 to 7 after it.

**Builds and Tests**

- `Debug | Win32`: Full build passed, 304 client tests passed.
- `Release | Win32`: Full build passed.
- `Debug | x64`: Full build passed.
- `Release | x64`: Full build passed.
- Ran `clang-format`.

## Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.