### PR TITLE
Fix jetpack staying visible and audible across interiors

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -174,20 +174,6 @@ DWORD RETURN_CPhysical_ProcessCollisionSectorList = 0x54BB9A;
 DWORD RETURN_CTaskSimpleClimb_ScanToGrabSectorList = 0x67DF36;
 DWORD SKIP_CTaskSimpleClimb_ScanToGrabSectorList = 0x67E580;
 
-// CTaskSimpleJetPack::RenderJetPack draws the jetpack from its own clump, separate from the ped's;
-// interior-based alpha hiding never reaches it. This hook skips the render and its thruster FX
-// whenever the ped itself is hidden.
-#define HOOKPOS_CTaskSimpleJetPack_RenderJetPack 0x67F6A0
-DWORD RETURN_CTaskSimpleJetPack_RenderJetPack = 0x67F6AC;
-DWORD SKIP_CTaskSimpleJetPack_RenderJetPack = 0x67FA11;
-
-// CAEPedAudioEntity::UpdateJetPack recomputes the engine sound's volume from its own ramp state
-// every tick; this hook releases the sound channels while the ped is hidden and recreates them
-// once visible again, so a hidden jetpack neither plays nor keeps its channels mixing for nothing.
-#define HOOKPOS_CAEPedAudioEntity_UpdateJetPack 0x4E0EE0
-DWORD RETURN_CAEPedAudioEntity_UpdateJetPack = 0x4E0EE6;
-DWORD SKIP_CAEPedAudioEntity_UpdateJetPack = 0x4E1112;
-
 #define HOOKPOS_CheckAnimMatrix 0x7C5A5C
 DWORD RETURN_CheckAnimMatrix = 0x7C5A61;
 
@@ -520,8 +506,6 @@ void HOOK_CrashFix_Misc21();
 void HOOK_CrashFix_Misc22();
 void HOOK_CrashFix_Misc23();
 void HOOK_CrashFix_Misc24();
-void HOOK_CTaskSimpleJetPack_RenderJetPack();
-void HOOK_CAEPedAudioEntity_UpdateJetPack();
 void HOOK_CheckAnimMatrix();
 void HOOK_VehColCB();
 void HOOK_VehCol();
@@ -702,8 +686,6 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_CPed_AddGogglesModel, (DWORD)HOOK_CPed_AddGogglesModel, 6);
     HookInstall(HOOKPOS_CPhysical_ProcessCollisionSectorList, (DWORD)HOOK_CPhysical_ProcessCollisionSectorList, 7);
     HookInstall(HOOKPOS_CTaskSimpleClimb_ScanToGrabSectorList, (DWORD)HOOK_CTaskSimpleClimb_ScanToGrabSectorList, 8);
-    HookInstall(HOOKPOS_CTaskSimpleJetPack_RenderJetPack, (DWORD)HOOK_CTaskSimpleJetPack_RenderJetPack, 12);
-    HookInstall(HOOKPOS_CAEPedAudioEntity_UpdateJetPack, (DWORD)HOOK_CAEPedAudioEntity_UpdateJetPack, 6);
     HookInstall(HOOKPOS_CheckAnimMatrix, (DWORD)HOOK_CheckAnimMatrix, 5);
 
     HookInstall(HOOKPOS_VehColCB, (DWORD)HOOK_VehColCB, 29);
