### PR TITLE
Add the ability to return Lua functions  through the new argument parser

### DIFF
--- a/Shared/mods/deathmatch/logic/lua/LuaBasic.h
+++ b/Shared/mods/deathmatch/logic/lua/LuaBasic.h
@@ -93,6 +93,14 @@ namespace lua
         args.PushAsTable(L);
     }
 
+    inline void Push(lua_State* L, const CLuaFunctionRef& value)
+    {
+        if (value.ToInt() != LUA_NOREF && value.ToInt() != LUA_REFNIL)
+            lua_getref(L, value.ToInt());
+        else
+            lua_pushnil(L);
+    }
+
     inline void Push(lua_State* L, const CVector2D& value)
     {
         lua_pushvector(L, value);


### PR DESCRIPTION
#### Summary
This PR adds the ability to return Lua functions to Lua through the new argument parser.

#### Motivation
The `getEventHandlers` function currently returns Lua functions to Lua, so the new parser needs to support this as well. Need for #5240 

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
