### PR TITLE
Allow Vector and Matrix Data Types in Network Events and RPCs

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaArgument.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaArgument.cpp
@@ -10,6 +10,11 @@
 
 #include "StdInc.h"
 #include "net/SyncStructures.h"
+#include "lua/CLuaVector2.h"
+#include "lua/CLuaVector3.h"
+#include "lua/CLuaVector4.h"
+#include "lua/CLuaMatrix.h"
+#include "lua/LuaCommon.h"
 
 #define ARGUMENT_TYPE_INT   9
 #define ARGUMENT_TYPE_FLOAT 10
@@ -35,6 +40,7 @@ CLuaArgument::CLuaArgument()
     m_iIndex = -1;
     m_pTableData = NULL;
     m_pUserData = NULL;
+    m_matrixData = nullptr;
     m_bWeakTableRef = false;
 }
 
@@ -42,6 +48,7 @@ CLuaArgument::CLuaArgument(const CLuaArgument& Argument, CFastHashMap<CLuaArgume
 {
     // Initialize and call our = on the argument
     m_pTableData = NULL;
+    m_matrixData = nullptr;
     CopyRecursive(Argument, pKnownTables);
 }
 
@@ -50,6 +57,7 @@ CLuaArgument::CLuaArgument(NetBitStreamInterface& bitStream, std::vector<CLuaArg
     m_iType = LUA_TNIL;
     m_pTableData = NULL;
     m_pUserData = NULL;
+    m_matrixData = nullptr;
     m_bWeakTableRef = false;
     ReadFromBitStream(bitStream, pKnownTables);
 }
@@ -58,6 +66,7 @@ CLuaArgument::CLuaArgument(lua_State* luaVM, int iArgument, CFastHashMap<const v
 {
     // Read the argument out of the lua VM
     m_pTableData = NULL;
+    m_matrixData = nullptr;
     m_iIndex = iArgument;
     Read(luaVM, iArgument, pKnownTables);
 }
@@ -122,6 +131,23 @@ void CLuaArgument::CopyRecursive(const CLuaArgument& Argument, CFastHashMap<CLua
         case LUA_TSTRING:
         {
             m_strString = Argument.m_strString;
+            break;
+        }
+
+        case LUA_TVECTOR2:
+        case LUA_TVECTOR3:
+        case LUA_TVECTOR4:
+        {
+            m_vectorData = Argument.m_vectorData;
+            break;
+        }
+
+        case LUA_TMATRIX:
+        {
+            if (Argument.m_matrixData)
+                m_matrixData = new CMatrix(*Argument.m_matrixData);
+            else
+                m_matrixData = nullptr;
             break;
         }
 
@@ -200,6 +226,32 @@ bool CLuaArgument::CompareRecursive(const CLuaArgument& Argument, std::set<CLuaA
         {
             return m_strString == Argument.m_strString;
         }
+        case LUA_TVECTOR2:
+        {
+            return m_vectorData.fX == Argument.m_vectorData.fX && m_vectorData.fY == Argument.m_vectorData.fY;
+        }
+        case LUA_TVECTOR3:
+        {
+            return m_vectorData.fX == Argument.m_vectorData.fX && m_vectorData.fY == Argument.m_vectorData.fY && m_vectorData.fZ == Argument.m_vectorData.fZ;
+        }
+        case LUA_TVECTOR4:
+        {
+            return m_vectorData.fX == Argument.m_vectorData.fX && m_vectorData.fY == Argument.m_vectorData.fY && m_vectorData.fZ == Argument.m_vectorData.fZ &&
+                   m_vectorData.fW == Argument.m_vectorData.fW;
+        }
+        case LUA_TMATRIX:
+        {
+            if (m_matrixData && Argument.m_matrixData)
+            {
+                return m_matrixData->vRight.fX == Argument.m_matrixData->vRight.fX && m_matrixData->vRight.fY == Argument.m_matrixData->vRight.fY &&
+                       m_matrixData->vRight.fZ == Argument.m_matrixData->vRight.fZ && m_matrixData->vFront.fX == Argument.m_matrixData->vFront.fX &&
+                       m_matrixData->vFront.fY == Argument.m_matrixData->vFront.fY && m_matrixData->vFront.fZ == Argument.m_matrixData->vFront.fZ &&
+                       m_matrixData->vUp.fX == Argument.m_matrixData->vUp.fX && m_matrixData->vUp.fY == Argument.m_matrixData->vUp.fY &&
+                       m_matrixData->vUp.fZ == Argument.m_matrixData->vUp.fZ && m_matrixData->vPos.fX == Argument.m_matrixData->vPos.fX &&
+                       m_matrixData->vPos.fY == Argument.m_matrixData->vPos.fY && m_matrixData->vPos.fZ == Argument.m_matrixData->vPos.fZ;
+            }
+            return m_matrixData == Argument.m_matrixData;
+        }
     }
 
     return true;
@@ -265,7 +317,27 @@ void CLuaArgument::Read(lua_State* luaVM, int iArgument, CFastHashMap<const void
 
             case LUA_TUSERDATA:
             {
-                m_pUserData = *((void**)lua_touserdata(luaVM, iArgument));
+                void* pData = *((void**)lua_touserdata(luaVM, iArgument));
+                if (CLuaVector3D* vector3 = UserDataCast((CLuaVector3D*)pData, luaVM))
+                {
+                    ReadVector(*vector3);
+                }
+                else if (CLuaVector2D* vector2 = UserDataCast((CLuaVector2D*)pData, luaVM))
+                {
+                    ReadVector(*vector2);
+                }
+                else if (CLuaVector4D* vector4 = UserDataCast((CLuaVector4D*)pData, luaVM))
+                {
+                    ReadVector(*vector4);
+                }
+                else if (CLuaMatrix* matrix = UserDataCast((CLuaMatrix*)pData, luaVM))
+                {
+                    ReadMatrix(*matrix);
+                }
+                else
+                {
+                    m_pUserData = pData;
+                }
                 break;
             }
 
@@ -311,16 +383,16 @@ void CLuaArgument::Read(lua_State* luaVM, int iArgument, CFastHashMap<const void
 void CLuaArgument::ReadBool(bool bBool)
 {
     m_strString = "";
-    m_iType = LUA_TBOOLEAN;
     DeleteTableData();
+    m_iType = LUA_TBOOLEAN;
     m_bBoolean = bBool;
 }
 
 void CLuaArgument::ReadNumber(double dNumber)
 {
     m_strString = "";
-    m_iType = LUA_TNUMBER;
     DeleteTableData();
+    m_iType = LUA_TNUMBER;
     m_Number = dNumber;
 }
 
@@ -390,6 +462,44 @@ void CLuaArgument::ReadTable(CLuaArguments* table)
     m_iType = LUA_TTABLE;
 }
 
+void CLuaArgument::ReadVector(const CVector2D& vector)
+{
+    m_strString = "";
+    DeleteTableData();
+    m_iType = LUA_TVECTOR2;
+    m_vectorData.fX = vector.fX;
+    m_vectorData.fY = vector.fY;
+    m_vectorData.fZ = 0.0f;
+    m_vectorData.fW = 0.0f;
+}
+
+void CLuaArgument::ReadVector(const CVector& vector)
+{
+    m_strString = "";
+    DeleteTableData();
+    m_iType = LUA_TVECTOR3;
+    m_vectorData.fX = vector.fX;
+    m_vectorData.fY = vector.fY;
+    m_vectorData.fZ = vector.fZ;
+    m_vectorData.fW = 0.0f;
+}
+
+void CLuaArgument::ReadVector(const CVector4D& vector)
+{
+    m_strString = "";
+    DeleteTableData();
+    m_iType = LUA_TVECTOR4;
+    m_vectorData = vector;
+}
+
+void CLuaArgument::ReadMatrix(const CMatrix& matrix)
+{
+    m_strString = "";
+    DeleteTableData();
+    m_iType = LUA_TMATRIX;
+    m_matrixData = new CMatrix(matrix);
+}
+
 CClientEntity* CLuaArgument::GetElement() const
 {
     ElementID ID = TO_ELEMENTID(m_pUserData);
@@ -455,6 +565,33 @@ void CLuaArgument::Push(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKn
         case LUA_TSTRING:
         {
             lua_pushlstring(luaVM, m_strString.c_str(), m_strString.length());
+            break;
+        }
+
+        case LUA_TVECTOR2:
+        {
+            lua_pushvector(luaVM, CVector2D(m_vectorData.fX, m_vectorData.fY));
+            break;
+        }
+
+        case LUA_TVECTOR3:
+        {
+            lua_pushvector(luaVM, CVector(m_vectorData.fX, m_vectorData.fY, m_vectorData.fZ));
+            break;
+        }
+
+        case LUA_TVECTOR4:
+        {
+            lua_pushvector(luaVM, m_vectorData);
+            break;
+        }
+
+        case LUA_TMATRIX:
+        {
+            if (m_matrixData)
+                lua_pushmatrix(luaVM, *m_matrixData);
+            else
+                lua_pushnil(luaVM);
             break;
         }
 
@@ -626,6 +763,52 @@ bool CLuaArgument::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vect
             }
             break;
         }
+
+        // Vector2 type
+        case LUA_TVECTOR2:
+        {
+            float x, y;
+            if (bitStream.Read(x) && bitStream.Read(y))
+            {
+                ReadVector(CVector2D(x, y));
+            }
+            break;
+        }
+
+        // Vector3 type
+        case LUA_TVECTOR3:
+        {
+            float x, y, z;
+            if (bitStream.Read(x) && bitStream.Read(y) && bitStream.Read(z))
+            {
+                ReadVector(CVector(x, y, z));
+            }
+            break;
+        }
+
+        // Vector4 type
+        case LUA_TVECTOR4:
+        {
+            float x, y, z, w;
+            if (bitStream.Read(x) && bitStream.Read(y) && bitStream.Read(z) && bitStream.Read(w))
+            {
+                ReadVector(CVector4D(x, y, z, w));
+            }
+            break;
+        }
+
+        // Matrix type
+        case LUA_TMATRIX:
+        {
+            CMatrix matrix;
+            if (bitStream.Read(matrix.vRight.fX) && bitStream.Read(matrix.vRight.fY) && bitStream.Read(matrix.vRight.fZ) && bitStream.Read(matrix.vFront.fX) &&
+                bitStream.Read(matrix.vFront.fY) && bitStream.Read(matrix.vFront.fZ) && bitStream.Read(matrix.vUp.fX) && bitStream.Read(matrix.vUp.fY) &&
+                bitStream.Read(matrix.vUp.fZ) && bitStream.Read(matrix.vPos.fX) && bitStream.Read(matrix.vPos.fY) && bitStream.Read(matrix.vPos.fZ))
+            {
+                ReadMatrix(matrix);
+            }
+            break;
+        }
     }
     return true;
 }
@@ -750,6 +933,62 @@ bool CLuaArgument::WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashM
             break;
         }
 
+        // Vector2 argument
+        case LUA_TVECTOR2:
+        {
+            type.data.ucType = LUA_TVECTOR2;
+            bitStream.Write(&type);
+            bitStream.Write(m_vectorData.fX);
+            bitStream.Write(m_vectorData.fY);
+            break;
+        }
+
+        // Vector3 argument
+        case LUA_TVECTOR3:
+        {
+            type.data.ucType = LUA_TVECTOR3;
+            bitStream.Write(&type);
+            bitStream.Write(m_vectorData.fX);
+            bitStream.Write(m_vectorData.fY);
+            bitStream.Write(m_vectorData.fZ);
+            break;
+        }
+
+        // Vector4 argument
+        case LUA_TVECTOR4:
+        {
+            type.data.ucType = LUA_TVECTOR4;
+            bitStream.Write(&type);
+            bitStream.Write(m_vectorData.fX);
+            bitStream.Write(m_vectorData.fY);
+            bitStream.Write(m_vectorData.fZ);
+            bitStream.Write(m_vectorData.fW);
+            break;
+        }
+
+        // Matrix argument
+        case LUA_TMATRIX:
+        {
+            type.data.ucType = LUA_TMATRIX;
+            bitStream.Write(&type);
+            if (m_matrixData)
+            {
+                bitStream.Write(m_matrixData->vRight.fX);
+                bitStream.Write(m_matrixData->vRight.fY);
+                bitStream.Write(m_matrixData->vRight.fZ);
+                bitStream.Write(m_matrixData->vFront.fX);
+                bitStream.Write(m_matrixData->vFront.fY);
+                bitStream.Write(m_matrixData->vFront.fZ);
+                bitStream.Write(m_matrixData->vUp.fX);
+                bitStream.Write(m_matrixData->vUp.fY);
+                bitStream.Write(m_matrixData->vUp.fZ);
+                bitStream.Write(m_matrixData->vPos.fX);
+                bitStream.Write(m_matrixData->vPos.fY);
+                bitStream.Write(m_matrixData->vPos.fZ);
+            }
+            break;
+        }
+
         // Element packet
         case LUA_TLIGHTUSERDATA:
         case LUA_TUSERDATA:
@@ -772,6 +1011,47 @@ bool CLuaArgument::WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashM
                     bitStream.Write(&type);
                     return false;
                 }
