### PR TITLE
Fix ped targeting marker being interiorless

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA_Peds.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Peds.cpp
@@ -205,6 +205,23 @@ static void __declspec(naked) HOOK_CAEPedAudioEntity_UpdateJetPack()
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
+// RenderEffects
+//
+// GitHub Issue #5255
+// Prevents the ped targeting marker from being rendered when they are in different interiors
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+static void __fastcall CanRenderPedTargetingMarker(CPlayerPedSAInterface* playerPed)
+{
+    if (!playerPed || !playerPed->mouseTargetEntity)
+        return;
+
+    if (playerPed->m_areaCode == playerPed->mouseTargetEntity->m_areaCode)
+        ((void(__thiscall*)(CPlayerPedSAInterface*))0x60BA80)(playerPed);  // Call CPlayerPed::DrawTriangleForMouseRecruitPed
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
 // CMultiplayerSA::InitHooks_Peds
 //
 // Setup hooks
@@ -216,4 +233,6 @@ void CMultiplayerSA::InitHooks_Peds()
 
     HookInstall(HOOKPOS_CTaskSimpleJetPack_RenderJetPack, (DWORD)HOOK_CTaskSimpleJetPack_RenderJetPack, 12);
     HookInstall(HOOKPOS_CAEPedAudioEntity_UpdateJetPack, (DWORD)HOOK_CAEPedAudioEntity_UpdateJetPack, 6);
+
+    HookInstallCall(0x53E20E, reinterpret_cast<DWORD>(CanRenderPedTargetingMarker));
 }

--- a/Client/multiplayer_sa/StdInc.h
+++ b/Client/multiplayer_sa/StdInc.h
@@ -24,5 +24,6 @@
 #include "..\game_sa\CEntitySA.h"
 #include "..\game_sa\CPedSA.h"
 #include "..\game_sa\CProjectileSA.h"
+#include "../game_sa/CPlayerPedSA.h"
 
 extern CMultiplayerSA* pMultiplayer;


### PR DESCRIPTION
#### Summary
The targeting marker is not rendered if the ped is in a different interior.

#### Motivation
Fixes #5255

#### Test plan
```lua
srun p = createPed(0, me.position)
srun p.interior = 1
```


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
