### PR TITLE
[1.6] Replace per-frame voice decode cap with a real-time token bucket

### DIFF
--- a/Client/mods/deathmatch/CVoiceRecorder.cpp
+++ b/Client/mods/deathmatch/CVoiceRecorder.cpp
@@ -18,6 +18,8 @@ CVoiceRecorder::CVoiceRecorder()
 
     m_VoiceState = VOICESTATE_AWAITING_INPUT;
     m_SampleRate = SAMPLERATE_WIDEBAND;
+    m_ucQuality = 4;
+    m_ucDecodeBurst = VOICE_DECODE_BURST_DEFAULT;
 
     m_pAudioStream = NULL;
 
@@ -52,9 +54,10 @@ int CVoiceRecorder::PACallback(const void* inputBuffer, void* outputBuffer, unsi
     return 0;
 }
 
-void CVoiceRecorder::Init(bool bEnabled, unsigned int uiServerSampleRate, unsigned char ucQuality, unsigned int uiBitrate)
+void CVoiceRecorder::Init(bool bEnabled, unsigned int uiServerSampleRate, unsigned char ucQuality, unsigned int uiBitrate, unsigned char ucDecodeBurst)
 {
     m_bEnabled = bEnabled;
+    m_ucDecodeBurst = ucDecodeBurst > 0 ? ucDecodeBurst : VOICE_DECODE_BURST_DEFAULT;
 
     if (!bEnabled)  // If we aren't enabled, don't bother continuing
         return;

--- a/Client/mods/deathmatch/CVoiceRecorder.h
+++ b/Client/mods/deathmatch/CVoiceRecorder.h
@@ -18,6 +18,12 @@
 #define FRAME_OUTGOING_BUFFER_COUNT 100
 #define FRAME_INCOMING_BUFFER_COUNT 100
 
+// Speex produces one 20 ms frame per packet regardless of sample rate
+#define VOICE_FRAME_DURATION_MS 20
+// Max decoded frames a single remote speaker may have queued at once (500 ms of audio).
+// Legit speech never exceeds real-time, so only bursts and floods reach this ceiling.
+#define VOICE_DECODE_BURST_DEFAULT 25
+
 #include <mutex>
 #include <speex/speex.h>
 #include <speex/speex_preprocess.h>
@@ -50,7 +56,7 @@ public:
     CVoiceRecorder();
     ~CVoiceRecorder();
 
-    void Init(bool bEnabled, unsigned int uiServerSampleRate, unsigned char ucQuality, unsigned int uiBitrate);
+    void Init(bool bEnabled, unsigned int uiServerSampleRate, unsigned char ucQuality, unsigned int uiBitrate, unsigned char ucDecodeBurst);
 
     bool IsEnabled() { return m_bEnabled; }
 
@@ -61,6 +67,7 @@ public:
 
     unsigned int  GetSampleRate() { return m_SampleRate; }
     unsigned char GetSampleQuality() { return m_ucQuality; }
+    unsigned char GetDecodeBurst() { return m_ucDecodeBurst; }
 
     const SpeexMode* getSpeexModeFromSampleRate();
 
@@ -92,6 +99,7 @@ private:
 
     eSampleRate   m_SampleRate;
     unsigned char m_ucQuality;
+    unsigned char m_ucDecodeBurst;
 
     std::list<SString> m_EventQueue;
     std::mutex         m_Mutex;

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -6205,11 +6205,11 @@ bool CClientGame::VerifySADataFiles(int iEnableClientChecks)
     return true;
 }
 
-void CClientGame::InitVoice(bool bEnabled, unsigned int uiServerSampleRate, unsigned char ucQuality, unsigned int uiBitrate)
+void CClientGame::InitVoice(bool bEnabled, unsigned int uiServerSampleRate, unsigned char ucQuality, unsigned int uiBitrate, unsigned char ucDecodeBurst)
 {
     if (m_pVoiceRecorder)
     {
-        m_pVoiceRecorder->Init(bEnabled, uiServerSampleRate, ucQuality, uiBitrate);
+        m_pVoiceRecorder->Init(bEnabled, uiServerSampleRate, ucQuality, uiBitrate, ucDecodeBurst);
     }
 }
 

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -268,7 +268,7 @@ public:
 
     void StartPlayback();
     void EnablePacketRecorder(const char* szFilename);
