### PR TITLE
Add #5089: Extra controller options for device, triggers, vibration and saturation

### DIFF
--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -327,6 +327,8 @@ void CClientVariables::LoadDefaults()
     DEFAULT("fly_with_mouse", false);                                       // flying with mouse controls
     DEFAULT("steer_with_mouse", false);                                     // steering with mouse controls
     DEFAULT("classic_controls", false);                                     // classic/standard controls
+    DEFAULT("controller_device", _S("auto"));                               // auto / xinput:N / dinput:guid
+    DEFAULT("controller_vibration", true);                                  // XInput rumble from GTA pad shake
     DEFAULT("mastervolume", 1.0f);                                          // master volume
     DEFAULT("mtavolume", 1.0f);                                             // custom sound's volume
     DEFAULT("voicevolume", 1.0f);                                           // voice chat output volume

--- a/Client/core/CJoystickManager.cpp
+++ b/Client/core/CJoystickManager.cpp
@@ -15,6 +15,7 @@
 #include <dinputd.h>
 #include <atomic>
 #include <thread>
+#include <vector>
 
 using std::string;
 
@@ -40,10 +41,80 @@ constexpr uint JOYSTICK_RETRY_DELAY_MS = 3000;
 // interface
 constexpr uint JOYSTICK_DEVICE_CHANGE_SETTLE_MS = 300;
 
+// Stick/trigger deadzone is a percentage of throw. Saturation 0-100 keeps the old mapping
+// (100 = linear, lower = reaches max sooner). Values 101-200 multiply beyond linear so a
+// worn stick that never hits the physical extreme can still produce a full GTA axis.
+constexpr int JOYSTICK_DEADZONE_MAX = 49;
+constexpr int JOYSTICK_SATURATION_MAX = 200;
+constexpr int JOYSTICK_DEFAULT_TRIGGER_DEADZONE = 5;
+
 SString GUIDToString(const GUID& g)
 {
     return SString("%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x", g.Data1, g.Data2, g.Data3, g.Data4[0], g.Data4[1], g.Data4[2], g.Data4[3], g.Data4[4],
                    g.Data4[5], g.Data4[6], g.Data4[7]);
+}
+
+bool StringToGUID(const char* szGuid, GUID& g)
+{
+    unsigned int d1 = 0, d2 = 0, d3 = 0, b[8] = {};
+    if (!szGuid ||
+        sscanf(szGuid, "%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x", &d1, &d2, &d3, &b[0], &b[1], &b[2], &b[3], &b[4], &b[5], &b[6], &b[7]) != 11)
+        return false;
+
+    g.Data1 = d1;
+    g.Data2 = static_cast<WORD>(d2);
+    g.Data3 = static_cast<WORD>(d3);
+    for (int i = 0; i < 8; i++)
+        g.Data4[i] = static_cast<BYTE>(b[i]);
+    return true;
+}
+
+struct SParsedControllerId
+{
+    enum eType
+    {
+        Auto,
+        XInput,
+        DirectInput,
+    } type = Auto;
+    int  iXInputIndex = 0;
+    GUID guidInstance{};
+    bool bHasGuid = false;
+};
+
+SParsedControllerId ParseControllerId(const string& strId)
+{
+    SParsedControllerId parsed;
+    if (strId.empty() || strId == "auto")
+        return parsed;
+
+    if (strId.compare(0, 7, "xinput:") == 0)
+    {
+        parsed.type = SParsedControllerId::XInput;
+        parsed.iXInputIndex = Clamp(0, atoi(strId.c_str() + 7), 3);
+        return parsed;
+    }
+
+    if (strId.compare(0, 7, "dinput:") == 0)
+    {
+        parsed.type = SParsedControllerId::DirectInput;
+        parsed.bHasGuid = StringToGUID(strId.c_str() + 7, parsed.guidInstance);
+        return parsed;
+    }
+
+    return parsed;
+}
+
+SString GetXInputDisplayName(int iIndex, const XINPUT_CAPABILITIES& Capabilities)
+{
+    const char* subTypeNames[] = {"Unknown", "Gamepad", "Wheel", "Arcade stick", "Flight stick", "Dance pad", "Guitar", "Drum kit"};
+    SString     strType;
+    if (Capabilities.SubType < NUMELMS(subTypeNames))
+        strType = subTypeNames[Capabilities.SubType];
+    else
+        strType = SString("Subtype %d", Capabilities.SubType);
+
+    return SString(_("%s (controller %d)"), strType.c_str(), iIndex + 1);
 }
 
 DEFINE_GUID(GUID_Xbox360Controller, 0x028E045E, 0x0000, 0x0000, 0x00, 0x00, 0x50, 0x49, 0x44, 0x56, 0x49, 0x44);
@@ -104,6 +175,8 @@ struct SInputDeviceInfo
     int                   iAxisCount;
     int                   iDeadZone;
     int                   iSaturation;
+    int                   iTriggerDeadZone;
+    int                   iTriggerSaturation;
     GUID                  guidProduct;
     string                strGuid;
     string                strProductName;
