### PR TITLE
improve CGUI exception handling and fix some bugs

### DIFF
--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -651,9 +651,11 @@ bool CCore::IsCursorForcedVisible()
 
 void CCore::ApplyConsoleSettings()
 {
-    CVector2D vec;
     CConsole* pConsole = m_pLocalGUI->GetConsole();
+    if (!pConsole)
+        return;
 
+    CVector2D vec;
     CVARS_GET("console_pos", vec);
     pConsole->SetPosition(vec);
     CVARS_GET("console_size", vec);

--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -652,7 +652,7 @@ bool CCore::IsCursorForcedVisible()
 void CCore::ApplyConsoleSettings()
 {
     CConsole* pConsole = m_pLocalGUI->GetConsole();
-    if (!pConsole)
+    if (!pConsole) [[unlikely]]
         return;
 
     CVector2D vec;

--- a/Client/core/CGUI.cpp
+++ b/Client/core/CGUI.cpp
@@ -58,6 +58,26 @@ CLocalGUI::~CLocalGUI()
 
 void CLocalGUI::SetSkin(const char* szName)
 {
+    // Guard against re-entrant calls. MessageBoxW pumps the message loop, so the
+    // fatal CC51 dialog below would otherwise trigger pulse calls that touch
+    // m_pConsole while windows are half-destroyed (DestroyWindows called but
+    // CreateWindows not yet reached). The guard also clears the flag if a
+    // window rebuild throws, so a failed skin change cannot disable later ones.
+    static bool s_bInSetSkin = false;
+    if (s_bInSetSkin)
+        return;
+    struct SetSkinGuard
+    {
+        bool& flag;
+        explicit SetSkinGuard(bool& inFlag) : flag(inFlag) { flag = true; }
+        ~SetSkinGuard() { flag = false; }
+    } guard(s_bInSetSkin);
+
+    // A fatal fault dialog may be pumping the message loop; do not rebuild the
+    // windows inside that pump.
+    if (CLocalGUI::IsFaultDialogOpen())
+        return;
+
     CVector2D consolePos, consoleSize;
 
     bool guiWasLoaded = m_pMainMenu != NULL;
@@ -90,7 +110,11 @@ void CLocalGUI::SetSkin(const char* szName)
         }
         catch (...)
         {
-            // Even the default skin doesn't work, so give up
+            // Both the selected and the default skin failed. MessageBoxW pumps the
+            // message loop (re-entrant), but the guard above prevents further damage
+            // before TerminateProcess takes effect. Mark the dialog as open so a
+            // nested fault during the pump terminates instead of stacking another.
+            CLocalGUI::SetFaultDialogOpen(true);
             MessageBoxUTF8(0, _("The skin you selected could not be loaded, and the default skin also could not be loaded, please reinstall MTA."),
                            _("Error") + _E("CC51"), MB_OK | MB_ICONERROR | MB_TOPMOST);
             TerminateProcess(GetCurrentProcess(), 9);
@@ -115,6 +139,16 @@ void CLocalGUI::SetSkin(const char* szName)
 
 void CLocalGUI::ChangeLocale(const char* szName)
 {
+    // Guard against re-entrant calls while the windows are half-destroyed during
+    // a skin change (the fatal skin dialog pumps the message loop).
+    if (!m_pConsole)
+        return;
+
+    // A fatal fault dialog may be pumping the message loop; do not rebuild the
+    // windows inside that pump.
+    if (CLocalGUI::IsFaultDialogOpen())
+        return;
+
     bool guiWasLoaded = m_pMainMenu != NULL;
     assert(guiWasLoaded);
 
@@ -322,7 +356,8 @@ void CLocalGUI::ApplyQueuedLocale()
 
     if (CCore::GetSingleton().GetModManager()->IsLoaded())
     {
-        CCore::GetSingleton().GetConsole()->Printf("Please disconnect before changing language");
+        if (CConsoleInterface* pConsole = CCore::GetSingleton().GetConsole())
+            pConsole->Printf("Please disconnect before changing language");
         if (cvars)
             cvars->Set("locale", m_LastLocaleName);
 
@@ -374,7 +409,8 @@ void CLocalGUI::DoPulse()
                 SetSkin(currentSkinName);
             else
             {
-                CCore::GetSingleton().GetConsole()->Printf("Please disconnect before changing skin");
+                if (CConsoleInterface* pConsole = CCore::GetSingleton().GetConsole())
+                    pConsole->Printf("Please disconnect before changing skin");
                 cvars->Set("current_skin", m_LastSkinName);
             }
         }
@@ -409,13 +445,79 @@ void CLocalGUI::DoPulse()
     // Show after any deferred locale/skin work so a prior prompt is not lost
     TryShowRestartPrompt();
 }
+// Set while a fatal GUI fault dialog is open, so a nested fault during the
+// dialog's message-loop pump terminates without stacking more dialogs.
+static bool s_bFaultDialogOpen = false;
+bool        CLocalGUI::IsFaultDialogOpen()
+{
+    return s_bFaultDialogOpen;
+}
+void CLocalGUI::SetFaultDialogOpen(bool bOpen)
+{
+    s_bFaultDialogOpen = bOpen;
+}
+
+// Error reporting for SEH faults in GUI rendering
+static void ReportGUISEHFault(DWORD dwExceptionCode, const char* szContext)
+{
+    // A nested fault can fire while this dialog pumps the message loop (the
+    // game frame keeps running). Show one dialog, then terminate immediately.
+    if (CLocalGUI::IsFaultDialogOpen())
+    {
+        TerminateProcess(GetCurrentProcess(), 9);
+        return;
+    }
+    CLocalGUI::SetFaultDialogOpen(true);
+
+    SString strMsg(
+        "Rendering fault in %s (code 0x%08X).\n\n"
+        "Usually caused by missing GUI/loading-screen assets.\n\n"
+        "Please verify game files or reinstall.",
+        szContext, dwExceptionCode);
+    WriteDebugEvent(SString("CLocalGUI::Draw SEH fault in %s code=0x%08X", szContext, dwExceptionCode));
+    MessageBoxUTF8(0, strMsg, _("Error") + _E("CC54"), MB_OK | MB_ICONERROR | MB_TOPMOST);
+    TerminateProcess(GetCurrentProcess(), 9);
+}
+
+// SEH filter for GUI rendering faults. Access violations and C++ exceptions
+// (CEGUI errors) are the common failures with missing or corrupt GUI assets;
+// other faults are left for the wider OnPresent guard.
+static int FilterGUISehFault(unsigned int uiExceptionCode)
+{
+    if (uiExceptionCode == EXCEPTION_ACCESS_VIOLATION || uiExceptionCode == 0xE06D7363)
+        return EXCEPTION_EXECUTE_HANDLER;
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+
+// SEH wrapper for the entire Draw body.
+static void DrawSEHGuard(CLocalGUI* pLocalGUI)
+{
+    __try
+    {
+        pLocalGUI->DrawInternal();
+    }
+    __except (FilterGUISehFault(GetExceptionCode()))
+    {
+        ReportGUISEHFault(GetExceptionCode(), "CLocalGUI::Draw");
+    }
+}
 
 void CLocalGUI::Draw()
+{
+    DrawSEHGuard(this);
+}
+
+void CLocalGUI::DrawInternal()
 {
     // Get the game interface
     CGame*      pGame = CCore::GetSingleton().GetGame();
     SystemState systemState = pGame->GetSystemState();
     CGUI*       pGUI = CCore::GetSingleton().GetGUI();
+
+    // The windows may be half-destroyed while a fatal dialog pumps the message
+    // loop during a skin or locale change, so skip drawing until they are back.
+    if (!m_pMainMenu)
+        return;
 
     // Update mainmenu stuff
     m_pMainMenu->Update();

--- a/Client/core/CGUI.cpp
+++ b/Client/core/CGUI.cpp
@@ -141,7 +141,7 @@ void CLocalGUI::ChangeLocale(const char* szName)
 {
     // Guard against re-entrant calls while the windows are half-destroyed during
     // a skin change (the fatal skin dialog pumps the message loop).
-    if (!m_pConsole)
+    if (!m_pConsole) [[unlikely]]
         return;
 
     // A fatal fault dialog may be pumping the message loop; do not rebuild the
@@ -448,11 +448,11 @@ void CLocalGUI::DoPulse()
 // Set while a fatal GUI fault dialog is open, so a nested fault during the
 // dialog's message-loop pump terminates without stacking more dialogs.
 static bool s_bFaultDialogOpen = false;
-bool        CLocalGUI::IsFaultDialogOpen()
+bool        CLocalGUI::IsFaultDialogOpen() noexcept
 {
     return s_bFaultDialogOpen;
 }
-void CLocalGUI::SetFaultDialogOpen(bool bOpen)
+void CLocalGUI::SetFaultDialogOpen(bool bOpen) noexcept
 {
     s_bFaultDialogOpen = bOpen;
 }
@@ -484,7 +484,7 @@ static void ReportGUISEHFault(DWORD dwExceptionCode, const char* szContext)
 // other faults are left for the wider OnPresent guard.
 static int FilterGUISehFault(unsigned int uiExceptionCode)
 {
-    if (uiExceptionCode == EXCEPTION_ACCESS_VIOLATION || uiExceptionCode == 0xE06D7363)
+    if (uiExceptionCode == EXCEPTION_ACCESS_VIOLATION || uiExceptionCode == CPP_EXCEPTION_CODE)
         return EXCEPTION_EXECUTE_HANDLER;
     return EXCEPTION_CONTINUE_SEARCH;
 }
@@ -516,7 +516,7 @@ void CLocalGUI::DrawInternal()
 
     // The windows may be half-destroyed while a fatal dialog pumps the message
     // loop during a skin or locale change, so skip drawing until they are back.
-    if (!m_pMainMenu)
+    if (!m_pMainMenu) [[unlikely]]
         return;
 
     // Update mainmenu stuff

--- a/Client/core/CGUI.h
+++ b/Client/core/CGUI.h
@@ -52,8 +52,15 @@ public:
     void DoPulse();
 
     void Draw();
+    void DrawInternal();
     void Invalidate();
     void Restore();
+
+    // True while a fatal GUI fault dialog is open, so a nested fault during the
+    // dialog's message-loop pump terminates without stacking more dialogs, and
+    // window-rebuild paths (skin and locale changes) do not run inside the pump.
+    static bool IsFaultDialogOpen();
+    static void SetFaultDialogOpen(bool bOpen);
 
     void DrawMouseCursor();
     void SetCursorPos(int iX, int iY, bool bForce = false, bool overrideStored = true);

--- a/Client/core/CGUI.h
+++ b/Client/core/CGUI.h
@@ -59,8 +59,8 @@ public:
     // True while a fatal GUI fault dialog is open, so a nested fault during the
     // dialog's message-loop pump terminates without stacking more dialogs, and
     // window-rebuild paths (skin and locale changes) do not run inside the pump.
-    static bool IsFaultDialogOpen();
-    static void SetFaultDialogOpen(bool bOpen);
+    static bool IsFaultDialogOpen() noexcept;
+    static void SetFaultDialogOpen(bool bOpen) noexcept;
 
     void DrawMouseCursor();
     void SetCursorPos(int iX, int iY, bool bForce = false, bool overrideStored = true);

--- a/Client/core/DXHook/CDirect3DEvents9.cpp
+++ b/Client/core/DXHook/CDirect3DEvents9.cpp
@@ -1487,7 +1487,7 @@ int               FilterException(uint exceptionCode)
         WriteDebugEvent("FilterException: caught in-page error");
         return EXCEPTION_EXECUTE_HANDLER;
     }
-    if (exceptionCode == 0xE06D7363)
+    if (exceptionCode == CPP_EXCEPTION_CODE)
     {
         WriteDebugEvent("FilterException: caught Microsoft C++ exception");
         return EXCEPTION_EXECUTE_HANDLER;

--- a/Client/core/DXHook/CDirect3DEvents9.cpp
+++ b/Client/core/DXHook/CDirect3DEvents9.cpp
@@ -577,7 +577,42 @@ void CDirect3DEvents9::OnRestore(IDirect3DDevice9* pDevice)
     CCore::GetSingleton().OnDeviceRestore();
 }
 
+int FilterException(uint exceptionCode);
+
+static void ReportOnPresentSEHFault(DWORD dwExceptionCode)
+{
+    // A nested fault can fire while this dialog pumps the message loop (the
+    // game frame keeps running). Show one dialog, then terminate immediately.
+    if (CLocalGUI::IsFaultDialogOpen())
+    {
+        TerminateProcess(GetCurrentProcess(), 9);
+        return;
+    }
+    CLocalGUI::SetFaultDialogOpen(true);
+
+    SString strMsg(
+        "Rendering fault during frame rendering (code 0x%08X).\n\n"
+        "Usually caused by missing GUI/loading-screen assets.\n\n"
+        "Please verify game files or reinstall.",
+        dwExceptionCode);
+    WriteDebugEvent(SString("OnPresent SEH fault code=0x%08X", dwExceptionCode));
+    MessageBoxUTF8(0, strMsg, _("Error") + _E("CC54"), MB_OK | MB_ICONERROR | MB_TOPMOST);
+    TerminateProcess(GetCurrentProcess(), 9);
+}
+
 void CDirect3DEvents9::OnPresent(IDirect3DDevice9* pDevice, IDirect3DDevice9* pStateDevice)
+{
+    __try
+    {
+        OnPresentInternal(pDevice, pStateDevice);
+    }
+    __except (FilterException(GetExceptionCode()))
+    {
+        ReportOnPresentSEHFault(GetExceptionCode());
+    }
+}
+
+void CDirect3DEvents9::OnPresentInternal(IDirect3DDevice9* pDevice, IDirect3DDevice9* pStateDevice)
 {
     TIMING_CHECKPOINT("+OnPresent1");
     CGraphics::GetSingleton().SetSkipMTARenderThisFrame(false);

--- a/Client/core/DXHook/CDirect3DEvents9.h
+++ b/Client/core/DXHook/CDirect3DEvents9.h
@@ -19,6 +19,7 @@ public:
     static void    OnDirect3DDeviceCreate(IDirect3DDevice9* pDevice);
     static void    OnDirect3DDeviceDestroy(IDirect3DDevice9* pDevice);
     static void    OnPresent(IDirect3DDevice9* pDevice, IDirect3DDevice9* pStateDevice);
+    static void    OnPresentInternal(IDirect3DDevice9* pDevice, IDirect3DDevice9* pStateDevice);
     static void    OnBeginScene(IDirect3DDevice9* pDevice);
     static bool    OnEndScene(IDirect3DDevice9* pDevice);
     static void    OnInvalidate(IDirect3DDevice9* pDevice);

--- a/Client/gui/CGUIStaticImage_Impl.cpp
+++ b/Client/gui/CGUIStaticImage_Impl.cpp
@@ -77,13 +77,21 @@ bool CGUIStaticImage_Impl::LoadFromFile(const char* szFilename)
 
 bool CGUIStaticImage_Impl::LoadFromTexture(CGUITexture* pTexture)
 {
-    if (m_pImageset && m_pImage)
-    {
-        m_pImageset->undefineAllImages();
-    }
+    if (!pTexture)
+        return false;
 
     if (m_pTexture && pTexture != m_pTexture)
     {
+        // The widget and its imageset keep references to the old texture, so
+        // release them before the texture is replaced to avoid drawing from a
+        // stale or freed texture.
+        reinterpret_cast<CEGUI::StaticImage*>(m_pWindow)->setImage(nullptr);
+        if (m_pImageset)
+        {
+            m_pImagesetManager->destroyImageset(m_pImageset);
+            m_pImageset = nullptr;
+        }
+        m_pImage = nullptr;
         if (m_bCreatedTexture)
         {
             delete m_pTexture;
@@ -101,23 +109,42 @@ bool CGUIStaticImage_Impl::LoadFromTexture(CGUITexture* pTexture)
     char szUnique[CGUI_CHAR_SIZE];
     m_pGUI->GetUniqueName(szUnique);
 
-    // Create an imageset
-    if (!m_pImageset)
+    try
     {
-        while (m_pImagesetManager->isImagesetPresent(szUnique))
-            m_pGUI->GetUniqueName(szUnique);
-        m_pImageset = m_pImagesetManager->createImageset(szUnique, pCEGUITexture, true);
+        // Clear any previously defined images so the widget cannot keep drawing
+        // an image that a failed re-load has invalidated
+        if (m_pImageset && m_pImage)
+        {
+            m_pImageset->undefineAllImages();
+        }
+
+        // Create an imageset
+        if (!m_pImageset)
+        {
+            while (m_pImagesetManager->isImagesetPresent(szUnique))
+                m_pGUI->GetUniqueName(szUnique);
+            m_pImageset = m_pImagesetManager->createImageset(szUnique, pCEGUITexture, true);
+        }
+
+        // Get an unique identifier for CEGUI for the image
+        m_pGUI->GetUniqueName(szUnique);
+
+        // Define an image and get its pointer
+        m_pImageset->defineImage(szUnique, CEGUI::Point(0, 0), CEGUI::Size(pCEGUITexture->getWidth(), pCEGUITexture->getHeight()), CEGUI::Point(0, 0));
+        m_pImage = &m_pImageset->getImage(szUnique);
+
+        // Set the image just loaded as the image to be drawn for the widget
+        reinterpret_cast<CEGUI::StaticImage*>(m_pWindow)->setImage(m_pImage);
     }
-
-    // Get an unique identifier for CEGUI for the image
-    m_pGUI->GetUniqueName(szUnique);
-
-    // Define an image and get its pointer
-    m_pImageset->defineImage(szUnique, CEGUI::Point(0, 0), CEGUI::Size(pCEGUITexture->getWidth(), pCEGUITexture->getHeight()), CEGUI::Point(0, 0));
-    m_pImage = &m_pImageset->getImage(szUnique);
-
-    // Set the image just loaded as the image to be drawn for the widget
-    reinterpret_cast<CEGUI::StaticImage*>(m_pWindow)->setImage(m_pImage);
+    catch (const CEGUI::Exception& e)
+    {
+        OutputDebugLine(SString("CGUIStaticImage_Impl::LoadFromTexture failed: %s", e.getMessage().c_str()));
+        // The imageset may have been cleared before the failure, so stop the
+        // widget from drawing an image that no longer exists.
+        reinterpret_cast<CEGUI::StaticImage*>(m_pWindow)->setImage(nullptr);
+        m_pImage = nullptr;
+        return false;
+    }
 
     // Success
     return true;
@@ -133,14 +160,17 @@ void CGUIStaticImage_Impl::Clear()
     {
         m_pImageset->undefineAllImages();
         m_pImagesetManager->destroyImageset(m_pImageset);
-        if (m_bCreatedTexture)
-        {
-            delete m_pTexture;
-            m_pTexture = NULL;
-            m_bCreatedTexture = false;
-        }
         m_pImage = NULL;
         m_pImageset = NULL;
+    }
+
+    // The imageset does not own the texture, so a texture created by this widget
+    // must be released here even if the imageset never got created.
+    if (m_bCreatedTexture)
+    {
+        delete m_pTexture;
+        m_pTexture = nullptr;
+        m_bCreatedTexture = false;
     }
 }
 

--- a/Client/gui/CGUIWebBrowser_Impl.cpp
+++ b/Client/gui/CGUIWebBrowser_Impl.cpp
@@ -17,6 +17,7 @@ CGUIWebBrowser_Impl::CGUIWebBrowser_Impl(CGUI_Impl* pGUI, CGUIElement* pParent)
     m_pImagesetManager = pGUI->GetImageSetManager();
     m_pImageset = nullptr;
     m_pImage = nullptr;
+    m_pTexture = nullptr;
     m_pGUI = pGUI;
     SetManager(pGUI);
     m_pWebView = nullptr;
@@ -77,41 +78,63 @@ void CGUIWebBrowser_Impl::Clear()
         m_pImage = nullptr;
         m_pImageset = nullptr;
     }
+
+    // The imageset does not own the texture, so it must be released here
+    if (m_pTexture)
+    {
+        delete m_pTexture;
+        m_pTexture = nullptr;
+    }
 }
 
 void CGUIWebBrowser_Impl::LoadFromWebView(CWebViewInterface* pWebView)
 {
     m_pWebView = pWebView;
 
-    if (m_pImageset && m_pImage)
+    if (!pWebView)
     {
-        m_pImageset->undefineAllImages();
+        // No web view available (creation failed), so leave the widget blank
+        Clear();
+        return;
     }
 
-    CGUIWebBrowserTexture* pCEGUITexture = new CGUIWebBrowserTexture(m_pGUI->GetRenderer(), m_pWebView);
+    // Release any previous imageset and texture so a re-load cannot draw stale
+    // content from an old web view or leak the old texture.
+    Clear();
 
-    // Get an unique identifier for CEGUI for the imageset
-    char szUnique[CGUI_CHAR_SIZE];
-    m_pGUI->GetUniqueName(szUnique);
-
-    // Create an imageset
-    if (!m_pImageset)
+    try
     {
-        while (m_pImagesetManager->isImagesetPresent(szUnique))
-            m_pGUI->GetUniqueName(szUnique);
-        m_pImageset = m_pImagesetManager->createImageset(szUnique, pCEGUITexture, true);
+        m_pTexture = new CGUIWebBrowserTexture(m_pGUI->GetRenderer(), m_pWebView);
+
+        // Get an unique identifier for CEGUI for the imageset
+        char szUnique[CGUI_CHAR_SIZE];
+        m_pGUI->GetUniqueName(szUnique);
+
+        // Create an imageset
+        if (!m_pImageset)
+        {
+            while (m_pImagesetManager->isImagesetPresent(szUnique))
+                m_pGUI->GetUniqueName(szUnique);
+            m_pImageset = m_pImagesetManager->createImageset(szUnique, m_pTexture, true);
+        }
+
+        // Get an unique identifier for CEGUI for the image
+        m_pGUI->GetUniqueName(szUnique);
+
+        // Define an image and get its pointer
+        m_pImageset->defineImage(szUnique, CEGUI::Point(0, 0), CEGUI::Size(m_pTexture->getWidth(), m_pTexture->getHeight()), CEGUI::Point(0, 0));
+        m_pImage = const_cast<CEGUI::Image*>(
+            &m_pImageset->getImage(szUnique));  // const_cast here is a huge hack, but is okay here since all images generated here are unique
+
+        // Set the image just loaded as the image to be drawn for the widget
+        reinterpret_cast<CEGUI::StaticImage*>(m_pWindow)->setImage(m_pImage);
     }
-
-    // Get an unique identifier for CEGUI for the image
-    m_pGUI->GetUniqueName(szUnique);
-
-    // Define an image and get its pointer
-    m_pImageset->defineImage(szUnique, CEGUI::Point(0, 0), CEGUI::Size(pCEGUITexture->getWidth(), pCEGUITexture->getHeight()), CEGUI::Point(0, 0));
-    m_pImage = const_cast<CEGUI::Image*>(
-        &m_pImageset->getImage(szUnique));  // const_cast here is a huge hack, but is okay here since all images generated here are unique
-
-    // Set the image just loaded as the image to be drawn for the widget
-    reinterpret_cast<CEGUI::StaticImage*>(m_pWindow)->setImage(m_pImage);
+    catch (const CEGUI::Exception& e)
+    {
+        OutputDebugLine(SString("CGUIWebBrowser_Impl::LoadFromWebView failed: %s", e.getMessage().c_str()));
+        // Release any partially created imageset or texture and leave the widget blank.
+        Clear();
+    }
 }
 
 void CGUIWebBrowser_Impl::SetFrameEnabled(bool bFrameEnabled)
@@ -136,6 +159,8 @@ void CGUIWebBrowser_Impl::Render()
 
 bool CGUIWebBrowser_Impl::HasInputFocus()
 {
+    if (!m_pWebView)
+        return false;
     return m_pWebView->HasInputFocus();
 }
 
@@ -156,6 +181,9 @@ void CGUIWebBrowser_Impl::SetSize(const CVector2D& vecSize, bool bRelative)
 
 bool CGUIWebBrowser_Impl::Event_MouseButtonDown(const CEGUI::EventArgs& e)
 {
+    if (!m_pWebView)
+        return true;
+
     const CEGUI::MouseEventArgs& args = reinterpret_cast<const CEGUI::MouseEventArgs&>(e);
 
     if (args.button == CEGUI::MouseButton::LeftButton)
@@ -170,6 +198,9 @@ bool CGUIWebBrowser_Impl::Event_MouseButtonDown(const CEGUI::EventArgs& e)
 
 bool CGUIWebBrowser_Impl::Event_MouseButtonUp(const CEGUI::EventArgs& e)
 {
+    if (!m_pWebView)
+        return true;
+
     const CEGUI::MouseEventArgs& args = reinterpret_cast<const CEGUI::MouseEventArgs&>(e);
 
     if (args.button == CEGUI::MouseButton::LeftButton)
@@ -184,6 +215,9 @@ bool CGUIWebBrowser_Impl::Event_MouseButtonUp(const CEGUI::EventArgs& e)
 
 bool CGUIWebBrowser_Impl::Event_MouseDoubleClick(const CEGUI::EventArgs& e)
 {
+    if (!m_pWebView)
+        return true;
+
     const CEGUI::MouseEventArgs& args = reinterpret_cast<const CEGUI::MouseEventArgs&>(e);
 
     if (args.button == CEGUI::MouseButton::LeftButton)
@@ -198,6 +232,9 @@ bool CGUIWebBrowser_Impl::Event_MouseDoubleClick(const CEGUI::EventArgs& e)
 
 bool CGUIWebBrowser_Impl::Event_MouseMove(const CEGUI::EventArgs& e)
 {
+    if (!m_pWebView)
+        return true;
+
     const CEGUI::MouseEventArgs& args = reinterpret_cast<const CEGUI::MouseEventArgs&>(e);
 
     m_pWebView->InjectMouseMove((int)(args.position.d_x - m_pWindow->windowToScreenX(0.0f)), (int)(args.position.d_y - m_pWindow->windowToScreenY(0.0f)));
@@ -206,6 +243,9 @@ bool CGUIWebBrowser_Impl::Event_MouseMove(const CEGUI::EventArgs& e)
 
 bool CGUIWebBrowser_Impl::Event_MouseWheel(const CEGUI::EventArgs& e)
 {
+    if (!m_pWebView)
+        return true;
+
     const CEGUI::MouseEventArgs& args = reinterpret_cast<const CEGUI::MouseEventArgs&>(e);
 
     m_pWebView->InjectMouseWheel((int)(args.wheelChange * 40), 0);
@@ -214,12 +254,16 @@ bool CGUIWebBrowser_Impl::Event_MouseWheel(const CEGUI::EventArgs& e)
 
 bool CGUIWebBrowser_Impl::Event_Activated(const CEGUI::EventArgs& e)
 {
+    if (!m_pWebView)
+        return true;
     m_pWebView->Focus(true);
     return true;
 }
 
 bool CGUIWebBrowser_Impl::Event_Deactivated(const CEGUI::EventArgs& e)
 {
+    if (!m_pWebView)
+        return true;
     m_pWebView->Focus(false);
     return true;
 }

--- a/Client/gui/CGUIWebBrowser_Impl.h
+++ b/Client/gui/CGUIWebBrowser_Impl.h
@@ -20,6 +20,7 @@
 class CGUITexture;
 class CGUITexture_Impl;
 class CGUI_Impl;
+class CGUIWebBrowserTexture;
 class CWebViewInterface;
 
 class CGUIWebBrowser_Impl : public CGUIWebBrowser, public CGUIElement_Impl
@@ -57,6 +58,7 @@ private:
     CEGUI::ImagesetManager* m_pImagesetManager;
     CEGUI::Imageset*        m_pImageset;
     CEGUI::Image*           m_pImage;
+    CGUIWebBrowserTexture*  m_pTexture;
 
     CWebViewInterface* m_pWebView;
 

--- a/Client/gui/CGUI_Impl.cpp
+++ b/Client/gui/CGUI_Impl.cpp
@@ -120,7 +120,7 @@ CGUI_Impl::CGUI_Impl(IDirect3DDevice9* pDevice)
         m_pUniFont = (CGUIFont_Impl*)CreateFnt("unifont", CGUI_MTA_SUBSTITUTE_FONT, 9, 0, false);
         m_pFontManager->setSubstituteFont(m_pUniFont->GetFont());
     }
-    catch (CEGUI::InvalidRequestException e)
+    catch (const CEGUI::Exception& e)
     {
         SString strMessage = e.getMessage().c_str();
         BrowseToSolution("create-fonts", EXIT_GAME_FIRST | ASK_GO_ONLINE, SString("Error loading fonts!\n\n%s", *strMessage));
@@ -138,7 +138,7 @@ CGUI_Impl::CGUI_Impl(IDirect3DDevice9* pDevice)
         m_pSAGothicFont = (CGUIFont_Impl*)CreateFnt("sa-gothic", CGUI_SA_GOTHIC_FONT, CGUI_SA_GOTHIC_SIZE, 0, true);
         m_pSansFont = (CGUIFont_Impl*)CreateFnt("sans", CGUI_MTA_SANS_FONT, CGUI_MTA_SANS_FONT_SIZE, 0, false);
     }
-    catch (CEGUI::InvalidRequestException e)
+    catch (const CEGUI::Exception& e)
     {
         SString strMessage = e.getMessage().c_str();
         BrowseToSolution("create-fonts", EXIT_GAME_FIRST | ASK_GO_ONLINE, SString("Error loading fonts!\n\n%s", *strMessage));
@@ -277,7 +277,15 @@ void CGUI_Impl::Draw()
 
 void CGUI_Impl::Invalidate()
 {
-    reinterpret_cast<CEGUI::DirectX9Renderer*>(m_pRenderer)->preD3DReset();
+    try
+    {
+        reinterpret_cast<CEGUI::DirectX9Renderer*>(m_pRenderer)->preD3DReset();
+    }
+    catch (const CEGUI::Exception& exception)
+    {
+        MessageBox(0, exception.getMessage().c_str(), "CEGUI Exception", MB_OK | MB_ICONERROR | MB_TOPMOST);
+        TerminateProcess(GetCurrentProcess(), 1);
+    }
 }
 
 void CGUI_Impl::Restore()
@@ -286,7 +294,7 @@ void CGUI_Impl::Restore()
     {
         reinterpret_cast<CEGUI::DirectX9Renderer*>(m_pRenderer)->postD3DReset();
     }
-    catch (CEGUI::RendererException& exception)
+    catch (const CEGUI::Exception& exception)
     {
         MessageBox(0, exception.getMessage().c_str(), "CEGUI Exception", MB_OK | MB_ICONERROR | MB_TOPMOST);
         TerminateProcess(GetCurrentProcess(), 1);


### PR DESCRIPTION
This PR makes the client a lot less likely to randomly crash when GUI-related things go wrong. The main idea is that instead of silently crashing to desktop (which often happened through std::terminate and without dialog or info), the client now shows a clear error message telling the player to reinstall MTA, and then exits cleanly. I also fixed smaller bugs I ran into while working on this, i.e. memory leaks, null pointer crashes, and broken error dialogs stacking on top of each other.

**What was happening before:**

- When a skin file was missing or corrupted, the error dialog that popped up would actually cause more crashes while it was open, because the game keeps running in the background and tries to draw GUI windows that were already destroyed. This led to either a silent crash or two error dialogs stacked on top of each other.

- When textures or web browser elements failed to load (happens with custom resources a lot), CEGUI exceptions would escape all the way up and crash the process with no message at all.

- When the D3D device got lost (Alt+Tab, fullscreen switch, screensaver), the pre-reset cleanup could throw a CEGUI exception that had no handler, causing a crash in the COM layer which is even harder to debug.

- The web browser widget would crash if you clicked on it after CEF failed to start up, because it tried to send input to a web view that didn't exist.

- Textures created by static image widgets would leak if the imageset creation step failed partway through.

- Some font-loading exceptions would go uncaught because the catch blocks were too narrow (only catching one specific type instead of the base CEGUI exception class).

**What the PR does:**

The client now catches crashes during GUI drawing (both C++ exceptions and access violations) and shows a "Rendering fault -- missing GUI/loading-screen assets" dialog instead of just disappearing. This covers both the per-frame draw and the D3D present call.

When skin loading fails and that big CC51 error dialog appears, the code now sets a flag telling everything else it's drawn and not to draw or rebuild more windows. If a second fault somehow fires during that dialog, the process just terminates immediately instead of stacking another dialog on top.

Skin and locale change functions now check whether that flag is set (or whether windows are half-destroyed) and bail out early instead of touching destroyed objects.

Console-related code in DoPulse and ApplyQueuedLocale now checks if the console object actually exists before trying to print to it, since it can be destroyed during a skin change while the error dialog is pumping messages.

Static image loading is wrapped in a try/catch so if CEGUI fails to create the imageset, the widget just goes blank and logs the error instead of crashing. The old texture/imageset cleanup was also reordered to properly detach things from the widget before destroying them (no more dangling references inside CEGUI's renderer).

Web browser loading got the same treatment, plus a bunch of null checks in the mouse/keyboard event handlers so if the browser element fails to create its web view, clicking on it doesn't crash.

The browser widget now properly tracks and frees the texture it creates (was leaking before, and the leak path was basically guaranteed if CEF failed).

The D3D device-lost handler (Invalidate) now catches CEGUI exceptions, shows a message, and terminates instead of letting the exception cross into COM.

Font-loading catch blocks were widened from the specific InvalidRequestException to the base CEGUI Exception class, so other CEGUI errors during font creation don't escape the constructor.

The ApplyConsoleSettings function got an early-out if the console isn't ready yet (happens during early startup or during skin changes).

A bunch of exception catches were changed from catching-by-value (which slices the exception object) to catching-by-const-reference.