### PR TITLE
Fix jacked players warping while being pulled out

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -1643,7 +1643,9 @@ CClientVehicle* CClientPed::RemoveFromVehicle(bool bSkipWarpIfGettingOut)
                 bSkipWarpIfGettingOut = false;
 
             // Jax: this should be safe, doesn't remove the player if he's getting dragged out already (fix for getting stuck on back after being jacked)
-            if (!bSkipWarpIfGettingOut || (!IsGettingOutOfVehicle()))
+            // IsGettingOutOfVehicle only covers the voluntary leave car task; a jack victim's drag task
+            // got ripped away mid animation here and the warp put him on the vehicle roof for a moment.
+            if (!bSkipWarpIfGettingOut || (!IsGettingOutOfVehicle() && !IsGettingJacked()))
             {
                 // Warp the player out
                 InternalRemoveFromVehicle(pGameVehicle);
@@ -5489,7 +5491,9 @@ void CClientPed::SetTargetPosition(const CVector& vecPosition, unsigned long ulD
     if (pTargetOriginSource)
         pTargetOriginSource->GetPosition(vecOrigin);
 
-    UpdateUnderFloorFix(vecPosition, vecOrigin);
+    // This one warps on its own, so it gets the same jack window as UpdateTargetPosition
+    if (!IsGettingJacked())
+        UpdateUnderFloorFix(vecPosition, vecOrigin);
 
     // Update the references to the contact entity
     if (pTargetOriginSource != m_interp.pTargetOriginSource)
@@ -5542,6 +5546,11 @@ void CClientPed::RemoveTargetPosition()
 
 void CClientPed::UpdateTargetPosition()
 {
+    // The jack drag task positions the ped itself for its whole length; synced positions applied
+    // over it fight the animation frame by frame, so let it finish and resume then.
+    if (IsGettingJacked())
+        return;
+
     if (HasTargetPosition())
     {
         unsigned long ulCurrentTime = CClientTime::GetTime();

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -379,6 +379,14 @@ void CClientVehicle::GetPosition(CVector& vecPosition) const
     }
 }
 
+// A ped that is getting out or being dragged out and has physically left the car is owned by his
+// own exit animation; moving him with the vehicle would keep warping him back inside it.
+static bool CanMoveOccupantWithVehicle(CClientPed* pOccupant)
+{
+    const int iState = pOccupant->GetVehicleInOutState();
+    return (iState != VEHICLE_INOUT_GETTING_OUT && iState != VEHICLE_INOUT_GETTING_JACKED) || pOccupant->GetRealOccupiedVehicle();
+}
+
 void CClientVehicle::SetPosition(const CVector& vecPosition, bool bResetInterpolation, bool bAllowGroundLoadFreeze)
 {
     // Is the local player in the vehicle
@@ -419,10 +427,9 @@ void CClientVehicle::SetPosition(const CVector& vecPosition, bool bResetInterpol
     }
 
     // If we have any occupants, update their positions
-    // Make sure we dont update their position if they are getting out and have physically left the car
     for (int i = 0; i <= NUMELMS(m_pPassengers); i++)
         if (CClientPed* pOccupant = GetOccupant(i))
-            if (pOccupant->GetVehicleInOutState() != VEHICLE_INOUT_GETTING_OUT || pOccupant->GetRealOccupiedVehicle())
+            if (CanMoveOccupantWithVehicle(pOccupant))
                 pOccupant->SetPosition(vecPosition);
 
     // Reset interpolation
@@ -455,7 +462,8 @@ void CClientVehicle::UpdatePedPositions(const CVector& vecPosition)
     // If we have any occupants, update their positions
     for (int i = 0; i <= NUMELMS(m_pPassengers); i++)
         if (CClientPed* pOccupant = GetOccupant(i))
-            pOccupant->SetPosition(vecPosition);
+            if (CanMoveOccupantWithVehicle(pOccupant))
+                pOccupant->SetPosition(vecPosition);
 }
 
 void CClientVehicle::GetRotationDegrees(CVector& vecRotation) const
@@ -573,10 +581,9 @@ bool CClientVehicle::SetMatrix(const CMatrix& Matrix)
     m_matFrozen = Matrix;
 
     // If we have any occupants, update their positions
-    // Make sure we dont update their position if they are getting out and have physically left the car
     for (int i = 0; i <= NUMELMS(m_pPassengers); i++)
         if (CClientPed* pOccupant = GetOccupant(i))
-            if (pOccupant->GetVehicleInOutState() != VEHICLE_INOUT_GETTING_OUT || pOccupant->GetRealOccupiedVehicle())
+            if (CanMoveOccupantWithVehicle(pOccupant))
                 pOccupant->SetPosition(m_Matrix.vPos);
 
     return true;

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -1849,7 +1849,9 @@ void CPacketHandler::Packet_Vehicle_InOut(NetBitStreamInterface& bitStream)
                                 {
                                     // Desynced? Outside but supposed to be in
                                     // For local player or synced peds this is taken care of in CClientPed::UpdateVehicleInOut()
-                                    if (pJacked->GetOccupiedVehicle() && !pJacked->GetRealOccupiedVehicle())
+                                    // Not while his drag animation still plays; an aborted jack ends with him out anyway,
+                                    // and his own client is about to notify that.
+                                    if (pJacked->GetOccupiedVehicle() && !pJacked->GetRealOccupiedVehicle() && !pJacked->IsGettingJacked())
                                     {
                                         // Warp him back in
                                         pJacked->WarpIntoVehicle(pJacked->GetOccupiedVehicle(), pJacked->GetOccupiedVehicleSeat());
@@ -1917,7 +1919,9 @@ void CPacketHandler::Packet_Vehicle_InOut(NetBitStreamInterface& bitStream)
                             pPed->ResetVehicleInOut();
 
                         // Make sure we're removed from the vehicle
-                        bool bDontWarpIfGettingDraggedOut = pPed->IsLocalPlayer() || pPed->IsSyncing();
+                        // A jack victim also leaves through here when the jacker aborts, and his drag
+                        // animation may still be playing on clients watching it; let it finish.
+                        bool bDontWarpIfGettingDraggedOut = pPed->IsLocalPlayer() || pPed->IsSyncing() || pPed->IsGettingJacked();
                         pPed->RemoveFromVehicle(bDontWarpIfGettingDraggedOut);
 
                         if (ucSeat == 0)

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -2070,7 +2070,9 @@ void CPacketHandler::Packet_Vehicle_InOut(NetBitStreamInterface& bitStream)
                                 }
 
                                 // Warp him out
-                                bool bDontWarpIfGettingDraggedOut = pOutsidePed->IsLocalPlayer() || pOutsidePed->IsSyncing();
+                                // The confirmation only waits for the jacker's own enter animation, so it can arrive while
+                                // the jacked ped's drag animation still plays on clients watching it; let it finish.
+                                bool bDontWarpIfGettingDraggedOut = pOutsidePed->IsLocalPlayer() || pOutsidePed->IsSyncing() || pOutsidePed->IsGettingJacked();
                                 pOutsidePed->RemoveFromVehicle(bDontWarpIfGettingDraggedOut);
 
                                 // Reset interpolation so he won't appear on the roof of the vehicle until next sync


### PR DESCRIPTION
#### Summary

The exit confirmation can arrive while the victim's drag animation is still playing on clients watching it. The hard warp then cut it off and teleported him to the exit spot, the vehicle kept repositioning him to its center as one of its occupants, and his own position sync fought the fall.

The drag task now owns the ped until it ends: the warp guards recognize the jack task, the vehicle occupant updates leave out a ped who has physically left the car, and his position interpolation and under floor fix skip the same window.

The second commit covers the jacker cancelling after pulling the victim out; the victim leaves through the notify out path there, and the abort handler also warped him back into the vehicle as desynced mid animation.

**Without fix:** https://streamable.com/0zvdi5
**With the fix:** https://streamable.com/cc5v0t

#### Motivation

Fixes #1750.

#### Test plan

1. With a second client watching, jack a player out of his vehicle.
2. He should get dragged out, fall and stand up in one continuous animation; before this he flashed on the roof and flickered between the ground and the center of the car, lifting the vehicle.
3. Repeat but walk away with WASD right after pulling him out instead of entering; before this he flashed at the center of the car for an instant.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.