### PR TITLE
Fix UV animated textures not working on custom loaded DFF models

### DIFF
--- a/Client/game_sa/CFileLoaderSA.cpp
+++ b/Client/game_sa/CFileLoaderSA.cpp
@@ -194,23 +194,22 @@ bool CFileLoader_LoadAtomicFile(RwStream* stream, unsigned int modelId)
 // its own effect type set, or the render pipeline keeps sampling static UVs.
 static constexpr std::uint32_t RP_UVANIM_DUAL_PASS_CHANNEL = 1;
 
+static RpMaterial* EnableMaterialUVAnimCB(RpMaterial* material, void* data)
+{
+    if (!material || !RpMaterialUVAnimExists(material))
+        return material;
+
+    RpMatFXAtomicEnableEffects(static_cast<RpAtomic*>(data));
+
+    const bool bDual = RpMaterialUVAnimGetInterpolator(material, RP_UVANIM_DUAL_PASS_CHANNEL) != nullptr;
+    RpMatFXMaterialSetEffects(material, bDual ? rpMATFXEFFECTDUALUVTRANSFORM : rpMATFXEFFECTUVTRANSFORM);
+    return material;
+}
+
 static void EnableUVAnimIfPresent(RpAtomic* atomic)
 {
-    RpGeometry* geometry = atomic->geometry;
-    if (!geometry)
-        return;
-
-    for (std::int32_t i = 0; i < geometry->materials.entries; i++)
-    {
-        RpMaterial* material = geometry->materials.materials[i];
-        if (!material || !RpMaterialUVAnimExists(material))
-            continue;
-
-        RpMatFXAtomicEnableEffects(atomic);
-
-        const bool bDual = RpMaterialUVAnimGetInterpolator(material, RP_UVANIM_DUAL_PASS_CHANNEL) != nullptr;
-        RpMatFXMaterialSetEffects(material, bDual ? rpMATFXEFFECTDUALUVTRANSFORM : rpMATFXEFFECTUVTRANSFORM);
-    }
+    if (atomic->geometry)
+        RpGeometryForAllMaterials(atomic->geometry, EnableMaterialUVAnimCB, atomic);
 }
 
 RpAtomic* CFileLoader_SetRelatedModelInfoCB(RpAtomic* atomic, SRelatedModelInfo* pRelatedModelInfo)

--- a/Client/game_sa/CFileLoaderSA.cpp
+++ b/Client/game_sa/CFileLoaderSA.cpp
@@ -143,6 +143,23 @@ static void CVehicleModelInfo_StopUsingCommonVehicleTexDicationary()
 static auto          CModelInfo_ms_modelInfoPtrs = (CBaseModelInfoSAInterface**)ARRAY_ModelInfo;
 static unsigned int& gAtomicModelId = *reinterpret_cast<unsigned int*>(DWORD_AtomicsReplacerModelID);
 
+// UV anim keyframes live in a dictionary chunk preceding the clump; peek the header instead of
+// RwStreamFindChunk, which would skip the whole chunk by its declared length.
+static constexpr std::uint32_t RW_CHUNK_UVANIMDICT = 0x2B;
+static const std::uintptr_t    ARRAY_RpUVAnimDictSchema = 0x8DED50;
+
+RtDict* CFileLoader_ReadLeadingUVAnimDict(RwStream* stream, RwChunkHeaderInfo& outLeadingChunk)
+{
+    RwStreamReadChunkHeaderInfo(stream, &outLeadingChunk);
+    if (outLeadingChunk.type != RW_CHUNK_UVANIMDICT)
+        return nullptr;
+
+    auto*   schema = reinterpret_cast<RtDictSchema*>(ARRAY_RpUVAnimDictSchema);
+    RtDict* dict = RtDictSchemaStreamReadDict(schema, stream);
+    RtDictSchemaSetCurrentDict(schema, dict);
+    return dict;
+}
+
 bool CFileLoader_LoadAtomicFile(RwStream* stream, unsigned int modelId)
 {
     CBaseModelInfoSAInterface* pBaseModelInfo = CModelInfo_ms_modelInfoPtrs[modelId];
@@ -156,11 +173,18 @@ bool CFileLoader_LoadAtomicFile(RwStream* stream, unsigned int modelId)
     }
 
     const unsigned int rwID_CLUMP = 16;
