### PR TITLE
Add .webp support

### DIFF
--- a/Client/core/CFileFormat.h
+++ b/Client/core/CFileFormat.h
@@ -23,3 +23,8 @@ bool IsPng(const void* pData, uint uiDataSize);
 bool PngGetDimensions(const void* pData, uint uiDataSize, uint& uiOutWidth, uint& uiOutHeight);
 bool PngEncode(uint uiWidth, uint uiHeight, const void* pData, uint uiDataSize, CBuffer& outBuffer);
 bool PngDecode(const void* pData, uint uiDataSize, CBuffer* pOutBuffer, uint& uiOutWidth, uint& uiOutHeight);
+
+// WebP stuff
+bool IsWebP(const void* pData, uint uiDataSize);
+bool WebPGetDimensions(const void* pData, uint uiDataSize, uint& uiOutWidth, uint& uiOutHeight);
+bool WebPDecode(const void* pData, uint uiDataSize, CBuffer* pOutBuffer, uint& uiOutWidth, uint& uiOutHeight);

--- a/Client/core/CFileFormatWebP.cpp
+++ b/Client/core/CFileFormatWebP.cpp
@@ -1,0 +1,85 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        core/CFileFormatWebP.cpp
+ *  PURPOSE:     WebP image format helpers (decode only).
+ *
+ *  Multi Theft Auto is available from https://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+#include <webp/decode.h>
+
+///////////////////////////////////////////////////////////////
+//
+// IsWebP
+//
+// Check for the RIFF....WEBP magic.
+//
+///////////////////////////////////////////////////////////////
+bool IsWebP(const void* pData, uint uiDataSize)
+{
+    if (uiDataSize < 12)
+        return false;
+
+    const unsigned char* p = static_cast<const unsigned char*>(pData);
+    return p[0] == 'R' && p[1] == 'I' && p[2] == 'F' && p[3] == 'F' && p[8] == 'W' && p[9] == 'E' && p[10] == 'B' && p[11] == 'P';
+}
+
+///////////////////////////////////////////////////////////////
+//
+// WebPGetDimensions
+//
+///////////////////////////////////////////////////////////////
+bool WebPGetDimensions(const void* pData, uint uiDataSize, uint& uiOutWidth, uint& uiOutHeight)
+{
+    int width = 0;
+    int height = 0;
+    if (!WebPGetInfo(static_cast<const uint8_t*>(pData), uiDataSize, &width, &height))
+        return false;
+
+    if (width <= 0 || height <= 0)
+        return false;
+
+    uiOutWidth = static_cast<uint>(width);
+    uiOutHeight = static_cast<uint>(height);
+    return true;
+}
+
+///////////////////////////////////////////////////////////////
+//
+// WebPDecode
+//
+// Decodes into BGRA byte order to match SColor / D3DFMT_A8R8G8B8 memory layout
+//
+///////////////////////////////////////////////////////////////
+bool WebPDecode(const void* pData, uint uiDataSize, CBuffer* pOutBuffer, uint& uiOutWidth, uint& uiOutHeight)
+{
+    if (!pOutBuffer)
+        return false;
+
+    int width = 0;
+    int height = 0;
+    if (!WebPGetInfo(static_cast<const uint8_t*>(pData), uiDataSize, &width, &height))
+        return false;
+
+    if (width <= 0 || height <= 0)
+        return false;
+
+    const size_t stride = static_cast<size_t>(width) * 4;
+    const size_t total = stride * static_cast<size_t>(height);
+
+    pOutBuffer->SetSize(static_cast<uint>(total));
+
+    uint8_t* pDst = reinterpret_cast<uint8_t*>(pOutBuffer->GetData());
+    if (!WebPDecodeBGRAInto(static_cast<const uint8_t*>(pData), uiDataSize, pDst, static_cast<size_t>(total), static_cast<int>(stride)))
+    {
+        return false;
+    }
+
+    uiOutWidth = static_cast<uint>(width);
+    uiOutHeight = static_cast<uint>(height);
+    return true;
+}

