### PR TITLE
Fix camera view modes resetting every session

### DIFF
--- a/Client/mods/deathmatch/logic/CClientCamera.cpp
+++ b/Client/mods/deathmatch/logic/CClientCamera.cpp
@@ -143,6 +143,68 @@ CClientCamera::CClientCamera(CClientManager* pManager) : ClassInit(this), CClien
     m_hasCenterOfWorld = false;
 }
 
+// GTA only remembers the view modes the change camera key cycles through in its save files, which
+// MTA never uses, so they reset every session; keep them in the client settings instead.
+void CClientCamera::PersistViewModes()
+{
+    if (!m_bViewModesRestored)
+    {
+        // The camera is reinitialised while the game world comes up; restoring any earlier would
+        // get overwritten and the change tracker below would persist the defaults back
+        if (!g_pGame || g_pGame->GetSystemState() != SystemState::GS_PLAYING_GAME)
+            return;
+
+        m_bViewModesRestored = true;
+
+        // Read as text and validate strictly; the settings file is hand editable, and a lenient
+        // numeric read would turn garbage or an empty value into mode zero
+        const auto GetStoredViewMode = [](const char* szName, int iMinMode, int iMaxMode)
+        {
+            std::string strValue;
+            g_pCore->GetCVars()->Get(szName, strValue);
+            if (strValue.size() != 1 || strValue[0] < '0' || strValue[0] > '9')
+                return -1;
+
+            const int iValue = strValue[0] - '0';
+            return (iValue >= iMinMode && iValue <= iMaxMode) ? iValue : -1;
+        };
+
+        const int iVehicleViewMode =
+            GetStoredViewMode("camera_vehicle_view", static_cast<int>(eVehicleCamMode::BUMPER), static_cast<int>(eVehicleCamMode::CINEMATIC));
+        // The native ped view modes run from 1 to 3; ePedCamMode does not match them
+        const int iPedViewMode = GetStoredViewMode("camera_ped_view", 1, 3);
+
+        if (iVehicleViewMode >= 0)
+            SetCameraVehicleViewMode(static_cast<eVehicleCamMode>(iVehicleViewMode));
+        if (iPedViewMode >= 0)
+            SetCameraPedViewMode(static_cast<ePedCamMode>(iPedViewMode));
+
+        m_ucLastVehicleViewMode = static_cast<unsigned char>(GetCameraVehicleViewMode());
+        m_ucLastPedViewMode = static_cast<unsigned char>(GetCameraPedViewMode());
+
+        // Heal missing or mangled entries and flush right away; waiting for the quit save
+        // would lose them if the game does not close cleanly
+        if (iVehicleViewMode != m_ucLastVehicleViewMode || iPedViewMode != m_ucLastPedViewMode)
+        {
+            g_pCore->GetCVars()->Set("camera_vehicle_view", static_cast<int>(m_ucLastVehicleViewMode));
+            g_pCore->GetCVars()->Set("camera_ped_view", static_cast<int>(m_ucLastPedViewMode));
+            g_pCore->SaveConfig();
+        }
+        return;
+    }
+
+    const unsigned char ucVehicleViewMode = static_cast<unsigned char>(GetCameraVehicleViewMode());
+    const unsigned char ucPedViewMode = static_cast<unsigned char>(GetCameraPedViewMode());
+    if (ucVehicleViewMode == m_ucLastVehicleViewMode && ucPedViewMode == m_ucLastPedViewMode)
+        return;
+
+    m_ucLastVehicleViewMode = ucVehicleViewMode;
+    m_ucLastPedViewMode = ucPedViewMode;
+    g_pCore->GetCVars()->Set("camera_vehicle_view", static_cast<int>(ucVehicleViewMode));
+    g_pCore->GetCVars()->Set("camera_ped_view", static_cast<int>(ucPedViewMode));
+    g_pCore->SaveConfig();
+}
+
 CClientCamera::~CClientCamera()
 {
     // We need to be ingame
@@ -156,6 +218,8 @@ CClientCamera::~CClientCamera()
 
 void CClientCamera::DoPulse()
 {
+    PersistViewModes();
+
     InvalidateCachedTransforms();
 
     // If we're fixed, force the target vector

--- a/Client/mods/deathmatch/logic/CClientCamera.cpp
+++ b/Client/mods/deathmatch/logic/CClientCamera.cpp
@@ -149,14 +149,14 @@ CClientCamera::CClientCamera(CClientManager* pManager) : ClassInit(this), CClien
 // MTA never uses, so they reset every session; keep them in the client settings instead.
 void CClientCamera::PersistViewModes()
 {
-    if (!m_bViewModesRestored)
+    if (!m_viewModesRestored)
     {
         // The camera is reinitialised while the game world comes up; restoring any earlier would
         // get overwritten and the change tracker below would persist the defaults back
         if (!g_pGame || g_pGame->GetSystemState() != SystemState::GS_PLAYING_GAME)
             return;
 
-        m_bViewModesRestored = true;
+        m_viewModesRestored = true;
 
         // Read as text and validate strictly; the settings file is hand editable, and a lenient
         // numeric read would turn garbage or an empty value into mode zero
@@ -183,27 +183,27 @@ void CClientCamera::PersistViewModes()
         if (pedViewMode)
             SetCameraPedViewMode(static_cast<ePedCamMode>(*pedViewMode));
 
-        m_ucLastVehicleViewMode = static_cast<unsigned char>(GetCameraVehicleViewMode());
-        m_ucLastPedViewMode = static_cast<unsigned char>(GetCameraPedViewMode());
+        m_lastVehicleViewMode = static_cast<std::uint8_t>(GetCameraVehicleViewMode());
+        m_lastPedViewMode = static_cast<std::uint8_t>(GetCameraPedViewMode());
 
         // Heal missing or mangled entries and flush right away; waiting for the quit save
         // would lose them if the game does not close cleanly
-        if (vehicleViewMode != m_ucLastVehicleViewMode || pedViewMode != m_ucLastPedViewMode)
+        if (vehicleViewMode != m_lastVehicleViewMode || pedViewMode != m_lastPedViewMode)
         {
-            g_pCore->GetCVars()->Set("camera_vehicle_view", static_cast<int>(m_ucLastVehicleViewMode));
-            g_pCore->GetCVars()->Set("camera_ped_view", static_cast<int>(m_ucLastPedViewMode));
+            g_pCore->GetCVars()->Set("camera_vehicle_view", static_cast<int>(m_lastVehicleViewMode));
+            g_pCore->GetCVars()->Set("camera_ped_view", static_cast<int>(m_lastPedViewMode));
             g_pCore->SaveConfig();
         }
         return;
     }
 
-    const unsigned char vehicleViewMode = static_cast<unsigned char>(GetCameraVehicleViewMode());
-    const unsigned char pedViewMode = static_cast<unsigned char>(GetCameraPedViewMode());
-    if (vehicleViewMode == m_ucLastVehicleViewMode && pedViewMode == m_ucLastPedViewMode)
+    const std::uint8_t vehicleViewMode = static_cast<std::uint8_t>(GetCameraVehicleViewMode());
+    const std::uint8_t pedViewMode = static_cast<std::uint8_t>(GetCameraPedViewMode());
+    if (vehicleViewMode == m_lastVehicleViewMode && pedViewMode == m_lastPedViewMode)
         return;
 
-    m_ucLastVehicleViewMode = vehicleViewMode;
-    m_ucLastPedViewMode = pedViewMode;
+    m_lastVehicleViewMode = vehicleViewMode;
+    m_lastPedViewMode = pedViewMode;
     g_pCore->GetCVars()->Set("camera_vehicle_view", static_cast<int>(vehicleViewMode));
     g_pCore->GetCVars()->Set("camera_ped_view", static_cast<int>(pedViewMode));
     g_pCore->SaveConfig();

--- a/Client/mods/deathmatch/logic/CClientCamera.cpp
+++ b/Client/mods/deathmatch/logic/CClientCamera.cpp
@@ -11,7 +11,9 @@
 #include <StdInc.h>
 #include <game/CCam.h>
 #include <array>
+#include <charconv>
 #include <cmath>
+#include <optional>
 #include <utility>
 
 #define PI_2 6.283185307179586476925286766559f
@@ -158,33 +160,35 @@ void CClientCamera::PersistViewModes()
 
         // Read as text and validate strictly; the settings file is hand editable, and a lenient
         // numeric read would turn garbage or an empty value into mode zero
-        const auto GetStoredViewMode = [](const char* szName, int iMinMode, int iMaxMode)
+        const auto GetStoredViewMode = [](const char* name, std::uint8_t minMode, std::uint8_t maxMode) -> std::optional<std::uint8_t>
         {
-            std::string strValue;
-            g_pCore->GetCVars()->Get(szName, strValue);
-            if (strValue.size() != 1 || strValue[0] < '0' || strValue[0] > '9')
-                return -1;
+            std::string value;
+            g_pCore->GetCVars()->Get(name, value);
 
-            const int iValue = strValue[0] - '0';
-            return (iValue >= iMinMode && iValue <= iMaxMode) ? iValue : -1;
+            std::uint8_t parsedMode = 0;
+            const auto [ptr, ec] = std::from_chars(value.data(), value.data() + value.size(), parsedMode);
+            if (ec != std::errc{} || ptr != value.data() + value.size())
+                return std::nullopt;
+
+            return (parsedMode >= minMode && parsedMode <= maxMode) ? std::optional{parsedMode} : std::nullopt;
         };
 
-        const int iVehicleViewMode =
-            GetStoredViewMode("camera_vehicle_view", static_cast<int>(eVehicleCamMode::BUMPER), static_cast<int>(eVehicleCamMode::CINEMATIC));
+        const std::optional<std::uint8_t> vehicleViewMode =
+            GetStoredViewMode("camera_vehicle_view", static_cast<std::uint8_t>(eVehicleCamMode::BUMPER), static_cast<std::uint8_t>(eVehicleCamMode::CINEMATIC));
         // The native ped view modes run from 1 to 3; ePedCamMode does not match them
-        const int iPedViewMode = GetStoredViewMode("camera_ped_view", 1, 3);
+        const std::optional<std::uint8_t> pedViewMode = GetStoredViewMode("camera_ped_view", 1, 3);
 
-        if (iVehicleViewMode >= 0)
-            SetCameraVehicleViewMode(static_cast<eVehicleCamMode>(iVehicleViewMode));
-        if (iPedViewMode >= 0)
-            SetCameraPedViewMode(static_cast<ePedCamMode>(iPedViewMode));
+        if (vehicleViewMode)
+            SetCameraVehicleViewMode(static_cast<eVehicleCamMode>(*vehicleViewMode));
+        if (pedViewMode)
+            SetCameraPedViewMode(static_cast<ePedCamMode>(*pedViewMode));
 
         m_ucLastVehicleViewMode = static_cast<unsigned char>(GetCameraVehicleViewMode());
         m_ucLastPedViewMode = static_cast<unsigned char>(GetCameraPedViewMode());
 
         // Heal missing or mangled entries and flush right away; waiting for the quit save
         // would lose them if the game does not close cleanly
-        if (iVehicleViewMode != m_ucLastVehicleViewMode || iPedViewMode != m_ucLastPedViewMode)
+        if (vehicleViewMode != m_ucLastVehicleViewMode || pedViewMode != m_ucLastPedViewMode)
         {
             g_pCore->GetCVars()->Set("camera_vehicle_view", static_cast<int>(m_ucLastVehicleViewMode));
             g_pCore->GetCVars()->Set("camera_ped_view", static_cast<int>(m_ucLastPedViewMode));
@@ -193,15 +197,15 @@ void CClientCamera::PersistViewModes()
         return;
     }
 
-    const unsigned char ucVehicleViewMode = static_cast<unsigned char>(GetCameraVehicleViewMode());
-    const unsigned char ucPedViewMode = static_cast<unsigned char>(GetCameraPedViewMode());
-    if (ucVehicleViewMode == m_ucLastVehicleViewMode && ucPedViewMode == m_ucLastPedViewMode)
+    const unsigned char vehicleViewMode = static_cast<unsigned char>(GetCameraVehicleViewMode());
+    const unsigned char pedViewMode = static_cast<unsigned char>(GetCameraPedViewMode());
+    if (vehicleViewMode == m_ucLastVehicleViewMode && pedViewMode == m_ucLastPedViewMode)
         return;
 
-    m_ucLastVehicleViewMode = ucVehicleViewMode;
-    m_ucLastPedViewMode = ucPedViewMode;
-    g_pCore->GetCVars()->Set("camera_vehicle_view", static_cast<int>(ucVehicleViewMode));
-    g_pCore->GetCVars()->Set("camera_ped_view", static_cast<int>(ucPedViewMode));
+    m_ucLastVehicleViewMode = vehicleViewMode;
+    m_ucLastPedViewMode = pedViewMode;
+    g_pCore->GetCVars()->Set("camera_vehicle_view", static_cast<int>(vehicleViewMode));
+    g_pCore->GetCVars()->Set("camera_ped_view", static_cast<int>(pedViewMode));
     g_pCore->SaveConfig();
 }
 

--- a/Client/mods/deathmatch/logic/CClientCamera.h
+++ b/Client/mods/deathmatch/logic/CClientCamera.h
@@ -117,6 +117,8 @@ private:
     void InvalidateEntity(CClientEntity* pEntity);
     void RestoreEntity(CClientEntity* pEntity);
 
+    void PersistViewModes();
+
     CClientPlayerManager* m_pPlayerManager;
 
     CClientPlayerPtr m_pFocusedPlayer;
@@ -138,6 +140,10 @@ private:
     CVector         m_lastCenterOfWorldPos;
     float           m_lastCenterOfWorldRot;
     bool            m_hasCenterOfWorld;
+
+    bool          m_bViewModesRestored{false};
+    unsigned char m_ucLastVehicleViewMode{0};
+    unsigned char m_ucLastPedViewMode{0};
 
     CCamera* m_pCamera;
 };

--- a/Client/mods/deathmatch/logic/CClientCamera.h
+++ b/Client/mods/deathmatch/logic/CClientCamera.h
@@ -141,9 +141,9 @@ private:
     float           m_lastCenterOfWorldRot;
     bool            m_hasCenterOfWorld;
 
-    bool          m_bViewModesRestored{false};
-    unsigned char m_ucLastVehicleViewMode{0};
-    unsigned char m_ucLastPedViewMode{0};
+    bool         m_viewModesRestored{false};
+    std::uint8_t m_lastVehicleViewMode{0};
+    std::uint8_t m_lastPedViewMode{0};
 
     CCamera* m_pCamera;
 };


### PR DESCRIPTION
#### Summary

GTA only persists the camera view modes (the ones the change camera key cycles through) in its save files, which MTA never loads, so every session starts back on the defaults. The client now keeps both modes in coreconfig.xml: they are restored once the game world is up, and saved with an immediate config flush the moment they change, so an unclean exit cannot lose them.

The stored values are validated strictly since the settings file is hand editable; garbage, out of range or missing entries fall back to the defaults and heal themselves.

#### Motivation

Requested by @SpeedyFolf in #669.

#### Test plan

Change the view mode with V (on foot and in a vehicle), quit MTA, reopen and rejoin; both modes are back.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.