### PR TITLE
Fix splash window ordering during startup

### DIFF
--- a/Client/loader/MainFunctions.cpp
+++ b/Client/loader/MainFunctions.cpp
@@ -1986,10 +1986,20 @@ int LaunchGame(SString strCmdLine)
         else
         {
             // Wait for game window
-            DWORD status = WAIT_TIMEOUT;
-            for (uint i = 0; i < 20 && status == WAIT_TIMEOUT; ++i)  // Max 20 iterations
+            constexpr DWORD startupTimeoutMs = 20000;
+            constexpr DWORD waitIntervalMs = 100;
+            constexpr uint  maxWaitCount = startupTimeoutMs / waitIntervalMs;
+            DWORD           status = WAIT_TIMEOUT;
+            bool            splashHidden = false;
+            for (uint i = 0; i < maxWaitCount && status == WAIT_TIMEOUT; ++i)
             {
-                status = WaitForSingleObject(piLoadee.hProcess, 1000);  // 1 second timeout
+                status = WaitForSingleObject(piLoadee.hProcess, waitIntervalMs);
+
+                if (!splashHidden && IsGameWindowOpen(piLoadee.dwProcessId))
+                {
+                    HideSplash();
+                    splashHidden = true;
+                }
 
                 if (!WatchDogIsSectionOpen("L3"))  // Gets closed when loading screen is shown
                 {
@@ -2001,7 +2011,6 @@ int LaunchGame(SString strCmdLine)
                 if (IsDeviceSelectionDialogOpen(piLoadee.dwProcessId) && i > 0)
                 {
                     --i;  // Don't count this iteration
-                    Sleep(100);
                 }
             }
 
@@ -2014,7 +2023,9 @@ int LaunchGame(SString strCmdLine)
                 AddReportLog(7103, SString("Loader - Premature exit (code %lu) - possible missing runtime dependencies or injection failure", dwEarlyExitCode));
             }
 
-            HideSplash();
+            // Ensure the splash is hidden if no game window was detected
+            if (!splashHidden)
+                HideSplash();
 
             // Handle process if stuck at startup
             if (status == WAIT_TIMEOUT)

--- a/Client/loader/SplashWindow.cpp
+++ b/Client/loader/SplashWindow.cpp
@@ -120,8 +120,8 @@ bool Splash::CreateSplashWindow(HINSTANCE instance)
             return false;
     }
 
-    HWND window = CreateWindowExA(WS_EX_TOPMOST, windowClass.lpszClassName, "Multi Theft Auto Launcher", WS_POPUP, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
-    							NULL, NULL, instance, NULL);
+    HWND window = CreateWindowExA(WS_EX_TOPMOST, windowClass.lpszClassName, "Multi Theft Auto Launcher", WS_POPUP, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
+                                  CW_USEDEFAULT, NULL, NULL, instance, NULL);
 
     if (window == nullptr)
     {

--- a/Client/loader/Utils.cpp
+++ b/Client/loader/Utils.cpp
@@ -2289,7 +2289,8 @@ BOOL CALLBACK MyEnumWindowsProc(HWND hwnd, LPARAM lParam)
             GetWindowThreadProcessId(hwnd, &dwWindowProcessId);
             if (lParam == dwWindowProcessId)
             {
-                SetWindowPos(hwnd, HWND_TOP, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+                // Match the topmost splash so GTA's device selection remains visible above it.
+                SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
                 return false;
             }
         }

--- a/Client/loader/Utils.cpp
+++ b/Client/loader/Utils.cpp
@@ -2283,14 +2283,14 @@ BOOL CALLBACK MyEnumWindowsProc(HWND hwnd, LPARAM lParam)
     WINDOWINFO windowInfo{sizeof(WINDOWINFO)};
     if (GetWindowInfo(hwnd, &windowInfo))
     {
-        if (windowInfo.atomWindowType == reinterpret_cast<uint>(WC_DIALOG))
+        if (windowInfo.atomWindowType == static_cast<ATOM>(reinterpret_cast<ULONG_PTR>(WC_DIALOG)))
         {
             DWORD dwWindowProcessId = 0;
             GetWindowThreadProcessId(hwnd, &dwWindowProcessId);
             if (lParam == dwWindowProcessId)
             {
                 // Match the topmost splash so GTA's device selection remains visible above it.
-                SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW);
+                SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_SHOWWINDOW | SWP_NOACTIVATE);
                 return false;
             }
         }
