### PR TITLE
Add runtime-generated collision models from Lua

### DIFF
--- a/Client/mods/deathmatch/logic/CClientColModel.cpp
+++ b/Client/mods/deathmatch/logic/CClientColModel.cpp
@@ -51,6 +51,39 @@ bool CClientColModel::Load(bool isRaw, SString input)
     }
 }
 
+bool CClientColModel::LoadFromGeneratedData(SString buffer)
+{
+    if (m_pColModel)
+        return false;
+
+    m_pColModel = g_pGame->GetRenderWare()->ReadCOL(std::move(buffer));
+    return m_pColModel != nullptr;
+}
+
+bool CClientColModel::SetGeneratedData(SString buffer)
+{
+    if (!m_pColModel)
+        return false;
+
+    CColModel* newColModel = g_pGame->GetRenderWare()->ReadCOL(std::move(buffer));
+    if (!newColModel)
+        return false;
+
+    // Repoint every replaced GTA model before destroying the old collision so
+    // no model info can retain a dangling collision pointer.
+    for (unsigned short modelId : m_Replaced)
+    {
+        CModelInfo* modelInfo = g_pGame->GetModelInfo(modelId);
+        if (modelInfo)
+            modelInfo->SetColModel(newColModel);
+    }
+
+    CColModel* oldColModel = m_pColModel;
+    m_pColModel = newColModel;
+    oldColModel->Destroy();
+    return true;
+}
+
 bool CClientColModel::LoadFromFile(SString filePath)
 {
     SString buffer;

--- a/Client/mods/deathmatch/logic/CClientColModel.h
+++ b/Client/mods/deathmatch/logic/CClientColModel.h
@@ -25,6 +25,8 @@ public:
     eClientEntityType GetType() const { return CCLIENTCOL; }
 
     bool Load(bool isRaw, SString input);
+    bool LoadFromGeneratedData(SString buffer);
+    bool SetGeneratedData(SString buffer);
 
     bool IsLoaded() { return m_pColModel != NULL; };
 

--- a/Client/mods/deathmatch/logic/CRuntimeColModel.cpp
+++ b/Client/mods/deathmatch/logic/CRuntimeColModel.cpp
@@ -1,0 +1,409 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        mods/deathmatch/logic/CRuntimeColModel.cpp
+ *  PURPOSE:     Runtime collision model serialization
+ *
+ *  Multi Theft Auto is available from https://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#ifndef RUNTIME_COL_MODEL_STANDALONE
+    #include "StdInc.h"
+#endif
+#include "CRuntimeColModel.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <limits>
+
+namespace RuntimeCollision
+{
+    namespace
+    {
+#pragma pack(push, 1)
+        struct ColFileHeader
+        {
+            char          version[4];
+            std::uint32_t size;
+            char          name[24];
+        };
+
+        struct SurfaceRecord
+        {
+            std::uint8_t material;
+            std::uint8_t piece;
+            std::uint8_t brightness;
+            std::uint8_t lighting;
+        };
+
+        struct BoundsRecord
+        {
+            float radius;
+            float centerX;
+            float centerY;
+            float centerZ;
+            float minX;
+            float minY;
+            float minZ;
+            float maxX;
+            float maxY;
+            float maxZ;
+        };
+
+        struct SphereRecord
+        {
+            float         radius;
+            float         x;
+            float         y;
+            float         z;
+            SurfaceRecord surface;
+        };
+
+        struct BoxRecord
+        {
+            float         minX;
+            float         minY;
+            float         minZ;
+            float         maxX;
+            float         maxY;
+            float         maxZ;
+            SurfaceRecord surface;
+        };
+
+        struct VertexRecord
+        {
+            float x;
+            float y;
+            float z;
+        };
+
+        struct FaceRecord
+        {
+            std::uint32_t a;
+            std::uint32_t b;
+            std::uint32_t c;
+            SurfaceRecord surface;
+        };
+#pragma pack(pop)
+
+        static_assert(sizeof(ColFileHeader) == 0x20);
+        static_assert(sizeof(SurfaceRecord) == 0x4);
+        static_assert(sizeof(BoundsRecord) == 0x28);
+        static_assert(sizeof(SphereRecord) == 0x14);
+        static_assert(sizeof(BoxRecord) == 0x1C);
+        static_assert(sizeof(VertexRecord) == 0x0C);
+        static_assert(sizeof(FaceRecord) == 0x10);
+
+        constexpr std::size_t  kMaxNativeCount = std::numeric_limits<std::uint16_t>::max();
+        constexpr std::size_t  kMaxNativeVertices = kMaxNativeCount + 1;
+        constexpr std::uint8_t kMaxSurfaceMaterial = 178;
+        constexpr float        kMinCompressedVertex = -256.0f;
+        constexpr float        kMaxCompressedVertex = 32767.0f / 128.0f;
+
+        bool IsFinite(float value)
+        {
+            return std::isfinite(value);
+        }
+
+        bool IsFinite(const CVector& value)
+        {
+            return IsFinite(value.fX) && IsFinite(value.fY) && IsFinite(value.fZ);
+        }
+
+        bool ValidateMaterial(std::uint8_t material, std::string& outError)
+        {
+            if (material <= kMaxSurfaceMaterial)
+                return true;
+
+            outError = "material must be in range 0-178";
+            return false;
+        }
+
+        SurfaceRecord MakeSurface(std::uint8_t material)
+        {
+            return SurfaceRecord{material, 0, 0, 0xFF};
+        }
+
+        template <class T>
+        void Append(std::string& buffer, const T& value)
+        {
+            buffer.append(reinterpret_cast<const char*>(&value), sizeof(value));
+        }
+
+        void ExtendBounds(const CVector& point, CVector& minimum, CVector& maximum, bool& initialized)
+        {
+            if (!initialized)
+            {
+                minimum = point;
+                maximum = point;
+                initialized = true;
+                return;
+            }
+
+            minimum.fX = std::min(minimum.fX, point.fX);
+            minimum.fY = std::min(minimum.fY, point.fY);
+            minimum.fZ = std::min(minimum.fZ, point.fZ);
+            maximum.fX = std::max(maximum.fX, point.fX);
+            maximum.fY = std::max(maximum.fY, point.fY);
+            maximum.fZ = std::max(maximum.fZ, point.fZ);
+        }
+
+        bool IsCompressedVertexInRange(const CVector& vertex)
+        {
+            return vertex.fX >= kMinCompressedVertex && vertex.fX <= kMaxCompressedVertex && vertex.fY >= kMinCompressedVertex &&
+                   vertex.fY <= kMaxCompressedVertex && vertex.fZ >= kMinCompressedVertex && vertex.fZ <= kMaxCompressedVertex;
+        }
+    }  // namespace
+
+    bool BuildCOLBuffer(const Model& model, std::string& outBuffer, std::string& outError)
+    {
+        outBuffer.clear();
+        outError.clear();
+
+        if (model.spheres.empty() && model.boxes.empty() && model.meshes.empty())
+        {
+            outError = "collision must contain at least one sphere, box, or mesh";
+            return false;
+        }
+
+        if (model.spheres.size() > kMaxNativeCount)
+        {
+            outError = "too many spheres";
+            return false;
+        }
+
+        if (model.boxes.size() > kMaxNativeCount)
+        {
+            outError = "too many boxes";
+            return false;
+        }
+
+        std::size_t totalVertices = 0;
+        std::size_t totalTriangles = 0;
+
+        for (const Mesh& mesh : model.meshes)
+        {
+            if (!ValidateMaterial(mesh.material, outError))
+                return false;
+
+            if (mesh.vertices.empty())
+            {
+                outError = "mesh must contain vertices";
+                return false;
+            }
+
+            if (mesh.indices.empty() || mesh.indices.size() % 3 != 0)
+            {
+                outError = "mesh indices must contain complete triangles";
+                return false;
+            }
+
+            if (mesh.vertices.size() > kMaxNativeVertices - totalVertices)
+            {
+                outError = "combined mesh vertex count exceeds 65536";
+                return false;
+            }
+
+            totalVertices += mesh.vertices.size();
+
+            const std::size_t meshTriangles = mesh.indices.size() / 3;
+            if (meshTriangles > kMaxNativeCount - totalTriangles)
+            {
+                outError = "combined triangle count exceeds 65535";
+                return false;
+            }
+
+            totalTriangles += meshTriangles;
+        }
+
+        std::vector<VertexRecord> vertices;
+        std::vector<FaceRecord>   faces;
+        vertices.reserve(totalVertices);
+        faces.reserve(totalTriangles);
+
+        CVector boundsMin;
+        CVector boundsMax;
+        bool    boundsInitialized = false;
+
+        for (const Sphere& sphere : model.spheres)
+        {
+            if (!IsFinite(sphere.position) || !IsFinite(sphere.radius) || sphere.radius <= 0.0f)
+            {
+                outError = "sphere position and radius must be finite, with radius > 0";
+                return false;
+            }
+
+            if (!ValidateMaterial(sphere.material, outError))
+                return false;
+
+            CVector minimum{sphere.position.fX - sphere.radius, sphere.position.fY - sphere.radius, sphere.position.fZ - sphere.radius};
+            CVector maximum{sphere.position.fX + sphere.radius, sphere.position.fY + sphere.radius, sphere.position.fZ + sphere.radius};
+            if (!IsFinite(minimum) || !IsFinite(maximum))
+            {
+                outError = "sphere bounds overflowed";
+                return false;
+            }
+
+            ExtendBounds(minimum, boundsMin, boundsMax, boundsInitialized);
+            ExtendBounds(maximum, boundsMin, boundsMax, boundsInitialized);
+        }
+
+        for (const Box& box : model.boxes)
+        {
+            if (!IsFinite(box.position) || !IsFinite(box.size) || box.size.fX <= 0.0f || box.size.fY <= 0.0f || box.size.fZ <= 0.0f)
+            {
+                outError = "box position and size must be finite, with all size components > 0";
+                return false;
+            }
+
+            if (!ValidateMaterial(box.material, outError))
+                return false;
+
+            const CVector half{box.size.fX * 0.5f, box.size.fY * 0.5f, box.size.fZ * 0.5f};
+            CVector       minimum{box.position.fX - half.fX, box.position.fY - half.fY, box.position.fZ - half.fZ};
+            CVector       maximum{box.position.fX + half.fX, box.position.fY + half.fY, box.position.fZ + half.fZ};
+            if (!IsFinite(minimum) || !IsFinite(maximum))
+            {
+                outError = "box bounds overflowed";
+                return false;
+            }
+
+            ExtendBounds(minimum, boundsMin, boundsMax, boundsInitialized);
+            ExtendBounds(maximum, boundsMin, boundsMax, boundsInitialized);
+        }
+
+        std::size_t vertexBase = 0;
+        for (const Mesh& mesh : model.meshes)
+        {
+            for (const CVector& vertex : mesh.vertices)
+            {
+                if (!IsFinite(vertex))
+                {
+                    outError = "mesh vertices must be finite";
+                    return false;
+                }
+
+                if (!IsCompressedVertexInRange(vertex))
+                {
+                    outError = "mesh vertex coordinate exceeds GTA collision range [-256, 255.9921875]";
+                    return false;
+                }
+
+                vertices.push_back(VertexRecord{vertex.fX, vertex.fY, vertex.fZ});
+                ExtendBounds(vertex, boundsMin, boundsMax, boundsInitialized);
+            }
+
+            for (std::size_t index = 0; index < mesh.indices.size(); index += 3)
+            {
+                const std::uint32_t localA = mesh.indices[index];
+                const std::uint32_t localB = mesh.indices[index + 1];
+                const std::uint32_t localC = mesh.indices[index + 2];
+
+                if (localA >= mesh.vertices.size() || localB >= mesh.vertices.size() || localC >= mesh.vertices.size())
+                {
+                    outError = "mesh triangle index references a missing vertex";
+                    return false;
+                }
+
+                if (localA == localB || localA == localC || localB == localC)
+                {
+                    outError = "mesh triangle must reference three different vertices";
+                    return false;
+                }
+
+                const std::size_t globalA = vertexBase + localA;
+                const std::size_t globalB = vertexBase + localB;
+                const std::size_t globalC = vertexBase + localC;
+                if (globalA > kMaxNativeCount || globalB > kMaxNativeCount || globalC > kMaxNativeCount)
+                {
+                    outError = "mesh triangle index exceeds 65535";
+                    return false;
+                }
+
+                faces.push_back(FaceRecord{static_cast<std::uint32_t>(globalA), static_cast<std::uint32_t>(globalB), static_cast<std::uint32_t>(globalC),
+                                           MakeSurface(mesh.material)});
+            }
+
+            vertexBase += mesh.vertices.size();
+        }
+
+        if (!boundsInitialized)
+        {
+            outError = "collision has no bounds";
+            return false;
+        }
+
+        const CVector center{static_cast<float>((static_cast<double>(boundsMin.fX) + boundsMax.fX) * 0.5),
+                             static_cast<float>((static_cast<double>(boundsMin.fY) + boundsMax.fY) * 0.5),
+                             static_cast<float>((static_cast<double>(boundsMin.fZ) + boundsMax.fZ) * 0.5)};
+        const double  extentX = static_cast<double>(boundsMax.fX) - center.fX;
+        const double  extentY = static_cast<double>(boundsMax.fY) - center.fY;
+        const double  extentZ = static_cast<double>(boundsMax.fZ) - center.fZ;
+        const double  radiusDouble = std::sqrt(extentX * extentX + extentY * extentY + extentZ * extentZ);
+
+        if (!std::isfinite(radiusDouble) || radiusDouble <= 0.0 || radiusDouble > std::numeric_limits<float>::max())
+        {
+            outError = "collision bounds produce an invalid bounding sphere";
+            return false;
+        }
+
+        const BoundsRecord bounds{static_cast<float>(radiusDouble),
+                                  center.fX,
+                                  center.fY,
+                                  center.fZ,
+                                  boundsMin.fX,
+                                  boundsMin.fY,
+                                  boundsMin.fZ,
+                                  boundsMax.fX,
+                                  boundsMax.fY,
+                                  boundsMax.fZ};
+
+        std::string payload;
+        payload.reserve(sizeof(bounds) + sizeof(std::uint32_t) * 5 + model.spheres.size() * sizeof(SphereRecord) + model.boxes.size() * sizeof(BoxRecord) +
+                        vertices.size() * sizeof(VertexRecord) + faces.size() * sizeof(FaceRecord));
+
+        Append(payload, bounds);
+
+        const std::uint32_t sphereCount = static_cast<std::uint32_t>(model.spheres.size());
+        Append(payload, sphereCount);
+        for (const Sphere& sphere : model.spheres)
+        {
+            Append(payload, SphereRecord{sphere.radius, sphere.position.fX, sphere.position.fY, sphere.position.fZ, MakeSurface(sphere.material)});
+        }
+
+        const std::uint32_t lineCount = 0;
+        Append(payload, lineCount);
+
+        const std::uint32_t boxCount = static_cast<std::uint32_t>(model.boxes.size());
+        Append(payload, boxCount);
+        for (const Box& box : model.boxes)
+        {
+            const CVector half{box.size.fX * 0.5f, box.size.fY * 0.5f, box.size.fZ * 0.5f};
+            Append(payload, BoxRecord{box.position.fX - half.fX, box.position.fY - half.fY, box.position.fZ - half.fZ, box.position.fX + half.fX,
+                                      box.position.fY + half.fY, box.position.fZ + half.fZ, MakeSurface(box.material)});
+        }
+
+        const std::uint32_t vertexCount = static_cast<std::uint32_t>(vertices.size());
+        Append(payload, vertexCount);
+        for (const VertexRecord& vertex : vertices)
+            Append(payload, vertex);
+
+        const std::uint32_t triangleCount = static_cast<std::uint32_t>(faces.size());
+        Append(payload, triangleCount);
+        for (const FaceRecord& face : faces)
+            Append(payload, face);
+
+        ColFileHeader header{};
+        std::memcpy(header.version, "COLL", 4);
+        std::memcpy(header.name, "runtime", 7);
+        header.size = static_cast<std::uint32_t>(sizeof(header) - 8 + payload.size());
+
+        outBuffer.reserve(sizeof(header) + payload.size());
+        Append(outBuffer, header);
+        outBuffer.append(payload);
+        return true;
+    }
+}  // namespace RuntimeCollision

--- a/Client/mods/deathmatch/logic/CRuntimeColModel.h
+++ b/Client/mods/deathmatch/logic/CRuntimeColModel.h
@@ -1,0 +1,51 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        mods/deathmatch/logic/CRuntimeColModel.h
+ *  PURPOSE:     Runtime collision model serialization
+ *
+ *  Multi Theft Auto is available from https://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#pragma once
+
+#include <SharedUtil.Defines.h>
+#include <CVector.h>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace RuntimeCollision
+{
+    struct Sphere
+    {
+        CVector      position;
+        float        radius = 0.0f;
+        std::uint8_t material = 0;
+    };
+
+    struct Box
+    {
+        CVector      position;
+        CVector      size;
+        std::uint8_t material = 0;
+    };
+
+    struct Mesh
+    {
+        std::vector<CVector>       vertices;
+        std::vector<std::uint32_t> indices;
+        std::uint8_t               material = 0;
+    };
+
+    struct Model
+    {
+        std::vector<Sphere> spheres;
+        std::vector<Box>    boxes;
+        std::vector<Mesh>   meshes;
+    };
+
+    bool BuildCOLBuffer(const Model& model, std::string& outBuffer, std::string& outError);
+}  // namespace RuntimeCollision

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -89,6 +89,7 @@ void CLuaEngineDefs::LoadFunctions()
         {"engineFreeModel", EngineFreeModel},
         {"engineLoadTXD", EngineLoadTXD},
         {"engineLoadCOL", EngineLoadCOL},
+        {"engineSetCOLData", ArgumentParser<EngineSetCOLData>},
         {"engineLoadDFF", EngineLoadDFF},
         {"engineLoadIFP", EngineLoadIFP},
         {"engineImportTXD", EngineImportTXD},
@@ -245,6 +246,7 @@ void CLuaEngineDefs::AddEngineColClass(lua_State* luaVM)
 
     lua_classfunction(luaVM, "create", "engineLoadCOL");
     lua_classfunction(luaVM, "replace", "engineReplaceCOL");
+    lua_classfunction(luaVM, "setData", "engineSetCOLData");
 
     lua_registerclass(luaVM, "EngineCOL", "Element");
 }
