### PR TITLE
refactor: move remaining vehicle hooks to CMultiplayerSA_Vehicles.cpp

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -36,17 +36,14 @@ extern CGame* pGameInterface;
 #define HOOKPOS_CRunningScript_Process                   0x469F00
 #define HOOKPOS_CExplosion_AddExplosion                  0x736A50
 #define HOOKPOS_CCustomRoadsignMgr__RenderRoadsignAtomic 0x6FF35B
-#define HOOKPOS_Trailer_BreakTowLink                     0x6E0027
 #define HOOKPOS_CRadar__DrawRadarGangOverlay             0x586650
 #define HOOKPOS_CTaskComplexJump__CreateSubTask          0x67DABE
-#define HOOKPOS_CTrain_ProcessControl_Derail             0x6F8DBA
 #define HOOKPOS_CVehicle_SetupRender                     0x6D6512
 #define HOOKPOS_CVehicle_ResetAfterRender                0x6D0E3E
 #define HOOKPOS_CObject_Render                           0x59F1ED
 #define HOOKPOS_EndWorldColors                           0x561795
 #define HOOKPOS_CWorld_ProcessVerticalLineSectorList     0x563357
 #define HOOKPOS_ComputeDamageResponse_StartChoking       0x4C05B9
-#define HOOKPOS_CAutomobile__ProcessSwingingDoor         0x6A9DAF
 
 #define FUNC_CStreaming_Update                     0x40E670
 #define FUNC_CAudioEngine__DisplayRadioStationName 0x507030
@@ -120,13 +117,6 @@ DWORD RETURN_VehicleLookBehind = 0x520891;
 DWORD RETURN_VehicleLookAside = 0x520FDC;
 #define CALL_VehicleLookAsideUp 0x5211E0
 
-#define HOOKPOS_OccupiedVehicleBurnCheck 0x570C84
-DWORD RETURN_OccupiedVehicleBurnCheck = 0x570C8A;
-#define HOOKPOS_UnoccupiedVehicleBurnCheck 0x6A76DC
-DWORD RETURN_UnoccupiedVehicleBurnCheck = 0x6A76E4;
-#define HOOKPOS_ApplyCarBlowHop 0x6B3816
-DWORD RETURN_ApplyCarBlowHop = 0x6B3831;
-
 #define HOOKPOS_CVehicle_ApplyBoatWaterResistance 0x6D2771
 DWORD RETURN_CVehicle_ApplyBoatWaterResistance = 0x6D2777;
 
@@ -177,20 +167,6 @@ DWORD SKIP_CTaskSimpleClimb_ScanToGrabSectorList = 0x67E580;
 #define HOOKPOS_CheckAnimMatrix 0x7C5A5C
 DWORD RETURN_CheckAnimMatrix = 0x7C5A61;
 
-#define HOOKPOS_VehColCB 0x04C838D
-DWORD RETURN_VehColCB = 0x04C83AA;
-
-#define HOOKPOS_VehCol 0x06D6603
-DWORD RETURN_VehCol = 0x06D660C;
-
-#define HOOKPOS_Transmission_CalculateDriveAcceleration 0x6D05E0
-DWORD RETURN_Transmission_CalculateDriveAcceleration = 0x6D05E6;
-// Handling fix - driveType is per model
-#define HOOKPOS_CHandlingData_isNotRWD 0x6A048C
-DWORD RETURN_CHandlingData_isNotRWD = 0x6A0493;
-#define HOOKPOS_CHandlingData_isNotFWD 0x6A04BC
-DWORD RETURN_CHandlingData_isNotFWD = 0x6A04C3;
-// end of handling fix
 #define CALL_CAutomobile_ProcessEntityCollision   0x6AD053
 #define CALL_CMonsterTruck_ProcessEntityCollision 0x6C8B9E
 DWORD RETURN_ProcessEntityCollision = 0x4185C0;
@@ -251,11 +227,6 @@ DWORD RETURN_CClothes_RebuildPlayerb = 0x5A837F;
 #define HOOKPOS_CProjectileInfo_FindPlayerPed     0x739321
 #define HOOKPOS_CProjectileInfo_FindPlayerVehicle 0x739570
 
-#define HOOKPOS_CHeli_ProcessHeliKill 0x6DB201
-DWORD RETURN_CHeli_ProcessHeliKill_RETN_Cancel = 0x6DB9E0;
-DWORD RETURN_CHeli_ProcessHeliKill_RETN_Cont_Zero = 0x6DB207;
-DWORD RETURN_CHeli_ProcessHeliKill_6DB437h = 0x6DB437;
-
 #define HOOKPOS_CObject_ProcessBreak 0x5A0F0F
 DWORD RETURN_CObject_ProcessBreak = 0x5A0F14;
 #define HOOKPOS_CObject_ProcessDamage 0x5A0E0D
@@ -300,8 +271,6 @@ const DWORD RETURN_Idle_CWorld_ProcessPedsAfterPreRender = 0x53EA08;
 
 #define HOOKPOS_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StartRadio 0x4D7198
 #define HOOKPOS_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StopRadio  0x4D71E7
-
-#define HOOKPOS_CAutomobile__dmgDrawCarCollidingParticles 0x6A6FF0
 
 #define HOOKPOS_CWeapon__TakePhotograph 0x73C26E
 
@@ -436,7 +405,6 @@ void HOOK_CHud_Draw_Caller();
 void HOOK_CRunningScript_Process();
 void HOOK_CExplosion_AddExplosion();
 void HOOK_CCustomRoadsignMgr__RenderRoadsignAtomic();
-void HOOK_Trailer_BreakTowLink();
 void HOOK_CRadar__DrawRadarGangOverlay();
 void HOOK_CTaskComplexJump__CreateSubTask();
 void HOOK_FxManager_CreateFxSystem();
@@ -445,7 +413,6 @@ void HOOK_CCam_ProcessFixed();
 void HOOK_Render3DStuff();
 void HOOK_CTaskSimplePlayerOnFoot_ProcessPlayerWeapon();
 void HOOK_CPed_IsPlayer();
-void HOOK_CTrain_ProcessControl_Derail();
 void HOOK_CVehicle_SetupRender();
 void HOOK_CVehicle_ResetAfterRender();
 void HOOK_CObject_Render();
@@ -464,9 +431,6 @@ void HOOK_VehicleCamUp();
 void HOOK_VehicleCamEnd();
 void HOOK_VehicleLookBehind();
 void HOOK_VehicleLookAside();
-void HOOK_OccupiedVehicleBurnCheck();
-void HOOK_UnoccupiedVehicleBurnCheck();
-void HOOK_ApplyCarBlowHop();
 void HOOK_CWorld_SetWorldOnFire();
 void HOOK_CTaskSimplePlayerOnFire_ProcessPed();
 void HOOK_CFire_ProcessFire();
