### PR TITLE
Improve voice system. Fix long-standing and recent bugs (stutter, loss of speech)

### DIFF
--- a/Client/mods/deathmatch/CVoiceRecorder.cpp
+++ b/Client/mods/deathmatch/CVoiceRecorder.cpp
@@ -18,6 +18,7 @@ CVoiceRecorder::CVoiceRecorder()
 
     m_VoiceState = VOICESTATE_AWAITING_INPUT;
     m_SampleRate = SAMPLERATE_WIDEBAND;
+    m_ucQuality = 0;
 
     m_pAudioStream = NULL;
 
@@ -28,6 +29,7 @@ CVoiceRecorder::CVoiceRecorder()
     m_uiOutgoingReadIndex = 0;
     m_uiOutgoingWriteIndex = 0;
     m_bIsSendingVoiceData = false;
+    m_bOutgoingBufferFull = false;
 
     m_ulTimeOfLastSend = 0;
 
@@ -104,6 +106,7 @@ void CVoiceRecorder::Init(bool bEnabled, unsigned int uiServerSampleRate, unsign
     m_pOutgoingBuffer = (unsigned char*)malloc(m_uiBufferSizeBytes * FRAME_OUTGOING_BUFFER_COUNT);
     m_uiOutgoingReadIndex = 0;
     m_uiOutgoingWriteIndex = 0;
+    m_bOutgoingBufferFull = false;
 
     // Initialise the speex preprocessor
     int iSamplingRate;
@@ -158,6 +161,7 @@ void CVoiceRecorder::DeInit()
     m_uiOutgoingReadIndex = 0;
     m_uiOutgoingWriteIndex = 0;
     m_bIsSendingVoiceData = false;
+    m_bOutgoingBufferFull = false;
     m_ulTimeOfLastSend = 0;
     m_uiBufferSizeBytes = 0;
 }
@@ -199,7 +203,8 @@ void CVoiceRecorder::SetPTTState(bool bState)
 
     if (bState)
     {
-        if (m_VoiceState == VOICESTATE_AWAITING_INPUT)
+        // A re-press while the last packet is still draining continues the burst
+        if (m_VoiceState == VOICESTATE_AWAITING_INPUT || m_VoiceState == VOICESTATE_RECORDING_LAST_PACKET)
         {
             // Call event on the local player for starting to talk
             if (g_pClientGame->GetLocalPlayer())
@@ -213,7 +218,7 @@ void CVoiceRecorder::SetPTTState(bool bState)
 
                 m_Mutex.lock();
 
-                if (m_VoiceState == VOICESTATE_AWAITING_INPUT)
+                if (m_VoiceState == VOICESTATE_AWAITING_INPUT || m_VoiceState == VOICESTATE_RECORDING_LAST_PACKET)
                     m_VoiceState = VOICESTATE_RECORDING;
             }
         }
