### PR TITLE
Optimize and decouple debug hook manager for modern event system

### DIFF
--- a/Client/mods/deathmatch/logic/CClientEntity.cpp
+++ b/Client/mods/deathmatch/logic/CClientEntity.cpp
@@ -746,7 +746,7 @@ bool CClientEntity::CallEvent(const char* szName, const CLuaArguments& Arguments
     CDebugHookManager* debugHookManager = g_pClientGame->GetDebugHookManager();
     if (debugHookManager->HasPreEventHooks())
     {
-        if (!debugHookManager->OnPreEvent(szName, Arguments, this, NULL))
+        if (!debugHookManager->OnPreEvent(szName, Arguments, this, nullptr))
             return false;
     }
 
@@ -777,7 +777,7 @@ bool CClientEntity::CallEvent(const char* szName, const CLuaArguments& Arguments
     }
 
     if (debugHookManager->HasPostEventHooks())
-        debugHookManager->OnPostEvent(szName, Arguments, this, NULL);
+        debugHookManager->OnPostEvent(szName, Arguments, this, nullptr);
 
     // Return whether it got cancelled or not
     return (!pEvents->WasEventCancelled());

--- a/Client/mods/deathmatch/logic/CClientEntity.cpp
+++ b/Client/mods/deathmatch/logic/CClientEntity.cpp
@@ -743,8 +743,12 @@ bool CClientEntity::AddEvent(CLuaMain* pLuaMain, const char* szName, const CLuaF
 
 bool CClientEntity::CallEvent(const char* szName, const CLuaArguments& Arguments, bool bCallOnChildren, const char* minClientVersion)
 {
-    if (!g_pClientGame->GetDebugHookManager()->OnPreEvent(szName, Arguments, this, NULL))
-        return false;
+    CDebugHookManager* debugHookManager = g_pClientGame->GetDebugHookManager();
+    if (debugHookManager->HasPreEventHooks())
+    {
+        if (!debugHookManager->OnPreEvent(szName, Arguments, this, NULL))
+            return false;
+    }
 
     TIMEUS startTime = GetTimeUs();
 
@@ -772,7 +776,8 @@ bool CClientEntity::CallEvent(const char* szName, const CLuaArguments& Arguments
             TIMING_DETAIL(SString("Event: %s [%d ms]", szName, deltaTimeUs / 1000));
     }
 
-    g_pClientGame->GetDebugHookManager()->OnPostEvent(szName, Arguments, this, NULL);
+    if (debugHookManager->HasPostEventHooks())
+        debugHookManager->OnPostEvent(szName, Arguments, this, NULL);
 
     // Return whether it got cancelled or not
     return (!pEvents->WasEventCancelled());

--- a/Client/mods/deathmatch/logic/CMapEventManager.cpp
+++ b/Client/mods/deathmatch/logic/CMapEventManager.cpp
@@ -194,8 +194,12 @@ bool CMapEventManager::Call(const char* szName, const CLuaArguments& Arguments, 
                     if (bEnabled)
                         g_pCore->LogEvent(0, "Lua Event", luaMain->GetScriptName(), szName);
 
-                    if (!g_pClientGame->GetDebugHookManager()->OnPreEventFunction(szName, Arguments, pSource, nullptr, pMapEvent))
-                        continue;
+                    CDebugHookManager* debugHookManager = g_pClientGame->GetDebugHookManager();
+                    if (debugHookManager->HasPreEventFunctionHooks())
+                    {
+                        if (!debugHookManager->OnPreEventFunction(szName, Arguments, pSource, nullptr, pMapEvent))
+                            continue;
+                    }
 
                     // Store the current values of the globals
                     lua_getglobal(pState, "source");
@@ -251,7 +255,8 @@ bool CMapEventManager::Call(const char* szName, const CLuaArguments& Arguments, 
                     pMapEvent->Call(Arguments);
                     bCalled = true;
 
-                    g_pClientGame->GetDebugHookManager()->OnPostEventFunction(szName, Arguments, pSource, nullptr, pMapEvent);
+                    if (debugHookManager->HasPostEventFunctionHooks())
+                        debugHookManager->OnPostEventFunction(szName, Arguments, pSource, nullptr, pMapEvent);
 
                     // Reset the globals on that VM
                     OldSource.Push(pState);

--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -165,8 +165,8 @@ bool CStaticFunctionDefinitions::TriggerEvent(const char* szName, CClientEntity&
     if (m_pEvents->Exists(szName))
     {
         // Call the event
-        Entity.CallEvent(szName, Arguments, true);
-        bWasCancelled = m_pEvents->WasEventCancelled();
+        bool bSuccess = Entity.CallEvent(szName, Arguments, true);
+        bWasCancelled = m_pEvents->WasEventCancelled() || !bSuccess;
         return true;
     }
 

--- a/Server/mods/deathmatch/logic/CElement.cpp
+++ b/Server/mods/deathmatch/logic/CElement.cpp
@@ -435,8 +435,12 @@ bool CElement::AddEvent(CLuaMain* pLuaMain, const char* szName, const CLuaFuncti
 
 bool CElement::CallEvent(const char* szName, const CLuaArguments& Arguments, CPlayer* pCaller)
 {
-    if (!g_pGame->GetDebugHookManager()->OnPreEvent(szName, Arguments, this, pCaller))
-        return false;
+    CDebugHookManager* debugHookManager = g_pGame->GetDebugHookManager();
+    if (debugHookManager->HasPreEventHooks())
+    {
+        if (!debugHookManager->OnPreEvent(szName, Arguments, this, pCaller))
+            return false;
+    }
 
     CEvents* pEvents = g_pGame->GetEvents();
 
@@ -452,7 +456,8 @@ bool CElement::CallEvent(const char* szName, const CLuaArguments& Arguments, CPl
     // Tell the event manager that we're done calling the event
     pEvents->PostEventPulse();
 
-    g_pGame->GetDebugHookManager()->OnPostEvent(szName, Arguments, this, pCaller);
+    if (debugHookManager->HasPostEventHooks())
+        debugHookManager->OnPostEvent(szName, Arguments, this, pCaller);
 
     // Return whether our event was cancelled or not
     return (!pEvents->WasEventCancelled());

--- a/Server/mods/deathmatch/logic/CMapEventManager.cpp
+++ b/Server/mods/deathmatch/logic/CMapEventManager.cpp
@@ -175,8 +175,12 @@ bool CMapEventManager::Call(const char* szName, const CLuaArguments& Arguments, 
                     const bool   timingActive = CPerfStatLuaTiming::GetSingleton()->IsActive();
                     const TIMEUS startTime = timingActive ? GetTimeUs() : 0;
 
-                    if (!g_pGame->GetDebugHookManager()->OnPreEventFunction(szName, Arguments, pSource, pCaller, pMapEvent))
-                        continue;
+                    CDebugHookManager* debugHookManager = g_pGame->GetDebugHookManager();
+                    if (debugHookManager->HasPreEventFunctionHooks())
+                    {
+                        if (!debugHookManager->OnPreEventFunction(szName, Arguments, pSource, pCaller, pMapEvent))
+                            continue;
+                    }
 
                     // Store the current values of the globals
                     lua_getglobal(pState, "source");
@@ -247,7 +251,8 @@ bool CMapEventManager::Call(const char* szName, const CLuaArguments& Arguments, 
                     pMapEvent->Call(Arguments);
                     bCalled = true;
 
-                    g_pGame->GetDebugHookManager()->OnPostEventFunction(szName, Arguments, pSource, pCaller, pMapEvent);
+                    if (debugHookManager->HasPostEventFunctionHooks())
+                        debugHookManager->OnPostEventFunction(szName, Arguments, pSource, pCaller, pMapEvent);
 
                     // Reset the globals on that VM
                     OldSource.Push(pState);

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -204,8 +204,8 @@ bool CStaticFunctionDefinitions::TriggerEvent(const char* szName, CElement* pEle
     if (m_pEvents->Exists(szName))
     {
         // Call the event
-        pElement->CallEvent(szName, Arguments);
-        bWasCanceled = m_pEvents->WasEventCancelled();
+        bool bSuccess = pElement->CallEvent(szName, Arguments);
+        bWasCanceled = m_pEvents->WasEventCancelled() || !bSuccess;
         return true;
     }
 

--- a/Shared/mods/deathmatch/logic/CDebugHookManager.cpp
+++ b/Shared/mods/deathmatch/logic/CDebugHookManager.cpp
@@ -206,47 +206,51 @@ void GetDebugInfo(lua_State* luaVM, lua_Debug& debugInfo, const char*& szFilenam
 
 ///////////////////////////////////////////////////////////////
 //
-// GetMapEventDebugInfo
+// GetFunctionDebugInfo
 //
-// Get current Lua source file and line number
+// Get current Lua source file and line number for a specific Lua function
 //
 ///////////////////////////////////////////////////////////////
-void GetMapEventDebugInfo(CMapEvent* pMapEvent, const char*& szFilename, int& iLineNumber)
+void GetFunctionDebugInfo(CLuaMain* luaMain, const CLuaFunctionRef& functionRef, const char*& filename, int& lineNumber)
 {
-    CLuaMain* pLuaMain = pMapEvent->GetVM();
-
-    if (!pLuaMain)
+    if (!luaMain)
         return;
 
-    lua_State* luaVM = pLuaMain->GetVirtualMachine();
+    lua_State* luaVM = luaMain->GetVirtualMachine();
 
-    if (!luaVM)
+    if (!luaVM || functionRef.ToInt() <= 0)
         return;
 
-    const CLuaFunctionRef& iLuaFunction = pMapEvent->GetLuaFunction();
-    lua_Debug              debugInfo;
-    lua_getref(luaVM, iLuaFunction.ToInt());
+    lua_Debug debugInfo;
+    lua_getref(luaVM, functionRef.ToInt());
 
     if (lua_getinfo(luaVM, ">lS", &debugInfo))
     {
         // Make sure this function isn't defined in a string
         if (debugInfo.source[0] == '@')
         {
-            szFilename = debugInfo.source;
-            iLineNumber = debugInfo.currentline != -1 ? debugInfo.currentline : debugInfo.linedefined;
+            filename = debugInfo.source;
+            lineNumber = debugInfo.currentline != -1 ? debugInfo.currentline : debugInfo.linedefined;
         }
         else
         {
-            szFilename = debugInfo.short_src;
+            filename = debugInfo.short_src;
         }
 
         // Remove path
-        if (const char* szNext = strrchr(szFilename, '\\'))
-            szFilename = szNext + 1;
+        if (const char* next = strrchr(filename, '\\'))
+            filename = next + 1;
 
-        if (const char* szNext = strrchr(szFilename, '/'))
-            szFilename = szNext + 1;
+        if (const char* next = strrchr(filename, '/'))
+            filename = next + 1;
     }
+}
+
+// Backward-compatible wrapper for Server CMapEvent
+void GetMapEventDebugInfo(CMapEvent* mapEvent, const char*& filename, int& lineNumber)
+{
+    if (mapEvent)
+        GetFunctionDebugInfo(mapEvent->GetVM(), mapEvent->GetLuaFunction(), filename, lineNumber);
 }
 
 ///////////////////////////////////////////////////////////////
@@ -431,19 +435,28 @@ void CDebugHookManager::GetEventCallHookArguments(CLuaArguments& NewArguments, c
 // Returns false if function call should be skipped
 //
 ///////////////////////////////////////////////////////////////
-bool CDebugHookManager::OnPreEventFunction(const char* szName, const CLuaArguments& Arguments, CElement* pSource, CPlayer* pCaller, CMapEvent* pMapEvent)
+bool CDebugHookManager::OnPreEventFunction(const char* name, const CLuaArguments& args, CElement* source, CPlayer* caller, CLuaMain* functionLuaMain,
+                                           const CLuaFunctionRef& functionRef)
 {
     if (m_PreEventFunctionHookList.empty())
         return true;
 
     // Check if named event function is pre hooked
-    if (!IsNameAllowed(szName, m_PreEventFunctionHookList))
+    if (!IsNameAllowed(name, m_PreEventFunctionHookList))
         return true;
 
-    CLuaArguments NewArguments;
-    GetEventFunctionCallHookArguments(NewArguments, szName, Arguments, pSource, pCaller, pMapEvent);
+    CLuaArguments newArgs;
+    GetEventFunctionCallHookArguments(newArgs, name, args, source, caller, functionLuaMain, functionRef);
 
-    return CallHook(szName, m_PreEventFunctionHookList, NewArguments);
+    return CallHook(name, m_PreEventFunctionHookList, newArgs);
+}
+
+bool CDebugHookManager::OnPreEventFunction(const char* szName, const CLuaArguments& Arguments, CElement* pSource, CPlayer* pCaller, CMapEvent* pMapEvent)
+{
+    if (!pMapEvent)
+        return true;
+
+    return OnPreEventFunction(szName, Arguments, pSource, pCaller, pMapEvent->GetVM(), pMapEvent->GetLuaFunction());
 }
 
 ///////////////////////////////////////////////////////////////
@@ -453,19 +466,28 @@ bool CDebugHookManager::OnPreEventFunction(const char* szName, const CLuaArgumen
 // Called after a Lua event function is called
 //
 ///////////////////////////////////////////////////////////////
-void CDebugHookManager::OnPostEventFunction(const char* szName, const CLuaArguments& Arguments, CElement* pSource, CPlayer* pCaller, CMapEvent* pMapEvent)
+void CDebugHookManager::OnPostEventFunction(const char* name, const CLuaArguments& args, CElement* source, CPlayer* caller, CLuaMain* functionLuaMain,
+                                            const CLuaFunctionRef& functionRef)
 {
     if (m_PostEventFunctionHookList.empty())
         return;
 
     // Check if named event function is post hooked
-    if (!IsNameAllowed(szName, m_PostEventFunctionHookList))
+    if (!IsNameAllowed(name, m_PostEventFunctionHookList))
         return;
 
-    CLuaArguments NewArguments;
-    GetEventFunctionCallHookArguments(NewArguments, szName, Arguments, pSource, pCaller, pMapEvent);
+    CLuaArguments newArgs;
+    GetEventFunctionCallHookArguments(newArgs, name, args, source, caller, functionLuaMain, functionRef);
 
-    CallHook(szName, m_PostEventFunctionHookList, NewArguments);
+    CallHook(name, m_PostEventFunctionHookList, newArgs);
+}
+
+void CDebugHookManager::OnPostEventFunction(const char* szName, const CLuaArguments& Arguments, CElement* pSource, CPlayer* pCaller, CMapEvent* pMapEvent)
+{
+    if (!pMapEvent)
+        return;
+
+    OnPostEventFunction(szName, Arguments, pSource, pCaller, pMapEvent->GetVM(), pMapEvent->GetLuaFunction());
 }
 
 ///////////////////////////////////////////////////////////////
@@ -475,49 +497,55 @@ void CDebugHookManager::OnPostEventFunction(const char* szName, const CLuaArgume
 // Get call hook arguments for OnPre/PostEventFunction
 //
 ///////////////////////////////////////////////////////////////
+void CDebugHookManager::GetEventFunctionCallHookArguments(CLuaArguments& newArguments, const SString& name, const CLuaArguments& args, CElement* source,
+                                                          CPlayer* caller, CLuaMain* functionLuaMain, const CLuaFunctionRef& functionRef)
+{
+    CLuaMain*  eventLuaMain = g_pGame->GetScriptDebugging()->GetTopLuaMain();
+    CResource* eventResource = eventLuaMain ? eventLuaMain->GetResource() : nullptr;
+
+    // Get file/line number for event trigger point
+    const char* eventFilename = "";
+    int         eventLineNumber = 0;
+    lua_Debug   eventDebugInfo;
+    lua_State*  eventLuaVM = eventLuaMain ? eventLuaMain->GetVM() : nullptr;
+    if (eventLuaVM)
+        GetDebugInfo(eventLuaVM, eventDebugInfo, eventFilename, eventLineNumber);
+
+    // Get file/line number for target handler function
+    const char* functionFilename = "";
+    int         functionLineNumber = 0;
+    GetFunctionDebugInfo(functionLuaMain, functionRef, functionFilename, functionLineNumber);
+
+    CResource* functionResource = functionLuaMain ? functionLuaMain->GetResource() : nullptr;
+
+    // resource eventResource, string eventName, element eventSource, element eventClient, string eventFilename, int eventLineNumber,
+    if (eventResource)
+        newArguments.PushResource(eventResource);
+    else
+        newArguments.PushNil();
+
+    newArguments.PushString(name);
+    newArguments.PushElement(source);
+    newArguments.PushElement(caller);
+    newArguments.PushString(eventFilename);
+    newArguments.PushNumber(eventLineNumber);
+
+    // resource functionResource, string functionFilename, int functionLineNumber, ...args
+    if (functionResource)
+        newArguments.PushResource(functionResource);
+    else
+        newArguments.PushNil();
+
+    newArguments.PushString(functionFilename);
+    newArguments.PushNumber(functionLineNumber);
+    newArguments.PushArguments(args);
+}
+
 void CDebugHookManager::GetEventFunctionCallHookArguments(CLuaArguments& NewArguments, const SString& strName, const CLuaArguments& Arguments,
                                                           CElement* pSource, CPlayer* pCaller, CMapEvent* pMapEvent)
 {
-    CLuaMain*  pEventLuaMain = g_pGame->GetScriptDebugging()->GetTopLuaMain();
-    CResource* pEventResource = pEventLuaMain ? pEventLuaMain->GetResource() : NULL;
-
-    // Get file/line number for event
-    const char* szEventFilename = "";
-    int         iEventLineNumber = 0;
-    lua_Debug   eventDebugInfo;
-    lua_State*  eventLuaVM = pEventLuaMain ? pEventLuaMain->GetVM() : NULL;
-    if (eventLuaVM)
-        GetDebugInfo(eventLuaVM, eventDebugInfo, szEventFilename, iEventLineNumber);
-
-    // Get file/line number for function
-    const char* szFunctionFilename = "";
-    int         iFunctionLineNumber = 0;
-    GetMapEventDebugInfo(pMapEvent, szFunctionFilename, iFunctionLineNumber);
-
-    CLuaMain*  pFunctionLuaMain = pMapEvent->GetVM();
-    CResource* pFunctionResource = pFunctionLuaMain ? pFunctionLuaMain->GetResource() : NULL;
-
-    // resource eventResource, string eventName, element eventSource, element eventClient, string eventFilename, int eventLineNumber,
-    if (pEventResource)
-        NewArguments.PushResource(pEventResource);
-    else
-        NewArguments.PushNil();
-
-    NewArguments.PushString(strName);
-    NewArguments.PushElement(pSource);
-    NewArguments.PushElement(pCaller);
-    NewArguments.PushString(szEventFilename);
-    NewArguments.PushNumber(iEventLineNumber);
-
-    // resource functionResource, string functionFilename, int functionLineNumber, ...args
-    if (pFunctionResource)
-        NewArguments.PushResource(pFunctionResource);
-    else
-        NewArguments.PushNil();
-
-    NewArguments.PushString(szFunctionFilename);
-    NewArguments.PushNumber(iFunctionLineNumber);
-    NewArguments.PushArguments(Arguments);
+    if (pMapEvent)
+        GetEventFunctionCallHookArguments(NewArguments, strName, Arguments, pSource, pCaller, pMapEvent->GetVM(), pMapEvent->GetLuaFunction());
 }
 
 ///////////////////////////////////////////////////////////////

--- a/Shared/mods/deathmatch/logic/CDebugHookManager.h
+++ b/Shared/mods/deathmatch/logic/CDebugHookManager.h
@@ -66,12 +66,29 @@ public:
     void OnPostFunction(lua_CFunction f, lua_State* luaVM);
     bool OnPreEvent(const char* szName, const CLuaArguments& Arguments, CElement* pSource, CPlayer* pCaller);
     void OnPostEvent(const char* szName, const CLuaArguments& Arguments, CElement* pSource, CPlayer* pCaller);
+
+    // Modern decoupled event function hooks accepting direct VM and function reference
+    bool OnPreEventFunction(const char* name, const CLuaArguments& args, CElement* source, CPlayer* caller, CLuaMain* functionLuaMain,
+                            const CLuaFunctionRef& functionRef);
+    void OnPostEventFunction(const char* name, const CLuaArguments& args, CElement* source, CPlayer* caller, CLuaMain* functionLuaMain,
+                             const CLuaFunctionRef& functionRef);
+
+    // Legacy overload for Server CMapEvent compatibility
     bool OnPreEventFunction(const char* szName, const CLuaArguments& Arguments, CElement* pSource, CPlayer* pCaller, CMapEvent* pMapEvent);
     void OnPostEventFunction(const char* szName, const CLuaArguments& Arguments, CElement* pSource, CPlayer* pCaller, CMapEvent* pMapEvent);
-    bool HasPostFunctionHooks() const { return !m_PostFunctionHookList.empty() || m_uiPostFunctionOverride; }
+
+    // Fast inline presence checkers to eliminate function call overhead when no debug hooks are active
+    inline bool HasPreEventHooks() const noexcept { return !m_PreEventHookList.empty(); }
+    inline bool HasPostEventHooks() const noexcept { return !m_PostEventHookList.empty(); }
+    inline bool HasPreFunctionHooks() const noexcept { return !m_PreFunctionHookList.empty(); }
+    inline bool HasPostFunctionHooks() const noexcept { return !m_PostFunctionHookList.empty() || m_uiPostFunctionOverride; }
+    inline bool HasPreEventFunctionHooks() const noexcept { return !m_PreEventFunctionHookList.empty(); }
+    inline bool HasPostEventFunctionHooks() const noexcept { return !m_PostEventFunctionHookList.empty(); }
 
 protected:
     void GetFunctionCallHookArguments(CLuaArguments& NewArguments, const SString& strName, lua_State* luaVM, bool bAllowed);
+    void GetEventFunctionCallHookArguments(CLuaArguments& newArgs, const SString& name, const CLuaArguments& args, CElement* source, CPlayer* caller,
+                                           CLuaMain* functionLuaMain, const CLuaFunctionRef& functionRef);
     void GetEventFunctionCallHookArguments(CLuaArguments& NewArguments, const SString& strName, const CLuaArguments& Arguments, CElement* pSource,
                                            CPlayer* pCaller, CMapEvent* pMapEvent);
     void GetEventCallHookArguments(CLuaArguments& NewArguments, const SString& strName, const CLuaArguments& Arguments, CElement* pSource, CPlayer* pCaller);


### PR DESCRIPTION
### Summary

for #5240 

- Decoupled debug info extraction to work directly with Lua function references, fully restoring all 4 event hook types without legacy dependencies.
- Added inlined presence checks to reduce the hotpath hook check to an $O(1)$ branch, ensuring zero function-call overhead during normal gameplay when no hooks are active.
- Fixed event triggering to properly mark events as cancelled and return false when aborted by a pre-event hook.
- Kept backward compatibility wrappers for server-side event handling.

### Testing

- Tested with an automated [test_debug_hooks.zip](https://github.com/user-attachments/files/31490001/test_debug_hooks.zip) verifying all 4 event hook types, metadata extraction, selective handler skipping, and cancellation handling.
