### PR TITLE
Refactor fire hooks and enable ground fire ignition for peds

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -133,16 +133,8 @@ DWORD RETURN_CVehicle_ApplyBoatWaterResistance = 0x6D2777;
 #define HOOKPOS_CPhysical_ApplyGravity 0x543081
 DWORD RETURN_CPhysical_ApplyGravity = 0x543093;
 
-#define HOOKPOS_CWorld_SetWorldOnFire 0x56B983
-DWORD RETURN_CWorld_SetWorldOnFire = 0x56B989;
-#define HOOKPOS_CTaskSimplePlayerOnFire_ProcessPed 0x6336DA
-DWORD RETURN_CTaskSimplePlayerOnFire_ProcessPed = 0x6336E0;
-#define HOOKPOS_CFire_ProcessFire 0x53AC1A
-DWORD RETURN_CFire_ProcessFire = 0x53AC1F;
 #define HOOKPOS_CExplosion_Update 0x7377D3
 DWORD RETURN_CExplosion_Update = 0x7377D8;
-#define HOOKPOS_CWeapon_FireAreaEffect 0x73EBFE
-DWORD RETURN_CWeapon_FireAreaEffect = 0x73EC03;
 
 #define CALL_RenderScene_Plants  0x53E103
 #define HOOKPOS_RenderScene_end  0x53E159
@@ -467,11 +459,7 @@ void HOOK_VehicleLookAside();
 void HOOK_OccupiedVehicleBurnCheck();
 void HOOK_UnoccupiedVehicleBurnCheck();
 void HOOK_ApplyCarBlowHop();
-void HOOK_CWorld_SetWorldOnFire();
-void HOOK_CTaskSimplePlayerOnFire_ProcessPed();
-void HOOK_CFire_ProcessFire();
 void HOOK_CExplosion_Update();
-void HOOK_CWeapon_FireAreaEffect();
 void HOOK_CGame_Process();
 void HOOK_CWeather_Update();
 void HOOK_Idle();
@@ -673,11 +661,7 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_OccupiedVehicleBurnCheck, (DWORD)HOOK_OccupiedVehicleBurnCheck, 6);
     HookInstall(HOOKPOS_UnoccupiedVehicleBurnCheck, (DWORD)HOOK_UnoccupiedVehicleBurnCheck, 5);
     HookInstall(HOOKPOS_ApplyCarBlowHop, (DWORD)HOOK_ApplyCarBlowHop, 6);
-    HookInstall(HOOKPOS_CWorld_SetWorldOnFire, (DWORD)HOOK_CWorld_SetWorldOnFire, 5);
-    HookInstall(HOOKPOS_CTaskSimplePlayerOnFire_ProcessPed, (DWORD)HOOK_CTaskSimplePlayerOnFire_ProcessPed, 5);
-    HookInstall(HOOKPOS_CFire_ProcessFire, (DWORD)HOOK_CFire_ProcessFire, 5);
     HookInstall(HOOKPOS_CExplosion_Update, (DWORD)HOOK_CExplosion_Update, 5);
-    HookInstall(HOOKPOS_CWeapon_FireAreaEffect, (DWORD)HOOK_CWeapon_FireAreaEffect, 5);
     HookInstall(HOOKPOS_CGame_Process, (DWORD)HOOK_CGame_Process, 10);
     HookInstallCall(CALL_CWeather_Update_FromCGameProcess, (DWORD)HOOK_CWeather_Update);
     HookInstall(HOOKPOS_Idle, (DWORD)HOOK_Idle, 10);
@@ -5829,63 +5813,6 @@ static void __declspec(naked) HOOK_CVehicle_DoHeadLightReflectionSingle()
 
 // ---------------------------------------------------
 
-// Report fire damage, with correct inflictor entity
-
-static void __declspec(naked) HOOK_CWorld_SetWorldOnFire()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // Actually pass the pCreatorEntity parameter that this function receives to CFireManager::StartFire
-    // (instead of a null pointer)
-    // clang-format off
-    __asm
-    {
-        push 7000
-        push [esp+0x18+0x14]
-        jmp RETURN_CWorld_SetWorldOnFire
-    }
-    // clang-format on
-}
-
-static void __declspec(naked) HOOK_CTaskSimplePlayerOnFire_ProcessPed()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // Actually pass the fire's pCreatorEntity to the damage event (instead of a null pointer)
-    // clang-format off
-    __asm
-    {
-        push 3
-        push 0x25
-        push edx
-        mov eax, [edi+0x730]    // eax = pPed->pFire
-        mov eax, [eax+0x14]     // eax = pFire->pCreator
-        push eax
-        jmp RETURN_CTaskSimplePlayerOnFire_ProcessPed
-    }
-    // clang-format on
-}
-
-static void __declspec(naked) HOOK_CFire_ProcessFire()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // Set the new fire's creator to the original fire's creator
-    // clang-format off
-    __asm
-    {
-        mov eax, 0x53A450       // CCreepingFire::TryToStartFireAtCoors
-        call eax
-        test eax, eax
-        jz fail
-        mov ecx, [esi+0x14]
-        mov [eax+0x14], ecx
-fail:
-        jmp RETURN_CFire_ProcessFire
-    }
-    // clang-format on
-}
-
 static void __declspec(naked) HOOK_CExplosion_Update()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
