### PR TITLE
Fix Splash Window (Prevent memory leak when fetching GetDpiForWindow)

### DIFF
--- a/Client/loader/SplashWindow.cpp
+++ b/Client/loader/SplashWindow.cpp
@@ -627,8 +627,14 @@ static UINT GetWindowDpi(HWND window)
     using GetDpiForWindow_t = UINT(WINAPI*)(HWND);
 
     static GetDpiForWindow_t Win32GetDpiForWindow = ([] {
-        HMODULE user32 = LoadLibrary("user32");
-        return user32 ? reinterpret_cast<GetDpiForWindow_t>(static_cast<void*>(GetProcAddress(user32, "GetDpiForWindow"))) : nullptr;
+        HMODULE hUser32 = GetModuleHandleA("user32.dll");
+        if (hUser32)
+        {
+            return reinterpret_cast<GetDpiForWindow_t>(
+                GetProcAddress(hUser32, "GetDpiForWindow")
+            );
+        }
+        return static_cast<GetDpiForWindow_t>(nullptr);
     })();
 
     if (Win32GetDpiForWindow)


### PR DESCRIPTION
#### Summary
Replaced `LoadLibrary("user32")` with `GetModuleHandleA("user32.dll")` when retrieving function pointers from `user32.dll`.


#### Motivation
Calling `LoadLibrary` increments the module's reference count. Because matching calls to `FreeLibrary` were not being made, this resulted in resource and memory leaks over time.

Since `user32.dll` is already loaded into the process address space by default for Win32 GUI applications, using `GetModuleHandleA` safely retrieves the existing module handle without modifying the reference count or leaking resources.


#### Test plan
Compiled the solution and launched the application.
Verified that all features relying on the dynamically retrieved user32.dll functions continue to execute correctly.


#### Checklist
* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.