### PR TITLE
Async file I/O & performance optimizations

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaArgument.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaArgument.cpp
@@ -441,8 +441,7 @@ void CLuaArgument::Push(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKn
             if (pKnownTables && (pTableId = MapFind(*pKnownTables, m_pTableData)))
             {
                 lua_getfield(luaVM, LUA_REGISTRYINDEX, "cache");
-                lua_pushnumber(luaVM, *pTableId);
-                lua_gettable(luaVM, -2);
+                lua_rawgeti(luaVM, -1, *pTableId);
                 lua_remove(luaVM, -2);
             }
             else
@@ -1119,5 +1118,115 @@ bool CLuaArgument::ReadFromJSONObject(json_object* object, std::vector<CLuaArgum
                 return false;
         }
     }
+    return true;
+}
+
+bool CLuaArgument::ReadFromRapidValue(const rapidjson::Value& value, std::vector<CLuaArguments*>* pKnownTables)
+{
+    DeleteTableData();
+
+    if (value.IsNull())
+    {
+        m_iType = LUA_TNIL;
+    }
+    else if (value.IsBool())
+    {
+        ReadBool(value.GetBool());
+    }
+    else if (value.IsNumber())
+    {
+        ReadNumber(value.GetDouble());
+    }
+    else if (value.IsObject())
+    {
+        m_pTableData = new CLuaArguments();
+        m_pTableData->ReadFromRapidObject(value, pKnownTables);
+        m_bWeakTableRef = false;
+        m_iType = LUA_TTABLE;
+    }
+    else if (value.IsArray())
+    {
+        m_pTableData = new CLuaArguments();
+        m_pTableData->ReadFromRapidArray(value, pKnownTables);
+        m_bWeakTableRef = false;
+        m_iType = LUA_TTABLE;
+    }
+    else if (value.IsString())
+    {
+        const char* szString = value.GetString();
+        size_t      iLength = value.GetStringLength();
+
+        if (iLength > 3 && szString[0] == '^' && szString[2] == '^' && szString[1] != '^')
+        {
+            switch (szString[1])
+            {
+                case 'E':  // element
+                {
+                    int            id = atoi(szString + 3);
+                    CClientEntity* element = NULL;
+                    if (id != INT_MAX && id != INT_MIN && id != 0)
+                        element = CElementIDs::GetElement(id);
+                    if (element)
+                    {
+                        ReadElement(element);
+                    }
+                    else
+                    {
+                        m_iType = LUA_TNIL;
+                    }
+                    break;
+                }
+                case 'R':  // resource
+                {
+                    CResource* resource = g_pClientGame->GetResourceManager()->GetResource(szString + 3);
+                    if (resource)
+                    {
+                        ReadScriptID(resource->GetScriptID());
+                    }
+                    else
+                    {
+                        g_pClientGame->GetScriptDebugging()->LogError(NULL, "Invalid resource specified in JSON string '%s'.", szString);
+                        m_iType = LUA_TNIL;
+                    }
+                    break;
+                }
+                case 'T':  // Table reference
+                {
+                    unsigned long ulTableID = static_cast<unsigned long>(atol(szString + 3));
+                    if (pKnownTables && ulTableID < pKnownTables->size())
+                    {
+                        m_pTableData = pKnownTables->at(ulTableID);
+                        m_bWeakTableRef = true;
+                        m_iType = LUA_TTABLE;
+                    }
+                    else
+                    {
+                        g_pClientGame->GetScriptDebugging()->LogError(NULL, "Invalid table reference specified in JSON string '%s'.", szString);
+                        m_iType = LUA_TNIL;
+                    }
+                    break;
+                }
+                default:
+                {
+                    ReadString(std::string_view(szString, iLength));
+                    break;
+                }
+            }
+        }
+        else if (iLength >= 2 && szString[0] == '^' && szString[1] == '^')
+        {
+            // Escaped caret
+            ReadString(std::string_view(szString + 1, iLength - 1));
+        }
+        else
+        {
+            ReadString(std::string_view(szString, iLength));
+        }
+    }
+    else
+    {
+        m_iType = LUA_TNIL;
+    }
+
     return true;
 }

--- a/Client/mods/deathmatch/logic/lua/CLuaArgument.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaArgument.h
@@ -18,6 +18,7 @@ extern "C"
 #include <string>
 #include "json.h"
 #include "CStringName.h"
+#include <rapidjson/document.h>
 
 class CClientEntity;
 class CLuaArguments;
@@ -66,6 +67,7 @@ public:
     bool         WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL) const;
     json_object* WriteToJSONObject(bool bSerialize = false, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL);
     bool         ReadFromJSONObject(json_object* object, std::vector<CLuaArguments*>* pKnownTables = NULL);
+    bool         ReadFromRapidValue(const rapidjson::Value& value, std::vector<CLuaArguments*>* pKnownTables = NULL);
     char*        WriteToString(char* szBuffer, int length);
 
     [[nodiscard]] bool IsString() const noexcept { return m_iType == LUA_TSTRING; }

--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
@@ -161,14 +161,14 @@ void CLuaArguments::PushAsTable(lua_State* luaVM, CFastHashMap<CLuaArguments*, i
         lua_setfield(luaVM, LUA_REGISTRYINDEX, "cache");
     }
 
-    lua_newtable(luaVM);
+    // Pre-allocate the exact table capacity to eliminate re-hashing
+    lua_createtable(luaVM, 0, static_cast<int>(m_Arguments.size() / 2));
 
     // push it onto the known tables
     int size = pKnownTables->size();
     lua_getfield(luaVM, LUA_REGISTRYINDEX, "cache");
-    lua_pushnumber(luaVM, ++size);
-    lua_pushvalue(luaVM, -3);
-    lua_settable(luaVM, -3);
+    lua_pushvalue(luaVM, -2);
+    lua_rawseti(luaVM, -2, ++size);
     lua_pop(luaVM, 1);
     pKnownTables->insert(std::make_pair((CLuaArguments*)this, size));
 
@@ -178,7 +178,7 @@ void CLuaArguments::PushAsTable(lua_State* luaVM, CFastHashMap<CLuaArguments*, i
         (*iter)->Push(luaVM, pKnownTables);  // index
         iter++;
         (*iter)->Push(luaVM, pKnownTables);  // value
-        lua_settable(luaVM, -3);
+        lua_rawset(luaVM, -3);
     }
 
     if (bKnownTablesCreated)
