### PR TITLE
Expose GTA CULL zones to client Lua

### DIFF
--- a/Client/game_sa/CCullZonesSA.cpp
+++ b/Client/game_sa/CCullZonesSA.cpp
@@ -173,8 +173,8 @@ namespace
         return ToInt16(input.centerX - vector1X - vector2X, output.cornerX) && ToInt16(input.centerY - vector1Y - vector2Y, output.cornerY) &&
                ToInt16(vector1X * 2.0f, output.vector1X) && ToInt16(vector1Y * 2.0f, output.vector1Y) && ToInt16(vector2X * 2.0f, output.vector2X) &&
                ToInt16(vector2Y * 2.0f, output.vector2Y) && ToInt16(input.centerZ - input.height * 0.5f, output.minZ) &&
-               ToInt16(input.centerZ + input.height * 0.5f, output.maxZ) && output.minZ < output.maxZ &&
-               (output.vector1X != 0 || output.vector1Y != 0) && (output.vector2X != 0 || output.vector2Y != 0);
+               ToInt16(input.centerZ + input.height * 0.5f, output.maxZ) && output.minZ < output.maxZ && (output.vector1X != 0 || output.vector1Y != 0) &&
+               (output.vector2X != 0 || output.vector2Y != 0);
     }
 
     bool BuildNativeMirrorZone(const SCullZoneDefinition& input, SNativeMirrorZone& output)

