### PR TITLE
Fix/requested model spoilers

### DIFF
--- a/Client/mods/deathmatch/logic/CVehicleUpgrades.cpp
+++ b/Client/mods/deathmatch/logic/CVehicleUpgrades.cpp
@@ -617,6 +617,12 @@ void CVehicleUpgrades::ForceAddUpgrade(unsigned short usUpgrade)
             if (ucSlot == 2)
             {
                 CModelInfo* pVehicleModelInfo = g_pGame->GetModelInfo(m_pVehicle->GetModel());
+                if (!pVehicleModelInfo)
+                    return;
+
+                if (pVehicleModelInfo->GetParentID() != 0)
+                    pVehicleModelInfo = g_pGame->GetModelInfo(static_cast<unsigned short>(pVehicleModelInfo->GetParentID()));
+
                 if (!pVehicleModelInfo || !pVehicleModelInfo->GetVehicleSupportedUpgrades().m_bSpoiler)
                 {
                     // Vehicle doesn't support this spoiler upgrade - skip it

--- a/Client/mods/deathmatch/logic/CVehicleUpgrades.cpp
+++ b/Client/mods/deathmatch/logic/CVehicleUpgrades.cpp
@@ -621,7 +621,7 @@ void CVehicleUpgrades::ForceAddUpgrade(unsigned short usUpgrade)
                     return;
 
                 if (pVehicleModelInfo->GetParentID() != 0)
-                    pVehicleModelInfo = g_pGame->GetModelInfo(static_cast<unsigned short>(pVehicleModelInfo->GetParentID()));
+                    pVehicleModelInfo = g_pGame->GetModelInfo(pVehicleModelInfo->GetParentID());
 
                 if (!pVehicleModelInfo || !pVehicleModelInfo->GetVehicleSupportedUpgrades().m_bSpoiler)
                 {


### PR DESCRIPTION
### Summary
Fix spoiler upgrades not being applied to vehicles using `engineRequestModel`.
The spoiler check now resolves the requested model to its parent model before checking if spoilers are supported.

### Motivation
[#4398](https://github.com/multitheftauto/mtasa-blue/pull/4398) added parent model handling for vehicle upgrades using `engineRequestModel`.

Later, [#4824](https://github.com/multitheftauto/mtasa-blue/pull/4824) added a spoiler support check in `ForceAddUpgrade`, but it checks the requested model directly. Because of this, requested models based on vehicles that support spoilers, like Sultan (560), were incorrectly blocked.

This keeps the behavior from #4824 while making the check work correctly for requested vehicle models.

### Test plan

- Spawn a Sultan (560) and enter it.
- Run:
  `crun engineRequestModel("vehicle", 560)`
- Use the returned model ID:
  `crun setElementModel(getPedOccupiedVehicle(localPlayer), MODEL_ID)`
- Open the Freeroam vehicle upgrades menu and verify that spoilers can be installed.
- Repeat with an Infernus (411) and verify that spoilers are still blocked.

### Checklist

- [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
- [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.