### PR TITLE
Add a prewater render stage for 3D lines and 3D primitives

### DIFF
--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -2007,6 +2007,19 @@ void CCore::OnDeviceRestore()
     m_uiNextRenderTargetRetryTime = 0;
 }
 
+void CCore::OnPreWaterRender()
+{
+    if (!CGraphics::GetSingleton().HasLine3DPreWaterQueueItems() && !CGraphics::GetSingleton().HasPrimitive3DPreWaterQueueItems())
+        return;
+
+    CGraphics::GetSingleton().EnteringMTARenderZone();
+
+    CGraphics::GetSingleton().DrawLine3DPreWaterQueue();
+    CGraphics::GetSingleton().DrawPrimitive3DPreWaterQueue();
+
+    CGraphics::GetSingleton().LeavingMTARenderZone();
+}
+
 //
 // OnPreFxRender
 //

--- a/Client/core/CCore.h
+++ b/Client/core/CCore.h
@@ -246,6 +246,7 @@ public:
     bool                                WasLaunchedWithConnectURI();
     void                                HandleCrashDumpEncryption();
 
+    void                 OnPreWaterRender();
     void                 OnPreFxRender();
     void                 OnPreHUDRender();
     void                 OnDeviceRestore();

--- a/Client/core/Graphics/CGraphics.cpp
+++ b/Client/core/Graphics/CGraphics.cpp
@@ -93,15 +93,19 @@ CGraphics::CGraphics(CLocalGUI* pGUI)
     auto line3DPreGUI = std::make_unique<CLine3DBatcher>(true);
     auto line3DPostFX = std::make_unique<CLine3DBatcher>(true);
     auto line3DPostGUI = std::make_unique<CLine3DBatcher>(false);
+    auto line3DPreWater = std::make_unique<CLine3DBatcher>(true);
     auto materialLinePreGUI = std::make_unique<CMaterialLine3DBatcher>(true);
     auto materialLinePostFX = std::make_unique<CMaterialLine3DBatcher>(true);
     auto materialLinePostGUI = std::make_unique<CMaterialLine3DBatcher>(false);
+    auto materialLinePreWater = std::make_unique<CMaterialLine3DBatcher>(true);
     auto primitive3DPreGUI = std::make_unique<CPrimitive3DBatcher>(true);
     auto primitive3DPostFX = std::make_unique<CPrimitive3DBatcher>(true);
     auto primitive3DPostGUI = std::make_unique<CPrimitive3DBatcher>(false);
+    auto primitive3DPreWater = std::make_unique<CPrimitive3DBatcher>(true);
     auto materialPrimitivePreGUI = std::make_unique<CMaterialPrimitive3DBatcher>(true, this);
     auto materialPrimitivePostFX = std::make_unique<CMaterialPrimitive3DBatcher>(true, this);
     auto materialPrimitivePostGUI = std::make_unique<CMaterialPrimitive3DBatcher>(false, this);
+    auto materialPrimitivePreWater = std::make_unique<CMaterialPrimitive3DBatcher>(true, this);
     auto primitiveBatcher = std::make_unique<CPrimitiveBatcher>();
     auto primitiveMaterialBatcher = std::make_unique<CPrimitiveMaterialBatcher>(this);
     auto screenGrabber = std::unique_ptr<CScreenGrabberInterface>(NewScreenGrabber());
@@ -113,15 +117,19 @@ CGraphics::CGraphics(CLocalGUI* pGUI)
     m_pLine3DBatcherPreGUI = line3DPreGUI.release();
     m_pLine3DBatcherPostFX = line3DPostFX.release();
     m_pLine3DBatcherPostGUI = line3DPostGUI.release();
+    m_pLine3DBatcherPreWater = line3DPreWater.release();
     m_pMaterialLine3DBatcherPreGUI = materialLinePreGUI.release();
     m_pMaterialLine3DBatcherPostFX = materialLinePostFX.release();
     m_pMaterialLine3DBatcherPostGUI = materialLinePostGUI.release();
+    m_pMaterialLine3DBatcherPreWater = materialLinePreWater.release();
     m_pPrimitive3DBatcherPreGUI = primitive3DPreGUI.release();
     m_pPrimitive3DBatcherPostFX = primitive3DPostFX.release();
     m_pPrimitive3DBatcherPostGUI = primitive3DPostGUI.release();
