### PR TITLE
Add #5234: Automatic connection retries

### DIFF
--- a/Client/core/CConnectManager.cpp
+++ b/Client/core/CConnectManager.cpp
@@ -136,7 +136,7 @@ bool CConnectManager::Connect(const char* szHost, unsigned short usPort, const c
 
     m_bIsConnecting = true;
     m_tConnectStarted = time(NULL);
-    m_bHasTriedSecondConnect = false;
+    m_uiConnectAttempt = 1;
 
     // Load server password
     if (m_strPassword.empty())
@@ -258,18 +258,22 @@ void CConnectManager::DoPulse()
 
         int iConnectTimeDelta = time(NULL) - m_tConnectStarted;
 
-        // Try connect again if no response after 4 seconds
-        if (iConnectTimeDelta >= 4 && !m_bHasTriedSecondConnect && g_pCore->GetNetwork()->GetExtendedErrorCode() == 0)
+        // Retry the connection every RETRY_INTERVAL_SEC if no response, up to MAX_CONNECT_ATTEMPTS
+        unsigned int uiExpectedAttempt = (iConnectTimeDelta / RETRY_INTERVAL_SEC) + 1;
+        if (uiExpectedAttempt > m_uiConnectAttempt && m_uiConnectAttempt < MAX_CONNECT_ATTEMPTS &&
+            g_pCore->GetNetwork()->GetExtendedErrorCode() == 0)
         {
-            m_bHasTriedSecondConnect = true;
+            m_uiConnectAttempt = uiExpectedAttempt;
             SString strAddress = inet_ntoa(m_Address);
             g_pCore->GetNetwork()->StartNetwork(strAddress, m_usPort, CVARS_GET_VALUE<bool>("packet_tag"));
+
+            SString strBuffer(_("Connecting to %s:%u ... (attempt %u/%u)"), m_strHost.c_str(), m_usPort, m_uiConnectAttempt, MAX_CONNECT_ATTEMPTS);
+            CCore::GetSingleton().ShowMessageBox(_("CONNECTING"), strBuffer, MB_BUTTON_CANCEL | MB_ICON_INFO, m_pOnCancelClick);
         }
 
-        // Time to timeout the connection?
-        if (iConnectTimeDelta >= 8)
+        // Time to timeout after all attempts have been exhausted
+        if (iConnectTimeDelta >= RETRY_INTERVAL_SEC * static_cast<int>(MAX_CONNECT_ATTEMPTS))
         {
-            // Show a message that the connection timed out and abort
             g_pCore->ShowNetErrorMessageBox(_("Error") + _E("CC23"), _("Connection timed out"), "connect-timed-out", true);
             Abort();
         }

--- a/Client/core/CConnectManager.h
+++ b/Client/core/CConnectManager.h
@@ -54,8 +54,11 @@ private:
     bool           m_bIsConnecting;
     bool           m_bReconnect;
     bool           m_bSave;
-    time_t         m_tConnectStarted;
-    bool           m_bHasTriedSecondConnect;
+    time_t       m_tConnectStarted;
+    unsigned int m_uiConnectAttempt;
+
+    static constexpr unsigned int MAX_CONNECT_ATTEMPTS = 5;
+    static constexpr int          RETRY_INTERVAL_SEC = 4;
 
     GUI_CALLBACK* m_pOnCancelClick;
 


### PR DESCRIPTION
#### Summary
Retry connecting to a server up to 5 times (every 4 seconds) instead of the previous single retry. The connection dialog now shows the current attempt number (e.g. `Connecting to ... (attempt 2/5)`).

#### Motivation
Fixes #5234. When a server is temporarily busy or a UDP packet is dropped, users had to manually press Join again. This automates retries so the client keeps trying for 20 seconds total before giving up. Errors like bans, invalid passwords, or a full server still abort immediately without retrying.

#### Test plan
- Connect to an offline server and verify 5 retry attempts are shown before timeout
- Connect to a running server and verify normal connection still works on first attempt
- Get banned/wrong password and verify no retry occurs

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.