@@ -6472,129 +6454,6 @@ static void __declspec(naked) HOOK_CTaskSimpleClimb_ScanToGrabSectorList()
         __asm
         {
             jmp     RETURN_CTaskSimpleClimb_ScanToGrabSectorList
-        }
-        // clang-format on
-    }
-}
-
-// CWorld::m_CurrentArea, read directly rather than through CWorldSA to keep this hook self
-// contained (same value CClientPed already compares a ped's own m_areaCode against to hide it).
-#define VAR_CWorld_CurrentArea 0xB72914
-
-CPedSAInterface* pJetpackHookPedInterface;
-
-bool CTaskSimpleJetPack_ShouldHide()
-{
-    return pJetpackHookPedInterface && pJetpackHookPedInterface->m_areaCode != *reinterpret_cast<BYTE*>(VAR_CWorld_CurrentArea);
-}
-
-static void __declspec(naked) HOOK_CTaskSimpleJetPack_RenderJetPack()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // clang-format off
-    __asm
-    {
-        mov     eax, [esp+4]
-        mov     pJetpackHookPedInterface, eax
-
-        // Replicate the bytes this hook overwrites so the rest of the function keeps working
-        sub     esp, 1Ch
-        push    ebp
-        mov     ebp, ecx
-        mov     eax, [ebp+40h]
-        push    esi
-        xor     esi, esi
-    }
-    // clang-format on
-
-    if (CTaskSimpleJetPack_ShouldHide())
-    {
-        // Same cleanup the game runs when the jetpack is dropped; kills both thruster FX and
-        // skips the clump render entirely. EBP still holds this, callee-saved across the call
-        // above, and that's all this path needs.
-        // clang-format off
-        __asm
-        {
-            jmp     SKIP_CTaskSimpleJetPack_RenderJetPack
-        }
-        // clang-format on
-    }
-    else
-    {
-        // clang-format off
-        __asm
-        {
-            // EAX isn't preserved across the call above, so reload the clump pointer it held
-            mov     eax, [ebp+40h]
-            jmp     RETURN_CTaskSimpleJetPack_RenderJetPack
-        }
-        // clang-format on
-    }
-}
-
-DWORD FUNC_CAEPedAudioEntity_TurnOnJetPack = 0x4E28A0;
-DWORD FUNC_CAEPedAudioEntity_TurnOffJetPack = 0x4E2A70;
-
-CPedSoundEntitySAInterface* pJetpackAudioHookInterface;
-
-bool CAEPedAudioEntity_IsJetpackHidden()
-{
-    return pJetpackAudioHookInterface && pJetpackAudioHookInterface->ped &&
-           pJetpackAudioHookInterface->ped->m_areaCode != *reinterpret_cast<BYTE*>(VAR_CWorld_CurrentArea);
-}
-
-static void __declspec(naked) HOOK_CAEPedAudioEntity_UpdateJetPack()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // clang-format off
-    __asm
-    {
-        mov     pJetpackAudioHookInterface, ecx
-
-        // Replicate the byte this hook overwrites so the rest of the function keeps working
-        mov     al, [ecx+98h]
-    }
-    // clang-format on
-
-    if (CAEPedAudioEntity_IsJetpackHidden())
-    {
-        // Releases the sound channels, so a hidden jetpack costs nothing to mix. TurnOffJetPack()
-        // also clears jetpackSoundPlaying, which TurnOnJetPack() below requires to be false before
-        // it will recreate them; skipping that would leave the jetpack silent for good once hidden,
-        // even after becoming visible again. Repeating this every tick while hidden is harmless,
-        // TurnOffJetPack() only touches anything if the channels aren't already gone. Jumping to
-        // the game's own "nothing to update" exit then skips this tick's now pointless ramp calc.
-        // clang-format off
-        __asm
-        {
-            mov     ecx, pJetpackAudioHookInterface
-            cmp     dword ptr [ecx+9Ch], 0
-            jz      alreadyStopped
-            call    FUNC_CAEPedAudioEntity_TurnOffJetPack
-        alreadyStopped:
-            jmp     SKIP_CAEPedAudioEntity_UpdateJetPack
-        }
-        // clang-format on
-    }
-    else
-    {
-        // clang-format off
-        __asm
-        {
-            // Coming back into view with the channels released (we stopped them earlier): bring
-            // them back the same way the game originally started them, ramping up from silence
-            // instead of popping straight to full volume.
-            mov     ecx, pJetpackAudioHookInterface
-            cmp     dword ptr [ecx+9Ch], 0
-            jnz     alreadyPlaying
-            call    FUNC_CAEPedAudioEntity_TurnOnJetPack
-        alreadyPlaying:
-            // EAX/ECX/EDX aren't preserved across a call, so reload what the resumed code needs
-            mov     ecx, pJetpackAudioHookInterface
-            mov     al, [ecx+98h]
-            jmp     RETURN_CAEPedAudioEntity_UpdateJetPack
         }
         // clang-format on
     }

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -174,6 +174,20 @@ DWORD RETURN_CPhysical_ProcessCollisionSectorList = 0x54BB9A;
 DWORD RETURN_CTaskSimpleClimb_ScanToGrabSectorList = 0x67DF36;
 DWORD SKIP_CTaskSimpleClimb_ScanToGrabSectorList = 0x67E580;
 
