### PR TITLE
refactor: move legacy task hooks to `CMultiplayerSA_Tasks`

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -38,7 +38,6 @@ extern CGame* pGameInterface;
 #define HOOKPOS_CCustomRoadsignMgr__RenderRoadsignAtomic 0x6FF35B
 #define HOOKPOS_Trailer_BreakTowLink                     0x6E0027
 #define HOOKPOS_CRadar__DrawRadarGangOverlay             0x586650
-#define HOOKPOS_CTaskComplexJump__CreateSubTask          0x67DABE
 #define HOOKPOS_CTrain_ProcessControl_Derail             0x6F8DBA
 #define HOOKPOS_CVehicle_SetupRender                     0x6D6512
 #define HOOKPOS_CVehicle_ResetAfterRender                0x6D0E3E
@@ -62,12 +61,10 @@ extern CGame* pGameInterface;
 DWORD RETURN_FxManager_CreateFxSystem = 0x4A9BE8;
 DWORD RETURN_FxManager_DestroyFxSystem = 0x4A9817;
 
-#define HOOKPOS_CCam_ProcessFixed                           0x51D470
-#define HOOKPOS_CTaskSimplePlayerOnFoot_ProcessPlayerWeapon 0x6859a0
-#define HOOKPOS_CPed_IsPlayer                               0x5DF8F0
+#define HOOKPOS_CCam_ProcessFixed 0x51D470
+#define HOOKPOS_CPed_IsPlayer     0x5DF8F0
 
 DWORD RETURN_CCam_ProcessFixed = 0x51D475;
-DWORD RETURN_CTaskSimplePlayerOnFoot_ProcessPlayerWeapon = 0x6859A7;
 DWORD RETURN_CPed_IsPlayer = 0x5DF8F6;
 
 #define VAR_CollisionStreamRead_ModelInfo 0x9689E0
@@ -135,8 +132,6 @@ DWORD RETURN_CPhysical_ApplyGravity = 0x543093;
 
 #define HOOKPOS_CWorld_SetWorldOnFire 0x56B983
 DWORD RETURN_CWorld_SetWorldOnFire = 0x56B989;
-#define HOOKPOS_CTaskSimplePlayerOnFire_ProcessPed 0x6336DA
-DWORD RETURN_CTaskSimplePlayerOnFire_ProcessPed = 0x6336E0;
 #define HOOKPOS_CFire_ProcessFire 0x53AC1A
 DWORD RETURN_CFire_ProcessFire = 0x53AC1F;
 #define HOOKPOS_CExplosion_Update 0x7377D3
@@ -167,12 +162,6 @@ DWORD**       VAR_TagInfoArray = (DWORD**)0xA9A8C0;
 
 #define HOOKPOS_CPhysical_ProcessCollisionSectorList 0x54BB93
 DWORD RETURN_CPhysical_ProcessCollisionSectorList = 0x54BB9A;
-
-// CTaskSimpleClimb::ScanToGrabSectorList. Hooked right after its own collision check, so climb
-// and vault scans also skip entities excluded via setElementCollidableWith.
-#define HOOKPOS_CTaskSimpleClimb_ScanToGrabSectorList 0x67DF28
-DWORD RETURN_CTaskSimpleClimb_ScanToGrabSectorList = 0x67DF36;
-DWORD SKIP_CTaskSimpleClimb_ScanToGrabSectorList = 0x67E580;
 
 #define HOOKPOS_CheckAnimMatrix 0x7C5A5C
 DWORD RETURN_CheckAnimMatrix = 0x7C5A61;
@@ -277,9 +266,6 @@ constexpr const DWORD CALL_FROM_CPhysical_ApplyCollision_2 = 0x5490AE;
 constexpr const DWORD CALL_FROM_CPhysical_ApplySoftCollision = 0x54A816;
 
 #define HOOKPOS_FxManager_c__DestroyFxSystem 0x4A989A
-
-#define HOOKPOS_CTaskSimplyGangDriveBy__ProcessPed 0x62D5A7
-DWORD RETURN_CTaskSimplyGangDriveBy__ProcessPed = 0x62D5AC;
 
 #define HOOKPOS_CAERadioTrackManager__ChooseMusicTrackIndex 0x4EA296
 DWORD RETURN_CAERadioTrackManager__ChooseMusicTrackIndex = 0x4EA2A0;
@@ -417,12 +403,12 @@ IdleHandler*                               m_pIdleHandler = NULL;
 PreFxRenderHandler*                        m_pPreFxRenderHandler = NULL;
 PostColorFilterRenderHandler*              m_pPostColorFilterRenderHandler = nullptr;
 PreHudRenderHandler*                       m_pPreHudRenderHandler = NULL;
-ProcessCollisionHandler*                   m_pProcessCollisionHandler = NULL;
+ProcessCollisionHandler*                   CMultiplayerSA::m_pProcessCollisionHandler = NULL;
 HeliKillHandler*                           m_pHeliKillHandler = NULL;
 ObjectDamageHandler*                       m_pObjectDamageHandler = NULL;
 ObjectBreakHandler*                        m_pObjectBreakHandler = NULL;
 FxSystemDestructionHandler*                m_pFxSystemDestructionHandler = NULL;