+            }
+            else if (CLuaVector3D* vector3 = UserDataCast((CLuaVector3D*)m_pUserData, nullptr))
+            {
+                type.data.ucType = LUA_TVECTOR3;
+                bitStream.Write(&type);
+                bitStream.Write(vector3->fX);
+                bitStream.Write(vector3->fY);
+                bitStream.Write(vector3->fZ);
+            }
+            else if (CLuaVector2D* vector2 = UserDataCast((CLuaVector2D*)m_pUserData, nullptr))
+            {
+                type.data.ucType = LUA_TVECTOR2;
+                bitStream.Write(&type);
+                bitStream.Write(vector2->fX);
+                bitStream.Write(vector2->fY);
+            }
+            else if (CLuaVector4D* vector4 = UserDataCast((CLuaVector4D*)m_pUserData, nullptr))
+            {
+                type.data.ucType = LUA_TVECTOR4;
+                bitStream.Write(&type);
+                bitStream.Write(vector4->fX);
+                bitStream.Write(vector4->fY);
+                bitStream.Write(vector4->fZ);
+                bitStream.Write(vector4->fW);
+            }
+            else if (CLuaMatrix* matrix = UserDataCast((CLuaMatrix*)m_pUserData, nullptr))
+            {
+                type.data.ucType = LUA_TMATRIX;
+                bitStream.Write(&type);
+                bitStream.Write(matrix->vRight.fX);
+                bitStream.Write(matrix->vRight.fY);
+                bitStream.Write(matrix->vRight.fZ);
+                bitStream.Write(matrix->vFront.fX);
+                bitStream.Write(matrix->vFront.fY);
+                bitStream.Write(matrix->vFront.fZ);
+                bitStream.Write(matrix->vUp.fX);
+                bitStream.Write(matrix->vUp.fY);
+                bitStream.Write(matrix->vUp.fZ);
+                bitStream.Write(matrix->vPos.fX);
+                bitStream.Write(matrix->vPos.fY);
+                bitStream.Write(matrix->vPos.fZ);
             }
             else
             {
@@ -826,6 +1106,11 @@ void CLuaArgument::DeleteTableData()
         if (!m_bWeakTableRef)
             delete m_pTableData;
         m_pTableData = NULL;
+    }
+    if (m_matrixData)
+    {
+        delete m_matrixData;
+        m_matrixData = nullptr;
     }
 }
 
