### PR TITLE
Fix #5200: Apply BiDi reordering to Persian chat text

### DIFF
--- a/Client/core/CChat.cpp
+++ b/Client/core/CChat.cpp
@@ -1112,6 +1112,17 @@ float CChat::GetTextExtent(const char* szText, float fScale)
     return g_pCore->GetGraphics()->GetDXTextExtent(szText, fScale, g_pChat->m_pDXFont);
 }
 
+SString CChat::BidifyText(const char* szText)
+{
+    if (!szText || szText[0] == '\0')
+        return SString();
+
+    if (!g_pChat || !g_pChat->m_pManager)
+        return szText;
+
+    return g_pChat->m_pManager->BidifyText(szText);
+}
+
 void CChat::DrawTextString(const char* szText, CRect2D DrawArea, float fZ, CRect2D ClipRect, unsigned long ulFormat, unsigned long ulColor, float fScaleX,
                            float fScaleY, bool bOutline, const CRect2D& RenderBounds)
 {
@@ -1175,6 +1186,12 @@ CChatLine::CChatLine()
 void CChatLine::UpdateCreationTime()
 {
     m_ulCreationTime = GetTickCount32();
+}
+
+void CChatLine::ApplyBidi()
+{
+    for (auto& section : m_Sections)
+        section.SetText(section.m_text.c_str());
 }
 
 //
@@ -1243,10 +1260,12 @@ const char* CChatLine::Format(const char* text, float width, CColor& color, bool
 
     if (*sectionEnd == '\0')
     {
+        ApplyBidi();
         return nullptr;
     }
     else if (*sectionEnd == '\n')
     {
+        ApplyBidi();
         return CalcAnsiPtr(text, sectionEnd + 1);
     }
     else
@@ -1259,6 +1278,7 @@ const char* CChatLine::Format(const char* text, float width, CColor& color, bool
             {
                 // The line consists of one huge word. Leave the one section we created as it
                 // is (with the huge word cut off) and return remaining as the rest of the word
+                ApplyBidi();
                 return CalcAnsiPtr(text, sectionEnd);
             }
             else
@@ -1275,6 +1295,7 @@ const char* CChatLine::Format(const char* text, float width, CColor& color, bool
             wstrTemp.resize(lastWrapPoint - sectionStart);
             last.m_text = UTF16ToMbUTF8(wstrTemp);
         }
+        ApplyBidi();
         return CalcAnsiPtr(text, lastWrapPoint);
     }
 }
@@ -1364,6 +1385,12 @@ CChatLineSection& CChatLineSection::operator=(const CChatLineSection& other)
     m_cachedWidth = other.m_cachedWidth;
     m_cachedLength = other.m_cachedLength;
     return *this;
+}
+
+void CChatLineSection::SetText(const char* text)
+{
+    m_text = CChat::BidifyText(text);
+    InvalidateCache();
 }
 
 void CChatLineSection::Draw(const CVector2D& position, unsigned char alpha, bool shadow, bool outline, const CRect2D& renderBounds)

--- a/Client/core/CChat.h
+++ b/Client/core/CChat.h
@@ -68,7 +68,7 @@ public:
     void        Draw(const CVector2D& position, unsigned char alpha, bool shadow, bool outline, const CRect2D& renderBounds);
     float       GetWidth() const;
     const char* GetText() { return m_text.c_str(); }
-    void        SetText(const char* text) { m_text = text; }
+    void        SetText(const char* text);
     void        GetColor(CColor& color) { color = m_color; }
     void        SetColor(const CColor& color) { m_color = color; }
     void        InvalidateCache();
@@ -96,6 +96,8 @@ public:
     void          InvalidateCache();
 
 protected:
+    void ApplyBidi();
+
     bool                          m_bActive;
     std::vector<CChatLineSection> m_Sections;
     unsigned long                 m_ulCreationTime;
@@ -188,9 +190,10 @@ public:
     void        SetCommand(const char* szCommand);
     CVector2D   CalcInputSize();
 
-    static float GetFontHeight(float fScale = 1.0f);
-    static float GetTextExtent(const char* szText, float fScale = 1.0f);
-    static void  DrawTextString(const char* szText, CRect2D DrawArea, float fZ, CRect2D ClipRect, unsigned long ulFormat, unsigned long ulColor, float fScaleX,
+    static float   GetFontHeight(float fScale = 1.0f);
+    static float   GetTextExtent(const char* szText, float fScale = 1.0f);
+    static SString BidifyText(const char* szText);
+    static void    DrawTextString(const char* szText, CRect2D DrawArea, float fZ, CRect2D ClipRect, unsigned long ulFormat, unsigned long ulColor, float fScaleX,
                                 float fScaleY, bool bOutline, const CRect2D& RenderBounds);
 
     void SetColor(const CColor& Color);

--- a/Client/gui/CGUI_Impl.cpp
+++ b/Client/gui/CGUI_Impl.cpp
@@ -216,6 +216,17 @@ void CGUI_Impl::SetBidiEnabled(bool bEnabled)
     m_pSystem->SetBidiEnabled(bEnabled);
 }
 
+SString CGUI_Impl::BidifyText(const char* szText)
+{
+    if (!szText || szText[0] == '\0')
+        return SString();
+
+    // Reuse CEGUI minibidi (UAX #9 + Arabic/Persian shaping) so DX chat
+    // matches GUI editboxes for mixed RTL/LTR strings.
+    const CEGUI::String bidified = GetUTFString(szText).bidify();
+    return SString(bidified.c_str());
+}
+
 void CGUI_Impl::SubscribeToMouseEvents()
 {
     // Mouse events

--- a/Client/gui/CGUI_Impl.h
+++ b/Client/gui/CGUI_Impl.h
@@ -70,6 +70,7 @@ public:
 
     void SetSkin(const char* szName);
     void SetBidiEnabled(bool bEnabled);
+    SString BidifyText(const char* szText);
 
     void Draw();
     void Invalidate();

--- a/Client/sdk/gui/CGUI.h
+++ b/Client/sdk/gui/CGUI.h
@@ -52,6 +52,7 @@ class CGUI
 public:
     virtual void SetSkin(const char* szName) = 0;
     virtual void SetBidiEnabled(bool bEnabled) = 0;
+    virtual SString BidifyText(const char* szText) = 0;
 
     virtual void Draw() = 0;
     virtual void Invalidate() = 0;


### PR DESCRIPTION
#### Summary
Chat messages were drawn in logical UTF-8 order, so mixed Persian/English strings appeared LTR. CEGUI already runs minibidi (`String::bidify`, UAX-9 plus Arabic/Persian shaping) for GUI widgets; the DX chat path did not.

`CGUI::BidifyText` now exposes that same conversion, and chat line sections use it after wrapping so `سلام Azmoon. خوبی؟` is displayed as `خوبی؟ .Azmoon سلام`.

#### Motivation
Fixes #5200. Persian is a right-to-left language; without BiDi, English fragments and punctuation sit in the wrong visual order.

#### Test plan
1. Join a server and open chat (or F8 `say`).
2. Send `سلام Azmoon. خوبی؟` - it should read visually as `خوبی؟ .Azmoon سلام`.
3. Send a Persian-only message and an English-only message - both should still look normal.
4. Send a color-coded line (`#FF0000سلام #FFFFFFAzmoon`) and confirm it does not crash.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.