@@ -507,11 +471,6 @@ void HOOK_CrashFix_Misc22();
 void HOOK_CrashFix_Misc23();
 void HOOK_CrashFix_Misc24();
 void HOOK_CheckAnimMatrix();
-void HOOK_VehColCB();
-void HOOK_VehCol();
-void HOOK_Transmission_CalculateDriveAcceleration();
-void HOOK_isVehDriveTypeNotRWD();
-void HOOK_isVehDriveTypeNotFWD();
 void HOOK_PreFxRender();
 void HOOK_PostColorFilterRender();
 void HOOK_PreHUDRender();
@@ -519,8 +478,6 @@ void HOOK_PreHUDRender();
 void HOOK_CTrafficLights_GetPrimaryLightState();
 void HOOK_CTrafficLights_GetSecondaryLightState();
 void HOOK_CTrafficLights_DisplayActualLight();
-
-void HOOK_CAutomobile__ProcessSwingingDoor();
 
 void vehicle_lights_init();
 
@@ -550,8 +507,6 @@ void HOOK_CClothes_RebuildPlayer();
 
 void HOOK_CProjectileInfo_Update_FindLocalPlayer_FindLocalPlayerVehicle();
 
-void HOOK_CHeli_ProcessHeliKill();
-
 void HOOK_CObject_ProcessDamage();
 void HOOK_CObject_ProcessBreak();
 void HOOK_CObject_ProcessCollision();
@@ -572,8 +527,6 @@ void HOOK_Idle_CWorld_ProcessPedsAfterPreRender();
 
 void HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StartRadio();
 void HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StopRadio();
-
-void HOOK_CAutomobile__dmgDrawCarCollidingParticles();
 
 void HOOK_CWeapon__TakePhotograph();
 
@@ -644,7 +597,6 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_CRunningScript_Process, (DWORD)HOOK_CRunningScript_Process, 6);
     HookInstall(HOOKPOS_CExplosion_AddExplosion, (DWORD)HOOK_CExplosion_AddExplosion, 6);
     HookInstall(HOOKPOS_CCustomRoadsignMgr__RenderRoadsignAtomic, (DWORD)HOOK_CCustomRoadsignMgr__RenderRoadsignAtomic, 6);
-    HookInstall(HOOKPOS_Trailer_BreakTowLink, (DWORD)HOOK_Trailer_BreakTowLink, 6);
     HookInstall(HOOKPOS_CRadar__DrawRadarGangOverlay, (DWORD)HOOK_CRadar__DrawRadarGangOverlay, 6);
     HookInstall(HOOKPOS_CTaskComplexJump__CreateSubTask, (DWORD)HOOK_CTaskComplexJump__CreateSubTask, 6);
     HookInstall(HOOKPOS_FxManager_CreateFxSystem, (DWORD)HOOK_FxManager_CreateFxSystem, 8);
@@ -652,7 +604,6 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_CCam_ProcessFixed, (DWORD)HOOK_CCam_ProcessFixed, 5);
     HookInstall(HOOKPOS_CTaskSimplePlayerOnFoot_ProcessPlayerWeapon, (DWORD)HOOK_CTaskSimplePlayerOnFoot_ProcessPlayerWeapon, 7);
     HookInstall(HOOKPOS_CPed_IsPlayer, (DWORD)HOOK_CPed_IsPlayer, 6);
-    HookInstall(HOOKPOS_CTrain_ProcessControl_Derail, (DWORD)HOOK_CTrain_ProcessControl_Derail, 6);
     HookInstall(HOOKPOS_CVehicle_SetupRender, (DWORD)HOOK_CVehicle_SetupRender, 5);
     HookInstall(HOOKPOS_CVehicle_ResetAfterRender, (DWORD)HOOK_CVehicle_ResetAfterRender, 5);
     HookInstall(HOOKPOS_CObject_Render, (DWORD)HOOK_CObject_Render, 5);
@@ -670,9 +621,6 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_VehicleLookAside, (DWORD)HOOK_VehicleLookAside, 6);
     HookInstall(HOOKPOS_CVehicle_ApplyBoatWaterResistance, (DWORD)HOOK_CVehicle_ApplyBoatWaterResistance, 6);
     HookInstall(HOOKPOS_CPhysical_ApplyGravity, (DWORD)HOOK_CPhysical_ApplyGravity, 6);
-    HookInstall(HOOKPOS_OccupiedVehicleBurnCheck, (DWORD)HOOK_OccupiedVehicleBurnCheck, 6);
-    HookInstall(HOOKPOS_UnoccupiedVehicleBurnCheck, (DWORD)HOOK_UnoccupiedVehicleBurnCheck, 5);
-    HookInstall(HOOKPOS_ApplyCarBlowHop, (DWORD)HOOK_ApplyCarBlowHop, 6);
     HookInstall(HOOKPOS_CWorld_SetWorldOnFire, (DWORD)HOOK_CWorld_SetWorldOnFire, 5);
     HookInstall(HOOKPOS_CTaskSimplePlayerOnFire_ProcessPed, (DWORD)HOOK_CTaskSimplePlayerOnFire_ProcessPed, 5);
     HookInstall(HOOKPOS_CFire_ProcessFire, (DWORD)HOOK_CFire_ProcessFire, 5);
@@ -688,17 +636,9 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_CTaskSimpleClimb_ScanToGrabSectorList, (DWORD)HOOK_CTaskSimpleClimb_ScanToGrabSectorList, 8);
     HookInstall(HOOKPOS_CheckAnimMatrix, (DWORD)HOOK_CheckAnimMatrix, 5);
 
-    HookInstall(HOOKPOS_VehColCB, (DWORD)HOOK_VehColCB, 29);
-    HookInstall(HOOKPOS_VehCol, (DWORD)HOOK_VehCol, 9);
     HookInstall(HOOKPOS_PreFxRender, (DWORD)HOOK_PreFxRender, 5);
     HookInstall(HOOKPOS_PostColorFilterRender, (DWORD)HOOK_PostColorFilterRender, 5);
     HookInstall(HOOKPOS_PreHUDRender, (DWORD)HOOK_PreHUDRender, 5);
-    HookInstall(HOOKPOS_CAutomobile__ProcessSwingingDoor, (DWORD)HOOK_CAutomobile__ProcessSwingingDoor, 7);
-
-    HookInstall(HOOKPOS_Transmission_CalculateDriveAcceleration, (DWORD)HOOK_Transmission_CalculateDriveAcceleration, 5);
-
-    HookInstall(HOOKPOS_CHandlingData_isNotRWD, (DWORD)HOOK_isVehDriveTypeNotRWD, 7);
-    HookInstall(HOOKPOS_CHandlingData_isNotFWD, (DWORD)HOOK_isVehDriveTypeNotFWD, 7);
 
     HookInstallCall(CALL_Render3DStuff, (DWORD)HOOK_Render3DStuff);
     HookInstallCall(CALL_VehicleCamUp, (DWORD)HOOK_VehicleCamUp);