--- a/Client/game_sa/CCullZonesSA.cpp
+++ b/Client/game_sa/CCullZonesSA.cpp
@@ -1,0 +1,586 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  PURPOSE:     GTA SA CULL zone relocation and editable catalog
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+#include "CCullZonesSA.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstring>
+#include <numbers>
+
+namespace
+{
+    constexpr std::size_t ATTRIBUTE_ZONE_CAPACITY = 4096;
+    constexpr std::size_t TUNNEL_ZONE_CAPACITY = 256;
+    constexpr std::size_t MIRROR_ZONE_CAPACITY = 256;
+
+    constexpr std::uintptr_t ORIGINAL_ATTRIBUTE_ZONES = 0xC81F50;
+    constexpr std::uintptr_t ORIGINAL_TUNNEL_ZONES = 0xC81C80;
+    constexpr std::uintptr_t ORIGINAL_MIRROR_ZONES = 0xC815C0;
+    constexpr std::uintptr_t NUM_ATTRIBUTE_ZONES = 0xC87AC8;
+    constexpr std::uintptr_t NUM_TUNNEL_ZONES = 0xC87AC0;
+    constexpr std::uintptr_t NUM_MIRROR_ZONES = 0xC87AC4;
+    constexpr std::uintptr_t CURRENT_FLAGS_PLAYER = 0xC87AB8;
+    constexpr std::uintptr_t CURRENT_FLAGS_CAMERA = 0xC87ABC;
+    constexpr std::uintptr_t MIRROR_RENDER_STATE_DIRTY = 0xC7C729;
+
+    struct SNativeZoneDef
+    {
+        std::int16_t cornerX;
+        std::int16_t cornerY;
+        std::int16_t vector1X;
+        std::int16_t vector1Y;
+        std::int16_t vector2X;
+        std::int16_t vector2Y;
+        std::int16_t minZ;
+        std::int16_t maxZ;
+    };
+
+    struct SNativeAttributeZone
+    {
+        SNativeZoneDef def;
+        std::uint16_t  flags;
+    };
+
+    struct SNativeMirrorZone
+    {
+        SNativeZoneDef def;
+        float          mirrorV;
+        std::int8_t    normalX;
+        std::int8_t    normalY;
+        std::int8_t    normalZ;
+        std::uint8_t   flags;
+    };
+
+    static_assert(sizeof(SNativeZoneDef) == 0x10, "Invalid GTA CULL zone definition size");
+    static_assert(sizeof(SNativeAttributeZone) == 0x12, "Invalid GTA CULL attribute zone size");
+    static_assert(sizeof(SNativeMirrorZone) == 0x18, "Invalid GTA CULL mirror zone size");
+    static_assert(offsetof(SNativeAttributeZone, flags) == 0x10, "Invalid GTA CULL attribute flags offset");
+    static_assert(offsetof(SNativeMirrorZone, mirrorV) == 0x10, "Invalid GTA CULL mirror V offset");
+    static_assert(offsetof(SNativeMirrorZone, normalX) == 0x14, "Invalid GTA CULL mirror normal offset");
+    static_assert(offsetof(SNativeMirrorZone, flags) == 0x17, "Invalid GTA CULL mirror flags offset");
+
+    std::array<SNativeAttributeZone, ATTRIBUTE_ZONE_CAPACITY> g_attributeZones{};
+    std::array<SNativeAttributeZone, TUNNEL_ZONE_CAPACITY>    g_tunnelZones{};
+    std::array<SNativeMirrorZone, MIRROR_ZONE_CAPACITY>       g_mirrorZones{};
+
+    template <class T>
+    T& NativeGlobal(std::uintptr_t address)
+    {
+        return *reinterpret_cast<T*>(address);
+    }
+
+    void PatchPointer(std::uintptr_t operandAddress, const void* pointer)
+    {
+        MemPut<DWORD>(operandAddress, reinterpret_cast<DWORD>(pointer));
+    }
+
+    const void* Field(const void* object, std::size_t offset)
+    {
+        return static_cast<const std::uint8_t*>(object) + offset;
+    }
+
+    void InstallRelocation()
+    {
+        static bool installed = false;
+        if (installed)
+            return;
+
+        // Preserve data if another startup path happened to load CULL entries before
+        // the MTA game wrapper was constructed. Normally all three counts are zero here.
+        const int attributeCount = std::clamp(NativeGlobal<int>(NUM_ATTRIBUTE_ZONES), 0, static_cast<int>(ATTRIBUTE_ZONE_CAPACITY));
+        const int tunnelCount = std::clamp(NativeGlobal<int>(NUM_TUNNEL_ZONES), 0, static_cast<int>(TUNNEL_ZONE_CAPACITY));
+        const int mirrorCount = std::clamp(NativeGlobal<int>(NUM_MIRROR_ZONES), 0, static_cast<int>(MIRROR_ZONE_CAPACITY));
+        std::memcpy(g_attributeZones.data(), reinterpret_cast<const void*>(ORIGINAL_ATTRIBUTE_ZONES), attributeCount * sizeof(SNativeAttributeZone));
+        std::memcpy(g_tunnelZones.data(), reinterpret_cast<const void*>(ORIGINAL_TUNNEL_ZONES), tunnelCount * sizeof(SNativeAttributeZone));
+        std::memcpy(g_mirrorZones.data(), reinterpret_cast<const void*>(ORIGINAL_MIRROR_ZONES), mirrorCount * sizeof(SNativeMirrorZone));
+
+        // GTA SA 1.0 US operands verified against the corresponding lookup and
+        // loader functions. Every field operand must move with its native array.
+        PatchPointer(0x72DA85, g_mirrorZones.data());               // CCullZones::FindMirrorAttributesForCoors: array base
+        PatchPointer(0x72DAC8, Field(g_mirrorZones.data(), 0x00));  // CCullZones::FindMirrorAttributesForCoors: corner X
+        PatchPointer(0x72DC35, Field(g_mirrorZones.data(), 0x00));  // CCullZones::AddMirrorAttributeZone: corner X
+        PatchPointer(0x72DC52, Field(g_mirrorZones.data(), 0x02));  // CCullZones::AddMirrorAttributeZone: corner Y
+        PatchPointer(0x72DC64, Field(g_mirrorZones.data(), 0x04));  // CCullZones::AddMirrorAttributeZone: first vector X
+        PatchPointer(0x72DC74, Field(g_mirrorZones.data(), 0x06));  // CCullZones::AddMirrorAttributeZone: first vector Y
+        PatchPointer(0x72DC86, Field(g_mirrorZones.data(), 0x0C));  // CCullZones::AddMirrorAttributeZone: minimum Z
+        PatchPointer(0x72DC98, Field(g_mirrorZones.data(), 0x08));  // CCullZones::AddMirrorAttributeZone: second vector X
+        PatchPointer(0x72DCA8, Field(g_mirrorZones.data(), 0x0A));  // CCullZones::AddMirrorAttributeZone: second vector Y
+        PatchPointer(0x72DCC2, Field(g_mirrorZones.data(), 0x0E));  // CCullZones::AddMirrorAttributeZone: maximum Z
+        PatchPointer(0x72DCCC, Field(g_mirrorZones.data(), 0x17));  // CCullZones::AddMirrorAttributeZone: flags
+        PatchPointer(0x72DCD2, Field(g_mirrorZones.data(), 0x10));  // CCullZones::AddMirrorAttributeZone: mirror V
+        PatchPointer(0x72DCE7, Field(g_mirrorZones.data(), 0x14));  // CCullZones::AddMirrorAttributeZone: normal X
+        PatchPointer(0x72DCFC, Field(g_mirrorZones.data(), 0x15));  // CCullZones::AddMirrorAttributeZone: normal Y
+        PatchPointer(0x72DD0F, Field(g_mirrorZones.data(), 0x16));  // CCullZones::AddMirrorAttributeZone: normal Z
+
+        PatchPointer(0x72DA13, Field(g_tunnelZones.data(), 0x10));  // CCullZones::FindTunnelAttributesForCoors: flags
+        PatchPointer(0x72DB74, Field(g_tunnelZones.data(), 0x00));  // CCullZones::AddTunnelAttributeZone: corner X
+        PatchPointer(0x72DB91, Field(g_tunnelZones.data(), 0x02));  // CCullZones::AddTunnelAttributeZone: corner Y
+        PatchPointer(0x72DBA3, Field(g_tunnelZones.data(), 0x04));  // CCullZones::AddTunnelAttributeZone: first vector X
+        PatchPointer(0x72DBB3, Field(g_tunnelZones.data(), 0x06));  // CCullZones::AddTunnelAttributeZone: first vector Y
+        PatchPointer(0x72DBC5, Field(g_tunnelZones.data(), 0x0C));  // CCullZones::AddTunnelAttributeZone: minimum Z
+        PatchPointer(0x72DBD7, Field(g_tunnelZones.data(), 0x08));  // CCullZones::AddTunnelAttributeZone: second vector X
+        PatchPointer(0x72DBE7, Field(g_tunnelZones.data(), 0x0A));  // CCullZones::AddTunnelAttributeZone: second vector Y
+        PatchPointer(0x72DBF3, Field(g_tunnelZones.data(), 0x0E));  // CCullZones::AddTunnelAttributeZone: maximum Z
+        PatchPointer(0x72DC07, Field(g_tunnelZones.data(), 0x10));  // CCullZones::AddTunnelAttributeZone: flags
+
+        PatchPointer(0x72D993, Field(g_attributeZones.data(), 0x10));  // CCullZones lookup at 0x72D970: flags
+        PatchPointer(0x72DAFA, g_attributeZones.data());               // CCullZones lookup at 0x72DAD0: array base
+        PatchPointer(0x72DB42, Field(g_attributeZones.data(), 0x00));  // CCullZones lookup at 0x72DAD0: corner X
+        PatchPointer(0x72DFDA, Field(g_attributeZones.data(), 0x00));  // CCullZones loader at 0x72DF70: corner X
+        PatchPointer(0x72DFF7, Field(g_attributeZones.data(), 0x02));  // CCullZones loader at 0x72DF70: corner Y
+        PatchPointer(0x72E009, Field(g_attributeZones.data(), 0x04));  // CCullZones loader at 0x72DF70: first vector X
+        PatchPointer(0x72E019, Field(g_attributeZones.data(), 0x06));  // CCullZones loader at 0x72DF70: first vector Y
+        PatchPointer(0x72E02B, Field(g_attributeZones.data(), 0x0C));  // CCullZones loader at 0x72DF70: minimum Z
+        PatchPointer(0x72E03D, Field(g_attributeZones.data(), 0x08));  // CCullZones loader at 0x72DF70: second vector X
+        PatchPointer(0x72E04D, Field(g_attributeZones.data(), 0x0A));  // CCullZones loader at 0x72DF70: second vector Y
+        PatchPointer(0x72E05A, Field(g_attributeZones.data(), 0x0E));  // CCullZones loader at 0x72DF70: maximum Z
+        PatchPointer(0x72E068, Field(g_attributeZones.data(), 0x10));  // CCullZones loader at 0x72DF70: flags
+
+        installed = true;
+    }
+
+    bool ToInt16(float value, std::int16_t& output)
+    {
+        if (!std::isfinite(value) || value < -32768.0f || value > 32767.0f)
+            return false;
+        output = static_cast<std::int16_t>(value);
+        return true;
+    }
+
+    bool BuildNativeDef(const SCullZoneDefinition& input, SNativeZoneDef& output)
+    {
+        if (!std::isfinite(input.centerX) || !std::isfinite(input.centerY) || !std::isfinite(input.centerZ) || !std::isfinite(input.width) ||
+            !std::isfinite(input.depth) || !std::isfinite(input.height) || !std::isfinite(input.rotationDegrees) || input.width <= 0.0f ||
+            input.depth <= 0.0f || input.height <= 0.0f)
+            return false;
+
+        const float radians = input.rotationDegrees * std::numbers::pi_v<float> / 180.0f;
+        const float halfWidth = input.width * 0.5f;
+        const float halfDepth = input.depth * 0.5f;
+        const float vector1X = std::cos(radians) * halfWidth;
+        const float vector1Y = std::sin(radians) * halfWidth;
+        const float vector2X = -std::sin(radians) * halfDepth;
+        const float vector2Y = std::cos(radians) * halfDepth;
+
+        return ToInt16(input.centerX - vector1X - vector2X, output.cornerX) && ToInt16(input.centerY - vector1Y - vector2Y, output.cornerY) &&
+               ToInt16(vector1X * 2.0f, output.vector1X) && ToInt16(vector1Y * 2.0f, output.vector1Y) && ToInt16(vector2X * 2.0f, output.vector2X) &&
+               ToInt16(vector2Y * 2.0f, output.vector2Y) && ToInt16(input.centerZ - input.height * 0.5f, output.minZ) &&
+               ToInt16(input.centerZ + input.height * 0.5f, output.maxZ) && output.minZ < output.maxZ &&
+               (output.vector1X != 0 || output.vector1Y != 0) && (output.vector2X != 0 || output.vector2Y != 0);
+    }
+
+    bool BuildNativeMirrorZone(const SCullZoneDefinition& input, SNativeMirrorZone& output)
+    {
+        if (input.flags > 0xFF || !BuildNativeDef(input, output.def) || !std::isfinite(input.mirrorV) || !std::isfinite(input.mirrorNormalX) ||
+            !std::isfinite(input.mirrorNormalY) || !std::isfinite(input.mirrorNormalZ))
+            return false;
+
+        // GTA constructs a reflection matrix directly from this normal. A
+        // non-unit vector can make that matrix singular instead of reflecting.
+        const float normalLength = std::hypot(input.mirrorNormalX, input.mirrorNormalY, input.mirrorNormalZ);
+        if (std::abs(normalLength - 1.0f) > 0.01f)
+            return false;
+
+        output.flags = static_cast<std::uint8_t>(input.flags);
+        output.mirrorV = input.mirrorV;
+        // Native IPL normals are signed percentages. Unit diagonals therefore
+        // quantize to roughly 0.99 length, matching GTA's original precision.
+        output.normalX = static_cast<std::int8_t>(input.mirrorNormalX * 100.0f);
+        output.normalY = static_cast<std::int8_t>(input.mirrorNormalY * 100.0f);
+        output.normalZ = static_cast<std::int8_t>(input.mirrorNormalZ * 100.0f);
+        return true;
+    }
+
+    SCullZoneDefinition ToDefinition(ECullZoneType type, const SNativeZoneDef& native, std::uint16_t flags)
+    {
+        SCullZoneDefinition output;
+        output.type = type;
+        output.centerX = native.cornerX + (native.vector1X + native.vector2X) * 0.5f;
+        output.centerY = native.cornerY + (native.vector1Y + native.vector2Y) * 0.5f;
+        output.centerZ = (native.minZ + native.maxZ) * 0.5f;
+        output.width = std::hypot(static_cast<float>(native.vector1X), static_cast<float>(native.vector1Y));
+        output.depth = std::hypot(static_cast<float>(native.vector2X), static_cast<float>(native.vector2Y));
+        output.height = static_cast<float>(native.maxZ - native.minZ);
+        output.rotationDegrees = std::atan2(static_cast<float>(native.vector1Y), static_cast<float>(native.vector1X)) * 180.0f / std::numbers::pi_v<float>;
+        output.flags = flags;
+        return output;
+    }
+
+    bool IsPointWithin(const SNativeZoneDef& zone, const CVector& point)
+    {
+        if (zone.minZ >= point.fZ || zone.maxZ <= point.fZ)
+            return false;
+
+        const float deltaX = point.fX - zone.cornerX;
+        const float deltaY = point.fY - zone.cornerY;
+        const float vector1X = zone.vector1X;
+        const float vector1Y = zone.vector1Y;
+        const float vector2X = zone.vector2X;
+        const float vector2Y = zone.vector2Y;
+        const float projection1 = vector1X * deltaX + vector1Y * deltaY;
+        const float projection2 = vector2X * deltaX + vector2Y * deltaY;
+        const float length1Squared = vector1X * vector1X + vector1Y * vector1Y;
+        const float length2Squared = vector2X * vector2X + vector2Y * vector2Y;
+        return projection1 >= 0.0f && projection1 <= length1Squared && projection2 >= 0.0f && projection2 <= length2Squared;
+    }
+
+    std::uint16_t FindAttributeFlags(const CVector& point)
+    {
+        const int     count = std::clamp(NativeGlobal<int>(NUM_ATTRIBUTE_ZONES), 0, static_cast<int>(ATTRIBUTE_ZONE_CAPACITY));
+        std::uint16_t flags = 0;
+        for (int i = 0; i < count; ++i)
+        {
+            if (IsPointWithin(g_attributeZones[i].def, point))
+                flags |= g_attributeZones[i].flags;
+        }
+        return flags;
+    }
+}  // namespace
+
+struct CCullZonesSA::SZoneEntry
+{
+    std::uint32_t        id{};
+    ECullZoneType        type{ECullZoneType::ATTRIBUTE};
+    ECullZoneType        originalType{ECullZoneType::ATTRIBUTE};
+    SNativeAttributeZone attribute{};
+    SNativeMirrorZone    mirror{};
+    SNativeAttributeZone originalAttribute{};
+    SNativeMirrorZone    originalMirror{};
+    const void*          owner{};
+    bool                 enabled{true};
+    bool                 original{false};
+};
+
+CCullZonesSA::CCullZonesSA()
+{
+    InstallRelocation();
+}
+
+CCullZonesSA::~CCullZonesSA() = default;
+
+void CCullZonesSA::EnsureCatalog()
+{
+    if (m_catalogReady)
+        return;
+
+    const int attributeCount = std::clamp(NativeGlobal<int>(NUM_ATTRIBUTE_ZONES), 0, static_cast<int>(ATTRIBUTE_ZONE_CAPACITY));
+    const int tunnelCount = std::clamp(NativeGlobal<int>(NUM_TUNNEL_ZONES), 0, static_cast<int>(TUNNEL_ZONE_CAPACITY));
+    const int mirrorCount = std::clamp(std::max(NativeGlobal<int>(NUM_MIRROR_ZONES), m_savedMirrorCount), 0, static_cast<int>(MIRROR_ZONE_CAPACITY));
+    OutputReleaseLine(SString("[CULL] adopted native zones: attribute=%d tunnel=%d mirror=%d", attributeCount, tunnelCount, mirrorCount));
+    m_entries.reserve(attributeCount + tunnelCount + mirrorCount + 64);
+
+    const auto addAttributeEntries = [this](ECullZoneType type, const SNativeAttributeZone* zones, int count)
+    {
+        for (int i = 0; i < count; ++i)
+        {
+            SZoneEntry entry;
+            entry.id = m_nextId++;
+            entry.type = type;
+            entry.originalType = type;
+            entry.attribute = zones[i];
+            entry.originalAttribute = zones[i];
+            entry.original = true;
+            m_entries.push_back(entry);
+        }
+    };
+
+    addAttributeEntries(ECullZoneType::ATTRIBUTE, g_attributeZones.data(), attributeCount);
+    addAttributeEntries(ECullZoneType::TUNNEL, g_tunnelZones.data(), tunnelCount);
+    for (int i = 0; i < mirrorCount; ++i)
+    {
+        SZoneEntry entry;
+        entry.id = m_nextId++;
+        entry.type = ECullZoneType::MIRROR;
+        entry.originalType = ECullZoneType::MIRROR;
+        entry.mirror = g_mirrorZones[i];
+        entry.originalMirror = g_mirrorZones[i];
+        entry.original = true;
+        m_entries.push_back(entry);
+    }
+
+    m_catalogReady = true;
+    m_savedMirrorCount = -1;
+    if (!m_mirrorsEnabled)
+        RebuildNativeArrays();
+}
+
+std::size_t CCullZonesSA::GetCount()
+{
+    EnsureCatalog();
+    return m_entries.size();
+}
+
+bool CCullZonesSA::GetByIndex(std::size_t index, SCullZoneInfo& outInfo)
+{
+    EnsureCatalog();
+    if (index >= m_entries.size())
+        return false;
+
+    const SZoneEntry&   entry = m_entries[index];
+    SCullZoneDefinition definition;
+    if (entry.type == ECullZoneType::MIRROR)
+    {
+        definition = ToDefinition(entry.type, entry.mirror.def, entry.mirror.flags);
+        definition.mirrorV = entry.mirror.mirrorV;
+        definition.mirrorNormalX = entry.mirror.normalX / 100.0f;
+        definition.mirrorNormalY = entry.mirror.normalY / 100.0f;
+        definition.mirrorNormalZ = entry.mirror.normalZ / 100.0f;
+    }
+    else
+        definition = ToDefinition(entry.type, entry.attribute.def, entry.attribute.flags);
+
+    static_cast<SCullZoneDefinition&>(outInfo) = definition;
+    outInfo.id = entry.id;
+    outInfo.enabled = entry.enabled;
+    outInfo.original = entry.original;
+    return true;
+}
+
+CCullZonesSA::SZoneEntry* CCullZonesSA::Find(std::uint32_t id)
+{
+    auto it = std::find_if(m_entries.begin(), m_entries.end(), [id](const SZoneEntry& entry) { return entry.id == id; });
+    return it == m_entries.end() ? nullptr : &*it;
+}
+
+bool CCullZonesSA::CanClaim(SZoneEntry& entry, const void* owner)
+{
+    if (!owner || (!entry.original && entry.owner != owner) || (entry.original && entry.owner && entry.owner != owner))
+        return false;
+    entry.owner = owner;
+    return true;
+}
+
+bool CCullZonesSA::HasCapacityFor(ECullZoneType type, const SZoneEntry* replacedEntry) const
+{
+    std::size_t count = 0;
+    for (const SZoneEntry& entry : m_entries)
+    {
+        if (&entry == replacedEntry)
+            continue;
+
+        // A modified original must retain capacity in its vanilla array. This
+        // guarantees that resource cleanup can always restore it, even when a
+        // different resource creates zones while the original is disabled.
+        if (entry.enabled && entry.type == type)
+            ++count;
+        else if (entry.original && entry.originalType == type)
+            ++count;
+    }
+
+    const std::size_t capacity = type == ECullZoneType::ATTRIBUTE ? ATTRIBUTE_ZONE_CAPACITY
+                                 : type == ECullZoneType::TUNNEL  ? TUNNEL_ZONE_CAPACITY
+                                                                  : MIRROR_ZONE_CAPACITY;
+    return count < capacity;
+}
+
+std::uint32_t CCullZonesSA::Create(const SCullZoneDefinition& definition, const void* owner)
+{
+    EnsureCatalog();
+    if (!owner || !HasCapacityFor(definition.type))
+        return 0;
+
+    SZoneEntry entry;
+    entry.id = m_nextId++;
+    entry.type = definition.type;
+    entry.owner = owner;
+    if (definition.type == ECullZoneType::MIRROR)
+    {
+        if (!BuildNativeMirrorZone(definition, entry.mirror))
+            return 0;
+    }
+    else
+    {
+        if (!BuildNativeDef(definition, entry.attribute.def))
+            return 0;
+        entry.attribute.flags = definition.flags;
+    }
+
+    m_entries.push_back(entry);
+    RebuildNativeArrays();
+    return entry.id;
+}
+
+bool CCullZonesSA::Set(std::uint32_t id, const SCullZoneDefinition& definition, const void* owner)
+{
+    EnsureCatalog();
+    SZoneEntry* entry = Find(id);
+    if (!entry || !owner || (!entry->original && entry->owner != owner) || (entry->original && entry->owner && entry->owner != owner) ||
+        (!entry->enabled && !HasCapacityFor(definition.type, entry)) ||
+        (entry->enabled && entry->type != definition.type && !HasCapacityFor(definition.type, entry)))
+        return false;
+
+    SNativeAttributeZone attribute{};
+    SNativeMirrorZone    mirror{};
+    if (definition.type == ECullZoneType::MIRROR)
+    {
+        if (!BuildNativeMirrorZone(definition, mirror))
+            return false;
+    }
+    else
+    {
+        if (!BuildNativeDef(definition, attribute.def))
+            return false;
+        attribute.flags = definition.flags;
+    }
+
+    entry->owner = owner;
+    entry->type = definition.type;
+    entry->attribute = attribute;
+    entry->mirror = mirror;
+    entry->enabled = true;
+    RebuildNativeArrays();
+    return true;
+}
+
+bool CCullZonesSA::SetEnabled(std::uint32_t id, bool enabled, const void* owner)
+{
+    EnsureCatalog();
+    SZoneEntry* entry = Find(id);
+    if (!entry || !owner || (!entry->original && entry->owner != owner) || (entry->original && entry->owner && entry->owner != owner) ||
+        (enabled && !entry->enabled && !HasCapacityFor(entry->type, entry)))
+        return false;
+    entry->owner = owner;
+    entry->enabled = enabled;
+    RebuildNativeArrays();
+    return true;
+}
+
+bool CCullZonesSA::Remove(std::uint32_t id, const void* owner)
+{
+    EnsureCatalog();
+    auto it = std::find_if(m_entries.begin(), m_entries.end(), [id](const SZoneEntry& entry) { return entry.id == id; });
+    if (it == m_entries.end() || !CanClaim(*it, owner))
+        return false;
+
+    if (it->original)
+        it->enabled = false;
+    else
+        m_entries.erase(it);
+    RebuildNativeArrays();
+    return true;
+}
+
+bool CCullZonesSA::Restore(std::uint32_t id, const void* owner)
+{
+    EnsureCatalog();
+    SZoneEntry* entry = Find(id);
+    if (!entry || !entry->original || entry->owner != owner || !HasCapacityFor(entry->originalType, entry))
+        return false;
+
+    entry->type = entry->originalType;
+    entry->attribute = entry->originalAttribute;
+    entry->mirror = entry->originalMirror;
+    entry->enabled = true;
+    entry->owner = nullptr;
+    RebuildNativeArrays();
+    return true;
+}
+
+void CCullZonesSA::RemoveChangesByOwner(const void* owner)
+{
+    if (!owner || !m_catalogReady)
+        return;
+
+    bool changed = false;
+    for (SZoneEntry& entry : m_entries)
+    {
+        if (entry.original && entry.owner == owner)
+        {
+            entry.type = entry.originalType;
+            entry.attribute = entry.originalAttribute;
+            entry.mirror = entry.originalMirror;
+            entry.enabled = true;
+            entry.owner = nullptr;
+            changed = true;
+        }
+    }
+
+    const auto oldSize = m_entries.size();
+    m_entries.erase(std::remove_if(m_entries.begin(), m_entries.end(), [owner](const SZoneEntry& entry) { return !entry.original && entry.owner == owner; }),
+                    m_entries.end());
+    if (changed || oldSize != m_entries.size())
+        RebuildNativeArrays();
+}
+
+void CCullZonesSA::SetMirrorsEnabled(bool enabled)
+{
+    m_mirrorsEnabled = enabled;
+    if (!m_catalogReady)
+    {
+        int& nativeCount = NativeGlobal<int>(NUM_MIRROR_ZONES);
+        if (!enabled)
+        {
+            // Core can toggle mirrors before GTA loads CULL IPL sections. Preserve
+            // any count already loaded without freezing an empty Lua catalog.
+            m_savedMirrorCount = std::max(m_savedMirrorCount, nativeCount);
+            nativeCount = 0;
+        }
+        else if (m_savedMirrorCount >= 0)
+        {
+            nativeCount = std::max(nativeCount, m_savedMirrorCount);
+            m_savedMirrorCount = -1;
+            NativeGlobal<std::uint8_t>(MIRROR_RENDER_STATE_DIRTY) = true;
+        }
+        return;
+    }
+
+    RebuildNativeArrays();
+}
+
+void CCullZonesSA::UpdateCurrentFlags(const CVector& playerPosition, const CVector& cameraPosition)
+{
+    NativeGlobal<int>(CURRENT_FLAGS_PLAYER) = FindAttributeFlags(playerPosition);
+    NativeGlobal<int>(CURRENT_FLAGS_CAMERA) = FindAttributeFlags(cameraPosition);
+}
+
+void CCullZonesSA::RebuildNativeArrays()
+{
+    std::size_t attributeCount = 0;
+    std::size_t tunnelCount = 0;
+    std::size_t mirrorCount = 0;
+    for (const SZoneEntry& entry : m_entries)
+    {
+        if (!entry.enabled)
+            continue;
+
+        switch (entry.type)
+        {
+            case ECullZoneType::ATTRIBUTE:
+                if (attributeCount < g_attributeZones.size())
+                    g_attributeZones[attributeCount++] = entry.attribute;
+                else
+                    assert(false && "CULL attribute capacity invariant violated");
+                break;
+            case ECullZoneType::TUNNEL:
+                if (tunnelCount < g_tunnelZones.size())
+                    g_tunnelZones[tunnelCount++] = entry.attribute;
+                else
+                    assert(false && "CULL tunnel capacity invariant violated");
+                break;
+            case ECullZoneType::MIRROR:
+                if (mirrorCount < g_mirrorZones.size())
+                    g_mirrorZones[mirrorCount++] = entry.mirror;
+                else
+                    assert(false && "CULL mirror capacity invariant violated");
+                break;
+        }
+    }
+
+    NativeGlobal<int>(NUM_ATTRIBUTE_ZONES) = static_cast<int>(attributeCount);
+    NativeGlobal<int>(NUM_TUNNEL_ZONES) = static_cast<int>(tunnelCount);
+    NativeGlobal<int>(NUM_MIRROR_ZONES) = m_mirrorsEnabled ? static_cast<int>(mirrorCount) : 0;
+
+    // Prevent removed attributes from lingering until the next attribute-mask
+    // refresh, and ask the mirror renderer to recreate its buffers.
+    NativeGlobal<int>(CURRENT_FLAGS_PLAYER) = 0;
+    NativeGlobal<int>(CURRENT_FLAGS_CAMERA) = 0;
+    NativeGlobal<std::uint8_t>(MIRROR_RENDER_STATE_DIRTY) = true;
+}

