### PR TITLE
Fix water staying invisible across dimensions

### DIFF
--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -4191,11 +4191,6 @@ retry:
                         pWater =
                             new CClientWater(g_pClientGame->GetManager(), EntityID, vecVertices[0], vecVertices[1], vecVertices[2], vecVertices[3], bShallow);
                     }
-                    if (!pWater->Exists())
-                    {
-                        delete pWater;
-                        pWater = NULL;
-                    }
                     pEntity = pWater;
                     break;
                 }


### PR DESCRIPTION
#### Summary
Fixes water elements created in a dimension different from the local player's current dimension being deleted instead of just hidden.

#### Motivation
Resolves #849. `CClientWater`'s constructor calls `RelateDimension()` right away, comparing its own dimension (still the default 0, since the real value hasn't been read from the network packet yet) against the local player's current dimension. On a mismatch it calls `Destroy()` instead of `Create()`, leaving `m_pPoly` null.

`Packet_EntityAdd` treated that as a creation failure: `if (!pWater->Exists()) { delete pWater; pWater = NULL; }`, deleting the element right after construction, before the packet handler even reaches the line further down that applies the water's real dimension (`pEntity->SetDimension(usDimension)`). That check dates back to when water had no dimension concept and `m_pPoly == nullptr` could only mean the native call genuinely failed (invalid vertices, water pool full); it was never updated when dimension support was added, so it can no longer tell a real failure apart from water that's just correctly waiting for its dimension to be applied.

#### Test plan
Created water server-side in dimension 0 while standing in dimension 1, then switched to dimension 0. Before the fix, the water never appeared; after the fix, it shows up correctly once dimensions match.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.