### PR TITLE
Fix setElementDimension not working on buildings

### DIFF
--- a/Client/mods/deathmatch/logic/CClientBuilding.cpp
+++ b/Client/mods/deathmatch/logic/CClientBuilding.cpp
@@ -27,7 +27,7 @@ CClientBuilding::CClientBuilding(class CClientManager* pManager, ElementID ID, u
     m_pModelInfo = g_pGame->GetModelInfo(usModelId);
     SetTypeName("building");
     m_pBuildingManager->AddToList(this);
-    Create();
+    RelateDimension(m_pBuildingManager->GetDimension());
     UpdateSpatialData();
 }
 
@@ -95,6 +95,20 @@ void CClientBuilding::SetInterior(uint8_t ucInterior)
         return;
     m_interior = ucInterior;
     Recreate();
+}
+
+void CClientBuilding::SetDimension(unsigned short usDimension)
+{
+    CClientEntity::SetDimension(usDimension);
+    RelateDimension(m_pBuildingManager->GetDimension());
+}
+
+void CClientBuilding::RelateDimension(unsigned short usDimension)
+{
+    if (usDimension == GetDimension())
+        Create();
+    else
+        Destroy();
 }
 
 void CClientBuilding::SetModel(uint16_t model)

--- a/Client/mods/deathmatch/logic/CClientBuilding.h
+++ b/Client/mods/deathmatch/logic/CClientBuilding.h
@@ -37,6 +37,13 @@ public:
     bool SetMatrix(const CMatrix& matrix) override;
 
     void SetInterior(uint8_t ucInterior) override;
+    void SetDimension(unsigned short usDimension) override;
+
+    // Buildings aren't a CClientStreamElement, so unlike objects/peds/vehicles they get no
+    // automatic dimension-based streaming; this is what the manager calls on every building
+    // whenever the local player's dimension changes, and what our own SetDimension calls to
+    // re-evaluate this one building right after its own dimension changes.
+    void RelateDimension(unsigned short usDimension);
 
     uint16_t GetModel() const noexcept { return m_usModelId; };
     void     SetModel(uint16_t ulModel);

--- a/Client/mods/deathmatch/logic/CClientBuildingManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientBuildingManager.cpp
@@ -43,6 +43,14 @@ void CClientBuildingManager::RemoveAll()
     m_bRemoveFromList = true;
 }
 
+void CClientBuildingManager::SetDimension(unsigned short usDimension)
+{
+    for (CClientBuilding* building : m_List)
+        building->RelateDimension(usDimension);
+
+    m_usDimension = usDimension;
+}
+
 bool CClientBuildingManager::Exists(CClientBuilding* pBuilding)
 {
     return std::find(m_List.begin(), m_List.end(), pBuilding) != m_List.end();
@@ -103,7 +111,7 @@ void CClientBuildingManager::RestoreDestroyed()
             if (highLodBuilding && !highLodBuilding->IsValid())
                 hasInvalidLods = true;
             else
-                building->Create();
+                building->RelateDimension(m_usDimension);
         }
     }
 }

--- a/Client/mods/deathmatch/logic/CClientBuildingManager.h
+++ b/Client/mods/deathmatch/logic/CClientBuildingManager.h
@@ -28,6 +28,9 @@ public:
 
     const std::list<CClientBuilding*>& GetBuildings() { return m_List; };
 
+    unsigned short GetDimension() const noexcept { return m_usDimension; };
+    void           SetDimension(unsigned short usDimension);
+
     static bool IsValidModel(uint16_t modelId);
     static bool IsValidPosition(const CVector& pos) noexcept;
 
@@ -49,4 +52,5 @@ private:
 
     std::list<CClientBuilding*> m_List;
     bool                        m_bRemoveFromList;
+    unsigned short              m_usDimension{0};
 };

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -2196,6 +2196,7 @@ void CClientGame::SetAllDimensions(unsigned short usDimension)
     m_pManager->GetSoundManager()->SetDimension(usDimension);
     m_pManager->GetPointLightsManager()->SetDimension(usDimension);
     m_pManager->GetWaterManager()->SetDimension(usDimension);
+    m_pManager->GetBuildingManager()->SetDimension(usDimension);
     m_pNametags->SetDimension(usDimension);
     m_pCamera->SetDimension(usDimension);
 }

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -4218,6 +4218,7 @@ retry:
                                                                      rotationRadians.data.vecRotation, ucInterior);
 
                     pBuilding->SetUsesCollision(bCollisonsEnabled);
+                    pEntity = pBuilding;
                     break;
                 }
 

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1370,6 +1370,7 @@ bool CStaticFunctionDefinitions::SetElementDimension(CClientEntity& Entity, unsi
         case CCLIENTWORLDMESH:
         case CCLIENTSOUND:
         case CCLIENTWATER:
+        case CCLIENTBUILDING:
         {
             Entity.SetDimension(usDimension);
             return true;


### PR DESCRIPTION
#### Summary

`CClientBuilding` extends `CClientEntity` directly, not `CClientStreamElement`, so unlike objects, peds and vehicles it never got automatic dimension-based streaming; `SetDimension` only stored the value, nothing ever compared it to the local player's dimension to actually show or hide the building.

Added the same `RelateDimension` pattern already used by `CClientPointLights`, `CClientRadarArea`, `CClientRadarMarker` and `CClientWater`, the other element types that also aren't stream elements: `CClientBuildingManager` tracks the local player's dimension and calls `RelateDimension` on every building when it changes; `CClientBuilding` overrides `SetDimension` to re-evaluate itself the same way. Also fixed `RestoreDestroyed()`, which recreated every building unconditionally on pool resize, ignoring dimension entirely.

#### Motivation

`setElementDimension` silently did nothing on buildings; scripts had no way to hide a `createBuilding` building in a different dimension.

#### Test plan

Created a building, moved the local player between dimensions and called `setElementDimension` on the building both ways: it now shows only when its dimension matches the player's, and correctly disappears/reappears when either side changes.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.