### PR TITLE
Fix Dumper ramp not working on custom vehicle models

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -144,6 +144,232 @@ static void __declspec(naked) HOOK_CAutomobile__GetTowBarPos()
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
+// The Dumper's tipping ramp on custom vehicle models
+//
+// Built on CMonsterTruck, not plain CAutomobile: ProcessControl decides whether the ramp moves,
+// UpdateMovingCollision moves it and picks the rotation formula, GetMovingCollisionOffset answers
+// how far it's tipped, and CMonsterTruck::PreRender does the actual swing. All gate on model index
+// alone, so a clone matches none of them. IsSubMonsterTruck() (a runtime flag, not model index)
+// already recognises a clone and is left untouched.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+static bool __fastcall IsDumperOrClone(CVehicleSAInterface* vehicle)
+{
+    const std::uint32_t modelId = vehicle->m_nModelIndex;
+    if (modelId == static_cast<std::uint32_t>(VehicleType::VT_DUMPER))
+        return true;
+
+    CModelInfo* modelInfo = pGameInterface->GetModelInfo(modelId);
+    return modelInfo && modelInfo->GetParentID() == static_cast<unsigned int>(VehicleType::VT_DUMPER);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CAutomobile::ProcessControl, the switch that reaches UpdateMovingCollision at all
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6B1F9B | 66 3D 96 01 | cmp     ax, 0x196
+// >>> 0x6B1F9F | 74 6E       | je      0x6B200F
+//     0x6B1FA1 | 66 3D 0C 02 | cmp     ax, 0x20C
+#define HOOKPOS_CAutomobile__ProcessControl_DumperDispatch  0x6B1F9B
+#define HOOKSIZE_CAutomobile__ProcessControl_DumperDispatch 6
+static const DWORD CONTINUE_CAutomobile__ProcessControl_DumperDispatch = 0x6B200F;
+static const DWORD SKIP_CAutomobile__ProcessControl_DumperDispatch = 0x6B1FA1;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessControl_DumperDispatch()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // ax (model id) is read again on skip
+        push    eax
+        mov     ecx, esi
+        call    IsDumperOrClone
+        test    al, al
+        pop     eax
+        jz      notDumper
+
+        jmp     CONTINUE_CAutomobile__ProcessControl_DumperDispatch
+
+        notDumper:
+        jmp     SKIP_CAutomobile__ProcessControl_DumperDispatch
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CAutomobile::UpdateMovingCollision, resetting the ramp's previous angle for this tick
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6A1498 | 66 81 F9 96 01 | cmp     cx, 0x196
+// >>> 0x6A149D | 74 15          | je      0x6A14B4
+//     0x6A149F | 66 81 F9 0C 02 | cmp     cx, 0x20C
+#define HOOKPOS_CAutomobile__UpdateMovingCollision_DumperAngleReset  0x6A1498
+#define HOOKSIZE_CAutomobile__UpdateMovingCollision_DumperAngleReset 7
+static const DWORD CONTINUE_CAutomobile__UpdateMovingCollision_DumperAngleReset = 0x6A14B4;
+static const DWORD SKIP_CAutomobile__UpdateMovingCollision_DumperAngleReset = 0x6A149F;
+
+static void __declspec(naked) HOOK_CAutomobile__UpdateMovingCollision_DumperAngleReset()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // cx (model id) is read again on skip
+        push    ecx
+        mov     ecx, edi
+        call    IsDumperOrClone
+        test    al, al
+        pop     ecx
+        jz      notDumper
+
+        jmp     CONTINUE_CAutomobile__UpdateMovingCollision_DumperAngleReset
+
+        notDumper:
+        jmp     SKIP_CAutomobile__UpdateMovingCollision_DumperAngleReset
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CAutomobile::UpdateMovingCollision, letting the ramp into the block that moves it this tick
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6A14FB | 66 81 F9 96 01 | cmp     cx, 0x196
+// >>> 0x6A1500 | 74 5A          | je      0x6A155C
+//     0x6A1502 | 66 81 F9 0C 02 | cmp     cx, 0x20C
+#define HOOKPOS_CAutomobile__UpdateMovingCollision_DumperMiscGate  0x6A14FB
+#define HOOKSIZE_CAutomobile__UpdateMovingCollision_DumperMiscGate 7
+static const DWORD CONTINUE_CAutomobile__UpdateMovingCollision_DumperMiscGate = 0x6A155C;
+static const DWORD SKIP_CAutomobile__UpdateMovingCollision_DumperMiscGate = 0x6A1502;
+
+static void __declspec(naked) HOOK_CAutomobile__UpdateMovingCollision_DumperMiscGate()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // cx (model id) is read again on skip
+        push    ecx
+        mov     ecx, edi
+        call    IsDumperOrClone
+        test    al, al
+        pop     ecx
+        jz      notDumper
+
+        jmp     CONTINUE_CAutomobile__UpdateMovingCollision_DumperMiscGate
+
+        notDumper:
+        jmp     SKIP_CAutomobile__UpdateMovingCollision_DumperMiscGate
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CAutomobile::UpdateMovingCollision, picking the ramp's own rotation formula
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6A179C | 66 3D 96 01 | cmp     ax, 0x196
+// >>> 0x6A17A0 | 75 4D       | jne     0x6A17EF
+//     0x6A17A2 | 83 BF 94 05 00 00 01 | cmp dword ptr [edi + 0x594], 1
+#define HOOKPOS_CAutomobile__UpdateMovingCollision_DumperRotation  0x6A179C
+#define HOOKSIZE_CAutomobile__UpdateMovingCollision_DumperRotation 6
+static const DWORD CONTINUE_CAutomobile__UpdateMovingCollision_DumperRotation = 0x6A17A2;
+static const DWORD SKIP_CAutomobile__UpdateMovingCollision_DumperRotation = 0x6A17EF;
+
+static void __declspec(naked) HOOK_CAutomobile__UpdateMovingCollision_DumperRotation()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // ax (model id) is read again on skip
+        push    eax
+        mov     ecx, edi
+        call    IsDumperOrClone
+        test    al, al
+        pop     eax
+        jz      notDumper
+
+        jmp     CONTINUE_CAutomobile__UpdateMovingCollision_DumperRotation
+
+        notDumper:
+        jmp     SKIP_CAutomobile__UpdateMovingCollision_DumperRotation
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CAutomobile::GetMovingCollisionOffset, the ramp's case in the model switch
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6A2166 | 66 3D 96 01 | cmp     ax, 0x196
+// >>> 0x6A216A | 75 1E       | jne     0x6A218A
+//     0x6A216C | 8B B1 A0 06 00 00 | mov esi, [ecx + 0x6A0]
+#define HOOKPOS_CAutomobile__GetMovingCollisionOffset_Dumper  0x6A2166
+#define HOOKSIZE_CAutomobile__GetMovingCollisionOffset_Dumper 6
+static const DWORD CONTINUE_CAutomobile__GetMovingCollisionOffset_Dumper = 0x6A216C;
+static const DWORD SKIP_CAutomobile__GetMovingCollisionOffset_Dumper = 0x6A218A;
+
+static void __declspec(naked) HOOK_CAutomobile__GetMovingCollisionOffset_Dumper()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // ecx is the vehicle (already the call arg); ax and dx are both read again past here
+        push    eax
+        push    ecx
+        push    edx
+        call    IsDumperOrClone
+        test    al, al
+        pop     edx
+        pop     ecx
+        pop     eax
+        jz      notDumper
+
+        jmp     CONTINUE_CAutomobile__GetMovingCollisionOffset_Dumper
+
+        notDumper:
+        jmp     SKIP_CAutomobile__GetMovingCollisionOffset_Dumper
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CMonsterTruck::PreRender, swinging the misc_c component out
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6C7F30 | 66 81 7E 22 96 01 | cmp     word ptr [esi + 0x22], 0x196
+// >>> 0x6C7F36 | 75 2F             | jne     0x6C7F67
+//     0x6C7F38 | 8B 86 A0 06 00 00 | mov     eax, [esi + 0x6A0]
+#define HOOKPOS_CMonsterTruck__PreRender_DumperSwing  0x6C7F30
+#define HOOKSIZE_CMonsterTruck__PreRender_DumperSwing 8
+static const DWORD CONTINUE_CMonsterTruck__PreRender_DumperSwing = 0x6C7F38;
+static const DWORD SKIP_CMonsterTruck__PreRender_DumperSwing = 0x6C7F67;
+
+static void __declspec(naked) HOOK_CMonsterTruck__PreRender_DumperSwing()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // esi is callee-saved; nothing past here reads eax/ecx/edx from before the call
+        mov     ecx, esi
+        call    IsDumperOrClone
+        test    al, al
+        jz      notDumper
+
+        jmp     CONTINUE_CMonsterTruck__PreRender_DumperSwing
+
+        notDumper:
+        jmp     SKIP_CMonsterTruck__PreRender_DumperSwing
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
 // CMultiplayerSA::InitHooks_Vehicles
 //
 // Setup hooks
@@ -153,4 +379,10 @@ void CMultiplayerSA::InitHooks_Vehicles()
 {
     EZHookInstall(CDamageManager__ProgressDoorDamage);
     EZHookInstall(CAutomobile__GetTowBarPos);
+    EZHookInstall(CAutomobile__ProcessControl_DumperDispatch);
+    EZHookInstall(CAutomobile__UpdateMovingCollision_DumperAngleReset);
+    EZHookInstall(CAutomobile__UpdateMovingCollision_DumperMiscGate);
+    EZHookInstall(CAutomobile__UpdateMovingCollision_DumperRotation);
+    EZHookInstall(CAutomobile__GetMovingCollisionOffset_Dumper);
+    EZHookInstall(CMonsterTruck__PreRender_DumperSwing);
 }

--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -507,7 +507,7 @@ static void __declspec(naked) HOOK_CAutomobile__GetTowBarPos()
 //////////////////////////////////////////////////////////////////////////////////////////
 static bool __fastcall IsDumperOrClone(CVehicleSAInterface* vehicle)
 {
-    const std::uint32_t modelId = vehicle->m_nModelIndex;
+    const std::uint32_t modelId = static_cast<std::uint32_t>(vehicle->m_nModelIndex);
     if (modelId == static_cast<std::uint32_t>(VehicleType::VT_DUMPER))
         return true;
 


### PR DESCRIPTION
#### Summary
Fixes the Dumper's tipping ramp so it works on clones made with engineRequestModel, same as the stock model.

<img width="1366" height="768" alt="mta-screen_2026-08-10_00-14-44" src="https://github.com/user-attachments/assets/20141cf6-2bff-4966-902d-d47cdd6aef06" />


#### Motivation
Part of #1861. The Dumper runs on CMonsterTruck rather than plain CAutomobile, and the ramp is driven by six separate model index checks across ProcessControl, UpdateMovingCollision, GetMovingCollisionOffset and CMonsterTruck::PreRender. A clone carries its own model ID, so it matched none of them and the ramp never moved.

#### Test plan
Spawn a clone of the Dumper with engineRequestModel and confirm the ramp tips with the same input as a stock one, then confirm a stock Dumper still behaves exactly as before.

[dumper.zip](https://github.com/user-attachments/files/30884536/dumper.zip)


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.