### PR TITLE
Fix vehicle door model flags not applying via setVehicleHandling

### DIFF
--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -1578,13 +1578,13 @@ void CVehicleSA::RecalculateHandling()
     RecalculateSwingingChassis();
 
     // Same story as the chassis above: the door setup below is also only ever applied once, inside
-    // the game's vehicle constructor (0x6B0DBE / 0x6B0DF4 / 0x6B0E4B).
+    // the game's vehicle constructor.
     RecalculateDoorModelFlags();
 }
 
-// Mirrors the native vehicle constructor's bonnet, boot and NO_DOORS setup (0x6B0DBE / 0x6B0DF4 /
-// 0x6B0E4B) so a live REVERSE_BONNET/HANGING_BOOT/TAILGATE_BOOT/NO_DOORS change actually reaches an
-// already spawned vehicle instead of only ever taking effect for one created after the change.
+// Mirrors the native vehicle constructor's bonnet, boot and NO_DOORS setup, so a live
+// REVERSE_BONNET, HANGING_BOOT, TAILGATE_BOOT or NO_DOORS change reaches an already spawned
+// vehicle instead of only ever taking effect for one created after the change.
 void CVehicleSA::RecalculateDoorModelFlags()
 {
     if (GetVehicleInterface()->m_vehicleClass != VehicleClass::AUTOMOBILE)
@@ -1598,8 +1598,8 @@ void CVehicleSA::RecalculateDoorModelFlags()
     constexpr std::uint16_t extraBased = 0x10;
     constexpr std::uint16_t extraLowGravity = 0x20;
 
-    auto*              pInt = static_cast<CAutomobileSAInterface*>(GetVehicleInterface());
-    const unsigned int uiModelFlags = m_pHandlingData->GetInterface()->uiModelFlags;
+    auto*               pInt = static_cast<CAutomobileSAInterface*>(GetVehicleInterface());
+    const std::uint32_t uiModelFlags = m_pHandlingData->GetInterface()->uiModelFlags;
 
     CDoorSAInterface& bonnet = pInt->m_doors[eDoors::BONNET];
     if (uiModelFlags & MODELFLAGS_REVERSE_BONNET)
@@ -1638,28 +1638,32 @@ void CVehicleSA::RecalculateDoorModelFlags()
     boot.m_fClosedAngle = 0.0f;
 
     // Same constructor-only story again: NO_DOORS marks the four side doors missing once, at
-    // creation. Removing the flag doesn't restore them; the constructor never does that either, and
-    // this damage state is meant to keep holding once a real door actually blows off for the same
-    // reason. Going through CDamageManager::SetDoorStatus alone (the same call damage sync already
-    // uses) isn't enough on a live vehicle though: it runs into CAutomobile::SetDoorDamage's own
-    // lock check, which for a locked vehicle's front doors quietly turns the request into a plain
-    // dent and returns before ever hiding anything - a case the constructor itself never hits,
-    // since it runs before any lock state exists yet. Hiding the door mesh here directly, the same
-    // call that status route would otherwise make on its own, sidesteps that gate instead of
-    // fighting it.
+    // creation, and removing the flag doesn't restore them, since the constructor never does that
+    // either. The status alone isn't enough on a live vehicle, though; a locked vehicle's front
+    // doors quietly turn the request into a dent instead, so the door mesh is hidden directly here
+    // too.
     if (uiModelFlags & MODELFLAGS_NO_DOORS)
     {
-        static constexpr eCarNodes doorNodes[] = {eCarNodes::DOOR_LF, eCarNodes::DOOR_RF, eCarNodes::DOOR_LR, eCarNodes::DOOR_RR};
-        static constexpr eDoors    doorIds[] = {eDoors::FRONT_LEFT_DOOR, eDoors::FRONT_RIGHT_DOOR, eDoors::REAR_LEFT_DOOR, eDoors::REAR_RIGHT_DOOR};
+        struct SSideDoor
+        {
+            eDoors    id;
+            eCarNodes node;
+        };
+        static constexpr SSideDoor sideDoors[] = {
+            {eDoors::FRONT_LEFT_DOOR, eCarNodes::DOOR_LF},
+            {eDoors::FRONT_RIGHT_DOOR, eCarNodes::DOOR_RF},
+            {eDoors::REAR_LEFT_DOOR, eCarNodes::DOOR_LR},
+            {eDoors::REAR_RIGHT_DOOR, eCarNodes::DOOR_RR},
+        };
 
         if (CDamageManager* pDamageManager = GetDamageManager())
         {
-            for (std::size_t i = 0; i < std::size(doorIds); ++i)
+            for (const SSideDoor& sideDoor : sideDoors)
             {
-                pDamageManager->SetDoorStatus(doorIds[i], DT_DOOR_MISSING, false);
+                pDamageManager->SetDoorStatus(sideDoor.id, DT_DOOR_MISSING, false);
 
-                if (RwFrame* pFrame = pInt->m_aCarNodes[static_cast<std::size_t>(doorNodes[i])])
-                    pInt->SetComponentVisibility(pFrame, 0);            // ATOMIC_IS_NOT_PRESENT
+                if (RwFrame* pFrame = pInt->m_aCarNodes[static_cast<std::size_t>(sideDoor.node)])
+                    pInt->SetComponentVisibility(pFrame, 0);  // ATOMIC_IS_NOT_PRESENT
             }
         }
     }

--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -1577,14 +1577,14 @@ void CVehicleSA::RecalculateHandling()
     // Redo that setup here so a live handling change actually takes effect.
     RecalculateSwingingChassis();
 
-    // Same story as the chassis above: the bonnet and boot hinge setup below is also only ever
-    // applied once, inside the game's vehicle constructor (0x6B0DBE / 0x6B0DF4).
+    // Same story as the chassis above: the door setup below is also only ever applied once, inside
+    // the game's vehicle constructor (0x6B0DBE / 0x6B0DF4 / 0x6B0E4B).
     RecalculateDoorModelFlags();
 }
 
