### PR TITLE
Fix dark mode in 1.6

### DIFF
--- a/Client/core/DXHook/CProxyDirect3D9.cpp
+++ b/Client/core/DXHook/CProxyDirect3D9.cpp
@@ -331,8 +331,20 @@ HRESULT CProxyDirect3D9::CreateDevice(UINT Adapter, D3DDEVTYPE DeviceType, HWND 
 #endif
 
     // Set dark titlebar if needed
-    BOOL darkTitleBar =
-        GetSystemRegistryValue((uint)HKEY_CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize", "AppsUseLightTheme") == "\x0";
+    int           themeStatus = 0;
+    const SString appsUseLightTheme =
+        GetSystemRegistryValue((uint)HKEY_CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize", "AppsUseLightTheme", &themeStatus);
+    BOOL darkTitleBar = FALSE;
+    if (themeStatus > 0)
+    {
+        // Parse the registry value into a numeric flag
+        char*      themeEnd = nullptr;
+        const long themeNumeric = strtol(appsUseLightTheme.c_str(), &themeEnd, 10);
+        if (themeEnd != appsUseLightTheme.c_str() && *themeEnd == '\0')
+        {
+            darkTitleBar = (themeNumeric == 0);
+        }
+    }
     DwmSetWindowAttribute(hFocusWindow, DWMWA_USE_IMMERSIVE_DARK_MODE, &darkTitleBar, sizeof(darkTitleBar));
 
     // Update icon
@@ -1182,7 +1194,7 @@ namespace
 //
 // Hook CCore::OnPreCreateDevice
 //
-// Modify paramters
+// Modify parameters
 //
 ////////////////////////////////////////////////
 void CCore::OnPreCreateDevice(IDirect3D9* pDirect3D, UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD& BehaviorFlags,
@@ -1212,7 +1224,7 @@ void CCore::OnPreCreateDevice(IDirect3D9* pDirect3D, UINT Adapter, D3DDEVTYPE De
     BehaviorFlagsOrig = BehaviorFlags;
     presentationParametersOrig = *pPresentationParameters;
 
-    WriteDebugEvent("  Original paramters:");
+    WriteDebugEvent("  Original parameters:");
     WriteDebugEvent(ToString(Adapter, DeviceType, hFocusWindow, BehaviorFlags, *pPresentationParameters));
 
     // Make sure DirectX Get...() calls will work
@@ -1223,7 +1235,7 @@ void CCore::OnPreCreateDevice(IDirect3D9* pDirect3D, UINT Adapter, D3DDEVTYPE De
 
     GetVideoModeManager()->PreCreateDevice(pPresentationParameters);
 
-    WriteDebugEvent("  Modified paramters:");
+    WriteDebugEvent("  Modified parameters:");
     WriteDebugEvent(ToString(Adapter, DeviceType, hFocusWindow, BehaviorFlags, *pPresentationParameters));
 }
 
@@ -1297,7 +1309,7 @@ HRESULT CCore::OnPostCreateDevice(HRESULT hResult, IDirect3D9* pDirect3D, UINT A
     BehaviorFlagsOrig = BehaviorFlags;
     presentationParametersOrig = *pPresentationParameters;
 
-    WriteDebugEvent("  Original paramters:");
+    WriteDebugEvent("  Original parameters:");
     WriteDebugEvent(ToString(Adapter, DeviceType, hFocusWindow, BehaviorFlags, *pPresentationParameters));
 
     // Make sure DirectX Get...() calls will work
@@ -1308,7 +1320,7 @@ HRESULT CCore::OnPostCreateDevice(HRESULT hResult, IDirect3D9* pDirect3D, UINT A
 
     GetVideoModeManager()->PreCreateDevice(pPresentationParameters);
 
-    WriteDebugEvent("  Modified paramters:");
+    WriteDebugEvent("  Modified parameters:");
     WriteDebugEvent(ToString(Adapter, DeviceType, hFocusWindow, BehaviorFlags, *pPresentationParameters));
 
     hResult = CreateDeviceInsist(2, 1000, pDirect3D, Adapter, DeviceType, hFocusWindow, BehaviorFlags, pPresentationParameters, ppReturnedDeviceInterface);


### PR DESCRIPTION
#### Summary
<!-- What change are you making? -->
<!-- When changing Lua APIs, consider including code samples and documentation. -->
Porting from 1.7 (master). Parse AppsUseLightTheme registry and fix typos. Read AppsUseLightTheme with a status out param, robustly parse it as a numeric value (strtol) and set darkTitleBar when the value is 0 — replacing the previous incorrect string comparison. Also correct several instances of a spelling error: 'paramters' -> 'parameters' in debug messages and comments.

#### Motivation
<!-- Why are you making this change? Which GitHub issue does this resolve, if any? Any additional context? -->
Dark mode on the window titlebar formerly worked in 1.6 but stopped in or around [r24000](https://buildinfo.multitheftauto.com/index.php?Revision=24000&Branch=1.7), this fixes it.

#### Test plan
<!-- How have you tested this change? This should give confidence to the reviewer that your change is safe. -->
<!-- If someone makes changes to this code in the future, what steps can they follow to check that it's still working correctly? -->


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.