### PR TITLE
Fix engineRequestModel objects having no physics

### DIFF
--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -1871,7 +1871,6 @@ void CModelInfoSA::MakeObjectModel(ushort usBaseID)
     m_pInterface->usNumberOfRefs = 0;
     m_pInterface->pRwObject = nullptr;
     m_pInterface->usUnknown = 65535;
-    m_pInterface->usDynamicIndex = 65535;
     m_pInterface->m_nAnimFileIndex = 0xFFFFFFFF;
 
     ppModelInfo[m_dwModelID] = m_pInterface;
@@ -1889,7 +1888,6 @@ void CModelInfoSA::MakeObjectDamageableModel(std::uint16_t baseModel)
     m_pInterface->usNumberOfRefs = 0;
     m_pInterface->pRwObject = nullptr;
     m_pInterface->usUnknown = 65535;
-    m_pInterface->usDynamicIndex = 65535;
     m_pInterface->m_damagedAtomic = nullptr;
 
     ppModelInfo[m_dwModelID] = m_pInterface;
@@ -1907,7 +1905,6 @@ void CModelInfoSA::MakeTimedObjectModel(ushort usBaseID)
     m_pInterface->usNumberOfRefs = 0;
     m_pInterface->pRwObject = nullptr;
     m_pInterface->usUnknown = 65535;
-    m_pInterface->usDynamicIndex = 65535;
     m_pInterface->timeInfo.m_wOtherTimeModel = -1;
 
     ppModelInfo[m_dwModelID] = m_pInterface;
@@ -1924,7 +1921,6 @@ void CModelInfoSA::MakeClumpModel(ushort usBaseID)
     pNewInterface->usNumberOfRefs = 0;
     pNewInterface->pRwObject = nullptr;
     pNewInterface->usUnknown = 65535;
-    pNewInterface->usDynamicIndex = 65535;
 
     ppModelInfo[m_dwModelID] = pNewInterface;
 

