### PR TITLE
Fix engineImageLink not applying to weapon models

### DIFF
--- a/Client/mods/deathmatch/logic/CClientIMG.cpp
+++ b/Client/mods/deathmatch/logic/CClientIMG.cpp
@@ -224,6 +224,11 @@ bool CClientIMG::LinkModel(unsigned int uiModelID, size_t uiFileID)
     if (CClientVehicleManager::IsValidModel(uiModelID))
         g_pClientGame->GetVehicleManager()->RestreamVehicles(static_cast<unsigned short>(uiModelID));
 
+    // Weapon models already in a ped's hand keep their old RW clump until the weapon slot is
+    // re-requested, same as vehicles above (see CClientDFF::ReplaceWeaponModel for the equivalent case)
+    if (CClientPedManager::IsValidWeaponModel(uiModelID))
+        g_pClientGame->GetPedManager()->RestreamWeapon(static_cast<unsigned short>(uiModelID));
+
     g_pGame->GetStreaming()->SetStreamingInfo(uiModelID, m_ucArchiveID, pFileInfo->uiOffset, pFileInfo->usSize);
 
     return true;


### PR DESCRIPTION
#### Summary

`CClientIMG::LinkModel` now restreams weapon models the same way it already does for vehicle models.

<img width="1366" height="768" alt="mta-screen_2026-08-03_13-52-50" src="https://github.com/user-attachments/assets/e1863715-2a20-4145-96b0-c4e4d9281b5c" />


#### Motivation

Resolves #5145.

`engineImageLinkDFF`/`engineImageLinkTXD` link a new model through `CClientIMG::LinkModel`, which already restreams vehicle models so they pick up the new one. Weapon models were missing that call, so a weapon a ped was already holding kept its old RW clump and only picked up the replacement once something else happened to restream it. `CClientDFF`, `CClientTXD` and `CClientGame` already call `CClientPedManager::RestreamWeapon` for the same case, so `CClientIMG` now does the same.

#### Test plan

[imgweapon.zip](https://github.com/user-attachments/files/30670283/imgweapon.zip)

With a ped already holding a M4, linking a replacement dff for model 356 now swaps the held weapon model.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit by commit.