### PR TITLE
Fix fixed camera desync when the player's vehicle gets destroyed

### DIFF
--- a/Client/mods/deathmatch/logic/CClientCamera.cpp
+++ b/Client/mods/deathmatch/logic/CClientCamera.cpp
@@ -736,18 +736,13 @@ void CClientCamera::ToggleCameraFixedMode(bool bEnabled)
 {
     if (bEnabled)
     {
-        CClientPlayer*  pLocalPlayer = m_pManager->GetPlayerManager()->GetLocalPlayer();
-        CClientVehicle* pLocalVehicle = NULL;
+        CClientPlayer* pLocalPlayer = m_pManager->GetPlayerManager()->GetLocalPlayer();
 
-        // Get the local vehicle, if any
-        if (pLocalPlayer)
-            pLocalVehicle = pLocalPlayer->GetOccupiedVehicle();
-
-        // Use the local vehicle, otherwise use the local player
-        if (pLocalVehicle)
-            SetFocus(pLocalVehicle, MODE_FIXED, false);
-        else
-            SetFocus(pLocalPlayer, MODE_FIXED, false);
+        // Anchor on the player ped; the cast picks the entity overload, skipping its vehicle
+        // redirect. GTA keeps a tracked reference to the entity handed to TakeControl, and a
+        // vehicle destroyed while the camera is fixed makes it quietly retarget the camera,
+        // desyncing our fixed state. The ped doesn't get destroyed from under us.
+        SetFocus(static_cast<CClientEntity*>(pLocalPlayer), MODE_FIXED, false);
 
         // Set the target position
         SetFocus(&m_matFixedMatrix.vPos, false);


### PR DESCRIPTION
#### Summary

Entering fixed camera mode calls GTA's TakeControl with a real entity to switch the native camera mode, and GTA keeps a tracked reference to it for as long as fixed mode lasts. CClientCamera preferred the local player's vehicle, so destroying it (or a resource restart cleaning it up) made GTA notice the dead reference and quietly point the camera back at the player; getCameraMatrix and the world streaming desynced from the native camera, which is where the collisionless world in the reports comes from.

Anchoring on the player ped removes the dangling reference; the ped doesn't get destroyed from under us, and for players on foot this was already the behavior.

#### Motivation

Fixes #544.
Fixes #1463.

#### Test plan

1. Enter a vehicle, set the camera far away with setCameraMatrix, then destroy the vehicle; the camera stays where the script put it and the world around it keeps its collision.
2. Same but exiting the vehicle and restarting the resource instead.
3. Regular camera work is unaffected: fixed camera while driving, moving it around, restoring with setCameraTarget, and changing the player's model with the camera fixed.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.