### PR TITLE
Fix wrong RwFrame freed when replacing a model atomic

### DIFF
--- a/Client/game_sa/CFileLoaderSA.cpp
+++ b/Client/game_sa/CFileLoaderSA.cpp
@@ -213,6 +213,10 @@ RpAtomic* CFileLoader_SetRelatedModelInfoCB(RpAtomic* atomic, SRelatedModelInfo*
     CVisibilityPlugins_SetAtomicRenderCallback(atomic, 0);
 
     RpAtomic* pOldAtomic = reinterpret_cast<RpAtomic*>(pBaseModelInfo->pRwObject);
+
+    // Not pOldFrame: that one belongs to the incoming clone, which the caller destroys.
+    RwFrame* pOldAtomicFrame = pOldAtomic ? reinterpret_cast<RwFrame*>(pOldAtomic->object.object.parent) : nullptr;
+
     if (bDamage)
     {
         auto pDamagableModelInfo = reinterpret_cast<CDamagableModelInfo*>(pAtomicModelInfo);
@@ -234,11 +238,10 @@ RpAtomic* CFileLoader_SetRelatedModelInfoCB(RpAtomic* atomic, SRelatedModelInfo*
         if (pOldAtomic)
         {
             RpAtomicDestroy(pOldAtomic);
-        }
-
-        if (pOldFrame)
-        {
-            RwFrameDestroy(pOldFrame);
+            if (pOldAtomicFrame && pOldAtomicFrame != pOldFrame)
+            {
+                RwFrameDestroy(pOldAtomicFrame);
+            }
         }
     }
     return atomic;


### PR DESCRIPTION
#### Summary

`CFileLoader_SetRelatedModelInfoCB` frees the wrong `RwFrame` when a model's atomic is replaced. It destroys `pOldFrame` - the frame of the atomic being *installed*, which belongs to the caller's clone - while the replaced atomic's own frame is never freed.

Take the frame from the replaced atomic instead, and free it with that atomic. This is what `CAtomicModelInfo::DeleteRwObject` (0x4C4440) does: read `atomic->object.object.parent`, then `RpAtomicDestroy` + `RwFrameDestroy`.

Dropping `RwFrameDestroy(pOldFrame)` leaks nothing - `pOldFrame` stays in the clone's hierarchy, and `ReplaceAllAtomicsInModel` destroys that clump immediately after the walk (`CRenderWareSA.cpp:558`).

The damaged atomic has a leak of its own - `SetDamagedAtomic` overwrites the previous one without freeing it - but that is pre-existing and outside the block this touches, so it is left alone here.

#### Motivation

Part of #4956. Follow-up to #1265 (`ad78737`), which added this cleanup for #359 and picked the wrong frame: `pOldFrame` was in scope, the replaced atomic's was not. The game's own `CFileLoader::SetRelatedModelInfoCB` (0x537150) frees neither, which is the leak #359 reported.

Freeing `pOldFrame` early was also unsafe: `RwFrameDestroy` leaves attached objects' parent pointers dangling, so on a DFF whose clone parents several atomics to one frame, a later iteration of the same walk reads a freed frame at `CFileLoaderSA.cpp:197`.

#### Test plan

1. Replace atomic models with `engineReplaceModel` and stream them in and out repeatedly.
2. With counters compiled into the callback, over 200 replacements: it read an already-destroyed frame 76 times before the change and 0 times after, and frames freed now match atomics freed exactly (216 / 216).
3. 25 minutes with 2061 replaced models at the 256 MB streaming limit - no crash.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
