### PR TITLE
Save hostnames in server lists instead of resolved IPs

### DIFF
--- a/Client/core/CConnectManager.cpp
+++ b/Client/core/CConnectManager.cpp
@@ -463,7 +463,7 @@ void CConnectManager::OnServerExists()
     if (m_bNotifyServerBrowser)
     {
         m_bNotifyServerBrowser = false;
-        CServerBrowser::GetSingletonPtr()->NotifyServerExists(m_Address, m_usPort);
+        CServerBrowser::GetSingletonPtr()->NotifyServerExists(m_Address, m_usPort, m_strHost);
     }
 }
 

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -1889,7 +1889,9 @@ void CCore::UpdateRecentlyPlayed()
         CServerBrowser* pServerBrowser = CCore::GetSingleton().GetLocalGUI()->GetMainMenu()->GetServerBrowser();
         CServerList*    pRecentList = pServerBrowser->GetRecentList();
         pRecentList->Remove(Address, usPort);
-        pRecentList->AddUnique(Address, usPort, true);
+        CServerListItem* pItem = pRecentList->AddUnique(Address, usPort, true);
+        if (pItem && CServerListItem::IsHostName(strHost.c_str()))
+            pItem->strHostName = strHost;
 
         pServerBrowser->SaveRecentlyPlayedList();
         if (!m_pConnectManager->m_strLastPassword.empty())

--- a/Client/core/ServerBrowser/CServerBrowser.cpp
+++ b/Client/core/ServerBrowser/CServerBrowser.cpp
@@ -1644,12 +1644,14 @@ bool CServerBrowser::OnConnectClick(CGUIElement* pElement)
     return true;
 }
 