@@ -667,6 +667,9 @@ json_object* CLuaArguments::WriteTableToJSONObject(bool bSerialize, CFastHashMap
 
 bool CLuaArguments::ReadFromJSONString(const char* szJSON)
 {
+    if (!szJSON)
+        return false;
+
     // Fast isJSON check: Check first non-white space character is '[' or '{'
     for (const char* ptr = szJSON; true;)
     {
@@ -678,44 +681,111 @@ bool CLuaArguments::ReadFromJSONString(const char* szJSON)
         return false;
     }
 
-    json_object* object = json_tokener_parse(szJSON);
-    if (object)
+    rapidjson::Document doc;
+    doc.Parse<rapidjson::kParseStopWhenDoneFlag>(szJSON);
+    if (doc.HasParseError())
+        return false;
+
+    std::vector<CLuaArguments*> knownTables;
+
+    if (doc.IsArray())
     {
-        if (json_object_get_type(object) == json_type_array)
+        for (rapidjson::SizeType i = 0; i < doc.Size(); ++i)
         {
-            bool bSuccess = true;
-
-            std::vector<CLuaArguments*> knownTables;
-
-            for (uint i = 0; i < json_object_array_length(object); i++)
+            auto pArgument = new CLuaArgument();
+            if (!pArgument->ReadFromRapidValue(doc[i], &knownTables))
             {
-                json_object*  arrayObject = json_object_array_get_idx(object, i);
-                CLuaArgument* pArgument = new CLuaArgument();
-                bSuccess = pArgument->ReadFromJSONObject(arrayObject, &knownTables);
-                m_Arguments.push_back(pArgument);  // then the value
-                if (!bSuccess)
-                    break;
+                delete pArgument;
+                return false;
             }
-            json_object_put(object);  // dereference
-            return bSuccess;
+            m_Arguments.push_back(pArgument);
         }
-        else if (json_object_get_type(object) == json_type_object)
-        {
-            std::vector<CLuaArguments*> knownTables;
-            CLuaArgument*               pArgument = new CLuaArgument();
-            bool                        bSuccess = pArgument->ReadFromJSONObject(object, &knownTables);
-            m_Arguments.push_back(pArgument);  // value
-            json_object_put(object);
-
-            return bSuccess;
-        }
-        json_object_put(object);  // dereference
+        return true;
     }
-    //    else
-    //        g_pClientGame->GetScriptDebugging()->LogError ( "Could not parse invalid JSON object.");
-    //   else
-    //        g_pClientGame->GetScriptDebugging()->LogError ( "Could not parse HTTP POST request, ensure data uses JSON.");
+    else if (doc.IsObject())
+    {
+        auto pArgument = new CLuaArgument();
+        if (!pArgument->ReadFromRapidValue(doc, &knownTables))
+        {
+            delete pArgument;
+            return false;
+        }
+        m_Arguments.push_back(pArgument);
+        return true;
+    }
+
     return false;
+}
+
+bool CLuaArguments::ReadFromRapidObject(const rapidjson::Value& object, std::vector<CLuaArguments*>* pKnownTables)
+{
+    if (!object.IsObject())
+        return false;
+
+    bool bKnownTablesCreated = false;
+    if (!pKnownTables)
+    {
+        pKnownTables = new std::vector<CLuaArguments*>();
+        bKnownTablesCreated = true;
+    }
+
+    pKnownTables->push_back(this);
+
+    bool bSuccess = true;
+    for (auto iter = object.MemberBegin(); iter != object.MemberEnd(); ++iter)
+    {
+        auto pKeyArgument = new CLuaArgument();
+        pKeyArgument->ReadString(std::string_view(iter->name.GetString(), iter->name.GetStringLength()));
+        m_Arguments.push_back(pKeyArgument);
+
+        auto pValArgument = new CLuaArgument();
+        bSuccess = pValArgument->ReadFromRapidValue(iter->value, pKnownTables);
+        m_Arguments.push_back(pValArgument);
+
+        if (!bSuccess)
+            break;
+    }
+
+    if (bKnownTablesCreated)
+        delete pKnownTables;
+
+    return bSuccess;
+}
+
+bool CLuaArguments::ReadFromRapidArray(const rapidjson::Value& array, std::vector<CLuaArguments*>* pKnownTables)
+{
+    if (!array.IsArray())
+        return false;
+
+    bool bKnownTablesCreated = false;
+    if (!pKnownTables)
+    {
+        pKnownTables = new std::vector<CLuaArguments*>();
+        bKnownTablesCreated = true;
+    }
+
+    pKnownTables->push_back(this);
+
+    bool         bSuccess = true;
+    unsigned int index = 1;
+    for (auto iter = array.Begin(); iter != array.End(); ++iter, ++index)
+    {
+        auto pKeyArgument = new CLuaArgument();
+        pKeyArgument->ReadNumber(index);
+        m_Arguments.push_back(pKeyArgument);
+
+        auto pValArgument = new CLuaArgument();
+        bSuccess = pValArgument->ReadFromRapidValue(*iter, pKnownTables);
+        m_Arguments.push_back(pValArgument);
+
+        if (!bSuccess)
+            break;
+    }
+
+    if (bKnownTablesCreated)
+        delete pKnownTables;
+
+    return bSuccess;
 }
 
 bool CLuaArguments::ReadFromJSONObject(json_object* object, std::vector<CLuaArguments*>* pKnownTables)
@@ -794,4 +864,104 @@ bool CLuaArguments::ReadFromJSONArray(json_object* object, std::vector<CLuaArgum
     //    else
     //        g_pClientGame->GetScriptDebugging()->LogError ( "Could not parse invalid JSON object.");
     return false;
+}
+
+void CLuaArguments::PushRapidValue(lua_State* luaVM, const rapidjson::Value& value)
+{
+    if (value.IsNull())
+    {
+        lua_pushnil(luaVM);
+    }
+    else if (value.IsBool())
+    {
+        lua_pushboolean(luaVM, value.GetBool());
+    }
+    else if (value.IsInt())
+    {
+        lua_pushnumber(luaVM, value.GetInt());
+    }
+    else if (value.IsUint())
+    {
+        lua_pushnumber(luaVM, value.GetUint());
+    }
+    else if (value.IsInt64())
+    {
+        lua_pushnumber(luaVM, static_cast<lua_Number>(value.GetInt64()));
+    }
+    else if (value.IsUint64())
+    {
+        lua_pushnumber(luaVM, static_cast<lua_Number>(value.GetUint64()));
+    }
+    else if (value.IsDouble())
+    {
+        lua_pushnumber(luaVM, value.GetDouble());
+    }
+    else if (value.IsString())
+    {
+        const char*         szString = value.GetString();
+        rapidjson::SizeType iLength = value.GetStringLength();
+
+        if (iLength >= 3 && szString[0] == '^' && szString[2] == '^')
+        {
+            switch (szString[1])
+            {
+                case 'E':  // Element
+                {
+                    unsigned int uiElementID = static_cast<unsigned int>(atol(szString + 3));
+                    lua_pushuserdata(luaVM, (void*)reinterpret_cast<unsigned int*>(uiElementID));
+                    break;
+                }
+                case 'R':  // Resource
+                {
+                    CResource* resource = g_pClientGame->GetResourceManager()->GetResource(szString + 3);
+                    if (resource)
+                    {
+                        lua_pushuserdata(luaVM, reinterpret_cast<void*>(resource->GetScriptID()));
+                    }
+                    else
+                    {
+                        lua_pushnil(luaVM);
+                    }
+                    break;
+                }
+                default:
+                {
+                    lua_pushlstring(luaVM, szString, iLength);
+                    break;
+                }
+            }
+        }
+        else if (iLength >= 2 && szString[0] == '^' && szString[1] == '^')
+        {
+            lua_pushlstring(luaVM, szString + 1, iLength - 1);
+        }
+        else
+        {
+            lua_pushlstring(luaVM, szString, iLength);
+        }
+    }
+    else if (value.IsArray())
+    {
+        lua_createtable(luaVM, value.Size(), 0);
+        rapidjson::SizeType idx = 1;
+        for (auto iter = value.Begin(); iter != value.End(); ++iter, ++idx)
+        {
+            PushRapidValue(luaVM, *iter);
+            lua_rawseti(luaVM, -2, idx);
+        }
+    }
+    else if (value.IsObject())
+    {
+        lua_createtable(luaVM, 0, value.MemberCount());
+        for (auto iter = value.MemberBegin(); iter != value.MemberEnd(); ++iter)
+        {
+            lua_pushlstring(luaVM, iter->name.GetString(), iter->name.GetStringLength());
+            PushRapidValue(luaVM, iter->value);
+            lua_rawset(luaVM, -3);
+        }
+    }
+    else
+    {
+        lua_pushnil(luaVM);
+    }
 }

--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -20,6 +20,7 @@ extern "C"
 #include "json.h"
 #include <vector>
 #include "CLuaFunctionRef.h"
+#include <rapidjson/document.h>
 
 inline void LUA_CHECKSTACK(lua_State* L, int size)
 {
@@ -73,7 +74,10 @@ public:
     bool         WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL) const;
     void         ValidateTableKeys();
     bool         ReadFromJSONString(const char* szJSON);
+    bool         ReadFromRapidObject(const rapidjson::Value& object, std::vector<CLuaArguments*>* pKnownTables = NULL);
+    bool         ReadFromRapidArray(const rapidjson::Value& array, std::vector<CLuaArguments*>* pKnownTables = NULL);
     bool         WriteToJSONString(std::string& strJSON, bool bSerialize = false, int flags = JSON_C_TO_STRING_PLAIN);
+    static void  PushRapidValue(lua_State* luaVM, const rapidjson::Value& value);
     json_object* WriteTableToJSONObject(bool bSerialize = false, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL);
     json_object* WriteToJSONArray(bool bSerialize);
     bool         ReadFromJSONObject(json_object* object, std::vector<CLuaArguments*>* pKnownTables = NULL);

--- a/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -26,6 +26,7 @@ SString             CLuaMain::ms_strExpectedUndumpHash;
 #include "luascripts/coroutine_debug.lua.h"
 #include "luascripts/exports.lua.h"
 #include "luascripts/inspect.lua.h"
+#include "luascripts/async_coroutine.lua.h"
 
 CLuaMain::CLuaMain(CLuaManager* pLuaManager, CResource* pResourceOwner, bool bEnableOOP)
 {
@@ -187,6 +188,7 @@ void CLuaMain::LoadEmbeddedScripts()
     LoadScript(EmbeddedLuaCode::exports);
     LoadScript(EmbeddedLuaCode::coroutine_debug);
     LoadScript(EmbeddedLuaCode::inspect);
+    LoadScript(EmbeddedLuaCode::async_coroutine);
     DECLARE_PROFILER_SECTION(OnPostLoadScript)
 }
 

--- a/Client/mods/deathmatch/premake5.lua
+++ b/Client/mods/deathmatch/premake5.lua
@@ -46,7 +46,13 @@ project "Client Deathmatch"
 			"../../../Shared/animation",
 			"../../../Shared",
 			"../../../vendor/sparsehash/src/",
-			"../../../vendor/lunasvg/include"
+			"../../../vendor/lunasvg/include",
+			"../../../vendor/discord-rpc/discord/thirdparty/rapidjson/include"
+	}
+
+	defines {
+		"RAPIDJSON_HAS_STDSTRING=1",
+		"RAPIDJSON_SSE2=1",
 	}
 
 	files {

--- a/Server/mods/deathmatch/logic/CScriptFile.cpp
+++ b/Server/mods/deathmatch/logic/CScriptFile.cpp
@@ -65,6 +65,7 @@ bool CScriptFile::Load(CResource* pResourceForFilePath, eMode Mode)
         // Return whether we successfully opened it or not
         if (m_pFile)
         {
+            m_strAbsPath = strFilePath;
             CResource* pResource = g_pGame->GetResourceManager()->GetResourceFromScriptID(m_uiScriptId);
             if (pResource && pResource->GetVirtualMachine())
                 pResource->GetVirtualMachine()->OnOpenFile(m_strFilename);

--- a/Server/mods/deathmatch/logic/CScriptFile.h
+++ b/Server/mods/deathmatch/logic/CScriptFile.h
@@ -39,6 +39,7 @@ public:
     void           Unload();
     bool           IsLoaded() { return m_pFile != NULL; };
     const SString& GetFilePath() { return m_strFilename; };
+    const SString& GetAbsPath() const { return m_strAbsPath; };
 
     // Get the owning resource
     CResource* GetResource();
@@ -77,6 +78,7 @@ private:
     FILE*         m_pFile;
     uint          m_uiScriptId;
     SString       m_strFilename;
+    SString       m_strAbsPath;
     unsigned long m_ulMaxSize;
     SLuaDebugInfo m_LuaDebugInfo;
 };

--- a/Server/mods/deathmatch/logic/lua/CLuaArgument.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaArgument.cpp
@@ -284,8 +284,7 @@ void CLuaArgument::Push(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKn
             if (pKnownTables && (pTableId = MapFind(*pKnownTables, m_pTableData)))
             {
                 lua_getfield(luaVM, LUA_REGISTRYINDEX, "cache");
-                lua_pushnumber(luaVM, *pTableId);
-                lua_gettable(luaVM, -2);
+                lua_rawgeti(luaVM, -1, *pTableId);
                 lua_remove(luaVM, -2);
             }
             else
@@ -1110,5 +1109,115 @@ bool CLuaArgument::ReadFromJSONObject(json_object* object, std::vector<CLuaArgum
                 return false;
         }
     }
+    return true;
+}
+
+bool CLuaArgument::ReadFromRapidValue(const rapidjson::Value& value, std::vector<CLuaArguments*>* pKnownTables)
+{
+    DeleteTableData();
+
+    if (value.IsNull())
+    {
+        m_iType = LUA_TNIL;
+    }
+    else if (value.IsBool())
+    {
+        ReadBool(value.GetBool());
+    }
+    else if (value.IsNumber())
+    {
+        ReadNumber(value.GetDouble());
+    }
+    else if (value.IsObject())
+    {
+        m_pTableData = new CLuaArguments();
+        m_pTableData->ReadFromRapidObject(value, pKnownTables);
+        m_bWeakTableRef = false;
+        m_iType = LUA_TTABLE;
+    }
+    else if (value.IsArray())
+    {
+        m_pTableData = new CLuaArguments();
+        m_pTableData->ReadFromRapidArray(value, pKnownTables);
+        m_bWeakTableRef = false;
+        m_iType = LUA_TTABLE;
+    }
+    else if (value.IsString())
+    {
+        const char* szString = value.GetString();
+        size_t      iLength = value.GetStringLength();
+
+        if (iLength > 3 && szString[0] == '^' && szString[2] == '^' && szString[1] != '^')
+        {
+            switch (szString[1])
+            {
+                case 'E':  // element
+                {
+                    int       id = atoi(szString + 3);
+                    CElement* element = NULL;
+                    if (id != INT_MAX && id != INT_MIN && id != 0)
+                        element = CElementIDs::GetElement(id);
+                    if (element)
+                    {
+                        ReadElement(element);
+                    }
+                    else
+                    {
+                        m_iType = LUA_TNIL;
+                    }
+                    break;
+                }
+                case 'R':  // resource
+                {
+                    CResource* resource = g_pGame->GetResourceManager()->GetResource(szString + 3);
+                    if (resource)
+                    {
+                        ReadScriptID(resource->GetScriptID());
+                    }
+                    else
+                    {
+                        g_pGame->GetScriptDebugging()->LogError(NULL, "Invalid resource specified in JSON string '%s'.", szString);
+                        m_iType = LUA_TNIL;
+                    }
+                    break;
+                }
+                case 'T':  // Table reference
+                {
+                    unsigned long ulTableID = static_cast<unsigned long>(atol(szString + 3));
+                    if (pKnownTables && ulTableID < pKnownTables->size())
+                    {
+                        m_pTableData = pKnownTables->at(ulTableID);
+                        m_bWeakTableRef = true;
+                        m_iType = LUA_TTABLE;
+                    }
+                    else
+                    {
+                        g_pGame->GetScriptDebugging()->LogError(NULL, "Invalid table reference specified in JSON string '%s'.", szString);
+                        m_iType = LUA_TNIL;
+                    }
+                    break;
+                }
+                default:
+                {
+                    ReadString(std::string_view(szString, iLength));
+                    break;
+                }
+            }
+        }
+        else if (iLength >= 2 && szString[0] == '^' && szString[1] == '^')
+        {
+            // Escaped caret
+            ReadString(std::string_view(szString + 1, iLength - 1));
+        }
+        else
+        {
+            ReadString(std::string_view(szString, iLength));
+        }
+    }
+    else
+    {
+        m_iType = LUA_TNIL;
+    }
+
     return true;
 }