-DrivebyAnimationHandler*                   m_pDrivebyAnimationHandler = NULL;
+DrivebyAnimationHandler*                   CMultiplayerSA::m_pDrivebyAnimationHandler = NULL;
 AudioZoneRadioSwitchHandler*               m_pAudioZoneRadioSwitchHandler = NULL;
 
 CEntitySAInterface* dwSavedPlayerPointer = 0;
@@ -438,12 +424,10 @@ void HOOK_CExplosion_AddExplosion();
 void HOOK_CCustomRoadsignMgr__RenderRoadsignAtomic();
 void HOOK_Trailer_BreakTowLink();
 void HOOK_CRadar__DrawRadarGangOverlay();
-void HOOK_CTaskComplexJump__CreateSubTask();
 void HOOK_FxManager_CreateFxSystem();
 void HOOK_FxManager_DestroyFxSystem();
 void HOOK_CCam_ProcessFixed();
 void HOOK_Render3DStuff();
-void HOOK_CTaskSimplePlayerOnFoot_ProcessPlayerWeapon();
 void HOOK_CPed_IsPlayer();
 void HOOK_CTrain_ProcessControl_Derail();
 void HOOK_CVehicle_SetupRender();
@@ -468,7 +452,6 @@ void HOOK_OccupiedVehicleBurnCheck();
 void HOOK_UnoccupiedVehicleBurnCheck();
 void HOOK_ApplyCarBlowHop();
 void HOOK_CWorld_SetWorldOnFire();
-void HOOK_CTaskSimplePlayerOnFire_ProcessPed();
 void HOOK_CFire_ProcessFire();
 void HOOK_CExplosion_Update();
 void HOOK_CWeapon_FireAreaEffect();
@@ -482,7 +465,6 @@ void HOOK_CEventHandler_ComputeKnockOffBikeResponse();
 void HOOK_CPed_GetWeaponSkill();
 void HOOK_CPed_AddGogglesModel();
 void HOOK_CPhysical_ProcessCollisionSectorList();
-void HOOK_CTaskSimpleClimb_ScanToGrabSectorList();
 void HOOK_CrashFix_Misc1();
 void HOOK_CrashFix_Misc2();
 void HOOK_CrashFix_Misc4();
@@ -559,8 +541,6 @@ void HOOK_CGlass_WindowRespondsToCollision();
 void HOOK_CGlass__BreakGlassPhysically();
 
 void HOOK_FxManager_c__DestroyFxSystem();
-
-void HOOK_CTaskSimpleGangDriveBy__ProcessPed();
 
 void HOOK_CAERadioTrackManager__ChooseMusicTrackIndex();
 
@@ -646,11 +626,9 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_CCustomRoadsignMgr__RenderRoadsignAtomic, (DWORD)HOOK_CCustomRoadsignMgr__RenderRoadsignAtomic, 6);
     HookInstall(HOOKPOS_Trailer_BreakTowLink, (DWORD)HOOK_Trailer_BreakTowLink, 6);
     HookInstall(HOOKPOS_CRadar__DrawRadarGangOverlay, (DWORD)HOOK_CRadar__DrawRadarGangOverlay, 6);
-    HookInstall(HOOKPOS_CTaskComplexJump__CreateSubTask, (DWORD)HOOK_CTaskComplexJump__CreateSubTask, 6);
     HookInstall(HOOKPOS_FxManager_CreateFxSystem, (DWORD)HOOK_FxManager_CreateFxSystem, 8);
     HookInstall(HOOKPOS_FxManager_DestroyFxSystem, (DWORD)HOOK_FxManager_DestroyFxSystem, 7);
     HookInstall(HOOKPOS_CCam_ProcessFixed, (DWORD)HOOK_CCam_ProcessFixed, 5);
-    HookInstall(HOOKPOS_CTaskSimplePlayerOnFoot_ProcessPlayerWeapon, (DWORD)HOOK_CTaskSimplePlayerOnFoot_ProcessPlayerWeapon, 7);
     HookInstall(HOOKPOS_CPed_IsPlayer, (DWORD)HOOK_CPed_IsPlayer, 6);
     HookInstall(HOOKPOS_CTrain_ProcessControl_Derail, (DWORD)HOOK_CTrain_ProcessControl_Derail, 6);
     HookInstall(HOOKPOS_CVehicle_SetupRender, (DWORD)HOOK_CVehicle_SetupRender, 5);
@@ -674,7 +652,6 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_UnoccupiedVehicleBurnCheck, (DWORD)HOOK_UnoccupiedVehicleBurnCheck, 5);
     HookInstall(HOOKPOS_ApplyCarBlowHop, (DWORD)HOOK_ApplyCarBlowHop, 6);
     HookInstall(HOOKPOS_CWorld_SetWorldOnFire, (DWORD)HOOK_CWorld_SetWorldOnFire, 5);