@@ -742,8 +682,6 @@ void CMultiplayerSA::InitHooks()
     HookInstallCall((DWORD)HOOKPOS_CProjectileInfo_FindPlayerPed, (DWORD)HOOK_CProjectileInfo_Update_FindLocalPlayer_FindLocalPlayerVehicle);
     HookInstallCall((DWORD)HOOKPOS_CProjectileInfo_FindPlayerVehicle, (DWORD)HOOK_CProjectileInfo_Update_FindLocalPlayer_FindLocalPlayerVehicle);
 
-    HookInstall((DWORD)HOOKPOS_CHeli_ProcessHeliKill, (DWORD)HOOK_CHeli_ProcessHeliKill, 6);
-
     // Hooks for object break events
     HookInstall(HOOKPOS_CObject_ProcessDamage, (DWORD)HOOK_CObject_ProcessDamage, 6);
     HookInstall(HOOKPOS_CObject_ProcessBreak, (DWORD)HOOK_CObject_ProcessBreak, 5);
@@ -775,8 +713,6 @@ void CMultiplayerSA::InitHooks()
                 (DWORD)HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StartRadio, 5);
     HookInstall(HOOKPOS_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StopRadio,
                 (DWORD)HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StopRadio, 5);
-
-    HookInstall(HOOKPOS_CAutomobile__dmgDrawCarCollidingParticles, (DWORD)HOOK_CAutomobile__dmgDrawCarCollidingParticles, 0x91);
 
     HookInstall(HOOKPOS_CWeapon__TakePhotograph, (DWORD)HOOK_CWeapon__TakePhotograph, 3 + 2);
 
@@ -3108,17 +3044,6 @@ no_render:
     // clang-format on
 }
 
-bool CallBreakTowLinkHandler(CVehicleSAInterface* vehicle)
-{
-    SClientEntity<CVehicleSA>* pVehicleClientEntity = pGameInterface->GetPools()->GetVehicle((DWORD*)vehicle);
-    CVehicle*                  pVehicle = pVehicleClientEntity ? pVehicleClientEntity->pEntity : nullptr;
-    if (pVehicle && m_pBreakTowLinkHandler)
-    {
-        return m_pBreakTowLinkHandler(pVehicle);
-    }
-    return true;
-}
-
 static void __declspec(naked) HOOK_CRadar__DrawRadarGangOverlay()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
@@ -3137,50 +3062,6 @@ static void __declspec(naked) HOOK_CRadar__DrawRadarGangOverlay()
     {
         popad
         retn
-    }
-    // clang-format on
-}
-
-CVehicleSAInterface* towingVehicle;
-
-static void __declspec(naked) HOOK_Trailer_BreakTowLink()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // clang-format off
-    __asm
-    {
-        mov     towingVehicle, ecx
-        pushad
-    }
-    // clang-format on
-
-    if (CallBreakTowLinkHandler(towingVehicle))
-    {
-        // clang-format off
-        __asm
-        {
-            popad
-            call    dword ptr [edx+0xF8]
-        }
-        // clang-format on
-    }
-    else
-    {
-        // clang-format off
-        __asm
-        {
-            popad
-        }
-        // clang-format on
-    }
-
-    // clang-format off
-    __asm
-    {
-        mov     ecx, HOOKPOS_Trailer_BreakTowLink
-        add     ecx, 6
-        jmp     ecx
     }
     // clang-format on
 }
@@ -3808,50 +3689,6 @@ static void __declspec(naked) HOOK_CRunningScript_Process()
         retn
     }
     // clang-format on
