### PR TITLE
Fix AlwaysOnTop CEGUI elements appearing above the main menu and console

### DIFF
--- a/Client/gui/CGUIElement_Impl.h
+++ b/Client/gui/CGUIElement_Impl.h
@@ -167,3 +167,19 @@ protected:
     GUI_CALLBACK_MOUSE m_OnClickWithArgs;
     GUI_CALLBACK_KEY   m_OnKeyDownWithArgs;
 };
+
+class CGUIDefaultWindow_Impl : public CGUIElement_Impl
+{
+public:
+    CGUIDefaultWindow_Impl(CGUI_Impl* gui, CEGUI::Window* window)
+    {
+        SetManager(gui);
+        m_pWindow = window;
+        if (m_pWindow)
+            m_pWindow->setUserData(reinterpret_cast<void*>(this));
+    }
+
+    virtual ~CGUIDefaultWindow_Impl() { DestroyElement(); }
+
+    eCGUIType GetType() override { return CGUI_WINDOW; }
+};

--- a/Client/gui/CGUI_Impl.cpp
+++ b/Client/gui/CGUI_Impl.cpp
@@ -62,6 +62,8 @@ CGUI_Impl::CGUI_Impl(IDirect3DDevice9* pDevice)
       m_pSchemeManager(nullptr),
       m_pWindowManager(nullptr),
       m_pTop(nullptr),
+      m_ScriptTop(nullptr),
+      m_ScriptRoot(nullptr),
       m_pCursor(nullptr),
       m_pDefaultFont(nullptr),
       m_pSmallFont(nullptr),
@@ -147,6 +149,12 @@ CGUI_Impl::CGUI_Impl(IDirect3DDevice9* pDevice)
 
 CGUI_Impl::~CGUI_Impl()
 {
+    if (m_ScriptRoot)
+    {
+        delete m_ScriptRoot;
+        m_ScriptRoot = nullptr;
+    }
+
     // Clean up font objects to prevent memory leaks
     delete m_pUniFont;
     delete m_pDefaultFont;
@@ -170,6 +178,16 @@ void CGUI_Impl::CreateRootWindow()
     // Create dummy GUI root
     m_pTop = reinterpret_cast<CEGUI::DefaultWindow*>(m_pWindowManager->createWindow("DefaultWindow", "guiroot"));
     m_pSystem->setGUISheet(m_pTop);
+
+    // Create a dedicated script GUI root container to isolate script elements from MTA Core UI (Main Menu & Console).
+    // This ensures script AlwaysOnTop elements can never render above system UI while preserving AlwaysOnTop among script elements.
+    m_ScriptTop = reinterpret_cast<CEGUI::DefaultWindow*>(m_pWindowManager->createWindow("DefaultWindow", "guiroot_script"));
+    m_ScriptTop->setRect(CEGUI::Relative, CEGUI::Rect(0.0f, 0.0f, 1.0f, 1.0f));
+    m_ScriptTop->setMousePassThroughEnabled(true);
+    m_ScriptTop->setDestroyedByParent(false);
+    m_pTop->addChildWindow(m_ScriptTop);
+
+    m_ScriptRoot = new CGUIDefaultWindow_Impl(this, m_ScriptTop);
 }
 
 void CGUI_Impl::SetSkin(const char* szName)
