### PR TITLE
Fix three leaks in the world texture watch

### DIFF
--- a/Client/game_sa/CRenderWareSA.ShaderMatching.cpp
+++ b/Client/game_sa/CRenderWareSA.ShaderMatching.cpp
@@ -112,6 +112,25 @@ void CMatchChannelManager::RemoveTexture(STexInfo* pTexInfo)
     dassert(MapContains(pTexNameInfo->usedByTexInfoList, pTexInfo));
     MapRemove(pTexNameInfo->usedByTexInfoList, pTexInfo);
     pTexInfo->pAssociatedTexNameInfo = NULL;
+
+    MaybeDeleteTexNameInfo(pTexNameInfo);
+}
+
+//////////////////////////////////////////////////////////////////
+//
+// CMatchChannelManager::MaybeDeleteTexNameInfo
+//
+// Both lists together are every reference that can exist: the texinfos
+// pointing back at it, and the channels holding it in m_MatchedTextureList.
+//
+//////////////////////////////////////////////////////////////////
+void CMatchChannelManager::MaybeDeleteTexNameInfo(STexNameInfo* pTexNameInfo)
+{
+    if (pTexNameInfo->usedByTexInfoList.empty() && pTexNameInfo->matchChannelList.empty())
+    {
+        MapRemove(m_AllTextureList, pTexNameInfo->strTextureName);
+        delete pTexNameInfo;
+    }
 }
 
 //////////////////////////////////////////////////////////////////
@@ -614,6 +633,7 @@ void CMatchChannelManager::ProcessRematchTexturesQueue()
             pChannel->RemoveTexture(pTexNameInfo);
             MapRemove(pTexNameInfo->matchChannelList, pChannel);
             pTexNameInfo->ResetReplacementResults();  // Do this here as it won't get picked up in RecalcEverything now
+            MaybeDeleteTexNameInfo(pTexNameInfo);
         }
 
         // Rematch against texture list
@@ -822,6 +842,7 @@ void CMatchChannelManager::DeleteChannel(CMatchChannel* pChannel)
 
         // Reset shader matches now as this channel is going
         pTexNameInfo->ResetReplacementResults();
+        MaybeDeleteTexNameInfo(pTexNameInfo);
     }
 
 #ifdef SHADER_DEBUG_CHECKS

--- a/Client/game_sa/CRenderWareSA.ShaderMatching.h
+++ b/Client/game_sa/CRenderWareSA.ShaderMatching.h
@@ -292,6 +292,7 @@ protected:
 
     STexShaderReplacement* UpdateTexShaderReplacement(STexNameInfo* pTexNameInfo, CClientEntityBase* pClientEntity, int iEntityType);
     void                   UpdateTexShaderReplacementNoEntity(STexNameInfo* pTexNameInfo, STexShaderReplacement& texNoEntityShader, int iEntityType);
+    void                   MaybeDeleteTexNameInfo(STexNameInfo* pTexNameInfo);
     void                   FinalizeLayers(SShaderInfoLayers& shaderLayers);
 
     bool                                           m_bChangesPending;

--- a/Client/game_sa/CRenderWareSA.ShaderSupport.cpp
+++ b/Client/game_sa/CRenderWareSA.ShaderSupport.cpp
@@ -112,7 +112,7 @@ static void __declspec(naked) HOOK_CTxdStore_SetupTxdParent()
 ////////////////////////////////////////////////////////////////
 __declspec(noinline) void _cdecl OnStreamingRemoveTxd(DWORD dwTxdId)
 {
-    ushort usTxdId = (ushort)dwTxdId - pGame->GetBaseIDforTXD();
+    ushort usTxdId = (ushort)dwTxdId;
     // Ensure there are no previous events for this txd
     ms_txdStreamEventList.remove(STxdStreamEvent(true, usTxdId));
     ms_txdStreamEventList.remove(STxdStreamEvent(false, usTxdId));
@@ -130,9 +130,9 @@ static void __declspec(naked) HOOK_CTxdStore_RemoveTxd()
     {
         // Hooked from 731E90  6 bytes
 
-        // esi - txd id + 20000
+        // __cdecl txd id - esi still holds the caller's value at this address
         pushad
-        push    esi
+        push    [esp+32+4*1]
         call    OnStreamingRemoveTxd
         add     esp, 4
         popad

--- a/Client/game_sa/CRenderWareSA.ShaderSupport.cpp
+++ b/Client/game_sa/CRenderWareSA.ShaderSupport.cpp
@@ -77,8 +77,7 @@ static CMappedArray<STxdStreamEvent> ms_txdStreamEventList;
 __declspec(noinline) void _cdecl OnStreamingAddedTxd(DWORD dwTxdId)
 {
     ushort usTxdId = (ushort)dwTxdId;
-    // Ensure there are no previous events for this txd
-    ms_txdStreamEventList.remove(STxdStreamEvent(false, usTxdId));
+    // Drop a duplicate 'added' only - a pending 'removed' still has to reach the watch
     ms_txdStreamEventList.remove(STxdStreamEvent(true, usTxdId));
     // Append 'added'
     ms_txdStreamEventList.push_back(STxdStreamEvent(true, usTxdId));


### PR DESCRIPTION
#### Summary
Three independent leaks in the world-texture watch.

- `OnStreamingAddedTxd` dropped queued `removed` events, so a txd slot reused within one watch period never streamed out and its `STexInfo` objects were never destroyed.
- `HOOK_CTxdStore_RemoveTxd` took the txd id from `ESI`, which only holds it when the game itself is the caller. `CTxdPoolSA::RemoveTextureDictonarySlot` calls `0x731E90` directly, so on the `engineFreeTXD` path the id was unrelated to the slot being released. The function is `__cdecl` — read the stack argument.
- `m_AllTextureList` had no erase site at all: one entry per texture name ever seen, kept for the life of the client.

#### Motivation
Part of #4956: client memory grows without bound on servers that stream large numbers of custom models.

#### Test plan
2061 replaced models streaming continuously at the 256 MB limit for 25 minutes, with a second resource creating and destroying world-texture shaders throughout (705 created, 701 destroyed, no crash). Then the same run with only `game_sa.dll` swapped back:

- `m_AllTextureList` decreased 5 times with the fix over 90 samples, and never without — not once in 403 samples over 100 minutes.
- `m_TexInfoMap` went from 19423 → 26521 and never decreasing, to 19099 → 19457 and oscillating.

No process-memory reduction is claimed; that comparison is window-dependent.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.