+// CTaskSimpleJetPack::RenderJetPack draws the jetpack from its own clump, separate from the ped's;
+// interior-based alpha hiding never reaches it. This hook skips the render and its thruster FX
+// whenever the ped itself is hidden.
+#define HOOKPOS_CTaskSimpleJetPack_RenderJetPack 0x67F6A0
+DWORD RETURN_CTaskSimpleJetPack_RenderJetPack = 0x67F6AC;
+DWORD SKIP_CTaskSimpleJetPack_RenderJetPack = 0x67FA11;
+
+// CAEPedAudioEntity::UpdateJetPack recomputes the engine sound's volume from its own ramp state
+// every tick; this hook releases the sound channels while the ped is hidden and recreates them
+// once visible again, so a hidden jetpack neither plays nor keeps its channels mixing for nothing.
+#define HOOKPOS_CAEPedAudioEntity_UpdateJetPack 0x4E0EE0
+DWORD RETURN_CAEPedAudioEntity_UpdateJetPack = 0x4E0EE6;
+DWORD SKIP_CAEPedAudioEntity_UpdateJetPack = 0x4E1112;
+
 #define HOOKPOS_CheckAnimMatrix 0x7C5A5C
 DWORD RETURN_CheckAnimMatrix = 0x7C5A61;
 
@@ -506,6 +520,8 @@ void HOOK_CrashFix_Misc21();
 void HOOK_CrashFix_Misc22();
 void HOOK_CrashFix_Misc23();
 void HOOK_CrashFix_Misc24();
+void HOOK_CTaskSimpleJetPack_RenderJetPack();
+void HOOK_CAEPedAudioEntity_UpdateJetPack();
 void HOOK_CheckAnimMatrix();
 void HOOK_VehColCB();
 void HOOK_VehCol();
@@ -686,6 +702,8 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_CPed_AddGogglesModel, (DWORD)HOOK_CPed_AddGogglesModel, 6);
     HookInstall(HOOKPOS_CPhysical_ProcessCollisionSectorList, (DWORD)HOOK_CPhysical_ProcessCollisionSectorList, 7);
     HookInstall(HOOKPOS_CTaskSimpleClimb_ScanToGrabSectorList, (DWORD)HOOK_CTaskSimpleClimb_ScanToGrabSectorList, 8);
+    HookInstall(HOOKPOS_CTaskSimpleJetPack_RenderJetPack, (DWORD)HOOK_CTaskSimpleJetPack_RenderJetPack, 12);
+    HookInstall(HOOKPOS_CAEPedAudioEntity_UpdateJetPack, (DWORD)HOOK_CAEPedAudioEntity_UpdateJetPack, 6);
     HookInstall(HOOKPOS_CheckAnimMatrix, (DWORD)HOOK_CheckAnimMatrix, 5);
 
     HookInstall(HOOKPOS_VehColCB, (DWORD)HOOK_VehColCB, 29);
