### PR TITLE
FIX- Add integrity guard against inline hooks on the Lua script loader

### DIFF
--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -40,6 +40,7 @@
 #include <windowsx.h>
 #include "CServerInfo.h"
 #include "CClientPed.h"
+#include "lua/CLuaHookGuard.h"
 
 SString StringZeroPadout(const SString& strInput, uint uiPadoutSize)
 {
@@ -83,6 +84,10 @@ CClientGame::CClientGame(bool bLocalPlay) : m_ServerInfo(new CServerInfo())
 {
     // Init the global var with ourself
     g_pClientGame = this;
+
+    // Snapshot the Lua loader code so inline hooks can be detected before
+    // any script data reaches the loader
+    CLuaHookGuard::Initialize();
 
     CStaticFunctionDefinitions::PreInitialize(g_pCore, g_pGame, this, &m_Events);
 

--- a/Client/mods/deathmatch/logic/lua/CLuaHookGuard.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaHookGuard.cpp
@@ -1,0 +1,159 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        mods/deathmatch/logic/lua/CLuaHookGuard.cpp
+ *  PURPOSE:     Integrity guard against inline hooks on the Lua script loader
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+#include "CLuaHookGuard.h"
+#include "CLuaMain.h"
+
+extern CClientGame* g_pClientGame;
+
+#define LUA_HOOKGUARD_REPORT_ID 1006
+
+CLuaHookGuard::SGuardedFunction CLuaHookGuard::ms_GuardedFunctions[] = {
+    {"CLuaMain::LuaLoadBuffer", reinterpret_cast<void*>(&CLuaMain::LuaLoadBuffer), {}, false},
+};
+std::atomic<bool> CLuaHookGuard::ms_bInitialized{false};
+std::atomic<bool> CLuaHookGuard::ms_bTamperReported{false};
+
+///////////////////////////////////////////////////////////////
+//
+// CLuaHookGuard::IsPrologueHooked
+//
+// Heuristic for hook engine prologues (relative/near jump or
+// push+ret). A legitimate incremental link thunk also starts
+// with a jmp, but it targets a location inside our own module,
+// while foreign hooks transfer control to memory allocated
+// outside of our image. Anything jumping outside is hostile.
+//
+///////////////////////////////////////////////////////////////
+bool CLuaHookGuard::IsPrologueHooked(const SGuardedFunction& func)
+{
+    const unsigned char* pBytes = reinterpret_cast<const unsigned char*>(func.pCode);
+    const size_t         uiSize = sizeof(func.aReference);
+
+    // Resolve the module range that contains the guarded function
+    HMODULE hModule = NULL;
+    if (!GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, reinterpret_cast<LPCSTR>(func.pCode),
+                            &hModule))
+        return true;  // Cannot verify, assume the worst
+
+    const IMAGE_DOS_HEADER* pDosHeader = reinterpret_cast<const IMAGE_DOS_HEADER*>(hModule);
+    if (pDosHeader->e_magic != IMAGE_DOS_SIGNATURE)
+        return true;
+
+    const IMAGE_NT_HEADERS* pNtHeader = reinterpret_cast<const IMAGE_NT_HEADERS*>(reinterpret_cast<const BYTE*>(hModule) + pDosHeader->e_lfanew);
+    const uintptr_t         uiImageStart = reinterpret_cast<const uintptr_t>(hModule);
+    const uintptr_t         uiImageEnd = uiImageStart + pNtHeader->OptionalHeader.SizeOfImage;
+
+    auto IsInsideOwnModule = [&](const void* pTarget)
+    {
+        const uintptr_t uiTarget = reinterpret_cast<uintptr_t>(pTarget);
+        return uiTarget >= uiImageStart && uiTarget < uiImageEnd;
+    };
+
+    if (uiSize >= 5 && pBytes[0] == 0xE9)
+    {
+        // jmp rel32
+        const void* pTarget = pBytes + 5 + *reinterpret_cast<const int32_t*>(pBytes + 1);
+        return !IsInsideOwnModule(pTarget);
+    }
+
+    if (uiSize >= 6 && pBytes[0] == 0x68 && pBytes[5] == 0xC3)
+    {
+        // push imm32; ret
+        const void* pTarget = *reinterpret_cast<void* const*>(pBytes + 1);
+        return !IsInsideOwnModule(pTarget);
+    }
+
+    if (uiSize >= 6 && pBytes[0] == 0xFF && pBytes[1] == 0x25)
+    {
+        // jmp [disp32]; hook engines emit it with zero displacement so the
+        // absolute target address is stored right after the instruction
+        const void* pTarget = *reinterpret_cast<void* const*>(pBytes + 6);
+        return !IsInsideOwnModule(pTarget);
+    }
+
+    if (uiSize >= 2 && pBytes[0] == 0xEB)
+    {
+        // jmp rel8 into unowned territory is suspicious even for short jumps
+        const void* pTarget = pBytes + 2 + static_cast<signed char>(pBytes[1]);
+        return !IsInsideOwnModule(pTarget);
+    }
+
+    return false;
+}
+
+///////////////////////////////////////////////////////////////
+//
+// CLuaHookGuard::Initialize
+//
+// Snapshot the prologue bytes of every guarded function.
+//
+///////////////////////////////////////////////////////////////
+void CLuaHookGuard::Initialize()
+{
+    for (SGuardedFunction& func : ms_GuardedFunctions)
+    {
+        if (!func.pCode)
+            continue;
+
+        memcpy(func.aReference, func.pCode, sizeof(func.aReference));
+        func.bValid = !IsPrologueHooked(func);
+
+        if (!func.bValid)
+            AddReportLog(3400 + LUA_HOOKGUARD_REPORT_ID, SString("Hook guard detected patched prologue of %s during startup", func.szName), 10);
+    }
+    ms_bInitialized = true;
+}
+
+///////////////////////////////////////////////////////////////
+//
+// CLuaHookGuard::IsIntact
+//
+///////////////////////////////////////////////////////////////
+bool CLuaHookGuard::IsIntact()
+{
+    if (!ms_bInitialized.load(std::memory_order_acquire))
+        return true;
+
+    for (const SGuardedFunction& func : ms_GuardedFunctions)
+    {
+        if (!func.pCode || !func.bValid)
+            continue;
+
+        if (memcmp(func.aReference, func.pCode, sizeof(func.aReference)) != 0)
+            return false;
+    }
+    return true;
+}
+
+///////////////////////////////////////////////////////////////
+//
+// CLuaHookGuard::VerifyAndReport
+//
+// Returns false when script data must not be handed to the
+// loader. Reports tampering exactly once per session so the
+// server can act on it without being spammed.
+//
+///////////////////////////////////////////////////////////////
+bool CLuaHookGuard::VerifyAndReport(uint uiReportId, const SString& strContext)
+{
+    if (IsIntact())
+        return true;
+
+    if (!ms_bTamperReported.exchange(true))
+    {
+        SString strMessage("CLIENT TAMPERING: Lua loader integrity check failed (%s). Script loading is disabled.", *strContext);
+        if (g_pClientGame)
+            g_pClientGame->TellServerSomethingImportant(uiReportId, strMessage);
+        else
+            AddReportLog(3400 + uiReportId, strMessage, 10);
+    }
+    return false;
+}

--- a/Client/mods/deathmatch/logic/lua/CLuaHookGuard.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaHookGuard.h
@@ -1,0 +1,50 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        mods/deathmatch/logic/lua/CLuaHookGuard.h
+ *  PURPOSE:     Integrity guard against inline hooks on the Lua script loader
+ *
+ *  Third party modules may install inline hooks (MinHook, Detours, ...) on
+ *  CLuaMain::LuaLoadBuffer to intercept deobfuscated script buffers and dump
+ *  client side scripts. This guard takes a reference snapshot of the machine
+ *  code prologue of guarded functions at startup and refuses to pass any
+ *  script data to the loader while the code differs from the snapshot.
+ *
+ *****************************************************************************/
+
+#pragma once
+
+#include <atomic>
+
+class CLuaHookGuard
+{
+public:
+    // Capture reference bytes of all guarded functions.
+    // Call once during client mod startup, before any script is loaded.
+    static void Initialize();
+
+    // True when every guarded function still matches its startup snapshot.
+    static bool IsIntact();
+
+    // IsIntact() plus a one shot diagnostic report to the current server when
+    // tampering is detected. Returns false if script loading must be refused.
+    static bool VerifyAndReport(uint uiReportId, const SString& strContext);
+
+private:
+    struct SGuardedFunction
+    {
+        const char*   szName;
+        void*         pCode;
+        unsigned char aReference[16];
+        bool          bValid;
+    };
+
+    // Detects jump based prologue patches. The jump destination must stay
+    // inside our own module, otherwise it is treated as a foreign hook.
+    static bool IsPrologueHooked(const SGuardedFunction& func);
+
+    static SGuardedFunction  ms_GuardedFunctions[];
+    static std::atomic<bool> ms_bInitialized;
+    static std::atomic<bool> ms_bTamperReported;
+};

--- a/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -10,6 +10,7 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include "CLuaHookGuard.h"
 #define DECLARE_PROFILER_SECTION_CLuaMain
 #include "profiler/SharedUtil.Profiler.h"
 
@@ -213,6 +214,10 @@ void CLuaMain::InstructionCountHook(lua_State* luaVM, lua_Debug* pDebug)
 
 bool CLuaMain::LoadScriptFromBuffer(const char* cpInBuffer, unsigned int uiInSize, const char* szFileName)
 {
+    // Refuse to hand any script data to a potentially hooked Lua loader
+    if (!CLuaHookGuard::VerifyAndReport(1006, ConformResourcePath(szFileName)))
+        return false;
+
     SString strNiceFilename = ConformResourcePath(szFileName);
 
     // Deobfuscate if required

--- a/Client/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaResourceDefs.cpp
@@ -11,6 +11,7 @@
 
 #include "StdInc.h"
 #include <lua/CLuaFunctionParser.h>
+#include "lua/CLuaHookGuard.h"
 
 using std::list;
 
@@ -429,6 +430,13 @@ int CLuaResourceDefs::LoadString(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
+        // Refuse to hand script data to a potentially hooked loader
+        if (!CLuaHookGuard::VerifyAndReport(1006, m_pResourceManager->GetResourceName(luaVM) + "/loadstring"))
+            argStream.SetCustomError("loader integrity check failed");
+    }
+
+    if (!argStream.HasErrors())
+    {
         const char* szChunkname = strName.empty() ? *strInput : *strName;
         const char* cpInBuffer = strInput;
         uint        uiInSize = strInput.length();
@@ -477,6 +485,13 @@ int CLuaResourceDefs::Load(lua_State* luaVM)
     argStream.ReadFunction(iLuaFunction);
     argStream.ReadString(strName, "=(load)");
     argStream.ReadFunctionComplete();
+
+    if (!argStream.HasErrors())
+    {
+        // Refuse to hand script data to a potentially hooked loader
+        if (!CLuaHookGuard::VerifyAndReport(1006, m_pResourceManager->GetResourceName(luaVM) + "/load"))
+            argStream.SetCustomError("loader integrity check failed");
+    }
 
     if (!argStream.HasErrors())
     {


### PR DESCRIPTION
#### Summary
<!-- What change are you making? -->
<!-- When changing Lua APIs, consider including code samples and documentation. -->

Adds `CLuaHookGuard` (`Client/mods/deathmatch/logic/lua/CLuaHookGuard.{h,cpp}`), a small integrity guard that protects the client-side Lua script loader `CLuaMain::LuaLoadBuffer` against inline hooks used by cheating modules to dump deobfuscated client scripts (`.lua` / `.luac`) from memory.

How it works:

- Snapshots the machine-code prologue of guarded functions once when the client mod starts (`CClientGame` constructor).
- Detects jump-based prologue patches (`E9 rel32`, `FF 25`, `push imm32; ret`, `EB rel8`). A jump destination **outside** our own module image is treated as a foreign hook, while legitimate incremental-link thunks (which stay inside our image) do not cause false positives.
- Verifies the snapshot before any script data reaches the loader, covering every entry point that hands buffers to `CLuaMain::LuaLoadBuffer`: `CLuaMain::LoadScriptFromBuffer` (network-delivered resource scripts) and the Lua built-ins `loadstring` / `load`.
- On tamper detection the buffer is never passed to the hooked loader (nothing can be dumped), script loading stays disabled for the rest of the session, and diagnostic report id `1006` is sent to the current server via `CClientGame::TellServerSomethingImportant` (+ `AddReportLog`), so server owners can kick/ban the client on their side.

#### Motivation
<!-- Why are you making this change? Which GitHub issue does this resolve, if any? Any additional context? -->

Public cheat frameworks ship a "lua dumper" feature that signature-scans `client.dll` for `CLuaMain::LuaLoadBuffer` and installs a MinHook/Detours style inline hook on it. Since client scripts are necessarily deobfuscated immediately before this call (`g_pNet->DeobfuscateScript` runs first), such a hook observes every script in plaintext and writes whole resources to disk, defeating `luac` obfuscation entirely.

This raises the difficulty of that specific attack vector in the same spirit as #3719 hardened debug hooks: cheaters can no longer passively capture every loaded client script with a trivial prologue hook.

#### Test plan
<!-- How have you tested this change? This should give confidence to the reviewer that your change is safe. -->
<!-- If someone makes changes to this code in the future, what steps can they follow to check that it's still working correctly? -->

- Normal connect and resource loading must be unaffected (no false positives from incremental-link thunks or runtime relocations, since only out-of-image jumps are flagged at startup and later changes are compared against the startup snapshot).
- To verify detection: connect to any server, then patch the first byte of `CLuaMain::LuaLoadBuffer` in memory (e.g. write `0xE9 ...` with a debugger). The next script load must be refused with the tampering console message, and `PACKET_ID_PLAYER_DIAGNOSTIC` id `1006` ("CLIENT TAMPERING: Lua loader integrity check failed") must arrive server-side.
- The build itself is validated by CI.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