+    m_pPrimitive3DBatcherPreWater = primitive3DPreWater.release();
     m_pMaterialPrimitive3DBatcherPreGUI = materialPrimitivePreGUI.release();
     m_pMaterialPrimitive3DBatcherPostFX = materialPrimitivePostFX.release();
     m_pMaterialPrimitive3DBatcherPostGUI = materialPrimitivePostGUI.release();
+    m_pMaterialPrimitive3DBatcherPreWater = materialPrimitivePreWater.release();
     m_pPrimitiveBatcher = primitiveBatcher.release();
     m_pPrimitiveMaterialBatcher = primitiveMaterialBatcher.release();
     m_pScreenGrabber = screenGrabber.release();
@@ -172,17 +180,21 @@ CGraphics::~CGraphics()
     SAFE_DELETE(m_pLine3DBatcherPreGUI);
     SAFE_DELETE(m_pLine3DBatcherPostFX);
     SAFE_DELETE(m_pLine3DBatcherPostGUI);
+    SAFE_DELETE(m_pLine3DBatcherPreWater);
     SAFE_DELETE(m_pMaterialLine3DBatcherPreGUI);
     SAFE_DELETE(m_pMaterialLine3DBatcherPostFX);
     SAFE_DELETE(m_pMaterialLine3DBatcherPostGUI);
+    SAFE_DELETE(m_pMaterialLine3DBatcherPreWater);
     SAFE_DELETE(m_pPrimitiveBatcher);
     SAFE_DELETE(m_pPrimitiveMaterialBatcher);
     SAFE_DELETE(m_pPrimitive3DBatcherPreGUI);
     SAFE_DELETE(m_pPrimitive3DBatcherPostFX);
     SAFE_DELETE(m_pPrimitive3DBatcherPostGUI);
+    SAFE_DELETE(m_pPrimitive3DBatcherPreWater);
     SAFE_DELETE(m_pMaterialPrimitive3DBatcherPreGUI);
     SAFE_DELETE(m_pMaterialPrimitive3DBatcherPostFX);
     SAFE_DELETE(m_pMaterialPrimitive3DBatcherPostGUI);
+    SAFE_DELETE(m_pMaterialPrimitive3DBatcherPreWater);
     SAFE_DELETE(m_pScreenGrabber);
     SAFE_DELETE(m_pPixelsManager);
     SAFE_DELETE(m_pAspectRatioConverter);
@@ -942,6 +954,8 @@ void CGraphics::DrawLine3DQueued(const CVector& vecBegin, const CVector& vecEnd,
         m_pLine3DBatcherPostGUI->AddLine3D(vecBegin, vecEnd, fWidth, ulColor);
     else if (stage == eRenderStage::PRE_FX)
         m_pLine3DBatcherPreGUI->AddLine3D(vecBegin, vecEnd, fWidth, ulColor);
+    else if (stage == eRenderStage::PRE_WATER)
+        m_pLine3DBatcherPreWater->AddLine3D(vecBegin, vecEnd, fWidth, ulColor);
     else
         m_pLine3DBatcherPostFX->AddLine3D(vecBegin, vecEnd, fWidth, ulColor);
 }
