### PR TITLE
Fix trailers not attaching to custom vehicle models

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -9,6 +9,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include <enums/VehicleType.h>
 
 static bool __fastcall AreVehicleDoorsUndamageable(CVehicleSAInterface* vehicle)
 {
@@ -64,6 +65,85 @@ static void __declspec(naked) HOOK_CDamageManager__ProgressDoorDamage()
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
+// CAutomobile::GetTowBarPos
+//
+// This hook lets trailers attach to trucks created with engineRequestModel.
+//
+// CVehicle::UpdateTractorLink asks the truck where its tow bar sits every frame, and the answer
+// comes from a switch over the model index; the trucks built to pull a trailer return their misc_a
+// dummy, everything else gets a generic point off the front bumper. A cloned truck carries a model
+// ID of its own, so it matches no case and the trailer hangs off the wrong end.
+//
+// Redirecting just the model index that switch reads, to the ID the model was cloned from, is
+// enough. The branch it then takes reads nothing but the vehicle's own misc_a dummy, so the clone
+// gets its tow bar straight out of its own DFF.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6AF250 | 66 8B 41 22 | mov     ax, word ptr [ecx + 0x22]
+// >>> 0x6AF254 | 83 EC 0C    | sub     esp, 0xC
+//     0x6AF257 | 66 3D 0D 02 | cmp     ax, 0x20D
+#define HOOKPOS_CAutomobile__GetTowBarPos  0x6AF250
+#define HOOKSIZE_CAutomobile__GetTowBarPos 7
+static const DWORD CONTINUE_CAutomobile__GetTowBarPos = 0x6AF257;
+
+// Models that answer with their misc_a dummy, so a clone of one still tows.
+//
+// The tow truck and the tractor are left out; they derive the bar from their hoist angle, and the
+// rest of their behaviour stays gated on the stock model index, so a clone would only half work.
+// The trailers in that same switch, artict3 and the two baggage boxes, are vehicles.ide type
+// trailer and so become CTrailer, which overrides this function and never reaches it.
+static constexpr bool HasTowBarDummy(VehicleType model)
+{
+    switch (model)
+    {
+        case VehicleType::VT_LINERUN:
+        case VehicleType::VT_BAGGAGE:
+        case VehicleType::VT_PETRO:
+        case VehicleType::VT_RDTRAIN:
+        case VehicleType::VT_UTILITY:
+        case VehicleType::VT_TUG:
+            return true;
+        default:
+            return false;
+    }
+}
+
+static std::uint32_t __fastcall GetTowBarModelId(CVehicleSAInterface* vehicle)
+{
+    const std::uint32_t modelId = vehicle->m_nModelIndex;
+
+    CModelInfo* modelInfo = pGameInterface->GetModelInfo(modelId);
+    if (!modelInfo)
+        return modelId;
+
+    // Only engineRequestModel models carry a parent, so stock vehicles keep their index and take
+    // the branch they always did.
+    const std::uint32_t parentId = modelInfo->GetParentID();
+    if (parentId == 0 || !HasTowBarDummy(static_cast<VehicleType>(parentId)))
+        return modelId;
+
+    return parentId;
+}
+
+static void __declspec(naked) HOOK_CAutomobile__GetTowBarPos()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    ecx
+        call    GetTowBarModelId        // vehicle in ecx; model index comes back in ax
+        pop     ecx
+
+        sub     esp, 0x0C
+        jmp     CONTINUE_CAutomobile__GetTowBarPos
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
 // CMultiplayerSA::InitHooks_Vehicles
 //
 // Setup hooks
@@ -72,4 +152,5 @@ static void __declspec(naked) HOOK_CDamageManager__ProgressDoorDamage()
 void CMultiplayerSA::InitHooks_Vehicles()
 {
     EZHookInstall(CDamageManager__ProgressDoorDamage);
+    EZHookInstall(CAutomobile__GetTowBarPos);
 }

--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -110,7 +110,7 @@ static constexpr bool HasTowBarDummy(VehicleType model)
 
 static std::uint32_t __fastcall GetTowBarModelId(CVehicleSAInterface* vehicle)
 {
-    const std::uint32_t modelId = vehicle->m_nModelIndex;
+    const std::uint32_t modelId = static_cast<std::uint32_t>(vehicle->m_nModelIndex);
 
     CModelInfo* modelInfo = pGameInterface->GetModelInfo(modelId);
     if (!modelInfo)


### PR DESCRIPTION
#### Summary

Trailers now attach to trucks whose model was created with engineRequestModel, exactly as they do to the stock ones. Nothing new is exposed to scripts; it works on its own.

#### Motivation

Fixes #4525. Part of #1861. CVehicle::UpdateTractorLink asks the towing vehicle where its tow bar sits every frame, and CAutomobile::GetTowBarPos answers from a switch over the model index: the trucks built to pull a trailer return their misc_a dummy, everything else gets a generic point off the front bumper. A model created by engineRequestModel carries an ID of its own, so a cloned truck matches no case and its trailer ends up hanging off the wrong end.

The hook redirects only the model index that switch reads, to the ID the model was cloned from. The branch it then takes reads nothing but the vehicle's own misc_a dummy, so the clone resolves its tow bar from its own DFF. Stock vehicles have no parent ID, so they keep the index they had and take the branch they always did.

The tow truck and the tractor are deliberately left out: they derive the bar from their hoist angle, and the rest of their behaviour stays gated on the stock model index, so a clone would only half work.

#### Test plan

Clone a Tanker with engineRequestModel, apply petro.dff and petro.txd, and setElementModel a vehicle to it. Attach a stock trailer with attachTrailerToVehicle and confirm it sits on the tow bar and follows correctly while driving; backing the cloned truck up to a loose trailer picks it up too. Confirm a stock truck and trailer are unchanged.

[ctruck.zip](https://github.com/user-attachments/files/30848644/ctruck.zip)


#### Checklist

* [x] Your code should follow the coding guidelines.
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit by commit.