### PR TITLE
Fix ped shadows remaining visible at zero alpha

### DIFF
--- a/Client/game_sa/CPedSA.cpp
+++ b/Client/game_sa/CPedSA.cpp
@@ -26,6 +26,25 @@ extern CGameSA* pGame;
 
 static bool g_onlyUpdateRotations = false;
 
+namespace
+{
+    constexpr std::uintptr_t FUNC_CRealTimeShadowManager_ReturnRealTimeShadow = 0x705B30;
+    constexpr std::uintptr_t CLASS_CRealTimeShadowManager = 0xC40350;
+    constexpr std::uintptr_t FUNC_CVisibilityPlugins_GetClumpAlpha = 0x732B20;
+    constexpr std::uintptr_t FUNC_CShadows_StoreShadowForPedObject = 0x707B40;
+    constexpr std::uintptr_t CALL_CPed_PreRenderAfterTest_StoreShadowForPedObject = 0x5E6900;
+
+    void __cdecl StoreShadowForPedObject(CPedSAInterface* ped, float displacementX, float displacementY, float frontX, float frontY, float sideX, float sideY)
+    {
+        using GetClumpAlpha = int(__cdecl*)(RpClump*);
+        if (reinterpret_cast<GetClumpAlpha>(FUNC_CVisibilityPlugins_GetClumpAlpha)(ped->m_pRwObject) == 0)
+            return;
+
+        using StoreShadow = void(__cdecl*)(CPedSAInterface*, float, float, float, float, float, float);
+        reinterpret_cast<StoreShadow>(FUNC_CShadows_StoreShadowForPedObject)(ped, displacementX, displacementY, frontX, frontY, sideX, sideY);
+    }
+}
+
 CPedSA::~CPedSA()
 {
     // Make sure this ped is not refed in the flame shot info array
@@ -78,6 +97,20 @@ void CPedSA::SetModelIndex(std::uint32_t modelIndex)
 
     std::uint32_t type = modelInfo->pedType;
     GetPedInterface()->pedSound.m_bIsFemale = type == 5 || type == 22;
+}
+
+void CPedSA::SetVisible(bool visible)
+{
+    CEntitySA::SetVisible(visible);
+
+    CShadowDataSA* shadow = GetPedInterface()->m_pShadowData;
+    if (visible || !shadow)
+        return;
+
+    // Real-time shadows are owned separately from the ped. Return an existing
+    // shadow immediately so an invisible ped cannot leave it fading in-world.
+    using ReturnRealTimeShadow = void(__thiscall*)(void*, CShadowDataSA*);
+    reinterpret_cast<ReturnRealTimeShadow>(FUNC_CRealTimeShadowManager_ReturnRealTimeShadow)(reinterpret_cast<void*>(CLASS_CRealTimeShadowManager), shadow);
 }
 
 bool CPedSA::AddProjectile(eWeaponType weaponType, CVector origin, float force, CVector* target, CEntity* targetEntity)
