### PR TITLE
Fix dead peds replaying their death animation on stream in

### DIFF
--- a/Client/game_sa/CPedSA.h
+++ b/Client/game_sa/CPedSA.h
@@ -483,6 +483,7 @@ public:
 
     CEntitySAInterface* GetTargetedObject() const override { return GetPedInterface()->pTargetedObject; }
     PedState            GetPedState() const override { return static_cast<PedState>(GetPedInterface()->pedState); }
+    void                SetPedState(PedState state) override { GetPedInterface()->pedState = static_cast<int>(state); }
 
     void GetAttachedSatchels(std::vector<SSatchelsData>& satchelsList) const override;
 

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -161,6 +161,9 @@ void CClientPed::Init(CClientManager* pManager, unsigned long ulModelID, bool bI
     m_fHealth = 100.0f;
     m_armor = 0.0f;
     m_bDead = false;
+    // Kill() defaults; poses a ped that was already dead before we ever saw it alive.
+    m_deathAnimGroup = 0;
+    m_deathAnimID = 15;
     m_bWorldIgnored = false;
     m_fCurrentRotation = 0.0f;
     m_fMoveSpeed = 0.0f;
@@ -1889,6 +1892,20 @@ bool CClientPed::IsDead()
     return m_bDead;
 }
 