-    HookInstall(HOOKPOS_CTaskSimplePlayerOnFire_ProcessPed, (DWORD)HOOK_CTaskSimplePlayerOnFire_ProcessPed, 5);
     HookInstall(HOOKPOS_CFire_ProcessFire, (DWORD)HOOK_CFire_ProcessFire, 5);
     HookInstall(HOOKPOS_CExplosion_Update, (DWORD)HOOK_CExplosion_Update, 5);
     HookInstall(HOOKPOS_CWeapon_FireAreaEffect, (DWORD)HOOK_CWeapon_FireAreaEffect, 5);
@@ -685,7 +662,6 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_CPed_GetWeaponSkill, (DWORD)HOOK_CPed_GetWeaponSkill, 8);
     HookInstall(HOOKPOS_CPed_AddGogglesModel, (DWORD)HOOK_CPed_AddGogglesModel, 6);
     HookInstall(HOOKPOS_CPhysical_ProcessCollisionSectorList, (DWORD)HOOK_CPhysical_ProcessCollisionSectorList, 7);
-    HookInstall(HOOKPOS_CTaskSimpleClimb_ScanToGrabSectorList, (DWORD)HOOK_CTaskSimpleClimb_ScanToGrabSectorList, 8);
     HookInstall(HOOKPOS_CheckAnimMatrix, (DWORD)HOOK_CheckAnimMatrix, 5);
 
     HookInstall(HOOKPOS_VehColCB, (DWORD)HOOK_VehColCB, 29);
@@ -753,9 +729,6 @@ void CMultiplayerSA::InitHooks()
 
     // Post-destruction hook for FxSystems
     HookInstall(HOOKPOS_FxManager_c__DestroyFxSystem, (DWORD)HOOK_FxManager_c__DestroyFxSystem, 5);
-
-    // CTaskSimpleGangDriveBy::ProcessPed hook for disabling certain animations
-    HookInstall(HOOKPOS_CTaskSimplyGangDriveBy__ProcessPed, (DWORD)HOOK_CTaskSimpleGangDriveBy__ProcessPed, 5);
 
     SString strTrakLkupMd5 = CMD5Hasher::CalculateHexString(PathJoin(GetLaunchPath(), "audio", "CONFIG", "TrakLkup.dat"));
     if (strTrakLkupMd5 != "528E75D663B8BAE072A01351081A2145")
@@ -3305,73 +3278,6 @@ static void __declspec(naked) HOOK_CExplosion_AddExplosion()
     // clang-format on
 }
 
-CEntitySAInterface* entity;
-float*              entityEdgeHeight;
-float               edgeHeight;
-CVector*            pedPosition;
-
-bool processGrab()
-{
-    if (entity->nType == ENTITY_TYPE_OBJECT)
-    {
-        // CObjectSA * object = (CObjectSA*)entity;
-        // CModelInfo * info = pGameInterface->GetModelInfo(entity->m_nModelIndex);
-        if (entity->matrix)
-            edgeHeight = *entityEdgeHeight + entity->matrix->vPos.fZ;
-        else
-            edgeHeight = *entityEdgeHeight + entity->m_transform.m_translate.fZ;
-    }
-    else
-        edgeHeight = *entityEdgeHeight;
-
-    if (edgeHeight - pedPosition->fZ >= 1.4f)
-        return true;
-    return false;
-}
-
-// 0x67DABE
-static void __declspec(naked) HOOK_CTaskComplexJump__CreateSubTask()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // clang-format off
-    __asm
-    {
-        mov     pedPosition, eax
-        mov     eax, [esi+28]
-        mov     entity, eax
-        mov     eax, esi
-        add     eax, 16
-        mov     entityEdgeHeight, eax
-        mov     eax, pedPosition
-        pushad
-    }
-    // clang-format on
-
-    if (processGrab())
-    {
-        // clang-format off
-        __asm
-        {
-            popad
-            mov     eax, 0x67DAD6
-            jmp     eax
-        }
-        // clang-format on
-    }
-    else
-    {
-        // clang-format off
-        __asm
-        {
-            popad
-            mov     eax, 0x67DAD1
-            jmp     eax
-        }
-        // clang-format on
-    }
-}
-
 char*  szCreateFxSystem_ExplosionType = 0;
 DWORD* pCreateFxSystem_Matrix = 0;
 DWORD* pNewCreateFxSystem_Matrix = 0;
@@ -3548,69 +3454,6 @@ static void __declspec(naked) HOOK_Render3DStuff()
         ret
     }
     // clang-format on
