### PR TITLE
Apply the same set of security fixes to release/1.6.0 as we did on master on July 31st.

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaArgument.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaArgument.cpp
@@ -461,7 +461,7 @@ void CLuaArgument::Push(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKn
 }
 
 // Can't use bitStream.Version() here as it is sometimes not set
-bool CLuaArgument::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables)
+bool CLuaArgument::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables, unsigned int uiDepth)
 {
     DeleteTableData();
     m_iType = LUA_TNIL;
@@ -523,7 +523,7 @@ bool CLuaArgument::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vect
         case LUA_TTABLE:
         {
             m_pTableData = new CLuaArguments();
-            if (!m_pTableData->ReadFromBitStream(bitStream, pKnownTables))
+            if (!m_pTableData->ReadFromBitStream(bitStream, pKnownTables, uiDepth + 1))
             {
                 DeleteTableData();
                 return false;

--- a/Client/mods/deathmatch/logic/lua/CLuaArgument.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaArgument.h
@@ -60,7 +60,7 @@ public:
     CLuaArguments* GetTable() const { return m_pTableData; }
     CClientEntity* GetElement() const;
 
-    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL);
+    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL, unsigned int uiDepth = 0);
     bool         WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL) const;
     json_object* WriteToJSONObject(bool bSerialize = false, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL);
     bool         ReadFromJSONObject(json_object* object, std::vector<CLuaArguments*>* pKnownTables = NULL);

--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
@@ -452,8 +452,11 @@ void CLuaArguments::ValidateTableKeys()
     }
 }
 
-bool CLuaArguments::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables)
+bool CLuaArguments::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables, unsigned int uiDepth)
 {
+    if (uiDepth > MaxBitStreamTableReadDepth)
+        return false;
+
     bool bKnownTablesCreated = false;
     if (!pKnownTables)
     {

--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -32,6 +32,8 @@ class CLuaArguments;
 class CLuaArguments
 {
 public:
+    static constexpr unsigned int MaxBitStreamTableReadDepth = 64;
+
     CLuaArguments() {}
     CLuaArguments(const CLuaArguments& Arguments, CFastHashMap<CLuaArguments*, CLuaArguments*>* pKnownTables = NULL);
     CLuaArguments(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL);
@@ -66,7 +68,7 @@ public:
     void DeleteArguments();
     void Pop();
 
-    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL);
+    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL, unsigned int uiDepth = 0);
     bool         WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL) const;
     void         ValidateTableKeys();
     bool         ReadFromJSONString(const char* szJSON);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaBrowserDefs.cpp
@@ -192,6 +192,10 @@ int CLuaBrowserDefs::RequestBrowserDomains(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
+        // Remove whitespaces
+        for (auto& url : pages)
+            url.erase(std::remove_if(url.begin(), url.end(), [](unsigned char c) { return std::isspace(c); }), url.end());
+
         // Remove empty and invalid URLs
         std::regex invalidSynmbolsRegex("[^A-Za-z0-9._~!#$&'()*+,;=:@/?%-]");
 

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -977,6 +977,8 @@ bool CGame::Start(int iArgumentCount, char* szArguments[])
     // Register our packethandler
     g_pNetServer->RegisterPacketHandler(CGame::StaticProcessPacket);
 
+    CalculateMinClientRequirement();
+
     // Try to start the network
     if (!g_pNetServer->StartNetwork(strServerIPList, usServerPort, uiMaxPlayers, m_pMainConfig->GetServerName().c_str()))
     {
@@ -1569,6 +1571,9 @@ void CGame::QuitPlayer(CPlayer& Player, CClient::eQuitReasons Reason, bool bSayI
 
         Player.CallEvent("onPlayerQuit", Arguments);
 
+        // Tell the resource manager
+        m_pResourceManager->OnPlayerQuit(Player);
+
         // Tell the map manager
         m_pMapManager->OnPlayerQuit(Player);
 
@@ -1930,9 +1935,10 @@ void CGame::Packet_PlayerJoinData(CPlayerJoinDataPacket& Packet)
                                 // Tell the console
                                 CLogger::LogPrintf("CONNECT: %s failed to connect (Client version is below minimum) (%s)\n", szNick, strIPAndSerial.c_str());
 
-                                // Tell the player
-                                pPlayer->Send(CUpdateInfoPacket("Mandatory", CalculateMinClientRequirement()));
-                                DisconnectPlayer(this, *pPlayer, CPlayerDisconnectedPacket::NO_REASON);
+                                // Tell the player and let them know which exact version is required
+                                const CMtaVersion strRequiredVersion = CalculateMinClientRequirement();
+                                pPlayer->Send(CUpdateInfoPacket("Mandatory", strRequiredVersion));
+                                DisconnectPlayer(this, *pPlayer, CPlayerDisconnectedPacket::BAD_VERSION, strRequiredVersion.c_str());
                                 return;
                             }
 
@@ -1944,9 +1950,10 @@ void CGame::Packet_PlayerJoinData(CPlayerJoinDataPacket& Packet)
                                 CLogger::LogPrintf("CONNECT: %s advised to update (Client version is below recommended) (%s)\n", szNick,
                                                    strIPAndSerial.c_str());
 
-                                // Tell the player
-                                pPlayer->Send(CUpdateInfoPacket("Optional", GetConfig()->GetRecommendedClientVersion()));
-                                DisconnectPlayer(this, *pPlayer, "");
+                                // Tell the player and let them know which exact version is recommended
+                                const CMtaVersion strRecommendedVersion = GetConfig()->GetRecommendedClientVersion();
+                                pPlayer->Send(CUpdateInfoPacket("Optional", strRecommendedVersion));
+                                DisconnectPlayer(this, *pPlayer, CPlayerDisconnectedPacket::BAD_VERSION, strRecommendedVersion.c_str());
                                 return;
                             }
 
@@ -2215,6 +2222,10 @@ void CGame::Packet_PlayerWasted(CPlayerWastedPacket& Packet)
             pPlayer->SetWeaponAmmoInClip(0, slot);
             pPlayer->SetWeaponTotalAmmo(0, slot);
         }
+
+        // Active satchels are wiped client-side when the player dies. Reset our count
+        // so the next life isn't blocked by the per-life cap from the old life's throws.
+        pPlayer->m_uiActiveSatchelCount = 0;
     }
 }
 