@@ -2311,7 +2311,7 @@ BOOL CALLBACK FindVisibleGameWindow(HWND hwnd, LPARAM lParam)
         return true;
 
     WINDOWINFO windowInfo{sizeof(WINDOWINFO)};
-    return !GetWindowInfo(hwnd, &windowInfo) || windowInfo.atomWindowType == reinterpret_cast<uint>(WC_DIALOG);
+    return !GetWindowInfo(hwnd, &windowInfo) || windowInfo.atomWindowType == static_cast<ATOM>(reinterpret_cast<ULONG_PTR>(WC_DIALOG));
 }
 
 bool IsGameWindowOpen(DWORD processID)

--- a/Client/loader/Utils.cpp
+++ b/Client/loader/Utils.cpp
@@ -2280,7 +2280,7 @@ SString PadLeft(const SString& strText, uint uiNumSpaces, char cCharacter)
 //////////////////////////////////////////////////////////
 BOOL CALLBACK MyEnumWindowsProc(HWND hwnd, LPARAM lParam)
 {
-    WINDOWINFO windowInfo;
+    WINDOWINFO windowInfo{sizeof(WINDOWINFO)};
     if (GetWindowInfo(hwnd, &windowInfo))
     {
         if (windowInfo.atomWindowType == reinterpret_cast<uint>(WC_DIALOG))
@@ -2301,6 +2301,22 @@ BOOL CALLBACK MyEnumWindowsProc(HWND hwnd, LPARAM lParam)
 bool IsDeviceSelectionDialogOpen(DWORD processID)
 {
     return !EnumWindows(MyEnumWindowsProc, processID);
+}
+
+BOOL CALLBACK FindVisibleGameWindow(HWND hwnd, LPARAM lParam)
+{
+    DWORD windowProcessId = 0;
+    GetWindowThreadProcessId(hwnd, &windowProcessId);
+    if (windowProcessId != static_cast<DWORD>(lParam) || !IsWindowVisible(hwnd))
+        return true;
+
+    WINDOWINFO windowInfo{sizeof(WINDOWINFO)};
+    return !GetWindowInfo(hwnd, &windowInfo) || windowInfo.atomWindowType == reinterpret_cast<uint>(WC_DIALOG);
+}
+
+bool IsGameWindowOpen(DWORD processID)
+{
+    return !EnumWindows(FindVisibleGameWindow, processID);
 }
 
 //////////////////////////////////////////////////////////

--- a/Client/loader/Utils.h
+++ b/Client/loader/Utils.h
@@ -127,6 +127,7 @@ bool               VerifyEmbeddedSignature(const SString& strFilename);
 void               LogSettings();
 SString            PadLeft(const SString& strText, uint uiNumSpaces, char cCharacter);
 bool               IsDeviceSelectionDialogOpen(DWORD processID);
+bool               IsGameWindowOpen(DWORD processID);
 std::vector<DWORD> MyEnumProcesses(bool bInclude64bit = false, bool bIncludeCurrent = false);
 SString            GetProcessPathFilename(DWORD processID);
 SString            GetProcessFilename(DWORD processID);


### PR DESCRIPTION
#### Summary

Fixed splash window ordering during startup (regressions from #5289)

- Keep the GTA device selection dialog above the splash.
- Hide the splash when the MTA game window becomes visible.
  - Improved game window detection: check every 100ms (was up to 1100) while keeping the original 20 second timeout.

#### Motivation

The splash could cover the GTA device selection dialog, and also the MTA main window temporarily before the splash disappeared.

#### Test plan

1. Launch MTA with the GTA device selection dialog enabled.
2. Confirm the dialog appears above the splash.
3. Confirm the device selection and continue startup.
4. Confirm the splash disappears instantly when the MTA main window opens.
5. Launch MTA with `skins` folder renamed to trigger an error dialog during splash screen, to prove the splash does not cover error dialogs.


<img width="499" height="247" alt="image" src="https://github.com/user-attachments/assets/53d71b65-7036-4acb-a678-cd94975a4302" />

<img width="499" height="249" alt="image" src="https://github.com/user-attachments/assets/1825bbcf-2cc9-4221-9b49-0aaa932cddb6" />


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.