### PR TITLE
Fix vehicle door and panel damage states resetting on custom model change (#2571)

### DIFF
--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -1052,6 +1052,17 @@ void CClientVehicle::SetModelBlocking(unsigned short usModel, unsigned char ucVa
         // Are we swapping from a vehicle without doors?
         bool bResetWheelAndDoorStates = (!CClientVehicleManager::HasDoors(m_usModel) || m_eVehicleType != CClientVehicleManager::GetVehicleType(usModel));
 
+        // For non-local (server-synchronized) vehicles transitioning to/from custom models,
+        // preserve the damage states if both models support doors and damage models.
+        if (!IsLocalEntity() && (!CClientVehicleManager::IsStandardModel(usModel) || !CClientVehicleManager::IsStandardModel(m_usModel)))
+        {
+            if (CClientVehicleManager::HasDoors(m_usModel) && CClientVehicleManager::HasDoors(usModel) &&
+                m_eVehicleType == CClientVehicleManager::GetVehicleType(usModel))
+            {
+                bResetWheelAndDoorStates = false;
+            }
+        }
+
         // Apply variant requirements
         if (ucVariant == 255 && ucVariant2 == 255)
             CClientVehicleManager::GetRandomVariation(usModel, ucVariant, ucVariant2);
@@ -1431,7 +1442,7 @@ unsigned char CClientVehicle::GetDoorStatus(unsigned char ucDoor)
 {
     if (ucDoor < MAX_DOORS)
     {
-        if (m_pVehicle && HasDamageModel())
+        if (m_pVehicle && HasDamageModel() && !m_bJustStreamedIn)
         {
             return m_pVehicle->GetDamageManager()->GetDoorStatus(static_cast<eDoors>(ucDoor));
         }
@@ -1478,7 +1489,7 @@ unsigned char CClientVehicle::GetPanelStatus(unsigned char ucPanel)
 {
     if (ucPanel < MAX_PANELS)
     {
-        if (m_pVehicle && HasDamageModel())
+        if (m_pVehicle && HasDamageModel() && !m_bJustStreamedIn)
             return m_pVehicle->GetDamageManager()->GetPanelStatus(ucPanel);
 
         return m_ucPanelStates[ucPanel];
@@ -1491,7 +1502,7 @@ unsigned char CClientVehicle::GetLightStatus(unsigned char ucLight)
 {
     if (ucLight < MAX_LIGHTS)
     {
-        if (m_pVehicle && HasDamageModel())
+        if (m_pVehicle && HasDamageModel() && !m_bJustStreamedIn)
             return m_pVehicle->GetDamageManager()->GetLightStatus(ucLight);
 
         return m_ucLightStates[ucLight];

--- a/Client/mods/deathmatch/logic/CClientVehicleManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicleManager.cpp
@@ -722,6 +722,14 @@ bool CClientVehicleManager::HasDoors(unsigned long ulModel)
 
     if (HasDamageModel(ulModel) == true)
     {
+        // Custom models allocated via engineRequestModel inherit properties from their parent model.
+        if (!IsStandardModel(ulModel) && IsValidModel(ulModel))
+        {
+            CModelInfo* pModelInfo = g_pGame->GetModelInfo(ulModel);
+            if (pModelInfo && pModelInfo->GetParentID() != 0)
+                ulModel = pModelInfo->GetParentID();
+        }
+
         switch (static_cast<VehicleType>(ulModel))
         {
             case VehicleType::VT_BFINJECT:

--- a/Client/mods/deathmatch/logic/CDeathmatchVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CDeathmatchVehicle.cpp
@@ -49,6 +49,11 @@ bool CDeathmatchVehicle::SyncDamageModel()
     if (IsBlown())
         return false;
 
+    // Do not send premature damage sync states if the vehicle clump has just been
+    // recreated/streamed in and its cached damage states are awaiting application in StreamedInPulse.
+    if (m_bJustStreamedIn)
+        return false;
+
     SVehicleDamageSync damage(true, true, true, true, true);
     bool               bChanges = false;
 


### PR DESCRIPTION
Fixes #2571

Fixed vehicle door, panel, and wheel damage states resetting to intact when changing to a custom model ID via `setElementModel`.

### Testing Steps
1. Start `runcode`:
   ```text
   start runcode
   ```

2. Allocate a custom vehicle model on the client:
   ```lua
   crun customId = engineRequestModel("vehicle", 411)
   ```

3. Spawn a damaged vehicle on the server and put the player in it:
   ```lua
   srun p = getRandomPlayer(); veh = createVehicle(411, getElementPosition(p)); warpPedIntoVehicle(p, veh); setVehicleDoorState(veh, 0, 2)
   ```

4. Switch to the custom model on the client:
   ```lua
   crun veh = getPedOccupiedVehicle(localPlayer); setElementModel(veh, customId)
   ```

5. Verify that the door damage remains preserved (`2`) instead of resetting to intact (`0`):
   ```lua
   crun outputChatBox("Door 0 state: " .. tostring(getVehicleDoorState(veh, 0)))
   ```