### PR TITLE
Fix aim/arm getting stuck after playing a custom animation

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -3234,8 +3234,8 @@ void CClientPed::ApplyControllerStateFixes(CControllerState& Current)
     {
         // Entering as driver or passenger?
         int iTaskType = pTask->GetTaskType();
-        if (iTaskType == TASK_COMPLEX_ENTER_CAR_AS_DRIVER || iTaskType == TASK_COMPLEX_ENTER_CAR_AS_PASSENGER || iTaskType == TASK_COMPLEX_ENTER_BOAT_AS_DRIVER ||
-            iTaskType == TASK_SIMPLE_NAMED_ANIM || iTaskType == TASK_SIMPLE_ANIM)
+        if (iTaskType == TASK_COMPLEX_ENTER_CAR_AS_DRIVER || iTaskType == TASK_COMPLEX_ENTER_CAR_AS_PASSENGER ||
+            iTaskType == TASK_COMPLEX_ENTER_BOAT_AS_DRIVER || iTaskType == TASK_SIMPLE_NAMED_ANIM || iTaskType == TASK_SIMPLE_ANIM)
         {
             // Don't allow the aiming key (RightShoulder1)
             // This fixes bug allowing you to run around in aim mode while

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -3234,7 +3234,8 @@ void CClientPed::ApplyControllerStateFixes(CControllerState& Current)
     {
         // Entering as driver or passenger?
         int iTaskType = pTask->GetTaskType();
-        if (iTaskType == TASK_COMPLEX_ENTER_CAR_AS_DRIVER || iTaskType == TASK_COMPLEX_ENTER_CAR_AS_PASSENGER || iTaskType == TASK_COMPLEX_ENTER_BOAT_AS_DRIVER)
+        if (iTaskType == TASK_COMPLEX_ENTER_CAR_AS_DRIVER || iTaskType == TASK_COMPLEX_ENTER_CAR_AS_PASSENGER || iTaskType == TASK_COMPLEX_ENTER_BOAT_AS_DRIVER ||
+            iTaskType == TASK_SIMPLE_NAMED_ANIM || iTaskType == TASK_SIMPLE_ANIM)
         {
             // Don't allow the aiming key (RightShoulder1)
             // This fixes bug allowing you to run around in aim mode while
@@ -5966,6 +5967,8 @@ void CClientPed::RunNamedAnimation(std::unique_ptr<CAnimBlock>& pBlock, const ch
             if (pTask)
             {
                 pTask->SetAsPedTask(m_pPlayerPed, TASK_PRIORITY_PRIMARY);
+                KillTaskSecondary(TASK_SECONDARY_ATTACK);
+                KillTaskSecondary(TASK_SECONDARY_IK);
                 g_pClientGame->InsertRunNamedAnimTaskToMap(reinterpret_cast<CTaskSimpleRunNamedAnimSAInterface*>(pTask->GetInterface()), this);
             }
         }


### PR DESCRIPTION
#### Summary
`RunNamedAnimation` was assigning the new animation directly to `TASK_PRIORITY_PRIMARY` without touching `TASK_SECONDARY_ATTACK` or `TASK_SECONDARY_IK`. Now it kills both secondary tasks first, so their normal abort cleanup runs before the animation takes over.

#### Motivation
Fixes #883. Aiming a weapon and then playing a `setPedAnimation` animation replaced the primary task but left the aiming task running on its own secondary slot with nothing driving it anymore.

#### Test plan
Bind a key to `setPedAnimation`, equip a weapon, hold aim, move the camera around, then press the bind while still aiming. Arm and aim target should reset properly instead of freezing/breaking.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.