### PR TITLE
Fix getElementRadius returning false for buildings

### DIFF
--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -625,6 +625,12 @@ bool CStaticFunctionDefinitions::GetElementRadius(CClientEntity& Entity, float& 
             pModelInfo = g_pGame->GetModelInfo(Object.GetModel());
             break;
         }
+        case CCLIENTBUILDING:
+        {
+            CClientBuilding& Building = static_cast<CClientBuilding&>(Entity);
+            pModelInfo = g_pGame->GetModelInfo(Building.GetModel());
+            break;
+        }
     }
     if (pModelInfo)
     {


### PR DESCRIPTION
#### Summary

getElementRadius's type switch never had a case for buildings; it fell through to the final `return false`, even though `CClientBuilding` already exposes `GetModel()` the same way objects and peds do. Added the missing case, same pattern already used right below it in `GetElementDistanceFromCentreOfMassToBaseOfModel`.

#### Motivation

Fixes #5137.

#### Test plan

Created a building with `createBuilding`, called `getElementRadius` on it; now returns the model's bounding radius instead of `false`. Also re-tested `getElementRadius` on a ped, vehicle and object to confirm the existing cases are untouched.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.