### PR TITLE
Fix HTTP file mismatch (CRC:00000000) when a resource file is re-downloaded

### DIFF
--- a/Client/mods/deathmatch/logic/CDownloadableResource.cpp
+++ b/Client/mods/deathmatch/logic/CDownloadableResource.cpp
@@ -14,6 +14,35 @@
 static bool    s_bChecksumBatchActive = false;
 static int64_t s_checksumBatchAccumMs = 0;
 
+static bool IsEmptyFileChecksum(const CChecksum& checksum)
+{
+    static const CChecksum emptyFileChecksum = CChecksum::GenerateChecksumFromBuffer("", 0);
+    return checksum == emptyFileChecksum;
+}
+
+// A download that is still writing the file makes it read as zero bytes, whose checksum is a valid
+// but meaningless value. Retry briefly so a race is not reported to the player as a file mismatch.
+// A file that does not exist yet checksums to CChecksum() instead, so it never enters this path.
+static CChecksum GenerateChecksumWithEmptyFileRetry(const SString& strFilename, uint uiExpectedSize)
+{
+    constexpr int MAX_ATTEMPTS = 5;
+    constexpr int RETRY_DELAY_MS = 20;
+
+    CChecksum checksum = CChecksum::GenerateChecksumFromFileUnsafe(strFilename);
+
+    if (uiExpectedSize == 0)
+        return checksum;
+
+    for (int attempt = 1; attempt < MAX_ATTEMPTS && IsEmptyFileChecksum(checksum); ++attempt)
+    {
+        Sleep(RETRY_DELAY_MS);
+        CChecksum::InvalidateChecksumCacheEntry(strFilename);
+        checksum = CChecksum::GenerateChecksumFromFileUnsafe(strFilename);
+    }
+
+    return checksum;
+}
+
 void CDownloadableResource::BeginChecksumBatch()
 {
     if (!s_bChecksumBatchActive)
@@ -72,7 +101,7 @@ CChecksum CDownloadableResource::GenerateClientChecksum()
     }
 
     long long startMs = GetTickCount64_();
-    m_LastClientChecksum = CChecksum::GenerateChecksumFromFileUnsafe(m_strName);
+    m_LastClientChecksum = GenerateChecksumWithEmptyFileRetry(m_strName, m_uiDownloadSize);
     m_bClientChecksumVerified = true;
 
     if (s_bChecksumBatchActive)

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -5298,6 +5298,7 @@ void CPacketHandler::Packet_ResourceStart(NetBitStreamInterface& bitStream)
 
                                 // Delete the file that already exists
                                 FileDelete(strName);
