### PR TITLE
Fix heap over-read in CVoiceDataPacket relay

### DIFF
--- a/Server/mods/deathmatch/logic/packets/CVoiceDataPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CVoiceDataPacket.cpp
@@ -43,7 +43,16 @@ bool CVoiceDataPacket::Read(NetBitStreamInterface& BitStream)
         BitStream.Read(m_usActualDataLength);
         if (m_usActualDataLength)
         {
-            BitStream.Read(reinterpret_cast<char*>(m_pBuffer), m_usActualDataLength <= m_usDataBufferSize ? m_usActualDataLength : m_usDataBufferSize);
+            // Reject oversized payloads. The declared length must fit the buffer,
+            // otherwise the relayed packet would contain data beyond what the
+            // client actually sent (read from adjacent heap memory).
+            if (m_usActualDataLength > m_usDataBufferSize)
+                return false;
+
+            // Reject truncated payloads, otherwise the uninitialized remainder
+            // of the buffer would be relayed to other players.
+            if (!BitStream.Read(reinterpret_cast<char*>(m_pBuffer), m_usActualDataLength))
+                return false;
         }
         return true;
     }


### PR DESCRIPTION
## Summary

`CVoiceDataPacket::Read` keeps the client declared data length even when it exceeds the fixed 1024 byte receive buffer, and it never checks the result of the payload read. During relay, `SetData` copies the full declared length from that buffer, so the server broadcasts up to ~64 KiB of adjacent heap memory to every connected player (`CGame::Packet_Voice_Data`).

## Impact

Any connected client can repeat this to harvest server process memory. Voice packet id 71 has no size or rate limits, and the relay amplifies it by the player count. I am afraid a bunch of skids have already used this to get sensitive info from servers.

I know master already reworked this in #5069 and #5081, but that fix is not in any release tag, so all shipped 1.6.0 servers are still vulnerable. This is a minimal backport for the release/1.6.0 branch in case another 1.6.x build gets cut.

## Fix

Reject voice data packets whose declared length exceeds the buffer, and reject truncated payloads so uninitialized buffer contents are never relayed. `CPacketTranslator` already drops packets whose `Read()` returns false, so oversized packets are discarded cleanly.

## Testing

Not runtime tested (needs the full server build). The change only affects packet acceptance: legitimate voice frames (tens of bytes) pass unchanged, oversized declared lengths are dropped.
