### PR TITLE
Fix #664: Prevent vehicle doors freezing after passenger exits

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -15,6 +15,7 @@
 #include <game/CCam.h>
 #include <game/CCarEnterExit.h>
 #include <game/CColPoint.h>
+#include <game/CDoor.h>
 #include <game/CPedIntelligence.h>
 #include <game/CPedSound.h>
 #include <game/CStreaming.h>
@@ -1620,7 +1621,9 @@ CClientVehicle* CClientPed::RemoveFromVehicle(bool bSkipWarpIfGettingOut)
 
     if (pVehicle)
     {
-        pVehicle->SetSwingingDoorsAllowed(false);
+        // Only disable swinging doors if the driver left the vehicle, so passenger doors can continue swinging with physics
+        if (pVehicle->GetOccupant(0) == this || pVehicle->m_pOccupyingDriver == this)
+            pVehicle->SetSwingingDoorsAllowed(false);
 
         // Warp the player out of the vehicle
         CVehicle* pGameVehicle = pVehicle->m_pVehicle;

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -2474,7 +2474,24 @@ void CClientVehicle::StreamedInPulse()
             {
                 CDoor* pDoor = m_pVehicle->GetDoor(i);
                 if (pDoor)
+                {
                     m_fDoorOpenRatio[i] = pDoor->GetAngleOpenRatio();
+
+                    // If a swinging door has reached the closed position while moving, latch it shut
+                    if (m_fDoorOpenRatio[i] <= 0.01f && m_bSwingingDoorsAllowed)
+                    {
+                        auto* damageManager = m_pVehicle->GetDamageManager();
+                        if (damageManager)
+                        {
+                            auto const status = damageManager->GetDoorStatus(static_cast<eDoors>(i));
+                            if (status == 1 || status == 3)  // DT_DOOR_SWINGING_FREE (1) or DT_DOOR_BASHED_AND_SWINGING_FREE (3)
+                            {
+                                damageManager->SetDoorStatus(static_cast<eDoors>(i), status - 1, false);  // Set to CLOSED (0 or 2)
+                                SetDoorOpenRatio(i, 0.0f, 0, true);
+                            }
+                        }
+                    }
+                }
             }
         }
 
@@ -4207,6 +4224,16 @@ void CClientVehicle::SetPedOccupiedVehicle(CClientPed* pClientPed, CClientVehicl
         pVehicle->AllowDoorRatioSetting(ucDoor, true);
     else if (uiSeat < 4)
         pVehicle->AllowDoorRatioSetting(uiSeat + 2, true);
+
+    // If the occupant has entered an automobile seat, close and latch the seat door smoothly so it doesn't snap or flap unlatched
+    if (uiSeat < 4 && CClientVehicleManager::HasDoors(pVehicle->GetModel()))
+    {
+        auto const seatDoor = (ucDoor != 0xFF) ? ucDoor : static_cast<std::uint8_t>(uiSeat + 2);
+        if (pVehicle->GetDoorOpenRatio(seatDoor) <= 0.1f)
+            pVehicle->SetDoorOpenRatio(seatDoor, 0.0f, 0, true);
+        else
+            pVehicle->SetDoorOpenRatio(seatDoor, 0.0f, 400, true);
+    }
 
     // Checks
     ValidatePedAndVehiclePair(pClientPed, pVehicle);


### PR DESCRIPTION
Fixes #664

This problem has existed for years:
- Vehicle doors freezing in mid-air after a passenger exits while driving.
- Swinging doors never auto-latching shut when pushed closed by vehicle motion.
- Doors remaining unlatched and flapping after an occupant enters.

All are now fixed.

https://github.com/user-attachments/assets/58e7ab5b-c4f8-4af2-a79c-377fa3c1458c