@@ -2793,11 +2804,17 @@ void CGame::Packet_DetonateSatchels(CDetonateSatchelsPacket& Packet)
     CPlayer* pPlayer = Packet.GetSourcePlayer();
     if (pPlayer && pPlayer->IsJoined())
     {
+        constexpr unsigned long long DETONATE_SATCHEL_COOLDOWN_MS = 1000;
+        if (pPlayer->m_DetonateSatchelTimer.Get() < DETONATE_SATCHEL_COOLDOWN_MS)
+            return;
+        pPlayer->m_DetonateSatchelTimer.Reset();
+
         // Trigger Lua event and see if we are allowed to continue
         CLuaArguments arguments;
         if (!pPlayer->CallEvent("onPlayerDetonateSatchels", arguments))
             return;
 
+        pPlayer->m_uiActiveSatchelCount = 0;
         // Tell everyone to blow up this guy's satchels
         m_pPlayerManager->BroadcastOnlyJoined(Packet);
         // Take away their detonator
@@ -2811,6 +2828,11 @@ void CGame::Packet_DestroySatchels(CDestroySatchelsPacket& Packet)
     CPlayer* pPlayer = Packet.GetSourcePlayer();
     if (pPlayer && pPlayer->IsJoined())
     {
+        constexpr unsigned long long DESTROY_SATCHEL_COOLDOWN_MS = 1000;
+        if (pPlayer->m_DestroySatchelTimer.Get() < DESTROY_SATCHEL_COOLDOWN_MS)
+            return;
+        pPlayer->m_DestroySatchelTimer.Reset();
+        pPlayer->m_uiActiveSatchelCount = 0;
         // Tell everyone to destroy up this player's satchels
         m_pPlayerManager->BroadcastOnlyJoined(Packet);
         // Take away their detonator
@@ -2946,6 +2968,14 @@ void CGame::Packet_ProjectileSync(CProjectileSyncPacket& Packet)
     CPlayer* pPlayer = Packet.GetSourcePlayer();
     if (pPlayer && pPlayer->IsJoined())
     {
+        if (Packet.m_ucWeaponType == 39)
+        {
+            constexpr unsigned int MAX_PLAYER_SATCHELS = 128;
+            if (pPlayer->m_uiActiveSatchelCount >= MAX_PLAYER_SATCHELS)
+                return;
+            pPlayer->m_uiActiveSatchelCount++;
+        }
+
         CVector vecPosition = Packet.m_vecOrigin;
         if (Packet.m_OriginID != INVALID_ELEMENT_ID)
         {
@@ -4192,28 +4222,107 @@ void CGame::Packet_PlayerTransgression(CPlayerTransgressionPacket& Packet)
     }
 }
 
+namespace
+{
+    constexpr size_t MAX_PLAYER_DIAGNOSTIC_LOG_LENGTH = 512;
+
+    bool IsKnownPlayerDiagnosticLevel(uint uiLevel)
+    {
+        switch (uiLevel)
+        {
+            case 1000:
+            case 1002:
+            case 1003:
+            case 1004:
+            case 1005:
+            case 1007:
+            case 1008:
+            case 1009:
+            case 1010:
+            case 1011:
+            case 1012:
+            case 1013:
+                return true;
+        }
+
+        return false;
+    }
+
+    bool IsHexDigest(const SString& strValue, size_t uiExpectedLength)
+    {
+        if (strValue.length() != uiExpectedLength)
+            return false;
+
+        for (size_t i = 0; i < strValue.length(); i++)
+        {
+            if (!isxdigit(static_cast<uchar>(strValue[i])))
+                return false;
+        }
+
+        return true;
+    }
+
+    bool HasUsableD3d9Info(const SString& strD3d9Md5, const SString& strD3d9Sha256, uint uiD3d9Size)
+    {
+        if (strD3d9Md5.empty() && strD3d9Sha256.empty())
+            return uiD3d9Size == 0;
+
+        return IsHexDigest(strD3d9Md5, 32) && IsHexDigest(strD3d9Sha256, 64);
+    }
+
+    bool BuildDetectedAcList(const std::vector<uchar>& idList, SString& strDetectedAC)
+    {
+        strDetectedAC.clear();
+        bool bSeenIds[64] = {};
+
+        for (size_t i = 0; i < idList.size(); i++)
+        {
+            const uchar ucId = idList[i];
+            if (ucId > 63 || bSeenIds[ucId])
+                return false;
+
+            bSeenIds[ucId] = true;
+            if (!strDetectedAC.empty())
+                strDetectedAC += ",";
+            strDetectedAC += SString("%u", static_cast<uint>(ucId));
+        }
+
+        return true;
+    }
+
+    SString SanitizePlayerDiagnosticMessage(const SString& strMessage)
+    {
+        SString strResult;
+        const size_t uiCopyLength = Min<size_t>(strMessage.length(), MAX_PLAYER_DIAGNOSTIC_LOG_LENGTH);
+
+        for (size_t i = 0; i < uiCopyLength; i++)
+        {
+            const uchar ucChar = static_cast<uchar>(strMessage[i]);
+            if (ucChar == '\r' || ucChar == '\n' || ucChar == '\t')
+                strResult += ' ';
+            else if (ucChar < 0x20 || ucChar == 0x7F)
+                strResult += '?';
+            else
+                strResult += strMessage[i];
+        }
+
+        if (strMessage.length() > MAX_PLAYER_DIAGNOSTIC_LOG_LENGTH)
+            strResult += "...";
+
+        return strResult;
+    }
+}
+
 void CGame::Packet_PlayerDiagnostic(CPlayerDiagnosticPacket& Packet)
 {
     CPlayer* pPlayer = Packet.GetSourcePlayer();
     if (pPlayer && pPlayer->IsJoined())
     {
-        if (Packet.m_uiLevel == 236)
+        if (Packet.m_uiLevel != 236 &&
+            (IsKnownPlayerDiagnosticLevel(Packet.m_uiLevel) || g_pGame->GetConfig()->IsEnableDiagnostic(SString("%d", Packet.m_uiLevel))))
         {
-            // Handle special info
-            std::vector<SString> parts;
-            Packet.m_strMessage.Split(",", parts);
-            if (parts.size() > 3)
-            {
-                pPlayer->m_strDetectedAC = parts[0].Replace("|", ",");
-                pPlayer->m_uiD3d9Size = atoi(parts[1]);
-                pPlayer->m_strD3d9Md5 = parts[2];
-                pPlayer->m_strD3d9Sha256 = parts[3];
-            }
-        }
-        else if (Packet.m_uiLevel >= 1000 || g_pGame->GetConfig()->IsEnableDiagnostic(SString("%d", Packet.m_uiLevel)))
-        {
-            // If diagnosticis enabled on this server, log it
-            SString strMessageCombo("DIAGNOSTIC: %s #%d %s\n", pPlayer->GetNick(), Packet.m_uiLevel, Packet.m_strMessage.c_str());
+            const SString strSanitizedMessage = SanitizePlayerDiagnosticMessage(Packet.m_strMessage);
+            const SString strMessageCombo("DIAGNOSTIC: %s #%d %s\n", pPlayer->GetNick(), Packet.m_uiLevel, *strSanitizedMessage);
             CLogger::LogPrint(strMessageCombo);
         }
     }
@@ -4253,11 +4362,15 @@ void CGame::Packet_PlayerScreenShot(CPlayerScreenShotPacket& Packet)
                 // Check if new start
                 if (Packet.m_usPartNumber == 0)
                 {
+                    if (!info.bRequested)
+                        return;
+
                     info.bInProgress = true;
                     info.usNextPartNumber = 0;
                     info.usScreenShotId = Packet.m_usScreenShotId;
 
                     info.llTimeStamp = Packet.m_llServerGrabTime;
+                    info.llStartTime = GetTickCount64_();
                     info.uiTotalBytes = Packet.m_uiTotalBytes;
                     info.usTotalParts = Packet.m_usTotalParts;
                     info.usResourceNetId = Packet.m_pResource ? Packet.m_pResource->GetNetID() : INVALID_RESOURCE_NET_ID;
@@ -4268,6 +4381,25 @@ void CGame::Packet_PlayerScreenShot(CPlayerScreenShotPacket& Packet)
             // Add data if valid
             if (info.bInProgress)
             {
+                // Reject if accumulated data exceeds 50MB
+                constexpr uint MAX_SCREENSHOT_SIZE = 50 * 1024 * 1024;
+                if (info.buffer.GetSize() + Packet.m_buffer.GetSize() > MAX_SCREENSHOT_SIZE)
+                {
+                    info.bInProgress = false;
+                    info.bRequested = false;
+                    info.buffer.Clear();
+                    return;
+                }
+
+                // Timeout stale transfers after 30 seconds
+                if (GetTickCount64_() - info.llStartTime > 30000)
+                {
+                    info.bInProgress = false;
+                    info.bRequested = false;
+                    info.buffer.Clear();
+                    return;
+                }
+
                 info.buffer += Packet.m_buffer;
                 info.usNextPartNumber++;
 
@@ -4287,6 +4419,7 @@ void CGame::Packet_PlayerScreenShot(CPlayerScreenShotPacket& Packet)
                     }
 
                     info.bInProgress = false;
+                    info.bRequested = false;
                     info.buffer.Clear();
                 }
             }
@@ -4325,15 +4458,75 @@ void CGame::Packet_PlayerNetworkStatus(CPlayerNetworkStatusPacket& Packet)
 void CGame::Packet_PlayerResourceStart(CPlayerResourceStartPacket& Packet)
 {
     CPlayer* pPlayer = Packet.GetSourcePlayer();
-    if (pPlayer)
+    if (pPlayer && pPlayer->IsJoined() && !pPlayer->IsLeavingServer())
     {
         CResource* pResource = Packet.GetResource();
-        if (pResource)
+
+        // Packets with no valid resource (stale ID, race with resource stop) are
+        // harmless and should not consume or count toward disconnect.
+        if (!pResource)
+            return;
+
+        // Acks for the current send are expected traffic, not flood traffic.
+        const EPlayerResourceStartAck ackResult =
+            pResource->AddPlayerResourceStart(pPlayer, Packet.GetStartGeneration(), Packet.HasStartGeneration());
+
+        if (ackResult == EPlayerResourceStartAck::Accepted)
         {
             CLuaArguments Arguments;
             Arguments.PushResource(pResource);
             pPlayer->CallEvent("onPlayerResourceStart", Arguments, NULL);
+            return;
         }
+
+        // Race condition acks (resource stopped before ack arrived, stale generation)
+        // are normal during join and shouldnt cost the player tokens.
+        if (ackResult == EPlayerResourceStartAck::RaceMiss)
+            return;
+
+        // Only genuine duplicate acks reach here. Apply the rate limit.
+        constexpr unsigned int RESOURCE_START_RATE_LIMIT = 50;
+        constexpr unsigned int RESOURCE_START_RATE_PERIOD_MS = 2000;
+        constexpr unsigned int RESOURCE_START_TOKEN_INTERVAL_MS = RESOURCE_START_RATE_PERIOD_MS / RESOURCE_START_RATE_LIMIT;
+
+        // Preserve sub-token time so normal packet jitter doesn't reduce the effective refill rate.
+        unsigned long long elapsed = pPlayer->m_ResourceStartPacketTimer.Get();
+        pPlayer->m_ResourceStartPacketTimer.Reset();
+
+        if (pPlayer->m_ResourceStartTokens < RESOURCE_START_RATE_LIMIT)
+        {
+            pPlayer->m_ResourceStartRefillRemainderMs += elapsed;
+            unsigned int refill = static_cast<unsigned int>(pPlayer->m_ResourceStartRefillRemainderMs / RESOURCE_START_TOKEN_INTERVAL_MS);
+
+            if (refill)
+            {
+                unsigned int tokens = pPlayer->m_ResourceStartTokens + refill;
+                pPlayer->m_ResourceStartTokens = (tokens > RESOURCE_START_RATE_LIMIT) ? RESOURCE_START_RATE_LIMIT : tokens;
+                pPlayer->m_ResourceStartRefillRemainderMs %= RESOURCE_START_TOKEN_INTERVAL_MS;
+
+                // Only reset the drop counter when the bucket is fully restored. Resetting on
+                // any partial refill lets a sender pace at ~40ms and never accumulate drops.
+                if (pPlayer->m_ResourceStartTokens == RESOURCE_START_RATE_LIMIT)
+                {
+                    pPlayer->m_ResourceStartDrops = 0;
+                    pPlayer->m_ResourceStartRefillRemainderMs = 0;
+                }
+            }
+        }
+        else
+        {
+            // A stalled sender shouldn't hold extra burst capacity beyond the bucket cap.
+            pPlayer->m_ResourceStartRefillRemainderMs = 0;
+        }
+
+        if (pPlayer->m_ResourceStartTokens == 0)
+        {
+            if (++pPlayer->m_ResourceStartDrops >= 10)
+                DisconnectPlayer(this, *pPlayer, "Trigger Flooding");
+            return;
+        }
+
+        --pPlayer->m_ResourceStartTokens;
     }
 }
 
@@ -4435,6 +4628,28 @@ void CGame::Packet_PlayerACInfo(CPlayerACInfoPacket& Packet)
     CPlayer* pPlayer = Packet.GetSourcePlayer();
     if (pPlayer)
     {
+        SString strDetectedAC;
+        uint    uiD3d9Size = 0;
+        SString strD3d9Md5;
+        SString strD3d9Sha256;
+
+        // Build the comma-separated detected AC list and update the cached d3d9 fields when the
+        // hashes are usable. The event is fired unconditionally so scripts always see the report.
+        if (BuildDetectedAcList(Packet.m_IdList, strDetectedAC))
+        {
+            pPlayer->m_strDetectedAC = strDetectedAC;
+
+            if (HasUsableD3d9Info(Packet.m_strD3d9MD5, Packet.m_strD3d9SHA256, Packet.m_uiD3d9Size))
+            {
+                uiD3d9Size = Packet.m_uiD3d9Size;
+                strD3d9Md5 = Packet.m_strD3d9MD5;
+                strD3d9Sha256 = Packet.m_strD3d9SHA256;
+                pPlayer->m_uiD3d9Size = uiD3d9Size;
+                pPlayer->m_strD3d9Md5 = strD3d9Md5;
+                pPlayer->m_strD3d9Sha256 = strD3d9Sha256;
+            }
+        }
+
         CLuaArguments acList;
         for (uint i = 0; i < Packet.m_IdList.size(); i++)
         {
@@ -4444,9 +4659,9 @@ void CGame::Packet_PlayerACInfo(CPlayerACInfoPacket& Packet)
 
         CLuaArguments Arguments;
         Arguments.PushTable(&acList);
-        Arguments.PushNumber(Packet.m_uiD3d9Size);
-        Arguments.PushString(Packet.m_strD3d9MD5);
-        Arguments.PushString(Packet.m_strD3d9SHA256);
+        Arguments.PushNumber(uiD3d9Size);
+        Arguments.PushString(strD3d9Md5);
+        Arguments.PushString(strD3d9Sha256);
         pPlayer->CallEvent("onPlayerACInfo", Arguments);
     }
 }
@@ -4986,6 +5201,9 @@ CMtaVersion CGame::CalculateMinClientRequirement()
     if (strNewMin < RELEASE_MIN_CLIENT_VERSION)
         strNewMin = RELEASE_MIN_CLIENT_VERSION;
 #endif
+
+    if (g_pNetServer)
+        g_pNetServer->SetMinClientRequirement(*strNewMin);
 
     return strNewMin;
 }

--- a/Server/mods/deathmatch/logic/CPlayer.h
+++ b/Server/mods/deathmatch/logic/CPlayer.h
@@ -55,9 +55,11 @@ typedef CFastHashMap<CPlayer*, SViewerInfo> SViewerMapType;
 struct SScreenShotInfo
 {
     bool      bInProgress;
+    bool      bRequested;
     ushort    usNextPartNumber;
     ushort    usScreenShotId;
     long long llTimeStamp;
+    long long llStartTime;
     uint      uiTotalBytes;
     ushort    usTotalParts;
     ushort    usResourceNetId;
@@ -345,6 +347,15 @@ public:
     uint                   m_uiD3d9Size;
     SString                m_strD3d9Md5;
     SString                m_strD3d9Sha256;
+
+    CElapsedTime m_ResourceStartPacketTimer;
+    unsigned int m_ResourceStartTokens{50};
+    unsigned long long m_ResourceStartRefillRemainderMs{};
+    unsigned int m_ResourceStartDrops{};
+
+    unsigned int m_uiActiveSatchelCount{};
+    CElapsedTime m_DetonateSatchelTimer;
+    CElapsedTime m_DestroySatchelTimer;
 
 private:
     SLightweightSyncData m_lightweightSyncData;

--- a/Server/mods/deathmatch/logic/CResource.cpp
+++ b/Server/mods/deathmatch/logic/CResource.cpp
@@ -362,6 +362,37 @@ void CResource::Reload()
     Load();
 }
 
+EPlayerResourceStartAck CResource::AddPlayerResourceStart(CPlayer* player, unsigned int uiStartGeneration, bool bHasStartGeneration)
+{
+    if (!player || !player->IsJoined() || player->IsLeavingServer())
+        return EPlayerResourceStartAck::RaceMiss;
+
+    // Resource must have been started at least once and still be running.
+    if (!m_startCounter || m_eState != EResourceState::Running)
+        return EPlayerResourceStartAck::RaceMiss;
+
+    // First valid ack from this player for the current resource incarnation always wins.
+    // A generation mismatch here means the player's ack was in flight when a server-side
+    // restart bumped the counter; rejecting it left the join loading gate closed until the
+    // second cycle's ack arrived seconds later.
+    auto [it, inserted] = m_playersStarted.insert(player);
+    if (inserted)
+        return EPlayerResourceStartAck::Accepted;
+
+    // Player is already acked. Distinguish a stale-generation ack (race) from a true duplicate.
+    // Old clients don't send a generation, so they fall through as the current counter.
+    unsigned int uiExpectedGeneration = bHasStartGeneration ? uiStartGeneration : m_startCounter;
+    if (uiExpectedGeneration != m_startCounter)
+        return EPlayerResourceStartAck::RaceMiss;
+
+    return EPlayerResourceStartAck::Duplicate;
+}
+
+void CResource::OnPlayerQuit(CPlayer& Player)
+{
+    m_playersStarted.erase(&Player);
+}
+
 CResource::~CResource()
 {
     CIdArray::PushUniqueId(this, EIdClass::RESOURCE, m_uiScriptID);
@@ -1023,6 +1054,12 @@ bool CResource::Start(std::list<CResource*>* pDependents, bool bManualStart, con
 
     m_eState = EResourceState::Running;
 
+    // Bump the generation counter before any handler can observe the resource as running.
+    // The CResourceStartPacket broadcast below carries this value, and onResourceStart
+    // handlers must see the same value clients will be told to ack against. Clamped past
+    // zero so a UINT_MAX wrap never reuses the "never started" value.
+    m_startCounter = std::max<unsigned int>(m_startCounter + 1, 1);
+
     // Call the onResourceStart event. If it returns false, cancel this script again
     CLuaArguments Arguments;
     Arguments.PushResource(this);
@@ -1047,7 +1084,7 @@ bool CResource::Start(std::list<CResource*>* pDependents, bool bManualStart, con
 
     // Broadcast new resourceelement that is loaded and tell the players that a new resource was started
     g_pGame->GetMapManager()->BroadcastResourceElements(m_pResourceElement, m_pDefaultElementGroup);
-    g_pGame->GetPlayerManager()->BroadcastOnlyJoined(CResourceStartPacket(m_strResourceName.c_str(), this));
+    g_pGame->GetPlayerManager()->BroadcastOnlyJoined(CResourceStartPacket(m_strResourceName.c_str(), this, m_startCounter));
     SendNoClientCacheScripts();
     m_bClientSync = true;
 
@@ -1123,6 +1160,7 @@ bool CResource::Stop(bool bManualStop)
     // Tell all the players that have joined that this resource is stopped
     g_pGame->GetPlayerManager()->BroadcastOnlyJoined(CResourceStopPacket(m_usNetID));
     m_bClientSync = false;
+    m_playersStarted.clear();
 
     // Call the onResourceStop event on this resource element
     CLuaArguments Arguments;
@@ -3334,7 +3372,7 @@ bool CResource::CheckState()
 void CResource::OnPlayerJoin(CPlayer& Player)
 {
     // do the player join crap
-    Player.Send(CResourceStartPacket(m_strResourceName.c_str(), this));
+    Player.Send(CResourceStartPacket(m_strResourceName.c_str(), this, m_startCounter));
     SendNoClientCacheScripts(&Player);
 }
 

--- a/Server/mods/deathmatch/logic/CResource.h
+++ b/Server/mods/deathmatch/logic/CResource.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <unordered_set>
 #include "packets/CResourceStartPacket.h"
 #include "packets/CResourceStopPacket.h"
 #include "packets/CEntityRemovePacket.h"
@@ -131,6 +132,15 @@ enum class EResourceState : unsigned char
     Stopping,  // the resource is stopping
 };
 
+// Return value for AddPlayerResourceStart. Used to distinguish normal race conditions
+// (resource stopped before ack arrived) from actually duplicate acks.
+enum class EPlayerResourceStartAck : unsigned char
+{
+    Accepted,    // ack is valid for the current start, event should fire
+    RaceMiss,    // resource not running or stale generation - normal race, no token charge
+    Duplicate,   // player already had their ack accepted for this start - genuine duplicate
+};
+
 // A resource is either a directory with files or a ZIP file which contains the content of such directory.
 // The directory or ZIP file must contain a meta.xml file, which describes the required content by the resource.
 // It's a process-like environment for scripts, maps, images and other files.
@@ -152,6 +162,8 @@ public:
     bool Unload();
 
     void Reload();
+
+    EPlayerResourceStartAck AddPlayerResourceStart(CPlayer* player, unsigned int uiStartGeneration, bool bHasStartGeneration);
 
     // Get a resource default setting
     bool GetDefaultSetting(const char* szName, char* szValue, size_t sizeBuffer);
@@ -265,9 +277,12 @@ public:
     void           SetNetID(unsigned short usNetID) { m_usNetID = usNetID; }
     unsigned short GetNetID() const noexcept { return m_usNetID; }
 
+    unsigned int GetStartCounter() const noexcept { return m_startCounter; }
+
     uint GetScriptID() const noexcept { return m_uiScriptID; }
 
     void OnPlayerJoin(CPlayer& Player);
+    void OnPlayerQuit(CPlayer& Player);
     void SendNoClientCacheScripts(CPlayer* pPlayer = nullptr);
 
     void OnResourceStateChange(const char* state) noexcept;
@@ -394,6 +409,9 @@ private:
     CDummy*        m_pResourceDynamicElementRoot = nullptr;
     CElementGroup* m_pDefaultElementGroup = nullptr;  // stores elements created by scripts in this resource
     CLuaMain*      m_pVM = nullptr;
+
+    unsigned int                      m_startCounter{};
+    std::unordered_set<CPlayer*>      m_playersStarted;
 
     KeyValueMap                    m_Info;
     std::list<CIncludedResources*> m_IncludedResources;  // we store them here temporarily, then read them once all the resources are loaded

--- a/Server/mods/deathmatch/logic/CResourceManager.cpp
+++ b/Server/mods/deathmatch/logic/CResourceManager.cpp
@@ -543,6 +543,14 @@ void CResourceManager::OnPlayerJoin(CPlayer& Player)
     }
 }
 
+void CResourceManager::OnPlayerQuit(CPlayer& Player)
+{
+    for (auto iter = IterBegin(); iter != IterEnd(); ++iter)
+    {
+        (*iter)->OnPlayerQuit(Player);
+    }
+}
+
 //
 // Add resource <-> luaVM lookup mapping
 //

--- a/Server/mods/deathmatch/logic/CResourceManager.h
+++ b/Server/mods/deathmatch/logic/CResourceManager.h
@@ -67,6 +67,7 @@ public:
     unsigned int GetResourceLoadedCount() { return m_uiResourceLoadedCount; }
     unsigned int GetResourceFailedCount() { return m_uiResourceFailedCount; }
     void         OnPlayerJoin(CPlayer& Player);
+    void         OnPlayerQuit(CPlayer& Player);
 
     const char* GetResourceDirectory();
 

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -3277,6 +3277,8 @@ bool CStaticFunctionDefinitions::TakePlayerScreenShot(CElement* pElement, uint u
         BitStream.pBitStream->Write(GetTickCount32());
         pPlayer->Send(CLuaPacket(TAKE_PLAYER_SCREEN_SHOT, *BitStream.pBitStream));
 
+        pPlayer->GetScreenShotInfo().bRequested = true;
+
         return true;
     }
 

--- a/Server/mods/deathmatch/logic/lua/CLuaArgument.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaArgument.cpp
@@ -428,7 +428,7 @@ bool CLuaArgument::GetAsString(SString& strBuffer)
 }
 
 // Can't use bitStream.Version() here as it is sometimes not set
