### PR TITLE
Optimize command handling and add support for command aliases

### DIFF
--- a/Client/mods/deathmatch/logic/CRegisteredCommands.cpp
+++ b/Client/mods/deathmatch/logic/CRegisteredCommands.cpp
@@ -23,12 +23,12 @@ CRegisteredCommands::~CRegisteredCommands()
     ClearCommands();
 }
 
-bool CRegisteredCommands::AddCommand(CLuaMain* pLuaMain, const char* szKey, const CLuaFunctionRef& iLuaFunction, bool bCaseSensitive)
+bool CRegisteredCommands::AddCommand(CLuaMain* luaMain, const char* commandName, const CLuaFunctionRef& luaFunction, bool caseSensitive)
 {
-    assert(pLuaMain);
-    assert(szKey);
+    assert(luaMain);
+    assert(commandName);
 
-    if (CommandExists(szKey, nullptr))
+    if (CommandExists(commandName, nullptr))
     {
         const MultiCommandHandlerPolicy allowMultiHandlers = g_pClientGame->GetAllowMultiCommandHandlers();
 
@@ -36,11 +36,11 @@ bool CRegisteredCommands::AddCommand(CLuaMain* pLuaMain, const char* szKey, cons
         {
             case MultiCommandHandlerPolicy::BLOCK:
                 g_pClientGame->GetScriptDebugging()->LogError(
-                    pLuaMain->GetVM(), "addCommandHandler: Duplicate command registration blocked for '%s' (multiple handlers disabled)", szKey);
+                    luaMain->GetVM(), "addCommandHandler: Duplicate command registration blocked for '%s' (multiple handlers disabled)", commandName);
                 return false;
 
             case MultiCommandHandlerPolicy::WARN:
-                g_pClientGame->GetScriptDebugging()->LogWarning(pLuaMain->GetVM(), "addCommandHandler: Attempt to register duplicate command '%s'", szKey);
+                g_pClientGame->GetScriptDebugging()->LogWarning(luaMain->GetVM(), "addCommandHandler: Attempt to register duplicate command '%s'", commandName);
                 break;
 
             case MultiCommandHandlerPolicy::ALLOW:
@@ -50,90 +50,89 @@ bool CRegisteredCommands::AddCommand(CLuaMain* pLuaMain, const char* szKey, cons
     }
 
     // Check if we already have this key and handler
-    SCommand* pCommand = GetCommand(szKey, pLuaMain);
-    if (pCommand)
+    SCommand* existingCommand = GetCommand(commandName, luaMain);
+    if (existingCommand && existingCommand->luaFunction == luaFunction)
     {
-        if (pCommand->iLuaFunction == iLuaFunction)
-            return false;
+        return false;
     }
 
     // Create the entry
-    pCommand = new SCommand;
-    pCommand->pLuaMain = pLuaMain;
-    pCommand->strKey.AssignLeft(szKey, MAX_REGISTERED_COMMAND_LENGTH);
-    pCommand->iLuaFunction = iLuaFunction;
-    pCommand->bCaseSensitive = bCaseSensitive;
+    auto command = new SCommand;
+    command->luaMain = luaMain;
+    command->commandName.AssignLeft(commandName, MAX_REGISTERED_COMMAND_LENGTH);
+    command->luaFunction = luaFunction;
+    command->caseSensitive = caseSensitive;
 
     // Add it to our list
-    m_Commands.push_back(pCommand);
+    m_Commands.push_back(command);
     return true;
 }
 
-bool CRegisteredCommands::RemoveCommand(CLuaMain* pLuaMain, const char* szKey)
+bool CRegisteredCommands::RemoveCommand(CLuaMain* luaMain, const char* commandName, const CLuaFunctionRef& luaFunction)
 {
-    assert(pLuaMain);
-    assert(szKey);
+    assert(luaMain);
+    assert(commandName);
 
     // Call the handler for every virtual machine that matches the given key
-    bool                      bFound = false;
+    bool                      found = false;
     list<SCommand*>::iterator iter = m_Commands.begin();
-    int                       iCompareResult;
 
     while (iter != m_Commands.end())
     {
-        if ((*iter)->bCaseSensitive)
-            iCompareResult = strcmp((*iter)->strKey, szKey);
-        else
-            iCompareResult = stricmp((*iter)->strKey, szKey);
+        const int compareResult = (*iter)->caseSensitive ? strcmp((*iter)->commandName, commandName) : stricmp((*iter)->commandName, commandName);
 
-        // Matching vm's and names?
-        if ((*iter)->pLuaMain == pLuaMain && iCompareResult == 0)
+        // Matching VMs and names?
+        if ((*iter)->luaMain == luaMain && compareResult == 0)
         {
-            bFound = true;
+            if (VERIFY_FUNCTION(luaFunction) && (*iter)->luaFunction != luaFunction)
+            {
+                ++iter;
+                continue;
+            }
+
+            found = true;
             // Delete it and remove it from our list
             if (m_bIteratingList)
             {
                 m_TrashCan.emplace(*iter);
+                ++iter;
             }
             else
             {
                 delete *iter;
-                m_Commands.erase(iter);
-                iter = m_Commands.begin();
-                continue;
+                iter = m_Commands.erase(iter);
             }
         }
-        iter++;
+        else
+            ++iter;
     }
 
-    return bFound;
+    return found;
 }
 
 void CRegisteredCommands::ClearCommands()
 {
     // Delete all the commands
-    list<SCommand*>::const_iterator iter = m_Commands.begin();
-    for (; iter != m_Commands.end(); iter++)
+    for (SCommand* command : m_Commands)
     {
-        delete *iter;
+        delete command;
     }
 
     // Clear the list
     m_Commands.clear();
 }
 
-void CRegisteredCommands::CleanUpForVM(CLuaMain* pLuaMain)
+void CRegisteredCommands::CleanUpForVM(CLuaMain* luaMain)
 {
-    assert(pLuaMain);
+    assert(luaMain);
 
     // Delete every command that matches
     list<SCommand*>::iterator iter = m_Commands.begin();
-    for (; iter != m_Commands.end();)
+    while (iter != m_Commands.end())
     {
-        // Matching VM's?
-        if ((*iter)->pLuaMain == pLuaMain)
+        // Matching VM?
+        if ((*iter)->luaMain == luaMain)
         {
-            // Delete the entry and remove it from the list
             delete *iter;
             iter = m_Commands.erase(iter);
         }
@@ -144,131 +143,125 @@ void CRegisteredCommands::CleanUpForVM(CLuaMain* pLuaMain)
     }
 }
 
-bool CRegisteredCommands::CommandExists(const char* szKey, CLuaMain* pLuaMain)
+bool CRegisteredCommands::CommandExists(const char* commandName, CLuaMain* luaMain)
 {
-    assert(szKey);
+    assert(commandName);
 
-    return GetCommand(szKey, pLuaMain) != nullptr;
+    return GetCommand(commandName, luaMain) != nullptr;
 }
 
-bool CRegisteredCommands::ProcessCommand(const char* szKey, const char* szArguments)
+bool CRegisteredCommands::ProcessCommand(const char* commandName, const char* arguments)
 {
-    assert(szKey);
+    assert(commandName);
 
-    // Call the handler for every virtual machine that matches the given key
-    int  iCompareResult;
-    bool bHandled = false;
+    bool handled = false;
     m_bIteratingList = true;
-    list<SCommand*>::const_iterator iter = m_Commands.begin();
-    for (; iter != m_Commands.end(); iter++)
+
+    for (SCommand* command : m_Commands)
     {
-        if ((*iter)->bCaseSensitive)
-            iCompareResult = strcmp((*iter)->strKey, szKey);
-        else
-            iCompareResult = stricmp((*iter)->strKey, szKey);
+        const int compareResult = command->caseSensitive ? strcmp(command->commandName, commandName) : stricmp(command->commandName, commandName);
 
         // Matching names?
-        if (iCompareResult == 0)
+        if (compareResult == 0)
         {
-            // Call it
-            CallCommandHandler((*iter)->pLuaMain, (*iter)->iLuaFunction, (*iter)->strKey, szArguments);
-            bHandled = true;
+            CallCommandHandler(command->luaMain, command->luaFunction, command->commandName, arguments);
+            handled = true;
         }
     }
+
     m_bIteratingList = false;
     TakeOutTheTrash();
 
-    // Return whether some handler was called or not
-    return bHandled;
+    return handled;
 }
 
-CRegisteredCommands::SCommand* CRegisteredCommands::GetCommand(const char* szKey, class CLuaMain* pLuaMain)
+CRegisteredCommands::SCommand* CRegisteredCommands::GetCommand(const char* commandName, CLuaMain* luaMain)
 {
-    assert(szKey);
+    assert(commandName);
 
-    // Try to find an entry with a matching name in our list
-    list<SCommand*>::const_iterator iter = m_Commands.begin();
-    int                             iCompareResult;
-
-    for (; iter != m_Commands.end(); iter++)
+    for (SCommand* command : m_Commands)
     {
-        if ((*iter)->bCaseSensitive)
-            iCompareResult = strcmp((*iter)->strKey, szKey);
-        else
-            iCompareResult = stricmp((*iter)->strKey, szKey);
+        const int compareResult = command->caseSensitive ? strcmp(command->commandName, commandName) : stricmp(command->commandName, commandName);
 
         // Matching name and no given VM or matching VM
-        if (iCompareResult == 0 && (!pLuaMain || pLuaMain == (*iter)->pLuaMain))
+        if (compareResult == 0 && (!luaMain || luaMain == command->luaMain))
         {
-            return *iter;
+            return command;
         }
     }
 
-    // Doesn't exist
     return nullptr;
 }
 
-void CRegisteredCommands::CallCommandHandler(CLuaMain* pLuaMain, const CLuaFunctionRef& iLuaFunction, const char* szKey, const char* szArguments)
+void CRegisteredCommands::CallCommandHandler(CLuaMain* luaMain, const CLuaFunctionRef& luaFunction, const char* commandName, const char* arguments)
 {
-    assert(pLuaMain);
-    assert(szKey);
+    assert(luaMain);
+    assert(commandName);
 
-    CLuaArguments Arguments;
-    Arguments.PushString(szKey);
+    CLuaArguments luaArguments;
+    luaArguments.PushString(commandName);
 
-    if (szArguments)
+    if (arguments && *arguments)
     {
-        // Create a copy and strtok modifies the string
-        char* szTempArguments = new char[strlen(szArguments) + 1];
-        strcpy(szTempArguments, szArguments);
-        char* arg;
-        arg = strtok(szTempArguments, " ");
+        // Avoid dynamic heap allocations for typical command arguments (< 512 bytes)
+        char                    stackBuffer[512];
+        char*                   argumentBuffer = stackBuffer;
+        const size_t            argumentLength = strlen(arguments);
+        std::unique_ptr<char[]> heapBuffer;
+
+        if (argumentLength >= sizeof(stackBuffer))
+        {
+            heapBuffer = std::make_unique<char[]>(argumentLength + 1);
+            argumentBuffer = heapBuffer.get();
+        }
+
+        memcpy(argumentBuffer, arguments, argumentLength + 1);
+        char* arg = strtok(argumentBuffer, " ");
         while (arg)
         {
-            Arguments.PushString(arg);
+            luaArguments.PushString(arg);
             arg = strtok(nullptr, " ");
         }
-        delete[] szTempArguments;
     }
 
     // Call the handler with the arguments we pushed
-    Arguments.Call(pLuaMain, iLuaFunction);
+    luaArguments.Call(luaMain, luaFunction);
 }
 
 void CRegisteredCommands::GetCommands(lua_State* luaVM)
 {
-    unsigned int uiIndex = 0;
+    unsigned int index = 0;
 
     lua_newtable(luaVM);
 
-    for (SCommand* pCommand : m_Commands)
+    for (SCommand* command : m_Commands)
     {
         // Create an entry table: {'command', resource}
-        lua_pushinteger(luaVM, ++uiIndex);
+        lua_pushinteger(luaVM, ++index);
         lua_createtable(luaVM, 0, 2);
         {
-            lua_pushstring(luaVM, pCommand->strKey.c_str());
+            lua_pushstring(luaVM, command->commandName.c_str());
             lua_rawseti(luaVM, -2, 1);
 
-            lua_pushresource(luaVM, pCommand->pLuaMain->GetResource());
+            lua_pushresource(luaVM, command->luaMain->GetResource());
             lua_rawseti(luaVM, -2, 2);
         }
         lua_settable(luaVM, -3);
     }
 }
 
-void CRegisteredCommands::GetCommands(lua_State* luaVM, CLuaMain* pTargetLuaMain)
+void CRegisteredCommands::GetCommands(lua_State* luaVM, CLuaMain* targetLuaMain)
 {
-    unsigned int uiIndex = 0;
+    unsigned int index = 0;
 
     lua_newtable(luaVM);
 
-    for (SCommand* pCommand : m_Commands)
+    for (SCommand* command : m_Commands)
     {
-        if (pCommand->pLuaMain == pTargetLuaMain)
+        if (command->luaMain == targetLuaMain)
         {
-            lua_pushinteger(luaVM, ++uiIndex);
-            lua_pushstring(luaVM, pCommand->strKey.c_str());
+            lua_pushinteger(luaVM, ++index);
+            lua_pushstring(luaVM, command->commandName.c_str());
             lua_settable(luaVM, -3);
         }
     }

--- a/Client/mods/deathmatch/logic/CRegisteredCommands.h
+++ b/Client/mods/deathmatch/logic/CRegisteredCommands.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "lua/CLuaFunctionRef.h"
 #include <cstdint>
 #include <list>
 #include <unordered_set>
@@ -28,31 +29,31 @@ class CRegisteredCommands
 {
     struct SCommand
     {
-        class CLuaMain* pLuaMain;
-        SString         strKey;
-        CLuaFunctionRef iLuaFunction;
-        bool            bCaseSensitive;
+        class CLuaMain* luaMain;
+        SString         commandName;
+        CLuaFunctionRef luaFunction;
+        bool            caseSensitive;
     };
 
 public:
     CRegisteredCommands();
     ~CRegisteredCommands();
 
-    bool AddCommand(class CLuaMain* pLuaMain, const char* szKey, const CLuaFunctionRef& iLuaFunction, bool bCaseSensitive);
-    bool RemoveCommand(class CLuaMain* pLuaMain, const char* szKey);
+    bool AddCommand(class CLuaMain* luaMain, const char* commandName, const CLuaFunctionRef& luaFunction, bool caseSensitive);
+    bool RemoveCommand(class CLuaMain* luaMain, const char* commandName, const CLuaFunctionRef& luaFunction = CLuaFunctionRef());
     void ClearCommands();
-    void CleanUpForVM(class CLuaMain* pLuaMain);
+    void CleanUpForVM(class CLuaMain* luaMain);
 
-    bool CommandExists(const char* szKey, class CLuaMain* pLuaMain = NULL);
+    bool CommandExists(const char* commandName, class CLuaMain* luaMain = nullptr);
 
     void GetCommands(lua_State* luaVM);
-    void GetCommands(lua_State* luaVM, CLuaMain* pTargetLuaMain);
+    void GetCommands(lua_State* luaVM, CLuaMain* targetLuaMain);
 
-    bool ProcessCommand(const char* szKey, const char* szArguments);
+    bool ProcessCommand(const char* commandName, const char* arguments);
 
 private:
-    SCommand* GetCommand(const char* szKey, class CLuaMain* pLuaMain = NULL);
-    void      CallCommandHandler(class CLuaMain* pLuaMain, const CLuaFunctionRef& iLuaFunction, const char* szKey, const char* szArguments);
+    SCommand* GetCommand(const char* commandName, class CLuaMain* luaMain = nullptr);
+    void      CallCommandHandler(class CLuaMain* luaMain, const CLuaFunctionRef& luaFunction, const char* commandName, const char* arguments);
 
     void TakeOutTheTrash();
 

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Commands.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Commands.cpp
@@ -4,104 +4,51 @@
  *               (Shared logic for modifications)
  *  LICENSE:     See LICENSE in the top level directory
  *  FILE:        mods/shared_logic/lua/CLuaFunctionDefs.Commands.cpp
- *  PURPOSE:     Lua function definitions class
+ *  PURPOSE:     Lua command function definitions class
+ *
+ *  Multi Theft Auto is available from https://www.multitheftauto.com/
  *
  *****************************************************************************/
 
 #include "StdInc.h"
 
-int CLuaFunctionDefs::AddCommandHandler(lua_State* luaVM)
+bool CLuaFunctionDefs::AddCommandHandler(lua_State* luaVM, std::string commandName, CLuaFunctionRef handlerFunction, std::optional<bool> maybeCaseSensitive)
 {
-    //  bool addCommandHandler ( string commandName, function handlerFunction, [bool caseSensitive = true] )
-    SString         strKey;
-    CLuaFunctionRef iLuaFunction;
-    bool            bCaseSensitive;
+    // bool addCommandHandler ( string commandName, function handlerFunction, [bool caseSensitive = true] )
+    if (commandName.empty())
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadString(strKey);
-    argStream.ReadFunction(iLuaFunction);
-    argStream.ReadBool(bCaseSensitive, true);
-    argStream.ReadFunctionComplete();
+    CLuaMain* luaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+    if (!luaMain)
+        return false;
 
-    if (!argStream.HasErrors())
-    {
-        // Grab our VM
-        CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
-        if (pLuaMain)
-        {
-            // Add them to our list over command handlers
-            if (m_pRegisteredCommands->AddCommand(pLuaMain, strKey, iLuaFunction, bCaseSensitive))
-            {
-                lua_pushboolean(luaVM, true);
-                return 1;
-            }
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    const bool caseSensitive = maybeCaseSensitive.value_or(true);
+    return m_pRegisteredCommands->AddCommand(luaMain, commandName.c_str(), handlerFunction, caseSensitive);
 }
 
-int CLuaFunctionDefs::RemoveCommandHandler(lua_State* luaVM)
+bool CLuaFunctionDefs::RemoveCommandHandler(lua_State* luaVM, std::string commandName, std::optional<CLuaFunctionRef> maybeHandlerFunction)
 {
-    //  bool removeCommandHandler ( string commandName )
-    SString strKey;
+    // bool removeCommandHandler ( string commandName [, function handler] )
+    if (commandName.empty())
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadString(strKey);
+    CLuaMain* luaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+    if (!luaMain)
+        return false;
 
-    if (!argStream.HasErrors())
-    {
-        // Grab our VM
-        CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
-        if (pLuaMain)
-        {
-            // Remove it from our list
-            if (m_pRegisteredCommands->RemoveCommand(pLuaMain, strKey))
-            {
-                lua_pushboolean(luaVM, true);
-                return 1;
-            }
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    const CLuaFunctionRef handlerFunction = maybeHandlerFunction.value_or(CLuaFunctionRef());
+    return m_pRegisteredCommands->RemoveCommand(luaMain, commandName.c_str(), handlerFunction);
 }
 
-int CLuaFunctionDefs::ExecuteCommandHandler(lua_State* luaVM)
+bool CLuaFunctionDefs::ExecuteCommandHandler(lua_State* luaVM, std::string commandName, std::optional<std::string> maybeArgs)
 {
-    //  bool executeCommandHandler ( string commandName, [ string args ] )
-    SString strKey;
-    SString strArgs;
+    // bool executeCommandHandler ( string commandName, [ string args ] )
+    CLuaMain* luaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+    if (!luaMain)
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadString(strKey);
-    argStream.ReadString(strArgs, "");
-
-    if (!argStream.HasErrors())
-    {
-        // Grab our VM
-        CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
-        if (pLuaMain)
-        {
-            // Call it
-            if (m_pRegisteredCommands->ProcessCommand(strKey, strArgs))
-            {
-                lua_pushboolean(luaVM, true);
-                return 1;
-            }
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    const std::string args = maybeArgs.value_or("");
+    return m_pRegisteredCommands->ProcessCommand(commandName.c_str(), args.c_str());
 }
 
 int CLuaFunctionDefs::GetCommandHandlers(lua_State* luaVM)

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Commands.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.Commands.cpp
@@ -12,32 +12,82 @@
 
 #include "StdInc.h"
 
-bool CLuaFunctionDefs::AddCommandHandler(lua_State* luaVM, std::string commandName, CLuaFunctionRef handlerFunction, std::optional<bool> maybeCaseSensitive)
+bool CLuaFunctionDefs::AddCommandHandler(lua_State* luaVM, std::variant<std::string, std::vector<std::string>> commandNames, CLuaFunctionRef handlerFunction,
+                                         std::optional<bool> maybeCaseSensitive)
 {
-    // bool addCommandHandler ( string commandName, function handlerFunction, [bool caseSensitive = true] )
-    if (commandName.empty())
-        return false;
-
+    // bool addCommandHandler ( string / table commandNames, function handlerFunction, [bool caseSensitive = true] )
     CLuaMain* luaMain = m_pLuaManager->GetVirtualMachine(luaVM);
     if (!luaMain)
         return false;
 
     const bool caseSensitive = maybeCaseSensitive.value_or(true);
-    return m_pRegisteredCommands->AddCommand(luaMain, commandName.c_str(), handlerFunction, caseSensitive);
-}
 
-bool CLuaFunctionDefs::RemoveCommandHandler(lua_State* luaVM, std::string commandName, std::optional<CLuaFunctionRef> maybeHandlerFunction)
-{
-    // bool removeCommandHandler ( string commandName [, function handler] )
-    if (commandName.empty())
+    if (std::holds_alternative<std::string>(commandNames))
+    {
+        const std::string& commandName = std::get<std::string>(commandNames);
+        if (commandName.empty())
+            return false;
+
+        return m_pRegisteredCommands->AddCommand(luaMain, commandName.c_str(), handlerFunction, caseSensitive);
+    }
+
+    const auto& nameList = std::get<std::vector<std::string>>(commandNames);
+    if (nameList.empty())
         return false;
 
+    std::unordered_set<std::string> uniqueCommands;
+    bool                            success = false;
+
+    for (const std::string& commandName : nameList)
+    {
+        if (commandName.empty())
+            continue;
+
+        // Skip duplicates within the same array registration
+        if (!uniqueCommands.insert(commandName).second)
+            continue;
+
+        if (m_pRegisteredCommands->AddCommand(luaMain, commandName.c_str(), handlerFunction, caseSensitive))
+            success = true;
+    }
+
+    return success;
+}
+
+bool CLuaFunctionDefs::RemoveCommandHandler(lua_State* luaVM, std::variant<std::string, std::vector<std::string>> commandNames,
+                                            std::optional<CLuaFunctionRef> maybeHandlerFunction)
+{
+    // bool removeCommandHandler ( string / table commandNames [, function handler] )
     CLuaMain* luaMain = m_pLuaManager->GetVirtualMachine(luaVM);
     if (!luaMain)
         return false;
 
     const CLuaFunctionRef handlerFunction = maybeHandlerFunction.value_or(CLuaFunctionRef());
-    return m_pRegisteredCommands->RemoveCommand(luaMain, commandName.c_str(), handlerFunction);
+
+    if (std::holds_alternative<std::string>(commandNames))
+    {
+        const std::string& commandName = std::get<std::string>(commandNames);
+        if (commandName.empty())
+            return false;
+
+        return m_pRegisteredCommands->RemoveCommand(luaMain, commandName.c_str(), handlerFunction);
+    }
+
+    const auto& nameList = std::get<std::vector<std::string>>(commandNames);
+    if (nameList.empty())
+        return false;
+
+    bool success = false;
+    for (const std::string& commandName : nameList)
+    {
+        if (commandName.empty())
+            continue;
+
+        if (m_pRegisteredCommands->RemoveCommand(luaMain, commandName.c_str(), handlerFunction))
+            success = true;
+    }
+
+    return success;
 }
 
 bool CLuaFunctionDefs::ExecuteCommandHandler(lua_State* luaVM, std::string commandName, std::optional<std::string> maybeArgs)

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.h
@@ -103,8 +103,10 @@ public:
     LUA_DECLARE(ToggleAllControls);
 
     // Command funcs
-    static bool AddCommandHandler(lua_State* luaVM, std::string commandName, CLuaFunctionRef handlerFunction, std::optional<bool> maybeCaseSensitive);
-    static bool RemoveCommandHandler(lua_State* luaVM, std::string commandName, std::optional<CLuaFunctionRef> maybeHandlerFunction);
+    static bool AddCommandHandler(lua_State* luaVM, std::variant<std::string, std::vector<std::string>> commandNames, CLuaFunctionRef handlerFunction,
+                                  std::optional<bool> maybeCaseSensitive);
+    static bool RemoveCommandHandler(lua_State* luaVM, std::variant<std::string, std::vector<std::string>> commandNames,
+                                     std::optional<CLuaFunctionRef> maybeHandlerFunction);
     static bool ExecuteCommandHandler(lua_State* luaVM, std::string commandName, std::optional<std::string> maybeArgs);
     LUA_DECLARE(GetCommandHandlers);
 

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionDefs.h
@@ -15,6 +15,11 @@ class CLuaFunctionDefinitions;
 #include "LuaCommon.h"
 #include "CLuaMain.h"
 #include "CLuaTimerManager.h"
+#include "CLuaFunctionRef.h"
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
 
 class CRegisteredCommands;
 
@@ -98,9 +103,9 @@ public:
     LUA_DECLARE(ToggleAllControls);
 
     // Command funcs
-    LUA_DECLARE(AddCommandHandler);
-    LUA_DECLARE(RemoveCommandHandler);
-    LUA_DECLARE(ExecuteCommandHandler);
+    static bool AddCommandHandler(lua_State* luaVM, std::string commandName, CLuaFunctionRef handlerFunction, std::optional<bool> maybeCaseSensitive);
+    static bool RemoveCommandHandler(lua_State* luaVM, std::string commandName, std::optional<CLuaFunctionRef> maybeHandlerFunction);
+    static bool ExecuteCommandHandler(lua_State* luaVM, std::string commandName, std::optional<std::string> maybeArgs);
     LUA_DECLARE(GetCommandHandlers);
 
     // Utility

--- a/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaManager.cpp
@@ -218,9 +218,9 @@ void CLuaManager::LoadCFunctions()
         {"toggleAllControls", CLuaFunctionDefs::ToggleAllControls},
 
         // Command funcs
-        {"addCommandHandler", CLuaFunctionDefs::AddCommandHandler},
-        {"removeCommandHandler", CLuaFunctionDefs::RemoveCommandHandler},
-        {"executeCommandHandler", CLuaFunctionDefs::ExecuteCommandHandler},
+        {"addCommandHandler", CLuaDefs::ArgumentParser<CLuaFunctionDefs::AddCommandHandler>},
+        {"removeCommandHandler", CLuaDefs::ArgumentParser<CLuaFunctionDefs::RemoveCommandHandler>},
+        {"executeCommandHandler", CLuaDefs::ArgumentParser<CLuaFunctionDefs::ExecuteCommandHandler>},
         {"getCommandHandlers", CLuaFunctionDefs::GetCommandHandlers},
 
         // Utility

--- a/Client/mods/deathmatch/logic/luadefs/CLuaDefs.h
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaDefs.h
@@ -70,7 +70,7 @@ public:
     static CClientIMGManager*         m_pImgManager;
     static CClientBuildingManager*    m_pBuildingManager;
 
-protected:
+public:
     // Old style: Only warn on failure. This should
     // not be used for new functions. ReturnOnError
     // must be a value to use as result on invalid argument

--- a/Server/mods/deathmatch/logic/CRegisteredCommands.cpp
+++ b/Server/mods/deathmatch/logic/CRegisteredCommands.cpp
@@ -22,9 +22,9 @@
 #include "CScriptDebugging.h"
 #include "CMainConfig.h"
 
-CRegisteredCommands::CRegisteredCommands(CAccessControlListManager* pACLManager)
+CRegisteredCommands::CRegisteredCommands(CAccessControlListManager* aclManager)
 {
-    m_pACLManager = pACLManager;
+    m_pACLManager = aclManager;
     m_bIteratingList = false;
 }
 
@@ -33,24 +33,24 @@ CRegisteredCommands::~CRegisteredCommands()
     ClearCommands();
 }
 
-bool CRegisteredCommands::AddCommand(CLuaMain* pLuaMain, const char* szKey, const CLuaFunctionRef& iLuaFunction, bool bRestricted, bool bCaseSensitive)
+bool CRegisteredCommands::AddCommand(CLuaMain* luaMain, const char* commandName, const CLuaFunctionRef& luaFunction, bool restricted, bool caseSensitive)
 {
-    assert(pLuaMain);
-    assert(szKey);
+    assert(luaMain);
+    assert(commandName);
 
-    if (CommandExists(szKey, nullptr))
+    if (CommandExists(commandName, nullptr))
     {
-        auto policy = static_cast<MultiCommandHandlerPolicy>(g_pGame->GetConfig()->GetAllowMultiCommandHandlers());
+        const auto policy = static_cast<MultiCommandHandlerPolicy>(g_pGame->GetConfig()->GetAllowMultiCommandHandlers());
 
         switch (policy)
         {
             case MultiCommandHandlerPolicy::BLOCK:
                 g_pGame->GetScriptDebugging()->LogError(
-                    pLuaMain->GetVM(), "addCommandHandler: Duplicate command registration blocked for '%s' (multiple handlers disabled)", szKey);
+                    luaMain->GetVM(), "addCommandHandler: Duplicate command registration blocked for '%s' (multiple handlers disabled)", commandName);
                 return false;
 
             case MultiCommandHandlerPolicy::WARN:
-                g_pGame->GetScriptDebugging()->LogWarning(pLuaMain->GetVM(), "Attempt to register duplicate command '%s'", szKey);
+                g_pGame->GetScriptDebugging()->LogWarning(luaMain->GetVM(), "Attempt to register duplicate command '%s'", commandName);
                 break;
 
             case MultiCommandHandlerPolicy::ALLOW:
@@ -60,48 +60,45 @@ bool CRegisteredCommands::AddCommand(CLuaMain* pLuaMain, const char* szKey, cons
     }
 
     // Check if we already have this key and handler
-    SCommand* pCommand = GetCommand(szKey, pLuaMain);
+    SCommand* existingCommand = GetCommand(commandName, luaMain);
 
-    if (pCommand && iLuaFunction == pCommand->iLuaFunction)
+    if (existingCommand && luaFunction == existingCommand->luaFunction)
         return false;
 
     // Create the entry
-    pCommand = new SCommand;
-    pCommand->pLuaMain = pLuaMain;
-    pCommand->strKey.AssignLeft(szKey, MAX_REGISTERED_COMMAND_LENGTH);
-    pCommand->iLuaFunction = iLuaFunction;
-    pCommand->bRestricted = bRestricted;
-    pCommand->bCaseSensitive = bCaseSensitive;
+    auto command = new SCommand;
+    command->luaMain = luaMain;
+    command->commandName.AssignLeft(commandName, MAX_REGISTERED_COMMAND_LENGTH);
+    command->luaFunction = luaFunction;
+    command->restricted = restricted;
+    command->caseSensitive = caseSensitive;
 
     // Add it to our list
-    m_Commands.push_back(pCommand);
+    m_Commands.push_back(command);
 
     return true;
 }
 
-bool CRegisteredCommands::RemoveCommand(CLuaMain* pLuaMain, const char* szKey, const CLuaFunctionRef& iLuaFunction)
+bool CRegisteredCommands::RemoveCommand(CLuaMain* luaMain, const char* commandName, const CLuaFunctionRef& luaFunction)
 {
-    assert(pLuaMain);
-    assert(szKey);
+    assert(luaMain);
+    assert(commandName);
 
     // Call the handler for every virtual machine that matches the given key
-    int                            iCompareResult;
-    bool                           bFound = false;
+    bool                           found = false;
     std::list<SCommand*>::iterator iter = m_Commands.begin();
 
     while (iter != m_Commands.end())
     {
-        if ((*iter)->bCaseSensitive)
-            iCompareResult = strcmp((*iter)->strKey.c_str(), szKey);
-        else
-            iCompareResult = stricmp((*iter)->strKey.c_str(), szKey);
+        const int compareResult =
+            (*iter)->caseSensitive ? strcmp((*iter)->commandName.c_str(), commandName) : stricmp((*iter)->commandName.c_str(), commandName);
 
         // Matching VM's and names?
-        if ((*iter)->pLuaMain == pLuaMain && iCompareResult == 0)
+        if ((*iter)->luaMain == luaMain && compareResult == 0)
         {
-            if (VERIFY_FUNCTION(iLuaFunction) && (*iter)->iLuaFunction != iLuaFunction)
+            if (VERIFY_FUNCTION(luaFunction) && (*iter)->luaFunction != luaFunction)
             {
-                iter++;
+                ++iter;
                 continue;
             }
 
@@ -117,30 +114,28 @@ bool CRegisteredCommands::RemoveCommand(CLuaMain* pLuaMain, const char* szKey, c
                 iter = m_Commands.erase(iter);
             }
 
-            bFound = true;
+            found = true;
         }
         else
             ++iter;
     }
 
-    return bFound;
+    return found;
 }
 
 void CRegisteredCommands::ClearCommands()
 {
     // Delete all the commands
-    std::list<SCommand*>::const_iterator iter = m_Commands.begin();
-
-    for (; iter != m_Commands.end(); iter++)
-        delete *iter;
+    for (SCommand* command : m_Commands)
+        delete command;
 
     // Clear the list
     m_Commands.clear();
 }
 
-void CRegisteredCommands::CleanUpForVM(CLuaMain* pLuaMain)
+void CRegisteredCommands::CleanUpForVM(CLuaMain* luaMain)
 {
-    assert(pLuaMain);
+    assert(luaMain);
 
     // Delete every command that matches
     std::list<SCommand*>::iterator iter = m_Commands.begin();
@@ -148,7 +143,7 @@ void CRegisteredCommands::CleanUpForVM(CLuaMain* pLuaMain)
     while (iter != m_Commands.end())
     {
         // Matching VM's?
-        if ((*iter)->pLuaMain == pLuaMain)
+        if ((*iter)->luaMain == luaMain)
         {
             // Delete the entry and remove it from the list
             delete *iter;
@@ -159,42 +154,39 @@ void CRegisteredCommands::CleanUpForVM(CLuaMain* pLuaMain)
     }
 }
 
-bool CRegisteredCommands::CommandExists(const char* szKey, CLuaMain* pLuaMain)
+bool CRegisteredCommands::CommandExists(const char* commandName, CLuaMain* luaMain)
 {
-    assert(szKey);
+    assert(commandName);
 
-    return GetCommand(szKey, pLuaMain) != nullptr;
+    return GetCommand(commandName, luaMain) != nullptr;
 }
 
-bool CRegisteredCommands::ProcessCommand(const char* szKey, const char* szArguments, CClient* pClient)
+bool CRegisteredCommands::ProcessCommand(const char* commandName, const char* arguments, CClient* client)
 {
-    assert(szKey);
+    assert(commandName);
 
     // Call the handler for every virtual machine that matches the given key
-    bool                                 bHandled = false;
-    int                                  iCompareResult;
+    bool                                 handled = false;
     std::list<SCommand*>::const_iterator iter = m_Commands.begin();
 
     m_bIteratingList = true;
 
-    for (; iter != m_Commands.end(); iter++)
+    for (; iter != m_Commands.end(); ++iter)
     {
-        if ((*iter)->bCaseSensitive)
-            iCompareResult = strcmp((*iter)->strKey.c_str(), szKey);
-        else
-            iCompareResult = stricmp((*iter)->strKey.c_str(), szKey);
+        const int compareResult =
+            (*iter)->caseSensitive ? strcmp((*iter)->commandName.c_str(), commandName) : stricmp((*iter)->commandName.c_str(), commandName);
 
         // Matching names?
-        if (iCompareResult == 0)
+        if (compareResult == 0)
         {
             if (m_pACLManager->CanObjectUseRight(
-                    pClient->GetAccount()->GetName().c_str(), CAccessControlListGroupObject::OBJECT_TYPE_USER, (*iter)->strKey,
+                    client->GetAccount()->GetName().c_str(), CAccessControlListGroupObject::OBJECT_TYPE_USER, (*iter)->commandName,
                     CAccessControlListRight::RIGHT_TYPE_COMMAND,
-                    !(*iter)->bRestricted))  // If this command is restricted, the default access should be false unless granted specially
+                    !(*iter)->restricted))  // If this command is restricted, the default access should be false unless granted specially
             {
                 // Call it
-                CallCommandHandler((*iter)->pLuaMain, (*iter)->iLuaFunction, (*iter)->strKey, szArguments, pClient);
-                bHandled = true;
+                CallCommandHandler((*iter)->luaMain, (*iter)->luaFunction, (*iter)->commandName, arguments, client);
+                handled = true;
             }
         }
     }
@@ -203,124 +195,125 @@ bool CRegisteredCommands::ProcessCommand(const char* szKey, const char* szArgume
     TakeOutTheTrash();
 
     // Return whether some handler was called or not
-    return bHandled;
+    return handled;
 }
 
-CRegisteredCommands::SCommand* CRegisteredCommands::GetCommand(const char* szKey, class CLuaMain* pLuaMain)
+CRegisteredCommands::SCommand* CRegisteredCommands::GetCommand(const char* commandName, class CLuaMain* luaMain)
 {
-    assert(szKey);
+    assert(commandName);
 
     // Try to find an entry with a matching name in our list
-    int                                  iCompareResult;
-    std::list<SCommand*>::const_iterator iter = m_Commands.begin();
-
-    for (; iter != m_Commands.end(); iter++)
+    for (SCommand* command : m_Commands)
     {
-        if ((*iter)->bCaseSensitive)
-            iCompareResult = strcmp((*iter)->strKey.c_str(), szKey);
-        else
-            iCompareResult = stricmp((*iter)->strKey.c_str(), szKey);
+        const int compareResult =
+            command->caseSensitive ? strcmp(command->commandName.c_str(), commandName) : stricmp(command->commandName.c_str(), commandName);
 
         // Matching name and no given VM or matching VM
-        if (iCompareResult == 0 && (!pLuaMain || pLuaMain == (*iter)->pLuaMain))
-            return *iter;
+        if (compareResult == 0 && (!luaMain || luaMain == command->luaMain))
+            return command;
     }
 
     // Doesn't exist
     return nullptr;
 }
 
-void CRegisteredCommands::CallCommandHandler(CLuaMain* pLuaMain, const CLuaFunctionRef& iLuaFunction, const char* szKey, const char* szArguments,
-                                             CClient* pClient)
+void CRegisteredCommands::CallCommandHandler(CLuaMain* luaMain, const CLuaFunctionRef& luaFunction, const char* commandName, const char* arguments,
+                                             CClient* client)
 {
-    assert(pLuaMain);
-    assert(szKey);
+    assert(luaMain);
+    assert(commandName);
 
-    CLuaArguments Arguments;
+    CLuaArguments luaArguments;
 
     // First, try to call a handler with the same number of arguments
-    if (pClient)
+    if (client)
     {
-        switch (pClient->GetClientType())
+        switch (client->GetClientType())
         {
             case CClient::CLIENT_PLAYER:
             {
-                Arguments.PushElement(static_cast<CPlayer*>(pClient));
+                luaArguments.PushElement(static_cast<CPlayer*>(client));
                 break;
             }
             case CClient::CLIENT_CONSOLE:
             {
-                Arguments.PushElement(static_cast<CConsoleClient*>(pClient));
+                luaArguments.PushElement(static_cast<CConsoleClient*>(client));
                 break;
             }
             default:
             {
-                Arguments.PushBoolean(false);
+                luaArguments.PushBoolean(false);
                 break;
             }
         }
     }
     else
-        Arguments.PushBoolean(false);
+        luaArguments.PushBoolean(false);
 
-    Arguments.PushString(szKey);
+    luaArguments.PushString(commandName);
 
-    if (szArguments)
+    if (arguments && *arguments)
     {
-        // Create a copy and strtok modifies the string
-        char* szTempArguments = new char[strlen(szArguments) + 1];
-        strcpy(szTempArguments, szArguments);
+        // Avoid dynamic heap allocations for typical command arguments (< 512 bytes)
+        char                    stackBuffer[512];
+        char*                   argumentBuffer = stackBuffer;
+        const size_t            argumentLength = strlen(arguments);
+        std::unique_ptr<char[]> heapBuffer;
 
-        char* arg;
-        arg = strtok(szTempArguments, " ");
+        if (argumentLength >= sizeof(stackBuffer))
+        {
+            heapBuffer = std::make_unique<char[]>(argumentLength + 1);
+            argumentBuffer = heapBuffer.get();
+        }
+
+        memcpy(argumentBuffer, arguments, argumentLength + 1);
+        char* arg = strtok(argumentBuffer, " ");
 
         while (arg)
         {
-            Arguments.PushString(arg);
+            luaArguments.PushString(arg);
             arg = strtok(nullptr, " ");
         }
-
-        delete[] szTempArguments;
     }
 
     // Call the handler with the arguments we pushed
-    Arguments.Call(pLuaMain, iLuaFunction);
+    luaArguments.Call(luaMain, luaFunction);
 }
 
 void CRegisteredCommands::GetCommands(lua_State* luaVM)
 {
-    unsigned int uiIndex = 0;
+    unsigned int index = 0;
 
     lua_newtable(luaVM);
 
-    for (SCommand* pCommand : m_Commands)
+    for (SCommand* command : m_Commands)
     {
         // Create an entry table: {'command', resource}
-        lua_pushinteger(luaVM, ++uiIndex);
+        lua_pushinteger(luaVM, ++index);
         lua_createtable(luaVM, 0, 2);
         {
-            lua_pushstring(luaVM, pCommand->strKey.c_str());
+            lua_pushstring(luaVM, command->commandName.c_str());
             lua_rawseti(luaVM, -2, 1);
 
-            lua_pushresource(luaVM, pCommand->pLuaMain->GetResource());
+            lua_pushresource(luaVM, command->luaMain->GetResource());
             lua_rawseti(luaVM, -2, 2);
         }
         lua_settable(luaVM, -3);
     }
 }
 
-void CRegisteredCommands::GetCommands(lua_State* luaVM, CLuaMain* pTargetLuaMain)
+void CRegisteredCommands::GetCommands(lua_State* luaVM, CLuaMain* targetLuaMain)
 {
-    unsigned int uiIndex = 0;
+    unsigned int index = 0;
 
     lua_newtable(luaVM);
 
-    for (SCommand* pCommand : m_Commands)
+    for (SCommand* command : m_Commands)
     {
-        if (pCommand->pLuaMain == pTargetLuaMain)
+        if (command->luaMain == targetLuaMain)
         {
-            lua_pushinteger(luaVM, ++uiIndex);
-            lua_pushstring(luaVM, pCommand->strKey.c_str());
+            lua_pushinteger(luaVM, ++index);
+            lua_pushstring(luaVM, command->commandName.c_str());
             lua_settable(luaVM, -3);
         }
     }

--- a/Server/mods/deathmatch/logic/CRegisteredCommands.h
+++ b/Server/mods/deathmatch/logic/CRegisteredCommands.h
@@ -30,32 +30,32 @@ class CRegisteredCommands
 {
     struct SCommand
     {
-        class CLuaMain* pLuaMain;
-        SString         strKey;
-        CLuaFunctionRef iLuaFunction;
-        bool            bRestricted;
-        bool            bCaseSensitive;
+        class CLuaMain* luaMain;
+        SString         commandName;
+        CLuaFunctionRef luaFunction;
+        bool            restricted;
+        bool            caseSensitive;
     };
 
 public:
-    CRegisteredCommands(class CAccessControlListManager* pACLManager);
+    CRegisteredCommands(class CAccessControlListManager* aclManager);
     ~CRegisteredCommands();
 
-    bool AddCommand(class CLuaMain* pLuaMain, const char* szKey, const CLuaFunctionRef& iLuaFunction, bool bRestricted, bool bCaseSensitive);
-    bool RemoveCommand(class CLuaMain* pLuaMain, const char* szKey, const CLuaFunctionRef& iLuaFunction = CLuaFunctionRef());
+    bool AddCommand(class CLuaMain* luaMain, const char* commandName, const CLuaFunctionRef& luaFunction, bool restricted, bool caseSensitive);
+    bool RemoveCommand(class CLuaMain* luaMain, const char* commandName, const CLuaFunctionRef& luaFunction = CLuaFunctionRef());
     void ClearCommands();
-    void CleanUpForVM(class CLuaMain* pLuaMain);
+    void CleanUpForVM(class CLuaMain* luaMain);
 
-    bool CommandExists(const char* szKey, class CLuaMain* pLuaMain = NULL);
+    bool CommandExists(const char* commandName, class CLuaMain* luaMain = nullptr);
 
     void GetCommands(lua_State* luaVM);
-    void GetCommands(lua_State* luaVM, CLuaMain* pTargetLuaMain);
+    void GetCommands(lua_State* luaVM, CLuaMain* targetLuaMain);
 
-    bool ProcessCommand(const char* szKey, const char* szArguments, class CClient* pClient);
+    bool ProcessCommand(const char* commandName, const char* arguments, class CClient* client);
 
 private:
-    SCommand* GetCommand(const char* szKey, class CLuaMain* pLuaMain = NULL);
-    void CallCommandHandler(class CLuaMain* pLuaMain, const CLuaFunctionRef& iLuaFunction, const char* szKey, const char* szArguments, class CClient* pClient);
+    SCommand* GetCommand(const char* commandName, class CLuaMain* luaMain = nullptr);
+    void CallCommandHandler(class CLuaMain* luaMain, const CLuaFunctionRef& luaFunction, const char* commandName, const char* arguments, class CClient* client);
 
     void TakeOutTheTrash();
 

--- a/Server/mods/deathmatch/logic/luadefs/CLuaDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaDefs.h
@@ -72,7 +72,7 @@ protected:
     static CMainConfig*               m_pMainConfig;
     static inline CLuaModuleManager*  m_pLuaModuleManager = nullptr;
 
-protected:
+public:
     // Old style: Only warn on failure. This should
     // not be used for new functions. ReturnOnError
     // must be a value to use as result on invalid argument

--- a/Server/mods/deathmatch/logic/luadefs/CLuaFunctionDefs.Server.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaFunctionDefs.Server.cpp
@@ -24,112 +24,48 @@
 #define MIN_SERVER_REQ_CALLREMOTE_OPTIONS_TABLE       "1.5.4-9.11342"
 #define MIN_SERVER_REQ_CALLREMOTE_OPTIONS_FORMFIELDS  "1.5.4-9.11413"
 
-int CLuaFunctionDefs::AddCommandHandler(lua_State* luaVM)
+bool CLuaFunctionDefs::AddCommandHandler(lua_State* luaVM, std::string commandName, CLuaFunctionRef handlerFunction, std::optional<bool> maybeRestricted,
+                                         std::optional<bool> maybeCaseSensitive)
 {
-    //  bool addCommandHandler ( string commandName, function handlerFunction, [bool restricted = false, bool caseSensitive = true] )
-    SString         strKey;
-    CLuaFunctionRef iLuaFunction;
-    bool            bRestricted;
-    bool            bCaseSensitive;
+    // bool addCommandHandler ( string commandName, function handlerFunction, [bool restricted = false, bool caseSensitive = true] )
+    if (commandName.empty())
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadString(strKey);
-    argStream.ReadFunction(iLuaFunction);
-    argStream.ReadBool(bRestricted, false);
-    argStream.ReadBool(bCaseSensitive, true);
-    argStream.ReadFunctionComplete();
+    CLuaMain* luaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+    if (!luaMain)
+        return false;
 
-    if (!argStream.HasErrors())
-    {
-        // Grab our VM
-        CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
-        if (pLuaMain)
-        {
-            // Add them to our list over command handlers
-            if (m_pRegisteredCommands->AddCommand(pLuaMain, strKey, iLuaFunction, bRestricted, bCaseSensitive))
-            {
-                lua_pushboolean(luaVM, true);
-                return 1;
-            }
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    const bool restricted = maybeRestricted.value_or(false);
+    const bool caseSensitive = maybeCaseSensitive.value_or(true);
+    return m_pRegisteredCommands->AddCommand(luaMain, commandName.c_str(), handlerFunction, restricted, caseSensitive);
 }
 
-int CLuaFunctionDefs::RemoveCommandHandler(lua_State* luaVM)
+bool CLuaFunctionDefs::RemoveCommandHandler(lua_State* luaVM, std::string commandName, std::optional<CLuaFunctionRef> maybeHandlerFunction)
 {
-    //  bool removeCommandHandler ( string commandName [, function handler] )
-    SString         strKey;
-    CLuaFunctionRef iLuaFunction;
+    // bool removeCommandHandler ( string commandName [, function handler] )
+    if (commandName.empty())
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadString(strKey);
-    argStream.ReadFunction(iLuaFunction, LUA_REFNIL);
-    argStream.ReadFunctionComplete();
+    CLuaMain* luaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+    if (!luaMain)
+        return false;
 
-    if (!argStream.HasErrors())
-    {
-        // Grab our VM
-        CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
-        if (pLuaMain)
-        {
-            // Remove it from our list
-            if (m_pRegisteredCommands->RemoveCommand(pLuaMain, strKey, iLuaFunction))
-            {
-                lua_pushboolean(luaVM, true);
-                return 1;
-            }
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    const CLuaFunctionRef handlerFunction = maybeHandlerFunction.value_or(CLuaFunctionRef());
+    return m_pRegisteredCommands->RemoveCommand(luaMain, commandName.c_str(), handlerFunction);
 }
 
-int CLuaFunctionDefs::ExecuteCommandHandler(lua_State* luaVM)
+bool CLuaFunctionDefs::ExecuteCommandHandler(lua_State* luaVM, std::string commandName, CPlayer* player, std::optional<std::string> maybeArgs)
 {
-    //  bool executeCommandHandler ( string commandName, player thePlayer, [ string args ] )
-    SString   strKey;
-    CElement* pElement;
-    SString   strArgs;
+    // bool executeCommandHandler ( string commandName, player thePlayer, [ string args ] )
+    if (commandName.empty() || !player)
+        return false;
 
-    CScriptArgReader argStream(luaVM);
-    argStream.ReadString(strKey);
-    argStream.ReadUserData(pElement);
-    argStream.ReadString(strArgs, "");
+    CLuaMain* luaMain = m_pLuaManager->GetVirtualMachine(luaVM);
+    if (!luaMain)
+        return false;
 
-    if (!argStream.HasErrors())
-    {
-        // Grab our VM
-        CLuaMain* pLuaMain = m_pLuaManager->GetVirtualMachine(luaVM);
-        if (pLuaMain)
-        {
-            CClient* pClient = NULL;
-            if (pElement->GetType() == CElement::PLAYER)
-                pClient = static_cast<CClient*>(static_cast<CPlayer*>(pElement));
-
-            if (pClient)
-            {
-                // Call it
-                if (m_pRegisteredCommands->ProcessCommand(strKey, strArgs, pClient))
-                {
-                    lua_pushboolean(luaVM, true);
-                    return 1;
-                }
-            }
-        }
-    }
-    else
-        m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
-
-    lua_pushboolean(luaVM, false);
-    return 1;
+    const std::string args = maybeArgs.value_or("");
+    return m_pRegisteredCommands->ProcessCommand(commandName.c_str(), args.c_str(), player);
 }
 
 int CLuaFunctionDefs::GetCommandHandlers(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaFunctionDefs.Server.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaFunctionDefs.Server.cpp
@@ -24,34 +24,83 @@
 #define MIN_SERVER_REQ_CALLREMOTE_OPTIONS_TABLE       "1.5.4-9.11342"
 #define MIN_SERVER_REQ_CALLREMOTE_OPTIONS_FORMFIELDS  "1.5.4-9.11413"
 
-bool CLuaFunctionDefs::AddCommandHandler(lua_State* luaVM, std::string commandName, CLuaFunctionRef handlerFunction, std::optional<bool> maybeRestricted,
-                                         std::optional<bool> maybeCaseSensitive)
+bool CLuaFunctionDefs::AddCommandHandler(lua_State* luaVM, std::variant<std::string, std::vector<std::string>> commandNames, CLuaFunctionRef handlerFunction,
+                                         std::optional<bool> maybeRestricted, std::optional<bool> maybeCaseSensitive)
 {
-    // bool addCommandHandler ( string commandName, function handlerFunction, [bool restricted = false, bool caseSensitive = true] )
-    if (commandName.empty())
-        return false;
-
+    // bool addCommandHandler ( string / table commandNames, function handlerFunction, [bool restricted = false, bool caseSensitive = true] )
     CLuaMain* luaMain = m_pLuaManager->GetVirtualMachine(luaVM);
     if (!luaMain)
         return false;
 
     const bool restricted = maybeRestricted.value_or(false);
     const bool caseSensitive = maybeCaseSensitive.value_or(true);
-    return m_pRegisteredCommands->AddCommand(luaMain, commandName.c_str(), handlerFunction, restricted, caseSensitive);
-}
 
-bool CLuaFunctionDefs::RemoveCommandHandler(lua_State* luaVM, std::string commandName, std::optional<CLuaFunctionRef> maybeHandlerFunction)
-{
-    // bool removeCommandHandler ( string commandName [, function handler] )
-    if (commandName.empty())
+    if (std::holds_alternative<std::string>(commandNames))
+    {
+        const std::string& commandName = std::get<std::string>(commandNames);
+        if (commandName.empty())
+            return false;
+
+        return m_pRegisteredCommands->AddCommand(luaMain, commandName.c_str(), handlerFunction, restricted, caseSensitive);
+    }
+
+    const auto& nameList = std::get<std::vector<std::string>>(commandNames);
+    if (nameList.empty())
         return false;
 
+    std::unordered_set<std::string> uniqueCommands;
+    bool                            success = false;
+
+    for (const std::string& commandName : nameList)
+    {
+        if (commandName.empty())
+            continue;
+
+        // Skip duplicates within the same array registration
+        if (!uniqueCommands.insert(commandName).second)
+            continue;
+
+        if (m_pRegisteredCommands->AddCommand(luaMain, commandName.c_str(), handlerFunction, restricted, caseSensitive))
+            success = true;
+    }
+
+    return success;
+}
+
+bool CLuaFunctionDefs::RemoveCommandHandler(lua_State* luaVM, std::variant<std::string, std::vector<std::string>> commandNames,
+                                            std::optional<CLuaFunctionRef> maybeHandlerFunction)
+{
+    // bool removeCommandHandler ( string / table commandNames [, function handler] )
     CLuaMain* luaMain = m_pLuaManager->GetVirtualMachine(luaVM);
     if (!luaMain)
         return false;
 
     const CLuaFunctionRef handlerFunction = maybeHandlerFunction.value_or(CLuaFunctionRef());
-    return m_pRegisteredCommands->RemoveCommand(luaMain, commandName.c_str(), handlerFunction);
+
+    if (std::holds_alternative<std::string>(commandNames))
+    {
+        const std::string& commandName = std::get<std::string>(commandNames);
+        if (commandName.empty())
+            return false;
+
+        return m_pRegisteredCommands->RemoveCommand(luaMain, commandName.c_str(), handlerFunction);
+    }
+
+    const auto& nameList = std::get<std::vector<std::string>>(commandNames);
+    if (nameList.empty())
+        return false;
+
+    bool success = false;
+    for (const std::string& commandName : nameList)
+    {
+        if (commandName.empty())
+            continue;
+
+        if (m_pRegisteredCommands->RemoveCommand(luaMain, commandName.c_str(), handlerFunction))
+            success = true;
+    }
+
+    return success;
 }
 
 bool CLuaFunctionDefs::ExecuteCommandHandler(lua_State* luaVM, std::string commandName, CPlayer* player, std::optional<std::string> maybeArgs)

--- a/Server/mods/deathmatch/logic/luadefs/CLuaFunctionDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaFunctionDefs.cpp
@@ -71,9 +71,9 @@ void CLuaFunctionDefs::LoadFunctions()
 #endif
 
         // Console funcs
-        {"addCommandHandler", CLuaFunctionDefs::AddCommandHandler},
-        {"removeCommandHandler", CLuaFunctionDefs::RemoveCommandHandler},
-        {"executeCommandHandler", CLuaFunctionDefs::ExecuteCommandHandler},
+        {"addCommandHandler", ArgumentParser<CLuaFunctionDefs::AddCommandHandler>},
+        {"removeCommandHandler", ArgumentParser<CLuaFunctionDefs::RemoveCommandHandler>},
+        {"executeCommandHandler", ArgumentParser<CLuaFunctionDefs::ExecuteCommandHandler>},
         {"getCommandHandlers", CLuaFunctionDefs::GetCommandHandlers},
 
         // Loaded map funcs

--- a/Server/mods/deathmatch/logic/luadefs/CLuaFunctionDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaFunctionDefs.h
@@ -74,9 +74,10 @@ public:
     LUA_DECLARE(SetWeaponClipAmmo);
 
     // Console functions
-    static bool AddCommandHandler(lua_State* luaVM, std::string commandName, CLuaFunctionRef handlerFunction, std::optional<bool> maybeRestricted,
-                                  std::optional<bool> maybeCaseSensitive);
-    static bool RemoveCommandHandler(lua_State* luaVM, std::string commandName, std::optional<CLuaFunctionRef> maybeHandlerFunction);
+    static bool AddCommandHandler(lua_State* luaVM, std::variant<std::string, std::vector<std::string>> commandNames, CLuaFunctionRef handlerFunction,
+                                  std::optional<bool> maybeRestricted, std::optional<bool> maybeCaseSensitive);
+    static bool RemoveCommandHandler(lua_State* luaVM, std::variant<std::string, std::vector<std::string>> commandNames,
+                                     std::optional<CLuaFunctionRef> maybeHandlerFunction);
     static bool ExecuteCommandHandler(lua_State* luaVM, std::string commandName, CPlayer* player, std::optional<std::string> maybeArgs);
     LUA_DECLARE(GetCommandHandlers);
 

--- a/Server/mods/deathmatch/logic/luadefs/CLuaFunctionDefs.h
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaFunctionDefs.h
@@ -74,9 +74,10 @@ public:
     LUA_DECLARE(SetWeaponClipAmmo);
 
     // Console functions
-    LUA_DECLARE(AddCommandHandler);
-    LUA_DECLARE(RemoveCommandHandler);
-    LUA_DECLARE(ExecuteCommandHandler);
+    static bool AddCommandHandler(lua_State* luaVM, std::string commandName, CLuaFunctionRef handlerFunction, std::optional<bool> maybeRestricted,
+                                  std::optional<bool> maybeCaseSensitive);
+    static bool RemoveCommandHandler(lua_State* luaVM, std::string commandName, std::optional<CLuaFunctionRef> maybeHandlerFunction);
+    static bool ExecuteCommandHandler(lua_State* luaVM, std::string commandName, CPlayer* player, std::optional<std::string> maybeArgs);
     LUA_DECLARE(GetCommandHandlers);
 
     // Standard server functions


### PR DESCRIPTION
This PR is split into two commits / parts:

### Part 1: Command Handling Refactor & Performance Optimization
- Eliminated dynamic heap allocations (`new`/`delete`) on every command execution by using a fast stack-allocated buffer on both client and server, removing unnecessary heap churn.
- Optimized client command removal from $O(N^2)$ to $O(N)$ by eliminating repeated list iteration restarts when deleting matching commands.
- Modernized command bindings to use `ArgumentParser` and cleaned up Hungarian notation across the command manager.


### Part 2: Command Aliases Support
Scripters often struggle when trying to assign or remove multiple aliases for the same command in a single line. For example, they currently have to write:

```lua
addCommandHandler("pm", sendPrivateMessage)
addCommandHandler("msg", sendPrivateMessage)
addCommandHandler("tell", sendPrivateMessage)
addCommandHandler("whisper", sendPrivateMessage)
addCommandHandler("w", sendPrivateMessage)
```

Now, they can simply do:

```lua
addCommandHandler({"pm", "msg", "tell", "whisper", "w"}, sendPrivateMessage)
```

And similarly for removing them:

```lua
removeCommandHandler({"pm", "msg", "tell", "whisper", "w"}, sendPrivateMessage)
```

So... why not? It's a very useful QoL feature. While workarounds exist using Lua wrapper loops, having native core support is much cleaner, faster, and standardizes the workflow.

Everything is backward compatible with single string commands.

---

### API Changes

#### `addCommandHandler`
```lua
bool addCommandHandler ( string / table commandNames, function handlerFunction [, bool restricted = false, bool caseSensitive = true ] ) -- Server
bool addCommandHandler ( string / table commandNames, function handlerFunction [, bool caseSensitive = true ] ) -- Client
```

#### `removeCommandHandler`
```lua
bool removeCommandHandler ( string / table commandNames [, function handlerFunction ] )
```

---

### Testing
An automated test resource [test_command_aliases.zip](https://github.com/user-attachments/files/31577271/test_command_aliases.zip) was created to verify all changes:
- Runs test automatically on start and prints results directly to the chatbox on both client and server.
-  Multi-command aliases are included for manual in-game testing:
  - **Server:** `/sv_test`, `/sv_alias`, `/sv_hello`
  - **Client:** `/cl_test`, `/cl_alias`, `/cl_hello`