@@ -6454,6 +6472,129 @@ static void __declspec(naked) HOOK_CTaskSimpleClimb_ScanToGrabSectorList()
         __asm
         {
             jmp     RETURN_CTaskSimpleClimb_ScanToGrabSectorList
+        }
+        // clang-format on
+    }
+}
+
+// CWorld::m_CurrentArea, read directly rather than through CWorldSA to keep this hook self
+// contained (same value CClientPed already compares a ped's own m_areaCode against to hide it).
+#define VAR_CWorld_CurrentArea 0xB72914
+
+CPedSAInterface* pJetpackHookPedInterface;
+
+bool CTaskSimpleJetPack_ShouldHide()
+{
+    return pJetpackHookPedInterface && pJetpackHookPedInterface->m_areaCode != *reinterpret_cast<BYTE*>(VAR_CWorld_CurrentArea);
+}
+
+static void __declspec(naked) HOOK_CTaskSimpleJetPack_RenderJetPack()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        mov     eax, [esp+4]
+        mov     pJetpackHookPedInterface, eax
+
+        // Replicate the bytes this hook overwrites so the rest of the function keeps working
+        sub     esp, 1Ch
+        push    ebp
+        mov     ebp, ecx
+        mov     eax, [ebp+40h]
+        push    esi
+        xor     esi, esi
+    }
+    // clang-format on
+
+    if (CTaskSimpleJetPack_ShouldHide())
+    {
+        // Same cleanup the game runs when the jetpack is dropped; kills both thruster FX and
+        // skips the clump render entirely. EBP still holds this, callee-saved across the call
+        // above, and that's all this path needs.
+        // clang-format off
+        __asm
+        {
+            jmp     SKIP_CTaskSimpleJetPack_RenderJetPack
+        }
+        // clang-format on
+    }
+    else
+    {
+        // clang-format off
+        __asm
+        {
+            // EAX isn't preserved across the call above, so reload the clump pointer it held
+            mov     eax, [ebp+40h]
+            jmp     RETURN_CTaskSimpleJetPack_RenderJetPack
+        }
+        // clang-format on
+    }
+}
+
+DWORD FUNC_CAEPedAudioEntity_TurnOnJetPack = 0x4E28A0;
+DWORD FUNC_CAEPedAudioEntity_TurnOffJetPack = 0x4E2A70;
+
+CPedSoundEntitySAInterface* pJetpackAudioHookInterface;
+
+bool CAEPedAudioEntity_IsJetpackHidden()
+{
+    return pJetpackAudioHookInterface && pJetpackAudioHookInterface->ped &&
+           pJetpackAudioHookInterface->ped->m_areaCode != *reinterpret_cast<BYTE*>(VAR_CWorld_CurrentArea);
+}
+
+static void __declspec(naked) HOOK_CAEPedAudioEntity_UpdateJetPack()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        mov     pJetpackAudioHookInterface, ecx
+
+        // Replicate the byte this hook overwrites so the rest of the function keeps working
+        mov     al, [ecx+98h]
+    }
+    // clang-format on
+
+    if (CAEPedAudioEntity_IsJetpackHidden())
+    {
+        // Releases the sound channels, so a hidden jetpack costs nothing to mix. TurnOffJetPack()
+        // also clears jetpackSoundPlaying, which TurnOnJetPack() below requires to be false before
+        // it will recreate them; skipping that would leave the jetpack silent for good once hidden,
+        // even after becoming visible again. Repeating this every tick while hidden is harmless,
+        // TurnOffJetPack() only touches anything if the channels aren't already gone. Jumping to
+        // the game's own "nothing to update" exit then skips this tick's now pointless ramp calc.
+        // clang-format off
+        __asm
+        {
+            mov     ecx, pJetpackAudioHookInterface
+            cmp     dword ptr [ecx+9Ch], 0
+            jz      alreadyStopped
+            call    FUNC_CAEPedAudioEntity_TurnOffJetPack
+        alreadyStopped:
+            jmp     SKIP_CAEPedAudioEntity_UpdateJetPack
+        }
+        // clang-format on
+    }
+    else
+    {
+        // clang-format off
+        __asm
+        {
+            // Coming back into view with the channels released (we stopped them earlier): bring
+            // them back the same way the game originally started them, ramping up from silence
+            // instead of popping straight to full volume.
+            mov     ecx, pJetpackAudioHookInterface
+            cmp     dword ptr [ecx+9Ch], 0
+            jnz     alreadyPlaying
+            call    FUNC_CAEPedAudioEntity_TurnOnJetPack
+        alreadyPlaying:
+            // EAX/ECX/EDX aren't preserved across a call, so reload what the resumed code needs
+            mov     ecx, pJetpackAudioHookInterface
+            mov     al, [ecx+98h]
+            jmp     RETURN_CAEPedAudioEntity_UpdateJetPack
         }
         // clang-format on
     }

