### PR TITLE
Fix #1073: toJSON incorrectly wraps single table in array

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
@@ -536,11 +536,23 @@ bool CLuaArguments::WriteToBitStream(NetBitStreamInterface& bitStream, CFastHash
 
 bool CLuaArguments::WriteToJSONString(std::string& strJSON, bool bSerialize, int flags)
 {
-    json_object* my_array = WriteToJSONArray(bSerialize);
-    if (my_array)
+    json_object* my_object = nullptr;
+
+    // If there is exactly one argument and it is a table, serialize it directly as a JSON object
+    // This fixes toJSON({ key = value }) returning "[{...}]" instead of "{...}"
+    if (m_Arguments.size() == 1 && m_Arguments[0]->GetType() == LUA_TTABLE)
     {
-        strJSON = json_object_to_json_string_ext(my_array, flags);
-        json_object_put(my_array);  // dereference - causes a crash, is actually commented out in the example too
+        my_object = m_Arguments[0]->WriteToJSONObject(bSerialize);
+    }
+    else
+    {
+        my_object = WriteToJSONArray(bSerialize);
+    }
+
+    if (my_object)
+    {
+        strJSON = json_object_to_json_string_ext(my_object, flags);
+        json_object_put(my_object);
         return true;
     }
     return false;

--- a/Server/mods/deathmatch/logic/lua/CLuaArguments.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaArguments.cpp
@@ -604,11 +604,23 @@ bool CLuaArguments::WriteToBitStream(NetBitStreamInterface& bitStream, CFastHash
 
 bool CLuaArguments::WriteToJSONString(std::string& strJSON, bool bSerialize, int flags)
 {
-    json_object* my_array = WriteToJSONArray(bSerialize);
-    if (my_array)
+    json_object* my_object = nullptr;
+
+    // If there is exactly one argument and it is a table, serialize it directly as a JSON object
+    // This fixes toJSON({ key = value }) returning "[{...}]" instead of "{...}"
+    if (m_Arguments.size() == 1 && m_Arguments[0]->GetType() == LUA_TTABLE)
     {
-        strJSON = json_object_to_json_string_ext(my_array, flags);
-        json_object_put(my_array);  // dereference - causes a crash, is actually commented out in the example too
+        my_object = m_Arguments[0]->WriteToJSONObject(bSerialize);
+    }
+    else
+    {
+        my_object = WriteToJSONArray(bSerialize);
+    }
+
+    if (my_object)
+    {
+        strJSON = json_object_to_json_string_ext(my_object, flags);
+        json_object_put(my_object);
         return true;
     }
     return false;


### PR DESCRIPTION
Problem:
- toJSON({ key = value }) returned '[{...}]' instead of '{...}'
- WriteToJSONString() always called WriteToJSONArray(), wrapping all results in a JSON array even for single table arguments

Solution:
- Check if there is exactly one argument and it is a table (LUA_TTABLE)
- If so, serialize it directly using WriteToJSONObject() instead of wrapping it in an array via WriteToJSONArray()
- Otherwise, fall back to existing array behavior

Files changed:
- Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
- Server/mods/deathmatch/logic/lua/CLuaArguments.cpp

This fix maintains backward compatibility for multiple arguments and non-table single arguments.

#### Summary
<!-- What change are you making? -->
<!-- When changing Lua APIs, consider including code samples and documentation. -->


#### Motivation
<!-- Why are you making this change? Which GitHub issue does this resolve, if any? Any additional context? -->


#### Test plan
<!-- How have you tested this change? This should give confidence to the reviewer that your change is safe. -->
<!-- If someone makes changes to this code in the future, what steps can they follow to check that it's still working correctly? -->


#### Checklist

* [ ] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [ ] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
