### PR TITLE
Fix stealth kill animation playing on the wrong ped/player

### DIFF
--- a/Client/game_sa/TaskAttackSA.h
+++ b/Client/game_sa/TaskAttackSA.h
@@ -191,3 +191,16 @@ public:
     CTaskSimpleFightSA() {};
     CTaskSimpleFightSA(CEntity* pTargetEntity, int nCommand, unsigned int nIdlePeriod = 10000);
 };
+
+class CTaskSimpleStealthKillSAInterface : public CTaskSimpleSAInterface
+{
+public:
+    bool                   m_bKeepTargetAlive;
+    CPed*                  m_pTarget;
+    AssocGroupId           m_nAnimGroup;
+    bool                   m_bIsAborting;
+    bool                   m_bIsFinished;
+    CAnimBlendAssociation* m_pAnim;
+    unsigned int           m_nSpentWaitingMs;
+};
+static_assert(sizeof(CTaskSimpleStealthKillSAInterface) == 0x20, "Invalid CTaskSimpleStealthKillSAInterface size");

--- a/Client/game_sa/TaskAttackSA.h
+++ b/Client/game_sa/TaskAttackSA.h
@@ -195,12 +195,12 @@ public:
 class CTaskSimpleStealthKillSAInterface : public CTaskSimpleSAInterface
 {
 public:
-    bool                   m_bKeepTargetAlive;
-    CPed*                  m_pTarget;
-    AssocGroupId           m_nAnimGroup;
-    bool                   m_bIsAborting;
-    bool                   m_bIsFinished;
-    CAnimBlendAssociation* m_pAnim;
-    unsigned int           m_nSpentWaitingMs;
+    bool                   m_keepTargetAlive;
+    CPed*                  m_target;
+    AssocGroupId           m_animGroup;
+    bool                   m_isAborting;
+    bool                   m_isFinished;
+    CAnimBlendAssociation* m_anim;
+    unsigned int           m_spentWaitingMs;
 };
 static_assert(sizeof(CTaskSimpleStealthKillSAInterface) == 0x20, "Invalid CTaskSimpleStealthKillSAInterface size");

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -16,6 +16,7 @@
 #include <game/CPedDamageResponse.h>
 #include <game/CEventList.h>
 #include <game/CEventDamage.h>
+#include "../game_sa/TaskAttackSA.h"
 
 class CEventDamageSAInterface;
 
@@ -4205,26 +4206,11 @@ static void __declspec(naked) HOOK_ComputeDamageResponse_StartChoking()
 // attacker still runs a CTaskSimpleStealthKill, without checking who that task is for; a knife
 // kill keeps it active for the whole animation, so a tear gas tick or a stray bullet from the
 // same attacker makes a nearby ped play the stealth death too.
-class CTaskSimpleStealthKillSAInterface
-{
-public:
-    void*            pVTable;
-    void*            pParent;
-    bool             bKeepTargetAlive;
-    CPedSAInterface* pTarget;
-    int              animGroupId;
-    bool             bIsAborting;
-    bool             bIsFinished;
-    void*            pAnim;
-    unsigned int     uiSpentWaitingMs;
-};
-static_assert(sizeof(CTaskSimpleStealthKillSAInterface) == 0x20, "Invalid CTaskSimpleStealthKillSAInterface size");
-
 // The original code compares the task's type further down, but on any other task type this reads
 // a field that can't match the ped, so the outcome doesn't change
-bool _cdecl IsStealthKillTaskTarget(CTaskSimpleStealthKillSAInterface* pStealthKillTask, CPedSAInterface* pPed)
+bool _cdecl IsStealthKillTaskTarget(CTaskSimpleStealthKillSAInterface* pStealthKillTask, CPed* pPed)
 {
-    return pStealthKillTask && pStealthKillTask->pTarget == pPed;
+    return pStealthKillTask && pStealthKillTask->m_pTarget == pPed;
 }
 
 DWORD                         RETURN_ComputeDamageResponse_StealthKillTarget = 0x4C0365;

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -46,7 +46,8 @@ extern CGame* pGameInterface;
 #define HOOKPOS_EndWorldColors                           0x561795
 #define HOOKPOS_CWorld_ProcessVerticalLineSectorList     0x563357
 #define HOOKPOS_ComputeDamageResponse_StartChoking       0x4C05B9