--- a/Client/multiplayer_sa/CMultiplayerSA_Peds.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Peds.cpp
@@ -59,6 +59,152 @@ static void __declspec(naked) HOOK_CPed_DoFootLanded()
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
+// CTaskSimpleJetPack::RenderJetPack / CAEPedAudioEntity::UpdateJetPack
+//
+// Hide and mute a ped's jetpack whenever the ped itself is hidden due to being in a different
+// interior
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// CTaskSimpleJetPack::RenderJetPack draws the jetpack from its own clump, separate from the ped's;
+// interior-based alpha hiding never reaches it. This hook skips the render and its thruster FX
+// whenever the ped itself is hidden.
+#define HOOKPOS_CTaskSimpleJetPack_RenderJetPack 0x67F6A0
+DWORD RETURN_CTaskSimpleJetPack_RenderJetPack = 0x67F6AC;
+DWORD SKIP_CTaskSimpleJetPack_RenderJetPack = 0x67FA11;
+
+// CAEPedAudioEntity::UpdateJetPack recomputes the engine sound's volume from its own ramp state
+// every tick; this hook releases the sound channels while the ped is hidden and recreates them
+// once visible again, so a hidden jetpack neither plays nor keeps its channels mixing for nothing.
+#define HOOKPOS_CAEPedAudioEntity_UpdateJetPack 0x4E0EE0
+DWORD RETURN_CAEPedAudioEntity_UpdateJetPack = 0x4E0EE6;
+DWORD SKIP_CAEPedAudioEntity_UpdateJetPack = 0x4E1112;
+
+// CWorld::m_CurrentArea, read directly rather than through CWorldSA to keep this hook self
+// contained (same value CClientPed already compares a ped's own m_areaCode against to hide it).
+static constexpr std::uintptr_t CWorld_CurrentArea = 0xB72914;
+
+CPedSAInterface* pJetpackHookPedInterface;
+
+bool CTaskSimpleJetPack_ShouldHide()
+{
+    return pJetpackHookPedInterface && pJetpackHookPedInterface->m_areaCode != *reinterpret_cast<std::uint8_t*>(CWorld_CurrentArea);
+}
+
+static void __declspec(naked) HOOK_CTaskSimpleJetPack_RenderJetPack()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        mov     eax, [esp+4]
+        mov     pJetpackHookPedInterface, eax
+
+        // Replicate the bytes this hook overwrites so the rest of the function keeps working
+        sub     esp, 1Ch
+        push    ebp
+        mov     ebp, ecx
+        mov     eax, [ebp+40h]
+        push    esi
+        xor     esi, esi
+    }
+    // clang-format on
+
+    if (CTaskSimpleJetPack_ShouldHide())
+    {
+        // Same cleanup the game runs when the jetpack is dropped; kills both thruster FX and
+        // skips the clump render entirely. EBP still holds this, callee-saved across the call
+        // above, and that's all this path needs.
+        // clang-format off
+        __asm
+        {
+            jmp     SKIP_CTaskSimpleJetPack_RenderJetPack
+        }
+        // clang-format on
+    }
+    else
+    {
+        // clang-format off
+        __asm
+        {
+            // EAX isn't preserved across the call above, so reload the clump pointer it held
+            mov     eax, [ebp+40h]
+            jmp     RETURN_CTaskSimpleJetPack_RenderJetPack
+        }
+        // clang-format on
+    }
+}
+
+DWORD FUNC_CAEPedAudioEntity_TurnOnJetPack = 0x4E28A0;
+DWORD FUNC_CAEPedAudioEntity_TurnOffJetPack = 0x4E2A70;
+
+CPedSoundEntitySAInterface* pJetpackAudioHookInterface;
+
+bool CAEPedAudioEntity_IsJetpackHidden()
+{
+    return pJetpackAudioHookInterface && pJetpackAudioHookInterface->ped &&
+           pJetpackAudioHookInterface->ped->m_areaCode != *reinterpret_cast<std::uint8_t*>(CWorld_CurrentArea);
+}
+
+static void __declspec(naked) HOOK_CAEPedAudioEntity_UpdateJetPack()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        mov     pJetpackAudioHookInterface, ecx
+
+        // Replicate the byte this hook overwrites so the rest of the function keeps working
+        mov     al, [ecx+98h]
+    }
+    // clang-format on
+
+    if (CAEPedAudioEntity_IsJetpackHidden())
+    {
+        // Releases the sound channels, so a hidden jetpack costs nothing to mix. TurnOffJetPack()
+        // also clears jetpackSoundPlaying, which TurnOnJetPack() below requires to be false before
+        // it will recreate them; skipping that would leave the jetpack silent for good once hidden,
+        // even after becoming visible again. Repeating this every tick while hidden is harmless,
+        // TurnOffJetPack() only touches anything if the channels aren't already gone. Jumping to
+        // the game's own "nothing to update" exit then skips this tick's now pointless ramp calc.
+        // clang-format off
+        __asm
+        {
+            mov     ecx, pJetpackAudioHookInterface
+            cmp     dword ptr [ecx+9Ch], 0
+            jz      alreadyStopped
+            call    FUNC_CAEPedAudioEntity_TurnOffJetPack
+        alreadyStopped:
+            jmp     SKIP_CAEPedAudioEntity_UpdateJetPack
+        }
+        // clang-format on
+    }
+    else
+    {
+        // clang-format off
+        __asm
+        {
+            // Coming back into view with the channels released (we stopped them earlier): bring
+            // them back the same way the game originally started them, ramping up from silence
+            // instead of popping straight to full volume.
+            mov     ecx, pJetpackAudioHookInterface
+            cmp     dword ptr [ecx+9Ch], 0
+            jnz     alreadyPlaying
+            call    FUNC_CAEPedAudioEntity_TurnOnJetPack
+        alreadyPlaying:
+            // EAX/ECX/EDX aren't preserved across a call, so reload what the resumed code needs
+            mov     ecx, pJetpackAudioHookInterface
+            mov     al, [ecx+98h]
+            jmp     RETURN_CAEPedAudioEntity_UpdateJetPack
+        }
+        // clang-format on
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
 // CMultiplayerSA::InitHooks_Peds
 //
 // Setup hooks
@@ -67,4 +213,7 @@ static void __declspec(naked) HOOK_CPed_DoFootLanded()
 void CMultiplayerSA::InitHooks_Peds()
 {
     EZHookInstall(CPed_DoFootLanded);
+
+    HookInstall(HOOKPOS_CTaskSimpleJetPack_RenderJetPack, (DWORD)HOOK_CTaskSimpleJetPack_RenderJetPack, 12);
+    HookInstall(HOOKPOS_CAEPedAudioEntity_UpdateJetPack, (DWORD)HOOK_CAEPedAudioEntity_UpdateJetPack, 6);
 }


### PR DESCRIPTION
#### Summary

The jetpack model, its thruster FX and its engine sound are each driven by their own clump/channels, separate from the ped's own; interior-based hiding only alphas the ped's clump, so none of the three were ever actually hidden by it. A ped in a different interior still showed and played a full jetpack.

Hooks `CTaskSimpleJetPack::RenderJetPack` to skip the render and FX, and `CAEPedAudioEntity::UpdateJetPack` to release the sound channels while hidden and recreate them once visible again, both keyed off the ped's own area code against the camera's current one.

#### Motivation

Fixes #598.

#### Test plan

Tested with two peds independently, plus the local player, each wearing a jetpack and switching interior back and forth. For each: visible and audible when sharing the camera's interior; model, thruster FX and engine sound all gone when it doesn't; everything restores correctly (sound included) when returning to a shared interior. Each ped's state is independent of the others.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.