-    void InitVoice(bool bEnabled, unsigned int uiServerSampleRate, unsigned char ucQuality, unsigned int uiBitrate);
+    void InitVoice(bool bEnabled, unsigned int uiServerSampleRate, unsigned char ucQuality, unsigned int uiBitrate, unsigned char ucDecodeBurst);
 
     bool IsWindowFocused() const { return m_bFocused; }
 

--- a/Client/mods/deathmatch/logic/CClientPlayerVoice.cpp
+++ b/Client/mods/deathmatch/logic/CClientPlayerVoice.cpp
@@ -31,6 +31,8 @@ CClientPlayerVoice::CClientPlayerVoice(CClientPlayer* pPlayer, CVoiceRecorder* p
     m_SampleRate = SAMPLERATE_WIDEBAND;
     m_pSpeexDecoderState = NULL;
     m_iSpeexIncomingFrameSampleCount = 0;
+    m_fDecodeCredit = 0.0f;
+    m_ulDecodeCreditTime = 0;
 
     // Get initial voice volume
     m_fVolume = 1.0f;
@@ -103,8 +105,6 @@ void CClientPlayerVoice::DeInit()
 
 void CClientPlayerVoice::DoPulse()
 {
-    m_voiceFramesThisPulse = 0;
-
     // Dispatch queued events
     ServiceEventQueue();
 
@@ -134,10 +134,8 @@ void CClientPlayerVoice::DecodeAndBuffer(const unsigned char* voiceBuffer, unsig
     if (!m_pSpeexDecoderState)
         return;
 
-    // Limit decodes per frame to bound CPU from relay floods
-    if (m_voiceFramesThisPulse >= 6)
+    if (!TakeDecodeCredit())
         return;
-    ++m_voiceFramesThisPulse;
 
     char      pTempBuffer[2048];
     SpeexBits speexBits;
@@ -176,6 +174,39 @@ void CClientPlayerVoice::DecodeAndBuffer(const unsigned char* voiceBuffer, unsig
 
     if (m_pBassPlaybackStream)
         BASS_StreamPutData(m_pBassPlaybackStream, (void*)pTempBuffer, uiSpeexBlockSize);
+}
+
+// Bounds decode CPU against relay floods without starving legitimate speech.
+//
+// The previous fixed cap of N decodes per game frame dropped real packets whenever
+// the client rendered slower than the 50 Hz voice frame rate, or whenever the
+// network delivered a burst, and every dropped packet stalled the BASS stream and
+// fired onClientPlayerVoiceStop mid-sentence. Credit is now earned in real time and
+// only the burst ceiling is capped, so steady speech is never throttled.
+bool CClientPlayerVoice::TakeDecodeCredit()
+{
+    const unsigned long ulNow = CClientTime::GetTime();
+    const float         fBurst = static_cast<float>(m_pVoiceRecorder->GetDecodeBurst());
+
+    if (m_ulDecodeCreditTime == 0)
+    {
+        m_ulDecodeCreditTime = ulNow;
+        m_fDecodeCredit = fBurst;
+    }
+    else if (ulNow > m_ulDecodeCreditTime)
+    {
+        m_fDecodeCredit += static_cast<float>(ulNow - m_ulDecodeCreditTime) / VOICE_FRAME_DURATION_MS;
+        m_ulDecodeCreditTime = ulNow;
+
+        if (m_fDecodeCredit > fBurst)
+            m_fDecodeCredit = fBurst;
+    }
+
+    if (m_fDecodeCredit < 1.0f)
+        return false;
+
+    m_fDecodeCredit -= 1.0f;
+    return true;
 }
 
 void CClientPlayerVoice::ServiceEventQueue()

--- a/Client/mods/deathmatch/logic/CClientPlayerVoice.h
+++ b/Client/mods/deathmatch/logic/CClientPlayerVoice.h
@@ -108,5 +108,10 @@ private:
     SFixedArray<int, 9> m_EnabledEffects;
     SFixedArray<HFX, 9> m_FxEffects;
 
-    unsigned char m_voiceFramesThisPulse;   // Decodes per frame limit
+    // Decode throttle. Credit accrues at the real-time frame rate (one frame per
+    // VOICE_FRAME_DURATION_MS) up to the server-configured burst ceiling, so a
+    // speaker who is merely ahead of a slow client frame is never dropped, while a
+    // flood is capped at the ceiling and then held to real-time.
+    float         m_fDecodeCredit;
+    unsigned long m_ulDecodeCreditTime;
 };

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -397,7 +397,12 @@ void CPacketHandler::Packet_ServerJoined(NetBitStreamInterface& bitStream)
     unsigned int iBitrate;
     bitStream.ReadCompressed(iBitrate);
 
-    g_pClientGame->InitVoice(bVoiceEnabled, (unsigned int)sampleRate, quality, iBitrate);
+    // Per-speaker decode burst limit; older servers do not send it
+    unsigned char ucVoiceDecodeBurst = VOICE_DECODE_BURST_DEFAULT;
+    if (bitStream.Can(eBitStreamVersion::VoiceDecodeBurstLimit))
+        bitStream.Read(ucVoiceDecodeBurst);
+
+    g_pClientGame->InitVoice(bVoiceEnabled, (unsigned int)sampleRate, quality, iBitrate, ucVoiceDecodeBurst);
 
     // Get fakelag command enabled
     if (bitStream.Can(eBitStreamVersion::FakeLagCommand))

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -1375,11 +1375,11 @@ void CGame::JoinPlayer(CPlayer& Player)
     marker.Set("Start");
 
     // Let him join
-    Player.Send(CPlayerJoinCompletePacket(Player.GetID(), m_pMapManager->GetRootElement()->GetID(), m_pMainConfig->GetHTTPDownloadType(),
-                                          m_pMainConfig->GetHTTPPort(), m_pMainConfig->GetHTTPDownloadURL().c_str(),
-                                          m_pMainConfig->GetHTTPMaxConnectionsPerClient(), m_pMainConfig->GetEnableClientChecks(),
-                                          m_pMainConfig->IsVoiceEnabled(), m_pMainConfig->GetVoiceSampleRate(), m_pMainConfig->GetVoiceQuality(),
-                                          m_pMainConfig->GetVoiceBitrate(), m_pMainConfig->GetServerName().c_str()));
+    Player.Send(CPlayerJoinCompletePacket(
+        Player.GetID(), m_pMapManager->GetRootElement()->GetID(), m_pMainConfig->GetHTTPDownloadType(), m_pMainConfig->GetHTTPPort(),
+        m_pMainConfig->GetHTTPDownloadURL().c_str(), m_pMainConfig->GetHTTPMaxConnectionsPerClient(), m_pMainConfig->GetEnableClientChecks(),
+        m_pMainConfig->IsVoiceEnabled(), m_pMainConfig->GetVoiceSampleRate(), m_pMainConfig->GetVoiceQuality(), m_pMainConfig->GetVoiceBitrate(),
+        static_cast<unsigned char>(m_pMainConfig->GetMaxVoiceDecodeBurst()), m_pMainConfig->GetServerName().c_str()));
 
     marker.Set("CPlayerJoinCompletePacket");
 

--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -1538,6 +1538,7 @@ const std::vector<SIntSetting>& CMainConfig::GetIntSettingList()
         {true, true, 50, 100, 1000, "voice_packets_interval", &m_voicePacketsInterval, nullptr},
         {true, true, 1, 32, 200, "max_voice_packets_per_interval", &m_maxVoicePacketsPerInterval, nullptr},
         {true, true, 128, 512, 2048, "max_voice_buffer_size", &m_maxVoiceBufferSize, nullptr},
+        {true, true, 6, 25, 200, "max_voice_decode_burst", &m_maxVoiceDecodeBurst, nullptr},
     };
 
     static std::vector<SIntSetting> settingsList;

--- a/Server/mods/deathmatch/logic/CMainConfig.h
+++ b/Server/mods/deathmatch/logic/CMainConfig.h
@@ -153,6 +153,7 @@ public:
     int GetVoicePacketsInterval() const noexcept { return m_voicePacketsInterval; }
     int GetMaxVoicePacketsPerInterval() const noexcept { return m_maxVoicePacketsPerInterval; }
     int GetMaxVoiceBufferSize() const noexcept { return m_maxVoiceBufferSize; }
+    int GetMaxVoiceDecodeBurst() const noexcept { return m_maxVoiceDecodeBurst; }
 
 private:
     void RegisterCommand(const char* szName, FCommandHandler* pFunction, bool bRestricted, const char* szConsoleHelpText);
@@ -241,4 +242,5 @@ private:
     int                        m_voicePacketsInterval{};
     int                        m_maxVoicePacketsPerInterval{};
     int                        m_maxVoiceBufferSize{};
+    int                        m_maxVoiceDecodeBurst{};
 };