@@ -126,10 +199,12 @@ struct SInputDeviceInfo
 //
 struct SJoystickScanResult
 {
-    IDirectInputDevice8A* pDevice = nullptr;
-    int                   iAxisCount = 0;
-    GUID                  guidProduct{};
-    string                strProductName;
+    IDirectInputDevice8A*                pDevice = nullptr;
+    int                                  iAxisCount = 0;
+    GUID                                 guidProduct{};
+    GUID                                 guidInstance{};
+    string                               strProductName;
+    std::vector<std::pair<GUID, string>> listedDevices;
 
     struct
     {
@@ -174,14 +249,23 @@ public:
     virtual void OnPossibleDeviceChange();
 
     // Settings
-    virtual string GetControllerName();
-    virtual int    GetDeadZone();
-    virtual int    GetSaturation();
-    virtual void   SetDeadZone(int iDeadZone);
-    virtual void   SetSaturation(int iSaturation);
-    virtual int    GetSettingsRevision();
-    virtual void   SetDefaults();
-    virtual bool   SaveToXML();
+    virtual string                             GetControllerName();
+    virtual int                                GetDeadZone();
+    virtual int                                GetSaturation();
+    virtual int                                GetTriggerDeadZone();
+    virtual int                                GetTriggerSaturation();
+    virtual void                               SetDeadZone(int iDeadZone);
+    virtual void                               SetSaturation(int iSaturation);
+    virtual void                               SetTriggerDeadZone(int iDeadZone);
+    virtual void                               SetTriggerSaturation(int iSaturation);
+    virtual bool                               GetVibrationEnabled();
+    virtual void                               SetVibrationEnabled(bool bEnabled);
+    virtual string                             GetSelectedControllerId();
+    virtual void                               SetSelectedControllerId(const string& strId);
+    virtual std::vector<SJoystickDeviceChoice> GetAvailableControllers();
+    virtual int                                GetSettingsRevision();
+    virtual void                               SetDefaults();
+    virtual bool                               SaveToXML();
 
     // Binding
     virtual int    GetOutputCount();
@@ -202,21 +286,38 @@ private:
     void      ReadCurrentState();
     CXMLNode* GetConfigNode(bool bCreateIfRequired);
     bool      LoadFromXML();
+    bool      IsTriggerSourceAxis(int iAxisIndex) const;
+    void      ApplyAxisResponse(float& fResult, int iSaturation);
+    void      ApplyVibration();
+    void      StopVibration();
+    void      SyncGtaVibrationPref();
+    void      ReleaseDirectInputDevice();
+    void      ApplyControllerSelection(bool bReleaseCurrent);
+    void      RefreshDirectInputDeviceList();
+    int       FindFirstXInputIndex() const;
 
-    bool             m_bDoneInit;
-    int              m_SettingsRevision;
-    SInputDeviceInfo m_DevInfo;
-    SJoystickState   m_JoystickState;
-    SMappingLine     m_currentMapping[10];
-    bool             m_bUseXInput;
-    bool             m_bXInputDeviceAttached;
-    uint             m_uiXInputReattachDelay;
-    CElapsedTime     m_XInputReattachTimer;
-    uint             m_uiDirectInputReattachDelay;
-    CElapsedTime     m_DirectInputReattachTimer;
-    CElapsedTime     m_PollFailTimer;
-    bool             m_bAutoDeadZoneEnabled;
-    int              m_iAutoDeadZoneCounter;
+    bool                                 m_bDoneInit;
+    int                                  m_SettingsRevision;
+    SInputDeviceInfo                     m_DevInfo;
+    SJoystickState                       m_JoystickState;
+    SMappingLine                         m_currentMapping[10];
+    bool                                 m_bUseXInput;
+    bool                                 m_bXInputDeviceAttached;
+    int                                  m_iXInputUserIndex;
+    uint                                 m_uiXInputReattachDelay;
+    CElapsedTime                         m_XInputReattachTimer;
+    uint                                 m_uiDirectInputReattachDelay;
+    CElapsedTime                         m_DirectInputReattachTimer;
+    CElapsedTime                         m_PollFailTimer;
+    bool                                 m_bAutoDeadZoneEnabled;
+    int                                  m_iAutoDeadZoneCounter;
+    string                               m_strSelectedControllerId;
+    bool                                 m_bVibrationEnabled;
+    bool                                 m_bVibrationWasActive;
+    CElapsedTime                         m_VibrationTimer;
+    bool                                 m_bPreferredInstanceValid;
+    GUID                                 m_PreferredInstanceGuid;
+    std::vector<std::pair<GUID, string>> m_ListedDInputDevices;
 
     // Used during axis binding
     bool           m_bCaptureAxis;
@@ -261,27 +362,28 @@ CJoystickManager::CJoystickManager()
 {
     m_iAutoDeadZoneCounter = 20;
     m_bAutoDeadZoneEnabled = true;
+    m_strSelectedControllerId = "auto";
+    m_bVibrationEnabled = true;
+    m_iXInputUserIndex = 0;
 
-    // See if we have a XInput compatible device
-    XINPUT_CAPABILITIES Capabilities;
-    DWORD               dwStatus = XInputGetCapabilities(0, XINPUT_FLAG_GAMEPAD, &Capabilities);
-    if (dwStatus == ERROR_SUCCESS)
+    // CVars may not be loaded yet if this is constructed very early; ApplyControllerSelection
+    // then just auto-picks the first XInput slot like we used to.
+    if (CClientVariables::GetSingletonPtr())
     {
-        WriteDebugEvent(SString("XInput device detected. Type:%d SubType:%d Flags:0x%04x", Capabilities.Type, Capabilities.SubType, Capabilities.Flags));
-        WriteDebugEvent(SString("XInput - wButtons:0x%04x  bLeftTrigger:0x%02x  bRightTrigger:0x%02x", Capabilities.Gamepad.wButtons,
-                                Capabilities.Gamepad.bLeftTrigger, Capabilities.Gamepad.bRightTrigger));
-        WriteDebugEvent(SString("XInput - sThumbLX:0x%04x  sThumbLY:0x%04x  sThumbRX:0x%04x  sThumbRY:0x%04x", Capabilities.Gamepad.sThumbLX,
-                                Capabilities.Gamepad.sThumbLY, Capabilities.Gamepad.sThumbRX, Capabilities.Gamepad.sThumbRY));
-        WriteDebugEvent(SString("XInput - wLeftMotorSpeed:0x%04x  wRightMotorSpeed:0x%04x", Capabilities.Vibration.wLeftMotorSpeed,
-                                Capabilities.Vibration.wRightMotorSpeed));
-        m_bUseXInput = true;
+        std::string strDevice;
+        if (CVARS_GET("controller_device", strDevice) && !strDevice.empty())
+            m_strSelectedControllerId = strDevice;
+        CVARS_GET("controller_vibration", m_bVibrationEnabled);
     }
 
+    ApplyControllerSelection(false);
     SetDefaults();
 }
 
 CJoystickManager::~CJoystickManager()
 {
+    StopVibration();
+
     // Let a scan still in flight finish before the members it writes into go away
     if (m_ScanThread.joinable())
         m_ScanThread.join();
@@ -303,17 +405,23 @@ namespace
 {
     struct SJoystickEnumContext
     {
-        bool                  bPreferredValid = false;
-        GUID                  preferredGuidInstance{};
-        IDirectInputDevice8A* pDevice = nullptr;
+        bool                                 bPreferredValid = false;
+        GUID                                 preferredGuidInstance{};
+        IDirectInputDevice8A*                pDevice = nullptr;
+        std::vector<std::pair<GUID, string>> listedDevices;
     };
 
     BOOL CALLBACK EnumJoysticksCallbackAsync(const DIDEVICEINSTANCE* pdidInstance, VOID* pContext)
     {
         auto* pCtx = static_cast<SJoystickEnumContext*>(pContext);
 
-        // Skip anything other than the perferred Joystick device as defined by the control panel.
-        // Instead you could store all the enumerated Joysticks and let the user pick.
+        pCtx->listedDevices.push_back({pdidInstance->guidInstance, pdidInstance->tszProductName});
+
+        // If the user picked a specific DirectInput pad, skip everything else. Otherwise take
+        // the first device (Windows' preferred joystick when that GUID was supplied).
+        if (pCtx->pDevice)
+            return DIENUM_CONTINUE;
+
         if (pCtx->bPreferredValid && !IsEqualGUID(pdidInstance->guidInstance, pCtx->preferredGuidInstance))
             return DIENUM_CONTINUE;
 
@@ -322,9 +430,14 @@ namespace
         if (FAILED(g_pDirectInput8->CreateDevice(pdidInstance->guidInstance, &pCtx->pDevice, NULL)))
             return DIENUM_CONTINUE;
 
-        // Stop enumeration. Note: we're just taking the first Joystick we get. You
-        // could store all the enumerated Joysticks and let the user pick.
-        return DIENUM_STOP;
+        return DIENUM_CONTINUE;
+    }
+
+    BOOL CALLBACK EnumJoysticksListCallback(const DIDEVICEINSTANCE* pdidInstance, VOID* pContext)
+    {
+        auto* pList = static_cast<std::vector<std::pair<GUID, string>>*>(pContext);
+        pList->push_back({pdidInstance->guidInstance, pdidInstance->tszProductName});
+        return DIENUM_CONTINUE;
     }
 
     // Same axis setup CJoystickManager used to do synchronously the moment a device's first Poll()
@@ -393,25 +506,31 @@ namespace
         return DIENUM_CONTINUE;
     }
 
-    SJoystickScanResult ScanForDirectInputDevice(HWND hWindow)
+    SJoystickScanResult ScanForDirectInputDevice(HWND hWindow, bool bPreferredValid, const GUID& preferredGuidInstance)
     {
         SJoystickScanResult  result;
         SJoystickEnumContext ctx;
+        ctx.bPreferredValid = bPreferredValid;
+        ctx.preferredGuidInstance = preferredGuidInstance;
 
-        IDirectInputJoyConfig8* pJoyConfig = NULL;
-        if (SUCCEEDED(g_pDirectInput8->QueryInterface(IID_IDirectInputJoyConfig8, (void**)&pJoyConfig)))
+        if (!bPreferredValid)
         {
-            DIJOYCONFIG PreferredJoyCfg = {0};
-            PreferredJoyCfg.dwSize = sizeof(PreferredJoyCfg);
-            if (SUCCEEDED(pJoyConfig->GetConfig(0, &PreferredJoyCfg, DIJC_GUIDINSTANCE)))  // Expected to fail if no Joystick is attached
+            IDirectInputJoyConfig8* pJoyConfig = NULL;
+            if (SUCCEEDED(g_pDirectInput8->QueryInterface(IID_IDirectInputJoyConfig8, (void**)&pJoyConfig)))
             {
-                ctx.bPreferredValid = true;
-                ctx.preferredGuidInstance = PreferredJoyCfg.guidInstance;
+                DIJOYCONFIG PreferredJoyCfg = {0};
+                PreferredJoyCfg.dwSize = sizeof(PreferredJoyCfg);
+                if (SUCCEEDED(pJoyConfig->GetConfig(0, &PreferredJoyCfg, DIJC_GUIDINSTANCE)))  // Expected to fail if no Joystick is attached
+                {
+                    ctx.bPreferredValid = true;
+                    ctx.preferredGuidInstance = PreferredJoyCfg.guidInstance;
+                }
+                SAFE_RELEASE(pJoyConfig);
             }
-            SAFE_RELEASE(pJoyConfig);
         }
 
         g_pDirectInput8->EnumDevices(DI8DEVCLASS_GAMECTRL, EnumJoysticksCallbackAsync, &ctx, DIEDFL_ATTACHEDONLY);
+        result.listedDevices = std::move(ctx.listedDevices);
 
         if (!ctx.pDevice)
             return result;
@@ -440,6 +559,7 @@ namespace
         if (SUCCEEDED(ctx.pDevice->GetDeviceInfo(&didi)))
         {
             result.guidProduct = didi.guidProduct;
+            result.guidInstance = didi.guidInstance;
             result.strProductName = didi.tszProductName;
         }
 
@@ -476,10 +596,12 @@ void CJoystickManager::StartDirectInputScan()
     m_bScanReady = false;
 
     HWND hWindow = g_pCore->GetHookedWindow();
+    bool bPreferredValid = m_bPreferredInstanceValid;
+    GUID preferredGuid = m_PreferredInstanceGuid;
     m_ScanThread = std::thread(
-        [this, hWindow]()
+        [this, hWindow, bPreferredValid, preferredGuid]()
         {
-            m_ScanResult = ScanForDirectInputDevice(hWindow);
+            m_ScanResult = ScanForDirectInputDevice(hWindow, bPreferredValid, preferredGuid);
             m_bScanReady.store(true, std::memory_order_release);
         });
 }
@@ -503,6 +625,8 @@ void CJoystickManager::CollectDirectInputScanResult()
     m_bScanReady = false;
     m_bScanRunning = false;
 
+    m_ListedDInputDevices = std::move(result.listedDevices);
+
     if (!result.pDevice)
     {
         WriteDebugEvent("InitDirectInput - No Joystick found");
@@ -513,6 +637,14 @@ void CJoystickManager::CollectDirectInputScanResult()
     {
         // An XInput pad showed up while this scan was in flight, so it's not needed anymore
         result.pDevice->Release();
+        return;
+    }
+
+    if (m_bPreferredInstanceValid && !IsEqualGUID(result.guidInstance, m_PreferredInstanceGuid))
+    {
+        // User picked a different DirectInput pad while this scan was in flight
+        result.pDevice->Release();
+        StartDirectInputScan();
         return;
     }
 
@@ -561,17 +693,26 @@ void CJoystickManager::DoPulse()
         m_bDoneInit = true;
         StartDirectInputScan();
     }
-    else if (!m_bUseXInput && !m_DevInfo.pDevice)
+    else
     {
         CollectDirectInputScanResult();
 
-        // Not using XInput yet and no DirectInput joystick either, so keep checking both in case
-        // an XInput pad (e.g. an Xbox controller) got connected after startup
-        if (!m_DevInfo.pDevice)
+        if (!m_bUseXInput && !m_DevInfo.pDevice)
         {
-            if (IsXInputDeviceAttached())
-                m_bUseXInput = true;
-            else if (!m_bScanRunning && m_DirectInputReattachTimer.Get() >= m_uiDirectInputReattachDelay)
+            // Not using XInput yet and no DirectInput joystick either. Auto mode may pick up an
+            // XInput pad that appeared after startup; a user-picked DirectInput device stays put.
+            SParsedControllerId parsed = ParseControllerId(m_strSelectedControllerId);
+            if (parsed.type != SParsedControllerId::DirectInput)
+            {
+                int iXInputIndex = (parsed.type == SParsedControllerId::XInput) ? parsed.iXInputIndex : FindFirstXInputIndex();
+                if (iXInputIndex >= 0)
+                {
+                    m_iXInputUserIndex = iXInputIndex;
+                    m_bUseXInput = true;
+                }
+            }
+
+            if (!m_bUseXInput && !m_bScanRunning && m_DirectInputReattachTimer.Get() >= m_uiDirectInputReattachDelay)
             {
                 StartDirectInputScan();
                 m_DirectInputReattachTimer.Reset();
@@ -582,7 +723,10 @@ void CJoystickManager::DoPulse()
 
     // Stop if no joystick
     if (!IsJoypadConnected())
+    {
+        ApplyVibration();
         return;
+    }
 
     //
     // Try to read current state
@@ -712,6 +856,8 @@ void CJoystickManager::DoPulse()
                 }
         }
     }
+
+    ApplyVibration();
 }
 
 ///////////////////////////////////////////////////////////////
@@ -739,7 +885,8 @@ void CJoystickManager::ReadCurrentState()
         bool    bOutputStatus = (g_pCore->GetDiagnosticDebug() == EDiagnosticDebug::JOYSTICK_0000) && !g_pCore->IsConnected();
         if (bOutputStatus)
         {
-            strStatus += SString("iSaturation:%d iDeadZone:%d\n", m_DevInfo.iSaturation, m_DevInfo.iDeadZone);
+            strStatus += SString("iSaturation:%d iDeadZone:%d iTriggerSaturation:%d iTriggerDeadZone:%d\n", m_DevInfo.iSaturation, m_DevInfo.iDeadZone,
+                                 m_DevInfo.iTriggerSaturation, m_DevInfo.iTriggerDeadZone);
         }
 
         if (m_iAutoDeadZoneCounter)
@@ -758,29 +905,35 @@ void CJoystickManager::ReadCurrentState()
                 // (-min - half(size)) * 2.f / size
                 float fResult = ((&js.lX)[a] - lMin - lSize / 2) * 2.f / lSize;
 
-                // Apply saturation
-                float Saturation = m_DevInfo.iSaturation * (1 / 100.f);
-                fResult += fResult * (1 - Saturation);
+                const bool bTriggerAxis = IsTriggerSourceAxis(a);
+                const int  iSaturation = bTriggerAxis ? m_DevInfo.iTriggerSaturation : m_DevInfo.iSaturation;
+                const int  iDeadZoneSetting = bTriggerAxis ? m_DevInfo.iTriggerDeadZone : m_DevInfo.iDeadZone;
+
+                ApplyAxisResponse(fResult, iSaturation);
 
                 // Handle dead zone
-                float DeadZone = m_DevInfo.iDeadZone * (1 / 100.f);
+                float DeadZone = iDeadZoneSetting * (1 / 100.f);
 
-                // Handle auto dead zone detection
-                if (m_iAutoDeadZoneCounter > 1)
+                // Handle auto dead zone detection (sticks only — trigger rest is 0, not centered)
+                if (!bTriggerAxis)
                 {
-                    // Sample phase - Record lowest axis value
-                    if (abs(fResult) < m_DevInfo.axis[a].fAutoDeadZoneSample || m_DevInfo.axis[a].fAutoDeadZoneSample == 0.f)
-                        m_DevInfo.axis[a].fAutoDeadZoneSample = abs(fResult);
-                }
-                else
-                {
-                    // Use auto dead zone if required
-                    int iAutoDeadZone = m_DevInfo.axis[a].fAutoDeadZoneSample * 110;
-                    if (iAutoDeadZone < 30 && iAutoDeadZone > m_DevInfo.iDeadZone && m_bAutoDeadZoneEnabled)
+                    if (m_iAutoDeadZoneCounter > 1)
                     {
-                        DeadZone = iAutoDeadZone * (1 / 100.f);
-                        if (m_iAutoDeadZoneCounter == 1)
-                            WriteDebugEvent(SString("CJoystickManager - Changing deadzone for axis %d from %d to %d", a, m_DevInfo.iDeadZone, iAutoDeadZone));
+                        // Sample phase - Record lowest axis value
+                        if (abs(fResult) < m_DevInfo.axis[a].fAutoDeadZoneSample || m_DevInfo.axis[a].fAutoDeadZoneSample == 0.f)
+                            m_DevInfo.axis[a].fAutoDeadZoneSample = abs(fResult);
+                    }
+                    else
+                    {
+                        // Use auto dead zone if required
+                        int iAutoDeadZone = m_DevInfo.axis[a].fAutoDeadZoneSample * 110;
+                        if (iAutoDeadZone < 30 && iAutoDeadZone > m_DevInfo.iDeadZone && m_bAutoDeadZoneEnabled)
+                        {
+                            DeadZone = iAutoDeadZone * (1 / 100.f);
+                            if (m_iAutoDeadZoneCounter == 1)
+                                WriteDebugEvent(
+                                    SString("CJoystickManager - Changing deadzone for axis %d from %d to %d", a, m_DevInfo.iDeadZone, iAutoDeadZone));
+                        }
                     }
                 }
 
@@ -976,7 +1129,7 @@ bool CJoystickManager::HandleXInputGetState(XINPUT_STATE& XInputState)
     if (!IsXInputDeviceAttached())
         return false;
 
-    DWORD dwStatus = XInputGetState(0, &XInputState);
+    DWORD dwStatus = XInputGetState(m_iXInputUserIndex, &XInputState);
 
     if (dwStatus == ERROR_DEVICE_NOT_CONNECTED)
     {
@@ -1008,7 +1161,7 @@ bool CJoystickManager::IsXInputDeviceAttached()
         m_uiXInputReattachDelay = JOYSTICK_RETRY_DELAY_MS;
 
         XINPUT_CAPABILITIES Capabilities;
-        DWORD               dwStatus = XInputGetCapabilities(0, XINPUT_FLAG_GAMEPAD, &Capabilities);
+        DWORD               dwStatus = XInputGetCapabilities(m_iXInputUserIndex, XINPUT_FLAG_GAMEPAD, &Capabilities);
         if (dwStatus != ERROR_SUCCESS)
             return false;
 
@@ -1047,11 +1200,7 @@ bool CJoystickManager::IsXInputDeviceAttached()
         m_DevInfo.guidProduct.Data3 = Capabilities.SubType;
 
         // Compose a product name
-        const char* subTypeNames[] = {"Unknown", "Gamepad", "Wheel", "Arcade stick", "Flight stick", "Dance pad", "Guitar", "Drum kit"};
-        if (Capabilities.SubType < NUMELMS(subTypeNames))
-            m_DevInfo.strProductName = subTypeNames[Capabilities.SubType];
-        else
-            m_DevInfo.strProductName = SString("Subtype %d", Capabilities.SubType);
+        m_DevInfo.strProductName = GetXInputDisplayName(m_iXInputUserIndex, Capabilities);
 
         m_DevInfo.strGuid = GUIDToString(m_DevInfo.guidProduct);
 
@@ -1235,6 +1384,7 @@ bool CJoystickManager::IsJoypadConnected()
 ///////////////////////////////////////////////////////////////
 void CJoystickManager::OnPossibleDeviceChange()
 {
+    m_SettingsRevision++;
     m_uiDirectInputReattachDelay = JOYSTICK_DEVICE_CHANGE_SETTLE_MS;
     m_DirectInputReattachTimer.Reset();
 
@@ -1263,18 +1413,95 @@ int CJoystickManager::GetSaturation()
     return m_DevInfo.iSaturation;
 }
 
+int CJoystickManager::GetTriggerDeadZone()
+{
+    return m_DevInfo.iTriggerDeadZone;
+}
+
+int CJoystickManager::GetTriggerSaturation()
+{
+    return m_DevInfo.iTriggerSaturation;
+}
+
 void CJoystickManager::SetDeadZone(int iDeadZone)
 {
     m_SettingsRevision++;
     if (iDeadZone != m_DevInfo.iDeadZone)
         m_bAutoDeadZoneEnabled = false;  // Disable auto dead zone on change (user edit)
-    m_DevInfo.iDeadZone = Clamp(0, iDeadZone, 49);
+    m_DevInfo.iDeadZone = Clamp(0, iDeadZone, JOYSTICK_DEADZONE_MAX);
 }
 
 void CJoystickManager::SetSaturation(int iSaturation)
 {
     m_SettingsRevision++;
-    m_DevInfo.iSaturation = Clamp(0, iSaturation, 100);
+    m_DevInfo.iSaturation = Clamp(0, iSaturation, JOYSTICK_SATURATION_MAX);
+}
+
+void CJoystickManager::SetTriggerDeadZone(int iDeadZone)
+{
+    m_SettingsRevision++;
+    m_DevInfo.iTriggerDeadZone = Clamp(0, iDeadZone, JOYSTICK_DEADZONE_MAX);
+}
+
+void CJoystickManager::SetTriggerSaturation(int iSaturation)
+{
+    m_SettingsRevision++;
+    m_DevInfo.iTriggerSaturation = Clamp(0, iSaturation, JOYSTICK_SATURATION_MAX);
+}
+
+bool CJoystickManager::GetVibrationEnabled()
+{
+    return m_bVibrationEnabled;
+}
+
+void CJoystickManager::SetVibrationEnabled(bool bEnabled)
+{
+    if (m_bVibrationEnabled == bEnabled)
+        return;
+
+    m_bVibrationEnabled = bEnabled;
+    CVARS_SET("controller_vibration", bEnabled);
+    m_SettingsRevision++;
+    SyncGtaVibrationPref();
+    if (!bEnabled)
+        StopVibration();
+}
+
+string CJoystickManager::GetSelectedControllerId()
+{
+    return m_strSelectedControllerId;
+}
+
+void CJoystickManager::SetSelectedControllerId(const string& strId)
+{
+    string strNew = strId.empty() ? "auto" : strId;
+    if (strNew == m_strSelectedControllerId)
+        return;
+
+    StopVibration();
+    m_strSelectedControllerId = strNew;
+    CVARS_SET("controller_device", m_strSelectedControllerId);
+    m_SettingsRevision++;
+    ApplyControllerSelection(true);
+}
+
+std::vector<SJoystickDeviceChoice> CJoystickManager::GetAvailableControllers()
+{
+    std::vector<SJoystickDeviceChoice> list;
+    list.push_back({"auto", _("Automatic")});
+
+    for (int i = 0; i < 4; i++)
+    {
+        XINPUT_CAPABILITIES Capabilities;
+        if (XInputGetCapabilities(i, XINPUT_FLAG_GAMEPAD, &Capabilities) == ERROR_SUCCESS)
+            list.push_back({SString("xinput:%d", i), GetXInputDisplayName(i, Capabilities)});
+    }
+
+    RefreshDirectInputDeviceList();
+    for (const auto& device : m_ListedDInputDevices)
+        list.push_back({SString("dinput:%s", GUIDToString(device.first).c_str()), device.second});
+
+    return list;
 }
 
 int CJoystickManager::GetSettingsRevision()
@@ -1404,6 +1631,8 @@ void CJoystickManager::SetDefaults()
 
         m_DevInfo.iDeadZone = 20;
         m_DevInfo.iSaturation = 99;
+        m_DevInfo.iTriggerDeadZone = JOYSTICK_DEFAULT_TRIGGER_DEADZONE;
+        m_DevInfo.iTriggerSaturation = 99;
     }
     else if (m_DevInfo.pDevice && m_DevInfo.iAxisCount == 5 && m_DevInfo.guidProduct == GUID_Xbox360Controller)
     {
@@ -1413,6 +1642,8 @@ void CJoystickManager::SetDefaults()
 
         m_DevInfo.iDeadZone = 18;
         m_DevInfo.iSaturation = 99;
+        m_DevInfo.iTriggerDeadZone = JOYSTICK_DEFAULT_TRIGGER_DEADZONE;
+        m_DevInfo.iTriggerSaturation = 99;
     }
     else
     {
@@ -1422,6 +1653,8 @@ void CJoystickManager::SetDefaults()
 
         m_DevInfo.iDeadZone = 12;
         m_DevInfo.iSaturation = 99;
+        m_DevInfo.iTriggerDeadZone = JOYSTICK_DEFAULT_TRIGGER_DEADZONE;
+        m_DevInfo.iTriggerSaturation = 99;
     }
 }
 
@@ -1455,14 +1688,25 @@ bool CJoystickManager::LoadFromXML()
 
             CXMLAttribute* pA = NULL;
             if (pA = pAttributes->Find("deadzone"))
-                m_DevInfo.iDeadZone = Clamp(0, atoi(pA->GetValue().c_str()), 49);
+                m_DevInfo.iDeadZone = Clamp(0, atoi(pA->GetValue().c_str()), JOYSTICK_DEADZONE_MAX);
             else
                 iErrors++;
 
             if (pA = pAttributes->Find("saturation"))
-                m_DevInfo.iSaturation = Clamp(0, atoi(pA->GetValue().c_str()), 100);
+                m_DevInfo.iSaturation = Clamp(0, atoi(pA->GetValue().c_str()), JOYSTICK_SATURATION_MAX);
             else
                 iErrors++;
+
+            // Missing trigger fields keep the stick values so existing configs don't change feel.
+            if (pA = pAttributes->Find("trigger_deadzone"))
+                m_DevInfo.iTriggerDeadZone = Clamp(0, atoi(pA->GetValue().c_str()), JOYSTICK_DEADZONE_MAX);
+            else
+                m_DevInfo.iTriggerDeadZone = m_DevInfo.iDeadZone;
+
+            if (pA = pAttributes->Find("trigger_saturation"))
+                m_DevInfo.iTriggerSaturation = Clamp(0, atoi(pA->GetValue().c_str()), JOYSTICK_SATURATION_MAX);
+            else
+                m_DevInfo.iTriggerSaturation = m_DevInfo.iSaturation;
         }
         else
             iErrors++;
