### PR TITLE
Implement Native Lua Vector Datatype

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaArgument.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaArgument.cpp
@@ -125,6 +125,15 @@ void CLuaArgument::CopyRecursive(const CLuaArgument& Argument, CFastHashMap<CLua
             break;
         }
 
+        case LUA_TVEC:
+        {
+            m_vecData[0] = Argument.m_vecData[0];
+            m_vecData[1] = Argument.m_vecData[1];
+            m_vecData[2] = Argument.m_vecData[2];
+            m_vecData[3] = Argument.m_vecData[3];
+            break;
+        }
+
         default:
             break;
     }
@@ -173,6 +182,12 @@ bool CLuaArgument::CompareRecursive(const CLuaArgument& Argument, std::set<CLuaA
         case LUA_TNUMBER:
         {
             return m_Number == Argument.m_Number;
+        }
+
+        case LUA_TVEC:
+        {
+            return m_vecData[0] == Argument.m_vecData[0] && m_vecData[1] == Argument.m_vecData[1] && m_vecData[2] == Argument.m_vecData[2] &&
+                   m_vecData[3] == Argument.m_vecData[3];
         }
 
         case LUA_TTABLE:
@@ -286,6 +301,19 @@ void CLuaArgument::Read(lua_State* luaVM, int iArgument, CFastHashMap<const void
                 break;
             }
 
+            case LUA_TVEC:
+            {
+                const float* v = lua_tovec(luaVM, iArgument);
+                if (v)
+                {
+                    m_vecData[0] = v[0];
+                    m_vecData[1] = v[1];
+                    m_vecData[2] = v[2];
+                    m_vecData[3] = v[3];
+                }
+                break;
+            }
+
             case LUA_TFUNCTION:
             {
                 // TODO: add function reading (has to work inside tables too)
@@ -322,6 +350,17 @@ void CLuaArgument::ReadNumber(double dNumber)
     m_iType = LUA_TNUMBER;
     DeleteTableData();
     m_Number = dNumber;
+}
+
+void CLuaArgument::ReadVector(float x, float y, float z, float w)
+{
+    m_strString = "";
+    m_iType = LUA_TVEC;
+    DeleteTableData();
+    m_vecData[0] = x;
+    m_vecData[1] = y;
+    m_vecData[2] = z;
+    m_vecData[3] = w;
 }
 
 void CLuaArgument::ReadString(const std::string& string)
@@ -426,6 +465,12 @@ void CLuaArgument::Push(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKn
         case LUA_TNUMBER:
         {
             lua_pushnumber(luaVM, m_Number);
+            break;
+        }
+
+        case LUA_TVEC:
+        {
+            lua_pushvec(luaVM, m_vecData[0], m_vecData[1], m_vecData[2], m_vecData[3]);
             break;
         }
 
@@ -626,6 +671,17 @@ bool CLuaArgument::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vect
             }
             break;
         }
+
+        // Vector type
+        case LUA_TVEC:
+        {
+            m_iType = LUA_TVEC;
+            bitStream.Read(m_vecData[0]);
+            bitStream.Read(m_vecData[1]);
+            bitStream.Read(m_vecData[2]);
+            bitStream.Read(m_vecData[3]);
+            break;
+        }
     }
     return true;
 }
@@ -783,6 +839,18 @@ bool CLuaArgument::WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashM
             break;
         }
 
+        // Vector argument
+        case LUA_TVEC:
+        {
+            type.data.ucType = LUA_TVEC;
+            bitStream.Write(&type);
+            bitStream.Write(m_vecData[0]);
+            bitStream.Write(m_vecData[1]);
+            bitStream.Write(m_vecData[2]);
+            bitStream.Write(m_vecData[3]);
+            break;
+        }
+
         // Unpacketizable type.
         default:
         {
@@ -921,6 +989,15 @@ json_object* CLuaArgument::WriteToJSONObject(bool bSerialize, CFastHashMap<CLuaA
             }
             break;
         }
+        case LUA_TVEC:
+        {
+            json_object* jsonArray = json_object_new_array();
+            json_object_array_add(jsonArray, json_object_new_double(m_vecData[0]));
+            json_object_array_add(jsonArray, json_object_new_double(m_vecData[1]));
+            json_object_array_add(jsonArray, json_object_new_double(m_vecData[2]));
+            json_object_array_add(jsonArray, json_object_new_double(m_vecData[3]));
+            return jsonArray;
+        }
         default:
         {
             g_pClientGame->GetScriptDebugging()->LogError(
@@ -983,6 +1060,11 @@ char* CLuaArgument::WriteToString(char* szBuffer, int length)
                 g_pClientGame->GetScriptDebugging()->LogError(NULL, "String is too long. Limit is 65535 characters.");
             }
             break;
+        }
+        case LUA_TVEC:
+        {
+            snprintf(szBuffer, length, "vector(%f,%f,%f,%f)", m_vecData[0], m_vecData[1], m_vecData[2], m_vecData[3]);
+            return szBuffer;
         }
         case LUA_TLIGHTUSERDATA:
         case LUA_TUSERDATA:

--- a/Client/mods/deathmatch/logic/lua/CLuaArgument.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaArgument.h
@@ -22,8 +22,8 @@ extern "C"
 class CClientEntity;
 class CLuaArguments;
 
-#define LUA_TTABLEREF    9
-#define LUA_TSTRING_LONG 10
+#define LUA_TTABLEREF    11
+#define LUA_TSTRING_LONG 12
 
 class CLuaArgument
 {
@@ -49,6 +49,7 @@ public:
     void ReadScriptID(uint uiScriptID);
     void ReadElementID(ElementID ID);
     void ReadTable(class CLuaArguments* table);
+    void ReadVector(float x, float y, float z, float w = 0.0f);
 
     void Push(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKnownTables = NULL) const;
 
@@ -61,6 +62,7 @@ public:
     void*          GetUserData() const { return m_pUserData; };
     CLuaArguments* GetTable() const { return m_pTableData; }
     CClientEntity* GetElement() const;
+    const float*   GetVector() const { return m_vecData; }
 
     bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL, unsigned int uiDepth = 0);
     bool         WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables = NULL) const;
@@ -69,6 +71,7 @@ public:
     char*        WriteToString(char* szBuffer, int length);
 
     [[nodiscard]] bool IsString() const noexcept { return m_iType == LUA_TSTRING; }
+    [[nodiscard]] bool IsVector() const noexcept { return m_iType == LUA_TVEC; }
 
     [[nodiscard]] bool TryGetString(std::string_view& string) const noexcept
     {
@@ -121,6 +124,7 @@ private:
     void*          m_pUserData;
     CLuaArguments* m_pTableData;
     bool           m_bWeakTableRef;
+    float          m_vecData[4];
 
 #ifdef MTA_DEBUG
     std::string m_strFilename;

--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
@@ -418,6 +418,14 @@ CLuaArgument* CLuaArguments::PushTable(CLuaArguments* table)
     return pArgument;
 }
 
+CLuaArgument* CLuaArguments::PushVector(float x, float y, float z, float w)
+{
+    CLuaArgument* pArgument = new CLuaArgument();
+    pArgument->ReadVector(x, y, z, w);
+    m_Arguments.push_back(pArgument);
+    return pArgument;
+}
+
 // Gets rid of all the arguments in the list
 void CLuaArguments::DeleteArguments()
 {

--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -65,6 +65,7 @@ public:
     CLuaArgument* PushArgument(const CLuaArgument& argument);
     CLuaArgument* PushResource(CResource* pResource);
     CLuaArgument* PushTable(CLuaArguments* table);
+    CLuaArgument* PushVector(float x, float y, float z, float w = 0.0f);
 
     void DeleteArguments();
     void Pop();

--- a/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -151,6 +151,7 @@ void CLuaMain::InitVM()
     luaopen_debug(m_luaVM);
     luaopen_utf8(m_luaVM);
     luaopen_os(m_luaVM);
+    luaopen_vec(m_luaVM);
 
     // Initialize security restrictions. Very important to prevent lua trojans and viruses!
     InitSecurity();

--- a/Server/mods/deathmatch/logic/lua/CLuaArgument.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaArgument.cpp
@@ -111,6 +111,15 @@ void CLuaArgument::CopyRecursive(const CLuaArgument& Argument, CFastHashMap<CLua
             break;
         }
 
+        case LUA_TVEC:
+        {
+            m_vecData[0] = Argument.m_vecData[0];
+            m_vecData[1] = Argument.m_vecData[1];
+            m_vecData[2] = Argument.m_vecData[2];
+            m_vecData[3] = Argument.m_vecData[3];
+            break;
+        }
+
         default:
             break;
     }
