### PR TITLE
Add #5215: Add onClientMouseMove event for raw mouse delta

### DIFF
--- a/Client/core/CMessageLoopHook.cpp
+++ b/Client/core/CMessageLoopHook.cpp
@@ -191,7 +191,7 @@ LRESULT CALLBACK CMessageLoopHook::ProcessMessage(HWND hwnd, UINT uMsg, WPARAM w
             }
         }
 
-        // When updating m_bFocused in CClientGame from CPacketHandler (to fix another bug ù see the note there),
+        // When updating m_bFocused in CClientGame from CPacketHandler (to fix another bug - see the note there),
         // the window might not actually have focus at that moment (even though Windows reports it as focused).
         // In this case, isMTAWindowFocused returns false even though the window has focus.
         // Therefore, we need to intercept the window return operation and manually set the focus in CClientGame.

--- a/Client/core/CMessageLoopHook.cpp
+++ b/Client/core/CMessageLoopHook.cpp
@@ -81,6 +81,15 @@ void CMessageLoopHook::ApplyHook(HWND hFocusWindow)
         notificationFilter.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
         notificationFilter.dbcc_classguid = GUID_DevInterfaceHID;
         m_hDeviceNotify = RegisterDeviceNotification(hFocusWindow, &notificationFilter, DEVICE_NOTIFY_WINDOW_HANDLE);
+
+        // Register for raw mouse input so we can detect mouse deltas even when the cursor is
+        // hidden or clamped (WM_MOUSEMOVE only gives clamped absolute coordinates).
+        RAWINPUTDEVICE rid = {};
+        rid.usUsagePage = 0x01;            // HID_USAGE_PAGE_GENERIC
+        rid.usUsage = 0x02;                // HID_USAGE_GENERIC_MOUSE
+        rid.dwFlags = RIDEV_INPUTSINK;     // Receive input even when unfocused
+        rid.hwndTarget = hFocusWindow;
+        RegisterRawInputDevices(&rid, 1, sizeof(rid));
     }
 }
 
@@ -182,7 +191,7 @@ LRESULT CALLBACK CMessageLoopHook::ProcessMessage(HWND hwnd, UINT uMsg, WPARAM w
             }
         }
 
-        // When updating m_bFocused in CClientGame from CPacketHandler (to fix another bug ó see the note there),
+        // When updating m_bFocused in CClientGame from CPacketHandler (to fix another bug ù see the note there),
         // the window might not actually have focus at that moment (even though Windows reports it as focused).
         // In this case, isMTAWindowFocused returns false even though the window has focus.
         // Therefore, we need to intercept the window return operation and manually set the focus in CClientGame.

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -2586,6 +2586,34 @@ bool CClientGame::ProcessMessageForCursorEvents(HWND hwnd, UINT uMsg, WPARAM wPa
             }
             break;
         }
+        case WM_INPUT:
+        {
+            UINT dwSize = 0;
+            GetRawInputData(reinterpret_cast<HRAWINPUT>(lParam), RID_INPUT, nullptr, &dwSize, sizeof(RAWINPUTHEADER));
+            if (dwSize == 0)
+                break;
+
+            std::vector<BYTE> buffer(dwSize);
+            if (GetRawInputData(reinterpret_cast<HRAWINPUT>(lParam), RID_INPUT, buffer.data(), &dwSize, sizeof(RAWINPUTHEADER)) != dwSize)
+                break;
+
+            const RAWINPUT* raw = reinterpret_cast<const RAWINPUT*>(buffer.data());
+            if (raw->header.dwType != RIM_TYPEMOUSE)
+                break;
+
+            LONG lDeltaX = raw->data.mouse.lLastX;
+            LONG lDeltaY = raw->data.mouse.lLastY;
+
+            if (lDeltaX == 0 && lDeltaY == 0)
+                break;
+
+            // Raw mouse delta — works regardless of cursor visibility or camera target
+            CLuaArguments Arguments;
+            Arguments.PushNumber(static_cast<double>(lDeltaX));
+            Arguments.PushNumber(static_cast<double>(lDeltaY));
+            m_pRootEntity->CallEvent("onClientMouseMove", Arguments, false);
+            break;
+        }
     }
     return false;
 }
@@ -2769,6 +2797,7 @@ void CClientGame::AddBuiltInEvents()
     // Cursor events
     m_Events.AddEvent("onClientClick", "button, state, screenX, screenY, worldX, worldY, worldZ, gui_clicked", NULL, false);
     m_Events.AddEvent("onClientCursorMove", "relativeX, relativeX, absoluteX, absoluteY, worldX, worldY, worldZ", NULL, false);
+    m_Events.AddEvent("onClientMouseMove", "deltaX, deltaY", NULL, false);
 
     // Marker events
     m_Events.AddEvent("onClientMarkerHit", "entity, matchingDimension", nullptr, false);


### PR DESCRIPTION
#### Summary
Adds a new `onClientMouseMove` event that fires raw mouse deltas (deltaX, deltaY) using Windows Raw Input (`WM_INPUT`). Unlike `onClientCursorMove` which only reports clamped screen coordinates, this event works regardless of cursor visibility or camera target.

#### Motivation
Fixes #5215. `onClientCursorMove` arguments don't update when the cursor is hidden and the camera isn't targeting an entity, because it relies on `WM_MOUSEMOVE` which gives absolute clamped coordinates. This new event uses Raw Input to capture actual mouse deltas, enabling mouse flick detection for anti-cheats and first-person camera implementations.

#### Test plan
1. `addEventHandler("onClientMouseMove", root, function(dx, dy) outputChatBox(dx.." "..dy) end)` - move mouse with cursor hidden, verify deltas are reported.
2. Show cursor with `showCursor(true)` - both `onClientCursorMove` and `onClientMouseMove` fire.
3. Fix camera at a position with no target entity - `onClientMouseMove` still reports deltas while `onClientCursorMove` coordinates stay clamped.
4. Verify no performance regression from Raw Input registration.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