-}
-
-CPedSAInterface* pProcessPlayerWeaponPed = NULL;
-bool             ProcessPlayerWeapon()
-{
-    if (IsLocalPlayer(pProcessPlayerWeaponPed))
-        return true;
-
-    SClientEntity<CPedSA>* pPedClientEntity = pGameInterface->GetPools()->GetPed((DWORD*)pProcessPlayerWeaponPed);
-    CPlayerPed*            pPed = pPedClientEntity ? dynamic_cast<CPlayerPed*>(pPedClientEntity->pEntity) : nullptr;
-    if (pPed)
-    {
-        CRemoteDataStorageSA* pData = CRemoteDataSA::GetRemoteDataStorage(pPed);
-        if (pData)
-        {
-            if (pData->ProcessPlayerWeapon())
-            {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
-static void __declspec(naked) HOOK_CTaskSimplePlayerOnFoot_ProcessPlayerWeapon()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    /*
-    006859A0  push        0FFFFFFFFh                        <hook>
-    006859A2  push        846BCEh                           <hook>
-    006859A7  mov         eax,dword ptr fs:[00000000h]      <return>
-    */
-    // clang-format off
-    __asm
-    {
-        mov     eax, [esp+4]
-        mov     pProcessPlayerWeaponPed, eax
-        pushad
-    }
-    // clang-format on
-    if (ProcessPlayerWeapon())
-    {
-        // clang-format off
-        __asm
-        {
-            popad
-            push    0FFFFFFFFh
-            push    846BCEh
-            jmp     RETURN_CTaskSimplePlayerOnFoot_ProcessPlayerWeapon
-        }
-        // clang-format on
-    }
-    else
-    {
-        // clang-format off
-        __asm
-        {
-            popad
-            ret 4
-        }
-        // clang-format on
-    }
 }
 
 CPedSAInterface* pIsPlayerPed = NULL;
@@ -5847,25 +5690,6 @@ static void __declspec(naked) HOOK_CWorld_SetWorldOnFire()
     // clang-format on
 }
 
-static void __declspec(naked) HOOK_CTaskSimplePlayerOnFire_ProcessPed()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // Actually pass the fire's pCreatorEntity to the damage event (instead of a null pointer)
-    // clang-format off
-    __asm
-    {
-        push 3
-        push 0x25
-        push edx
-        mov eax, [edi+0x730]    // eax = pPed->pFire
-        mov eax, [eax+0x14]     // eax = pFire->pCreator
-        push eax
-        jmp RETURN_CTaskSimplePlayerOnFire_ProcessPed
-    }
-    // clang-format on
-}
-
 static void __declspec(naked) HOOK_CFire_ProcessFire()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
@@ -6356,7 +6180,7 @@ bool                  CPhysical_ProcessCollisionSectorList()
 {
     if (pCollisionPhysicalThis && pCollisionPhysical)
     {
-        if (m_pProcessCollisionHandler && !m_pProcessCollisionHandler(pCollisionPhysicalThis, pCollisionPhysical))
+        if (CMultiplayerSA::m_pProcessCollisionHandler && !CMultiplayerSA::m_pProcessCollisionHandler(pCollisionPhysicalThis, pCollisionPhysical))
         {
             return false;
         }
@@ -6401,59 +6225,6 @@ static void __declspec(naked) HOOK_CPhysical_ProcessCollisionSectorList()
             test    edi, 1
             mov     edi, pCollisionPhysical
             jmp     RETURN_CPhysical_ProcessCollisionSectorList
-        }
-        // clang-format on
-    }
-}
-
-CEntitySAInterface* pClimbScanPedInterface;
-CEntitySAInterface* pClimbScanTargetInterface;
-BYTE                bClimbScanTargetUsesCollision;
-
-bool CTaskSimpleClimb_ShouldSkipEntity()
-{
-    // Same as the game's own check this replaces: no collision on the entity at all
-    if (!bClimbScanTargetUsesCollision)
-        return true;
-
-    // Also skip entities the ped was explicitly made non-collidable with (setElementCollidableWith)
-    if (pClimbScanPedInterface && pClimbScanTargetInterface && m_pProcessCollisionHandler)
-        return !m_pProcessCollisionHandler(pClimbScanPedInterface, pClimbScanTargetInterface);
-
-    return false;
-}
-
-static void __declspec(naked) HOOK_CTaskSimpleClimb_ScanToGrabSectorList()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // clang-format off
-    __asm
-    {
-        mov     pClimbScanPedInterface, ebx
-        mov     pClimbScanTargetInterface, esi
-        test    byte ptr [esi+1Ch], 1
-        mov     word ptr [esi+2Ch], cx
-        setne   al
-        mov     bClimbScanTargetUsesCollision, al
-    }
-    // clang-format on
-
-    if (CTaskSimpleClimb_ShouldSkipEntity())
-    {
-        // clang-format off
-        __asm
-        {
-            jmp     SKIP_CTaskSimpleClimb_ScanToGrabSectorList
-        }
-        // clang-format on
-    }
-    else
-    {
-        // clang-format off
-        __asm
-        {
-            jmp     RETURN_CTaskSimpleClimb_ScanToGrabSectorList
         }
         // clang-format on
     }
@@ -7703,46 +7474,6 @@ static void __declspec(naked) HOOK_FxManager_c__DestroyFxSystem()
         pop ebx
         pop ecx
         retn 4