--- a/Client/game_sa/CCullZonesSA.cpp
+++ b/Client/game_sa/CCullZonesSA.cpp
@@ -1,8 +1,11 @@
 /*****************************************************************************
  *
- *  PROJECT:     Multi Theft Auto v1.0
+ *  PROJECT:     Multi Theft Auto
  *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        game_sa/CCullZonesSA.cpp
  *  PURPOSE:     GTA SA CULL zone relocation and editable catalog
+ *
+ *  Multi Theft Auto is available from https://www.multitheftauto.com/
  *
  *****************************************************************************/
 

--- a/Client/game_sa/CCullZonesSA.h
+++ b/Client/game_sa/CCullZonesSA.h
@@ -1,0 +1,46 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  PURPOSE:     GTA SA CULL zone relocation and editable catalog
+ *
+ *****************************************************************************/
+
+#pragma once
+
+#include <game/CWorld.h>
+#include <cstdint>
+#include <vector>
+
+class CCullZonesSA
+{
+public:
+    CCullZonesSA();
+    ~CCullZonesSA();
+
+    std::size_t   GetCount();
+    bool          GetByIndex(std::size_t index, SCullZoneInfo& outInfo);
+    std::uint32_t Create(const SCullZoneDefinition& definition, const void* owner);
+    bool          Set(std::uint32_t id, const SCullZoneDefinition& definition, const void* owner);
+    bool          SetEnabled(std::uint32_t id, bool enabled, const void* owner);
+    bool          Remove(std::uint32_t id, const void* owner);
+    bool          Restore(std::uint32_t id, const void* owner);
+    void          RemoveChangesByOwner(const void* owner);
+    void          SetMirrorsEnabled(bool enabled);
+    void          UpdateCurrentFlags(const CVector& playerPosition, const CVector& cameraPosition);
+
+private:
+    struct SZoneEntry;
+
+    void        EnsureCatalog();
+    void        RebuildNativeArrays();
+    SZoneEntry* Find(std::uint32_t id);
+    bool        CanClaim(SZoneEntry& entry, const void* owner);
+    bool        HasCapacityFor(ECullZoneType type, const SZoneEntry* replacedEntry = nullptr) const;
+
+    bool                    m_catalogReady{false};
+    bool                    m_mirrorsEnabled{true};
+    int                     m_savedMirrorCount{-1};
+    std::uint32_t           m_nextId{1};
+    std::vector<SZoneEntry> m_entries;
+};