--- a/Server/mods/deathmatch/logic/lua/CLuaArgument.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaArgument.h
@@ -19,6 +19,7 @@ extern "C"
 }
 #include "../common/CBitStream.h"
 #include "json.h"
+#include <rapidjson/document.h>
 
 class CElement;
 class CLuaArguments;
@@ -66,6 +67,7 @@ public:
     bool         WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL) const;
     json_object* WriteToJSONObject(bool bSerialize = false, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL);
     bool         ReadFromJSONObject(json_object* object, std::vector<CLuaArguments*>* pKnownTables = NULL);
+    bool         ReadFromRapidValue(const rapidjson::Value& value, std::vector<CLuaArguments*>* pKnownTables = NULL);
     char*        WriteToString(char* szBuffer, int length);
 
     bool IsEqualTo(const CLuaArgument& compareTo, std::set<const CLuaArguments*>* knownTables = nullptr) const;

--- a/Server/mods/deathmatch/logic/lua/CLuaArguments.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaArguments.cpp
@@ -166,14 +166,14 @@ void CLuaArguments::PushAsTable(lua_State* luaVM, CFastHashMap<CLuaArguments*, i
         lua_setfield(luaVM, LUA_REGISTRYINDEX, "cache");
     }
 
-    lua_newtable(luaVM);
+    // Pre-allocate the exact table capacity to eliminate re-hashing
+    lua_createtable(luaVM, 0, static_cast<int>(m_Arguments.size() / 2));
 
     // push it onto the known tables
     int size = pKnownTables->size();
     lua_getfield(luaVM, LUA_REGISTRYINDEX, "cache");
-    lua_pushnumber(luaVM, ++size);
-    lua_pushvalue(luaVM, -3);
-    lua_settable(luaVM, -3);
+    lua_pushvalue(luaVM, -2);
+    lua_rawseti(luaVM, -2, ++size);
     lua_pop(luaVM, 1);
     pKnownTables->insert(std::make_pair((CLuaArguments*)this, size));
 
@@ -183,7 +183,7 @@ void CLuaArguments::PushAsTable(lua_State* luaVM, CFastHashMap<CLuaArguments*, i
         (*iter)->Push(luaVM, pKnownTables);  // index
         ++iter;
         (*iter)->Push(luaVM, pKnownTables);  // value
-        lua_settable(luaVM, -3);
+        lua_rawset(luaVM, -3);
     }
 
     if (bKnownTablesCreated)