@@ -966,6 +980,9 @@ void CGraphics::DrawMaterialLine3DQueued(const CVector& vecBegin, const CVector&
     else if (stage == eRenderStage::PRE_FX)
         m_pMaterialLine3DBatcherPreGUI->AddLine3D(vecBegin, vecEnd, fWidth, ulColor, pMaterial, fU, fV, fSizeU, fSizeV, bRelativeUV, bFlipUV, bUseFaceToward,
                                                   vecFaceToward);
+    else if (stage == eRenderStage::PRE_WATER)
+        m_pMaterialLine3DBatcherPreWater->AddLine3D(vecBegin, vecEnd, fWidth, ulColor, pMaterial, fU, fV, fSizeU, fSizeV, bRelativeUV, bFlipUV, bUseFaceToward,
+                                                    vecFaceToward);
     else
         m_pMaterialLine3DBatcherPostFX->AddLine3D(vecBegin, vecEnd, fWidth, ulColor, pMaterial, fU, fV, fSizeU, fSizeV, bRelativeUV, bFlipUV, bUseFaceToward,
                                                   vecFaceToward);
@@ -1059,6 +1076,8 @@ void CGraphics::DrawPrimitive3DQueued(std::vector<PrimitiveVertice>* pVecVertice
         m_pPrimitive3DBatcherPostGUI->AddPrimitive(eType, pVecVertices);
     else if (stage == eRenderStage::PRE_FX)
         m_pPrimitive3DBatcherPreGUI->AddPrimitive(eType, pVecVertices);
+    else if (stage == eRenderStage::PRE_WATER)
+        m_pPrimitive3DBatcherPreWater->AddPrimitive(eType, pVecVertices);
     else
         m_pPrimitive3DBatcherPostFX->AddPrimitive(eType, pVecVertices);
 }
@@ -1084,6 +1103,8 @@ void CGraphics::DrawMaterialPrimitive3DQueued(std::vector<PrimitiveMaterialVerti
         m_pMaterialPrimitive3DBatcherPostGUI->AddPrimitive(eType, pMaterial, pVecVertices);
     else if (stage == eRenderStage::PRE_FX)
         m_pMaterialPrimitive3DBatcherPreGUI->AddPrimitive(eType, pMaterial, pVecVertices);
+    else if (stage == eRenderStage::PRE_WATER)
+        m_pMaterialPrimitive3DBatcherPreWater->AddPrimitive(eType, pMaterial, pVecVertices);
     else
         m_pMaterialPrimitive3DBatcherPostFX->AddPrimitive(eType, pMaterial, pVecVertices);
 }
@@ -1680,17 +1701,21 @@ void CGraphics::OnDeviceCreate(IDirect3DDevice9* pDevice)
     m_pLine3DBatcherPreGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pLine3DBatcherPostFX->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pLine3DBatcherPostGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
+    m_pLine3DBatcherPreWater->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pMaterialLine3DBatcherPreGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pMaterialLine3DBatcherPostFX->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pMaterialLine3DBatcherPostGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
+    m_pMaterialLine3DBatcherPreWater->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pPrimitiveBatcher->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pPrimitiveMaterialBatcher->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pPrimitive3DBatcherPreGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pPrimitive3DBatcherPostFX->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pPrimitive3DBatcherPostGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
+    m_pPrimitive3DBatcherPreWater->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pMaterialPrimitive3DBatcherPreGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pMaterialPrimitive3DBatcherPostFX->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pMaterialPrimitive3DBatcherPostGUI->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
+    m_pMaterialPrimitive3DBatcherPreWater->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pRenderItemManager->OnDeviceCreate(pDevice, GetViewportWidth(), GetViewportHeight());
     m_pScreenGrabber->OnDeviceCreate(pDevice);
     m_pPixelsManager->OnDeviceCreate(pDevice);
@@ -1805,10 +1830,22 @@ void CGraphics::DrawLine3DPostFXQueue(void)
     m_pMaterialLine3DBatcherPostFX->Flush();
 }
 
+void CGraphics::DrawLine3DPreWaterQueue()
+{
+    m_pLine3DBatcherPreWater->Flush();
+    m_pMaterialLine3DBatcherPreWater->Flush();
+}
+
 void CGraphics::DrawPrimitive3DPreGUIQueue(void)
 {
     m_pPrimitive3DBatcherPreGUI->Flush();
     m_pMaterialPrimitive3DBatcherPreGUI->Flush();
+}
+
+void CGraphics::DrawPrimitive3DPreWaterQueue()
+{
+    m_pPrimitive3DBatcherPreWater->Flush();
+    m_pMaterialPrimitive3DBatcherPreWater->Flush();
 }
 
 bool CGraphics::HasLine3DPreGUIQueueItems(void)
@@ -1819,6 +1856,11 @@ bool CGraphics::HasLine3DPreGUIQueueItems(void)
 bool CGraphics::HasLine3DPostFXQueueItems()
 {
     return m_pLine3DBatcherPostFX->HasItems() || m_pMaterialLine3DBatcherPostFX->HasItems();
+}
+
+bool CGraphics::HasLine3DPreWaterQueueItems()
+{
+    return m_pLine3DBatcherPreWater->HasItems() || m_pMaterialLine3DBatcherPreWater->HasItems();
 }
 
 void CGraphics::DrawPrimitive3DPostFXQueue(void)