+void CClientPed::FreezeDeathAnimationOnLastFrame()
+{
+    std::unique_ptr<CAnimBlendAssociation> pAnimAssoc = BlendAnimation(m_deathAnimGroup, m_deathAnimID, 1000.0f);
+    if (!pAnimAssoc)
+        return;
+
+    // Full blend amount applies the pose on this frame instead of easing in from the idle the recreated
+    // ped starts on. Death animations don't loop, so full progress clamps to the last frame and a zero
+    // speed holds it there.
+    pAnimAssoc->SetBlendAmount(1.0f);
+    pAnimAssoc->SetCurrentProgress(1.0f);
+    pAnimAssoc->SetCurrentSpeed(0.0f);
+}
+
 void CClientPed::BeHit(CClientPed* pClientPedAttacker, ePedPieceTypes hitBodyPart, int hitBodySide, int weaponId)
 {
     CPlayerPed* pPedAttacker = pClientPedAttacker->GetGamePlayer();
@@ -1904,8 +1921,10 @@ void CClientPed::BeHit(CClientPed* pClientPedAttacker, ePedPieceTypes hitBodyPar
 
 void CClientPed::Kill(eWeaponType weaponType, unsigned char ucBodypart, bool bStealth, bool bSetDirectlyDead, AssocGroupId animGroup, AnimationId animID)
 {
-    // Don't change task if already dead or dying
-    if (m_pPlayerPed && !IsDead() && !IsDying())
+    // Don't change task if already dead or dying. bSetDirectlyDead restores the dead state onto a ped
+    // the streamer just recreated; that ped holds no tasks yet, while IsDead() still reports the cached
+    // m_bDead left over from the original death and would veto giving it the dead task.
+    if (m_pPlayerPed && !IsDying() && (bSetDirectlyDead || !IsDead()))
     {
         // Do we have the in_water task?
         CTask* pTask = m_pTaskManager->GetTask(TASK_PRIORITY_EVENT_RESPONSE_NONTEMP);
@@ -1925,12 +1944,16 @@ void CClientPed::Kill(eWeaponType weaponType, unsigned char ucBodypart, bool bSt
 
         if (bSetDirectlyDead)
         {
-            // TODO: Avoid the animation, try to make it go directly to the last animation frame.
             pTask = g_pGame->GetTasks()->CreateTaskSimpleDead(GetTickCount32(), true);
             if (pTask)
             {
                 pTask->SetAsPedTask(m_pPlayerPed, TASK_PRIORITY_DEFAULT);
             }
+
+            // The task only marks the ped dead on its next update and never poses one killed on foot,
+            // leaving the game free to run a death sequence of its own first.
+            m_pPlayerPed->SetPedState(PedState::PED_DEAD);
+            FreezeDeathAnimationOnLastFrame();
         }
         else if (bStealth)
         {
@@ -1973,6 +1996,13 @@ void CClientPed::Kill(eWeaponType weaponType, unsigned char ucBodypart, bool bSt
     // Clear the targeting marker so it doesn't stay on screen after death
     if (m_pPlayerPed)
         m_pPlayerPed->SetTargetedEntity(nullptr);
+
+    // Kept here rather than read back off the ped, which may be streamed out when the pose is restored.
+    if (!bSetDirectlyDead)
+    {
+        m_deathAnimGroup = animGroup;
+        m_deathAnimID = animID;
+    }
 
     m_bDead = true;
 }

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -703,7 +703,6 @@ public:
     float                                    m_fHealth;
     float                                    m_armor;
     bool                                     m_bDead;
-    // Animation this ped died with; restores its final pose when the streamer recreates it.
     AssocGroupId                             m_deathAnimGroup;
     AnimationId                              m_deathAnimID;
     bool                                     m_bWorldIgnored;

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -293,6 +293,8 @@ public:
     void SetIsDead(bool bDead) noexcept { m_bDead = bDead; };
     void Kill(eWeaponType weaponType, unsigned char ucBodypart, bool bStealth = false, bool bSetDirectlyDead = false, AssocGroupId animGroup = 0,
               AnimationId animID = 15);
+    // Holds the death animation on its last frame so a recreated ped is posed at once.
+    void FreezeDeathAnimationOnLastFrame();
     void StealthKill(CClientPed* pPed);
     void BeHit(CClientPed* pClientPedAttacker, ePedPieceTypes hitBodyPart, int hitBodySide, int weaponId);
 
@@ -701,6 +703,9 @@ public:
     float                                    m_fHealth;
     float                                    m_armor;
     bool                                     m_bDead;
+    // Animation this ped died with; restores its final pose when the streamer recreates it.
+    AssocGroupId                             m_deathAnimGroup;
+    AnimationId                              m_deathAnimID;
     bool                                     m_bWorldIgnored;
     float                                    m_fCurrentRotation;
     float                                    m_fMoveSpeed;

--- a/Client/sdk/game/CPed.h
+++ b/Client/sdk/game/CPed.h
@@ -306,6 +306,7 @@ public:
 
     virtual CEntitySAInterface* GetTargetedObject() const = 0;
     virtual PedState            GetPedState() const = 0;
+    virtual void                SetPedState(PedState state) = 0;
 
     virtual void GetAttachedSatchels(std::vector<SSatchelsData>& satchelsList) const = 0;
 


### PR DESCRIPTION
#### Summary

The client recreates a ped's game entity every time it streams in. When the ped was already dead, `CClientPed::Kill` refused to give the new entity its dead task, so the ped came back alive at zero health and the game ran a death of its own, replaying the animation and shifting the ped forward on every stream in. The dead state is now restored directly on the recreated ped.

#### Motivation

Resolves #965.

`_CreateModel` calls `Kill(..., bSetDirectlyDead = true)` to put the dead state back, guarded by `!IsDead()`. `IsDead()` reads the game ped's task at `TASK_PRIORITY_EVENT_RESPONSE_NONTEMP` and falls back to the cached `m_bDead` when there is none. A freshly created game entity holds no tasks at all, so the guard read the stale `m_bDead` left over from the original death and skipped creating the dead task. That left a ped at zero health with no death task, so the game generated its own death, ran `CTaskComplexDie` and applied its root translation again on every stream in, which is where both the repeated animation and the drift came from.

A ped that is already dead the first time it streams in was never affected, because the entity add path only calls `SetHealth` and never `SetIsDead`, so `m_bDead` is still false and the guard passes.

Two further details, both confirmed against `CTaskSimpleDead::ProcessPed` (`0x630600`): it only sets `PEDSTATE_DEAD` on its first update a frame later, which left the game a window to start a death of its own first, and it does not pose a ped that died on foot. The ped state is now set immediately, and `Kill` records the animation group and id from the real death so the restore can hold that animation on its last frame, which is what the `TODO` removed here was asking for.

#### Test plan

```lua
local ped = createPed(192, 0, 0, 3)
killPed(ped)
```

Stand next to the ped, then switch dimension away and back several times with `setElementDimension(localPlayer, 1)` and `setElementDimension(localPlayer, 0)`. Before this change the ped stood up, died again and crept forward on every switch. After it, the ped streams in already lying in its final pose and stays on the spot it died on.

Also checked that a normal death still plays its full animation, that a ped which died while it was streamed out appears dead without animating.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit by commit.