--- a/Client/game_sa/CCullZonesSA.h
+++ b/Client/game_sa/CCullZonesSA.h
@@ -1,8 +1,11 @@
 /*****************************************************************************
  *
- *  PROJECT:     Multi Theft Auto v1.0
+ *  PROJECT:     Multi Theft Auto
  *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        game_sa/CCullZonesSA.h
  *  PURPOSE:     GTA SA CULL zone relocation and editable catalog
+ *
+ *  Multi Theft Auto is available from https://www.multitheftauto.com/
  *
  *****************************************************************************/
 

--- a/Client/game_sa/CWorldSA.cpp
+++ b/Client/game_sa/CWorldSA.cpp
@@ -10,6 +10,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include "CCullZonesSA.h"
 #include <numbers>
 #include <multiplayer/CMultiplayer.h>
 #include <core/CCoreInterface.h>
@@ -30,11 +31,61 @@ namespace
     extern const unsigned char aOriginalSurfaceInfo[2292];
 }
 
-CWorldSA::CWorldSA()
+CWorldSA::CWorldSA() : m_pSurfaceInfo(reinterpret_cast<CSurfaceType*>(ARRAY_SurfaceInfos)), m_cullZones(std::make_unique<CCullZonesSA>())
 {
-    m_pSurfaceInfo = reinterpret_cast<CSurfaceType*>(ARRAY_SurfaceInfos);
-
     InstallHooks();
+}
+
+CWorldSA::~CWorldSA() = default;
+
+std::size_t CWorldSA::GetCullZoneCount()
+{
+    return m_cullZones->GetCount();
+}
+
+bool CWorldSA::GetCullZoneByIndex(std::size_t index, SCullZoneInfo& outInfo)
+{
+    return m_cullZones->GetByIndex(index, outInfo);
+}
+
+std::uint32_t CWorldSA::CreateCullZone(const SCullZoneDefinition& definition, const void* owner)
+{
+    return m_cullZones->Create(definition, owner);
+}
+
+bool CWorldSA::SetCullZone(std::uint32_t id, const SCullZoneDefinition& definition, const void* owner)
+{
+    return m_cullZones->Set(id, definition, owner);
+}
+
+bool CWorldSA::SetCullZoneEnabled(std::uint32_t id, bool enabled, const void* owner)
+{
+    return m_cullZones->SetEnabled(id, enabled, owner);
+}
+
+bool CWorldSA::RemoveCullZone(std::uint32_t id, const void* owner)
+{
+    return m_cullZones->Remove(id, owner);
+}
+
+bool CWorldSA::RestoreCullZone(std::uint32_t id, const void* owner)
+{
+    return m_cullZones->Restore(id, owner);
+}
+
+void CWorldSA::RemoveCullZoneChangesByOwner(const void* owner)
+{
+    m_cullZones->RemoveChangesByOwner(owner);
+}
+
+void CWorldSA::SetCullMirrorZonesEnabled(bool enabled)
+{
+    m_cullZones->SetMirrorsEnabled(enabled);
+}
+
+void CWorldSA::UpdateCullZoneFlags(const CVector& playerPosition, const CVector& cameraPosition)
+{
+    m_cullZones->UpdateCurrentFlags(playerPosition, cameraPosition);
 }
 
 CSurfaceType* CWorldSA::GetSurfaceInfo()