-#define HOOKPOS_ComputeDamageResponse_StealthKillTarget  0x4C03AB
+#define HOOKPOS_ComputeDamageResponse_StealthKillTarget  0x4C035C
+#define FUNC_CTaskManager_GetActiveTask                  0x681720
 #define HOOKPOS_CAutomobile__ProcessSwingingDoor         0x6A9DAF
 
 #define FUNC_CStreaming_Update                     0x40E670
@@ -654,7 +655,7 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_EndWorldColors, (DWORD)HOOK_EndWorldColors, 5);
     HookInstall(HOOKPOS_CWorld_ProcessVerticalLineSectorList, (DWORD)HOOK_CWorld_ProcessVerticalLineSectorList, 8);
     HookInstall(HOOKPOS_ComputeDamageResponse_StartChoking, (DWORD)HOOK_ComputeDamageResponse_StartChoking, 7);
-    HookInstall(HOOKPOS_ComputeDamageResponse_StealthKillTarget, (DWORD)HOOK_ComputeDamageResponse_StealthKillTarget, 5);
+    HookInstall(HOOKPOS_ComputeDamageResponse_StealthKillTarget, (DWORD)HOOK_ComputeDamageResponse_StealthKillTarget, 9);
     HookInstall(HOOKPOS_CollisionStreamRead, (DWORD)HOOK_CollisionStreamRead, 6);
     HookInstall(HOOKPOS_VehicleCamStart, (DWORD)HOOK_VehicleCamStart, 6);
     HookInstall(HOOKPOS_VehicleCamTargetZTweak, (DWORD)HOOK_VehicleCamTargetZTweak, 8);
@@ -4204,16 +4205,29 @@ static void __declspec(naked) HOOK_ComputeDamageResponse_StartChoking()
 // attacker still runs a CTaskSimpleStealthKill, without checking who that task is for; a knife
 // kill keeps it active for the whole animation, so a tear gas tick or a stray bullet from the
 // same attacker makes a nearby ped play the stealth death too.
-bool _cdecl IsStealthKillTaskTarget(DWORD dwStealthKillTask, DWORD dwPed)
+class CTaskSimpleStealthKillSAInterface
 {
-    if (!dwStealthKillTask)
-        return false;
+public:
+    void*            pVTable;
+    void*            pParent;
+    bool             bKeepTargetAlive;
+    CPedSAInterface* pTarget;
+    int              animGroupId;
+    bool             bIsAborting;
+    bool             bIsFinished;
+    void*            pAnim;
+    unsigned int     uiSpentWaitingMs;
+};
+static_assert(sizeof(CTaskSimpleStealthKillSAInterface) == 0x20, "Invalid CTaskSimpleStealthKillSAInterface size");
 
-    // CTaskSimpleStealthKill::m_target
-    return *reinterpret_cast<DWORD*>(dwStealthKillTask + 0xC) == dwPed;
+// The original code compares the task's type further down, but on any other task type this reads
+// a field that can't match the ped, so the outcome doesn't change
+bool _cdecl IsStealthKillTaskTarget(CTaskSimpleStealthKillSAInterface* pStealthKillTask, CPedSAInterface* pPed)
+{
+    return pStealthKillTask && pStealthKillTask->pTarget == pPed;
 }
 
