### PR TITLE
Fix crash when detaching an element from a colshape hit event

### DIFF
--- a/Client/mods/deathmatch/logic/CClientEntity.cpp
+++ b/Client/mods/deathmatch/logic/CClientEntity.cpp
@@ -1193,6 +1193,11 @@ void CClientEntity::DoAttaching()
         if (!SetMatrix(returnMatrix))
             SetPosition(returnMatrix.vPos);
 
+        // Moving us can run script events (a colshape firing hit/leave events here), and a
+        // handler may have detached us, so make sure we are still attached before going on
+        if (!m_pAttachedToEntity)
+            return;
+
         // The game only recalculates an entity's surface brightness from its surroundings
         // while it's not attached to anything (see CObject::PreRender), so an attached
         // entity would otherwise stay stuck at its default (too bright) value forever.


### PR DESCRIPTION
#### Summary

DoAttaching moves the attached element to follow whatever it is attached to. Moving a colshape fires its hit and leave events right there, so script handlers run while DoAttaching is still in the middle of the update. If one of those handlers detaches the element, m_pAttachedToEntity turns null while the function is still using it; the lighting sync added in #4984 reads that pointer again after the move, so it crashed on the null pointer. The attachment is now checked again after moving, and the update simply stops there if the element got detached.

#### Motivation

Fixes #5164. ~~Two hours to reproduce the crash and 2 minutes to fix it.~~

#### Test plan

Reproduced it with a small clientside resource: create a ped with a colsphere attached to it, add an onClientColShapeHit handler that calls detachElements when the local player enters, then teleport the ped onto the local player. DoAttaching drags the colshape onto the player, the hit event fires and the handler detaches it; without this change the client crashes right after the handler returns, with this change the detach just works and the game carries on. Also checked that attached objects still take the lighting of the entity they are attached to, so the #4984 behaviour stays intact when nothing detaches.

[repro.zip](https://github.com/user-attachments/files/31112160/repro.zip)


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.