### PR TITLE
Return default siren parameters and beacons in `getVehicleSirens`

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -3092,13 +3092,27 @@ int CLuaVehicleDefs::GetVehicleSirenParams(lua_State* luaVM)
 {
     CScriptArgReader argStream(luaVM);
     CClientVehicle*  pVehicle = NULL;
-    unsigned char    ucSirenID = 0;
     SSirenInfo       tSirenInfo;
 
     argStream.ReadUserData(pVehicle);
     if (!argStream.HasErrors())
     {
         tSirenInfo = pVehicle->m_tSirenBeaconInfo;  // Grab the siren structure data
+
+        // If custom sirens are not overridden, query native GTA:SA default sirens
+        if (!tSirenInfo.m_bOverrideSirens)
+        {
+            if (const auto defaultSirens = SharedUtil::GetDefaultVehicleSirens(pVehicle->GetModel()); defaultSirens.has_value())
+            {
+                tSirenInfo.m_ucSirenCount = defaultSirens->sirenCount;
+                tSirenInfo.m_ucSirenType = defaultSirens->sirenType;
+                tSirenInfo.m_b360Flag = defaultSirens->flag360;
+                tSirenInfo.m_bDoLOSCheck = defaultSirens->doLOSCheck;
+                tSirenInfo.m_bUseRandomiser = defaultSirens->useRandomiser;
+                tSirenInfo.m_bSirenSilent = defaultSirens->sirenSilent;
+            }
+        }
+
         lua_newtable(luaVM);
 
         lua_pushstring(luaVM, "SirenCount");
@@ -3143,13 +3157,28 @@ int CLuaVehicleDefs::GetVehicleSirens(lua_State* luaVM)
 {
     CScriptArgReader argStream(luaVM);
     CClientVehicle*  pVehicle = NULL;
-    unsigned char    ucSirenID = 0;
     SSirenInfo       tSirenInfo;
 
     argStream.ReadUserData(pVehicle);
     if (!argStream.HasErrors())
     {
         tSirenInfo = pVehicle->m_tSirenBeaconInfo;  // Grab the siren structure data
+
+        // If custom sirens are not overridden, query native GTA:SA default sirens
+        if (!tSirenInfo.m_bOverrideSirens)
+        {
+            if (const auto defaultSirens = SharedUtil::GetDefaultVehicleSirens(pVehicle->GetModel()); defaultSirens.has_value())
+            {
+                tSirenInfo.m_ucSirenCount = defaultSirens->sirenCount;
+                for (std::size_t i = 0; i < defaultSirens->sirenCount; ++i)
+                {
+                    tSirenInfo.m_tSirenInfo[i].m_vecSirenPositions = defaultSirens->beacons[i].position;
+                    tSirenInfo.m_tSirenInfo[i].m_RGBBeaconColour = defaultSirens->beacons[i].color;
+                    tSirenInfo.m_tSirenInfo[i].m_dwMinSirenAlpha = defaultSirens->beacons[i].minAlpha;
+                }
+            }
+        }
+
         lua_newtable(luaVM);
 
         for (int i = 0; i < tSirenInfo.m_ucSirenCount; i++)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -650,6 +650,21 @@ int CLuaVehicleDefs::GetVehicleSirenParams(lua_State* luaVM)
     if (argStream.HasErrors() == false)
     {
         tSirenInfo = pVehicle->m_tSirenBeaconInfo;  // Create a new table
+
+        // If custom sirens are not overridden, query native GTA:SA default sirens
+        if (!tSirenInfo.m_bOverrideSirens)
+        {
+            if (const auto defaultSirens = SharedUtil::GetDefaultVehicleSirens(pVehicle->GetModel()); defaultSirens.has_value())
+            {
+                tSirenInfo.m_ucSirenCount = defaultSirens->sirenCount;
+                tSirenInfo.m_ucSirenType = defaultSirens->sirenType;
+                tSirenInfo.m_b360Flag = defaultSirens->flag360;
+                tSirenInfo.m_bDoLOSCheck = defaultSirens->doLOSCheck;
+                tSirenInfo.m_bUseRandomiser = defaultSirens->useRandomiser;
+                tSirenInfo.m_bSirenSilent = defaultSirens->sirenSilent;
+            }
+        }
+
         lua_newtable(luaVM);
 
         lua_pushstring(luaVM, "SirenCount");
@@ -700,6 +715,22 @@ int CLuaVehicleDefs::GetVehicleSirens(lua_State* luaVM)
     if (argStream.HasErrors() == false)
     {
         tSirenInfo = pVehicle->m_tSirenBeaconInfo;  // Create a new table
+
+        // If custom sirens are not overridden, query native GTA:SA default sirens
+        if (!tSirenInfo.m_bOverrideSirens)
+        {
+            if (const auto defaultSirens = SharedUtil::GetDefaultVehicleSirens(pVehicle->GetModel()); defaultSirens.has_value())
+            {
+                tSirenInfo.m_ucSirenCount = defaultSirens->sirenCount;
+                for (std::size_t i = 0; i < defaultSirens->sirenCount; ++i)
+                {
+                    tSirenInfo.m_tSirenInfo[i].m_vecSirenPositions = defaultSirens->beacons[i].position;
+                    tSirenInfo.m_tSirenInfo[i].m_RGBBeaconColour = defaultSirens->beacons[i].color;
+                    tSirenInfo.m_tSirenInfo[i].m_dwMinSirenAlpha = defaultSirens->beacons[i].minAlpha;
+                }
+            }
+        }
+
         lua_newtable(luaVM);
 
         for (int i = 0; i < tSirenInfo.m_ucSirenCount; i++)

--- a/Shared/sdk/SharedUtil.Game.h
+++ b/Shared/sdk/SharedUtil.Game.h
@@ -12,6 +12,10 @@
 
 #include "SharedUtil.IntTypes.h"
 #include "SharedUtil.Misc.h"
+#include "CVector.h"
+#include <array>
+#include <cstdint>
+#include <optional>
 
 namespace SharedUtil
 {
@@ -132,4 +136,26 @@ namespace SharedUtil
 #define WD_COUNTER_CRASH_CHAIN_BEFORE_ONLINE_GAME    "CR1"  // Counts consecutive crashes before the online game starts
 #define WD_COUNTER_CRASH_CHAIN_BEFORE_LOADING_SCREEN "CR2"  // Counts consecutive crashes before the loading screen is shown
 #define WD_COUNTER_CRASH_CHAIN_BEFORE_USED_MAIN_MENU "CR3"  // Counts consecutive crashes before the main menu is used
+
+    struct SDefaultSirenBeacon
+    {
+        CVector       position;
+        SColor        color;
+        std::uint32_t minAlpha{0};
+    };
+
+    struct SDefaultVehicleSirens
+    {
+        std::uint8_t                       sirenCount{0};
+        std::uint8_t                       sirenType{0};
+        bool                               flag360{false};
+        bool                               doLOSCheck{true};
+        bool                               useRandomiser{true};
+        bool                               sirenSilent{false};
+        std::array<SDefaultSirenBeacon, 8> beacons{};
+    };
+
+    // Retrieves the native GTA:SA siren configuration and coordinates for emergency vehicles
+    std::optional<SDefaultVehicleSirens> GetDefaultVehicleSirens(std::uint16_t modelId) noexcept;
+    bool                                 DoesVehicleModelHaveDefaultSirens(std::uint16_t modelId) noexcept;
 }  // namespace SharedUtil

--- a/Shared/sdk/SharedUtil.Game.hpp
+++ b/Shared/sdk/SharedUtil.Game.hpp
@@ -253,4 +253,135 @@ namespace SharedUtil
         return SColorRGBA(r, g, b, 0);
     }
 
+    // Default GTA:SA emergency vehicle siren configurations derived from CAutomobile::PreRender (0x6AAB50) and CBike::PreRender (0x6BD090)
+    std::optional<SDefaultVehicleSirens> GetDefaultVehicleSirens(std::uint16_t modelId) noexcept
+    {
+        SDefaultVehicleSirens sirenData;
+
+        switch (modelId)
+        {
+            // Police LS / SF / LV
+            case 596:
+            case 597:
+            case 598:
+            {
+                sirenData.sirenCount = 2;
+                sirenData.sirenType = 2;
+                sirenData.flag360 = true;
+                sirenData.doLOSCheck = true;
+                sirenData.useRandomiser = true;
+                sirenData.sirenSilent = false;
+                sirenData.beacons[0] = {CVector(0.7f, -0.4f, 1.0f), SColorRGBA(0, 0, 255, 255), 0};
+                sirenData.beacons[1] = {CVector(-0.7f, -0.4f, 1.0f), SColorRGBA(255, 0, 0, 255), 0};
+                return sirenData;
+            }
+
+            // Police Ranger
+            case 599:
+            {
+                sirenData.sirenCount = 2;
+                sirenData.sirenType = 2;
+                sirenData.flag360 = true;
+                sirenData.doLOSCheck = true;
+                sirenData.useRandomiser = true;
+                sirenData.sirenSilent = false;
+                sirenData.beacons[0] = {CVector(0.7f, -0.1f, 1.2f), SColorRGBA(0, 0, 255, 255), 0};
+                sirenData.beacons[1] = {CVector(-0.7f, -0.1f, 1.2f), SColorRGBA(255, 0, 0, 255), 0};
+                return sirenData;
+            }
+
+            // Ambulance
+            case 416:
+            {
+                sirenData.sirenCount = 2;
+                sirenData.sirenType = 2;
+                sirenData.flag360 = true;
+                sirenData.doLOSCheck = true;
+                sirenData.useRandomiser = true;
+                sirenData.sirenSilent = false;
+                sirenData.beacons[0] = {CVector(0.6f, 0.9f, 1.2f), SColorRGBA(0, 0, 255, 255), 0};
+                sirenData.beacons[1] = {CVector(-0.6f, 0.9f, 1.2f), SColorRGBA(255, 0, 0, 255), 0};
+                return sirenData;
+            }
+
+            // Firetruck / Firetruck with ladder
+            case 407:
+            case 544:
+            {
+                sirenData.sirenCount = 2;
+                sirenData.sirenType = 2;
+                sirenData.flag360 = true;
+                sirenData.doLOSCheck = true;
+                sirenData.useRandomiser = true;
+                sirenData.sirenSilent = false;
+                sirenData.beacons[0] = {CVector(0.9f, 3.2f, 1.3f), SColorRGBA(255, 255, 0, 255), 0};
+                sirenData.beacons[1] = {CVector(-0.9f, 3.2f, 1.3f), SColorRGBA(255, 0, 0, 255), 0};
+                return sirenData;
+            }
+
+            // Enforcer
+            case 427:
+            {
+                sirenData.sirenCount = 2;
+                sirenData.sirenType = 2;
+                sirenData.flag360 = true;
+                sirenData.doLOSCheck = true;
+                sirenData.useRandomiser = true;
+                sirenData.sirenSilent = false;
+                sirenData.beacons[0] = {CVector(0.55f, 1.1f, 1.4f), SColorRGBA(0, 0, 255, 255), 0};
+                sirenData.beacons[1] = {CVector(-0.55f, 1.1f, 1.4f), SColorRGBA(255, 0, 0, 255), 0};
+                return sirenData;
+            }
+
+            // FBI Rancher & FBI Truck
+            case 490:
+            case 528:
+            {
+                sirenData.sirenCount = 1;
+                sirenData.sirenType = 1;
+                sirenData.flag360 = false;
+                sirenData.doLOSCheck = true;
+                sirenData.useRandomiser = false;
+                sirenData.sirenSilent = false;
+                sirenData.beacons[0] = {CVector(0.0f, 1.2f, 0.5f), SColorRGBA(0, 0, 255, 255), 0};
+                return sirenData;
+            }
+
+            // Police Bike (HPV-1000)
+            case 523:
+            {
+                sirenData.sirenCount = 2;
+                sirenData.sirenType = 2;
+                sirenData.flag360 = false;
+                sirenData.doLOSCheck = true;
+                sirenData.useRandomiser = true;
+                sirenData.sirenSilent = false;
+                sirenData.beacons[0] = {CVector(0.28f, 0.60f, 0.30f), SColorRGBA(0, 0, 255, 255), 0};
+                sirenData.beacons[1] = {CVector(-0.28f, 0.60f, 0.30f), SColorRGBA(255, 0, 0, 255), 0};
+                return sirenData;
+            }
+
+            // SWAT
+            case 601:
+            {
+                sirenData.sirenCount = 1;
+                sirenData.sirenType = 1;
+                sirenData.flag360 = true;
+                sirenData.doLOSCheck = true;
+                sirenData.useRandomiser = false;
+                sirenData.sirenSilent = false;
+                sirenData.beacons[0] = {CVector(0.0f, 0.0f, 1.2f), SColorRGBA(0, 0, 255, 255), 0};
+                return sirenData;
+            }
+
+            default:
+                return std::nullopt;
+        }
+    }
+
+    bool DoesVehicleModelHaveDefaultSirens(std::uint16_t modelId) noexcept
+    {
+        return GetDefaultVehicleSirens(modelId).has_value();
+    }
+
 }  // namespace SharedUtil


### PR DESCRIPTION
Fixes #4175
<img width="1882" height="342" alt="image" src="https://github.com/user-attachments/assets/227f75b0-fcbe-43c9-a5d2-b5057882dc86" />
<img width="1724" height="517" alt="image" src="https://github.com/user-attachments/assets/1270f8c2-56cf-44a8-a517-cd977d46e47d" />

- Added GTA:SA default emergency siren definitions (beacons, coordinates, colors, and flags) for all 12 emergency vehicle models.
- Updated `getVehicleSirens` and `getVehicleSirenParams` to return default siren data when no custom override is active instead of returning empty tables.
- Non-emergency vehicles continue to return empty tables / `0`.