### PR TITLE
Fix transparency regression for draw-last DFFs with active alpha test

### DIFF
--- a/Client/core/DXHook/CDirect3DEvents9.cpp
+++ b/Client/core/DXHook/CDirect3DEvents9.cpp
@@ -752,16 +752,11 @@ HRESULT CDirect3DEvents9::OnDrawPrimitive(IDirect3DDevice9* pDevice, IDirect3DDe
     if (!pLayers)
     {
         // No shaders for this texture.
-        // Dual-pass alpha z-write emulation for blended 3D geometry (not pre-transformed 2D).
-        // Pass 1 z-writes pixels >= threshold, pass 2 blends the rest without z-write, so fence
-        // holes don't occlude what's behind them. only runs when the game has no meaningful alpha
-        // test of its own (ref at the DefinedState baseline of 2 or below): an active test at ref
-        // 100/140 already clips transparent pixels before z-write like vanilla, and forcing the
-        // dual pass over it draws the sub-ref gradient in pass 2, which is what kept the LV neon
-        // lines smeared no matter what the game side ALPHAREF was set to.
-        const bool bGameAlphaTestActive = g_pDeviceState->RenderState.ALPHATESTENABLE && g_pDeviceState->RenderState.ALPHAREF > 2;
-        if (!bGameAlphaTestActive && g_pDeviceState->RenderState.ALPHABLENDENABLE && g_pDeviceState->RenderState.ZWRITEENABLE &&
-            !g_pDeviceState->VertexDeclState.PositionT)
+        // Apply the dual-pass split even when GTA has an active alpha test. Draw-last custom DFFs
+        // can carry ALPHAREF 100/140 while still relying on the second, non-z-writing pass for the
+        // soft alpha texels in hair and similar layered geometry. Treating a meaningful ALPHAREF
+        // as proof that the split is unnecessary regressed the release/1.6.0 rendering behavior.
+        if (g_pDeviceState->RenderState.ALPHABLENDENABLE && g_pDeviceState->RenderState.ZWRITEENABLE && !g_pDeviceState->VertexDeclState.PositionT)
         {
             // Save current alpha test state
             const DWORD dwOrigAlphaTestEnable = g_pDeviceState->RenderState.ALPHATESTENABLE;
@@ -1008,12 +1003,9 @@ HRESULT CDirect3DEvents9::OnDrawIndexedPrimitive(IDirect3DDevice9* pDevice, IDir
     if (!pLayers)
     {
         // No shaders for this texture.
-        // Dual-pass alpha z-write emulation, same rules as OnDrawPrimitive: skip when the game
-        // is already running a meaningful alpha test, it clips transparent pixels before z-write
-        // on its own and the dual pass would draw the sub-ref gradient in pass 2.
-        const bool bGameAlphaTestActive = g_pDeviceState->RenderState.ALPHATESTENABLE && g_pDeviceState->RenderState.ALPHAREF > 2;
-        if (!bGameAlphaTestActive && g_pDeviceState->RenderState.ALPHABLENDENABLE && g_pDeviceState->RenderState.ZWRITEENABLE &&
-            !g_pDeviceState->VertexDeclState.PositionT)
+        // Keep indexed draws aligned with OnDrawPrimitive. A model's active alpha test does not
+        // replace the depth-safe second pass needed by draw-last DFFs with soft texture alpha.
+        if (g_pDeviceState->RenderState.ALPHABLENDENABLE && g_pDeviceState->RenderState.ZWRITEENABLE && !g_pDeviceState->VertexDeclState.PositionT)
         {
             // Save current alpha test state
             const DWORD dwOrigAlphaTestEnable = g_pDeviceState->RenderState.ALPHATESTENABLE;


### PR DESCRIPTION
## Summary

Restores the dual-pass transparency behavior used in release/1.6.0 for blended 3D primitives that write to the depth buffer.

In 1.7, the #5006 change skips the second transparency pass when alpha test is enabled with `ALPHAREF > 2`. This can cause incorrect transparency and lighting in custom `draw_last` DFF models that use soft texture alpha.

This removes that alpha-test gate from both primitive draw paths:

- `CDirect3DEvents9::OnDrawPrimitive`
- `CDirect3DEvents9::OnDrawIndexedPrimitive`

The existing constraints remain unchanged: the dual pass still only applies to blended, depth-writing, non-`PositionT` 3D draws. HUD and screen-space rendering remain excluded.

## Reproduction

Load a custom DFF with smooth/partial texture alpha and enable its transparency:

```lua
engineReplaceModel(dff, modelId, true)

--additional
engineSetModelFlag(modelId, "draw_last", true)
engineSetModelFlag(modelId, "additive", true)
```
With alpha test active, the #5006 condition prevents the second transparency pass, causing the rendering regression shown below.

## Before

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c5f75efc-0326-45d3-af64-d184f974550d" />

## After
<img width="1920" height="1080" alt="mta-screen_2026-08-10_18-41-14" src="https://github.com/user-attachments/assets/77b1d3b7-55db-486a-8d0a-ab2f78759819" />

## Testing

Built Release|Win32 successfully.

Tested in-game with a custom model using alpha transparency.

Confirmed that the interior no longer exhibits the transparency/lighting regression.
Restores the same dual-pass decision rule used by the latest release/1.6.0 branch.