@@ -735,6 +735,9 @@ json_object* CLuaArguments::WriteTableToJSONObject(bool bSerialize, CFastHashMap
 
 bool CLuaArguments::ReadFromJSONString(const char* szJSON)
 {
+    if (!szJSON)
+        return false;
+
     // Fast isJSON check: Check first non-white space character is '[' or '{'
     for (const char* ptr = szJSON; true;)
     {
@@ -746,44 +749,111 @@ bool CLuaArguments::ReadFromJSONString(const char* szJSON)
         return false;
     }
 
-    json_object* object = json_tokener_parse(szJSON);
-    if (object)
+    rapidjson::Document doc;
+    doc.Parse<rapidjson::kParseStopWhenDoneFlag>(szJSON);
+    if (doc.HasParseError())
+        return false;
+
+    std::vector<CLuaArguments*> knownTables;
+
+    if (doc.IsArray())
     {
-        if (json_object_get_type(object) == json_type_array)
+        for (rapidjson::SizeType i = 0; i < doc.Size(); ++i)
         {
-            bool bSuccess = true;
-
-            std::vector<CLuaArguments*> knownTables;
-
-            for (uint i = 0; i < json_object_array_length(object); i++)
+            auto pArgument = new CLuaArgument();
+            if (!pArgument->ReadFromRapidValue(doc[i], &knownTables))
             {
-                json_object*  arrayObject = json_object_array_get_idx(object, i);
-                CLuaArgument* pArgument = new CLuaArgument();
-                bSuccess = pArgument->ReadFromJSONObject(arrayObject, &knownTables);
-                m_Arguments.push_back(pArgument);  // then the value
-                if (!bSuccess)
-                    break;
+                delete pArgument;
+                return false;
             }
-            json_object_put(object);  // dereference
-            return bSuccess;
+            m_Arguments.push_back(pArgument);
         }
-        else if (json_object_get_type(object) == json_type_object)
-        {
-            std::vector<CLuaArguments*> knownTables;
-            CLuaArgument*               pArgument = new CLuaArgument();
-            bool                        bSuccess = pArgument->ReadFromJSONObject(object, &knownTables);
-            m_Arguments.push_back(pArgument);  // value
-            json_object_put(object);
-
-            return bSuccess;
-        }
-        json_object_put(object);  // dereference
+        return true;
     }
-    //    else
-    //        g_pGame->GetScriptDebugging()->LogError ( "Could not parse invalid JSON object.");
-    //   else
-    //        g_pGame->GetScriptDebugging()->LogError ( "Could not parse HTTP POST request, ensure data uses JSON.");
+    else if (doc.IsObject())
+    {
+        auto pArgument = new CLuaArgument();
+        if (!pArgument->ReadFromRapidValue(doc, &knownTables))
+        {
+            delete pArgument;
+            return false;
+        }
+        m_Arguments.push_back(pArgument);
+        return true;
+    }
+
     return false;
+}
+
+bool CLuaArguments::ReadFromRapidObject(const rapidjson::Value& object, std::vector<CLuaArguments*>* pKnownTables)
+{
+    if (!object.IsObject())
+        return false;
+
+    bool bKnownTablesCreated = false;
+    if (!pKnownTables)
+    {
+        pKnownTables = new std::vector<CLuaArguments*>();
+        bKnownTablesCreated = true;
+    }
+
+    pKnownTables->push_back(this);
+
+    bool bSuccess = true;
+    for (auto iter = object.MemberBegin(); iter != object.MemberEnd(); ++iter)
+    {
+        auto pKeyArgument = new CLuaArgument();
+        pKeyArgument->ReadString(std::string_view(iter->name.GetString(), iter->name.GetStringLength()));
+        m_Arguments.push_back(pKeyArgument);
+
+        auto pValArgument = new CLuaArgument();
+        bSuccess = pValArgument->ReadFromRapidValue(iter->value, pKnownTables);
+        m_Arguments.push_back(pValArgument);
+
+        if (!bSuccess)
+            break;
+    }
+
+    if (bKnownTablesCreated)
+        delete pKnownTables;
+
+    return bSuccess;
+}
+
+bool CLuaArguments::ReadFromRapidArray(const rapidjson::Value& array, std::vector<CLuaArguments*>* pKnownTables)
+{
+    if (!array.IsArray())
+        return false;
+
+    bool bKnownTablesCreated = false;
+    if (!pKnownTables)
+    {
+        pKnownTables = new std::vector<CLuaArguments*>();
+        bKnownTablesCreated = true;
+    }
+
+    pKnownTables->push_back(this);
+
+    bool         bSuccess = true;
+    unsigned int index = 1;
+    for (auto iter = array.Begin(); iter != array.End(); ++iter, ++index)
+    {
+        auto pKeyArgument = new CLuaArgument();
+        pKeyArgument->ReadNumber(index);
+        m_Arguments.push_back(pKeyArgument);
+
+        auto pValArgument = new CLuaArgument();
+        bSuccess = pValArgument->ReadFromRapidValue(*iter, pKnownTables);
+        m_Arguments.push_back(pValArgument);
+
+        if (!bSuccess)
+            break;
+    }
+
+    if (bKnownTablesCreated)
+        delete pKnownTables;
+
+    return bSuccess;
 }
 
 bool CLuaArguments::ReadFromJSONObject(json_object* object, std::vector<CLuaArguments*>* pKnownTables)
@@ -879,4 +949,106 @@ bool CLuaArguments::IsEqualTo(const CLuaArguments& compareTo, std::set<const CLu
 
     return std::equal(std::begin(m_Arguments), std::end(m_Arguments), std::begin(compareTo.m_Arguments),
                       [knownTables](const CLuaArgument* lhs, const CLuaArgument* rhs) { return lhs->IsEqualTo(*rhs, knownTables); });
+}
+
+extern CGame* g_pGame;
+
+void CLuaArguments::PushRapidValue(lua_State* luaVM, const rapidjson::Value& value)
+{
+    if (value.IsNull())
+    {
+        lua_pushnil(luaVM);
+    }
+    else if (value.IsBool())
+    {
+        lua_pushboolean(luaVM, value.GetBool());
+    }
+    else if (value.IsInt())
+    {
+        lua_pushnumber(luaVM, value.GetInt());
+    }
+    else if (value.IsUint())
+    {
+        lua_pushnumber(luaVM, value.GetUint());
+    }
+    else if (value.IsInt64())
+    {
+        lua_pushnumber(luaVM, static_cast<lua_Number>(value.GetInt64()));
+    }
+    else if (value.IsUint64())
+    {
+        lua_pushnumber(luaVM, static_cast<lua_Number>(value.GetUint64()));
+    }
+    else if (value.IsDouble())
+    {
+        lua_pushnumber(luaVM, value.GetDouble());
+    }
+    else if (value.IsString())
+    {
+        const char*         szString = value.GetString();
+        rapidjson::SizeType iLength = value.GetStringLength();
+
+        if (iLength >= 3 && szString[0] == '^' && szString[2] == '^')
+        {
+            switch (szString[1])
+            {
+                case 'E':  // Element
+                {
+                    unsigned int uiElementID = static_cast<unsigned int>(atol(szString + 3));
+                    lua_pushuserdata(luaVM, (void*)reinterpret_cast<unsigned int*>(uiElementID));
+                    break;
+                }
+                case 'R':  // Resource
+                {
+                    CResource* resource = g_pGame->GetResourceManager()->GetResource(szString + 3);
+                    if (resource)
+                    {
+                        lua_pushuserdata(luaVM, reinterpret_cast<void*>(resource->GetScriptID()));
+                    }
+                    else
+                    {
+                        lua_pushnil(luaVM);
+                    }
+                    break;
+                }
+                default:
+                {
+                    lua_pushlstring(luaVM, szString, iLength);
+                    break;
+                }
+            }
+        }
+        else if (iLength >= 2 && szString[0] == '^' && szString[1] == '^')
+        {
+            lua_pushlstring(luaVM, szString + 1, iLength - 1);
+        }
+        else
+        {
+            lua_pushlstring(luaVM, szString, iLength);
+        }
+    }
+    else if (value.IsArray())
+    {
+        lua_createtable(luaVM, value.Size(), 0);
+        rapidjson::SizeType idx = 1;
+        for (auto iter = value.Begin(); iter != value.End(); ++iter, ++idx)
+        {
+            PushRapidValue(luaVM, *iter);
+            lua_rawseti(luaVM, -2, idx);
+        }
+    }
+    else if (value.IsObject())
+    {
+        lua_createtable(luaVM, 0, value.MemberCount());
+        for (auto iter = value.MemberBegin(); iter != value.MemberEnd(); ++iter)
+        {
+            lua_pushlstring(luaVM, iter->name.GetString(), iter->name.GetStringLength());
+            PushRapidValue(luaVM, iter->value);
+            lua_rawset(luaVM, -3);
+        }
+    }
+    else
+    {
+        lua_pushnil(luaVM);
+    }
 }

--- a/Server/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -21,6 +21,7 @@ extern "C"
 #include "../common/CBitStream.h"
 #include "json.h"
 #include "CLuaFunctionRef.h"
+#include <rapidjson/document.h>
 
 inline void LUA_CHECKSTACK(lua_State* L, int size)
 {
@@ -93,8 +94,11 @@ public:
 
     bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL, unsigned int uiDepth = 0);
     bool         ReadFromJSONString(const char* szJSON);
+    bool         ReadFromRapidObject(const rapidjson::Value& object, std::vector<CLuaArguments*>* pKnownTables = NULL);
+    bool         ReadFromRapidArray(const rapidjson::Value& array, std::vector<CLuaArguments*>* pKnownTables = NULL);
     bool         WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL) const;
     bool         WriteToJSONString(std::string& strJSON, bool bSerialize = false, int flags = JSON_C_TO_STRING_PLAIN);
