### PR TITLE
Fix custom partial animations from custom IFP banks staying rigid

### DIFF
--- a/Client/game_sa/CAnimBlendAssociationSA.cpp
+++ b/Client/game_sa/CAnimBlendAssociationSA.cpp
@@ -149,6 +149,19 @@ void CAnimBlendAssociationSA::RestrictToBonesOf(const CAnimBlendStaticAssociatio
     }
 }
 
+void CAnimBlendAssociationSA::RestrictToBones(std::bitset<32> animatedBonesMask)
+{
+    // Same padding problem as RestrictToBonesOf, but for animations played directly from a custom IFP
+    // bank rather than replacing a built-in one. There's no built-in association to compare against, so
+    // the caller passes the set of bones the source IFP animation itself defines (see CClientIFP).
+    for (unsigned short i = 0; i < m_pInterface->cNumBlendNodes; i++)
+    {
+        const bool isAnimated = i < animatedBonesMask.size() && animatedBonesMask.test(i);
+        if (!isAnimated)
+            m_pInterface->pAnimBlendNodeArray[i].pAnimSequence = nullptr;
+    }
+}
+
 void CAnimBlendAssociationSA::SetCurrentProgress(float fProgress)
 {
     float fTime = m_pInterface->pAnimHierarchy->fTotalTime * fProgress;

--- a/Client/game_sa/CAnimBlendAssociationSA.h
+++ b/Client/game_sa/CAnimBlendAssociationSA.h
@@ -166,6 +166,7 @@ public:
     void  SetBlendAmount(float fAmount) { m_pInterface->fBlendAmount = fAmount; }
     bool  IsPartial() const override { return m_pInterface->m_bPartial; }
     void  RestrictToBonesOf(const CAnimBlendStaticAssociationSAInterface* pOriginalAssoc) override;
+    void  RestrictToBones(std::bitset<32> animatedBonesMask) override;
     void  SetCurrentProgress(float fProgress);
     float GetCurrentProgress() const noexcept { return m_pInterface->fCurrentTime; }
     float GetCurrentSpeed() const noexcept { return m_pInterface->fSpeed; }

--- a/Client/mods/deathmatch/logic/CClientIFP.cpp
+++ b/Client/mods/deathmatch/logic/CClientIFP.cpp
@@ -114,7 +114,7 @@ void CClientIFP::ReadIFPVersion1()
         Animation.pSequencesMemory = AllocateSequencesMemory(Animation.pHierarchy);
         Animation.pHierarchy->SetSequences(reinterpret_cast<CAnimBlendSequenceSAInterface*>(Animation.pSequencesMemory + 4));
 
-        *(DWORD*)Animation.pSequencesMemory = ReadSequencesWithDummies(Animation.pHierarchy);
+        *(DWORD*)Animation.pSequencesMemory = ReadSequencesWithDummies(Animation.pHierarchy, Animation.AnimatedBonesMask);
         PreProcessAnimationHierarchy(Animation.pHierarchy);
     }
 }
@@ -138,17 +138,17 @@ void CClientIFP::ReadIFPVersion2(bool bAnp3)
         Animation.pSequencesMemory = AllocateSequencesMemory(Animation.pHierarchy);
         Animation.pHierarchy->SetSequences(reinterpret_cast<CAnimBlendSequenceSAInterface*>(Animation.pSequencesMemory + 4));
 
-        *(DWORD*)Animation.pSequencesMemory = ReadSequencesWithDummies(Animation.pHierarchy);
+        *(DWORD*)Animation.pSequencesMemory = ReadSequencesWithDummies(Animation.pHierarchy, Animation.AnimatedBonesMask);
         PreProcessAnimationHierarchy(Animation.pHierarchy);
     }
 }
 
-WORD CClientIFP::ReadSequencesWithDummies(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy)
+WORD CClientIFP::ReadSequencesWithDummies(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy, std::bitset<32>& outAnimatedBonesMask)
 {
     SequenceMapType MapOfSequences;
     WORD            wUnknownSequences = ReadSequences(pAnimationHierarchy, MapOfSequences);
 
-    MoveSequencesWithDummies(pAnimationHierarchy, MapOfSequences);
+    MoveSequencesWithDummies(pAnimationHierarchy, MapOfSequences, outAnimatedBonesMask);
     WORD cSequences = m_kcIFPSequences + wUnknownSequences;
 
     // As we need support for all 32 bones, we must change the total sequences count
@@ -512,7 +512,8 @@ void CClientIFP::PreProcessAnimationHierarchy(std::unique_ptr<CAnimBlendHierarch
     }
 }
 