@@ -1835,6 +1877,11 @@ bool CGraphics::HasPrimitive3DPreGUIQueueItems(void)
 bool CGraphics::HasPrimitive3DPostFXQueueItems()
 {
     return m_pMaterialPrimitive3DBatcherPostFX->HasItems() || m_pPrimitive3DBatcherPostFX->HasItems();
+}
+
+bool CGraphics::HasPrimitive3DPreWaterQueueItems()
+{
+    return m_pMaterialPrimitive3DBatcherPreWater->HasItems() || m_pPrimitive3DBatcherPreWater->HasItems();
 }
 
 void CGraphics::DrawQueue(std::vector<sDrawQueueItem>& Queue)

--- a/Client/core/Graphics/CGraphics.h
+++ b/Client/core/Graphics/CGraphics.h
@@ -195,12 +195,16 @@ public:
     void DrawPostGUIQueue(void);
     void DrawLine3DPreGUIQueue(void);
     void DrawLine3DPostFXQueue(void);
+    void DrawLine3DPreWaterQueue();
     bool HasLine3DPreGUIQueueItems(void);
     bool HasLine3DPostFXQueueItems();
+    bool HasLine3DPreWaterQueueItems();
     void DrawPrimitive3DPostFXQueue(void);
     void DrawPrimitive3DPreGUIQueue(void);
+    void DrawPrimitive3DPreWaterQueue();
     bool HasPrimitive3DPreGUIQueueItems(void);
     bool HasPrimitive3DPostFXQueueItems();
+    bool HasPrimitive3DPreWaterQueueItems();
 
     void DidRenderScene();
     void SetProgressMessage(const SString& strMessage);
@@ -243,17 +247,21 @@ private:
     CLine3DBatcher*              m_pLine3DBatcherPreGUI = nullptr;
     CLine3DBatcher*              m_pLine3DBatcherPostFX = nullptr;
     CLine3DBatcher*              m_pLine3DBatcherPostGUI = nullptr;
+    CLine3DBatcher*              m_pLine3DBatcherPreWater = nullptr;
     CMaterialLine3DBatcher*      m_pMaterialLine3DBatcherPreGUI = nullptr;
     CMaterialLine3DBatcher*      m_pMaterialLine3DBatcherPostFX = nullptr;
     CMaterialLine3DBatcher*      m_pMaterialLine3DBatcherPostGUI = nullptr;
+    CMaterialLine3DBatcher*      m_pMaterialLine3DBatcherPreWater = nullptr;
     CPrimitiveBatcher*           m_pPrimitiveBatcher = nullptr;
     CPrimitiveMaterialBatcher*   m_pPrimitiveMaterialBatcher = nullptr;
     CPrimitive3DBatcher*         m_pPrimitive3DBatcherPreGUI = nullptr;
     CPrimitive3DBatcher*         m_pPrimitive3DBatcherPostFX = nullptr;
     CPrimitive3DBatcher*         m_pPrimitive3DBatcherPostGUI = nullptr;
+    CPrimitive3DBatcher*         m_pPrimitive3DBatcherPreWater = nullptr;
     CMaterialPrimitive3DBatcher* m_pMaterialPrimitive3DBatcherPreGUI = nullptr;
     CMaterialPrimitive3DBatcher* m_pMaterialPrimitive3DBatcherPostFX = nullptr;
     CMaterialPrimitive3DBatcher* m_pMaterialPrimitive3DBatcherPostGUI = nullptr;
+    CMaterialPrimitive3DBatcher* m_pMaterialPrimitive3DBatcherPreWater = nullptr;
     CAspectRatioConverter*       m_pAspectRatioConverter = nullptr;
     bool                         m_bSkipMTARenderThisFrame = false;
     D3DVIEWPORT9                 m_prevViewportForMTA = {};

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -289,6 +289,7 @@ CClientGame::CClientGame(bool bLocalPlay) : m_ServerInfo(new CServerInfo())
     g_pMultiplayer->SetPreWorldProcessHandler(CClientGame::StaticPreWorldProcessHandler);
     g_pMultiplayer->SetPostWorldProcessHandler(CClientGame::StaticPostWorldProcessHandler);
     g_pMultiplayer->SetPostWorldProcessPedsAfterPreRenderHandler(CClientGame::StaticPostWorldProcessPedsAfterPreRenderHandler);
+    g_pMultiplayer->SetPreWaterRenderHandler(CClientGame::StaticPreWaterRenderHandler);
     g_pMultiplayer->SetPreFxRenderHandler(CClientGame::StaticPreFxRenderHandler);
     g_pMultiplayer->SetPostColorFilterRenderHandler(CClientGame::StaticPostColorFilterRenderHandler);
     g_pMultiplayer->SetPreHudRenderHandler(CClientGame::StaticPreHudRenderHandler);