+    static void  PushRapidValue(lua_State* luaVM, const rapidjson::Value& value);
     json_object* WriteTableToJSONObject(bool bSerialize = false, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL);
     json_object* WriteToJSONArray(bool bSerialize);
     bool         ReadFromJSONObject(json_object* object, std::vector<CLuaArguments*>* pKnownTables = NULL);

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -61,6 +61,7 @@ extern CNetServer* g_pRealNetServer;
 #include "luascripts/coroutine_debug.lua.h"
 #include "luascripts/exports.lua.h"
 #include "luascripts/inspect.lua.h"
+#include "luascripts/async_coroutine.lua.h"
 
 CLuaMain::CLuaMain(CLuaManager* pLuaManager, CObjectManager* pObjectManager, CPlayerManager* pPlayerManager, CVehicleManager* pVehicleManager,
                    CBlipManager* pBlipManager, CRadarAreaManager* pRadarAreaManager, CMapManager* pMapManager, CResource* pResourceOwner, bool bEnableOOP)
@@ -246,6 +247,7 @@ void CLuaMain::LoadEmbeddedScripts()
     LoadScript(EmbeddedLuaCode::exports);
     LoadScript(EmbeddedLuaCode::coroutine_debug);
     LoadScript(EmbeddedLuaCode::inspect);
+    LoadScript(EmbeddedLuaCode::async_coroutine);
 }
 
 void CLuaMain::RegisterModuleFunctions()

--- a/Server/mods/deathmatch/premake5.lua
+++ b/Server/mods/deathmatch/premake5.lua
@@ -34,12 +34,13 @@ project "Deathmatch"
 			"../../../Shared/publicsdk/include",
 			"../../../Shared",
 			"../../../vendor/sparsehash/src/",
+			"../../../vendor/discord-rpc/discord/thirdparty/rapidjson/include",
 			"logic",
 			"utils",
 			"."
 		}
 
-	defines { "SDK_WITH_BCRYPT" }
+	defines { "SDK_WITH_BCRYPT", "RAPIDJSON_HAS_STDSTRING=1", "RAPIDJSON_SSE2=1" }
 	links {
 		"Lua_Server", "sqlite", "cryptopp", "pme", "pcre2", "json-c", "zip", "glob", "zlib", "blowfish_bcrypt",
 	}

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.cpp
@@ -19,6 +19,8 @@
 #include "CScriptFile.h"
 #include "CScriptArgReader.h"
 #include <lua/CLuaFunctionParser.h>
+#include <lua/CLuaArguments.h>
+#include <lua/CLuaShared.h>
 
 #define DEFAULT_MAX_FILESIZE 52428800
 
@@ -47,6 +49,7 @@ void CLuaFileDefs::LoadFunctions()
         {"fileClose", fileClose},
         {"fileFlush", fileFlush},
         {"fileRead", fileRead},
+        {"fileReadAsync", ArgumentParser<fileReadAsync>},
         {"fileWrite", fileWrite},
         {"fileGetPos", fileGetPos},
         {"fileGetSize", fileGetSize},
@@ -54,6 +57,7 @@ void CLuaFileDefs::LoadFunctions()
         {"fileIsEOF", fileIsEOF},
         {"fileSetPos", fileSetPos},
         {"fileGetContents", ArgumentParser<fileGetContents>},
+        {"fileGetContentsAsync", ArgumentParser<fileGetContentsAsync>},
         {"fileGetHash", ArgumentParser<fileGetHash>},
     };
 
@@ -84,12 +88,14 @@ void CLuaFileDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "close", "fileClose");
     lua_classfunction(luaVM, "flush", "fileFlush");
     lua_classfunction(luaVM, "read", "fileRead");
+    lua_classfunction(luaVM, "readAsync", "fileReadAsync");
     lua_classfunction(luaVM, "write", "fileWrite");
 
     lua_classfunction(luaVM, "getPos", "fileGetPos");
     lua_classfunction(luaVM, "getSize", "fileGetSize");
     lua_classfunction(luaVM, "getPath", "fileGetPath");
     lua_classfunction(luaVM, "getContents", "fileGetContents");
+    lua_classfunction(luaVM, "getContentsAsync", "fileGetContentsAsync");
     lua_classfunction(luaVM, "getHash", "fileGetHash");
     lua_classfunction(luaVM, "isEOF", "fileIsEOF");
 
@@ -858,6 +864,260 @@ std::optional<std::string> CLuaFileDefs::fileGetContents(lua_State* L, CScriptFi
     }
 
     return {};
