### PR TITLE
Fix jump and climb ignoring setElementCollidableWith

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -168,6 +168,12 @@ DWORD**       VAR_TagInfoArray = (DWORD**)0xA9A8C0;
 #define HOOKPOS_CPhysical_ProcessCollisionSectorList 0x54BB93
 DWORD RETURN_CPhysical_ProcessCollisionSectorList = 0x54BB9A;
 
+// CTaskSimpleClimb::ScanToGrabSectorList. Hooked right after its own collision check, so climb
+// and vault scans also skip entities excluded via setElementCollidableWith.
+#define HOOKPOS_CTaskSimpleClimb_ScanToGrabSectorList 0x67DF28
+DWORD RETURN_CTaskSimpleClimb_ScanToGrabSectorList = 0x67DF36;
+DWORD SKIP_CTaskSimpleClimb_ScanToGrabSectorList = 0x67E580;
+
 #define HOOKPOS_CheckAnimMatrix 0x7C5A5C
 DWORD RETURN_CheckAnimMatrix = 0x7C5A61;
 
@@ -476,6 +482,7 @@ void HOOK_CEventHandler_ComputeKnockOffBikeResponse();
 void HOOK_CPed_GetWeaponSkill();
 void HOOK_CPed_AddGogglesModel();
 void HOOK_CPhysical_ProcessCollisionSectorList();
+void HOOK_CTaskSimpleClimb_ScanToGrabSectorList();
 void HOOK_CrashFix_Misc1();
 void HOOK_CrashFix_Misc2();
 void HOOK_CrashFix_Misc4();
@@ -678,6 +685,7 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_CPed_GetWeaponSkill, (DWORD)HOOK_CPed_GetWeaponSkill, 8);
     HookInstall(HOOKPOS_CPed_AddGogglesModel, (DWORD)HOOK_CPed_AddGogglesModel, 6);
     HookInstall(HOOKPOS_CPhysical_ProcessCollisionSectorList, (DWORD)HOOK_CPhysical_ProcessCollisionSectorList, 7);
+    HookInstall(HOOKPOS_CTaskSimpleClimb_ScanToGrabSectorList, (DWORD)HOOK_CTaskSimpleClimb_ScanToGrabSectorList, 8);
     HookInstall(HOOKPOS_CheckAnimMatrix, (DWORD)HOOK_CheckAnimMatrix, 5);
 
     HookInstall(HOOKPOS_VehColCB, (DWORD)HOOK_VehColCB, 29);
@@ -6393,6 +6401,62 @@ static void __declspec(naked) HOOK_CPhysical_ProcessCollisionSectorList()
             test    edi, 1
             mov     edi, pCollisionPhysical
             jmp     RETURN_CPhysical_ProcessCollisionSectorList
+        }
+        // clang-format on
+    }
+}
+
+CEntitySAInterface* pClimbScanPedInterface;
+CEntitySAInterface* pClimbScanTargetInterface;
+BYTE                bClimbScanTargetUsesCollision;
+
+bool CTaskSimpleClimb_ShouldSkipEntity()
+{
+    // Same as the game's own check this replaces: no collision on the entity at all
+    if (!bClimbScanTargetUsesCollision)
+        return true;
+
+    // Also skip entities the ped was explicitly made non-collidable with (setElementCollidableWith)
+    if (pClimbScanPedInterface && pClimbScanTargetInterface && m_pProcessCollisionHandler)
+        return !m_pProcessCollisionHandler(pClimbScanPedInterface, pClimbScanTargetInterface);
+
+    return false;
+}
+
+static void __declspec(naked) HOOK_CTaskSimpleClimb_ScanToGrabSectorList()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        mov     pClimbScanPedInterface, ebx
+        mov     pClimbScanTargetInterface, esi
+        test    byte ptr [esi+1Ch], 1
+        mov     word ptr [esi+2Ch], cx
+        setne   al
+        mov     bClimbScanTargetUsesCollision, al
+        pushad
+    }
+    // clang-format on
+
+    if (CTaskSimpleClimb_ShouldSkipEntity())
+    {
+        // clang-format off
+        __asm
+        {
+            popad
+            jmp     SKIP_CTaskSimpleClimb_ScanToGrabSectorList
+        }
+        // clang-format on
+    }
+    else
+    {
+        // clang-format off
+        __asm
+        {
+            popad
+            jmp     RETURN_CTaskSimpleClimb_ScanToGrabSectorList
         }
         // clang-format on
     }

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -6436,7 +6436,6 @@ static void __declspec(naked) HOOK_CTaskSimpleClimb_ScanToGrabSectorList()
         mov     word ptr [esi+2Ch], cx
         setne   al
         mov     bClimbScanTargetUsesCollision, al
-        pushad
     }
     // clang-format on
 
@@ -6445,7 +6444,6 @@ static void __declspec(naked) HOOK_CTaskSimpleClimb_ScanToGrabSectorList()
         // clang-format off
         __asm
         {
-            popad
             jmp     SKIP_CTaskSimpleClimb_ScanToGrabSectorList
         }
         // clang-format on
@@ -6455,7 +6453,6 @@ static void __declspec(naked) HOOK_CTaskSimpleClimb_ScanToGrabSectorList()
         // clang-format off
         __asm
         {
-            popad
             jmp     RETURN_CTaskSimpleClimb_ScanToGrabSectorList
         }
         // clang-format on


### PR DESCRIPTION
#### Summary

Jump and climb detection now respects setElementCollidableWith. CTaskSimpleClimb's scan did its own collision check and never went through the game's existing collision handler; this hooks it into the same one setElementCollidableWith already uses.

#### Motivation

Fixes #1758. An object made non collidable with a ped via setElementCollidableWith could still be jumped on or climbed, since the climb scan bypassed the collision handler entirely.

#### Test plan

Tested in game. Created an object, disabled collision with the local player via setElementCollidableWith, then tried to jump on and climb it; the player now falls through instead of grabbing a ledge. Also confirmed normal climbing on regular objects still works.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit by commit.