### PR TITLE
Add real-time download speed indicator to the transfer box

### DIFF
--- a/Client/mods/deathmatch/logic/CTransferBox.cpp
+++ b/Client/mods/deathmatch/logic/CTransferBox.cpp
@@ -39,7 +39,7 @@ CTransferBox::CTransferBox(TransferBoxType transferType) : m_GUI(g_pCore->GetGUI
 void CTransferBox::CreateTransferWindow()
 {
     // Find our largest piece of text, so we can size accordingly
-    std::string largeTextSample = m_titleProgressPrefix + " " + SString(_("%s of %s (%s)"), "999.99 kB", "999.99 kB", "999.99 kB");
+    std::string largeTextSample = m_titleProgressPrefix + " " + SString(_("%s of %s (%s)"), "999.99 kB", "999.99 kB", "999.99 kB/s");
     float       fTransferBoxWidth = m_GUI->GetTextExtent(largeTextSample.c_str(), "default-bold-small");
     fTransferBoxWidth = std::max<float>(fTransferBoxWidth, m_GUI->GetTextExtent(_("Disconnect to cancel download"), "default-normal"));
 

--- a/Client/mods/deathmatch/logic/CTransferBox.cpp
+++ b/Client/mods/deathmatch/logic/CTransferBox.cpp
@@ -39,7 +39,7 @@ CTransferBox::CTransferBox(TransferBoxType transferType) : m_GUI(g_pCore->GetGUI
 void CTransferBox::CreateTransferWindow()
 {
     // Find our largest piece of text, so we can size accordingly
-    std::string largeTextSample = m_titleProgressPrefix + " " + SString(_("%s of %s (Speed: %s)"), "999.99 kB", "999.99 kB", "999.99 kB");
+    std::string largeTextSample = m_titleProgressPrefix + " " + SString(_("%s of %s (%s)"), "999.99 kB", "999.99 kB", "999.99 kB");
     float       fTransferBoxWidth = m_GUI->GetTextExtent(largeTextSample.c_str(), "default-bold-small");
     fTransferBoxWidth = std::max<float>(fTransferBoxWidth, m_GUI->GetTextExtent(_("Disconnect to cancel download"), "default-normal"));
 
@@ -141,7 +141,7 @@ void CTransferBox::SetDownloadProgress(uint64_t downloadedSizeTotal)
     else
         speedStr = SString(_("%d B/s"), (int)m_smoothedSpeed);
 
-    SString progress = m_titleProgressPrefix + " " + SString(_("%s of %s (Speed: %s)"), current.c_str(), total.c_str(), speedStr.c_str());
+    SString progress = m_titleProgressPrefix + " " + SString(_("%s of %s (%s)"), current.c_str(), total.c_str(), speedStr.c_str());
     m_window->SetText(progress.c_str());
 
     if (m_downloadTotalSize > 0)

--- a/Client/mods/deathmatch/logic/CTransferBox.cpp
+++ b/Client/mods/deathmatch/logic/CTransferBox.cpp
@@ -39,7 +39,7 @@ CTransferBox::CTransferBox(TransferBoxType transferType) : m_GUI(g_pCore->GetGUI
 void CTransferBox::CreateTransferWindow()
 {
     // Find our largest piece of text, so we can size accordingly
-    std::string largeTextSample = m_titleProgressPrefix + " " + SString(_("%s of %s"), "999.99 kB", "999.99 kB");
+    std::string largeTextSample = m_titleProgressPrefix + " " + SString(_("%s of %s (Speed: %s)"), "999.99 kB", "999.99 kB", "999.99 kB");
     float       fTransferBoxWidth = m_GUI->GetTextExtent(largeTextSample.c_str(), "default-bold-small");
     fTransferBoxWidth = std::max<float>(fTransferBoxWidth, m_GUI->GetTextExtent(_("Disconnect to cancel download"), "default-normal"));
 
@@ -100,11 +100,54 @@ void CTransferBox::Hide()
 
 void CTransferBox::SetDownloadProgress(uint64_t downloadedSizeTotal)
 {
+    uint32_t currentTime = GetTickCount32();
+
+    if (m_lastTimeCheck == 0)
+    {
+        m_lastTimeCheck = currentTime;
+        m_lastDownloadedSize = downloadedSizeTotal;
+        m_smoothedSpeed = 0.0f;
+    }
+
+    uint32_t timeElapsed = currentTime - m_lastTimeCheck;
+
+    if (timeElapsed >= 250)
+    {
+        uint64_t bytesDelta = (downloadedSizeTotal > m_lastDownloadedSize) ? (downloadedSizeTotal - m_lastDownloadedSize) : 0;
+        float    instantaneousSpeed = (float)bytesDelta / (timeElapsed / 1000.0f);
+
+        if (m_smoothedSpeed == 0.0f)
+        {
+            m_smoothedSpeed = instantaneousSpeed;
+        }
+        else
+        {
+            float alpha = 0.2f;
+            m_smoothedSpeed = alpha * instantaneousSpeed + (1.0f - alpha) * m_smoothedSpeed;
+        }
+
+        m_lastDownloadedSize = downloadedSizeTotal;
+        m_lastTimeCheck = currentTime;
+    }
+
     SString current = GetDataUnit(downloadedSizeTotal);
     SString total = GetDataUnit(m_downloadTotalSize);
-    SString progress = m_titleProgressPrefix + " " + SString(_("%s of %s"), current.c_str(), total.c_str());
+
+    SString speedStr;
+    if (m_smoothedSpeed >= 1024.0f * 1024.0f)
+        speedStr = SString(_("%.2f MB/s"), m_smoothedSpeed / (1024.0f * 1024.0f));
+    else if (m_smoothedSpeed >= 1024.0f)
+        speedStr = SString(_("%.2f KB/s"), m_smoothedSpeed / 1024.0f);
+    else
+        speedStr = SString(_("%d B/s"), (int)m_smoothedSpeed);
+
+    SString progress = m_titleProgressPrefix + " " + SString(_("%s of %s (Speed: %s)"), current.c_str(), total.c_str(), speedStr.c_str());
     m_window->SetText(progress.c_str());
-    m_progressBar->SetProgress(static_cast<float>(static_cast<double>(downloadedSizeTotal) / m_downloadTotalSize));
+
+    if (m_downloadTotalSize > 0)
+    {
+        m_progressBar->SetProgress(static_cast<float>(static_cast<double>(downloadedSizeTotal) / m_downloadTotalSize));
+    }
 }
 
 void CTransferBox::DoPulse()

--- a/Client/mods/deathmatch/logic/CTransferBox.h
+++ b/Client/mods/deathmatch/logic/CTransferBox.h
@@ -69,4 +69,8 @@ private:
 
     std::bitset<TB_VISIBILITY_SOURCES_SIZE> m_visible;
     bool                                    m_alwaysVisible = true;
+
+    uint64_t m_lastDownloadedSize = 0;
+    uint32_t m_lastTimeCheck = 0;
+    float    m_smoothedSpeed = 0.0f;
 };


### PR DESCRIPTION
#### Summary
Introduces a real-time download speed calculation and display feature to the MTA transfer box UI. Players can now see their active resource and map download speeds formatted cleanly in GB/s, MB/s, KB/s, or B/s alongside the progress percentages.


#### Motivation
Previously, the transfer box showed only downloaded and total sizes, leaving players without a clear indication of their actual download performance or whether a slow download had stalled. This enhancement provides immediate, transparent feedback on network throughput during asset transfers.


#### Test plan
1. Compiled the MTA client source code locally.
2. Connected to a test server with large resources or map assets to trigger the transfer box.
3. Verified that the download speed is dynamically calculated and displayed in the window title.
4. Confirmed that the speed properly scales between B/s, KB/s, MB/s, and GB/s and remains stable.


#### Checklist
* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.


**Note: The prefix 'Speed:' has been removed, so now only the value itself is displayed e.g. (3.87 MB/s)**


<img width="1920" height="1080" alt="Screenshot 2026-09-01 004600" src="https://github.com/user-attachments/assets/c7f5ac13-a1fe-41ce-bbe5-170579931541" />