+}
+
+bool CLuaFileDefs::fileGetContentsAsync(lua_State* luaVM, CScriptFile* scriptFile, CLuaFunctionRef callback, std::optional<bool> maybeVerifyContents)
+{
+    // bool fileGetContentsAsync ( file target, function callback [, bool verifyContents = true ] )
+    if (!scriptFile || !scriptFile->IsLoaded())
+    {
+        m_pScriptDebugging->LogBadPointer(luaVM, "file", 1);
+        return false;
+    }
+
+    CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+    if (!pLuaMain)
+        return false;
+
+    const SString strAbsPath = scriptFile->GetAbsPath();
+    if (strAbsPath.empty())
+    {
+        m_pScriptDebugging->LogWarning(luaVM, "fileGetContentsAsync: failed to resolve file path for async read");
+        return false;
+    }
+
+    const bool bVerify = maybeVerifyContents.value_or(true);
+    bool       bHasExpectedChecksum = false;
+    CChecksum  expectedChecksum;
+    SString    warningFilePath;
+
+    if (bVerify)
+    {
+        CResource& thisResource = lua_getownerresource(luaVM);
+        if (CResourceFile* resourceFile = scriptFile->GetResourceFile(); resourceFile != nullptr)
+        {
+            bHasExpectedChecksum = true;
+#ifdef MTA_CLIENT
+            expectedChecksum = resourceFile->GetServerChecksum();
+#else
+            expectedChecksum = resourceFile->GetLastChecksum();
+#endif
+            warningFilePath = getResourceFilePath(&thisResource, scriptFile->GetResource(), scriptFile->GetFilePath());
+        }
+        else
+        {
+            warningFilePath = getResourceFilePath(&thisResource, scriptFile->GetResource(), scriptFile->GetFilePath());
+        }
+    }
+
+    struct SFileAsyncResult
+    {
+        enum class EStatus
+        {
+            SUCCESS,
+            OUT_OF_MEMORY,
+            READ_ERROR,
+            CHECKSUM_MISMATCH,
+            RESOURCE_FILE_NOT_FOUND
+        } status{EStatus::SUCCESS};
+        std::string buffer;
+        CChecksum   currentChecksum;
+        CChecksum   expectedChecksum;
+        SString     warningFilePath;
+    };
+
+    CLuaShared::GetAsyncTaskScheduler()->PushTask(
+        [strAbsPath, bVerify, bHasExpectedChecksum, expectedChecksum, warningFilePath]() -> SFileAsyncResult
+        {
+            SFileAsyncResult result;
+            result.expectedChecksum = expectedChecksum;
+            result.warningFilePath = warningFilePath;
+
+            FILE* pFile = File::Fopen(strAbsPath.c_str(), "rb");
+            if (!pFile)
+            {
+                result.status = SFileAsyncResult::EStatus::READ_ERROR;
+                return result;
+            }
+
+            fseek(pFile, 0, SEEK_END);
+            long fileSize = ftell(pFile);
+            fseek(pFile, 0, SEEK_SET);
+
+            if (fileSize < 0)
+            {
+                fclose(pFile);
+                result.status = SFileAsyncResult::EStatus::READ_ERROR;
+                return result;
+            }
+
+            if (fileSize > 0)
+            {
+                try
+                {
+                    result.buffer.resize(fileSize);
+                    size_t bytesRead = fread(result.buffer.data(), 1, fileSize, pFile);
+                    result.buffer.resize(bytesRead);
+                }
+                catch (const std::bad_alloc&)
+                {
+                    fclose(pFile);
+                    result.buffer.clear();
+                    result.status = SFileAsyncResult::EStatus::OUT_OF_MEMORY;
+                    return result;
+                }
+            }
+            fclose(pFile);
+
+            if (bVerify)
+            {
+                if (!bHasExpectedChecksum)
+                {
+                    result.status = SFileAsyncResult::EStatus::RESOURCE_FILE_NOT_FOUND;
+                    return result;
+                }
+
+                result.currentChecksum = CChecksum::GenerateChecksumFromBuffer(result.buffer.data(), static_cast<unsigned long>(result.buffer.size()));
+                if (result.currentChecksum != result.expectedChecksum)
+                {
+                    result.status = SFileAsyncResult::EStatus::CHECKSUM_MISMATCH;
+                    return result;
+                }
+            }
+
+            return result;
+        },
+        [luaFunctionRef = callback](SFileAsyncResult result)
+        {
+            CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaFunctionRef.GetLuaVM());
+            if (!pLuaMain)
+                return;
+
+            CLuaArguments arguments;
+
+            switch (result.status)
+            {
+                case SFileAsyncResult::EStatus::SUCCESS:
+                    arguments.PushString(std::move(result.buffer));
+                    break;
+                case SFileAsyncResult::EStatus::OUT_OF_MEMORY:
+                    m_pScriptDebugging->LogWarning(pLuaMain->GetVM(), "fileGetContentsAsync: out of memory");
+                    arguments.PushBoolean(false);
+                    break;
+                case SFileAsyncResult::EStatus::READ_ERROR:
+                    m_pScriptDebugging->LogWarning(pLuaMain->GetVM(), "fileGetContentsAsync: failed to read file");
+                    arguments.PushBoolean(false);
+                    break;
+                case SFileAsyncResult::EStatus::CHECKSUM_MISMATCH:
+                    m_pScriptDebugging->LogWarning(pLuaMain->GetVM(), "verification failed: checksum mismatch for resource file '%s' (expected %08X, got %08X)",
+                                                   result.warningFilePath.c_str(), result.expectedChecksum.ulCRC, result.currentChecksum.ulCRC);
+                    arguments.PushBoolean(false);
+                    break;
+                case SFileAsyncResult::EStatus::RESOURCE_FILE_NOT_FOUND:
+                    m_pScriptDebugging->LogWarning(pLuaMain->GetVM(), "verification failed: resource file not found '%s'", result.warningFilePath.c_str());
+                    arguments.PushBoolean(false);
+                    break;
+            }
+
+            arguments.Call(pLuaMain, luaFunctionRef);
+        });
+
+    return true;
+}
+
+bool CLuaFileDefs::fileReadAsync(lua_State* luaVM, CScriptFile* scriptFile, unsigned long count, CLuaFunctionRef callback)
+{
+    // bool fileReadAsync ( file target, int count, function callback )
+    if (!scriptFile || !scriptFile->IsLoaded())
+    {
+        m_pScriptDebugging->LogBadPointer(luaVM, "file", 1);
+        return false;
+    }
+
+    CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+    if (!pLuaMain)
+        return false;
+
+    if (count == 0)
+    {
+        CLuaArguments arguments;
+        arguments.PushString("");
+        arguments.Call(pLuaMain, callback);
+        return true;
+    }
+
+    const SString strAbsPath = scriptFile->GetAbsPath();
+    if (strAbsPath.empty())
+    {
+        m_pScriptDebugging->LogWarning(luaVM, "fileReadAsync: failed to resolve file path for async read");
+        return false;
+    }
+
+    const unsigned long ulCurrentPos = static_cast<unsigned long>(scriptFile->GetPointer());
+
+    struct SFileReadAsyncResult
+    {
+        bool          success{false};
+        std::string   buffer;
+        unsigned long bytesRead{0};
+    };
+
+    CLuaShared::GetAsyncTaskScheduler()->PushTask(
+        [strAbsPath, ulCurrentPos, count]() -> SFileReadAsyncResult
+        {
+            SFileReadAsyncResult result;
+            FILE*                pFile = File::Fopen(strAbsPath.c_str(), "rb");
+            if (!pFile)
+                return result;
+
+            if (fseek(pFile, ulCurrentPos, SEEK_SET) != 0)
+            {
+                fclose(pFile);
+                return result;
+            }
+
+            try
+            {
+                result.buffer.resize(count);
+                size_t actualRead = fread(result.buffer.data(), 1, count, pFile);
+                result.buffer.resize(actualRead);
+                result.bytesRead = static_cast<unsigned long>(actualRead);
+                result.success = true;
+            }
+            catch (const std::bad_alloc&)
+            {
+                result.buffer.clear();
+                result.success = false;
+            }
+
+            fclose(pFile);
+            return result;
+        },
+        [luaFunctionRef = callback, scriptFile, ulCurrentPos](SFileReadAsyncResult result)
+        {
+            CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaFunctionRef.GetLuaVM());
+            if (!pLuaMain)
+                return;
+
+            if (scriptFile && scriptFile->IsLoaded())
+            {
+                scriptFile->SetPointer(ulCurrentPos + result.bytesRead);
+            }
+
+            CLuaArguments arguments;
+            if (result.success)
+            {
+                arguments.PushString(std::move(result.buffer));
+            }
+            else
+            {
+                arguments.PushBoolean(false);
+            }
+
+            arguments.Call(pLuaMain, luaFunctionRef);
+        });
+
+    return true;
 }
 
 template <typename, typename = std::void_t<>>

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.h
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaFileDefs.h
@@ -29,8 +29,10 @@ private:
     LUA_DECLARE(fileClose);
     LUA_DECLARE(fileFlush);
     LUA_DECLARE(fileRead);
+    static bool fileReadAsync(lua_State* luaVM, CScriptFile* scriptFile, unsigned long count, CLuaFunctionRef callback);
     LUA_DECLARE(fileWrite);
     static std::optional<std::string> fileGetContents(lua_State* L, CScriptFile* scriptFile, std::optional<bool> maybeVerifyContents);
+    static bool fileGetContentsAsync(lua_State* luaVM, CScriptFile* scriptFile, CLuaFunctionRef callback, std::optional<bool> maybeVerifyContents);
     static std::optional<std::string> fileGetHash(lua_State* const luaVM, CScriptFile* scriptFile, HashFunctionType hashFunction,
                                                   std::optional<std::unordered_map<std::string, std::string>> options);
 

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
@@ -13,6 +13,8 @@
 #include "CScriptArgReader.h"
 #include "Utils.h"
 #include <lua/CLuaFunctionParser.h>
+#include <lua/CLuaArguments.h>
+#include <lua/CLuaShared.h>
 #include <SharedUtil.Memory.h>
 
 #ifndef MTA_CLIENT
@@ -60,6 +62,7 @@ void CLuaUtilDefs::LoadFunctions()
         // JSON funcs
         {"toJSON", toJSON},
         {"fromJSON", fromJSON},
+        {"fromJSONAsync", ArgumentParser<fromJSONAsync>},
 
         // PCRE functions
         {"pregFind", PregFind},
@@ -493,13 +496,12 @@ int CLuaUtilDefs::fromJSON(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        // Read it into lua arguments
-        CLuaArguments Converted;
-        if (Converted.ReadFromJSONString(strJson))
+        rapidjson::Document document;
+        document.Parse(strJson.c_str());
+        if (!document.HasParseError())
         {
-            // Return it as data
-            Converted.PushArguments(luaVM);
-            return static_cast<int>(Converted.Count());
+            CLuaArguments::PushRapidValue(luaVM, document);
+            return 1;
         }
     }
     else
@@ -508,6 +510,74 @@ int CLuaUtilDefs::fromJSON(lua_State* luaVM)
     // Failed
     lua_pushnil(luaVM);
     return 1;
+}
+
+bool CLuaUtilDefs::fromJSONAsync(lua_State* luaVM, std::string jsonString, CLuaFunctionRef callback)
+{
+    // bool fromJSONAsync ( string jsonString, function callback )
+    CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+    if (!pLuaMain)
+        return false;
+
+    CLuaShared::GetAsyncTaskScheduler()->PushTask(
+        [jsonString = std::move(jsonString)]() -> std::shared_ptr<rapidjson::Document>
+        {
+            try
+            {
+                auto pDoc = std::make_shared<rapidjson::Document>();
+                pDoc->Parse(jsonString.c_str());
+                if (pDoc->HasParseError())
+                {
+                    return nullptr;
+                }
+                return pDoc;
+            }
+            catch (const std::bad_alloc&)
+            {
+                return nullptr;
+            }
+        },
+        [luaFunctionRef = callback](std::shared_ptr<rapidjson::Document> pDoc)
+        {
+            CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaFunctionRef.GetLuaVM());
+            if (!pLuaMain)
+                return;
+
+            lua_State* luaVM = pLuaMain->GetVirtualMachine();
+            if (!luaVM)
+                return;
+
+            int luaStackPointer = lua_gettop(luaVM);
+            lua_getref(luaVM, luaFunctionRef.ToInt());
+
+            if (pDoc)
+            {
+                CLuaArguments::PushRapidValue(luaVM, *pDoc);
+                pDoc.reset();
+            }
+            else
+            {
+                lua_pushnil(luaVM);
+            }
+
+            pLuaMain->ResetInstructionCount();
+            int iret = pLuaMain->PCall(luaVM, 1, LUA_MULTRET, 0);
+            if (iret == LUA_ERRRUN || iret == LUA_ERRMEM)
+            {
+                std::string strRes = ConformResourcePath(lua_tostring(luaVM, -1));
+                m_pScriptDebugging->LogPCallError(luaVM, strRes);
+
+                while (lua_gettop(luaVM) - luaStackPointer > 0)
+                    lua_pop(luaVM, 1);
+            }
+            else
+            {
+                while (lua_gettop(luaVM) - luaStackPointer > 0)
+                    lua_pop(luaVM, 1);
+            }
+        });
+
+    return true;
 }
 
 int CLuaUtilDefs::PregFind(lua_State* luaVM)

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.h
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.h
@@ -40,6 +40,7 @@ public:
     // JSON funcs
     LUA_DECLARE(toJSON);
     LUA_DECLARE(fromJSON);
