### PR TITLE
Reduce FPSLimiter CPU usage and stabilize its frame pacing

### DIFF
--- a/Client/core/CModManager.cpp
+++ b/Client/core/CModManager.cpp
@@ -103,9 +103,6 @@ void CModManager::DoPulsePostFrame()
 
     handleStateChange();  // Handle state changes after pulse
 
-    // TODO: ENSURE "CModManager::DoPulsePostFrame" IS THE LAST THING BEFORE THE FRAME ENDS
-    CCore::GetSingleton().GetFPSLimiter()->OnFrameEnd();  // Apply FPS limiting
-
     TIMING_GRAPH("-DoPulsePostFrame");
     TIMING_GRAPH("");
 }

--- a/Client/core/DXHook/CProxyDirect3DDevice9.cpp
+++ b/Client/core/DXHook/CProxyDirect3DDevice9.cpp
@@ -1073,6 +1073,12 @@ HRESULT CProxyDirect3DDevice9::Present(CONST RECT* pSourceRect, CONST RECT* pDes
     TIMING_GRAPH("Present");
     HRESULT hr = CDirect3DEvents9::PresentGuarded(m_pDevice, pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion);
     TIMING_GRAPH("PostPresent");
+
+    // Apply FPS limiting here, as the last thing before the frame ends, so pacing accounts
+    // for the full frame (GUI draw and the real Present/vsync) instead of just the portion
+    // of the frame that happens before GUI draw.
+    CCore::GetSingleton().GetFPSLimiter()->OnFrameEnd();
+
     return hr;
 }
 

--- a/Client/core/FPSLimiter.cpp
+++ b/Client/core/FPSLimiter.cpp
@@ -13,10 +13,24 @@
 #include "FPSLimiter.h"
 #include "CGraphStats.h"
 #include <SharedUtil.Misc.h>
+#include <algorithm>
 
 namespace FPSLimiter
 {
     constexpr std::uint16_t DEFAULT_FPS_VSYNC = 60;  // Default user-defined FPS limit
+
+    // Tuning for the adaptive busy-wait margin used by SetFrameRateThrottle.
+    // Rather than always reserving a fixed amount of time for the final precision spin,
+    // we measure how much the waitable timer actually overshoots on this machine and
+    // size the margin to match. This keeps precision the same while avoiding wasted
+    // spinning on systems where the timer already wakes up on time.
+    constexpr double INITIAL_TIMER_JITTER_MS = 1.0;        // Starting margin, matches the previous fixed-margin behaviour
+    constexpr double MIN_SPIN_MARGIN_MS = 0.05;            // Never spin less than this, in case of a very lucky measurement
+    constexpr double MAX_SPIN_MARGIN_MS = 1.0;             // Never spin more than the old fixed margin
+    constexpr double SPIN_MARGIN_SAFETY_BUFFER_MS = 0.05;  // Extra headroom on top of the measured peak jitter
+    constexpr double TIMER_JITTER_DECAY = 0.98;            // Per-frame decay applied when the timer wakes up on time
+    constexpr int    FINAL_SPIN_BATCH_SIZE = 16;           // PAUSE instructions issued between two TSC reads in the final spin
+    static_assert(MIN_SPIN_MARGIN_MS <= MAX_SPIN_MARGIN_MS);
 
     FPSLimiter::FPSLimiter()
 
@@ -24,6 +38,7 @@ namespace FPSLimiter
           m_lastFrameTime{0},
           m_lastFrameTSC{__rdtsc()},
           m_hTimer(nullptr),
+          m_timerJitterPeakMs{INITIAL_TIMER_JITTER_MS},
           m_serverEnforcedFps{0},
           m_clientEnforcedFps{0},
           m_userDefinedFps{0},
@@ -240,10 +255,14 @@ namespace FPSLimiter
                 } while (lastMeasuredTSC + 5000 < targetTSC);  // Stop 5000 cycles early
             }
 
-            // Final precision loop
+            // Final precision loop. PAUSE calls are batched between TSC reads because
+            // __rdtsc() is a serializing instruction; checking it less often lowers the
+            // per-frame instruction overhead while bounding the worst-case overshoot to
+            // a handful of PAUSE instructions (well under a microsecond).
             do
             {
-                _mm_pause();
+                for (int i = 0; i < FINAL_SPIN_BATCH_SIZE; ++i)
+                    _mm_pause();
                 lastMeasuredTSC = __rdtsc();
             } while (lastMeasuredTSC < targetTSC);
 