@@ -1561,6 +1805,12 @@ bool CJoystickManager::SaveToXML()
                 pA = pAttributes->Create("saturation");
                 pA->SetValue(m_DevInfo.iSaturation);
 
+                pA = pAttributes->Create("trigger_deadzone");
+                pA->SetValue(m_DevInfo.iTriggerDeadZone);
+
+                pA = pAttributes->Create("trigger_saturation");
+                pA->SetValue(m_DevInfo.iTriggerSaturation);
+
                 pA = pAttributes->Create("product_name");
                 pA->SetValue(m_DevInfo.strProductName.c_str());
             }
@@ -1602,6 +1852,171 @@ bool CJoystickManager::SaveToXML()
         return true;
     }
     return false;
+}
+
+///////////////////////////////////////////////////////////////
+//
+// CJoystickManager::IsTriggerSourceAxis
+//
+// True when this physical axis is mapped to accelerate or brake, so we can apply
+// trigger-specific deadzone/saturation instead of the stick settings.
+//
+///////////////////////////////////////////////////////////////
+bool CJoystickManager::IsTriggerSourceAxis(int iAxisIndex) const
+{
+    for (int i = 0; i < NUMELMS(m_currentMapping); i++)
+    {
+        const SMappingLine& line = m_currentMapping[i];
+        if (line.bEnabled && line.SourceAxisIndex == iAxisIndex && (line.OutputAxisIndex == eAccelerate || line.OutputAxisIndex == eBrake))
+            return true;
+    }
+    return false;
+}
+
+void CJoystickManager::ApplyAxisResponse(float& fResult, int iSaturation)
+{
+    float Saturation = iSaturation * (1 / 100.f);
+    if (Saturation <= 1.f)
+        fResult += fResult * (1 - Saturation);
+    else
+        fResult *= Saturation;
+}
+
+void CJoystickManager::StopVibration()
+{
+    XINPUT_VIBRATION vibration{};
+    XInputSetState(m_iXInputUserIndex, &vibration);
+    m_bVibrationWasActive = false;
+}
+
+void CJoystickManager::SyncGtaVibrationPref()
+{
+    // CPad::StartShake (0x53F920) returns immediately unless this frontend pref is set.
+    // PC SA never exposes it, so our checkbox has to drive it or rumble never starts.
+    if (!g_pCore->GetGame())
+        return;
+
+    *reinterpret_cast<bool*>(0xBA6748 + 0x20) = m_bVibrationEnabled;
+}
+
+void CJoystickManager::ApplyVibration()
+{
+    // Get() is time since the last Reset, not a one-shot delta. Always tick it or a later
+    // XInput switch inherits minutes of idle time and eats the whole ShakeDur in one frame.
+    const int iElapsedMs = static_cast<int>(std::min<unsigned long long>(m_VibrationTimer.Get(), 50));
+    m_VibrationTimer.Reset();
+
+    if (!m_bUseXInput)
+        return;
+
+    XINPUT_VIBRATION vibration{};
+    bool             bShouldRumble = false;
+
+    CGame* pGame = g_pCore->GetGame();
+    if (pGame && pGame->GetSystemState() == SystemState::GS_PLAYING_GAME)
+        SyncGtaVibrationPref();
+
+    if (m_bVibrationEnabled && m_bXInputDeviceAttached && IsJoypadConnected())
+    {
+        if (pGame && pGame->GetSystemState() == SystemState::GS_PLAYING_GAME)
+        {
+            if (CPad* pPad = pGame->GetPad())
+            {
+                short         iShakeDur = pPad->GetShakeDur();
+                unsigned char ucShakeFreq = pPad->GetShakeFreq();
+                if (iShakeDur > 0)
+                {
+                    short iRemaining = static_cast<short>(std::max(0, static_cast<int>(iShakeDur) - std::max(iElapsedMs, 1)));
+                    pPad->SetShakeDur(iRemaining);
+                    if (iRemaining > 0 && ucShakeFreq > 0)
+                    {
+                        WORD wSpeed = static_cast<WORD>(ucShakeFreq * 257);
+                        vibration.wLeftMotorSpeed = wSpeed;
+                        vibration.wRightMotorSpeed = wSpeed;
+                        bShouldRumble = true;
+                    }
+                }
+            }
+        }
+    }
+
+    if (bShouldRumble || m_bVibrationWasActive)
+        XInputSetState(m_iXInputUserIndex, &vibration);
+
+    m_bVibrationWasActive = bShouldRumble;
+}
+
+void CJoystickManager::ReleaseDirectInputDevice()
+{
+    if (m_DevInfo.pDevice)
+    {
+        m_DevInfo.pDevice->Unacquire();
+        m_DevInfo.pDevice->Release();
+        m_DevInfo.pDevice = nullptr;
+    }
+    m_DevInfo.bDoneEnumAxes = false;
+    m_DevInfo.iAxisCount = 0;
+}
+
+int CJoystickManager::FindFirstXInputIndex() const
+{
+    for (int i = 0; i < 4; i++)
+    {
+        XINPUT_CAPABILITIES Capabilities;
+        if (XInputGetCapabilities(i, XINPUT_FLAG_GAMEPAD, &Capabilities) == ERROR_SUCCESS)
+            return i;
+    }
+    return -1;
+}
+
+void CJoystickManager::ApplyControllerSelection(bool bReleaseCurrent)
+{
+    if (bReleaseCurrent)
+        ReleaseDirectInputDevice();
+
+    m_bXInputDeviceAttached = false;
+    m_bUseXInput = false;
+    m_bPreferredInstanceValid = false;
+    m_iXInputUserIndex = 0;
+
+    SParsedControllerId parsed = ParseControllerId(m_strSelectedControllerId);
+
+    if (parsed.type == SParsedControllerId::XInput)
+    {
+        m_bUseXInput = true;
+        m_iXInputUserIndex = parsed.iXInputIndex;
+        return;
+    }
+
+    if (parsed.type == SParsedControllerId::DirectInput && parsed.bHasGuid)
+    {
+        m_bPreferredInstanceValid = true;
+        m_PreferredInstanceGuid = parsed.guidInstance;
+        if (bReleaseCurrent)
+            StartDirectInputScan();
+        return;
+    }
+
+    int iXInputIndex = FindFirstXInputIndex();
+    if (iXInputIndex >= 0)
+    {
+        m_bUseXInput = true;
+        m_iXInputUserIndex = iXInputIndex;
+        return;
+    }
+
+    if (bReleaseCurrent)
+        StartDirectInputScan();
+}
+
+void CJoystickManager::RefreshDirectInputDeviceList()
+{
+    // EnumDevices races the background scan's CreateDevice/EnumDevices on the same IDirectInput8.
+    if (!g_pDirectInput8 || m_bScanRunning)
+        return;
+
+    m_ListedDInputDevices.clear();
+    g_pDirectInput8->EnumDevices(DI8DEVCLASS_GAMECTRL, EnumJoysticksListCallback, &m_ListedDInputDevices, DIEDFL_ATTACHEDONLY);
 }
 
 ///////////////////////////////////////////////////////////////

