### PR TITLE
Fix getVehicleName returning empty string for requested models

### DIFF
--- a/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaVehicleDefs.cpp
@@ -1290,7 +1290,13 @@ int CLuaVehicleDefs::GetVehicleName(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
-        const char* szVehicleName = CVehicleNames::GetVehicleName(pVehicle->GetModel());
+        unsigned short model = pVehicle->GetModel();
+        CModelInfo*    modelInfo = g_pGame->GetModelInfo(model);
+
+        if (modelInfo && modelInfo->GetParentID() != 0)
+            model = modelInfo->GetParentID();
+
+        const char* szVehicleName = CVehicleNames::GetVehicleName(model);
         if (szVehicleName)
         {
             lua_pushstring(luaVM, szVehicleName);


### PR DESCRIPTION
The title is pretty self explanatory.

#### Test plan
- Call **getVehicleName** on a vehicle with a requested model

Before **(Tested with an Infernus)**:
```
Executing client-side command: getVehicleName(getPedOccupiedVehicle(me)), getElementModel(getPedOccupiedVehicle(me))
Command results:  [string], 332 [number]
```

After:
```
Executing client-side command: getVehicleName(getPedOccupiedVehicle(me)), getElementModel(getPedOccupiedVehicle(me))
Command results: Infernus [string], 332 [number]
```