@@ -887,6 +1172,41 @@ json_object* CLuaArgument::WriteToJSONObject(bool bSerialize, CFastHashMap<CLuaA
                                                               "Couldn't convert argument list to JSON. Invalid string specified, limit is 65535 characters.");
             }
             break;
+        }
+        case LUA_TVECTOR2:
+        {
+            json_object* jsonObject = json_object_new_object();
+            json_object_object_add(jsonObject, "x", json_object_new_double(m_vectorData.fX));
+            json_object_object_add(jsonObject, "y", json_object_new_double(m_vectorData.fY));
+            return jsonObject;
+        }
+        case LUA_TVECTOR3:
+        {
+            json_object* jsonObject = json_object_new_object();
+            json_object_object_add(jsonObject, "x", json_object_new_double(m_vectorData.fX));
+            json_object_object_add(jsonObject, "y", json_object_new_double(m_vectorData.fY));
+            json_object_object_add(jsonObject, "z", json_object_new_double(m_vectorData.fZ));
+            return jsonObject;
+        }
+        case LUA_TVECTOR4:
+        {
+            json_object* jsonObject = json_object_new_object();
+            json_object_object_add(jsonObject, "x", json_object_new_double(m_vectorData.fX));
+            json_object_object_add(jsonObject, "y", json_object_new_double(m_vectorData.fY));
+            json_object_object_add(jsonObject, "z", json_object_new_double(m_vectorData.fZ));
+            json_object_object_add(jsonObject, "w", json_object_new_double(m_vectorData.fW));
+            return jsonObject;
+        }
+        case LUA_TMATRIX:
+        {
+            if (!m_matrixData)
+                return json_object_new_null();
+            json_object* jsonArray = json_object_new_array();
+            float        buffer[16];
+            m_matrixData->GetBuffer(buffer);
+            for (int i = 0; i < 16; ++i)
+                json_object_array_add(jsonArray, json_object_new_double(buffer[i]));
+            return jsonArray;
         }
         case LUA_TUSERDATA:
         case LUA_TLIGHTUSERDATA:

