### PR TITLE
Fix tow truck and tractor hooks on custom vehicle models

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -784,12 +784,9 @@ static void __declspec(naked) HOOK_CVehicle__DoVehicleLights_PopUpLights()
 #define HOOKSIZE_CAutomobile__GetTowBarPos 7
 static const DWORD CONTINUE_CAutomobile__GetTowBarPos = 0x6AF257;
 
-// Models that answer with their misc_a dummy, so a clone of one still tows.
-//
-// The tow truck and the tractor are left out; they derive the bar from their hoist angle, and the
-// rest of their behaviour stays gated on the stock model index, so a clone would only half work.
-// The trailers in that same switch, artict3 and the two baggage boxes, are vehicles.ide type
-// trailer and so become CTrailer, which overrides this function and never reaches it.
+// Models that answer with their misc_a dummy, so a clone of one still tows. Tow truck and tractor
+// share a different branch below, handled by GetTowBarModelId; artict3 and the baggage boxes are
+// CTrailer, which overrides this function entirely.
 static constexpr bool HasTowBarDummy(VehicleType model)
 {
     switch (model)
@@ -817,7 +814,12 @@ static std::uint32_t __fastcall GetTowBarModelId(CVehicleSAInterface* vehicle)
     // Only engineRequestModel models carry a parent, so stock vehicles keep their index and take
     // the branch they always did.
     const std::uint32_t parentId = modelInfo->GetParentID();
-    if (parentId == 0 || !HasTowBarDummy(static_cast<VehicleType>(parentId)))
+    if (parentId == 0)
+        return modelId;
+
+    // Tow truck and tractor share a further branch below; let a clone's parent take it too.
+    const auto parentType = static_cast<VehicleType>(parentId);
+    if (!HasTowBarDummy(parentType) && parentType != VehicleType::VT_TOWTRUCK && parentType != VehicleType::VT_TRACTOR)
         return modelId;
 
     return parentId;
@@ -836,6 +838,421 @@ static void __declspec(naked) HOOK_CAutomobile__GetTowBarPos()
 
         sub     esp, 0x0C
         jmp     CONTINUE_CAutomobile__GetTowBarPos
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// The tug (and baggage/bagboxa/bagboxb, which share this same branch) only reaches the dummy read
+// below if what it's hooking onto is a bagboxa, bagboxb or tugstair by raw id, so a clone of one of
+// those, or the utility trailer entirely, never gets recognised. Resolve clones the usual way and
+// also accept the utility trailer, letting the tug (and its trailermates) tow it too.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6AF2B6 | 66 8B 42 22 | mov     ax, word ptr [edx + 0x22]
+// >>> 0x6AF2BA | 66 3D 5E 02 | cmp     ax, 0x25E
+// >>> 0x6AF2BE | 74 0C       | je      0x6AF2CC
+// >>> 0x6AF2C0 | 66 3D 5F 02 | cmp     ax, 0x25F
+// >>> 0x6AF2C4 | 74 06       | je      0x6AF2CC
+// >>> 0x6AF2C6 | 66 3D 60 02 | cmp     ax, 0x260
+// >>> 0x6AF2CA | 75 34       | jne     0x6AF300
+#define HOOKPOS_CAutomobile__GetTowBarPos_TugAttachWhitelist  0x6AF2B6
+#define HOOKSIZE_CAutomobile__GetTowBarPos_TugAttachWhitelist 22
+static const DWORD CONTINUE_CAutomobile__GetTowBarPos_TugAttachWhitelist = 0x6AF2CC;
+static const DWORD SKIP_CAutomobile__GetTowBarPos_TugAttachWhitelist = 0x6AF300;
+
+static constexpr bool IsTugAttachable(VehicleType model)
+{
+    switch (model)
+    {
+        case VehicleType::VT_BAGBOXA:
+        case VehicleType::VT_BAGBOXB:
+        case VehicleType::VT_TUGSTAIR:
+        case VehicleType::VT_UTILTR1:
+            return true;
+        default:
+            return false;
+    }
+}
+
+static bool __fastcall IsTugAttachableOrClone(CVehicleSAInterface* attachTo)
+{
+    const std::uint32_t modelId = static_cast<std::uint32_t>(attachTo->m_nModelIndex);
+    if (IsTugAttachable(static_cast<VehicleType>(modelId)))
+        return true;
+
+    CModelInfo* modelInfo = pGameInterface->GetModelInfo(modelId);
+    return modelInfo && IsTugAttachable(static_cast<VehicleType>(modelInfo->GetParentID()));
+}
+
+static void __declspec(naked) HOOK_CAutomobile__GetTowBarPos_TugAttachWhitelist()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    ecx                          // this (the tug), needed by both targets below
+        mov     ecx, edx
+        call    IsTugAttachableOrClone
+        pop     ecx
+        test    al, al
+        jz      notAttachable
+
+        jmp     CONTINUE_CAutomobile__GetTowBarPos_TugAttachWhitelist
+
+        notAttachable:
+        jmp     SKIP_CAutomobile__GetTowBarPos_TugAttachWhitelist
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// The tug's dummy is exported as misc_b, not misc_a like every other model on this branch, so the
+// unconditional misc_a read above finds nothing; fall back to misc_b only when misc_a is absent.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6AF2CC | 8B 81 98 06 00 00 | mov     eax, dword ptr [ecx + 0x698]
+//     0x6AF2D2 | 85 C0             | test    eax, eax
+#define HOOKPOS_CAutomobile__GetTowBarPos_TugDummy  0x6AF2CC
+#define HOOKSIZE_CAutomobile__GetTowBarPos_TugDummy 6
+static const DWORD CONTINUE_CAutomobile__GetTowBarPos_TugDummy = 0x6AF2D2;
+
+static RwFrame* __fastcall GetAutomobileTowBarFrame(CAutomobileSAInterface* vehicle)
+{
+    RwFrame* misc_a = vehicle->m_aCarNodes[static_cast<std::size_t>(eCarNodes::MISC_A)];
+    return misc_a ? misc_a : vehicle->m_aCarNodes[static_cast<std::size_t>(eCarNodes::MISC_B)];
+}
+
+static void __declspec(naked) HOOK_CAutomobile__GetTowBarPos_TugDummy()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        call    GetAutomobileTowBarFrame    // ecx=vehicle, returns frame in eax
+        jmp     CONTINUE_CAutomobile__GetTowBarPos_TugDummy
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CTrailer::GetTowBarPos only answers with a bounding box guess unless the model is a baggage box,
+// so the artict3's own misc_b dummy at its tail never gets read and a second trailer can't attach.
+// Read that dummy's position directly and answer true for the artict3 and its clones.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6CFD60 | 8A 44 24 08 | mov     al, byte ptr [esp + 8]
+// >>> 0x6CFD64 | 83 EC 0C    | sub     esp, 0xC
+//     0x6CFD67 | 84 C0       | test    al, al
+#define HOOKPOS_CTrailer__GetTowBarPos  0x6CFD60
+#define HOOKSIZE_CTrailer__GetTowBarPos 7
+static const DWORD CONTINUE_CTrailer__GetTowBarPos = 0x6CFD67;
+
+static bool __fastcall TryGetArtict3FifthWheelPos(CVehicleSAInterface* trailer, CVector* outPos)
+{
+    const std::uint32_t modelId = static_cast<std::uint32_t>(trailer->m_nModelIndex);
+    bool                isArtict3 = modelId == static_cast<std::uint32_t>(VehicleType::VT_ARTICT3);
+    if (!isArtict3)
+    {
+        CModelInfo* modelInfo = pGameInterface->GetModelInfo(modelId);
+        isArtict3 = modelInfo && modelInfo->GetParentID() == static_cast<unsigned int>(VehicleType::VT_ARTICT3);
+    }
+    if (!isArtict3)
+        return false;
+
+    RwFrame* fifthWheel = reinterpret_cast<CAutomobileSAInterface*>(trailer)->m_aCarNodes[static_cast<std::size_t>(eCarNodes::MISC_B)];
+    if (!fifthWheel)
+        return false;
+
+    const RwMatrix* worldTransform = ((RwMatrix * (__cdecl*)(RwFrame*))0x7F0990)(fifthWheel);  // RwFrameGetLTM
+    outPos->fX = worldTransform->pos.x;
+    outPos->fY = worldTransform->pos.y;
+    outPos->fZ = worldTransform->pos.z;
+    return true;
+}
+
+static void __declspec(naked) HOOK_CTrailer__GetTowBarPos()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    ecx                          // trailer (this)
+        mov     edx, [esp + 8]                // &posnOut
+        call    TryGetArtict3FifthWheelPos    // al = result
+        pop     ecx
+        test    al, al
+        jz      notArtict3
+
+        retn    0x0C
+
+        notArtict3:
+        mov     al, byte ptr [esp + 8]
+        sub     esp, 0x0C
+        jmp     CONTINUE_CTrailer__GetTowBarPos
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// PreRender, ProcessControl, UpdateTrailerLink and UpdateTractorLink each gate the tow truck's hook
+// and tow line on model index, so a clone matches none of them. The tractor reaches the exact same
+// TowTruckControl and tow line checks, so ProcessControl and UpdateTrailerLink test both in one
+// patched span; PreRender's swing and UpdateTractorLink's offset calc diverge and get their own.
+//////////////////////////////////////////////////////////////////////////////////////////
+static bool __fastcall IsTowTruckOrClone(CVehicleSAInterface* vehicle)
+{
+    const std::uint32_t modelId = static_cast<std::uint32_t>(vehicle->m_nModelIndex);
+    if (modelId == static_cast<std::uint32_t>(VehicleType::VT_TOWTRUCK))
+        return true;
+
+    CModelInfo* modelInfo = pGameInterface->GetModelInfo(modelId);
+    return modelInfo && modelInfo->GetParentID() == static_cast<unsigned int>(VehicleType::VT_TOWTRUCK);
+}
+
+static bool __fastcall IsTractorOrClone(CVehicleSAInterface* vehicle)
+{
+    const std::uint32_t modelId = static_cast<std::uint32_t>(vehicle->m_nModelIndex);
+    if (modelId == static_cast<std::uint32_t>(VehicleType::VT_TRACTOR))
+        return true;
+
+    CModelInfo* modelInfo = pGameInterface->GetModelInfo(modelId);
+    return modelInfo && modelInfo->GetParentID() == static_cast<unsigned int>(VehicleType::VT_TRACTOR);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CAutomobile::PreRender, swinging the misc_a component out
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6AC507 | 66 3D 0D 02          | cmp     ax, 0x20D
+// >>> 0x6AC50B | 0F 85 C8 01 00 00    | jne     0x6AC6D9
+//     0x6AC511 | 0F B7 8E 6C 08 00 00 | movzx   ecx, word ptr [esi + 0x86C]
+#define HOOKPOS_CAutomobile__PreRender_TowTruckHook  0x6AC507
+#define HOOKSIZE_CAutomobile__PreRender_TowTruckHook 10
+static const DWORD CONTINUE_CAutomobile__PreRender_TowTruckHook = 0x6AC511;
+static const DWORD SKIP_CAutomobile__PreRender_TowTruckHook = 0x6AC6D9;
+
+static void __declspec(naked) HOOK_CAutomobile__PreRender_TowTruckHook()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    eax
+        mov     ecx, esi
+        call    IsTowTruckOrClone
+        test    al, al
+        pop     eax
+        jz      notTowTruck
+
+        jmp     CONTINUE_CAutomobile__PreRender_TowTruckHook
+
+        notTowTruck:
+        jmp     SKIP_CAutomobile__PreRender_TowTruckHook
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CAutomobile::PreRender again, the tractor's swing; it lands on a different, shorter
+// continuation than the tow truck's, so it needs a branch of its own instead of sharing one.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6AC6D9 | 66 3D 13 02 | cmp     ax, 0x213
+// >>> 0x6AC6DD | 75 3D       | jne     0x6AC71C
+//     0x6AC6DF | 0F B7 8E 6C 08 00 00 | movzx   ecx, word ptr [esi + 0x86C]
+#define HOOKPOS_CAutomobile__PreRender_TractorHook  0x6AC6D9
+#define HOOKSIZE_CAutomobile__PreRender_TractorHook 6
+static const DWORD CONTINUE_CAutomobile__PreRender_TractorHook = 0x6AC6DF;
+static const DWORD SKIP_CAutomobile__PreRender_TractorHook = 0x6AC71C;
+
+static void __declspec(naked) HOOK_CAutomobile__PreRender_TractorHook()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    eax
+        mov     ecx, esi
+        call    IsTractorOrClone
+        test    al, al
+        pop     eax
+        jz      notTractor
+
+        jmp     CONTINUE_CAutomobile__PreRender_TractorHook
+
+        notTractor:
+        jmp     SKIP_CAutomobile__PreRender_TractorHook
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CAutomobile::ProcessControl, the switch that reaches TowTruckControl; the tow truck's and
+// tractor's compares sit back to back and reach the same call, so one span covers both.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6B1FB3 | 66 3D 0D 02 | cmp     ax, 0x20D
+// >>> 0x6B1FB7 | 74 4D       | je      0x6B2006
+// >>> 0x6B1FB9 | 66 3D 13 02 | cmp     ax, 0x213
+// >>> 0x6B1FBD | 74 47       | je      0x6B2006
+//     0x6B1FBF | F7 86 8C 03 00 00 00 00 02 00 | test    dword ptr [esi + 0x38C], 0x20000
+#define HOOKPOS_CAutomobile__ProcessControl_TowTruckDispatch  0x6B1FB3
+#define HOOKSIZE_CAutomobile__ProcessControl_TowTruckDispatch 12
+static const DWORD CONTINUE_CAutomobile__ProcessControl_TowTruckDispatch = 0x6B2006;
+static const DWORD SKIP_CAutomobile__ProcessControl_TowTruckDispatch = 0x6B1FBF;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessControl_TowTruckDispatch()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        mov     ecx, esi
+        call    IsTowTruckOrClone
+        test    al, al
+        jnz     isMatch
+
+        mov     ecx, esi
+        call    IsTractorOrClone
+        test    al, al
+        jz      notMatch
+
+        isMatch:
+        jmp     CONTINUE_CAutomobile__ProcessControl_TowTruckDispatch
+
+        notMatch:
+        jmp     SKIP_CAutomobile__ProcessControl_TowTruckDispatch
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CVehicle::UpdateTrailerLink; same back to back compares as ProcessControl above.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6DFDB6 | 66 3D 0D 02 | cmp     ax, 0x20D
+// >>> 0x6DFDBA | 74 06       | je      0x6DFDC2
+// >>> 0x6DFDBC | 66 3D 13 02 | cmp     ax, 0x213
+// >>> 0x6DFDC0 | 75 19       | jne     0x6DFDDB
+//     0x6DFDC2 | 0F B7 0D 3C 31 8D 00 | movzx   ecx, word ptr [0x8D313C]
+#define HOOKPOS_CVehicle__UpdateTrailerLink_TowTruck  0x6DFDB6
+#define HOOKSIZE_CVehicle__UpdateTrailerLink_TowTruck 12
+static const DWORD CONTINUE_CVehicle__UpdateTrailerLink_TowTruck = 0x6DFDC2;
+static const DWORD SKIP_CVehicle__UpdateTrailerLink_TowTruck = 0x6DFDDB;
+
+static void __declspec(naked) HOOK_CVehicle__UpdateTrailerLink_TowTruck()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        mov     ecx, ebx
+        call    IsTowTruckOrClone
+        test    al, al
+        jnz     isMatch
+
+        mov     ecx, ebx
+        call    IsTractorOrClone
+        test    al, al
+        jz      notMatch
+
+        isMatch:
+        jmp     CONTINUE_CVehicle__UpdateTrailerLink_TowTruck
+
+        notMatch:
+        jmp     SKIP_CVehicle__UpdateTrailerLink_TowTruck
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CVehicle::UpdateTractorLink; the compare feeds a jz several FPU instructions later, so this
+// restores ax to the real stock id instead of redirecting, the original compares take it from there.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6E00D0 | 66 8B 46 22 | mov     ax, word ptr [esi + 0x22]
+// >>> 0x6E00D4 | 66 3D 0D 02 | cmp     ax, 0x20D
+//     0x6E00D8 | D8 64 24 10 | fsub    dword ptr [esp + 0x10]
+#define HOOKPOS_CVehicle__UpdateTractorLink_TowTruck  0x6E00D0
+#define HOOKSIZE_CVehicle__UpdateTractorLink_TowTruck 8
+static const DWORD CONTINUE_CVehicle__UpdateTractorLink_TowTruck = 0x6E00D8;
+
+static void __declspec(naked) HOOK_CVehicle__UpdateTractorLink_TowTruck()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        mov     ecx, esi
+        call    IsTowTruckOrClone
+        test    al, al
+        jnz     isTowTruck
+
+        mov     ecx, esi
+        call    IsTractorOrClone
+        test    al, al
+        jnz     isTractor
+
+        mov     ax, word ptr [esi + 0x22]
+        jmp     doCompare
+
+        isTowTruck:
+        mov     ax, 0x20D
+        jmp     doCompare
+
+        isTractor:
+        mov     ax, 0x213
+
+        doCompare:
+        cmp     ax, 0x20D
+        jmp     CONTINUE_CVehicle__UpdateTractorLink_TowTruck
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// CAutomobile::CAutomobile, registering the hook's misc_b (tow truck) or CAR_BOOT (tractor) as a
+// bouncing panel; that's what gives it physics driven sway instead of sitting rigid, and it only
+// ever runs once, at construction, gated the same raw way.
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6B0EE2 | 66 8B 46 22 | mov     ax, word ptr [esi + 0x22]
+// >>> 0x6B0EE6 | 66 3D 0D 02 | cmp     ax, 0x20D
+//     0x6B0EEA | 75 23       | jne     0x6B0F0F
+#define HOOKPOS_CAutomobile__Constructor_TowTruckBouncingPanel  0x6B0EE2
+#define HOOKSIZE_CAutomobile__Constructor_TowTruckBouncingPanel 8
+static const DWORD CONTINUE_CAutomobile__Constructor_TowTruckBouncingPanel = 0x6B0EEA;
+
+static void __declspec(naked) HOOK_CAutomobile__Constructor_TowTruckBouncingPanel()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        mov     ecx, esi
+        call    IsTowTruckOrClone
+        test    al, al
+        jnz     isTowTruck
+
+        mov     ecx, esi
+        call    IsTractorOrClone
+        test    al, al
+        jnz     isTractor
+
+        mov     ax, word ptr [esi + 0x22]
+        jmp     doCompare
+
+        isTowTruck:
+        mov     ax, 0x20D
+        jmp     doCompare
+
+        isTractor:
+        mov     ax, 0x213
+
+        doCompare:
+        cmp     ax, 0x20D
+        jmp     CONTINUE_CAutomobile__Constructor_TowTruckBouncingPanel
     }
     // clang-format on
 }