--- a/Client/mods/deathmatch/logic/CClientModelManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientModelManager.cpp
@@ -66,7 +66,7 @@ bool CClientModelManager::Remove(const std::shared_ptr<CClientModel>& pModel)
 
 int CClientModelManager::GetFirstFreeModelID(void)
 {
-    const unsigned int uiMaxModelID = g_pGame->GetBaseIDforCOL();
+    const unsigned int uiMaxModelID = MAX_MODEL_DFF_ID;
     for (unsigned int i = 0; i < uiMaxModelID; i++)
     {
         CModelInfo* pModelInfo = g_pGame->GetModelInfo(i, true);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -2014,9 +2014,9 @@ int CLuaEngineDefs::EngineGetModelPhysicalPropertiesGroup(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        if (modelId >= g_pGame->GetBaseIDforTXD())
+        if (modelId >= g_pGame->GetBaseIDforCOL())
         {
-            argStream.SetCustomError(SString("Expected model ID in range [0-%u] at argument 1", g_pGame->GetBaseIDforTXD() - 1));
+            argStream.SetCustomError(SString("Expected model ID in range [0-%u] at argument 1", g_pGame->GetBaseIDforCOL() - 1));
             return luaL_error(luaVM, argStream.GetFullErrorMessage());
         }
 
@@ -2045,9 +2045,9 @@ int CLuaEngineDefs::EngineSetModelPhysicalPropertiesGroup(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        if (modelId > g_pGame->GetBaseIDforTXD() - 1)
+        if (modelId > g_pGame->GetBaseIDforCOL() - 1)
         {
-            argStream.SetCustomError(SString("Expected model ID in range [0-%u] at argument 1", g_pGame->GetBaseIDforTXD() - 1));
+            argStream.SetCustomError(SString("Expected model ID in range [0-%u] at argument 1", g_pGame->GetBaseIDforCOL() - 1));
             return luaL_error(luaVM, argStream.GetFullErrorMessage());
         }
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -2080,9 +2080,9 @@ int CLuaEngineDefs::EngineRestoreModelPhysicalPropertiesGroup(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        if (modelId > g_pGame->GetBaseIDforTXD() - 1)
+        if (modelId > g_pGame->GetBaseIDforCOL() - 1)
         {
-            argStream.SetCustomError(SString("Expected model ID in range [0-%u] at argument 1", g_pGame->GetBaseIDforTXD() - 1));
+            argStream.SetCustomError(SString("Expected model ID in range [0-%u] at argument 1", g_pGame->GetBaseIDforCOL() - 1));
             return luaL_error(luaVM, argStream.GetFullErrorMessage());
         }
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -2014,9 +2014,9 @@ int CLuaEngineDefs::EngineGetModelPhysicalPropertiesGroup(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        if (modelId >= g_pGame->GetBaseIDforCOL())
+        if (modelId >= g_pGame->GetBaseIDforTXD())
         {
-            argStream.SetCustomError(SString("Expected model ID in range [0-%u] at argument 1", g_pGame->GetBaseIDforCOL() - 1));
+            argStream.SetCustomError(SString("Expected model ID in range [0-%u] at argument 1", g_pGame->GetBaseIDforTXD() - 1));
             return luaL_error(luaVM, argStream.GetFullErrorMessage());
         }
 
@@ -2045,9 +2045,9 @@ int CLuaEngineDefs::EngineSetModelPhysicalPropertiesGroup(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        if (modelId > g_pGame->GetBaseIDforCOL() - 1)
+        if (modelId > g_pGame->GetBaseIDforTXD() - 1)
         {
-            argStream.SetCustomError(SString("Expected model ID in range [0-%u] at argument 1", g_pGame->GetBaseIDforCOL() - 1));
+            argStream.SetCustomError(SString("Expected model ID in range [0-%u] at argument 1", g_pGame->GetBaseIDforTXD() - 1));
             return luaL_error(luaVM, argStream.GetFullErrorMessage());
         }
 
@@ -2080,9 +2080,9 @@ int CLuaEngineDefs::EngineRestoreModelPhysicalPropertiesGroup(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        if (modelId > g_pGame->GetBaseIDforCOL() - 1)
+        if (modelId > g_pGame->GetBaseIDforTXD() - 1)
         {
-            argStream.SetCustomError(SString("Expected model ID in range [0-%u] at argument 1", g_pGame->GetBaseIDforCOL() - 1));
+            argStream.SetCustomError(SString("Expected model ID in range [0-%u] at argument 1", g_pGame->GetBaseIDforTXD() - 1));
             return luaL_error(luaVM, argStream.GetFullErrorMessage());
         }
 


### PR DESCRIPTION
#### Summary
Cloned objects with `engineRequestModel('object')` now keep the parent's physics properties group instead of being forced static, and `engineGetModelPhysicalPropertiesGroup`/`engineSetModelPhysicalPropertiesGroup` no longer reject requested model ids.

#### Motivation
Fixes #3074.

#### Test plan
Created an object and a clone of it via `engineRequestModel`, gave both velocity on stream in; both now behave the same instead of the clone falling through the ground. Also confirmed `engineGetModelPhysicalPropertiesGroup`/`engineSetModelPhysicalPropertiesGroup` no longer error on a requested model id, and that the clone already reports the same group as its parent without calling the setter at all.

```lua
local parentModel = 1252
local model = engineRequestModel('object', parentModel)
--local model = engineRequestModel('object') -- Test with another object

function velocityOnStreamIn()
    setElementVelocity(source, 0.1, 0, 0)
end

addCommandHandler('testme', function()
    local parentGroup = engineGetModelPhysicalPropertiesGroup(parentModel)
    local cloneGroup = engineGetModelPhysicalPropertiesGroup(model)
    outputChatBox('parent group: ' .. tostring(parentGroup) .. ' | clone group (already inherited): ' .. tostring(cloneGroup))

    local success = engineSetModelPhysicalPropertiesGroup(model, parentGroup)
    outputChatBox('explicit set: ' .. tostring(success))

    local x, y, z = getElementPosition(localPlayer)
    local o1 = createObject(parentModel, x + 2, y, z)
    local o2 = createObject(model, x + 2, y + 2, z)
    addEventHandler('onClientElementStreamIn', o1, velocityOnStreamIn)
    addEventHandler('onClientElementStreamIn', o2, velocityOnStreamIn)
end)
```

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.