### PR TITLE
Fix crash blending death animations from unloaded groups

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -1921,6 +1921,14 @@ void CClientPed::BeHit(CClientPed* pClientPedAttacker, ePedPieceTypes hitBodyPar
 
 void CClientPed::Kill(eWeaponType weaponType, unsigned char ucBodypart, bool bStealth, bool bSetDirectlyDead, AssocGroupId animGroup, AnimationId animID)
 {
+    // These come off the wire; the death task hands them to CAnimManager::BlendAnimation, which
+    // indexes the association groups array with no checks. Fall back to the DoWastedCheck defaults.
+    if (animGroup >= static_cast<AssocGroupId>(eAnimGroup::ANIM_TOTAL_GROUPS) || animID >= static_cast<AnimationId>(eAnimID::ANIM_ID_MAX))
+    {
+        animGroup = static_cast<AssocGroupId>(eAnimGroup::ANIM_GROUP_DEFAULT);
+        animID = static_cast<AnimationId>(eAnimID::ANIM_ID_KO_SHOT_FRONT_0);
+    }
+
     // Don't change task if already dead or dying. bSetDirectlyDead restores the dead state onto a ped
     // the streamer just recreated; that ped holds no tasks yet, while IsDead() still reports the cached
     // m_bDead left over from the original death and would veto giving it the dead task.

--- a/Client/multiplayer_sa/CMultiplayerSA_CrashFixHacks.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_CrashFixHacks.cpp
@@ -3572,7 +3572,8 @@ static void __declspec(naked) HOOK_RpAnimBlendClumpGetFirstAssociation()
 ////////////////////////////////////////////////////////////////////////
 // CAnimManager::BlendAnimation
 //
-// Adds a nullptr check for the clump object pointer.
+// Adds a nullptr check for the clump object pointer, and range checks for the group and animation
+// ids; an out of range group walks unmapped memory and an unstreamed group hands back garbage.
 //
 // >>> 0x4D4610 | 83 EC 14          | sub esp, 14h
 // >>> 0x4D4613 | 8B 4C 24 18       | mov ecx, [esp+18h]
@@ -3591,13 +3592,69 @@ static void __declspec(naked) HOOK_CAnimManager__BlendAnimation()
     {
         mov     eax, [esp+4]            // RpClump* clump
         test    eax, eax
-        jnz     continueAfterFixLocation
-        retn
+        jz      returnNull
 
-        continueAfterFixLocation:
+        mov     eax, [esp+8]                  // animation group id
+        cmp     eax, dword ptr ds:[0B4EA28h]  // CAnimManager::ms_numAnimAssocDefinitions
+        jae     returnNull
+
+        mov     ecx, dword ptr ds:[0B4EA34h]  // CAnimManager::ms_aAnimAssocGroups
+        lea     eax, [eax+eax*4]
+        mov     edx, [esp+0Ch]                // animation id
+        sub     edx, [ecx+eax*4+0Ch]          // - CAnimBlendAssocGroup::m_IdOffset
+        cmp     edx, [ecx+eax*4+8]            // CAnimBlendAssocGroup::m_NumAnims, zero while the group's block isn't streamed in
+        jae     returnNull
+
         sub     esp, 14h
         mov     ecx, [esp+18h]
         jmp     CONTINUE_CAnimManager__BlendAnimation
+
+    returnNull:
+        xor     eax, eax
+        retn
+    }
+    // clang-format on
+}
+
+////////////////////////////////////////////////////////////////////////
+// CTaskSimpleDie::StartAnim
+//
+// Stores whatever BlendAnimation returned and calls SetFinishCallback on it with no checks; a ped
+// dying with an animation from a group whose IFP block isn't streamed in gets null back here.
+// Leaving m_animAssociation null and skipping the rest makes ProcessPed call StartAnim again on
+// the next tick.
+//
+// >>> 0x637554 | 83 C4 10       | add     esp, 10h
+// >>> 0x637557 | 56             | push    esi
+// >>> 0x637558 | 68 10 FC 62 00 | push    62FC10h
+//     0x63755D | 8B C8          | mov     ecx, eax
+////////////////////////////////////////////////////////////////////////
+#define HOOKPOS_CTaskSimpleDie_StartAnim   0x637554
+#define HOOKSIZE_CTaskSimpleDie_StartAnim  9
+#define HOOKCHECK_CTaskSimpleDie_StartAnim 0x83
+static DWORD CONTINUE_CTaskSimpleDie_StartAnim = 0x63755D;
+static DWORD SKIP_CTaskSimpleDie_StartAnim = 0x6375AB;
+
+static void __declspec(naked) HOOK_CTaskSimpleDie_StartAnim()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        add     esp, 10h
+        test    eax, eax
+        jz      skipDieAnim
+
+        // Replaced code
+        push    esi
+        push    62FC10h
+        jmp     CONTINUE_CTaskSimpleDie_StartAnim
+
+    skipDieAnim:
+        // Straight to the epilogue; the skipped tail only wires up the returned animation and
+        // finalizes the death state, all of which runs on the retry
+        jmp     SKIP_CTaskSimpleDie_StartAnim
     }
     // clang-format on
 }
@@ -4167,6 +4224,7 @@ void CMultiplayerSA::InitHooks_CrashFixHacks()
     EZHookInstall(RpClumpForAllAtomics);
     EZHookInstall(RpAnimBlendClumpGetFirstAssociation);
     EZHookInstall(CAnimManager__BlendAnimation);
+    EZHookInstallChecked(CTaskSimpleDie_StartAnim);
     EZHookInstall(FxSystemBP_c__Load);
     EZHookInstall(FxPrim_c__Enable);
     EZHookInstall(CFire_ProcessFire);


### PR DESCRIPTION
#### Summary

CAnimManager::BlendAnimation indexes the association groups array and the group's own animation array with no checks. An out of range group id makes it walk a group read from unmapped memory, and a valid group whose IFP block isn't streamed in hands back a garbage pointer; either way whoever dereferences the result crashes. Peds dying in batches hit this reliably, since the death task requests its animation the moment it starts, whether the block is resident or not.

The fix has three small parts: the existing clump check hook on BlendAnimation now also validates the group and animation ids and returns null on a bad request, CTaskSimpleDie::StartAnim handles that null by leaving the association empty so ProcessPed retries on the next tick, and CClientPed::Kill validates the anim ids it receives from the wire before building the death task.

**Known limitation:** a ped whose animation block never becomes available skips its death animation and dies in its last pose, which beats taking the whole game crash with it.

**Without fix:** https://streamable.com/f7g7u4

#### Motivation

Fixes #447.

Despite the original title, setWaterLevel itself was never the problem; raising the water is just what makes a whole batch of peds drown and request death animations at the same instant. Any spawn of many peds dying at once can trigger the same crash.

#### Test plan

1. Spawn a large batch of peds and raise the water level so they all drown at once.
2. Before this change the client crashed in the animation lookup; now they all die normally.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.