### PR TITLE
Fix custom partial animations leaving peds rigid

### DIFF
--- a/Client/game_sa/CAnimBlendAssociationSA.cpp
+++ b/Client/game_sa/CAnimBlendAssociationSA.cpp
@@ -12,6 +12,7 @@
 #include "StdInc.h"
 #include "CAnimBlendAssociationSA.h"
 #include "CAnimBlendHierarchySA.h"
+#include "CAnimBlendStaticAssociationSA.h"
 #include "CAnimManagerSA.h"
 #include "CGameSA.h"
 
@@ -126,6 +127,26 @@ std::unique_ptr<CAnimBlendHierarchy> CAnimBlendAssociationSA::GetAnimHierarchy()
 const std::unique_ptr<CAnimBlendHierarchy> CAnimBlendAssociationSA::GetAnimHierarchy() const noexcept
 {
     return pGame->GetAnimManager()->GetAnimBlendHierarchy(m_pInterface->pAnimHierarchy);
+}
+
+void CAnimBlendAssociationSA::RestrictToBonesOf(const CAnimBlendStaticAssociationSAInterface* pOriginalAssoc)
+{
+    if (!pOriginalAssoc || !pOriginalAssoc->pAnimBlendNodesSequenceArray)
+        return;
+
+    // Custom animations are padded out to the full 32 bone skeleton when their IFP is loaded, with a
+    // fixed pose standing in for every bone the animation doesn't define. That padding is what a full
+    // body animation needs, but for a partial one it would drive the root, pelvis and legs the original
+    // never touched, leaving the ped rigid. Keep only the bones the original animation itself animates.
+    void* const*         ppOriginalSequences = reinterpret_cast<void* const*>(pOriginalAssoc->pAnimBlendNodesSequenceArray);
+    const unsigned short numOriginalNodes = pOriginalAssoc->nNumBlendNodes;
+
+    for (unsigned short i = 0; i < m_pInterface->cNumBlendNodes; i++)
+    {
+        const bool isAnimatedByOriginal = i < numOriginalNodes && ppOriginalSequences[i] != nullptr;
+        if (!isAnimatedByOriginal)
+            m_pInterface->pAnimBlendNodeArray[i].pAnimSequence = nullptr;
+    }
 }
 
 void CAnimBlendAssociationSA::SetCurrentProgress(float fProgress)

--- a/Client/game_sa/CAnimBlendAssociationSA.h
+++ b/Client/game_sa/CAnimBlendAssociationSA.h
@@ -164,6 +164,8 @@ public:
 
     float GetBlendAmount() { return m_pInterface->fBlendAmount; }
     void  SetBlendAmount(float fAmount) { m_pInterface->fBlendAmount = fAmount; }
+    bool  IsPartial() const noexcept { return m_pInterface->m_bPartial; }
+    void  RestrictToBonesOf(const CAnimBlendStaticAssociationSAInterface* pOriginalAssoc);
     void  SetCurrentProgress(float fProgress);
     float GetCurrentProgress() const noexcept { return m_pInterface->fCurrentTime; }
     float GetCurrentSpeed() const noexcept { return m_pInterface->fSpeed; }

--- a/Client/game_sa/CAnimBlendAssociationSA.h
+++ b/Client/game_sa/CAnimBlendAssociationSA.h
@@ -164,8 +164,8 @@ public:
 
     float GetBlendAmount() { return m_pInterface->fBlendAmount; }
     void  SetBlendAmount(float fAmount) { m_pInterface->fBlendAmount = fAmount; }
-    bool  IsPartial() const noexcept { return m_pInterface->m_bPartial; }
-    void  RestrictToBonesOf(const CAnimBlendStaticAssociationSAInterface* pOriginalAssoc);
+    bool  IsPartial() const override { return m_pInterface->m_bPartial; }
+    void  RestrictToBonesOf(const CAnimBlendStaticAssociationSAInterface* pOriginalAssoc) override;
     void  SetCurrentProgress(float fProgress);
     float GetCurrentProgress() const noexcept { return m_pInterface->fCurrentTime; }
     float GetCurrentSpeed() const noexcept { return m_pInterface->fSpeed; }

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -4097,6 +4097,13 @@ bool CClientGame::AssocGroupCopyAnimationHandler(CAnimBlendAssociationSAInterfac
             pAnimAssociation->SetFlags(pOriginalAnimStaticAssoc->GetFlags());
             pAnimAssociation->SetAnimID(pOriginalAnimStaticAssoc->GetAnimID());
             pAnimAssociation->SetAnimGroup(pOriginalAnimStaticAssoc->GetAnimGroup());
+
+            // A partial anim (e.g. weapon fire) only animates part of the skeleton and leaves the rest to
+            // whatever movement anim is playing. Loading an IFP pads its animations out to all 32 bones,
+            // so without this the replacement would also drive the root, pelvis and legs with a fixed pose
+            // and the ped would go rigid.
+            if (pAnimAssociation->IsPartial())
+                pAnimAssociation->RestrictToBonesOf(pOriginalAnimStaticAssoc->GetInterface());
         }
     }
 