-    }
-    // clang-format on
-}
-
-DWORD pProcessedGangDriveBySimpleTask;
-void  CTaskSimpleGangDriveBy__ProcessPed()
-{
-    AnimationId* pRequiredAnim = ((AnimationId*)(pProcessedGangDriveBySimpleTask + 0x24));
-    AssocGroupId requiredAnimGroup = *((AssocGroupId*)(pProcessedGangDriveBySimpleTask + 0x28));
-
-    if (m_pDrivebyAnimationHandler != NULL)
-        *pRequiredAnim = m_pDrivebyAnimationHandler(*pRequiredAnim, requiredAnimGroup);
-}
-
-DWORD                         RETURN_CTaskSimpleGangDriveBy_ProcessPed_Cancel = 0x62D5C1;
-static void __declspec(naked) HOOK_CTaskSimpleGangDriveBy__ProcessPed()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // esi contains 'this'
-    // clang-format off
-    __asm
-    {
-        mov pProcessedGangDriveBySimpleTask, esi
-        pushad
-    }
-    // clang-format on
-    CTaskSimpleGangDriveBy__ProcessPed();
-    // clang-format off
-    __asm
-    {
-        popad
-        // Replaced code
-        cmp[esi + 28h], edi                // .text:0062D5A7
-        jnz GangDriveBy_ProcessPed_Cancel  // .text:0062D5AA
-        // Return to original code
-        jmp RETURN_CTaskSimplyGangDriveBy__ProcessPed
-
-    GangDriveBy_ProcessPed_Cancel:
-        jmp RETURN_CTaskSimpleGangDriveBy_ProcessPed_Cancel
     }
     // clang-format on
 }

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -374,6 +374,9 @@ public:
     static char* ms_PlayerImgCachePtr;
     bool         m_bBadDrivebyHitboxesDisabled;
 
+    static ProcessCollisionHandler* m_pProcessCollisionHandler;
+    static DrivebyAnimationHandler* m_pDrivebyAnimationHandler;
+
 private:
     std::vector<char>   m_PlayerImgCache;
     EFastClothesLoading m_FastClothesLoading;

--- a/Client/multiplayer_sa/CMultiplayerSA_Tasks.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Tasks.cpp
@@ -8,6 +8,9 @@
  *
  *****************************************************************************/
 #include "StdInc.h"
