### PR TITLE
Fix camera view modes not working while spectating

### DIFF
--- a/Client/game_sa/CCameraSA.cpp
+++ b/Client/game_sa/CCameraSA.cpp
@@ -57,6 +57,21 @@ static std::atomic<uint8_t> s_cameraClipMask{static_cast<uint8_t>(CameraClipFlag
 DWORD RETURN_Camera_CollisionDetection = 0x520195;
 void  HOOK_Camera_CollisionDetection();
 
+#define PATCH_CamControl_VehicleViewCycleGate 0x5281BD
+#define PATCH_CamControl_PedViewCycleGate     0x528D6D
+#define PATCH_CamControl_ViewChangeSoundGate  0x52B6DA
+
+#define FUNC_CEntity_CleanUpOldReference 0x571A00
+#define FUNC_CEntity_RegisterReference   0x571B70
+
+// The interface layout past its SA update marker is stale, so these fields are read absolutely
+#define VAR_CameraTargetEntity    0xB6F980
+#define VAR_CameraFixedModeVector 0xB6F888
+#define VAR_CameraModeToGoTo      0xB6FC60
+#define VAR_CameraTypeOfSwitch    0xB6FC64
+
+static bool s_scriptViewModeCycling = false;
+
 CCameraSA::CCameraSA(CCameraSAInterface* cameraInterface)
 {
     if (!cameraInterface)
@@ -703,6 +718,90 @@ void CCameraSA::SetCameraVehicleViewMode(BYTE dwCamMode)
 void CCameraSA::SetCameraPedViewMode(BYTE dwCamMode)
 {
     MemPutFast<BYTE>(VAR_PedCameraView, dwCamMode);
+}
+
+// CamControl only cycles the view modes and plays the change camera click while the camera belongs
+// to the player, and its zoom easing follows script values while a script owns it; open those
+// gates and keep the indices driving the zoom so the native cycling works on script cameras too
+void CCameraSA::SetScriptViewModeCycling(bool bEnabled)
+{
+    CCameraSAInterface* cameraInterface = GetInterface();
+    if (!cameraInterface)
+        return;
+
+    if (bEnabled)
+    {
+        cameraInterface->m_bUseScriptZoomValuePed = false;
+        cameraInterface->m_bUseScriptZoomValueCar = false;
+    }
+
+    if (bEnabled == s_scriptViewModeCycling)
+        return;
+    s_scriptViewModeCycling = bEnabled;
+
+    constexpr BYTE nops[6] = {0x90, 0x90, 0x90, 0x90, 0x90, 0x90};
+    constexpr BYTE vehicleCycleGate[6] = {0x0F, 0x85, 0xA3, 0x00, 0x00, 0x00};
+    constexpr BYTE pedCycleGate[2] = {0x75, 0x4E};
+    constexpr BYTE soundGate[2] = {0x75, 0x3F};
+
+    if (bEnabled)
+    {
+        MemCpy((void*)PATCH_CamControl_VehicleViewCycleGate, nops, sizeof(vehicleCycleGate));
+        MemCpy((void*)PATCH_CamControl_PedViewCycleGate, nops, sizeof(pedCycleGate));
+        MemCpy((void*)PATCH_CamControl_ViewChangeSoundGate, nops, sizeof(soundGate));
+    }
+    else
+    {
+        MemCpy((void*)PATCH_CamControl_VehicleViewCycleGate, vehicleCycleGate, sizeof(vehicleCycleGate));
+        MemCpy((void*)PATCH_CamControl_PedViewCycleGate, pedCycleGate, sizeof(pedCycleGate));
+        MemCpy((void*)PATCH_CamControl_ViewChangeSoundGate, soundGate, sizeof(soundGate));
+    }
+}
+
+// CamControl consumes a TakeControl request in its jumpcut block, which switches the active cam
+// mode and target; commit it right away so refocusing between a ped and a vehicle takes effect
+// even when that block gets starved under script control. Mirrors the code at 0x52B351
+void CCameraSA::ApplyScriptCamSwitch()
+{
+    CCameraSAInterface* cameraInterface = GetInterface();
+    if (!cameraInterface)
+        return;
+
+    CEntitySAInterface* pTargetEntity = *(CEntitySAInterface**)VAR_CameraTargetEntity;
+    if (!cameraInterface->m_bStartInterScript || *(WORD*)VAR_CameraTypeOfSwitch != 2 || !pTargetEntity)
+        return;
+
+    CCamSAInterface& activeCam = cameraInterface->Cams[cameraInterface->ActiveCam];
+    activeCam.Mode = static_cast<short>(*(WORD*)VAR_CameraModeToGoTo);
+    activeCam.ResetStatics = true;
+    activeCam.m_cvecCamFixedModeVector = *(CVector*)VAR_CameraFixedModeVector;
+
+    CEntitySAInterface** ppCamTarget = &activeCam.CamTargetEntity;
+    CEntitySAInterface*  pOldTarget = *ppCamTarget;
+    DWORD                dwCleanUpOldReference = FUNC_CEntity_CleanUpOldReference;
+    DWORD                dwRegisterReference = FUNC_CEntity_RegisterReference;
+    // clang-format off
+    __asm
+    {
+        mov     eax, ppCamTarget
+        mov     ecx, pOldTarget
+        test    ecx, ecx
+        jz      noOldTarget
+        push    eax
+        call    dwCleanUpOldReference
+        mov     eax, ppCamTarget
+    noOldTarget:
+        mov     ecx, pTargetEntity
+        mov     [eax], ecx
+        push    eax
+        call    dwRegisterReference
+    }
+    // clang-format on
+
+    cameraInterface->m_bJust_Switched = 1;
+    cameraInterface->m_uiTransitionState = 0;
+    cameraInterface->m_vecDoingSpecialInterPolation = false;
+    cameraInterface->m_bStartInterScript = false;
 }
 
 void CCameraSA::SetShakeForce(float fShakeForce)

--- a/Client/game_sa/CCameraSA.h
+++ b/Client/game_sa/CCameraSA.h
@@ -419,6 +419,8 @@ public:
     float        GetTransitionFOV() const override;
     bool         GetTransitionMatrix(CMatrix& matrix) const override;
     bool         IsSphereVisible(CVector* center, float radius) const override;
+    void         SetScriptViewModeCycling(bool bEnabled) override;
+    void         ApplyScriptCamSwitch() override;
 
     // Additional overload not in base interface
     virtual CCam* GetCam(CCamSAInterface* camInterface);

--- a/Client/loader/SplashWindow.cpp
+++ b/Client/loader/SplashWindow.cpp
@@ -120,8 +120,8 @@ bool Splash::CreateSplashWindow(HINSTANCE instance)
             return false;
     }
 
-    HWND window = CreateWindowExA(WS_EX_TOPMOST, windowClass.lpszClassName, "Multi Theft Auto Launcher", WS_POPUP, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
-    							NULL, NULL, instance, NULL);
+    HWND window = CreateWindowExA(WS_EX_TOPMOST, windowClass.lpszClassName, "Multi Theft Auto Launcher", WS_POPUP, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
+                                  CW_USEDEFAULT, NULL, NULL, instance, NULL);
 
     if (window == nullptr)
     {

--- a/Client/mods/deathmatch/logic/CClientCamera.cpp
+++ b/Client/mods/deathmatch/logic/CClientCamera.cpp
@@ -151,12 +151,33 @@ CClientCamera::~CClientCamera()
         // Restore the camera to the local player
         SetFocusToLocalPlayerImpl();
     }
+    // The gate patches live in game_sa and would outlive us
+    if (m_pCamera)
+        m_pCamera->SetScriptViewModeCycling(false);
+
     CClientEntityRefManager::RemoveEntityRefs(0, &m_pFocusedPlayer, &m_pFocusedEntity, NULL);
 }
 
 void CClientCamera::DoPulse()
 {
     InvalidateCachedTransforms();
+
+    if (m_pCamera)
+    {
+        // GTA ignores the change camera key while a script owns the camera, which is how
+        // setCameraTarget holds it; open the native cycling while we follow an entity
+        const bool bFollowingEntity = !m_bFixed && !m_bInvalidated && m_pFocusedGameEntity != nullptr;
+        m_pCamera->SetScriptViewModeCycling(bFollowingEntity);
+
+        // The native mode switch stays off under script control, so a vehicle index outside the
+        // three zoom levels sinks the camera into the vehicle or leaves it stale
+        if (bFollowingEntity && m_pFocusedEntity && m_pFocusedEntity->GetType() == CCLIENTVEHICLE)
+        {
+            const eVehicleCamMode eViewMode = GetCameraVehicleViewMode();
+            if (eViewMode < eVehicleCamMode::CLOSE_EXTERNAL || eViewMode > eVehicleCamMode::FAR_EXTERNAL)
+                SetCameraVehicleViewMode(eVehicleCamMode::FAR_EXTERNAL);
+        }
+    }
 
     // If we're fixed, force the target vector
     if (m_bFixed)
@@ -507,6 +528,10 @@ void CClientCamera::SetFocus(CClientEntity* pEntity, eCamMode eMode, bool bSmoot
 
             // Do it
             m_pCamera->TakeControl(pGameEntity, eMode, iSwitchStyle);
+
+            // Commit the switch so refocusing between a ped and a vehicle engages the new mode
+            if (eMode == MODE_CAM_ON_A_STRING || eMode == MODE_FOLLOWPED)
+                m_pCamera->ApplyScriptCamSwitch();
 
             // Store
             m_pFocusedEntity = pEntity;

--- a/Client/sdk/game/CCamera.h
+++ b/Client/sdk/game/CCamera.h
@@ -157,4 +157,7 @@ public:
     virtual bool         GetTransitionMatrix(CMatrix& matrix) const = 0;
 
     virtual bool IsSphereVisible(CVector* center, float radius) const = 0;
+
+    virtual void SetScriptViewModeCycling(bool bEnabled) = 0;
+    virtual void ApplyScriptCamSwitch() = 0;
 };


### PR DESCRIPTION
#### Summary

GTA handles the change camera key inside CCamera::CamControl, but it stays dead while a script owns the camera, which is how setCameraTarget takes it: the cycle and click sound gates require a player owned camera, and the zoom easing follows leftover script zoom values that discard the index. While the camera follows a focused entity the client now opens those gates and clears the script zoom flags, so the native cycling runs untouched, and restores everything when the camera is released.

Refocusing between a ped and a vehicle is committed right after TakeControl, mirroring the jumpcut block CamControl uses, so the camera switches properly when the spectated player enters or leaves a vehicle.

**The bumper and cinematic modes stay out:** the cinematic system retargets using the local player, and the bumper view relies on the vehicle shell falling outside the near plane, which does not hold on remote vehicles. Spectating cycles through the three zoom levels. _(Maybe we can fix or implement them later)_

https://streamable.com/1l4hy5

#### Motivation

Fixes #669.

#### Test plan

1. setCameraTarget another player and press the change camera key; the three zooms cycle with the native click sound, both on foot and in a vehicle.
2. Spectate someone who enters and leaves a vehicle; the camera follows the change.
3. Regular gameplay, setCameraMatrix fixed cameras and restoring the camera afterwards behave as before.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.