@@ -353,24 +371,24 @@ bool CGUI_Impl::GetGUIInputEnabled()
         {
             if (m_pTop)
             {
-                CEGUI::Window* pActiveWindow = m_pTop->getActiveChild();
-                if (!pActiveWindow || pActiveWindow == m_pTop || !pActiveWindow->isVisible())
+                CEGUI::Window* activeWindow = m_pTop->getActiveChild();
+                if (!activeWindow || activeWindow == m_pTop || activeWindow == m_ScriptTop || !activeWindow->isVisible())
                 {
                     return false;
                 }
-                if (pActiveWindow->getType() == "CGUI/Editbox")
+                if (activeWindow->getType() == "CGUI/Editbox")
                 {
-                    CEGUI::Editbox* pEditBox = reinterpret_cast<CEGUI::Editbox*>(pActiveWindow);
+                    CEGUI::Editbox* pEditBox = reinterpret_cast<CEGUI::Editbox*>(activeWindow);
                     return (!pEditBox->isReadOnly() && pEditBox->hasInputFocus());
                 }
-                else if (pActiveWindow->getType() == "CGUI/MultiLineEditbox")
+                else if (activeWindow->getType() == "CGUI/MultiLineEditbox")
                 {
-                    CEGUI::MultiLineEditbox* pMultiLineEditBox = reinterpret_cast<CEGUI::MultiLineEditbox*>(pActiveWindow);
+                    CEGUI::MultiLineEditbox* pMultiLineEditBox = reinterpret_cast<CEGUI::MultiLineEditbox*>(activeWindow);
                     return (!pMultiLineEditBox->isReadOnly() && pMultiLineEditBox->hasInputFocus());
                 }
-                else if (pActiveWindow->getType() == CGUIWEBBROWSER_NAME)
+                else if (activeWindow->getType() == CGUIWEBBROWSER_NAME)
                 {
-                    auto pElement = reinterpret_cast<CGUIElement_Impl*>(pActiveWindow->getUserData());
+                    auto pElement = reinterpret_cast<CGUIElement_Impl*>(activeWindow->getUserData());
                     if (pElement->GetType() == CGUI_WEBBROWSER)
                     {
                         auto pWebBrowser = reinterpret_cast<CGUIWebBrowser_Impl*>(pElement);
@@ -1179,18 +1197,18 @@ bool CGUI_Impl::Event_MouseButtonDown(const CEGUI::EventArgs& Args)
     CGUIElement* pElement = reinterpret_cast<CGUIElement*>(wnd->getUserData());
 
     // Call global and object handlers
-    if (pElement)
+    if (pElement && pElement != m_ScriptRoot)
         pElement->Event_OnMouseButtonDown();
     else
     {
         if (m_pTop)
         {
-            // If there's no element, we're probably dealing with the root element
-            CEGUI::Window* pActiveWindow = m_pTop->getActiveChild();
-            if (m_pTop == wnd && pActiveWindow)
+            // If there's no element (or root element), we're probably dealing with the root background
+            CEGUI::Window* activeWindow = m_pTop->getActiveChild();
+            if ((m_pTop == wnd || m_ScriptTop == wnd) && activeWindow)
             {
                 // Deactivate active window to trigger onClientGUIBlur
-                pActiveWindow->deactivate();
+                activeWindow->deactivate();
             }
         }
     }
@@ -1831,6 +1849,13 @@ void CGUI_Impl::Cleanup()
     {
         CleanDeadPool();
 
+        if (m_ScriptRoot)
+        {
+            delete m_ScriptRoot;
+            m_ScriptRoot = nullptr;
+        }
+
+        m_ScriptTop = nullptr;
         m_pTop = nullptr;
 
         if (m_pWindowManager)
@@ -1846,11 +1871,13 @@ void CGUI_Impl::Cleanup()
     catch (const std::exception& e)
     {
         WriteDebugEvent(SString("CGUI_Impl::Cleanup - Exception: %s", e.what()));
+        m_ScriptTop = nullptr;
         m_pTop = nullptr;
     }
     catch (...)
     {
         WriteDebugEvent("CGUI_Impl::Cleanup() failed with unknown exception");
+        m_ScriptTop = nullptr;
         m_pTop = nullptr;
     }
 }

--- a/Client/gui/CGUI_Impl.h
+++ b/Client/gui/CGUI_Impl.h
@@ -287,6 +287,8 @@ public:
     // Cleanup CEGUI active resources (dead pool)
     void Cleanup();
 
+    CGUIElement* GetScriptRoot() override { return m_ScriptRoot; }
+
 private:
     friend class CGUIElement_Impl;
     CGUIButton*      _CreateButton(CGUIElement_Impl* pParent = NULL, const char* szCaption = "");
@@ -319,6 +321,8 @@ private:
     CEGUI::WindowManager*   m_pWindowManager;
 
     CEGUI::DefaultWindow* m_pTop;
+    CEGUI::DefaultWindow* m_ScriptTop;
+    CGUIElement*          m_ScriptRoot;
     const CEGUI::Image*   m_pCursor;
     float                 m_fCurrentServerCursorAlpha;
 

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1271,6 +1271,11 @@ bool CStaticFunctionDefinitions::SetElementParent(CClientEntity& Entity, CClient
 
         CClientGUIElement& GUIElement = static_cast<CClientGUIElement&>(Entity);
 
+        if (Parent.GetType() == CCLIENTGUI)
+            GUIElement.GetCGUIElement()->SetParent(static_cast<CClientGUIElement&>(Parent).GetCGUIElement());
+        else
+            GUIElement.GetCGUIElement()->SetParent(m_pGUI->GetScriptRoot());
+
         GUIElement.SetParent(&Parent);
         return true;
     }
@@ -5311,7 +5316,7 @@ eCursorType CStaticFunctionDefinitions::GUIGetCursorType()
 CClientGUIElement* CStaticFunctionDefinitions::GUICreateWindow(CLuaMain& LuaMain, const CVector2D& position, const CVector2D& size, const char* szCaption,
                                                                bool bRelative)
 {
-    CGUIElement* pElement = m_pGUI->CreateWnd(NULL, szCaption);
+    CGUIElement* pElement = m_pGUI->CreateWnd(m_pGUI->GetScriptRoot(), szCaption);
     pElement->SetPosition(position, bRelative);
     pElement->SetSize(size, bRelative);
 
@@ -5330,7 +5335,7 @@ CClientGUIElement* CStaticFunctionDefinitions::GUICreateWindow(CLuaMain& LuaMain
 CClientGUIElement* CStaticFunctionDefinitions::GUICreateStaticImage(CLuaMain& LuaMain, const CVector2D& position, const CVector2D& size, const SString& strPath,
                                                                     bool bRelative, CClientGUIElement* pParent)
 {
-    CGUIElement* pElement = m_pGUI->CreateStaticImage(pParent ? pParent->GetCGUIElement() : NULL);
+    CGUIElement* pElement = m_pGUI->CreateStaticImage(pParent ? pParent->GetCGUIElement() : m_pGUI->GetScriptRoot());
     pElement->SetPosition(position, bRelative);
     pElement->SetSize(size, bRelative);
 
@@ -5405,7 +5410,7 @@ bool CStaticFunctionDefinitions::GUIStaticImageGetNativeSize(CClientEntity& Enti
 CClientGUIElement* CStaticFunctionDefinitions::GUICreateLabel(CLuaMain& LuaMain, const CVector2D& position, const CVector2D& size, const char* szCaption,
                                                               bool bRelative, CClientGUIElement* pParent)
 {
-    CGUIElement* pElement = m_pGUI->CreateLabel(pParent ? pParent->GetCGUIElement() : NULL, szCaption);
+    CGUIElement* pElement = m_pGUI->CreateLabel(pParent ? pParent->GetCGUIElement() : m_pGUI->GetScriptRoot(), szCaption);
     pElement->SetPosition(position, bRelative);
     pElement->SetSize(size, bRelative);
 
@@ -5419,7 +5424,7 @@ CClientGUIElement* CStaticFunctionDefinitions::GUICreateLabel(CLuaMain& LuaMain,
 CClientGUIElement* CStaticFunctionDefinitions::GUICreateButton(CLuaMain& LuaMain, const CVector2D& position, const CVector2D& size, const char* szCaption,
                                                                bool bRelative, CClientGUIElement* pParent)
 {
-    CGUIElement* pElement = m_pGUI->CreateButton(pParent ? pParent->GetCGUIElement() : NULL, szCaption);
+    CGUIElement* pElement = m_pGUI->CreateButton(pParent ? pParent->GetCGUIElement() : m_pGUI->GetScriptRoot(), szCaption);
     pElement->SetPosition(position, bRelative);
     pElement->SetSize(size, bRelative);
 
@@ -5437,7 +5442,7 @@ CClientGUIElement* CStaticFunctionDefinitions::GUICreateButton(CLuaMain& LuaMain
 CClientGUIElement* CStaticFunctionDefinitions::GUICreateProgressBar(CLuaMain& LuaMain, const CVector2D& position, const CVector2D& size, bool bRelative,
                                                                     CClientGUIElement* pParent)
 {
-    CGUIElement* pElement = m_pGUI->CreateProgressBar(pParent ? pParent->GetCGUIElement() : NULL);
+    CGUIElement* pElement = m_pGUI->CreateProgressBar(pParent ? pParent->GetCGUIElement() : m_pGUI->GetScriptRoot());
     pElement->SetPosition(position, bRelative);
     pElement->SetSize(size, bRelative);
 
@@ -5451,7 +5456,7 @@ CClientGUIElement* CStaticFunctionDefinitions::GUICreateProgressBar(CLuaMain& Lu
 CClientGUIElement* CStaticFunctionDefinitions::GUICreateScrollBar(CLuaMain& LuaMain, const CVector2D& position, const CVector2D& size, bool bHorizontal,
                                                                   bool bRelative, CClientGUIElement* pParent)
 {
-    CGUIElement* pElement = m_pGUI->CreateScrollBar(bHorizontal, pParent ? pParent->GetCGUIElement() : NULL);
+    CGUIElement* pElement = m_pGUI->CreateScrollBar(bHorizontal, pParent ? pParent->GetCGUIElement() : m_pGUI->GetScriptRoot());
     pElement->SetPosition(position, bRelative);
     pElement->SetSize(size, bRelative);
 
@@ -5469,7 +5474,7 @@ CClientGUIElement* CStaticFunctionDefinitions::GUICreateScrollBar(CLuaMain& LuaM
 CClientGUIElement* CStaticFunctionDefinitions::GUICreateCheckBox(CLuaMain& LuaMain, const CVector2D& position, const CVector2D& size, const char* szCaption,
                                                                  bool bChecked, bool bRelative, CClientGUIElement* pParent)
 {
-    CGUIElement* pElement = m_pGUI->CreateCheckBox(pParent ? pParent->GetCGUIElement() : NULL, szCaption, bChecked);
+    CGUIElement* pElement = m_pGUI->CreateCheckBox(pParent ? pParent->GetCGUIElement() : m_pGUI->GetScriptRoot(), szCaption, bChecked);
     pElement->SetPosition(position, bRelative);
     pElement->SetSize(size, bRelative);
 
@@ -5487,7 +5492,7 @@ CClientGUIElement* CStaticFunctionDefinitions::GUICreateCheckBox(CLuaMain& LuaMa
 CClientGUIElement* CStaticFunctionDefinitions::GUICreateRadioButton(CLuaMain& LuaMain, const CVector2D& position, const CVector2D& size, const char* szCaption,
                                                                     bool bRelative, CClientGUIElement* pParent)
 {
-    CGUIElement* pElement = m_pGUI->CreateRadioButton(pParent ? pParent->GetCGUIElement() : NULL, szCaption);
+    CGUIElement* pElement = m_pGUI->CreateRadioButton(pParent ? pParent->GetCGUIElement() : m_pGUI->GetScriptRoot(), szCaption);
     pElement->SetPosition(position, bRelative);
     pElement->SetSize(size, bRelative);
 
@@ -5505,7 +5510,7 @@ CClientGUIElement* CStaticFunctionDefinitions::GUICreateRadioButton(CLuaMain& Lu
 CClientGUIElement* CStaticFunctionDefinitions::GUICreateEdit(CLuaMain& LuaMain, const CVector2D& position, const CVector2D& size, const char* szCaption,
                                                              bool bRelative, CClientGUIElement* pParent)
 {
-    CGUIElement* pElement = m_pGUI->CreateEdit(pParent ? pParent->GetCGUIElement() : NULL, szCaption);
+    CGUIElement* pElement = m_pGUI->CreateEdit(pParent ? pParent->GetCGUIElement() : m_pGUI->GetScriptRoot(), szCaption);
     pElement->SetPosition(position, bRelative);
     pElement->SetSize(size, bRelative);
     pElement->SetText(szCaption);
@@ -5525,7 +5530,7 @@ CClientGUIElement* CStaticFunctionDefinitions::GUICreateEdit(CLuaMain& LuaMain, 
 CClientGUIElement* CStaticFunctionDefinitions::GUICreateMemo(CLuaMain& LuaMain, const CVector2D& position, const CVector2D& size, const char* szCaption,
                                                              bool bRelative, CClientGUIElement* pParent)
 {
-    CGUIElement* pElement = m_pGUI->CreateMemo(pParent ? pParent->GetCGUIElement() : NULL, szCaption);
+    CGUIElement* pElement = m_pGUI->CreateMemo(pParent ? pParent->GetCGUIElement() : m_pGUI->GetScriptRoot(), szCaption);
     pElement->SetPosition(position, bRelative);
     pElement->SetSize(size, bRelative);
     pElement->SetText(szCaption);
@@ -5544,7 +5549,7 @@ CClientGUIElement* CStaticFunctionDefinitions::GUICreateMemo(CLuaMain& LuaMain, 
 CClientGUIElement* CStaticFunctionDefinitions::GUICreateGridList(CLuaMain& LuaMain, const CVector2D& position, const CVector2D& size, bool bRelative,
                                                                  CClientGUIElement* pParent)
 {
-    CGUIElement* pElement = m_pGUI->CreateGridList(pParent ? pParent->GetCGUIElement() : NULL, true);
+    CGUIElement* pElement = m_pGUI->CreateGridList(pParent ? pParent->GetCGUIElement() : m_pGUI->GetScriptRoot(), true);
     pElement->SetPosition(position, bRelative);
     pElement->SetSize(size, bRelative);
 
@@ -5558,7 +5563,7 @@ CClientGUIElement* CStaticFunctionDefinitions::GUICreateGridList(CLuaMain& LuaMa
 CClientGUIElement* CStaticFunctionDefinitions::GUICreateTabPanel(CLuaMain& LuaMain, const CVector2D& position, const CVector2D& size, bool bRelative,
                                                                  CClientGUIElement* pParent)
 {
-    CGUIElement* pElement = m_pGUI->CreateTabPanel(pParent ? pParent->GetCGUIElement() : NULL);
+    CGUIElement* pElement = m_pGUI->CreateTabPanel(pParent ? pParent->GetCGUIElement() : m_pGUI->GetScriptRoot());
     pElement->SetPosition(position, bRelative);
     pElement->SetSize(size, bRelative);
 
@@ -5576,7 +5581,7 @@ CClientGUIElement* CStaticFunctionDefinitions::GUICreateTabPanel(CLuaMain& LuaMa
 CClientGUIElement* CStaticFunctionDefinitions::GUICreateScrollPane(CLuaMain& LuaMain, const CVector2D& position, const CVector2D& size, bool bRelative,
                                                                    CClientGUIElement* pParent)
 {
-    CGUIElement* pElement = m_pGUI->CreateScrollPane(pParent ? pParent->GetCGUIElement() : NULL);
+    CGUIElement* pElement = m_pGUI->CreateScrollPane(pParent ? pParent->GetCGUIElement() : m_pGUI->GetScriptRoot());
     pElement->SetPosition(position, bRelative);
     pElement->SetSize(size, bRelative);
 
@@ -5654,7 +5659,7 @@ bool CStaticFunctionDefinitions::GUIDeleteTab(CLuaMain& LuaMain, CClientGUIEleme
 CClientGUIElement* CStaticFunctionDefinitions::GUICreateComboBox(CLuaMain& LuaMain, const CVector2D& position, const CVector2D& size, const char* szCaption,
                                                                  bool bRelative, CClientGUIElement* pParent)
 {
-    CGUIElement* pElement = m_pGUI->CreateComboBox(pParent ? pParent->GetCGUIElement() : NULL, szCaption);
+    CGUIElement* pElement = m_pGUI->CreateComboBox(pParent ? pParent->GetCGUIElement() : m_pGUI->GetScriptRoot(), szCaption);
     pElement->SetPosition(position, bRelative);
     pElement->SetSize(size, bRelative);
 
@@ -5881,7 +5886,7 @@ bool CStaticFunctionDefinitions::GUIComboBoxIsOpen(CClientEntity& Entity)
 CClientGUIElement* CStaticFunctionDefinitions::GUICreateBrowser(CLuaMain& LuaMain, const CVector2D& position, const CVector2D& size, bool bIsLocal,
                                                                 bool bIsTransparent, bool bRelative, CClientGUIElement* pParent)
 {
-    CGUIWebBrowser* pElement = m_pGUI->CreateWebBrowser(pParent ? pParent->GetCGUIElement() : nullptr);
+    CGUIWebBrowser* pElement = m_pGUI->CreateWebBrowser(pParent ? pParent->GetCGUIElement() : m_pGUI->GetScriptRoot());
     pElement->SetPosition(position, bRelative);
     pElement->SetSize(size, bRelative);
 
@@ -5987,20 +5992,8 @@ void CStaticFunctionDefinitions::GUISetProperty(CClientEntity& Entity, const cha
     {
         CClientGUIElement& GUIElement = static_cast<CClientGUIElement&>(Entity);
 
-        bool bConsoleHadInputFocus = g_pCore->GetConsole()->IsInputActive();
-
         // Set the property
         GUIElement.GetCGUIElement()->SetProperty(szProperty, szValue);
-
-        // HACK: If the property being set is AlwaysOnTop, move it to the back so it's not in front of the main menu
-        if ((stricmp(szProperty, "AlwaysOnTop") == 0) && (stricmp(szValue, "True") == 0))
-        {
-            GUIElement.GetCGUIElement()->MoveToBack();
-
-            // Restore input focus to the console if required
-            if (bConsoleHadInputFocus)
-                g_pCore->GetConsole()->ActivateInput();
-        }
     }
 }
 
@@ -6022,20 +6015,16 @@ bool CStaticFunctionDefinitions::GUIBringToFront(CClientEntity& Entity)
     if (IS_GUI(&Entity))
     {
         CClientGUIElement& GUIElement = static_cast<CClientGUIElement&>(Entity);
-        // We don't allow AlwaysOnTop GUI to be brought to the front (so it doesn't appear on top of the main menu)
-        std::string strValue = GUIElement.GetCGUIElement()->GetProperty("AlwaysOnTop");
-        if (strValue.compare("True") != 0)
-        {
-            bool bConsoleHadInputFocus = g_pCore->GetConsole()->IsInputActive();
 
-            // Bring it to the front
-            GUIElement.GetCGUIElement()->BringToFront();
+        bool consoleHadInputFocus = g_pCore->GetConsole()->IsInputActive();
 
-            // Restore input focus to the console if required
-            if (bConsoleHadInputFocus)
-                g_pCore->GetConsole()->ActivateInput();
-            return true;
-        }
+        // Bring it to the front
+        GUIElement.GetCGUIElement()->BringToFront();
+
+        // Restore input focus to the console if required
+        if (consoleHadInputFocus)
+            g_pCore->GetConsole()->ActivateInput();
+        return true;
     }
     return false;
 }

--- a/Client/sdk/gui/CGUI.h
+++ b/Client/sdk/gui/CGUI.h
@@ -171,5 +171,6 @@ public:
     virtual CGUIWindow* LoadLayout(CGUIElement* pParent, const SString& strFilename) = 0;
     virtual bool        LoadImageset(const SString& strFilename) = 0;
 
-    virtual void Cleanup() = 0;
+    virtual void         Cleanup() = 0;
+    virtual CGUIElement* GetScriptRoot() = 0;
 };


### PR DESCRIPTION
Fixes #2984

- Isolated script-created GUI elements in a dedicated root container layer (`guiroot_script`) underneath the system UI layer.
- `AlwaysOnTop` ordering remains fully functional among script windows, but script windows can no longer exceed their layer to render over the main menu or console.
- Removed the legacy `MoveToBack()` hack from `guiSetProperty` and enabled `guiBringToFront` for `AlwaysOnTop` elements.

### Testing
Tested using the reproduction script from the issue:
1. Created a GUI window with `guiSetProperty(window, "AlwaysOnTop", "True")`.
2. Opened the console (`F8`) and main menu (`ESC`).
3. Clicked on the window and verified it stays completely behind the console and menu.
4. Verified interaction with normal GUI elements and world click pass-through.