@@ -217,6 +226,19 @@ void CLuaArgument::Read(lua_State* luaVM, int iArgument, CFastHashMap<const void
                 break;
             }
 
+            case LUA_TVEC:
+            {
+                const float* v = lua_tovec(luaVM, iArgument);
+                if (v)
+                {
+                    m_vecData[0] = v[0];
+                    m_vecData[1] = v[1];
+                    m_vecData[2] = v[2];
+                    m_vecData[3] = v[3];
+                }
+                break;
+            }
+
             case LUA_TFUNCTION:
             {
                 // TODO: add function reading (has to work inside tables too)
@@ -269,6 +291,12 @@ void CLuaArgument::Push(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKn
         case LUA_TNUMBER:
         {
             lua_pushnumber(luaVM, m_Number);
+            break;
+        }
+
+        case LUA_TVEC:
+        {
+            lua_pushvec(luaVM, m_vecData[0], m_vecData[1], m_vecData[2], m_vecData[3]);
             break;
         }
 
@@ -333,6 +361,17 @@ void CLuaArgument::ReadNumber(double dNumber)
     DeleteTableData();
     m_iType = LUA_TNUMBER;
     m_Number = dNumber;
+}
+
+void CLuaArgument::ReadVector(float x, float y, float z, float w)
+{
+    m_strString = "";
+    m_iType = LUA_TVEC;
+    DeleteTableData();
+    m_vecData[0] = x;
+    m_vecData[1] = y;
+    m_vecData[2] = z;
+    m_vecData[3] = w;
 }
 
 void CLuaArgument::ReadString(const std::string& string)
@@ -416,6 +455,9 @@ bool CLuaArgument::GetAsString(SString& strBuffer)
             break;
         case LUA_TSTRING:
             strBuffer = m_strString;
+            break;
+        case LUA_TVEC:
+            strBuffer = SString("vector(%f, %f, %f, %f)", m_vecData[0], m_vecData[1], m_vecData[2], m_vecData[3]);
             break;
         case LUA_TUSERDATA:
             return false;
@@ -588,6 +630,17 @@ bool CLuaArgument::ReadFromBitStream(NetBitStreamInterface& bitStream, std::vect
                 }
                 break;
             }
+
+            // Vector type
+            case LUA_TVEC:
+            {
+                m_iType = LUA_TVEC;
+                bitStream.Read(m_vecData[0]);
+                bitStream.Read(m_vecData[1]);
+                bitStream.Read(m_vecData[2]);
+                bitStream.Read(m_vecData[3]);
+                break;
+            }
         }
     }
     else
@@ -742,6 +795,18 @@ bool CLuaArgument::WriteToBitStream(NetBitStreamInterface& bitStream, CFastHashM
             break;
         }
 
+        // Vector argument
+        case LUA_TVEC:
+        {
+            type.data.ucType = LUA_TVEC;
+            bitStream.Write(&type);
+            bitStream.Write(m_vecData[0]);
+            bitStream.Write(m_vecData[1]);
+            bitStream.Write(m_vecData[2]);
+            bitStream.Write(m_vecData[3]);
+            break;
+        }
+
         // Unpacketizable type.
         default:
         {
@@ -879,6 +944,15 @@ json_object* CLuaArgument::WriteToJSONObject(bool bSerialize, CFastHashMap<CLuaA
             }
             break;
         }