--- a/Client/core/CJoystickManager.cpp
+++ b/Client/core/CJoystickManager.cpp
@@ -344,9 +344,9 @@ private:
     SJoystickScanResult m_ScanResult;
 
     // Lightweight background refresh of the DirectInput device list for the settings combo.
-    std::thread       m_ListRefreshThread;
-    std::atomic<bool> m_bListRefreshRunning{false};
-    std::atomic<bool> m_bListRefreshReady{false};
+    std::thread                          m_ListRefreshThread;
+    std::atomic<bool>                    m_bListRefreshRunning{false};
+    std::atomic<bool>                    m_bListRefreshReady{false};
     std::vector<std::pair<GUID, string>> m_ListRefreshResult;
 };
 
@@ -716,11 +716,12 @@ void CJoystickManager::StartDirectInputListRefresh()
     m_bListRefreshRunning = true;
     m_bListRefreshReady = false;
 
-    m_ListRefreshThread = std::thread([this]()
-                                      {
-                                          m_ListRefreshResult = EnumerateDirectInputDeviceList();
-                                          m_bListRefreshReady.store(true, std::memory_order_release);
-                                      });
+    m_ListRefreshThread = std::thread(
+        [this]()
+        {
+            m_ListRefreshResult = EnumerateDirectInputDeviceList();
+            m_bListRefreshReady.store(true, std::memory_order_release);
+        });
 }
 
 void CJoystickManager::CollectDirectInputListRefresh()