+    static bool fromJSONAsync(lua_State* luaVM, std::string jsonString, CLuaFunctionRef callback);
 
     // PCRE functions
     LUA_DECLARE(PregFind);

--- a/Shared/mods/deathmatch/logic/luascripts/async_coroutine.lua.h
+++ b/Shared/mods/deathmatch/logic/luascripts/async_coroutine.lua.h
@@ -1,0 +1,157 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Shared/mods/deathmatch/logic/luascripts/async_coroutine.lua.h
+ *  PURPOSE:     Embedded Lua primitive helpers for async/await and non-blocking sleep
+ *
+ *  Multi Theft Auto is available from https://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#pragma once
+
+namespace EmbeddedLuaCode
+{
+    const char* const async_coroutine = R"~LUA~(
+
+--[[
+    SERVER AND CLIENT.
+
+    Native Async/Await and non-blocking sleep primitives using Lua coroutines.
+    Eliminates callback hell when chaining asynchronous MTA functions (fetchRemote,
+    dbQuery, fileGetContentsAsync, passwordHash, etc.).
+--]]
+
+local type = type
+local tostring = tostring
+local tonumber = tonumber
+local unpack = unpack
+local pcall = pcall
+local error = error
+local table_insert = table.insert
+local outputDebugString = outputDebugString
+local setTimer = setTimer
+local debug_traceback = debug and debug.traceback
+
+-- Internal coroutine runner
+local _coroutine_create = coroutine.create
+local _coroutine_running = coroutine.running
+local _coroutine_yield = coroutine.yield
+local _coroutine_resume = coroutine.resume
+
+-- Known MTA async functions with fixed callback argument positions
+local mtaCallbackPositions = {
+    dbQuery = 1,
+    dbExec = 1,
+    fileGetContentsAsync = 2,
+    fileReadAsync = 3,
+    fromJSONAsync = 2,
+    passwordHash = 4,
+    passwordVerify = 4,
+}
+
+function Async(fn, ...)
+    if type(fn) ~= "function" then
+        outputDebugString("[Async] First argument must be a function.", 1)
+        return nil
+    end
+
+    local co = _coroutine_create(fn)
+    local results = { _coroutine_resume(co, ...) }
+    if not results[1] then
+        local err = results[2]
+        if debug_traceback then
+            err = debug_traceback(co, tostring(err))
+        end
+        outputDebugString("[Async Error] " .. tostring(err), 1)
+    end
+    return co
+end
+
+function await(asyncFunc, ...)
+    local co = _coroutine_running()
+    if not co then
+        error("await() must be called inside an Async() coroutine context.", 2)
+    end
+
+    local funcName = nil
+    if type(asyncFunc) == "string" then
+        funcName = asyncFunc
+        asyncFunc = _G[funcName]
+    end
+
+    if type(asyncFunc) ~= "function" then
+        error("await() expected a function or valid function name as first argument.", 2)
+    end
+
+    local args = { ... }
+    local hasResumed = false
+
+    local function asyncCallback(...)
+        if not hasResumed then
+            hasResumed = true
+            local cbArgs = { ... }
+            local results = { _coroutine_resume(co, unpack(cbArgs)) }
+            if not results[1] then
+                local err = results[2]
+                if debug_traceback then
+                    err = debug_traceback(co, tostring(err))
+                end
+                outputDebugString("[Async Await Callback Error] " .. tostring(err), 1)
+            end
+        end
+    end
+
+    -- Determine callback parameter position
+    local pos = nil
+    if funcName and mtaCallbackPositions[funcName] then
+        pos = mtaCallbackPositions[funcName]
+    elseif funcName == "fetchRemote" then
+        -- fetchRemote(url, callback) or fetchRemote(url, options, callback)
+        pos = (type(args[2]) == "table" or type(args[2]) == "string") and 3 or 2
+    end
+
+    if pos and pos <= (#args + 1) then
+        table_insert(args, pos, asyncCallback)
+    else
+        table_insert(args, asyncCallback)
+    end
+
+    local ok, callResult = pcall(asyncFunc, unpack(args))
+    if not ok then
+        error("await() failed to execute async function: " .. tostring(callResult), 2)
+    elseif callResult == false and not hasResumed then
+        -- If the function returned false immediately and did not schedule callback
+        hasResumed = true
+        return nil, "Async operation failed to start."
+    end
+
+    return _coroutine_yield()
+end
+
+function sleep(ms)
+    local co = _coroutine_running()
+    if not co then
+        error("sleep() must be called inside an Async() coroutine context.", 2)
+    end
+
+    ms = tonumber(ms) or 0
+    if ms < 0 then ms = 0 end
+
+    setTimer(function()
+        local results = { _coroutine_resume(co) }
+        if not results[1] then
+            local err = results[2]
+            if debug_traceback then
+                err = debug_traceback(co, tostring(err))
+            end
+            outputDebugString("[Async Sleep Error] " .. tostring(err), 1)
+        end
+    end, ms, 1)
+
+    return _coroutine_yield()
+end
+
+    )~LUA~";
+}

--- a/Shared/sdk/CChecksum.h
+++ b/Shared/sdk/CChecksum.h
@@ -99,17 +99,40 @@ public:
             }
         }
 
-        SString buf;
-        if (!SharedUtil::FileLoadWithTimeout(strFilename, buf, 2000))
+        if (wide.empty())
         {
             if (!hasMeta)
                 return SString("File not found or inaccessible: %s", strFilename.c_str());
             return SString("Could not read: %s", strFilename.c_str());
         }
 
+        FILE* pFile = _wfopen(wide.c_str(), L"rb");
+        if (!pFile)
+        {
+            if (!hasMeta)
+                return SString("File not found or inaccessible: %s", strFilename.c_str());
+            return SString("Could not read: %s", strFilename.c_str());
+        }
+
+        CMD5Hasher md5Hasher;
+        md5Hasher.Init();
+        unsigned long           currentCRC = 0;
+        constexpr size_t        bufferSize = 1024 * 1024;
+        std::unique_ptr<char[]> buffer = std::make_unique<char[]>(bufferSize);
+
+        size_t bytesRead = 0;
+        while ((bytesRead = fread(buffer.get(), 1, bufferSize, pFile)) > 0)
+        {
+            currentCRC = CRCGenerator::GetCRCFromBuffer(buffer.get(), bytesRead, currentCRC);
+            md5Hasher.Update(reinterpret_cast<unsigned char*>(buffer.get()), static_cast<unsigned int>(bytesRead));
+        }
+
+        fclose(pFile);
+
+        md5Hasher.Finalize();
         CChecksum r;