-void CClientIFP::MoveSequencesWithDummies(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy, SequenceMapType& mapOfSequences)
+void CClientIFP::MoveSequencesWithDummies(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy, SequenceMapType& mapOfSequences,
+                                          std::bitset<32>& outAnimatedBonesMask)
 {
     for (size_t SequenceIndex = 0; SequenceIndex < m_kcIFPSequences; SequenceIndex++)
     {
@@ -528,6 +529,7 @@ void CClientIFP::MoveSequencesWithDummies(std::unique_ptr<CAnimBlendHierarchy>& 
             pAnimationSequence->CopySequenceProperties(pMapAnimSequenceInterface);
             // Delete the interface because we are moving, not copying
             m_pAnimManager->DeleteCustomAnimSequenceInterface(pMapAnimSequenceInterface);
+            outAnimatedBonesMask.set(SequenceIndex);
         }
         else
         {
@@ -1149,4 +1151,16 @@ CAnimBlendHierarchySAInterface* CClientIFP::GetAnimationHierarchy(const SString&
         return it->pHierarchy->GetInterface();
     }
     return nullptr;
+}
+
+std::bitset<32> CClientIFP::GetAnimatedBonesMask(const SString& strAnimationName)
+{
+    const unsigned int uiAnimationNameHash = HashString(strAnimationName.ToLower());
+    auto               it = std::find_if(m_pVecAnimations->begin(), m_pVecAnimations->end(),
+                                         [&uiAnimationNameHash](SAnimation const& Animation) { return Animation.uiNameHash == uiAnimationNameHash; });
+    if (it != m_pVecAnimations->end())
+    {
+        return it->AnimatedBonesMask;
+    }
+    return {};
 }

--- a/Client/mods/deathmatch/logic/CClientIFP.h
+++ b/Client/mods/deathmatch/logic/CClientIFP.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <bitset>
 #include "CClientEntity.h"
 #include "CFileReader.h"
 #include "CIFPAnimations.h"
@@ -211,6 +212,7 @@ public:
     const unsigned int& GetBlockNameHash() { return m_u32Hashkey; }
 
     CAnimBlendHierarchySAInterface* GetAnimationHierarchy(const SString& strAnimationName);
+    std::bitset<32>                 GetAnimatedBonesMask(const SString& strAnimationName);
     std::shared_ptr<CIFPAnimations> GetIFPAnimationsPointer() { return m_pIFPAnimations; }
 
     // Sorta a hack that these are required by CClientEntity...
@@ -223,7 +225,7 @@ private:
     void ReadIFPVersion1();
     void ReadIFPVersion2(bool bAnp3);
 
-    WORD         ReadSequencesWithDummies(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy);
+    WORD         ReadSequencesWithDummies(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy, std::bitset<32>& outAnimatedBonesMask);
     WORD         ReadSequences(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy, SequenceMapType& MapOfSequences);
     WORD         ReadSequencesVersion1(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy, SequenceMapType& MapOfSequences);
     WORD         ReadSequencesVersion2(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy, SequenceMapType& MapOfSequences);
@@ -260,7 +262,7 @@ private:
     void  InitializeAnimationSequence(std::unique_ptr<CAnimBlendSequence>& pAnimationSequence, const SString& strName, const std::int32_t& iBoneID);
     void  PreProcessAnimationHierarchy(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy);
     void  MoveSequencesWithDummies(std::unique_ptr<CAnimBlendHierarchy>&                 pAnimationHierarchy,
-                                   std::map<DWORD, std::unique_ptr<CAnimBlendSequence>>& mapOfSequences);
+                                   std::map<DWORD, std::unique_ptr<CAnimBlendSequence>>& mapOfSequences, std::bitset<32>& outAnimatedBonesMask);
     BYTE* AllocateSequencesMemory(std::unique_ptr<CAnimBlendHierarchy>& pAnimationHierarchy);
 
     void    InsertAnimationDummySequence(std::unique_ptr<CAnimBlendSequence>& pAnimationSequence, const SString& BoneName, const DWORD& dwBoneID);

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -2936,6 +2936,13 @@ void CClientPed::StreamedInPulse(bool bDoStandardPulses)
         if (m_pAnimationBlock && m_AnimationCache.progressWaitForStreamIn && IsAnimationInProgress())
             UpdateAnimationProgressAndSpeed();
 
+        // Same "next frame" issue as above: the gateway swap to our custom hierarchy (see
+        // CClientGame::BlendAnimationHierarchyHandler) only takes effect in the game's animation blend
+        // a frame after RunNamedAnimation was called, so we can only trim a partial anim's padding once
+        // it's actually playing. Runs every frame while a custom animation is active; cheap and idempotent.
+        if (m_pAnimationBlock && m_bisCurrentAnimationCustom)
+            UpdateCustomPartialAnimationBones();
+
         // Update our alpha
         unsigned char ucAlpha = m_ucAlpha;
         // Are we in a different interior to the camera? set our alpha to 0
@@ -6033,6 +6040,31 @@ void CClientPed::UpdateAnimationProgressAndSpeed()
     animAssoc->SetCurrentSpeed(m_AnimationCache.speed);
 
     m_AnimationCache.progressWaitForStreamIn = false;
+}
+
+void CClientPed::UpdateCustomPartialAnimationBones()
+{
+    std::shared_ptr<CClientIFP> pIFP = GetCustomAnimationIFP();
+    if (!pIFP)
+        return;
+
+    // This is the same name handed to SetNextAnimationCustom for the swap that's now live
+    // (m_bisCurrentAnimationCustom); it isn't cleared once consumed.
+    const SString& strCustomAnimName = GetNextAnimationCustomName();
+
+    auto* pCustomHierarchyInterface = pIFP->GetAnimationHierarchy(strCustomAnimName);
+    if (!pCustomHierarchyInterface)
+        return;
+
+    // Bones the source IFP animation doesn't define are padded out to a fixed pose (see CClientIFP),
+    // so a full mask means there's nothing to restrict and we can skip finding the association at all.
+    std::bitset<32> animatedBonesMask = pIFP->GetAnimatedBonesMask(strCustomAnimName);
+    if (animatedBonesMask.all())
+        return;
+
+    auto pCustomAnimAssociation = GetAnimAssociation(pCustomHierarchyInterface);
+    if (pCustomAnimAssociation)
+        pCustomAnimAssociation->RestrictToBones(animatedBonesMask);
 }
 
 void CClientPed::PostWeaponFire()

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -479,6 +479,7 @@ public:
     const SAnimationCache&      GetAnimationCache() const noexcept { return m_AnimationCache; }
     void                        RunAnimationFromCache();
     void                        UpdateAnimationProgressAndSpeed();
