### PR TITLE
Addendum to cbda874: guard siren arrays on all layers, not just packet paths

### DIFF
--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -2050,6 +2050,9 @@ void CVehicleSA::RecalculateSuspensionLines()
 
 void CVehicleSA::GiveVehicleSirens(unsigned char ucSirenType, unsigned char ucSirenCount)
 {
+    if (ucSirenCount > SIREN_COUNT_MAX)
+        ucSirenCount = SIREN_COUNT_MAX;
+
     m_tSirenInfo.m_bOverrideSirens = true;
     m_tSirenInfo.m_ucSirenType = ucSirenType;
     m_tSirenInfo.m_ucSirenCount = ucSirenCount;
@@ -2057,11 +2060,18 @@ void CVehicleSA::GiveVehicleSirens(unsigned char ucSirenType, unsigned char ucSi
 
 void CVehicleSA::SetVehicleSirenPosition(unsigned char ucSirenID, CVector vecPos)
 {
+    if (ucSirenID >= SIREN_COUNT_MAX)
+        return;
     m_tSirenInfo.m_tSirenInfo[ucSirenID].m_vecSirenPositions = vecPos;
 }
 
 void CVehicleSA::GetVehicleSirenPosition(unsigned char ucSirenID, CVector& vecPos)
 {
+    if (ucSirenID >= SIREN_COUNT_MAX)
+    {
+        vecPos = CVector();
+        return;
+    }
     vecPos = m_tSirenInfo.m_tSirenInfo[ucSirenID].m_vecSirenPositions;
 }
 

--- a/Client/game_sa/CVehicleSA.h
+++ b/Client/game_sa/CVehicleSA.h
@@ -656,18 +656,32 @@ public:
 
     void GiveVehicleSirens(unsigned char ucSirenType, unsigned char ucSirenCount);
     void RemoveVehicleSirens() { m_tSirenInfo.m_bOverrideSirens = false; }
-    void SetVehicleSirenMinimumAlpha(unsigned char ucSirenCount, DWORD dwPercentage)
+    void SetVehicleSirenMinimumAlpha(unsigned char ucSirenID, DWORD dwPercentage)
     {
-        m_tSirenInfo.m_tSirenInfo[ucSirenCount].m_dwMinSirenAlpha = dwPercentage;
+        if (ucSirenID >= SIREN_COUNT_MAX)
+            return;
+        m_tSirenInfo.m_tSirenInfo[ucSirenID].m_dwMinSirenAlpha = dwPercentage;
     }
-    void               SetVehicleSirenPosition(unsigned char ucSirenID, CVector vecPos);
-    void               GetVehicleSirenPosition(unsigned char ucSirenID, CVector& vecPos);
-    unsigned char      GetVehicleSirenCount() { return m_tSirenInfo.m_ucSirenCount; }
-    unsigned char      GetVehicleSirenType() { return m_tSirenInfo.m_ucSirenType; }
-    DWORD              GetVehicleSirenMinimumAlpha(unsigned char ucSirenID) { return m_tSirenInfo.m_tSirenInfo[ucSirenID].m_dwMinSirenAlpha; }
-    SharedUtil::SColor GetVehicleSirenColour(unsigned char ucSirenID) { return m_tSirenInfo.m_tSirenInfo[ucSirenID].m_RGBBeaconColour; }
-    void               SetVehicleSirenColour(unsigned char ucSirenID, SharedUtil::SColor tVehicleSirenColour)
+    void          SetVehicleSirenPosition(unsigned char ucSirenID, CVector vecPos);
+    void          GetVehicleSirenPosition(unsigned char ucSirenID, CVector& vecPos);
+    unsigned char GetVehicleSirenCount() { return m_tSirenInfo.m_ucSirenCount; }
+    unsigned char GetVehicleSirenType() { return m_tSirenInfo.m_ucSirenType; }
+    DWORD         GetVehicleSirenMinimumAlpha(unsigned char ucSirenID)
     {
+        if (ucSirenID >= SIREN_COUNT_MAX)
+            return 0;
+        return m_tSirenInfo.m_tSirenInfo[ucSirenID].m_dwMinSirenAlpha;
+    }
+    SharedUtil::SColor GetVehicleSirenColour(unsigned char ucSirenID)
+    {
+        if (ucSirenID >= SIREN_COUNT_MAX)
+            return SharedUtil::SColor();
+        return m_tSirenInfo.m_tSirenInfo[ucSirenID].m_RGBBeaconColour;
+    }
+    void SetVehicleSirenColour(unsigned char ucSirenID, SharedUtil::SColor tVehicleSirenColour)
+    {
+        if (ucSirenID >= SIREN_COUNT_MAX)
+            return;
         m_tSirenInfo.m_tSirenInfo[ucSirenID].m_RGBBeaconColour = tVehicleSirenColour;
     }
     void                              SetVehicleCurrentSirenID(unsigned char ucCurrentSirenID) { m_tSirenInfo.m_ucCurrentSirenID = ucCurrentSirenID; }

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -4594,6 +4594,9 @@ void CClientVehicle::HandleWaitingForGroundToLoad()
 
 bool CClientVehicle::GiveVehicleSirens(unsigned char ucSirenType, unsigned char ucSirenCount)
 {
+    if (ucSirenCount > SIREN_COUNT_MAX)
+        ucSirenCount = SIREN_COUNT_MAX;
+
     m_tSirenBeaconInfo.m_bOverrideSirens = true;
     m_tSirenBeaconInfo.m_ucSirenType = ucSirenType;
     m_tSirenBeaconInfo.m_ucSirenCount = ucSirenCount;
@@ -4605,6 +4608,9 @@ bool CClientVehicle::GiveVehicleSirens(unsigned char ucSirenType, unsigned char 
 }
 void CClientVehicle::SetVehicleSirenPosition(unsigned char ucSirenID, CVector vecPos)
 {
+    if (ucSirenID >= SIREN_COUNT_MAX)
+        return;
+
     m_tSirenBeaconInfo.m_tSirenInfo[ucSirenID].m_vecSirenPositions = vecPos;
 
     if (m_pVehicle)
@@ -4613,6 +4619,9 @@ void CClientVehicle::SetVehicleSirenPosition(unsigned char ucSirenID, CVector ve
 
 void CClientVehicle::SetVehicleSirenMinimumAlpha(unsigned char ucSirenID, DWORD dwPercentage)
 {
+    if (ucSirenID >= SIREN_COUNT_MAX)
+        return;
+
     m_tSirenBeaconInfo.m_tSirenInfo[ucSirenID].m_dwMinSirenAlpha = dwPercentage;
 
     if (m_pVehicle)
@@ -4621,6 +4630,9 @@ void CClientVehicle::SetVehicleSirenMinimumAlpha(unsigned char ucSirenID, DWORD 
 
 void CClientVehicle::SetVehicleSirenColour(unsigned char ucSirenID, SColor tVehicleSirenColour)
 {
+    if (ucSirenID >= SIREN_COUNT_MAX)
+        return;
+
     m_tSirenBeaconInfo.m_tSirenInfo[ucSirenID].m_RGBBeaconColour = tVehicleSirenColour;
 
     if (m_pVehicle)

--- a/Server/mods/deathmatch/logic/CVehicle.cpp
+++ b/Server/mods/deathmatch/logic/CVehicle.cpp
@@ -869,16 +869,22 @@ void CVehicle::GenerateHandlingData() noexcept
 
 void CVehicle::SetVehicleSirenPosition(unsigned char ucSirenID, CVector vecPos)
 {
+    if (ucSirenID >= SIREN_COUNT_MAX)
+        return;
     m_tSirenBeaconInfo.m_tSirenInfo[ucSirenID].m_vecSirenPositions = vecPos;
 }
 
 void CVehicle::SetVehicleSirenMinimumAlpha(unsigned char ucSirenID, DWORD dwPercentage)
 {
+    if (ucSirenID >= SIREN_COUNT_MAX)
+        return;
     m_tSirenBeaconInfo.m_tSirenInfo[ucSirenID].m_dwMinSirenAlpha = dwPercentage;
 }
 
 void CVehicle::SetVehicleSirenColour(unsigned char ucSirenID, SColor tVehicleSirenColour)
 {
+    if (ucSirenID >= SIREN_COUNT_MAX)
+        return;
     m_tSirenBeaconInfo.m_tSirenInfo[ucSirenID].m_RGBBeaconColour = tVehicleSirenColour;
 }
 
@@ -891,7 +897,7 @@ void CVehicle::SetVehicleFlags(bool bEnable360, bool bEnableRandomiser, bool bEn
 }
 void CVehicle::RemoveVehicleSirens()
 {
-    for (unsigned char i = 0; i <= 7; i++)
+    for (int i = 0; i < SIREN_COUNT_MAX; i++)
     {
         m_tSirenBeaconInfo.m_tSirenInfo[i] = SSirenBeaconInfo();
         SetVehicleSirenPosition(i, CVector(0, 0, 0));

--- a/Server/mods/deathmatch/logic/packets/CEntityAddPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CEntityAddPacket.cpp
@@ -659,6 +659,8 @@ bool CEntityAddPacket::Write(NetBitStreamInterface& BitStream) const
                         BitStream.WriteBit(false);
 
                     unsigned char ucSirenCount = pVehicle->m_tSirenBeaconInfo.m_ucSirenCount;
+                    if (ucSirenCount > SIREN_COUNT_MAX)
+                        ucSirenCount = SIREN_COUNT_MAX;
                     unsigned char ucSirenType = pVehicle->m_tSirenBeaconInfo.m_ucSirenType;
                     bool          bSync = pVehicle->m_tSirenBeaconInfo.m_bOverrideSirens;
                     BitStream.WriteBit(bSync);


### PR DESCRIPTION
Simple change, explains itself.
Addendum to cbda874: guard siren arrays on all layers, not just packet paths