+                                CChecksum::InvalidateChecksumCacheEntry(strName);
                                 if (FileExists(strName))
                                 {
                                     SString strMessage("Unable to delete old file %s", *ConformResourcePath(strName));

--- a/Client/mods/deathmatch/logic/CResource.cpp
+++ b/Client/mods/deathmatch/logic/CResource.cpp
@@ -255,6 +255,7 @@ bool CResource::VerifyPendingClientChecksums()
 
         const SString strName = pDownloadableResource->GetName();
         FileDelete(strName);
+        CChecksum::InvalidateChecksumCacheEntry(strName);
         if (FileExists(strName))
         {
             SString strMessage("Unable to delete old file %s", *ConformResourcePath(strName));
@@ -386,7 +387,10 @@ void CResource::Load()
         {
             if (!pResourceFile->DoesClientAndServerChecksumMatch())
             {
-                HandleDownloadedFileTrouble(pResourceFile, false);
+                // The cached checksum can predate the file finishing on disk, so confirm with a fresh read
+                CChecksum::InvalidateChecksumCacheEntry(pResourceFile->GetName());
+                if (pResourceFile->GenerateClientChecksum() != pResourceFile->GetServerChecksum())
+                    HandleDownloadedFileTrouble(pResourceFile, false);
             }
         }
     }

--- a/Client/mods/deathmatch/logic/CResourceFileDownloadManager.cpp
+++ b/Client/mods/deathmatch/logic/CResourceFileDownloadManager.cpp
@@ -310,6 +310,7 @@ void CResourceFileDownloadManager::DownloadFinished(const SHttpDownloadResult& r
     if (result.bSuccess)
     {
         CDownloadableResource::EndChecksumBatch();
+        CChecksum::InvalidateChecksumCacheEntry(pResourceFile->GetName());
         CChecksum checksum = pResourceFile->GenerateClientChecksum();
         if (checksum != pResourceFile->GetServerChecksum())
         {

--- a/Client/mods/deathmatch/logic/CSingularFileDownload.cpp
+++ b/Client/mods/deathmatch/logic/CSingularFileDownload.cpp
@@ -29,6 +29,7 @@ CSingularFileDownload::CSingularFileDownload(CResource* pResource, const char* s
 
     m_bBeingDeleted = false;
 
+    CChecksum::InvalidateChecksumCacheEntry(m_strName);
     GenerateClientChecksum();
 
     if (!DoesClientAndServerChecksumMatch())

--- a/Shared/sdk/CChecksum.h
+++ b/Shared/sdk/CChecksum.h
@@ -55,14 +55,7 @@ private:
         return m;
     }
 
-public:
-    static void ClearChecksumCache()
-    {
-        std::lock_guard<std::mutex> l(CacheMtx());
-        Cache().clear();
-    }
-
-    static std::variant<CChecksum, std::string> GenerateChecksumFromFile(const SString& strFilename)
+    static std::string MakeCacheKey(const SString& strFilename)
     {
         std::string key = strFilename;
         for (char& c : key)
@@ -72,25 +65,37 @@ public:
             if (c == '\\')
                 c = '/';
         }
+        return key;
+    }
 
-        WIN32_FILE_ATTRIBUTE_DATA attr;
-        WString                   wide;
-        try
+public:
+    static void ClearChecksumCache()
+    {
+        std::lock_guard<std::mutex> l(CacheMtx());
+        Cache().clear();
+    }
+
+    // Call after deleting or replacing a file, so a later checksum cannot be answered from the entry
+    // that describes its previous contents
+    static void InvalidateChecksumCacheEntry(const SString& strFilename)
+    {
+        std::lock_guard<std::mutex> l(CacheMtx());
+        Cache().erase(MakeCacheKey(strFilename));
+    }
+
+    static std::variant<CChecksum, std::string> GenerateChecksumFromFile(const SString& strFilename)
+    {
+        const std::string key = MakeCacheKey(strFilename);
+
+        // Size and write time come from an open handle so the cache is validated against the same
+        // view of the file that the read below would see
+        SharedUtil::SFileReadInfo info;
+        const bool                hasInfo = SharedUtil::GetFileInfoWithTimeout(strFilename, info, 500);
+        if (hasInfo)
         {
-            wide = SharedUtil::FromUTF8(strFilename);
-        }
-        catch (...)
-        {
-        }
-        bool          hasMeta = !wide.empty() && SharedUtil::GetFileAttributesExWithTimeout(wide.c_str(), attr, 500);
-        std::uint64_t sz = 0, mt = 0;
-        if (hasMeta)
-        {
-            sz = (std::uint64_t(attr.nFileSizeHigh) << 32) | attr.nFileSizeLow;
-            mt = (std::uint64_t(attr.ftLastWriteTime.dwHighDateTime) << 32) | attr.ftLastWriteTime.dwLowDateTime;
             std::lock_guard<std::mutex> l(CacheMtx());
             auto                        it = Cache().find(key);
-            if (it != Cache().end() && it->second.size == sz && it->second.mtime == mt)
+            if (it != Cache().end() && it->second.size == info.size && it->second.mtime == info.mtime)
             {
                 CChecksum cached;
                 cached.ulCRC = it->second.crc;
@@ -99,10 +104,11 @@ public:
             }
         }
 
-        SString buf;
-        if (!SharedUtil::FileLoadWithTimeout(strFilename, buf, 2000))
+        SString                   buf;
+        SharedUtil::SFileReadInfo readInfo;
+        if (!SharedUtil::FileLoadWithTimeout(strFilename, buf, 2000, &readInfo))
         {
-            if (!hasMeta)
+            if (!hasInfo)
                 return SString("File not found or inaccessible: %s", strFilename.c_str());
             return SString("Could not read: %s", strFilename.c_str());
         }
@@ -111,17 +117,18 @@ public:
         r.ulCRC = CRCGenerator::GetCRCFromBuffer(buf.data(), buf.size());
         CMD5Hasher().Calculate(buf.data(), buf.size(), r.md5);
 
-        if (hasMeta && SharedUtil::GetFileAttributesExWithTimeout(wide.c_str(), attr, 500) &&
-            sz == ((std::uint64_t(attr.nFileSizeHigh) << 32) | attr.nFileSizeLow) &&
-            mt == ((std::uint64_t(attr.ftLastWriteTime.dwHighDateTime) << 32) | attr.ftLastWriteTime.dwLowDateTime))
+        // Never cache an empty file: it is the shape a read caught mid-write takes, and re-hashing nothing is free
+        if (readInfo.size > 0)
         {
             std::lock_guard<std::mutex> l(CacheMtx());
-            Cache()[key] = {sz, mt, r.ulCRC, r.md5};
+            Cache()[key] = {readInfo.size, readInfo.mtime, r.ulCRC, r.md5};
         }
         return r;
     }
 #else
     static void ClearChecksumCache() {}
+
+    static void InvalidateChecksumCacheEntry(const SString&) {}
 
     // Server and non-Windows builds use the original implementation
     static std::variant<CChecksum, std::string> GenerateChecksumFromFile(const SString& strFilename)

--- a/Shared/sdk/SharedUtil.File.h
+++ b/Shared/sdk/SharedUtil.File.h
@@ -16,10 +16,7 @@
 #include "WString.h"
 
 #if defined(_WIN32) && defined(MTA_CLIENT)
-// Workaround to prevent pulling in the fat windows.h header
-// Callers that need WIN32_FILE_ATTRIBUTE_DATA as a value type must include <windows.h> after all.
-struct _WIN32_FILE_ATTRIBUTE_DATA;
-typedef struct _WIN32_FILE_ATTRIBUTE_DATA WIN32_FILE_ATTRIBUTE_DATA;
+    #include <cstdint>
 #endif
 
 namespace SharedUtil
@@ -38,8 +35,17 @@ namespace SharedUtil
     bool FileLoad(std::nothrow_t, const SString& filePath, SString& outBuffer, size_t maxSize = INT_MAX, size_t offset = 0) noexcept;
 
 #if defined(_WIN32) && defined(MTA_CLIENT)
-    bool GetFileAttributesExWithTimeout(const wchar_t* path, WIN32_FILE_ATTRIBUTE_DATA& attr, unsigned long timeoutMs) noexcept;
-    bool FileLoadWithTimeout(const SString& filePath, SString& outBuffer, unsigned long timeoutMs) noexcept;
+    // File identity as reported by an open handle. Sizing a read from directory entry metadata instead
+    // samples the length and the bytes at two different moments, so a file being rewritten underneath
+    // yields an empty or short buffer that still looks like a successful read.
+    struct SFileReadInfo
+    {
+        std::uint64_t size = 0;
+        std::uint64_t mtime = 0;
+    };
+
+    bool GetFileInfoWithTimeout(const SString& filePath, SFileReadInfo& outInfo, unsigned long timeoutMs) noexcept;
+    bool FileLoadWithTimeout(const SString& filePath, SString& outBuffer, unsigned long timeoutMs, SFileReadInfo* pOutInfo = nullptr) noexcept;
 #endif
 
     //

--- a/Shared/sdk/SharedUtil.File.hpp
+++ b/Shared/sdk/SharedUtil.File.hpp
@@ -167,19 +167,6 @@ bool SharedUtil::FileLoad(std::nothrow_t, const SString& filePath, SString& outB
         return false;
     }
 
-    WIN32_FILE_ATTRIBUTE_DATA fileAttributeData;
-
-    if (!GetFileAttributesExW(wideFilePath, GetFileExInfoStandard, &fileAttributeData))
-        return false;
-
-    if (fileAttributeData.nFileSizeHigh > 0 || fileAttributeData.nFileSizeLow > GIBIBYTE)
-        return false;
-
-    DWORD fileSize = fileAttributeData.nFileSizeLow;
-
-    if (fileSize == 0 || fileSize <= static_cast<DWORD>(offset))
-        return true;
-
     constexpr int MAX_RETRY_ATTEMPTS = 20;
     constexpr int RETRY_DELAY_MS = 10;
 
@@ -200,6 +187,24 @@ bool SharedUtil::FileLoad(std::nothrow_t, const SString& filePath, SString& outB
 
     if (handle == INVALID_HANDLE_VALUE)
         return false;
+
+    // The size has to come from the handle. Reading it from the directory entry instead samples the
+    // length before the bytes, so a file being rewritten underneath produces an empty or short buffer
+    LARGE_INTEGER fileSizeResult{};
+
+    if (!GetFileSizeEx(handle, &fileSizeResult) || fileSizeResult.HighPart > 0 || fileSizeResult.LowPart > GIBIBYTE)
+    {
+        CloseHandle(handle);
+        return false;
+    }
+
+    DWORD fileSize = fileSizeResult.LowPart;
+
+    if (fileSize == 0 || fileSize <= static_cast<DWORD>(offset))
+    {
+        CloseHandle(handle);
+        return true;
+    }
 
     if (offset > 0)
     {
@@ -246,35 +251,44 @@ bool SharedUtil::FileLoad(std::nothrow_t, const SString& filePath, SString& outB
     CloseHandle(handle);
     return true;
 #else
+    FILE* handle = fopen(filePath, "rb");
+
+    if (!handle)
+        return false;
+
+    // Size comes from the open descriptor so a concurrent rewrite cannot make us read a stale length
     #ifdef __APPLE__
     struct stat info;
 
-    if (stat(filePath, &info) != 0)
-        return false;
+    if (fstat(fileno(handle), &info) != 0)
     #else
     struct stat64 info;
 
-    if (stat64(filePath, &info) != 0)
-        return false;
+    if (fstat64(fileno(handle), &info) != 0)
     #endif
+    {
+        fclose(handle);
+        return false;
+    }
 
     size_t fileSize = static_cast<size_t>(info.st_size);
 
     if (fileSize > GIBIBYTE)
+    {
+        fclose(handle);
         return false;
+    }
 
-    if (fileSize == 0 || static_cast<size_t>(fileSize) <= offset)
+    if (fileSize == 0 || fileSize <= offset)
+    {
+        fclose(handle);
         return true;
+    }
 
     size_t numBytesToRead = fileSize - offset;
 
     if (numBytesToRead > maxSize)
         numBytesToRead = maxSize;
-
-    FILE* handle = fopen(filePath, "rb");
-
-    if (!handle)
-        return false;
 
     try
     {
@@ -1768,145 +1782,176 @@ std::vector<std::string> SharedUtil::ListDir(const char* szPath) noexcept
 #if defined(_WIN32) && defined(MTA_CLIENT)
 namespace
 {
-    // Helper to call GetFileAttributesExW with timeout to prevent indefinite hangs due to env issues
-    struct GetAttributesParams
+    // NtCreateFile can hang indefinitely on a broken filesystem or an interfering AV, so the whole
+    // open/measure/read sequence runs on a worker thread the caller is able to abandon on timeout.
+    struct FileReadParams
     {
-        wchar_t*                  pathCopy;
-        WIN32_FILE_ATTRIBUTE_DATA attrLocal;
-        BOOL                      result;
-        std::atomic<bool>         abandoned;
+        wchar_t*                  pathCopy = nullptr;
+        bool                      contentWanted = false;
+        SString                   data;
+        SharedUtil::SFileReadInfo info;
+        bool                      result = false;
+        std::atomic<int>          refCount{2};
     };
 
-    DWORD WINAPI GetAttributesThread(LPVOID param)
+    void ReleaseFileReadParams(FileReadParams* p)
     {
-        auto* p = static_cast<GetAttributesParams*>(param);
-        p->result = GetFileAttributesExW(p->pathCopy, GetFileExInfoStandard, &p->attrLocal);
-        if (p->abandoned.load(std::memory_order_acquire))
+        if (p->refCount.fetch_sub(1, std::memory_order_acq_rel) == 1)
         {
             delete[] p->pathCopy;
             delete p;
         }
+    }
+
+    // Size and write time must come from the open handle. Taking them from GetFileAttributesEx first
+    // means the length and the bytes are sampled at two different moments, and a file being rewritten
+    // in between silently yields an empty buffer that still reports success.
+    bool ReadWholeFileFromHandle(HANDLE handle, bool contentWanted, SString& outData, SharedUtil::SFileReadInfo& outInfo)
+    {
+        LARGE_INTEGER fileSize{};
+        if (!GetFileSizeEx(handle, &fileSize) || fileSize.HighPart > 0)
+            return false;
+
+        outInfo.size = static_cast<std::uint64_t>(fileSize.QuadPart);
+
+        FILETIME writeTime{};
+        if (GetFileTime(handle, nullptr, nullptr, &writeTime))
+            outInfo.mtime = (static_cast<std::uint64_t>(writeTime.dwHighDateTime) << 32) | writeTime.dwLowDateTime;
+
+        if (!contentWanted || fileSize.LowPart == 0)
+            return true;
+
+        try
+        {
+            outData.resize(fileSize.LowPart);
+        }
+        catch (...)
+        {
+            return false;
+        }
+
+        DWORD numBytesRead = 0;
+        if (!ReadFile(handle, &outData[0], fileSize.LowPart, &numBytesRead, nullptr) || numBytesRead != fileSize.LowPart)
+        {
+            outData.clear();
+            return false;
+        }
+
+        return true;
+    }
+
+    DWORD WINAPI ReadFileThread(LPVOID param)
+    {
+        auto* p = static_cast<FileReadParams*>(param);
+
+        constexpr int MAX_RETRY_ATTEMPTS = 20;
+        constexpr int RETRY_DELAY_MS = 10;
+
+        HANDLE handle = INVALID_HANDLE_VALUE;
+        for (int attempt = 0; attempt < MAX_RETRY_ATTEMPTS; ++attempt)
+        {
+            handle = CreateFileW(p->pathCopy, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING,
+                                 FILE_ATTRIBUTE_NORMAL, nullptr);
+            if (handle != INVALID_HANDLE_VALUE)
+                break;
+
+            DWORD errorCode = GetLastError();
+            if (errorCode != ERROR_SHARING_VIOLATION && errorCode != ERROR_LOCK_VIOLATION)
+                break;
+
+            if (attempt + 1 < MAX_RETRY_ATTEMPTS)
+                Sleep(RETRY_DELAY_MS);
+        }
+
+        if (handle != INVALID_HANDLE_VALUE)
+        {
+            p->result = ReadWholeFileFromHandle(handle, p->contentWanted, p->data, p->info);
+            CloseHandle(handle);
+        }
+
+        ReleaseFileReadParams(p);
         return 0;
     }
-}
 
-bool SharedUtil::GetFileAttributesExWithTimeout(const wchar_t* path, WIN32_FILE_ATTRIBUTE_DATA& attr, DWORD timeoutMs) noexcept
-{
-    size_t   pathLen = wcslen(path) + 1;
-    wchar_t* pathCopy = new (std::nothrow) wchar_t[pathLen];
-    if (!pathCopy)
-        return false;
+    bool RunFileReadWithTimeout(const SString& filePath, bool contentWanted, SString* pOutBuffer, SharedUtil::SFileReadInfo* pOutInfo, DWORD timeoutMs) noexcept
+    {
+        if (pOutBuffer)
+            pOutBuffer->clear();
+
+        if (!SharedUtil::File::IsPathSafe(filePath.c_str()))
+            return false;
+
+        WString wideFilePath;
+        try
+        {
+            wideFilePath = SharedUtil::FromUTF8(filePath);
+        }
+        catch (...)
+        {
+            return false;
+        }
+
+        if (wideFilePath.empty())
+            return false;
+
+        size_t   pathLen = wideFilePath.length() + 1;
+        wchar_t* pathCopy = new (std::nothrow) wchar_t[pathLen];
+        if (!pathCopy)
+            return false;
 
     #ifdef _MSC_VER
-    wcscpy_s(pathCopy, pathLen, path);
+        wcscpy_s(pathCopy, pathLen, wideFilePath.c_str());
     #else
-    wcscpy(pathCopy, path);
+        wcscpy(pathCopy, wideFilePath.c_str());
     #endif
 
-    auto* params = new (std::nothrow) GetAttributesParams{pathCopy, {}, FALSE, {false}};
-    if (!params)
-    {
-        delete[] pathCopy;
-        return false;
-    }
+        auto* params = new (std::nothrow) FileReadParams();
+        if (!params)
+        {
+            delete[] pathCopy;
+            return false;
+        }
 
-    DWORD  threadId;
-    HANDLE thread = CreateThread(nullptr, 0, GetAttributesThread, params, 0, &threadId);
-    if (!thread)
-    {
-        delete[] params->pathCopy;
-        delete params;
-        return false;
-    }
+        params->pathCopy = pathCopy;
+        params->contentWanted = contentWanted;
 
-    DWORD waitResult = WaitForSingleObject(thread, timeoutMs);
+        HANDLE thread = CreateThread(nullptr, 0, ReadFileThread, params, 0, nullptr);
+        if (!thread)
+        {
+            // No worker thread to share ownership with
+            delete[] params->pathCopy;
+            delete params;
+            return false;
+        }
 
-    if (waitResult == WAIT_OBJECT_0)
-    {
+        bool timedOut = WaitForSingleObject(thread, timeoutMs) != WAIT_OBJECT_0;
         CloseHandle(thread);
-        attr = params->attrLocal;
-        bool success = params->result != FALSE;
-        delete[] params->pathCopy;
-        delete params;
-        return success;
-    }
 
-    // Timeout - let the worker thread clean up when it finishes
-    params->abandoned.store(true, std::memory_order_release);
-    CloseHandle(thread);
-    return false;
+        bool result = false;
+        if (!timedOut && params->result)
+        {
+            result = true;
+            if (pOutBuffer)
+                *pOutBuffer = params->data;
+            if (pOutInfo)
+                *pOutInfo = params->info;
+        }
+
+        ReleaseFileReadParams(params);
+        return result;
+    }
 }
 
-bool SharedUtil::FileLoadWithTimeout(const SString& filePath, SString& outBuffer, DWORD timeoutMs) noexcept
+bool SharedUtil::GetFileInfoWithTimeout(const SString& filePath, SFileReadInfo& outInfo, DWORD timeoutMs) noexcept
 {
-    outBuffer.clear();
+    outInfo = SFileReadInfo();
+    return RunFileReadWithTimeout(filePath, false, nullptr, &outInfo, timeoutMs);
+}
 
-    if (!File::IsPathSafe(filePath.c_str()))
-        return false;
-
-    WString wideFilePath;
-    try
-    {
-        wideFilePath = FromUTF8(filePath);
-    }
-    catch (...)
-    {
-        return false;
-    }
-
-    if (wideFilePath.empty())
-        return false;
-
-    WIN32_FILE_ATTRIBUTE_DATA attr;
-    if (!GetFileAttributesExWithTimeout(wideFilePath.c_str(), attr, timeoutMs) || attr.nFileSizeHigh > 0)
-        return false;
-
-    DWORD fileSize = attr.nFileSizeLow;
-    if (fileSize == 0)
-        return true;
-
-    HANDLE fh = CreateFileW(wideFilePath.c_str(), GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr, OPEN_EXISTING,
-                            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED, nullptr);
-    if (fh == INVALID_HANDLE_VALUE)
-        return false;
-
-    HANDLE ev = CreateEventW(nullptr, TRUE, FALSE, nullptr);
-    if (!ev)
-    {
-        CloseHandle(fh);
-        return false;
-    }
-
-    bool ok = false;
-    try
-    {
-        outBuffer.resize(fileSize);
-    }
-    catch (...)
-    {
-        goto done;
-    }
-
-    {
-        OVERLAPPED ov{};
-        ov.hEvent = ev;
-        DWORD n = 0;
-        if (!ReadFile(fh, &outBuffer[0], fileSize, &n, &ov) && GetLastError() == ERROR_IO_PENDING)
-        {
-            if (WaitForSingleObject(ev, timeoutMs) != WAIT_OBJECT_0)
-            {
-                CancelIo(fh);
-                GetOverlappedResult(fh, &ov, &n, TRUE);
-                goto done;
-            }
-        }
-        ok = GetOverlappedResult(fh, &ov, &n, FALSE) && n == fileSize;
-    }
-done:
-    CloseHandle(ev);
-    CloseHandle(fh);
-    if (!ok)
-        outBuffer.clear();
-    return ok;
+bool SharedUtil::FileLoadWithTimeout(const SString& filePath, SString& outBuffer, DWORD timeoutMs, SFileReadInfo* pOutInfo) noexcept
+{
+    if (pOutInfo)
+        *pOutInfo = SFileReadInfo();
+    return RunFileReadWithTimeout(filePath, true, &outBuffer, pOutInfo, timeoutMs);
 }
 #endif

--- a/Tests/client/SharedUtilFile_Tests.cpp
+++ b/Tests/client/SharedUtilFile_Tests.cpp
@@ -1,0 +1,239 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Tests/client/SharedUtilFile_Tests.cpp
+ *  PURPOSE:     Tests for the file loading helpers in Shared/sdk/SharedUtil.File.hpp
+ *
+ *  These cover the contract that the number of bytes read must come from the open
+ *  handle. Directory entry metadata (GetFileAttributesEx) is not guaranteed to be current
+ *  on NTFS, so sizing a read from it can silently produce an empty or truncated buffer
+ *  and still report success - see issue #5120.
+ *
+ *****************************************************************************/
+
+#include <gtest/gtest.h>
+#include <SharedUtil.h>
+
+#include <filesystem>
+#include <string>
+
+#ifdef _WIN32
+    #include <windows.h>
+#endif
+
+using namespace SharedUtil;
+
+namespace
+{
+    class TempFile
+    {
+    public:
+        explicit TempFile(const char* szSuffix)
+        {
+            const std::filesystem::path path = std::filesystem::temp_directory_path() / (std::string("mta_filetest_") + szSuffix + ".bin");
+            m_strPath = path.string().c_str();
+            Remove();
+        }
+
+        ~TempFile() { Remove(); }
+
+        const SString& Path() const { return m_strPath; }
+
+        void Write(const std::string& data) const { ASSERT_TRUE(FileSave(m_strPath, data.data(), static_cast<unsigned long>(data.size()), true)); }
+
+        void Remove() const { FileDelete(m_strPath); }
+
+    private:
+        SString m_strPath;
+    };
+
+    std::string MakePayload(size_t size, char seed)
+    {
+        std::string data(size, '\0');
+        for (size_t i = 0; i < size; ++i)
+            data[i] = static_cast<char>(seed + static_cast<char>(i % 61));
+        return data;
+    }
+}  // namespace
+
+///////////////////////////////////////////////////////////////
+//
+// FileLoad(std::nothrow_t, ...)
+//
+///////////////////////////////////////////////////////////////
+
+TEST(SharedUtilFile, FileLoadNoThrowReadsWholeFile)
+{
+    TempFile          file("nothrow_whole");
+    const std::string payload = MakePayload(5000, 'a');
+    file.Write(payload);
+
+    SString buffer;
+    ASSERT_TRUE(FileLoad(std::nothrow, file.Path(), buffer));
+    EXPECT_EQ(buffer.size(), payload.size());
+    EXPECT_EQ(std::string(buffer.data(), buffer.size()), payload);
+}
+
+TEST(SharedUtilFile, FileLoadNoThrowEmptyFileSucceedsWithEmptyBuffer)
+{
+    TempFile file("nothrow_empty");
+    file.Write(std::string());
+
+    SString buffer;
+    EXPECT_TRUE(FileLoad(std::nothrow, file.Path(), buffer));
+    EXPECT_TRUE(buffer.empty());
+}
+
+TEST(SharedUtilFile, FileLoadNoThrowMissingFileFails)
+{
+    TempFile file("nothrow_missing");
+
+    SString buffer = "leftovers";
+    EXPECT_FALSE(FileLoad(std::nothrow, file.Path(), buffer));
+    EXPECT_TRUE(buffer.empty());
+}
+
+TEST(SharedUtilFile, FileLoadNoThrowHonoursOffsetAndMaxSize)
+{
+    TempFile          file("nothrow_offset");
+    const std::string payload = MakePayload(1000, 'q');
+    file.Write(payload);
+
+    SString buffer;
+    ASSERT_TRUE(FileLoad(std::nothrow, file.Path(), buffer, 100, 200));
+    EXPECT_EQ(buffer.size(), 100u);
+    EXPECT_EQ(std::string(buffer.data(), buffer.size()), payload.substr(200, 100));
+}
+
+// Deleting and re-creating a file with different contents must not serve the old length
+TEST(SharedUtilFile, FileLoadNoThrowSeesRewrittenContents)
+{
+    TempFile file("nothrow_rewrite");
+
+    for (int i = 1; i <= 8; ++i)
+    {
+        const std::string payload = MakePayload(static_cast<size_t>(i) * 733, static_cast<char>('a' + i));
+        file.Remove();
+        file.Write(payload);
+
+        SString buffer;
+        ASSERT_TRUE(FileLoad(std::nothrow, file.Path(), buffer)) << "iteration " << i;
+        EXPECT_EQ(buffer.size(), payload.size()) << "iteration " << i;
+        EXPECT_EQ(std::string(buffer.data(), buffer.size()), payload) << "iteration " << i;
+    }
+}
+
+#if defined(_WIN32) && defined(MTA_CLIENT)
+
+///////////////////////////////////////////////////////////////
+//
+// FileLoadWithTimeout / GetFileInfoWithTimeout
+//
+///////////////////////////////////////////////////////////////
+
+TEST(SharedUtilFile, FileLoadWithTimeoutReadsWholeFile)
+{
+    TempFile          file("timeout_whole");
+    const std::string payload = MakePayload(5000, 'a');
+    file.Write(payload);
+
+    SString       buffer;
+    SFileReadInfo info;
+    ASSERT_TRUE(FileLoadWithTimeout(file.Path(), buffer, 2000, &info));
+    EXPECT_EQ(buffer.size(), payload.size());
+    EXPECT_EQ(std::string(buffer.data(), buffer.size()), payload);
+    EXPECT_EQ(info.size, payload.size());
+    EXPECT_NE(info.mtime, 0u);
+}
+
+TEST(SharedUtilFile, FileLoadWithTimeoutEmptyFileSucceedsWithEmptyBuffer)
+{
+    TempFile file("timeout_empty");
+    file.Write(std::string());
+
+    SString       buffer;
+    SFileReadInfo info;
+    EXPECT_TRUE(FileLoadWithTimeout(file.Path(), buffer, 2000, &info));
+    EXPECT_TRUE(buffer.empty());
+    EXPECT_EQ(info.size, 0u);
+}
+
+TEST(SharedUtilFile, FileLoadWithTimeoutMissingFileFails)
+{
+    TempFile file("timeout_missing");
+
+    SString buffer = "leftovers";
+    EXPECT_FALSE(FileLoadWithTimeout(file.Path(), buffer, 2000));
+    EXPECT_TRUE(buffer.empty());
+}
+
+TEST(SharedUtilFile, FileLoadWithTimeoutSeesRewrittenContents)
+{
+    TempFile file("timeout_rewrite");
+
+    for (int i = 1; i <= 8; ++i)
+    {
+        const std::string payload = MakePayload(static_cast<size_t>(i) * 733, static_cast<char>('a' + i));
+        file.Remove();
+        file.Write(payload);
+
+        SString       buffer;
+        SFileReadInfo info;
+        ASSERT_TRUE(FileLoadWithTimeout(file.Path(), buffer, 2000, &info)) << "iteration " << i;
+        EXPECT_EQ(buffer.size(), payload.size()) << "iteration " << i;
+        EXPECT_EQ(std::string(buffer.data(), buffer.size()), payload) << "iteration " << i;
+        EXPECT_EQ(info.size, payload.size()) << "iteration " << i;
+    }
+}
+
+TEST(SharedUtilFile, GetFileInfoWithTimeoutReportsHandleSize)
+{
+    TempFile          file("timeout_info");
+    const std::string payload = MakePayload(1234, 'z');
+    file.Write(payload);
+
+    SFileReadInfo info;
+    ASSERT_TRUE(GetFileInfoWithTimeout(file.Path(), info, 2000));
+    EXPECT_EQ(info.size, payload.size());
+    EXPECT_NE(info.mtime, 0u);
+
+    file.Remove();
+    SFileReadInfo missingInfo;
+    EXPECT_FALSE(GetFileInfoWithTimeout(file.Path(), missingInfo, 2000));
+    EXPECT_EQ(missingInfo.size, 0u);
+}
+
+// A writer holding the file open is the state in which the directory entry is most likely to
+// disagree with the file, since it is refreshed on close or flush rather than on every write
+TEST(SharedUtilFile, ReadsFileWithUnflushedWriterHandleOpen)
+{
+    TempFile          file("timeout_unflushed");
+    const std::string payload = MakePayload(64 * 1024, 'k');
+
+    const WString wide = FromUTF8(file.Path());
+    HANDLE        writer = CreateFileW(wide.c_str(), GENERIC_WRITE, FILE_SHARE_READ, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    ASSERT_NE(writer, INVALID_HANDLE_VALUE);
+
+    DWORD written = 0;
+    ASSERT_TRUE(WriteFile(writer, payload.data(), static_cast<DWORD>(payload.size()), &written, nullptr));
+    ASSERT_EQ(written, payload.size());
+
+    SString       buffer;
+    SFileReadInfo info;
+    const bool    loaded = FileLoadWithTimeout(file.Path(), buffer, 2000, &info);
+
+    SString    noThrowBuffer;
+    const bool noThrowLoaded = FileLoad(std::nothrow, file.Path(), noThrowBuffer);
+
+    CloseHandle(writer);
+
+    ASSERT_TRUE(loaded);
+    EXPECT_EQ(info.size, payload.size());
+    EXPECT_EQ(std::string(buffer.data(), buffer.size()), payload);
+
+    ASSERT_TRUE(noThrowLoaded);
+    EXPECT_EQ(std::string(noThrowBuffer.data(), noThrowBuffer.size()), payload);
+}
+
+#endif


### PR DESCRIPTION
#### Summary

Client-side file reads could return an **empty buffer while reporting success**, which made a
freshly downloaded resource file checksum to `CRC:00000000 MD5:D41D8CD98F00B204E9800998ECF8427E`
— the checksum of zero bytes. Three changes:

1. **`CDownloadableResource::GenerateClientChecksum()`** now retries briefly (4 × 20 ms) when a
   file reads as empty *and* the server-reported download size is non-zero. A file that does not
   exist yet checksums to `CChecksum()` instead, so files still awaiting download never enter this
   path and pay no cost.
2. **`SharedUtil::FileLoadWithTimeout()` and `SharedUtil::FileLoad(std::nothrow, …)`** took the
   number of bytes to read from `GetFileAttributesExW` and returned `true` with an empty buffer when
   that reported 0. Sizing a read from the directory entry samples the length and the bytes at two
   different moments. Both now open the handle first and size the read with `GetFileSizeEx`, and a
   short read is never reported as success. `FileLoadWithTimeout` moves the whole open/measure/read
   sequence onto the single worker thread that already provided the hang timeout — this keeps the
   protection from 7bc2315 / 7e69069 end-to-end and drops thread spawns per call from 3 to 2.
   `FileLoad(std::nothrow, …)` is what `CClientDFF`/`CClientTXD`/`CClientColModel` use, so the same
   defect could load a model from an empty buffer even when the checksum passed.
   The POSIX branch switches from `stat64(path)` to `fstat64(fd)` for the same reason.
3. **`CChecksum`'s Windows client cache** is now validated and populated with size/mtime taken from
   the open handle, never caches a zero-byte result, and gains
   `InvalidateChecksumCacheEntry(path)` — called wherever a file is deleted or replaced
   (`CPacketHandler::Packet_ResourceStart`, `CResource::VerifyPendingClientChecksums`,
   `CResourceFileDownloadManager::DownloadFinished`, `CSingularFileDownload`).

`CResource::Load()` also re-reads once before reporting a mismatch, so a lost race becomes a silent
retry rather than a player-visible error.

`GetFileAttributesExWithTimeout()` had no callers left after this and was removed, along with the
`WIN32_FILE_ATTRIBUTE_DATA` forward declaration that existed only for it.

#### Motivation

Resolves #5120.

Restarting a resource that contains `.dff` / `.txd` / `.hf` / `.mp3` files produced
`HTTP server file mismatch!` with `Got CRC:00000000` on every restart, and the model was not
replaced. A second restart of the same resource worked.

That MD5 is the MD5 of an empty input, so the client was hashing zero bytes for a file that had
downloaded correctly. Client scripts were unaffected because `CResource::Load()` reads those through
`FileLoad()` (stdio, length from the open stream); only the auto-download files went through
`GenerateChecksumFromFileUnsafe()` → `FileLoadWithTimeout()`.

#### Test plan

**New unit tests** — `Tests/client/SharedUtilFile_Tests.cpp`, 11 cases covering both loaders: whole
file, genuinely empty file, missing file, offset/maxSize, repeated delete + rewrite, a writer handle
still open, and `GetFileInfoWithTimeout`. Full suite: 315/315 pass
(`Bin/tests/Tests_Client_d.exe`).

**Measured before/after** with a standalone harness running the pre-fix and post-fix
implementations side by side against a writer thread doing delete → create → write → close, counting
calls that returned success with a buffer that was not the complete payload:

| Scenario | before | after | after + retry |
|---|---|---|---|
| A: static complete file (3000 calls) | 0 | 0 | — |
| D: writer handle open, unflushed (3000 calls) | 0 | 0 | — |
| B: concurrent rewrite (20000 calls) | 1736 | 567 | **0** |
| C: concurrent rewrite, 1 ms zero-byte window (3000 calls) | 2208 | 1751 | **0** |

A and D show the read is fine once the file is settled; B and C are the failure mode, and the retry
closes it completely.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