--- a/Client/mods/deathmatch/logic/lua/CLuaArgument.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaArgument.h
@@ -18,12 +18,20 @@ extern "C"
 #include <string>
 #include "json.h"
 #include "CStringName.h"
+#include <CVector.h>
+#include <CVector2D.h>
+#include <CVector4D.h>
+#include <CMatrix.h>
 
 class CClientEntity;
 class CLuaArguments;
 
 #define LUA_TTABLEREF    9
 #define LUA_TSTRING_LONG 10
+#define LUA_TVECTOR2     11
+#define LUA_TVECTOR3     12
+#define LUA_TVECTOR4     13
+#define LUA_TMATRIX      14
 
 class CLuaArgument
 {
@@ -49,18 +57,24 @@ public:
     void ReadScriptID(uint uiScriptID);
     void ReadElementID(ElementID ID);
     void ReadTable(class CLuaArguments* table);
+    void ReadVector(const CVector2D& vector);
+    void ReadVector(const CVector& vector);
+    void ReadVector(const CVector4D& vector);
+    void ReadMatrix(const CMatrix& matrix);
 
     void Push(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKnownTables = NULL) const;
 
     int GetType() const { return m_iType; };
     int GetIndex() const { return m_iIndex; };
 
-    bool           GetBoolean() const { return m_bBoolean; };
-    lua_Number     GetNumber() const { return m_Number; };
-    const SString& GetString() { return m_strString; };
-    void*          GetUserData() const { return m_pUserData; };
-    CLuaArguments* GetTable() const { return m_pTableData; }
-    CClientEntity* GetElement() const;
+    bool             GetBoolean() const { return m_bBoolean; };
+    lua_Number       GetNumber() const { return m_Number; };
+    const SString&   GetString() { return m_strString; };
+    void*            GetUserData() const { return m_pUserData; };
+    CLuaArguments*   GetTable() const { return m_pTableData; }
+    CClientEntity*   GetElement() const;
+    const CVector4D& GetVector() const noexcept { return m_vectorData; }
+    const CMatrix*   GetMatrix() const noexcept { return m_matrixData; }
 
     bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL, unsigned int uiDepth = 0);
     bool         WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL) const;
@@ -110,6 +124,11 @@ public:
         return false;
     }
 
+    [[nodiscard]] bool IsVector2() const noexcept { return m_iType == LUA_TVECTOR2; }
+    [[nodiscard]] bool IsVector3() const noexcept { return m_iType == LUA_TVECTOR3; }
+    [[nodiscard]] bool IsVector4() const noexcept { return m_iType == LUA_TVECTOR4; }
+    [[nodiscard]] bool IsMatrix() const noexcept { return m_iType == LUA_TMATRIX && m_matrixData != nullptr; }
+
 private:
     void LogUnableToPacketize(const char* szMessage) const;
 
@@ -121,6 +140,8 @@ private:
     void*          m_pUserData;
     CLuaArguments* m_pTableData;
     bool           m_bWeakTableRef;
+    CVector4D      m_vectorData;
+    CMatrix*       m_matrixData;
 
 #ifdef MTA_DEBUG
     std::string m_strFilename;

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
@@ -1103,6 +1103,8 @@ SString GetUserDataClassName(void* ptr, lua_State* luaVM, bool bFindElementType)
         return GetClassTypeName(pVar);
     if (auto* pVar = UserDataCast((CLuaVector4D*)ptr, luaVM))
         return GetClassTypeName(pVar);
+    if (auto* pVar = UserDataCast((CLuaMatrix*)ptr, luaVM))
+        return GetClassTypeName(pVar);
     if (auto* pVar = UserDataCast((CRemoteCall*)ptr, luaVM))
         return GetClassTypeName(pVar);
 

--- a/Server/mods/deathmatch/logic/lua/CLuaArgument.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaArgument.cpp
@@ -13,6 +13,12 @@
 #include "CLuaArgument.h"
 #include "CLuaArguments.h"
 #include "LuaCommon.h"
+#include "lua/CLuaVector2.h"
+#include "lua/CLuaVector3.h"
+#include "lua/CLuaVector4.h"
+#include "lua/CLuaMatrix.h"
+#include "CLuaFunctionParseHelpers.h"
+#include "net/SyncStructures.h"
 #include "CGame.h"
 #include "CElementIDs.h"
 #include "CScriptDebugging.h"