--- a/Server/mods/deathmatch/logic/packets/CPlayerJoinCompletePacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerJoinCompletePacket.cpp
@@ -27,13 +27,14 @@ CPlayerJoinCompletePacket::CPlayerJoinCompletePacket()
     m_ucSampleRate = 1;
     m_ucQuality = 4;
     m_uiBitrate = 0;
+    m_ucVoiceDecodeBurst = 25;
     m_szServerName = "";
 }
 
 CPlayerJoinCompletePacket::CPlayerJoinCompletePacket(ElementID PlayerID, ElementID RootElementID, eHTTPDownloadType ucHTTPDownloadType,
                                                      unsigned short usHTTPDownloadPort, const char* szHTTPDownloadURL, int iHTTPMaxConnectionsPerClient,
                                                      int iEnableClientChecks, bool bVoiceEnabled, unsigned char ucSampleRate, unsigned char ucVoiceQuality,
-                                                     unsigned int uiBitrate, const char* szServerName)
+                                                     unsigned int uiBitrate, unsigned char ucVoiceDecodeBurst, const char* szServerName)
 {
     m_PlayerID = PlayerID;
     m_RootElementID = RootElementID;
@@ -44,6 +45,7 @@ CPlayerJoinCompletePacket::CPlayerJoinCompletePacket(ElementID PlayerID, Element
     m_ucSampleRate = ucSampleRate;
     m_ucQuality = ucVoiceQuality;
     m_uiBitrate = uiBitrate;
+    m_ucVoiceDecodeBurst = ucVoiceDecodeBurst;
     m_szServerName = szServerName;
 
     switch (m_ucHTTPDownloadType)
@@ -88,6 +90,10 @@ bool CPlayerJoinCompletePacket::Write(NetBitStreamInterface& BitStream) const
 
     // Transmit the max bitrate for voice
     BitStream.WriteCompressed(m_uiBitrate);
+
+    // Transmit the per-speaker decode burst limit for voice
+    if (BitStream.Can(eBitStreamVersion::VoiceDecodeBurstLimit))
+        BitStream.Write(m_ucVoiceDecodeBurst);
 
     // fakelag command enabled
     if (BitStream.Can(eBitStreamVersion::FakeLagCommand))

--- a/Server/mods/deathmatch/logic/packets/CPlayerJoinCompletePacket.h
+++ b/Server/mods/deathmatch/logic/packets/CPlayerJoinCompletePacket.h
@@ -21,7 +21,8 @@ public:
     CPlayerJoinCompletePacket();
     CPlayerJoinCompletePacket(ElementID PlayerID, ElementID RootElementID, eHTTPDownloadType ucHTTPDownloadType, unsigned short usHTTPDownloadPort,
                               const char* szHTTPDownloadURL, int iHTTPMaxConnectionsPerClient, int iEnableClientChecks, bool bVoiceEnabled,
-                              unsigned char ucSampleRate, unsigned char ucVoiceQuality, unsigned int uiBitrate, const char* szServerName);
+                              unsigned char ucSampleRate, unsigned char ucVoiceQuality, unsigned int uiBitrate, unsigned char ucVoiceDecodeBurst,
+                              const char* szServerName);
 
     ePacketID     GetPacketID() const { return PACKET_ID_SERVER_JOINEDGAME; };
     unsigned long GetFlags() const { return PACKET_HIGH_PRIORITY | PACKET_RELIABLE | PACKET_SEQUENCED; };
@@ -40,5 +41,6 @@ private:
     unsigned char     m_ucSampleRate;
     unsigned char     m_ucQuality;
     unsigned int      m_uiBitrate;
+    unsigned char     m_ucVoiceDecodeBurst;
     const char*       m_szServerName;
 };