-// Mirrors the native vehicle constructor's bonnet and boot door setup (0x6B0DBE / 0x6B0DF4) so a
-// live REVERSE_BONNET/HANGING_BOOT/TAILGATE_BOOT change actually reaches an already spawned
-// vehicle instead of only ever taking effect for one created after the change.
+// Mirrors the native vehicle constructor's bonnet, boot and NO_DOORS setup (0x6B0DBE / 0x6B0DF4 /
+// 0x6B0E4B) so a live REVERSE_BONNET/HANGING_BOOT/TAILGATE_BOOT/NO_DOORS change actually reaches an
+// already spawned vehicle instead of only ever taking effect for one created after the change.
 void CVehicleSA::RecalculateDoorModelFlags()
 {
     if (GetVehicleInterface()->m_vehicleClass != VehicleClass::AUTOMOBILE)
@@ -1636,6 +1636,33 @@ void CVehicleSA::RecalculateDoorModelFlags()
         boot.m_nDirn = axisNegY | extraBased;
     }
     boot.m_fClosedAngle = 0.0f;
+
+    // Same constructor-only story again: NO_DOORS marks the four side doors missing once, at
+    // creation. Removing the flag doesn't restore them; the constructor never does that either, and
+    // this damage state is meant to keep holding once a real door actually blows off for the same
+    // reason. Going through CDamageManager::SetDoorStatus alone (the same call damage sync already
+    // uses) isn't enough on a live vehicle though: it runs into CAutomobile::SetDoorDamage's own
+    // lock check, which for a locked vehicle's front doors quietly turns the request into a plain
+    // dent and returns before ever hiding anything - a case the constructor itself never hits,
+    // since it runs before any lock state exists yet. Hiding the door mesh here directly, the same
+    // call that status route would otherwise make on its own, sidesteps that gate instead of
+    // fighting it.
+    if (uiModelFlags & MODELFLAGS_NO_DOORS)
+    {
+        static constexpr eCarNodes doorNodes[] = {eCarNodes::DOOR_LF, eCarNodes::DOOR_RF, eCarNodes::DOOR_LR, eCarNodes::DOOR_RR};
+        static constexpr eDoors    doorIds[] = {eDoors::FRONT_LEFT_DOOR, eDoors::FRONT_RIGHT_DOOR, eDoors::REAR_LEFT_DOOR, eDoors::REAR_RIGHT_DOOR};
+
+        if (CDamageManager* pDamageManager = GetDamageManager())
+        {
+            for (std::size_t i = 0; i < std::size(doorIds); ++i)
+            {
+                pDamageManager->SetDoorStatus(doorIds[i], DT_DOOR_MISSING, false);
+
+                if (RwFrame* pFrame = pInt->m_aCarNodes[static_cast<std::size_t>(doorNodes[i])])
+                    pInt->SetComponentVisibility(pFrame, 0);            // ATOMIC_IS_NOT_PRESENT
+            }
+        }
+    }
 }
 
 void CVehicleSA::RecalculateSwingingChassis()