@@ -31,6 +37,7 @@ CLuaArgument::CLuaArgument()
     m_iType = LUA_TNIL;
     m_pTableData = NULL;
     m_pUserData = NULL;
+    m_matrixData = nullptr;
     m_bWeakTableRef = false;
 }
 
@@ -38,6 +45,7 @@ CLuaArgument::CLuaArgument(const CLuaArgument& Argument, CFastHashMap<CLuaArgume
 {
     // Initialize and call our = on the argument
     m_pTableData = NULL;
+    m_matrixData = nullptr;
     CopyRecursive(Argument, pKnownTables);
 }
 
@@ -45,6 +53,7 @@ CLuaArgument::CLuaArgument(lua_State* luaVM, int iArgument, CFastHashMap<const v
 {
     // Read the argument out of the lua VM
     m_pTableData = NULL;
+    m_matrixData = nullptr;
     Read(luaVM, iArgument, pKnownTables);
 }
 
@@ -108,6 +117,23 @@ void CLuaArgument::CopyRecursive(const CLuaArgument& Argument, CFastHashMap<CLua
         case LUA_TSTRING:
         {
             m_strString = Argument.m_strString;
+            break;
+        }
+
+        case LUA_TVECTOR2:
+        case LUA_TVECTOR3:
+        case LUA_TVECTOR4:
+        {
+            m_vectorData = Argument.m_vectorData;
+            break;
+        }
+
+        case LUA_TMATRIX:
+        {
+            if (Argument.m_matrixData)
+                m_matrixData = new CMatrix(*Argument.m_matrixData);
+            else
+                m_matrixData = nullptr;
             break;
         }
 
@@ -196,7 +222,27 @@ void CLuaArgument::Read(lua_State* luaVM, int iArgument, CFastHashMap<const void
 
             case LUA_TUSERDATA:
             {
-                m_pUserData = *((void**)lua_touserdata(luaVM, iArgument));
+                void* pData = *((void**)lua_touserdata(luaVM, iArgument));
+                if (CLuaVector3D* vector3 = UserDataCast((CLuaVector3D*)pData, luaVM))
+                {
+                    ReadVector(*vector3);
+                }
+                else if (CLuaVector2D* vector2 = UserDataCast((CLuaVector2D*)pData, luaVM))
+                {
+                    ReadVector(*vector2);
+                }
+                else if (CLuaVector4D* vector4 = UserDataCast((CLuaVector4D*)pData, luaVM))
+                {
+                    ReadVector(*vector4);
+                }
+                else if (CLuaMatrix* matrix = UserDataCast((CLuaMatrix*)pData, luaVM))
+                {
+                    ReadMatrix(*matrix);
+                }
+                else
+                {
+                    m_pUserData = pData;
+                }
                 break;
             }
 
@@ -301,6 +347,33 @@ void CLuaArgument::Push(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKn
             break;
         }
 
+        case LUA_TVECTOR2:
+        {
+            lua_pushvector(luaVM, CVector2D(m_vectorData.fX, m_vectorData.fY));
+            break;
+        }
+
+        case LUA_TVECTOR3:
+        {
+            lua_pushvector(luaVM, CVector(m_vectorData.fX, m_vectorData.fY, m_vectorData.fZ));
+            break;
+        }
+
+        case LUA_TVECTOR4:
+        {
+            lua_pushvector(luaVM, m_vectorData);
+            break;
+        }
+
+        case LUA_TMATRIX:
+        {
+            if (m_matrixData)
+                lua_pushmatrix(luaVM, *m_matrixData);
+            else
+                lua_pushnil(luaVM);
+            break;
+        }
+
         default:
         {
             // Unexpected type, keep the stack balanced for callers
@@ -392,6 +465,44 @@ void CLuaArgument::ReadScriptID(uint uiScriptID)
     m_pUserData = reinterpret_cast<void*>(uiScriptID);
 }
 
+void CLuaArgument::ReadVector(const CVector2D& vector)
+{
+    m_strString = "";
+    DeleteTableData();
+    m_iType = LUA_TVECTOR2;
+    m_vectorData.fX = vector.fX;
+    m_vectorData.fY = vector.fY;
+    m_vectorData.fZ = 0.0f;
+    m_vectorData.fW = 0.0f;
+}
+
+void CLuaArgument::ReadVector(const CVector& vector)
+{
+    m_strString = "";
+    DeleteTableData();
+    m_iType = LUA_TVECTOR3;
+    m_vectorData.fX = vector.fX;
+    m_vectorData.fY = vector.fY;
+    m_vectorData.fZ = vector.fZ;
+    m_vectorData.fW = 0.0f;
+}
+
+void CLuaArgument::ReadVector(const CVector4D& vector)
+{
+    m_strString = "";
+    DeleteTableData();
+    m_iType = LUA_TVECTOR4;
+    m_vectorData = vector;
+}
+
+void CLuaArgument::ReadMatrix(const CMatrix& matrix)
+{
+    m_strString = "";
+    DeleteTableData();
+    m_iType = LUA_TMATRIX;
+    m_matrixData = new CMatrix(matrix);
+}
+
 CElement* CLuaArgument::GetElement() const
 {
     ElementID ID = TO_ELEMENTID(m_pUserData);
@@ -426,6 +537,18 @@ bool CLuaArgument::GetAsString(SString& strBuffer)
             else
                 strBuffer = SString("%f", m_Number);
 
+            break;
+        case LUA_TVECTOR2:
+            strBuffer = SString("Vector2(%.3f, %.3f)", m_vectorData.fX, m_vectorData.fY);
+            break;
+        case LUA_TVECTOR3:
+            strBuffer = SString("Vector3(%.3f, %.3f, %.3f)", m_vectorData.fX, m_vectorData.fY, m_vectorData.fZ);
+            break;
+        case LUA_TVECTOR4:
+            strBuffer = SString("Vector4(%.3f, %.3f, %.3f, %.3f)", m_vectorData.fX, m_vectorData.fY, m_vectorData.fZ, m_vectorData.fW);
+            break;
+        case LUA_TMATRIX:
+            strBuffer = "Matrix(...)";
             break;
         default:
             return false;
@@ -588,6 +711,53 @@ bool CLuaArgument::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vect
                 }
                 break;
             }
+
+            // Vector2 type
+            case LUA_TVECTOR2:
+            {
+                float x, y;
+                if (bitStream.Read(x) && bitStream.Read(y))
+                {
+                    ReadVector(CVector2D(x, y));
+                }
+                break;
+            }
+
+            // Vector3 type
+            case LUA_TVECTOR3:
+            {
+                float x, y, z;
+                if (bitStream.Read(x) && bitStream.Read(y) && bitStream.Read(z))
+                {
+                    ReadVector(CVector(x, y, z));
+                }
+                break;
+            }
+
+            // Vector4 type
+            case LUA_TVECTOR4:
+            {
+                float x, y, z, w;
+                if (bitStream.Read(x) && bitStream.Read(y) && bitStream.Read(z) && bitStream.Read(w))
+                {
+                    ReadVector(CVector4D(x, y, z, w));
+                }
+                break;
+            }
+
+            // Matrix type
+            case LUA_TMATRIX:
+            {
+                CMatrix matrix;
+                if (bitStream.Read(matrix.vRight.fX) && bitStream.Read(matrix.vRight.fY) && bitStream.Read(matrix.vRight.fZ) &&
+                    bitStream.Read(matrix.vFront.fX) && bitStream.Read(matrix.vFront.fY) && bitStream.Read(matrix.vFront.fZ) && bitStream.Read(matrix.vUp.fX) &&
+                    bitStream.Read(matrix.vUp.fY) && bitStream.Read(matrix.vUp.fZ) && bitStream.Read(matrix.vPos.fX) && bitStream.Read(matrix.vPos.fY) &&
+                    bitStream.Read(matrix.vPos.fZ))
+                {
+                    ReadMatrix(matrix);
+                }
+                break;
+            }
         }
     }
     else
@@ -715,6 +885,62 @@ bool CLuaArgument::WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashM
             break;
         }
 