@@ -753,6 +786,10 @@ void CPedSA::StaticSetHooks()
 {
     EZHookInstall(CPed_PreRenderAfterTest);
     EZHookInstall(CPed_PreRenderAfterTest_Mid);
+
+    // GTA's player-specific blob-shadow path assumes that the local player is
+    // always opaque. Do not enqueue it when MTA has made the clump invisible.
+    HookInstallCall(CALL_CPed_PreRenderAfterTest_StoreShadowForPedObject, reinterpret_cast<DWORD>(StoreShadowForPedObject));
 
     HookInstallCall(0x68025A, (DWORD)CPedSA::RemoveWeaponWhenEnteringVehicle);  // CTaskSimpleJetPack::ProcessPed
     HookInstallCall(0x64DB4D, (DWORD)CPedSA::RemoveWeaponWhenEnteringVehicle);  // CTaskSimpleCarGetIn::ProcessPed

--- a/Client/game_sa/CPedSA.cpp
+++ b/Client/game_sa/CPedSA.cpp
@@ -12,6 +12,7 @@
 #include "StdInc.h"
 #include "CGameSA.h"
 #include "CPedSA.h"
+#include "CVisibilityPluginsSA.h"
 #include "CPedModelInfoSA.h"
 #include "CPlayerInfoSA.h"
 #include "CStatsSA.h"
@@ -30,14 +31,12 @@ namespace
 {
     constexpr std::uintptr_t FUNC_CRealTimeShadowManager_ReturnRealTimeShadow = 0x705B30;
     constexpr std::uintptr_t CLASS_CRealTimeShadowManager = 0xC40350;
-    constexpr std::uintptr_t FUNC_CVisibilityPlugins_GetClumpAlpha = 0x732B20;
     constexpr std::uintptr_t FUNC_CShadows_StoreShadowForPedObject = 0x707B40;
     constexpr std::uintptr_t CALL_CPed_PreRenderAfterTest_StoreShadowForPedObject = 0x5E6900;
 
     void __cdecl StoreShadowForPedObject(CPedSAInterface* ped, float displacementX, float displacementY, float frontX, float frontY, float sideX, float sideY)
     {
-        using GetClumpAlpha = int(__cdecl*)(RpClump*);
-        if (reinterpret_cast<GetClumpAlpha>(FUNC_CVisibilityPlugins_GetClumpAlpha)(ped->m_pRwObject) == 0)
+        if (CVisibilityPluginsSA::GetClumpAlpha(ped->m_pRwObject) == 0)
             return;
 
         using StoreShadow = void(__cdecl*)(CPedSAInterface*, float, float, float, float, float, float);

--- a/Client/game_sa/CPedSA.h
+++ b/Client/game_sa/CPedSA.h
@@ -368,6 +368,7 @@ public:
     void Init();
 
     void SetModelIndex(std::uint32_t modelIndex) override;
+    void SetVisible(bool visible) override;
 
     bool InternalAttachEntityToEntity(DWORD entityInterface, const CVector* position, const CVector* rotation) override;
     void DetachPedFromEntity() override;

--- a/Client/game_sa/CVisibilityPluginsSA.cpp
+++ b/Client/game_sa/CVisibilityPluginsSA.cpp
@@ -14,6 +14,12 @@
 
 #define FUNC_CVisibilityPlugins_InsertEntityIntoEntityList 0x733DD0
 
+int CVisibilityPluginsSA::GetClumpAlpha(RpClump* pClump)
+{
+    using GetClumpAlpha = int(__cdecl*)(RpClump*);
+    return reinterpret_cast<GetClumpAlpha>(0x732B20)(pClump);
+}
+
 void CVisibilityPluginsSA::SetClumpAlpha(RpClump* pClump, int iAlpha)
 {
     DWORD dwFunc = FUNC_CVisiblityPlugins_SetClumpAlpha;

--- a/Client/game_sa/CVisibilityPluginsSA.h
+++ b/Client/game_sa/CVisibilityPluginsSA.h
@@ -19,8 +19,9 @@
 class CVisibilityPluginsSA : public CVisibilityPlugins
 {
 public:
-    void SetClumpAlpha(RpClump* pClump, int iAlpha);
-    int  GetAtomicId(RwObject* pAtomic);
+    void       SetClumpAlpha(RpClump* pClump, int iAlpha);
+    static int GetClumpAlpha(RpClump* pClump);
+    int        GetAtomicId(RwObject* pAtomic);
 
     bool InsertEntityIntoEntityList(void* entity, float distance, void* callback);
 

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -1692,11 +1692,8 @@ bool CClientPed::IsVisible()
 
 void CClientPed::SetVisible(bool bVisible)
 {
-    if (m_pPlayerPed)
-    {
-        m_pPlayerPed->SetVisible(bVisible);
-    }
     m_bVisible = bVisible;
+    UpdateAlphaAndVisibility();
 }
 
 bool CClientPed::GetUsesCollision()
@@ -2973,14 +2970,7 @@ void CClientPed::StreamedInPulse(bool bDoStandardPulses)
         if (m_pAnimationBlock && m_bisCurrentAnimationCustom)
             UpdateCustomPartialAnimationBones();
 
-        // Update our alpha
-        unsigned char ucAlpha = m_ucAlpha;
-        // Are we in a different interior to the camera? set our alpha to 0
-        if (m_ucInterior != g_pGame->GetWorld()->GetCurrentArea())
-            ucAlpha = 0;
-        RpClump* pClump = m_pPlayerPed->GetRpClump();
-        if (pClump)
-            g_pGame->GetVisibilityPlugins()->SetClumpAlpha(pClump, ucAlpha);
+        UpdateAlphaAndVisibility();
 
         // Grab our current position
         CVector vecPosition = *m_pPlayerPed->GetPosition();
@@ -5356,14 +5346,25 @@ float CClientPed::GetDistanceFromCentreOfMassToBaseOfModel()
 
 void CClientPed::SetAlpha(unsigned char ucAlpha)
 {
-    /* Handled in ::StreamedInPulse
-    if ( m_pPlayerPed )
-    {
-        RpClump * pClump = m_pPlayerPed->GetRpClump ();
-        if ( pClump ) g_pGame->GetVisibilityPlugins ()->SetClumpAlpha ( pClump, ucAlpha );
-    }
-    */
     m_ucAlpha = ucAlpha;
+    UpdateAlphaAndVisibility();
+}
+
+void CClientPed::UpdateAlphaAndVisibility()
+{
+    if (!m_pPlayerPed)
+        return;
+
+    unsigned char effectiveAlpha = m_ucAlpha;
+    if (m_ucInterior != g_pGame->GetWorld()->GetCurrentArea())
+        effectiveAlpha = 0;
+
+    if (RpClump* clump = m_pPlayerPed->GetRpClump())
+        g_pGame->GetVisibilityPlugins()->SetClumpAlpha(clump, effectiveAlpha);
+
+    // GTA decides whether to create ped shadows from its visibility flag, not
+    // the RenderWare clump alpha. Keep both states aligned at zero alpha.
+    m_pPlayerPed->SetVisible(m_bVisible && effectiveAlpha != 0);
 }
 
 void CClientPed::Respawn(CVector* pvecPosition, bool bRestoreState, bool bCameraCut)

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -579,6 +579,7 @@ protected:
     void Init(CClientManager* pManager, unsigned long ulModelID, bool bIsLocalPlayer);
 
     void StreamedInPulse(bool bDoStandardPulses);
+    void UpdateAlphaAndVisibility();
     void ApplyControllerStateFixes(CControllerState& Current);
 
     void Interpolate();


### PR DESCRIPTION
#### Summary

Fix ped shadows remaining visible when the ped's effective alpha is `0`.

**Before**
<img width="1152" height="738" alt="image" src="https://github.com/user-attachments/assets/44c4365d-656e-4be3-9e90-4e5a290d7447" />

**After**
<img width="950" height="754" alt="image" src="https://github.com/user-attachments/assets/68114e75-d154-46a3-be75-a8ca146ef1d5" />


#### Motivation

An invisible ped could still be located by its shadow when using:

```lua
setElementAlpha(ped, 0)
```

The shadow should disappear together with the ped and return normally when its alpha is restored.

#### Test plan

Tested in game on the local player:

[ped-shadow-alpha-player-test.zip](https://github.com/user-attachments/files/31424588/ped-shadow-alpha-player-test.zip)

1. Disable dynamic ped shadows to use blob shadows
2. Use `/pedshadow 0`
3. Confirm the player and blob shadow disappear
4. Use `/pedshadow 255`
5. Confirm the player and shadow return
6. Enable dynamic ped shadows and repeat the same test

Also verified that restoring alpha to `255` recreates the shadow normally.

#### Checklist

- [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/wiki/Coding_guidelines).
- [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