@@ -3729,6 +4146,9 @@ void CMultiplayerSA::InitHooks_Vehicles()
     EZHookInstall(CAutomobile__PreRender_PopUpLights);
     EZHookInstall(CVehicle__DoVehicleLights_PopUpLights);
     EZHookInstall(CAutomobile__GetTowBarPos);
+    EZHookInstall(CAutomobile__GetTowBarPos_TugAttachWhitelist);
+    EZHookInstall(CAutomobile__GetTowBarPos_TugDummy);
+    EZHookInstall(CTrailer__GetTowBarPos);
     EZHookInstall(CAutomobile__ProcessControl_DumperDispatch);
     EZHookInstall(CAutomobile__UpdateMovingCollision_DumperAngleReset);
     EZHookInstall(CAutomobile__UpdateMovingCollision_DumperMiscGate);
@@ -3835,4 +4255,10 @@ void CMultiplayerSA::InitHooks_Vehicles()
     EZHookInstall(CAEVehicleAudioEntity__ProcessMovingParts_AndromGate);
     EZHookInstall(CAEVehicleAudioEntity__ProcessMovingParts_AndromCreakCase);
     EZHookInstall(CPlane__PreRender_AndromRampBlock);
+    EZHookInstall(CAutomobile__PreRender_TowTruckHook);
+    EZHookInstall(CAutomobile__PreRender_TractorHook);
+    EZHookInstall(CAutomobile__ProcessControl_TowTruckDispatch);
+    EZHookInstall(CVehicle__UpdateTrailerLink_TowTruck);
+    EZHookInstall(CVehicle__UpdateTractorLink_TowTruck);
+    EZHookInstall(CAutomobile__Constructor_TowTruckBouncingPanel);
 }