+        case LUA_TVEC:
+        {
+            json_object* jsonArray = json_object_new_array();
+            json_object_array_add(jsonArray, json_object_new_double(m_vecData[0]));
+            json_object_array_add(jsonArray, json_object_new_double(m_vecData[1]));
+            json_object_array_add(jsonArray, json_object_new_double(m_vecData[2]));
+            json_object_array_add(jsonArray, json_object_new_double(m_vecData[3]));
+            return jsonArray;
+        }
         default:
         {
             g_pGame->GetScriptDebugging()->LogError(
@@ -943,6 +1017,12 @@ char* CLuaArgument::WriteToString(char* szBuffer, int length)
             break;
         }
 
+        case LUA_TVEC:
+        {
+            snprintf(szBuffer, length, "vector(%f,%f,%f,%f)", m_vecData[0], m_vecData[1], m_vecData[2], m_vecData[3]);
+            return szBuffer;
+        }
+
         case LUA_TLIGHTUSERDATA:
         case LUA_TUSERDATA:
         {
@@ -994,6 +1074,11 @@ bool CLuaArgument::IsEqualTo(const CLuaArgument& compareTo, std::set<const CLuaA
         case LUA_TNUMBER:
         {
             return m_Number == compareTo.m_Number;
+        }
+        case LUA_TVEC:
+        {
+            return m_vecData[0] == compareTo.m_vecData[0] && m_vecData[1] == compareTo.m_vecData[1] && m_vecData[2] == compareTo.m_vecData[2] &&
+                   m_vecData[3] == compareTo.m_vecData[3];
         }
         case LUA_TTABLE:
         {

--- a/Server/mods/deathmatch/logic/lua/CLuaArgument.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaArgument.h
@@ -23,8 +23,8 @@ extern "C"
 class CElement;
 class CLuaArguments;
 
-#define LUA_TTABLEREF    9
-#define LUA_TSTRING_LONG 10
+#define LUA_TTABLEREF    11
+#define LUA_TSTRING_LONG 12
 
 class CLuaArgument
 {
@@ -51,6 +51,7 @@ public:
     void ReadElementID(ElementID ID);
     void ReadScriptID(uint uiScriptID);
     void ReadTable(class CLuaArguments* table);
+    void ReadVector(float x, float y, float z, float w = 0.0f);
 
     int GetType() const { return m_iType; };
 
@@ -60,6 +61,7 @@ public:
     void*              GetUserData() const { return m_pUserData; };
     CLuaArguments*     GetTable() const { return m_pTableData; }
     CElement*          GetElement() const;
+    const float*       GetVector() const { return m_vecData; }
     bool               GetAsString(SString& strBuffer);
 
     bool         ReadFromBitStream(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables = NULL, unsigned int uiDepth = 0);
@@ -71,6 +73,7 @@ public:
     bool IsEqualTo(const CLuaArgument& compareTo, std::set<const CLuaArguments*>* knownTables = nullptr) const;
 
     [[nodiscard]] bool IsString() const noexcept { return m_iType == LUA_TSTRING; }
+    [[nodiscard]] bool IsVector() const noexcept { return m_iType == LUA_TVEC; }
 
     [[nodiscard]] bool TryGetString(std::string_view& string) const noexcept
     {
@@ -122,6 +125,7 @@ private:
     void*          m_pUserData;
     CLuaArguments* m_pTableData;
     bool           m_bWeakTableRef;
+    float          m_vecData[4];
 
 #ifdef MTA_DEBUG
     std::string m_strFilename;

--- a/Server/mods/deathmatch/logic/lua/CLuaArguments.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaArguments.cpp
@@ -476,6 +476,14 @@ CLuaArgument* CLuaArguments::PushDbQuery(CDbJobData* pJobData)
     return pArgument;
 }
 
+CLuaArgument* CLuaArguments::PushVector(float x, float y, float z, float w)
+{
+    CLuaArgument* pArgument = new CLuaArgument();
+    pArgument->ReadVector(x, y, z, w);
+    m_Arguments.push_back(pArgument);
+    return pArgument;
+}
+
 void CLuaArguments::DeleteArguments()
 {
     // Delete each item

--- a/Server/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -86,6 +86,7 @@ public:
 
     CLuaArgument* PushArgument(const CLuaArgument& argument);
     CLuaArgument* PushTable(CLuaArguments* table);
+    CLuaArgument* PushVector(float x, float y, float z, float w = 0.0f);
 
     void DeleteArguments();
     void ValidateTableKeys();

--- a/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaMain.cpp
@@ -215,6 +215,7 @@ void CLuaMain::Initialize()
     luaopen_debug(m_luaVM);
     luaopen_utf8(m_luaVM);
     luaopen_os(m_luaVM);
+    luaopen_vec(m_luaVM);
 
     // Initialize security restrictions. Very important to prevent lua trojans and viruses!
     InitSecurity();

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
@@ -255,6 +255,12 @@ int CLuaUtilDefs::GetUserdataType(lua_State* luaVM)
     CScriptArgReader argStream(luaVM);
     int              iArgument = lua_type(luaVM, 1);
 
+    if (iArgument == LUA_TVEC)
+    {
+        lua_pushstring(luaVM, "vector");
+        return 1;
+    }
+
     if (argStream.NextIsUserData())
     {
         SString strType;

--- a/Shared/sdk/CScriptArgReader.h
+++ b/Shared/sdk/CScriptArgReader.h
@@ -147,7 +147,16 @@ public:
     void ReadVector2D(CVector2D& outValue)
     {
         int iArgument = lua_type(m_luaVM, m_iIndex);
-        if (iArgument == LUA_TSTRING || iArgument == LUA_TNUMBER)
+        if (iArgument == LUA_TVEC)
+        {
+            const float* v = lua_tovec(m_luaVM, m_iIndex++);
+            if (v)
+            {
+                outValue = CVector2D(v[0], v[1]);
+                return;
+            }
+        }
+        else if (iArgument == LUA_TSTRING || iArgument == LUA_TNUMBER)
         {
             ReadNumber(outValue.fX);
             ReadNumber(outValue.fY);
@@ -208,7 +217,16 @@ public:
     {
         outValue = vecDefault;
         int iArgument = lua_type(m_luaVM, m_iIndex);
-        if (iArgument == LUA_TSTRING || iArgument == LUA_TNUMBER)
+        if (iArgument == LUA_TVEC)
+        {
+            const float* v = lua_tovec(m_luaVM, m_iIndex++);
+            if (v)
+            {
+                outValue = CVector2D(v[0], v[1]);
+                return;
+            }
+        }
+        else if (iArgument == LUA_TSTRING || iArgument == LUA_TNUMBER)
         {
             ReadNumber(outValue.fX, vecDefault.fX);
             ReadNumber(outValue.fY, vecDefault.fY);
@@ -272,7 +290,16 @@ public:
     void ReadVector3D(CVector& outValue)
     {
         int iArgument = lua_type(m_luaVM, m_iIndex);
-        if (iArgument == LUA_TSTRING || iArgument == LUA_TNUMBER)
+        if (iArgument == LUA_TVEC)
+        {
+            const float* v = lua_tovec(m_luaVM, m_iIndex++);
+            if (v)
+            {
+                outValue = CVector(v[0], v[1], v[2]);
+                return;
+            }
+        }
+        else if (iArgument == LUA_TSTRING || iArgument == LUA_TNUMBER)
         {
             ReadNumber(outValue.fX);
             ReadNumber(outValue.fY);
@@ -304,7 +331,7 @@ public:
                     outValue = *pVector;
                     return;
                 }
-                outValue = CVector4D();
+                outValue = CVector();
                 return;  // Error set in ReadUserData
             }
         }
@@ -321,7 +348,16 @@ public:
     {
         outValue = vecDefault;
         int iArgument = lua_type(m_luaVM, m_iIndex);
-        if (iArgument == LUA_TSTRING || iArgument == LUA_TNUMBER)
+        if (iArgument == LUA_TVEC)
+        {
+            const float* v = lua_tovec(m_luaVM, m_iIndex++);
+            if (v)
+            {
+                outValue = CVector(v[0], v[1], v[2]);
+                return;
+            }
+        }
+        else if (iArgument == LUA_TSTRING || iArgument == LUA_TNUMBER)
         {
             ReadNumber(outValue.fX, vecDefault.fX);
             ReadNumber(outValue.fY, vecDefault.fY);
@@ -353,7 +389,7 @@ public:
                     outValue = *pVector;
                     return;
                 }
-                outValue = CVector4D();
+                outValue = CVector();
                 return;  // Error set in ReadUserData
             }
         }
@@ -373,7 +409,16 @@ public:
     void ReadVector4D(CVector4D& outValue)
     {
         int iArgument = lua_type(m_luaVM, m_iIndex);
-        if (iArgument == LUA_TSTRING || iArgument == LUA_TNUMBER)
+        if (iArgument == LUA_TVEC)
+        {
+            const float* v = lua_tovec(m_luaVM, m_iIndex++);
+            if (v)
+            {
+                outValue = CVector4D(v[0], v[1], v[2], v[3]);
+                return;
+            }
+        }
+        else if (iArgument == LUA_TSTRING || iArgument == LUA_TNUMBER)
         {
             ReadNumber(outValue.fX);
             ReadNumber(outValue.fY);
@@ -410,7 +455,16 @@ public:
     {
         outValue = vecDefault;
         int iArgument = lua_type(m_luaVM, m_iIndex);
-        if (iArgument == LUA_TSTRING || iArgument == LUA_TNUMBER)
+        if (iArgument == LUA_TVEC)
+        {
+            const float* v = lua_tovec(m_luaVM, m_iIndex++);
+            if (v)
+            {
+                outValue = CVector4D(v[0], v[1], v[2], v[3]);
+                return;
+            }
+        }
+        else if (iArgument == LUA_TSTRING || iArgument == LUA_TNUMBER)
         {
             ReadNumber(outValue.fX, vecDefault.fX);
             ReadNumber(outValue.fY, vecDefault.fY);
@@ -1313,6 +1367,7 @@ public:
     bool NextIsString(int iOffset = 0) const { return NextIs(LUA_TSTRING, iOffset); }
     bool NextIsTable(int iOffset = 0) const { return NextIs(LUA_TTABLE, iOffset); }
     bool NextIsFunction(int iOffset = 0) const { return NextIs(LUA_TFUNCTION, iOffset); }
+    bool NextIsVector(int iOffset = 0) const { return NextIs(LUA_TVEC, iOffset); }
     bool NextCouldBeNumber(int iOffset = 0) const { return NextIsNumber(iOffset) || NextIsString(iOffset); }
     bool NextCouldBeString(int iOffset = 0) const { return NextIsNumber(iOffset) || NextIsString(iOffset); }
 
@@ -1348,19 +1403,20 @@ public:
 
     bool NextIsVector4D() const
     {
-        return (NextCouldBeNumber() && NextCouldBeNumber(1) && NextCouldBeNumber(2) && NextCouldBeNumber(3)) || NextIsUserDataOfType<CLuaVector4D>();
+        return (NextCouldBeNumber() && NextCouldBeNumber(1) && NextCouldBeNumber(2) && NextCouldBeNumber(3)) || NextIsUserDataOfType<CLuaVector4D>() ||
+               NextIsVector();
     }
 
     bool NextIsVector3D() const
     {
         return (NextCouldBeNumber() && NextCouldBeNumber(1) && NextCouldBeNumber(2)) || NextIsUserDataOfType<CLuaVector3D>() ||
-               NextIsUserDataOfType<CLuaVector4D>();
+               NextIsUserDataOfType<CLuaVector4D>() || NextIsVector();
     }
 
     bool NextIsVector2D() const
     {
         return (NextCouldBeNumber() && NextCouldBeNumber(1)) || NextIsUserDataOfType<CLuaVector2D>() || NextIsUserDataOfType<CLuaVector3D>() ||
-               NextIsUserDataOfType<CLuaVector4D>();
+               NextIsUserDataOfType<CLuaVector4D>() || NextIsVector();
     }
 
     //

--- a/vendor/lua/src/Makefile.am
+++ b/vendor/lua/src/Makefile.am
@@ -7,10 +7,10 @@ liblua_la_SOURCES = \
 	lobject.c lopcodes.c lparser.c lstate.c lstring.c ltable.c ltm.c  \
 	lundump.c lvm.c lzio.c \
 	lauxlib.c lbaselib.c ldblib.c liolib.c lmathlib.c loslib.c ltablib.c \
-	lstrlib.c loadlib.c linit.c \
+	lstrlib.c loadlib.c linit.c lveclib.c lvector.c \
 	lapi.h ldebug.h lgc.h lmem.h lparser.h ltable.h lzio.h ldo.h llex.h \
 	lobject.h lstate.h ltm.h lundump.h lcode.h lfunc.h llimits.h lopcodes.h \
-	lstring.h lvm.h \
+	lstring.h lvm.h lvector.h \
 	unidata.h lutf8lib.c
 
 EXTRA_DIST = luaconf.h.template.in

--- a/vendor/lua/src/Makefile.std
+++ b/vendor/lua/src/Makefile.std
@@ -27,9 +27,9 @@ PLATS= aix ansi bsd freebsd generic linux macosx mingw posix solaris
 LUA_A=	liblua$(SFX).a
 CORE_O=	lapi.o lcode.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o lmem.o \
 	lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o ltm.o  \
-	lundump.o lvm.o lzio.o
+	lundump.o lvm.o lzio.o lvector.o
 LIB_O=	lauxlib.o lbaselib.o ldblib.o liolib.o lmathlib.o loslib.o ltablib.o \
-	lstrlib.o loadlib.o linit.o
+	lstrlib.o loadlib.o linit.o lveclib.o
 
 LUA_T=	lua$(SFX)
 LUA_O=	lua.o

--- a/vendor/lua/src/lapi.c
+++ b/vendor/lua/src/lapi.c
@@ -28,6 +28,7 @@
 #include "ltm.h"
 #include "lundump.h"
 #include "lvm.h"
+#include "lvector.h"
 
 
 
@@ -398,6 +399,7 @@ LUA_API size_t lua_objlen (lua_State *L, int idx) {
     case LUA_TSTRING: return tsvalue(o)->len;
     case LUA_TUSERDATA: return uvalue(o)->len;
     case LUA_TTABLE: return luaH_getn(hvalue(o));
+    case LUA_TVEC: return 4;
     case LUA_TNUMBER: {
       size_t l;
       lua_lock(L);  /* `luaV_tostring' may create a new string */
@@ -438,11 +440,18 @@ LUA_API const void *lua_topointer (lua_State *L, int idx) {
     case LUA_TTABLE: return hvalue(o);
     case LUA_TFUNCTION: return clvalue(o);
     case LUA_TTHREAD: return thvalue(o);
+    case LUA_TVEC: return vvalue(o)->vec;
     case LUA_TUSERDATA:
     case LUA_TLIGHTUSERDATA:
       return lua_touserdata(L, idx);
     default: return NULL;
   }
+}
+
+/* LUA-VEC */
+LUA_API const float *lua_tovec (lua_State *L, int idx) {
+  StkId o = index2adr(L, idx);
+  return (!ttisvec(o)) ? NULL : vvalue(o)->vec;
 }
 
 
@@ -556,6 +565,15 @@ LUA_API int lua_pushthread (lua_State *L) {
   api_incr_top(L);
   lua_unlock(L);
   return (G(L)->mainthread == L);
+}
+
+/* LUA-VEC */
+LUA_API void lua_pushvec (lua_State *L, float x, float y, float z, float w) {
+  lua_lock(L);
+  luaC_checkGC(L);
+  setvvalue(L, L->top, luaVec_new(L, x, y, z, w));
+  api_incr_top(L);
+  lua_unlock(L);
 }
 
 

--- a/vendor/lua/src/lauxlib.c
+++ b/vendor/lua/src/lauxlib.c
@@ -185,6 +185,18 @@ LUALIB_API lua_Number luaL_optnumber (lua_State *L, int narg, lua_Number def) {
   return luaL_opt(L, luaL_checknumber, narg, def);
 }
 
+/* LUA-VEC */
+LUALIB_API const float *luaL_checkvec (lua_State *L, int narg) {
+  const float *v = lua_tovec(L, narg);
+  if (v == NULL && !lua_isvec(L, narg))
+    tag_error(L, narg, LUA_TVEC);
+  return v;
+}
+
+/* LUA-VEC */
+LUALIB_API const float *luaL_optvec (lua_State *L, int narg, const float *def) {
+  return luaL_opt(L, luaL_checkvec, narg, def);
+}
 
 LUALIB_API lua_Integer luaL_checkinteger (lua_State *L, int narg) {
   lua_Integer d = lua_tointeger(L, narg);

--- a/vendor/lua/src/lauxlib.h
+++ b/vendor/lua/src/lauxlib.h
@@ -54,6 +54,9 @@ LUALIB_API const char *(luaL_optlstring) (lua_State *L, int numArg,
 LUALIB_API lua_Number (luaL_checknumber) (lua_State *L, int numArg);
 LUALIB_API lua_Number (luaL_optnumber) (lua_State *L, int nArg, lua_Number def);
 
+LUALIB_API const float *(luaL_checkvec) (lua_State *L, int numArg);
+LUALIB_API const float *(luaL_optvec) (lua_State *L, int nArg, const float *def);
+
 LUALIB_API lua_Integer (luaL_checkinteger) (lua_State *L, int numArg);
 LUALIB_API lua_Integer (luaL_optinteger) (lua_State *L, int nArg,
                                           lua_Integer def);

--- a/vendor/lua/src/lbaselib.c
+++ b/vendor/lua/src/lbaselib.c
@@ -340,6 +340,23 @@ static int luaB_assert (lua_State *L) {
 
 
 static int luaB_unpack (lua_State *L) {
+  if (lua_type(L, 1) == LUA_TVEC) {
+    const float *v = lua_tovec(L, 1);
+    if (v != NULL) {
+      if (v[3] == 0.0f) {
+        lua_pushnumber(L, (lua_Number)v[0]);
+        lua_pushnumber(L, (lua_Number)v[1]);
+        lua_pushnumber(L, (lua_Number)v[2]);
+        return 3;
+      } else {
+        lua_pushnumber(L, (lua_Number)v[0]);
+        lua_pushnumber(L, (lua_Number)v[1]);
+        lua_pushnumber(L, (lua_Number)v[2]);
+        lua_pushnumber(L, (lua_Number)v[3]);
+        return 4;
+      }
+    }
+  }
   int i, e, n;
   luaL_checktype(L, 1, LUA_TTABLE);
   i = luaL_optint(L, 2, 1);
@@ -410,6 +427,19 @@ static int luaB_tostring (lua_State *L) {
     case LUA_TNIL:
       lua_pushliteral(L, "nil");
       break;
+    case LUA_TVEC: {
+      const float *v = lua_tovec(L, 1);
+      if (v != NULL) {
+        if (v[3] == 0.0f) {
+          lua_pushfstring(L, "vector(%f, %f, %f)", (double)v[0], (double)v[1], (double)v[2]);
+        } else {
+          lua_pushfstring(L, "vector(%f, %f, %f, %f)", (double)v[0], (double)v[1], (double)v[2], (double)v[3]);
+        }
+      } else {
+        lua_pushliteral(L, "vector");
+      }
+      break;
+    }
     default:
       lua_pushfstring(L, "%s: %p", luaL_typename(L, 1), lua_topointer(L, 1));
       break;

--- a/vendor/lua/src/lgc.c
+++ b/vendor/lua/src/lgc.c
@@ -21,6 +21,7 @@
 #include "lstring.h"
 #include "ltable.h"
 #include "ltm.h"
+#include "lvector.h"
 
 
 #define GCSTEPSIZE	1024u
@@ -105,6 +106,10 @@ static void reallymarkobject (global_State *g, GCObject *o) {
     case LUA_TPROTO: {
       gco2p(o)->gclist = g->gray;
       g->gray = o;
+      break;
+    }
+    case LUA_TVEC: {
+      gray2black(o);
       break;
     }
     default: lua_assert(0);
@@ -393,6 +398,10 @@ static void freeobj (lua_State *L, GCObject *o) {
     }
     case LUA_TUSERDATA: {
       luaM_freemem(L, o, sizeudata(gco2u(o)));
+      break;
+    }
+    case LUA_TVEC: {
+      luaVec_free(L, o);
       break;
     }
     default: lua_assert(0);

--- a/vendor/lua/src/linit.c
+++ b/vendor/lua/src/linit.c
@@ -22,6 +22,7 @@ static const luaL_Reg lualibs[] = {
   {LUA_OSLIBNAME, luaopen_os},
   {LUA_STRLIBNAME, luaopen_string},
   {LUA_MATHLIBNAME, luaopen_math},
+  {LUA_VECLIBNAME, luaopen_vec},
   {LUA_DBLIBNAME, luaopen_debug},
   {NULL, NULL}
 };

--- a/vendor/lua/src/lobject.c
+++ b/vendor/lua/src/lobject.c
@@ -80,6 +80,11 @@ int luaO_rawequalObj (const TValue *t1, const TValue *t2) {
       return bvalue(t1) == bvalue(t2);  /* boolean true must be 1 !! */
     case LUA_TLIGHTUSERDATA:
       return pvalue(t1) == pvalue(t2);
+    case LUA_TVEC: {
+      const float *v1 = vvalue(t1)->vec;
+      const float *v2 = vvalue(t2)->vec;
+      return (v1[0] == v2[0] && v1[1] == v2[1] && v1[2] == v2[2] && v1[3] == v2[3]);
+    }
     default:
       lua_assert(iscollectable(t1));
       return gcvalue(t1) == gcvalue(t2);

--- a/vendor/lua/src/lobject.h
+++ b/vendor/lua/src/lobject.h
@@ -17,7 +17,7 @@
 
 
 /* tags for values visible from Lua */
-#define LAST_TAG	LUA_TTHREAD
+#define LAST_TAG	LUA_TVEC
 
 #define NUM_TAGS	(LAST_TAG+1)
 
@@ -85,6 +85,7 @@ typedef struct lua_TValue {
 #define ttisuserdata(o)	(ttype(o) == LUA_TUSERDATA)
 #define ttisthread(o)	(ttype(o) == LUA_TTHREAD)
 #define ttislightuserdata(o)	(ttype(o) == LUA_TLIGHTUSERDATA)
+#define ttisvec(o)	(ttype(o) == LUA_TVEC)
 
 /* Macros to access values */
 #define ttype(o)	((o)->tt)
@@ -99,6 +100,7 @@ typedef struct lua_TValue {
 #define hvalue(o)	check_exp(ttistable(o), &(o)->value.gc->h)
 #define bvalue(o)	check_exp(ttisboolean(o), (o)->value.b)
 #define thvalue(o)	check_exp(ttisthread(o), &(o)->value.gc->th)
+#define vvalue(o)	check_exp(ttisvec(o), &(o)->value.gc->v)
 
 #define l_isfalse(o)	(ttisnil(o) || (ttisboolean(o) && bvalue(o) == 0))
 
@@ -155,7 +157,10 @@ typedef struct lua_TValue {
     i_o->value.gc=cast(GCObject *, (x)); i_o->tt=LUA_TPROTO; \
     checkliveness(G(L),i_o); }
 
-
+#define setvvalue(L,obj,x) \
+  { TValue *i_o=(obj); \
+    i_o->value.gc=cast(GCObject *, (x)); i_o->tt=LUA_TVEC; \
+    checkliveness(G(L),i_o); }
 
 
 #define setobj(L,obj1,obj2) \
@@ -347,6 +352,13 @@ typedef struct Table {
   int sizearray;  /* size of `array' array */
 } Table;
 
+/*
+** Vector (LUA-VEC)
+*/
+typedef struct Vector {
+    CommonHeader;
+    float vec[LUA_VEC_SIZE];
+} Vector;
 
 
 /*

--- a/vendor/lua/src/lstate.h
+++ b/vendor/lua/src/lstate.h
@@ -147,6 +147,7 @@ union GCObject {
   struct Proto p;
   struct UpVal uv;
   struct lua_State th;  /* thread */
+  struct Vector v;  /* LUA-VEC */
 };
 
 
@@ -162,6 +163,7 @@ union GCObject {
 #define ngcotouv(o) \
 	check_exp((o) == NULL || (o)->gch.tt == LUA_TUPVAL, &((o)->uv))
 #define gco2th(o)	check_exp((o)->gch.tt == LUA_TTHREAD, &((o)->th))
+#define gco2v(o)	check_exp((o)->gch.tt == LUA_TVEC, &((o)->v))  /* LUA-VEC */
 
 /* macro to convert any Lua object into a GCObject */
 #define obj2gco(v)	(cast(GCObject *, (v)))

--- a/vendor/lua/src/ltable.c
+++ b/vendor/lua/src/ltable.c
@@ -91,6 +91,15 @@ static Node *hashnum (const Table *t, lua_Number n) {
   return hashmod(t, a[0]);
 }
 
+/*
+** hash for Vectors (LUA-VEC)
+*/
+static Node *hashvec (const Table *t, const float *v) {
+  unsigned int a[4];
+  memcpy(a, v, sizeof(a));
+  unsigned int h = a[0] ^ (a[1] << 5) ^ (a[2] << 11) ^ (a[3] << 17);
+  return hashmod(t, h);
+}
 
 
 /*
@@ -107,6 +116,8 @@ static Node *mainposition (const Table *t, const TValue *key) {
       return hashboolean(t, bvalue(key));
     case LUA_TLIGHTUSERDATA:
       return hashpointer(t, pvalue(key));
+    case LUA_TVEC:
+      return hashvec(t, vvalue(key)->vec);
     default:
       return hashpointer(t, gcvalue(key));
   }

--- a/vendor/lua/src/ltm.c
+++ b/vendor/lua/src/ltm.c
@@ -23,6 +23,7 @@
 const char *const luaT_typenames[] = {
   "nil", "boolean", "userdata", "number",
   "string", "table", "function", "userdata", "thread",
+  "vector",
   "proto", "upval"
 };
 

--- a/vendor/lua/src/lua.h
+++ b/vendor/lua/src/lua.h
@@ -92,6 +92,10 @@ typedef void * (*lua_Alloc) (void *ud, void *ptr, size_t osize, size_t nsize);
 #define LUA_TFUNCTION		6
 #define LUA_TUSERDATA		7
 #define LUA_TTHREAD		8
+#define LUA_TVEC		9
+
+/* LUA_VEC - Number of components in a vec */
+#define LUA_VEC_SIZE		4
 
 
 
@@ -170,6 +174,7 @@ LUA_API lua_CFunction   (lua_tocfunction) (lua_State *L, int idx);
 LUA_API void	       *(lua_touserdata) (lua_State *L, int idx);
 LUA_API lua_State      *(lua_tothread) (lua_State *L, int idx);
 LUA_API const void     *(lua_topointer) (lua_State *L, int idx);
+LUA_API const float    *(lua_tovec) (lua_State *L, int idx);
 
 // Custom function added by MTA
 LUA_API unsigned        (lua_tostringhash) (lua_State *L, int idx);
@@ -190,6 +195,7 @@ LUA_API void  (lua_pushcclosure) (lua_State *L, lua_CFunction fn, int n);
 LUA_API void  (lua_pushboolean) (lua_State *L, int b);
 LUA_API void  (lua_pushlightuserdata) (lua_State *L, void *p);
 LUA_API int   (lua_pushthread) (lua_State *L);
+LUA_API void  (lua_pushvec) (lua_State *L, float x, float y, float z, float w);
 
 /*
 ** get functions (Lua -> stack)
@@ -296,6 +302,7 @@ LUA_API void lua_setallocf (lua_State *L, lua_Alloc f, void *ud);
 #define lua_isthread(L,n)	(lua_type(L, (n)) == LUA_TTHREAD)
 #define lua_isnone(L,n)		(lua_type(L, (n)) == LUA_TNONE)
 #define lua_isnoneornil(L, n)	(lua_type(L, (n)) <= 0)
+#define lua_isvec(L, n)		(lua_type(L, (n)) == LUA_TVEC)
 
 #define lua_pushliteral(L, s)	\
 	lua_pushlstring(L, "" s, (sizeof(s)/sizeof(char))-1)

--- a/vendor/lua/src/lualib.h
+++ b/vendor/lua/src/lualib.h
@@ -39,6 +39,10 @@ LUALIB_API int (luaopen_debug) (lua_State *L);
 #define LUA_LOADLIBNAME	"package"
 LUALIB_API int (luaopen_package) (lua_State *L);
 
+/* LUA-VEC */
+#define LUA_VECLIBNAME	"vec"
+LUALIB_API int (luaopen_vec) (lua_State *L);
+
 
 /* open all previous libraries */
 LUALIB_API void (luaL_openlibs) (lua_State *L); 

--- a/vendor/lua/src/lveclib.c
+++ b/vendor/lua/src/lveclib.c
@@ -1,0 +1,187 @@
+/*
+** Vector math library (LUA-VEC)
+** See Copyright Notice in lua.h
+*/
+
+#include <stdlib.h>
+#include <math.h>
+
+#define lveclib_c
+#define LUA_LIB
+
+#include "lua.h"
+
+#include "lauxlib.h"
+#include "lualib.h"
+
+static int vec_new(lua_State *L) {
+  float x = (float)lua_tonumber(L, 1);
+  float y = (float)lua_tonumber(L, 2);
+  float z = (float)lua_tonumber(L, 3);
+  float w = (float)lua_tonumber(L, 4);
+  lua_pushvec(L, x, y, z, w);
+  return 1;
+}
+
+static int vec_call(lua_State *L) {
+  /* In __call, first argument is the table itself, subsequent args are x, y, z, w */
+  float x = (float)lua_tonumber(L, 2);
+  float y = (float)lua_tonumber(L, 3);
+  float z = (float)lua_tonumber(L, 4);
+  float w = (float)lua_tonumber(L, 5);
+  lua_pushvec(L, x, y, z, w);
+  return 1;
+}
+
+static int vec_dot(lua_State *L) {
+  const float *v1 = luaL_checkvec(L, 1);
+  const float *v2 = luaL_checkvec(L, 2);
+  lua_pushnumber(L, (lua_Number)(v1[0] * v2[0] + v1[1] * v2[1] + v1[2] * v2[2] + v1[3] * v2[3]));
+  return 1;
+}
+
+static int vec_cross(lua_State *L) {
+  const float *v1 = luaL_checkvec(L, 1);
+  const float *v2 = luaL_checkvec(L, 2);
+  lua_pushvec(L,
+              v1[1] * v2[2] - v1[2] * v2[1],
+              v1[2] * v2[0] - v1[0] * v2[2],
+              v1[0] * v2[1] - v1[1] * v2[0],
+              0.0f);
+  return 1;
+}
+
+static int vec_length(lua_State *L) {
+  const float *v = luaL_checkvec(L, 1);
+  lua_pushnumber(L, (lua_Number)sqrtf(v[0] * v[0] + v[1] * v[1] + v[2] * v[2] + v[3] * v[3]));
+  return 1;
+}
+
+static int vec_lengthSquared(lua_State *L) {
+  const float *v = luaL_checkvec(L, 1);
+  lua_pushnumber(L, (lua_Number)(v[0] * v[0] + v[1] * v[1] + v[2] * v[2] + v[3] * v[3]));
+  return 1;
+}
+
+static int vec_normalize(lua_State *L) {
+  const float *v = luaL_checkvec(L, 1);
+  float lenSq = v[0] * v[0] + v[1] * v[1] + v[2] * v[2] + v[3] * v[3];
+  if (lenSq > 0.0f) {
+    float s = 1.0f / sqrtf(lenSq);
+    lua_pushvec(L, v[0] * s, v[1] * s, v[2] * s, v[3] * s);
+  } else {
+    lua_pushvec(L, 0.0f, 0.0f, 0.0f, 0.0f);
+  }
+  return 1;
+}
+
+static int vec_distance(lua_State *L) {
+  const float *v1 = luaL_checkvec(L, 1);
+  const float *v2 = luaL_checkvec(L, 2);
+  float dx = v1[0] - v2[0];
+  float dy = v1[1] - v2[1];
+  float dz = v1[2] - v2[2];
+  float dw = v1[3] - v2[3];
+  lua_pushnumber(L, (lua_Number)sqrtf(dx * dx + dy * dy + dz * dz + dw * dw));
+  return 1;
+}
+
+static int vec_distanceSquared(lua_State *L) {
+  const float *v1 = luaL_checkvec(L, 1);
+  const float *v2 = luaL_checkvec(L, 2);
+  float dx = v1[0] - v2[0];
+  float dy = v1[1] - v2[1];
+  float dz = v1[2] - v2[2];
+  float dw = v1[3] - v2[3];
+  lua_pushnumber(L, (lua_Number)(dx * dx + dy * dy + dz * dz + dw * dw));
+  return 1;
+}
+
+static int vec_unpack(lua_State *L) {
+  const float *v = luaL_checkvec(L, 1);
+  if (v[3] == 0.0f) {
+    lua_pushnumber(L, (lua_Number)v[0]);
+    lua_pushnumber(L, (lua_Number)v[1]);
+    lua_pushnumber(L, (lua_Number)v[2]);
+    return 3;
+  }
+  lua_pushnumber(L, (lua_Number)v[0]);
+  lua_pushnumber(L, (lua_Number)v[1]);
+  lua_pushnumber(L, (lua_Number)v[2]);
+  lua_pushnumber(L, (lua_Number)v[3]);
+  return 4;
+}
+
+static int vec_abs(lua_State *L) {
+  const float *v = luaL_checkvec(L, 1);
+  lua_pushvec(L, fabsf(v[0]), fabsf(v[1]), fabsf(v[2]), fabsf(v[3]));
+  return 1;
+}
+
+static int vec_floor(lua_State *L) {
+  const float *v = luaL_checkvec(L, 1);
+  lua_pushvec(L, floorf(v[0]), floorf(v[1]), floorf(v[2]), floorf(v[3]));
+  return 1;
+}
+
+static int vec_ceil(lua_State *L) {
+  const float *v = luaL_checkvec(L, 1);
+  lua_pushvec(L, ceilf(v[0]), ceilf(v[1]), ceilf(v[2]), ceilf(v[3]));
+  return 1;
+}
+
+static const luaL_Reg veclib[] = {
+  {"create",            vec_new},
+  {"new",               vec_new},
+  {"dot",               vec_dot},
+  {"getDotProduct",     vec_dot},
+  {"cross",             vec_cross},
+  {"getCrossProduct",   vec_cross},
+  {"length",            vec_length},
+  {"getLength",         vec_length},
+  {"lengthSquared",     vec_lengthSquared},
+  {"getLengthSquared",  vec_lengthSquared},
+  {"normalize",         vec_normalize},
+  {"getNormalized",     vec_normalize},
+  {"distance",          vec_distance},
+  {"getDistance",       vec_distance},
+  {"distanceSquared",   vec_distanceSquared},
+  {"getDistanceSquared",vec_distanceSquared},
+  {"unpack",            vec_unpack},
+  {"getComponents",     vec_unpack},
+  {"abs",               vec_abs},
+  {"floor",             vec_floor},
+  {"ceil",              vec_ceil},
+  {NULL, NULL}
+};
+
+/*
+** Open veclib
+*/
+LUALIB_API int luaopen_vec(lua_State *L) {
+  luaL_register(L, LUA_VECLIBNAME, veclib);
+
+  /* Make the vector table directly callable: vector(x, y, z) */
+  lua_newtable(L);
+  lua_pushcfunction(L, vec_call);
+  lua_setfield(L, -2, "__call");
+  lua_setmetatable(L, -2);
+
+  /* Set global alias 'vector' */
+  lua_pushvalue(L, -1);
+  lua_setglobal(L, "vector");
+
+  /* Numeric constants */
+  lua_pushvec(L, 0.0f, 0.0f, 0.0f, 0.0f);
+  lua_setfield(L, -2, "zero");
+  lua_pushvec(L, 1.0f, 1.0f, 1.0f, 1.0f);
+  lua_setfield(L, -2, "one");
+  lua_pushvec(L, 0.0f, 1.0f, 0.0f, 0.0f);
+  lua_setfield(L, -2, "forward");
+  lua_pushvec(L, 1.0f, 0.0f, 0.0f, 0.0f);
+  lua_setfield(L, -2, "right");
+  lua_pushvec(L, 0.0f, 0.0f, 1.0f, 0.0f);
+  lua_setfield(L, -2, "up");
+
+  return 1;
+}

--- a/vendor/lua/src/lvector.c
+++ b/vendor/lua/src/lvector.c
@@ -1,0 +1,29 @@
+/*
+** LUA-VEC
+** Lua Vectors
+** See Copyright Notice in lua.h
+*/
+
+#define lvector_c
+#define LUA_CORE
+
+#include "lua.h"
+
+#include "lmem.h"
+#include "lobject.h"
+#include "lstate.h"
+#include "lvector.h"
+
+Vector *luaVec_new(lua_State *L, float x, float y, float z, float w) {
+  Vector *v = luaM_new(L, Vector);
+  luaC_link(L, obj2gco(v), LUA_TVEC);
+  v->vec[0] = x;
+  v->vec[1] = y;
+  v->vec[2] = z;
+  v->vec[3] = w;
+  return v;
+}
+
+void luaVec_free(lua_State *L, GCObject *o) {
+  luaM_free(L, gco2v(o));
+}

--- a/vendor/lua/src/lvector.h
+++ b/vendor/lua/src/lvector.h
@@ -1,0 +1,17 @@
+/*
+** LUA-VEC
+** Lua Vectors
+** See Copyright Notice in lua.h
+*/
+
+#ifndef lvector_h
+#define lvector_h
+
+#include "lgc.h"
+#include "lobject.h"
+#include "lstate.h"
+
+LUAI_FUNC Vector *luaVec_new(lua_State *L, float x, float y, float z, float w);
+LUAI_FUNC void    luaVec_free(lua_State *L, GCObject *o);
+
+#endif

--- a/vendor/lua/src/lvm.c
+++ b/vendor/lua/src/lvm.c
@@ -25,6 +25,7 @@
 #include "ltable.h"
 #include "ltm.h"
 #include "lvm.h"
+#include "lvector.h"
 
 
 
@@ -45,15 +46,24 @@ const TValue *luaV_tonumber (const TValue *obj, TValue *n) {
 
 
 int luaV_tostring (lua_State *L, StkId obj) {
-  if (!ttisnumber(obj))
-    return 0;
-  else {
+  if (ttisnumber(obj)) {
     char s[LUAI_MAXNUMBER2STR];
     lua_Number n = nvalue(obj);
     lua_number2str(s, n);
     setsvalue2s(L, obj, luaS_new(L, s));
     return 1;
   }
+  else if (ttisvec(obj)) {
+    char s[128];
+    const float *v = vvalue(obj)->vec;
+    if (v[3] == 0.0f)
+      snprintf(s, sizeof(s), "vector(%g, %g, %g)", v[0], v[1], v[2]);
+    else
+      snprintf(s, sizeof(s), "vector(%g, %g, %g, %g)", v[0], v[1], v[2], v[3]);
+    setsvalue2s(L, obj, luaS_new(L, s));
+    return 1;
+  }
+  return 0;
 }
 
 
@@ -119,6 +129,70 @@ void luaV_gettable (lua_State *L, const TValue *t, TValue *key, StkId val) {
       }
       /* else will try the tag method */
     }
+    else if (ttisvec(t)) { /* LUA-VEC -- vec[idx] operator */
+      if (ttisnumber(key) && (nvalue(key) >= 1 && nvalue(key) <= LUA_VEC_SIZE)) {
+        TValue res;
+        setnvalue(&res, vvalue(t)->vec[cast_int(nvalue(key)) - 1]);
+        setobj2s(L, val, &res);
+        return;
+      }
+      else if (ttisstring(key)) {
+        const char *s = getstr(tsvalue(key));
+        size_t len = tsvalue(key)->len;
+        if (len == 1) {
+          TValue res;
+          switch (s[0]) {
+            case 'x': case 'X': setnvalue(&res, vvalue(t)->vec[0]); setobj2s(L, val, &res); return;
+            case 'y': case 'Y': setnvalue(&res, vvalue(t)->vec[1]); setobj2s(L, val, &res); return;
+            case 'z': case 'Z': setnvalue(&res, vvalue(t)->vec[2]); setobj2s(L, val, &res); return;
+            case 'w': case 'W': setnvalue(&res, vvalue(t)->vec[3]); setobj2s(L, val, &res); return;
+            default: break;
+          }
+        }
+        else if (len <= LUA_VEC_SIZE) {
+          float v[LUA_VEC_SIZE] = {0};
+          unsigned int idx;
+          int isSwizzle = 1;
+          for (idx = 0; idx < len; ++idx) {
+            switch (s[idx]) {
+              case 'x': case 'X': v[idx] = vvalue(t)->vec[0]; break;
+              case 'y': case 'Y': v[idx] = vvalue(t)->vec[1]; break;
+              case 'z': case 'Z': v[idx] = vvalue(t)->vec[2]; break;
+              case 'w': case 'W': v[idx] = vvalue(t)->vec[3]; break;
+              default: isSwizzle = 0; break;
+            }
+            if (!isSwizzle) break;
+          }
+          if (isSwizzle) {
+            TValue res;
+            setvvalue(L, &res, luaVec_new(L, v[0], v[1], v[2], v[3]));
+            setobj2s(L, val, &res);
+            return;
+          }
+        }
+        /* Method lookup fallback from global vector table */
+        Table *env = NULL;
+        if (L->ci && L->ci->func && ttisfunction(L->ci->func)) {
+          Closure *cl = clvalue(L->ci->func);
+          env = cl->c.isC ? cl->c.env : cl->l.env;
+        }
+        if (!env && ttistable(gt(L))) env = hvalue(gt(L));
+        if (env) {
+          const TValue *gvec = luaH_getstr(env, luaS_newliteral(L, "vector"));
+          if (!ttistable(gvec) && ttistable(gt(L)) && env != hvalue(gt(L))) {
+            gvec = luaH_getstr(hvalue(gt(L)), luaS_newliteral(L, "vector"));
+          }
+          if (ttistable(gvec)) {
+            const TValue *fn = luaH_get(hvalue(gvec), key);
+            if (!ttisnil(fn)) {
+              setobj2s(L, val, fn);
+              return;
+            }
+          }
+        }
+      }
+      luaG_typeerror(L, t, "index");
+    }
     else if (ttisnil(tm = luaT_gettmbyobj(L, t, TM_INDEX)))
       luaG_typeerror(L, t, "index");
     if (ttisfunction(tm)) {
@@ -147,6 +221,33 @@ void luaV_settable (lua_State *L, const TValue *t, TValue *key, StkId val) {
         return;
       }
       /* else will try the tag method */
+    }
+    else if (ttisvec(t)) {
+      Vector *vecObj = vvalue(t);
+      lua_Number num = 0;
+      if (!tonumber(val, &temp)) {
+        luaG_runerror(L, "attempt to assign non-numeric value to vector component");
+        return;
+      }
+      num = nvalue(val);
+      if (ttisnumber(key)) {
+        int idx = (int)nvalue(key);
+        if (idx >= 1 && idx <= 4) {
+          vecObj->vec[idx - 1] = (float)num;
+          return;
+        }
+      }
+      else if (ttisstring(key)) {
+        const char *s = svalue(key);
+        if (s[0] != '\0' && s[1] == '\0') {
+          if (s[0] == 'x' || s[0] == 'X') { vecObj->vec[0] = (float)num; return; }
+          if (s[0] == 'y' || s[0] == 'Y') { vecObj->vec[1] = (float)num; return; }
+          if (s[0] == 'z' || s[0] == 'Z') { vecObj->vec[2] = (float)num; return; }
+          if (s[0] == 'w' || s[0] == 'W') { vecObj->vec[3] = (float)num; return; }
+        }
+      }
+      luaG_runerror(L, "invalid vector component index for assignment");
+      return;
     }
     else if (ttisnil(tm = luaT_gettmbyobj(L, t, TM_NEWINDEX)))
       luaG_typeerror(L, t, "index");
@@ -271,6 +372,11 @@ int luaV_equalval (lua_State *L, const TValue *t1, const TValue *t2) {
       tm = get_compTM(L, hvalue(t1)->metatable, hvalue(t2)->metatable, TM_EQ);
       break;  /* will try TM */
     }
+    case LUA_TVEC: {
+      const float *v1 = vvalue(t1)->vec;
+      const float *v2 = vvalue(t2)->vec;
+      return (v1[0] == v2[0] && v1[1] == v2[1] && v1[2] == v2[2] && v1[3] == v2[3]);
+    }
     default: return gcvalue(t1) == gcvalue(t2);
   }
   if (tm == NULL) return 0;  /* no TM? */
@@ -283,7 +389,7 @@ void luaV_concat (lua_State *L, int total, int last) {
   do {
     StkId top = L->base + last + 1;
     int n = 2;  /* number of elements handled in this pass (at least 2) */
-    if (!(ttisstring(top-2) || ttisnumber(top-2)) || !tostring(L, top-1)) {
+    if (!(ttisstring(top-2) || ttisnumber(top-2) || ttisvec(top-2)) || !tostring(L, top-1)) {
       if (!call_binTM(L, top-2, top-1, top-2, TM_CONCAT))
         luaG_concaterror(L, top-2, top-1);
     } else if (tsvalue(top-1)->len == 0)  /* second op is empty? */
@@ -367,8 +473,19 @@ static void Arith (lua_State *L, StkId ra, const TValue *rb,
         if (ttisnumber(rb) && ttisnumber(rc)) { \
           lua_Number nb = nvalue(rb), nc = nvalue(rc); \
           setnvalue(ra, op(nb, nc)); \
-        } \
-        else \
+        } else if (ttisvec(rb) && ttisvec(rc) && (tm==TM_ADD || tm==TM_SUB || tm==TM_MUL || tm==TM_DIV || tm==TM_POW)) { \
+          const float* nb = vvalue(rb)->vec; \
+          const float* nc = vvalue(rc)->vec; \
+          setvvalue(L, ra, luaVec_new(L, (float)op(nb[0], nc[0]), (float)op(nb[1], nc[1]), (float)op(nb[2], nc[2]), (float)op(nb[3], nc[3]))); \
+        } else if (ttisvec(rb) && ttisnumber(rc) && (tm==TM_MUL || tm==TM_DIV || tm==TM_POW)) { \
+          const float* nb = vvalue(rb)->vec; \
+          lua_Number nc = nvalue(rc); \
+          setvvalue(L, ra, luaVec_new(L, (float)op(nb[0], nc), (float)op(nb[1], nc), (float)op(nb[2], nc), (float)op(nb[3], nc))); \
+        } else if (ttisnumber(rb) && ttisvec(rc) && tm==TM_MUL) { \
+          lua_Number nb = nvalue(rb); \
+          const float* nc = vvalue(rc)->vec; \
+          setvvalue(L, ra, luaVec_new(L, (float)op(nb, nc[0]), (float)op(nb, nc[1]), (float)op(nb, nc[2]), (float)op(nb, nc[3]))); \
+        } else \
           Protect(Arith(L, ra, rb, rc, tm)); \
       }
 
@@ -501,6 +618,10 @@ void luaV_execute (lua_State *L, int nexeccalls) {
           lua_Number nb = nvalue(rb);
           setnvalue(ra, luai_numunm(nb));
         }
+        else if (ttisvec(rb)) {
+          const float *vb = vvalue(rb)->vec;
+          setvvalue(L, ra, luaVec_new(L, -vb[0], -vb[1], -vb[2], -vb[3]));
+        }
         else {
           Protect(Arith(L, ra, rb, rb, TM_UNM));
         }
@@ -520,6 +641,10 @@ void luaV_execute (lua_State *L, int nexeccalls) {
           }
           case LUA_TSTRING: {
             setnvalue(ra, cast_num(tsvalue(rb)->len));
+            break;
+          }
+          case LUA_TVEC: {
+            setnvalue(ra, 4);
             break;
           }
           default: {  /* try metamethod */


### PR DESCRIPTION
Replaces #1728
Fixes #321

This is basically the last part of the OOP/vector optimization work from #5278, #5279, #5280 and #5290. It completes the native vector idea that was originally started by @pirulax in #1728.

The main goal here was to make vectors actual native Lua values instead of relying on userdata/metatables and C function calls. With these changes in place, OOP element properties are now faster than procedural calls (6ms vs. 41ms), while native vector math is 12.6× faster than legacy OOP vectors, getting close to raw CPU performance.

### What changed

* Added `vector` / `LUA_TVEC` as a native 128-bit 4D floating point type in the Lua runtime.
* Arithmetic such as `+`, `-`, `*`, `/`, `^`, unary `-` and length calculations now have VM fast paths, without going through metamethods or C functions.
* Supports `.x`, `.y`, `.z`, `.w`, numeric indexing (`[1]` to `[4]`) and swizzling like `.xy`, `.xyz`, etc.
* Native vectors are supported by `CScriptArgReader`, `CLuaArgument` event serialization and the JSON converters.
* Added the usual constructors and helper functions through the global `vector` library.

## Lua API

Creating a vector:

```lua
vector vector ( float x, float y, float z [, float w = 0.0 ] )
```

`x`, `y` and `z` are required. `w` is optional and defaults to `0.0`.

Example:

```lua
local pos = vector(0, 5, 3)
local target = pos + vector.forward * 10

print("Target position: " .. target)
print("Distance: " .. pos:distance(target))
```

### Available methods

Both method and static versions are available:

* `vec:dot(otherVec)` / `vector.dot(v1, v2)`
* `vec:cross(otherVec)` / `vector.cross(v1, v2)`
* `vec:length()` / `vector.length(v)`
* `vec:lengthSquared()` / `vector.lengthSquared(v)`
* `vec:normalize()` / `vector.normalize(v)`
* `vec:distance(otherVec)` / `vector.distance(v1, v2)`
* `vec:distanceSquared(otherVec)` / `vector.distanceSquared(v1, v2)`

Constants:

* `vector.zero` = `vector(0, 0, 0, 0)`
* `vector.one` = `vector(1, 1, 1, 1)`
* `vector.forward` = `vector(0, 1, 0, 0)`
* `vector.right` = `vector(1, 0, 0, 0)`
* `vector.up` = `vector(0, 0, 1, 0)`

## Benchmarks

500,000 operations per test:

| Test                               | Inline OOP | Native SIMD vector | Improvement |
| ---------------------------------- | ---------: | -----------------: | ----------: |
| Vector arithmetic (`+`, `-`, `*`)  | `2,918 ms` |           `230 ms` |     `12.7x` |
| Vector math (`:dot`, `:length`)    | `263.6 ms` |          `56.3 ms` |      `4.7x` |
| Component reads (`.x`, `.y`, `.z`) | `695.3 ms` |          `21.3 ms` |       `33x` |
| Total                              | `3,877 ms` |         `307.3 ms` |     `12.6x` |

Sounds a bit unrealistic? Yeah, test it yourself :)))
[vector_benchmark.zip](https://github.com/user-attachments/files/31664494/vector_benchmark.zip)

For comparison, running around 1.5 million synchronous operations in a single frame previously froze the game for roughly 4 seconds and triggered the black loading screen. With native vectors, the same workload causes only a frame drop of around a second or less, so normal gameplay shouldn't be affected.