### PR TITLE
Add per-element, per-model and per-type stream distance functions

### DIFF
--- a/Client/mods/deathmatch/logic/CClientManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientManager.cpp
@@ -303,12 +303,13 @@ void CClientManager::OnLowLODElementDestroyed()
         g_pCore->GetMultiplayer()->SetLODSystemEnabled(false);
 }
 
-// Markers have no model, so they can only be targeted by an element type override
+// Markers and searchlights have no model, so they can only be targeted by an element type override
 static std::optional<std::uint16_t> GetStreamElementModel(CClientStreamElement* pElement)
 {
     switch (pElement->GetType())
     {
         case CCLIENTOBJECT:
+        case CCLIENTWEAPON:
             return static_cast<CClientObject*>(pElement)->GetModel();
         case CCLIENTVEHICLE:
             return static_cast<CClientVehicle*>(pElement)->GetModel();
@@ -324,6 +325,7 @@ static std::optional<std::uint16_t> GetStreamElementModel(CClientStreamElement* 
 
 void CClientManager::ForEachStreamElement(const std::function<void(CClientStreamElement*)>& callback)
 {
+    // Weapons are CClientObject derived and live in the object list as well
     for (CClientObject* pObject : m_pObjectManager->GetObjects())
         callback(pObject);
 
@@ -339,13 +341,19 @@ void CClientManager::ForEachStreamElement(const std::function<void(CClientStream
 
     for (CClientMarker* pMarker : m_pMarkerManager->m_Markers)
         callback(pMarker);
+
+    for (CClientSearchLight* pSearchLight : m_pPointLightsManager->m_SearchLightList)
+        callback(pSearchLight);
 }
 
 CClientStreamer* CClientManager::GetStreamerForType(eClientEntityType type) const
 {
     switch (type)
     {
+        // Low LOD objects live on a separate streamer, but the regular object radius is the more
+        // useful answer for a script asking about "object"
         case CCLIENTOBJECT:
+        case CCLIENTWEAPON:
             return m_pObjectStreamer;
         case CCLIENTVEHICLE:
             return m_pVehicleStreamer;
@@ -356,6 +364,8 @@ CClientStreamer* CClientManager::GetStreamerForType(eClientEntityType type) cons
             return m_pPickupStreamer;
         case CCLIENTMARKER:
             return m_pMarkerStreamer;
+        case CCLIENTSEARCHLIGHT:
+            return m_pLightStreamer;
         default:
             return nullptr;
     }

--- a/Client/mods/deathmatch/logic/CClientManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientManager.cpp
@@ -302,3 +302,133 @@ void CClientManager::OnLowLODElementDestroyed()
     if (m_iNumLowLODElements == 0)
         g_pCore->GetMultiplayer()->SetLODSystemEnabled(false);
 }
+
+// Markers have no model, so they can only be targeted by an element type override
+static std::optional<std::uint16_t> GetStreamElementModel(CClientStreamElement* pElement)
+{
+    switch (pElement->GetType())
+    {
+        case CCLIENTOBJECT:
+            return static_cast<CClientObject*>(pElement)->GetModel();
+        case CCLIENTVEHICLE:
+            return static_cast<CClientVehicle*>(pElement)->GetModel();
+        case CCLIENTPED:
+        case CCLIENTPLAYER:
+            return static_cast<std::uint16_t>(static_cast<CClientPed*>(pElement)->GetModel());
+        case CCLIENTPICKUP:
+            return static_cast<CClientPickup*>(pElement)->GetModel();
+        default:
+            return std::nullopt;
+    }
+}
+
+void CClientManager::ForEachStreamElement(const std::function<void(CClientStreamElement*)>& callback)
+{
+    for (CClientObject* pObject : m_pObjectManager->GetObjects())
+        callback(pObject);
+
+    for (auto iter = m_pVehicleManager->IterBegin(); iter != m_pVehicleManager->IterEnd(); ++iter)
+        callback(*iter);
+
+    // Players are CClientPed derived and live in the ped list as well
+    for (auto iter = m_pPedManager->IterBegin(); iter != m_pPedManager->IterEnd(); ++iter)
+        callback(*iter);
+
+    for (auto iter = m_pPickupManager->IterBegin(); iter != m_pPickupManager->IterEnd(); ++iter)
+        callback(*iter);
+
+    for (CClientMarker* pMarker : m_pMarkerManager->m_Markers)
+        callback(pMarker);
+}
+
+CClientStreamer* CClientManager::GetStreamerForType(eClientEntityType type) const
+{
+    switch (type)
+    {
+        case CCLIENTOBJECT:
+            return m_pObjectStreamer;
+        case CCLIENTVEHICLE:
+            return m_pVehicleStreamer;
+        case CCLIENTPED:
+        case CCLIENTPLAYER:
+            return m_pPlayerStreamer;
+        case CCLIENTPICKUP:
+            return m_pPickupStreamer;
+        case CCLIENTMARKER:
+            return m_pMarkerStreamer;
+        default:
+            return nullptr;
+    }
+}
+
+float CClientManager::ResolveStreamDistance(CClientStreamElement* pElement) const
+{
+    if (pElement->HasCustomStreamDistance())
+        return pElement->GetCustomStreamDistance();
+
+    if (!m_ModelStreamDistances.empty())
+    {
+        if (std::optional<std::uint16_t> model = GetStreamElementModel(pElement))
+        {
+            auto iter = m_ModelStreamDistances.find(model.value());
+            if (iter != m_ModelStreamDistances.end())
+                return iter->second;
+        }
+    }
+
+    auto iter = m_TypeStreamDistances.find(pElement->GetType());
+    if (iter != m_TypeStreamDistances.end())
+        return iter->second;
+
+    return pElement->GetStreamer()->GetDefaultStreamDistance();
+}
+
+bool CClientManager::SetTypeStreamDistance(eClientEntityType type, std::optional<float> distance)
+{
+    if (distance.has_value())
+        m_TypeStreamDistances[type] = distance.value();
+    else if (m_TypeStreamDistances.erase(type) == 0)
+        return false;
+
+    ForEachStreamElement(
+        [type](CClientStreamElement* pElement)
+        {
+            if (pElement->GetType() == type)
+                pElement->RefreshStreamDistance();
+        });
+
+    return true;
+}
+
+float CClientManager::GetTypeStreamDistance(eClientEntityType type) const
+{
+    auto iter = m_TypeStreamDistances.find(type);
+    if (iter != m_TypeStreamDistances.end())
+        return iter->second;
+
+    CClientStreamer* pStreamer = GetStreamerForType(type);
+    return pStreamer ? pStreamer->GetDefaultStreamDistance() : 0.0f;
+}
+
+bool CClientManager::SetModelStreamDistance(std::uint16_t usModel, std::optional<float> distance)
+{
+    if (distance.has_value())
+        m_ModelStreamDistances[usModel] = distance.value();
+    else if (m_ModelStreamDistances.erase(usModel) == 0)
+        return false;
+
+    ForEachStreamElement(
+        [usModel](CClientStreamElement* pElement)
+        {
+            if (GetStreamElementModel(pElement) == usModel)
+                pElement->RefreshStreamDistance();
+        });
+
+    return true;
+}
+
+float CClientManager::GetModelStreamDistance(std::uint16_t usModel) const
+{
+    auto iter = m_ModelStreamDistances.find(usModel);
+    return iter != m_ModelStreamDistances.end() ? iter->second : 0.0f;
+}

--- a/Client/mods/deathmatch/logic/CClientManager.h
+++ b/Client/mods/deathmatch/logic/CClientManager.h
@@ -45,6 +45,10 @@ class CClientManager;
 #include "CClientIMGManager.h"
 #include "CClientBuildingManager.h"
 
+#include <functional>
+#include <optional>
+#include <unordered_map>
+
 class CClientProjectileManager;
 class CClientExplosionManager;
 
@@ -114,7 +118,18 @@ public:
     void OnLowLODElementCreated();
     void OnLowLODElementDestroyed();
 
+    // Stream distance overrides, resolved per element as element > model > element type > streamer default
+    float            ResolveStreamDistance(CClientStreamElement* pElement) const;
+    CClientStreamer* GetStreamerForType(eClientEntityType type) const;
+
+    bool  SetTypeStreamDistance(eClientEntityType type, std::optional<float> distance);
+    float GetTypeStreamDistance(eClientEntityType type) const;
+    bool  SetModelStreamDistance(std::uint16_t usModel, std::optional<float> distance);
+    float GetModelStreamDistance(std::uint16_t usModel) const;
+
 private:
+    void ForEachStreamElement(const std::function<void(CClientStreamElement*)>& callback);
+
     CAntiCheat                   m_AntiCheat;
     CClientCamera*               m_pCamera;
     CClientColModelManager*      m_pColModelManager;
@@ -157,4 +172,7 @@ private:
     bool                         m_bBeingDeleted;
     bool                         m_bGameUnloadedFlag;
     int                          m_iNumLowLODElements;
+
+    std::unordered_map<int, float>           m_TypeStreamDistances;
+    std::unordered_map<std::uint16_t, float> m_ModelStreamDistances;
 };

--- a/Client/mods/deathmatch/logic/CClientMarker.cpp
+++ b/Client/mods/deathmatch/logic/CClientMarker.cpp
@@ -38,6 +38,8 @@ CClientMarker::CClientMarker(CClientManager* pManager, ElementID ID, int iMarker
     // Add us to marker manager list
     m_pMarkerManager->AddToList(this);
     UpdateSpatialData();
+
+    RefreshStreamDistance();
 }
 
 CClientMarker::~CClientMarker()

--- a/Client/mods/deathmatch/logic/CClientModelCacheManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientModelCacheManager.cpp
@@ -10,18 +10,20 @@
 #include "StdInc.h"
 #include "../../../core/CModelCacheManager.h"
 
-#define PED_STREAM_IN_DISTANCE             (250)
-#define VEHICLE_STREAM_IN_DISTANCE         (250)
-#define STREAMER_STREAM_OUT_EXTRA_DISTANCE (50)
-
-#define PED_MAX_STREAM_DISTANCE    (PED_STREAM_IN_DISTANCE + STREAMER_STREAM_OUT_EXTRA_DISTANCE)
-#define PED_MAX_STREAM_DISTANCE_SQ (PED_MAX_STREAM_DISTANCE * PED_MAX_STREAM_DISTANCE)
-
-#define VEHICLE_MAX_STREAM_DISTANCE    (VEHICLE_STREAM_IN_DISTANCE + STREAMER_STREAM_OUT_EXTRA_DISTANCE)
-#define VEHICLE_MAX_STREAM_DISTANCE_SQ (VEHICLE_MAX_STREAM_DISTANCE * VEHICLE_MAX_STREAM_DISTANCE)
-
 #define PED_MAX_VELOCITY     (10)
 #define VEHICLE_MAX_VELOCITY (10)
+
+// Caching has to happen before the streamer asks for a model, so follow the streamers' actual
+// ranges rather than their defaults - scripts can widen them with a custom stream distance
+static float GetPedStreamInDistance()
+{
+    return g_pClientGame->GetManager()->GetPlayerStreamer()->GetLargestStreamDistance() + CClientStreamer::STREAM_OUT_EXTRA_DISTANCE;
+}
+
+static float GetVehicleStreamInDistance()
+{
+    return g_pClientGame->GetManager()->GetVehicleStreamer()->GetLargestStreamDistance() + CClientStreamer::STREAM_OUT_EXTRA_DISTANCE;
+}
 
 ///////////////////////////////////////////////////////////////
 //
@@ -162,8 +164,10 @@ void CClientModelCacheManagerImpl::DoPulse()
 ///////////////////////////////////////////////////////////////
 void CClientModelCacheManagerImpl::DoPulsePedModels()
 {
+    const float fPedStreamInDistance = GetPedStreamInDistance();
+
     // Scale up query radius to compensate for the camera speed and possible ped speeds
-    float fPedQueryRadius = PED_STREAM_IN_DISTANCE + STREAMER_STREAM_OUT_EXTRA_DISTANCE + m_fSmoothCameraSpeed * 2 + PED_MAX_VELOCITY * 2;
+    float fPedQueryRadius = fPedStreamInDistance + m_fSmoothCameraSpeed * 2 + PED_MAX_VELOCITY * 2;
 
     // Get all entities within range
     CClientEntityResult result;
@@ -189,8 +193,8 @@ void CClientModelCacheManagerImpl::DoPulsePedModels()
 
     // Compile a list of ped models which should be cached
     std::map<ushort, float> newNeedCacheList;
-    ProcessPlayerList(newNeedCacheList, playerList, Square(PED_STREAM_IN_DISTANCE + STREAMER_STREAM_OUT_EXTRA_DISTANCE + m_fSmoothCameraSpeed * 2));
-    ProcessPedList(newNeedCacheList, pedList, Square(PED_STREAM_IN_DISTANCE + STREAMER_STREAM_OUT_EXTRA_DISTANCE + m_fSmoothCameraSpeed * 2));
+    ProcessPlayerList(newNeedCacheList, playerList, Square(fPedStreamInDistance + m_fSmoothCameraSpeed * 2));
+    ProcessPedList(newNeedCacheList, pedList, Square(fPedStreamInDistance + m_fSmoothCameraSpeed * 2));
 
     // Apply desired caching
     m_pCoreModelCacheManager->UpdatePedModelCaching(newNeedCacheList);
@@ -205,8 +209,10 @@ void CClientModelCacheManagerImpl::DoPulsePedModels()
 ///////////////////////////////////////////////////////////////
 void CClientModelCacheManagerImpl::DoPulseVehicleModels()
 {
+    const float fVehicleStreamInDistance = GetVehicleStreamInDistance();
+
     // Scale up query radius to compensate for the camera speed and possible vehicle speeds
-    float fVehicleQueryRadius = VEHICLE_STREAM_IN_DISTANCE + STREAMER_STREAM_OUT_EXTRA_DISTANCE + m_fSmoothCameraSpeed * 2 + VEHICLE_MAX_VELOCITY * 2;
+    float fVehicleQueryRadius = fVehicleStreamInDistance + m_fSmoothCameraSpeed * 2 + VEHICLE_MAX_VELOCITY * 2;
 
     // Get all entities within range
     CClientEntityResult result;
@@ -227,7 +233,7 @@ void CClientModelCacheManagerImpl::DoPulseVehicleModels()
 
     // Compile a list of vehicle models which should be cached
     std::map<ushort, float> newNeedCacheList;
-    ProcessVehicleList(newNeedCacheList, vehicleList, Square(VEHICLE_STREAM_IN_DISTANCE + STREAMER_STREAM_OUT_EXTRA_DISTANCE + m_fSmoothCameraSpeed * 2));
+    ProcessVehicleList(newNeedCacheList, vehicleList, Square(fVehicleStreamInDistance + m_fSmoothCameraSpeed * 2));
 
     // Apply desired caching
     m_pCoreModelCacheManager->UpdateVehicleModelCaching(newNeedCacheList);

--- a/Client/mods/deathmatch/logic/CClientModelCacheManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientModelCacheManager.cpp
@@ -13,8 +13,8 @@
 #define PED_MAX_VELOCITY     (10)
 #define VEHICLE_MAX_VELOCITY (10)
 
-// Caching has to happen before the streamer asks for a model, so follow the streamers' actual
-// ranges rather than their defaults - scripts can widen them with a custom stream distance
+// Follow the streamers' actual ranges rather than their defaults, otherwise a custom stream
+// distance would stream elements in before their model was ever cached
 static float GetPedStreamInDistance()
 {
     return g_pClientGame->GetManager()->GetPlayerStreamer()->GetLargestStreamDistance() + CClientStreamer::STREAM_OUT_EXTRA_DISTANCE;

--- a/Client/mods/deathmatch/logic/CClientObject.cpp
+++ b/Client/mods/deathmatch/logic/CClientObject.cpp
@@ -54,6 +54,8 @@ CClientObject::CClientObject(CClientManager* pManager, ElementID ID, unsigned sh
     if (m_bIsLowLod)
         m_pManager->OnLowLODElementCreated();
     m_clientModel = pManager->GetModelManager()->FindModelByID(usModel);
+
+    RefreshStreamDistance();
 }
 
 CClientObject::~CClientObject()
@@ -286,6 +288,7 @@ void CClientObject::SetModel(unsigned short usModel)
             m_clientModel = nullptr;
         m_pModelInfo = g_pGame->GetModelInfo(usModel);
         UpdateSpatialData();
+        RefreshStreamDistance();
 
         // Create the object if we're streamed in
         if (IsStreamedIn())

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -85,6 +85,8 @@ CClientPed::CClientPed(CClientManager* pManager, unsigned long ulModelID, Elemen
 
     // Add it to our ped manager
     pManager->GetPedManager()->AddToList(this);
+
+    RefreshStreamDistance();
 }
 
 CClientPed::CClientPed(CClientManager* pManager, unsigned long ulModelID, ElementID ID, bool bIsLocalPlayer)
@@ -1072,6 +1074,7 @@ bool CClientPed::SetModel(unsigned long ulModel, bool bTemp)
             m_ulModel = ulModel;
             m_pModelInfo = g_pGame->GetModelInfo(ulModel);
             UpdateSpatialData();
+            RefreshStreamDistance();
 
             // Are we loaded?
             if (m_pPlayerPed)

--- a/Client/mods/deathmatch/logic/CClientPickup.cpp
+++ b/Client/mods/deathmatch/logic/CClientPickup.cpp
@@ -35,6 +35,8 @@ CClientPickup::CClientPickup(CClientManager* pManager, ElementID ID, unsigned sh
     m_fAmount = 0.0f;
     m_usAmmo = 0;
 
+    RefreshStreamDistance();
+
     // Make sure our streamer knows where we are to start with
     UpdateStreamPosition(m_vecPosition = vecPosition);
 }
@@ -90,6 +92,7 @@ void CClientPickup::SetModel(unsigned short usModel)
         // Set the model and recreate the pickup
         m_usModel = usModel;
         UpdateSpatialData();
+        RefreshStreamDistance();
         ReCreate();
     }
 }

--- a/Client/mods/deathmatch/logic/CClientPlayer.cpp
+++ b/Client/mods/deathmatch/logic/CClientPlayer.cpp
@@ -83,6 +83,8 @@ CClientPlayer::CClientPlayer(CClientManager* pManager, ElementID ID, bool bIsLoc
     // Add us to the player list
     m_pManager->GetPlayerManager()->AddToList(this);
 
+    RefreshStreamDistance();
+
 #ifdef MTA_DEBUG
     m_bShowingWepdata = false;
 #endif

--- a/Client/mods/deathmatch/logic/CClientSearchLight.cpp
+++ b/Client/mods/deathmatch/logic/CClientSearchLight.cpp
@@ -16,6 +16,8 @@ CClientSearchLight::CClientSearchLight(CClientManager* pManager, ElementID ID) :
     pManager->GetPointLightsManager()->AddToSearchLightList(this);
 
     SetTypeName("searchlight");
+
+    RefreshStreamDistance();
 }
 
 CClientSearchLight::~CClientSearchLight()

--- a/Client/mods/deathmatch/logic/CClientStreamElement.cpp
+++ b/Client/mods/deathmatch/logic/CClientStreamElement.cpp
@@ -55,8 +55,6 @@ void CClientStreamElement::ApplyStreamDistance(float fDistance)
 
 void CClientStreamElement::RefreshStreamDistance()
 {
-    // Derived constructors assign m_pManager before calling us, but keep the streamer default
-    // if that ever stops being true rather than dereferencing null
     if (!m_pManager)
         return;
 
@@ -65,9 +63,6 @@ void CClientStreamElement::RefreshStreamDistance()
         return;
 
     ApplyStreamDistance(fResolved);
-
-    // The streamer keeps elements reaching beyond its own radius permanently active,
-    // so it has to re-evaluate that classification
     m_pStreamer->OnElementStreamDistanceChanged(this);
 }
 

--- a/Client/mods/deathmatch/logic/CClientStreamElement.cpp
+++ b/Client/mods/deathmatch/logic/CClientStreamElement.cpp
@@ -18,11 +18,17 @@ CClientStreamElement::CClientStreamElement(CClientStreamer* pStreamer, ElementID
     m_pStreamRow = NULL;
     m_pStreamSector = NULL;
     m_fExpDistance = 0.0f;
+    m_fStreamPriority = 0.0f;
+    m_fCustomStreamDistance = 0.0f;
     m_bStreamedIn = false;
     m_bAttemptingToStreamIn = false;
     m_lastStreamOutTime = 0u;
     m_usStreamReferences = 0;
     m_usStreamReferencesScript = 0;
+
+    // AddElement() already needs a usable range, but our type and model are only assigned by the
+    // derived constructor, which calls RefreshStreamDistance() once it can resolve overrides.
+    ApplyStreamDistance(m_pStreamer->GetDefaultStreamDistance());
     m_pStreamer->AddElement(this);
 
     m_fCachedRadius = 0;
@@ -33,6 +39,46 @@ CClientStreamElement::CClientStreamElement(CClientStreamer* pStreamer, ElementID
 CClientStreamElement::~CClientStreamElement()
 {
     m_pStreamer->RemoveElement(this);
+}
+
+void CClientStreamElement::ApplyStreamDistance(float fDistance)
+{
+    m_fStreamDistance = fDistance;
+    m_fStreamDistanceExp = fDistance * fDistance;
+
+    // Mirror the streamer's stream-out hysteresis so custom ranges don't flicker at the border
+    const float fThreshold = fDistance + CClientStreamer::STREAM_OUT_EXTRA_DISTANCE;
+    m_fStreamThresholdExp = fThreshold * fThreshold;
+
+    m_fInvStreamDistanceExp = (m_fStreamDistanceExp > 0.0f) ? (1.0f / m_fStreamDistanceExp) : 0.0f;
+}
+
+void CClientStreamElement::RefreshStreamDistance()
+{
+    // Derived constructors assign m_pManager before calling us, but keep the streamer default
+    // if that ever stops being true rather than dereferencing null
+    if (!m_pManager)
+        return;
+
+    const float fResolved = m_pManager->ResolveStreamDistance(this);
+    if (fResolved == m_fStreamDistance)
+        return;
+
+    ApplyStreamDistance(fResolved);
+
+    // The streamer keeps elements reaching beyond its own radius permanently active,
+    // so it has to re-evaluate that classification
+    m_pStreamer->OnElementStreamDistanceChanged(this);
+}
+
+void CClientStreamElement::SetCustomStreamDistance(std::optional<float> distance)
+{
+    const float fCustom = distance.value_or(0.0f);
+    if (fCustom == m_fCustomStreamDistance)
+        return;
+
+    m_fCustomStreamDistance = fCustom;
+    RefreshStreamDistance();
 }
 
 void CClientStreamElement::UpdateStreamPosition(const CVector& vecPosition)

--- a/Client/mods/deathmatch/logic/CClientStreamElement.h
+++ b/Client/mods/deathmatch/logic/CClientStreamElement.h
@@ -12,6 +12,7 @@
 
 #include "CClientEntity.h"
 #include <cstdint>
+#include <optional>
 class CClientStreamer;
 class CClientStreamSector;
 class CClientStreamSectorRow;
@@ -47,6 +48,24 @@ public:
     virtual CSphere         GetWorldBoundingSphere();
     float                   GetDistanceToBoundingBoxSquared(const CVector& vecPosition);
 
+    CClientStreamer* GetStreamer() const noexcept { return m_pStreamer; }
+
+    // Effective range, resolved as element > model > element type > streamer default.
+    // Derived forms are cached because Restream() reads them for every active element every frame.
+    float GetStreamDistance() const noexcept { return m_fStreamDistance; }
+    float GetStreamDistanceExp() const noexcept { return m_fStreamDistanceExp; }
+    float GetStreamThresholdExp() const noexcept { return m_fStreamThresholdExp; }
+    float GetInvStreamDistanceExp() const noexcept { return m_fInvStreamDistanceExp; }
+
+    // Camera distance as a fraction of this element's own range, so elements with different
+    // ranges can be prioritised against each other fairly.
+    float GetStreamPriority() const noexcept { return m_fStreamPriority; }
+
+    bool  HasCustomStreamDistance() const noexcept { return m_fCustomStreamDistance > 0.0f; }
+    float GetCustomStreamDistance() const noexcept { return m_fCustomStreamDistance; }
+    void  SetCustomStreamDistance(std::optional<float> distance);
+    void  RefreshStreamDistance();
+
     bool IsStreamingCompatibleClass() { return true; };
 
     virtual bool IsVisibleInAllDimensions() { return false; };
@@ -55,11 +74,20 @@ private:
     void SetStreamRow(CClientStreamSectorRow* pRow) { m_pStreamRow = pRow; }
     void SetStreamSector(CClientStreamSector* pSector) { m_pStreamSector = pSector; }
     void SetExpDistance(float fDistance) { m_fExpDistance = fDistance; }
+    void SetStreamPriority(float fPriority) { m_fStreamPriority = fPriority; }
+
+    void ApplyStreamDistance(float fDistance);
 
     CClientStreamSectorRow* m_pStreamRow;
     CClientStreamSector*    m_pStreamSector;
     CVector                 m_vecStreamPosition;
     float                   m_fExpDistance;
+    float                   m_fStreamPriority;
+    float                   m_fCustomStreamDistance;
+    float                   m_fStreamDistance;
+    float                   m_fStreamDistanceExp;
+    float                   m_fStreamThresholdExp;
+    float                   m_fInvStreamDistanceExp;
     unsigned short          m_usStreamReferences, m_usStreamReferencesScript;
 
 protected:

--- a/Client/mods/deathmatch/logic/CClientStreamElement.h
+++ b/Client/mods/deathmatch/logic/CClientStreamElement.h
@@ -50,15 +50,14 @@ public:
 
     CClientStreamer* GetStreamer() const noexcept { return m_pStreamer; }
 
-    // Effective range, resolved as element > model > element type > streamer default.
-    // Derived forms are cached because Restream() reads them for every active element every frame.
+    // Derived forms are cached because Restream() reads them for every active element every frame
     float GetStreamDistance() const noexcept { return m_fStreamDistance; }
     float GetStreamDistanceExp() const noexcept { return m_fStreamDistanceExp; }
     float GetStreamThresholdExp() const noexcept { return m_fStreamThresholdExp; }
     float GetInvStreamDistanceExp() const noexcept { return m_fInvStreamDistanceExp; }
 
-    // Camera distance as a fraction of this element's own range, so elements with different
-    // ranges can be prioritised against each other fairly.
+    // Camera distance as a fraction of this element's own range, so elements with different ranges
+    // can be prioritised against each other fairly
     float GetStreamPriority() const noexcept { return m_fStreamPriority; }
 
     bool  HasCustomStreamDistance() const noexcept { return m_fCustomStreamDistance > 0.0f; }

--- a/Client/mods/deathmatch/logic/CClientStreamer.cpp
+++ b/Client/mods/deathmatch/logic/CClientStreamer.cpp
@@ -18,9 +18,14 @@ CClientStreamer::CClientStreamer(StreamerLimitReachedFunction* pLimitReachedFunc
     : m_fSectorSize(fSectorSize), m_fRowSize(fRowSize)
 {
     // Setup our distance variables
-    m_fMaxDistanceExp = fMaxDistance * fMaxDistance;
-    m_fMaxDistanceThreshold = (fMaxDistance + 50.0f) * (fMaxDistance + 50.0f);
+    m_fMaxDistance = fMaxDistance;
+    m_fLargestPinnedDistance = 0.0f;
     m_usDimension = 0;
+
+    // Restream() ranks elements by the fraction of their own range, so the swap hysteresis has to
+    // live in that space too. Deriving it from the default range keeps the original behaviour for
+    // elements without a custom stream distance.
+    m_fSwapHysteresisRatio = (10.0f * 10.0f) / (fMaxDistance * fMaxDistance);
 
     // We need the limit reached func
     assert(pLimitReachedFunc);
@@ -188,7 +193,7 @@ void                CClientStreamer::DoPulse(CVector& vecPosition)
 
     // Update distances every frame
     SetExpDistances(&m_ActiveElements);
-    m_ActiveElements.sort(CompareExpDistance);
+    m_ActiveElements.sort(CompareStreamPriority);
 
     Restream(bMovedFar);
 }
@@ -311,7 +316,7 @@ void CClientStreamer::OnUpdateStreamPosition(CClientStreamElement* pElement)
     else
     {
         // Make sure our distance is updated
-        pElement->SetExpDistance(pElement->GetDistanceToBoundingBoxSquared(m_vecPosition));
+        UpdateElementDistance(pElement);
     }
 }
 
@@ -332,6 +337,18 @@ void CClientStreamer::RemoveElement(CClientStreamElement* pElement)
     m_ActiveElements.remove(pElement);
     m_ActiveElementSet.erase(pElement);
     m_ToStreamOut.remove(pElement);
+
+    if (m_PinnedElements.erase(pElement) > 0)
+        RecalculateLargestPinnedDistance();
+}
+
+void CClientStreamer::UpdateElementDistance(CClientStreamElement* pElement)
+{
+    const float fDistance = pElement->GetDistanceToBoundingBoxSquared(m_vecPosition);
+
+    // m_fExpDistance stays in world units because other systems (nametags) read it directly
+    pElement->SetExpDistance(fDistance);
+    pElement->SetStreamPriority(fDistance * pElement->GetInvStreamDistanceExp());
 }
 
 void CClientStreamer::SetExpDistances(list<CClientStreamElement*>* pList)
@@ -343,15 +360,14 @@ void CClientStreamer::SetExpDistances(list<CClientStreamElement*>* pList)
     {
         pElement = *iter;
         // Set its distance ^ 2
-        pElement->SetExpDistance(pElement->GetDistanceToBoundingBoxSquared(m_vecPosition));
+        UpdateElementDistance(pElement);
     }
 }
 
 void CClientStreamer::AddToSortedList(list<CClientStreamElement*>* pList, CClientStreamElement* pElement)
 {
     // Make sure it's exp distance is updated
-    float fDistance = pElement->GetDistanceToBoundingBoxSquared(m_vecPosition);
-    pElement->SetExpDistance(fDistance);
+    UpdateElementDistance(pElement);
 
     // Don't add if already in the list (O(1) check)
     if (m_ActiveElementSet.count(pElement))
@@ -364,9 +380,54 @@ void CClientStreamer::AddToSortedList(list<CClientStreamElement*>* pList, CClien
     pList->push_back(pElement);
 }
 
-bool CClientStreamer::CompareExpDistance(CClientStreamElement* p1, CClientStreamElement* p2)
+bool CClientStreamer::CompareStreamPriority(CClientStreamElement* p1, CClientStreamElement* p2)
 {
-    return p1->GetExpDistance() < p2->GetExpDistance();
+    return p1->GetStreamPriority() < p2->GetStreamPriority();
+}
+
+void CClientStreamer::OnElementStreamDistanceChanged(CClientStreamElement* pElement)
+{
+    const bool bShouldPin = pElement->GetStreamDistance() > m_fMaxDistance;
+    const bool bIsPinned = IsPinnedElement(pElement);
+
+    if (bShouldPin)
+    {
+        m_PinnedElements.insert(pElement);
+
+        // A pinned element must be considered no matter which sectors are currently active
+        if (!m_ActiveElementSet.count(pElement))
+            AddToSortedList(&m_ActiveElements, pElement);
+    }
+    else if (bIsPinned)
+    {
+        m_PinnedElements.erase(pElement);
+
+        // Back to normal rules: only stay active while its sector is
+        CClientStreamSector* pSector = pElement->GetStreamSector();
+        if ((!pSector || !pSector->IsActivated()) && m_ActiveElementSet.erase(pElement) > 0)
+            m_ActiveElements.remove(pElement);
+    }
+
+    if (bShouldPin || bIsPinned)
+        RecalculateLargestPinnedDistance();
+
+    UpdateElementDistance(pElement);
+}
+
+void CClientStreamer::RestorePinnedElements()
+{
+    for (CClientStreamElement* pElement : m_PinnedElements)
+    {
+        if (!m_ActiveElementSet.count(pElement))
+            AddToSortedList(&m_ActiveElements, pElement);
+    }
+}
+
+void CClientStreamer::RecalculateLargestPinnedDistance()
+{
+    m_fLargestPinnedDistance = 0.0f;
+    for (CClientStreamElement* pElement : m_PinnedElements)
+        m_fLargestPinnedDistance = std::max(m_fLargestPinnedDistance, pElement->GetStreamDistance());
 }
 
 bool CClientStreamer::IsActiveElement(CClientStreamElement* pElement)
@@ -376,9 +437,6 @@ bool CClientStreamer::IsActiveElement(CClientStreamElement* pElement)
 
 void CClientStreamer::Restream(bool bMovedFar)
 {
-    // Avoid swap ping-pong when two candidates are almost the same distance.
-    // Distances are squared, so compare against squared hysteresis too.
-    constexpr float         swapHysteresisDistanceSq = 10.0f * 10.0f;
     constexpr std::uint32_t minStreamInDelayAfterOutMs = 100u;
     const std::uint32_t     currentTime = static_cast<std::uint32_t>(CClientTime::GetTime());
 
@@ -417,10 +475,15 @@ void CClientStreamer::Restream(bool bMovedFar)
     bool bReachedLimit = ReachedLimit();
     // Loop through our active elements list (they should be ordered closest to furthest)
     list<CClientStreamElement*>::iterator iter = m_ActiveElements.begin();
-    for (; iter != m_ActiveElements.end(); iter++)
+    while (iter != m_ActiveElements.end())
     {
         CClientStreamElement* pElement = *iter;
-        float                 fElementDistanceExp = pElement->GetExpDistance();
+
+        // Advance before streaming, because the stream in/out events let scripts remove this
+        // element from the active list (destroyElement, setElementModel, a stream distance change)
+        ++iter;
+
+        float fElementDistanceExp = pElement->GetExpDistance();
 
         // Is this element streamed in?
         if (pElement->IsStreamedIn())
@@ -458,7 +521,7 @@ void CClientStreamer::Restream(bool bMovedFar)
                 }
             }
             // Too far away? Use the threshold so we won't flicker load it if it's on the border moving.
-            if (fElementDistanceExp > m_fMaxDistanceThreshold)
+            if (fElementDistanceExp > pElement->GetStreamThresholdExp())
             {
                 // Unstream it now?
                 if (iMaxOut > 0)
@@ -489,7 +552,7 @@ void CClientStreamer::Restream(bool bMovedFar)
             if (pElement->GetDimension() == m_usDimension || pElement->IsVisibleInAllDimensions())
             {
                 // Too far away? Stop here.
-                if (fElementDistanceExp > m_fMaxDistanceExp)
+                if (fElementDistanceExp > pElement->GetStreamDistanceExp())
                     continue;
 
                 if (IS_VEHICLE(pElement))
@@ -582,7 +645,7 @@ void CClientStreamer::Restream(bool bMovedFar)
             // See if ClosestStreamedOut is nearer than FurthestStreamedIn
             CClientStreamElement* pFurthestStreamedIn = FurthestStreamedInList[iFurthestStreamedInIndex];
             CClientStreamElement* pClosestStreamedOut = ClosestStreamedOutList[uiClosestStreamedOutIndex];
-            if ((pClosestStreamedOut->GetExpDistance() + swapHysteresisDistanceSq) >= pFurthestStreamedIn->GetExpDistance())
+            if ((pClosestStreamedOut->GetStreamPriority() + m_fSwapHysteresisRatio) >= pFurthestStreamedIn->GetStreamPriority())
                 break;
 
             // Stream out FurthestStreamedIn candidate if possible
@@ -634,7 +697,7 @@ void CClientStreamer::OnEnterSector(CClientStreamSector* pSector)
                     for (; iter != pTempSector->End(); iter++)
                     {
                         pElement = *iter;
-                        if (pElement->IsStreamedIn())
+                        if (pElement->IsStreamedIn() && !IsPinnedElement(pElement))
                         {
                             // Add it to our streaming out list
                             m_ToStreamOut.push_back(pElement);
@@ -662,8 +725,9 @@ void CClientStreamer::OnEnterSector(CClientStreamSector* pSector)
         }
     }
     m_pSector = pSector;
+    RestorePinnedElements();
     SetExpDistances(&m_ActiveElements);
-    m_ActiveElements.sort(CompareExpDistance);
+    m_ActiveElements.sort(CompareStreamPriority);
 }
 
 void CClientStreamer::OnElementEnterSector(CClientStreamElement* pElement, CClientStreamSector* pSector)
@@ -692,6 +756,12 @@ void CClientStreamer::OnElementEnterSector(CClientStreamElement* pElement, CClie
                 // Add this element to our active-elements list
                 AddToSortedList(&m_ActiveElements, pElement);
             }
+        }
+        else if (IsPinnedElement(pElement))
+        {
+            // Pinned elements ignore the sector window entirely
+            if (!m_ActiveElementSet.count(pElement))
+                AddToSortedList(&m_ActiveElements, pElement);
         }
         else
         {

--- a/Client/mods/deathmatch/logic/CClientStreamer.cpp
+++ b/Client/mods/deathmatch/logic/CClientStreamer.cpp
@@ -22,9 +22,8 @@ CClientStreamer::CClientStreamer(StreamerLimitReachedFunction* pLimitReachedFunc
     m_fLargestPinnedDistance = 0.0f;
     m_usDimension = 0;
 
-    // Restream() ranks elements by the fraction of their own range, so the swap hysteresis has to
-    // live in that space too. Deriving it from the default range keeps the original behaviour for
-    // elements without a custom stream distance.
+    // Restream() ranks elements by the fraction of their own range, so the swap hysteresis lives in
+    // that space too. Deriving it from the default keeps the original behaviour for regular elements
     m_fSwapHysteresisRatio = (10.0f * 10.0f) / (fMaxDistance * fMaxDistance);
 
     // We need the limit reached func
@@ -394,7 +393,6 @@ void CClientStreamer::OnElementStreamDistanceChanged(CClientStreamElement* pElem
     {
         m_PinnedElements.insert(pElement);
 
-        // A pinned element must be considered no matter which sectors are currently active
         if (!m_ActiveElementSet.count(pElement))
             AddToSortedList(&m_ActiveElements, pElement);
     }
@@ -759,7 +757,6 @@ void CClientStreamer::OnElementEnterSector(CClientStreamElement* pElement, CClie
         }
         else if (IsPinnedElement(pElement))
         {
-            // Pinned elements ignore the sector window entirely
             if (!m_ActiveElementSet.count(pElement))
                 AddToSortedList(&m_ActiveElements, pElement);
         }

--- a/Client/mods/deathmatch/logic/CClientStreamer.h
+++ b/Client/mods/deathmatch/logic/CClientStreamer.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "CClientCommon.h"
+#include <algorithm>
 #include <list>
 #include <unordered_map>
 #include <unordered_set>
@@ -24,13 +25,16 @@ class CClientStreamer
     friend class CClientStreamElement;
 
 public:
+    // Extra distance an element may travel past its stream-in range before being streamed out
+    static constexpr float STREAM_OUT_EXTRA_DISTANCE = 50.0f;
+
     CClientStreamer(StreamerLimitReachedFunction* pLimitReachedFunc, float fMaxDistance, float fSectorSize, float fRowSize);
     ~CClientStreamer();
 
     void DoPulse(CVector& vecPosition);
     void SetDimension(unsigned short usDimension);
 
-    static bool CompareExpDistance(CClientStreamElement* p1, CClientStreamElement* p2);
+    static bool CompareStreamPriority(CClientStreamElement* p1, CClientStreamElement* p2);
 
     unsigned int                               CountActiveElements() { return (unsigned int)m_ActiveElements.size(); }
     bool                                       IsActiveElement(CClientStreamElement* pElement);
@@ -38,6 +42,11 @@ public:
     std::list<CClientStreamElement*>::iterator ActiveElementsEnd() { return m_ActiveElements.end(); }
 
     std::uint16_t GetDimension() const noexcept { return m_usDimension; }
+
+    float GetDefaultStreamDistance() const noexcept { return m_fMaxDistance; }
+    float GetLargestStreamDistance() const noexcept { return std::max(m_fMaxDistance, m_fLargestPinnedDistance); }
+
+    void OnElementStreamDistanceChanged(CClientStreamElement* pElement);
 
 private:
     void CreateSectors(std::list<CClientStreamSectorRow*>* pList, CVector2D& vecSize, CVector2D& vecBottomLeft, CVector2D& vecTopRight);
@@ -51,6 +60,7 @@ private:
     void AddElement(CClientStreamElement* pElement);
     void RemoveElement(CClientStreamElement* pElement);
 
+    void UpdateElementDistance(CClientStreamElement* pElement);
     void SetExpDistances(std::list<CClientStreamElement*>* pList);
     void AddToSortedList(std::list<CClientStreamElement*>* pList, CClientStreamElement* pElement);
 
@@ -63,10 +73,15 @@ private:
     void OnElementForceStreamOut(CClientStreamElement* pElement);
     void OnElementDimension(CClientStreamElement* pElement);
 
+    bool IsPinnedElement(CClientStreamElement* pElement) const { return m_PinnedElements.count(pElement) > 0; }
+    void RestorePinnedElements();
+    void RecalculateLargestPinnedDistance();
+
     const float                                      m_fSectorSize;
     const float                                      m_fRowSize;
-    float                                            m_fMaxDistanceExp;
-    float                                            m_fMaxDistanceThreshold;
+    float                                            m_fMaxDistance;
+    float                                            m_fSwapHysteresisRatio;
+    float                                            m_fLargestPinnedDistance;
     StreamerLimitReachedFunction*                    m_pLimitReachedFunc;
     std::list<CClientStreamSectorRow*>               m_WorldRows;
     std::unordered_map<int, CClientStreamSectorRow*> m_ExtraRows;
@@ -77,6 +92,10 @@ private:
     std::list<CClientStreamElement*>                 m_ActiveElements;
     std::unordered_set<CClientStreamElement*>        m_ActiveElementSet;
     std::list<CClientStreamElement*>                 m_ToStreamOut;
+
+    // Elements reaching further than m_fMaxDistance can sit outside the active sector window, so
+    // they are kept in m_ActiveElements unconditionally instead of widening the window for everyone
+    std::unordered_set<CClientStreamElement*> m_PinnedElements;
 
     static void* pAddingElement;
 };

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -255,6 +255,8 @@ CClientVehicle::CClientVehicle(CClientManager* pManager, ElementID ID, unsigned 
     m_clientModel = pManager->GetModelManager()->FindModelByID(usModel);
 
     m_pSoundSettingsEntry = nullptr;
+
+    RefreshStreamDistance();
 }
 
 CClientVehicle::~CClientVehicle()
@@ -1141,6 +1143,8 @@ void CClientVehicle::SetModelBlocking(unsigned short usModel, unsigned char ucVa
         // Reset stored dummy positions
         m_copyDummyPositions = true;
         m_dummyPositions = {};
+
+        RefreshStreamDistance();
 
         // Create the vehicle if we're streamed in
         if (IsStreamedIn())

--- a/Client/mods/deathmatch/logic/CClientWeapon.cpp
+++ b/Client/mods/deathmatch/logic/CClientWeapon.cpp
@@ -34,6 +34,9 @@ CClientWeapon::CClientWeapon(CClientManager* pManager, ElementID ID, eWeaponType
 
     SetTypeName("weapon");
 
+    // CClientObject already resolved our range as an object, redo it now that we are a weapon
+    RefreshStreamDistance();
+
     SetFrozen(true);
     Create();
 #ifdef MARKER_DEBUG

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -71,6 +71,9 @@ void CLuaElementDefs::LoadFunctions()
         {"isElementCallPropagationEnabled", IsElementCallPropagationEnabled},
         {"isElementWaitingForGroundToLoad", IsElementWaitingForGroundToLoad},
         {"isElementOnFire", ArgumentParser<IsElementOnFire>},
+        {"getElementStreamDistance", ArgumentParser<GetElementStreamDistance>},
+        {"getElementTypeStreamDistance", ArgumentParser<GetElementTypeStreamDistance>},
+        {"getElementModelStreamDistance", ArgumentParser<GetElementModelStreamDistance>},
 
         // Element set funcs
         {"createElement", CreateElement},
@@ -101,6 +104,9 @@ void CLuaElementDefs::LoadFunctions()
         {"setElementCallPropagationEnabled", SetElementCallPropagationEnabled},
         {"setElementLighting", ArgumentParser<SetElementLighting>},
         {"setElementOnFire", ArgumentParser<SetElementOnFire>},
+        {"setElementStreamDistance", ArgumentParser<SetElementStreamDistance>},
+        {"setElementTypeStreamDistance", ArgumentParser<SetElementTypeStreamDistance>},
+        {"setElementModelStreamDistance", ArgumentParser<SetElementModelStreamDistance>},
     };
 
     // Add functions
@@ -172,6 +178,7 @@ void CLuaElementDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getData", "getElementData");
     lua_classfunction(luaVM, "getAllData", "getAllElementData");
     lua_classfunction(luaVM, "isOnFire", "isElementOnFire");
+    lua_classfunction(luaVM, "getStreamDistance", "getElementStreamDistance");
 
     lua_classfunction(luaVM, "setAttachedOffsets", "setElementAttachedOffsets");
     lua_classfunction(luaVM, "setData", "setElementData");
@@ -196,6 +203,7 @@ void CLuaElementDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setStreamable", "setElementStreamable");
     lua_classfunction(luaVM, "setLighting", "setElementLighting");
     lua_classfunction(luaVM, "setOnFire", "setElementOnFire");
+    lua_classfunction(luaVM, "setStreamDistance", "setElementStreamDistance");
 
     lua_classvariable(luaVM, "callPropagationEnabled", "setElementCallPropagationEnabled", "isElementCallPropagationEnabled");
     lua_classvariable(luaVM, "waitingForGroundToLoad", NULL, "isElementWaitingForGroundToLoad");
@@ -232,6 +240,7 @@ void CLuaElementDefs::AddClass(lua_State* luaVM)
     lua_classvariable(luaVM, "isElement", NULL, "isElement");
     lua_classvariable(luaVM, "lighting", "setElementLighting", "getElementLighting");
     lua_classvariable(luaVM, "onFire", "setElementOnFire", "isElementOnFire");
+    lua_classvariable(luaVM, "streamDistance", "setElementStreamDistance", "getElementStreamDistance");
     // TODO: Support element data: player.data["age"] = 1337; <=> setElementData(player, "age", 1337)
 
     lua_registerclass(luaVM, "Element");
@@ -2519,6 +2528,94 @@ bool CLuaElementDefs::SetElementOnFire(CClientEntity* entity, bool onFire) noexc
         return false;
 
     return entity->SetOnFire(onFire);
+}
+
+namespace
+{
+    // The upper bound keeps a single script from pinning half the map into the streamer's
+    // permanently active list, which costs a distance update and a sort slot every frame
+    constexpr float MIN_STREAM_DISTANCE = 1.0f;
+    constexpr float MAX_STREAM_DISTANCE = 3000.0f;
+
+    eClientEntityType ReadStreamableType(const std::string& type)
+    {
+        static const std::unordered_map<std::string, eClientEntityType> streamableTypes{
+            {"object", CCLIENTOBJECT}, {"vehicle", CCLIENTVEHICLE}, {"ped", CCLIENTPED},
+            {"player", CCLIENTPLAYER}, {"pickup", CCLIENTPICKUP},   {"marker", CCLIENTMARKER},
+        };
+
+        auto iter = streamableTypes.find(type);
+        if (iter == streamableTypes.end())
+            throw std::invalid_argument("Element type is not streamable");
+
+        return iter->second;
+    }
+
+    std::uint16_t ReadModelId(std::uint32_t model)
+    {
+        if (model > std::numeric_limits<std::uint16_t>::max())
+            throw std::invalid_argument("Invalid model id");
+
+        return static_cast<std::uint16_t>(model);
+    }
+
+    std::optional<float> ReadStreamDistance(std::optional<float> distance)
+    {
+        if (distance.has_value() && (distance.value() < MIN_STREAM_DISTANCE || distance.value() > MAX_STREAM_DISTANCE))
+            throw std::invalid_argument(SString("Stream distance must be between %g and %g", MIN_STREAM_DISTANCE, MAX_STREAM_DISTANCE));
+
+        return distance;
+    }
+
+    CClientStreamElement* ReadStreamElement(CClientEntity* entity)
+    {
+        if (!entity->IsStreamingCompatibleClass())
+            throw std::invalid_argument("Element is not streamable");
+
+        return static_cast<CClientStreamElement*>(entity);
+    }
+}  // namespace
+
+bool CLuaElementDefs::SetElementStreamDistance(CClientEntity* entity, std::optional<float> distance)
+{
+    //  bool setElementStreamDistance ( element theElement [, float distance ] )
+    ReadStreamElement(entity)->SetCustomStreamDistance(ReadStreamDistance(distance));
+    return true;
+}
+
+float CLuaElementDefs::GetElementStreamDistance(CClientEntity* entity)
+{
+    //  float getElementStreamDistance ( element theElement )
+    return ReadStreamElement(entity)->GetStreamDistance();
+}
+
+bool CLuaElementDefs::SetElementTypeStreamDistance(std::string type, std::optional<float> distance)
+{
+    //  bool setElementTypeStreamDistance ( string elementType [, float distance ] )
+    return m_pManager->SetTypeStreamDistance(ReadStreamableType(type), ReadStreamDistance(distance));
+}
+
+float CLuaElementDefs::GetElementTypeStreamDistance(std::string type)
+{
+    //  float getElementTypeStreamDistance ( string elementType )
+    return m_pManager->GetTypeStreamDistance(ReadStreamableType(type));
+}
+
+bool CLuaElementDefs::SetElementModelStreamDistance(std::uint32_t model, std::optional<float> distance)
+{
+    //  bool setElementModelStreamDistance ( int modelId [, float distance ] )
+    return m_pManager->SetModelStreamDistance(ReadModelId(model), ReadStreamDistance(distance));
+}
+
+// There is no element type to fall back on for a bare model id, so report "not set" instead of a default
+std::variant<bool, float> CLuaElementDefs::GetElementModelStreamDistance(std::uint32_t model)
+{
+    //  float getElementModelStreamDistance ( int modelId )
+    const float fDistance = m_pManager->GetModelStreamDistance(ReadModelId(model));
+    if (fDistance <= 0.0f)
+        return false;
+
+    return fDistance;
 }
 
 int CLuaElementDefs::IsElementLowLod(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -2532,16 +2532,18 @@ bool CLuaElementDefs::SetElementOnFire(CClientEntity* entity, bool onFire) noexc
 
 namespace
 {
-    // The upper bound keeps a single script from pinning half the map into the streamer's
-    // permanently active list, which costs a distance update and a sort slot every frame
+    // The upper bound keeps a script from pinning half the map into the streamer's permanently
+    // active list, which costs a distance update and a sort slot every frame
     constexpr float MIN_STREAM_DISTANCE = 1.0f;
     constexpr float MAX_STREAM_DISTANCE = 3000.0f;
 
+    // Every element type that goes through CClientStreamer. Buildings, sounds, lights, effects and
+    // projectiles are absent because they are not streamed by the streamer at all
     eClientEntityType ReadStreamableType(const std::string& type)
     {
         static const std::unordered_map<std::string, eClientEntityType> streamableTypes{
-            {"object", CCLIENTOBJECT}, {"vehicle", CCLIENTVEHICLE}, {"ped", CCLIENTPED},
-            {"player", CCLIENTPLAYER}, {"pickup", CCLIENTPICKUP},   {"marker", CCLIENTMARKER},
+            {"object", CCLIENTOBJECT}, {"vehicle", CCLIENTVEHICLE}, {"ped", CCLIENTPED},       {"player", CCLIENTPLAYER},
+            {"pickup", CCLIENTPICKUP}, {"marker", CCLIENTMARKER},   {"weapon", CCLIENTWEAPON}, {"searchlight", CCLIENTSEARCHLIGHT},
         };
 
         auto iter = streamableTypes.find(type);
@@ -2578,39 +2580,33 @@ namespace
 
 bool CLuaElementDefs::SetElementStreamDistance(CClientEntity* entity, std::optional<float> distance)
 {
-    //  bool setElementStreamDistance ( element theElement [, float distance ] )
     ReadStreamElement(entity)->SetCustomStreamDistance(ReadStreamDistance(distance));
     return true;
 }
 
 float CLuaElementDefs::GetElementStreamDistance(CClientEntity* entity)
 {
-    //  float getElementStreamDistance ( element theElement )
     return ReadStreamElement(entity)->GetStreamDistance();
 }
 
 bool CLuaElementDefs::SetElementTypeStreamDistance(std::string type, std::optional<float> distance)
 {
-    //  bool setElementTypeStreamDistance ( string elementType [, float distance ] )
     return m_pManager->SetTypeStreamDistance(ReadStreamableType(type), ReadStreamDistance(distance));
 }
 
 float CLuaElementDefs::GetElementTypeStreamDistance(std::string type)
 {
-    //  float getElementTypeStreamDistance ( string elementType )
     return m_pManager->GetTypeStreamDistance(ReadStreamableType(type));
 }
 
 bool CLuaElementDefs::SetElementModelStreamDistance(std::uint32_t model, std::optional<float> distance)
 {
-    //  bool setElementModelStreamDistance ( int modelId [, float distance ] )
     return m_pManager->SetModelStreamDistance(ReadModelId(model), ReadStreamDistance(distance));
 }
 
-// There is no element type to fall back on for a bare model id, so report "not set" instead of a default
+// A bare model id has no element type to fall back on, so report "not set" instead of a default
 std::variant<bool, float> CLuaElementDefs::GetElementModelStreamDistance(std::uint32_t model)
 {
-    //  float getElementModelStreamDistance ( int modelId )
     const float fDistance = m_pManager->GetModelStreamDistance(ReadModelId(model));
     if (fDistance <= 0.0f)
         return false;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaElementDefs.h
@@ -71,7 +71,10 @@ public:
     LUA_DECLARE(IsElementLowLod);
     LUA_DECLARE(IsElementCallPropagationEnabled);
     LUA_DECLARE(IsElementWaitingForGroundToLoad);
-    static bool IsElementOnFire(CClientEntity* entity) noexcept;
+    static bool                      IsElementOnFire(CClientEntity* entity) noexcept;
+    static float                     GetElementStreamDistance(CClientEntity* entity);
+    static float                     GetElementTypeStreamDistance(std::string type);
+    static std::variant<bool, float> GetElementModelStreamDistance(std::uint32_t model);
 
     // Element set funcs
     LUA_DECLARE(CreateElement);
@@ -102,4 +105,7 @@ public:
     LUA_DECLARE(SetElementCallPropagationEnabled);
     static bool SetElementLighting(CClientEntity* entity, float lighting);
     static bool SetElementOnFire(CClientEntity* entity, bool onFire) noexcept;
+    static bool SetElementStreamDistance(CClientEntity* entity, std::optional<float> distance);
+    static bool SetElementTypeStreamDistance(std::string type, std::optional<float> distance);
+    static bool SetElementModelStreamDistance(std::uint32_t model, std::optional<float> distance);
 };


### PR DESCRIPTION
#### Summary

Adds client-side Lua functions to override the streaming radius per element, per model and per element type, instead of every streamed element being tied to its streamer's fixed radius (markers 600, objects 500, low-LOD objects 1700, pickups 100, peds/players 250, vehicles 250, lights 600).

```lua
setElementStreamDistance(element, distance)       -- nil/omitted resets to the inherited value
getElementStreamDistance(element)                 -- effective distance actually used by the streamer
setElementTypeStreamDistance(elementType, distance)
getElementTypeStreamDistance(elementType)         -- override, or the streamer default when unset
setElementModelStreamDistance(modelId, distance)
getElementModelStreamDistance(modelId)            -- false when no override is set
```
OOP: `Element:setStreamDistance()`, `Element:getStreamDistance()`, `element.streamDistance`.

The effective range is resolved as **element > model > element type > streamer default**. Accepted range is 1–3000; supported element types are `object`, `vehicle`, `ped`, `player`, `pickup`, `marker`. Everything is client-only — no RPC, bitstream or server changes.

    -- small props stop costing GPU time at long range
    setElementModelStreamDistance(1337, 60)

    -- a large custom vehicle streams in well before it can pop in
    setElementStreamDistance(myVehicle, 600)

Implementation notes:

* `CClientStreamElement` caches the resolved distance plus its squared / inverse-squared forms, because `CClientStreamer::Restream` reads them for every active element every frame. The stream-out check now uses a per-element threshold, so the existing `+50` hysteresis applies to custom ranges too.
* Active elements are sorted by *fraction of their own range* rather than by raw squared distance, so elements with different ranges compete fairly for the pool budget. `m_fExpDistance` keeps its world-unit meaning because `CNametags` reads it directly. The swap hysteresis was moved into that same ratio space and is derived from the streamer default, which reproduces the previous behaviour exactly for elements without a custom distance.
* Each streamer only keeps the camera's 3×3 sector window active, so an element asking for more than the streamer default would never reach `Restream`. Rather than widening that window for everyone (cost scales with map density), only elements that ask for a longer range are pinned into the active list. With the feature unused, behaviour is unchanged.
* `CClientModelCacheManager` had `PED_STREAM_IN_DISTANCE` / `VEHICLE_STREAM_IN_DISTANCE` hardcoded to 250. It now follows the streamers' actual largest range, otherwise raising ped/vehicle distance would skip model pre-caching and reintroduce blocking loads. The duplicated `+50` constant is now `CClientStreamer::STREAM_OUT_EXTRA_DISTANCE`.
* `Restream`'s main loop now advances its iterator before streaming, since the stream in/out events let scripts remove the current element from the active list.

Known behaviour worth calling out: `setElementTypeStreamDistance("object", …)` also applies to low-LOD objects, which otherwise default to 1700.

#### Motivation

Fixes #5132.

Every streamed element currently shares one fixed radius per streamer, which is wrong in both directions. Large custom vehicle and object models appear abruptly in front of the camera (wheel/suspension settling artifacts), while small decorative objects are still drawn at 500 units and waste GPU time on lower-end machines. Doing this in Lua means a per-frame distance loop over every element, which is expensive at high element counts and is not frame-accurate. Exposing the streamer's radius at core level fixes both cases with no scripting overhead and no network round trip.

#### Test plan

Built and tested on Windows / Release / Win32.

* `Client Deathmatch` compiles and links cleanly, no new warnings in the touched files.
* `Tests_Client` (gtest): 304/304 pass.
* clang-format produces no diff.

In-game, with a test resource:

1. `setElementStreamDistance(obj, 50)` — the object streams out at ~50 units and back in when approaching; confirmed via `onClientElementStreamIn` / `onClientElementStreamOut` logging.
2. `setElementStreamDistance(veh, 600)` — the vehicle streams in at ~600 and out at ~650 (hysteresis), with no pop-in and no blocking load, confirming the model was pre-cached.
3. `setElementModelStreamDistance(411, 700)` applies to all Infernus vehicles; a per-element `setElementStreamDistance` on one of them wins over the model value, which in turn wins over the type value.
4. `setElementTypeStreamDistance("object", 100)` takes effect immediately on already-created objects, and on objects created afterwards.
5. Passing `nil` as the distance resets to the inherited value; `getElementStreamDistance` reports the effective value at each step.
6. Reconnecting to a different server clears the model/type tables (they live on `CClientManager`).

Regression checks:

* On a server that never calls these functions, vehicle/ped/object streaming and nametag range are unchanged, and FPS on a dense map matches the previous build.
* `setElementStreamable`, `isElementStreamedIn` and low-LOD object handover still behave as before.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