--- a/Client/core/Graphics/CPixelsManager.cpp
+++ b/Client/core/Graphics/CPixelsManager.cpp
@@ -642,6 +642,10 @@ bool CPixelsManager::GetPixelsSize(const CPixels& pixels, uint& uiOutWidth, uint
             g_pCore->DebugEchoColor(("JPEG error: " + strError).c_str(), 255, 0, 0);
         return false;
     }
+    else if (format == EPixelsFormat::WEBP)
+    {
+        return WebPGetDimensions(pixels.GetData(), pixels.GetSize(), uiOutWidth, uiOutHeight);
+    }
 
     return false;
 }
@@ -650,7 +654,7 @@ bool CPixelsManager::GetPixelsSize(const CPixels& pixels, uint& uiOutWidth, uint
 //
 // CPixelsManager::GetPixelsFormat
 //
-// Auto detect PNG, JPEG, DDS or PLAIN
+// Auto detect PNG, JPEG, DDS, WEBP or PLAIN
 //
 ////////////////////////////////////////////////////////////////
 EPixelsFormatType CPixelsManager::GetPixelsFormat(const CPixels& pixels)
@@ -670,6 +674,10 @@ EPixelsFormatType CPixelsManager::GetPixelsFormat(const CPixels& pixels)
     static byte ddsHeader[] = {0x44, 0x44, 0x53, 0x20};
     if (uiDataSize >= sizeof(ddsHeader) && memcmp(pData, ddsHeader, sizeof(ddsHeader)) == 0)
         return EPixelsFormat::DDS;
+
+    // Check if webp
+    if (IsWebP(pData, uiDataSize))
+        return EPixelsFormat::WEBP;
 
     // Check if plain
     if (uiDataSize >= 8)
@@ -752,7 +760,8 @@ bool CPixelsManager::GetPlainDimensions(const CPixels& pixels, uint& uiOutWidth,
 //
 // CPixelsManager::ChangePixelsFormat
 //
-// JPEG <-> PNG <-> PLAIN
+// JPEG <-> PNG <-> WEBP <-> PLAIN
+// Note: WEBP is not supported for encoding, only decoding
 //
 ////////////////////////////////////////////////////////////////
 bool CPixelsManager::ChangePixelsFormat(const CPixels& oldPixels, CPixels& newPixels, EPixelsFormatType newFormat, int uiQuality)
@@ -809,6 +818,15 @@ bool CPixelsManager::ChangePixelsFormat(const CPixels& oldPixels, CPixels& newPi
         {
             uint uiWidth, uiHeight;
             if (PngDecode(oldPixels.GetData(), oldPixels.GetSize(), &newPixels.buffer, uiWidth, uiHeight))
+            {
+                newPixels.buffer.SetSize(uiWidth * uiHeight * 4 + SIZEOF_PLAIN_TAIL);
+                return SetPlainDimensions(newPixels, uiWidth, uiHeight);
+            }
+        }
+        else if (oldFormat == EPixelsFormat::WEBP)
+        {
+            uint uiWidth, uiHeight;
+            if (WebPDecode(oldPixels.GetData(), oldPixels.GetSize(), &newPixels.buffer, uiWidth, uiHeight))
             {
                 newPixels.buffer.SetSize(uiWidth * uiHeight * 4 + SIZEOF_PLAIN_TAIL);
                 return SetPlainDimensions(newPixels, uiWidth, uiHeight);

--- a/Client/core/Graphics/CRenderItem.FileTexture.cpp
+++ b/Client/core/Graphics/CRenderItem.FileTexture.cpp
@@ -139,6 +139,7 @@ void CFileTextureItem::CreateUnderlyingData(const SString& strFilename, bool bMi
 
     // D3DX cannot decode every format we support, so we need to perform the following steps:
     // Load the file, ask CPixelsManager what it is, and if it's not something D3DX can handle, convert to PLAIN and upload manually
+    if (strFilename.EndsWithI(".webp"))
     {
         std::vector<char> fileBytes;
         if (FileLoad(strFilename, fileBytes) && !fileBytes.empty())

--- a/Client/core/Graphics/CRenderItem.FileTexture.cpp
+++ b/Client/core/Graphics/CRenderItem.FileTexture.cpp
@@ -9,6 +9,49 @@
 
 #include "StdInc.h"
 
+namespace
+{
+    // Upload PLAIN (BGRA) CPixels to a new D3DFMT_A8R8G8B8 texture, used for any input format that D3DX cannot decode itself
+    // The caller must have already converted the source to EPixelsFormat::PLAIN via CPixelsManager
+    bool CreateD3DTextureFromPlainPixels(IDirect3DDevice9* pDevice, CPixelsManagerInterface* pPixelsManager, const CPixels& plain, bool bMipMaps,
+                                         IDirect3DTexture9*& pOutTexture, uint& uiOutWidth, uint& uiOutHeight)
+    {
+        pOutTexture = NULL;
+
+        uint uiWidth = 0, uiHeight = 0;
+        if (!pPixelsManager->GetPixelsSize(plain, uiWidth, uiHeight) || uiWidth == 0 || uiHeight == 0)
+            return false;
+
+        IDirect3DTexture9* pD3DTex = NULL;
+        int                iMipLevels = bMipMaps ? 0 : 1;  // 0 = full chain
+        if (FAILED(D3DXCreateTexture(pDevice, uiWidth, uiHeight, iMipLevels, 0, D3DFMT_A8R8G8B8, D3DPOOL_MANAGED, &pD3DTex)))
+            return false;
+
+        D3DLOCKED_RECT locked = {};
+        if (FAILED(pD3DTex->LockRect(0, &locked, NULL, 0)))
+        {
+            pD3DTex->Release();
+            return false;
+        }
+
+        const uint  uiRowBytes = uiWidth * 4;
+        const BYTE* pSrc = reinterpret_cast<const BYTE*>(plain.GetData());
+        BYTE*       pDst = reinterpret_cast<BYTE*>(locked.pBits);
+        for (uint y = 0; y < uiHeight; ++y)
+            memcpy(pDst + y * locked.Pitch, pSrc + y * uiRowBytes, uiRowBytes);
+
+        pD3DTex->UnlockRect(0);
+
+        if (bMipMaps)
+            D3DXFilterTexture(pD3DTex, NULL, D3DX_DEFAULT, D3DX_DEFAULT);
+
+        pOutTexture = pD3DTex;
+        uiOutWidth = uiWidth;
+        uiOutHeight = uiHeight;
+        return true;
+    }
+}
+
 ////////////////////////////////////////////////////////////////
 //
 // CFileTextureItem::PostConstruct
@@ -94,6 +137,44 @@ void CFileTextureItem::CreateUnderlyingData(const SString& strFilename, bool bMi
 {
     assert(!m_pD3DTexture);
 
+    // D3DX cannot decode every format we support, so we need to perform the following steps:
+    // Load the file, ask CPixelsManager what it is, and if it's not something D3DX can handle, convert to PLAIN and upload manually
+    {
+        std::vector<char> fileBytes;
+        if (FileLoad(strFilename, fileBytes) && !fileBytes.empty())
+        {
+            CPixelsManagerInterface* pPixelsManager = CCore::GetSingleton().GetGraphics()->GetPixelsManager();
+
+            CPixels srcPixels;
+            srcPixels.externalData.pData = fileBytes.data();
+            srcPixels.externalData.uiSize = (uint)fileBytes.size();
+
+            if (pPixelsManager->GetPixelsFormat(srcPixels) == EPixelsFormat::WEBP)
+            {
+                CPixels plainPixels;
+                if (!pPixelsManager->ChangePixelsFormat(srcPixels, plainPixels, EPixelsFormat::PLAIN))
+                    return;
+
+                IDirect3DTexture9* pD3DTex = NULL;
+                uint               uiWidth = 0, uiHeight = 0;
+                if (!CreateD3DTextureFromPlainPixels(m_pDevice, pPixelsManager, plainPixels, bMipMaps, pD3DTex, uiWidth, uiHeight))
+                    return;
+
+                m_uiSizeX = uiWidth;
+                m_uiSizeY = uiHeight;
+
+                D3DSURFACE_DESC desc;
+                pD3DTex->GetLevelDesc(0, &desc);
+                m_uiSurfaceSizeX = desc.Width;
+                m_uiSurfaceSizeY = desc.Height;
+
+                m_pD3DTexture = pD3DTex;
+                m_iMemoryKBUsed = CRenderItemManager::CalcD3DResourceMemoryKBUsage(m_pD3DTexture);
+                return;
+            }
+        }
+    }
+
     D3DXIMAGE_INFO imageInfo;
     if (FAILED(D3DXGetImageInfoFromFile(strFilename, &imageInfo)))
         return;
@@ -163,12 +244,36 @@ void CFileTextureItem::CreateUnderlyingData(const CPixels* pInPixels, bool bMipM
     CPixelsManagerInterface* pPixelsManager = CCore::GetSingleton().GetGraphics()->GetPixelsManager();
 
     // Copy from plain
-    const CPixels* pPixels = pInPixels;
-    CPixels        pixelsTemp;
-    if (pPixelsManager->GetPixelsFormat(*pPixels) == EPixelsFormat::PLAIN)
+    const CPixels*    pPixels = pInPixels;
+    CPixels           pixelsTemp;
+    EPixelsFormatType inFormat = pPixelsManager->GetPixelsFormat(*pPixels);
+    if (inFormat == EPixelsFormat::PLAIN)
     {
         pPixelsManager->ChangePixelsFormat(*pPixels, pixelsTemp, EPixelsFormat::PNG);
         pPixels = &pixelsTemp;
+    }
+    else if (inFormat == EPixelsFormat::WEBP)  // any format that D3DX cannot decode itself
+    {
+        CPixels plainPixels;
+        if (!pPixelsManager->ChangePixelsFormat(*pPixels, plainPixels, EPixelsFormat::PLAIN))
+            return;
+
+        IDirect3DTexture9* pD3DTex = NULL;
+        uint               uiWidth = 0, uiHeight = 0;
+        if (!CreateD3DTextureFromPlainPixels(m_pDevice, pPixelsManager, plainPixels, bMipMaps, pD3DTex, uiWidth, uiHeight))
+            return;
+
+        m_uiSizeX = uiWidth;
+        m_uiSizeY = uiHeight;
+
+        D3DSURFACE_DESC desc;
+        pD3DTex->GetLevelDesc(0, &desc);
+        m_uiSurfaceSizeX = desc.Width;
+        m_uiSurfaceSizeY = desc.Height;
+
+        m_pD3DTexture = pD3DTex;
+        m_iMemoryKBUsed = CRenderItemManager::CalcD3DResourceMemoryKBUsage(m_pD3DTexture);
+        return;
     }
 
     D3DXIMAGE_INFO imageInfo;

--- a/Client/core/premake5.lua
+++ b/Client/core/premake5.lua
@@ -23,6 +23,7 @@ project "Client Core"
 			"../../vendor/tinygettext",
 			"../../vendor/zlib",
 			"../../vendor/jpeg-9f",
+			"../../vendor/libwebp/src",
 			"../../vendor/pthreads/include",
 			"../../vendor/sparsehash/src/",
 			"../../vendor/detours/4.0.1/src",
@@ -59,7 +60,7 @@ project "Client Core"
 		"ws2_32", "d3dx9", "Userenv", "DbgHelp", "xinput", "Imagehlp", "dxguid", "dinput8",
 		"strmiids",	"odbc32", "odbccp32", "shlwapi", "winmm", "gdi32", "Imm32", "Psapi", "dwmapi",
 		"pthread", "libpng", "jpeg", "zlib", "tinygettext", "discord-rpc", "wintrust", "crypt32",
-		"bcrypt",
+		"bcrypt", "libwebp",
 	}
 
 	defines {

--- a/Client/sdk/core/CPixelsManagerInterface.h
+++ b/Client/sdk/core/CPixelsManagerInterface.h
@@ -16,7 +16,8 @@ namespace EPixelsFormat
         PLAIN,
         JPEG,
         PNG,
-        DDS
+        DDS,
+        WEBP
     };
 }
 using EPixelsFormat::EPixelsFormatType;

--- a/premake5.lua
+++ b/premake5.lua
@@ -6,6 +6,7 @@ require "install_resources"
 require "install_cef"
 require "install_unifont"
 require "install_discord"
+require "install_libwebp"
 
 -- Set CI Build global
 local ci = os.getenv("CI")
@@ -186,6 +187,7 @@ workspace "MTASA"
 		include "vendor/jpeg-9f"
 		include "vendor/ksignals"
 		include "vendor/libpng"
+		include "vendor/libwebp"
 		include "vendor/tinygettext"
 		include "vendor/pthreads"
 		include "vendor/libspeex"

--- a/utils/buildactions/install_libwebp.lua
+++ b/utils/buildactions/install_libwebp.lua
@@ -1,0 +1,169 @@
+require 'utils'
+
+premake.modules.install_libwebp = {}
+
+-- Config variables
+local LIBWEBP_PATH = "vendor/libwebp/"
+local LIBWEBP_TEMP = "vendor/libwebp/libwebp.zip"
+local LIBWEBP_UPDATE = "https://api.github.com/repos/webmproject/libwebp/releases/latest"
+local LIBWEBP_URL = "https://github.com/webmproject/libwebp/archive/refs/tags/"
+local LIBWEBP_EXT = ".zip"
+
+-- Auto-update variables
+-- NOTE: On first run the downloaded hash will differ; the script prints it and
+-- offers to write it back into this file when invoked with the "upgrade" arg.
+local LIBWEBP_VERSION = "v1.6.0"
+local LIBWEBP_HASH = "7a89bb7a6a0c30b5c0f521c2673635381b4e7c916585f4a1f702d3b47f15d5e5"
+
+-- Sentinel file used to detect a completed install
+local LIBWEBP_SENTINEL = "src/webp/decode.h"
+
+function make_download_url(url, version, ext)
+	return url..http.escapeUrlParam(version)..ext
+end
+
+function update_install_libwebp(variable, version, hash)
+	local filename = "utils/buildactions/install_libwebp.lua"
+	local f = io.open(filename)
+	local text = f:read("*all")
+	f:close()
+
+	local version_line = 'local '.. variable ..'_VERSION = "' .. version .. '"'
+	local hash_line = 'local '.. variable ..'_HASH = "' .. hash .. '"'
+	text = text:gsub('local '.. variable ..'_VERSION = ".-"', version_line, 1)
+	text = text:gsub('local '.. variable ..'_HASH = ".-"', hash_line, 1)
+
+	local f = io.open(filename, "w")
+	f:write(text)
+	f:close()
+end
+
+local function check_github_update(name, url, version)
+	print("Checking github for ".. name .. " update...")
+	local resource, result_str, result_code = http.get(url)
+	if result_str ~= "OK" or result_code ~= 200 then
+		errormsg(("Could not get page with status code %s: "):format(result_code), result_str)
+		os.exit(1)
+		return
+	end
+
+	local meta, err = json.decode(resource)
+	if err then
+		errormsg("Could not parse json meta data:", err)
+		os.exit(1)
+		return
+	end
+
+	if meta["tag_name"] == version then
+		print((name .. " is already up to date (%s)"):format(meta["tag_name"]))
+		return false
+	end
+
+	io.write(("Does version '%s' look OK to you? (Y/n) "):format(meta["tag_name"]))
+	local input = io.read():lower()
+	if not (input == "y" or input == "yes") then
+		errormsg("Aborting due to user request.")
+		return false
+	end
+	return meta["tag_name"]
+end
+
+local function check_libwebp(should_upgrade)
+	local has_libwebp_sources = os.isfile(LIBWEBP_PATH .. LIBWEBP_SENTINEL)
+
+	-- Check file hash
+	local archive_path = LIBWEBP_TEMP
+	local hash_passed = os.isfile(archive_path) and os.sha256_file(archive_path) == LIBWEBP_HASH
+	if hash_passed then
+		print("libwebp consistency checks succeeded")
+
+		if has_libwebp_sources then
+			return
+		end
+	else
+		-- Download libwebp
+		print("Downloading libwebp " .. LIBWEBP_VERSION ..  "...")
+		if not http.download_print_errors(make_download_url(LIBWEBP_URL, LIBWEBP_VERSION, LIBWEBP_EXT), archive_path) then
+			os.exit(1)
+			return
+		end
+	end
+
+	local downloaded_hash = os.sha256_file(archive_path)
+	if should_upgrade then
+		print("New libwebp hash is:", downloaded_hash)
+		LIBWEBP_HASH = downloaded_hash
+
+		io.write("Update `install_libwebp.lua` file? (Y/n) ")
+		local input = io.read():lower()
+		if (input == "y" or input == "yes") then
+			update_install_libwebp("LIBWEBP", LIBWEBP_VERSION, downloaded_hash)
+		end
+	end
+
+	if downloaded_hash == LIBWEBP_HASH then
+		print("libwebp consistency checks succeeded")
+	else
+		errormsg("libwebp consistency checks failed.", ("Expected %s, got %s"):format(LIBWEBP_HASH, downloaded_hash))
+		os.exit(1)
+		return
+	end
+
+	-- Seriously abort now if we're not using Windows
+	if os.host() ~= "windows" then
+		return
+	end
+
+	-- Extract zip into a scratch subfolder then move contents up.
+	-- We do NOT rmdir vendor/libwebp/ because that folder also contains our
+	-- own premake5.lua / README.md.
+	local extract_dir = LIBWEBP_PATH .. "_extract/"
+	if os.isdir(extract_dir) then
+		if not os.rmdir(extract_dir) then
+			errormsg("ERROR: Could not delete libwebp extract folder")
+			os.exit(1)
+			return
+		end
+	end
+
+	if not os.mkdir(extract_dir) then
+		errormsg("ERROR: Could not create libwebp extract folder")
+		os.exit(1)
+		return
+	end
+
+	if not os.extract_archive(archive_path, extract_dir, true) then
+		errormsg("ERROR: Could not extract libwebp .zip")
+		os.exit(1)
+		return
+	end
+
+	-- Move all files from _extract/libwebp*/* to vendor/libwebp/
+	os.expanddir_wildcard(extract_dir .. "libwebp*", LIBWEBP_PATH)
+
+	-- Clean up scratch folder
+	os.rmdir(extract_dir)
+end
+
+newaction {
+	trigger = "install_libwebp",
+	description = "Downloads and installs libwebp",
+
+	execute = function(...)
+		local should_upgrade = _ARGS[1] == "upgrade"
+		if should_upgrade then
+			local libwebp = check_github_update("libwebp", LIBWEBP_UPDATE, LIBWEBP_VERSION)
+			if libwebp then
+				LIBWEBP_VERSION = libwebp
+				LIBWEBP_HASH = ""
+			end
+		end
+
+		-- Only execute on Windows in normal scenarios
+		if os.host() ~= "windows" and not should_upgrade then
+			return
+		end
+
+		check_libwebp(should_upgrade)
+	end
+}

--- a/vendor/libwebp/.gitignore
+++ b/vendor/libwebp/.gitignore
@@ -1,0 +1,7 @@
+# Everything in this folder is downloaded/extracted by
+# utils/buildactions/install_libwebp.lua, EXCEPT for our own scaffolding files
+# listed below.
+*
+!.gitignore
+!premake5.lua
+!README.md

--- a/vendor/libwebp/README.md
+++ b/vendor/libwebp/README.md
@@ -1,0 +1,53 @@
+# WebP Codec
+
+```
+      __   __  ____  ____  ____
+     /  \\/  \/  _ \/  _ )/  _ \
+     \       /   __/  _  \   __/
+      \__\__/\____/\_____/__/ ____  ___
+            / _/ /    \    \ /  _ \/ _/
+           /  \_/   / /   \ \   __/  \__
+           \____/____/\_____/_____/____/v1.6.0
+```
+
+WebP codec is a library to encode and decode images in WebP format. This package
+contains the library that can be used in other programs to add WebP support, as
+well as the command line tools 'cwebp' and 'dwebp' to compress and decompress
+images respectively.
+
+See https://developers.google.com/speed/webp for details on the image format.
+
+The latest source tree is available at
+https://chromium.googlesource.com/webm/libwebp
+
+It is released under the same license as the WebM project. See
+https://www.webmproject.org/license/software/ or the "COPYING" file for details.
+An additional intellectual property rights grant can be found in the file
+PATENTS.
+
+## Building
+
+See the [building documentation](doc/building.md).
+
+## Encoding and Decoding Tools
+
+The examples/ directory contains tools to encode and decode images and
+animations, view information about WebP images, and more. See the
+[tools documentation](doc/tools.md).
+
+## APIs
+
+See the [APIs documentation](doc/api.md), and API usage examples in the
+`examples/` directory.
+
+## Bugs
+
+Please report all bugs to the issue tracker: https://bugs.chromium.org/p/webp
+
+Patches welcome! See [how to contribute](CONTRIBUTING.md).
+
+## Discuss
+
+Email: webp-discuss@webmproject.org
+
+Web: https://groups.google.com/a/webmproject.org/group/webp-discuss

--- a/vendor/libwebp/premake5.lua
+++ b/vendor/libwebp/premake5.lua
@@ -1,0 +1,56 @@
+project "libwebp"
+	language "C"
+	kind "StaticLib"
+	targetname "libwebp"
+	targetdir(buildpath("mta"))
+	warnings "Off"
+
+	defines {
+		"_CRT_SECURE_NO_WARNINGS",
+		"WEBP_USE_THREAD=0",
+	}
+
+	vpaths {
+		["Headers/*"] = { "src/**.h" },
+		["Sources/*"] = { "src/**.c" },
+		["*"] = "premake5.lua"
+	}
+
+	-- Decoder-only subset of libwebp.
+	-- src/enc/**, src/mux/**, src/demux/** and examples/** are intentionally excluded.
+	files {
+		"premake5.lua",
+		"src/dec/**.c",
+		"src/dec/**.h",
+		"src/dsp/**.c",
+		"src/dsp/**.h",
+		"src/utils/**.c",
+		"src/utils/**.h",
+		"src/webp/**.h",
+	}
+
+	-- Encoder files may live under src/dsp with names like *_enc*.c; keep them.
+	-- The decoder needs *_dec*.c, generic *.c, and the SSE/NEON variants.
+	-- Removing enc-only files is not strictly necessary: they compile fine as
+	-- part of the static lib and are dead-stripped by the linker if unused.
+	-- If binary size becomes a concern, exclude them here.
+
+	includedirs {
+		".",
+		"src"
+	}
+
+	filter "system:windows"
+		disablewarnings {
+			"4244", -- possible loss of data
+			"4267", -- conversion from 'size_t'
+			"4146", -- unary minus operator applied to unsigned type
+			"4334", -- result of 32-bit shift implicitly converted to 64 bits
+			"4996", -- deprecated function
+		}
+
+	filter "architecture:not x86"
+		flags { "ExcludeFromBuild" }
+
+	filter "system:not windows"
+		flags { "ExcludeFromBuild" }

--- a/win-create-projects.bat
+++ b/win-create-projects.bat
@@ -18,6 +18,9 @@ utils\premake5.exe %PREMAKE5_FLAGS% install_unifont
 rem Update discord-rpc
 utils\premake5.exe %PREMAKE5_FLAGS% install_discord
 
+rem Update libwebp
+utils\premake5.exe %PREMAKE5_FLAGS% install_libwebp
+
 rem Generate solutions
 utils\premake5.exe %PREMAKE5_FLAGS% vs2026
 


### PR DESCRIPTION
#### Summary
This PR adds support for the [WebP](https://developers.google.com/speed/webp) image format to the MTA client's texture pipeline. Scripts can now pass `.webp` files (and in-memory WebP byte buffers) to `dxCreateTexture`, and they will be decoded and uploaded just like PNG/JPG.


#### Motivation
WebP typically produces 25–35% smaller files than PNG at equivalent visual quality, with full alpha-channel support. For resources with a lot of images, this can reduce download size without sacrificing quality. It's also quickly becoming the default for web-based applications, which means we can use the same images for our website as well as our MTA server in-game.


#### Test plan
I have attached a small test resource that displays two .webp images, one using `dxCreateTexture` and one using `dxDrawImage` directly with the file path. The two images are drawn one over another, to showcase the transparancy working for the second image.

[webp.zip](https://github.com/user-attachments/files/30879006/webp.zip)

#### Checklist
* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