--- a/Client/core/CJoystickManager.cpp
+++ b/Client/core/CJoystickManager.cpp
@@ -41,6 +41,9 @@ constexpr uint JOYSTICK_RETRY_DELAY_MS = 3000;
 // interface
 constexpr uint JOYSTICK_DEVICE_CHANGE_SETTLE_MS = 300;
 
+// DirectInput Acquire() can block while Windows is still enumerating USB devices; don't hammer it every frame.
+constexpr uint JOYSTICK_ACQUIRE_RETRY_MS = 500;
+
 // Stick/trigger deadzone is a percentage of throw. Saturation 0-100 keeps the old mapping
 // (100 = linear, lower = reaches max sooner). Values 101-200 multiply beyond linear so a
 // worn stick that never hits the physical extreme can still produce a full GTA axis.
@@ -264,6 +267,7 @@ public:
     virtual void                               SetSelectedControllerId(const string& strId);
     virtual std::vector<SJoystickDeviceChoice> GetAvailableControllers();
     virtual int                                GetSettingsRevision();
+    virtual int                                GetDeviceListRevision();
     virtual void                               SetDefaults();
     virtual bool                               SaveToXML();
 
@@ -283,6 +287,9 @@ private:
     bool      IsJoypadValid();
     void      StartDirectInputScan();
     void      CollectDirectInputScanResult();
+    void      StartDirectInputListRefresh();
+    void      CollectDirectInputListRefresh();
+    void      BumpDeviceListRevision();
     void      ReadCurrentState();
     CXMLNode* GetConfigNode(bool bCreateIfRequired);
     bool      LoadFromXML();
@@ -298,6 +305,8 @@ private:
 
     bool                                 m_bDoneInit;
     int                                  m_SettingsRevision;
+    int                                  m_iDeviceListRevision;
+    bool                                 m_bPendingDeviceListRefresh;
     SInputDeviceInfo                     m_DevInfo;
     SJoystickState                       m_JoystickState;
     SMappingLine                         m_currentMapping[10];
@@ -309,6 +318,8 @@ private:
     uint                                 m_uiDirectInputReattachDelay;
     CElapsedTime                         m_DirectInputReattachTimer;
     CElapsedTime                         m_PollFailTimer;
+    CElapsedTime                         m_AcquireRetryTimer;
+    uint                                 m_uiAcquireRetryDelay;
     bool                                 m_bAutoDeadZoneEnabled;
     int                                  m_iAutoDeadZoneCounter;
     string                               m_strSelectedControllerId;
@@ -331,6 +342,12 @@ private:
     std::atomic<bool>   m_bScanRunning{false};
     std::atomic<bool>   m_bScanReady{false};
     SJoystickScanResult m_ScanResult;
+
+    // Lightweight background refresh of the DirectInput device list for the settings combo.
+    std::thread       m_ListRefreshThread;
+    std::atomic<bool> m_bListRefreshRunning{false};
+    std::atomic<bool> m_bListRefreshReady{false};
+    std::vector<std::pair<GUID, string>> m_ListRefreshResult;
 };
 
 ///////////////////////////////////////////////////////////////
@@ -365,6 +382,7 @@ CJoystickManager::CJoystickManager()
     m_strSelectedControllerId = "auto";
     m_bVibrationEnabled = true;
     m_iXInputUserIndex = 0;
+    m_uiAcquireRetryDelay = JOYSTICK_ACQUIRE_RETRY_MS;
 
     // CVars may not be loaded yet if this is constructed very early; ApplyControllerSelection
     // then just auto-picks the first XInput slot like we used to.
@@ -387,6 +405,8 @@ CJoystickManager::~CJoystickManager()
     // Let a scan still in flight finish before the members it writes into go away
     if (m_ScanThread.joinable())
         m_ScanThread.join();
+    if (m_ListRefreshThread.joinable())
+        m_ListRefreshThread.join();
 }
 
 ///////////////////////////////////////////////////////////////
@@ -565,6 +585,14 @@ namespace
 
         return result;
     }
+
+    std::vector<std::pair<GUID, string>> EnumerateDirectInputDeviceList()
+    {
+        std::vector<std::pair<GUID, string>> list;
+        if (g_pDirectInput8)
+            g_pDirectInput8->EnumDevices(DI8DEVCLASS_GAMECTRL, EnumJoysticksListCallback, &list, DIEDFL_ATTACHEDONLY);
+        return list;
+    }
 }  // namespace
 
 ///////////////////////////////////////////////////////////////