### PR DESCRIPTION
#### Summary
Extends `engineRequestModel` custom vehicle model support to the tow truck and tractor, so a cloned one behaves exactly like the stock model: the hook swings, it attaches to a trailer, and it bounces with movement instead of sitting rigid.

As an extra, based on a fix from SilentPatch, the tug can now hook up to trailers it couldn't before (including the utility trailer) and the artict3 can now tow a second trailer behind it, both on the stock models and on their clones.

**So now, you can have B-Trains:**
<img width="1366" height="768" alt="mta-screen_2026-08-16_23-23-56" src="https://github.com/user-attachments/assets/b405b9f0-0d2c-47c7-ac2e-4be69e6c4ffb" />


#### Motivation
Continues the ongoing series of fixes for vehicles with hardcoded native behaviour that `engineRequestModel` clones don't inherit (#5161, #5162, #5165, #5166, #5171, #5181). The tractor is included here since it shares the same code as the tow truck; the tug and artict3 fixes came up while working through that same area.

Part of https://github.com/multitheftauto/mtasa-blue/issues/1861.

#### Test plan
Tested in game with clones of the tow truck, tractor and tug, and with both the stock and cloned artict3. Stock vehicles behave exactly as before, since the tow truck/tractor hooks are gated on the same model checks the game already used, and the tug/artict3 fixes only touch behaviour that was already broken without any custom models involved.

[towtruck.zip](https://github.com/user-attachments/files/31127558/towtruck.zip)

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.