-}
-
-static CVehicleSAInterface*   pDerailingTrain = NULL;
-static void __declspec(naked) HOOK_CTrain_ProcessControl_Derail()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // If the train wouldn't derail, don't modify anything
-    // clang-format off
-    __asm
-    {
-        jnp     train_would_derail
-        mov     eax, 0x6F8F89
-        jmp     eax
-train_would_derail:
-        pushad
-        mov     pDerailingTrain, esi
-    }
-    // clang-format on
-
-    // At this point we know that GTA wants to derail the train
-    if (pDerailingTrain->m_pVehicle->IsDerailable())
-    {
-        // Go back to the derailment code
-        // clang-format off
-        __asm
-        {
-            popad
-            mov     eax, 0x6F8DC0
-            jmp     eax
-        }
-        // clang-format on
-    }
-    else
-    {
-        // clang-format off
-        __asm
-        {
-            popad
-            mov     eax, 0x6F8F89
-            jmp     eax
-        }
-        // clang-format on
-    }
 }
 
 /**
@@ -4653,102 +4490,6 @@ static void __declspec(naked) HOOK_CTrafficLights_DisplayActualLight()
     // clang-format on
 }
 
-static CVehicleSAInterface* pHandlingDriveTypeVeh = NULL;
-unsigned char               ucDriveType = '4';
-void                        GetVehicleDriveType()
-{
-    // Get the car drive type from the Vehicle interface
-    ucDriveType = static_cast<unsigned char>(pHandlingDriveTypeVeh->m_pVehicle->GetHandlingData()->GetCarDriveType());
-}
-
-static CTransmission* pCurTransmission = nullptr;
-static ::byte*        pCurGear = nullptr;
-
-void CheckVehicleMaxGear()
-{
-    if (*pCurGear > pCurTransmission->numOfGears)
-    {
-        *pCurGear = pCurTransmission->numOfGears;
-    }
-}
-
-static void __declspec(naked) HOOK_Transmission_CalculateDriveAcceleration()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // clang-format off
-    __asm
-    {
-        push eax
-        mov pCurTransmission, ecx
-        mov eax, [esp+0xC]
-        mov pCurGear, eax
-        pop eax
-        pushad
-    }
-    // clang-format on
-
-    CheckVehicleMaxGear();
-
-    // clang-format off
-    __asm
-    {
-        popad
-        mov eax, [esp+0x10]
-        mov edx, [eax]
-        jmp RETURN_Transmission_CalculateDriveAcceleration
-    }
-    // clang-format on
-}
-
-static void __declspec(naked) HOOK_isVehDriveTypeNotRWD()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // Get the Vehicle interface from esi
-    // clang-format off
-    __asm
-    {
-         mov pHandlingDriveTypeVeh, esi
-    }
-    // clang-format on
-
-    GetVehicleDriveType();
-
-    // push our drive type into bl :)
-    // clang-format off
-    __asm
-    {
-        mov bl, ucDriveType
-        jmp RETURN_CHandlingData_isNotRWD
-    }
-    // clang-format on
-}
-
-static void __declspec(naked) HOOK_isVehDriveTypeNotFWD()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // Get the Vehicle SA interface from esi
-    // clang-format off
-    __asm
-    {
-         mov pHandlingDriveTypeVeh, esi
-    }
-    // clang-format on
-
-    GetVehicleDriveType();
-
-    // push our drive type into bl :)
-    // clang-format off
-    __asm
-    {
-        mov bl, ucDriveType
-        jmp RETURN_CHandlingData_isNotFWD
-    }
-    // clang-format on
-}
-
 unsigned char CMultiplayerSA::GetTrafficLightState()
 {
     return ucTrafficLightState;
@@ -5256,97 +4997,6 @@ static void __declspec(naked) HOOK_VehicleLookAside()
         lea ebp, [esi+0x19C]
         mov ecx, [esi+0x21C]
         jmp RETURN_VehicleLookAside
-    }
-    // clang-format on
-}
-
-// ---------------------------------------------------
-
-float _cdecl VehicleBurnCheck(DWORD pVehicleInterface)
-{
-    // To check if a vehicle is lying upside down on its roof, SA checks if the z coordinate
-    // of the vehicle's up vector is negative. We replace this z by the dot product of the up vector
-    // and the negated gravity vector.
-    SClientEntity<CVehicleSA>* pVehicleClientEntity = pGameInterface->GetPools()->GetVehicle((DWORD*)pVehicleInterface);
-    CVehicle*                  pVehicle = pVehicleClientEntity ? pVehicleClientEntity->pEntity : nullptr;
-    if (!pVehicle)
-        return 1.0f;
-
-    CVector vecGravity;
-    CMatrix matVehicle;
-    pVehicle->GetGravity(&vecGravity);
-    pVehicle->GetMatrix(&matVehicle);
-    vecGravity = -vecGravity;
-    return matVehicle.vUp.DotProduct(&vecGravity);
-}
-
-static void __declspec(naked) HOOK_OccupiedVehicleBurnCheck()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // clang-format off
-    __asm
-    {
-        push eax
-        call VehicleBurnCheck
-        add esp, 4
-        jmp RETURN_OccupiedVehicleBurnCheck
-    }
-    // clang-format on
-}
-
-static void __declspec(naked) HOOK_UnoccupiedVehicleBurnCheck()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // clang-format off
-    __asm
-    {
-        mov word ptr [esp+0x78], cx
-
-        push esi
-        call VehicleBurnCheck
-        add esp, 4
-        jmp RETURN_UnoccupiedVehicleBurnCheck
-    }
-    // clang-format on
-}
-
-// ---------------------------------------------------
-
-void _cdecl ApplyVehicleBlowHop(DWORD pVehicleInterface)
-{
-    // Custom application of the little jump that vehicles make when they blow up,
-    // taking into account custom gravity
-    SClientEntity<CVehicleSA>* pVehicleClientEntity = pGameInterface->GetPools()->GetVehicle((DWORD*)pVehicleInterface);
-    CVehicle*                  pVehicle = pVehicleClientEntity ? pVehicleClientEntity->pEntity : nullptr;
-    if (!pVehicle)
-        return;
-
-    CVector vecGravity, vecVelocity;
-    pVehicle->GetGravity(&vecGravity);
-    pVehicle->GetMoveSpeed(&vecVelocity);
-    vecVelocity -= vecGravity * 0.13f;
-    pVehicle->SetMoveSpeed(vecVelocity);
-}
-
-static void __declspec(naked) HOOK_ApplyCarBlowHop()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // clang-format off
-    __asm
-    {
-        push esi
-        call ApplyVehicleBlowHop
-        add esp, 4
-
-        mov dl, [esi+0x36]
-        mov ecx, [esi+0x18]
-        and dl, 7
-        or dl, 0x28
-        mov [esi+0x36], dl
-        jmp RETURN_ApplyCarBlowHop
     }
     // clang-format on
 }
@@ -6562,119 +6212,6 @@ static void __declspec(naked) HOOK_CheckAnimMatrix()
     // clang-format on
 }
 
-static SColor vehColors[4];
-
-void _cdecl SaveVehColors(DWORD dwThis)
-{
-    SClientEntity<CVehicleSA>* pVehicleClientEntity = pGameInterface->GetPools()->GetVehicle((DWORD*)dwThis);
-    CVehicle*                  pVehicle = pVehicleClientEntity ? pVehicleClientEntity->pEntity : nullptr;
-    if (pVehicle)
-    {
-        pVehicle->GetColor(&vehColors[0], &vehColors[1], &vehColors[2], &vehColors[3], true);
-    }
-}
-
-static void __declspec(naked) HOOK_VehCol()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // clang-format off
-    __asm
-    {
-        // Get vehColors for this vehicle
-        pushad
-        push esi
-        call SaveVehColors
-        add esp, 4
-        popad
-
-        // Hooked from 006D6603  9 bytes
-        mov         dl, 3
-        mov         al, 2
-        mov         cl, 1
-        push        edx
-        xor         edx,edx
-        mov         dl,byte ptr [esi+434h]
-        mov         dl, 0
-
-        jmp     RETURN_VehCol  // 006D660C
-    }
-    // clang-format on
-}
-
-static void __declspec(naked) HOOK_VehColCB()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // clang-format off
-    __asm
-    {
-        // Hooked from 004C838D  29 bytes
-
-        // Apply vehColors for this vehicle
-        mov         cl,byte ptr [esi*4+vehColors.R]
-        mov         byte ptr [eax+4],cl
-
-        mov         cl,byte ptr [esi*4+vehColors.G]
-        mov         byte ptr [eax+5],cl
-
-        mov         cl,byte ptr [esi*4+vehColors.B]
-        mov         byte ptr [eax+6],cl
-
-        jmp     RETURN_VehColCB  // 004C83AA
-    }
-    // clang-format on
-}
-
-// Check if this vehicle is allowed to process swinging doors.
-static DWORD       dwSwingingDoorAutomobile;
-static const DWORD dwSwingingRet1 = 0x6A9DB6;
-static const DWORD dwSwingingRet2 = 0x6AA1DA;
-static bool        AllowSwingingDoors()
-{
-    SClientEntity<CVehicleSA>* pVehicleClientEntity = pGameInterface->GetPools()->GetVehicle((DWORD*)dwSwingingDoorAutomobile);
-    CVehicle*                  pVehicle = pVehicleClientEntity ? pVehicleClientEntity->pEntity : nullptr;
-    if (pVehicle == 0 || pVehicle->AreSwingingDoorsAllowed())
-        return true;
-    else
-        return false;
-}
-
-static void __declspec(naked) HOOK_CAutomobile__ProcessSwingingDoor()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // clang-format off
-    __asm
-    {
-        mov     dwSwingingDoorAutomobile, esi
-        mov     ecx, [esi+eax*4+0x648]
-        pushad
-    }
-    // clang-format on
-
-    if (AllowSwingingDoors())
-    {
-        // clang-format off
-        __asm
-        {
-            popad
-            jmp     dwSwingingRet1
-        }
-        // clang-format on
-    }
-    else
-    {
-        // clang-format off
-        __asm
-        {
-            popad
-            jmp     dwSwingingRet2
-        }
-        // clang-format on
-    }
-}
-
 void* SetModelSuspensionLinesToVehiclePrivate(CVehicleSAInterface* pVehicleIntf)
 {
     // Set the per-model suspension line data of the vehicle's model to the per-vehicle
@@ -7313,72 +6850,6 @@ void CMultiplayerSA::SetVehicleEngineAutoStartEnabled(bool enabled)
     {
         MemSet((void*)0x64BC03, 0x90, 5);                // prevent vehicle engine from turning on (driver enter)
         MemCpy((void*)0x6C4EA9, "\xE9\x15\x03\x00", 4);  // prevent aircraft engine from turning off (driver exit)
-    }
-}
-
-// Storage
-CVehicleSAInterface* pHeliKiller = NULL;
-CEntitySAInterface*  pHitByHeli = NULL;
-bool                 CallHeliKillEvent()
-{
-    // Is our handler alive
-    if (m_pHeliKillHandler)
-    {
-        // Return our handlers return
-        return m_pHeliKillHandler(pHeliKiller, pHitByHeli);
-    }
-    // Return true else
-    return true;
-}
-
-static void __declspec(naked) HOOK_CHeli_ProcessHeliKill()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // 006DB201 0F 85 30 02 00 00                         jnz     loc_6DB437 < HOOK >
-    // 006DB207 8B 47 14                                  mov     eax, [edi+14h] < RETURN CONTINUE >
-    // 006DB9E0 8B 44 24 6C                               mov     eax, [esp+1C8h+var_15C] < RETURN CANCEL >
-    // Hook is in Process Heli blades I think it's processing a Heli's blades against peds inside a collision shape.
-    // We hook just after the check if he's touched the blade as before that it's just got the results of if he's near enough the heli to hit the blades
-    // esi = Heli
-    // edi = ped
-    // clang-format off
-    __asm
-    {
-        pushfd
-        pushad
-        mov pHeliKiller, esi
-        mov pHitByHeli, edi
-    }
-    // clang-format on
-    //   Call our event
-    if (CallHeliKillEvent() == false)
-    {
-        // clang-format off
-        __asm
-        {
-            popad
-            popfd
-            // Go to the end of the while loop and let it start again
-            jmp RETURN_CHeli_ProcessHeliKill_RETN_Cancel
-        }
-        // clang-format on
-    }
-    else
-    {
-        // clang-format off
-        __asm
-        {
-            popad
-            popfd
-            // do our JNZ
-            jnz lp1
-            // if it failed do our continue
-            jmp RETURN_CHeli_ProcessHeliKill_RETN_Cont_Zero
-
-lp1:        jmp RETURN_CHeli_ProcessHeliKill_6DB437h
-        }
-        // clang-format on
     }
 }
 
@@ -8131,44 +7602,6 @@ static void __declspec(naked) HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackA
         pop     ebx
         add     esp, 36
         retn
-    }
-    // clang-format on
-}
-
-static void AddVehicleColoredDebris(CAutomobileSAInterface* pVehicleInterface, CVector& vecPosition, int count)
-{
-    SClientEntity<CVehicleSA>* pVehicleClientEntity = pGameInterface->GetPools()->GetVehicle((DWORD*)pVehicleInterface);
-    CVehicle*                  pVehicle = pVehicleClientEntity ? pVehicleClientEntity->pEntity : nullptr;
-    if (pVehicle)
-    {
-        SColor colors[4];
-        pVehicle->GetColor(&colors[0], &colors[1], &colors[2], &colors[3], false);
-
-        RwColor color = {static_cast<unsigned char>(colors[0].R * pVehicleInterface->m_fLighting),
-                         static_cast<unsigned char>(colors[0].G * pVehicleInterface->m_fLighting),
-                         static_cast<unsigned char>(colors[0].B * pVehicleInterface->m_fLighting), 0xFF};
-
-        // Fx_c::AddDebris
-        ((void(__thiscall*)(int, CVector&, RwColor&, float, int))0x49F750)(CLASS_CFx, vecPosition, color, 0.06f, count / 100 + 1);
-    }
-}
-
-const DWORD                   RETURN_CAutomobile__dmgDrawCarCollidingParticles = 0x6A7081;
-static void __declspec(naked) HOOK_CAutomobile__dmgDrawCarCollidingParticles()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // clang-format off
-    __asm
-    {
-        lea eax, [esp + 0x1C]
-        push ebp                // count
-        push eax                // pos
-        push edi                // vehicle
-        call AddVehicleColoredDebris
-        add esp, 12
-
-        jmp RETURN_CAutomobile__dmgDrawCarCollidingParticles
     }
     // clang-format on
 }

--- a/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Vehicles.cpp
@@ -3705,6 +3705,547 @@ static void __declspec(naked) HOOK_CPlane__PreRender_AndromRampBlock()
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
+// CVehicle::ProcessControl (Occupied Vehicle Inversion Check)
+//
+// Replaces GTA's default Z up-vector check with custom gravity-aware dot product to detect
+// if an occupied vehicle is lying upside down on its roof.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x570C84 | 50             | push    eax
+//     0x570C85 | E8 D6 0C F7 FF | call    CVehicle::GetMatrix
+//     0x570C8A | D9 44 24 14    | fld     dword ptr [esp + 14h]
+#define HOOKPOS_CVehicle__ProcessControl_OccupiedBurnCheck  0x570C84
+#define HOOKSIZE_CVehicle__ProcessControl_OccupiedBurnCheck 6
+static constexpr std::uintptr_t CONTINUE_CVehicle__ProcessControl_OccupiedBurnCheck = 0x570C8A;
+
+static float VehicleBurnCheck(CVehicleSAInterface* vehicleInterface)
+{
+    SClientEntity<CVehicleSA>* vehicleClientEntity = pGameInterface->GetPools()->GetVehicle(reinterpret_cast<DWORD*>(vehicleInterface));
+    CVehicle*                  vehicle = vehicleClientEntity ? vehicleClientEntity->pEntity : nullptr;
+    if (!vehicle)
+        return 1.0f;
+
+    CVector gravity;
+    CMatrix vehicleMatrix;
+    vehicle->GetGravity(&gravity);
+    vehicle->GetMatrix(&vehicleMatrix);
+    gravity = -gravity;
+    return vehicleMatrix.vUp.DotProduct(&gravity);
+}
+
+static void __declspec(naked) HOOK_CVehicle__ProcessControl_OccupiedBurnCheck()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    eax
+        call    VehicleBurnCheck
+        add     esp, 4
+        jmp     CONTINUE_CVehicle__ProcessControl_OccupiedBurnCheck
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CAutomobile::ProcessControl (Unoccupied Vehicle Inversion Check)
+//
+// Replaces GTA's default Z up-vector check with custom gravity-aware check to detect if an
+// unoccupied vehicle is lying upside down on its roof.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6A76DC | 66 89 4C 24 78 | mov     word ptr [esp + 78h], cx
+//     0x6A76E1 | E8 3A 00 00 00 | call    ...
+//     0x6A76E6 | D9 44 24 78    | fld     ...
+#define HOOKPOS_CAutomobile__ProcessControl_UnoccupiedBurnCheck  0x6A76DC
+#define HOOKSIZE_CAutomobile__ProcessControl_UnoccupiedBurnCheck 5
+static constexpr std::uintptr_t CONTINUE_CAutomobile__ProcessControl_UnoccupiedBurnCheck = 0x6A76E4;
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessControl_UnoccupiedBurnCheck()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        mov     word ptr [esp + 78h], cx
+
+        push    esi
+        call    VehicleBurnCheck
+        add     esp, 4
+        jmp     CONTINUE_CAutomobile__ProcessControl_UnoccupiedBurnCheck
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CAutomobile::BlowUpCar (Blow-up Jump Velocity)
+//
+// Applies upward hop velocity when a vehicle explodes taking custom gravity into account.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6B3816 | D9 46 4C       | fld     dword ptr [esi + 4Ch]
+//     0x6B3819 | D8 05 90 28 87 | fadd    ds:dbl_872890
+//     0x6B381F | D9 5E 4C       | fstp    dword ptr [esi + 4Ch]
+#define HOOKPOS_CAutomobile__BlowUpCarsInPath_ApplyCarBlowHop  0x6B3816
+#define HOOKSIZE_CAutomobile__BlowUpCarsInPath_ApplyCarBlowHop 6
+static constexpr std::uintptr_t CONTINUE_CAutomobile__BlowUpCarsInPath_ApplyCarBlowHop = 0x6B3831;
+
+static void ApplyVehicleBlowHop(CVehicleSAInterface* vehicleInterface)
+{
+    SClientEntity<CVehicleSA>* vehicleClientEntity = pGameInterface->GetPools()->GetVehicle(reinterpret_cast<DWORD*>(vehicleInterface));
+    CVehicle*                  vehicle = vehicleClientEntity ? vehicleClientEntity->pEntity : nullptr;
+    if (!vehicle)
+        return;
+
+    CVector gravity, velocity;
+    vehicle->GetGravity(&gravity);
+    vehicle->GetMoveSpeed(&velocity);
+    velocity -= gravity * 0.13f;
+    vehicle->SetMoveSpeed(velocity);
+}
+
+static void __declspec(naked) HOOK_CAutomobile__BlowUpCarsInPath_ApplyCarBlowHop()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    esi
+        call    ApplyVehicleBlowHop
+        add     esp, 4
+
+        mov     dl, [esi + 36h]
+        mov     ecx, [esi + 18h]
+        and     dl, 7
+        or      dl, 28h
+        mov     [esi + 36h], dl
+        jmp     CONTINUE_CAutomobile__BlowUpCarsInPath_ApplyCarBlowHop
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CTrailer::BreakTowLink
+//
+// Intercepts trailer detachment to invoke MTA's BreakTowLinkHandler.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6E0027 | 8B 02          | mov     eax, [edx]
+//     0x6E0029 | FF 90 F8 00 00 | call    dword ptr [eax + 0F8h]
+#define HOOKPOS_CTrailer__BreakTowLink  0x6E0027
+#define HOOKSIZE_CTrailer__BreakTowLink 6
+static constexpr std::uintptr_t CONTINUE_CTrailer__BreakTowLink = 0x6E002D;
+
+extern BreakTowLinkHandler* m_pBreakTowLinkHandler;
+
+static bool CallBreakTowLinkHandler(CVehicleSAInterface* vehicleInterface)
+{
+    SClientEntity<CVehicleSA>* vehicleClientEntity = pGameInterface->GetPools()->GetVehicle(reinterpret_cast<DWORD*>(vehicleInterface));
+    CVehicle*                  vehicle = vehicleClientEntity ? vehicleClientEntity->pEntity : nullptr;
+    if (vehicle && m_pBreakTowLinkHandler)
+    {
+        return m_pBreakTowLinkHandler(vehicle);
+    }
+    return true;
+}
+
+static void __declspec(naked) HOOK_CTrailer__BreakTowLink()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        pushad
+        push    ecx                     // vehicle interface
+        call    CallBreakTowLinkHandler
+        add     esp, 4
+        test    al, al
+        jz      skipBreakTowLinkCall
+
+        popad
+        call    dword ptr [edx + 0F8h]
+        jmp     CONTINUE_CTrailer__BreakTowLink
+
+    skipBreakTowLinkCall:
+        popad
+        jmp     CONTINUE_CTrailer__BreakTowLink
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CTrain::ProcessControl (Train Derailment Check)
+//
+// Ensures trains only derail if CVehicle::IsDerailable() returns true.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6F8DBA | 0F 8B C9 01 00 00 | jnp     loc_6F8F89
+#define HOOKPOS_CTrain__ProcessControl_Derail  0x6F8DBA
+#define HOOKSIZE_CTrain__ProcessControl_Derail 6
+static constexpr std::uintptr_t CONTINUE_CTrain__ProcessControl_Derail_Allow = 0x6F8DC0;
+static constexpr std::uintptr_t CONTINUE_CTrain__ProcessControl_Derail_Deny = 0x6F8F89;
+
+static bool IsTrainDerailable(CVehicleSAInterface* trainInterface)
+{
+    if (!trainInterface || !trainInterface->m_pVehicle)
+        return true;
+    return trainInterface->m_pVehicle->IsDerailable();
+}
+
+static void __declspec(naked) HOOK_CTrain__ProcessControl_Derail()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        jnp     trainWouldDerail
+        jmp     CONTINUE_CTrain__ProcessControl_Derail_Deny
+
+    trainWouldDerail:
+        pushad
+        push    esi                     // CTrainSAInterface*
+        call    IsTrainDerailable
+        add     esp, 4
+        test    al, al
+        jz      preventDerail
+
+        popad
+        jmp     CONTINUE_CTrain__ProcessControl_Derail_Allow
+
+    preventDerail:
+        popad
+        jmp     CONTINUE_CTrain__ProcessControl_Derail_Deny
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CAutomobile::ProcessSwingingDoor
+//
+// Checks if the vehicle allows swinging doors before processing door physics on impacts.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6A9DAF | 8B 8C 86 48 06 00 00 | mov     ecx, [esi + eax*4 + 648h]
+#define HOOKPOS_CAutomobile__ProcessSwingingDoor  0x6A9DAF
+#define HOOKSIZE_CAutomobile__ProcessSwingingDoor 7
+static constexpr std::uintptr_t CONTINUE_CAutomobile__ProcessSwingingDoor_Allow = 0x6A9DB6;
+static constexpr std::uintptr_t CONTINUE_CAutomobile__ProcessSwingingDoor_Deny = 0x6AA1DA;
+
+static bool AllowSwingingDoors(CVehicleSAInterface* vehicleInterface)
+{
+    SClientEntity<CVehicleSA>* vehicleClientEntity = pGameInterface->GetPools()->GetVehicle(reinterpret_cast<DWORD*>(vehicleInterface));
+    CVehicle*                  vehicle = vehicleClientEntity ? vehicleClientEntity->pEntity : nullptr;
+    return !vehicle || vehicle->AreSwingingDoorsAllowed();
+}
+
+static void __declspec(naked) HOOK_CAutomobile__ProcessSwingingDoor()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        mov     ecx, [esi + eax*4 + 648h]
+        pushad
+        push    esi                     // CAutomobileSAInterface*
+        call    AllowSwingingDoors
+        add     esp, 4
+        test    al, al
+        jz      denySwinging
+
+        popad
+        jmp     CONTINUE_CAutomobile__ProcessSwingingDoor_Allow
+
+    denySwinging:
+        popad
+        jmp     CONTINUE_CAutomobile__ProcessSwingingDoor_Deny
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// cTransmission::CalculateDriveAcceleration & Vehicle Drive Type
+//
+// Clamps vehicle gear index and reads custom per-vehicle drive type (RWD/FWD/AWD).
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6D05E0 | 8B 44 24 10 | mov     eax, [esp + 10h]
+//     0x6D05E4 | 8B 10       | mov     edx, [eax]
+#define HOOKPOS_CTransmission__CalculateDriveAcceleration  0x6D05E0
+#define HOOKSIZE_CTransmission__CalculateDriveAcceleration 5
+static constexpr std::uintptr_t CONTINUE_CTransmission__CalculateDriveAcceleration = 0x6D05E6;
+
+#define HOOKPOS_CHandlingData__isNotRWD  0x6A048C
+#define HOOKSIZE_CHandlingData__isNotRWD 7
+static constexpr std::uintptr_t CONTINUE_CHandlingData__isNotRWD = 0x6A0493;
+
+#define HOOKPOS_CHandlingData__isNotFWD  0x6A04BC
+#define HOOKSIZE_CHandlingData__isNotFWD 7
+static constexpr std::uintptr_t CONTINUE_CHandlingData__isNotFWD = 0x6A04C3;
+
+static void CheckVehicleMaxGear(CTransmission* transmission, std::uint8_t* currentGear)
+{
+    if (transmission && currentGear && *currentGear > transmission->numOfGears)
+    {
+        *currentGear = transmission->numOfGears;
+    }
+}
+
+static void __declspec(naked) HOOK_CTransmission__CalculateDriveAcceleration()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        pushad
+        mov     eax, [esp + 20h + 0Ch]   // current gear pointer (after pushad 0x20 offset)
+        push    eax
+        push    ecx                     // CTransmission*
+        call    CheckVehicleMaxGear
+        add     esp, 8
+        popad
+
+        mov     eax, [esp + 10h]
+        mov     edx, [eax]
+        jmp     CONTINUE_CTransmission__CalculateDriveAcceleration
+    }
+    // clang-format on
+}
+
+static unsigned char GetVehicleDriveType(CVehicleSAInterface* vehicleInterface)
+{
+    if (vehicleInterface && vehicleInterface->m_pVehicle && vehicleInterface->m_pVehicle->GetHandlingData())
+    {
+        return static_cast<unsigned char>(vehicleInterface->m_pVehicle->GetHandlingData()->GetCarDriveType());
+    }
+    return '4';
+}
+
+static void __declspec(naked) HOOK_CHandlingData__isNotRWD()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    esi                     // CVehicleSAInterface*
+        call    GetVehicleDriveType
+        add     esp, 4
+        mov     bl, al
+        jmp     CONTINUE_CHandlingData__isNotRWD
+    }
+    // clang-format on
+}
+
+static void __declspec(naked) HOOK_CHandlingData__isNotFWD()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        push    esi                     // CVehicleSAInterface*
+        call    GetVehicleDriveType
+        add     esp, 4
+        mov     bl, al
+        jmp     CONTINUE_CHandlingData__isNotFWD
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CAutomobile::dmgDrawCarCollidingParticles
+//
+// Spawns vehicle collision paint debris particles matching MTA's custom vehicle color.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+#define HOOKPOS_CAutomobile__dmgDrawCarCollidingParticles  0x6A6FF0
+#define HOOKSIZE_CAutomobile__dmgDrawCarCollidingParticles 0x91
+static constexpr std::uintptr_t CONTINUE_CAutomobile__dmgDrawCarCollidingParticles = 0x6A7081;
+
+static void AddVehicleColoredDebris(CAutomobileSAInterface* vehicleInterface, CVector& position, int count)
+{
+    SClientEntity<CVehicleSA>* vehicleClientEntity = pGameInterface->GetPools()->GetVehicle(reinterpret_cast<DWORD*>(vehicleInterface));
+    CVehicle*                  vehicle = vehicleClientEntity ? vehicleClientEntity->pEntity : nullptr;
+    if (vehicle)
+    {
+        SColor colors[4];
+        vehicle->GetColor(&colors[0], &colors[1], &colors[2], &colors[3], false);
+
+        RwColor color = {static_cast<unsigned char>(colors[0].R * vehicleInterface->m_fLighting),
+                         static_cast<unsigned char>(colors[0].G * vehicleInterface->m_fLighting),
+                         static_cast<unsigned char>(colors[0].B * vehicleInterface->m_fLighting), 0xFF};
+
+        // Fx_c::AddDebris
+        reinterpret_cast<void(__thiscall*)(int, CVector&, RwColor&, float, int)>(0x49F750)(CLASS_CFx, position, color, 0.06f, count / 100 + 1);
+    }
+}
+
+static void __declspec(naked) HOOK_CAutomobile__dmgDrawCarCollidingParticles()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        lea     eax, [esp + 1Ch]
+        push    ebp                     // count
+        push    eax                     // position
+        push    edi                     // vehicleInterface
+        call    AddVehicleColoredDebris
+        add     esp, 12
+
+        jmp     CONTINUE_CAutomobile__dmgDrawCarCollidingParticles
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CHeli::ProcessControl (Heli Blade Kill Event)
+//
+// Notifies MTA when a helicopter's blades strike an entity.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6DB201 | 0F 85 30 02 00 00 | jnz     loc_6DB437
+#define HOOKPOS_CHeli__ProcessHeliKill  0x6DB201
+#define HOOKSIZE_CHeli__ProcessHeliKill 6
+static constexpr std::uintptr_t CONTINUE_CHeli__ProcessHeliKill_Cont = 0x6DB207;
+static constexpr std::uintptr_t CONTINUE_CHeli__ProcessHeliKill_Branch = 0x6DB437;
+static constexpr std::uintptr_t CANCEL_CHeli__ProcessHeliKill = 0x6DB9E0;
+
+extern HeliKillHandler* m_pHeliKillHandler;
+
+static bool CallHeliKillEvent(CVehicleSAInterface* heliInterface, CEntitySAInterface* hitEntityInterface)
+{
+    if (m_pHeliKillHandler)
+    {
+        return m_pHeliKillHandler(heliInterface, hitEntityInterface);
+    }
+    return true;
+}
+
+static void __declspec(naked) HOOK_CHeli__ProcessHeliKill()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        pushfd
+        pushad
+        push    edi                     // hit entity
+        push    esi                     // heli
+        call    CallHeliKillEvent
+        add     esp, 8
+        test    al, al
+        jz      cancelHeliKill
+
+        popad
+        popfd
+        jnz     branchTarget
+        jmp     CONTINUE_CHeli__ProcessHeliKill_Cont
+
+    branchTarget:
+        jmp     CONTINUE_CHeli__ProcessHeliKill_Branch
+
+    cancelHeliKill:
+        popad
+        popfd
+        jmp     CANCEL_CHeli__ProcessHeliKill
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CVehicle::VehicleColor & Callback
+//
+// Applies custom vehicle colors during vehicle rendering.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+// >>> 0x6D6603 | ...
+#define HOOKPOS_CVehicle__VehicleColor  0x6D6603
+#define HOOKSIZE_CVehicle__VehicleColor 9
+static constexpr std::uintptr_t CONTINUE_CVehicle__VehicleColor = 0x6D660C;
+
+#define HOOKPOS_CVehicle__VehicleColorCallback  0x4C838D
+#define HOOKSIZE_CVehicle__VehicleColorCallback 29
+static constexpr std::uintptr_t CONTINUE_CVehicle__VehicleColorCallback = 0x4C83AA;
+
+static SColor s_vehicleColors[4];
+
+static void SaveVehColors(CVehicleSAInterface* vehicleInterface)
+{
+    SClientEntity<CVehicleSA>* vehicleClientEntity = pGameInterface->GetPools()->GetVehicle(reinterpret_cast<DWORD*>(vehicleInterface));
+    CVehicle*                  vehicle = vehicleClientEntity ? vehicleClientEntity->pEntity : nullptr;
+    if (vehicle)
+    {
+        vehicle->GetColor(&s_vehicleColors[0], &s_vehicleColors[1], &s_vehicleColors[2], &s_vehicleColors[3], true);
+    }
+}
+
+static void __declspec(naked) HOOK_CVehicle__VehicleColor()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        pushad
+        push    esi                     // CVehicleSAInterface*
+        call    SaveVehColors
+        add     esp, 4
+        popad
+
+        mov     dl, 3
+        mov     al, 2
+        mov     cl, 1
+        push    edx
+        xor     edx, edx
+        mov     dl, byte ptr [esi + 434h]
+        mov     dl, 0
+        jmp     CONTINUE_CVehicle__VehicleColor
+    }
+    // clang-format on
+}
+
+static void __declspec(naked) HOOK_CVehicle__VehicleColorCallback()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        mov     cl, byte ptr [esi * 4 + s_vehicleColors.R]
+        mov     byte ptr [eax + 4], cl
+
+        mov     cl, byte ptr [esi * 4 + s_vehicleColors.G]
+        mov     byte ptr [eax + 5], cl
+
+        mov     cl, byte ptr [esi * 4 + s_vehicleColors.B]
+        mov     byte ptr [eax + 6], cl
+
+        jmp     CONTINUE_CVehicle__VehicleColorCallback
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
 // CMultiplayerSA::InitHooks_Vehicles
 //
 // Setup hooks
@@ -3835,4 +4376,18 @@ void CMultiplayerSA::InitHooks_Vehicles()
     EZHookInstall(CAEVehicleAudioEntity__ProcessMovingParts_AndromGate);
     EZHookInstall(CAEVehicleAudioEntity__ProcessMovingParts_AndromCreakCase);
     EZHookInstall(CPlane__PreRender_AndromRampBlock);
+
+    EZHookInstall(CVehicle__ProcessControl_OccupiedBurnCheck);
+    EZHookInstall(CAutomobile__ProcessControl_UnoccupiedBurnCheck);
+    EZHookInstall(CAutomobile__BlowUpCarsInPath_ApplyCarBlowHop);
+    EZHookInstall(CTrailer__BreakTowLink);
+    EZHookInstall(CTrain__ProcessControl_Derail);
+    EZHookInstall(CAutomobile__ProcessSwingingDoor);
+    EZHookInstall(CTransmission__CalculateDriveAcceleration);
+    EZHookInstall(CHandlingData__isNotRWD);
+    EZHookInstall(CHandlingData__isNotFWD);
+    EZHookInstall(CAutomobile__dmgDrawCarCollidingParticles);
+    EZHookInstall(CHeli__ProcessHeliKill);
+    EZHookInstall(CVehicle__VehicleColor);
+    EZHookInstall(CVehicle__VehicleColorCallback);
 }


### PR DESCRIPTION
Continuing the ongoing cleanup of legacy hooks in `CMultiplayerSA.cpp`, this PR extracts and modernizes the remaining vehicle-related hooks into `CMultiplayerSA_Vehicles.cpp`.

### Testing
[vehicle_hooks_test.zip](https://github.com/user-attachments/files/31162330/vehicle_hooks_test.zip)


To test these changes:
1. Start the test resource in console: `start vehicle_hooks_test`
2. **Test trailer link:** Run `/drivetrailer` and press `X` or type `/detach` to unhook the trailer, or turn sharply to break the link with physics.
3. **Test helicopter blades:** Run `/testhelikill` to spawn in a Maverick and tilt forward into the dummy peds to chop them with the rotor blades.
4. **Test flipped vehicle burn:** Run `/testvehburn` to spawn an upside-down car and verify it catches fire after a few seconds.
5. **Test explosion hop:** Run `/testvehblow` to detonate a car and verify the upward jump velocity.
6. **Test handling & gears:** Run `/testvehhandling` to spawn a car with custom drive type and gear limits.
7. **Test vehicle colors:** Run `/testvehcolor` to verify custom RGBA vehicle colors and paint debris.

### Checklist
- [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
- [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