@@ -240,15 +245,17 @@ void CVoiceRecorder::SetPTTState(bool bState)
 
 bool CVoiceRecorder::GetPTTState()
 {
-    return m_VoiceState != VOICESTATE_AWAITING_INPUT;
+    // The key is up while the last packet drains, so only count active recording
+    std::lock_guard<std::mutex> lock(m_Mutex);
+    return m_VoiceState == VOICESTATE_RECORDING;
 }
 
 void CVoiceRecorder::DoPulse()
 {
     std::lock_guard<std::mutex> lock(m_Mutex);
 
-    // Only send every 100 ms
-    if (CClientTime::GetTime() - m_ulTimeOfLastSend > 100 && m_VoiceState != VOICESTATE_AWAITING_INPUT)
+    // Only send every 100 ms, or flush the last packet right away on release
+    if ((CClientTime::GetTime() - m_ulTimeOfLastSend > 100 || m_VoiceState == VOICESTATE_RECORDING_LAST_PACKET) && m_VoiceState != VOICESTATE_AWAITING_INPUT)
     {
         unsigned char* pInputBuffer;
         unsigned char  audioBuffer[2048]{};
@@ -257,7 +264,9 @@ void CVoiceRecorder::DoPulse()
         m_bIsSendingVoiceData = false;
         unsigned int uiBytesAvailable = 0;
 
-        if (m_uiOutgoingWriteIndex >= m_uiOutgoingReadIndex)
+        if (m_bOutgoingBufferFull)
+            uiBytesAvailable = uiTotalBufferSize;
+        else if (m_uiOutgoingWriteIndex >= m_uiOutgoingReadIndex)
             uiBytesAvailable = m_uiOutgoingWriteIndex - m_uiOutgoingReadIndex;
         else
             uiBytesAvailable = m_uiOutgoingWriteIndex + (uiTotalBufferSize - m_uiOutgoingReadIndex);
@@ -280,7 +289,7 @@ void CVoiceRecorder::DoPulse()
                 {
                     unsigned t;
                     for (t = 0; t < uiSpeexBlockSize; t++)
-                        audioBuffer[t] = m_pOutgoingBuffer[t % uiTotalBufferSize];
+                        audioBuffer[t] = m_pOutgoingBuffer[(m_uiOutgoingReadIndex + t) % uiTotalBufferSize];
                     pInputBuffer = audioBuffer;
                 }
                 else
@@ -317,11 +326,17 @@ void CVoiceRecorder::DoPulse()
             speex_bits_destroy(&speexBits);
 
             m_ulTimeOfLastSend = CClientTime::GetTime();
+            m_bOutgoingBufferFull = false;
         }
     }
 
     if (m_VoiceState == VOICESTATE_RECORDING_LAST_PACKET)  // End of voice data (for events)
     {
+        // The flush sends whole frames only; discard the unsent partial frame so
+        // the next talk burst does not start with stale audio
+        m_uiOutgoingReadIndex = m_uiOutgoingWriteIndex;
+        m_bOutgoingBufferFull = false;
+
         m_VoiceState = VOICESTATE_AWAITING_INPUT;
 
         if (g_pClientGame->GetPlayerManager()->GetLocalPlayer())
@@ -330,7 +345,7 @@ void CVoiceRecorder::DoPulse()
 
             if (pBitStream)
             {
-                g_pNet->SendPacket(PACKET_ID_VOICE_END, pBitStream, PACKET_PRIORITY_LOW, PACKET_RELIABILITY_UNRELIABLE_SEQUENCED, PACKET_ORDERING_VOICE);
+                g_pNet->SendPacket(PACKET_ID_VOICE_END, pBitStream, PACKET_PRIORITY_LOW, PACKET_RELIABILITY_RELIABLE_SEQUENCED, PACKET_ORDERING_VOICE);
                 g_pNet->DeallocateNetBitStream(pBitStream);
             }
         }
@@ -348,7 +363,9 @@ void CVoiceRecorder::SendFrame(const void* inputBuffer)
     unsigned int uiTotalBufferSize = m_uiBufferSizeBytes * FRAME_OUTGOING_BUFFER_COUNT;
 
     // Calculate how much of our buffer is remaining
-    if (m_uiOutgoingWriteIndex >= m_uiOutgoingReadIndex)
+    if (m_bOutgoingBufferFull)
+        remainingBufferSize = 0;
+    else if (m_uiOutgoingWriteIndex >= m_uiOutgoingReadIndex)
         remainingBufferSize = uiTotalBufferSize - (m_uiOutgoingWriteIndex - m_uiOutgoingReadIndex);
     else
         remainingBufferSize = m_uiOutgoingReadIndex - m_uiOutgoingWriteIndex;
@@ -363,7 +380,11 @@ void CVoiceRecorder::SendFrame(const void* inputBuffer)
     if (m_uiOutgoingWriteIndex == uiTotalBufferSize)
         m_uiOutgoingWriteIndex = 0;
 
-    // Wrap around the buffer?
+    // Wrap around the buffer? Skip exactly the bytes the incoming chunk overwrote.
+    // If the indices meet, the ring is exactly full; the fullness flag keeps that
+    // state distinct from empty for the flush
     if (m_uiBufferSizeBytes >= remainingBufferSize)
-        m_uiOutgoingReadIndex = (m_uiOutgoingReadIndex + m_iSpeexOutgoingFrameSampleCount * VOICE_SAMPLE_SIZE) % uiTotalBufferSize;
+        m_uiOutgoingReadIndex = (m_uiOutgoingReadIndex + m_uiBufferSizeBytes - remainingBufferSize) % uiTotalBufferSize;
+
+    m_bOutgoingBufferFull = (m_uiOutgoingWriteIndex == m_uiOutgoingReadIndex);
 }

