### PR TITLE
Fix #5222, #5223, #5224: Wire missing element getter/setter types

### DIFF
--- a/Client/mods/deathmatch/logic/CClientBuilding.cpp
+++ b/Client/mods/deathmatch/logic/CClientBuilding.cpp
@@ -20,6 +20,7 @@ CClientBuilding::CClientBuilding(class CClientManager* pManager, ElementID ID, u
       m_interior(interior),
       m_pBuilding(nullptr),
       m_usesCollision(true),
+      m_ucAlpha(255),
       m_pHighBuilding(nullptr),
       m_pLowBuilding(nullptr)
 {
@@ -140,6 +141,15 @@ void CClientBuilding::SetUsesCollision(bool state)
     m_usesCollision = state;
 }
 
+void CClientBuilding::SetAlpha(unsigned char ucAlpha)
+{
+    m_ucAlpha = ucAlpha;
+    // Buildings are not CObject, so they never hit the per-entity object alpha hook. Apply
+    // SetRwObjectAlpha on the game entity (and again in Create after Recreate).
+    if (m_pBuilding)
+        m_pBuilding->SetAlpha(ucAlpha);
+}
+
 void CClientBuilding::Create()
 {
     if (m_pBuilding)
@@ -162,6 +172,8 @@ void CClientBuilding::Create()
     {
         m_pBuilding->SetUsesCollision(m_usesCollision);
     }
+    if (m_ucAlpha != 255)
+        m_pBuilding->SetAlpha(m_ucAlpha);
     if (m_pHighBuilding)
     {
         m_pHighBuilding->GetBuildingEntity()->SetLod(m_pBuilding);

--- a/Client/mods/deathmatch/logic/CClientBuilding.h
+++ b/Client/mods/deathmatch/logic/CClientBuilding.h
@@ -50,7 +50,11 @@ public:
 
     eClientEntityType GetType() const { return CCLIENTBUILDING; }
 
+    bool GetUsesCollision() const noexcept { return m_usesCollision; }
     void SetUsesCollision(bool state);
+
+    unsigned char GetAlpha() const noexcept { return m_ucAlpha; }
+    void          SetAlpha(unsigned char ucAlpha);
 
     void Create();
     void Destroy();
@@ -76,12 +80,13 @@ private:
 private:
     CClientBuildingManager* m_pBuildingManager;
 
-    CBuilding* m_pBuilding;
-    uint16_t   m_usModelId;
-    CVector    m_vPos;
-    CVector    m_vRot;
-    uint8_t    m_interior;
-    bool       m_usesCollision;
+    CBuilding*    m_pBuilding;
+    uint16_t      m_usModelId;
+    CVector       m_vPos;
+    CVector       m_vRot;
+    uint8_t       m_interior;
+    bool          m_usesCollision;
+    unsigned char m_ucAlpha;
 
     CClientBuilding* m_pHighBuilding;
     CClientBuilding* m_pLowBuilding;

--- a/Client/mods/deathmatch/logic/CClientProjectile.cpp
+++ b/Client/mods/deathmatch/logic/CClientProjectile.cpp
@@ -47,6 +47,8 @@ CClientProjectile::CClientProjectile(class CClientManager* pManager, CProjectile
 
     m_pInitiateData = NULL;
     m_bInitiate = true;
+    m_ucAlpha = 255;
+    m_bFrozen = false;
 
     m_pProjectileManager->AddToList(this);
     m_bLinked = true;
@@ -330,4 +332,31 @@ CClientEntity* CClientProjectile::GetSatchelAttachedTo()
 
     CPools* pPools = g_pGame->GetPools();
     return pPools->GetClientEntity((DWORD*)pAttachedToSA->GetInterface());
+}
+
+unsigned char CClientProjectile::GetAlpha() const
+{
+    return m_pProjectile ? m_pProjectile->GetAlpha() : m_ucAlpha;
+}
+
+void CClientProjectile::SetAlpha(unsigned char ucAlpha)
+{
+    m_ucAlpha = ucAlpha;
+    if (m_pProjectile)
+        m_pProjectile->SetAlpha(ucAlpha);
+}
+
+void CClientProjectile::SetFrozen(bool bFrozen)
+{
+    m_bFrozen = bFrozen;
+    if (!m_pProjectile)
+        return;
+
+    m_pProjectile->SetFrozen(bFrozen);
+    if (bFrozen)
+    {
+        CVector vecZero;
+        m_pProjectile->SetMoveSpeed(vecZero);
+        m_pProjectile->SetTurnSpeed(&vecZero);
+    }
 }

--- a/Client/mods/deathmatch/logic/CClientProjectile.h
+++ b/Client/mods/deathmatch/logic/CClientProjectile.h
@@ -94,6 +94,11 @@ public:
     bool           IsLocal() { return m_bLocal; }
     CClientEntity* GetSatchelAttachedTo();
 
+    unsigned char GetAlpha() const;
+    void          SetAlpha(unsigned char ucAlpha);
+    bool          IsFrozen() const { return m_bFrozen; }
+    void          SetFrozen(bool bFrozen);
+
 protected:
     CClientProjectileManager* m_pProjectileManager;
     bool                      m_bLinked;
@@ -113,4 +118,6 @@ protected:
     bool                     m_bInitiate;
     CProjectileInitiateData* m_pInitiateData;
     bool                     m_bCorrected;
+    unsigned char            m_ucAlpha;
+    bool                     m_bFrozen;
 };

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -719,6 +719,16 @@ bool CStaticFunctionDefinitions::GetElementAlpha(CClientEntity& Entity, unsigned
             ucAlpha = Object.GetAlpha();
             break;
         }
+        case CCLIENTBUILDING:
+        {
+            ucAlpha = static_cast<CClientBuilding&>(Entity).GetAlpha();
+            break;
+        }
+        case CCLIENTPROJECTILE:
+        {
+            ucAlpha = static_cast<CClientProjectile&>(Entity).GetAlpha();
+            break;
+        }
         case CCLIENTMARKER:
         {
             CClientMarker& Marker = static_cast<CClientMarker&>(Entity);
@@ -914,15 +924,19 @@ bool CStaticFunctionDefinitions::GetElementCollisionsEnabled(CClientEntity& Enti
             return Vehicle.IsCollisionEnabled();
         }
         case CCLIENTOBJECT:
+        case CCLIENTWEAPON:
         {
-            CClientObject& Object = static_cast<CClientObject&>(Entity);
-            return Object.IsCollisionEnabled();
+            return static_cast<CClientObject&>(Entity).IsCollisionEnabled();
         }
         case CCLIENTPED:
         case CCLIENTPLAYER:
         {
             CClientPed& Ped = static_cast<CClientPed&>(Entity);
             return Ped.GetUsesCollision();
+        }
+        case CCLIENTBUILDING:
+        {
+            return static_cast<CClientBuilding&>(Entity).GetUsesCollision();
         }
         default:
             return false;
@@ -949,9 +963,15 @@ bool CStaticFunctionDefinitions::IsElementFrozen(CClientEntity& Entity, bool& bF
             break;
         }
         case CCLIENTOBJECT:
+        case CCLIENTWEAPON:
         {
             CClientObject& Object = static_cast<CClientObject&>(Entity);
             bFrozen = Object.IsFrozen();
+            break;
+        }
+        case CCLIENTPROJECTILE:
+        {
+            bFrozen = static_cast<CClientProjectile&>(Entity).IsFrozen();
             break;
         }
         default:
@@ -1497,6 +1517,16 @@ bool CStaticFunctionDefinitions::SetElementAlpha(CClientEntity& Entity, unsigned
         {
             CClientObject& Object = static_cast<CClientObject&>(Entity);
             Object.SetAlpha(ucAlpha);
+            break;
+        }
+        case CCLIENTBUILDING:
+        {
+            static_cast<CClientBuilding&>(Entity).SetAlpha(ucAlpha);
+            break;
+        }
+        case CCLIENTPROJECTILE:
+        {
+            static_cast<CClientProjectile&>(Entity).SetAlpha(ucAlpha);
             break;
         }
         case CCLIENTMARKER:
@@ -3921,9 +3951,15 @@ bool CStaticFunctionDefinitions::SetElementFrozen(CClientEntity& Entity, bool bF
             break;
         }
         case CCLIENTOBJECT:
+        case CCLIENTWEAPON:
         {
             CClientObject& Object = static_cast<CClientObject&>(Entity);
             Object.SetFrozen(bFrozen);
+            break;
+        }
+        case CCLIENTPROJECTILE:
+        {
+            static_cast<CClientProjectile&>(Entity).SetFrozen(bFrozen);
             break;
         }
         default:

--- a/Client/mods/deathmatch/logic/rpc/CElementRPCs.cpp
+++ b/Client/mods/deathmatch/logic/rpc/CElementRPCs.cpp
@@ -458,6 +458,16 @@ void CElementRPCs::SetElementAlpha(CClientEntity* pSource, NetBitStreamInterface
                 pObject->SetAlpha(ucAlpha);
                 break;
             }
+            case CCLIENTBUILDING:
+            {
+                static_cast<CClientBuilding*>(pSource)->SetAlpha(ucAlpha);
+                break;
+            }
+            case CCLIENTPROJECTILE:
+            {
+                static_cast<CClientProjectile*>(pSource)->SetAlpha(ucAlpha);
+                break;
+            }
             default:
                 break;
         }
@@ -669,6 +679,7 @@ void CElementRPCs::SetElementCollisionsEnabled(CClientEntity* pSource, NetBitStr
             }
 
             case CCLIENTOBJECT:
+            case CCLIENTWEAPON:
             {
                 CClientObject* pObject = static_cast<CClientObject*>(pSource);
                 pObject->SetCollisionEnabled(bEnable);
@@ -708,9 +719,15 @@ void CElementRPCs::SetElementFrozen(CClientEntity* pSource, NetBitStreamInterfac
             }
 
             case CCLIENTOBJECT:
+            case CCLIENTWEAPON:
             {
                 CClientObject* pObject = static_cast<CClientObject*>(pSource);
                 pObject->SetFrozen(bFrozen);
+                break;
+            }
+            case CCLIENTPROJECTILE:
+            {
+                static_cast<CClientProjectile*>(pSource)->SetFrozen(bFrozen);
                 break;
             }
         }

--- a/Server/mods/deathmatch/logic/CBuilding.cpp
+++ b/Server/mods/deathmatch/logic/CBuilding.cpp
@@ -27,6 +27,7 @@ CBuilding::CBuilding(CElement* pParent, CBuildingManager* pBuildingManager) : CE
     m_model = 0xFFFF;
     m_bDoubleSided = false;
     m_bCollisionsEnabled = true;
+    m_ucAlpha = 255;
     m_pLowLodBuilding = nullptr;
     m_pHighLodBuilding = nullptr;
 
@@ -46,6 +47,7 @@ CBuilding::CBuilding(const CBuilding& Copy) : CElement(Copy.m_pParent), m_pLowLo
     m_vecPosition = Copy.m_vecPosition;
     m_vecRotation = Copy.m_vecRotation;
     m_bCollisionsEnabled = Copy.m_bCollisionsEnabled;
+    m_ucAlpha = Copy.m_ucAlpha;
     m_pHighLodBuilding = nullptr;
 
     // Add us to the manager's list

--- a/Server/mods/deathmatch/logic/CBuilding.h
+++ b/Server/mods/deathmatch/logic/CBuilding.h
@@ -48,6 +48,9 @@ public:
     bool GetCollisionEnabled() const noexcept { return m_bCollisionsEnabled; }
     void SetCollisionEnabled(bool bCollisionEnabled) noexcept { m_bCollisionsEnabled = bCollisionEnabled; }
 
+    unsigned char GetAlpha() const noexcept { return m_ucAlpha; }
+    void          SetAlpha(unsigned char ucAlpha) noexcept { m_ucAlpha = ucAlpha; }
+
     bool       SetLowLodBuilding(CBuilding* pLowLodBuilding) noexcept;
     CBuilding* GetLowLodElement() const noexcept { return m_pLowLodBuilding; }
 
@@ -63,7 +66,8 @@ private:
     std::uint16_t     m_model;
 
 protected:
-    bool m_bCollisionsEnabled;
+    bool          m_bCollisionsEnabled;
+    unsigned char m_ucAlpha;
 
     CBuilding* m_pLowLodBuilding;
     CBuilding* m_pHighLodBuilding;

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -625,9 +625,15 @@ bool CStaticFunctionDefinitions::GetElementAlpha(CElement* pElement, unsigned ch
             break;
         }
         case CElement::OBJECT:
+        case CElement::WEAPON:
         {
             CObject* pObject = static_cast<CObject*>(pElement);
             ucAlpha = pObject->GetAlpha();
+            break;
+        }
+        case CElement::BUILDING:
+        {
+            ucAlpha = static_cast<CBuilding*>(pElement)->GetAlpha();
             break;
         }
         case CElement::MARKER:
@@ -770,6 +776,7 @@ bool CStaticFunctionDefinitions::GetElementCollisionsEnabled(CElement* pElement)
             return pVehicle->GetCollisionEnabled();
         }
         case CElement::OBJECT:
+        case CElement::WEAPON:
         {
             CObject* pObject = static_cast<CObject*>(pElement);
             return pObject->GetCollisionEnabled();
@@ -811,6 +818,7 @@ bool CStaticFunctionDefinitions::IsElementFrozen(CElement* pElement, bool& bFroz
             break;
         }
         case CElement::OBJECT:
+        case CElement::WEAPON:
         {
             CObject* pObject = static_cast<CObject*>(pElement);
             bFrozen = pObject->IsFrozen();
@@ -1758,9 +1766,15 @@ bool CStaticFunctionDefinitions::SetElementAlpha(CElement* pElement, unsigned ch
             break;
         }
         case CElement::OBJECT:
+        case CElement::WEAPON:
         {
             CObject* pObject = static_cast<CObject*>(pElement);
             pObject->SetAlpha(ucAlpha);
+            break;
+        }
+        case CElement::BUILDING:
+        {
+            static_cast<CBuilding*>(pElement)->SetAlpha(ucAlpha);
             break;
         }
         case CElement::MARKER:
@@ -2070,6 +2084,7 @@ bool CStaticFunctionDefinitions::SetElementCollisionsEnabled(CElement* pElement,
             break;
         }
         case CElement::OBJECT:
+        case CElement::WEAPON:
         {
             CObject* pObject = static_cast<CObject*>(pElement);
             pObject->SetCollisionEnabled(bEnable);
@@ -2119,6 +2134,7 @@ bool CStaticFunctionDefinitions::SetElementFrozen(CElement* pElement, bool bFroz
             break;
         }
         case CElement::OBJECT:
+        case CElement::WEAPON:
         {
             CObject* pObject = static_cast<CObject*>(pElement);
             pObject->SetFrozen(bFrozen);


### PR DESCRIPTION
#### Summary
`getElementAlpha` / `setElementAlpha`, `isElementFrozen` / `setElementFrozen` and `getElementCollisionsEnabled` were missing building, weapon and projectile in their type switches, so they returned `false` even when the matching setter already worked.

- Buildings: alpha and collisions getter
- Weapons: collisions getter and frozen get/set (`CClientWeapon` already inherits object alpha)
- Projectiles: alpha and frozen get/set

#### Motivation
Fixes #5222, #5223 and #5224. `crun b = createBuilding(1337, me.position)` then `b.alpha` / `getElementCollisionsEnabled(b)` returned false. `createProjectile` then `p.frozen` / `p.frozen = true` also returned false.

#### Test plan
1. `crun b = createBuilding(1337, me.position)` then `getElementCollisionsEnabled(b)` is true; `b.alpha` is 255; `b.alpha = 0` returns true and the building goes invisible.
2. `crun setElementCollisionsEnabled(b, false)` then `getElementCollisionsEnabled(b)` is false.
3. Create a custom weapon: `getElementCollisionsEnabled` matches the setter; `isElementFrozen` / `setElementFrozen` work.
4. `crun p = createProjectile(me, 16, me.position, 1.0) setProjectileCounter(p, 3000)` then `p.alpha` / `p.alpha = 0` and `p.frozen = true` return the real values, not false.
5. Existing ped/vehicle/object alpha, frozen and collisions unchanged.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.