@@ -626,6 +654,7 @@ void CJoystickManager::CollectDirectInputScanResult()
     m_bScanRunning = false;
 
     m_ListedDInputDevices = std::move(result.listedDevices);
+    BumpDeviceListRevision();
 
     if (!result.pDevice)
     {
@@ -674,6 +703,41 @@ void CJoystickManager::CollectDirectInputScanResult()
     m_PollFailTimer.Reset();
 }
 
+void CJoystickManager::BumpDeviceListRevision()
+{
+    m_iDeviceListRevision++;
+}
+
+void CJoystickManager::StartDirectInputListRefresh()
+{
+    if (m_bListRefreshRunning || m_bScanRunning || !g_pDirectInput8)
+        return;
+
+    m_bListRefreshRunning = true;
+    m_bListRefreshReady = false;
+
+    m_ListRefreshThread = std::thread([this]()
+                                      {
+                                          m_ListRefreshResult = EnumerateDirectInputDeviceList();
+                                          m_bListRefreshReady.store(true, std::memory_order_release);
+                                      });
+}
+
+void CJoystickManager::CollectDirectInputListRefresh()
+{
+    if (!m_bListRefreshReady.load(std::memory_order_acquire))
+        return;
+
+    if (m_ListRefreshThread.joinable())
+        m_ListRefreshThread.join();
+
+    m_ListedDInputDevices = std::move(m_ListRefreshResult);
+    m_ListRefreshResult.clear();
+    m_bListRefreshReady = false;
+    m_bListRefreshRunning = false;
+    BumpDeviceListRevision();
+}
+
 ///////////////////////////////////////////////////////////////
 //
 // CJoystickManager::DoPulse
@@ -696,6 +760,15 @@ void CJoystickManager::DoPulse()
     else
     {
         CollectDirectInputScanResult();
+        CollectDirectInputListRefresh();
+
+        // After a USB plug/unplug burst settles, refresh the device list off-thread so the
+        // settings combo can update without blocking gameplay on DirectInput enumeration.
+        if (m_bPendingDeviceListRefresh && m_DirectInputReattachTimer.Get() >= m_uiDirectInputReattachDelay)
+        {
+            m_bPendingDeviceListRefresh = false;
+            StartDirectInputListRefresh();
+        }
 
         if (!m_bUseXInput && !m_DevInfo.pDevice)
         {
@@ -1041,11 +1114,17 @@ bool CJoystickManager::ReadInputSubsystem(DIJOYSTATE2& js)
                 memset(m_DevInfo.axis, 0, sizeof(m_DevInfo.axis));
                 m_DevInfo.iAxisCount = 0;
             }
-            else
+            else if (m_AcquireRetryTimer.Get() >= m_uiAcquireRetryDelay)
+            {
+                // Acquire() can block while Windows is still enumerating unrelated USB devices,
+                // so retry occasionally instead of hammering it every frame.
                 m_DevInfo.pDevice->Acquire();
+                m_AcquireRetryTimer.Reset();
+            }
             return false;
         }
         m_PollFailTimer.Reset();
+        m_AcquireRetryTimer.Reset();
 
         if (FAILED(m_DevInfo.pDevice->GetDeviceState(sizeof(DIJOYSTATE2), &js)))
             return false;
@@ -1202,12 +1281,14 @@ bool CJoystickManager::IsXInputDeviceAttached()
         // Compose a product name
         m_DevInfo.strProductName = GetXInputDisplayName(m_iXInputUserIndex, Capabilities);
 
-        m_DevInfo.strGuid = GUIDToString(m_DevInfo.guidProduct);
-
-        // Load config for this guid, or set defaults
-        if (!LoadFromXML())
+        // Config is keyed by product GUID, so a brief disconnect/reconnect doesn't need a reload.
+        const string strNewGuid = GUIDToString(m_DevInfo.guidProduct);
+        const bool   bHadConfig = (strNewGuid == m_DevInfo.strGuid);
+        m_DevInfo.strGuid = strNewGuid;
+        if (!bHadConfig)
         {
-            SetDefaults();
+            if (!LoadFromXML())
+                SetDefaults();
         }
     }
 
@@ -1384,7 +1465,7 @@ bool CJoystickManager::IsJoypadConnected()
 ///////////////////////////////////////////////////////////////
 void CJoystickManager::OnPossibleDeviceChange()
 {
-    m_SettingsRevision++;
+    m_bPendingDeviceListRefresh = true;
     m_uiDirectInputReattachDelay = JOYSTICK_DEVICE_CHANGE_SETTLE_MS;
     m_DirectInputReattachTimer.Reset();
 
@@ -1497,7 +1578,6 @@ std::vector<SJoystickDeviceChoice> CJoystickManager::GetAvailableControllers()
             list.push_back({SString("xinput:%d", i), GetXInputDisplayName(i, Capabilities)});
     }
 
-    RefreshDirectInputDeviceList();
     for (const auto& device : m_ListedDInputDevices)
         list.push_back({SString("dinput:%s", GUIDToString(device.first).c_str()), device.second});
 
@@ -1507,6 +1587,11 @@ std::vector<SJoystickDeviceChoice> CJoystickManager::GetAvailableControllers()
 int CJoystickManager::GetSettingsRevision()
 {
     return m_SettingsRevision;
+}
+
+int CJoystickManager::GetDeviceListRevision()
+{
+    return m_iDeviceListRevision;
 }
 
 bool CJoystickManager::IsJoypadValid()

--- a/Client/core/CJoystickManager.h
+++ b/Client/core/CJoystickManager.h
@@ -50,6 +50,7 @@ public:
     virtual void                               SetSelectedControllerId(const std::string& strId) = 0;
     virtual std::vector<SJoystickDeviceChoice> GetAvailableControllers() = 0;
     virtual int                                GetSettingsRevision() = 0;
+    virtual int                                GetDeviceListRevision() = 0;
     virtual void                               SetDefaults() = 0;
     virtual bool                               SaveToXML() = 0;
 

--- a/Client/core/CJoystickManager.h
+++ b/Client/core/CJoystickManager.h
@@ -11,6 +11,15 @@
 
 #pragma once
 
+#include <string>
+#include <vector>
+
+struct SJoystickDeviceChoice
+{
+    std::string strId;
+    std::string strName;
+};
+
 class CJoystickManagerInterface
 {
 public:
@@ -26,14 +35,23 @@ public:
     virtual void OnPossibleDeviceChange() = 0;
 
     // Settings
-    virtual std::string GetControllerName() = 0;
-    virtual int         GetDeadZone() = 0;
-    virtual int         GetSaturation() = 0;
-    virtual void        SetDeadZone(int iDeadZone) = 0;
-    virtual void        SetSaturation(int iSaturation) = 0;
-    virtual int         GetSettingsRevision() = 0;
-    virtual void        SetDefaults() = 0;
-    virtual bool        SaveToXML() = 0;
+    virtual std::string                        GetControllerName() = 0;
+    virtual int                                GetDeadZone() = 0;
+    virtual int                                GetSaturation() = 0;
+    virtual int                                GetTriggerDeadZone() = 0;
+    virtual int                                GetTriggerSaturation() = 0;
+    virtual void                               SetDeadZone(int iDeadZone) = 0;
+    virtual void                               SetSaturation(int iSaturation) = 0;
+    virtual void                               SetTriggerDeadZone(int iDeadZone) = 0;
+    virtual void                               SetTriggerSaturation(int iSaturation) = 0;
+    virtual bool                               GetVibrationEnabled() = 0;
+    virtual void                               SetVibrationEnabled(bool bEnabled) = 0;
+    virtual std::string                        GetSelectedControllerId() = 0;
+    virtual void                               SetSelectedControllerId(const std::string& strId) = 0;
+    virtual std::vector<SJoystickDeviceChoice> GetAvailableControllers() = 0;
+    virtual int                                GetSettingsRevision() = 0;
+    virtual void                               SetDefaults() = 0;
+    virtual bool                               SaveToXML() = 0;
 
     // Binding
     virtual int         GetOutputCount() = 0;

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -730,6 +730,7 @@ void CSettings::CreateGUI()
     // Advanced Joypad settings
     {
         m_JoypadSettingsRevision = -1;
+        m_JoypadDeviceListRevision = -1;
 
         CJoystickManagerInterface* JoyMan = GetJoystickManager();
 
@@ -2583,11 +2584,13 @@ void CSettings::UpdateJoypadTab()
 {
     CJoystickManagerInterface* JoyMan = GetJoystickManager();
 
-    // Has anything changed?
-    if (m_JoypadSettingsRevision == JoyMan->GetSettingsRevision())
+    const bool bSettingsChanged = m_JoypadSettingsRevision != JoyMan->GetSettingsRevision();
+    const bool bDeviceListChanged = m_JoypadDeviceListRevision != JoyMan->GetDeviceListRevision();
+
+    if (!bSettingsChanged && !bDeviceListChanged)
         return;
 
-    if (m_pJoypadDeviceCombo && !m_pJoypadDeviceCombo->IsOpen())
+    if (bDeviceListChanged && m_pWindow->IsVisible() && m_pJoypadDeviceCombo && !m_pJoypadDeviceCombo->IsOpen())
     {
         m_bUpdatingJoypadCombo = true;
         std::vector<SJoystickDeviceChoice> devices = JoyMan->GetAvailableControllers();
@@ -2605,7 +2608,11 @@ void CSettings::UpdateJoypadTab()
         if (!devices.empty())
             m_pJoypadDeviceCombo->SetSelectedItemByIndex(iSelect);
         m_bUpdatingJoypadCombo = false;
+        m_JoypadDeviceListRevision = JoyMan->GetDeviceListRevision();
     }
+
+    if (!bSettingsChanged)
+        return;
 
     if (m_pCheckBoxJoypadVibration)
         m_pCheckBoxJoypadVibration->SetSelected(JoyMan->GetVibrationEnabled());
@@ -2669,6 +2676,7 @@ bool CSettings::OnJoypadDeviceChanged(CGUIElement* pElement)
 
     GetJoystickManager()->SetSelectedControllerId(static_cast<const char*>(pItem->GetData()));
     m_JoypadSettingsRevision = -1;
+    m_JoypadDeviceListRevision = -1;
     UpdateJoypadTab();
     return true;
 }

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -343,12 +343,15 @@ void CSettings::ResetGuiPointers()
     m_pBindsList = NULL;
     m_pBindsDefButton = NULL;
 
-    m_pJoypadName = NULL;
-    m_pJoypadUnderline = NULL;
+    m_pJoypadDeviceCombo = NULL;
     m_pEditDeadzone = NULL;
     m_pEditSaturation = NULL;
+    m_pEditTriggerDeadzone = NULL;
+    m_pEditTriggerSaturation = NULL;
+    m_pCheckBoxJoypadVibration = NULL;
     m_pJoypadLabels.clear();
     m_pJoypadButtons.clear();
+    m_bUpdatingJoypadCombo = false;
 
     m_pSelectedBind = NULL;
 
@@ -730,16 +733,17 @@ void CSettings::CreateGUI()
 
         CJoystickManagerInterface* JoyMan = GetJoystickManager();
 
-        m_pJoypadName = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabControls));
-        m_pJoypadName->SetHorizontalAlign(CGUI_ALIGN_HORIZONTALCENTER);
-        m_pJoypadName->SetVerticalAlign(CGUI_ALIGN_VERTICALCENTER);
-        m_pJoypadName->SetPosition(CVector2D(270, vecTemp.fY));
+        m_pJoypadDeviceCombo = reinterpret_cast<CGUIComboBox*>(pManager->CreateComboBox(pTabControls, ""));
+        m_pJoypadDeviceCombo->SetPosition(CVector2D(11, vecTemp.fY));
+        m_pJoypadDeviceCombo->SetSize(CVector2D(320.0f, 120.0f));
+        m_pJoypadDeviceCombo->SetReadOnly(true);
+        m_pJoypadDeviceCombo->SetSelectionHandler(GUI_CALLBACK(&CSettings::OnJoypadDeviceChanged, this));
 