--- a/Client/mods/deathmatch/CVoiceRecorder.h
+++ b/Client/mods/deathmatch/CVoiceRecorder.h
@@ -84,6 +84,7 @@ private:
     unsigned int   m_uiOutgoingReadIndex;
     unsigned int   m_uiOutgoingWriteIndex;
     bool           m_bIsSendingVoiceData;
+    bool           m_bOutgoingBufferFull;
 
     unsigned long m_ulTimeOfLastSend;
 

--- a/Client/mods/deathmatch/logic/CBassAudio.cpp
+++ b/Client/mods/deathmatch/logic/CBassAudio.cpp
@@ -519,10 +519,10 @@ HSTREAM CBassAudio::ConvertFileToMono(const SString& strPath)
     DWORD decodedLength = BASS_ChannelGetData(decoder, data, length);  // decode data
     BASS_StreamFree(decoder);                                          // free the decoder/mixer
 
-    if (decodedLength == static_cast<DWORD>(-1))
+    if (decodedLength == 0 || decodedLength == static_cast<DWORD>(-1))
     {
         free(data);
-        return 0;  // decode failed
+        return 0;  // no decoded data
     }
 
     HSTREAM stream = BASS_StreamCreate(ci.freq, 1, BASS_STREAM_AUTOFREE, STREAMPROC_PUSH, NULL);  // create stream
@@ -532,7 +532,7 @@ HSTREAM CBassAudio::ConvertFileToMono(const SString& strPath)
         return 0;  // stream creation failed
     }
 