--- a/Server/mods/deathmatch/mtaserver.conf
+++ b/Server/mods/deathmatch/mtaserver.conf
@@ -250,6 +250,13 @@
          The minimum value is 128, the maximum is 2048, and the default is 512 -->
     <max_voice_buffer_size>512</max_voice_buffer_size>
 
+    <!-- The maximum number of voice frames a client may decode from one speaker at once. Credit refills at the
+         real-time voice rate (one 20 ms frame per 20 ms), so legitimate speech is never throttled by this;
+         only bursts and floods reach the ceiling. Raise it if listeners with low FPS report choppy voice,
+         lower it to tighten CPU protection against relay floods.
+         The minimum value is 6, the maximum is 200, and the default is 25 (500 ms of audio) -->
+    <max_voice_decode_burst>25</max_voice_decode_burst>
+
     <!-- Specifies the voice bitrate, in bps. This optional parameter overrides the previous two settings.
          If not set, MTA handles this automatically.  Use with care. -->
     <!-- <voice_bitrate>24600</voice_bitrate> -->

--- a/Shared/sdk/net/bitstream.h
+++ b/Shared/sdk/net/bitstream.h
@@ -632,6 +632,10 @@ enum class eBitStreamVersion : unsigned short
     // 2026-04-06
     OnPlayerResourceStartGeneration,
 