+        // Vector2 argument
+        case LUA_TVECTOR2:
+        {
+            type.data.ucType = LUA_TVECTOR2;
+            bitStream.Write(&type);
+            bitStream.Write(m_vectorData.fX);
+            bitStream.Write(m_vectorData.fY);
+            break;
+        }
+
+        // Vector3 argument
+        case LUA_TVECTOR3:
+        {
+            type.data.ucType = LUA_TVECTOR3;
+            bitStream.Write(&type);
+            bitStream.Write(m_vectorData.fX);
+            bitStream.Write(m_vectorData.fY);
+            bitStream.Write(m_vectorData.fZ);
+            break;
+        }
+
+        // Vector4 argument
+        case LUA_TVECTOR4:
+        {
+            type.data.ucType = LUA_TVECTOR4;
+            bitStream.Write(&type);
+            bitStream.Write(m_vectorData.fX);
+            bitStream.Write(m_vectorData.fY);
+            bitStream.Write(m_vectorData.fZ);
+            bitStream.Write(m_vectorData.fW);
+            break;
+        }
+
+        // Matrix argument
+        case LUA_TMATRIX:
+        {
+            type.data.ucType = LUA_TMATRIX;
+            bitStream.Write(&type);
+            if (m_matrixData)
+            {
+                bitStream.Write(m_matrixData->vRight.fX);
+                bitStream.Write(m_matrixData->vRight.fY);
+                bitStream.Write(m_matrixData->vRight.fZ);
+                bitStream.Write(m_matrixData->vFront.fX);
+                bitStream.Write(m_matrixData->vFront.fY);
+                bitStream.Write(m_matrixData->vFront.fZ);
+                bitStream.Write(m_matrixData->vUp.fX);
+                bitStream.Write(m_matrixData->vUp.fY);
+                bitStream.Write(m_matrixData->vUp.fZ);
+                bitStream.Write(m_matrixData->vPos.fX);
+                bitStream.Write(m_matrixData->vPos.fY);
+                bitStream.Write(m_matrixData->vPos.fZ);
+            }
+            break;
+        }
+
         // Element argument
         case LUA_TLIGHTUSERDATA:
         case LUA_TUSERDATA:
@@ -727,6 +953,47 @@ bool CLuaArgument::WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashM
                 type.data.ucType = LUA_TUSERDATA;
                 bitStream.Write(&type);
                 bitStream.Write(pElement->GetID());