@@ -3660,6 +3661,12 @@ void CClientGame::StaticPostWorldProcessHandler()
 void CClientGame::StaticPostWorldProcessPedsAfterPreRenderHandler()
 {
     g_pClientGame->PostWorldProcessPedsAfterPreRenderHandler();
+}
+
+void CClientGame::StaticPreWaterRenderHandler()
+{
+    // Draw underwater 3D lines and primitives before calling CWaterLevel::RenderWater
+    g_pCore->OnPreWaterRender();
 }
 
 void CClientGame::StaticPreFxRenderHandler()

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -581,6 +581,7 @@ private:
     static void                              StaticPreWorldProcessHandler();
     static void                              StaticPostWorldProcessHandler();
     static void                              StaticPostWorldProcessPedsAfterPreRenderHandler();
+    static void                              StaticPreWaterRenderHandler();
     static void                              StaticPreFxRenderHandler();
     static void                              StaticPostColorFilterRenderHandler();
     static void                              StaticPreHudRenderHandler();

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
@@ -860,6 +860,7 @@ IMPLEMENT_ENUM_CLASS_BEGIN(eRenderStage)
 ADD_ENUM(eRenderStage::PRE_FX, "prefx")
 ADD_ENUM(eRenderStage::POST_FX, "postfx")
 ADD_ENUM(eRenderStage::POST_GUI, "postgui")
+ADD_ENUM(eRenderStage::PRE_WATER, "prewater")
 IMPLEMENT_ENUM_CLASS_END("render-stage")
 
 IMPLEMENT_ENUM_BEGIN(ePools)

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -408,6 +408,7 @@ PreWeatherUpdateHandler*                   m_pPreWeatherUpdateHandler = NULL;
 PreWorldProcessHandler*                    m_pPreWorldProcessHandler = NULL;
 PostWorldProcessHandler*                   m_pPostWorldProcessHandler = NULL;
 PostWorldProcessPedsAfterPreRenderHandler* m_postWorldProcessPedsAfterPreRenderHandler = nullptr;
+PreWaterRenderHandler*                     m_preWaterRenderHandler = nullptr;
 IdleHandler*                               m_pIdleHandler = NULL;
 PreFxRenderHandler*                        m_pPreFxRenderHandler = NULL;
 PostColorFilterRenderHandler*              m_pPostColorFilterRenderHandler = nullptr;
@@ -562,6 +563,8 @@ void HOOK_CAEVehicleAudioEntity__ProcessDummyHeli();
 void HOOK_CAEVehicleAudioEntity__ProcessDummyProp();
 
 void HOOK_Idle_CWorld_ProcessPedsAfterPreRender();
+
+void HOOK_RenderScene_PreWaterRender();
 
 void HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StartRadio();
 void HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StopRadio();
@@ -760,6 +763,9 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_CAEVEhicleAudioEntity__ProcessDummyProp, (DWORD)HOOK_CAEVehicleAudioEntity__ProcessDummyProp, 5);
 
     HookInstall(HOOKPOS_Idle_CWorld_ProcessPedsAfterPreRender, (DWORD)HOOK_Idle_CWorld_ProcessPedsAfterPreRender, 5);
+
+    HookInstallCall(0x53E004, reinterpret_cast<DWORD>(HOOK_RenderScene_PreWaterRender));
+    HookInstallCall(0x53E142, reinterpret_cast<DWORD>(HOOK_RenderScene_PreWaterRender));
 
     HookInstall(HOOKPOS_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StartRadio,
                 (DWORD)HOOK_CAEAmbienceTrackManager__UpdateAmbienceTrackAndVolume_StartRadio, 5);
@@ -2670,6 +2676,11 @@ void CMultiplayerSA::SetPostWorldProcessHandler(PostWorldProcessHandler* pHandle
 void CMultiplayerSA::SetPostWorldProcessPedsAfterPreRenderHandler(PostWorldProcessPedsAfterPreRenderHandler* pHandler)
 {
     m_postWorldProcessPedsAfterPreRenderHandler = pHandler;
+}
+
+void CMultiplayerSA::SetPreWaterRenderHandler(PreWaterRenderHandler* pHandler)
+{
+    m_preWaterRenderHandler = pHandler;
 }
 
 void CMultiplayerSA::SetIdleHandler(IdleHandler* pHandler)
@@ -8015,6 +8026,15 @@ static void __declspec(naked) HOOK_Idle_CWorld_ProcessPedsAfterPreRender()
        jmp RETURN_Idle_CWorld_ProcessPedsAfterPreRender
     }
     // clang-format on
