### PR TITLE
Fix testSphereAgainstWorld returning nil hitElement for buildings

### DIFF
--- a/Client/game_sa/CBuildingsPoolSA.cpp
+++ b/Client/game_sa/CBuildingsPoolSA.cpp
@@ -63,6 +63,16 @@ CClientEntity* CBuildingsPoolSA::GetClientBuilding(CBuildingSAInterface* pGameIn
     return m_buildingPool.entities[static_cast<size_t>(poolIndex)].pClientEntity;
 }
 
+CEntity* CBuildingsPoolSA::GetBuilding(CBuildingSAInterface* pGameInterface) const noexcept
+{
+    std::int32_t poolIndex = (*m_ppBuildingPoolInterface)->GetObjectIndexSafe(pGameInterface);
+
+    if (poolIndex == -1)
+        return nullptr;
+
+    return m_buildingPool.entities[static_cast<size_t>(poolIndex)].pEntity;
+}
+
 CBuilding* CBuildingsPoolSA::AddBuilding(CClientBuilding* pClientBuilding, uint16_t modelId, CVector* vPos, CVector* vRot, uint8_t interior)
 {
     if (!HasFreeBuildingSlot())

--- a/Client/game_sa/CBuildingsPoolSA.h
+++ b/Client/game_sa/CBuildingsPoolSA.h
@@ -31,6 +31,7 @@ public:
     bool           Resize(int size) override;
     int            GetSize() const override { return (m_ppBuildingPoolInterface && *m_ppBuildingPoolInterface) ? (*m_ppBuildingPoolInterface)->m_nSize : 0; };
     CClientEntity* GetClientBuilding(CBuildingSAInterface* pGameInterface) const noexcept;
+    CEntity*       GetBuilding(CBuildingSAInterface* pGameInterface) const noexcept;
 
 private:
     void RemoveBuildingFromWorld(CBuildingSAInterface* pBuilding);

--- a/Client/game_sa/CPoolsSA.cpp
+++ b/Client/game_sa/CPoolsSA.cpp
@@ -617,6 +617,12 @@ CEntity* CPoolsSA::GetEntity(DWORD* pGameInterface)
         {
             return pThePedEntity->pEntity;
         }
+
+        auto pTheBuildingEntity = m_BuildingsPool.GetBuilding(reinterpret_cast<CBuildingSAInterface*>(pGameInterface));
+        if (pTheBuildingEntity)
+        {
+            return pTheBuildingEntity;
+        }
     }
     return NULL;
 }

--- a/Client/mods/deathmatch/logic/CClientBuilding.cpp
+++ b/Client/mods/deathmatch/logic/CClientBuilding.cpp
@@ -139,6 +139,8 @@ void CClientBuilding::Create()
     if (!m_pBuilding)
         return;
 
+    m_pBuilding->SetStoredPointer(this);
+
     if (m_bDoubleSidedInit)
         m_pBuilding->SetBackfaceCulled(!m_bDoubleSided);
 


### PR DESCRIPTION
#### Summary
Fixes `hitElement` returning nil when `testSphereAgainstWorld` (and `processLineOfSight`) hits a building created with `createBuilding`.

#### Motivation
Resolves #5136. `CPoolsSA::GetEntity` never checked the buildings pool, so `CEntity*` resolution for a building always fell through to null. Even after that, `testSphereAgainstWorld` still returned nil because it resolves its element through `GetStoredPointer`, which `CClientBuilding::Create` never set on the native entity, unlike objects, peds and vehicles.

#### Test plan
Created a building with `createBuilding`, called `testSphereAgainstWorld` and `processLineOfSight` against it. Before the fix, both returned a hit with a nil `hitElement`; after the fix, `hitElement` correctly resolves to the building.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.