@@ -5902,26 +5829,6 @@ static void __declspec(naked) HOOK_CExplosion_Update()
         mov [eax+0x14], ecx
 fail:
         jmp RETURN_CExplosion_Update
-    }
-    // clang-format on
-}
-
-static void __declspec(naked) HOOK_CWeapon_FireAreaEffect()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // Set the new fire's creator to the weapon's owner
-    // clang-format off
-    __asm
-    {
-        mov eax, 0x53A450       // CCreepingFire::TryToStartFireAtCoors
-        call eax
-        test eax, eax
-        jz fail
-        mov ecx, [esp+0x6C+4]
-        mov [eax+0x14], ecx
-fail:
-        jmp RETURN_CWeapon_FireAreaEffect
     }
     // clang-format on
 }

--- a/Client/multiplayer_sa/CMultiplayerSA_Weapons.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Weapons.cpp
@@ -10,8 +10,9 @@
 
 #include "StdInc.h"
 #include <game/CEventDamage.h>
-#include "../game_sa/CWeaponInfoSA.h"
+
 extern EDamageReasonType g_GenerateDamageEventReason;
+extern FireHandler*      m_pFireHandler;
 static CElapsedTime      ms_LastFxTimer;
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -290,6 +291,224 @@ static void _declspec(naked) HOOK_CWaterLevel_TestLineAgainstWater()
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
+// CWorld::SetWorldOnFire
+//
+// Passes the creator entity parameter (creatorEntity) to CFireManager::StartFire
+// instead of passing a null pointer, so world fire damage is attributed to the creator entity.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+#define HOOKPOS_CWorld_SetWorldOnFire  0x56B983
+#define HOOKSIZE_CWorld_SetWorldOnFire 5
+static constexpr std::uintptr_t RETURN_CWorld_SetWorldOnFire = 0x56B989;
+
+static void __declspec(naked) HOOK_CWorld_SetWorldOnFire()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // Actually pass the creator entity parameter to CFireManager::StartFire (instead of null)
+    // clang-format off
+    __asm
+    {
+        push    7000
+        push    [esp + 18h + 14h]
+        jmp     RETURN_CWorld_SetWorldOnFire
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CFire::ProcessFire
+//
+// Sets new fire instances spawned from existing fire (creeping fire) to inherit
+// the parent fire's creator entity.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+#define HOOKPOS_CFire_ProcessFire  0x53AC1A
+#define HOOKSIZE_CFire_ProcessFire 5
+static constexpr std::uintptr_t RETURN_CFire_ProcessFire = 0x53AC1F;
+
+static void __declspec(naked) HOOK_CFire_ProcessFire()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // Set the new fire's creator to the parent fire's creator
+    // clang-format off
+    __asm
+    {
+        mov     eax, 0x53A450       // CCreepingFire::TryToStartFireAtCoors
+        call    eax
+        test    eax, eax
+        jz      fail
+        mov     ecx, [esi + 14h]
+        mov     [eax + 14h], ecx
+
+    fail:
+        jmp     RETURN_CFire_ProcessFire
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CWeapon::FireAreaEffect
+//
+// Sets new creeping fire instances spawned by area effect weapons (e.g. Flamethrower / Molotov)
+// to inherit the weapon owner entity.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+#define HOOKPOS_CWeapon_FireAreaEffect  0x73EBFE
+#define HOOKSIZE_CWeapon_FireAreaEffect 5
+static constexpr std::uintptr_t RETURN_CWeapon_FireAreaEffect = 0x73EC06;
+
+static void __declspec(naked) HOOK_CWeapon_FireAreaEffect()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // Set the new fire's creator to the weapon owner
+    // clang-format off
+    __asm
+    {
+        mov     eax, 0x53A450       // CCreepingFire::TryToStartFireAtCoors
+        call    eax
+        add     esp, 1Ch            // Pop the 7 arguments pushed before the call
+        test    eax, eax
+        jz      fail
+        mov     ecx, [esp + 54h]    // owner argument is at [esp + 54h] after popping the 28 bytes
+        mov     [eax + 14h], ecx    // set fire->entityCreator
+
+    fail:
+        jmp     RETURN_CWeapon_FireAreaEffect
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CFire::ProcessFire (Ped Check)
+//
+// In original GTA:SA single-player, creeping/ground fire only checked FindPlayerPed(-1).
+// This hook replaces the hardcoded local player check with a loop over CPools::ms_pPedPool
+// so that all script-created peds, bots, and remote players catch fire when walking over
+// fire on the ground.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+static void OnProcessPedsNearFire(CFireSAInterface* fire)
+{
+    if (!fire || !fire->bActive)
+        return;
+
+    // Only check ground / creeping fire (skip fire attached to peds, vehicles, or objects)
+    if (fire->entityTarget != nullptr)
+        return;
+
+    auto* pedPool = *reinterpret_cast<CPoolSAInterface<CPedSAInterface>**>(CLASS_CPedPool);
+    if (!pedPool)
+        return;
+
+    // GTA SA ped pool slot stride (1988)
+    constexpr std::uint32_t pedStride = 1988;
+    auto*                   poolBase = reinterpret_cast<std::uint8_t*>(pedPool->m_pObjects);
+
+    for (int i = 0; i < pedPool->m_nSize; ++i)
+    {
+        if (pedPool->IsEmpty(i))
+            continue;
+
+        auto* ped = reinterpret_cast<CPedSAInterface*>(poolBase + i * pedStride);
+        if (!ped)
+            continue;
+
+        // Skip if ped is already on fire
+        if (ped->pFireOnPed != nullptr)
+            continue;
+
+        // Skip if ped is dead or dying
+        if (ped->fHealth <= 0.0f)
+            continue;
+
+        // Skip if ped is inside a vehicle
+        if (ped->pVehicle != nullptr)
+            continue;
+
+        // Skip if ped is attached to another entity
+        if (ped->m_pAttachedEntity != nullptr || ped->bAttachedToEntity)
+            continue;
+
+        // Skip if ped is fire proof or invulnerable
+        if (ped->bFireProof || ped->bInvulnerable)
+            continue;
+
+        // Fast AABB Manhattan pre-filter (radius ~1.095m -> box threshold 1.1m) to reject distant peds with zero math
+        const CVector& pedPosition = ped->matrix ? ped->matrix->vPos : ped->m_transform.m_translate;
+        const float    deltaX = std::abs(pedPosition.fX - fire->vecPosition.fX);
+        if (deltaX >= 1.1f)
+            continue;
+
+        const float deltaY = std::abs(pedPosition.fY - fire->vecPosition.fY);
+        if (deltaY >= 1.1f)
+            continue;
+
+        const float deltaZ = std::abs(pedPosition.fZ - fire->vecPosition.fZ);
+        if (deltaZ >= 1.1f)
+            continue;
+
+        // Exact 3D distance squared check (threshold 1.2)
+        const float distanceSquared = deltaX * deltaX + deltaY * deltaY + deltaZ * deltaZ;
+        if (distanceSquared >= 1.2f)
+            continue;
+
+        // Validate entityCreator to ensure it points to a valid live ped entity
+        CEntitySAInterface* validCreator = nullptr;
+        if (fire->entityCreator)
+        {
+            const auto creatorPed = reinterpret_cast<CPedSAInterface*>(fire->entityCreator);
+            if (pedPool->IsContains(pedPool->GetObjectIndexSafe(creatorPed)))
+                validCreator = fire->entityCreator;
+        }
+
+        // Check friendly fire / team rules if a fire handler is registered
+        if (m_pFireHandler && !m_pFireHandler(reinterpret_cast<CEntitySAInterface*>(ped), validCreator))
+            continue;
+
+        // If local player or player ped, call CPlayerPed::DoStuffToGoOnFire
+        if (ped->IsPlayer())
+        {
+            using DoStuffToGoOnFire_t = void(__thiscall*)(CPedSAInterface*);
+            reinterpret_cast<DoStuffToGoOnFire_t>(0x60A020)(ped);
+        }
+
+        // Start fire on the ped using native CFireManager::StartFire
+        using StartFire_t = CFireSAInterface*(__thiscall*)(void*, CEntitySAInterface*, CEntitySAInterface*, float, std::uint8_t, std::uint32_t, std::int8_t);
+        reinterpret_cast<StartFire_t>(0x53A050)(reinterpret_cast<void*>(CLASS_CFireManager), reinterpret_cast<CEntitySAInterface*>(ped), validCreator, 0.8f, 1,
+                                                7000, 100);
+    }
+}
+
+#define HOOKPOS_CFire_ProcessFire_PedCheck  0x53A7B4
+#define HOOKSIZE_CFire_ProcessFire_PedCheck 5
+static constexpr std::uintptr_t RETURN_CFire_ProcessFire_PedCheck = 0x53A8C5;
+
+static void __declspec(naked) HOOK_CFire_ProcessFire_PedCheck()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        pushad
+        push    esi                 // CFireSAInterface* (this pointer in CFire::ProcessFire)
+        call    OnProcessPedsNearFire
+        add     esp, 4
+        popad
+
+        jmp     RETURN_CFire_ProcessFire_PedCheck
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
 // CMultiplayerSA::InitHooks_Weapons
 //
 // Setup hooks
@@ -302,4 +521,8 @@ void CMultiplayerSA::InitHooks_Weapons()
     EZHookInstall(Fx_AddBulletImpact);
     EZHookInstall(CVisibilityPlugins_RenderWeaponPedsForPC);
     EZHookInstall(CWaterLevel_TestLineAgainstWater);
+    EZHookInstall(CWorld_SetWorldOnFire);
+    EZHookInstall(CFire_ProcessFire);
+    EZHookInstall(CFire_ProcessFire_PedCheck);
+    EZHookInstall(CWeapon_FireAreaEffect);
 }

--- a/Client/multiplayer_sa/StdInc.h
+++ b/Client/multiplayer_sa/StdInc.h
@@ -20,9 +20,14 @@
 #include "multiplayersa_init.h"
 #include "multiplayer_keysync.h"
 #include "multiplayer_hooksystem.h"
-#include "..\game_sa\CCameraSA.h"
-#include "..\game_sa\CEntitySA.h"
-#include "..\game_sa\CPedSA.h"
-#include "..\game_sa\CProjectileSA.h"
+#include "../game_sa/CCameraSA.h"
+#include "../game_sa/CEntitySA.h"
+#include "../game_sa/CPedSA.h"
+#include "../game_sa/CProjectileSA.h"
+#include "../game_sa/CFireSA.h"
+#include "../game_sa/CFireManagerSA.h"
+#include "../game_sa/CPoolsSA.h"
+#include "../game_sa/CPoolSAInterface.h"
+#include "../game_sa/CWeaponInfoSA.h"
 
 extern CMultiplayerSA* pMultiplayer;

--- a/Client/multiplayer_sa/multiplayer_shotsync.cpp
+++ b/Client/multiplayer_sa/multiplayer_shotsync.cpp
@@ -835,6 +835,13 @@ bool ProcessDamageEvent(CEventDamageSAInterface* event, CPedSAInterface* affects
 {
     if (m_pDamageHandler && event)
     {
+        // If damage was caused by fire and GTA SA did not populate an inflictor entity,
+        // attribute the damage to the creator entity attached to this burning ped's fire.
+        if (event->pInflictor == nullptr && affectsPed && affectsPed->pFireOnPed && affectsPed->pFireOnPed->entityCreator)
+        {
+            event->pInflictor = affectsPed->pFireOnPed->entityCreator;
+        }
+
         CPoolsSA*              pPools = (CPoolsSA*)pGameInterface->GetPools();
         SClientEntity<CPedSA>* pPedClientEntity = pPools->GetPed((DWORD*)affectsPed);
         CPed*                  pPed = pPedClientEntity ? pPedClientEntity->pEntity : nullptr;


### PR DESCRIPTION
As part of the ongoing cleanup of old hooks in `CMultiplayerSA.cpp`, this PR moves the remaining fire and weapon hooks over to `CMultiplayerSA_Weapons.cpp` and fixes a few long-standing issues with fire behavior.

### Fixes
- **Peds not catching fire from ground flames:** In original GTA:SA, ground fire only ever set the local player on fire. Non-player peds, bots, and remote players would just walk straight through flames without catching fire. They now ignite properly when stepping on active fire.
- **FPS drops when checking peds near fire:** Since fire checks run every frame, looping through all peds caused noticeable lag. Added quick bounding-box pre-checks so distant peds are skipped immediately without doing heavy math, keeping framerates solid.
- **Missing attacker / kill attribution from fire:** When fire spread or came from area weapons like Flamethrowers and Molotovs, the game forgot who started it and showed `nil` in logs. The original attacker is now preserved and credited for damage and kills.

### Testing
[task_hooks_test.zip](https://github.com/user-attachments/files/31161437/task_hooks_test.zip)

To test these changes:
1. Start the test resource in console: `start task_hooks_test`
2. Test walking ped ignition:
   - Run `/testwalkped` to spawn a bot walking toward you.
   - Spray flames on the floor with a Flamethrower or throw a Molotov.
   - Check that the ped catches fire as soon as he steps on the flames, the HUD shows `Ped On Fire State: YES`, and damage logs credit you without any lag.
3. Test damage attribution & explosions:
   - Run `/testexplosion` (or `/testped`) to spawn a stationary dummy.
   - Attack it with Molotovs, Flamethrower, or Rocket Launcher and verify your name shows up as the attacker in the chat logs.
4. You can use `/resetperf` at any point to reset the FPS and telemetry stats.

### Checklist
- [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
- [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