--- a/Client/game_sa/CVehicleSA.cpp
+++ b/Client/game_sa/CVehicleSA.cpp
@@ -31,6 +31,7 @@
 #include "gamesa_renderware.h"
 #include "CFireManagerSA.h"
 #include "enums/VehicleType.h"
+#include <game/CHandlingEntry.h>
 
 extern CCoreInterface* g_pCore;
 extern CGameSA*        pGame;
@@ -1575,6 +1576,66 @@ void CVehicleSA::RecalculateHandling()
     // The swinging chassis flag is only applied once, inside the game's vehicle constructor.
     // Redo that setup here so a live handling change actually takes effect.
     RecalculateSwingingChassis();
+
+    // Same story as the chassis above: the bonnet and boot hinge setup below is also only ever
+    // applied once, inside the game's vehicle constructor (0x6B0DBE / 0x6B0DF4).
+    RecalculateDoorModelFlags();
+}
+
+// Mirrors the native vehicle constructor's bonnet and boot door setup (0x6B0DBE / 0x6B0DF4) so a
+// live REVERSE_BONNET/HANGING_BOOT/TAILGATE_BOOT change actually reaches an already spawned
+// vehicle instead of only ever taking effect for one created after the change.
+void CVehicleSA::RecalculateDoorModelFlags()
+{
+    if (GetVehicleInterface()->m_vehicleClass != VehicleClass::AUTOMOBILE)
+        return;
+
+    constexpr std::uint8_t  axisX = 0;
+    constexpr std::uint8_t  axisY = 1;
+    constexpr std::uint8_t  axisZ = 2;
+    constexpr std::uint8_t  axisNegY = 4;
+    constexpr std::uint8_t  axisNegZ = 5;
+    constexpr std::uint16_t extraBased = 0x10;
+    constexpr std::uint16_t extraLowGravity = 0x20;
+
+    auto*              pInt = static_cast<CAutomobileSAInterface*>(GetVehicleInterface());
+    const unsigned int uiModelFlags = m_pHandlingData->GetInterface()->uiModelFlags;
+
+    CDoorSAInterface& bonnet = pInt->m_doors[eDoors::BONNET];
+    if (uiModelFlags & MODELFLAGS_REVERSE_BONNET)
+    {
+        bonnet.m_fOpenAngle = -0.3f * PI;
+        bonnet.m_nAxis = axisX;
+        bonnet.m_nDirn = axisNegY | extraLowGravity;
+    }
+    else
+    {
+        bonnet.m_fOpenAngle = 0.3f * PI;
+        bonnet.m_nAxis = axisX;
+        bonnet.m_nDirn = axisY | extraLowGravity;
+    }
+    bonnet.m_fClosedAngle = 0.0f;
+
+    CDoorSAInterface& boot = pInt->m_doors[eDoors::BOOT];
+    if (uiModelFlags & MODELFLAGS_HANGING_BOOT)
+    {
+        boot.m_fOpenAngle = -0.4f * PI;
+        boot.m_nAxis = axisX;
+        boot.m_nDirn = axisNegZ | extraBased;
+    }
+    else if (uiModelFlags & MODELFLAGS_TAILGATE_BOOT)
+    {
+        boot.m_fOpenAngle = 0.5f * PI;
+        boot.m_nAxis = axisX;
+        boot.m_nDirn = axisZ | extraBased;
+    }
+    else
+    {
+        boot.m_fOpenAngle = -0.3f * PI;
+        boot.m_nAxis = axisX;
+        boot.m_nDirn = axisNegY | extraBased;
+    }
+    boot.m_fClosedAngle = 0.0f;
 }
 
 void CVehicleSA::RecalculateSwingingChassis()

