### PR TITLE
Fix ZR-350 pop up headlights not working on custom vehicle models

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -79,7 +79,7 @@ static void __declspec(naked) HOOK_CDamageManager__ProgressDoorDamage()
 //////////////////////////////////////////////////////////////////////////////////////////
 static bool __fastcall HasPopUpHeadlights(CVehicleSAInterface* vehicle)
 {
-    const std::uint32_t modelId = vehicle->m_nModelIndex;
+    const std::uint32_t modelId = static_cast<std::uint32_t>(vehicle->m_nModelIndex);
     if (modelId == static_cast<std::uint32_t>(VehicleType::VT_ZR350))
         return true;
 

--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -9,6 +9,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include <enums/VehicleType.h>
 
 static bool __fastcall AreVehicleDoorsUndamageable(CVehicleSAInterface* vehicle)
 {
@@ -64,6 +65,96 @@ static void __declspec(naked) HOOK_CDamageManager__ProgressDoorDamage()
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
+// Pop up headlights on custom vehicle models
+//
+// The ZR-350 is the one car whose headlights swing out before they light up, and the game drives it
+// from two model index checks. CAutomobile::PreRender turns the misc_a component through
+// CVehicle::SetComponentRotation to deploy them, and CVehicle::DoVehicleLights waits for that
+// deployment to finish before it lets the headlights come on. A model created by engineRequestModel
+// carries an ID of its own, so a cloned ZR-350 misses both and its headlights stay shut.
+//
+// Both hooks answer the same question, whether this vehicle should behave as a ZR-350, and let the
+// model it was cloned from count. Everything else keeps the model index it already had.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+static bool __fastcall HasPopUpHeadlights(CVehicleSAInterface* vehicle)
+{
+    const std::uint32_t modelId = vehicle->m_nModelIndex;
+    if (modelId == static_cast<std::uint32_t>(VehicleType::VT_ZR350))
+        return true;
+
+    CModelInfo* modelInfo = pGameInterface->GetModelInfo(modelId);
+    return modelInfo && modelInfo->GetParentID() == static_cast<unsigned int>(VehicleType::VT_ZR350);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CAutomobile::PreRender, swinging the misc_a component out
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6ACA8D | 66 3D DD 01       | cmp     ax, 0x1DD
+// >>> 0x6ACA91 | 0F 85 30 01 00 00 | jne     0x6ACBC7
+//     0x6ACA97 | 8B 86 58 09 00 00 | mov     eax, [esi + 0x958]
+#define HOOKPOS_CAutomobile__PreRender_PopUpLights  0x6ACA8D
+#define HOOKSIZE_CAutomobile__PreRender_PopUpLights 10
+static const DWORD CONTINUE_CAutomobile__PreRender_PopUpLights = 0x6ACA97;
+static const DWORD SKIP_CAutomobile__PreRender_PopUpLights = 0x6ACBC7;
+
+static void __declspec(naked) HOOK_CAutomobile__PreRender_PopUpLights()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        pushad
+        mov     ecx, esi
+        call    HasPopUpHeadlights
+        test    al, al          // popad leaves the flags alone, so this survives it
+        popad
+        jz      notPopUpLights
+
+        jmp     CONTINUE_CAutomobile__PreRender_PopUpLights
+
+        notPopUpLights:
+        jmp     SKIP_CAutomobile__PreRender_PopUpLights
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CVehicle::DoVehicleLights, holding the headlights back until they are out
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6E1C17 | 66 81 7E 22 DD 01 | cmp     word ptr [esi + 0x22], 0x1DD
+// >>> 0x6E1C1D | 0F 85 AB 00 00 00 | jne     0x6E1CCE
+//     0x6E1C23 | 8A 56 36          | mov     dl, byte ptr [esi + 0x36]
+#define HOOKPOS_CVehicle__DoVehicleLights_PopUpLights  0x6E1C17
+#define HOOKSIZE_CVehicle__DoVehicleLights_PopUpLights 12
+static const DWORD CONTINUE_CVehicle__DoVehicleLights_PopUpLights = 0x6E1C23;
+static const DWORD SKIP_CVehicle__DoVehicleLights_PopUpLights = 0x6E1CCE;
+
+static void __declspec(naked) HOOK_CVehicle__DoVehicleLights_PopUpLights()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        pushad
+        mov     ecx, esi
+        call    HasPopUpHeadlights
+        test    al, al
+        popad
+        jz      notPopUpLights
+
+        jmp     CONTINUE_CVehicle__DoVehicleLights_PopUpLights
+
+        notPopUpLights:
+        jmp     SKIP_CVehicle__DoVehicleLights_PopUpLights
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
 // CMultiplayerSA::InitHooks_Vehicles
 //
 // Setup hooks
@@ -72,4 +163,6 @@ static void __declspec(naked) HOOK_CDamageManager__ProgressDoorDamage()
 void CMultiplayerSA::InitHooks_Vehicles()
 {
     EZHookInstall(CDamageManager__ProgressDoorDamage);
+    EZHookInstall(CAutomobile__PreRender_PopUpLights);
+    EZHookInstall(CVehicle__DoVehicleLights_PopUpLights);
 }

--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -105,11 +105,11 @@ static void __declspec(naked) HOOK_CAutomobile__PreRender_PopUpLights()
     // clang-format off
     __asm
     {
-        pushad
+        push    esi
         mov     ecx, esi
         call    HasPopUpHeadlights
-        test    al, al          // popad leaves the flags alone, so this survives it
-        popad
+        test    al, al
+        pop     esi
         jz      notPopUpLights
 
         jmp     CONTINUE_CAutomobile__PreRender_PopUpLights
@@ -138,11 +138,13 @@ static void __declspec(naked) HOOK_CVehicle__DoVehicleLights_PopUpLights()
     // clang-format off
     __asm
     {
-        pushad
+        push    esi
+        push    ecx
         mov     ecx, esi
         call    HasPopUpHeadlights
         test    al, al
-        popad
+        pop     ecx
+        pop     esi
         jz      notPopUpLights
 
         jmp     CONTINUE_CVehicle__DoVehicleLights_PopUpLights


### PR DESCRIPTION
#### Summary

The ZR-350's pop up headlights, misc_a swinging out before the lights turn on, now work on a clone of the model created with engineRequestModel, exactly as they do on the stock 477.

#### Motivation

Part of #1861. CAutomobile::PreRender only swings the misc_a component for model 477, and CVehicle::DoVehicleLights only waits for that swing to finish before turning the headlights on for model 477 too. A model created by engineRequestModel carries an ID of its own, so a cloned ZR-350 matches neither check and its headlights stay shut and never light up.

Both checks now also accept the model the clone was cloned from, so a clone behaves exactly like the stock car and everything else is untouched.

#### Test plan

Clone model 477 with engineRequestModel, replace it with the DFF and TXD, and setElementModel a vehicle to it. Confirm the headlights swing out and light up when turned on, and swing back in when turned off, same as an unmodified ZR-350.

[zrtest.zip](https://github.com/user-attachments/files/30883512/zrtest.zip)

#### Checklist

* [x] Your code should follow the coding guidelines.
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit by commit.