-DWORD                         RETURN_ComputeDamageResponse_StealthKillTarget = 0x4C03B0;
+DWORD                         RETURN_ComputeDamageResponse_StealthKillTarget = 0x4C0365;
 DWORD                         RETURN_ComputeDamageResponse_StealthKillSkip = 0x4C03D6;
 static void __declspec(naked) HOOK_ComputeDamageResponse_StealthKillTarget()
 {
@@ -4222,8 +4236,11 @@ static void __declspec(naked) HOOK_ComputeDamageResponse_StealthKillTarget()
     // clang-format off
     __asm
     {
-        // eax = attacker's active CTaskSimpleStealthKill, ebx = attacker, [edi] = ped taking the damage
-        pushad
+        // Replaced code: ecx already points at the attacker's task manager and eax gets his active
+        // task. Past the hook nothing reads eax, ecx or edx before writing them, on either path.
+        mov     edx, FUNC_CTaskManager_GetActiveTask
+        call    edx
+
         mov     ecx, [edi]
         push    ecx
         push    eax
@@ -4232,15 +4249,9 @@ static void __declspec(naked) HOOK_ComputeDamageResponse_StealthKillTarget()
         test    al, al
         jz      notTheTarget
 
-        popad
-        // Replaced code
-        mov     eax, [eax+0x10]
-        push    eax
-        push    ebx
         jmp     RETURN_ComputeDamageResponse_StealthKillTarget
 
         notTheTarget:
-        popad
         jmp     RETURN_ComputeDamageResponse_StealthKillSkip
     }
     // clang-format on

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -46,6 +46,7 @@ extern CGame* pGameInterface;
 #define HOOKPOS_EndWorldColors                           0x561795
 #define HOOKPOS_CWorld_ProcessVerticalLineSectorList     0x563357
 #define HOOKPOS_ComputeDamageResponse_StartChoking       0x4C05B9
+#define HOOKPOS_ComputeDamageResponse_StealthKillTarget  0x4C03AB
 #define HOOKPOS_CAutomobile__ProcessSwingingDoor         0x6A9DAF
 
 #define FUNC_CStreaming_Update                     0x40E670
@@ -447,6 +448,7 @@ void HOOK_CObject_Render();
 void HOOK_EndWorldColors();
 void HOOK_CWorld_ProcessVerticalLineSectorList();
 void HOOK_ComputeDamageResponse_StartChoking();
+void HOOK_ComputeDamageResponse_StealthKillTarget();
 void HOOK_CollisionStreamRead();
 void HOOK_CPhysical_ApplyGravity();
 void HOOK_VehicleCamStart();
@@ -652,6 +654,7 @@ void CMultiplayerSA::InitHooks()
     HookInstall(HOOKPOS_EndWorldColors, (DWORD)HOOK_EndWorldColors, 5);
     HookInstall(HOOKPOS_CWorld_ProcessVerticalLineSectorList, (DWORD)HOOK_CWorld_ProcessVerticalLineSectorList, 8);
     HookInstall(HOOKPOS_ComputeDamageResponse_StartChoking, (DWORD)HOOK_ComputeDamageResponse_StartChoking, 7);
+    HookInstall(HOOKPOS_ComputeDamageResponse_StealthKillTarget, (DWORD)HOOK_ComputeDamageResponse_StealthKillTarget, 5);
     HookInstall(HOOKPOS_CollisionStreamRead, (DWORD)HOOK_CollisionStreamRead, 6);
     HookInstall(HOOKPOS_VehicleCamStart, (DWORD)HOOK_VehicleCamStart, 6);
     HookInstall(HOOKPOS_VehicleCamTargetZTweak, (DWORD)HOOK_VehicleCamTargetZTweak, 8);
@@ -4193,6 +4196,52 @@ static void __declspec(naked) HOOK_ComputeDamageResponse_StartChoking()
         mov     ecx, [edi]
         mov     eax, [ecx+0x47C]
         jmp     dwChokingChoke
+    }
+    // clang-format on
+}
+
+// CEventHandler::ComputeDamageResponse turns any damage into a stealth kill death while the
+// attacker still runs a CTaskSimpleStealthKill, without checking who that task is for; a knife
+// kill keeps it active for the whole animation, so a tear gas tick or a stray bullet from the
+// same attacker makes a nearby ped play the stealth death too.
+bool _cdecl IsStealthKillTaskTarget(DWORD dwStealthKillTask, DWORD dwPed)
+{
+    if (!dwStealthKillTask)
+        return false;
+
+    // CTaskSimpleStealthKill::m_target
+    return *reinterpret_cast<DWORD*>(dwStealthKillTask + 0xC) == dwPed;
+}
+
+DWORD                         RETURN_ComputeDamageResponse_StealthKillTarget = 0x4C03B0;
+DWORD                         RETURN_ComputeDamageResponse_StealthKillSkip = 0x4C03D6;
+static void __declspec(naked) HOOK_ComputeDamageResponse_StealthKillTarget()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // eax = attacker's active CTaskSimpleStealthKill, ebx = attacker, [edi] = ped taking the damage
+        pushad
+        mov     ecx, [edi]
+        push    ecx
+        push    eax
+        call    IsStealthKillTaskTarget
+        add     esp, 8
+        test    al, al
+        jz      notTheTarget
+
+        popad
+        // Replaced code
+        mov     eax, [eax+0x10]
+        push    eax
+        push    ebx
+        jmp     RETURN_ComputeDamageResponse_StealthKillTarget
+
+        notTheTarget:
+        popad
+        jmp     RETURN_ComputeDamageResponse_StealthKillSkip
     }
     // clang-format on
 }

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -16,7 +16,6 @@
 #include <game/CPedDamageResponse.h>
 #include <game/CEventList.h>
 #include <game/CEventDamage.h>