--- a/Client/game_sa/CWorldSA.h
+++ b/Client/game_sa/CWorldSA.h
@@ -12,6 +12,9 @@
 #pragma once
 
 #include <game/CWorld.h>
+#include <memory>
+
+class CCullZonesSA;
 
 #define FUNC_Add                                     0x563220
 #define FUNC_Remove                                  0x563280
@@ -43,6 +46,7 @@ class CWorldSA : public CWorld
 {
 public:
     CWorldSA();
+    ~CWorldSA();
     void  InstallHooks();
     void  Add(CEntity* entity, eDebugCaller CallerId);
     void  Add(CEntitySAInterface* entityInterface, eDebugCaller CallerId);
@@ -78,7 +82,19 @@ public:
     CEntity* TestSphereAgainstWorld(const CVector& sphereCenter, float radius, CEntity* ignoredEntity, bool checkBuildings, bool checkVehicles, bool checkPeds,
                                     bool checkObjects, bool checkDummies, bool cameraIgnore, STestSphereAgainstWorldResult& result) override;
 
+    std::size_t   GetCullZoneCount() override;
+    bool          GetCullZoneByIndex(std::size_t index, SCullZoneInfo& outInfo) override;
+    std::uint32_t CreateCullZone(const SCullZoneDefinition& definition, const void* owner) override;
+    bool          SetCullZone(std::uint32_t id, const SCullZoneDefinition& definition, const void* owner) override;
+    bool          SetCullZoneEnabled(std::uint32_t id, bool enabled, const void* owner) override;
+    bool          RemoveCullZone(std::uint32_t id, const void* owner) override;
+    bool          RestoreCullZone(std::uint32_t id, const void* owner) override;
+    void          RemoveCullZoneChangesByOwner(const void* owner) override;
+    void          SetCullMirrorZonesEnabled(bool enabled) override;
+    void          UpdateCullZoneFlags(const CVector& playerPosition, const CVector& cameraPosition) override;
+
 private:
-    float         m_fAircraftMaxHeight;
-    CSurfaceType* m_pSurfaceInfo;
+    float                         m_fAircraftMaxHeight;
+    CSurfaceType*                 m_pSurfaceInfo;
+    std::unique_ptr<CCullZonesSA> m_cullZones;
 };

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -3922,6 +3922,17 @@ void CClientGame::PreRenderSkyHandler()
 
 void CClientGame::PreWeatherUpdateHandler()
 {
+    // CGame::Process does not reach GTA's later CCullZones::Update call on the
+    // multiplayer path. Refresh both attribute masks before weather consumes them.
+    if (m_pManager->IsGameLoaded() && m_pLocalPlayer && m_pCamera)
+    {
+        CVector playerPosition;
+        CVector cameraPosition;
+        m_pLocalPlayer->GetPosition(playerPosition);
+        m_pCamera->GetPosition(cameraPosition);
+        g_pGame->GetWorld()->UpdateCullZoneFlags(playerPosition, cameraPosition);
+    }
+
     // Fix #4803: Set MTA's weather types and zero InterpolationValue BEFORE
     // CWeather::Update runs. Zeroing InterpolationValue prevents the wrap branch
     // from ever firing (engine_interp >= 0 is always true), so the engine computes

--- a/Client/mods/deathmatch/logic/CResource.cpp
+++ b/Client/mods/deathmatch/logic/CResource.cpp
@@ -98,6 +98,11 @@ CResource::CResource(unsigned short usNetID, const char* szResourceName, CClient
 
 CResource::~CResource()
 {
+    // CULL zones are native state rather than client elements. Restore vanilla
+    // definitions and remove this resource's custom entries before its identity dies.
+    if (g_pGame && g_pGame->GetWorld())
+        g_pGame->GetWorld()->RemoveCullZoneChangesByOwner(this);
+
     // Remove refrences from requested models
     m_modelStreamer.ReleaseAll();
 
@@ -424,6 +429,11 @@ void CResource::Stop()
     CLuaArguments Arguments;
     Arguments.PushResource(this);
     m_pResourceEntity->CallEvent("onClientResourceStop", Arguments, true);
+
+    // Stop does not immediately destroy the resource object. Release its native
+    // ownership now so a same-session restart begins from the vanilla state.
+    if (g_pGame && g_pGame->GetWorld())
+        g_pGame->GetWorld()->RemoveCullZoneChangesByOwner(this);
 
     // When a custom application is used - reset discord stuff
     const auto discord = g_pCore->GetDiscord();

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
@@ -26,6 +26,12 @@ ADD_ENUM(static_cast<eLuaType>(LUA_TUSERDATA), "userdata")
 ADD_ENUM(static_cast<eLuaType>(LUA_TTHREAD), "thread")
 IMPLEMENT_ENUM_END("lua-type")
 
+IMPLEMENT_ENUM_CLASS_BEGIN(ECullZoneType)
+ADD_ENUM(ECullZoneType::ATTRIBUTE, "attribute")
+ADD_ENUM(ECullZoneType::TUNNEL, "tunnel")
+ADD_ENUM(ECullZoneType::MIRROR, "mirror")
+IMPLEMENT_ENUM_CLASS_END("cull-zone-type")
+
 IMPLEMENT_ENUM_BEGIN(CGUIVerticalAlign)
 ADD_ENUM(CGUI_ALIGN_TOP, "top")
 ADD_ENUM(CGUI_ALIGN_BOTTOM, "bottom")

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.h
@@ -14,6 +14,7 @@
 #include <game/CRenderWare.h>
 #include <game/CHud.h>
 #include <game/CStreaming.h>
+#include <game/CWorld.h>
 #include <type_traits>
 
 #include "enums/VehicleComponent.h"
@@ -97,6 +98,7 @@ DECLARE_ENUM_CLASS(eRenderStage);
 DECLARE_ENUM_CLASS(FxParticleSystems);
 DECLARE_ENUM(ePools);
 DECLARE_ENUM_CLASS(WorldProperty);
+DECLARE_ENUM_CLASS(ECullZoneType);
 DECLARE_ENUM_CLASS(eModelLoadState);
 DECLARE_ENUM_CLASS(PreloadAreaOption);
 DECLARE_ENUM_CLASS(RestreamOption);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -17,6 +17,126 @@
 #include <lua/CLuaFunctionParser.h>
 #include "CLuaEngineDefs.h"
 #include <enums/VehicleType.h>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+namespace
+{
+    using CullZoneValue = std::variant<std::uint32_t, float, bool, ECullZoneType>;
+    using CullZoneTable = std::unordered_map<std::string, CullZoneValue>;
+
+    std::uint16_t GetCullZoneFlags(ECullZoneType type, double flags)
+    {
+        const double maximumFlags = type == ECullZoneType::MIRROR ? std::numeric_limits<std::uint8_t>::max() : std::numeric_limits<std::uint16_t>::max();
+        if (flags < 0.0 || flags > maximumFlags || std::trunc(flags) != flags)
+            throw std::invalid_argument{"Flags must be a whole number in range for the selected CULL zone type"};
+
+        return static_cast<std::uint16_t>(flags);
+    }
+
+    std::uint32_t GetCullZoneId(double id)
+    {
+        if (id < 1.0 || id > std::numeric_limits<std::uint32_t>::max() || std::trunc(id) != id)
+            throw std::invalid_argument{"CULL zone ID must be a positive whole number"};
+
+        return static_cast<std::uint32_t>(id);
+    }
+
+    SCullZoneDefinition MakeCullZoneDefinition(ECullZoneType type, float centerX, float centerY, float centerZ, float width, float depth, float height,
+                                               double flags, std::optional<float> rotationDegrees, std::optional<float> mirrorV,
+                                               std::optional<float> mirrorNormalX, std::optional<float> mirrorNormalY, std::optional<float> mirrorNormalZ)
+    {
+        SCullZoneDefinition definition;
+        definition.type = type;
+        definition.centerX = centerX;
+        definition.centerY = centerY;
+        definition.centerZ = centerZ;
+        definition.width = width;
+        definition.depth = depth;
+        definition.height = height;
+        definition.flags = GetCullZoneFlags(type, flags);
+        definition.rotationDegrees = rotationDegrees.value_or(0.0f);
+        definition.mirrorV = mirrorV.value_or(0.0f);
+        definition.mirrorNormalX = mirrorNormalX.value_or(0.0f);
+        definition.mirrorNormalY = mirrorNormalY.value_or(0.0f);
+        definition.mirrorNormalZ = mirrorNormalZ.value_or(1.0f);
+        return definition;
+    }
+
+    std::vector<CullZoneTable> EngineGetCullZones(std::optional<ECullZoneType> type)
+    {
+        CWorld*                    world = g_pGame->GetWorld();
+        std::vector<CullZoneTable> result;
+        result.reserve(world->GetCullZoneCount());
+
+        for (std::size_t i = 0; i < world->GetCullZoneCount(); ++i)
+        {
+            SCullZoneInfo info;
+            if (!world->GetCullZoneByIndex(i, info) || (type && info.type != *type))
+                continue;
+
+            result.emplace_back(CullZoneTable{{"id", info.id},
+                                              {"type", info.type},
+                                              {"x", info.centerX},
+                                              {"y", info.centerY},
+                                              {"z", info.centerZ},
+                                              {"width", info.width},
+                                              {"depth", info.depth},
+                                              {"height", info.height},
+                                              {"rotation", info.rotationDegrees},
+                                              {"flags", static_cast<std::uint32_t>(info.flags)},
+                                              {"mirrorV", info.mirrorV},
+                                              {"normalX", info.mirrorNormalX},
+                                              {"normalY", info.mirrorNormalY},
+                                              {"normalZ", info.mirrorNormalZ},
+                                              {"enabled", info.enabled},
+                                              {"original", info.original}});
+        }
+        return result;
+    }
+
+    std::variant<bool, std::uint32_t> EngineCreateCullZone(lua_State* luaVM, ECullZoneType type, float centerX, float centerY, float centerZ, float width,
+                                                           float depth, float height, double flags, std::optional<float> rotationDegrees,
+                                                           std::optional<float> mirrorV, std::optional<float> mirrorNormalX, std::optional<float> mirrorNormalY,
+                                                           std::optional<float> mirrorNormalZ)
+    {
+        const SCullZoneDefinition definition = MakeCullZoneDefinition(type, centerX, centerY, centerZ, width, depth, height, flags, rotationDegrees, mirrorV,
+                                                                      mirrorNormalX, mirrorNormalY, mirrorNormalZ);
+        const std::uint32_t       id = g_pGame->GetWorld()->CreateCullZone(definition, &lua_getownerresource(luaVM));
+        return id ? std::variant<bool, std::uint32_t>{id} : std::variant<bool, std::uint32_t>{false};
+    }
+
+    bool EngineSetCullZone(lua_State* luaVM, double id, ECullZoneType type, float centerX, float centerY, float centerZ, float width, float depth, float height,
+                           double flags, std::optional<float> rotationDegrees, std::optional<float> mirrorV, std::optional<float> mirrorNormalX,
+                           std::optional<float> mirrorNormalY, std::optional<float> mirrorNormalZ)
+    {
+        const SCullZoneDefinition definition = MakeCullZoneDefinition(type, centerX, centerY, centerZ, width, depth, height, flags, rotationDegrees, mirrorV,
+                                                                      mirrorNormalX, mirrorNormalY, mirrorNormalZ);
+        return g_pGame->GetWorld()->SetCullZone(GetCullZoneId(id), definition, &lua_getownerresource(luaVM));
+    }
+
+    bool EngineSetCullZoneEnabled(lua_State* luaVM, double id, bool enabled)
+    {
+        return g_pGame->GetWorld()->SetCullZoneEnabled(GetCullZoneId(id), enabled, &lua_getownerresource(luaVM));
+    }
+
+    bool EngineRemoveCullZone(lua_State* luaVM, double id)
+    {
+        return g_pGame->GetWorld()->RemoveCullZone(GetCullZoneId(id), &lua_getownerresource(luaVM));
+    }
+
+    bool EngineRestoreCullZone(lua_State* luaVM, double id)
+    {
+        return g_pGame->GetWorld()->RestoreCullZone(GetCullZoneId(id), &lua_getownerresource(luaVM));
+    }
+}  // namespace
 
 //! Set the CModelCacheManager limits
 //! By passing `nil`/no value the original values are restored
@@ -104,6 +224,12 @@ void CLuaEngineDefs::LoadFunctions()
         {"engineGetModelLODDistance", EngineGetModelLODDistance},
         {"engineSetModelLODDistance", EngineSetModelLODDistance},
         {"engineResetModelLODDistance", EngineResetModelLODDistance},
+        {"engineGetCullZones", ArgumentParser<EngineGetCullZones>},
+        {"engineCreateCullZone", ArgumentParser<EngineCreateCullZone>},
+        {"engineSetCullZone", ArgumentParser<EngineSetCullZone>},
+        {"engineSetCullZoneEnabled", ArgumentParser<EngineSetCullZoneEnabled>},
+        {"engineRemoveCullZone", ArgumentParser<EngineRemoveCullZone>},
+        {"engineRestoreCullZone", ArgumentParser<EngineRestoreCullZone>},
         {"engineSetAsynchronousLoading", EngineSetAsynchronousLoading},
         {"engineApplyShaderToWorldTexture", EngineApplyShaderToWorldTexture},
         {"engineRemoveShaderFromWorldTexture", EngineRemoveShaderFromWorldTexture},

--- a/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
@@ -9,6 +9,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include <game/CWorld.h>
 #include <game/RenderWare.h>
 extern CCoreInterface*           g_pCore;
 GameEntityRenderHandler*         pGameEntityRenderHandler = nullptr;
@@ -16,15 +17,11 @@ PreRenderSkyHandler*             pPreRenderSkyHandlerHandler = nullptr;
 RenderHeliLightHandler*          pRenderHeliLightHandler = nullptr;
 RenderEverythingBarRoadsHandler* pRenderEverythingBarRoadsHandler = nullptr;
 
-#define VAR_CCullZones_NumMirrorAttributeZones 0x0C87AC4  // int
-#define VAR_CMirrors_d3dRestored               0x0C7C729  // uchar
-
 namespace
 {
     CEntitySAInterface* ms_Rendering = NULL;
     CEntitySAInterface* ms_RenderingOneNonRoad = NULL;
     bool                ms_bIsMinimizedAndNotConnected = false;
-    int                 ms_iSavedNumMirrorZones = 0;
 }  // namespace
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -798,27 +795,9 @@ void CMultiplayerSA::SetIsMinimizedAndNotConnected(bool bIsMinimizedAndNotConnec
 //////////////////////////////////////////////////////////////////////////////////////////
 void CMultiplayerSA::SetMirrorsEnabled(bool bEnabled)
 {
-    int&   iNumMirrorZones = *(int*)VAR_CCullZones_NumMirrorAttributeZones;
-    uchar& bResetMirror = *(uchar*)VAR_CMirrors_d3dRestored;
-
-    if (!bEnabled)
-    {
-        // Remove mirror zones
-        ms_iSavedNumMirrorZones += iNumMirrorZones;
-        iNumMirrorZones = 0;
-    }
-    else
-    {
-        if (ms_iSavedNumMirrorZones)
-        {
-            // Restore mirror zones
-            iNumMirrorZones += ms_iSavedNumMirrorZones;
-            ms_iSavedNumMirrorZones = 0;
-
-            // Recreate render buffers
-            bResetMirror = true;
-        }
-    }
+    // The CULL manager owns the published mirror count so resource edits made
+    // while mirrors are disabled cannot be lost when rendering resumes.
+    pGameInterface->GetWorld()->SetCullMirrorZonesEnabled(bEnabled);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/sdk/game/CWorld.h
+++ b/Client/sdk/game/CWorld.h
@@ -11,10 +11,12 @@
 
 #pragma once
 #include "CEntity.h"
+#include <CVector.h>
+#include <CVector2D.h>
+#include <cstddef>
+#include <cstdint>
 
 class CEntitySAInterface;
-class CVector;
-class CVector2D;
 class CColPoint;
 class CEntity;
 
@@ -71,6 +73,37 @@ struct STestSphereAgainstWorldResult
     CVector       entityRotation{};
     std::uint32_t lodID{0};
     eEntityType   type{ENTITY_TYPE_NOTHING};
+};
+
+enum class ECullZoneType : std::uint8_t
+{
+    ATTRIBUTE,
+    TUNNEL,
+    MIRROR,
+};
+
+struct SCullZoneDefinition
+{
+    ECullZoneType type{ECullZoneType::ATTRIBUTE};
+    float         centerX{};
+    float         centerY{};
+    float         centerZ{};
+    float         width{};
+    float         depth{};
+    float         height{};
+    float         rotationDegrees{};
+    std::uint16_t flags{};
+    float         mirrorV{};
+    float         mirrorNormalX{};
+    float         mirrorNormalY{};
+    float         mirrorNormalZ{1.0f};
+};
+
+struct SCullZoneInfo : SCullZoneDefinition
+{
+    std::uint32_t id{};
+    bool          enabled{};
+    bool          original{};
 };
 
 enum eDebugCaller
@@ -292,4 +325,15 @@ public:
 
     virtual CEntity* TestSphereAgainstWorld(const CVector& sphereCenter, float radius, CEntity* ignoredEntity, bool checkBuildings, bool checkVehicles,
                                             bool checkPeds, bool checkObjects, bool checkDummies, bool cameraIgnore, STestSphereAgainstWorldResult& result) = 0;
+
+    virtual std::size_t   GetCullZoneCount() = 0;
+    virtual bool          GetCullZoneByIndex(std::size_t index, SCullZoneInfo& outInfo) = 0;
+    virtual std::uint32_t CreateCullZone(const SCullZoneDefinition& definition, const void* owner) = 0;
+    virtual bool          SetCullZone(std::uint32_t id, const SCullZoneDefinition& definition, const void* owner) = 0;
+    virtual bool          SetCullZoneEnabled(std::uint32_t id, bool enabled, const void* owner) = 0;
+    virtual bool          RemoveCullZone(std::uint32_t id, const void* owner) = 0;
+    virtual bool          RestoreCullZone(std::uint32_t id, const void* owner) = 0;
+    virtual void          RemoveCullZoneChangesByOwner(const void* owner) = 0;
+    virtual void          SetCullMirrorZonesEnabled(bool enabled) = 0;
+    virtual void          UpdateCullZoneFlags(const CVector& playerPosition, const CVector& cameraPosition) = 0;
 };


### PR DESCRIPTION
#### Summary

This PR expose GTA attribute, tunnel and mirror CULL zones to client Lua:

- `engineGetCullZones`
- `engineCreateCullZone`
- `engineSetCullZone`
- `engineSetCullZoneEnabled`
- `engineRemoveCullZone`
- `engineRestoreCullZone`

Original zones can be queried, edited, disabled and restored. Resources can also create custom zones, but cannot edit custom zones created by another resource.
Custom zones are removed and original zones are restored when the resource stops.

The GTA CULL arrays are expanded to support custom zones. Invalid zone sizes, flags and mirror normals are rejected.

#### Motivation

Allow maps and gamemodes to inspect and manage GTA CULL zones from Lua.

#### Demo

https://www.youtube.com/watch?v=17QrE21uDgM

#### Test plan

Test resources: [mtasa-cull-zones.zip](https://github.com/user-attachments/files/30557753/mtasa-cull-zones.zip)

##### CRUD and validation

Server:

```text
refresh
start cull-zone-test
```

Client:

```text
/cullstats
/cullinvalid
/cullvisual all 200
/culltest attribute 8 40
/culledit 0 60
/cullenable off
/cullenable on
/culldelete
/cullstats
```

The first `/cullstats` gives the vanilla counts. `/cullinvalid` tries invalid geometry and mirror normals on both create and edit; it should return `PASS` without changing the count.

`/cullvisual all 200` displays original and custom zones within 200 units.
`/culltest attribute 8 40` creates a 40-unit `NO_RAIN` zone around the player.
`/culledit 0 60` moves it to the current position, resizes it to 60 units and removes the flag. 
With rainy weather, rain should be hidden by the first zone and return after the edit. The zone is then disabled, enabled and deleted. 
The final `/cullstats` should match the first one with no custom zone.

##### Mirrors

Server:

```text
start cull-mirror-floor-test
```

Client:

```text
/mirrorfloor2
/mirrorfloorinfo
/mirrorfloortoggle off
/mirrorfloortoggle on
/mirrorvanilla
/cullnearest mirror
/cullvanilladisable
/cullvanillarestore
/mirrorfloorleave
```

`/mirrorfloor2` enters the custom mirror showroom and `/mirrorfloorinfo` prints the nearest mirror definition and plane. The reflection should disappear and return when toggled.

`/mirrorvanilla` enters the original barbershop. `/cullnearest mirror` selects its original mirror zone, which should disappear and return when disabled and restored. `/mirrorfloorleave` returns to the previous position.

##### Resource cleanup

Server:

```text
stop cull-mirror-floor-test
```

Client:

```text
/culltest attribute 8 20
```

Server:

```text
restart cull-zone-test
```

Client:

```text
/cullstats
```

Stopping `cull-mirror-floor-test` removes its custom mirror. The attribute zone is then left active on purpose before restarting `cull-zone-test`. No custom zone should remain in `/cullstats` after the restart.

##### Resource ownership and capacity

Server:

```text
stop cull-mirror-floor-test
stop cull-zone-test
start cull-zone-owner-a
start cull-zone-owner-b
```

Client:

```text
/cullownera
/cullownerb
```

Owner A disables and claims one original mirror zone. Owner B checks that it cannot modify this zone, then fills all remaining custom mirror capacity.

Expected with the standard GTA data:

```text
PASS: created=191 expected=191 active=255 custom=191 disabledOriginal=1
```

Server:

```text
stop cull-zone-owner-a
```

Client:

```text
/cullownercheck
```

Stopping owner A should restore its original zone even while the mirror store
is full.

Expected:

```text
PASS: active=256 custom=191 disabledOriginal=0
```

Server:

```text
stop cull-zone-owner-b
start cull-zone-test
```

Client:

```text
/cullstats
```

Stopping owner B should remove all 191 custom zones and return to the vanilla mirror count.


#### Checklist

- [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
- [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.