+    void                        UpdateCustomPartialAnimationBones();
 
     bool IsUsingGun();
 

--- a/Client/mods/deathmatch/logic/CIFPAnimations.h
+++ b/Client/mods/deathmatch/logic/CIFPAnimations.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <bitset>
 #include "CClientIFP.h"
 
 class CIFPAnimations
@@ -21,6 +22,11 @@ public:
         unsigned int                         uiNameHash;
         std::unique_ptr<CAnimBlendHierarchy> pHierarchy;
         BYTE*                                pSequencesMemory;
+
+        // Bit i is set when bone i (see CClientIFP::m_karruBoneIds) is actually driven by this
+        // animation's own IFP data, as opposed to being padded out with a fixed pose because the
+        // file doesn't define that bone.
+        std::bitset<32> AnimatedBonesMask;
     };
 
     std::vector<SAnimation> vecAnimations;

--- a/Client/sdk/game/CAnimBlendAssociation.h
+++ b/Client/sdk/game/CAnimBlendAssociation.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <bitset>
 #include <memory>
 
 typedef unsigned long AssocGroupId;
@@ -42,7 +43,11 @@ public:
     virtual bool  IsPartial() const = 0;
     // Drops any blend node for a bone the original animation doesn't animate, so a custom replacement
     // for a partial anim can't drive the bones (root, pelvis, legs) the original left to the movement anim.
-    virtual void  RestrictToBonesOf(const CAnimBlendStaticAssociationSAInterface* pOriginalAssoc) = 0;
+    virtual void RestrictToBonesOf(const CAnimBlendStaticAssociationSAInterface* pOriginalAssoc) = 0;
+    // Same idea as RestrictToBonesOf, but driven directly by a bone mask (bit i set means bone i is
+    // animated) instead of comparing against another association. Used for custom animations played
+    // from a custom IFP bank, which have no built-in association to compare against.
+    virtual void  RestrictToBones(std::bitset<32> animatedBonesMask) = 0;
     virtual void  SetCurrentProgress(float fProgress) = 0;
     virtual float GetCurrentProgress() const noexcept = 0;
     virtual void  SetCurrentSpeed(float fSpeed) = 0;


### PR DESCRIPTION
#### Summary

Fixes custom partial animations played straight from a custom IFP bank (via `engineLoadIFP` + `setPedAnimation`) leaving the ped rigid, the same padding problem #5101 fixed for `engineReplaceAnimation`.

`CClientIFP` pads every loaded animation out to 32 bones regardless of what the source IFP actually defines. #5101 trimmed that padding by comparing against the built-in animation being replaced, but an animation played directly from a custom bank has no built-in original to compare against, so the fix never applied there and the padding kept driving the root, pelvis and legs.

`CClientIFP` now records which bones an animation actually defines while parsing it. `CAnimBlendAssociation` gains `RestrictToBones(mask)`, a sibling of `RestrictToBonesOf` driven by that record instead of a built-in original; `CClientPed` applies it once the animation is actually playing.

#### Motivation

Continuation of #5101. That fix only covered animations replacing a built-in one; partial animations loaded into their own custom bank and played directly still went rigid. Fixes #5121.

#### Test plan

Loaded a custom IFP with a partial animation (upper body only, e.g. `crry_prtial`) into a custom bank via `engineLoadIFP`, played it with `setPedAnimation` on a ped. Before the fix the ped froze in place; after, the custom animation plays on the upper body while walking, turning and leg movement keep working normally. Also re-tested #5101's original `engineReplaceAnimation` scenario to confirm that path is untouched.

Test script, thanks to @RughCuttle
[partialtest.zip](https://github.com/user-attachments/files/30626244/partialtest.zip)


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.