-        m_pJoypadUnderline = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabControls));
-        m_pJoypadUnderline->SetHorizontalAlign(CGUI_ALIGN_HORIZONTALCENTER);
-        m_pJoypadUnderline->SetVerticalAlign(CGUI_ALIGN_VERTICALCENTER);
-        m_pJoypadUnderline->SetPosition(CVector2D(270, vecTemp.fY + 2));
-        vecTemp.fY += 50;
+        m_pCheckBoxJoypadVibration = reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabControls, _("Vibration"), true));
+        m_pCheckBoxJoypadVibration->SetPosition(CVector2D(340, vecTemp.fY + 3.0f));
+        m_pCheckBoxJoypadVibration->AutoSize(NULL, 20.0f);
+        m_pCheckBoxJoypadVibration->SetClickHandler(GUI_CALLBACK(&CSettings::OnJoypadVibrationClick, this));
+        vecTemp.fY += 32;
 
         m_pEditDeadzone = reinterpret_cast<CGUIEdit*>(pManager->CreateEdit(pTabControls));
         m_pEditDeadzone->SetPosition(CVector2D(10, vecTemp.fY));
@@ -753,17 +757,41 @@ void CSettings::CreateGUI()
         m_pEditSaturation->SetSize(CVector2D(45.0f, 24.0f));
         m_pEditSaturation->SetMaxLength(3);
         m_pEditSaturation->SetTextChangedHandler(GUI_CALLBACK(&CSettings::OnJoypadTextChanged, this));
+        vecTemp.fY += 31;
 
-        CGUILabel* pLabelDeadZone = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabControls, _("Dead Zone")));
+        m_pEditTriggerDeadzone = reinterpret_cast<CGUIEdit*>(pManager->CreateEdit(pTabControls));
+        m_pEditTriggerDeadzone->SetPosition(CVector2D(10, vecTemp.fY));
+        m_pEditTriggerDeadzone->SetSize(CVector2D(45.0f, 24.0f));
+        m_pEditTriggerDeadzone->SetMaxLength(3);
+        m_pEditTriggerDeadzone->SetTextChangedHandler(GUI_CALLBACK(&CSettings::OnJoypadTextChanged, this));
+        vecTemp.fY += 31;
+
+        m_pEditTriggerSaturation = reinterpret_cast<CGUIEdit*>(pManager->CreateEdit(pTabControls));
+        m_pEditTriggerSaturation->SetPosition(CVector2D(10, vecTemp.fY));
+        m_pEditTriggerSaturation->SetSize(CVector2D(45.0f, 24.0f));
+        m_pEditTriggerSaturation->SetMaxLength(3);
+        m_pEditTriggerSaturation->SetTextChangedHandler(GUI_CALLBACK(&CSettings::OnJoypadTextChanged, this));
+
+        CGUILabel* pLabelDeadZone = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabControls, _("Stick dead zone")));
         pLabelDeadZone->SetPosition(m_pEditDeadzone->GetPosition() + CVector2D(52.f, 1.f));
         pLabelDeadZone->AutoSize();
         pLabelDeadZone->SetVerticalAlign(CGUI_ALIGN_VERTICALCENTER);
 
-        CGUILabel* pLabelSaturation = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabControls, _("Saturation")));
+        CGUILabel* pLabelSaturation = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabControls, _("Stick saturation")));
         pLabelSaturation->SetPosition(m_pEditSaturation->GetPosition() + CVector2D(52.f, 1.f));
         pLabelSaturation->AutoSize();
         pLabelSaturation->SetVerticalAlign(CGUI_ALIGN_VERTICALCENTER);
-        vecTemp.fY += 106;
+
+        CGUILabel* pLabelTriggerDeadZone = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabControls, _("Trigger dead zone")));
+        pLabelTriggerDeadZone->SetPosition(m_pEditTriggerDeadzone->GetPosition() + CVector2D(52.f, 1.f));
+        pLabelTriggerDeadZone->AutoSize();
+        pLabelTriggerDeadZone->SetVerticalAlign(CGUI_ALIGN_VERTICALCENTER);
+
+        CGUILabel* pLabelTriggerSaturation = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabControls, _("Trigger saturation")));
+        pLabelTriggerSaturation->SetPosition(m_pEditTriggerSaturation->GetPosition() + CVector2D(52.f, 1.f));
+        pLabelTriggerSaturation->AutoSize();
+        pLabelTriggerSaturation->SetVerticalAlign(CGUI_ALIGN_VERTICALCENTER);
+        vecTemp.fY += 44;
 
         CGUILabel* pLabelHelp = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabControls, _("Use the 'Binds' tab for joypad buttons.")));
         pLabelHelp->SetPosition(CVector2D(10, vecTemp.fY));
@@ -2479,6 +2507,9 @@ void CSettings::ProcessJoypad()
     // Update from GUI
     GetJoystickManager()->SetDeadZone(atoi(m_pEditDeadzone->GetText().c_str()));
     GetJoystickManager()->SetSaturation(atoi(m_pEditSaturation->GetText().c_str()));
+    GetJoystickManager()->SetTriggerDeadZone(atoi(m_pEditTriggerDeadzone->GetText().c_str()));
+    GetJoystickManager()->SetTriggerSaturation(atoi(m_pEditTriggerSaturation->GetText().c_str()));
+    GetJoystickManager()->SetVibrationEnabled(m_pCheckBoxJoypadVibration->GetSelected());
 
     GetJoystickManager()->SaveToXML();
 }
@@ -2556,34 +2587,43 @@ void CSettings::UpdateJoypadTab()
     if (m_JoypadSettingsRevision == JoyMan->GetSettingsRevision())
         return;
 
-    // Update the joystick name
-    string strJoystickName = JoyMan->IsJoypadConnected() ? JoyMan->GetControllerName() : _("Joypad not detected  -  Check connections and restart game");
+    if (m_pJoypadDeviceCombo && !m_pJoypadDeviceCombo->IsOpen())
+    {
+        m_bUpdatingJoypadCombo = true;
+        std::vector<SJoystickDeviceChoice> devices = JoyMan->GetAvailableControllers();
+        std::string                        strSelected = JoyMan->GetSelectedControllerId();
+        m_pJoypadDeviceCombo->Clear();
+        int iSelect = 0;
+        for (size_t i = 0; i < devices.size(); i++)
+        {
+            CGUIListItem* pItem = m_pJoypadDeviceCombo->AddItem(devices[i].strName.c_str());
+            if (pItem)
+                pItem->SetData(devices[i].strId.c_str());
+            if (devices[i].strId == strSelected)
+                iSelect = static_cast<int>(i);
+        }
+        if (!devices.empty())
+            m_pJoypadDeviceCombo->SetSelectedItemByIndex(iSelect);
+        m_bUpdatingJoypadCombo = false;
+    }
 
