### PR TITLE
Fix #5153: Delay bike/BMX exit until the rider can step off

### DIFF
--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -694,6 +694,11 @@ float CVehicleSA::GetHeliRotorSpeed() const
     return static_cast<CHeliSAInterface*>(m_pInterface)->m_wheelSpeed[1];
 }
 
+bool CVehicleSA::CanPedStepOutCar(bool bIgnoreSpeedUpright)
+{
+    return ((bool(__thiscall*)(CVehicleSAInterface*, bool))FUNC_CVehicle_CanPedStepOutCar)(GetVehicleInterface(), bIgnoreSpeedUpright);
+}
+
 void CVehicleSA::SetHeliRotorSpeed(float speed)
 {
     static_cast<CHeliSAInterface*>(GetInterface())->m_wheelSpeed[1] = speed;

--- a/Client/game_sa/CVehicleSA.h
+++ b/Client/game_sa/CVehicleSA.h
@@ -39,6 +39,7 @@ struct RwTexture;
 #define FUNC_CVehicle_IsUpsideDown               0x6D1D90
 #define FUNC_CVehicle_SetEngineOn                0x41BDD0
 #define FUNC_CVehicle_IsPassenger                0x6D1BD0
+#define FUNC_CVehicle_CanPedStepOutCar           0x6D1F30
 #define FUNC_CTrain_FindPositionOnTrackFromCoors 0x6F6CC0
 
 #define FUNC_CVehicle_QueryPickedUpEntityWithWinch   0x6d3cf0
@@ -559,6 +560,7 @@ public:
     bool           IsDrowning() { return GetVehicleInterface()->m_nVehicleFlags.bIsDrowning; };
     bool           IsEngineOn() { return GetVehicleInterface()->m_nVehicleFlags.bEngineOn; };
     bool           IsHandbrakeOn() { return GetVehicleInterface()->m_nVehicleFlags.bIsHandbrakeOn; };
+    bool           CanPedStepOutCar(bool bIgnoreSpeedUpright = false) override;
     bool           IsRCVehicle() { return GetVehicleInterface()->m_nVehicleFlags.bIsRCVehicle; };
     bool           GetAlwaysLeaveSkidMarks() { return GetVehicleInterface()->m_nVehicleFlags.bAlwaysSkidMarks; };
     bool           GetCanBeDamaged() { return GetVehicleInterface()->m_nVehicleFlags.bCanBeDamaged; };

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -1715,14 +1715,64 @@ void CClientGame::SetMimic(unsigned int uiMimicCount)
 
 #endif
 
+namespace
+{
+    bool IsBikeOrBmxVehicle(const CClientVehicle* pVehicle)
+    {
+        const eClientVehicleType eType = pVehicle->GetVehicleType();
+        return eType == CLIENTVEHICLE_BIKE || eType == CLIENTVEHICLE_BMX;
+    }
+
+    bool CanPedStepOutOfClientVehicle(CClientVehicle* pVehicle)
+    {
+        if (CVehicle* pGameVehicle = pVehicle->GetGameVehicle())
+            return pGameVehicle->CanPedStepOutCar();
+
+        // Streamed-out fallback matching CVehicle::CanPedStepOutCar (0x6D1F30) when upright:
+        // 2D speed <= 0.01 and |vz| <= 0.05.
+        CVector vecMoveSpeed;
+        pVehicle->GetMoveSpeed(vecMoveSpeed);
+        const float fAbsMoveSpeedZ = vecMoveSpeed.fZ < 0.0f ? -vecMoveSpeed.fZ : vecMoveSpeed.fZ;
+        return (vecMoveSpeed.fX * vecMoveSpeed.fX + vecMoveSpeed.fY * vecMoveSpeed.fY) <= (0.01f * 0.01f) && fAbsMoveSpeedZ <= 0.05f;
+    }
+}
+
 void CClientGame::DoVehicleInKeyCheck()
 {
     // Grab the controller state
     CControllerState cs;
     g_pGame->GetPad()->GetCurrentControllerState(&cs);
     static bool bButtonTriangleWasDown = false;
+    static bool bHoldExitOnBike = false;
+
+    CClientVehicle* pOccupiedVehicle = m_pLocalPlayer->GetOccupiedVehicle();
+    const bool      bOnBikeOrBmx = pOccupiedVehicle && IsBikeOrBmxVehicle(pOccupiedVehicle);
+
     if (cs.ButtonTriangle)
     {
+        // Bikes/BMX: native F is a brake until the bike is slow enough to step off.
+        // Sending VEHICLE_REQUEST_OUT on the key press makes remotes dismount while
+        // the local LeaveCar task is still waiting for a stop (#5153).
+        if (bOnBikeOrBmx && !m_pLocalPlayer->IsGettingOutOfVehicle())
+        {
+            if (!CanPedStepOutOfClientVehicle(pOccupiedVehicle))
+            {
+                bButtonTriangleWasDown = true;
+                bHoldExitOnBike = true;
+                return;
+            }
+
+            if (bHoldExitOnBike || !bButtonTriangleWasDown)
+            {
+                bButtonTriangleWasDown = true;
+                bHoldExitOnBike = false;
+                m_pLocalPlayer->ExitVehicle();
+                return;
+            }
+        }
+
+        bHoldExitOnBike = false;
+
         if (!bButtonTriangleWasDown)
         {
             bButtonTriangleWasDown = true;
@@ -1752,6 +1802,7 @@ void CClientGame::DoVehicleInKeyCheck()
     else
     {
         bButtonTriangleWasDown = false;
+        bHoldExitOnBike = false;
     }
 }
 

--- a/Client/mods/deathmatch/logic/CClientVehicle.h
+++ b/Client/mods/deathmatch/logic/CClientVehicle.h
@@ -170,7 +170,7 @@ public:
     eClientEntityType GetType() const { return CCLIENTVEHICLE; };
 
     const char*        GetNamePointer() { return m_pModelInfo->GetNameIfVehicle(); };
-    eClientVehicleType GetVehicleType() { return m_eVehicleType; };
+    eClientVehicleType GetVehicleType() const { return m_eVehicleType; };
 
     void GetPosition(CVector& vecPosition) const;
     void SetPosition(const CVector& vecPosition) { SetPosition(vecPosition, true); }

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -4258,12 +4258,10 @@ void CMultiplayerSA::DisableEnterExitVehicleKey(bool bDisabled)
         MemPut<BYTE>(0x6AD75D, 0x90);
         MemPut<BYTE>(0x6AD75E, 0x90);
 
-        // CBike__ProcessControlInputs
-        MemPut<BYTE>(0x6BE34B, 0x32);
-        MemPut<BYTE>(0x6BE34C, 0xC0);
-        MemPut<BYTE>(0x6BE34D, 0x90);
-        MemPut<BYTE>(0x6BE34E, 0x90);
-        MemPut<BYTE>(0x6BE34F, 0x90);
+        // Leave CBike::ProcessControlInputs (0x6BE34B CALL CPad::GetExitVehicle) alone.
+        // Patching it to XOR AL,AL removed the single-player F-brake on bikes/BMX.
+        // GetExitVehicle is held-state, not JustDown; it only feeds the brake. The
+        // actual native leave is CPad::ExitVehicleJustDown / CPlayerInfo::Process.
 
         // CTaskSimpleJetPack__ProcessControlInput
         MemPut<BYTE>(0x67E834, 0x32);

--- a/Client/sdk/game/CVehicle.h
+++ b/Client/sdk/game/CVehicle.h
@@ -198,6 +198,7 @@ public:
     virtual bool           IsDrowning() = 0;
     virtual bool           IsEngineOn() = 0;
     virtual bool           IsHandbrakeOn() = 0;
+    virtual bool           CanPedStepOutCar(bool bIgnoreSpeedUpright = false) = 0;
     virtual bool           IsRCVehicle() = 0;
     virtual bool           GetAlwaysLeaveSkidMarks() = 0;
     virtual bool           GetCanBeDamaged() = 0;


### PR DESCRIPTION
#### Summary
Pressing F on a moving bicycle/BMX sent `VEHICLE_REQUEST_OUT` immediately. Remote players started the leave animation while the local `LeaveCar` task was still waiting for a stop, so the rider stayed on the bike locally and appeared to dismount for everyone else.

MTA also NOP'd `CBike::ProcessControlInputs`'s `CPad::GetExitVehicle` call, which in single-player is the held-F brake (handbrake-like, no S-key lean). Native leave was already blocked via `CPlayerInfo` / `CPad::ExitVehicleJustDown`.

F on bikes/BMX now keeps that native brake, and the exit packet is only sent once `CanPedStepOutCar` is true while F is still held. Releasing F before a stop cancels the pending exit.

#### Motivation
Fixes #5153. Single-player brakes with F and only dismounts at ~0 speed if the key is still held. MTA skipped that brake and synced the leave too early.

#### Test plan
1. Ride a BMX slowly, hold F: the bike should brake, and you should only dismount near a complete stop. A second player should see the same.
2. Reach ~50 speed units, hold F: you should not jump off immediately; brake first, then dismount when stopped. The remote player must not dismount earlier.
3. Hold F while moving, then release before stopping: you should stay on the bike.
4. Repeat on a motorcycle. Cars/F should still exit on key press as before.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.