### PR TITLE
Fix aircraft not working on custom vehicle models

### DIFF
--- a/Client/game_sa/CVehicleAudioSettingsManagerSA.cpp
+++ b/Client/game_sa/CVehicleAudioSettingsManagerSA.cpp
@@ -10,8 +10,11 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include "CGameSA.h"
 #include "CVehicleAudioSettingsManagerSA.h"
 #include <array>
+
+extern CGameSA* pGame;
 
 const auto (&ORIGINAL_AUDIO_SETTINGS)[VEHICLES_COUNT] = *reinterpret_cast<const tVehicleAudioSettings (*)[VEHICLES_COUNT]>(0x860AF0);
 tVehicleAudioSettings const* pNextVehicleAudioSettings = nullptr;
@@ -32,6 +35,19 @@ std::unique_ptr<CVehicleAudioSettingsEntry> CVehicleAudioSettingsManagerSA::Crea
 CVehicleAudioSettingsEntry& CVehicleAudioSettingsManagerSA::GetVehicleModelAudioSettingsData(uint32_t modelId) noexcept
 {
     return m_modelEntrys[GetVehicleModelAudioSettingsID(modelId)];
+}
+
+size_t CVehicleAudioSettingsManagerSA::GetVehicleModelAudioSettingsID(uint32_t modelId) const noexcept
+{
+    // The table only holds the standard models, so a custom model has to be read under the model
+    // it was cloned from; without this its ID would index far past the end of the array.
+    if (modelId < 400 || modelId > 611)
+    {
+        if (CModelInfo* pModelInfo = pGame->GetModelInfo(modelId))
+            modelId = pModelInfo->GetParentID();
+    }
+
+    return (modelId >= 400 && modelId <= 611) ? modelId - 400 : 0;
 }
 
 void CVehicleAudioSettingsManagerSA::SetNextSettings(CVehicleAudioSettingsEntry const* pSettings) noexcept

--- a/Client/game_sa/CVehicleAudioSettingsManagerSA.h
+++ b/Client/game_sa/CVehicleAudioSettingsManagerSA.h
@@ -35,7 +35,7 @@ public:
     static void StaticSetHooks() noexcept;
 
 private:
-    size_t GetVehicleModelAudioSettingsID(uint32_t modelId) const noexcept { return modelId - 400; };
+    size_t GetVehicleModelAudioSettingsID(uint32_t modelId) const noexcept;
 
 private:
     // Array with the model audio settings entries

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -1357,6 +1357,21 @@ void CClientVehicle::SetLandingGearDown(bool bLandingGearDown)
     }
 }
 