-    if (RwStreamFindChunk(stream, rwID_CLUMP, nullptr, nullptr))
+
+    RwChunkHeaderInfo leadingChunk;
+    RtDict*           pUVAnimDict = CFileLoader_ReadLeadingUVAnimDict(stream, leadingChunk);
+
+    if (leadingChunk.type == rwID_CLUMP || RwStreamFindChunk(stream, rwID_CLUMP, nullptr, nullptr))
     {
         RpClump* pReadClump = RpClumpStreamRead(stream);
         if (!pReadClump)
         {
+            if (pUVAnimDict)
+                RtDictDestroy(pUVAnimDict);
+
             if (bUseCommonVehicleTexDictionary)
             {
                 CVehicleModelInfo_StopUsingCommonVehicleTexDicationary();
@@ -177,6 +201,9 @@ bool CFileLoader_LoadAtomicFile(RwStream* stream, unsigned int modelId)
         RpClumpDestroy(pReadClump);
     }
 
+    if (pUVAnimDict)
+        RtDictDestroy(pUVAnimDict);
+
     if (!pBaseModelInfo->pRwObject)
     {
         return false;
@@ -187,6 +214,29 @@ bool CFileLoader_LoadAtomicFile(RwStream* stream, unsigned int modelId)
         CVehicleModelInfo_StopUsingCommonVehicleTexDicationary();
     }
     return true;
+}
+
+// The atomic level MatFX flag alone does not animate UV coordinates; each material also needs
+// its own effect type set, or the render pipeline keeps sampling static UVs.
+static constexpr std::uint32_t RP_UVANIM_DUAL_PASS_CHANNEL = 1;
+
+static void EnableUVAnimIfPresent(RpAtomic* atomic)
+{
+    RpGeometry* geometry = atomic->geometry;
+    if (!geometry)
+        return;
+
+    for (std::int32_t i = 0; i < geometry->materials.entries; i++)
+    {
+        RpMaterial* material = geometry->materials.materials[i];
+        if (!material || !RpMaterialUVAnimExists(material))
+            continue;
+
+        RpMatFXAtomicEnableEffects(atomic);
+
+        const bool bDual = RpMaterialUVAnimGetInterpolator(material, RP_UVANIM_DUAL_PASS_CHANNEL) != nullptr;
+        RpMatFXMaterialSetEffects(material, bDual ? rpMATFXEFFECTDUALUVTRANSFORM : rpMATFXEFFECTUVTRANSFORM);
+    }
 }
 
 RpAtomic* CFileLoader_SetRelatedModelInfoCB(RpAtomic* atomic, SRelatedModelInfo* pRelatedModelInfo)
@@ -227,6 +277,7 @@ RpAtomic* CFileLoader_SetRelatedModelInfoCB(RpAtomic* atomic, SRelatedModelInfo*
     RwFrame* newFrame = RwFrameCreate();
     RpAtomicSetFrame(atomic, newFrame);
     CVisibilityPlugins_SetAtomicId(atomic, gAtomicModelId);
+    EnableUVAnimIfPresent(atomic);
 
     // Fix #359: engineReplaceModel memory leak
     if (!bDamage && pRelatedModelInfo->bDeleteOldRwObject)

--- a/Client/game_sa/CFileLoaderSA.cpp
+++ b/Client/game_sa/CFileLoaderSA.cpp
@@ -143,23 +143,6 @@ static void CVehicleModelInfo_StopUsingCommonVehicleTexDicationary()
 static auto          CModelInfo_ms_modelInfoPtrs = (CBaseModelInfoSAInterface**)ARRAY_ModelInfo;
 static unsigned int& gAtomicModelId = *reinterpret_cast<unsigned int*>(DWORD_AtomicsReplacerModelID);
 
-// UV anim keyframes live in a dictionary chunk preceding the clump; peek the header instead of
-// RwStreamFindChunk, which would skip the whole chunk by its declared length.
-static constexpr std::uint32_t RW_CHUNK_UVANIMDICT = 0x2B;
-static const std::uintptr_t    ARRAY_RpUVAnimDictSchema = 0x8DED50;
-
-RtDict* CFileLoader_ReadLeadingUVAnimDict(RwStream* stream, RwChunkHeaderInfo& outLeadingChunk)
-{
-    RwStreamReadChunkHeaderInfo(stream, &outLeadingChunk);
-    if (outLeadingChunk.type != RW_CHUNK_UVANIMDICT)
-        return nullptr;
-
-    auto*   schema = reinterpret_cast<RtDictSchema*>(ARRAY_RpUVAnimDictSchema);
-    RtDict* dict = RtDictSchemaStreamReadDict(schema, stream);
-    RtDictSchemaSetCurrentDict(schema, dict);
-    return dict;
-}
-
 bool CFileLoader_LoadAtomicFile(RwStream* stream, unsigned int modelId)
 {
     CBaseModelInfoSAInterface* pBaseModelInfo = CModelInfo_ms_modelInfoPtrs[modelId];
@@ -172,19 +155,13 @@ bool CFileLoader_LoadAtomicFile(RwStream* stream, unsigned int modelId)
         CVehicleModelInfo_UseCommonVehicleTexDicationary();
     }
 
+    // CStreaming::ConvertBufferToObject, this function's only caller, already reads the leading UV anim dictionary chunk.
     const unsigned int rwID_CLUMP = 16;
-
-    RwChunkHeaderInfo leadingChunk;
-    RtDict*           pUVAnimDict = CFileLoader_ReadLeadingUVAnimDict(stream, leadingChunk);
-
-    if (leadingChunk.type == rwID_CLUMP || RwStreamFindChunk(stream, rwID_CLUMP, nullptr, nullptr))
+    if (RwStreamFindChunk(stream, rwID_CLUMP, nullptr, nullptr))
     {
         RpClump* pReadClump = RpClumpStreamRead(stream);
         if (!pReadClump)
         {
-            if (pUVAnimDict)
-                RtDictDestroy(pUVAnimDict);
-
             if (bUseCommonVehicleTexDictionary)
             {
                 CVehicleModelInfo_StopUsingCommonVehicleTexDicationary();
@@ -200,9 +177,6 @@ bool CFileLoader_LoadAtomicFile(RwStream* stream, unsigned int modelId)
         RpClumpForAllAtomics(pReadClump, reinterpret_cast<RpClumpForAllAtomicsCB_t>(CFileLoader_SetRelatedModelInfoCB), &relatedModelInfo);
         RpClumpDestroy(pReadClump);
     }
-
-    if (pUVAnimDict)
-        RtDictDestroy(pUVAnimDict);
 
     if (!pBaseModelInfo->pRwObject)
     {

--- a/Client/game_sa/CFileLoaderSA.h
+++ b/Client/game_sa/CFileLoaderSA.h
@@ -8,8 +8,6 @@ class CEntitySAInterface;
 struct RpAtomic;
 struct RpClump;
 struct RwStream;
-struct RwChunkHeaderInfo;
-struct RtDict;
 
 struct SRelatedModelInfo
 {
@@ -43,7 +41,3 @@ public:
 bool                CFileLoader_LoadAtomicFile(RwStream* stream, unsigned int modelId);
 RpAtomic*           CFileLoader_SetRelatedModelInfoCB(RpAtomic* atomic, SRelatedModelInfo* pRelatedModelInfo);
 CEntitySAInterface* CFileLoader_LoadObjectInstance(const char* szLine);
-
-// Reads the UV anim dictionary preceding a clump, if present, and sets it current for
-// RpClumpStreamRead. outLeadingChunk receives the peeked header either way.
-RtDict* CFileLoader_ReadLeadingUVAnimDict(RwStream* stream, RwChunkHeaderInfo& outLeadingChunk);

--- a/Client/game_sa/CFileLoaderSA.h
+++ b/Client/game_sa/CFileLoaderSA.h
@@ -8,6 +8,8 @@ class CEntitySAInterface;
 struct RpAtomic;
 struct RpClump;
 struct RwStream;
+struct RwChunkHeaderInfo;
+struct RtDict;
 
 struct SRelatedModelInfo
 {
@@ -41,3 +43,7 @@ public:
 bool                CFileLoader_LoadAtomicFile(RwStream* stream, unsigned int modelId);
 RpAtomic*           CFileLoader_SetRelatedModelInfoCB(RpAtomic* atomic, SRelatedModelInfo* pRelatedModelInfo);
 CEntitySAInterface* CFileLoader_LoadObjectInstance(const char* szLine);
+
+// Reads the UV anim dictionary preceding a clump, if present, and sets it current for
+// RpClumpStreamRead. outLeadingChunk receives the peeked header either way.
+RtDict* CFileLoader_ReadLeadingUVAnimDict(RwStream* stream, RwChunkHeaderInfo& outLeadingChunk);

--- a/Client/game_sa/CRenderWareSA.cpp
+++ b/Client/game_sa/CRenderWareSA.cpp
@@ -244,6 +244,23 @@ RwTexDictionary* CRenderWareSA::ReadTXD(const SString& strFilename, const SStrin
     return pTex;
 }
 
+// UV anim keyframes live in a dictionary chunk preceding the clump; peek the header instead of
+// RwStreamFindChunk, which would skip the whole chunk by its declared length.
+static constexpr std::uint32_t RW_CHUNK_UVANIMDICT = 0x2B;
+static const std::uintptr_t    ARRAY_RpUVAnimDictSchema = 0x8DED50;
+
+static RtDict* ReadLeadingUVAnimDict(RwStream* stream, RwChunkHeaderInfo& outLeadingChunk)
+{
+    RwStreamReadChunkHeaderInfo(stream, &outLeadingChunk);
+    if (outLeadingChunk.type != RW_CHUNK_UVANIMDICT)
+        return nullptr;
+
+    auto*   schema = reinterpret_cast<RtDictSchema*>(ARRAY_RpUVAnimDictSchema);
+    RtDict* dict = RtDictSchemaStreamReadDict(schema, stream);
+    RtDictSchemaSetCurrentDict(schema, dict);
+    return dict;
+}
+
 // Reads and parses a DFF file specified by a path (szDFF) into a CModelInfo identified by the object id (usModelID)
 // bLoadEmbeddedCollisions should be true for vehicles
 // Any custom TXD should be imported before this call
@@ -275,10 +292,8 @@ RpClump* CRenderWareSA::ReadDFF(const SString& strFilename, const SString& buffe
     if (streamModel == NULL)
         return NULL;
 
-    // engineLoadDFF loads through here rather than CFileLoader_LoadAtomicFile, so it needs the
-    // same leading UV anim dictionary read.
     RwChunkHeaderInfo leadingChunk;
-    RtDict*           pUVAnimDict = CFileLoader_ReadLeadingUVAnimDict(streamModel, leadingChunk);
+    RtDict*           pUVAnimDict = ReadLeadingUVAnimDict(streamModel, leadingChunk);
 
     // DFF header id: 0x10
     // find our dff chunk

--- a/Client/game_sa/CRenderWareSA.cpp
+++ b/Client/game_sa/CRenderWareSA.cpp
@@ -275,10 +275,18 @@ RpClump* CRenderWareSA::ReadDFF(const SString& strFilename, const SString& buffe
     if (streamModel == NULL)
         return NULL;
 
+    // engineLoadDFF loads through here rather than CFileLoader_LoadAtomicFile, so it needs the
+    // same leading UV anim dictionary read.
+    RwChunkHeaderInfo leadingChunk;
+    RtDict*           pUVAnimDict = CFileLoader_ReadLeadingUVAnimDict(streamModel, leadingChunk);
+
     // DFF header id: 0x10
     // find our dff chunk
-    if (RwStreamFindChunk(streamModel, 0x10, NULL, NULL) == false)
+    if (leadingChunk.type != 0x10 && RwStreamFindChunk(streamModel, 0x10, NULL, NULL) == false)
     {
+        if (pUVAnimDict)
+            RtDictDestroy(pUVAnimDict);
+
         RwStreamClose(streamModel, NULL);
         return NULL;
     }
@@ -317,6 +325,9 @@ RpClump* CRenderWareSA::ReadDFF(const SString& strFilename, const SString& buffe
 
     // close the stream
     RwStreamClose(streamModel, NULL);
+
+    if (pUVAnimDict)
+        RtDictDestroy(pUVAnimDict);
 
     return pClump;
 }

--- a/Client/game_sa/CRenderWareSA.cpp
+++ b/Client/game_sa/CRenderWareSA.cpp
@@ -246,8 +246,8 @@ RwTexDictionary* CRenderWareSA::ReadTXD(const SString& strFilename, const SStrin
 
 // UV anim keyframes live in a dictionary chunk preceding the clump; peek the header instead of
 // RwStreamFindChunk, which would skip the whole chunk by its declared length.
-static constexpr std::uint32_t RW_CHUNK_UVANIMDICT = 0x2B;
-static const std::uintptr_t    ARRAY_RpUVAnimDictSchema = 0x8DED50;
+static constexpr std::uint32_t  RW_CHUNK_UVANIMDICT = 0x2B;
+static constexpr std::uintptr_t ARRAY_RpUVAnimDictSchema = 0x8DED50;
 
 static RtDict* ReadLeadingUVAnimDict(RwStream* stream, RwChunkHeaderInfo& outLeadingChunk)
 {

--- a/Client/game_sa/gamesa_renderware.h
+++ b/Client/game_sa/gamesa_renderware.h
@@ -64,6 +64,14 @@ typedef RwMatrix*(__cdecl* RwMatrixTranslate_t)(RwMatrix* matrix, const RwV3d* t
 typedef RwMatrix*(__cdecl* RwMatrixScale_t)(RwMatrix* matrix, const RwV3d* translation, RwTransformOrder order);
 typedef RpMaterial*(__cdecl* RpMaterialCreate_t)();
 typedef int(__cdecl* RpMaterialDestroy_t)(RpMaterial* mat);
+typedef int(__cdecl* RpMaterialUVAnimExists_t)(const RpMaterial* mat);
+typedef void*(__cdecl* RpMaterialUVAnimGetInterpolator_t)(RpMaterial* mat, unsigned int slot);
+typedef RpAtomic*(__cdecl* RpMatFXAtomicEnableEffects_t)(RpAtomic* atomic);
+typedef RpMaterial*(__cdecl* RpMatFXMaterialSetEffects_t)(RpMaterial* mat, RpMatFXMaterialFlags flags);
+typedef RwStream*(__cdecl* RwStreamReadChunkHeaderInfo_t)(RwStream* stream, RwChunkHeaderInfo* header);
+typedef RtDict*(__cdecl* RtDictSchemaStreamReadDict_t)(RtDictSchema* schema, RwStream* stream);
+typedef RtDictSchema*(__cdecl* RtDictSchemaSetCurrentDict_t)(RtDictSchema* schema, RtDict* dict);
+typedef int(__cdecl* RtDictDestroy_t)(RtDict* dict);
 typedef RwTexDictionary*(__cdecl* RwTexDictionarySetCurrent_t)(RwTexDictionary* dict);
 typedef const RwTexDictionary*(__cdecl* RwTexDictionaryForAllTextures_t)(const RwTexDictionary* dict, void* callback, void* data);
 typedef RwTexture*(__cdecl* RwTexDictionaryAddTexture_t)(RwTexDictionary* dict, RwTexture* texture);
@@ -166,6 +174,14 @@ RWFUNC(RpGeometryTriangleSetMaterial_t RpGeometryTriangleSetMaterial, (RpGeometr
 RWFUNC(RpMaterialCreate_t RpMaterialCreate, (RpMaterialCreate_t)0xDEAD)
 RWFUNC(RpGeometryDestroy_t RpGeometryDestroy, (RpGeometryDestroy_t)0xDEAD)
 RWFUNC(RpMaterialDestroy_t RpMaterialDestroy, (RpMaterialDestroy_t)0xDEAD)
+RWFUNC(RpMaterialUVAnimExists_t RpMaterialUVAnimExists, (RpMaterialUVAnimExists_t)0xDEAD)
+RWFUNC(RpMaterialUVAnimGetInterpolator_t RpMaterialUVAnimGetInterpolator, (RpMaterialUVAnimGetInterpolator_t)0xDEAD)
+RWFUNC(RpMatFXAtomicEnableEffects_t RpMatFXAtomicEnableEffects, (RpMatFXAtomicEnableEffects_t)0xDEAD)
+RWFUNC(RpMatFXMaterialSetEffects_t RpMatFXMaterialSetEffects, (RpMatFXMaterialSetEffects_t)0xDEAD)
+RWFUNC(RwStreamReadChunkHeaderInfo_t RwStreamReadChunkHeaderInfo, (RwStreamReadChunkHeaderInfo_t)0xDEAD)
+RWFUNC(RtDictSchemaStreamReadDict_t RtDictSchemaStreamReadDict, (RtDictSchemaStreamReadDict_t)0xDEAD)
+RWFUNC(RtDictSchemaSetCurrentDict_t RtDictSchemaSetCurrentDict, (RtDictSchemaSetCurrentDict_t)0xDEAD)
+RWFUNC(RtDictDestroy_t RtDictDestroy, (RtDictDestroy_t)0xDEAD)
 RWFUNC(RwV3dNormalize_t RwV3dNormalize, (RwV3dNormalize_t)0xDEAD)
 RWFUNC(RwIm3DTransform_t RwIm3DTransform, (RwIm3DTransform_t)0xDEAD)
 RWFUNC(RwIm3DRenderIndexedPrimitive_t RwIm3DRenderIndexedPrimitive, (RwIm3DRenderIndexedPrimitive_t)0xDEAD)

--- a/Client/game_sa/gamesa_renderware.h
+++ b/Client/game_sa/gamesa_renderware.h
@@ -64,6 +64,8 @@ typedef RwMatrix*(__cdecl* RwMatrixTranslate_t)(RwMatrix* matrix, const RwV3d* t
 typedef RwMatrix*(__cdecl* RwMatrixScale_t)(RwMatrix* matrix, const RwV3d* translation, RwTransformOrder order);
 typedef RpMaterial*(__cdecl* RpMaterialCreate_t)();
 typedef int(__cdecl* RpMaterialDestroy_t)(RpMaterial* mat);
+typedef RpMaterial*(__cdecl* RpMaterialCallBack_t)(RpMaterial* mat, void* data);
+typedef RpGeometry*(__cdecl* RpGeometryForAllMaterials_t)(RpGeometry* geometry, RpMaterialCallBack_t callback, void* data);
 typedef int(__cdecl* RpMaterialUVAnimExists_t)(const RpMaterial* mat);
 typedef void*(__cdecl* RpMaterialUVAnimGetInterpolator_t)(RpMaterial* mat, unsigned int slot);
 typedef RpAtomic*(__cdecl* RpMatFXAtomicEnableEffects_t)(RpAtomic* atomic);
@@ -174,6 +176,7 @@ RWFUNC(RpGeometryTriangleSetMaterial_t RpGeometryTriangleSetMaterial, (RpGeometr
 RWFUNC(RpMaterialCreate_t RpMaterialCreate, (RpMaterialCreate_t)0xDEAD)
 RWFUNC(RpGeometryDestroy_t RpGeometryDestroy, (RpGeometryDestroy_t)0xDEAD)
 RWFUNC(RpMaterialDestroy_t RpMaterialDestroy, (RpMaterialDestroy_t)0xDEAD)
+RWFUNC(RpGeometryForAllMaterials_t RpGeometryForAllMaterials, (RpGeometryForAllMaterials_t)0xDEAD)
 RWFUNC(RpMaterialUVAnimExists_t RpMaterialUVAnimExists, (RpMaterialUVAnimExists_t)0xDEAD)
 RWFUNC(RpMaterialUVAnimGetInterpolator_t RpMaterialUVAnimGetInterpolator, (RpMaterialUVAnimGetInterpolator_t)0xDEAD)
 RWFUNC(RpMatFXAtomicEnableEffects_t RpMatFXAtomicEnableEffects, (RpMatFXAtomicEnableEffects_t)0xDEAD)

--- a/Client/game_sa/gamesa_renderware.hpp
+++ b/Client/game_sa/gamesa_renderware.hpp
@@ -60,6 +60,14 @@ void InitRwFunctions()
     RpMaterialCreate = (RpMaterialCreate_t)0x0074D990;
     RpGeometryDestroy = (RpGeometryDestroy_t)0x0074CCC0;
     RpMaterialDestroy = (RpMaterialDestroy_t)0x0074DA20;
+    RpMaterialUVAnimExists = (RpMaterialUVAnimExists_t)0x007CC530;
+    RpMaterialUVAnimGetInterpolator = (RpMaterialUVAnimGetInterpolator_t)0x007CC430;
+    RpMatFXAtomicEnableEffects = (RpMatFXAtomicEnableEffects_t)0x00811C00;
+    RpMatFXMaterialSetEffects = (RpMatFXMaterialSetEffects_t)0x00811C80;
+    RwStreamReadChunkHeaderInfo = (RwStreamReadChunkHeaderInfo_t)0x007ED590;
+    RtDictSchemaStreamReadDict = (RtDictSchemaStreamReadDict_t)0x007CF240;
+    RtDictSchemaSetCurrentDict = (RtDictSchemaSetCurrentDict_t)0x007CEEF0;
+    RtDictDestroy = (RtDictDestroy_t)0x007CF130;
     RwV3dNormalize = (RwV3dNormalize_t)0x007ED9B0;
     RwIm3DTransform = (RwIm3DTransform_t)0x007EF450;
     RwIm3DRenderIndexedPrimitive = (RwIm3DRenderIndexedPrimitive_t)0x007EF550;

--- a/Client/game_sa/gamesa_renderware.hpp
+++ b/Client/game_sa/gamesa_renderware.hpp
@@ -60,6 +60,7 @@ void InitRwFunctions()
     RpMaterialCreate = (RpMaterialCreate_t)0x0074D990;
     RpGeometryDestroy = (RpGeometryDestroy_t)0x0074CCC0;
     RpMaterialDestroy = (RpMaterialDestroy_t)0x0074DA20;
+    RpGeometryForAllMaterials = (RpGeometryForAllMaterials_t)0x0074C790;
     RpMaterialUVAnimExists = (RpMaterialUVAnimExists_t)0x007CC530;
     RpMaterialUVAnimGetInterpolator = (RpMaterialUVAnimGetInterpolator_t)0x007CC430;
     RpMatFXAtomicEnableEffects = (RpMatFXAtomicEnableEffects_t)0x00811C00;

--- a/Client/sdk/game/RenderWare.h
+++ b/Client/sdk/game/RenderWare.h
@@ -51,6 +51,8 @@ typedef struct RwObjectFrame        RwObjectFrame;
 typedef struct RpAtomic             RpAtomic;
 typedef struct RwCamera             RwCamera;
 typedef struct RpLight              RpLight;
+typedef struct RtDict               RtDict;
+typedef struct RtDictSchema         RtDictSchema;
 
 typedef RwCamera* (*RwCameraPreCallback)(RwCamera* camera);
 typedef RwCamera* (*RwCameraPostCallback)(RwCamera* camera);
@@ -198,6 +200,11 @@ enum RpLightFlags
     LIGHT_ILLUMINATES_ATOMICS = 1,
     LIGHT_ILLUMINATES_GEOMETRY = 2,
     LIGHT_FLAGS_LAST = RW_STRUCT_ALIGN
+};
+enum RpMatFXMaterialFlags
+{
+    rpMATFXEFFECTUVTRANSFORM = 5,
+    rpMATFXEFFECTDUALUVTRANSFORM = 6
 };
 
 // RenderWare/plugin base types
@@ -528,6 +535,14 @@ struct RwStream
 struct RwError
 {
     int err1, err2;
+};
+struct RwChunkHeaderInfo
+{
+    unsigned int type;
+    unsigned int length;
+    unsigned int version;
+    unsigned int buildNum;
+    int          isComplex;
 };
 
 /*****************************************************************************/


### PR DESCRIPTION
#### Summary
Adds the missing leading UV anim dictionary read to CRenderWareSA::ReadDFF, the path used by engineLoadDFF and engineReplaceModel, so custom loaded DFF models with UV animated textures play those animations instead of staying static.

https://streamable.com/08znl7 (Now you can use SA:MP animated objects, for example)

#### Motivation
ReadDFF opens its own stream and parses the clump directly, with no upstream code reading the leading UV anim dictionary chunk first. Native streaming already handles this in ConvertBufferToObject, but engineLoadDFF/engineReplaceModel never got the same treatment, so a custom loaded model with UV animated textures streamed in without ever setting the dictionary those animations need, leaving them static.

Fixes #5151 

#### Test plan
Just replace any object with a model that has UV-animated textures.

[uvbboards.zip](https://github.com/user-attachments/files/31561797/uvbboards.zip)


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.