-#include "../game_sa/TaskAttackSA.h"
 
 class CEventDamageSAInterface;
 
@@ -4210,12 +4209,12 @@ static void __declspec(naked) HOOK_ComputeDamageResponse_StartChoking()
 // a field that can't match the ped, so the outcome doesn't change
 bool _cdecl IsStealthKillTaskTarget(CTaskSimpleStealthKillSAInterface* pStealthKillTask, CPed* pPed)
 {
-    return pStealthKillTask && pStealthKillTask->m_pTarget == pPed;
+    return pStealthKillTask && pStealthKillTask->m_target == pPed;
 }
 
-DWORD                         RETURN_ComputeDamageResponse_StealthKillTarget = 0x4C0365;
-DWORD                         RETURN_ComputeDamageResponse_StealthKillSkip = 0x4C03D6;
-static void __declspec(naked) HOOK_ComputeDamageResponse_StealthKillTarget()
+static constexpr std::uintptr_t RETURN_ComputeDamageResponse_StealthKillTarget = 0x4C0365;
+static constexpr std::uintptr_t RETURN_ComputeDamageResponse_StealthKillSkip = 0x4C03D6;
+static void __declspec(naked)   HOOK_ComputeDamageResponse_StealthKillTarget()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
 

--- a/Client/multiplayer_sa/StdInc.h
+++ b/Client/multiplayer_sa/StdInc.h
@@ -24,5 +24,6 @@
 #include "..\game_sa\CEntitySA.h"
 #include "..\game_sa\CPedSA.h"
 #include "..\game_sa\CProjectileSA.h"
+#include "..\game_sa\TaskAttackSA.h"
 
 extern CMultiplayerSA* pMultiplayer;


### PR DESCRIPTION
#### Summary

CEventHandler::ComputeDamageResponse has a shortcut that puts a damaged ped straight into the stealth kill death when the entity that caused the damage currently runs a CTaskSimpleStealthKill, without checking who that task is actually for. A knife kill keeps the task active on the killer for the whole animation, so any other damage they cause during that window (a tear gas tick from a grenade thrown earlier, a stray bullet) makes a different nearby ped play the stealth kill death animation and freeze up as if they were the victim.

This adds a hook at that shortcut which compares the task's real target (CTaskSimpleStealthKill::m_target) against the ped being processed; only the actual victim takes the stealth death path, everyone else gets the normal damage response.

**Whitout fix:** https://streamable.com/mp3i0d
**With fix:** https://streamable.com/psaelf

#### Motivation

Fixes #2897.

#### Test plan

1. Throw a tear gas grenade next to two peds or players.
2. While it ticks, stealth kill one of them with a knife.
3. Only the stabbed one plays the stealth kill death.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.