--- a/Client/game_sa/CVehicleSA.h
+++ b/Client/game_sa/CVehicleSA.h
@@ -737,6 +737,7 @@ private:
 
     void           RecalculateSuspensionLines();
     void           RecalculateSwingingChassis();
+    void           RecalculateDoorModelFlags();
     void           CopyGlobalSuspensionLinesToPrivate();
     SVehicleFrame* GetVehicleComponent(const SString& vehicleComponent);
     void           FinalizeFramesList();

--- a/Client/mods/deathmatch/logic/CClientVehicle.cpp
+++ b/Client/mods/deathmatch/logic/CClientVehicle.cpp
@@ -2846,13 +2846,13 @@ void CClientVehicle::Create()
         ResetInterpolation();
         ResetDoorInterpolation();
 
-        for (unsigned char i = 0; i < 6; ++i)
-            SetDoorOpenRatio(i, m_fDoorOpenRatio[i], 0, true);
-
         for (unsigned char i = 0; i < MAX_WINDOWS; ++i)
             SetWindowOpen(i, m_bWindowOpen[i]);
 
-        // Re-apply handling entry
+        // Re-apply handling entry before restoring the door open ratios below; the bonnet and boot
+        // hinge setup a handling change recalculates only takes effect for angles computed after it,
+        // so restoring an open door first would bake in the freshly (re)created vehicle's default
+        // hinge instead of the one this handling actually calls for.
         if (m_HandlingEntry)
         {
             m_pVehicle->SetHandlingData(m_HandlingEntry.get());
@@ -2874,6 +2874,9 @@ void CClientVehicle::Create()
             if (m_bHasCustomHandling)
                 ApplyHandling();
         }
+
+        for (unsigned char i = 0; i < 6; ++i)
+            SetDoorOpenRatio(i, m_fDoorOpenRatio[i], 0, true);
 
         // Applying wheel upgrades can change these values.
         // We should keep track of the original values to restore them


### PR DESCRIPTION
#### Summary
GTA:SA only applies these handling model flags once, inside the vehicle's native constructor, so a live handling change (or a vehicle simply spawning through MTA's own creation path) never picked them up correctly:

* `reverse_bonnet`: bonnet hinges and opens the other way around instead of the default direction.
* `hanging_boot`: boot hangs open instead of swinging like a rigid lid.
* `tailgate_boot`: boot opens like a pickup style tailgate instead of a regular lid.
* `no_doors`: marks the four side doors as missing; meant for vehicles with no door model at all, like the RC cars.

This PR recalculates the bonnet and boot hinge setup whenever handling changes, the same way an existing fix already does for the swinging chassis flag. It also fixes the order handling gets reapplied on stream in, since restoring a door's open ratio before the hinge fix ran baked in the wrong angle. `no_doors` additionally hides the door mesh directly, since a locked vehicle's front doors were quietly turning the request into a dent instead of hiding it.

Example of `reverse_bonnet`:
<img width="1024" height="576" alt="image" src="https://github.com/user-attachments/assets/9a06ea4d-3889-4677-ade2-70c4bf60015e" />

<img width="1024" height="576" alt="image" src="https://github.com/user-attachments/assets/25cd9cd3-6886-40ec-a1f0-8a2e3d33971a" />




#### Motivation
Related to #1993, which lists several handling flags that have a real effect in game but can't be applied through scripting. This PR resolves `no_doors` from that list; `reverse_bonnet`, `hanging_boot` and `tailgate_boot` share the exact same root cause and are fixed alongside it.

_Also, requested by, and made with care for, @rxyyy_

#### Test plan
* Applied each flag live via `setVehicleHandling`/`setModelHandling` on a normal car and confirmed the bonnet/boot now open the correct way, and side doors disappear for `no_doors`, including on a locked vehicle.
* Confirmed vanilla vehicles that ship with `reverse_bonnet` by default (Enforcer _looks like its bugged by default,_ Firetruck, Tractor, SWAT Van) open correctly too.
* Streamed a vehicle with an open, flagged bonnet out and back in; the hinge stays correct instead of resetting to the default direction.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.