+#include "CMultiplayerSA.h"
+#include "CRemoteDataSA.h"
+#include "multiplayer_shotsync.h"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
@@ -64,12 +67,263 @@ static void __declspec(naked)   HOOK_CTaskSimplePlayerOnFoot__MakeAbortable()
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
+// CTaskComplexJump::CreateSubTask
+//
+// In GTA:SA, ledge grab height calculation on dynamic objects fails to account for
+// the object's Z translation matrix. This hook adds object matrix position to the edge height.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+static bool ProcessGrab(CEntitySAInterface* pEntity, float fEntityEdgeHeight, const CVector* pPedPosition)
+{
+    float edgeHeight = fEntityEdgeHeight;
+    if (pEntity && pEntity->nType == ENTITY_TYPE_OBJECT)
+    {
+        if (pEntity->matrix)
+            edgeHeight = fEntityEdgeHeight + pEntity->matrix->vPos.fZ;
+        else
+            edgeHeight = fEntityEdgeHeight + pEntity->m_transform.m_translate.fZ;
+    }
+
+    return (pPedPosition && (edgeHeight - pPedPosition->fZ >= 1.4f));
+}
+
+#define HOOKPOS_CTaskComplexJump__CreateSubTask  0x67DABE
+#define HOOKSIZE_CTaskComplexJump__CreateSubTask 6
+static constexpr std::uintptr_t JUMP_CTaskComplexJump__CreateSubTask_Grab = 0x67DAD6;
+static constexpr std::uintptr_t JUMP_CTaskComplexJump__CreateSubTask_NoGrab = 0x67DAD1;
+
+static void __declspec(naked) HOOK_CTaskComplexJump__CreateSubTask()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // eax = pedPosition, esi = jumpTask (this->m_pSubTask)
+        // [esi + 28] = entity, [esi + 16] = edgeHeight
+        pushad
+        push    eax                     // pPedPosition
+        push    dword ptr [esi + 16]    // fEntityEdgeHeight
+        push    dword ptr [esi + 28]    // pEntity
+        call    ProcessGrab
+        add     esp, 12
+        test    al, al
+        jz      no_grab
+
+        popad
+        jmp     JUMP_CTaskComplexJump__CreateSubTask_Grab
+
+    no_grab:
+        popad
+        jmp     JUMP_CTaskComplexJump__CreateSubTask_NoGrab
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CTaskSimplePlayerOnFoot::ProcessPlayerWeapon
+//
+// Handles player weapon state processing and synchronizing remote player firing/aiming tasks.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+static bool ProcessPlayerWeapon(CPedSAInterface* pPedInterface)
+{
+    if (IsLocalPlayer(pPedInterface))
+        return true;
+
+    SClientEntity<CPedSA>* pPedClientEntity = pGameInterface->GetPools()->GetPed((DWORD*)pPedInterface);
+    CPlayerPed*            pPed = pPedClientEntity ? dynamic_cast<CPlayerPed*>(pPedClientEntity->pEntity) : nullptr;
+    if (pPed)
+    {
+        CRemoteDataStorageSA* pData = CRemoteDataSA::GetRemoteDataStorage(pPed);
+        if (pData && pData->ProcessPlayerWeapon())
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+#define HOOKPOS_CTaskSimplePlayerOnFoot_ProcessPlayerWeapon  0x6859A0
+#define HOOKSIZE_CTaskSimplePlayerOnFoot_ProcessPlayerWeapon 7
+static constexpr std::uintptr_t RETURN_CTaskSimplePlayerOnFoot_ProcessPlayerWeapon = 0x6859A7;
+
+static void __declspec(naked) HOOK_CTaskSimplePlayerOnFoot_ProcessPlayerWeapon()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        pushad
+        push    dword ptr [esp + 32 + 4]    // playa (arg1)
+        call    ProcessPlayerWeapon
+        add     esp, 4
+        test    al, al
+        jz      skip
+
+        popad
+        push    0FFFFFFFFh
+        push    846BCEh
+        jmp     RETURN_CTaskSimplePlayerOnFoot_ProcessPlayerWeapon
+
+    skip:
+        popad
+        retn    4
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CTaskSimplePlayerOnFire::ProcessPed
+//
+// Passes the fire's creator entity (pPed->pFire->pCreator) to the damage event instead of NULL,
+// allowing kill/damage attribution to function properly when players catch fire.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+#define HOOKPOS_CTaskSimplePlayerOnFire_ProcessPed  0x6336DA
+#define HOOKSIZE_CTaskSimplePlayerOnFire_ProcessPed 5
+static constexpr std::uintptr_t RETURN_CTaskSimplePlayerOnFire_ProcessPed = 0x6336E0;
+
+static void __declspec(naked) HOOK_CTaskSimplePlayerOnFire_ProcessPed()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    3
+        push    0x25
+        push    edx
+        mov     eax, [edi + 0x730]      // eax = pPed->pFire
+        mov     eax, [eax + 0x14]       // eax = pFire->pCreator
+        push    eax
+        jmp     RETURN_CTaskSimplePlayerOnFire_ProcessPed
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CTaskSimpleClimb::ScanToGrabSectorList
+//
+// Skips entities that have collision disabled or were explicitly set non-collidable
+// with the climbing ped via setElementCollidableWith.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+static bool CTaskSimpleClimb_ShouldSkipEntity(CPedSAInterface* pPed, CEntitySAInterface* pTarget, bool bTargetUsesCollision)
+{
+    if (!bTargetUsesCollision)
+        return true;
+
+    if (pPed && pTarget && CMultiplayerSA::m_pProcessCollisionHandler)
+        return !CMultiplayerSA::m_pProcessCollisionHandler(pPed, pTarget);
+
+    return false;
+}
+
+#define HOOKPOS_CTaskSimpleClimb_ScanToGrabSectorList  0x67DF28
+#define HOOKSIZE_CTaskSimpleClimb_ScanToGrabSectorList 8
+static constexpr std::uintptr_t RETURN_CTaskSimpleClimb_ScanToGrabSectorList = 0x67DF36;
+static constexpr std::uintptr_t SKIP_CTaskSimpleClimb_ScanToGrabSectorList = 0x67E580;
+
+static void __declspec(naked) HOOK_CTaskSimpleClimb_ScanToGrabSectorList()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // ebx = ped, esi = target entity, cx = target scan code
+        test    byte ptr [esi + 1Ch], 1
+        mov     word ptr [esi + 2Ch], cx
+        setne   al
+
+        pushad
+        movzx   eax, al
+        push    eax                     // bTargetUsesCollision
+        push    esi                     // pTarget
+        push    ebx                     // pPed
+        call    CTaskSimpleClimb_ShouldSkipEntity
+        add     esp, 12
+        test    al, al
+        jnz     skip_entity
+
+        popad
+        jmp     RETURN_CTaskSimpleClimb_ScanToGrabSectorList
+
+    skip_entity:
+        popad
+        jmp     SKIP_CTaskSimpleClimb_ScanToGrabSectorList
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CTaskSimpleGangDriveBy::ProcessPed
+//
+// Dispatches to custom drive-by animation handler to allow override/custom animations.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+static void CTaskSimpleGangDriveBy_ProcessPed(DWORD pProcessedGangDriveBySimpleTask)
+{
+    if (!pProcessedGangDriveBySimpleTask)
+        return;
+
+    auto*        pRequiredAnim = reinterpret_cast<AnimationId*>(pProcessedGangDriveBySimpleTask + 0x24);
+    AssocGroupId requiredAnimGroup = *reinterpret_cast<AssocGroupId*>(pProcessedGangDriveBySimpleTask + 0x28);
+
+    if (CMultiplayerSA::m_pDrivebyAnimationHandler != nullptr)
+        *pRequiredAnim = CMultiplayerSA::m_pDrivebyAnimationHandler(*pRequiredAnim, requiredAnimGroup);
+}
+
+#define HOOKPOS_CTaskSimpleGangDriveBy__ProcessPed  0x62D5A7
+#define HOOKSIZE_CTaskSimpleGangDriveBy__ProcessPed 5
+static constexpr std::uintptr_t RETURN_CTaskSimpleGangDriveBy__ProcessPed = 0x62D5AC;
+static constexpr std::uintptr_t CANCEL_CTaskSimpleGangDriveBy__ProcessPed = 0x62D5C1;
+
+static void __declspec(naked) HOOK_CTaskSimpleGangDriveBy__ProcessPed()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // esi contains 'this' (CTaskSimpleGangDriveBy)
+        pushad
+        push    esi
+        call    CTaskSimpleGangDriveBy_ProcessPed
+        add     esp, 4
+        popad
+
+        // Replaced code
+        cmp     [esi + 28h], edi
+        jnz     cancel
+
+        jmp     RETURN_CTaskSimpleGangDriveBy__ProcessPed
+
+    cancel:
+        jmp     CANCEL_CTaskSimpleGangDriveBy__ProcessPed
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
 // CMultiplayerSA::InitHooks_Tasks
 //
-// Setup hooks
+// Setup task hooks
 //
 //////////////////////////////////////////////////////////////////////////////////////////
 void CMultiplayerSA::InitHooks_Tasks()
 {
     EZHookInstall(CTaskSimplePlayerOnFoot__MakeAbortable);
+    EZHookInstall(CTaskComplexJump__CreateSubTask);
+    EZHookInstall(CTaskSimplePlayerOnFoot_ProcessPlayerWeapon);
+    EZHookInstall(CTaskSimplePlayerOnFire_ProcessPed);
+    EZHookInstall(CTaskSimpleClimb_ScanToGrabSectorList);
+    EZHookInstall(CTaskSimpleGangDriveBy__ProcessPed);
 }

--- a/Client/multiplayer_sa/CMultiplayerSA_Tasks.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Tasks.cpp
@@ -73,18 +73,18 @@ static void __declspec(naked)   HOOK_CTaskSimplePlayerOnFoot__MakeAbortable()
 // the object's Z translation matrix. This hook adds object matrix position to the edge height.
 //
 //////////////////////////////////////////////////////////////////////////////////////////
-static bool ProcessGrab(CEntitySAInterface* pEntity, float fEntityEdgeHeight, const CVector* pPedPosition)
+static bool ProcessGrab(CEntitySAInterface* entity, float entityEdgeHeight, const CVector* pedPosition)
 {
-    float edgeHeight = fEntityEdgeHeight;
-    if (pEntity && pEntity->nType == ENTITY_TYPE_OBJECT)
+    float edgeHeight = entityEdgeHeight;
+    if (entity && entity->nType == ENTITY_TYPE_OBJECT)
     {
-        if (pEntity->matrix)
-            edgeHeight = fEntityEdgeHeight + pEntity->matrix->vPos.fZ;
+        if (entity->matrix)
+            edgeHeight = entityEdgeHeight + entity->matrix->vPos.fZ;
         else
-            edgeHeight = fEntityEdgeHeight + pEntity->m_transform.m_translate.fZ;
+            edgeHeight = entityEdgeHeight + entity->m_transform.m_translate.fZ;
     }
 
-    return (pPedPosition && (edgeHeight - pPedPosition->fZ >= 1.4f));
+    return (pedPosition && (edgeHeight - pedPosition->fZ >= 1.4f));
 }
 
 #define HOOKPOS_CTaskComplexJump__CreateSubTask  0x67DABE
@@ -102,9 +102,9 @@ static void __declspec(naked) HOOK_CTaskComplexJump__CreateSubTask()
         // eax = pedPosition, esi = jumpTask (this->m_pSubTask)
         // [esi + 28] = entity, [esi + 16] = edgeHeight
         pushad
-        push    eax                     // pPedPosition
-        push    dword ptr [esi + 16]    // fEntityEdgeHeight
-        push    dword ptr [esi + 28]    // pEntity
+        push    eax                     // pedPosition
+        push    dword ptr [esi + 16]    // entityEdgeHeight
+        push    dword ptr [esi + 28]    // entity
         call    ProcessGrab
         add     esp, 12
         test    al, al
@@ -127,17 +127,17 @@ static void __declspec(naked) HOOK_CTaskComplexJump__CreateSubTask()
 // Handles player weapon state processing and synchronizing remote player firing/aiming tasks.
 //
 //////////////////////////////////////////////////////////////////////////////////////////
-static bool ProcessPlayerWeapon(CPedSAInterface* pPedInterface)
+static bool ProcessPlayerWeapon(CPedSAInterface* pedInterface)
 {
-    if (IsLocalPlayer(pPedInterface))
+    if (IsLocalPlayer(pedInterface))
         return true;
 
-    SClientEntity<CPedSA>* pPedClientEntity = pGameInterface->GetPools()->GetPed((DWORD*)pPedInterface);
-    CPlayerPed*            pPed = pPedClientEntity ? dynamic_cast<CPlayerPed*>(pPedClientEntity->pEntity) : nullptr;
-    if (pPed)
+    SClientEntity<CPedSA>* pedClientEntity = pGameInterface->GetPools()->GetPed((DWORD*)pedInterface);
+    CPlayerPed*            ped = pedClientEntity ? dynamic_cast<CPlayerPed*>(pedClientEntity->pEntity) : nullptr;
+    if (ped)
     {
-        CRemoteDataStorageSA* pData = CRemoteDataSA::GetRemoteDataStorage(pPed);
-        if (pData && pData->ProcessPlayerWeapon())
+        CRemoteDataStorageSA* remoteData = CRemoteDataSA::GetRemoteDataStorage(ped);
+        if (remoteData && remoteData->ProcessPlayerWeapon())
         {
             return true;
         }
@@ -157,7 +157,7 @@ static void __declspec(naked) HOOK_CTaskSimplePlayerOnFoot_ProcessPlayerWeapon()
     __asm
     {
         pushad
-        push    dword ptr [esp + 32 + 4]    // playa (arg1)
+        push    dword ptr [esp + 32 + 4]    // pedInterface (arg1)
         call    ProcessPlayerWeapon
         add     esp, 4
         test    al, al
@@ -179,7 +179,7 @@ static void __declspec(naked) HOOK_CTaskSimplePlayerOnFoot_ProcessPlayerWeapon()
 //
 // CTaskSimplePlayerOnFire::ProcessPed
 //
-// Passes the fire's creator entity (pPed->pFire->pCreator) to the damage event instead of NULL,
+// Passes the fire's creator entity (ped->pFire->pCreator) to the damage event instead of NULL,
 // allowing kill/damage attribution to function properly when players catch fire.
 //
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -197,7 +197,7 @@ static void __declspec(naked) HOOK_CTaskSimplePlayerOnFire_ProcessPed()
         push    3
         push    0x25
         push    edx
-        mov     eax, [edi + 0x730]      // eax = pPed->pFire
+        mov     eax, [edi + 0x730]      // eax = ped->pFire
         mov     eax, [eax + 0x14]       // eax = pFire->pCreator
         push    eax
         jmp     RETURN_CTaskSimplePlayerOnFire_ProcessPed
@@ -213,13 +213,13 @@ static void __declspec(naked) HOOK_CTaskSimplePlayerOnFire_ProcessPed()
 // with the climbing ped via setElementCollidableWith.
 //
 //////////////////////////////////////////////////////////////////////////////////////////
-static bool CTaskSimpleClimb_ShouldSkipEntity(CPedSAInterface* pPed, CEntitySAInterface* pTarget, bool bTargetUsesCollision)
+static bool CTaskSimpleClimb_ShouldSkipEntity(CPedSAInterface* ped, CEntitySAInterface* target, bool targetUsesCollision)
 {
-    if (!bTargetUsesCollision)
+    if (!targetUsesCollision)
         return true;
 
-    if (pPed && pTarget && CMultiplayerSA::m_pProcessCollisionHandler)
-        return !CMultiplayerSA::m_pProcessCollisionHandler(pPed, pTarget);
+    if (ped && target && CMultiplayerSA::m_pProcessCollisionHandler)
+        return !CMultiplayerSA::m_pProcessCollisionHandler(ped, target);
 
     return false;
 }
@@ -243,9 +243,9 @@ static void __declspec(naked) HOOK_CTaskSimpleClimb_ScanToGrabSectorList()
 
         pushad
         movzx   eax, al
-        push    eax                     // bTargetUsesCollision
-        push    esi                     // pTarget
-        push    ebx                     // pPed
+        push    eax                     // targetUsesCollision
+        push    esi                     // target
+        push    ebx                     // ped
         call    CTaskSimpleClimb_ShouldSkipEntity
         add     esp, 12
         test    al, al
@@ -268,16 +268,16 @@ static void __declspec(naked) HOOK_CTaskSimpleClimb_ScanToGrabSectorList()
 // Dispatches to custom drive-by animation handler to allow override/custom animations.
 //
 //////////////////////////////////////////////////////////////////////////////////////////
-static void CTaskSimpleGangDriveBy_ProcessPed(DWORD pProcessedGangDriveBySimpleTask)
+static void CTaskSimpleGangDriveBy_ProcessPed(DWORD gangDriveByTask)
 {
-    if (!pProcessedGangDriveBySimpleTask)
+    if (!gangDriveByTask)
         return;
 
-    auto*        pRequiredAnim = reinterpret_cast<AnimationId*>(pProcessedGangDriveBySimpleTask + 0x24);
-    AssocGroupId requiredAnimGroup = *reinterpret_cast<AssocGroupId*>(pProcessedGangDriveBySimpleTask + 0x28);
+    auto*        requiredAnim = reinterpret_cast<AnimationId*>(gangDriveByTask + 0x24);
+    AssocGroupId requiredAnimGroup = *reinterpret_cast<AssocGroupId*>(gangDriveByTask + 0x28);
 
     if (CMultiplayerSA::m_pDrivebyAnimationHandler != nullptr)
-        *pRequiredAnim = CMultiplayerSA::m_pDrivebyAnimationHandler(*pRequiredAnim, requiredAnimGroup);
+        *requiredAnim = CMultiplayerSA::m_pDrivebyAnimationHandler(*requiredAnim, requiredAnimGroup);
 }
 
 #define HOOKPOS_CTaskSimpleGangDriveBy__ProcessPed  0x62D5A7


### PR DESCRIPTION
Continuing the ongoing cleanup of legacy hooks in `CMultiplayerSA.cpp`, this PR extracts and modernizes the remaining task-related hooks into `CMultiplayerSA_Tasks.cpp`.

### Testing
- Tested in-game:
  - Jump and ledge-grab on elevated/dynamic objects.
  - Climb scan behavior on elements with disabled collision (`setElementCollidableWith`).
  - Fire damage and kill attribution with Flamethrower / Molotov.
  - Passenger gang drive-by aiming and shooting animations.