@@ -291,6 +293,9 @@ void CLuaEngineDefs::AddEngineDffClass(lua_State* luaVM)
 
 int CLuaEngineDefs::EngineLoadCOL(lua_State* luaVM)
 {
+    if (lua_istable(luaVM, 1))
+        return EngineLoadCOLFromTable(luaVM);
+
     SString          input;
     CScriptArgReader argStream(luaVM);
     // Grab the COL filename or data

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.h
@@ -13,6 +13,8 @@
 #include "CLuaDefs.h"
 #include <lua/CLuaMultiReturn.h>
 
+class CClientColModel;
+
 class CLuaEngineDefs : public CLuaDefs
 {
 public:
@@ -60,6 +62,7 @@ public:
     LUA_DECLARE(EngineRestoreObjectGroupPhysicalProperties)
 
     static bool                                            EngineAddClothingModel(CClientDFF* pDff, std::string strModelName);
+    static bool                                            EngineSetCOLData(lua_State* luaVM, CClientColModel* colModel);
     static bool                                            EngineAddClothingTXD(CClientTXD* pTxd, std::string strModelName);
     static uint                                            EngineGetModelFlags(uint uiModelID);
     static bool                                            EngineSetModelFlags(uint uiModelID, uint uiFlags, std::optional<bool> bIdeFlags);
@@ -100,6 +103,7 @@ public:
     static void EngineRestream(std::optional<RestreamOption> option);
 
 private:
+    static int  EngineLoadCOLFromTable(lua_State* luaVM);
     static void AddEngineColClass(lua_State* luaVM);
     static void AddEngineTxdClass(lua_State* luaVM);
     static void AddEngineDffClass(lua_State* luaVM);

--- a/Client/mods/deathmatch/logic/luadefs/CLuaRuntimeCollisionDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaRuntimeCollisionDefs.cpp
@@ -1,0 +1,483 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        mods/deathmatch/logic/luadefs/CLuaRuntimeCollisionDefs.cpp
+ *  PURPOSE:     Runtime collision model Lua bindings
+ *
+ *  Multi Theft Auto is available from https://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#include "StdInc.h"
+#include "CLuaEngineDefs.h"
+#include "../CClientColModel.h"
+#include "../CRuntimeColModel.h"
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <utility>
+
+namespace
+{
+    constexpr std::size_t kMaxNativeCount = std::numeric_limits<std::uint16_t>::max();
+    constexpr std::size_t kMaxNativeVertices = kMaxNativeCount + 1;
+
+    int AbsoluteIndex(lua_State* luaVM, int index)
+    {
+        return index < 0 ? lua_gettop(luaVM) + index + 1 : index;
+    }
+
+    bool ReadFiniteNumber(lua_State* luaVM, int index, float& outValue, std::string& outError, const std::string& path)
+    {
+        if (lua_type(luaVM, index) != LUA_TNUMBER)
+        {
+            outError = path + " must be a number";
+            return false;
+        }
+
+        const lua_Number value = lua_tonumber(luaVM, index);
+        if (!std::isfinite(value) || value < -std::numeric_limits<float>::max() || value > std::numeric_limits<float>::max())
+        {
+            outError = path + " must be finite";
+            return false;
+        }
+
+        outValue = static_cast<float>(value);
+        return true;
+    }
+
+    bool ReadVectorTable(lua_State* luaVM, int index, CVector& outValue, std::string& outError, const std::string& path)
+    {
+        index = AbsoluteIndex(luaVM, index);
+        if (!lua_istable(luaVM, index) || lua_objlen(luaVM, index) != 3)
+        {
+            outError = path + " must be a 3-number table";
+            return false;
+        }
+
+        float values[3]{};
+        for (int component = 0; component < 3; ++component)
+        {
+            lua_rawgeti(luaVM, index, component + 1);
+            const bool success = ReadFiniteNumber(luaVM, -1, values[component], outError, path + "[" + std::to_string(component + 1) + "]");
+            lua_pop(luaVM, 1);
+            if (!success)
+                return false;
+        }
+
+        outValue = CVector(values[0], values[1], values[2]);
+        return true;
+    }
+
+    bool ReadVectorField(lua_State* luaVM, int tableIndex, const char* fieldName, CVector& outValue, std::string& outError, const std::string& path)
+    {
+        tableIndex = AbsoluteIndex(luaVM, tableIndex);
+        lua_getfield(luaVM, tableIndex, fieldName);
+        const bool success = ReadVectorTable(luaVM, -1, outValue, outError, path + "." + fieldName);
+        lua_pop(luaVM, 1);
+        return success;
+    }
+
+    bool ReadMaterialField(lua_State* luaVM, int tableIndex, std::uint8_t& outMaterial, std::string& outError, const std::string& path)
+    {
+        tableIndex = AbsoluteIndex(luaVM, tableIndex);
+        lua_getfield(luaVM, tableIndex, "material");
+
+        if (lua_isnil(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            outMaterial = 0;
+            return true;
+        }
+
+        if (lua_type(luaVM, -1) != LUA_TNUMBER)
+        {
+            lua_pop(luaVM, 1);
+            outError = path + ".material must be an integer in range 0-178";
+            return false;
+        }
+
+        const lua_Number value = lua_tonumber(luaVM, -1);
+        lua_pop(luaVM, 1);
+
+        if (!std::isfinite(value) || std::floor(value) != value || value < 0 || value > 178)
+        {
+            outError = path + ".material must be an integer in range 0-178";
+            return false;
+        }
+
+        outMaterial = static_cast<std::uint8_t>(value);
+        return true;
+    }
+
+    bool ParseSpheres(lua_State* luaVM, int rootIndex, RuntimeCollision::Model& outModel, std::string& outError)
+    {
+        rootIndex = AbsoluteIndex(luaVM, rootIndex);
+        lua_getfield(luaVM, rootIndex, "spheres");
+
+        if (lua_isnil(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            return true;
+        }
+
+        if (!lua_istable(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            outError = "spheres must be a table";
+            return false;
+        }
+
+        const int         arrayIndex = AbsoluteIndex(luaVM, -1);
+        const std::size_t count = lua_objlen(luaVM, arrayIndex);
+        if (count > kMaxNativeCount)
+        {
+            lua_pop(luaVM, 1);
+            outError = "spheres exceeds the native limit of 65535";
+            return false;
+        }
+
+        outModel.spheres.reserve(count);
+
+        for (std::size_t i = 1; i <= count; ++i)
+        {
+            lua_rawgeti(luaVM, arrayIndex, static_cast<int>(i));
+            if (!lua_istable(luaVM, -1))
+            {
+                lua_pop(luaVM, 2);
+                outError = "spheres[" + std::to_string(i) + "] must be a table";
+                return false;
+            }
+
+            RuntimeCollision::Sphere sphere;
+            const std::string        path = "spheres[" + std::to_string(i) + "]";
+
+            if (!ReadVectorField(luaVM, -1, "position", sphere.position, outError, path))
+            {
+                lua_pop(luaVM, 2);
+                return false;
+            }
+
+            lua_getfield(luaVM, -1, "radius");
+            const bool radiusOk = ReadFiniteNumber(luaVM, -1, sphere.radius, outError, path + ".radius");
+            lua_pop(luaVM, 1);
+
+            if (!radiusOk || !ReadMaterialField(luaVM, -1, sphere.material, outError, path))
+            {
+                lua_pop(luaVM, 2);
+                return false;
+            }
+
+            outModel.spheres.push_back(sphere);
+            lua_pop(luaVM, 1);
+        }
+
+        lua_pop(luaVM, 1);
+        return true;
+    }
+
+    bool ParseBoxes(lua_State* luaVM, int rootIndex, RuntimeCollision::Model& outModel, std::string& outError)
+    {
+        rootIndex = AbsoluteIndex(luaVM, rootIndex);
+        lua_getfield(luaVM, rootIndex, "boxes");
+
+        if (lua_isnil(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            return true;
+        }
+
+        if (!lua_istable(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            outError = "boxes must be a table";
+            return false;
+        }
+
+        const int         arrayIndex = AbsoluteIndex(luaVM, -1);
+        const std::size_t count = lua_objlen(luaVM, arrayIndex);
+        if (count > kMaxNativeCount)
+        {
+            lua_pop(luaVM, 1);
+            outError = "boxes exceeds the native limit of 65535";
+            return false;
+        }
+
+        outModel.boxes.reserve(count);
+
+        for (std::size_t i = 1; i <= count; ++i)
+        {
+            lua_rawgeti(luaVM, arrayIndex, static_cast<int>(i));
+            if (!lua_istable(luaVM, -1))
+            {
+                lua_pop(luaVM, 2);
+                outError = "boxes[" + std::to_string(i) + "] must be a table";
+                return false;
+            }
+
+            RuntimeCollision::Box box;
+            const std::string     path = "boxes[" + std::to_string(i) + "]";
+
+            if (!ReadVectorField(luaVM, -1, "position", box.position, outError, path) || !ReadVectorField(luaVM, -1, "size", box.size, outError, path) ||
+                !ReadMaterialField(luaVM, -1, box.material, outError, path))
+            {
+                lua_pop(luaVM, 2);
+                return false;
+            }
+
+            outModel.boxes.push_back(box);
+            lua_pop(luaVM, 1);
+        }
+
+        lua_pop(luaVM, 1);
+        return true;
+    }
+
+    bool ParseMeshVertices(lua_State* luaVM, int meshIndex, RuntimeCollision::Mesh& outMesh, std::string& outError, const std::string& path)
+    {
+        meshIndex = AbsoluteIndex(luaVM, meshIndex);
+        lua_getfield(luaVM, meshIndex, "vertices");
+
+        if (!lua_istable(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            outError = path + ".vertices must be a flat number table";
+            return false;
+        }
+
+        const int         verticesIndex = AbsoluteIndex(luaVM, -1);
+        const std::size_t componentCount = lua_objlen(luaVM, verticesIndex);
+        if (componentCount == 0 || componentCount % 3 != 0)
+        {
+            lua_pop(luaVM, 1);
+            outError = path + ".vertices must contain xyz triplets";
+            return false;
+        }
+
+        if (componentCount / 3 > kMaxNativeVertices)
+        {
+            lua_pop(luaVM, 1);
+            outError = path + ".vertices exceeds the native limit of 65536";
+            return false;
+        }
+
+        outMesh.vertices.reserve(componentCount / 3);
+        for (std::size_t i = 1; i <= componentCount; i += 3)
+        {
+            float components[3]{};
+            for (int component = 0; component < 3; ++component)
+            {
+                const std::size_t componentIndex = i + component;
+                lua_rawgeti(luaVM, verticesIndex, static_cast<int>(componentIndex));
+                const bool success = ReadFiniteNumber(luaVM, -1, components[component], outError, path + ".vertices[" + std::to_string(componentIndex) + "]");
+                lua_pop(luaVM, 1);
+                if (!success)
+                {
+                    lua_pop(luaVM, 1);
+                    return false;
+                }
+            }
+
+            outMesh.vertices.emplace_back(components[0], components[1], components[2]);
+        }
+
+        lua_pop(luaVM, 1);
+        return true;
+    }
+
+    bool ParseMeshIndices(lua_State* luaVM, int meshIndex, RuntimeCollision::Mesh& outMesh, std::string& outError, const std::string& path)
+    {
+        meshIndex = AbsoluteIndex(luaVM, meshIndex);
+        lua_getfield(luaVM, meshIndex, "indices");
+
+        if (!lua_istable(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            outError = path + ".indices must be a flat integer table";
+            return false;
+        }
+
+        const int         indicesIndex = AbsoluteIndex(luaVM, -1);
+        const std::size_t indexCount = lua_objlen(luaVM, indicesIndex);
+        if (indexCount == 0 || indexCount % 3 != 0)
+        {
+            lua_pop(luaVM, 1);
+            outError = path + ".indices must contain triangle triplets";
+            return false;
+        }
+
+        if (indexCount / 3 > kMaxNativeCount)
+        {
+            lua_pop(luaVM, 1);
+            outError = path + ".indices exceeds the native triangle limit of 65535";
+            return false;
+        }
+
+        outMesh.indices.reserve(indexCount);
+        for (std::size_t i = 1; i <= indexCount; ++i)
+        {
+            lua_rawgeti(luaVM, indicesIndex, static_cast<int>(i));
+
+            if (lua_type(luaVM, -1) != LUA_TNUMBER)
+            {
+                lua_pop(luaVM, 2);
+                outError = path + ".indices[" + std::to_string(i) + "] must be a non-negative integer";
+                return false;
+            }
+
+            const lua_Number value = lua_tonumber(luaVM, -1);
+            lua_pop(luaVM, 1);
+
+            if (!std::isfinite(value) || std::floor(value) != value || value < 0 || value > std::numeric_limits<std::uint32_t>::max())
+            {
+                lua_pop(luaVM, 1);
+                outError = path + ".indices[" + std::to_string(i) + "] must be a non-negative integer";
+                return false;
+            }
+
+            outMesh.indices.push_back(static_cast<std::uint32_t>(value));
+        }
+
+        lua_pop(luaVM, 1);
+        return true;
+    }
+
+    bool ParseMeshes(lua_State* luaVM, int rootIndex, RuntimeCollision::Model& outModel, std::string& outError)
+    {
+        rootIndex = AbsoluteIndex(luaVM, rootIndex);
+        lua_getfield(luaVM, rootIndex, "meshes");
+
+        if (lua_isnil(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            return true;
+        }
+
+        if (!lua_istable(luaVM, -1))
+        {
+            lua_pop(luaVM, 1);
+            outError = "meshes must be a table";
+            return false;
+        }
+
+        const int         arrayIndex = AbsoluteIndex(luaVM, -1);
+        const std::size_t count = lua_objlen(luaVM, arrayIndex);
+        if (count > kMaxNativeCount)
+        {
+            lua_pop(luaVM, 1);
+            outError = "meshes exceeds the native collection limit of 65535";
+            return false;
+        }
+
+        outModel.meshes.reserve(count);
+
+        std::size_t totalVertices = 0;
+        std::size_t totalTriangles = 0;
+
+        for (std::size_t i = 1; i <= count; ++i)
+        {
+            lua_rawgeti(luaVM, arrayIndex, static_cast<int>(i));
+            if (!lua_istable(luaVM, -1))
+            {
+                lua_pop(luaVM, 2);
+                outError = "meshes[" + std::to_string(i) + "] must be a table";
+                return false;
+            }
+
+            RuntimeCollision::Mesh mesh;
+            const std::string      path = "meshes[" + std::to_string(i) + "]";
+
+            if (!ParseMeshVertices(luaVM, -1, mesh, outError, path) || !ParseMeshIndices(luaVM, -1, mesh, outError, path) ||
+                !ReadMaterialField(luaVM, -1, mesh.material, outError, path))
+            {
+                lua_pop(luaVM, 2);
+                return false;
+            }
+
+            if (mesh.vertices.size() > kMaxNativeVertices - totalVertices)
+            {
+                lua_pop(luaVM, 2);
+                outError = "combined mesh vertex count exceeds 65536";
+                return false;
+            }
+
+            const std::size_t triangleCount = mesh.indices.size() / 3;
+            if (triangleCount > kMaxNativeCount - totalTriangles)
+            {
+                lua_pop(luaVM, 2);
+                outError = "combined triangle count exceeds 65535";
+                return false;
+            }
+
+            totalVertices += mesh.vertices.size();
+            totalTriangles += triangleCount;
+
+            outModel.meshes.push_back(std::move(mesh));
+            lua_pop(luaVM, 1);
+        }
+
+        lua_pop(luaVM, 1);
+        return true;
+    }
+
+    bool ParseCollisionTable(lua_State* luaVM, int index, RuntimeCollision::Model& outModel, std::string& outError)
+    {
+        if (!lua_istable(luaVM, index))
+        {
+            outError = "expected collision table";
+            return false;
+        }
+
+        return ParseSpheres(luaVM, index, outModel, outError) && ParseBoxes(luaVM, index, outModel, outError) && ParseMeshes(luaVM, index, outModel, outError);
+    }
+
+    bool BuildCollisionBuffer(lua_State* luaVM, int index, std::string& outBuffer, std::string& outError)
+    {
+        RuntimeCollision::Model model;
+        return ParseCollisionTable(luaVM, index, model, outError) && RuntimeCollision::BuildCOLBuffer(model, outBuffer, outError);
+    }
+}  // namespace
+
+int CLuaEngineDefs::EngineLoadCOLFromTable(lua_State* luaVM)
+{
+    std::string buffer;
+    std::string error;
+    if (!BuildCollisionBuffer(luaVM, 1, buffer, error))
+        return luaL_error(luaVM, "Bad argument @ 'engineLoadCOL' [Invalid collision data: %s]", error.c_str());
+
+    CLuaMain*  luaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+    CResource* resource = luaMain ? luaMain->GetResource() : nullptr;
+    if (!resource)
+    {
+        lua_pushboolean(luaVM, false);
+        return 1;
+    }
+
+    CClientColModel* col = new CClientColModel(m_pManager, INVALID_ELEMENT_ID);
+    if (!col->LoadFromGeneratedData(SString(buffer)))
+    {
+        delete col;
+        lua_pushboolean(luaVM, false);
+        return 1;
+    }
+
+    col->SetParent(resource->GetResourceCOLModelRoot());
+    lua_pushelement(luaVM, col);
+    return 1;
+}
+
+bool CLuaEngineDefs::EngineSetCOLData(lua_State* luaVM, CClientColModel* colModel)
+{
+    if (!lua_istable(luaVM, 2))
+        luaL_error(luaVM, "Bad argument @ 'engineSetCOLData' [Expected table at argument 2]");
+
+    std::string buffer;
+    std::string error;
+    if (!BuildCollisionBuffer(luaVM, 2, buffer, error))
+        luaL_error(luaVM, "Bad argument @ 'engineSetCOLData' [Invalid collision data: %s]", error.c_str());
+
+    return colModel->SetGeneratedData(SString(buffer));
+}

--- a/Client/mods/deathmatch/premake5.lua
+++ b/Client/mods/deathmatch/premake5.lua
@@ -64,6 +64,11 @@ project "Client Deathmatch"
 	filter "system:windows"
 		buildoptions { "-Zm180" }
 
+	-- Keep the serializer independent from the client PCH so the same source
+	-- can be exercised by the standalone client tests.
+	filter "files:logic/CRuntimeColModel.cpp"
+		flags { "NoPCH" }
+
 	filter "architecture:not x86"
 		flags { "ExcludeFromBuild" }
 

--- a/Tests/client/CRuntimeColModel_Tests.cpp
+++ b/Tests/client/CRuntimeColModel_Tests.cpp
@@ -1,0 +1,254 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        Tests/client/CRuntimeColModel_Tests.cpp
+ *  PURPOSE:     Runtime collision model serializer tests
+ *
+ *  Multi Theft Auto is available from https://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#include "../../Client/mods/deathmatch/logic/CRuntimeColModel.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <string>
+#include <utility>
+
+namespace
+{
+#pragma pack(push, 1)
+    struct Header
+    {
+        char          version[4];
+        std::uint32_t size;
+        char          name[24];
+    };
+
+    struct Surface
+    {
+        std::uint8_t material;
+        std::uint8_t piece;
+        std::uint8_t brightness;
+        std::uint8_t lighting;
+    };
+
+    struct Bounds
+    {
+        float radius;
+        float centerX;
+        float centerY;
+        float centerZ;
+        float minX;
+        float minY;
+        float minZ;
+        float maxX;
+        float maxY;
+        float maxZ;
+    };
+
+    struct Face
+    {
+        std::uint32_t a;
+        std::uint32_t b;
+        std::uint32_t c;
+        Surface       surface;
+    };
+#pragma pack(pop)
+
+    template <class T>
+    T Read(const std::string& buffer, std::size_t offset)
+    {
+        T value{};
+        if (offset > buffer.size() || sizeof(T) > buffer.size() - offset)
+        {
+            ADD_FAILURE() << "Attempted to read past the serialized collision buffer";
+            return value;
+        }
+
+        std::memcpy(&value, buffer.data() + offset, sizeof(T));
+        return value;
+    }
+
+    RuntimeCollision::Mesh Triangle(float offset, std::uint8_t material)
+    {
+        RuntimeCollision::Mesh mesh;
+        mesh.material = material;
+        mesh.vertices = {
+            CVector(-1.0f + offset, -1.0f, 0.0f),
+            CVector(1.0f + offset, -1.0f, 0.0f),
+            CVector(offset, 1.0f, 0.0f),
+        };
+        mesh.indices = {0, 1, 2};
+        return mesh;
+    }
+
+    TEST(CRuntimeColModel, SerializesMixedCollision)
+    {
+        RuntimeCollision::Model model;
+        model.spheres.push_back({CVector(0.0f, 0.0f, 1.5f), 1.0f, 2});
+        model.boxes.push_back({CVector(0.0f, 0.0f, 0.0f), CVector(2.0f, 4.0f, 1.0f), 1});
+        model.meshes.push_back(Triangle(0.0f, 3));
+
+        std::string buffer;
+        std::string error;
+        ASSERT_TRUE(RuntimeCollision::BuildCOLBuffer(model, buffer, error)) << error;
+        ASSERT_GE(buffer.size(), sizeof(Header) + sizeof(Bounds));
+
+        const Header header = Read<Header>(buffer, 0);
+        EXPECT_EQ(std::string(header.version, 4), "COLL");
+        EXPECT_EQ(header.size, buffer.size() - 8);
+
+        const Bounds bounds = Read<Bounds>(buffer, sizeof(Header));
+        EXPECT_FLOAT_EQ(bounds.minX, -1.0f);
+        EXPECT_FLOAT_EQ(bounds.minY, -2.0f);
+        EXPECT_FLOAT_EQ(bounds.minZ, -0.5f);
+        EXPECT_FLOAT_EQ(bounds.maxX, 1.0f);
+        EXPECT_FLOAT_EQ(bounds.maxY, 2.0f);
+        EXPECT_FLOAT_EQ(bounds.maxZ, 2.5f);
+
+        std::size_t offset = sizeof(Header) + sizeof(Bounds);
+        EXPECT_EQ(Read<std::uint32_t>(buffer, offset), 1u);
+        offset += sizeof(std::uint32_t) + 0x14;
+
+        EXPECT_EQ(Read<std::uint32_t>(buffer, offset), 0u);
+        offset += sizeof(std::uint32_t);
+
+        EXPECT_EQ(Read<std::uint32_t>(buffer, offset), 1u);
+        offset += sizeof(std::uint32_t) + 0x1C;
+
+        EXPECT_EQ(Read<std::uint32_t>(buffer, offset), 3u);
+        offset += sizeof(std::uint32_t) + 3 * 0x0C;
+
+        EXPECT_EQ(Read<std::uint32_t>(buffer, offset), 1u);
+        offset += sizeof(std::uint32_t);
+
+        const Face face = Read<Face>(buffer, offset);
+        EXPECT_EQ(face.a, 0u);
+        EXPECT_EQ(face.b, 1u);
+        EXPECT_EQ(face.c, 2u);
+        EXPECT_EQ(face.surface.material, 3u);
+        EXPECT_EQ(face.surface.lighting, 0xFFu);
+    }
+
+    TEST(CRuntimeColModel, OffsetsIndicesAcrossMeshes)
+    {
+        RuntimeCollision::Model model;
+        model.meshes.push_back(Triangle(-3.0f, 1));
+        model.meshes.push_back(Triangle(3.0f, 2));
+
+        std::string buffer;
+        std::string error;
+        ASSERT_TRUE(RuntimeCollision::BuildCOLBuffer(model, buffer, error)) << error;
+
+        std::size_t offset = sizeof(Header) + sizeof(Bounds);
+        offset += sizeof(std::uint32_t);  // spheres
+        offset += sizeof(std::uint32_t);  // lines
+        offset += sizeof(std::uint32_t);  // boxes
+
+        const std::uint32_t vertexCount = Read<std::uint32_t>(buffer, offset);
+        EXPECT_EQ(vertexCount, 6u);
+        offset += sizeof(std::uint32_t) + vertexCount * 0x0C;
+
+        const std::uint32_t faceCount = Read<std::uint32_t>(buffer, offset);
+        ASSERT_EQ(faceCount, 2u);
+        offset += sizeof(std::uint32_t);
+
+        const Face first = Read<Face>(buffer, offset);
+        const Face second = Read<Face>(buffer, offset + sizeof(Face));
+
+        EXPECT_EQ(first.a, 0u);
+        EXPECT_EQ(first.b, 1u);
+        EXPECT_EQ(first.c, 2u);
+        EXPECT_EQ(second.a, 3u);
+        EXPECT_EQ(second.b, 4u);
+        EXPECT_EQ(second.c, 5u);
+        EXPECT_EQ(second.surface.material, 2u);
+    }
+
+    TEST(CRuntimeColModel, RejectsMissingGeometry)
+    {
+        RuntimeCollision::Model model;
+        std::string             buffer;
+        std::string             error;
+
+        EXPECT_FALSE(RuntimeCollision::BuildCOLBuffer(model, buffer, error));
+        EXPECT_FALSE(error.empty());
+    }
+
+    TEST(CRuntimeColModel, RejectsInvalidTriangleIndex)
+    {
+        RuntimeCollision::Model model;
+        auto                    mesh = Triangle(0.0f, 0);
+        mesh.indices = {0, 1, 3};
+        model.meshes.push_back(std::move(mesh));
+
+        std::string buffer;
+        std::string error;
+        EXPECT_FALSE(RuntimeCollision::BuildCOLBuffer(model, buffer, error));
+        EXPECT_NE(error.find("missing vertex"), std::string::npos);
+    }
+
+    TEST(CRuntimeColModel, RejectsRepeatedTriangleVertex)
+    {
+        RuntimeCollision::Model model;
+        auto                    mesh = Triangle(0.0f, 0);
+        mesh.indices = {0, 1, 1};
+        model.meshes.push_back(std::move(mesh));
+
+        std::string buffer;
+        std::string error;
+        EXPECT_FALSE(RuntimeCollision::BuildCOLBuffer(model, buffer, error));
+        EXPECT_NE(error.find("three different vertices"), std::string::npos);
+    }
+
+    TEST(CRuntimeColModel, RejectsCompressedVertexOverflow)
+    {
+        RuntimeCollision::Model model;
+        auto                    mesh = Triangle(0.0f, 0);
+        mesh.vertices[0].fX = 256.0f;
+        model.meshes.push_back(std::move(mesh));
+
+        std::string buffer;
+        std::string error;
+        EXPECT_FALSE(RuntimeCollision::BuildCOLBuffer(model, buffer, error));
+        EXPECT_NE(error.find("GTA collision range"), std::string::npos);
+    }
+
+    TEST(CRuntimeColModel, RejectsInvalidPrimitiveDimensions)
+    {
+        RuntimeCollision::Model model;
+        model.spheres.push_back({CVector(), 0.0f, 0});
+
+        std::string buffer;
+        std::string error;
+        EXPECT_FALSE(RuntimeCollision::BuildCOLBuffer(model, buffer, error));
+        EXPECT_NE(error.find("radius"), std::string::npos);
+    }
+
+    TEST(CRuntimeColModel, RejectsInvalidMaterial)
+    {
+        RuntimeCollision::Model model;
+        model.spheres.push_back({CVector(), 1.0f, 179});
+
+        std::string buffer;
+        std::string error;
+        EXPECT_FALSE(RuntimeCollision::BuildCOLBuffer(model, buffer, error));
+        EXPECT_NE(error.find("material"), std::string::npos);
+    }
+
+    TEST(CRuntimeColModel, RejectsNonFiniteGeometry)
+    {
+        RuntimeCollision::Model model;
+        model.boxes.push_back({CVector(), CVector(std::numeric_limits<float>::infinity(), 1.0f, 1.0f), 0});
+
+        std::string buffer;
+        std::string error;
+        EXPECT_FALSE(RuntimeCollision::BuildCOLBuffer(model, buffer, error));
+        EXPECT_NE(error.find("finite"), std::string::npos);
+    }
+}  // namespace

--- a/Tests/client/premake5.lua
+++ b/Tests/client/premake5.lua
@@ -23,12 +23,14 @@ project "Tests_Client"
 	files {
 		"premake5.lua",
 		"**.h",
-		"**.cpp"
+		"**.cpp",
+		"../../Client/mods/deathmatch/logic/CRuntimeColModel.cpp"
 	}
 
 	defines {
 		"GTEST_HAS_PTHREAD=0",
 		"MTA_CLIENT",
+		"RUNTIME_COL_MODEL_STANDALONE",
 		"SHARED_UTIL_WITH_HASH_MAP",
 	}
 


### PR DESCRIPTION
#### Summary

https://github.com/user-attachments/assets/483565a4-aa6b-4589-9f2f-5a8535bd7d1f


Allow `engineLoadCOL` to create collision models directly from Lua tables containing spheres, boxes and triangle meshes.

```lua
local col = engineLoadCOL({
    boxes = {
        {
            position = { 0, 0, 0 },
            size = { 10, 1, 3 },
            material = 1
        }
    }
})

engineReplaceCOL(col, modelId)
```

Collision data can also be updated while the resource is running:

```lua
engineSetCOLData(col, newData)
-- or
col:setData(newData)
```

Models using the collision are updated immediately. Existing file and raw data support in `engineLoadCOL` remains unchanged.

The input is validated before being passed to GTA, including materials, coordinates, indices and native format limits.

#### Motivation

Resources currently need a pre-generated `.col` file to load custom collision.

Creating custom collision currently requires generating and shipping a separate `.col` file, even for a simple box or sphere.

This allows resources to define collision directly next to their Lua code. The same collision can also be updated at runtime when an object's size or shape changes.

The video uses the included test resource. It creates a wall, resizes its collision while running and turns the same collision into a ramp.


#### Test plan

Tested the included wall/ramp resource:
  1. Start `runtime-collision-wall-demo`
  2. Use `/wall` and place both endpoints
  3. Hold `E` to resize the wall
  4. Hold `U` to change its height
  5. Press `P` to turn it into a ramp
  6. Walk or drive into the generated collision

Note : This feature was originally implemented in my fork and has been tested with my community in various scenarios, the [original documentation](https://mtasa-neon-wiki.vercel.app/neon/runtime-collision) covers the table format, limits and live updates.

Test resource : 
[runtime-collision-wall-demo.zip](https://github.com/user-attachments/files/31377918/runtime-collision-wall-demo.zip)


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.