### PR TITLE
Add Ctrl+V paste support to chatbox

### DIFF
--- a/Client/core/CChat.cpp
+++ b/Client/core/CChat.cpp
@@ -758,6 +758,45 @@ bool CChat::CharacterKeyHandler(CGUIKeyEventArgs KeyboardArgs)
             break;
         }
 
+        case 22: // CTRL + V
+        {
+            if (OpenClipboard(NULL))
+            {
+                HANDLE hData = GetClipboardData(CF_UNICODETEXT);
+                if (hData)
+                {
+                    wchar_t* pBuffer = static_cast<wchar_t*>(GlobalLock(hData));
+                    if (pBuffer)
+                    {
+                        std::string strClipboard = UTF16ToMbUTF8(pBuffer);
+                        GlobalUnlock(hData);
+
+                        strClipboard.erase(std::remove(strClipboard.begin(), strClipboard.end(), '\r'), strClipboard.end());
+                        strClipboard.erase(std::remove(strClipboard.begin(), strClipboard.end(), '\n'), strClipboard.end());
+
+                        std::wstring wCurrent = MbUTF8ToUTF16(m_strInputText);
+                        std::wstring wClipboard = MbUTF8ToUTF16(strClipboard);
+
+                        if (wCurrent.size() + wClipboard.size() <= static_cast<size_t>(m_iCharacterLimit))
+                        {
+                            SetInputText((m_strInputText + strClipboard).c_str());
+                        }
+                        else
+                        {
+                            size_t availableSpace = (m_iCharacterLimit > wCurrent.size()) ? (m_iCharacterLimit - wCurrent.size()) : 0;
+                            if (availableSpace > 0)
+                            {
+                                wClipboard.resize(availableSpace);
+                                SetInputText((m_strInputText + UTF16ToMbUTF8(wClipboard)).c_str());
+                            }
+                        }
+                    }
+                }
+                CloseClipboard();
+            }
+            break;
+        }
+
         default:
         {
             // Clear last namepart when pressing letter

--- a/Client/core/CChat.cpp
+++ b/Client/core/CChat.cpp
@@ -771,8 +771,10 @@ bool CChat::CharacterKeyHandler(CGUIKeyEventArgs KeyboardArgs)
                         std::string strClipboard = UTF16ToMbUTF8(pBuffer);
                         GlobalUnlock(hData);
 
-                        strClipboard.erase(std::remove(strClipboard.begin(), strClipboard.end(), '\r'), strClipboard.end());
-                        strClipboard.erase(std::remove(strClipboard.begin(), strClipboard.end(), '\n'), strClipboard.end());
+                        strClipboard.erase(std::remove(strClipboard.begin(), strClipboard.end(), '\r'),
+                                           strClipboard.end());
+                        strClipboard.erase(std::remove(strClipboard.begin(), strClipboard.end(), '\n'),
+                                           strClipboard.end());
 
                         std::wstring wCurrent = MbUTF8ToUTF16(m_strInputText);
                         std::wstring wClipboard = MbUTF8ToUTF16(strClipboard);
@@ -783,7 +785,8 @@ bool CChat::CharacterKeyHandler(CGUIKeyEventArgs KeyboardArgs)
                         }
                         else
                         {
-                            size_t availableSpace = (m_iCharacterLimit > wCurrent.size()) ? (m_iCharacterLimit - wCurrent.size()) : 0;
+                            size_t availableSpace =
+                                (m_iCharacterLimit > wCurrent.size()) ? (m_iCharacterLimit - wCurrent.size()) : 0;
                             if (availableSpace > 0)
                             {
                                 wClipboard.resize(availableSpace);

--- a/Client/core/CChat.cpp
+++ b/Client/core/CChat.cpp
@@ -758,7 +758,7 @@ bool CChat::CharacterKeyHandler(CGUIKeyEventArgs KeyboardArgs)
             break;
         }
 
-        case 22: // CTRL + V
+        case 22:  // CTRL + V
         {
             if (OpenClipboard(NULL))
             {
@@ -783,8 +783,7 @@ bool CChat::CharacterKeyHandler(CGUIKeyEventArgs KeyboardArgs)
                         }
                         else
                         {
-                            size_t availableSpace =
-                                (m_iCharacterLimit > wCurrent.size()) ? (m_iCharacterLimit - wCurrent.size()) : 0;
+                            size_t availableSpace = (m_iCharacterLimit > wCurrent.size()) ? (m_iCharacterLimit - wCurrent.size()) : 0;
                             if (availableSpace > 0)
                             {
                                 wClipboard.resize(availableSpace);

--- a/Client/core/CChat.cpp
+++ b/Client/core/CChat.cpp
@@ -771,10 +771,8 @@ bool CChat::CharacterKeyHandler(CGUIKeyEventArgs KeyboardArgs)
                         std::string strClipboard = UTF16ToMbUTF8(pBuffer);
                         GlobalUnlock(hData);
 
-                        strClipboard.erase(std::remove(strClipboard.begin(), strClipboard.end(), '\r'),
-                                           strClipboard.end());
-                        strClipboard.erase(std::remove(strClipboard.begin(), strClipboard.end(), '\n'),
-                                           strClipboard.end());
+                        strClipboard.erase(std::remove(strClipboard.begin(), strClipboard.end(), '\r'), strClipboard.end());
+                        strClipboard.erase(std::remove(strClipboard.begin(), strClipboard.end(), '\n'), strClipboard.end());
 
                         std::wstring wCurrent = MbUTF8ToUTF16(m_strInputText);
                         std::wstring wClipboard = MbUTF8ToUTF16(strClipboard);


### PR DESCRIPTION
#### Summary
Added `Ctrl+V` shortcut to `CChat::CharacterKeyHandler`. This allows players to paste text directly into the chat input box from the system clipboard.


#### Motivation
Players can now paste copied text, or long commands directly into the chat box without needing to type them out manually.


#### Test plan
1. Compiled the client and opened the in-game chat box.
2. Copied single-line text and pressed `Ctrl+V`. confirmed text pasted as expected.
3. Copied multi-line text containing `\r\n`. confirmed newlines were stripped cleanly.
4. Copied a string exceeding `m_iCharacterLimit`. confirmed text was safely truncated without buffer overflow or UI bugs.


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
