### PR TITLE
Fix audio only working after opening settings

### DIFF
--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -698,8 +698,8 @@ void CCore::ApplyGameSettings()
     pController->SetVerticalAimSensitivityRawValue(CVARS_GET_VALUE<float>("vertical_aim_sensitivity"));
     pController->SetVerticalAimSensitivitySameAsHorizontal(CVARS_GET_VALUE<bool>("use_mouse_sensitivity_for_aiming"));
     CVARS_GET("mastervolume", fVal);
-    pGameSettings->SetRadioVolume(pGameSettings->GetRadioVolume() * fVal);
-    pGameSettings->SetSFXVolume(pGameSettings->GetSFXVolume() * fVal);
+    pGameSettings->SetRadioVolume(CVARS_GET_VALUE<float>("radiovolume") * fVal * 64.0f);
+    pGameSettings->SetSFXVolume(CVARS_GET_VALUE<float>("sfxvolume") * fVal * 64.0f);
 }
 
 void CCore::SetConnected(bool bConnected)


### PR DESCRIPTION
#### Summary
Fix an issue where GTA radio/SFX audio can be muted after startup and only start working after opening the Settings menu.

Radio and SFX volumes are now restored from the persisted `radiovolume` / `sfxvolume` values when applying game settings.


#### Motivation
fix no audio

#### Test plan
To trigger the bug currently it's simple: set your master volume to 10% and keep radio and sfx to 100%
restart game
join a server: no sound (radio/sfx)
open settings once -> sound now works



#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
