### PR TITLE
Feat: Add camera vehicle view offset

### DIFF
--- a/Client/mods/deathmatch/logic/CClientCamera.cpp
+++ b/Client/mods/deathmatch/logic/CClientCamera.cpp
@@ -700,6 +700,28 @@ eVehicleCamMode CClientCamera::GetCameraVehicleViewMode()
     return (eVehicleCamMode)m_pCamera->GetCameraVehicleViewMode();
 }
 
+bool CClientCamera::SetVehicleViewOffset(eVehicleCamMode eMode, const CVector& vecOffset)
+{
+    if (!g_pMultiplayer)
+        return false;
+
+    return g_pMultiplayer->SetVehicleCameraViewOffset(static_cast<unsigned char>(eMode), vecOffset);
+}
+
+bool CClientCamera::GetVehicleViewOffset(eVehicleCamMode eMode, CVector& vecOffset)
+{
+    if (!g_pMultiplayer)
+        return false;
+
+    return g_pMultiplayer->GetVehicleCameraViewOffset(static_cast<unsigned char>(eMode), vecOffset);
+}
+
+void CClientCamera::ResetVehicleViewOffsets()
+{
+    if (g_pMultiplayer)
+        g_pMultiplayer->ResetVehicleCameraViewOffsets();
+}
+
 ePedCamMode CClientCamera::GetCameraPedViewMode()
 {
     if (!m_pCamera)

--- a/Client/mods/deathmatch/logic/CClientCamera.h
+++ b/Client/mods/deathmatch/logic/CClientCamera.h
@@ -80,9 +80,14 @@ public:
     void            SetCameraPedViewMode(ePedCamMode eMode);
     eVehicleCamMode GetCameraVehicleViewMode();
     ePedCamMode     GetCameraPedViewMode();
-    void            SetCameraClip(bool bObjects, bool bVehicles);
-    void            ResetCameraClip();
-    void            GetCameraClip(bool& bObjects, bool& bVehicles);
+
+    bool SetVehicleViewOffset(eVehicleCamMode eMode, const CVector& vecOffset);
+    bool GetVehicleViewOffset(eVehicleCamMode eMode, CVector& vecOffset);
+    void ResetVehicleViewOffsets();
+
+    void SetCameraClip(bool bObjects, bool bVehicles);
+    void ResetCameraClip();
+    void GetCameraClip(bool& bObjects, bool& bVehicles);
 
     bool IsInFixedMode() { return m_bFixed; }
     void ToggleCameraFixedMode(bool bEnabled);

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -3499,6 +3499,7 @@ void CClientGame::Event_OnIngame()
     g_pGame->GetWaterManager()->Reset();  // Deletes all custom water elements, ResetMapInfo only reverts changes to water level
     g_pGame->GetWaterManager()->SetWaterDrawnLast(true);
     m_pCamera->ResetCameraClip();
+    m_pCamera->ResetVehicleViewOffsets();
 
     // Deallocate all custom models
     m_pManager->GetModelManager()->RemoveAll();

--- a/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
@@ -436,7 +436,7 @@ bool CLuaCameraDefs::SetCameraViewMode(std::optional<unsigned char> ucVehicleVie
 
 // Offsets for the vehicle follow camera, see CMultiplayer::SetVehicleCameraViewOffset
 static constexpr unsigned char VEHICLE_VIEW_MODE_COUNT = 6;  // see eVehicleCamMode
-static constexpr float MAX_VEHICLE_VIEW_OFFSET = 20.0f;
+static constexpr float         MAX_VEHICLE_VIEW_OFFSET = 20.0f;
 
 bool CLuaCameraDefs::SetCameraVehicleViewOffset(unsigned char ucViewMode, std::optional<float> fOffsetX, std::optional<float> fOffsetY,
                                                 std::optional<float> fOffsetZ)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.cpp
@@ -30,6 +30,7 @@ void CLuaCameraDefs::LoadFunctions()
         {"getCameraGoggleEffect", ArgumentParserWarn<false, GetCameraGoggleEffect>},
         {"getCameraFieldOfView", GetCameraFieldOfView},
         {"getCameraDrunkLevel", ArgumentParserWarn<false, GetCameraDrunkLevel>},
+        {"getCameraVehicleViewOffset", ArgumentParser<GetCameraVehicleViewOffset>},
 
         // Cam set funcs
         {"setCameraMatrix", SetCameraMatrix},
@@ -40,6 +41,8 @@ void CLuaCameraDefs::LoadFunctions()
         {"setCameraClip", SetCameraClip},
         {"getCameraClip", GetCameraClip},
         {"setCameraViewMode", ArgumentParserWarn<false, SetCameraViewMode>},
+        {"setCameraVehicleViewOffset", ArgumentParser<SetCameraVehicleViewOffset>},
+        {"resetCameraVehicleViewOffset", ArgumentParser<ResetCameraVehicleViewOffset>},
         {"setCameraGoggleEffect", SetCameraGoggleEffect},
         {"setCameraDrunkLevel", ArgumentParserWarn<false, SetCameraDrunkLevel>},
 
@@ -65,6 +68,7 @@ void CLuaCameraDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "getTarget", "getCameraTarget");
     lua_classfunction(luaVM, "getInterior", "getCameraInterior");
     lua_classfunction(luaVM, "getViewMode", "getCameraViewMode");
+    lua_classfunction(luaVM, "getVehicleViewOffset", "getCameraVehicleViewOffset");
     lua_classfunction(luaVM, "getMatrix", ArgumentParserWarn<false, OOP_GetCameraMatrix>);
     lua_classfunction(luaVM, "getFieldOfView", "getCameraFieldOfView");
     lua_classfunction(luaVM, "getGoggleEffect", "getCameraGoggleEffect");
@@ -80,6 +84,8 @@ void CLuaCameraDefs::AddClass(lua_State* luaVM)
     lua_classfunction(luaVM, "setInterior", "setCameraInterior");
     lua_classfunction(luaVM, "setTarget", "setCameraTarget");
     lua_classfunction(luaVM, "setViewMode", "setCameraViewMode");
+    lua_classfunction(luaVM, "setVehicleViewOffset", "setCameraVehicleViewOffset");
+    lua_classfunction(luaVM, "resetVehicleViewOffset", "resetCameraVehicleViewOffset");
     lua_classfunction(luaVM, "setGoggleEffect", "setCameraGoggleEffect");
     lua_classfunction(luaVM, "setClip", "setCameraClip");
     lua_classfunction(luaVM, "setFarClipDistance", "setFarClipDistance");
@@ -426,6 +432,60 @@ bool CLuaCameraDefs::SetCameraViewMode(std::optional<unsigned char> ucVehicleVie
         pCamera->SetCameraPedViewMode((ePedCamMode)ucPedViewMode.value());
 
     return true;
+}
+
+// Offsets for the vehicle follow camera, see CMultiplayer::SetVehicleCameraViewOffset
+static constexpr unsigned char VEHICLE_VIEW_MODE_COUNT = 6;  // see eVehicleCamMode
+static constexpr float MAX_VEHICLE_VIEW_OFFSET = 20.0f;
+
+bool CLuaCameraDefs::SetCameraVehicleViewOffset(unsigned char ucViewMode, std::optional<float> fOffsetX, std::optional<float> fOffsetY,
+                                                std::optional<float> fOffsetZ)
+{
+    if (ucViewMode >= VEHICLE_VIEW_MODE_COUNT)
+        throw std::invalid_argument("Invalid vehicle camera view mode (0-5)");
+
+    CClientCamera*        pCamera = m_pManager->GetCamera();
+    const eVehicleCamMode eMode = static_cast<eVehicleCamMode>(ucViewMode);
+
+    CVector vecOffset;
+    if (!pCamera->GetVehicleViewOffset(eMode, vecOffset))
+        return false;
+
+    if (fOffsetX)
+        vecOffset.fX = Clamp(-MAX_VEHICLE_VIEW_OFFSET, fOffsetX.value(), MAX_VEHICLE_VIEW_OFFSET);
+    if (fOffsetY)
+        vecOffset.fY = Clamp(-MAX_VEHICLE_VIEW_OFFSET, fOffsetY.value(), MAX_VEHICLE_VIEW_OFFSET);
+    if (fOffsetZ)
+        vecOffset.fZ = Clamp(-MAX_VEHICLE_VIEW_OFFSET, fOffsetZ.value(), MAX_VEHICLE_VIEW_OFFSET);
+
+    return pCamera->SetVehicleViewOffset(eMode, vecOffset);
+}
+
+CLuaMultiReturn<float, float, float> CLuaCameraDefs::GetCameraVehicleViewOffset(unsigned char ucViewMode)
+{
+    if (ucViewMode >= VEHICLE_VIEW_MODE_COUNT)
+        throw std::invalid_argument("Invalid vehicle camera view mode (0-5)");
+
+    CVector vecOffset;
+    m_pManager->GetCamera()->GetVehicleViewOffset(static_cast<eVehicleCamMode>(ucViewMode), vecOffset);
+
+    return {vecOffset.fX, vecOffset.fY, vecOffset.fZ};
+}
+
+bool CLuaCameraDefs::ResetCameraVehicleViewOffset(std::optional<unsigned char> ucViewMode)
+{
+    CClientCamera* pCamera = m_pManager->GetCamera();
+
+    if (!ucViewMode)
+    {
+        pCamera->ResetVehicleViewOffsets();
+        return true;
+    }
+
+    if (ucViewMode.value() >= VEHICLE_VIEW_MODE_COUNT)
+        throw std::invalid_argument("Invalid vehicle camera view mode (0-5)");
+
+    return pCamera->SetVehicleViewOffset(static_cast<eVehicleCamMode>(ucViewMode.value()), CVector());
 }
 
 int CLuaCameraDefs::SetCameraGoggleEffect(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaCameraDefs.h
@@ -22,6 +22,11 @@ public:
     static bool SetCameraViewMode(std::optional<unsigned char> usVehicleViewMode, std::optional<unsigned char> usPedViewMode);
     static CLuaMultiReturn<unsigned char, unsigned char> GetCameraViewMode();
 
+    static bool SetCameraVehicleViewOffset(unsigned char ucViewMode, std::optional<float> fOffsetX, std::optional<float> fOffsetY,
+                                           std::optional<float> fOffsetZ);
+    static CLuaMultiReturn<float, float, float> GetCameraVehicleViewOffset(unsigned char ucViewMode);
+    static bool                                 ResetCameraVehicleViewOffset(std::optional<unsigned char> ucViewMode);
+
     // Cam get funcs
     static std::variant<CClientCamera*, bool>                                      GetCamera();
     static CLuaMultiReturn<float, float, float, float, float, float, float, float> GetCameraMatrix();

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -4880,6 +4880,55 @@ CMatrix gravcam_matInvertGravity;
 CMatrix gravcam_matVehicleTransform;
 CVector gravcam_vecVehicleVelocity;
 
+// VAR_VehicleCameraView (0xB6F0DC) comes from game_sa/CCameraSA.h via StdInc.h
+#define VEHICLE_CAM_VIEW_MODE_COUNT 6  // see eVehicleCamMode
+
+static CVector gravcam_vehicleCamViewOffsets[VEHICLE_CAM_VIEW_MODE_COUNT];
+static bool    gravcam_bVehicleCamViewOffsetActive = false;
+
+static void UpdateVehicleCamViewOffsetActive()
+{
+    for (const CVector& vecOffset : gravcam_vehicleCamViewOffsets)
+    {
+        if (vecOffset.LengthSquared() > 0.0f)
+        {
+            gravcam_bVehicleCamViewOffsetActive = true;
+            return;
+        }
+    }
+
+    gravcam_bVehicleCamViewOffsetActive = false;
+}
+
+static const CVector* GetActiveVehicleCamViewOffset()
+{
+    if (!gravcam_bVehicleCamViewOffsetActive)
+        return nullptr;
+
+    const unsigned char ucViewMode = *(unsigned char*)VAR_VehicleCameraView;
+    if (ucViewMode >= VEHICLE_CAM_VIEW_MODE_COUNT)
+        return nullptr;
+
+    return &gravcam_vehicleCamViewOffsets[ucViewMode];
+}
+
+// Translates the camera space offset into world space using the camera's current orbit
+// angle, so that "right" and "towards the vehicle" follow the camera instead of the
+// world axes. Beta is only updated later in CCam::Process_FollowCar_SA, so this basis
+// is one frame behind - not noticeable for an offset of a few units, and it matches the
+// value the surrounding SA code uses at this point.
+static CVector GetVehicleCamViewOffsetInWorldSpace(DWORD dwCam, const CVector& vecOffset)
+{
+    const float fPhi = *(float*)(dwCam + 0xBC);
+
+    // Direction from the vehicle towards the camera, flattened onto the gravity plane
+    const CVector vecBack = gravcam_matGravity.vRight * cos(fPhi) + gravcam_matGravity.vFront * sin(fPhi);
+    // Right hand side of the camera
+    const CVector vecRight = gravcam_matGravity.vFront * cos(fPhi) - gravcam_matGravity.vRight * sin(fPhi);
+
+    return vecRight * vecOffset.fX - vecBack * vecOffset.fY + gravcam_matGravity.vUp * vecOffset.fZ;
+}
+
 bool _cdecl VehicleCamStart(DWORD dwCam, DWORD pVehicleInterface)
 {
     // Inverse transform some things so that they match a downward pointing gravity.
@@ -4935,10 +4984,14 @@ fail:
 
 // ---------------------------------------------------
 
-void _cdecl VehicleCamTargetZTweak(CVector* pvecCamTarget, float fTargetZTweak)
+void _cdecl VehicleCamTargetZTweak(CVector* pvecCamTarget, float fTargetZTweak, DWORD dwCam)
 {
     // Replacement for "vecCamTarget = vecCarPosition + (0, 0, 1)*fZTweak"
     *pvecCamTarget += gravcam_matGravity.vUp * fTargetZTweak;
+
+    const CVector* pViewOffset = GetActiveVehicleCamViewOffset();
+    if (pViewOffset)
+        *pvecCamTarget += GetVehicleCamViewOffsetInWorldSpace(dwCam, *pViewOffset);
 }
 
 static void __declspec(naked) HOOK_VehicleCamTargetZTweak()
@@ -4951,10 +5004,11 @@ static void __declspec(naked) HOOK_VehicleCamTargetZTweak()
         fstp st
 
         lea eax, [esp+0x48]
-        push [esp+0x30]
-        push eax
+        push esi                  // pCam
+        push [esp+0x34]           // fTargetZTweak
+        push eax                  // pvecCamTarget
         call VehicleCamTargetZTweak
-        add esp, 8
+        add esp, 0xC
 
         fld [esp+0x30]
         fadd [esp+0x7C]
@@ -5162,6 +5216,35 @@ static void __declspec(naked) HOOK_VehicleCamEnd()
         jmp RETURN_VehicleCamEnd
     }
     // clang-format on
+}
+
+// ---------------------------------------------------
+
+bool CMultiplayerSA::SetVehicleCameraViewOffset(unsigned char ucViewMode, const CVector& vecOffset)
+{
+    if (ucViewMode >= VEHICLE_CAM_VIEW_MODE_COUNT)
+        return false;
+
+    gravcam_vehicleCamViewOffsets[ucViewMode] = vecOffset;
+    UpdateVehicleCamViewOffsetActive();
+    return true;
+}
+
+bool CMultiplayerSA::GetVehicleCameraViewOffset(unsigned char ucViewMode, CVector& vecOffset)
+{
+    if (ucViewMode >= VEHICLE_CAM_VIEW_MODE_COUNT)
+        return false;
+
+    vecOffset = gravcam_vehicleCamViewOffsets[ucViewMode];
+    return true;
+}
+
+void CMultiplayerSA::ResetVehicleCameraViewOffsets()
+{
+    for (CVector& vecOffset : gravcam_vehicleCamViewOffsets)
+        vecOffset = CVector();
+
+    gravcam_bVehicleCamViewOffsetActive = false;
 }
 
 // ---------------------------------------------------

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -306,6 +306,10 @@ public:
     bool IsCustomCameraRotationEnabled();
     void SetCustomCameraRotationEnabled(bool bEnabled);
 
+    bool SetVehicleCameraViewOffset(unsigned char ucViewMode, const CVector& vecOffset) override;
+    bool GetVehicleCameraViewOffset(unsigned char ucViewMode, CVector& vecOffset) override;
+    void ResetVehicleCameraViewOffsets() override;
+
     void SetDebugVars(float f1, float f2, float f3);
 
     CVector& GetAkimboTarget() { return m_vecAkimboTarget; };

--- a/Client/sdk/multiplayer/CMultiplayer.h
+++ b/Client/sdk/multiplayer/CMultiplayer.h
@@ -418,6 +418,10 @@ public:
     virtual bool IsCustomCameraRotationEnabled() = 0;
     virtual void SetCustomCameraRotationEnabled(bool bEnabled) = 0;
 
+    virtual bool SetVehicleCameraViewOffset(unsigned char ucViewMode, const CVector& vecOffset) = 0;
+    virtual bool GetVehicleCameraViewOffset(unsigned char ucViewMode, CVector& vecOffset) = 0;
+    virtual void ResetVehicleCameraViewOffsets() = 0;
+
     virtual void SetDebugVars(float f1, float f2, float f3) = 0;
 
     virtual CVector& GetAkimboTarget() = 0;


### PR DESCRIPTION
#### Summary
Adds three new clientside functions that let you offset the vehicle follow camera.
Each of the six view modes in eVehicleCamMode keeps its own offset once set.
```lua
bool setCameraVehicleViewOffset ( int viewMode [, float x, float y, float z] )
float, float, float getCameraVehicleViewOffset ( int viewMode )
bool resetCameraVehicleViewOffset ( [ int viewMode ] )
```
- viewMode is 0-5 (eVehicleCamMode: BUMPER, CLOSE_EXTERNAL, MIDDLE_EXTERNAL, FAR_EXTERNAL, LOW_EXTERNAL, CINEMATIC).
- Only the external chase views `1-4` can currently be offset.
- Both `BUMPER` and `CINEMATIC` are processed by different `CCam` functions and never reach `CCam::Process_FollowCar_SA` where the offset is applied thus currently resulting in no-ops -> Returning `false` for them instead would also be an option.
- The offset is in camera space -> x = right/left, y = towards/away from the vehicle, z = up/down, in game units, clamped to +-20.
- `resetCameraVehicleViewOffset()` without an argument clears every view mode.
- OOP: `Camera.setVehicleViewOffset`, `Camera.getVehicleViewOffset`, `Camera.resetVehicleViewOffset`.

#### Motivation
Currently trying to change the camera for the vehicle is only really possible by completely rebuilding it using `setCameraMatrix` on every frame. That loses SAs own camera behaviour and is a complex task by itself recreating said camera in Lua. To add to that trying to raise the camera for specific models on the z-axis is only possible by manipulating the model in certain ways (which may affect vehicle physics) but that way it can simply be handled via a simple single function call.


#### Test plan
1. Default behaviour remains unchanged -> Cycle through the different view modes
2. start runcode
3. crun `setCameraVehicleViewOffset(2, 0, 0, 2)` on any view mode with any settings (max +-20) -> Cycle through again
4. crun `getCameraVehicleViewOffset(2)` -> returns three floats: i.e. `0, 0, 2`
5. crun `resetCameraVehicleViewOffset(2)` -> Cycle through once again


#### Checklist

* [X] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [X] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