@@ -294,7 +313,10 @@ namespace FPSLimiter
 
                 if (m_hTimer)
                 {
-                    double timerWaitMs = waitTimeMs - 1.0;  // Leave margin for spin
+                    // Size the spin margin to what this machine's timer actually needs,
+                    // instead of always reserving the worst-case 1ms for it.
+                    const double spinMarginMs = std::clamp(m_timerJitterPeakMs + SPIN_MARGIN_SAFETY_BUFFER_MS, MIN_SPIN_MARGIN_MS, MAX_SPIN_MARGIN_MS);
+                    double       timerWaitMs = waitTimeMs - spinMarginMs;
                     if (timerWaitMs > 0.5)
                     {
                         LARGE_INTEGER dueTime;
@@ -303,6 +325,23 @@ namespace FPSLimiter
                         if (SetWaitableTimer(m_hTimer, &dueTime, 0, nullptr, nullptr, FALSE))
                         {
                             WaitForSingleObject(m_hTimer, INFINITE);
+
+                            // Measure how far the timer overshot its requested wait, and
+                            // remember the peak so future frames reserve enough margin to
+                            // still land the spin loop before targetTSC. The peak decays
+                            // slowly when the timer wakes up on time, so the margin shrinks
+                            // back down once the system proves it can be more precise.
+                            const std::uint64_t wakeTSC = __rdtsc();
+                            const double        expectedWaitTicks = (timerWaitMs / 1000.0) * tscFrequency;
+                            const double        actualWaitTicks = static_cast<double>(wakeTSC - currentTSC);
+                            const double        overshootMs = ((actualWaitTicks - expectedWaitTicks) * 1000.0) / tscFrequency;
+
+                            if (overshootMs > m_timerJitterPeakMs)
+                                m_timerJitterPeakMs = overshootMs;
+                            else
+                                m_timerJitterPeakMs *= TIMER_JITTER_DECAY;
+                            m_timerJitterPeakMs = std::clamp(m_timerJitterPeakMs, 0.0, MAX_SPIN_MARGIN_MS);
+
                             frameEndTSC = rdtscSpinWait(targetTSC);
                         }
                         else

--- a/Client/core/FPSLimiter.cpp
+++ b/Client/core/FPSLimiter.cpp
@@ -242,6 +242,11 @@ namespace FPSLimiter
         // RDTSC spin wait - reusable for all spin scenarios
         auto rdtscSpinWait = [&](std::uint64_t targetTSC) -> std::uint64_t
         {
+            // Briefly raise our priority so the OS is less likely to preempt us mid-spin.
+            HANDLE    hCurrentThread = GetCurrentThread();
+            const int savedPriority = GetThreadPriority(hCurrentThread);
+            SetThreadPriority(hCurrentThread, THREAD_PRIORITY_TIME_CRITICAL);
+
             std::uint64_t lastMeasuredTSC = __rdtsc();
             std::uint64_t remaining = targetTSC - lastMeasuredTSC;
             if (remaining > 10000)  // > ~3us at 3GHz
@@ -265,6 +270,8 @@ namespace FPSLimiter
                     _mm_pause();
                 lastMeasuredTSC = __rdtsc();
             } while (lastMeasuredTSC < targetTSC);
+
+            SetThreadPriority(hCurrentThread, savedPriority);
 
             return lastMeasuredTSC;
         };

--- a/Client/core/FPSLimiter.h
+++ b/Client/core/FPSLimiter.h
@@ -57,6 +57,7 @@ namespace FPSLimiter
         LARGE_INTEGER m_lastFrameTime;
         std::uint64_t m_lastFrameTSC;
         HANDLE        m_hTimer;
+        double        m_timerJitterPeakMs;   // Decaying peak of measured timer wake-up overshoot, used to size the busy-wait margin
         std::uint16_t m_serverEnforcedFps;   // Maximum FPS enforced by the server
         std::uint16_t m_clientEnforcedFps;   // Maximum FPS enforced by the client
         std::uint16_t m_userDefinedFps;      // Maximum FPS defined by the user (see `fps_limit` cvar)


### PR DESCRIPTION
#### Summary
The busy-wait in `SetFrameRateThrottle` used to spin for a fixed 1ms safety margin around the waitable timer on every frame; that margin is now sized from the timer's actually observed wake-up jitter on the current machine, so it shrinks wherever the timer already wakes up on time. The PAUSE instructions in the final precision loop are also batched between TSC reads now, since `__rdtsc()` is serializing and reading it after every single PAUSE was pure overhead.

On top of that, the throttle call itself was moved; it used to run mid-frame, before the GUI (HUD, chat, CEF) was drawn and before the real `Present()` call, so none of that time counted toward the frame budget and just got added on top of every throttled frame. It now runs right after `Present()` returns, so pacing accounts for the whole frame. The spin also briefly raises the thread to `THREAD_PRIORITY_TIME_CRITICAL` for its own bounded duration, which cuts down on the OS preempting it mid-spin and causing the small overshoots that read as jitter around the cap.

#### Motivation
Helps with #5147; the adaptive margin cuts the wasted spinning that kept a core boosted, worst on AMD where PAUSE retires much faster than on Intel, though it won't remove every source of busy-wait CPU time.

Also fixes #5163, or so it looks like from here; setting a lower FPS limit was consistently producing fewer frames than the limit itself, e.g. 100 capped down to 80-90 and unstable, and that traced back to the throttle running before part of the frame's cost was even paid. Both 80 and 100 caps hold steady on my machine now, but I'd rather see it confirmed on other hardware before treating the issue as closed for good.

#### Test plan
Tested `setFPSLimit(100)` and `setFPSLimit(80)` in a demanding gamemode; before the change FPS ran well under the cap and bounced around, after it holds close to the target with only minor jitter.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.