-bool CLuaArgument::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables)
+bool CLuaArgument::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables, unsigned int uiDepth)
 {
     DeleteTableData();
     m_iType = LUA_TNIL;
@@ -487,7 +487,7 @@ bool CLuaArgument::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vect
             case LUA_TTABLE:
             {
                 m_pTableData = new CLuaArguments();
-                if (!m_pTableData->ReadFromBitStream(bitStream, pKnownTables))
+                if (!m_pTableData->ReadFromBitStream(bitStream, pKnownTables, uiDepth + 1))
                 {
                     DeleteTableData();
                     return false;

--- a/Server/mods/deathmatch/logic/lua/CLuaArgument.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaArgument.h
@@ -61,7 +61,7 @@ public:
     CElement*          GetElement() const;
     bool               GetAsString(SString& strBuffer);
 
-    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL);
+    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL, unsigned int uiDepth = 0);
     bool         WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL) const;
     json_object* WriteToJSONObject(bool bSerialize = false, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL);
     bool         ReadFromJSONObject(json_object* object, std::vector<CLuaArguments*>* pKnownTables = NULL);

--- a/Server/mods/deathmatch/logic/lua/CLuaArguments.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaArguments.cpp
@@ -520,8 +520,12 @@ void CLuaArguments::ValidateTableKeys()
     }
 }
 