-    if (!BASS_StreamPutData(stream, data, decodedLength))  // set the stream data
+    if (BASS_StreamPutData(stream, data, decodedLength) == static_cast<DWORD>(-1))  // set the stream data
     {
         free(data);
         BASS_StreamFree(stream);

--- a/Client/mods/deathmatch/logic/CClientPlayerVoice.cpp
+++ b/Client/mods/deathmatch/logic/CClientPlayerVoice.cpp
@@ -23,6 +23,16 @@ void CALLBACK BeatCallback(DWORD chan, double beatpos, void* user);
 
 #define INVALID_FX_HANDLE (-1)  // Hope that BASS doesn't use this as a valid Fx handle
 
+// A stalled stream is only reported as stopped after this many milliseconds of
+// silence, so brief delivery gaps do not fire a false stop/start pair
+constexpr unsigned long VOICE_STALL_STOP_GRACE_MS = 250;
+
+// Pending frames kept when the per-frame decode cap is hit (bounded memory)
+constexpr unsigned int VOICE_PENDING_FRAME_LIMIT = 64;
+
+// Frames decoded per rendered frame to bound CPU from relay floods
+constexpr unsigned int VOICE_DECODES_PER_FRAME = 6;
+
 CClientPlayerVoice::CClientPlayerVoice(CClientPlayer* pPlayer, CVoiceRecorder* pVoiceRecorder)
 {
     m_pPlayer = pPlayer;
@@ -37,7 +47,8 @@ CClientPlayerVoice::CClientPlayerVoice(CClientPlayer* pPlayer, CVoiceRecorder* p
     g_pCore->GetCVars()->Get("voicevolume", m_fVolumeScale);
     m_fVolumeScale *= g_pCore->GetCVars()->GetValue<float>("mastervolume", 1.0f);
 
-    m_fVolume = m_fVolume * m_fVolumeScale;
+    // The user scale is applied to BASS at play time (m_fVolume * m_fVolumeScale),
+    // so m_fVolume must stay at the neutral value here
 
     if (pPlayer->IsLocalPlayer() == true)
     {
@@ -55,14 +66,8 @@ void CALLBACK BASS_VoiceStateChange(HSYNC handle, DWORD channel, DWORD data, voi
 {
     if (data == 0)
     {
-        CClientPlayerVoice*         pVoice = static_cast<CClientPlayerVoice*>(user);
-        std::lock_guard<std::mutex> lock(pVoice->m_Mutex);
-
-        if (pVoice->m_bVoiceActive)
-        {
-            pVoice->m_EventQueue.push_back("onClientPlayerVoiceStop");
-            pVoice->m_bVoiceActive = false;
-        }
+        CClientPlayerVoice* pVoice = static_cast<CClientPlayerVoice*>(user);
+        pVoice->OnVoiceStall();
     }
 }
 
@@ -76,7 +81,16 @@ void CClientPlayerVoice::Init()
     m_pBassPlaybackStream = BASS_StreamCreate(m_SampleRate / VOICE_SAMPLE_SIZE, 2, BASS_STREAM_AUTOFREE, STREAMPROC_PUSH, NULL);
     BASS_ChannelSetSync(m_pBassPlaybackStream, BASS_SYNC_STALL, 0, &BASS_VoiceStateChange, this);
 
+    // Cap the queue BASS keeps for push streams at one second of audio, so a
+    // paused or flooded stream cannot grow memory without bound; frames past
+    // the limit are refused and then held back by the pending queue instead
+    BASS_ChannelSetAttribute(m_pBassPlaybackStream, BASS_ATTRIB_PUSH_LIMIT, static_cast<float>(m_SampleRate * 2));
+
     BASS_ChannelPlay(m_pBassPlaybackStream, false);
+
+    // Fallback if the attribute read fails
+    m_fDefaultFrequency = static_cast<float>(m_SampleRate) / VOICE_SAMPLE_SIZE;
+    BASS_ChannelGetAttribute(m_pBassPlaybackStream, BASS_ATTRIB_FREQ, &m_fDefaultFrequency);
     BASS_ChannelSetAttribute(m_pBassPlaybackStream, BASS_ATTRIB_VOL, m_fVolume * m_fVolumeScale);
 
     // Get the relevant speex mode for the servers sample rate
@@ -90,12 +104,16 @@ void CClientPlayerVoice::Init()
 
 void CClientPlayerVoice::DeInit()
 {
-    BASS_ChannelStop(m_pBassPlaybackStream);
-    BASS_StreamFree(m_pBassPlaybackStream);
+    if (m_pBassPlaybackStream)
+    {
+        BASS_ChannelStop(m_pBassPlaybackStream);
+        BASS_StreamFree(m_pBassPlaybackStream);
+    }
 
     m_pBassPlaybackStream = NULL;
 
-    speex_decoder_destroy(m_pSpeexDecoderState);
+    if (m_pSpeexDecoderState)
+        speex_decoder_destroy(m_pSpeexDecoderState);
     m_pSpeexDecoderState = NULL;
 
     m_SampleRate = SAMPLERATE_WIDEBAND;
@@ -103,10 +121,64 @@ void CClientPlayerVoice::DeInit()
 
 void CClientPlayerVoice::DoPulse()
 {
-    m_voiceFramesThisPulse = 0;
+    // Reset before draining, so the drain gets first call on the shared decode
+    // budget and the next frame's packet intake only uses what the drain leaves
+    {
+        std::lock_guard<std::mutex> lock(m_Mutex);
+        m_voiceFramesThisPulse = 0;
+    }
+
+    // A stalled stream counts as ended only after the grace period, and only
+    // once every queued frame has been decoded, so a starved decode budget
+    // cannot cut a burst short while audio is still waiting to play
+    {
+        std::lock_guard<std::mutex> lock(m_Mutex);
+
+        // The stop also needs packet silence: a held but silent push-to-talk
+        // sends DTX packets and no audio, so the stall alone would fire a
+        // false stop/start pair mid-hold
+        const unsigned long ulNow = CClientTime::GetTime();
+        if (m_bStallPending && (m_ulTimeOfLastFrame == 0 || ulNow - m_ulTimeOfLastFrame > VOICE_STALL_STOP_GRACE_MS) &&
+            ulNow - m_ulTimeOfLastPacket > VOICE_STALL_STOP_GRACE_MS && m_PendingVoiceFrames.empty())
+        {
+            m_bStallPending = false;
+            if (m_bVoiceActive)
+            {
+                m_EventQueue.push_back("onClientPlayerVoiceStop");
+                m_bVoiceActive = false;
+            }
+        }
+
+        // Stalls do not end a muted burst, so clear the ignore flag once the
+        // speaker stops sending packets
+        if (m_bIgnoreStart && CClientTime::GetTime() - m_ulTimeOfLastPacket > VOICE_STALL_STOP_GRACE_MS)
+            m_bIgnoreStart = false;
+    }
 
     // Dispatch queued events
     ServiceEventQueue();
+
+    // Decode frames held back by the per-frame cap, using the same cap
+    while (true)
+    {
+        std::vector<unsigned char> frame;
+        {
+            std::lock_guard<std::mutex> lock(m_Mutex);
+            if (m_PendingVoiceFrames.empty() || m_voiceFramesThisPulse >= VOICE_DECODES_PER_FRAME)
+                break;
+            frame = std::move(m_PendingVoiceFrames.front());
+            m_PendingVoiceFrames.pop_front();
+            ++m_voiceFramesThisPulse;
+        }
+
+        if (ProcessFrame(frame.data(), static_cast<unsigned int>(frame.size())) == EVoiceFrameResult::Deferred)
+        {
+            // BASS refused the frame, so hold it back instead of losing it
+            std::lock_guard<std::mutex> lock(m_Mutex);
+            m_PendingVoiceFrames.push_front(std::move(frame));
+            break;
+        }
+    }
 
     float fPreviousVolume = 0.0f;
     g_pCore->GetCVars()->Get("voicevolume", fPreviousVolume);
@@ -126,17 +198,73 @@ void CClientPlayerVoice::DecodeAndBuffer(const unsigned char* voiceBuffer, unsig
     if (!voiceBuffer || !voiceBufferLength || voiceBufferLength > 2048)
         return;
 
-    // Skip uniform-byte noise before costly Speex decode
-    if (voiceBufferLength >= 4 && voiceBuffer[0] == voiceBuffer[1] && voiceBuffer[0] == voiceBuffer[2] && voiceBuffer[0] == voiceBuffer[3])
-        return;
+    // Packets are handled on the game thread, and the BASS stall callback runs
+    // on the audio thread, so every shared member is handled under the mutex;
+    // the decode itself stays outside the lock
+    {
+        std::lock_guard<std::mutex> lock(m_Mutex);
 
-    if (!m_pSpeexDecoderState)
-        return;
+        // Stamp before the uniform-byte skip so DTX silence keeps the burst alive
+        // for the ignore flag, which must outlast the whole held talk burst
+        m_ulTimeOfLastPacket = CClientTime::GetTime();
 
-    // Limit decodes per frame to bound CPU from relay floods
-    if (m_voiceFramesThisPulse >= 6)
-        return;
-    ++m_voiceFramesThisPulse;
+        // Skip uniform-byte noise before costly Speex decode
+        if (voiceBufferLength >= 4 && voiceBuffer[0] == voiceBuffer[1] && voiceBuffer[0] == voiceBuffer[2] && voiceBuffer[0] == voiceBuffer[3])
+            return;
+
+        if (!m_pSpeexDecoderState)
+            return;
+
+        // A canceled start event silences the rest of the talk burst
+        if (m_bIgnoreStart)
+            return;
+
+        // Limit decodes per frame to bound CPU from relay floods, and queue
+        // behind anything already waiting so playback keeps its order
+        if (m_voiceFramesThisPulse >= VOICE_DECODES_PER_FRAME || !m_PendingVoiceFrames.empty())
+        {
+            QueueVoiceFrame(voiceBuffer, voiceBufferLength);
+            return;
+        }
+        ++m_voiceFramesThisPulse;
+    }
+
+    if (ProcessFrame(voiceBuffer, voiceBufferLength) == EVoiceFrameResult::Deferred)
+    {
+        std::lock_guard<std::mutex> lock(m_Mutex);
+        QueueVoiceFrame(voiceBuffer, voiceBufferLength);
+    }
+}
+
+void CClientPlayerVoice::QueueVoiceFrame(const unsigned char* voiceBuffer, unsigned int voiceBufferLength)
+{
+    // Caller must hold m_Mutex: the deque is shared with the pulse drain
+    if (m_PendingVoiceFrames.size() >= VOICE_PENDING_FRAME_LIMIT)
+    {
+        // Recycle the oldest slot, keep the most recent audio
+        std::vector<unsigned char> recycled = std::move(m_PendingVoiceFrames.front());
+        m_PendingVoiceFrames.pop_front();
+        recycled.assign(voiceBuffer, voiceBuffer + voiceBufferLength);
+        m_PendingVoiceFrames.push_back(std::move(recycled));
+    }
+    else
+        m_PendingVoiceFrames.emplace_back(voiceBuffer, voiceBuffer + voiceBufferLength);
+}
+
+CClientPlayerVoice::EVoiceFrameResult CClientPlayerVoice::ProcessFrame(const unsigned char* voiceBuffer, unsigned int voiceBufferLength)
+{
+    // Guard: a muted burst must never feed BASS, whatever path a frame arrives by
+    {
+        std::lock_guard<std::mutex> lock(m_Mutex);
+        if (m_bIgnoreStart)
+            return EVoiceFrameResult::Suppressed;
+    }
+
+    // A stream that never opened can never accept frames, so drop before any
+    // start event or active state is published; that state would otherwise stay
+    // stuck active until destruction, with no BASS stall signal to end it
+    if (!m_pBassPlaybackStream)
+        return EVoiceFrameResult::Suppressed;
 
     char      pTempBuffer[2048];
     SpeexBits speexBits;
@@ -147,8 +275,9 @@ void CClientPlayerVoice::DecodeAndBuffer(const unsigned char* voiceBuffer, unsig
 
     speex_bits_destroy(&speexBits);
 
+    // Do not retry frames that can never decode, or they would block the queue
     if (decodeResult < 0)
-        return;
+        return EVoiceFrameResult::Suppressed;
 
     m_Mutex.lock();
 
@@ -160,10 +289,22 @@ void CClientPlayerVoice::DecodeAndBuffer(const unsigned char* voiceBuffer, unsig
 
         CLuaArguments Arguments;
         if (!m_pPlayer->CallEvent("onClientPlayerVoiceStart", Arguments, true))
-            return;
+        {
+            {
+                std::lock_guard<std::mutex> lock(m_Mutex);
+                m_bIgnoreStart = true;
+
+                // Frames queued before the cancel belong to the canceled burst, so
+                // drop them now; they would otherwise play after the ignore window
+                m_PendingVoiceFrames.clear();
+            }
+
+            return EVoiceFrameResult::Suppressed;
+        }
 
         m_Mutex.lock();
         m_bVoiceActive = true;
+        m_bStallPending = false;  // A fresh burst starts with no stale stall signal
         m_Mutex.unlock();
     }
     else
@@ -173,8 +314,18 @@ void CClientPlayerVoice::DecodeAndBuffer(const unsigned char* voiceBuffer, unsig
 
     unsigned int uiSpeexBlockSize = m_iSpeexIncomingFrameSampleCount * VOICE_SAMPLE_SIZE;
 
-    if (m_pBassPlaybackStream)
-        BASS_StreamPutData(m_pBassPlaybackStream, (void*)pTempBuffer, uiSpeexBlockSize);
+    // BASS queues any data that does not fit the playback buffer itself, so
+    // every non-error return keeps the frame. Only a refused frame is held
+    // back for a later pulse
+    if (BASS_StreamPutData(m_pBassPlaybackStream, (void*)pTempBuffer, uiSpeexBlockSize) != static_cast<DWORD>(-1))
+    {
+        std::lock_guard<std::mutex> lock(m_Mutex);
+        m_bStallPending = false;
+        m_ulTimeOfLastFrame = CClientTime::GetTime();
+        return EVoiceFrameResult::Accepted;
+    }
+
+    return EVoiceFrameResult::Deferred;
 }
 
 void CClientPlayerVoice::ServiceEventQueue()

--- a/Client/mods/deathmatch/logic/CClientPlayerVoice.h
+++ b/Client/mods/deathmatch/logic/CClientPlayerVoice.h
@@ -16,7 +16,9 @@
 #define VOICE_SAMPLE_SIZE               2
 */
 
+#include <deque>
 #include <mutex>
+#include <vector>
 #include <speex/speex.h>
 #include <CClientPlayer.h>
 #include <../deathmatch/CVoiceRecorder.h>
@@ -33,8 +35,16 @@ public:
 
     bool m_bVoiceActive;
 
+    // Called by the BASS thread when playback underflows
+    void OnVoiceStall()
+    {
+        std::lock_guard<std::mutex> lock(m_Mutex);
+        m_bStallPending = true;
+    }
+
     std::list<SString> m_EventQueue;
-    std::mutex         m_Mutex;  // Only for m_EventQueue and m_bVoiceActive
+    std::mutex         m_Mutex;  // Only for m_EventQueue, m_bVoiceActive, m_bStallPending, m_bIgnoreStart, m_ulTimeOfLastFrame,
+                                 // m_ulTimeOfLastPacket, m_voiceFramesThisPulse and m_PendingVoiceFrames
 
     void GetTempoValues(float& fSampleRate, float& fTempo, float& fPitch, bool& bReverse)
     {
@@ -79,10 +89,19 @@ public:
     bool IsActive() { return m_bVoiceActive; }
 
 private:
-    void Init();
-    void DeInit();
-    void ServiceEventQueue();
-    void ApplyFxEffects();
+    enum class EVoiceFrameResult
+    {
+        Accepted,   // Frame was fed to BASS
+        Deferred,   // BASS refused the frame; retry on a later pulse
+        Suppressed  // Frame dropped on purpose; do not retry
+    };
+
+    void              Init();
+    void              DeInit();
+    void              ServiceEventQueue();
+    EVoiceFrameResult ProcessFrame(const unsigned char* voiceBuffer, unsigned int voiceBufferLength);
+    void              QueueVoiceFrame(const unsigned char* voiceBuffer, unsigned int voiceBufferLength);
+    void              ApplyFxEffects();
 
     CClientPlayer*  m_pPlayer;
     CVoiceRecorder* m_pVoiceRecorder;
@@ -108,5 +127,11 @@ private:
     SFixedArray<int, 9> m_EnabledEffects;
     SFixedArray<HFX, 9> m_FxEffects;
 
-    unsigned char m_voiceFramesThisPulse;  // Decodes per frame limit
+    unsigned char m_voiceFramesThisPulse;  // Decodes per frame limit (shared by the packet intake and the pulse drain)
+
+    bool                                   m_bStallPending;       // Set by the BASS thread when playback underflows
+    unsigned long                          m_ulTimeOfLastFrame;   // Time of the last frame accepted into the BASS stream
+    unsigned long                          m_ulTimeOfLastPacket;  // Time of the last packet received from the speaker
+    bool                                   m_bIgnoreStart;        // Start event canceled; suppress until the burst ends
+    std::deque<std::vector<unsigned char>> m_PendingVoiceFrames;  // Frames waiting for a decode slot
 };

--- a/Server/mods/deathmatch/logic/CMainConfig.cpp
+++ b/Server/mods/deathmatch/logic/CMainConfig.cpp
@@ -1540,7 +1540,9 @@ const std::vector<SIntSetting>& CMainConfig::GetIntSettingList()
         {true, true, 0, 1, 1, "resource_client_file_checks", &m_checkResourceClientFiles, nullptr},
         {true, true, 0, 1, 2, "allow_multi_command_handlers", &m_allowMultiCommandHandlers, &CMainConfig::OnAllowMultiCommandHandlersChange},
         {true, true, 50, 100, 1000, "voice_packets_interval", &m_voicePacketsInterval, nullptr},
-        {true, true, 1, 32, 200, "max_voice_packets_per_interval", &m_maxVoicePacketsPerInterval, nullptr},
+        // Senders drain their full backlog in one flush on release, so leave
+        // room above the steady rate for post-stall catch-up bursts
+        {true, true, 1, 64, 200, "max_voice_packets_per_interval", &m_maxVoicePacketsPerInterval, nullptr},
         {true, true, 128, 512, 2048, "max_voice_buffer_size", &m_maxVoiceBufferSize, nullptr},
     };
 

--- a/Server/mods/deathmatch/mtaserver.conf
+++ b/Server/mods/deathmatch/mtaserver.conf
@@ -248,8 +248,8 @@
     <voice_packets_interval>100</voice_packets_interval>
 
     <!-- The maximum number of voice packets per interval.
-         The minimum value is 1, the maximum is 200, and the default is 32 -->
-    <max_voice_packets_per_interval>32</max_voice_packets_per_interval>
+         The minimum value is 1, the maximum is 200, and the default is 64 -->
+    <max_voice_packets_per_interval>64</max_voice_packets_per_interval>
 
     <!-- The maximum size of a voice packet buffer in bytes.
          The minimum value is 128, the maximum is 2048, and the default is 512 -->


### PR DESCRIPTION
Voice: fixes for the DoS-hardening regressions, plus the long-standing voice bugs

This is a follow-up for 9e28567, to fix voice stuttering and intermittent loss of speech. The hardening was good, but it introduced some user-visible problems, and while fixing those I also made fixes for bugs that have been in the voice code for years. The hardening's protections stay intact - where they dropped things, we now queue them instead.

**Part 1: improvements over the DoS hardening commit (9e28567)**

- No more dropped audio from the decode cap. The hardening limits the client to 6 Speex decodes per rendered frame so a packet flood can't eat your CPU. The problem: packets past that limit were just thrown away, which made relayed bursts sound choppy. This change queues the overflow (bounded to 64 frames, oldest recycled if it ever fills) and drains it on later frames, so the CPU stays bounded and the audio isn't lost.

- No more fake stop/start events mid-sentence. The hardening's dropped packets starve the playback buffer, which fires a BASS "stall" and the client immediately reported onClientPlayerVoiceStop - then a start again as soon as packets resumed. Scripts saw constant flicker. The stop is now only reported after 250ms of both audio silence and packet silence, and only once every queued frame has been decoded. (To be fair: the immediate-stop-on-stall behavior itself is old - 2018 - but the cap turned a rare glitch into a constant one, and this fix handles both.)

- Reworked the hardening's own additions so they cooperate with the queue: the packet timestamp is stamped before the uniform-byte skip (so silent-but-held push-to-talk still counts as "talking"), and the per-frame decode counter became a shared budget between packet intake and the queue drain, with the drain getting first pick.

**Part 2: "Long-standing voice bugs" (General improvements)**

_Sender side (the player talking):_
- Voice stuttering / garbled audio. The recording ring buffer kept its read/write positions in sync using a fixed-size advance that didn't match how much audio had actually been overwritten. Over a long talk session the positions drifted and the client re-encoded the wrong segments. The read position now advances by exactly what was overwritten, with a flag that tracks when the buffer is exactly full.
- Cut-off word tails on key release. Audio is only sent every 100ms. If you released the key between sends, the remaining audio sat unsent and only got flushed on the next press. Releasing now flushes the buffer immediately, and only the genuinely half-finished partial frame is discarded.
- Server stuck in "transmitting". The voice-end packet was unreliable. If it was lost in transit, the server never reset the speaker's state, scripts never got onClientPlayerVoiceStop, and the next press was treated as a continuation. The end packet is now sent reliably.
- PTT toggle doing nothing after release. During the tiny drain window getVoicePTTState reported "talking", so pressing toggle "turned it off" instead of on. It now reports active only while actually recording, and re-pressing during the drain correctly continues the burst.

_Listener side (the player hearing):_
- Volume bug from 2016. The user's volume scale was multiplied into m_fVolume at creation and again at play time, so setting volume back to 1.0 never restored full volume. The base value now stays neutral and the scale is applied only at play time.
Playback speed set to zero. m_fDefaultFrequency was never initialized (it sat at zero since 2016), so SetPlaybackSpeed multiplied against 0. It's now seeded from the sample rate and read back from BASS as a fallback.

- Canceled start events didn't actually mute. If a script canceled onClientPlayerVoiceStart, the client just returned for that one packet and re-asked for the next one, so a muted player kept triggering the event and kept being fed into BASS. Canceling now silences the whole burst and drops the frames already queued.

- BASS queue capped. The push stream now has a one-second limit, so a stalled or flooded stream can't grow memory without bound.

- Safe teardown. DeInit is guarded so a half-initialized voice object can't crash on cleanup.

_Server side:_
- max_voice_packets_per_interval default 32 > 64. (Note: this one isn't a bug fix over 9e28567 - the server-side packet cap came from an earlier hardening change. It's compensation: the new release-flush legitimately bursts past the old limit, and without the raise the server would discard the exact tail we're trying to keep. The cap still exists and still bounds floods.)

_Independent files:_
- ConvertFileToMono now handles zero-byte decodes and a wrong success check on BASS_StreamPutData (0 is a valid result, not an error), so bad sound files fail cleanly instead of creating broken silent streams.

**Testing**
- All scenarios tested with multiple clients