### PR TITLE
Force launcher window to stay always-on-top

### DIFF
--- a/Client/loader/SplashWindow.cpp
+++ b/Client/loader/SplashWindow.cpp
@@ -120,8 +120,8 @@ bool Splash::CreateSplashWindow(HINSTANCE instance)
             return false;
     }
 
-    HWND window = CreateWindow(windowClass.lpszClassName, "Multi Theft Auto Launcher", WS_POPUP, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
-                               NULL, NULL, instance, NULL);
+    HWND window = CreateWindowExA(WS_EX_TOPMOST, windowClass.lpszClassName, "Multi Theft Auto Launcher", WS_POPUP, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
+    							NULL, NULL, instance, NULL);
 
     if (window == nullptr)
     {
@@ -442,7 +442,7 @@ void Splash::BringToFront() const
     if (m_window)
     {
         SetForegroundWindow(m_window);
-        SetWindowPos(m_window, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+        SetWindowPos(m_window, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
     }
 }
 


### PR DESCRIPTION
#### Summary
Updated launcher window creation to use `CreateWindowExA` with the `WS_EX_TOPMOST` extended style, and changed `SetWindowPos` to use `HWND_TOPMOST` instead of `HWND_TOP`.


#### Motivation
Modern launchers and games typically keep their primary startup window pinned above other desktop applications to ensure a seamless focus transition, preventing the launcher from slipping behind background windows during launch. Utilizing `WS_EX_TOPMOST` and `HWND_TOPMOST` aligns the launcher behavior with modern game UI standards and ensures reliable window positioning on current Windows versions.


#### Test plan
Compiled the application and executed the launcher.
Verified that the launcher window consistently opens above all active desktop applications.


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