-bool CLuaArguments::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables)
+bool CLuaArguments::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables, unsigned int uiDepth)
 {
+    // Cap table nesting at 64 levels to prevent stack overflow
+    if (uiDepth > 64)
+        return false;
+
     bool bKnownTablesCreated = false;
     if (!pKnownTables)
     {
@@ -545,7 +549,7 @@ bool CLuaArguments::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vec
         for (unsigned int ui = 0; ui < uiNumArgs; ++ui)
         {
             CLuaArgument* pArgument = new CLuaArgument();
-            if (!pArgument->ReadFromBitStream(bitStream, pKnownTables))
+            if (!pArgument->ReadFromBitStream(bitStream, pKnownTables, uiDepth))
             {
                 delete pArgument;
                 if (bKnownTablesCreated)

--- a/Server/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -88,7 +88,7 @@ public:
     void ValidateTableKeys();
     void Pop();
 
-    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL);
+    bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL, unsigned int uiDepth = 0);
     bool         ReadFromJSONString(const char* szJSON);
     bool         WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL) const;
     bool         WriteToJSONString(std::string& strJSON, bool bSerialize = false, int flags = JSON_C_TO_STRING_PLAIN);

--- a/Server/mods/deathmatch/logic/net/CNetBuffer.cpp
+++ b/Server/mods/deathmatch/logic/net/CNetBuffer.cpp
@@ -11,9 +11,48 @@
 #include "SimHeaders.h"
 #include "CGame.h"
 #include "packets/CPlayerDisconnectedPacket.h"
+#ifndef WIN32
+    #include <dlfcn.h>
+#endif
 
 SThreadCPUTimesStore g_SyncThreadCPUTimes;
 uint                 g_uiNetSentByteCounter = 0;
+
+namespace
+{
+    using PFN_NotifyHqReachable = void (*)(int);
+    PFN_NotifyHqReachable ms_pfnNotifyHqReachable = nullptr;
+
+    void ResolveNotifyHqReachable()
+    {
+        if (ms_pfnNotifyHqReachable)
+            return;
+#ifdef WIN32
+        HMODULE hNetMod = GetModuleHandleA("net.dll");
+        if (!hNetMod)
+            hNetMod = GetModuleHandleA("net_d.dll");
+        if (hNetMod)
+            ms_pfnNotifyHqReachable = reinterpret_cast<PFN_NotifyHqReachable>(GetProcAddress(hNetMod, "NetServer_NotifyHqReachable"));
+#else
+        // Core loads net.so without RTLD_GLOBAL, so RTLD_DEFAULT cannot see its symbols.
+        // RTLD_NOLOAD returns a handle to the already-loaded module without reloading it.
+        void* hNetMod = dlopen("net.so", RTLD_NOW | RTLD_NOLOAD);
+        if (!hNetMod)
+            hNetMod = dlopen("net_d.so", RTLD_NOW | RTLD_NOLOAD);
+        if (hNetMod)
+        {
+            ms_pfnNotifyHqReachable = reinterpret_cast<PFN_NotifyHqReachable>(dlsym(hNetMod, "NetServer_NotifyHqReachable"));
+            dlclose(hNetMod);
+        }
+#endif
+    }
+}
+
+void NetServer_NotifyHqReachable(bool bReachable)
+{
+    if (ms_pfnNotifyHqReachable)
+        ms_pfnNotifyHqReachable(bReachable ? 1 : 0);
+}
 
 namespace
 {
@@ -116,6 +155,8 @@ CNetServerBuffer::CNetServerBuffer(CSimPlayerManager* pSimPlayerManager)
     m_pSimPlayerManager = pSimPlayerManager;
     ms_pNetServerBuffer = this;
     m_pRealNetServer = g_pRealNetServer;
+
+    ResolveNotifyHqReachable();
 
     // Begin the watchdog
     shared.m_pWatchDog = new CNetBufferWatchDog(this, false);

--- a/Server/mods/deathmatch/logic/packets/CLuaEventPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CLuaEventPacket.cpp
@@ -12,6 +12,11 @@
 #include "StdInc.h"
 #include "CLuaEventPacket.h"
 
+namespace
+{
+constexpr int MAX_LUA_EVENT_ARGUMENTS_SIZE = 1024 * 1024;
+}
+
 CLuaEventPacket::CLuaEventPacket()
 {
     m_ElementID = INVALID_ELEMENT_ID;
@@ -32,6 +37,9 @@ bool CLuaEventPacket::Read(NetBitStreamInterface& BitStream)
     {
         if (usNameLength < (MAX_EVENT_NAME_LENGTH - 1) && BitStream.ReadStringCharacters(m_strName, usNameLength) && BitStream.Read(m_ElementID))
         {
+            if (BitStream.GetNumberOfUnreadBits() > MAX_LUA_EVENT_ARGUMENTS_SIZE * 8)
+                return false;
+
             // Faster than using a constructor
             m_ArgumentsStore.DeleteArguments();
             if (!m_ArgumentsStore.ReadFromBitStream(BitStream))

--- a/Server/mods/deathmatch/logic/packets/CPlayerACInfoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerACInfoPacket.cpp
@@ -12,22 +12,31 @@
 #include "StdInc.h"
 #include "CPlayerACInfoPacket.h"
 
+namespace
+{
+    constexpr uchar MAX_PLAYER_ACINFO_ID_COUNT = 64;
+}
+
 bool CPlayerACInfoPacket::Read(NetBitStreamInterface& BitStream)
 {
     // Read type
     uchar ucNumItems = 0;
-    BitStream.Read(ucNumItems);
+    if (!BitStream.Read(ucNumItems) || ucNumItems > MAX_PLAYER_ACINFO_ID_COUNT)
+        return false;
+
+    m_IdList.clear();
+    bool bSeenIds[64] = {};
     for (uint i = 0; i < ucNumItems; i++)
     {
         uchar ucId;
-        if (!BitStream.Read(ucId))
+        if (!BitStream.Read(ucId) || ucId > 63 || bSeenIds[ucId])
             return false;
+
+        bSeenIds[ucId] = true;
         m_IdList.push_back(ucId);
     }
 
-    BitStream.Read(m_uiD3d9Size);
-    BitStream.ReadString(m_strD3d9MD5);
-    if (!BitStream.ReadString(m_strD3d9SHA256))
+    if (!BitStream.Read(m_uiD3d9Size) || !BitStream.ReadString(m_strD3d9MD5) || !BitStream.ReadString(m_strD3d9SHA256))
         return false;
 
     return true;

--- a/Server/mods/deathmatch/logic/packets/CPlayerDiagnosticPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerDiagnosticPacket.cpp
@@ -12,14 +12,61 @@
 #include "StdInc.h"
 #include "CPlayerDiagnosticPacket.h"
 
-bool CPlayerDiagnosticPacket::Read(NetBitStreamInterface& BitStream)
+namespace
 {
-    if (BitStream.ReadString(m_strMessage))
+    constexpr unsigned short MAX_PLAYER_DIAGNOSTIC_PACKET_LENGTH = 1024;
+    constexpr unsigned long long MAX_PLAYER_DIAGNOSTIC_LEVEL_VALUE = 0xFFFFFFFFULL;
+
+    bool ParsePlayerDiagnosticLevel(const std::string& strLevel, uint& uiLevel)
     {
-        SString strLevel;
-        m_strMessage.Split(",", &strLevel, &m_strMessage);
-        m_uiLevel = atoi(strLevel);
+        if (strLevel.empty() || strLevel.length() > 10)
+            return false;
+
+        unsigned long long ullValue = 0;
+        for (char c : strLevel)
+        {
+            if (c < '0' || c > '9')
+                return false;
+
+            ullValue = (ullValue * 10) + static_cast<unsigned long long>(c - '0');
+            if (ullValue > MAX_PLAYER_DIAGNOSTIC_LEVEL_VALUE)
+                return false;
+        }
+
+        uiLevel = static_cast<uint>(ullValue);
         return true;
     }
-    return false;
+}
+
+bool CPlayerDiagnosticPacket::Read(NetBitStreamInterface& BitStream)
+{
+    unsigned short usLength = 0;
+    if (!BitStream.Read(usLength) || !BitStream.CanReadNumberOfBytes(usLength) || usLength > MAX_PLAYER_DIAGNOSTIC_PACKET_LENGTH)
+        return false;
+
+    m_uiLevel = 0;
+    m_strMessage.clear();
+
+    if (usLength == 0)
+        return true;
+
+    std::string strPayload(usLength, '\0');
+    if (!BitStream.Read(&strPayload[0], usLength) || strPayload.find('\0') != std::string::npos)
+        return false;
+
+    const size_t uiCommaPos = strPayload.find(',');
+    if (uiCommaPos == std::string::npos)
+    {
+        // No level prefix in the payload. Keep level at 0 and store the message as-is.
+        m_strMessage = strPayload;
+        return true;
+    }
+
+    if (uiCommaPos > 0)
+        ParsePlayerDiagnosticLevel(strPayload.substr(0, uiCommaPos), m_uiLevel);
+
+    if (uiCommaPos + 1 < strPayload.length())
+        m_strMessage = strPayload.substr(uiCommaPos + 1);
+
+    return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CPlayerModInfoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerModInfoPacket.cpp
@@ -23,6 +23,14 @@ bool CPlayerModInfoPacket::Read(NetBitStreamInterface& BitStream)
     if (!BitStream.Read(uiCount))
         return false;
 
+    // Limit item count to prevent DoS via oversized payloads routed
+    // through the latent transfer path (CLatentReceiver). Without this
+    // cap, an attacker can send ~60K entries in a single 100MB latent
+    // packet, causing hundreds of thousands of heap allocations in
+    // Packet_PlayerModInfo and locking the main thread for seconds.
+    if (uiCount > 2048)
+        return false;
+
     // Read each item
     for (uint i = 0; i < uiCount; i++)
     {

--- a/Server/mods/deathmatch/logic/packets/CPlayerResourceStartPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerResourceStartPacket.cpp
@@ -16,7 +16,22 @@
 bool CPlayerResourceStartPacket::Read(NetBitStreamInterface& BitStream)
 {
     ushort usResourceNetId;
-    BitStream.Read(usResourceNetId);
+    if (!BitStream.Read(usResourceNetId))
+        return false;
+
+    if (BitStream.Can(eBitStreamVersion::OnPlayerResourceStartGeneration))
+    {
+        if (!BitStream.Read(m_uiStartGeneration))
+            return false;
+
+        m_bHasStartGeneration = true;
+    }
+    else
+    {
+        m_uiStartGeneration = 0;
+        m_bHasStartGeneration = false;
+    }
+
     m_pResource = g_pGame->GetResourceManager()->GetResourceFromNetID(usResourceNetId);
     return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CPlayerResourceStartPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerResourceStartPacket.h
@@ -26,7 +26,11 @@ public:
     bool Read(NetBitStreamInterface& BitStream);
 
     CResource* GetResource() const { return m_pResource; }
+    unsigned int GetStartGeneration() const { return m_uiStartGeneration; }
+    bool HasStartGeneration() const { return m_bHasStartGeneration; }
 
 private:
-    CResource* m_pResource;
+    CResource*   m_pResource{};
+    unsigned int m_uiStartGeneration{};
+    bool         m_bHasStartGeneration{};
 };

--- a/Server/mods/deathmatch/logic/packets/CResourceStartPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CResourceStartPacket.cpp
@@ -18,10 +18,11 @@
 #include "CResource.h"
 #include "CDummy.h"
 
-CResourceStartPacket::CResourceStartPacket(const char* szResourceName, CResource* pResource)
+CResourceStartPacket::CResourceStartPacket(const char* szResourceName, CResource* pResource, unsigned int uiStartCounter)
 {
     m_strResourceName = szResourceName;
     m_pResource = pResource;
+    m_uiStartCounter = uiStartCounter;
 }
 
 bool CResourceStartPacket::Write(NetBitStreamInterface& BitStream) const
@@ -75,6 +76,11 @@ bool CResourceStartPacket::Write(NetBitStreamInterface& BitStream) const
         if (BitStream.Version() >= 0x62)
         {
             BitStream.Write(m_pResource->GetDownloadPriorityGroup());
+        }
+
+        if (BitStream.Can(eBitStreamVersion::OnPlayerResourceStartGeneration))
+        {
+            BitStream.Write(m_uiStartCounter);
         }
 
         // Send the resource files info

--- a/Server/mods/deathmatch/logic/packets/CResourceStartPacket.h
+++ b/Server/mods/deathmatch/logic/packets/CResourceStartPacket.h
@@ -17,7 +17,7 @@
 class CResourceStartPacket final : public CPacket
 {
 public:
-    CResourceStartPacket(const char* szResourceName, class CResource* pResource);
+    CResourceStartPacket(const char* szResourceName, class CResource* pResource, unsigned int uiStartCounter);
 
     ePacketID     GetPacketID() const { return PACKET_ID_RESOURCE_START; };
     unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
@@ -25,6 +25,7 @@ public:
     bool Write(NetBitStreamInterface& BitStream) const;
 
 private:
-    std::string m_strResourceName;
-    CResource*  m_pResource;
+    std::string  m_strResourceName;
+    CResource*   m_pResource{};
+    unsigned int m_uiStartCounter{};
 };

--- a/Server/mods/deathmatch/logic/packets/CVehiclePuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CVehiclePuresyncPacket.cpp
@@ -165,6 +165,9 @@ bool CVehiclePuresyncPacket::Read(NetBitStreamInterface& BitStream)
                         CLuaArguments Arguments;
                         Arguments.PushNumber(fDeltaHealth);
                         pVehicle->CallEvent("onVehicleDamage", Arguments);
+                        // Skip health write if the event destroyed this vehicle.
+                        if (pVehicle->IsBeingDeleted())
+                            return false;
                     }
                 }
                 pVehicle->SetHealth(fHealth);
@@ -219,6 +222,8 @@ bool CVehiclePuresyncPacket::Read(NetBitStreamInterface& BitStream)
                                 CLuaArguments Arguments;
                                 Arguments.PushElement(pTowedByVehicle);
                                 pCurrentTrailer->CallEvent("onTrailerDetach", Arguments);
+                                if (pTowedByVehicle->IsBeingDeleted() || pTrailer->IsBeingDeleted())
+                                    return false;
                             }
 
                             // If something else is towing this trailer
@@ -236,6 +241,8 @@ bool CVehiclePuresyncPacket::Read(NetBitStreamInterface& BitStream)
                                 CLuaArguments Arguments;
                                 Arguments.PushElement(pCurrentVehicle);
                                 pTrailer->CallEvent("onTrailerDetach", Arguments);
+                                if (pTowedByVehicle->IsBeingDeleted() || pTrailer->IsBeingDeleted())
+                                    return false;
                             }
 
                             pTowedByVehicle->SetTowedVehicle(pTrailer);
@@ -245,6 +252,8 @@ bool CVehiclePuresyncPacket::Read(NetBitStreamInterface& BitStream)
                             CLuaArguments Arguments;
                             Arguments.PushElement(pTowedByVehicle);
                             bool bContinue = pTrailer->CallEvent("onTrailerAttach", Arguments);
+                            if (pTowedByVehicle->IsBeingDeleted() || pTrailer->IsBeingDeleted())
+                                return false;
 
                             // Attach or detach trailers depending on the event outcome
                             CVehicleTrailerPacket TrailerPacket(pTowedByVehicle, pTrailer, bContinue);
@@ -275,6 +284,9 @@ bool CVehiclePuresyncPacket::Read(NetBitStreamInterface& BitStream)
                     CLuaArguments Arguments;
                     Arguments.PushElement(pTowedByVehicle);
                     pCurrentTrailer->CallEvent("onTrailerDetach", Arguments);
+                    // Skip later vehicle writes if the event destroyed the vehicle.
+                    if (pVehicle->IsBeingDeleted())
+                        return false;
                 }
             }
 

--- a/Server/mods/deathmatch/utils/CHqComms.h
+++ b/Server/mods/deathmatch/utils/CHqComms.h
@@ -12,6 +12,8 @@
 
 #include "CStaticFunctionDefinitions.h"
 
+void NetServer_NotifyHqReachable(bool bReachable);
+
 enum
 {
     HQCOMMS_STAGE_NONE,
@@ -118,6 +120,7 @@ public:
         if (result.bSuccess)
         {
             m_Stage = HQCOMMS_STAGE_TIMER;
+            NetServer_NotifyHqReachable(true);
             CBitStream bitStream(result.pData, result.dataSize);
 
             // Process various parts of returned data
@@ -131,6 +134,7 @@ public:
         else
         {
             m_Stage = HQCOMMS_STAGE_TIMER;
+            NetServer_NotifyHqReachable(false);
         }
     }
 

--- a/Shared/mods/deathmatch/logic/CLatentReceiver.cpp
+++ b/Shared/mods/deathmatch/logic/CLatentReceiver.cpp
@@ -129,6 +129,15 @@ void CLatentReceiver::OnReceive(NetBitStreamInterface* pBitStream)
         if (uiFinalSize > 100 * 1024 * 1024)
             return OnReceiveError("uiFinalSize too large");
 
+        // CATEGORY_PACKET reassembles raw packet data and feeds it into
+        // the main packet dispatch (CGame::StaticProcessPacket). Without
+        // a tighter cap, an attacker can craft a 100MB payload targeting
+        // packet handlers that scale poorly with input size (e.g.
+        // CPlayerModInfoPacket). 10MB is well above any legitimate use.
+        constexpr uint LATENT_PACKET_MAX_SIZE = 10 * 1024 * 1024;
+        if (usCategory == CATEGORY_PACKET && uiFinalSize > LATENT_PACKET_MAX_SIZE)
+            return OnReceiveError("CATEGORY_PACKET payload too large");
+
         activeRx.usId = usId;
         activeRx.bReceiveStarted = true;
         activeRx.usCategory = usCategory;

--- a/Shared/mods/deathmatch/logic/CLatentTransferManager.cpp
+++ b/Shared/mods/deathmatch/logic/CLatentTransferManager.cpp
@@ -407,13 +407,24 @@ bool DoSendPacket(unsigned char ucPacketID, NetPlayerID remoteId, NetBitStreamIn
 
 bool DoStaticProcessPacket(unsigned char ucPacketID, NetPlayerID remoteId, NetBitStreamInterface* pBitStream, ushort usResourceNetId)
 {
-    // Check if latent packet should be ignored
-    if (usResourceNetId != 0xFFFF)
-    {
-        CResource* pResource = g_pGame->GetResourceManager()->GetResourceFromNetID(usResourceNetId);
-        if (!pResource)
-            return true;
-    }
+    // triggerLatentServerEvent is the only legitimate client-to-server latent
+    // path. It always sends PACKET_ID_LUA_EVENT with a valid resource net ID.
+    // Reject any other packet ID to prevent arbitrary packet handler dispatch
+    // via the latent transfer channel (e.g. routing PACKET_ID_PLAYER_MODINFO
+    // through a 100MB reassembled buffer to cause an unbounded heap storm).
+    if (ucPacketID != PACKET_ID_LUA_EVENT)
+        return false;
+
+    // The 0xFFFF sentinel skips the resource ownership check. Clients must
+    // never use it - legitimate triggerLatentServerEvent calls always carry
+    // the resource net ID of the Lua VM that originated the call.
+    if (usResourceNetId == 0xFFFF)
+        return false;
+
+    CResource* pResource = g_pGame->GetResourceManager()->GetResourceFromNetID(usResourceNetId);
+    if (!pResource)
+        return true;
+
     return CGame::StaticProcessPacket(ucPacketID, remoteId, pBitStream, NULL);
 }
 

--- a/Shared/sdk/net/bitstream.h
+++ b/Shared/sdk/net/bitstream.h
@@ -628,6 +628,10 @@ enum class eBitStreamVersion : unsigned short
     // 2025-06-05
     Glitch_VehicleRapidStop,
 
+    // Add resource start generation to onPlayerResourceStart ack
+    // 2026-04-06
+    OnPlayerResourceStartGeneration,
+
     // This allows us to automatically increment the BitStreamVersion when things are added to this enum.
     // Make sure you only add things above this comment.
     Next,


### PR DESCRIPTION
Apply the same set of security fixes to release/1.6.0 as we did on master on July 31st. Note that there are semantic differences for release/1.6.0 due to base code divergence.

This is done as one lump commit to backport them, but for reference, they were PR's on master, full list of these PR's is here:

<img width="998" height="974" alt="merges" src="https://github.com/user-attachments/assets/8125b8dc-9bf1-4d7c-af99-8f9dd32f49ab" />
