### PR TITLE
Add #4713: Optional async loading for dxCreateTexture

### DIFF
--- a/Client/core/Graphics/CRenderItem.FileTexture.cpp
+++ b/Client/core/Graphics/CRenderItem.FileTexture.cpp
@@ -275,6 +275,69 @@ void CFileTextureItem::CreateUnderlyingData(bool bMipMaps, uint uiSizeX, uint ui
 
 ////////////////////////////////////////////////////////////////
 //
+// CFileTextureItem::CreateUnderlyingDataFromFileMemory
+//
+// Same as CreateUnderlyingData(filename), but from an already-read file buffer.
+// D3D9 device calls stay on the calling thread (must be the main thread).
+//
+////////////////////////////////////////////////////////////////
+void CFileTextureItem::CreateUnderlyingDataFromFileMemory(const void* pData, uint uiSize, bool bMipMaps, uint uiSizeX, uint uiSizeY, ERenderFormat format)
+{
+    assert(!m_pD3DTexture);
+
+    if (!pData || uiSize == 0)
+        return;
+
+    D3DXIMAGE_INFO imageInfo;
+    if (FAILED(D3DXGetImageInfoFromFileInMemory(pData, uiSize, &imageInfo)))
+        return;
+
+    D3DFORMAT D3DFormat = (D3DFORMAT)format;
+    int       iMipMaps = bMipMaps ? D3DX_DEFAULT : 1;
+    if (uiSizeX != D3DX_DEFAULT)
+        imageInfo.Width = uiSizeX;
+    if (uiSizeY != D3DX_DEFAULT)
+        imageInfo.Height = uiSizeY;
+
+    m_uiSizeX = imageInfo.Width;
+    m_uiSizeY = imageInfo.Height;
+    m_uiSurfaceSizeX = imageInfo.Width;
+    m_uiSurfaceSizeY = imageInfo.Height;
+
+    if (imageInfo.ResourceType == D3DRTYPE_VOLUMETEXTURE)
+    {
+        if (FAILED(D3DXCreateVolumeTextureFromFileInMemoryEx(m_pDevice, pData, uiSize, uiSizeX, uiSizeY, D3DX_DEFAULT, iMipMaps, 0, D3DFormat, D3DPOOL_MANAGED,
+                                                             D3DX_DEFAULT, D3DX_DEFAULT, 0, NULL, NULL, (IDirect3DVolumeTexture9**)&m_pD3DTexture)))
+            return;
+    }
+    else if (imageInfo.ResourceType == D3DRTYPE_CUBETEXTURE)
+    {
+        if (FAILED(D3DXCreateCubeTextureFromFileInMemoryEx(m_pDevice, pData, uiSize, uiSizeX, iMipMaps, 0, D3DFormat, D3DPOOL_MANAGED, D3DX_DEFAULT,
+                                                           D3DX_DEFAULT, 0, NULL, NULL, (IDirect3DCubeTexture9**)&m_pD3DTexture)))
+            return;
+    }
+    else
+    {
+        if (uiSizeX == D3DX_DEFAULT)
+            uiSizeX = D3DX_DEFAULT_NONPOW2;
+        if (uiSizeY == D3DX_DEFAULT)
+            uiSizeY = D3DX_DEFAULT_NONPOW2;
+
+        if (FAILED(D3DXCreateTextureFromFileInMemoryEx(m_pDevice, pData, uiSize, uiSizeX, uiSizeY, iMipMaps, 0, D3DFormat, D3DPOOL_MANAGED, D3DX_DEFAULT,
+                                                       D3DX_DEFAULT, 0, NULL, NULL, (IDirect3DTexture9**)&m_pD3DTexture)))
+            return;
+
+        D3DSURFACE_DESC desc;
+        ((IDirect3DTexture9*)m_pD3DTexture)->GetLevelDesc(0, &desc);
+        m_uiSurfaceSizeX = desc.Width;
+        m_uiSurfaceSizeY = desc.Height;
+    }
+
+    m_iMemoryKBUsed = CRenderItemManager::CalcD3DResourceMemoryKBUsage(m_pD3DTexture);
+}
+
+////////////////////////////////////////////////////////////////
+//
 // CFileTextureItem::ReleaseUnderlyingData
 //
 //
@@ -283,4 +346,78 @@ void CFileTextureItem::CreateUnderlyingData(bool bMipMaps, uint uiSizeX, uint ui
 void CFileTextureItem::ReleaseUnderlyingData()
 {
     SAFE_RELEASE(m_pD3DTexture);
+}
+
+////////////////////////////////////////////////////////////////
+//
+// CFileTextureItem::ReplaceFromFileMemory
+//
+// Upload a decoded image over the current D3D texture without replacing the CFileTextureItem.
+// Create the new resource first so a failed decode keeps the previous (placeholder) texture drawable.
+//
+////////////////////////////////////////////////////////////////
+bool CFileTextureItem::ReplaceFromFileMemory(const void* pData, uint uiSize, bool bMipMaps, ERenderFormat format)
+{
+    IDirect3DBaseTexture9* pOldTexture = m_pD3DTexture;
+    const uint             uiOldSizeX = m_uiSizeX;
+    const uint             uiOldSizeY = m_uiSizeY;
+    const uint             uiOldSurfaceSizeX = m_uiSurfaceSizeX;
+    const uint             uiOldSurfaceSizeY = m_uiSurfaceSizeY;
+    const int              iOldMemoryKBUsed = m_iMemoryKBUsed;
+
+    m_pD3DTexture = NULL;
+    CreateUnderlyingDataFromFileMemory(pData, uiSize, bMipMaps, RDEFAULT, RDEFAULT, format);
+    if (!m_pD3DTexture)
+    {
+        m_pD3DTexture = pOldTexture;
+        m_uiSizeX = uiOldSizeX;
+        m_uiSizeY = uiOldSizeY;
+        m_uiSurfaceSizeX = uiOldSurfaceSizeX;
+        m_uiSurfaceSizeY = uiOldSurfaceSizeY;
+        m_iMemoryKBUsed = iOldMemoryKBUsed;
+        return false;
+    }
+
+    SAFE_RELEASE(pOldTexture);
+    m_iRevision++;
+    m_pManager->UpdateMemoryUsage();
+    return true;
+}
+
+////////////////////////////////////////////////////////////////
+//
+// CFileTextureItem::ReplaceFromPixels
+//
+// Same as ReplaceFromFileMemory, but through the pixels decoder (PLAIN is converted to PNG first).
+//
+////////////////////////////////////////////////////////////////
+bool CFileTextureItem::ReplaceFromPixels(const CPixels* pPixels, bool bMipMaps, ERenderFormat format)
+{
+    if (!pPixels || !pPixels->GetSize())
+        return false;
+
+    IDirect3DBaseTexture9* pOldTexture = m_pD3DTexture;
+    const uint             uiOldSizeX = m_uiSizeX;
+    const uint             uiOldSizeY = m_uiSizeY;
+    const uint             uiOldSurfaceSizeX = m_uiSurfaceSizeX;
+    const uint             uiOldSurfaceSizeY = m_uiSurfaceSizeY;
+    const int              iOldMemoryKBUsed = m_iMemoryKBUsed;
+
+    m_pD3DTexture = NULL;
+    CreateUnderlyingData(pPixels, bMipMaps, format);
+    if (!m_pD3DTexture)
+    {
+        m_pD3DTexture = pOldTexture;
+        m_uiSizeX = uiOldSizeX;
+        m_uiSizeY = uiOldSizeY;
+        m_uiSurfaceSizeX = uiOldSurfaceSizeX;
+        m_uiSurfaceSizeY = uiOldSurfaceSizeY;
+        m_iMemoryKBUsed = iOldMemoryKBUsed;
+        return false;
+    }
+
+    SAFE_RELEASE(pOldTexture);
+    m_iRevision++;
+    m_pManager->UpdateMemoryUsage();
+    return true;
 }

--- a/Client/core/Graphics/CRenderItemManager.cpp
+++ b/Client/core/Graphics/CRenderItemManager.cpp
@@ -201,6 +201,35 @@ CTextureItem* CRenderItemManager::CreateTexture(const SString& strFullFilePath, 
 
 ////////////////////////////////////////////////////////////////
 //
+// CRenderItemManager::ReplaceFileTextureFromMemory
+//
+// Replace the D3D resource of an existing file texture without changing the Lua element.
+// Used by async dxCreateTexture so a 1x1 placeholder can become the real image on the main thread.
+//
+////////////////////////////////////////////////////////////////
+bool CRenderItemManager::ReplaceFileTextureFromMemory(CTextureItem* pTextureItem, const void* pData, uint uiSize, bool bMipMaps, ERenderFormat format,
+                                                      bool bTreatAsPixels)
+{
+    if (!pTextureItem || !pData || uiSize == 0)
+        return false;
+
+    if (!pTextureItem->IsA(CFileTextureItem::GetClassId()))
+        return false;
+
+    CFileTextureItem* pFileItem = static_cast<CFileTextureItem*>(pTextureItem);
+    if (bTreatAsPixels)
+    {
+        CPixels pixels;
+        pixels.externalData.pData = const_cast<char*>(static_cast<const char*>(pData));
+        pixels.externalData.uiSize = uiSize;
+        return pFileItem->ReplaceFromPixels(&pixels, bMipMaps, format);
+    }
+
+    return pFileItem->ReplaceFromFileMemory(pData, uiSize, bMipMaps, format);
+}
+
+////////////////////////////////////////////////////////////////
+//
 // CRenderItemManager::CreateVectorGraphic
 //
 //

--- a/Client/core/Graphics/CRenderItemManager.h
+++ b/Client/core/Graphics/CRenderItemManager.h
@@ -58,6 +58,8 @@ public:
     virtual void           FlushNonAARenderTarget();
     virtual HRESULT        HandleStretchRect(IDirect3DSurface9* pSourceSurface, CONST RECT* pSourceRect, IDirect3DSurface9* pDestSurface, CONST RECT* pDestRect,
                                              int Filter);
+    virtual bool           ReplaceFileTextureFromMemory(CTextureItem* pTextureItem, const void* pData, uint uiSize, bool bMipMaps, ERenderFormat format,
+                                                        bool bTreatAsPixels);
 
     // CRenderItemManager
     void NotifyContructRenderItem(CRenderItem* pItem);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDrawingDefs.cpp
@@ -977,10 +977,69 @@ int CLuaDrawingDefs::OOP_DxGetFontHeight(lua_State* luaVM)
     return 1;
 }
 
+namespace
+{
+    void ReadDxCreateTextureAsyncArgs(CScriptArgReader& argStream, bool& bAsync, CLuaFunctionRef& callback, CLuaArguments& callbackArgs)
+    {
+        argStream.ReadBool(bAsync, false);
+        if (!bAsync)
+            return;
+
+        argStream.ReadFunction(callback, LUA_REFNIL);
+        if (argStream.NextIsTable())
+            argStream.ReadLuaArgumentsTable(callbackArgs);
+        argStream.ReadFunctionComplete();
+    }
+
+    CClientTexture* CreateDxTexturePlaceholder(CResource* pParentResource, ETextureAddress textureAddress)
+    {
+        // 1x1 so dxDrawImage on a not-yet-loaded texture cannot crash. Replaced in-place when the real image is ready.
+        CClientTexture* pTexture =
+            g_pClientGame->GetManager()->GetRenderElementManager()->CreateTexture("", nullptr, false, 1, 1, RFORMAT_ARGB, textureAddress);
+        if (pTexture)
+            pTexture->SetParent(pParentResource->GetResourceDynamicEntity());
+        return pTexture;
+    }
+
+    void CompleteAsyncDxTexture(ElementID textureId, const std::vector<char>& data, bool bMipMaps, ERenderFormat format, bool bTreatAsPixels,
+                                const CLuaFunctionRef& callback, const CLuaArguments& callbackArgs, const SString& strErrorContext)
+    {
+        CClientEntity* pEntity = CElementIDs::GetElement(textureId);
+        if (!pEntity || pEntity->GetType() != CCLIENTTEXTURE || pEntity->IsBeingDeleted())
+            return;
+
+        auto* pTexture = static_cast<CClientTexture*>(pEntity);
+        bool  bSuccess = false;
+        if (!data.empty())
+        {
+            bSuccess = g_pCore->GetGraphics()->GetRenderItemManager()->ReplaceFileTextureFromMemory(
+                pTexture->GetTextureItem(), data.data(), static_cast<uint>(data.size()), bMipMaps, format, bTreatAsPixels);
+        }
+
+        if (!bSuccess && callback.GetLuaVM())
+            CLuaDefs::m_pScriptDebugging->LogCustom(callback.GetLuaVM(), strErrorContext);
+
+        if (!VERIFY_FUNCTION(callback))
+            return;
+
+        CLuaMain* pLuaMain = CLuaDefs::m_pLuaManager->GetVirtualMachine(callback.GetLuaVM());
+        if (!pLuaMain)
+            return;
+
+        CLuaArguments arguments;
+        arguments.PushElement(pTexture);
+        arguments.PushBoolean(bSuccess);
+        arguments.PushArguments(callbackArgs);
+        arguments.Call(pLuaMain, callback);
+    }
+}  // namespace
+
 int CLuaDrawingDefs::DxCreateTexture(lua_State* luaVM)
 {
-    //  element dxCreateTexture( string filepath [, string textureFormat = "argb", bool mipmaps = true, string textureEdge = "wrap" ] )
-    //  element dxCreateTexture( string pixels [, string textureFormat = "argb", bool mipmaps = true, string textureEdge = "wrap" ] )
+    //  element dxCreateTexture( string filepath [, string textureFormat = "argb", bool mipmaps = true, string textureEdge = "wrap" [, bool async, function
+    //  callbackFunction, table callbackArguments ] ] )
+    //  element dxCreateTexture( string pixels [, string textureFormat = "argb", bool mipmaps = true, string textureEdge = "wrap" [, bool async, function
+    //  callbackFunction, table callbackArguments ] ] )
     //  element dxCreateTexture( int width, int height [, string textureFormat = "argb", string textureEdge = "wrap", string textureType = "2d", int depth ] )
     SString         strFilePath;
     CPixels         pixels;
@@ -991,6 +1050,9 @@ int CLuaDrawingDefs::DxCreateTexture(lua_State* luaVM)
     ETextureAddress textureAddress;
     ETextureType    textureType = TTYPE_TEXTURE;
     int             depth = 1;
+    bool            bAsync = false;
+    CLuaFunctionRef callback;
+    CLuaArguments   callbackArgs;
 
     CScriptArgReader argStream(luaVM);
     if (!argStream.NextIsNumber())
@@ -998,20 +1060,22 @@ int CLuaDrawingDefs::DxCreateTexture(lua_State* luaVM)
         argStream.ReadCharStringRef(pixels.externalData);
         if (!g_pCore->GetGraphics()->GetPixelsManager()->IsPixels(pixels))
         {
-            // element dxCreateTexture( string filepath [, string textureFormat = "argb", bool mipmaps = true, string textureEdge = "wrap" ] )
+            // element dxCreateTexture( string filepath [, ... [, bool async, function callbackFunction, table callbackArguments ] ] )
             pixels = CPixels();
             argStream = CScriptArgReader(luaVM);
             argStream.ReadString(strFilePath);
             argStream.ReadEnumString(renderFormat, RFORMAT_UNKNOWN);
             argStream.ReadBool(bMipMaps, true);
             argStream.ReadEnumString(textureAddress, TADDRESS_WRAP);
+            ReadDxCreateTextureAsyncArgs(argStream, bAsync, callback, callbackArgs);
         }
         else
         {
-            // element dxCreateTexture( string pixels [, string textureFormat = "argb", bool mipmaps = true, string textureEdge = "wrap" ] )
+            // element dxCreateTexture( string pixels [, ... [, bool async, function callbackFunction, table callbackArguments ] ] )
             argStream.ReadEnumString(renderFormat, RFORMAT_UNKNOWN);
             argStream.ReadBool(bMipMaps, true);
             argStream.ReadEnumString(textureAddress, TADDRESS_WRAP);
+            ReadDxCreateTextureAsyncArgs(argStream, bAsync, callback, callbackArgs);
         }
     }
     else
@@ -1043,6 +1107,41 @@ int CLuaDrawingDefs::DxCreateTexture(lua_State* luaVM)
                 {
                     if (FileExists(strPath))
                     {
+                        if (bAsync)
+                        {
+                            CClientTexture* pTexture = CreateDxTexturePlaceholder(pParentResource, textureAddress);
+                            if (!pTexture)
+                            {
+                                m_pScriptDebugging->LogCustom(
+                                    luaVM,
+                                    SString("[DxCreateTexture] Failed to create texture from file '%s' (may be corrupt, unsupported format, or out of memory)",
+                                            strFilePath.c_str()));
+                                lua_pushnil(luaVM);
+                                return 1;
+                            }
+
+                            // File IO on a worker: D3D9 is not thread-safe, so GPU upload happens later on the main thread.
+                            const ElementID textureId = pTexture->GetID();
+                            g_pClientGame->GetAsyncTaskScheduler()->PushTask(
+                                [strPath]
+                                {
+                                    std::vector<char> buffer;
+                                    if (!FileLoad(strPath, buffer) || buffer.empty())
+                                        return std::vector<char>{};
+                                    return buffer;
+                                },
+                                [textureId, bMipMaps, renderFormat, callback, callbackArgs, strFilePath](const std::vector<char>& data)
+                                {
+                                    CompleteAsyncDxTexture(textureId, data, bMipMaps, renderFormat, false, callback, callbackArgs,
+                                                           SString("[DxCreateTexture] Failed to create texture from file '%s' (may be corrupt, unsupported "
+                                                                   "format, or out of memory)",
+                                                                   strFilePath.c_str()));
+                                });
+
+                            lua_pushelement(luaVM, pTexture);
+                            return 1;
+                        }
+
                         CClientTexture* pTexture = g_pClientGame->GetManager()->GetRenderElementManager()->CreateTexture(
                             strPath, NULL, bMipMaps, RDEFAULT, RDEFAULT, renderFormat, textureAddress);
                         if (pTexture)
@@ -1072,6 +1171,32 @@ int CLuaDrawingDefs::DxCreateTexture(lua_State* luaVM)
             else if (pixels.GetSize())
             {
                 // From pixels
+                if (bAsync)
+                {
+                    CClientTexture* pTexture = CreateDxTexturePlaceholder(pParentResource, textureAddress);
+                    if (!pTexture)
+                    {
+                        m_pScriptDebugging->LogCustom(luaVM,
+                                                      "[DxCreateTexture:Pixels] Failed to create texture from pixel data (invalid format or out of memory)");
+                        lua_pushnil(luaVM);
+                        return 1;
+                    }
+
+                    // Copy now: the Lua string backing CPixels is not valid after this function returns.
+                    std::vector<char> pixelData(pixels.GetData(), pixels.GetData() + pixels.GetSize());
+                    const ElementID   textureId = pTexture->GetID();
+                    g_pClientGame->GetAsyncTaskScheduler()->PushTask(
+                        [pixelData = std::move(pixelData)]() mutable { return std::move(pixelData); },
+                        [textureId, bMipMaps, renderFormat, callback, callbackArgs](const std::vector<char>& data)
+                        {
+                            CompleteAsyncDxTexture(textureId, data, bMipMaps, renderFormat, true, callback, callbackArgs,
+                                                   "[DxCreateTexture:Pixels] Failed to create texture from pixel data (invalid format or out of memory)");
+                        });
+
+                    lua_pushelement(luaVM, pTexture);
+                    return 1;
+                }
+
                 CClientTexture* pTexture = g_pClientGame->GetManager()->GetRenderElementManager()->CreateTexture("", &pixels, bMipMaps, RDEFAULT, RDEFAULT,
                                                                                                                  renderFormat, textureAddress);
                 if (pTexture)

--- a/Client/sdk/core/CRenderItemManagerInterface.h
+++ b/Client/sdk/core/CRenderItemManagerInterface.h
@@ -190,6 +190,10 @@ public:
     virtual bool           IsUsingDefaultRenderTarget() = 0;
     virtual HRESULT        HandleStretchRect(IDirect3DSurface9* pSourceSurface, CONST RECT* pSourceRect, IDirect3DSurface9* pDestSurface, CONST RECT* pDestRect,
                                              int Filter) = 0;
+    // Swap a file texture's D3D resource in-place (used by async dxCreateTexture).
+    // bTreatAsPixels uses the pixels decoder (PNG/DDS/PLAIN); otherwise the file-in-memory path (2D/cube/volume).
+    virtual bool ReplaceFileTextureFromMemory(CTextureItem* pTextureItem, const void* pData, uint uiSize, bool bMipMaps, ERenderFormat format,
+                                              bool bTreatAsPixels) = 0;
 };
 
 ////////////////////////////////////////////////////////////////
@@ -474,7 +478,10 @@ class CFileTextureItem : public CTextureItem
     void         CreateUnderlyingData(const SString& strFilename, bool bMipMaps, uint uiSizeX, uint uiSizeY, ERenderFormat format);
     void         CreateUnderlyingData(const CPixels* pPixels, bool bMipMaps, ERenderFormat format);
     void         CreateUnderlyingData(bool bMipMaps, uint uiSizeX, uint uiSizeY, ERenderFormat format, ETextureType textureType, uint uiVolumeDepth);
+    void         CreateUnderlyingDataFromFileMemory(const void* pData, uint uiSize, bool bMipMaps, uint uiSizeX, uint uiSizeY, ERenderFormat format);
     void         ReleaseUnderlyingData();
+    bool         ReplaceFromFileMemory(const void* pData, uint uiSize, bool bMipMaps, ERenderFormat format);
+    bool         ReplaceFromPixels(const CPixels* pPixels, bool bMipMaps, ERenderFormat format);
 
     uint         m_uiVolumeDepth;
     ETextureType m_TextureType;


### PR DESCRIPTION
﻿#### Summary
Adds an optional async mode to `dxCreateTexture` so large file/pixel textures can load without stalling the calling frame.

`async = true` returns a drawable 1x1 placeholder immediately. The same element is swapped in-place once the image is ready. Optional callback is `function(textureElement, success, ...callbackArguments)`. Existing calls are unchanged.

File IO runs on a worker. D3D9 is not thread-safe, so D3DX upload stays on the main thread (same constraint that closed #1133).

```lua
dxCreateTexture(pathOrPixels [, textureFormat, mipmaps, textureEdge [, async, callback, callbackArguments ] ])

local function asyncTextureCallback(textureElement, success, textureKey)
    if not success then
        outputDebugString("Texture '" .. textureKey .. "' failed to load")
        return
    end
    outputDebugString("Texture '" .. textureKey .. "' loaded")
end

local minimap = dxCreateTexture("assets/minimap_4096.png", "argb", true, "clamp", true, asyncTextureCallback, { "minimap" })
```

#### Motivation
Fixes #4713. `dxCreateTexture` currently decodes and uploads on the calling frame, so large minimaps, liveries and generated textures hitch. Scripts need a way to lazy-load without `dxDrawImage` crashing on a texture that is not ready yet.

#### Test plan
1. Sync `dxCreateTexture` (file, pixels, blank) still works as before.
2. `dxCreateTexture(path, "argb", true, "clamp", true, callback, { "minimap" })` returns a drawable 1x1, then the callback fires with `success == true` and `dxGetMaterialSize` matches the real image.
3. `dxDrawImage` on the placeholder before the callback does not crash.
4. Missing/bad path still errors immediately (no placeholder).
5. `destroyElement` / resource stop before the load finishes does not crash.
6. Large PNG and DDS (dxt1/3/5) no longer hitch on the `dxCreateTexture` call itself.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