-void CServerBrowser::NotifyServerExists(in_addr Address, ushort usPort)
+void CServerBrowser::NotifyServerExists(in_addr Address, ushort usPort, const SString& strHost)
 {
     // If the connect button was pressed, and the server exists, add it to the history
     CServerList* pHistoryList = GetHistoryList();
     pHistoryList->Remove(Address, usPort);
-    pHistoryList->AddUnique(Address, usPort);
+    CServerListItem* pItem = pHistoryList->AddUnique(Address, usPort);
+    if (pItem && CServerListItem::IsHostName(strHost.c_str()))
+        pItem->strHostName = strHost;
     while (pHistoryList->GetServerCount() > 11)
     {
         CServerListItem* pLast = *pHistoryList->IteratorBegin();
@@ -1785,7 +1787,8 @@ bool CServerBrowser::OnFavouritesClick(CGUIElement* pElement)
     {
         in_addr Address;
 
-        CServerListItem::Parse(strHost.c_str(), Address);
+        if (!CServerListItem::Parse(strHost.c_str(), Address))
+            return true;
 
         // Do we have this entry already?  If so, remove it
         if (m_ServersFavourites.Remove(Address, usPort))
@@ -1799,8 +1802,11 @@ bool CServerBrowser::OnFavouritesClick(CGUIElement* pElement)
             return true;
         }
 
-        if (m_ServersFavourites.AddUnique(Address, usPort))
+        if (CServerListItem* pItem = m_ServersFavourites.AddUnique(Address, usPort))
         {
+            if (CServerListItem::IsHostName(strHost.c_str()))
+                pItem->strHostName = strHost;
+
             SaveFavouritesList();
             RequestFilterRefresh(ServerBrowserTypes::FAVOURITES, true);
             for (std::size_t iconIndex = 0; iconIndex < std::size(m_pAddressFavoriteIcon); ++iconIndex)
@@ -2130,12 +2136,23 @@ bool CServerBrowser::LoadServerList(CXMLNode* pNode, const std::string& strTagNa
             CXMLAttribute* pPortAttribute = pSubNode->GetAttributes().Find("port");
             if (pHostAttribute && pPortAttribute)
             {
-                if (CServerListItem::Parse(pHostAttribute->GetValue().c_str(), Address))
+                const std::string strHost = pHostAttribute->GetValue();
+                iPort = atoi(pPortAttribute->GetValue().c_str());
+                if (iPort <= 0 || iPort > 0xFFFF)
+                    continue;
+
+                if (!CServerListItem::Parse(strHost.c_str(), Address))
                 {
-                    iPort = atoi(pPortAttribute->GetValue().c_str());
-                    if (iPort > 0 && iPort <= 0xFFFF)
-                        pList->AddUnique(Address, static_cast<ushort>(iPort));
+                    if (!CServerListItem::IsHostName(strHost.c_str()))
+                        continue;
+
+                    // Hostname failed to resolve, keep the entry anyway so it isn't dropped from the config on the next save
+                    Address.S_un.S_addr = 0;
                 }
+
+                CServerListItem* pItem = pList->AddUnique(Address, static_cast<ushort>(iPort));
+                if (pItem && CServerListItem::IsHostName(strHost.c_str()))
+                    pItem->strHostName = strHost;
             }
         }
     }

--- a/Client/core/ServerBrowser/CServerBrowser.h
+++ b/Client/core/ServerBrowser/CServerBrowser.h
@@ -106,7 +106,7 @@ public:
     void SetNextHistoryText(bool bDown);
 
     void OnQuickConnectButtonClick();
-    void NotifyServerExists(in_addr Address, ushort usPort);
+    void NotifyServerExists(in_addr Address, ushort usPort, const SString& strHost);
 
     void TabSkip(bool bBackwards);
 

--- a/Client/core/ServerBrowser/CServerList.h
+++ b/Client/core/ServerBrowser/CServerList.h
@@ -130,6 +130,9 @@ public:
         return true;
     }
 
+    // Anything that is not a numeric IPv4 address is treated as a hostname
+    static bool IsHostName(const char* szAddress) { return szAddress[0] != '\0' && inet_addr(szAddress) == INADDR_NONE; }
+
     bool operator==(const CServerListItem& other) const { return (Address.S_un.S_addr == other.Address.S_un.S_addr && usGamePort == other.usGamePort); }
 
     void Init()


### PR DESCRIPTION
#### Summary
Servers added to favourites, recently played or connect history by hostname were stored in `coreconfig.xml` as the resolved IP, so a server changing address broke every saved entry. The hostname the player entered is now kept and resolved again on load.

`CServerListItem` already had a `strHostName` field and `SaveServerList` already preferred it over the IP when writing the config — it was simply never assigned. This fills it at the points where the typed address was discarded right after `CServerListItem::Parse()` resolved it, and makes the browser show it.

- the resolved IP is written alongside the hostname as an `ip` attribute and used as a fallback when a lookup fails, so a saved server is not lost while DNS is down
- selecting a row fills the address bar with the stored hostname instead of the resolved IP, and the favourite icon matches on it too
- `CServerList::AddUnique` now returns the item it added, mirroring `CServerListItemList::AddUnique`, so the hostname can be attached to it
- `OnFavouritesClick` no longer uses the `in_addr` uninitialised when the typed address cannot be resolved

Internal lookups still key on the resolved IP, so the address map, server cache and saved passwords are unaffected. Known limitation: two hostnames resolving to the same ip:port collapse into one entry, since the IP remains the key.

#### Motivation
Fixes #1314 and covers the favourites half of #688. Advertising a raw IP is fragile — changing host breaks every saved favourite and every address posted anywhere. With this, a server owner updates the DNS record and saved entries follow.

#### Test plan
Built from this branch on my own fork's CI and tested with the `windows-win32` artifact against a live server reached by domain.

* [x] Favourite added by domain is stored as the domain with the resolved address kept beside it: `<favourite_server host="mta.example.net" port="22003" ip="104.x.x.x"/>`
* [x] After a restart the entry is still there, the address bar shows `mtasa://mta.example.net:22003` when the row is selected, and the favourite icon is lit
* [x] Favourites added by IP are written exactly as before, with no `ip` attribute
* [x] Entries written by earlier builds load unchanged
* [ ] Connecting through a saved domain after the server's IP changes is not verified end to end: the tree builds as `VERSION_TYPE_CUSTOM`, which cannot join a public 1.6 server. Resolution goes through the same `CServerListItem::Parse` that `connect <host>` already uses today.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
