### PR TITLE
Fix #5154: Resume CEF rendering after setBrowserRenderingPaused

### DIFF
--- a/Client/cefweb/CWebView.cpp
+++ b/Client/cefweb/CWebView.cpp
@@ -302,6 +302,15 @@ void CWebView::SetRenderingPaused(bool bPaused)
             m_RenderData.bufferSize = 0;
             m_RenderData.popupBuffer.reset();
         }
+        else
+        {
+            // WasHidden(false) does not produce OnPaint with external begin-frame
+            // scheduling. Request a full frame so CSS hover / compositor updates
+            // are not left on the last cached texture.
+            m_pWebView->GetHost()->WasResized();
+            m_pWebView->GetHost()->Invalidate(PET_VIEW);
+            m_pWebView->GetHost()->SendExternalBeginFrame();
+        }
     }
 }
 


### PR DESCRIPTION
#### Summary
`setBrowserRenderingPaused(false)` did not properly resume CEF painting in 1.7. After #4634 browsers use external begin-frame scheduling, so `WasHidden(false)` alone does not produce `OnPaint`. Interactive CSS (hover) stayed on the last cached texture even though JavaScript still ran.

On resume the host now calls `WasResized()`, `Invalidate(PET_VIEW)` and `SendExternalBeginFrame()` so the compositor uploads a fresh frame.

#### Motivation
Fixes #5154. This worked in 1.6 and broke in 1.7 after the CEF performance changes. The report that `guiSetInputMode` made it easier to notice matches a paused browser being shown again without a forced repaint.

#### Test plan
1. Create a CEF browser with hover CSS (and optional mouseenter SFX).
2. `setBrowserRenderingPaused(browser, true)` then `setBrowserRenderingPaused(browser, false)`.
3. Move the cursor over interactive elements: hover styles should update, not stay on the previous frame.
4. Repeat together with `guiSetInputMode("no_binds")` / `"allow_binds"`.
5. Alt-tab away and back: rendering should still be correct.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.