### PR TITLE
Further hardening against voice-based DoS/lag effect on remote players

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPlayerVoice.cpp
+++ b/Client/mods/deathmatch/logic/CClientPlayerVoice.cpp
@@ -103,6 +103,8 @@ void CClientPlayerVoice::DeInit()
 
 void CClientPlayerVoice::DoPulse()
 {
+    m_voiceFramesThisPulse = 0;
+
     // Dispatch queued events
     ServiceEventQueue();
 
@@ -114,7 +116,8 @@ void CClientPlayerVoice::DoPulse()
     {
         m_fVolumeScale = fPreviousVolume;
         float fScaledVolume = m_fVolume * m_fVolumeScale;
-        BASS_ChannelSetAttribute(m_pBassPlaybackStream, BASS_ATTRIB_VOL, fScaledVolume);
+        if (m_pBassPlaybackStream)
+            BASS_ChannelSetAttribute(m_pBassPlaybackStream, BASS_ATTRIB_VOL, fScaledVolume);
     }
 }
 
@@ -122,6 +125,18 @@ void CClientPlayerVoice::DecodeAndBuffer(const unsigned char* voiceBuffer, unsig
 {
     if (!voiceBuffer || !voiceBufferLength || voiceBufferLength > 2048)
         return;
+
+    // Skip uniform-byte noise before costly Speex decode
+    if (voiceBufferLength >= 4 && voiceBuffer[0] == voiceBuffer[1] && voiceBuffer[0] == voiceBuffer[2] && voiceBuffer[0] == voiceBuffer[3])
+        return;
+
+    if (!m_pSpeexDecoderState)
+        return;
+
+    // Limit decodes per frame to bound CPU from relay floods
+    if (m_voiceFramesThisPulse >= 6)
+        return;
+    ++m_voiceFramesThisPulse;
 
     char      pTempBuffer[2048];
     SpeexBits speexBits;
@@ -147,7 +162,9 @@ void CClientPlayerVoice::DecodeAndBuffer(const unsigned char* voiceBuffer, unsig
         if (!m_pPlayer->CallEvent("onClientPlayerVoiceStart", Arguments, true))
             return;
 
+        m_Mutex.lock();
         m_bVoiceActive = true;
+        m_Mutex.unlock();
     }
     else
     {
@@ -156,7 +173,8 @@ void CClientPlayerVoice::DecodeAndBuffer(const unsigned char* voiceBuffer, unsig
 
     unsigned int uiSpeexBlockSize = m_iSpeexIncomingFrameSampleCount * VOICE_SAMPLE_SIZE;
 
-    BASS_StreamPutData(m_pBassPlaybackStream, (void*)pTempBuffer, uiSpeexBlockSize);
+    if (m_pBassPlaybackStream)
+        BASS_StreamPutData(m_pBassPlaybackStream, (void*)pTempBuffer, uiSpeexBlockSize);
 }
 
 void CClientPlayerVoice::ServiceEventQueue()

--- a/Client/mods/deathmatch/logic/CClientPlayerVoice.h
+++ b/Client/mods/deathmatch/logic/CClientPlayerVoice.h
@@ -107,4 +107,6 @@ private:
 
     SFixedArray<int, 9> m_EnabledEffects;
     SFixedArray<HFX, 9> m_FxEffects;
+
+    unsigned char m_voiceFramesThisPulse;  // Decodes per frame limit
 };

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -5468,7 +5468,7 @@ void CPacketHandler::Packet_VoiceData(NetBitStreamInterface& bitStream)
 
         if (pPlayer && bitStream.Read(voiceBufferLength) && voiceBufferLength <= 2048)
         {
-            const auto voiceBuffer = new unsigned char[voiceBufferLength];
+            unsigned char voiceBuffer[2048];
 
             if (bitStream.Read(reinterpret_cast<char*>(voiceBuffer), voiceBufferLength))
             {
@@ -5477,8 +5477,6 @@ void CPacketHandler::Packet_VoiceData(NetBitStreamInterface& bitStream)
                     pPlayer->GetVoice()->DecodeAndBuffer(voiceBuffer, voiceBufferLength);
                 }
             }
-
-            delete[] voiceBuffer;
         }
     }
 }

--- a/Server/mods/deathmatch/logic/CPlayer.h
+++ b/Server/mods/deathmatch/logic/CPlayer.h
@@ -271,6 +271,12 @@ public:
     void          SetVoiceDataPacketsInInterval(unsigned char count) noexcept { m_voiceDataPacketsInInterval = count; }
     void          IncrementVoiceDataPacketsInInterval() noexcept { ++m_voiceDataPacketsInInterval; }
 
+    long long     GetLastVoiceEndTime() const noexcept { return m_lastVoiceEndTime; }
+    void          SetLastVoiceEndTime(long long time) noexcept { m_lastVoiceEndTime = time; }
+    unsigned char GetVoiceEndPacketsInInterval() const noexcept { return m_voiceEndPacketsInInterval; }
+    void          SetVoiceEndPacketsInInterval(unsigned char count) noexcept { m_voiceEndPacketsInInterval = count; }
+    void          IncrementVoiceEndPacketsInInterval() noexcept { ++m_voiceEndPacketsInInterval; }
+
 protected:
     bool ReadSpecialData(const int iLine) override { return true; }
 
@@ -485,4 +491,6 @@ private:
     bool          m_teleported = false;
     long long     m_lastVoiceDataTime = 0;
     unsigned char m_voiceDataPacketsInInterval = 0;
+    long long     m_lastVoiceEndTime = 0;
+    unsigned char m_voiceEndPacketsInInterval = 0;
 };

--- a/Server/mods/deathmatch/logic/packets/CVoiceEndPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CVoiceEndPacket.cpp
@@ -12,6 +12,8 @@
 #include "StdInc.h"
 #include "CVoiceEndPacket.h"
 #include "CPlayer.h"
+#include "CGame.h"
+#include "CMainConfig.h"
 
 CVoiceEndPacket::CVoiceEndPacket(CPlayer* pPlayer)
 {
@@ -26,6 +28,25 @@ CVoiceEndPacket::~CVoiceEndPacket()
 
 bool CVoiceEndPacket::Read(NetBitStreamInterface& BitStream)
 {
+    CPlayer* pPlayer = GetSourcePlayer();
+    if (!pPlayer)
+        return false;
+
+    const auto*         mainConfig = g_pGame->GetConfig();
+    const long long     now = GetTickCount64_();
+    const bool          newInterval = pPlayer->GetLastVoiceEndTime() == 0 || now - pPlayer->GetLastVoiceEndTime() >= mainConfig->GetVoicePacketsInterval();
+    const unsigned char packetsInInterval = newInterval ? 0 : pPlayer->GetVoiceEndPacketsInInterval();
+
+    if (packetsInInterval >= mainConfig->GetMaxVoicePacketsPerInterval())
+        return false;
+
+    if (newInterval)
+    {
+        pPlayer->SetLastVoiceEndTime(now);
+        pPlayer->SetVoiceEndPacketsInInterval(1);
+    }
+    else
+        pPlayer->IncrementVoiceEndPacketsInInterval();
     return true;
 }
 


### PR DESCRIPTION
Explains itself.
Further hardening against voice-based DoS/lag effect on remote players.

This follows 63b91ff, 707593b, f1683fd