### PR TITLE
Fix Dozer blade not working on custom vehicle models

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -79,7 +79,7 @@ static void __declspec(naked) HOOK_CDamageManager__ProgressDoorDamage()
 //////////////////////////////////////////////////////////////////////////////////////////
 static bool __fastcall IsDozerOrClone(CVehicleSAInterface* vehicle)
 {
-    const std::uint32_t modelId = static_cast<std::uint32_t>(vehicle->m_nModelIndex);
+    const std::uint32_t modelId = vehicle->m_nModelIndex;
     if (modelId == static_cast<std::uint32_t>(VehicleType::VT_DOZER))
         return true;
 

--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -9,6 +9,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include <enums/VehicleType.h>
 
 static bool __fastcall AreVehicleDoorsUndamageable(CVehicleSAInterface* vehicle)
 {
@@ -64,6 +65,265 @@ static void __declspec(naked) HOOK_CDamageManager__ProgressDoorDamage()
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
+// The Dozer's blade on custom vehicle models
+//
+// CAutomobile::ProcessControl and CAutomobile::PreRender both decide whether to move the blade
+// (component misc_a) through their own separate model index checks, and the force the blade applies
+// to whatever it pushes is worked out the same way in a third place. A model created by
+// engineRequestModel carries an ID of its own, so a cloned Dozer matches none of them and the blade
+// just sits still.
+//
+// Every hook below asks the same question, whether this vehicle should behave as a Dozer, and lets
+// the model it was cloned from count. Everything else keeps the model index it already had.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+static bool __fastcall IsDozerOrClone(CVehicleSAInterface* vehicle)
+{
+    const std::uint32_t modelId = vehicle->m_nModelIndex;
+    if (modelId == static_cast<std::uint32_t>(VehicleType::VT_DOZER))
+        return true;
+
+    CModelInfo* modelInfo = pGameInterface->GetModelInfo(modelId);
+    return modelInfo && modelInfo->GetParentID() == static_cast<unsigned int>(VehicleType::VT_DOZER);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CAutomobile::ProcessControl, resetting the blade's previous angle for this tick
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6A1491 | 66 81 F9 E6 01 | cmp     cx, 0x1E6
+// >>> 0x6A1496 | 74 1C          | je      0x6A14B4
+//     0x6A1498 | 66 81 F9 96 01 | cmp     cx, 0x196
+#define HOOKPOS_CAutomobile__ProcessControl_DozerAngleReset  0x6A1491
+#define HOOKSIZE_CAutomobile__ProcessControl_DozerAngleReset 7
+static const DWORD CONTINUE_CAutomobile__ProcessControl_DozerAngleReset = 0x6A14B4;
+static const DWORD SKIP_CAutomobile__ProcessControl_DozerAngleReset = 0x6A1498;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessControl_DozerAngleReset()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        pushad
+        mov     ecx, edi
+        call    IsDozerOrClone
+        test    al, al
+        popad
+        jz      notDozer
+
+        jmp     CONTINUE_CAutomobile__ProcessControl_DozerAngleReset
+
+        notDozer:
+        jmp     SKIP_CAutomobile__ProcessControl_DozerAngleReset
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CAutomobile::ProcessControl, letting the blade into the block that moves it this tick
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6A14F4 | 66 81 F9 E6 01 | cmp     cx, 0x1E6
+// >>> 0x6A14F9 | 74 61          | je      0x6A155C
+//     0x6A14FB | 66 81 F9 96 01 | cmp     cx, 0x196
+#define HOOKPOS_CAutomobile__ProcessControl_DozerMiscGate  0x6A14F4
+#define HOOKSIZE_CAutomobile__ProcessControl_DozerMiscGate 7
+static const DWORD CONTINUE_CAutomobile__ProcessControl_DozerMiscGate = 0x6A155C;
+static const DWORD SKIP_CAutomobile__ProcessControl_DozerMiscGate = 0x6A14FB;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessControl_DozerMiscGate()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        pushad
+        mov     ecx, edi
+        call    IsDozerOrClone
+        test    al, al
+        popad
+        jz      notDozer
+
+        jmp     CONTINUE_CAutomobile__ProcessControl_DozerMiscGate
+
+        notDozer:
+        jmp     SKIP_CAutomobile__ProcessControl_DozerMiscGate
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// The force the blade applies to whatever it pushes, part one
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6A173F | 66 3D E6 01          | cmp     ax, 0x1E6
+// >>> 0x6A1743 | 89 9C 24 F8 00 00 00 | mov     dword ptr [esp + 0xF8], ebx
+// >>> 0x6A174A | 75 50                | jne     0x6A179C
+#define HOOKPOS_CAutomobile__MovingCollisionSpeed_Dozer  0x6A173F
+#define HOOKSIZE_CAutomobile__MovingCollisionSpeed_Dozer 13
+static const DWORD CONTINUE_CAutomobile__MovingCollisionSpeed_Dozer = 0x6A174C;
+static const DWORD SKIP_CAutomobile__MovingCollisionSpeed_Dozer = 0x6A179C;
+
+static void __declspec(naked) HOOK_CAutomobile__MovingCollisionSpeed_Dozer()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // ebx is already zero here (xor ebx, ebx a few instructions up), and this reset happens for
+        // every model that reaches this point, not only a matched one, so it stays unconditional.
+        mov     dword ptr [esp + 0xF8], ebx
+
+        pushad
+        mov     ecx, edi
+        call    IsDozerOrClone
+        test    al, al
+        popad
+        jz      notDozer
+
+        jmp     CONTINUE_CAutomobile__MovingCollisionSpeed_Dozer
+
+        notDozer:
+        jmp     SKIP_CAutomobile__MovingCollisionSpeed_Dozer
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// The force the blade applies to whatever it pushes, part two
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6A1FB6 | 66 81 F9 E6 01 | cmp     cx, 0x1E6
+// >>> 0x6A1FBB | 75 14          | jne     0x6A1FD1
+//     0x6A1FBD | 8B 86 98 06 00 00 | mov  eax, [esi + 0x698]
+#define HOOKPOS_CAutomobile__MovingCollisionSpeed_DozerExtraA  0x6A1FB6
+#define HOOKSIZE_CAutomobile__MovingCollisionSpeed_DozerExtraA 7
+static const DWORD CONTINUE_CAutomobile__MovingCollisionSpeed_DozerExtraA = 0x6A1FBD;
+static const DWORD SKIP_CAutomobile__MovingCollisionSpeed_DozerExtraA = 0x6A1FD1;
+
+static void __declspec(naked) HOOK_CAutomobile__MovingCollisionSpeed_DozerExtraA()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        pushad
+        mov     ecx, esi
+        call    IsDozerOrClone
+        test    al, al
+        popad
+        jz      notDozer
+
+        jmp     CONTINUE_CAutomobile__MovingCollisionSpeed_DozerExtraA
+
+        notDozer:
+        jmp     SKIP_CAutomobile__MovingCollisionSpeed_DozerExtraA
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// The force the blade applies to whatever it pushes, part three
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6A21A4 | 66 3D E6 01 | cmp     ax, 0x1E6
+// >>> 0x6A21A8 | 75 1E       | jne     0x6A21C8
+//     0x6A21AA | 8B B1 98 06 00 00 | mov ptr esi, [ecx + 0x698]
+#define HOOKPOS_CAutomobile__MovingCollisionSpeed_DozerExtraB  0x6A21A4
+#define HOOKSIZE_CAutomobile__MovingCollisionSpeed_DozerExtraB 6
+static const DWORD CONTINUE_CAutomobile__MovingCollisionSpeed_DozerExtraB = 0x6A21AA;
+static const DWORD SKIP_CAutomobile__MovingCollisionSpeed_DozerExtraB = 0x6A21C8;
+
+static void __declspec(naked) HOOK_CAutomobile__MovingCollisionSpeed_DozerExtraB()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // ecx already holds the vehicle pointer here, nothing to move into it.
+        pushad
+        call    IsDozerOrClone
+        test    al, al
+        popad
+        jz      notDozer
+
+        jmp     CONTINUE_CAutomobile__MovingCollisionSpeed_DozerExtraB
+
+        notDozer:
+        jmp     SKIP_CAutomobile__MovingCollisionSpeed_DozerExtraB
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CAutomobile::PreRender, swinging the misc_a component out
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6AC40C | 66 3D E6 01 | cmp     ax, 0x1E6
+// >>> 0x6AC410 | 75 29       | jne     0x6AC43B
+//     0x6AC412 | 0F B7 86 6C 08 00 00 | movzx eax, word ptr [esi + 0x86C]
+#define HOOKPOS_CAutomobile__PreRender_DozerSwing  0x6AC40C
+#define HOOKSIZE_CAutomobile__PreRender_DozerSwing 6
+static const DWORD CONTINUE_CAutomobile__PreRender_DozerSwing = 0x6AC412;
+static const DWORD SKIP_CAutomobile__PreRender_DozerSwing = 0x6AC43B;
+
+static void __declspec(naked) HOOK_CAutomobile__PreRender_DozerSwing()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        pushad
+        mov     ecx, esi
+        call    IsDozerOrClone
+        test    al, al
+        popad
+        jz      notDozer
+
+        jmp     CONTINUE_CAutomobile__PreRender_DozerSwing
+
+        notDozer:
+        jmp     SKIP_CAutomobile__PreRender_DozerSwing
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CAutomobile::ProcessControl, the model switch that reaches UpdateMovingCollision at all
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6B1F95 | 66 3D E6 01 | cmp     ax, 0x1E6
+// >>> 0x6B1F99 | 74 74       | je      0x6B200F
+//     0x6B1F9B | 66 3D 96 01 | cmp     ax, 0x196
+#define HOOKPOS_CAutomobile__ProcessControl_DozerDispatch  0x6B1F95
+#define HOOKSIZE_CAutomobile__ProcessControl_DozerDispatch 6
+static const DWORD CONTINUE_CAutomobile__ProcessControl_DozerDispatch = 0x6B200F;
+static const DWORD SKIP_CAutomobile__ProcessControl_DozerDispatch = 0x6B1F9B;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessControl_DozerDispatch()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        pushad
+        mov     ecx, esi
+        call    IsDozerOrClone
+        test    al, al
+        popad
+        jz      notDozer
+
+        jmp     CONTINUE_CAutomobile__ProcessControl_DozerDispatch
+
+        notDozer:
+        jmp     SKIP_CAutomobile__ProcessControl_DozerDispatch
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
 // CMultiplayerSA::InitHooks_Vehicles
 //
 // Setup hooks
@@ -72,4 +332,11 @@ static void __declspec(naked) HOOK_CDamageManager__ProgressDoorDamage()
 void CMultiplayerSA::InitHooks_Vehicles()
 {
     EZHookInstall(CDamageManager__ProgressDoorDamage);
+    EZHookInstall(CAutomobile__ProcessControl_DozerAngleReset);
+    EZHookInstall(CAutomobile__ProcessControl_DozerMiscGate);
+    EZHookInstall(CAutomobile__MovingCollisionSpeed_Dozer);
+    EZHookInstall(CAutomobile__MovingCollisionSpeed_DozerExtraA);
+    EZHookInstall(CAutomobile__MovingCollisionSpeed_DozerExtraB);
+    EZHookInstall(CAutomobile__PreRender_DozerSwing);
+    EZHookInstall(CAutomobile__ProcessControl_DozerDispatch);
 }

--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -79,7 +79,7 @@ static void __declspec(naked) HOOK_CDamageManager__ProgressDoorDamage()
 //////////////////////////////////////////////////////////////////////////////////////////
 static bool __fastcall IsDozerOrClone(CVehicleSAInterface* vehicle)
 {
-    const std::uint32_t modelId = vehicle->m_nModelIndex;
+    const std::uint32_t modelId = static_cast<std::uint32_t>(vehicle->m_nModelIndex);
     if (modelId == static_cast<std::uint32_t>(VehicleType::VT_DOZER))
         return true;
 
@@ -105,11 +105,11 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessControl_DozerAngleReset()
     // clang-format off
     __asm
     {
-        pushad
+        push    ecx
         mov     ecx, edi
         call    IsDozerOrClone
         test    al, al
-        popad
+        pop     ecx
         jz      notDozer
 
         jmp     CONTINUE_CAutomobile__ProcessControl_DozerAngleReset
@@ -138,11 +138,11 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessControl_DozerMiscGate()
     // clang-format off
     __asm
     {
-        pushad
+        push    ecx
         mov     ecx, edi
         call    IsDozerOrClone
         test    al, al
-        popad
+        pop     ecx
         jz      notDozer
 
         jmp     CONTINUE_CAutomobile__ProcessControl_DozerMiscGate
@@ -175,11 +175,11 @@ static void __declspec(naked) HOOK_CAutomobile__MovingCollisionSpeed_Dozer()
         // every model that reaches this point, not only a matched one, so it stays unconditional.
         mov     dword ptr [esp + 0xF8], ebx
 
-        pushad
+        push    eax
         mov     ecx, edi
         call    IsDozerOrClone
         test    al, al
-        popad
+        pop     eax
         jz      notDozer
 
         jmp     CONTINUE_CAutomobile__MovingCollisionSpeed_Dozer
@@ -208,11 +208,11 @@ static void __declspec(naked) HOOK_CAutomobile__MovingCollisionSpeed_DozerExtraA
     // clang-format off
     __asm
     {
-        pushad
+        push    ecx
         mov     ecx, esi
         call    IsDozerOrClone
         test    al, al
-        popad
+        pop     ecx
         jz      notDozer
 
         jmp     CONTINUE_CAutomobile__MovingCollisionSpeed_DozerExtraA
@@ -241,11 +241,12 @@ static void __declspec(naked) HOOK_CAutomobile__MovingCollisionSpeed_DozerExtraB
     // clang-format off
     __asm
     {
-        // ecx already holds the vehicle pointer here, nothing to move into it.
-        pushad
+        push    eax
+        push    ecx
         call    IsDozerOrClone
         test    al, al
-        popad
+        pop     ecx
+        pop     eax
         jz      notDozer
 
         jmp     CONTINUE_CAutomobile__MovingCollisionSpeed_DozerExtraB
@@ -274,11 +275,11 @@ static void __declspec(naked) HOOK_CAutomobile__PreRender_DozerSwing()
     // clang-format off
     __asm
     {
-        pushad
+        push    eax
         mov     ecx, esi
         call    IsDozerOrClone
         test    al, al
-        popad
+        pop     eax
         jz      notDozer
 
         jmp     CONTINUE_CAutomobile__PreRender_DozerSwing
@@ -307,11 +308,11 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessControl_DozerDispatch()
     // clang-format off
     __asm
     {
-        pushad
+        push    eax
         mov     ecx, esi
         call    IsDozerOrClone
         test    al, al
-        popad
+        pop     eax
         jz      notDozer
 
         jmp     CONTINUE_CAutomobile__ProcessControl_DozerDispatch


### PR DESCRIPTION
#### Summary

The Dozer's blade, the swing, the push force and the collision it applies, now works on a clone of the model created with engineRequestModel, exactly as it does on the stock 486.

<img width="1366" height="768" alt="mta-screen_2026-08-08_16-52-10" src="https://github.com/user-attachments/assets/fd422abe-e2a9-4b1a-a176-c2664ed77d1f" />


#### Motivation

Part of #1861. CAutomobile::ProcessControl and CAutomobile::PreRender both decide whether to move the blade through their own separate model index checks, and the force it applies to whatever it pushes is worked out the same way in a third place. A model created by engineRequestModel carries an ID of its own, so a cloned Dozer matched none of them and the blade just sat still.

#### Test plan

Clone model 486 with engineRequestModel, replace DFF and TXD, and setElementModel a vehicle to it. Drive it into an object or ped and confirm the blade swings, pushes things and reacts to collision the same way an unmodified Dozer does.

[dozer.zip](https://github.com/user-attachments/files/30862711/dozer.zip)


#### Checklist

* [x] Your code should follow the coding guidelines.
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit by commit.