--- a/Client/mods/deathmatch/logic/CIFPEngine.cpp
+++ b/Client/mods/deathmatch/logic/CIFPEngine.cpp
@@ -132,10 +132,22 @@ bool CIFPEngine::EngineApplyAnimation(CClientPed& Ped, CAnimBlendHierarchySAInte
             {
                 return true;
             }
+            // Remember if this was a partial anim before swapping its hierarchy, so the replacement can be
+            // trimmed back to the bones the original animated instead of the full skeleton the IFP padded it to.
+            const bool wasPartial = pCurrentAnimAssociation->IsPartial();
+
             auto pAnimHierarchy = pAnimationManager->GetAnimBlendHierarchy(pAnimHierarchyInterface);
             pAnimationManager->UncompressAnimation(pAnimHierarchy.get());
             pCurrentAnimAssociation->FreeAnimBlendNodeArray();
             pCurrentAnimAssociation->Init(pClump, pAnimHierarchyInterface);
+
+            if (wasPartial)
+            {
+                auto pOriginalStaticAssoc = pAnimationManager->GetAnimStaticAssociation(iGroupID, iAnimID);
+                if (pOriginalStaticAssoc)
+                    pCurrentAnimAssociation->RestrictToBonesOf(pOriginalStaticAssoc->GetInterface());
+            }
+
             pCurrentAnimAssociation->SetCurrentProgress(0.0);
             return true;
         }

--- a/Client/sdk/game/CAnimBlendAssociation.h
+++ b/Client/sdk/game/CAnimBlendAssociation.h
@@ -39,6 +39,10 @@ public:
 
     virtual float GetBlendAmount() = 0;
     virtual void  SetBlendAmount(float fAmount) = 0;
+    virtual bool  IsPartial() const noexcept = 0;
+    // Drops any blend node for a bone the original animation doesn't animate, so a custom replacement
+    // for a partial anim can't drive the bones (root, pelvis, legs) the original left to the movement anim.
+    virtual void  RestrictToBonesOf(const CAnimBlendStaticAssociationSAInterface* pOriginalAssoc) = 0;
     virtual void  SetCurrentProgress(float fProgress) = 0;
     virtual float GetCurrentProgress() const noexcept = 0;
     virtual void  SetCurrentSpeed(float fSpeed) = 0;

--- a/Client/sdk/game/CAnimBlendAssociation.h
+++ b/Client/sdk/game/CAnimBlendAssociation.h
@@ -39,7 +39,7 @@ public:
 
     virtual float GetBlendAmount() = 0;
     virtual void  SetBlendAmount(float fAmount) = 0;
-    virtual bool  IsPartial() const noexcept = 0;
+    virtual bool  IsPartial() const = 0;
     // Drops any blend node for a bone the original animation doesn't animate, so a custom replacement
     // for a partial anim can't drive the bones (root, pelvis, legs) the original left to the movement anim.
     virtual void  RestrictToBonesOf(const CAnimBlendStaticAssociationSAInterface* pOriginalAssoc) = 0;


### PR DESCRIPTION
#### Summary

Replacing a partial animation, like any of the weapon fire ones, with an animation loaded from a custom IFP left the ped rigid. It could still be walked around, but the legs and torso stopped animating and it stayed locked facing one direction.

Loading an IFP pads every animation out to all 32 bones and fills the ones the animation does not define with a fixed pose. A full body animation needs that padding, but a partial animation is only meant to drive part of the skeleton and leave the rest to whatever movement animation is playing, so the padding ended up driving the root, pelvis and legs as well.

The replacement is now trimmed back to the bones the original animation drives, read from its static association, so the padding can no longer reach bones the original never touched. This only runs for partial animations, so full body replacements keep taking exactly the same path as before.

**Before:** https://www.youtube.com/watch?v=gqyxviWVcJE

**After:**

https://github.com/user-attachments/assets/d2706649-f979-4060-bfdd-2791a5a95947




#### Motivation

Fixes #2733 and #3055.

Custom weapon animations have been unusable for a long time.

#### Test plan

[partialanimtest.zip](https://github.com/user-attachments/files/30487694/partialanimtest.zip)


Tested with a small resource that loads a custom shotgun.ifp and binds two keys, one calling `engineReplaceAnimation` on `"shotgun"` / `"shotgun_fire"` and the other calling `engineRestoreAnimation` to go back to the stock one.

Before the change, once the animation was replaced, aiming and firing the shotgun locked the ped facing a single direction with the legs and torso frozen, so it slid around without any walking animation.

After the change, the custom fire animation plays on the upper body while the ped keeps walking, turning and animating normally, and restoring brings the stock animation back.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.