+// The checks below compare against standard model IDs, so a custom model has to be read as the
+// model it was cloned from. The model info is looked up fresh rather than through m_pModelInfo,
+// since SetModelBlocking calls in here before that pointer has been updated.
+static VehicleType GetVehicleTypeForModel(unsigned short usModel)
+{
+    std::uint32_t ulModel = usModel;
+    if (ulModel < 400 || ulModel > 611)
+    {
+        if (CModelInfo* pModelInfo = g_pGame->GetModelInfo(ulModel))
+            ulModel = pModelInfo->GetParentID();
+    }
+
+    return static_cast<VehicleType>(ulModel);
+}
+
 unsigned short CClientVehicle::GetAdjustablePropertyValue()
 {
     unsigned short usPropertyValue;
@@ -1364,7 +1379,7 @@ unsigned short CClientVehicle::GetAdjustablePropertyValue()
     {
         usPropertyValue = m_pVehicle->GetAdjustablePropertyValue();
         // If it's a Hydra invert it with 5000 (as 0 is "forward"), so we can maintain a standard of 0 being "normal"
-        if (static_cast<VehicleType>(m_usModel) == VehicleType::VT_HYDRA)
+        if (GetVehicleTypeForModel(m_usModel) == VehicleType::VT_HYDRA)
             usPropertyValue = 5000 - usPropertyValue;
     }
     else
@@ -1378,7 +1393,7 @@ unsigned short CClientVehicle::GetAdjustablePropertyValue()
 
 void CClientVehicle::SetAdjustablePropertyValue(unsigned short usValue)
 {
-    if (static_cast<VehicleType>(m_usModel) == VehicleType::VT_HYDRA)
+    if (GetVehicleTypeForModel(m_usModel) == VehicleType::VT_HYDRA)
         usValue = 5000 - usValue;
 
     _SetAdjustablePropertyValue(usValue);
@@ -1406,7 +1421,7 @@ void CClientVehicle::_SetAdjustablePropertyValue(unsigned short usValue)
 
 bool CClientVehicle::HasMovingCollision()
 {
-    auto model = static_cast<VehicleType>(m_usModel);
+    auto model = GetVehicleTypeForModel(m_usModel);
 
     return (model == VehicleType::VT_FORKLIFT || model == VehicleType::VT_FIRELA || model == VehicleType::VT_ANDROM || model == VehicleType::VT_DUMPER ||
             model == VehicleType::VT_DOZER || model == VehicleType::VT_PACKER);
@@ -2513,7 +2528,7 @@ void CClientVehicle::StreamOut()
 
 bool CClientVehicle::DoCheckHasLandingGear()
 {
-    auto model = static_cast<VehicleType>(m_usModel);
+    auto model = GetVehicleTypeForModel(m_usModel);
 
     return (model == VehicleType::VT_ANDROM || model == VehicleType::VT_AT400 || model == VehicleType::VT_NEVADA || model == VehicleType::VT_RUSTLER ||
             model == VehicleType::VT_SHAMAL || model == VehicleType::VT_HYDRA || model == VehicleType::VT_STUNT);

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -1362,7 +1362,7 @@ void CClientVehicle::SetLandingGearDown(bool bLandingGearDown)
 // since SetModelBlocking calls in here before that pointer has been updated.
 static VehicleType GetVehicleTypeForModel(unsigned short usModel)
 {
-    std::uint32_t ulModel = usModel;
+    std::uint16_t ulModel = usModel;
     if (ulModel < 400 || ulModel > 611)
     {
         if (CModelInfo* pModelInfo = g_pGame->GetModelInfo(ulModel))

--- a/Client/mods/deathmatch/logic/CClientVehicleManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicleManager.cpp
@@ -664,24 +664,35 @@ bool CClientVehicleManager::HasTaxiLight(unsigned long ulModel)
     return (IsStandardModel(ulModel) && (g_ulVehicleAttributes[ulModel - 400] & VEHICLE_HAS_TAXI_LIGHTS));
 }
 
+// The attribute table only covers the standard models, so a custom model has to be looked up
+// under the model it was cloned from.
+static bool HasVehicleAttribute(unsigned long ulModel, unsigned long ulAttribute)
+{
+    // Use parent model ID for non-standard vehicle model IDs.
+    if ((ulModel < 400 || ulModel > 611) && CClientVehicleManager::IsValidModel(ulModel))
+        ulModel = g_pGame->GetModelInfo(ulModel)->GetParentID();
+
+    return (CClientVehicleManager::IsStandardModel(ulModel) && (g_ulVehicleAttributes[ulModel - 400] & ulAttribute));
+}
+
 bool CClientVehicleManager::HasSearchLight(unsigned long ulModel)
 {
-    return (IsStandardModel(ulModel) && (g_ulVehicleAttributes[ulModel - 400] & VEHICLE_HAS_SEARCH_LIGHT));
+    return HasVehicleAttribute(ulModel, VEHICLE_HAS_SEARCH_LIGHT);
 }
 
 bool CClientVehicleManager::HasLandingGears(unsigned long ulModel)
 {
-    return (IsStandardModel(ulModel) && (g_ulVehicleAttributes[ulModel - 400] & VEHICLE_HAS_LANDING_GEARS));
+    return HasVehicleAttribute(ulModel, VEHICLE_HAS_LANDING_GEARS);
 }
 
 bool CClientVehicleManager::HasAdjustableProperty(unsigned long ulModel)
 {
-    return (IsStandardModel(ulModel) && (g_ulVehicleAttributes[ulModel - 400] & VEHICLE_HAS_ADJUSTABLE_PROPERTY));
+    return HasVehicleAttribute(ulModel, VEHICLE_HAS_ADJUSTABLE_PROPERTY);
 }
 
 bool CClientVehicleManager::HasSmokeTrail(unsigned long ulModel)
 {
-    return (IsStandardModel(ulModel) && (g_ulVehicleAttributes[ulModel - 400] & VEHICLE_HAS_SMOKE_TRAIL));
+    return HasVehicleAttribute(ulModel, VEHICLE_HAS_SMOKE_TRAIL);
 }
 
 bool CClientVehicleManager::HasDamageModel(unsigned long ulModel)

--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -1014,7 +1014,7 @@ static void __declspec(naked) HOOK_CVehicle__GetPlaneNumGuns_ModelId()
     {
         push    ecx
         push    edx
-        movsx   ecx, word ptr [ecx + 0x22]
+        movzx   ecx, word ptr [ecx + 0x22]
         call    ResolveAircraftWeaponModelId
         pop     edx
         pop     ecx
@@ -1039,7 +1039,7 @@ static void __declspec(naked) HOOK_CVehicle__GetPlaneGunsAutoAimAngle_ModelId()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [ecx + 0x22]
+        movzx   ecx, word ptr [ecx + 0x22]
         call    ResolveAircraftWeaponModelId
         add     eax, 0xFFFFFE57
         jmp     CONTINUE_CVehicle__GetPlaneGunsAutoAimAngle_ModelId
@@ -1062,7 +1062,7 @@ static void __declspec(naked) HOOK_CVehicle__GetPlaneGunsRateOfFire_ModelId()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [ecx + 0x22]
+        movzx   ecx, word ptr [ecx + 0x22]
         call    ResolveAircraftWeaponModelId
         add     eax, 0xFFFFFE57
         jmp     CONTINUE_CVehicle__GetPlaneGunsRateOfFire_ModelId
@@ -1085,7 +1085,7 @@ static void __declspec(naked) HOOK_CVehicle__GetPlaneOrdnanceRateOfFire_ModelId(
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [ecx + 0x22]
+        movzx   ecx, word ptr [ecx + 0x22]
         call    ResolveAircraftWeaponModelId
         add     eax, 0xFFFFFE57
         jmp     CONTINUE_CVehicle__GetPlaneOrdnanceRateOfFire_ModelId
@@ -1159,7 +1159,7 @@ static void __declspec(naked) HOOK_CVehicle__SelectPlaneWeapon_ModelId()
     {
         push    ecx
         push    edx
-        movsx   ecx, word ptr [ecx + 0x22]
+        movzx   ecx, word ptr [ecx + 0x22]
         call    ResolveAircraftWeaponModelId
         pop     edx
         pop     ecx
@@ -1184,7 +1184,7 @@ static void __declspec(naked) HOOK_CVehicle__FirePlaneGuns_ModelId()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveAircraftWeaponModelId
         add     eax, 0xFFFFFE57
         jmp     CONTINUE_CVehicle__FirePlaneGuns_ModelId
@@ -1207,7 +1207,7 @@ static void __declspec(naked) HOOK_CVehicle__FireUnguidedMissile_ModelId()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveAircraftWeaponModelId
         sub     eax, 0x1A9
         jmp     CONTINUE_CVehicle__FireUnguidedMissile_ModelId
@@ -1230,7 +1230,7 @@ static void __declspec(naked) HOOK_CVehicle__GetPlaneWeaponFiringStatus_ModelId(
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveAircraftWeaponModelId
         add     eax, 0xFFFFFE57
         jmp     CONTINUE_CVehicle__GetPlaneWeaponFiringStatus_ModelId
@@ -1252,7 +1252,7 @@ static void __declspec(naked) HOOK_CVehicle__ProcessWeapons_HydraCheck()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveAircraftWeaponModelId
         cmp     eax, 0x208
         jmp     CONTINUE_CVehicle__ProcessWeapons_HydraCheck
@@ -1283,7 +1283,7 @@ static void __declspec(naked) HOOK_CHud__DrawCrossHairs_ModelCheck()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [eax + 0x22]
+        movzx   ecx, word ptr [eax + 0x22]
         call    ResolveAircraftWeaponModelId
         cmp     eax, 0x208
         je      matched
@@ -1309,7 +1309,7 @@ static void __declspec(naked) HOOK_CCam__Process_HydraLockOnCheck()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [eax + 0x22]
+        movzx   ecx, word ptr [eax + 0x22]
         call    ResolveAircraftWeaponModelId
         cmp     eax, 0x208
         jmp     CONTINUE_CCam__Process_HydraLockOnCheck
@@ -1412,7 +1412,7 @@ static void __declspec(naked) HOOK_CPlane__ProcessControlInputs_HydraNozzleTurn(
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveAircraftWeaponModelId
         cmp     eax, 0x208
         jmp     CONTINUE_CPlane__ProcessControlInputs_HydraNozzleTurn
@@ -1437,7 +1437,7 @@ static void __declspec(naked) HOOK_CAEVehicleAudioEntity__ProcessAircraft_JetCla
     {
         push    ecx
         push    edx
-        movsx   ecx, word ptr [edx + 0x22]
+        movzx   ecx, word ptr [edx + 0x22]
         call    ResolveJetAudioModelId
         pop     edx
         pop     ecx
@@ -1462,7 +1462,7 @@ static void __declspec(naked) HOOK_CAEVehicleAudioEntity__ProcessGenericJet_Mode
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [eax + 0x22]
+        movzx   ecx, word ptr [eax + 0x22]
         call    ResolveJetAudioModelId
         add     eax, 0xFFFFFDF9
         jmp     CONTINUE_CAEVehicleAudioEntity__ProcessGenericJet_ModelSelect
@@ -1486,7 +1486,7 @@ static void __declspec(naked) HOOK_CAEVehicleAudioEntity__ProcessSpecialVehicle_
     __asm
     {
         push    ecx
-        movsx   ecx, word ptr [eax + 0x22]
+        movzx   ecx, word ptr [eax + 0x22]
         call    ResolveVehicleParentModelId
         pop     ecx
         add     eax, 0xFFFFFE4D
@@ -1511,7 +1511,7 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessBuoyancy_AmphibiousRotorE
     __asm
     {
         // ax is left holding the resolved id for the untouched Leviathan compare at 0x6A8DF0.
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     ax, 0x1BF
         jmp     CONTINUE_CAutomobile__ProcessBuoyancy_AmphibiousRotorExempt
@@ -1535,7 +1535,7 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessBuoyancy_AmphibiousSafeFl
     __asm
     {
         // cx is left holding the resolved id for the Leviathan and Vortex compares below.
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         mov     ecx, eax
         cmp     cx, 0x1BF
@@ -1559,7 +1559,7 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessBuoyancy_VortexSpeedDampi
     __asm
     {
         // Don't touch the x87 stack; st(0) feeds the fstp at CONTINUE.
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x21B
         jmp     CONTINUE_CAutomobile__ProcessBuoyancy_VortexSpeedDampingExempt
@@ -1582,7 +1582,7 @@ static void __declspec(naked) HOOK_CPlane__ProcessControlInputs_VortexSteerAxis(
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x21B
         push    edi
@@ -1606,7 +1606,7 @@ static void __declspec(naked) HOOK_CPlane__ProcessControlInputs_VortexSteerAngle
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x21B
         mov     edx, dword ptr [esi + 0x384]
@@ -1630,7 +1630,7 @@ static void __declspec(naked) HOOK_CCam__ProcessFollowCarSA_DistanceCategoryMode
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [edi + 0x22]
+        movzx   ecx, word ptr [edi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     ax, 0x1B9
         jmp     CONTINUE_CCam__ProcessFollowCarSA_DistanceCategoryModel
@@ -1652,7 +1652,7 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessControl_SkimmerBoatContro
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1CC
         jmp     CONTINUE_CAutomobile__ProcessControl_SkimmerBoatControl
@@ -1674,7 +1674,7 @@ static void __declspec(naked) HOOK_CHeli__ProcessControl_SearchLightModel()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1F1
         jmp     CONTINUE_CHeli__ProcessControl_SearchLightModel
@@ -1696,7 +1696,7 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessControl_RCBaronFakePhysic
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1D0
         jmp     CONTINUE_CAutomobile__ProcessControl_RCBaronFakePhysicsGate
@@ -1718,7 +1718,7 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessControl_RCBaronNormalGate
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1D0
         jmp     CONTINUE_CAutomobile__ProcessControl_RCBaronNormalGate
@@ -1740,7 +1740,7 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessFlyingCarStuff_RCBaronFas
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     ax, 0x1D0
         jmp     CONTINUE_CAutomobile__ProcessFlyingCarStuff_RCBaronFastPathGate
@@ -1763,7 +1763,7 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessFlyingCarStuff_RCBaronCon
     __asm
     {
         push    eax
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     ax, 0x1D0
         pop     eax
@@ -1787,7 +1787,7 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessFlyingCarStuff_RCBaronBeh
     __asm
     {
         push    eax
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         mov     cx, ax
         cmp     cx, 0x1D0
@@ -1798,7 +1798,7 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessFlyingCarStuff_RCBaronBeh
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
-// >>> 0x6D6A7B | 0F BF 4E 22          | movsx   ecx, word ptr [esi + 0x22]
+// >>> 0x6D6A7B | 0F BF 4E 22          | movzx   ecx, word ptr [esi + 0x22]
 // >>> 0x6D6A7F | 88 86 88 04 00 00    | mov     byte ptr [esi + 0x488], al
 //     0x6D6A85 | 8D 81 47 FE FF FF    | lea     eax, [ecx - 0x1B9]
 #define HOOKPOS_CVehicle__SetModelIndex_RCVehicleFlag  0x6D6A7B
@@ -1813,7 +1813,7 @@ static void __declspec(naked) HOOK_CVehicle__SetModelIndex_RCVehicleFlag()
     __asm
     {
         mov     byte ptr [esi + 0x488], al
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         mov     ecx, eax
         jmp     CONTINUE_CVehicle__SetModelIndex_RCVehicleFlag
@@ -1836,7 +1836,7 @@ static void __declspec(naked) HOOK_CPlane__ProcessControl_SmokeEjectorModel()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     ax, 0x200
         jmp     CONTINUE_CPlane__ProcessControl_SmokeEjectorModel
@@ -1859,7 +1859,7 @@ static void __declspec(naked) HOOK_CPlane__ProcessControl_SmokeParticleModel()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     ax, 0x200
         jmp     CONTINUE_CPlane__ProcessControl_SmokeParticleModel
@@ -1881,7 +1881,7 @@ static void __declspec(naked) HOOK_CPlane__ProcessControl_VortexTrailModel()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x21B
         jmp     CONTINUE_CPlane__ProcessControl_VortexTrailModel
@@ -1904,7 +1904,7 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessControl_AmphibiousPhysics
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         mov     ecx, eax
         cmp     cx, 0x1BF
@@ -1927,7 +1927,7 @@ static void __declspec(naked) HOOK_CPlane__Constructor_HydraNozzlePrime()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x208
         jmp     CONTINUE_CPlane__Constructor_HydraNozzlePrime
@@ -1949,7 +1949,7 @@ static void __declspec(naked) HOOK_CVehicle__FlyingControl_HydraPlaneThrust()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x208
         jmp     CONTINUE_CVehicle__FlyingControl_HydraPlaneThrust
@@ -1971,7 +1971,7 @@ static void __declspec(naked) HOOK_CVehicle__FlyingControl_HydraHoverThrust()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x208
         jmp     CONTINUE_CVehicle__FlyingControl_HydraHoverThrust
@@ -1994,7 +1994,7 @@ static void __declspec(naked) HOOK_CPlane__PreRender_ComponentSwitch()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         add     eax, 0xFFFFFE24
         jmp     CONTINUE_CPlane__PreRender_ComponentSwitch
@@ -2016,7 +2016,7 @@ static void __declspec(naked) HOOK_CPlane__PreRender_HydraRotationMode()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x208
         jmp     CONTINUE_CPlane__PreRender_HydraRotationMode
@@ -2039,7 +2039,7 @@ static void __declspec(naked) HOOK_CPlane__PreRender_RampAndNozzleModel()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     ax, 0x250
         jmp     CONTINUE_CPlane__PreRender_RampAndNozzleModel
@@ -2260,7 +2260,7 @@ static void __declspec(naked) HOOK_CVehicle__ProcessBoatControl_SkimmerCapsizedB
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1CC
         jmp     CONTINUE_CVehicle__ProcessBoatControl_SkimmerCapsizedBuoyancy
@@ -2284,7 +2284,7 @@ static void __declspec(naked) HOOK_CVehicle__ProcessBoatControl_SkimmerWaterLand
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1CC
         jmp     CONTINUE_CVehicle__ProcessBoatControl_SkimmerWaterLandingDamping
@@ -2310,7 +2310,7 @@ static void __declspec(naked) HOOK_CVehicle__ProcessBoatControl_SkimmerAquaplane
     {
         // ecx (a physics-matrix pointer) is reused past CONTINUE at 0x6DC2B1/BE/C9.
         push    ecx
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         pop     ecx
         cmp     eax, 0x1CC
@@ -2335,7 +2335,7 @@ static void __declspec(naked) HOOK_CVehicle__ProcessBoatControl_SkimmerSlowingDo
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1CC
         jmp     CONTINUE_CVehicle__ProcessBoatControl_SkimmerSlowingDownGate
@@ -2359,7 +2359,7 @@ static void __declspec(naked) HOOK_CVehicle__ProcessBoatControl_SkimmerTurnResis
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1CC
         jmp     CONTINUE_CVehicle__ProcessBoatControl_SkimmerTurnResistanceSkip
@@ -2383,7 +2383,7 @@ static void __declspec(naked) HOOK_CVehicle__ApplyBoatWaterResistance_SkimmerHul
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1CC
         jmp     CONTINUE_CVehicle__ApplyBoatWaterResistance_SkimmerHullDrag
@@ -2411,7 +2411,7 @@ static void __declspec(naked) HOOK_CBuoyancy__PreCalcSetup_LeviathanSkimmerModel
     {
         push    ecx
         push    edx
-        movsx   ecx, word ptr [edi + 0x22]
+        movzx   ecx, word ptr [edi + 0x22]
         call    ResolveVehicleParentModelId
         pop     edx
         pop     ecx
@@ -2437,7 +2437,7 @@ static void __declspec(naked) HOOK_CPlane__ProcessControl_SkimmerWheelStatus()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1CC
         jmp     CONTINUE_CPlane__ProcessControl_SkimmerWheelStatus
@@ -2461,7 +2461,7 @@ static void __declspec(naked) HOOK_CPlane__PreRender_SkimmerBoatSplashesCall()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1CC
         jmp     CONTINUE_CPlane__PreRender_SkimmerBoatSplashesCall
@@ -2488,7 +2488,7 @@ static void __declspec(naked) HOOK_CVehicle__DoBoatSplashes_SkimmerIntensityMode
     {
         // edi keeps the literal target; only the vehicle's model is resolved
         mov     edi, 0x1CC
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     ax, di
         jmp     CONTINUE_CVehicle__DoBoatSplashes_SkimmerIntensityModel
@@ -2513,7 +2513,7 @@ static void __declspec(naked) HOOK_CWaterLevel__RenderBoatWakes_SkimmerModel()
     __asm
     {
         push    eax
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1CC
         pop     eax
@@ -2538,7 +2538,7 @@ static void __declspec(naked) HOOK_CBoat__Render_SkimmerPropellerSpin()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1CC
         jmp     CONTINUE_CBoat__Render_SkimmerPropellerSpin
@@ -2562,7 +2562,7 @@ static void __declspec(naked) HOOK_CCamera__CamControl_SkimmerCameraMode()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [ecx + 0x22]
+        movzx   ecx, word ptr [ecx + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1CC
         jmp     CONTINUE_CCamera__CamControl_SkimmerCameraMode
@@ -2586,7 +2586,7 @@ static void __declspec(naked) HOOK_CCam__TryToStartNewCamMode_SkimmerCheckA()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [eax + 0x22]
+        movzx   ecx, word ptr [eax + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1CC
         jmp     CONTINUE_CCam__TryToStartNewCamMode_SkimmerCheckA
@@ -2611,7 +2611,7 @@ static void __declspec(naked) HOOK_CCam__TryToStartNewCamMode_SkimmerCheckB()
     __asm
     {
         push    ecx
-        movsx   ecx, word ptr [ecx + 0x22]
+        movzx   ecx, word ptr [ecx + 0x22]
         call    ResolveVehicleParentModelId
         pop     ecx
         cmp     eax, 0x1CC
@@ -2636,7 +2636,7 @@ static void __declspec(naked) HOOK_CCam__TryToStartNewCamMode_SkimmerCheckC()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [eax + 0x22]
+        movzx   ecx, word ptr [eax + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1CC
         jmp     CONTINUE_CCam__TryToStartNewCamMode_SkimmerCheckC
@@ -2660,7 +2660,7 @@ static void __declspec(naked) HOOK_CCam__TryToStartNewCamMode_SkimmerCheckD()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [edx + 0x22]
+        movzx   ecx, word ptr [edx + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1CC
         jmp     CONTINUE_CCam__TryToStartNewCamMode_SkimmerCheckD
@@ -2684,7 +2684,7 @@ static void __declspec(naked) HOOK_CCam__TryToStartNewCamMode_SkimmerCheckE()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [ecx + 0x22]
+        movzx   ecx, word ptr [ecx + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1CC
         jmp     CONTINUE_CCam__TryToStartNewCamMode_SkimmerCheckE
@@ -2708,7 +2708,7 @@ static void __declspec(naked) HOOK_CCam__Process_SkimmerFramingA()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [edx + 0x22]
+        movzx   ecx, word ptr [edx + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1CC
         jmp     CONTINUE_CCam__Process_SkimmerFramingA
@@ -2732,7 +2732,7 @@ static void __declspec(naked) HOOK_CCam__Process_SkimmerFramingB()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [edx + 0x22]
+        movzx   ecx, word ptr [edx + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1CC
         jmp     CONTINUE_CCam__Process_SkimmerFramingB
@@ -2756,7 +2756,7 @@ static void __declspec(naked) HOOK_CCam__Process_SkimmerFramingC()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [ecx + 0x22]
+        movzx   ecx, word ptr [ecx + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1CC
         jmp     CONTINUE_CCam__Process_SkimmerFramingC
@@ -2780,7 +2780,7 @@ static void __declspec(naked) HOOK_CCam__Process_SkimmerFramingD()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [eax + 0x22]
+        movzx   ecx, word ptr [eax + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1CC
         jmp     CONTINUE_CCam__Process_SkimmerFramingD
@@ -2804,7 +2804,7 @@ static void __declspec(naked) HOOK_CCam__Process_SkimmerFramingE()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [eax + 0x22]
+        movzx   ecx, word ptr [eax + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x1CC
         jmp     CONTINUE_CCam__Process_SkimmerFramingE
@@ -2830,7 +2830,7 @@ static void __declspec(naked) HOOK_CRenderer__SetupEntityVisibility_SkimmerCulli
     // clang-format off
     __asm
     {
-        movsx   ecx, ax
+        movzx   ecx, ax
         call    ResolveVehicleParentModelId
         cmp     ax, 0x1CC
         jne     notSkimmer
@@ -2857,7 +2857,7 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessControl_VortexTractionBoo
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x21B
         jmp     CONTINUE_CAutomobile__ProcessControl_VortexTractionBoost
@@ -2879,7 +2879,7 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessControl_VortexWheelSettle
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x21B
         jmp     CONTINUE_CAutomobile__ProcessControl_VortexWheelSettleExempt
@@ -2901,7 +2901,7 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessSuspension_VortexSpringFo
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x21B
         jmp     CONTINUE_CAutomobile__ProcessSuspension_VortexSpringForceScale
@@ -2923,7 +2923,7 @@ static void __declspec(naked) HOOK_CAutomobile__ProcessSuspension_VortexGroundSp
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x21B
         jmp     CONTINUE_CAutomobile__ProcessSuspension_VortexGroundSpringExempt
@@ -2951,7 +2951,7 @@ static void __declspec(naked) HOOK_CVehicle__FlyingControl_VortexSkimmerGroundRe
     {
         // eax holds 1.0f, consumed by four untouched dword compares at 0x6D8E23/2B/33/3B.
         push    eax
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         mov     bx, ax
         pop     eax
@@ -2978,7 +2978,7 @@ static void __declspec(naked) HOOK_CVehicle__FlyingControl_VortexThrustFormula()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x21B
         jmp     CONTINUE_CVehicle__FlyingControl_VortexThrustFormula
@@ -3004,7 +3004,7 @@ static void __declspec(naked) HOOK_CVehicle__FlyingControl_VortexTurnDampingClam
     {
         // eax holds a pointer from call 0x542ce0, read again past CONTINUE via fld [eax]/[eax+4].
         push    eax
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         mov     edx, eax
         pop     eax
@@ -3031,7 +3031,7 @@ static void __declspec(naked) HOOK_CPlane__Constructor_VortexFlyerCollisionExemp
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x21B
         jmp     CONTINUE_CPlane__Constructor_VortexFlyerCollisionExempt
@@ -3058,7 +3058,7 @@ static void __declspec(naked) HOOK_CPlane__VehicleDamage_VortexCarStyleDamage()
         // eax/ecx hold globals stored to [esp+0xC]/[esp+8] right after CONTINUE.
         push    eax
         push    ecx
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         mov     edx, eax
         pop     ecx
@@ -3083,7 +3083,7 @@ static void __declspec(naked) HOOK_CPlane__PreRender_VortexFanFXMatrix()
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     eax, 0x21B
         jmp     CONTINUE_CPlane__PreRender_VortexFanFXMatrix
@@ -3109,7 +3109,7 @@ static void __declspec(naked) HOOK_CAEVehicleAudioEntity__Initialise_SpecialVehi
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [edx + 0x22]
+        movzx   ecx, word ptr [edx + 0x22]
         call    ResolveVehicleParentModelId
         add     eax, 0xFFFFFE40
         jmp     CONTINUE_CAEVehicleAudioEntity__Initialise_SpecialVehicleModelSwitch
@@ -3137,7 +3137,7 @@ static void __declspec(naked) HOOK_CPlane__PreRender_ShadowTypeModel()
     {
         push    ecx
         fstp    dword ptr [esp + 0x38]
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         pop     ecx
         // CONTINUE re-does the compare on ax, so none is needed here
@@ -3165,7 +3165,7 @@ static void __declspec(naked) HOOK_CCarEnterExit__IsRoomForPedToLeaveCar_AT400Do
     {
         // eax is read again on the not-taken path at 0x650878 (cmp eax, [esi + 0xFC]).
         push    eax
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     ax, 0x241
         pop     eax
@@ -3192,7 +3192,7 @@ static void __declspec(naked) HOOK_CCarEnterExit__IsRoomForPedToLeaveCar_Amphibi
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         // si is left holding the resolved id for the compares that follow
         mov     si, ax
@@ -3219,7 +3219,7 @@ static void __declspec(naked) HOOK_CCarEnterExit__IsPathToDoorBlockedByVehicleCo
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [edi + 0x22]
+        movzx   ecx, word ptr [edi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     ax, 0x241
         jmp     CONTINUE_CCarEnterExit__IsPathToDoorBlockedByVehicleCollisionModel_AT400DoorException
@@ -3244,7 +3244,7 @@ static void __declspec(naked) HOOK_CTaskUtilityLineUpPedWithCar__ProcessPed_AT40
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     ax, 0x241
         jmp     CONTINUE_CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetA
@@ -3268,7 +3268,7 @@ static void __declspec(naked) HOOK_CTaskUtilityLineUpPedWithCar__ProcessPed_AT40
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     ax, 0x241
         jmp     CONTINUE_CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetB
@@ -3292,7 +3292,7 @@ static void __declspec(naked) HOOK_CTaskUtilityLineUpPedWithCar__ProcessPed_AT40
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     ax, 0x241
         jmp     CONTINUE_CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetC
@@ -3319,7 +3319,7 @@ static void __declspec(naked) HOOK_CTaskComplexEnterCar__CreateFirstSubTask_Amph
     __asm
     {
         push    eax
-        movsx   ecx, word ptr [eax + 0x22]
+        movzx   ecx, word ptr [eax + 0x22]
         call    ResolveVehicleParentModelId
         // cx is left holding the resolved id for the compares further down
         mov     cx, ax
@@ -3347,7 +3347,7 @@ static void __declspec(naked) HOOK_CPlayerInfo__FindClosestCarSectorList_AT400Di
     __asm
     {
         push    eax
-        movsx   ecx, word ptr [esi + 0x22]
+        movzx   ecx, word ptr [esi + 0x22]
         call    ResolveVehicleParentModelId
         cmp     ax, 0x241
         pop     eax
@@ -3374,7 +3374,7 @@ static void __declspec(naked) HOOK_CPlayerInfo__Process_AmphibiousWaterExitChain
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [ebx + 0x22]
+        movzx   ecx, word ptr [ebx + 0x22]
         call    ResolveVehicleParentModelId
         // ax is left holding the resolved id for the compares that follow
         cmp     ax, 0x1CC
@@ -3401,7 +3401,7 @@ static void __declspec(naked) HOOK_CWeapon__FireInstantHit_MountedGunSpreadChain
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [edi + 0x22]
+        movzx   ecx, word ptr [edi + 0x22]
         call    ResolveAircraftWeaponModelId
         // ax is left holding the resolved id for the compares that follow
         cmp     ax, 0x1BF
@@ -3428,7 +3428,7 @@ static void __declspec(naked) HOOK_CShadows__StoreShadowForVehicle_ModelDispatch
     // clang-format off
     __asm
     {
-        movsx   ecx, word ptr [edi + 0x22]
+        movzx   ecx, word ptr [edi + 0x22]
         call    ResolveVehicleParentModelId
         mov     ebx, eax
         // call must not touch the x87 stack; this fstp is the only allowed pop

--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -911,6 +911,2643 @@ static void __declspec(naked) HOOK_CMonsterTruck__PreRender_DumperSwing()
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
+// Aircraft on custom vehicle models
+//
+// Raw model-index comparisons across the flight model, weapon code, audio and cameras don't
+// recognise a clone's own id. The three resolvers below map it back to the base aircraft:
+// ResolveAircraftWeaponModelId for individual armed aircraft, ResolveVehicleParentModelId for
+// whole vehicle classes, and ResolveJetAudioModelId for the jet engine sound.
+//////////////////////////////////////////////////////////////////////////////////////////
+static std::uint32_t __fastcall ResolveAircraftWeaponModelId(std::uint32_t modelId)
+{
+    // Standard models leave m_dwParentID uninitialised, so answer the vanilla range here instead of reading it.
+    if (modelId >= 400 && modelId <= 611)
+        return modelId;
+
+    CModelInfo* modelInfo = pGameInterface->GetModelInfo(modelId);
+    if (!modelInfo)
+        return modelId;
+
+    switch (static_cast<VehicleType>(modelInfo->GetParentID()))
+    {
+        case VehicleType::VT_SEASPAR:
+        case VehicleType::VT_SPARROW:
+        case VehicleType::VT_HUNTER:
+        case VehicleType::VT_HYDRA:
+        case VehicleType::VT_RUSTLER:
+        case VehicleType::VT_RCBARON:
+        case VehicleType::VT_RCTIGER:
+        case VehicleType::VT_TORNADO:
+        case VehicleType::VT_CARGOBOB:
+        case VehicleType::VT_MAVERICK:
+        case VehicleType::VT_POLMAV:
+            return static_cast<std::uint32_t>(modelInfo->GetParentID());
+        default:
+            return modelId;
+    }
+}
+
+static std::uint32_t __fastcall ResolveVehicleParentModelId(std::uint32_t modelId)
+{
+    // Standard models leave m_dwParentID uninitialised, so answer the vanilla range here instead of reading it.
+    if (modelId >= 400 && modelId <= 611)
+        return modelId;
+
+    CModelInfo* modelInfo = pGameInterface->GetModelInfo(modelId);
+    if (!modelInfo)
+        return modelId;
+
+    const std::uint32_t parentId = static_cast<std::uint32_t>(modelInfo->GetParentID());
+    return (parentId >= 400 && parentId <= 611) ? parentId : modelId;
+}
+
+static std::uint32_t __fastcall ResolveJetAudioModelId(std::uint32_t modelId)
+{
+    // Standard models leave m_dwParentID uninitialised, so answer the vanilla range here instead of reading it.
+    if (modelId >= 400 && modelId <= 611)
+        return modelId;
+
+    CModelInfo* modelInfo = pGameInterface->GetModelInfo(modelId);
+    if (!modelInfo)
+        return modelId;
+
+    switch (static_cast<VehicleType>(modelInfo->GetParentID()))
+    {
+        case VehicleType::VT_SHAMAL:
+        case VehicleType::VT_HYDRA:
+        case VehicleType::VT_AT400:
+        case VehicleType::VT_ANDROM:
+            return static_cast<std::uint32_t>(modelInfo->GetParentID());
+        default:
+            return modelId;
+    }
+}
+
+static bool __fastcall IsAndromadaOrClone(CVehicleSAInterface* vehicle)
+{
+    const std::uint32_t modelId = static_cast<std::uint32_t>(vehicle->m_nModelIndex);
+    if (modelId == static_cast<std::uint32_t>(VehicleType::VT_ANDROM))
+        return true;
+
+    // Same reasoning as the resolvers above: no other standard model can be a clone.
+    if (modelId >= 400 && modelId <= 611)
+        return false;
+
+    CModelInfo* modelInfo = pGameInterface->GetModelInfo(modelId);
+    return modelInfo && modelInfo->GetParentID() == static_cast<unsigned int>(VehicleType::VT_ANDROM);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6D3F30 | 0F BF 41 22    | movsx   eax, word ptr [ecx + 0x22]
+// >>> 0x6D3F34 | 05 57 FE FF FF | add     eax, 0xFFFFFE57
+//     0x6D3F39 | 3D 97 00 00 00 | cmp     eax, 0x97
+#define HOOKPOS_CVehicle__GetPlaneNumGuns_ModelId  0x6D3F30
+#define HOOKSIZE_CVehicle__GetPlaneNumGuns_ModelId 9
+static const DWORD CONTINUE_CVehicle__GetPlaneNumGuns_ModelId = 0x6D3F39;
+
+static void __declspec(naked) HOOK_CVehicle__GetPlaneNumGuns_ModelId()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    ecx
+        push    edx
+        movsx   ecx, word ptr [ecx + 0x22]
+        call    ResolveAircraftWeaponModelId
+        pop     edx
+        pop     ecx
+        add     eax, 0xFFFFFE57
+        jmp     CONTINUE_CVehicle__GetPlaneNumGuns_ModelId
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6D3E00 | 0F BF 41 22    | movsx   eax, word ptr [ecx + 0x22]
+// >>> 0x6D3E04 | 05 57 FE FF FF | add     eax, 0xFFFFFE57
+//     0x6D3E09 | 3D 97 00 00 00 | cmp     eax, 0x97
+#define HOOKPOS_CVehicle__GetPlaneGunsAutoAimAngle_ModelId  0x6D3E00
+#define HOOKSIZE_CVehicle__GetPlaneGunsAutoAimAngle_ModelId 9
+static const DWORD CONTINUE_CVehicle__GetPlaneGunsAutoAimAngle_ModelId = 0x6D3E09;
+
+static void __declspec(naked) HOOK_CVehicle__GetPlaneGunsAutoAimAngle_ModelId()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [ecx + 0x22]
+        call    ResolveAircraftWeaponModelId
+        add     eax, 0xFFFFFE57
+        jmp     CONTINUE_CVehicle__GetPlaneGunsAutoAimAngle_ModelId
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6D4125 | 0F BF 41 22    | movsx   eax, word ptr [ecx + 0x22]
+// >>> 0x6D4129 | 05 57 FE FF FF | add     eax, 0xFFFFFE57
+//     0x6D412E | 3D 97 00 00 00 | cmp     eax, 0x97
+#define HOOKPOS_CVehicle__GetPlaneGunsRateOfFire_ModelId  0x6D4125
+#define HOOKSIZE_CVehicle__GetPlaneGunsRateOfFire_ModelId 9
+static const DWORD CONTINUE_CVehicle__GetPlaneGunsRateOfFire_ModelId = 0x6D412E;
+
+static void __declspec(naked) HOOK_CVehicle__GetPlaneGunsRateOfFire_ModelId()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [ecx + 0x22]
+        call    ResolveAircraftWeaponModelId
+        add     eax, 0xFFFFFE57
+        jmp     CONTINUE_CVehicle__GetPlaneGunsRateOfFire_ModelId
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6D45D5 | 0F BF 41 22    | movsx   eax, word ptr [ecx + 0x22]
+// >>> 0x6D45D9 | 05 57 FE FF FF | add     eax, 0xFFFFFE57
+//     0x6D45DE | 3D 5F 00 00 00 | cmp     eax, 0x5F
+#define HOOKPOS_CVehicle__GetPlaneOrdnanceRateOfFire_ModelId  0x6D45D5
+#define HOOKSIZE_CVehicle__GetPlaneOrdnanceRateOfFire_ModelId 9
+static const DWORD CONTINUE_CVehicle__GetPlaneOrdnanceRateOfFire_ModelId = 0x6D45DE;
+
+static void __declspec(naked) HOOK_CVehicle__GetPlaneOrdnanceRateOfFire_ModelId()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [ecx + 0x22]
+        call    ResolveAircraftWeaponModelId
+        add     eax, 0xFFFFFE57
+        jmp     CONTINUE_CVehicle__GetPlaneOrdnanceRateOfFire_ModelId
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6D42FE | 8D 81 57 FE FF FF | lea     eax, [ecx + 0xFFFFFE57]
+//     0x6D4304 | 3D 97 00 00 00    | cmp     eax, 0x97
+#define HOOKPOS_CVehicle__GetPlaneGunsPosition_ModelId  0x6D42FE
+#define HOOKSIZE_CVehicle__GetPlaneGunsPosition_ModelId 6
+static const DWORD CONTINUE_CVehicle__GetPlaneGunsPosition_ModelId = 0x6D4304;
+
+static void __declspec(naked) HOOK_CVehicle__GetPlaneGunsPosition_ModelId()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    edx
+        call    ResolveAircraftWeaponModelId        ; ecx already holds the model id
+        pop     edx
+        add     eax, 0xFFFFFE57
+        jmp     CONTINUE_CVehicle__GetPlaneGunsPosition_ModelId
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6D474B | 8D 87 57 FE FF FF | lea     eax, [edi + 0xFFFFFE57]
+//     0x6D4751 | 3D 97 00 00 00    | cmp     eax, 0x97
+#define HOOKPOS_CVehicle__GetPlaneOrdnancePosition_ModelId  0x6D474B
+#define HOOKSIZE_CVehicle__GetPlaneOrdnancePosition_ModelId 6
+static const DWORD CONTINUE_CVehicle__GetPlaneOrdnancePosition_ModelId = 0x6D4751;
+
+static void __declspec(naked) HOOK_CVehicle__GetPlaneOrdnancePosition_ModelId()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    ecx
+        push    edx
+        mov     ecx, edi
+        call    ResolveAircraftWeaponModelId
+        pop     edx
+        pop     ecx
+        add     eax, 0xFFFFFE57
+        jmp     CONTINUE_CVehicle__GetPlaneOrdnancePosition_ModelId
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6D4900 | 0F BF 41 22    | movsx   eax, word ptr [ecx + 0x22]
+// >>> 0x6D4904 | 05 57 FE FF FF | add     eax, 0xFFFFFE57
+//     0x6D4909 | 3D 97 00 00 00 | cmp     eax, 0x97
+#define HOOKPOS_CVehicle__SelectPlaneWeapon_ModelId  0x6D4900
+#define HOOKSIZE_CVehicle__SelectPlaneWeapon_ModelId 9
+static const DWORD CONTINUE_CVehicle__SelectPlaneWeapon_ModelId = 0x6D4909;
+
+static void __declspec(naked) HOOK_CVehicle__SelectPlaneWeapon_ModelId()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    ecx
+        push    edx
+        movsx   ecx, word ptr [ecx + 0x22]
+        call    ResolveAircraftWeaponModelId
+        pop     edx
+        pop     ecx
+        add     eax, 0xFFFFFE57
+        jmp     CONTINUE_CVehicle__SelectPlaneWeapon_ModelId
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6D4D5E | 0F BF 46 22    | movsx   eax, word ptr [esi + 0x22]
+// >>> 0x6D4D62 | 05 57 FE FF FF | add     eax, 0xFFFFFE57
+//     0x6D4D67 | 3D 97 00 00 00 | cmp     eax, 0x97
+#define HOOKPOS_CVehicle__FirePlaneGuns_ModelId  0x6D4D5E
+#define HOOKSIZE_CVehicle__FirePlaneGuns_ModelId 9
+static const DWORD CONTINUE_CVehicle__FirePlaneGuns_ModelId = 0x6D4D67;
+
+static void __declspec(naked) HOOK_CVehicle__FirePlaneGuns_ModelId()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveAircraftWeaponModelId
+        add     eax, 0xFFFFFE57
+        jmp     CONTINUE_CVehicle__FirePlaneGuns_ModelId
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6D514F | 0F BF 46 22 | movsx   eax, word ptr [esi + 0x22]
+// >>> 0x6D5153 | 2D A9 01 00 00 | sub     eax, 0x1A9
+//     0x6D5158 | 74 0E          | jz      0x6D5168
+#define HOOKPOS_CVehicle__FireUnguidedMissile_ModelId  0x6D514F
+#define HOOKSIZE_CVehicle__FireUnguidedMissile_ModelId 9
+static const DWORD CONTINUE_CVehicle__FireUnguidedMissile_ModelId = 0x6D5158;
+
+static void __declspec(naked) HOOK_CVehicle__FireUnguidedMissile_ModelId()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveAircraftWeaponModelId
+        sub     eax, 0x1A9
+        jmp     CONTINUE_CVehicle__FireUnguidedMissile_ModelId
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6E3457 | 0F BF 46 22    | movsx   eax, word ptr [esi + 0x22]
+// >>> 0x6E345B | 05 57 FE FF FF | add     eax, 0xFFFFFE57
+//     0x6E3460 | 83 C4 08       | add     esp, 0x8
+#define HOOKPOS_CVehicle__GetPlaneWeaponFiringStatus_ModelId  0x6E3457
+#define HOOKSIZE_CVehicle__GetPlaneWeaponFiringStatus_ModelId 9
+static const DWORD CONTINUE_CVehicle__GetPlaneWeaponFiringStatus_ModelId = 0x6E3460;
+
+static void __declspec(naked) HOOK_CVehicle__GetPlaneWeaponFiringStatus_ModelId()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveAircraftWeaponModelId
+        add     eax, 0xFFFFFE57
+        jmp     CONTINUE_CVehicle__GetPlaneWeaponFiringStatus_ModelId
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6E39B8 | 66 81 7E 22 08 02 | cmp     word ptr [esi + 0x22], 0x208
+//     0x6E39BE | B1 01             | mov     cl, 0x1
+#define HOOKPOS_CVehicle__ProcessWeapons_HydraCheck  0x6E39B8
+#define HOOKSIZE_CVehicle__ProcessWeapons_HydraCheck 6
+static const DWORD CONTINUE_CVehicle__ProcessWeapons_HydraCheck = 0x6E39BE;
+
+static void __declspec(naked) HOOK_CVehicle__ProcessWeapons_HydraCheck()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveAircraftWeaponModelId
+        cmp     eax, 0x208
+        jmp     CONTINUE_CVehicle__ProcessWeapons_HydraCheck
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CHud::DrawCrossHairs, Hydra/Hunter gunsight crosshair for custom models; one resolve replaces
+// both compares and the second FindPlayerVehicle call.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x58E09F | 66 81 78 22 08 02 | cmp     word ptr [eax + 0x22], 0x208
+// >>> 0x58E0A5 | 74 14             | je      0x58E0BB
+// >>> 0x58E0A7 | 6A 00             | push    0
+// >>> 0x58E0A9 | 6A FF             | push    -1
+// >>> 0x58E0AB | E8 20 00 FE FF    | call    FindPlayerVehicle
+// >>> 0x58E0B0 | 83 C4 08          | add     esp, 8
+// >>> 0x58E0B3 | 66 81 78 22 A9 01 | cmp     word ptr [eax + 0x22], 0x1A9
+//     0x58E0B9 | 75 05             | jne     0x58E0C0
+#define HOOKPOS_CHud__DrawCrossHairs_ModelCheck  0x58E09F
+#define HOOKSIZE_CHud__DrawCrossHairs_ModelCheck 26
+static const DWORD CONTINUE_CHud__DrawCrossHairs_ModelCheck = 0x58E0B9;
+
+static void __declspec(naked) HOOK_CHud__DrawCrossHairs_ModelCheck()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [eax + 0x22]
+        call    ResolveAircraftWeaponModelId
+        cmp     eax, 0x208
+        je      matched
+        cmp     eax, 0x1A9
+
+        matched:
+        jmp     CONTINUE_CHud__DrawCrossHairs_ModelCheck
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x527058 | 66 81 78 22 08 02 | cmp     word ptr [eax + 0x22], 0x208
+//     0x52705E | 74 0A             | je      0x52706A
+#define HOOKPOS_CCam__Process_HydraLockOnCheck  0x527058
+#define HOOKSIZE_CCam__Process_HydraLockOnCheck 6
+static const DWORD CONTINUE_CCam__Process_HydraLockOnCheck = 0x52705E;
+
+static void __declspec(naked) HOOK_CCam__Process_HydraLockOnCheck()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [eax + 0x22]
+        call    ResolveAircraftWeaponModelId
+        cmp     eax, 0x208
+        jmp     CONTINUE_CCam__Process_HydraLockOnCheck
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6A53B5 | E8 66 F0 D5 FF    | call    0x404420 (GetModelIndex)
+// >>> 0x6A53BA | 3D 08 02 00 00    | cmp     eax, 0x208
+//     0x6A53BF | 0F 84 B2 00 00 00 | je      0x6A5477
+#define HOOKPOS_CAutomobile__ProcessCarWheelPair_HydraSteerExempt  0x6A53BA
+#define HOOKSIZE_CAutomobile__ProcessCarWheelPair_HydraSteerExempt 5
+static const DWORD CONTINUE_CAutomobile__ProcessCarWheelPair_HydraSteerExempt = 0x6A53BF;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessCarWheelPair_HydraSteerExempt()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        mov     ecx, eax
+        call    ResolveAircraftWeaponModelId
+        cmp     eax, 0x208
+        jmp     CONTINUE_CAutomobile__ProcessCarWheelPair_HydraSteerExempt
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6C41D9 | 81 FF A9 01 00 00 | cmp     edi, 0x1A9
+//     0x6C41DF | 89 5C 24 18       | mov     dword ptr [esp + 0x18], ebx
+#define HOOKPOS_CHeli__Constructor_HunterDoor  0x6C41D9
+#define HOOKSIZE_CHeli__Constructor_HunterDoor 6
+static const DWORD CONTINUE_CHeli__Constructor_HunterDoor = 0x6C41DF;
+
+static void __declspec(naked) HOOK_CHeli__Constructor_HunterDoor()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    eax
+        push    ecx
+        push    edx
+        mov     ecx, edi
+        call    ResolveAircraftWeaponModelId
+        cmp     eax, 0x1A9
+        pop     edx
+        pop     ecx
+        pop     eax
+        jmp     CONTINUE_CHeli__Constructor_HunterDoor
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CPlane::Constructor, resolves the model once before the door/panel/wheel-visibility switch,
+// covering the Hydra, Rustler, Cropduster, Shamal, Nevada, Vortex and Stunt Plane cases below.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6C8F10 | 81 FF 08 02 00 00 | cmp     edi, 0x208
+//     0x6C8F16 | 66 C7 86 A6 04 00 00 FF 00 | mov     word ptr [esi + 0x4A6], 0xFF
+#define HOOKPOS_CPlane__Constructor_ModelSwitch  0x6C8F10
+#define HOOKSIZE_CPlane__Constructor_ModelSwitch 6
+static const DWORD CONTINUE_CPlane__Constructor_ModelSwitch = 0x6C8F16;
+
+static void __declspec(naked) HOOK_CPlane__Constructor_ModelSwitch()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    ecx
+        push    edx
+        mov     ecx, edi
+        call    ResolveVehicleParentModelId
+        mov     edi, eax
+        pop     edx
+        pop     ecx
+        cmp     edi, 0x208
+        jmp     CONTINUE_CPlane__Constructor_ModelSwitch
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x406AF1 | 66 81 7E 22 08 02 | cmp     word ptr [esi + 0x22], 0x208
+//     0x406AF7 | E9 FD 49 2C 00    | jmp     0x6CB4F9
+#define HOOKPOS_CPlane__ProcessControlInputs_HydraNozzleTurn  0x406AF1
+#define HOOKSIZE_CPlane__ProcessControlInputs_HydraNozzleTurn 6
+static const DWORD CONTINUE_CPlane__ProcessControlInputs_HydraNozzleTurn = 0x406AF7;
+
+static void __declspec(naked) HOOK_CPlane__ProcessControlInputs_HydraNozzleTurn()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveAircraftWeaponModelId
+        cmp     eax, 0x208
+        jmp     CONTINUE_CPlane__ProcessControlInputs_HydraNozzleTurn
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x501C73 | 0F BF 42 22    | movsx   eax, word ptr [edx + 0x22]
+// >>> 0x501C77 | 05 F9 FD FF FF | add     eax, 0xFFFFFDF9
+//     0x501C7C | 83 F8 49       | cmp     eax, 0x49
+#define HOOKPOS_CAEVehicleAudioEntity__ProcessAircraft_JetClass  0x501C73
+#define HOOKSIZE_CAEVehicleAudioEntity__ProcessAircraft_JetClass 9
+static const DWORD CONTINUE_CAEVehicleAudioEntity__ProcessAircraft_JetClass = 0x501C7C;
+
+static void __declspec(naked) HOOK_CAEVehicleAudioEntity__ProcessAircraft_JetClass()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    ecx
+        push    edx
+        movsx   ecx, word ptr [edx + 0x22]
+        call    ResolveJetAudioModelId
+        pop     edx
+        pop     ecx
+        add     eax, 0xFFFFFDF9
+        jmp     CONTINUE_CAEVehicleAudioEntity__ProcessAircraft_JetClass
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x4FF980 | 0F BF 40 22    | movsx   eax, word ptr [eax + 0x22]
+// >>> 0x4FF984 | 05 F9 FD FF FF | add     eax, 0xFFFFFDF9
+//     0x4FF989 | 83 F8 49       | cmp     eax, 0x49
+#define HOOKPOS_CAEVehicleAudioEntity__ProcessGenericJet_ModelSelect  0x4FF980
+#define HOOKSIZE_CAEVehicleAudioEntity__ProcessGenericJet_ModelSelect 9
+static const DWORD CONTINUE_CAEVehicleAudioEntity__ProcessGenericJet_ModelSelect = 0x4FF989;
+
+static void __declspec(naked) HOOK_CAEVehicleAudioEntity__ProcessGenericJet_ModelSelect()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [eax + 0x22]
+        call    ResolveJetAudioModelId
+        add     eax, 0xFFFFFDF9
+        jmp     CONTINUE_CAEVehicleAudioEntity__ProcessGenericJet_ModelSelect
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x501AB9 | 0F BF 40 22    | movsx   eax, word ptr [eax + 0x22]
+// >>> 0x501ABD | 05 4D FE FF FF | add     eax, 0xFFFFFE4D
+//     0x501AC2 | 3D 9C 00 00 00 | cmp     eax, 0x9C
+#define HOOKPOS_CAEVehicleAudioEntity__ProcessSpecialVehicle_ModelSwitch  0x501AB9
+#define HOOKSIZE_CAEVehicleAudioEntity__ProcessSpecialVehicle_ModelSwitch 9
+static const DWORD CONTINUE_CAEVehicleAudioEntity__ProcessSpecialVehicle_ModelSwitch = 0x501AC2;
+
+static void __declspec(naked) HOOK_CAEVehicleAudioEntity__ProcessSpecialVehicle_ModelSwitch()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    ecx
+        movsx   ecx, word ptr [eax + 0x22]
+        call    ResolveVehicleParentModelId
+        pop     ecx
+        add     eax, 0xFFFFFE4D
+        jmp     CONTINUE_CAEVehicleAudioEntity__ProcessSpecialVehicle_ModelSwitch
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6A8DE2 | 66 8B 46 22 | mov     ax, word ptr [esi + 0x22]
+// >>> 0x6A8DE6 | 66 3D BF 01 | cmp     ax, 0x1BF
+//     0x6A8DEA | 0F 84 AE 00 00 00 | je      0x6A8E9E
+#define HOOKPOS_CAutomobile__ProcessBuoyancy_AmphibiousRotorExempt  0x6A8DE2
+#define HOOKSIZE_CAutomobile__ProcessBuoyancy_AmphibiousRotorExempt 8
+static const DWORD CONTINUE_CAutomobile__ProcessBuoyancy_AmphibiousRotorExempt = 0x6A8DEA;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessBuoyancy_AmphibiousRotorExempt()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // ax is left holding the resolved id for the untouched Leviathan compare at 0x6A8DF0.
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     ax, 0x1BF
+        jmp     CONTINUE_CAutomobile__ProcessBuoyancy_AmphibiousRotorExempt
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6A8F18 | 66 8B 4E 22       | mov     cx, word ptr [esi + 0x22]
+// >>> 0x6A8F1C | 66 81 F9 BF 01    | cmp     cx, 0x1BF
+//     0x6A8F21 | 74 07             | je      0x6A8F2A
+#define HOOKPOS_CAutomobile__ProcessBuoyancy_AmphibiousSafeFloat  0x6A8F18
+#define HOOKSIZE_CAutomobile__ProcessBuoyancy_AmphibiousSafeFloat 9
+static const DWORD CONTINUE_CAutomobile__ProcessBuoyancy_AmphibiousSafeFloat = 0x6A8F21;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessBuoyancy_AmphibiousSafeFloat()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // cx is left holding the resolved id for the Leviathan and Vortex compares below.
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        mov     ecx, eax
+        cmp     cx, 0x1BF
+        jmp     CONTINUE_CAutomobile__ProcessBuoyancy_AmphibiousSafeFloat
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6A8D4E | 66 81 7E 22 1B 02 | cmp     word ptr [esi + 0x22], 0x21B
+//     0x6A8D54 | D9 5C 24 14       | fstp    dword ptr [esp + 0x14]
+#define HOOKPOS_CAutomobile__ProcessBuoyancy_VortexSpeedDampingExempt  0x6A8D4E
+#define HOOKSIZE_CAutomobile__ProcessBuoyancy_VortexSpeedDampingExempt 6
+static const DWORD CONTINUE_CAutomobile__ProcessBuoyancy_VortexSpeedDampingExempt = 0x6A8D54;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessBuoyancy_VortexSpeedDampingExempt()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // Don't touch the x87 stack; st(0) feeds the fstp at CONTINUE.
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x21B
+        jmp     CONTINUE_CAutomobile__ProcessBuoyancy_VortexSpeedDampingExempt
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6CB176 | 66 39 6E 22 | cmp     word ptr [esi + 0x22], bp
+// >>> 0x6CB17A | 57          | push    edi
+//     0x6CB17B | 75 77       | jne     0x6CB1F4
+#define HOOKPOS_CPlane__ProcessControlInputs_VortexSteerAxis  0x6CB176
+#define HOOKSIZE_CPlane__ProcessControlInputs_VortexSteerAxis 5
+static const DWORD CONTINUE_CPlane__ProcessControlInputs_VortexSteerAxis = 0x6CB17B;
+
+static void __declspec(naked) HOOK_CPlane__ProcessControlInputs_VortexSteerAxis()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x21B
+        push    edi
+        jmp     CONTINUE_CPlane__ProcessControlInputs_VortexSteerAxis
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6CB281 | 66 39 6E 22       | cmp     word ptr [esi + 0x22], bp
+// >>> 0x6CB285 | 8B 96 84 03 00 00 | mov     edx, dword ptr [esi + 0x384]
+//     0x6CB28B | D9 82 A0 00 00 00 | fld     dword ptr [edx + 0xA0]
+#define HOOKPOS_CPlane__ProcessControlInputs_VortexSteerAngleSource  0x6CB281
+#define HOOKSIZE_CPlane__ProcessControlInputs_VortexSteerAngleSource 10
+static const DWORD CONTINUE_CPlane__ProcessControlInputs_VortexSteerAngleSource = 0x6CB28B;
+
+static void __declspec(naked) HOOK_CPlane__ProcessControlInputs_VortexSteerAngleSource()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x21B
+        mov     edx, dword ptr [esi + 0x384]
+        jmp     CONTINUE_CPlane__ProcessControlInputs_VortexSteerAngleSource
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x524624 | 66 8B 47 22 | mov     ax, word ptr [edi + 0x22]
+// >>> 0x524628 | 66 3D B9 01 | cmp     ax, 0x1B9
+//     0x52462C | 0F 84 8F 00 00 00 | je      0x5246C1
+#define HOOKPOS_CCam__ProcessFollowCarSA_DistanceCategoryModel  0x524624
+#define HOOKSIZE_CCam__ProcessFollowCarSA_DistanceCategoryModel 8
+static const DWORD CONTINUE_CCam__ProcessFollowCarSA_DistanceCategoryModel = 0x52462C;
+
+static void __declspec(naked) HOOK_CCam__ProcessFollowCarSA_DistanceCategoryModel()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [edi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     ax, 0x1B9
+        jmp     CONTINUE_CCam__ProcessFollowCarSA_DistanceCategoryModel
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6B217D | 66 81 7E 22 CC 01 | cmp     word ptr [esi + 0x22], 0x1CC
+//     0x6B2183 | 75 4A             | jne     0x6B21CF
+#define HOOKPOS_CAutomobile__ProcessControl_SkimmerBoatControl  0x6B217D
+#define HOOKSIZE_CAutomobile__ProcessControl_SkimmerBoatControl 6
+static const DWORD CONTINUE_CAutomobile__ProcessControl_SkimmerBoatControl = 0x6B2183;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessControl_SkimmerBoatControl()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CAutomobile__ProcessControl_SkimmerBoatControl
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6C7172 | 66 81 7E 22 F1 01 | cmp     word ptr [esi + 0x22], 0x1F1
+//     0x6C7178 | 75 17             | jne     0x6C7191
+#define HOOKPOS_CHeli__ProcessControl_SearchLightModel  0x6C7172
+#define HOOKSIZE_CHeli__ProcessControl_SearchLightModel 6
+static const DWORD CONTINUE_CHeli__ProcessControl_SearchLightModel = 0x6C7178;
+
+static void __declspec(naked) HOOK_CHeli__ProcessControl_SearchLightModel()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1F1
+        jmp     CONTINUE_CHeli__ProcessControl_SearchLightModel
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6B2239 | 66 81 7E 22 D0 01 | cmp     word ptr [esi + 0x22], 0x1D0
+//     0x6B223F | 75 0A             | jne     0x6B224B
+#define HOOKPOS_CAutomobile__ProcessControl_RCBaronFakePhysicsGate  0x6B2239
+#define HOOKSIZE_CAutomobile__ProcessControl_RCBaronFakePhysicsGate 6
+static const DWORD CONTINUE_CAutomobile__ProcessControl_RCBaronFakePhysicsGate = 0x6B223F;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessControl_RCBaronFakePhysicsGate()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1D0
+        jmp     CONTINUE_CAutomobile__ProcessControl_RCBaronFakePhysicsGate
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6B2B93 | 66 81 7E 22 D0 01 | cmp     word ptr [esi + 0x22], 0x1D0
+//     0x6B2B99 | 74 0A             | je      0x6B2BA5
+#define HOOKPOS_CAutomobile__ProcessControl_RCBaronNormalGate  0x6B2B93
+#define HOOKSIZE_CAutomobile__ProcessControl_RCBaronNormalGate 6
+static const DWORD CONTINUE_CAutomobile__ProcessControl_RCBaronNormalGate = 0x6B2B99;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessControl_RCBaronNormalGate()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1D0
+        jmp     CONTINUE_CAutomobile__ProcessControl_RCBaronNormalGate
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6CB977 | 66 81 7E 22 D0 01 | cmp     word ptr [esi + 0x22], 0x1D0
+//     0x6CB97D | 0F 84 67 07 00 00 | je      0x6CC0EA
+#define HOOKPOS_CAutomobile__ProcessFlyingCarStuff_RCBaronFastPathGate  0x6CB977
+#define HOOKSIZE_CAutomobile__ProcessFlyingCarStuff_RCBaronFastPathGate 6
+static const DWORD CONTINUE_CAutomobile__ProcessFlyingCarStuff_RCBaronFastPathGate = 0x6CB97D;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessFlyingCarStuff_RCBaronFastPathGate()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     ax, 0x1D0
+        jmp     CONTINUE_CAutomobile__ProcessFlyingCarStuff_RCBaronFastPathGate
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6CC20F | 66 81 7E 22 D0 01 | cmp     word ptr [esi + 0x22], 0x1D0
+//     0x6CC215 | 0F 95 C0          | setne   al
+#define HOOKPOS_CAutomobile__ProcessFlyingCarStuff_RCBaronControlScaleSelect  0x6CC20F
+#define HOOKSIZE_CAutomobile__ProcessFlyingCarStuff_RCBaronControlScaleSelect 6
+static const DWORD CONTINUE_CAutomobile__ProcessFlyingCarStuff_RCBaronControlScaleSelect = 0x6CC215;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessFlyingCarStuff_RCBaronControlScaleSelect()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    eax
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     ax, 0x1D0
+        pop     eax
+        jmp     CONTINUE_CAutomobile__ProcessFlyingCarStuff_RCBaronControlScaleSelect
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6CC318 | 66 8B 4E 22       | mov     cx, word ptr [esi + 0x22]
+//     0x6CC31C | 66 81 F9 D0 01    | cmp     cx, 0x1D0
+#define HOOKPOS_CAutomobile__ProcessFlyingCarStuff_RCBaronBehaviorDispatch  0x6CC318
+#define HOOKSIZE_CAutomobile__ProcessFlyingCarStuff_RCBaronBehaviorDispatch 9
+static const DWORD CONTINUE_CAutomobile__ProcessFlyingCarStuff_RCBaronBehaviorDispatch = 0x6CC321;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessFlyingCarStuff_RCBaronBehaviorDispatch()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    eax
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        mov     cx, ax
+        cmp     cx, 0x1D0
+        pop     eax
+        jmp     CONTINUE_CAutomobile__ProcessFlyingCarStuff_RCBaronBehaviorDispatch
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6D6A7B | 0F BF 4E 22          | movsx   ecx, word ptr [esi + 0x22]
+// >>> 0x6D6A7F | 88 86 88 04 00 00    | mov     byte ptr [esi + 0x488], al
+//     0x6D6A85 | 8D 81 47 FE FF FF    | lea     eax, [ecx - 0x1B9]
+#define HOOKPOS_CVehicle__SetModelIndex_RCVehicleFlag  0x6D6A7B
+#define HOOKSIZE_CVehicle__SetModelIndex_RCVehicleFlag 10
+static const DWORD CONTINUE_CVehicle__SetModelIndex_RCVehicleFlag = 0x6D6A85;
+
+static void __declspec(naked) HOOK_CVehicle__SetModelIndex_RCVehicleFlag()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        mov     byte ptr [esi + 0x488], al
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        mov     ecx, eax
+        jmp     CONTINUE_CVehicle__SetModelIndex_RCVehicleFlag
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6C926D | 66 8B 46 22 | mov     ax, word ptr [esi + 0x22]
+// >>> 0x6C9271 | 66 3D 00 02 | cmp     ax, 0x200
+//     0x6C9275 | 74 06       | je      0x6C927D
+#define HOOKPOS_CPlane__ProcessControl_SmokeEjectorModel  0x6C926D
+#define HOOKSIZE_CPlane__ProcessControl_SmokeEjectorModel 8
+static const DWORD CONTINUE_CPlane__ProcessControl_SmokeEjectorModel = 0x6C9275;
+
+static void __declspec(naked) HOOK_CPlane__ProcessControl_SmokeEjectorModel()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     ax, 0x200
+        jmp     CONTINUE_CPlane__ProcessControl_SmokeEjectorModel
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6CA945 | 66 8B 46 22 | mov     ax, word ptr [esi + 0x22]
+// >>> 0x6CA949 | 66 3D 00 02 | cmp     ax, 0x200
+//     0x6CA94D | 0F 85 88 00 00 00 | jne     0x6CA9DB
+#define HOOKPOS_CPlane__ProcessControl_SmokeParticleModel  0x6CA945
+#define HOOKSIZE_CPlane__ProcessControl_SmokeParticleModel 8
+static const DWORD CONTINUE_CPlane__ProcessControl_SmokeParticleModel = 0x6CA94D;
+
+static void __declspec(naked) HOOK_CPlane__ProcessControl_SmokeParticleModel()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     ax, 0x200
+        jmp     CONTINUE_CPlane__ProcessControl_SmokeParticleModel
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6C94FB | 66 81 7E 22 1B 02 | cmp     word ptr [esi + 0x22], 0x21B
+//     0x6C9501 | 75 0A             | jne     0x6C950D
+#define HOOKPOS_CPlane__ProcessControl_VortexTrailModel  0x6C94FB
+#define HOOKSIZE_CPlane__ProcessControl_VortexTrailModel 6
+static const DWORD CONTINUE_CPlane__ProcessControl_VortexTrailModel = 0x6C9501;
+
+static void __declspec(naked) HOOK_CPlane__ProcessControl_VortexTrailModel()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x21B
+        jmp     CONTINUE_CPlane__ProcessControl_VortexTrailModel
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6B1E26 | 66 8B 4E 22       | mov     cx, word ptr [esi + 0x22]
+// >>> 0x6B1E2A | 66 81 F9 BF 01    | cmp     cx, 0x1BF
+//     0x6B1E2F | 74 07             | je      0x6B1E38
+#define HOOKPOS_CAutomobile__ProcessControl_AmphibiousPhysicsKeepAlive  0x6B1E26
+#define HOOKSIZE_CAutomobile__ProcessControl_AmphibiousPhysicsKeepAlive 9
+static const DWORD CONTINUE_CAutomobile__ProcessControl_AmphibiousPhysicsKeepAlive = 0x6B1E2F;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessControl_AmphibiousPhysicsKeepAlive()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        mov     ecx, eax
+        cmp     cx, 0x1BF
+        jmp     CONTINUE_CAutomobile__ProcessControl_AmphibiousPhysicsKeepAlive
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6C9101 | 66 81 7E 22 08 02 | cmp     word ptr [esi + 0x22], 0x208
+//     0x6C9107 | 89 9E F8 09 00 00 | mov     [esi + 0x9F8], ebx
+#define HOOKPOS_CPlane__Constructor_HydraNozzlePrime  0x6C9101
+#define HOOKSIZE_CPlane__Constructor_HydraNozzlePrime 6
+static const DWORD CONTINUE_CPlane__Constructor_HydraNozzlePrime = 0x6C9107;
+
+static void __declspec(naked) HOOK_CPlane__Constructor_HydraNozzlePrime()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x208
+        jmp     CONTINUE_CPlane__Constructor_HydraNozzlePrime
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6D8FDA | 66 81 FB 08 02 | cmp     bx, 0x208
+//     0x6D8FDF | 8B 7E 14       | mov     edi, [esi + 0x14]
+#define HOOKPOS_CVehicle__FlyingControl_HydraPlaneThrust  0x6D8FDA
+#define HOOKSIZE_CVehicle__FlyingControl_HydraPlaneThrust 5
+static const DWORD CONTINUE_CVehicle__FlyingControl_HydraPlaneThrust = 0x6D8FDF;
+
+static void __declspec(naked) HOOK_CVehicle__FlyingControl_HydraPlaneThrust()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x208
+        jmp     CONTINUE_CVehicle__FlyingControl_HydraPlaneThrust
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6D9C04 | 66 81 7E 22 08 02 | cmp     word ptr [esi + 0x22], 0x208
+//     0x6D9C0A | 0F 85 85 00 00 00 | jne     0x6D9C95
+#define HOOKPOS_CVehicle__FlyingControl_HydraHoverThrust  0x6D9C04
+#define HOOKSIZE_CVehicle__FlyingControl_HydraHoverThrust 6
+static const DWORD CONTINUE_CVehicle__FlyingControl_HydraHoverThrust = 0x6D9C0A;
+
+static void __declspec(naked) HOOK_CVehicle__FlyingControl_HydraHoverThrust()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x208
+        jmp     CONTINUE_CVehicle__FlyingControl_HydraHoverThrust
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6C9D7E | 0F BF 46 22    | movsx   eax, word ptr [esi + 0x22]
+// >>> 0x6C9D82 | 05 24 FE FF FF | add     eax, 0xFFFFFE24
+//     0x6C9D87 | 83 CD FF       | or      ebp, 0xFFFFFFFF
+#define HOOKPOS_CPlane__PreRender_ComponentSwitch  0x6C9D7E
+#define HOOKSIZE_CPlane__PreRender_ComponentSwitch 9
+static const DWORD CONTINUE_CPlane__PreRender_ComponentSwitch = 0x6C9D87;
+
+static void __declspec(naked) HOOK_CPlane__PreRender_ComponentSwitch()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        add     eax, 0xFFFFFE24
+        jmp     CONTINUE_CPlane__PreRender_ComponentSwitch
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6C968E | 66 81 7E 22 08 02 | cmp     word ptr [esi + 0x22], 0x208
+//     0x6C9694 | 75 05             | jne     0x6C969B
+#define HOOKPOS_CPlane__PreRender_HydraRotationMode  0x6C968E
+#define HOOKSIZE_CPlane__PreRender_HydraRotationMode 6
+static const DWORD CONTINUE_CPlane__PreRender_HydraRotationMode = 0x6C9694;
+
+static void __declspec(naked) HOOK_CPlane__PreRender_HydraRotationMode()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x208
+        jmp     CONTINUE_CPlane__PreRender_HydraRotationMode
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6C9EE3 | 66 8B 46 22 | mov     ax, word ptr [esi + 0x22]
+// >>> 0x6C9EE7 | 66 3D 50 02 | cmp     ax, 0x250
+//     0x6C9EEB | 75 2F       | jne     0x6C9F1C
+#define HOOKPOS_CPlane__PreRender_RampAndNozzleModel  0x6C9EE3
+#define HOOKSIZE_CPlane__PreRender_RampAndNozzleModel 8
+static const DWORD CONTINUE_CPlane__PreRender_RampAndNozzleModel = 0x6C9EEB;
+
+static void __declspec(naked) HOOK_CPlane__PreRender_RampAndNozzleModel()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     ax, 0x250
+        jmp     CONTINUE_CPlane__PreRender_RampAndNozzleModel
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6A14A6 | 66 81 F9 50 02 | cmp     cx, 0x250
+// >>> 0x6A14AB | 74 07          | je      0x6A14B4
+//     0x6A14AD | 66 81 F9 12 02 | cmp     cx, 0x212
+#define HOOKPOS_CAutomobile__ProcessControl_AndromAngleReset  0x6A14A6
+#define HOOKSIZE_CAutomobile__ProcessControl_AndromAngleReset 7
+static const DWORD CONTINUE_CAutomobile__ProcessControl_AndromAngleReset = 0x6A14B4;
+static const DWORD SKIP_CAutomobile__ProcessControl_AndromAngleReset = 0x6A14AD;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessControl_AndromAngleReset()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    ecx
+        mov     ecx, edi
+        call    IsAndromadaOrClone
+        test    al, al
+        pop     ecx
+        jz      notAndrom
+
+        jmp     CONTINUE_CAutomobile__ProcessControl_AndromAngleReset
+
+        notAndrom:
+        jmp     SKIP_CAutomobile__ProcessControl_AndromAngleReset
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6A1509 | 66 81 F9 50 02 | cmp     cx, 0x250
+// >>> 0x6A150E | 74 4C          | je      0x6A155C
+//     0x6A1510 | 66 81 F9 20 02 | cmp     cx, 0x220
+#define HOOKPOS_CAutomobile__ProcessControl_AndromMiscGate  0x6A1509
+#define HOOKSIZE_CAutomobile__ProcessControl_AndromMiscGate 7
+static const DWORD CONTINUE_CAutomobile__ProcessControl_AndromMiscGate = 0x6A155C;
+static const DWORD SKIP_CAutomobile__ProcessControl_AndromMiscGate = 0x6A1510;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessControl_AndromMiscGate()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    ecx
+        mov     ecx, edi
+        call    IsAndromadaOrClone
+        test    al, al
+        pop     ecx
+        jz      notAndrom
+
+        jmp     CONTINUE_CAutomobile__ProcessControl_AndromMiscGate
+
+        notAndrom:
+        jmp     SKIP_CAutomobile__ProcessControl_AndromMiscGate
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6A17EF | 66 3D 50 02 | cmp     ax, 0x250
+// >>> 0x6A17F3 | 75 50       | jne     0x6A1845
+//     0x6A17F5 | 8B 87 A8 06 00 00 | mov eax, dword ptr [edi + 0x6A8]
+#define HOOKPOS_CAutomobile__MovingCollisionSpeed_AndromA  0x6A17EF
+#define HOOKSIZE_CAutomobile__MovingCollisionSpeed_AndromA 6
+static const DWORD CONTINUE_CAutomobile__MovingCollisionSpeed_AndromA = 0x6A17F5;
+static const DWORD SKIP_CAutomobile__MovingCollisionSpeed_AndromA = 0x6A1845;
+
+static void __declspec(naked) HOOK_CAutomobile__MovingCollisionSpeed_AndromA()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    eax
+        mov     ecx, edi
+        call    IsAndromadaOrClone
+        test    al, al
+        pop     eax
+        jz      notAndrom
+
+        jmp     CONTINUE_CAutomobile__MovingCollisionSpeed_AndromA
+
+        notAndrom:
+        jmp     SKIP_CAutomobile__MovingCollisionSpeed_AndromA
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6A1FD1 | 66 81 F9 50 02 | cmp     cx, 0x250
+// >>> 0x6A1FD6 | 75 2A          | jne     0x6A2002
+//     0x6A1FD8 | 8B B6 A8 06 00 00 | mov esi, dword ptr [esi + 0x6A8]
+#define HOOKPOS_CAutomobile__MovingCollisionSpeed_AndromB  0x6A1FD1
+#define HOOKSIZE_CAutomobile__MovingCollisionSpeed_AndromB 7
+static const DWORD CONTINUE_CAutomobile__MovingCollisionSpeed_AndromB = 0x6A1FD8;
+static const DWORD SKIP_CAutomobile__MovingCollisionSpeed_AndromB = 0x6A2002;
+
+static void __declspec(naked) HOOK_CAutomobile__MovingCollisionSpeed_AndromB()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    ecx
+        mov     ecx, esi
+        call    IsAndromadaOrClone
+        test    al, al
+        pop     ecx
+        jz      notAndrom
+
+        jmp     CONTINUE_CAutomobile__MovingCollisionSpeed_AndromB
+
+        notAndrom:
+        jmp     SKIP_CAutomobile__MovingCollisionSpeed_AndromB
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6A21C8 | 66 3D 50 02 | cmp     ax, 0x250
+// >>> 0x6A21CC | 75 1E       | jne     0x6A21EC
+//     0x6A21CE | 8B B1 A8 06 00 00 | mov esi, dword ptr [ecx + 0x6A8]
+#define HOOKPOS_CAutomobile__MovingCollisionSpeed_AndromC  0x6A21C8
+#define HOOKSIZE_CAutomobile__MovingCollisionSpeed_AndromC 6
+static const DWORD CONTINUE_CAutomobile__MovingCollisionSpeed_AndromC = 0x6A21CE;
+static const DWORD SKIP_CAutomobile__MovingCollisionSpeed_AndromC = 0x6A21EC;
+
+static void __declspec(naked) HOOK_CAutomobile__MovingCollisionSpeed_AndromC()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    eax
+        push    ecx
+        push    edx
+        call    IsAndromadaOrClone
+        test    al, al
+        pop     edx
+        pop     ecx
+        pop     eax
+        jz      notAndrom
+
+        jmp     CONTINUE_CAutomobile__MovingCollisionSpeed_AndromC
+
+        notAndrom:
+        jmp     SKIP_CAutomobile__MovingCollisionSpeed_AndromC
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6B1FA7 | 66 3D 50 02 | cmp     ax, 0x250
+// >>> 0x6B1FAB | 74 62       | je      0x6B200F
+//     0x6B1FAD | 66 3D 12 02 | cmp     ax, 0x212
+#define HOOKPOS_CAutomobile__ProcessControl_AndromDispatch  0x6B1FA7
+#define HOOKSIZE_CAutomobile__ProcessControl_AndromDispatch 6
+static const DWORD CONTINUE_CAutomobile__ProcessControl_AndromDispatch = 0x6B200F;
+static const DWORD SKIP_CAutomobile__ProcessControl_AndromDispatch = 0x6B1FAD;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessControl_AndromDispatch()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    eax
+        push    ecx
+        mov     ecx, esi
+        call    IsAndromadaOrClone
+        test    al, al
+        pop     ecx
+        pop     eax
+        jz      notAndrom
+
+        jmp     CONTINUE_CAutomobile__ProcessControl_AndromDispatch
+
+        notAndrom:
+        jmp     SKIP_CAutomobile__ProcessControl_AndromDispatch
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// Skimmer, Vortex, Sea Sparrow/Sparrow/RC Tiger weapon accuracy, amphibious ped exit, AT-400
+// and Andromada gaps on custom models, spanning boat physics, boat camera, hover flight,
+// ped enter/exit, weapon spread and vehicle shadows.
+//////////////////////////////////////////////////////////////////////////////////////////
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CVehicle::ProcessBoatControl, cutting the Skimmer's buoyancy force to 3% while capsized so it rights itself like the boat model
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6DBF0A | 66 81 7E 22 CC 01 | cmp     word ptr [esi + 0x22], 0x1CC
+//     0x6DBF10 | 8B 15 4C C9 C1 00 | mov     edx, dword ptr [0xC1C94C]
+#define HOOKPOS_CVehicle__ProcessBoatControl_SkimmerCapsizedBuoyancy  0x6DBF0A
+#define HOOKSIZE_CVehicle__ProcessBoatControl_SkimmerCapsizedBuoyancy 6
+static const DWORD CONTINUE_CVehicle__ProcessBoatControl_SkimmerCapsizedBuoyancy = 0x6DBF10;
+
+static void __declspec(naked) HOOK_CVehicle__ProcessBoatControl_SkimmerCapsizedBuoyancy()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CVehicle__ProcessBoatControl_SkimmerCapsizedBuoyancy
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CVehicle::ProcessBoatControl, damping the turn/move forces right after the Skimmer lands nose-first on water and resetting its m_f2ndSteerAngle timer
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6DC00B | 66 81 7E 22 CC 01 | cmp     word ptr [esi + 0x22], 0x1CC
+//     0x6DC011 | 0F 85 CB 01 00 00 | jne     0x6DC1E2
+#define HOOKPOS_CVehicle__ProcessBoatControl_SkimmerWaterLandingDamping  0x6DC00B
+#define HOOKSIZE_CVehicle__ProcessBoatControl_SkimmerWaterLandingDamping 6
+static const DWORD CONTINUE_CVehicle__ProcessBoatControl_SkimmerWaterLandingDamping = 0x6DC011;
+
+static void __declspec(naked) HOOK_CVehicle__ProcessBoatControl_SkimmerWaterLandingDamping()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CVehicle__ProcessBoatControl_SkimmerWaterLandingDamping
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CVehicle::ProcessBoatControl, giving the Skimmer aquaplane thrust of (gas + 1) instead of plain boat throttle so it can plane and take off from water
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6DC21B | 66 81 7E 22 CC 01 | cmp     word ptr [esi + 0x22], 0x1CC
+//     0x6DC221 | D9 46 4C          | fld     dword ptr [esi + 0x4C]
+#define HOOKPOS_CVehicle__ProcessBoatControl_SkimmerAquaplaneThrust  0x6DC21B
+#define HOOKSIZE_CVehicle__ProcessBoatControl_SkimmerAquaplaneThrust 6
+static const DWORD CONTINUE_CVehicle__ProcessBoatControl_SkimmerAquaplaneThrust = 0x6DC221;
+
+static void __declspec(naked) HOOK_CVehicle__ProcessBoatControl_SkimmerAquaplaneThrust()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // ecx (a physics-matrix pointer) is reused past CONTINUE at 0x6DC2B1/BE/C9.
+        push    ecx
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        pop     ecx
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CVehicle__ProcessBoatControl_SkimmerAquaplaneThrust
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CVehicle::ProcessBoatControl, forcing the Skimmer to always be treated as slowing down for the rudder/steer force block
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6DC621 | 66 81 7E 22 CC 01 | cmp     word ptr [esi + 0x22], 0x1CC
+//     0x6DC627 | 0F 84 13 03 00 00 | je      0x6DC940
+#define HOOKPOS_CVehicle__ProcessBoatControl_SkimmerSlowingDownGate  0x6DC621
+#define HOOKSIZE_CVehicle__ProcessBoatControl_SkimmerSlowingDownGate 6
+static const DWORD CONTINUE_CVehicle__ProcessBoatControl_SkimmerSlowingDownGate = 0x6DC627;
+
+static void __declspec(naked) HOOK_CVehicle__ProcessBoatControl_SkimmerSlowingDownGate()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CVehicle__ProcessBoatControl_SkimmerSlowingDownGate
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CVehicle::ProcessBoatControl, skipping the boat turn-resistance calculation while the Skimmer's water-landing timer is active
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6DCD63 | 66 81 7E 22 CC 01 | cmp     word ptr [esi + 0x22], 0x1CC
+//     0x6DCD69 | 75 17             | jne     0x6DCD82
+#define HOOKPOS_CVehicle__ProcessBoatControl_SkimmerTurnResistanceSkip  0x6DCD63
+#define HOOKSIZE_CVehicle__ProcessBoatControl_SkimmerTurnResistanceSkip 6
+static const DWORD CONTINUE_CVehicle__ProcessBoatControl_SkimmerTurnResistanceSkip = 0x6DCD69;
+
+static void __declspec(naked) HOOK_CVehicle__ProcessBoatControl_SkimmerTurnResistanceSkip()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CVehicle__ProcessBoatControl_SkimmerTurnResistanceSkip
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CVehicle::ApplyBoatWaterResistance, multiplying the Skimmer's hull water-drag speed multiplier by 30 so it doesn't glide frictionless across the surface
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6D274C | 66 81 7E 22 CC 01 | cmp     word ptr [esi + 0x22], 0x1CC
+//     0x6D2752 | 8B 86 84 03 00 00 | mov     eax, dword ptr [esi + 0x384]
+#define HOOKPOS_CVehicle__ApplyBoatWaterResistance_SkimmerHullDrag  0x6D274C
+#define HOOKSIZE_CVehicle__ApplyBoatWaterResistance_SkimmerHullDrag 6
+static const DWORD CONTINUE_CVehicle__ApplyBoatWaterResistance_SkimmerHullDrag = 0x6D2752;
+
+static void __declspec(naked) HOOK_CVehicle__ApplyBoatWaterResistance_SkimmerHullDrag()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CVehicle__ApplyBoatWaterResistance_SkimmerHullDrag
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CBuoyancy::PreCalcSetup, selecting the buoyancy volume/centre constants for the Leviathan and
+// the Skimmer; both are tested off the same resolved ax, so this one hook covers both models.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6C2D33 | 66 8B 47 22 | mov     ax, word ptr [edi + 0x22]
+// >>> 0x6C2D37 | 66 3D A1 01 | cmp     ax, 0x1A1
+//     0x6C2D3B | 75 23       | jne     0x6C2D60
+#define HOOKPOS_CBuoyancy__PreCalcSetup_LeviathanSkimmerModel  0x6C2D33
+#define HOOKSIZE_CBuoyancy__PreCalcSetup_LeviathanSkimmerModel 8
+static const DWORD CONTINUE_CBuoyancy__PreCalcSetup_LeviathanSkimmerModel = 0x6C2D3B;
+
+static void __declspec(naked) HOOK_CBuoyancy__PreCalcSetup_LeviathanSkimmerModel()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    ecx
+        push    edx
+        movsx   ecx, word ptr [edi + 0x22]
+        call    ResolveVehicleParentModelId
+        pop     edx
+        pop     ecx
+        cmp     ax, 0x1A1
+        jmp     CONTINUE_CBuoyancy__PreCalcSetup_LeviathanSkimmerModel
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CPlane::ProcessControl, forcing all four wheels to WHEEL_STATUS_MISSING every frame because the Skimmer has floats instead of wheels
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6C92EC | 66 81 7E 22 CC 01 | cmp     word ptr [esi + 0x22], 0x1CC
+//     0x6C92F2 | 75 1D             | jne     0x6C9311
+#define HOOKPOS_CPlane__ProcessControl_SkimmerWheelStatus  0x6C92EC
+#define HOOKSIZE_CPlane__ProcessControl_SkimmerWheelStatus 6
+static const DWORD CONTINUE_CPlane__ProcessControl_SkimmerWheelStatus = 0x6C92F2;
+
+static void __declspec(naked) HOOK_CPlane__ProcessControl_SkimmerWheelStatus()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CPlane__ProcessControl_SkimmerWheelStatus
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CPlane::PreRender, gating the call into CVehicle::DoBoatSplashes that drives the Skimmer's water spray FX
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6CAA93 | 66 81 7E 22 CC 01 | cmp     word ptr [esi + 0x22], 0x1CC
+//     0x6CAA99 | 75 16             | jne     0x6CAAB1
+#define HOOKPOS_CPlane__PreRender_SkimmerBoatSplashesCall  0x6CAA93
+#define HOOKSIZE_CPlane__PreRender_SkimmerBoatSplashesCall 6
+static const DWORD CONTINUE_CPlane__PreRender_SkimmerBoatSplashesCall = 0x6CAA99;
+
+static void __declspec(naked) HOOK_CPlane__PreRender_SkimmerBoatSplashesCall()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CPlane__PreRender_SkimmerBoatSplashesCall
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CVehicle::DoBoatSplashes, selecting the Skimmer-specific splash intensity multiplier and clamp
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6DD218 | BF CC 01 00 00 | mov     edi, 0x1CC
+// >>> 0x6DD21D | 66 39 7E 22    | cmp     word ptr [esi + 0x22], di
+//     0x6DD221 | D9 FA          | fsqrt
+#define HOOKPOS_CVehicle__DoBoatSplashes_SkimmerIntensityModel  0x6DD218
+#define HOOKSIZE_CVehicle__DoBoatSplashes_SkimmerIntensityModel 9
+static const DWORD CONTINUE_CVehicle__DoBoatSplashes_SkimmerIntensityModel = 0x6DD221;
+
+static void __declspec(naked) HOOK_CVehicle__DoBoatSplashes_SkimmerIntensityModel()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // edi keeps the literal target; only the vehicle's model is resolved
+        mov     edi, 0x1CC
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     ax, di
+        jmp     CONTINUE_CVehicle__DoBoatSplashes_SkimmerIntensityModel
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CWaterLevel::RenderBoatWakes, driving the Skimmer's wake trail on water for a clone.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6EDA0C | 66 81 7E 22 CC 01 | cmp     word ptr [esi + 0x22], 0x1CC
+//     0x6EDA12 | D9 40 0C          | fld     dword ptr [eax + 0xC]
+#define HOOKPOS_CWaterLevel__RenderBoatWakes_SkimmerModel  0x6EDA0C
+#define HOOKSIZE_CWaterLevel__RenderBoatWakes_SkimmerModel 6
+static const DWORD CONTINUE_CWaterLevel__RenderBoatWakes_SkimmerModel = 0x6EDA12;
+
+static void __declspec(naked) HOOK_CWaterLevel__RenderBoatWakes_SkimmerModel()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    eax
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1CC
+        pop     eax
+        jmp     CONTINUE_CWaterLevel__RenderBoatWakes_SkimmerModel
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CBoat::Render, selecting the Skimmer's propeller-spin special case for a clone at render time.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6F0234 | 66 81 7E 22 CC 01 | cmp     word ptr [esi + 0x22], 0x1CC
+//     0x6F023A | 0F 84 EC 06 00 00 | je      0x6F092C
+#define HOOKPOS_CBoat__Render_SkimmerPropellerSpin  0x6F0234
+#define HOOKSIZE_CBoat__Render_SkimmerPropellerSpin 6
+static const DWORD CONTINUE_CBoat__Render_SkimmerPropellerSpin = 0x6F023A;
+
+static void __declspec(naked) HOOK_CBoat__Render_SkimmerPropellerSpin()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CBoat__Render_SkimmerPropellerSpin
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CCamera::CamControl, entering the on-water camera-control branch for the Skimmer.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x528294 | 66 81 79 22 CC 01 | cmp     word ptr [ecx + 0x22], 0x1CC
+//     0x52829A | 75 4A             | jne     0x5282E6
+#define HOOKPOS_CCamera__CamControl_SkimmerCameraMode  0x528294
+#define HOOKSIZE_CCamera__CamControl_SkimmerCameraMode 6
+static const DWORD CONTINUE_CCamera__CamControl_SkimmerCameraMode = 0x52829A;
+
+static void __declspec(naked) HOOK_CCamera__CamControl_SkimmerCameraMode()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [ecx + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CCamera__CamControl_SkimmerCameraMode
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CCam::TryToStartNewCamMode, Skimmer gate 1 of 5.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x51E5AC | 66 81 78 22 CC 01 | cmp     word ptr [eax + 0x22], 0x1CC
+//     0x51E5B2 | 0F 85 34 0B 00 00 | jne     0x51F0EC
+#define HOOKPOS_CCam__TryToStartNewCamMode_SkimmerCheckA  0x51E5AC
+#define HOOKSIZE_CCam__TryToStartNewCamMode_SkimmerCheckA 6
+static const DWORD CONTINUE_CCam__TryToStartNewCamMode_SkimmerCheckA = 0x51E5B2;
+
+static void __declspec(naked) HOOK_CCam__TryToStartNewCamMode_SkimmerCheckA()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [eax + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CCam__TryToStartNewCamMode_SkimmerCheckA
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CCam::TryToStartNewCamMode, Skimmer gate 2 of 5.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x51E773 | 66 81 79 22 CC 01 | cmp     word ptr [ecx + 0x22], 0x1CC
+//     0x51E779 | 0F 85 6D 09 00 00 | jne     0x51F0EC
+#define HOOKPOS_CCam__TryToStartNewCamMode_SkimmerCheckB  0x51E773
+#define HOOKSIZE_CCam__TryToStartNewCamMode_SkimmerCheckB 6
+static const DWORD CONTINUE_CCam__TryToStartNewCamMode_SkimmerCheckB = 0x51E779;
+
+static void __declspec(naked) HOOK_CCam__TryToStartNewCamMode_SkimmerCheckB()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    ecx
+        movsx   ecx, word ptr [ecx + 0x22]
+        call    ResolveVehicleParentModelId
+        pop     ecx
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CCam__TryToStartNewCamMode_SkimmerCheckB
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CCam::TryToStartNewCamMode, Skimmer gate 3 of 5.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x51E937 | 66 81 78 22 CC 01 | cmp     word ptr [eax + 0x22], 0x1CC
+//     0x51E93D | 0F 85 A9 07 00 00 | jne     0x51F0EC
+#define HOOKPOS_CCam__TryToStartNewCamMode_SkimmerCheckC  0x51E937
+#define HOOKSIZE_CCam__TryToStartNewCamMode_SkimmerCheckC 6
+static const DWORD CONTINUE_CCam__TryToStartNewCamMode_SkimmerCheckC = 0x51E93D;
+
+static void __declspec(naked) HOOK_CCam__TryToStartNewCamMode_SkimmerCheckC()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [eax + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CCam__TryToStartNewCamMode_SkimmerCheckC
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CCam::TryToStartNewCamMode, Skimmer gate 4 of 5.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x51EF39 | 66 81 7A 22 CC 01 | cmp     word ptr [edx + 0x22], 0x1CC
+//     0x51EF3F | 0F 85 A7 01 00 00 | jne     0x51F0EC
+#define HOOKPOS_CCam__TryToStartNewCamMode_SkimmerCheckD  0x51EF39
+#define HOOKSIZE_CCam__TryToStartNewCamMode_SkimmerCheckD 6
+static const DWORD CONTINUE_CCam__TryToStartNewCamMode_SkimmerCheckD = 0x51EF3F;
+
+static void __declspec(naked) HOOK_CCam__TryToStartNewCamMode_SkimmerCheckD()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [edx + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CCam__TryToStartNewCamMode_SkimmerCheckD
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CCam::TryToStartNewCamMode, Skimmer gate 5 of 5.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x51F15B | 66 81 79 22 CC 01 | cmp     word ptr [ecx + 0x22], 0x1CC
+//     0x51F161 | 75 89             | jne     0x51F0EC
+#define HOOKPOS_CCam__TryToStartNewCamMode_SkimmerCheckE  0x51F15B
+#define HOOKSIZE_CCam__TryToStartNewCamMode_SkimmerCheckE 6
+static const DWORD CONTINUE_CCam__TryToStartNewCamMode_SkimmerCheckE = 0x51F161;
+
+static void __declspec(naked) HOOK_CCam__TryToStartNewCamMode_SkimmerCheckE()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [ecx + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CCam__TryToStartNewCamMode_SkimmerCheckE
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CCam::Process (boat/fixed cam framing region), Skimmer gate 1 of 5.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x51D864 | 66 81 7A 22 CC 01 | cmp     word ptr [edx + 0x22], 0x1CC
+//     0x51D86A | 0F 85 68 0C 00 00 | jne     0x51E4D8
+#define HOOKPOS_CCam__Process_SkimmerFramingA  0x51D864
+#define HOOKSIZE_CCam__Process_SkimmerFramingA 6
+static const DWORD CONTINUE_CCam__Process_SkimmerFramingA = 0x51D86A;
+
+static void __declspec(naked) HOOK_CCam__Process_SkimmerFramingA()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [edx + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CCam__Process_SkimmerFramingA
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CCam::Process (boat/fixed cam framing region), Skimmer gate 2 of 5.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x51D92B | 66 81 7A 22 CC 01 | cmp     word ptr [edx + 0x22], 0x1CC
+//     0x51D931 | 0F 85 A1 0B 00 00 | jne     0x51E4D8
+#define HOOKPOS_CCam__Process_SkimmerFramingB  0x51D92B
+#define HOOKSIZE_CCam__Process_SkimmerFramingB 6
+static const DWORD CONTINUE_CCam__Process_SkimmerFramingB = 0x51D931;
+
+static void __declspec(naked) HOOK_CCam__Process_SkimmerFramingB()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [edx + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CCam__Process_SkimmerFramingB
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CCam::Process (boat/fixed cam framing region), Skimmer gate 3 of 5.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x51DA60 | 66 81 79 22 CC 01 | cmp     word ptr [ecx + 0x22], 0x1CC
+//     0x51DA66 | 0F 85 6C 0A 00 00 | jne     0x51E4D8
+#define HOOKPOS_CCam__Process_SkimmerFramingC  0x51DA60
+#define HOOKSIZE_CCam__Process_SkimmerFramingC 6
+static const DWORD CONTINUE_CCam__Process_SkimmerFramingC = 0x51DA66;
+
+static void __declspec(naked) HOOK_CCam__Process_SkimmerFramingC()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [ecx + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CCam__Process_SkimmerFramingC
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CCam::Process (boat/fixed cam framing region), Skimmer gate 4 of 5.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x51DCFC | 66 81 78 22 CC 01 | cmp     word ptr [eax + 0x22], 0x1CC
+//     0x51DD02 | 0F 85 D0 07 00 00 | jne     0x51E4D8
+#define HOOKPOS_CCam__Process_SkimmerFramingD  0x51DCFC
+#define HOOKSIZE_CCam__Process_SkimmerFramingD 6
+static const DWORD CONTINUE_CCam__Process_SkimmerFramingD = 0x51DD02;
+
+static void __declspec(naked) HOOK_CCam__Process_SkimmerFramingD()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [eax + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CCam__Process_SkimmerFramingD
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CCam::Process (boat/fixed cam framing region), Skimmer gate 5 of 5.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x51DE84 | 66 81 78 22 CC 01 | cmp     word ptr [eax + 0x22], 0x1CC
+//     0x51DE8A | 0F 85 48 06 00 00 | jne     0x51E4D8
+#define HOOKPOS_CCam__Process_SkimmerFramingE  0x51DE84
+#define HOOKSIZE_CCam__Process_SkimmerFramingE 6
+static const DWORD CONTINUE_CCam__Process_SkimmerFramingE = 0x51DE8A;
+
+static void __declspec(naked) HOOK_CCam__Process_SkimmerFramingE()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [eax + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x1CC
+        jmp     CONTINUE_CCam__Process_SkimmerFramingE
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CRenderer::SetupEntityVisibility, first-person culling exception list for a clone's hull.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x554374 | 66 3D CC 01 | cmp     ax, 0x1CC
+// >>> 0x554378 | 75 12       | jne     0x55438C
+//     0x55437A | 89 35 D4 45 B7 00 | mov     dword ptr [0xB745D4], esi
+#define HOOKPOS_CRenderer__SetupEntityVisibility_SkimmerCulling  0x554374
+#define HOOKSIZE_CRenderer__SetupEntityVisibility_SkimmerCulling 6
+static const DWORD CONTINUE_CRenderer__SetupEntityVisibility_SkimmerCulling = 0x55437A;
+static const DWORD SKIP_CRenderer__SetupEntityVisibility_SkimmerCulling = 0x55438C;
+
+static void __declspec(naked) HOOK_CRenderer__SetupEntityVisibility_SkimmerCulling()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, ax
+        call    ResolveVehicleParentModelId
+        cmp     ax, 0x1CC
+        jne     notSkimmer
+
+        jmp     CONTINUE_CRenderer__SetupEntityVisibility_SkimmerCulling
+
+        notSkimmer:
+        jmp     SKIP_CRenderer__SetupEntityVisibility_SkimmerCulling
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6B284B | 66 81 7E 22 1B 02 | cmp     word ptr [esi + 0x22], 0x21b
+//     0x6B2851 | 75 21             | jne     0x6b2874
+#define HOOKPOS_CAutomobile__ProcessControl_VortexTractionBoost  0x6B284B
+#define HOOKSIZE_CAutomobile__ProcessControl_VortexTractionBoost 6
+static const DWORD CONTINUE_CAutomobile__ProcessControl_VortexTractionBoost = 0x6B2851;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessControl_VortexTractionBoost()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x21B
+        jmp     CONTINUE_CAutomobile__ProcessControl_VortexTractionBoost
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6B356A | 66 81 7E 22 1B 02 | cmp     word ptr [esi + 0x22], 0x21b
+//     0x6B3570 | 0F 84 B2 00 00 00 | je      0x6b3628
+#define HOOKPOS_CAutomobile__ProcessControl_VortexWheelSettleExempt  0x6B356A
+#define HOOKSIZE_CAutomobile__ProcessControl_VortexWheelSettleExempt 6
+static const DWORD CONTINUE_CAutomobile__ProcessControl_VortexWheelSettleExempt = 0x6B3570;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessControl_VortexWheelSettleExempt()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x21B
+        jmp     CONTINUE_CAutomobile__ProcessControl_VortexWheelSettleExempt
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6AFFEA | 66 81 7E 22 1B 02 | cmp     word ptr [esi + 0x22], 0x21b
+//     0x6AFFF0 | 75 1C             | jne     0x6b000e
+#define HOOKPOS_CAutomobile__ProcessSuspension_VortexSpringForceScale  0x6AFFEA
+#define HOOKSIZE_CAutomobile__ProcessSuspension_VortexSpringForceScale 6
+static const DWORD CONTINUE_CAutomobile__ProcessSuspension_VortexSpringForceScale = 0x6AFFF0;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessSuspension_VortexSpringForceScale()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x21B
+        jmp     CONTINUE_CAutomobile__ProcessSuspension_VortexSpringForceScale
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6B0017 | 66 81 7E 22 1B 02 | cmp     word ptr [esi + 0x22], 0x21b
+//     0x6B001D | 74 35             | je      0x6b0054
+#define HOOKPOS_CAutomobile__ProcessSuspension_VortexGroundSpringExempt  0x6B0017
+#define HOOKSIZE_CAutomobile__ProcessSuspension_VortexGroundSpringExempt 6
+static const DWORD CONTINUE_CAutomobile__ProcessSuspension_VortexGroundSpringExempt = 0x6B001D;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessSuspension_VortexGroundSpringExempt()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x21B
+        jmp     CONTINUE_CAutomobile__ProcessSuspension_VortexGroundSpringExempt
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CVehicle::FlyingControl, resolves bx once for both the Vortex and Skimmer ground-rest compares
+// that share this load (a separate, independent load feeds the VortexThrustFormula hook below).
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6D8E18 | 66 8B 5E 22       | mov     bx, word ptr [esi + 0x22]
+// >>> 0x6D8E1C | 66 81 FB 1B 02    | cmp     bx, 0x21b
+//     0x6D8E21 | 74 4C             | je      0x6d8e6f
+#define HOOKPOS_CVehicle__FlyingControl_VortexSkimmerGroundRestGate  0x6D8E18
+#define HOOKSIZE_CVehicle__FlyingControl_VortexSkimmerGroundRestGate 9
+static const DWORD CONTINUE_CVehicle__FlyingControl_VortexSkimmerGroundRestGate = 0x6D8E21;
+
+static void __declspec(naked) HOOK_CVehicle__FlyingControl_VortexSkimmerGroundRestGate()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // eax holds 1.0f, consumed by four untouched dword compares at 0x6D8E23/2B/33/3B.
+        push    eax
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        mov     bx, ax
+        pop     eax
+        cmp     bx, 0x21B
+        jmp     CONTINUE_CVehicle__FlyingControl_VortexSkimmerGroundRestGate
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CVehicle::FlyingControl, resolves the model id feeding the Vortex thrust-formula compare
+// (an independent load from the ground-rest gate hook above, not the same shared value).
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6D8F09 | 66 81 FB 1B 02    | cmp     bx, 0x21b
+//     0x6D8F0E | 8B 8E 88 03 00 00 | mov     ecx, dword ptr [esi + 0x388]
+#define HOOKPOS_CVehicle__FlyingControl_VortexThrustFormula  0x6D8F09
+#define HOOKSIZE_CVehicle__FlyingControl_VortexThrustFormula 5
+static const DWORD CONTINUE_CVehicle__FlyingControl_VortexThrustFormula = 0x6D8F0E;
+
+static void __declspec(naked) HOOK_CVehicle__FlyingControl_VortexThrustFormula()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x21B
+        jmp     CONTINUE_CVehicle__FlyingControl_VortexThrustFormula
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CVehicle::FlyingControl, the Vortex's pitch/turn damping clamp
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6D9233 | 66 81 7E 22 1B 02 | cmp     word ptr [esi + 0x22], 0x21b
+//     0x6D9239 | D8 4F 08          | fmul    dword ptr [edi + 8]
+#define HOOKPOS_CVehicle__FlyingControl_VortexTurnDampingClamp  0x6D9233
+#define HOOKSIZE_CVehicle__FlyingControl_VortexTurnDampingClamp 6
+static const DWORD CONTINUE_CVehicle__FlyingControl_VortexTurnDampingClamp = 0x6D9239;
+
+static void __declspec(naked) HOOK_CVehicle__FlyingControl_VortexTurnDampingClamp()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // eax holds a pointer from call 0x542ce0, read again past CONTINUE via fld [eax]/[eax+4].
+        push    eax
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        mov     edx, eax
+        pop     eax
+        cmp     edx, 0x21B
+        jmp     CONTINUE_CVehicle__FlyingControl_VortexTurnDampingClamp
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CPlane::Constructor, exempts a Vortex clone from the bDontCollideWithFlyers flag set on every
+// other plane model.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6C8E54 | 66 81 7E 22 1B 02 | cmp     word ptr [esi + 0x22], 0x21b
+//     0x6C8E5A | C7 06 48 19 87 00 | mov     dword ptr [esi], 0x871948
+#define HOOKPOS_CPlane__Constructor_VortexFlyerCollisionExempt  0x6C8E54
+#define HOOKSIZE_CPlane__Constructor_VortexFlyerCollisionExempt 6
+static const DWORD CONTINUE_CPlane__Constructor_VortexFlyerCollisionExempt = 0x6C8E5A;
+
+static void __declspec(naked) HOOK_CPlane__Constructor_VortexFlyerCollisionExempt()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x21B
+        jmp     CONTINUE_CPlane__Constructor_VortexFlyerCollisionExempt
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CPlane::VehicleDamage, the Vortex's car-style damage branch instead of the plane crash branch
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6CC4C4 | 66 81 7E 22 1B 02          | cmp     word ptr [esi + 0x22], 0x21b
+//     0x6CC4CA | C7 44 24 10 FA 7E AA 3E    | mov     dword ptr [esp + 0x10], 0x3eaa7efa
+#define HOOKPOS_CPlane__VehicleDamage_VortexCarStyleDamage  0x6CC4C4
+#define HOOKSIZE_CPlane__VehicleDamage_VortexCarStyleDamage 6
+static const DWORD CONTINUE_CPlane__VehicleDamage_VortexCarStyleDamage = 0x6CC4CA;
+
+static void __declspec(naked) HOOK_CPlane__VehicleDamage_VortexCarStyleDamage()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // eax/ecx hold globals stored to [esp+0xC]/[esp+8] right after CONTINUE.
+        push    eax
+        push    ecx
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        mov     edx, eax
+        pop     ecx
+        pop     eax
+        cmp     edx, 0x21B
+        jmp     CONTINUE_CPlane__VehicleDamage_VortexCarStyleDamage
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6C97E6 | 66 81 7E 22 1B 02 | cmp     word ptr [esi + 0x22], 0x21b
+//     0x6C97EC | 75 35             | jne     0x6c9823
+#define HOOKPOS_CPlane__PreRender_VortexFanFXMatrix  0x6C97E6
+#define HOOKSIZE_CPlane__PreRender_VortexFanFXMatrix 6
+static const DWORD CONTINUE_CPlane__PreRender_VortexFanFXMatrix = 0x6C97EC;
+
+static void __declspec(naked) HOOK_CPlane__PreRender_VortexFanFXMatrix()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     eax, 0x21B
+        jmp     CONTINUE_CPlane__PreRender_VortexFanFXMatrix
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CAEVehicleAudioEntity::Initialise, resolves before the rebase-then-table-jump so every model
+// in the [0x1C0..0x247] byte table gets the correct case for a clone, not just Vortex.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x4F7814 | 0F BF 42 22    | movsx   eax, word ptr [edx + 0x22]
+// >>> 0x4F7818 | 05 40 FE FF FF | add     eax, 0xfffffe40
+//     0x4F781D | 3D 87 00 00 00 | cmp     eax, 0x87
+#define HOOKPOS_CAEVehicleAudioEntity__Initialise_SpecialVehicleModelSwitch  0x4F7814
+#define HOOKSIZE_CAEVehicleAudioEntity__Initialise_SpecialVehicleModelSwitch 9
+static const DWORD CONTINUE_CAEVehicleAudioEntity__Initialise_SpecialVehicleModelSwitch = 0x4F781D;
+
+static void __declspec(naked) HOOK_CAEVehicleAudioEntity__Initialise_SpecialVehicleModelSwitch()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [edx + 0x22]
+        call    ResolveVehicleParentModelId
+        add     eax, 0xFFFFFE40
+        jmp     CONTINUE_CAEVehicleAudioEntity__Initialise_SpecialVehicleModelSwitch
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CPlane::PreRender, resolves the model id used to pick the AT-400/Andromada/Vortex jumbo
+// shadow variant in CShadows::StoreShadowForVehicle.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6CA70E | 66 8B 46 22 | mov     ax, word ptr [esi + 0x22]
+// >>> 0x6CA712 | D9 5C 24 34 | fstp    dword ptr [esp + 0x34]
+//     0x6CA716 | 66 3D 1B 02 | cmp     ax, 0x21B
+#define HOOKPOS_CPlane__PreRender_ShadowTypeModel  0x6CA70E
+#define HOOKSIZE_CPlane__PreRender_ShadowTypeModel 8
+static const DWORD CONTINUE_CPlane__PreRender_ShadowTypeModel = 0x6CA716;
+
+static void __declspec(naked) HOOK_CPlane__PreRender_ShadowTypeModel()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    ecx
+        fstp    dword ptr [esp + 0x38]
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        pop     ecx
+        // CONTINUE re-does the compare on ax, so none is needed here
+        jmp     CONTINUE_CPlane__PreRender_ShadowTypeModel
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CCarEnterExit::IsRoomForPedToLeaveCar, restores the AT-400's taller stair-door clearance
+// exemption for a clone.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x650870 | 66 81 7E 22 41 02 | cmp     word ptr [esi + 0x22], 0x241
+//     0x650876 | 74 0C             | je      0x650884
+#define HOOKPOS_CCarEnterExit__IsRoomForPedToLeaveCar_AT400DoorException  0x650870
+#define HOOKSIZE_CCarEnterExit__IsRoomForPedToLeaveCar_AT400DoorException 6
+static const DWORD CONTINUE_CCarEnterExit__IsRoomForPedToLeaveCar_AT400DoorException = 0x650876;
+
+static void __declspec(naked) HOOK_CCarEnterExit__IsRoomForPedToLeaveCar_AT400DoorException()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // eax is read again on the not-taken path at 0x650878 (cmp eax, [esi + 0xFC]).
+        push    eax
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     ax, 0x241
+        pop     eax
+        jmp     CONTINUE_CCarEnterExit__IsRoomForPedToLeaveCar_AT400DoorException
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CCarEnterExit::IsRoomForPedToLeaveCar, resolves the model id feeding the Skimmer/Vortex/
+// SeaSparrow/Leviathan amphibious water-exit check.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6508ED | 66 8B 76 22       | mov     si, word ptr [esi + 0x22]
+// >>> 0x6508F1 | 66 81 FE CC 01    | cmp     si, 0x1CC
+//     0x6508F6 | 74 5A             | je      0x650952
+#define HOOKPOS_CCarEnterExit__IsRoomForPedToLeaveCar_AmphibiousExitChain  0x6508ED
+#define HOOKSIZE_CCarEnterExit__IsRoomForPedToLeaveCar_AmphibiousExitChain 9
+static const DWORD CONTINUE_CCarEnterExit__IsRoomForPedToLeaveCar_AmphibiousExitChain = 0x6508F6;
+
+static void __declspec(naked) HOOK_CCarEnterExit__IsRoomForPedToLeaveCar_AmphibiousExitChain()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        // si is left holding the resolved id for the compares that follow
+        mov     si, ax
+        cmp     si, 0x1CC
+        jmp     CONTINUE_CCarEnterExit__IsRoomForPedToLeaveCar_AmphibiousExitChain
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CCarEnterExit::IsPathToDoorBlockedByVehicleCollisionModel, restores the AT-400's door-path
+// collision-model exemption for a clone.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x651233 | 66 81 7F 22 41 02 | cmp     word ptr [edi + 0x22], 0x241
+//     0x651239 | 0F 84 48 01 00 00 | je      0x651387
+#define HOOKPOS_CCarEnterExit__IsPathToDoorBlockedByVehicleCollisionModel_AT400DoorException  0x651233
+#define HOOKSIZE_CCarEnterExit__IsPathToDoorBlockedByVehicleCollisionModel_AT400DoorException 6
+static const DWORD CONTINUE_CCarEnterExit__IsPathToDoorBlockedByVehicleCollisionModel_AT400DoorException = 0x651239;
+
+static void __declspec(naked) HOOK_CCarEnterExit__IsPathToDoorBlockedByVehicleCollisionModel_AT400DoorException()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [edi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     ax, 0x241
+        jmp     CONTINUE_CCarEnterExit__IsPathToDoorBlockedByVehicleCollisionModel_AT400DoorException
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CTaskUtilityLineUpPedWithCar::ProcessPed, AT-400 stair door line-up offset; needs three
+// separate hooks, one per case handler of the same anim-id switch.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6515DD | 66 81 7E 22 41 02 | cmp     word ptr [esi + 0x22], 0x241
+//     0x6515E3 | 0F 85 9C 02 00 00 | jne     0x651885
+#define HOOKPOS_CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetA  0x6515DD
+#define HOOKSIZE_CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetA 6
+static const DWORD CONTINUE_CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetA = 0x6515E3;
+
+static void __declspec(naked) HOOK_CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetA()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     ax, 0x241
+        jmp     CONTINUE_CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetA
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// Second of the three repeats (see AT400StairOffsetA above for the full explanation).
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x651634 | 66 81 7E 22 41 02 | cmp     word ptr [esi + 0x22], 0x241
+//     0x65163A | 0F 85 45 02 00 00 | jne     0x651885
+#define HOOKPOS_CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetB  0x651634
+#define HOOKSIZE_CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetB 6
+static const DWORD CONTINUE_CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetB = 0x65163A;
+
+static void __declspec(naked) HOOK_CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetB()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     ax, 0x241
+        jmp     CONTINUE_CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetB
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// Third of the three repeats (see AT400StairOffsetA above for the full explanation).
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x651722 | 66 81 7E 22 41 02 | cmp     word ptr [esi + 0x22], 0x241
+//     0x651728 | 0F 85 57 01 00 00 | jne     0x651885
+#define HOOKPOS_CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetC  0x651722
+#define HOOKSIZE_CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetC 6
+static const DWORD CONTINUE_CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetC = 0x651728;
+
+static void __declspec(naked) HOOK_CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetC()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     ax, 0x241
+        jmp     CONTINUE_CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetC
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CTaskComplexEnterCar::CreateFirstSubTask, enter-from-water task variant for the
+// amphibious family (Skimmer/Vortex/Sea Sparrow/Leviathan).
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x643BE5 | 66 8B 48 22       | mov     cx, word ptr [eax + 0x22]
+// >>> 0x643BE9 | 66 81 F9 CC 01    | cmp     cx, 0x1CC
+//     0x643BEE | 74 15             | je      0x643C05
+#define HOOKPOS_CTaskComplexEnterCar__CreateFirstSubTask_AmphibiousWaterEntryChain  0x643BE5
+#define HOOKSIZE_CTaskComplexEnterCar__CreateFirstSubTask_AmphibiousWaterEntryChain 9
+static const DWORD CONTINUE_CTaskComplexEnterCar__CreateFirstSubTask_AmphibiousWaterEntryChain = 0x643BEE;
+
+static void __declspec(naked) HOOK_CTaskComplexEnterCar__CreateFirstSubTask_AmphibiousWaterEntryChain()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    eax
+        movsx   ecx, word ptr [eax + 0x22]
+        call    ResolveVehicleParentModelId
+        // cx is left holding the resolved id for the compares further down
+        mov     cx, ax
+        cmp     cx, 0x1CC
+        pop     eax
+        jmp     CONTINUE_CTaskComplexEnterCar__CreateFirstSubTask_AmphibiousWaterEntryChain
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CPlayerInfo::FindClosestCarSectorList, AT-400 closest-enterable-car distance test.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x56F5F9 | 66 81 7E 22 41 02 | cmp     word ptr [esi + 0x22], 0x241
+//     0x56F5FF | D9 00             | fld     dword ptr [eax]
+#define HOOKPOS_CPlayerInfo__FindClosestCarSectorList_AT400DistanceException  0x56F5F9
+#define HOOKSIZE_CPlayerInfo__FindClosestCarSectorList_AT400DistanceException 6
+static const DWORD CONTINUE_CPlayerInfo__FindClosestCarSectorList_AT400DistanceException = 0x56F5FF;
+
+static void __declspec(naked) HOOK_CPlayerInfo__FindClosestCarSectorList_AT400DistanceException()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    eax
+        movsx   ecx, word ptr [esi + 0x22]
+        call    ResolveVehicleParentModelId
+        cmp     ax, 0x241
+        pop     eax
+        jmp     CONTINUE_CPlayerInfo__FindClosestCarSectorList_AT400DistanceException
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CPlayerInfo::Process, water-exit handling (IsRoomForPedToLeaveCar + follow-up task) for
+// the amphibious family (Skimmer/Vortex/Sea Sparrow/Leviathan).
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x5707FD | 66 8B 43 22 | mov     ax, word ptr [ebx + 0x22]
+// >>> 0x570801 | 66 3D CC 01 | cmp     ax, 0x1CC
+//     0x570805 | 74 12       | je      0x570819
+#define HOOKPOS_CPlayerInfo__Process_AmphibiousWaterExitChain  0x5707FD
+#define HOOKSIZE_CPlayerInfo__Process_AmphibiousWaterExitChain 8
+static const DWORD CONTINUE_CPlayerInfo__Process_AmphibiousWaterExitChain = 0x570805;
+
+static void __declspec(naked) HOOK_CPlayerInfo__Process_AmphibiousWaterExitChain()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [ebx + 0x22]
+        call    ResolveVehicleParentModelId
+        // ax is left holding the resolved id for the compares that follow
+        cmp     ax, 0x1CC
+        jmp     CONTINUE_CPlayerInfo__Process_AmphibiousWaterExitChain
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CWeapon::FireInstantHit, tighter 0.1 spread (vs 0.3 default) for Sea Sparrow-mounted guns;
+// Sparrow/RC Tiger clones aren't covered since the resolver doesn't map them.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x7408E3 | 66 8B 47 22 | mov     ax, word ptr [edi + 0x22]
+// >>> 0x7408E7 | 66 3D BF 01 | cmp     ax, 0x1BF
+//     0x7408EB | 74 14       | je      0x740901
+#define HOOKPOS_CWeapon__FireInstantHit_MountedGunSpreadChain  0x7408E3
+#define HOOKSIZE_CWeapon__FireInstantHit_MountedGunSpreadChain 8
+static const DWORD CONTINUE_CWeapon__FireInstantHit_MountedGunSpreadChain = 0x7408EB;
+
+static void __declspec(naked) HOOK_CWeapon__FireInstantHit_MountedGunSpreadChain()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [edi + 0x22]
+        call    ResolveAircraftWeaponModelId
+        // ax is left holding the resolved id for the compares that follow
+        cmp     ax, 0x1BF
+        jmp     CONTINUE_CWeapon__FireInstantHit_MountedGunSpreadChain
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CShadows::StoreShadowForVehicle, resolves the model id once at the shared load feeding
+// both heli/plane shadow jump tables, fixing every clone they cover, not just this task's.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x70BF09 | 0F BF 5F 22 | movsx   ebx, word ptr [edi + 0x22]
+// >>> 0x70BF0D | DD D8       | fstp    st(0)
+//     0x70BF0F | 8B CF       | mov     ecx, edi
+#define HOOKPOS_CShadows__StoreShadowForVehicle_ModelDispatchResolve  0x70BF09
+#define HOOKSIZE_CShadows__StoreShadowForVehicle_ModelDispatchResolve 6
+static const DWORD CONTINUE_CShadows__StoreShadowForVehicle_ModelDispatchResolve = 0x70BF0F;
+
+static void __declspec(naked) HOOK_CShadows__StoreShadowForVehicle_ModelDispatchResolve()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        movsx   ecx, word ptr [edi + 0x22]
+        call    ResolveVehicleParentModelId
+        mov     ebx, eax
+        // call must not touch the x87 stack; this fstp is the only allowed pop
+        fstp    st(0)
+        jmp     CONTINUE_CShadows__StoreShadowForVehicle_ModelDispatchResolve
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CAEVehicleAudioEntity::ProcessMovingParts plays the Andromada's cargo-door creak, gated
+// on model ID twice (outer OR-chain, then a separate dispatch table); needs two hooks.
+//////////////////////////////////////////////////////////////////////////////////////////
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// Outer gate: patches the Andromada (0x250) leg of the six-way OR-chain that decides
+// whether moving-parts audio runs at all.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x4FB287 | 66 3D 50 02 | cmp     ax, 0x250
+// >>> 0x4FB28B | 74 0A       | je      0x4FB297
+//     0x4FB28D | 66 3D 12 02 | cmp     ax, 0x212
+#define HOOKPOS_CAEVehicleAudioEntity__ProcessMovingParts_AndromGate  0x4FB287
+#define HOOKSIZE_CAEVehicleAudioEntity__ProcessMovingParts_AndromGate 6
+static const DWORD CONTINUE_CAEVehicleAudioEntity__ProcessMovingParts_AndromGate = 0x4FB297;
+static const DWORD SKIP_CAEVehicleAudioEntity__ProcessMovingParts_AndromGate = 0x4FB28D;
+
+static void __declspec(naked) HOOK_CAEVehicleAudioEntity__ProcessMovingParts_AndromGate()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    eax
+        push    ecx
+        push    edx
+        call    IsAndromadaOrClone
+        test    al, al
+        pop     edx
+        pop     ecx
+        pop     eax
+        jz      notAndrom
+
+        jmp     CONTINUE_CAEVehicleAudioEntity__ProcessMovingParts_AndromGate
+
+        notAndrom:
+        jmp     SKIP_CAEVehicleAudioEntity__ProcessMovingParts_AndromGate
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// Inner dispatch: forces jump-table case index 4 (the Andromada creak block) since a
+// clone's model id falls outside the range-checked table and would otherwise miss it.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x4FB347 | 05 6A FE FF FF | add     eax, 0xFFFFFE6A
+//     0x4FB34C | 3D BA 00 00 00 | cmp     eax, 0xBA
+#define HOOKPOS_CAEVehicleAudioEntity__ProcessMovingParts_AndromCreakCase  0x4FB347
+#define HOOKSIZE_CAEVehicleAudioEntity__ProcessMovingParts_AndromCreakCase 5
+static const DWORD CONTINUE_CAEVehicleAudioEntity__ProcessMovingParts_AndromCreakCase = 0x4FB35E;
+static const DWORD SKIP_CAEVehicleAudioEntity__ProcessMovingParts_AndromCreakCase = 0x4FB34C;
+
+static void __declspec(naked) HOOK_CAEVehicleAudioEntity__ProcessMovingParts_AndromCreakCase()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    eax
+        mov     ecx, edx
+        call    IsAndromadaOrClone
+        test    al, al
+        pop     eax
+        jz      notAndrom
+
+        // force case index 4: the Andromada creak block
+        mov     eax, 4
+        jmp     CONTINUE_CAEVehicleAudioEntity__ProcessMovingParts_AndromCreakCase
+
+        notAndrom:
+        add     eax, 0xFFFFFE6A
+        jmp     SKIP_CAEVehicleAudioEntity__ProcessMovingParts_AndromCreakCase
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CPlane::PreRender, Andromada ramp/door visual transform block.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6C95B8 | 66 81 7E 22 50 02 | cmp     word ptr [esi + 0x22], 0x250
+// >>> 0x6C95BE | 0F 85 91 00 00 00 | jne     0x6C9655
+//     0x6C95C4 | D9 47 9C          | fld     dword ptr [edi - 0x64]
+#define HOOKPOS_CPlane__PreRender_AndromRampBlock  0x6C95B8
+#define HOOKSIZE_CPlane__PreRender_AndromRampBlock 12
+static const DWORD CONTINUE_CPlane__PreRender_AndromRampBlock = 0x6C95C4;
+static const DWORD SKIP_CPlane__PreRender_AndromRampBlock = 0x6C9655;
+
+static void __declspec(naked) HOOK_CPlane__PreRender_AndromRampBlock()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        mov     ecx, esi
+        call    IsAndromadaOrClone
+        test    al, al
+        jz      notAndrom
+
+        jmp     CONTINUE_CPlane__PreRender_AndromRampBlock
+
+        notAndrom:
+        jmp     SKIP_CPlane__PreRender_AndromRampBlock
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
 //
 // CMultiplayerSA::InitHooks_Vehicles
 //
@@ -941,4 +3578,104 @@ void CMultiplayerSA::InitHooks_Vehicles()
     EZHookInstall(CAutomobile__UpdateMovingCollision_DumperRotation);
     EZHookInstall(CAutomobile__GetMovingCollisionOffset_Dumper);
     EZHookInstall(CMonsterTruck__PreRender_DumperSwing);
+    EZHookInstall(CVehicle__GetPlaneNumGuns_ModelId);
+    EZHookInstall(CVehicle__GetPlaneGunsAutoAimAngle_ModelId);
+    EZHookInstall(CVehicle__GetPlaneGunsRateOfFire_ModelId);
+    EZHookInstall(CVehicle__GetPlaneOrdnanceRateOfFire_ModelId);
+    EZHookInstall(CVehicle__GetPlaneGunsPosition_ModelId);
+    EZHookInstall(CVehicle__GetPlaneOrdnancePosition_ModelId);
+    EZHookInstall(CVehicle__SelectPlaneWeapon_ModelId);
+    EZHookInstall(CVehicle__FirePlaneGuns_ModelId);
+    EZHookInstall(CVehicle__FireUnguidedMissile_ModelId);
+    EZHookInstall(CVehicle__GetPlaneWeaponFiringStatus_ModelId);
+    EZHookInstall(CVehicle__ProcessWeapons_HydraCheck);
+    EZHookInstall(CHud__DrawCrossHairs_ModelCheck);
+    EZHookInstall(CCam__Process_HydraLockOnCheck);
+    EZHookInstall(CAutomobile__ProcessCarWheelPair_HydraSteerExempt);
+    EZHookInstall(CHeli__Constructor_HunterDoor);
+    EZHookInstall(CPlane__Constructor_ModelSwitch);
+    EZHookInstall(CPlane__ProcessControlInputs_HydraNozzleTurn);
+    EZHookInstall(CAEVehicleAudioEntity__ProcessAircraft_JetClass);
+    EZHookInstall(CAEVehicleAudioEntity__ProcessGenericJet_ModelSelect);
+    EZHookInstall(CAEVehicleAudioEntity__ProcessSpecialVehicle_ModelSwitch);
+    EZHookInstall(CAutomobile__ProcessBuoyancy_AmphibiousRotorExempt);
+    EZHookInstall(CAutomobile__ProcessBuoyancy_AmphibiousSafeFloat);
+    EZHookInstall(CAutomobile__ProcessBuoyancy_VortexSpeedDampingExempt);
+    EZHookInstall(CPlane__ProcessControlInputs_VortexSteerAxis);
+    EZHookInstall(CPlane__ProcessControlInputs_VortexSteerAngleSource);
+    EZHookInstall(CCam__ProcessFollowCarSA_DistanceCategoryModel);
+    EZHookInstall(CAutomobile__ProcessControl_SkimmerBoatControl);
+    EZHookInstall(CHeli__ProcessControl_SearchLightModel);
+    EZHookInstall(CAutomobile__ProcessControl_RCBaronFakePhysicsGate);
+    EZHookInstall(CAutomobile__ProcessControl_RCBaronNormalGate);
+    EZHookInstall(CAutomobile__ProcessFlyingCarStuff_RCBaronFastPathGate);
+    EZHookInstall(CAutomobile__ProcessFlyingCarStuff_RCBaronControlScaleSelect);
+    EZHookInstall(CAutomobile__ProcessFlyingCarStuff_RCBaronBehaviorDispatch);
+    EZHookInstall(CVehicle__SetModelIndex_RCVehicleFlag);
+    EZHookInstall(CPlane__ProcessControl_SmokeEjectorModel);
+    EZHookInstall(CPlane__ProcessControl_SmokeParticleModel);
+    EZHookInstall(CPlane__ProcessControl_VortexTrailModel);
+    EZHookInstall(CAutomobile__ProcessControl_AmphibiousPhysicsKeepAlive);
+    EZHookInstall(CPlane__Constructor_HydraNozzlePrime);
+    EZHookInstall(CVehicle__FlyingControl_HydraPlaneThrust);
+    EZHookInstall(CVehicle__FlyingControl_HydraHoverThrust);
+    EZHookInstall(CPlane__PreRender_ComponentSwitch);
+    EZHookInstall(CPlane__PreRender_HydraRotationMode);
+    EZHookInstall(CPlane__PreRender_RampAndNozzleModel);
+    EZHookInstall(CAutomobile__ProcessControl_AndromAngleReset);
+    EZHookInstall(CAutomobile__ProcessControl_AndromMiscGate);
+    EZHookInstall(CAutomobile__MovingCollisionSpeed_AndromA);
+    EZHookInstall(CAutomobile__MovingCollisionSpeed_AndromB);
+    EZHookInstall(CAutomobile__MovingCollisionSpeed_AndromC);
+    EZHookInstall(CAutomobile__ProcessControl_AndromDispatch);
+    EZHookInstall(CVehicle__ProcessBoatControl_SkimmerCapsizedBuoyancy);
+    EZHookInstall(CVehicle__ProcessBoatControl_SkimmerWaterLandingDamping);
+    EZHookInstall(CVehicle__ProcessBoatControl_SkimmerAquaplaneThrust);
+    EZHookInstall(CVehicle__ProcessBoatControl_SkimmerSlowingDownGate);
+    EZHookInstall(CVehicle__ProcessBoatControl_SkimmerTurnResistanceSkip);
+    EZHookInstall(CVehicle__ApplyBoatWaterResistance_SkimmerHullDrag);
+    EZHookInstall(CBuoyancy__PreCalcSetup_LeviathanSkimmerModel);
+    EZHookInstall(CPlane__ProcessControl_SkimmerWheelStatus);
+    EZHookInstall(CPlane__PreRender_SkimmerBoatSplashesCall);
+    EZHookInstall(CVehicle__DoBoatSplashes_SkimmerIntensityModel);
+    EZHookInstall(CWaterLevel__RenderBoatWakes_SkimmerModel);
+    EZHookInstall(CBoat__Render_SkimmerPropellerSpin);
+    EZHookInstall(CCamera__CamControl_SkimmerCameraMode);
+    EZHookInstall(CCam__TryToStartNewCamMode_SkimmerCheckA);
+    EZHookInstall(CCam__TryToStartNewCamMode_SkimmerCheckB);
+    EZHookInstall(CCam__TryToStartNewCamMode_SkimmerCheckC);
+    EZHookInstall(CCam__TryToStartNewCamMode_SkimmerCheckD);
+    EZHookInstall(CCam__TryToStartNewCamMode_SkimmerCheckE);
+    EZHookInstall(CCam__Process_SkimmerFramingA);
+    EZHookInstall(CCam__Process_SkimmerFramingB);
+    EZHookInstall(CCam__Process_SkimmerFramingC);
+    EZHookInstall(CCam__Process_SkimmerFramingD);
+    EZHookInstall(CCam__Process_SkimmerFramingE);
+    EZHookInstall(CRenderer__SetupEntityVisibility_SkimmerCulling);
+    EZHookInstall(CAutomobile__ProcessControl_VortexTractionBoost);
+    EZHookInstall(CAutomobile__ProcessControl_VortexWheelSettleExempt);
+    EZHookInstall(CAutomobile__ProcessSuspension_VortexSpringForceScale);
+    EZHookInstall(CAutomobile__ProcessSuspension_VortexGroundSpringExempt);
+    EZHookInstall(CVehicle__FlyingControl_VortexSkimmerGroundRestGate);
+    EZHookInstall(CVehicle__FlyingControl_VortexThrustFormula);
+    EZHookInstall(CVehicle__FlyingControl_VortexTurnDampingClamp);
+    EZHookInstall(CPlane__Constructor_VortexFlyerCollisionExempt);
+    EZHookInstall(CPlane__VehicleDamage_VortexCarStyleDamage);
+    EZHookInstall(CPlane__PreRender_VortexFanFXMatrix);
+    EZHookInstall(CAEVehicleAudioEntity__Initialise_SpecialVehicleModelSwitch);
+    EZHookInstall(CPlane__PreRender_ShadowTypeModel);
+    EZHookInstall(CCarEnterExit__IsRoomForPedToLeaveCar_AT400DoorException);
+    EZHookInstall(CCarEnterExit__IsRoomForPedToLeaveCar_AmphibiousExitChain);
+    EZHookInstall(CCarEnterExit__IsPathToDoorBlockedByVehicleCollisionModel_AT400DoorException);
+    EZHookInstall(CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetA);
+    EZHookInstall(CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetB);
+    EZHookInstall(CTaskUtilityLineUpPedWithCar__ProcessPed_AT400StairOffsetC);
+    EZHookInstall(CTaskComplexEnterCar__CreateFirstSubTask_AmphibiousWaterEntryChain);
+    EZHookInstall(CPlayerInfo__FindClosestCarSectorList_AT400DistanceException);
+    EZHookInstall(CPlayerInfo__Process_AmphibiousWaterExitChain);
+    EZHookInstall(CWeapon__FireInstantHit_MountedGunSpreadChain);
+    EZHookInstall(CShadows__StoreShadowForVehicle_ModelDispatchResolve);
+    EZHookInstall(CAEVehicleAudioEntity__ProcessMovingParts_AndromGate);
+    EZHookInstall(CAEVehicleAudioEntity__ProcessMovingParts_AndromCreakCase);
+    EZHookInstall(CPlane__PreRender_AndromRampBlock);
 }


### PR DESCRIPTION
#### Summary

Planes, helicopters and Vortex cloned with `engineRequestModel` now behave like the model they were cloned from. Full breakdown by vehicle below.

| Model | Fixes |
|---|---|
| Hydra | Guns, homing missiles, gunsight, missile lock-on reticle & camera, VTOL nozzle turn + thrust vectoring (plane and hover mode), ground wheel steering exemption, door, jet engine sound, landing gear, adjustable nozzle-angle readout |
| Hunter | Minigun, missile lock, gunsight, door |
| Rustler | Guns, door, landing gear |
| Cropduster | Door, smoke trail |
| Shamal | Door, jet engine sound, landing gear |
| Nevada | Door, landing gear |
| Stunt Plane | Door / rear wheel visibility, smoke trail toggle key, smoke particle spawn |
| AT-400 | Landing gear, boarding/exit stair alignment, door collision model, exit door-height exemption, G-key closest-car targeting distance, jumbo shadow, jet engine sound |
| Andromada | Loading ramp physics, door, jet engine sound, jumbo shadow, cargo door creak sound, landing gear |
| Vortex | Traction/hover feel, suspension cushion, ground-rest exemption, steering, camera distance, thrust and turn damping, flyer-collision exemption, car-style crash damage, fan FX, hovercraft audio flag, engine sound, physics keep-alive, door panel |
| RC Baron | Flight (thrust/control response), camera, engine sound |
| Sea Sparrow | Water landing physics, buoyancy, mounted gun spread |
| Leviathan | Buoyancy constants, physics keep-alive |
| Skimmer | Boat physics (capsize recovery, water-landing damping, aquaplaning, steering, water drag), buoyancy constants, wheel status, splash FX, wake trail, propeller-spin render, boat camera (mode selection + framing), first-person culling |
| Police Maverick | Native searchlight (horn key) |
| RC Bandit, RC Raider, RC Goblin | Engine sound |
| RC Tiger | Engine sound, mounted gun spread |
| Sparrow | Mounted-gun-spread resolver now recognises it (shares code with Sea Sparrow) |

Stock vehicles are untouched; every hook resolves a custom model ID back to the one it was cloned from and falls through unchanged otherwise.

#### Motivation

Part of #1861. This started much smaller: get the Hunter's minigun and the Hydra's missiles firing on a cloned model. Testing that surfaced a much bigger problem; nothing about a cloned aircraft matches native code, since every system that decides what a vehicle is (the flight model, the weapon code, the audio entity, the constructors, the cameras) does it with a hardcoded model ID comparison, and a clone made with `engineRequestModel` carries an ID of its own. Fixing only the guns would have shipped a plane that could shoot but couldn't take off right, had no engine sound, and used the wrong camera.

It wasn't the plan to turn this into a PR this size. Splitting it up was considered, but a lot of these fixes share a resolved model ID across several native compares in the same function, a seven-way door switch collapsing into one resolve, for example; doing that piecemeal across separate PRs would have meant reopening already-merged code and reverifying register liveness a second time on the same instructions, which is exactly the kind of change that's easy to get subtly wrong in inline assembly. So the PR grew to cover the whole class of bug in one pass instead, merging every hook that could be merged to keep the total line count as small as the scope allows. It ended up being several days of work, most of it disassembly verification rather than writing code.

One thing worth calling out: the Vortex is implemented natively as a `CPlane`, not a boat class, despite behaving like a hovercraft in gameplay. That's why several of its fixes live in the same plane-specific functions as the Hydra's, and why a few hooks below end up fixing the Vortex and the Skimmer together off the same shared load even though they're unrelated vehicle types on paper.

#### Test plan

Tested with the attached Lua script (spawns a clone of each vehicle behind a chat command, e.g. `/sethydra`, `/setvortex`) against a stock instance of the same model, side by side, for every vehicle listed in the table above. Confirmed stock vehicles behave exactly as before the change.

[aircraft-test.zip](https://github.com/user-attachments/files/31094182/aircraft-test.zip)

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.