+            }
+            else if (CLuaVector3D* vector3 = UserDataCast((CLuaVector3D*)m_pUserData, nullptr))
+            {
+                type.data.ucType = LUA_TVECTOR3;
+                bitStream.Write(&type);
+                bitStream.Write(vector3->fX);
+                bitStream.Write(vector3->fY);
+                bitStream.Write(vector3->fZ);
+            }
+            else if (CLuaVector2D* vector2 = UserDataCast((CLuaVector2D*)m_pUserData, nullptr))
+            {
+                type.data.ucType = LUA_TVECTOR2;
+                bitStream.Write(&type);
+                bitStream.Write(vector2->fX);
+                bitStream.Write(vector2->fY);
+            }
+            else if (CLuaVector4D* vector4 = UserDataCast((CLuaVector4D*)m_pUserData, nullptr))
+            {
+                type.data.ucType = LUA_TVECTOR4;
+                bitStream.Write(&type);
+                bitStream.Write(vector4->fX);
+                bitStream.Write(vector4->fY);
+                bitStream.Write(vector4->fZ);
+                bitStream.Write(vector4->fW);
+            }
+            else if (CLuaMatrix* matrix = UserDataCast((CLuaMatrix*)m_pUserData, nullptr))
+            {
+                type.data.ucType = LUA_TMATRIX;
+                bitStream.Write(&type);
+                bitStream.Write(matrix->vRight.fX);
+                bitStream.Write(matrix->vRight.fY);
+                bitStream.Write(matrix->vRight.fZ);
+                bitStream.Write(matrix->vFront.fX);
+                bitStream.Write(matrix->vFront.fY);
+                bitStream.Write(matrix->vFront.fZ);
+                bitStream.Write(matrix->vUp.fX);
+                bitStream.Write(matrix->vUp.fY);
+                bitStream.Write(matrix->vUp.fZ);
+                bitStream.Write(matrix->vPos.fX);
+                bitStream.Write(matrix->vPos.fY);
+                bitStream.Write(matrix->vPos.fZ);
             }
             else
             {
@@ -785,6 +1052,11 @@ void CLuaArgument::DeleteTableData()
         if (!m_bWeakTableRef)
             delete m_pTableData;
         m_pTableData = NULL;
+    }
+    if (m_matrixData)
+    {
+        delete m_matrixData;
+        m_matrixData = nullptr;
     }
 }
 
@@ -845,6 +1117,41 @@ json_object* CLuaArgument::WriteToJSONObject(bool bSerialize, CFastHashMap<CLuaA
                 g_pGame->GetScriptDebugging()->LogError(NULL, "Couldn't convert argument list to JSON. Invalid string specified, limit is 65535 characters.");
             }
             break;
+        }
+        case LUA_TVECTOR2:
+        {
+            json_object* jsonObject = json_object_new_object();
+            json_object_object_add(jsonObject, "x", json_object_new_double(m_vectorData.fX));
+            json_object_object_add(jsonObject, "y", json_object_new_double(m_vectorData.fY));
+            return jsonObject;
+        }
+        case LUA_TVECTOR3:
+        {
+            json_object* jsonObject = json_object_new_object();
+            json_object_object_add(jsonObject, "x", json_object_new_double(m_vectorData.fX));
+            json_object_object_add(jsonObject, "y", json_object_new_double(m_vectorData.fY));
+            json_object_object_add(jsonObject, "z", json_object_new_double(m_vectorData.fZ));
+            return jsonObject;
+        }
+        case LUA_TVECTOR4:
+        {
+            json_object* jsonObject = json_object_new_object();
+            json_object_object_add(jsonObject, "x", json_object_new_double(m_vectorData.fX));
+            json_object_object_add(jsonObject, "y", json_object_new_double(m_vectorData.fY));
+            json_object_object_add(jsonObject, "z", json_object_new_double(m_vectorData.fZ));
+            json_object_object_add(jsonObject, "w", json_object_new_double(m_vectorData.fW));
+            return jsonObject;
+        }
+        case LUA_TMATRIX:
+        {
+            if (!m_matrixData)
+                return json_object_new_null();
+            json_object* jsonArray = json_object_new_array();
+            float        buffer[16];
+            m_matrixData->GetBuffer(buffer);
+            for (int i = 0; i < 16; ++i)
+                json_object_array_add(jsonArray, json_object_new_double(buffer[i]));
+            return jsonArray;
         }
         case LUA_TLIGHTUSERDATA:
         case LUA_TUSERDATA:
@@ -1002,6 +1309,32 @@ bool CLuaArgument::IsEqualTo(const CLuaArgument& compareTo, std::set<const CLuaA
         case LUA_TSTRING:
         {
             return m_strString == compareTo.m_strString;
+        }
+        case LUA_TVECTOR2:
+        {
+            return m_vectorData.fX == compareTo.m_vectorData.fX && m_vectorData.fY == compareTo.m_vectorData.fY;
+        }
+        case LUA_TVECTOR3:
+        {
+            return m_vectorData.fX == compareTo.m_vectorData.fX && m_vectorData.fY == compareTo.m_vectorData.fY && m_vectorData.fZ == compareTo.m_vectorData.fZ;
+        }
+        case LUA_TVECTOR4:
+        {
+            return m_vectorData.fX == compareTo.m_vectorData.fX && m_vectorData.fY == compareTo.m_vectorData.fY &&
+                   m_vectorData.fZ == compareTo.m_vectorData.fZ && m_vectorData.fW == compareTo.m_vectorData.fW;
+        }
+        case LUA_TMATRIX:
+        {
+            if (m_matrixData && compareTo.m_matrixData)
+            {
+                return m_matrixData->vRight.fX == compareTo.m_matrixData->vRight.fX && m_matrixData->vRight.fY == compareTo.m_matrixData->vRight.fY &&
+                       m_matrixData->vRight.fZ == compareTo.m_matrixData->vRight.fZ && m_matrixData->vFront.fX == compareTo.m_matrixData->vFront.fX &&
+                       m_matrixData->vFront.fY == compareTo.m_matrixData->vFront.fY && m_matrixData->vFront.fZ == compareTo.m_matrixData->vFront.fZ &&
+                       m_matrixData->vUp.fX == compareTo.m_matrixData->vUp.fX && m_matrixData->vUp.fY == compareTo.m_matrixData->vUp.fY &&
+                       m_matrixData->vUp.fZ == compareTo.m_matrixData->vUp.fZ && m_matrixData->vPos.fX == compareTo.m_matrixData->vPos.fX &&
+                       m_matrixData->vPos.fY == compareTo.m_matrixData->vPos.fY && m_matrixData->vPos.fZ == compareTo.m_matrixData->vPos.fZ;
+            }
+            return m_matrixData == compareTo.m_matrixData;
         }
     }
 