-    m_pJoypadName->SetPosition(CVector2D(270, m_pJoypadName->GetPosition().fY));
-    m_pJoypadName->SetText(strJoystickName.c_str());
-    m_pJoypadName->AutoSize(strJoystickName.c_str());
-    m_pJoypadName->SetPosition(m_pJoypadName->GetPosition() - CVector2D(m_pJoypadName->GetSize().fX * 0.5, 0.0f));
-
-    // Joystick name underline
-    string strUnderline = "";
-    int    inumChars = m_pJoypadName->GetSize().fX / 7.f + 0.5f;
-    for (int i = 0; i < inumChars; i++)
-        strUnderline = strUnderline + "_";
-
-    m_pJoypadUnderline->SetPosition(CVector2D(270, m_pJoypadUnderline->GetPosition().fY));
-    m_pJoypadUnderline->SetText(strUnderline.c_str());
-    m_pJoypadUnderline->AutoSize(strUnderline.c_str());
-    m_pJoypadUnderline->SetPosition(m_pJoypadUnderline->GetPosition() - CVector2D(m_pJoypadUnderline->GetSize().fX * 0.5, 0.0f));
-    m_pJoypadUnderline->SetVisible(JoyMan->IsJoypadConnected());
+    if (m_pCheckBoxJoypadVibration)
+        m_pCheckBoxJoypadVibration->SetSelected(JoyMan->GetVibrationEnabled());
 
     // Update DeadZone and Saturation edit boxes
     char szDeadzone[32] = "";
     char szSaturation[32] = "";
+    char szTriggerDeadzone[32] = "";
+    char szTriggerSaturation[32] = "";
     snprintf(szDeadzone, 10, "%d", JoyMan->GetDeadZone());
     snprintf(szSaturation, 10, "%d", JoyMan->GetSaturation());
+    snprintf(szTriggerDeadzone, 10, "%d", JoyMan->GetTriggerDeadZone());
+    snprintf(szTriggerSaturation, 10, "%d", JoyMan->GetTriggerSaturation());
 
     m_pEditDeadzone->SetText(szDeadzone);
     m_pEditSaturation->SetText(szSaturation);
+    m_pEditTriggerDeadzone->SetText(szTriggerDeadzone);
+    m_pEditTriggerSaturation->SetText(szTriggerSaturation);
 
     // Update axes labels and buttons
     for (int i = 0; i < JoyMan->GetOutputCount() && i < (int)m_pJoypadButtons.size(); i++)
@@ -2609,10 +2649,34 @@ bool CSettings::OnJoypadTextChanged(CGUIElement* pElement)
     // Update from GUI
     GetJoystickManager()->SetDeadZone(atoi(m_pEditDeadzone->GetText().c_str()));
     GetJoystickManager()->SetSaturation(atoi(m_pEditSaturation->GetText().c_str()));
+    GetJoystickManager()->SetTriggerDeadZone(atoi(m_pEditTriggerDeadzone->GetText().c_str()));
+    GetJoystickManager()->SetTriggerSaturation(atoi(m_pEditTriggerSaturation->GetText().c_str()));
 
     // Dont immediately read back these settings
     m_JoypadSettingsRevision = GetJoystickManager()->GetSettingsRevision();
 
+    return true;
+}
+
+bool CSettings::OnJoypadDeviceChanged(CGUIElement* pElement)
+{
+    if (m_bUpdatingJoypadCombo || !m_pJoypadDeviceCombo)
+        return true;
+
+    CGUIListItem* pItem = m_pJoypadDeviceCombo->GetSelectedItem();
+    if (!pItem || !pItem->GetData())
+        return true;
+
+    GetJoystickManager()->SetSelectedControllerId(static_cast<const char*>(pItem->GetData()));
+    m_JoypadSettingsRevision = -1;
+    UpdateJoypadTab();
+    return true;
+}
+
+bool CSettings::OnJoypadVibrationClick(CGUIElement* pElement)
+{
+    GetJoystickManager()->SetVibrationEnabled(m_pCheckBoxJoypadVibration->GetSelected());
+    m_JoypadSettingsRevision = GetJoystickManager()->GetSettingsRevision();
     return true;
 }
 

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -293,6 +293,7 @@ protected:
     std::vector<CGUILabel*>  m_pJoypadLabels;
     std::vector<CGUIButton*> m_pJoypadButtons;
     int                      m_JoypadSettingsRevision;
+    int                      m_JoypadDeviceListRevision;
     bool                     m_bUpdatingJoypadCombo;
 
     CGUILabel*     m_pControlsMouseLabel;

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -284,13 +284,16 @@ protected:
     CGUIButton*   m_pBindsDefButton;
     CGUIHandle    m_hBind, m_hPriKey, m_hSecKeys[SecKeyNum];
 
-    CGUILabel*               m_pJoypadName;
-    CGUILabel*               m_pJoypadUnderline;
+    CGUIComboBox*            m_pJoypadDeviceCombo;
     CGUIEdit*                m_pEditDeadzone;
     CGUIEdit*                m_pEditSaturation;
+    CGUIEdit*                m_pEditTriggerDeadzone;
+    CGUIEdit*                m_pEditTriggerSaturation;
+    CGUICheckBox*            m_pCheckBoxJoypadVibration;
     std::vector<CGUILabel*>  m_pJoypadLabels;
     std::vector<CGUIButton*> m_pJoypadButtons;
     int                      m_JoypadSettingsRevision;
+    bool                     m_bUpdatingJoypadCombo;
 
     CGUILabel*     m_pControlsMouseLabel;
     CGUICheckBox*  m_pInvertMouse;
@@ -374,6 +377,8 @@ protected:
     bool          m_bBrowserListsLoadEnabled;
 
     bool OnJoypadTextChanged(CGUIElement* pElement);
+    bool OnJoypadDeviceChanged(CGUIElement* pElement);
+    bool OnJoypadVibrationClick(CGUIElement* pElement);
     bool OnAxisSelectClick(CGUIElement* pElement);
     bool OnAudioDefaultClick(CGUIElement* pElement);
     bool OnControlsDefaultClick(CGUIElement* pElement);

--- a/Client/game_sa/CPadSA.cpp
+++ b/Client/game_sa/CPadSA.cpp
@@ -79,3 +79,18 @@ void CPadSA::SetLastTimeTouched(DWORD dwTime)
 {
     internalInterface->LastTimeTouched = dwTime;
 }
+
+short CPadSA::GetShakeDur()
+{
+    return internalInterface->ShakeDur;
+}
+
+unsigned char CPadSA::GetShakeFreq()
+{
+    return internalInterface->ShakeFreq;
+}
+
+void CPadSA::SetShakeDur(short sShakeDur)
+{
+    internalInterface->ShakeDur = sShakeDur;
+}

--- a/Client/game_sa/CPadSA.h
+++ b/Client/game_sa/CPadSA.h
@@ -79,4 +79,7 @@ public:
     CPadSAInterface*  GetInterface() { return internalInterface; };
     void              SetHornHistoryValue(bool value);
     void              SetLastTimeTouched(DWORD dwTime);
+    short             GetShakeDur();
+    unsigned char     GetShakeFreq();
+    void              SetShakeDur(short sShakeDur);
 };

--- a/Client/sdk/game/CPad.h
+++ b/Client/sdk/game/CPad.h
@@ -63,4 +63,10 @@ public:
     virtual void              Clear() = 0;
     virtual void              SetHornHistoryValue(bool value) = 0;
     virtual void              SetLastTimeTouched(DWORD dwTime) = 0;
+
+    // PC never consumes these itself (CPad::ProcessPCSpecificStuff is a stub), so joystick
+    // code reads/ticks them to drive XInput rumble.
+    virtual short         GetShakeDur() = 0;
+    virtual unsigned char GetShakeFreq() = 0;
+    virtual void          SetShakeDur(short sShakeDur) = 0;
 };


### PR DESCRIPTION
#### Summary
Settings → Controls now lets you pick which pad to use (Automatic, XInput slots, DirectInput devices), with separate dead zone / saturation for sticks vs accelerate/brake triggers, a vibration checkbox, and stick/trigger saturation up to 200.

XInput rumble is driven from GTA `CPad` shake. The checkbox also sets `CMenuManager::m_bPrefsUseVibration`, because `CPad::StartShake` is a no-op on PC without that pref. Existing joypad XML without trigger fields keeps the old stick values.

#### Motivation
Fixes #5089. Analog stick dead zone is too aggressive for triggers, saturation was capped at 100, XInput was hardcoded to user 0, and PC SA never exposed vibration.

#### Test plan
1. Settings → Controls: combo lists Automatic plus connected pads; picking one switches input without restart.
2. Raise stick dead zone on a drifting pad without losing trigger range; set trigger dead zone/saturation independently.
3. Set saturation to 150-200 on a stick that does not reach full throw.
4. Toggle Vibration in a vehicle (bumps/explosions) on an XInput pad - motors on when checked, off when unchecked.
5. Load defaults on Controls: mapping and DZ/sat reset, selected device stays.
6. Old config without `trigger_*` XML attributes keeps previous trigger feel.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.