+    // Server-configurable voice decode burst limit sent in the join packet
+    // 2026-08-16
+    VoiceDecodeBurstLimit,
+
     // This allows us to automatically increment the BitStreamVersion when things are added to this enum.
     // Make sure you only add things above this comment.
     Next,


### PR DESCRIPTION
#### Summary

Backport to `release/1.6.0` of the master fix that replaces the fixed per-game-frame voice decode cap (introduced in #5175, backported here in 0ce13e29) with a real-time token bucket, and exposes the burst ceiling as a new server setting `max_voice_decode_burst`.

**This affects the current 1.6 release line directly.** 0ce13e29 shipped in the 1.6 nightlies, so every player on a current 1.6 client is running the per-frame cap today. Merging this into `release/1.6.0` is what actually fixes voice for players; the master PR alone only fixes the next major version.

`CClientPlayerVoice::DecodeAndBuffer` currently drops every packet past the 6th one received in a single game frame from the same speaker. This PR replaces that counter with credit that accrues at the voice frame rate (one 20 ms frame per 20 ms) and is spent per decode, capped at a configurable ceiling. Steady speech can never outrun real time, so it is never throttled regardless of the listener's frame rate; a flood still fills the ceiling and is then held to real time, so the CPU bound that #5175 introduced is preserved.

Changes (identical in substance to the master PR; only conflict resolution differs):

- `CClientPlayerVoice`: `m_voiceFramesThisPulse` → `TakeDecodeCredit()` (real-time credit, burst ceiling). `DoPulse` no longer resets a counter.
- `CVoiceRecorder`: stores the ceiling received from the server; new `VOICE_FRAME_DURATION_MS` and `VOICE_DECODE_BURST_DEFAULT` constants.
- `CMainConfig`: new `max_voice_decode_burst` (6–200, default 25 = 500 ms of audio), in the `SIntSetting` table so it also works with `setServerConfigSetting`.
- `CPlayerJoinCompletePacket` / `CPacketHandler`: the ceiling is sent in the join packet, gated by a new `eBitStreamVersion::VoiceDecodeBurstLimit` appended to the end of the 1.6 enum. Either side lacking the version falls back to the default, so old server + new client and new server + old client both keep working.
- `mtaserver.conf`: documented the new setting next to the other `max_voice_*` entries.

#### Motivation

Since 0ce13e29 landed in the 1.6 nightlies, remote voice has become choppy for many players, most noticeably in crowded areas.

Speex emits one 20 ms frame per packet at every sample rate, so a speaker sends ~50 packets per second. The cap of 6 decodes per game frame is only safe while the listener renders at ≥ 50 FPS with perfectly even packet arrival. In practice:

- A listener at 20–30 FPS (typical in a crowded RP scene) accumulates 2–3 packets per frame on average.
- RakNet frequently delivers several voice packets in one batch, so a single frame can see 8–10 packets.

Everything past the 6th is silently discarded. Each dropped packet leaves a 20 ms hole; the BASS push stream has no jitter buffer, stalls on the hole, and fires `onClientPlayerVoiceStop` mid-sentence. Speech that used to arrive as one continuous stream now arrives as many 250–350 ms fragments.

Observed on a live 1.6 server (clients on 1.6 nightly 24138) with a client-side counter on `onClientPlayerVoiceStart`/`Stop` per speaker:

```
Speaker A: 42 segments, 40 stalls, ~384 ms per segment
Speaker B: 69 segments, 66 stalls, ~311 ms per segment
Speaker C: 140 segments, 136 stalls, ~298 ms per segment
Local player (own voice, no network): 5 segments, 2 stalls, ~4741 ms per segment
```

The local player's own voice goes through the same `DecodeAndBuffer` path but arrives one frame at a time with no network batching, which is why it is the only stream that stays intact — it never reaches the cap. Everyone else does.

The DoS concern behind #5175 is legitimate; the problem is that a per-frame counter conflates "flood" with "listener is slower than the sender". A time-based budget separates the two: it bounds decode work per unit of real time rather than per rendered frame.

`max_voice_decode_burst` lets operators trade the two off explicitly. 25 (500 ms) is comfortably above any legitimate burst — anything longer than that has already stalled the stream, so decoding it late buys nothing — while still capping a flood at 25 decodes per frame per speaker (~1 ms of Speex work). The minimum of 6 reproduces current behaviour.

#### Test plan

Reproduce the bug first on a current 1.6 nightly, so the fix has a baseline:

1. Bind a client-side counter to `onClientPlayerVoiceStart` / `onClientPlayerVoiceStop` per speaker (segment count, and average time between start and stop).
2. On the listener, `fpslimit 25`. Have 3–5 other players talk at once for ~30 seconds.
3. Expected on unfixed builds: dozens of segments per speaker, ~250–400 ms each, stop events firing while the speaker is clearly still holding the key.

Then with this change:

- **New 1.6 server + new 1.6 client, `fpslimit 25`, 3–5 concurrent speakers.** Segment count should be one per actual transmission; `onClientPlayerVoiceStop` should fire only on key release.
- **New server + new client, FPS uncapped.** No regression against current 1.6 — voice sounds identical to before 0ce13e29.
- **Old 1.6 server (without this PR) + new client.** Client should fall back to the default ceiling of 25 and voice should be continuous.
- **New server + old 1.6 client (pre- and post-0ce13e29).** Join must succeed; the old client behaves exactly as it does today. This is the important case for a release branch: mixed server/client versions will coexist for a while.
- **`setServerConfigSetting("max_voice_decode_burst", 6)`, reconnect.** Choppiness at low FPS should return, confirming the setting is live and 6 reproduces current behaviour. Set back to 25, reconnect: resolved. Note the value is applied at join, so a reconnect is required after changing it.
- **Flood check.** A client sending voice well above real time (or a relay flood test) should still be capped: decodes per frame for that speaker must never exceed the configured ceiling, and CPU should stay bounded as it is today.

For future regression checks: keep the per-speaker segment counter, cap FPS at 25, and confirm segment count stays at one per transmission.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