-        r.ulCRC = CRCGenerator::GetCRCFromBuffer(buf.data(), buf.size());
-        CMD5Hasher().Calculate(buf.data(), buf.size(), r.md5);
+        r.ulCRC = currentCRC;
+        memcpy(r.md5.data, md5Hasher.GetResult(), sizeof(r.md5.data));
 
         if (hasMeta && SharedUtil::GetFileAttributesExWithTimeout(wide.c_str(), attr, 500) &&
             sz == ((std::uint64_t(attr.nFileSizeHigh) << 32) | attr.nFileSizeLow) &&


### PR DESCRIPTION
> [!warning]
> **Awaiting Maintainer Feedback on RapidJSON Integration:**  
> macOS/Linux CI builds currently fail because `rapidjson/document.h` was referenced from the Windows-only Discord RPC directory. Awaiting feedback from maintainers/reviewers on whether to include RapidJSON directly under `vendor/rapidjson` (similar to `sparsehash` and `lunasvg`) or use a different vendor management approach.

Closes #1815  
Closes #1857  
Replaces #3285  

### Overview
This pull request introduces non-blocking asynchronous file I/O, built-in Lua coroutine helpers, and high-performance direct RapidJSON parsing to eliminate game freezes when reading large files and parsing heavy data.


### Improvements
- Added asynchronous file reading and chunked streaming to prevent the main thread from blocking or dropping frames during heavy file I/O operations.
- Upgraded the JSON parser to RapidJSON with hardware vector acceleration (SSE2), bringing parsing times down from ~9.6s to ~2.4s on a 100MB payload.
- Added non-blocking background JSON parsing (`fromJSONAsync`) so massive JSON payloads can be processed smoothly without interrupting the game loop.
- Integrated built-in `Async()`, `await()`, and non-blocking `sleep()` helpers to simplify chaining asynchronous tasks without nested callbacks.
- Optimized internal Lua table caching to speed up passing large and complex data structures between C++ and Lua.
- Added graceful out-of-memory protection for background tasks to prevent engine and server crashes under heavy load.

### Memory Pipeline
Previously, parsing JSON and validating files duplicated data 3 to 4 times across temporary C++ layers, causing severe RAM spikes and risking 32-bit out-of-memory crashes on large files.

**How It's Fixed:**
- RapidJSON now builds Lua tables directly in a single step, skipping intermediate C++ allocations and freeing temporary memory immediately.
- File buffers are moved (`std::move`) between background worker threads and Lua callbacks instead of being duplicated.
- Resource startup validates file checksums using a fixed 1MB streaming buffer instead of loading entire files into memory.

### Benchmark Comparison (100MB Stress Test)

> **Metric Definitions:**
> - **Duration:** Total elapsed time (in milliseconds) taken for the operation to complete from start to finish.
> - **Min FPS:** The lowest momentary frame rate recorded during the operation (indicates whether gameplay dropped or froze).
> - **Max Lag Spike:** The longest single frame freeze duration during execution (~16 ms is a smooth 60 FPS frame; 1000+ ms indicates a full 1-second freeze).
> - **RAM Delta:** The net change in allocated process memory (RAM) after the operation finishes.


#### Before
| # | Benchmark Test | Duration | Min FPS | Max Lag Spike | RAM Delta | Status |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 1 | **1. Sync File (100MB)** | 1101 ms | 1 FPS | 1101 ms | +0 KB | Freezes game completely |
| 2 | **2. Async File (100MB)** | — | — | — | — | ❌ *Not Supported (Function didn't exist)* |
| 3 | **3. fileReadAsync (5MB)** | — | — | — | — | ❌ *Not Supported (Function didn't exist)* |
| 4 | **4. Sync JSON (100MB)** | 🚩9665 ms | 1 FPS | 🚩9665 ms | +0 KB | Freezes game for ~9.6 seconds |
| 5 | **5. Async JSON (100MB)** | — | — | — | — | ❌ *Not Supported (Function didn't exist)* |
| 6 | **6. Await Pipeline** | — | — | — | — | ❌ *Not Supported (Function didn't exist)* |

#### After
| # | Benchmark Test | Duration | Min FPS | Max Lag Spike | RAM Delta | Result |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| 1 | **1. Sync File (100MB)** | 844 ms | 1 FPS | 844 ms | +0 KB | Backward compatibility preserved |
| 2 | **2. Async File (100MB)** | **992 ms** | **🟢 55 FPS** | **18 ms** | +24 KB | **Smooth 55-60 FPS (Zero freeze)** |
| 3 | **3. fileReadAsync (5MB)** | **281 ms** | **🟢 66 FPS** | **15 ms** | +20.0 MB | **Live streaming with UI progress** |
| 4 | **4. Sync JSON (100MB)** | **🟢 2465 ms** | 1 FPS | 🟢 2465 ms | +0 KB | **~4x faster (down from 9.6s to 2.4s)** |
| 5 | **5. Async JSON (100MB)** | **🟢 2519 ms** | **Background** | **196 ms** | +100.0 MB | **Parsed in background worker thread** |
| 6 | **6. Await Pipeline** | **🟢 2471 ms** | **Background** | **188 ms** | +100.0 MB | **Clean linear async flow without callbacks** |

> **Note on RAM Delta & Memory Behavior:**
> - **Synchronous tests (`+0 KB`):** Temporary file buffers and JSON DOM instances are deallocated and garbage-collected immediately once the function exits on the main thread, resulting in zero net lingering memory after the test finishes.
> - **Asynchronous JSON tests (`+100 MB`):** The background worker pushes the fully converted Lua tables directly into the callback closure, reflecting the true persistent memory retained for the 100MB dataset in the Lua VM.
> - **Peak Working Set:** Overall peak RAM during 100MB stress testing was reduced from ~2.0GB down to ~680MB thanks to RapidJSON's in-place parsing and zero-copy buffer transfers.


### Lua API Documentation

#### `fileGetContentsAsync`
Reads the entire file asynchronously in a background thread and triggers a callback upon completion.

**Syntax:**
```lua
bool fileGetContentsAsync(file theFile, function callback [, bool verifyContents = false])
```
- **`theFile`:** The file element to read.
- **`callback`:** The callback function receiving `(string content)` or `(false)` on failure.
- **`verifyContents`:** *(Optional)* If `true`, verifies the file checksum against the resource checksum before returning.
- **OOP:** `theFile:getContentsAsync(callback [, verifyContents = false])`

---

#### `fileReadAsync`
Reads a specific number of bytes from the file asynchronously without blocking the main thread.

**Syntax:**
```lua
bool fileReadAsync(file theFile, int count, function callback)
```
- **`theFile`:** The file element to read.
- **`count`:** Number of bytes to read.
- **`callback`:** The callback function receiving `(string chunk)` or `(false)` on EOF/failure.
- **OOP:** `theFile:readAsync(count, callback)`

---

#### `fromJSONAsync`
Parses a JSON string asynchronously on a background worker thread.

**Syntax:**
```lua
bool fromJSONAsync(string jsonString, function callback)
```
- **`jsonString`:** The JSON string to parse.
- **`callback`:** The callback function receiving the parsed Lua table/value.

---

#### `Async`
Creates and executes a new coroutine context safely with full traceback error reporting.

**Syntax:**
```lua
coroutine Async(function fn [, var arg1, ...])
```
- **`fn`:** The function to execute inside the coroutine.
- **`arg1, ...`:** *(Optional)* Arguments to pass to the function.
- **Returns:** Returns the created `coroutine` thread.

---

#### `await`
Suspends the current coroutine until the given asynchronous operation completes, resuming with its return values.

**Syntax:**
```lua
var... await(function / string asyncFunc [, var arg1, ...])
```
- **`asyncFunc`:** The asynchronous function (or function name as a string) to await.
- **`arg1, ...`:** *(Optional)* Arguments passed to the asynchronous function.
- **Returns:** Returns the unpacked values passed to the callback upon completion.

---

#### `sleep`
Suspends the current coroutine for a specified amount of time without blocking the game engine or server tick.

**Syntax:**
```lua
void sleep(int ms)
```
- **`ms`:** The duration in milliseconds to pause execution.


### Examples

#### 1. Chained Asynchronous Operations (Eliminating Callback Hell)

**❌ Before (Callback Hell & Nested Timers):**
```lua
fileGetContentsAsync(file, function(rawJson)
    fileClose(file)
    fromJSONAsync(rawJson, function(data)
        setTimer(function()
            outputChatBox("Data loaded successfully!")
        end, 1000, 1)
    end)
end)
```

**✅ After (Clean & Linear Async/Await Flow):**
```lua
Async(function()
    local rawJson = await(fileGetContentsAsync, file)
    fileClose(file)

    local data = await(fromJSONAsync, rawJson)
    sleep(1000)

    outputChatBox("Data loaded successfully!")
end)
```

---

#### 2. Smooth Asset Loading Without Game Freezes
Instead of loading multiple custom vehicle models and textures synchronously and causing noticeable frame drops, developers can stream assets in the background using `Async`, `await`, and `sleep`:

```lua
Async(function()
    for _, vehicle in ipairs(customVehicles) do
        -- 1. Read vehicle texture and model files in the background
        local txdData = await(fileGetContentsAsync, vehicle.txdFile)
        local txd = engineLoadTXD(txdData)
        engineImportTXD(txd, vehicle.modelID)

        local dffData = await(fileGetContentsAsync, vehicle.dffFile)
        local dff = engineLoadDFF(dffData)
        engineReplaceModel(dff, vehicle.modelID)

        -- 2. Pause for 50ms before loading the next vehicle to maintain smooth 60 FPS
        sleep(50)
    end

    outputChatBox("All custom vehicles loaded smoothly with zero frame drops!")
end)
```


### Testing & Verification
1. Place the [async_file_test.zip](https://github.com/user-attachments/files/31213958/async_file_test.zip) resource inside your server's `resources/` folder.
2. *Note:* To keep the repository clean and lightweight, the 100MB benchmark files (`100mb-examplefile-com.txt` and `data_100mb.json`) are excluded. You can download them [json](https://github.com/seductiveapps/largeJSON/blob/master/100mb.json) & [file](https://www.examplefile.com/document/pdf/100-mb-pdf) and place them into the resource folder.
3. Start the resource with `start async_file_test`.
4. Press `M` to toggle the cursor and click the benchmark buttons.