--- a/Server/mods/deathmatch/logic/lua/CLuaArgument.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaArgument.h
@@ -19,12 +19,20 @@ extern "C"
 }
 #include "../common/CBitStream.h"
 #include "json.h"
+#include <CVector.h>
+#include <CVector2D.h>
+#include <CVector4D.h>
+#include <CMatrix.h>
 
 class CElement;
 class CLuaArguments;
 
 #define LUA_TTABLEREF    9
 #define LUA_TSTRING_LONG 10
+#define LUA_TVECTOR2     11
+#define LUA_TVECTOR3     12
+#define LUA_TVECTOR4     13
+#define LUA_TMATRIX      14
 
 class CLuaArgument
 {
@@ -51,6 +59,10 @@ public:
     void ReadElementID(ElementID ID);
     void ReadScriptID(uint uiScriptID);
     void ReadTable(class CLuaArguments* table);
+    void ReadVector(const CVector2D& vector);
+    void ReadVector(const CVector& vector);
+    void ReadVector(const CVector4D& vector);
+    void ReadMatrix(const CMatrix& matrix);
 
     int GetType() const { return m_iType; };
 
@@ -61,6 +73,8 @@ public:
     CLuaArguments*     GetTable() const { return m_pTableData; }
     CElement*          GetElement() const;
     bool               GetAsString(SString& strBuffer);
+    const CVector4D&   GetVector() const noexcept { return m_vectorData; }
+    const CMatrix*     GetMatrix() const noexcept { return m_matrixData; }
 
     bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL, unsigned int uiDepth = 0);
     bool         WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL) const;
@@ -112,6 +126,11 @@ public:
         return false;
     }
 
+    [[nodiscard]] bool IsVector2() const noexcept { return m_iType == LUA_TVECTOR2; }
+    [[nodiscard]] bool IsVector3() const noexcept { return m_iType == LUA_TVECTOR3; }
+    [[nodiscard]] bool IsVector4() const noexcept { return m_iType == LUA_TVECTOR4; }
+    [[nodiscard]] bool IsMatrix() const noexcept { return m_iType == LUA_TMATRIX && m_matrixData != nullptr; }
+
 private:
     void LogUnableToPacketize(const char* szMessage) const;
 
@@ -122,6 +141,8 @@ private:
     void*          m_pUserData;
     CLuaArguments* m_pTableData;
     bool           m_bWeakTableRef;
+    CVector4D      m_vectorData;
+    CMatrix*       m_matrixData;
 
 #ifdef MTA_DEBUG
     std::string m_strFilename;

--- a/Shared/sdk/net/SyncStructures.h
+++ b/Shared/sdk/net/SyncStructures.h
@@ -2266,6 +2266,11 @@ struct SOverrideLightsSync : public ISyncStructure
 //              Lua types               //
 //                                      //
 //////////////////////////////////////////
+#define LUA_TVECTOR2 11
+#define LUA_TVECTOR3 12
+#define LUA_TVECTOR4 13
+#define LUA_TMATRIX  14
+
 struct SLuaTypeSync : public ISyncStructure
 {
     enum

--- a/Tests/client/SyncMisc_Tests.cpp
+++ b/Tests/client/SyncMisc_Tests.cpp
@@ -309,6 +309,24 @@ TEST(SLuaTypeSync, RoundTrip)
     EXPECT_EQ(9, out.data.ucType);
 }
 
+TEST(SLuaTypeSync, RoundTrip_VectorAndMatrix)
+{
+    const unsigned char types[] = {LUA_TVECTOR2, LUA_TVECTOR3, LUA_TVECTOR4, LUA_TMATRIX};
+
+    for (unsigned char typeVal : types)
+    {
+        MockBitStream bs;
+        SLuaTypeSync  sync;
+        sync.data.ucType = typeVal;
+        sync.Write(bs);
+        EXPECT_EQ(4, bs.GetNumberOfBitsUsed());
+        bs.ResetReadPointer();
+        SLuaTypeSync out;
+        EXPECT_TRUE(out.Read(bs));
+        EXPECT_EQ(typeVal, out.data.ucType);
+    }
+}
+
 // Mouse button: 3-bit value (left=1, middle=2, right=3, etc.).
 TEST(SMouseButtonSync, RoundTrip)
 {


### PR DESCRIPTION
Enables native transmission of `Vector2`, `Vector3`, `Vector4`, and `Matrix` data types across network events and latent events (`triggerClientEvent`, `triggerServerEvent`), including when nested inside tables.

Closes #374

### Testing
- Validated network serialization roundtrip in unit test suite (`SyncMisc_Tests`).
- Verified event roundtrips with automated test [test_vector_sync.zip](https://github.com/user-attachments/files/31597945/test_vector_sync.zip).