+}
+
+static void HOOK_RenderScene_PreWaterRender()
+{
+    if (m_preWaterRenderHandler)
+        m_preWaterRenderHandler();
+
+    // Call CWaterLevel::RenderWater
+    ((void(__cdecl*)())0x6EF650)();
 }
 
 DWORD dwLastRequestedStation = -1;

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -123,6 +123,7 @@ public:
     void SetPreWorldProcessHandler(PreWorldProcessHandler* pHandler);
     void SetPostWorldProcessHandler(PostWorldProcessHandler* pHandler);
     void SetPostWorldProcessPedsAfterPreRenderHandler(PostWorldProcessPedsAfterPreRenderHandler* pHandler);
+    void SetPreWaterRenderHandler(PreWaterRenderHandler* pHandler);
     void SetIdleHandler(IdleHandler* pHandler);
     void SetPreFxRenderHandler(PreFxRenderHandler* pHandler);
     void SetPostColorFilterRenderHandler(PostColorFilterRenderHandler* pHandler) override;

--- a/Client/sdk/core/CCoreInterface.h
+++ b/Client/sdk/core/CCoreInterface.h
@@ -146,6 +146,7 @@ public:
     virtual bool IsOptionalUpdateInfoRequired(const char* szHost) = 0;
     virtual void InitiateDataFilesFix() = 0;
 
+    virtual void                 OnPreWaterRender() = 0;
     virtual void                 OnPreFxRender() = 0;
     virtual void                 OnPreHUDRender() = 0;
     virtual uint                 GetMinStreamingMemory() = 0;

--- a/Client/sdk/core/CGraphicsInterface.h
+++ b/Client/sdk/core/CGraphicsInterface.h
@@ -94,7 +94,8 @@ enum class eRenderStage
 {
     PRE_FX,
     POST_FX,
-    POST_GUI
+    POST_GUI,
+    PRE_WATER,
 };
 
 class CGraphicsInterface

--- a/Client/sdk/multiplayer/CMultiplayer.h
+++ b/Client/sdk/multiplayer/CMultiplayer.h
@@ -102,6 +102,7 @@ typedef void(PreWorldProcessHandler)();
 typedef void(PostWorldProcessHandler)();
 typedef void(PostWorldProcessPedsAfterPreRenderHandler)();
 typedef void(IdleHandler)();
+typedef void(PreWaterRenderHandler)();
 typedef void(PreFxRenderHandler)();
 typedef void(PostColorFilterRenderHandler)();
 typedef void(PreHudRenderHandler)();
@@ -233,6 +234,7 @@ public:
     virtual void  SetPreWorldProcessHandler(PreWorldProcessHandler* pHandler) = 0;
     virtual void  SetPostWorldProcessHandler(PostWorldProcessHandler* pHandler) = 0;
     virtual void  SetPostWorldProcessPedsAfterPreRenderHandler(PostWorldProcessPedsAfterPreRenderHandler* pHandler) = 0;
+    virtual void  SetPreWaterRenderHandler(PreWaterRenderHandler* pHandler) = 0;
     virtual void  SetIdleHandler(IdleHandler* pHandler) = 0;
     virtual void  SetPreFxRenderHandler(PreFxRenderHandler* pHandler) = 0;
     virtual void  SetPostColorFilterRenderHandler(PostColorFilterRenderHandler* pHandler) = 0;


### PR DESCRIPTION
#### Summary
This PR adds a new `prewater` render stage to the 3D line and 3D primitive rendering functions, allowing them to be rendered underwater.

<img width="1544" height="676" alt="image" src="https://github.com/user-attachments/assets/b2514aac-ca09-4120-92ab-23aa3e294730" />

<img width="1372" height="775" alt="image" src="https://github.com/user-attachments/assets/7e5ebcfe-c43b-40dd-a729-421143ce30c1" />

#### Motivation
Closes #4671 

#### Test plan
```lua
addEventHandler("onClientPreRender", root, function()
	dxDrawLine3D(2604, -2698, -6, 2604, -2398, -6, 0xffffffff, 10, 'prewater')
end)
``