### PR TITLE
Fix server DoS via latent transfer CATEGORY_PACKET path

### DIFF
--- a/Server/mods/deathmatch/logic/packets/CPlayerModInfoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerModInfoPacket.cpp
@@ -23,6 +23,14 @@ bool CPlayerModInfoPacket::Read(NetBitStreamInterface& BitStream)
     if (!BitStream.Read(uiCount))
         return false;
 
+    // Limit item count to prevent DoS via oversized payloads routed
+    // through the latent transfer path (CLatentReceiver). Without this
+    // cap, an attacker can send ~60K entries in a single 100MB latent
+    // packet, causing hundreds of thousands of heap allocations in
+    // Packet_PlayerModInfo and locking the main thread for seconds.
+    if (uiCount > 2048)
+        return false;
+
     // Read each item
     for (uint i = 0; i < uiCount; i++)
     {

--- a/Shared/mods/deathmatch/logic/CLatentReceiver.cpp
+++ b/Shared/mods/deathmatch/logic/CLatentReceiver.cpp
@@ -128,6 +128,15 @@ void CLatentReceiver::OnReceive(NetBitStreamInterface* pBitStream)
         if (uiFinalSize > 100 * 1024 * 1024)
             return OnReceiveError("uiFinalSize too large");
 
+        // CATEGORY_PACKET reassembles raw packet data and feeds it into
+        // the main packet dispatch (CGame::StaticProcessPacket). Without
+        // a tighter cap, an attacker can craft a 100MB payload targeting
+        // packet handlers that scale poorly with input size (e.g.
+        // CPlayerModInfoPacket). 10MB is well above any legitimate use.
+        constexpr uint LATENT_PACKET_MAX_SIZE = 10 * 1024 * 1024;
+        if (usCategory == CATEGORY_PACKET && uiFinalSize > LATENT_PACKET_MAX_SIZE)
+            return OnReceiveError("CATEGORY_PACKET payload too large");
+
         activeRx.usId = usId;
         activeRx.bReceiveStarted = true;
         activeRx.usCategory = usCategory;

--- a/Shared/mods/deathmatch/logic/CLatentTransferManager.cpp
+++ b/Shared/mods/deathmatch/logic/CLatentTransferManager.cpp
@@ -407,13 +407,21 @@ bool DoSendPacket(unsigned char ucPacketID, NetPlayerID remoteId, NetBitStreamIn
 
 bool DoStaticProcessPacket(unsigned char ucPacketID, NetPlayerID remoteId, NetBitStreamInterface* pBitStream, ushort usResourceNetId)
 {
-    // Check if latent packet should be ignored
-    if (usResourceNetId != 0xFFFF)
-    {
-        CResource* pResource = g_pGame->GetResourceManager()->GetResourceFromNetID(usResourceNetId);
-        if (!pResource)
-            return true;
-    }
+    // triggerLatentServerEvent is the only legitimate client-to-server latent
+    // path. It always sends PACKET_ID_LUA_EVENT with a valid resource net ID.
+    // Reject any other packet ID to prevent arbitrary packet handler dispatch
+    // via the latent transfer channel (e.g. routing PACKET_ID_PLAYER_MODINFO
+    // through a 100MB reassembled buffer to cause an unbounded heap storm).
+    if (ucPacketID != PACKET_ID_LUA_EVENT)
+        return false;
+
+    if (usResourceNetId == 0xFFFF)
+        return false;
+
+    CResource* pResource = g_pGame->GetResourceManager()->GetResourceFromNetID(usResourceNetId);
+    if (!pResource)
+        return true;
+
     return CGame::StaticProcessPacket(ucPacketID, remoteId, pBitStream, NULL);
 }
 


### PR DESCRIPTION
Fix server DoS via latent transfer CATEGORY_PACKET path

Weakness: CLatentReceiver accepted up to 100MB for CATEGORY_PACKET transfers,
bypassing RakNet's normal ~64KB message cap. The reassembled buffer is routed to
CGame::StaticProcessPacket, making all server packet handlers reachable with
attacker-controlled payloads up to 100MB. CPlayerModInfoPacket::Read() has no item
count limit, so a crafted payload with ~60K entries causes 500K-2M heap allocations
in Packet_PlayerModInfo on the main thread, locking the server for multiple seconds.

Fix 1: Cap CPlayerModInfoPacket item count at 2048 (no legitimate client sends more).
Fix 2: Cap CATEGORY_PACKET latent payloads at 64KB (matches RakNet's inherent limit).

The latent cap is an additional safeguard for all packet handlers, not just CPlayerModInfoPacket.