### PR TITLE
Fix voice memory and bitstream leaks, crashes, game loop stall

### DIFF
--- a/Client/mods/deathmatch/CVoiceRecorder.cpp
+++ b/Client/mods/deathmatch/CVoiceRecorder.cpp
@@ -29,7 +29,6 @@ CVoiceRecorder::CVoiceRecorder()
     m_iSpeexOutgoingFrameSampleCount = 0;
     m_uiOutgoingReadIndex = 0;
     m_uiOutgoingWriteIndex = 0;
-    m_bIsSendingVoiceData = false;
     m_bOutgoingBufferFull = false;
 
     m_ulTimeOfLastSend = 0;
@@ -67,7 +66,7 @@ void CVoiceRecorder::Init(bool bEnabled, unsigned int uiServerSampleRate, unsign
     if (!bEnabled)  // If we aren't enabled, don't bother continuing
         return;
 
-    std::lock_guard<std::mutex> lock(m_Mutex);
+    std::unique_lock<std::mutex> lock(m_Mutex);
 
     // Convert the sample rate we received from the server (0-2) into an actual sample rate
     m_SampleRate = convertServerSampleRate(uiServerSampleRate);
@@ -87,9 +86,7 @@ void CVoiceRecorder::Init(bool bEnabled, unsigned int uiServerSampleRate, unsign
     const SpeexMode* speexMode = getSpeexModeFromSampleRate();
     m_pSpeexEncoderState = speex_encoder_init(speexMode);
 
-    Pa_Initialize();
-
-    int count = Pa_GetHostApiCount();
+    PaError error = Pa_Initialize();
 
     PaStreamParameters inputDevice;
     inputDevice.channelCount = 1;
@@ -98,10 +95,34 @@ void CVoiceRecorder::Init(bool bEnabled, unsigned int uiServerSampleRate, unsign
     inputDevice.hostApiSpecificStreamInfo = nullptr;
     inputDevice.suggestedLatency = 0;
 
-    Pa_OpenStream(&m_pAudioStream, &inputDevice, NULL, m_SampleRate, iFramesPerBuffer, paNoFlag, PACallback, this);
+    if (error == paNoError)
+        error = Pa_OpenStream(&m_pAudioStream, &inputDevice, NULL, m_SampleRate, iFramesPerBuffer, paNoFlag, PACallback, this);
+    if (error == paNoError && m_pAudioStream)
+        error = Pa_StartStream(m_pAudioStream);
 
-    if (m_pAudioStream)
-        Pa_StartStream(m_pAudioStream);
+    // A recorder that looks enabled but never captures is worse than one that
+    // reports the failure, so shut down cleanly when the mic stream cannot be
+    // opened or started. The stream close must run outside the mutex, same as
+    // DeInit, in case a host API leaves the callback running after a failed start
+    if (error != paNoError)
+    {
+        m_bEnabled = false;
+        lock.unlock();
+        if (m_pAudioStream)
+        {
+            Pa_CloseStream(m_pAudioStream);
+            m_pAudioStream = nullptr;
+        }
+        Pa_Terminate();
+        lock.lock();
+        if (m_pSpeexEncoderState)
+        {
+            speex_encoder_destroy(m_pSpeexEncoderState);
+            m_pSpeexEncoderState = nullptr;
+        }
+        g_pCore->GetConsole()->Printf("Voice: cannot open microphone stream (%s)", Pa_GetErrorText(error));
+        return;
+    }
 
     // Initialize our outgoing buffer. A failed encoder creation would leave these
     // calls on a null handle, so the whole config chain is skipped when the
@@ -110,13 +131,37 @@ void CVoiceRecorder::Init(bool bEnabled, unsigned int uiServerSampleRate, unsign
     if (m_pSpeexEncoderState)
     {
         speex_encoder_ctl(m_pSpeexEncoderState, SPEEX_GET_FRAME_SIZE, &m_iSpeexOutgoingFrameSampleCount);
-        speex_encoder_ctl(m_pSpeexEncoderState, SPEEX_SET_QUALITY, &m_ucQuality);
+        int iQuality = m_ucQuality;
+        speex_encoder_ctl(m_pSpeexEncoderState, SPEEX_SET_QUALITY, &iQuality);
         iBitRate = (int)uiBitrate;
         if (iBitRate)
             speex_encoder_ctl(m_pSpeexEncoderState, SPEEX_SET_BITRATE, &iBitRate);
     }
 
     m_pOutgoingBuffer = (unsigned char*)malloc(m_uiBufferSizeBytes * FRAME_OUTGOING_BUFFER_COUNT);
+    if (!m_pOutgoingBuffer)
+    {
+        // Without the ring the recorder would look enabled but never send,
+        // so shut down cleanly instead. The stream close must run outside the
+        // mutex: the callback can be waiting on it, and Pa_CloseStream waits
+        // for the callback to return
+        m_bEnabled = false;
+        lock.unlock();
+        if (m_pAudioStream)
+        {
+            Pa_CloseStream(m_pAudioStream);
+            m_pAudioStream = nullptr;
+        }
+        Pa_Terminate();
+        lock.lock();
+        if (m_pSpeexEncoderState)
+        {
+            speex_encoder_destroy(m_pSpeexEncoderState);
+            m_pSpeexEncoderState = nullptr;
+        }
+        g_pCore->GetConsole()->Printf("Voice: could not allocate the voice buffer");
+        return;
+    }
     m_uiOutgoingReadIndex = 0;
     m_uiOutgoingWriteIndex = 0;
     m_bOutgoingBufferFull = false;
@@ -186,7 +231,6 @@ void CVoiceRecorder::DeInit()
     m_iSpeexOutgoingFrameSampleCount = 0;
     m_uiOutgoingReadIndex = 0;
     m_uiOutgoingWriteIndex = 0;
-    m_bIsSendingVoiceData = false;
     m_bOutgoingBufferFull = false;
     m_ulTimeOfLastSend = 0;
     m_uiBufferSizeBytes = 0;
@@ -295,7 +339,6 @@ void CVoiceRecorder::DoPulse()
         static_assert(640 * sizeof(short) <= sizeof(audioBuffer), "Voice frame exceeds the local audio buffer");
         unsigned int uiTotalBufferSize = m_uiBufferSizeBytes * FRAME_OUTGOING_BUFFER_COUNT;
 
-        m_bIsSendingVoiceData = false;
         unsigned int uiBytesAvailable = 0;
 
         if (m_bOutgoingBufferFull)
@@ -344,11 +387,13 @@ void CVoiceRecorder::DoPulse()
                 }
 
                 // Encode our audio stream with speex
-                speex_encode_int(m_pSpeexEncoderState, (spx_int16_t*)pInputBuffer, &speexBits);
+                const int encodeResult = speex_encode_int(m_pSpeexEncoderState, (spx_int16_t*)pInputBuffer, &speexBits);
 
                 m_uiOutgoingReadIndex = (m_uiOutgoingReadIndex + uiSpeexBlockSize) % uiTotalBufferSize;
 
-                m_bIsSendingVoiceData = true;
+                // A failed encode produces no usable bits, so drop the frame
+                if (encodeResult < 0)
+                    continue;
 
                 unsigned int audioBufferLength = speex_bits_write(&speexBits, reinterpret_cast<char*>(audioBuffer), 2048);
 

--- a/Client/mods/deathmatch/CVoiceRecorder.cpp
+++ b/Client/mods/deathmatch/CVoiceRecorder.cpp
@@ -293,7 +293,7 @@ void CVoiceRecorder::DoPulse()
         // One frame at the highest Speex rate (32 kHz ultra-wideband) is 1280 bytes;
         // the check keeps the local buffer in step with the largest Speex frame
         static_assert(640 * sizeof(short) <= sizeof(audioBuffer), "Voice frame exceeds the local audio buffer");
-        unsigned int   uiTotalBufferSize = m_uiBufferSizeBytes * FRAME_OUTGOING_BUFFER_COUNT;
+        unsigned int uiTotalBufferSize = m_uiBufferSizeBytes * FRAME_OUTGOING_BUFFER_COUNT;
 
         m_bIsSendingVoiceData = false;
         unsigned int uiBytesAvailable = 0;

--- a/Client/mods/deathmatch/CVoiceRecorder.cpp
+++ b/Client/mods/deathmatch/CVoiceRecorder.cpp
@@ -131,7 +131,7 @@ void CVoiceRecorder::Init(bool bEnabled, unsigned int uiServerSampleRate, unsign
     if (m_pSpeexEncoderState)
     {
         speex_encoder_ctl(m_pSpeexEncoderState, SPEEX_GET_FRAME_SIZE, &m_iSpeexOutgoingFrameSampleCount);
-        int iQuality = m_ucQuality;
+        int iQuality = static_cast<int>(m_ucQuality);
         speex_encoder_ctl(m_pSpeexEncoderState, SPEEX_SET_QUALITY, &iQuality);
         iBitRate = (int)uiBitrate;
         if (iBitRate)

--- a/Client/mods/deathmatch/CVoiceRecorder.cpp
+++ b/Client/mods/deathmatch/CVoiceRecorder.cpp
@@ -20,11 +20,12 @@ CVoiceRecorder::CVoiceRecorder()
     m_SampleRate = SAMPLERATE_WIDEBAND;
     m_ucQuality = 0;
 
-    m_pAudioStream = NULL;
+    m_pAudioStream = nullptr;
 
-    m_pSpeexEncoderState = NULL;
+    m_pSpeexEncoderState = nullptr;
+    m_pSpeexPreprocState = nullptr;
 
-    m_pOutgoingBuffer = NULL;
+    m_pOutgoingBuffer = nullptr;
     m_iSpeexOutgoingFrameSampleCount = 0;
     m_uiOutgoingReadIndex = 0;
     m_uiOutgoingWriteIndex = 0;
@@ -56,6 +57,11 @@ int CVoiceRecorder::PACallback(const void* inputBuffer, void* outputBuffer, unsi
 
 void CVoiceRecorder::Init(bool bEnabled, unsigned int uiServerSampleRate, unsigned char ucQuality, unsigned int uiBitrate)
 {
+    // A re-init shouldnt leak the previous session's stream, encoder, preprocessor
+    // and buffer, and disabling must still clean up the old stream
+    if (m_bEnabled)
+        DeInit();
+
     m_bEnabled = bEnabled;
 
     if (!bEnabled)  // If we aren't enabled, don't bother continuing
@@ -89,19 +95,26 @@ void CVoiceRecorder::Init(bool bEnabled, unsigned int uiServerSampleRate, unsign
     inputDevice.channelCount = 1;
     inputDevice.device = Pa_GetDefaultInputDevice();
     inputDevice.sampleFormat = paInt16;
-    inputDevice.hostApiSpecificStreamInfo = NULL;
+    inputDevice.hostApiSpecificStreamInfo = nullptr;
     inputDevice.suggestedLatency = 0;
 
     Pa_OpenStream(&m_pAudioStream, &inputDevice, NULL, m_SampleRate, iFramesPerBuffer, paNoFlag, PACallback, this);
 
-    Pa_StartStream(m_pAudioStream);
+    if (m_pAudioStream)
+        Pa_StartStream(m_pAudioStream);
 
-    // Initialize our outgoing buffer
-    speex_encoder_ctl(m_pSpeexEncoderState, SPEEX_GET_FRAME_SIZE, &m_iSpeexOutgoingFrameSampleCount);
-    speex_encoder_ctl(m_pSpeexEncoderState, SPEEX_SET_QUALITY, &m_ucQuality);
-    int iBitRate = (int)uiBitrate;
-    if (iBitRate)
-        speex_encoder_ctl(m_pSpeexEncoderState, SPEEX_SET_BITRATE, &iBitRate);
+    // Initialize our outgoing buffer. A failed encoder creation would leave these
+    // calls on a null handle, so the whole config chain is skipped when the
+    // encoder is missing; DoPulse drops frames the same way
+    int iBitRate = 0;
+    if (m_pSpeexEncoderState)
+    {
+        speex_encoder_ctl(m_pSpeexEncoderState, SPEEX_GET_FRAME_SIZE, &m_iSpeexOutgoingFrameSampleCount);
+        speex_encoder_ctl(m_pSpeexEncoderState, SPEEX_SET_QUALITY, &m_ucQuality);
+        iBitRate = (int)uiBitrate;
+        if (iBitRate)
+            speex_encoder_ctl(m_pSpeexEncoderState, SPEEX_SET_BITRATE, &iBitRate);
+    }
 
     m_pOutgoingBuffer = (unsigned char*)malloc(m_uiBufferSizeBytes * FRAME_OUTGOING_BUFFER_COUNT);
     m_uiOutgoingReadIndex = 0;
@@ -109,20 +122,28 @@ void CVoiceRecorder::Init(bool bEnabled, unsigned int uiServerSampleRate, unsign
     m_bOutgoingBufferFull = false;
 
     // Initialise the speex preprocessor
-    int iSamplingRate;
-    speex_encoder_ctl(m_pSpeexEncoderState, SPEEX_GET_SAMPLING_RATE, &iSamplingRate);
-    m_pSpeexPreprocState = speex_preprocess_state_init(m_iSpeexOutgoingFrameSampleCount, iSamplingRate);
+    int iSamplingRate = 0;
+    if (m_pSpeexEncoderState)
+    {
+        speex_encoder_ctl(m_pSpeexEncoderState, SPEEX_GET_SAMPLING_RATE, &iSamplingRate);
+        m_pSpeexPreprocState = speex_preprocess_state_init(m_iSpeexOutgoingFrameSampleCount, iSamplingRate);
+    }
 
-    // Set our preprocessor parameters
+    // Set our preprocessor parameters, but only when the preprocessor exists
     int iEnable = 1;
     int iDisable = 0;
-    speex_preprocess_ctl(m_pSpeexPreprocState, SPEEX_PREPROCESS_SET_AGC, &iEnable);
-    speex_preprocess_ctl(m_pSpeexPreprocState, SPEEX_PREPROCESS_SET_DENOISE, &iEnable);
-    speex_preprocess_ctl(m_pSpeexPreprocState, SPEEX_PREPROCESS_SET_DEREVERB, &iEnable);
-    speex_preprocess_ctl(m_pSpeexPreprocState, SPEEX_PREPROCESS_SET_VAD, &iDisable);
-    speex_encoder_ctl(m_pSpeexEncoderState, SPEEX_SET_DTX, &iEnable);
-
-    speex_encoder_ctl(m_pSpeexEncoderState, SPEEX_GET_BITRATE, &iBitRate);
+    if (m_pSpeexPreprocState)
+    {
+        speex_preprocess_ctl(m_pSpeexPreprocState, SPEEX_PREPROCESS_SET_AGC, &iEnable);
+        speex_preprocess_ctl(m_pSpeexPreprocState, SPEEX_PREPROCESS_SET_DENOISE, &iEnable);
+        speex_preprocess_ctl(m_pSpeexPreprocState, SPEEX_PREPROCESS_SET_DEREVERB, &iEnable);
+        speex_preprocess_ctl(m_pSpeexPreprocState, SPEEX_PREPROCESS_SET_VAD, &iDisable);
+    }
+    if (m_pSpeexEncoderState)
+    {
+        speex_encoder_ctl(m_pSpeexEncoderState, SPEEX_SET_DTX, &iEnable);
+        speex_encoder_ctl(m_pSpeexEncoderState, SPEEX_GET_BITRATE, &iBitRate);
+    }
 
     g_pCore->GetConsole()->Printf("Server Voice Chat Quality [%i];  Sample Rate: [%iHz]; Bitrate [%ibps]", m_ucQuality, iSamplingRate, iBitRate);
 }
@@ -132,30 +153,35 @@ void CVoiceRecorder::DeInit()
     if (!m_bEnabled)
         return;
 
-    std::lock_guard<std::mutex> lock(m_Mutex);
-
+    // The audio callback can be mid-frame here; it must be able to finish
+    // before the stream closes, so take the mutex only after the stream teardown
     m_bEnabled = false;
 
-    Pa_CloseStream(m_pAudioStream);
+    if (m_pAudioStream)
+        Pa_CloseStream(m_pAudioStream);
     Pa_Terminate();
 
-    m_pAudioStream = NULL;
+    m_pAudioStream = nullptr;
+
+    std::lock_guard<std::mutex> lock(m_Mutex);
 
     m_iSpeexOutgoingFrameSampleCount = 0;
 
-    speex_encoder_destroy(m_pSpeexEncoderState);
-    m_pSpeexEncoderState = NULL;
+    if (m_pSpeexEncoderState)
+        speex_encoder_destroy(m_pSpeexEncoderState);
+    m_pSpeexEncoderState = nullptr;
 
-    speex_preprocess_state_destroy(m_pSpeexPreprocState);
-    m_pSpeexPreprocState = NULL;
+    if (m_pSpeexPreprocState)
+        speex_preprocess_state_destroy(m_pSpeexPreprocState);
+    m_pSpeexPreprocState = nullptr;
 
     free(m_pOutgoingBuffer);
-    m_pOutgoingBuffer = NULL;
+    m_pOutgoingBuffer = nullptr;
 
     m_VoiceState = VOICESTATE_AWAITING_INPUT;
     m_SampleRate = SAMPLERATE_WIDEBAND;
 
-    m_pAudioStream = NULL;
+    m_pAudioStream = nullptr;
 
     m_iSpeexOutgoingFrameSampleCount = 0;
     m_uiOutgoingReadIndex = 0;
@@ -254,11 +280,19 @@ void CVoiceRecorder::DoPulse()
 {
     std::lock_guard<std::mutex> lock(m_Mutex);
 
+    // A missing buffer still needs the flush below to run, so it can reset the
+    // last-packet state and send the voice end packet
+    if (!m_pOutgoingBuffer && m_VoiceState != VOICESTATE_RECORDING_LAST_PACKET)
+        return;
+
     // Only send every 100 ms, or flush the last packet right away on release
     if ((CClientTime::GetTime() - m_ulTimeOfLastSend > 100 || m_VoiceState == VOICESTATE_RECORDING_LAST_PACKET) && m_VoiceState != VOICESTATE_AWAITING_INPUT)
     {
         unsigned char* pInputBuffer;
         unsigned char  audioBuffer[2048]{};
+        // One frame at the highest Speex rate (32 kHz ultra-wideband) is 1280 bytes;
+        // the check keeps the local buffer in step with the largest Speex frame
+        static_assert(640 * sizeof(short) <= sizeof(audioBuffer), "Voice frame exceeds the local audio buffer");
         unsigned int   uiTotalBufferSize = m_uiBufferSizeBytes * FRAME_OUTGOING_BUFFER_COUNT;
 
         m_bIsSendingVoiceData = false;
@@ -273,7 +307,9 @@ void CVoiceRecorder::DoPulse()
 
         unsigned int uiSpeexBlockSize = m_iSpeexOutgoingFrameSampleCount * VOICE_SAMPLE_SIZE;
 
-        unsigned int uiSpeexFramesAvailable = uiBytesAvailable / uiSpeexBlockSize;
+        // A missing encoder leaves the frame size at zero; skip the division so
+        // the pulse degrades instead of dividing by zero
+        unsigned int uiSpeexFramesAvailable = uiSpeexBlockSize ? uiBytesAvailable / uiSpeexBlockSize : 0;
 
         if (uiSpeexFramesAvailable > 0)
         {
@@ -296,7 +332,16 @@ void CVoiceRecorder::DoPulse()
                     pInputBuffer = m_pOutgoingBuffer + m_uiOutgoingReadIndex;
 
                 // Run through our preprocessor (noise/echo cancelation)
-                speex_preprocess_run(m_pSpeexPreprocState, (spx_int16_t*)pInputBuffer);
+                if (m_pSpeexPreprocState)
+                    speex_preprocess_run(m_pSpeexPreprocState, (spx_int16_t*)pInputBuffer);
+
+                // A missing encoder leaves voice without a codec; drop the frame
+                // the same way an encode error is handled
+                if (!m_pSpeexEncoderState)
+                {
+                    m_uiOutgoingReadIndex = (m_uiOutgoingReadIndex + uiSpeexBlockSize) % uiTotalBufferSize;
+                    continue;
+                }
 
                 // Encode our audio stream with speex
                 speex_encode_int(m_pSpeexEncoderState, (spx_int16_t*)pInputBuffer, &speexBits);
@@ -319,8 +364,8 @@ void CVoiceRecorder::DoPulse()
 
                         g_pNet->SendPacket(PACKET_ID_VOICE_DATA, pBitStream, PACKET_PRIORITY_LOW, PACKET_RELIABILITY_UNRELIABLE_SEQUENCED,
                                            PACKET_ORDERING_VOICE);
-                        g_pNet->DeallocateNetBitStream(pBitStream);
                     }
+                    g_pNet->DeallocateNetBitStream(pBitStream);
                 }
             }
             speex_bits_destroy(&speexBits);
@@ -356,7 +401,7 @@ void CVoiceRecorder::SendFrame(const void* inputBuffer)
 {
     std::lock_guard<std::mutex> lock(m_Mutex);
 
-    if (m_VoiceState == VOICESTATE_AWAITING_INPUT || !m_bEnabled || !inputBuffer)
+    if (m_VoiceState == VOICESTATE_AWAITING_INPUT || !m_bEnabled || !inputBuffer || !m_pOutgoingBuffer)
         return;
 
     unsigned int remainingBufferSize = 0;

--- a/Client/mods/deathmatch/CVoiceRecorder.h
+++ b/Client/mods/deathmatch/CVoiceRecorder.h
@@ -73,7 +73,7 @@ private:
                           PaStreamCallbackFlags statusFlags, void* userData);
 
     std::atomic<bool> m_bEnabled;
-    eVoiceState      m_VoiceState;
+    eVoiceState       m_VoiceState;
 
     PaStream* m_pAudioStream;
 

--- a/Client/mods/deathmatch/CVoiceRecorder.h
+++ b/Client/mods/deathmatch/CVoiceRecorder.h
@@ -84,7 +84,6 @@ private:
     int            m_iSpeexOutgoingFrameSampleCount;
     unsigned int   m_uiOutgoingReadIndex;
     unsigned int   m_uiOutgoingWriteIndex;
-    bool           m_bIsSendingVoiceData;
     bool           m_bOutgoingBufferFull;
 
     unsigned long m_ulTimeOfLastSend;

--- a/Client/mods/deathmatch/CVoiceRecorder.h
+++ b/Client/mods/deathmatch/CVoiceRecorder.h
@@ -19,6 +19,7 @@
 #define FRAME_INCOMING_BUFFER_COUNT 100
 
 #include <mutex>
+#include <atomic>
 #include <speex/speex.h>
 #include <speex/speex_preprocess.h>
 #include <portaudio/portaudio.h>
@@ -71,8 +72,8 @@ private:
     static int PACallback(const void* inputBuffer, void* outputBuffer, unsigned long frameCount, const PaStreamCallbackTimeInfo* timeInfo,
                           PaStreamCallbackFlags statusFlags, void* userData);
 
-    bool        m_bEnabled;
-    eVoiceState m_VoiceState;
+    std::atomic<bool> m_bEnabled;
+    eVoiceState      m_VoiceState;
 
     PaStream* m_pAudioStream;
 

--- a/Client/mods/deathmatch/logic/CClientPlayerVoice.cpp
+++ b/Client/mods/deathmatch/logic/CClientPlayerVoice.cpp
@@ -73,9 +73,8 @@ void CALLBACK BASS_VoiceStateChange(HSYNC handle, DWORD channel, DWORD data, voi
 
 void CClientPlayerVoice::Init()
 {
-    // Grab our sample rate and quality
+    // Grab our sample rate
     m_SampleRate = m_pVoiceRecorder->GetSampleRate();
-    unsigned char ucQuality = m_pVoiceRecorder->GetSampleQuality();
 
     // Setup our BASS playback device
     m_pBassPlaybackStream = BASS_StreamCreate(m_SampleRate / VOICE_SAMPLE_SIZE, 2, BASS_STREAM_AUTOFREE, STREAMPROC_PUSH, NULL);
@@ -103,7 +102,7 @@ void CClientPlayerVoice::Init()
     {
         // Initialize our speex decoder
         speex_decoder_ctl(m_pSpeexDecoderState, SPEEX_GET_FRAME_SIZE, &m_iSpeexIncomingFrameSampleCount);
-        int iQuality = ucQuality;
+        int iQuality = static_cast<int>(m_pVoiceRecorder->GetSampleQuality());
         speex_decoder_ctl(m_pSpeexDecoderState, SPEEX_SET_QUALITY, &iQuality);
     }
 }

--- a/Client/mods/deathmatch/logic/CClientPlayerVoice.cpp
+++ b/Client/mods/deathmatch/logic/CClientPlayerVoice.cpp
@@ -79,7 +79,7 @@ void CClientPlayerVoice::Init()
 
     // Setup our BASS playback device
     m_pBassPlaybackStream = BASS_StreamCreate(m_SampleRate / VOICE_SAMPLE_SIZE, 2, BASS_STREAM_AUTOFREE, STREAMPROC_PUSH, NULL);
-    BASS_ChannelSetSync(m_pBassPlaybackStream, BASS_SYNC_STALL, 0, &BASS_VoiceStateChange, this);
+    m_hStallSync = BASS_ChannelSetSync(m_pBassPlaybackStream, BASS_SYNC_STALL, 0, &BASS_VoiceStateChange, this);
 
     // Cap the queue BASS keeps for push streams at one second of audio, so a
     // paused or flooded stream cannot grow memory without bound; frames past
@@ -97,20 +97,30 @@ void CClientPlayerVoice::Init()
     const SpeexMode* speexMode = m_pVoiceRecorder->getSpeexModeFromSampleRate();
     m_pSpeexDecoderState = speex_decoder_init(speexMode);
 
-    // Initialize our speex decoder
-    speex_decoder_ctl(m_pSpeexDecoderState, SPEEX_GET_FRAME_SIZE, &m_iSpeexIncomingFrameSampleCount);
-    speex_decoder_ctl(m_pSpeexDecoderState, SPEEX_SET_QUALITY, &ucQuality);
+    // A failed decoder creation leaves a null handle, so skip the config chain;
+    // the frame paths drop undecodable frames the same way
+    if (m_pSpeexDecoderState)
+    {
+        // Initialize our speex decoder
+        speex_decoder_ctl(m_pSpeexDecoderState, SPEEX_GET_FRAME_SIZE, &m_iSpeexIncomingFrameSampleCount);
+        int iQuality = ucQuality;
+        speex_decoder_ctl(m_pSpeexDecoderState, SPEEX_SET_QUALITY, &iQuality);
+    }
 }
 
 void CClientPlayerVoice::DeInit()
 {
     if (m_pBassPlaybackStream)
     {
+        // Remove the stall callback before freeing the stream so BASS cannot
+        // call back into this object after the stream is gone
+        BASS_ChannelRemoveSync(m_pBassPlaybackStream, m_hStallSync);
         BASS_ChannelStop(m_pBassPlaybackStream);
         BASS_StreamFree(m_pBassPlaybackStream);
     }
 
     m_pBassPlaybackStream = NULL;
+    m_hStallSync = 0;
 
     if (m_pSpeexDecoderState)
         speex_decoder_destroy(m_pSpeexDecoderState);
@@ -264,6 +274,9 @@ CClientPlayerVoice::EVoiceFrameResult CClientPlayerVoice::ProcessFrame(const uns
     // start event or active state is published; that state would otherwise stay
     // stuck active until destruction, with no BASS stall signal to end it
     if (!m_pBassPlaybackStream)
+        return EVoiceFrameResult::Suppressed;
+
+    if (!m_pSpeexDecoderState)
         return EVoiceFrameResult::Suppressed;
 
     char      pTempBuffer[2048];

--- a/Client/mods/deathmatch/logic/CClientPlayerVoice.h
+++ b/Client/mods/deathmatch/logic/CClientPlayerVoice.h
@@ -107,6 +107,7 @@ private:
     CVoiceRecorder* m_pVoiceRecorder;
     unsigned int    m_SampleRate;
     HSTREAM         m_pBassPlaybackStream;
+    HSYNC           m_hStallSync;
     void*           m_pSpeexDecoderState;
     int             m_iSpeexIncomingFrameSampleCount;
     float           m_fVolume;


### PR DESCRIPTION
Main benefits:
- Server voice reconfiguration and disable/enable cycles no longer leak streams, codec state, or buffers.
- Voice can no longer crash the client when Speex allocation fails or no microphone is present.
- Disabling voice no longer stalls the game loop.
- The enabled flag no longer races between the audio and game threads.
- Frames that fail to encode or decode, and any missing codec state, are dropped safely instead of corrupting the pipeline or stalling the queue.
- The BASS stall callback is unregistered before the playback stream is freed, so it can no longer fire into a destroyed player voice object.