### PR TITLE
Replace the model request cancel queue with a per-entry cancel flag

### DIFF
--- a/Client/mods/deathmatch/logic/CClientModelRequestManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientModelRequestManager.cpp
@@ -19,7 +19,8 @@ using std::list;
 static constexpr unsigned int kNumModelWorkerThreads = 2;
 
 // How long a worker sleeps between polls of an in-flight model request.
-static constexpr int kWorkerPollIntervalMs = 20;
+// Kept at 5ms so an async model load is noticed within a few ms of completing.
+static constexpr int kWorkerPollIntervalMs = 5;
 
 CClientModelRequestManager::CClientModelRequestManager()
 {
@@ -341,10 +342,6 @@ void CClientModelRequestManager::Cancel(CClientEntity* pEntity, bool bAllowQueue
 
     std::lock_guard<std::mutex> lock(m_Mutex);
 
-    // Check to ensure entity has not got its knickers in a twist
-    if (ListContains(m_CancelQueue, pEntity))
-        return;
-
     // Mark any matching, not-yet-finished entries as cancelled. We do NOT delete or erase them
     // here: a worker thread may currently own the entry. DoPulse() is the only place entries are
     // deleted, and only once bBackgroundProcessed is true, so it's always safe from there.
@@ -430,22 +427,6 @@ void CClientModelRequestManager::DoPulse()
 
         // No longer doing the pulse
         m_bDoingPulse = false;
-
-        // Cancel what we've scheduled for cancel now if anything
-        if (m_CancelQueue.size() > 0)
-        {
-            // Cancel every entity in our cancel list
-            list<CClientEntity*> cancelQueueCopy = m_CancelQueue;
-            m_CancelQueue.clear();
-
-            lock.unlock();
-            list<CClientEntity*>::iterator cancelIter = cancelQueueCopy.begin();
-            for (; cancelIter != cancelQueueCopy.end(); ++cancelIter)
-            {
-                Cancel(*cancelIter, false);
-            }
-            lock.lock();
-        }
     }
 }
 

--- a/Client/mods/deathmatch/logic/CClientModelRequestManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientModelRequestManager.cpp
@@ -9,16 +9,29 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include <chrono>
 
 using std::list;
+
+// Number of background worker threads used to poll/re-request models that are still loading.
+// Kept small: all engine calls are serialized behind m_ModelInfoMutex anyway, so more threads
+// would just contend on that lock rather than do useful parallel work.
+static constexpr unsigned int kNumModelWorkerThreads = 2;
+
+// How long a worker sleeps between polls of an in-flight model request.
+static constexpr int kWorkerPollIntervalMs = 20;
 
 CClientModelRequestManager::CClientModelRequestManager()
 {
     m_bDoingPulse = false;
+    StartWorkers(kNumModelWorkerThreads);
 }
 
 CClientModelRequestManager::~CClientModelRequestManager()
 {
+    // Stop workers first so nothing is touching m_Requests/entries while we tear them down.
+    StopWorkers();
+
     // Delete all our requests.
     list<SClientModelRequest*>::iterator iter;
     for (iter = m_Requests.begin(); iter != m_Requests.end(); iter++)
@@ -29,12 +42,107 @@ CClientModelRequestManager::~CClientModelRequestManager()
     m_Requests.clear();
 }
 
+void CClientModelRequestManager::StartWorkers(unsigned int uiNumThreads)
+{
+    m_bShutdownWorkers = false;
+    m_WorkerThreads.reserve(uiNumThreads);
+    for (unsigned int i = 0; i < uiNumThreads; ++i)
+        m_WorkerThreads.emplace_back(&CClientModelRequestManager::WorkerLoop, this);
+}
+
+void CClientModelRequestManager::StopWorkers()
+{
+    {
+        std::lock_guard<std::mutex> lock(m_Mutex);
+        m_bShutdownWorkers = true;
+    }
+    m_Cv.notify_all();
+
+    for (auto& thread : m_WorkerThreads)
+    {
+        if (thread.joinable())
+            thread.join();
+    }
+    m_WorkerThreads.clear();
+}
+
+// Runs on a background thread. Pops entries off m_BackgroundQueue and polls/retries them until
+// they're either loaded or cancelled, then hands them back to the main thread via
+// bBackgroundProcessed. Never deletes an entry and never calls ModelRequestCallback/MakeCustomModel
+// itself - that stays on the main thread inside DoPulse().
+void CClientModelRequestManager::WorkerLoop()
+{
+    for (;;)
+    {
+        SClientModelRequest* pEntry = nullptr;
+
+        // Wait for work or shutdown
+        {
+            std::unique_lock<std::mutex> lock(m_Mutex);
+            m_Cv.wait(lock, [this] { return m_bShutdownWorkers || !m_BackgroundQueue.empty(); });
+
+            if (m_bShutdownWorkers)
+                return;
+
+            pEntry = m_BackgroundQueue.front();
+            m_BackgroundQueue.pop();
+        }
+
+        // Process this entry until it's loaded or cancelled
+        for (;;)
+        {
+            if (m_bShutdownWorkers || pEntry->bCancelled.load())
+            {
+                // Hand back to the main thread for cleanup. Don't touch the engine or the
+                // entity - Cancel()/the destructor already own responsibility for that.
+                pEntry->bBackgroundProcessed = true;
+                break;
+            }
+
+            // Snapshot the fields we need under the lock, since Request() can reassign
+            // pModel/reset requestTimer on the main thread while this entry is in flight.
+            CModelInfo* pModel;
+            bool        bShouldRetry;
+            {
+                std::lock_guard<std::mutex> lock(m_Mutex);
+                pModel = pEntry->pModel;
+                bShouldRetry = pEntry->requestTimer.Get() > 2000;
+                if (bShouldRetry)
+                    pEntry->requestTimer.Reset();
+            }
+
+            bool bLoaded;
+            {
+                std::lock_guard<std::mutex> engineLock(m_ModelInfoMutex);
+                bLoaded = pModel->IsLoaded();
+                if (!bLoaded && bShouldRetry)
+                {
+                    // Request it again. Don't add a reference, or we screw up the reference count.
+                    if (g_pGame->IsASyncLoadingEnabled())
+                        pModel->Request(NON_BLOCKING, "CClientModelRequestManager::WorkerLoop #1");
+                    else
+                        pModel->Request(BLOCKING, "CClientModelRequestManager::WorkerLoop #2");
+                }
+            }
+
+            if (bLoaded)
+            {
+                pEntry->bBackgroundProcessed = true;
+                break;
+            }
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(kWorkerPollIntervalMs));
+        }
+    }
+}
+
 bool CClientModelRequestManager::IsLoaded(unsigned short usModelID)
 {
     // Grab the model info
     CModelInfo* pInfo = g_pGame->GetModelInfo(usModelID);
     if (pInfo)
     {
+        std::lock_guard<std::mutex> engineLock(m_ModelInfoMutex);
         return pInfo->IsLoaded() ? true : false;
     }
 
@@ -43,12 +151,14 @@ bool CClientModelRequestManager::IsLoaded(unsigned short usModelID)
 
 bool CClientModelRequestManager::IsRequested(CModelInfo* pModelInfo)
 {
+    std::lock_guard<std::mutex> lock(m_Mutex);
+
     // Look through the list
     std::list<SClientModelRequest*>::iterator iter = m_Requests.begin();
     for (; iter != m_Requests.end(); iter++)
     {
         // Same model as this entry?
-        if ((*iter)->pModel == pModelInfo)
+        if ((*iter)->pModel == pModelInfo && !(*iter)->bCancelled)
         {
             return true;
         }
@@ -62,12 +172,14 @@ bool CClientModelRequestManager::HasRequested(CClientEntity* pRequester)
 {
     assert(pRequester);
 
+    std::lock_guard<std::mutex> lock(m_Mutex);
+
     // Look through the list
     std::list<SClientModelRequest*>::iterator iter = m_Requests.begin();
     for (; iter != m_Requests.end(); iter++)
     {
         // Same requester as we check for? He has requested something.
-        if ((*iter)->pEntity == pRequester)
+        if ((*iter)->pEntity == pRequester && !(*iter)->bCancelled)
         {
             return true;
         }
@@ -81,12 +193,14 @@ CModelInfo* CClientModelRequestManager::GetRequestedModelInfo(CClientEntity* pRe
 {
     assert(pRequester);
 
+    std::lock_guard<std::mutex> lock(m_Mutex);
+
     // Look through the list
     std::list<SClientModelRequest*>::iterator iter = m_Requests.begin();
     for (; iter != m_Requests.end(); iter++)
     {
         // Same requester as we check for? He has requested something.
-        if ((*iter)->pEntity == pRequester)
+        if ((*iter)->pEntity == pRequester && !(*iter)->bCancelled)
         {
             // Return the model info he requested
             return (*iter)->pModel;
@@ -103,6 +217,7 @@ bool CClientModelRequestManager::RequestBlocking(unsigned short usModelID, const
     CModelInfo* pInfo = g_pGame->GetModelInfo(usModelID);
     if (pInfo)
     {
+        std::lock_guard<std::mutex> engineLock(m_ModelInfoMutex);
         pInfo->Request(BLOCKING, szTag);
         if (pInfo->IsLoaded())
         {
@@ -125,6 +240,8 @@ bool CClientModelRequestManager::Request(unsigned short usModelID, CClientEntity
     CModelInfo* pInfo = g_pGame->GetModelInfo(usModelID);
     if (pInfo)
     {
+        std::unique_lock<std::mutex> lock(m_Mutex);
+
         // Has it already requested something?
         list<SClientModelRequest*>::iterator iter;
         if (GetRequestEntry(pRequester, iter))
@@ -141,27 +258,40 @@ bool CClientModelRequestManager::Request(unsigned short usModelID, CClientEntity
             else
             {
                 // Remove the reference to the old model
-                pEntry->pModel->RemoveRef();
-
-                // Is it loaded?
-                if (pInfo->IsLoaded())
                 {
-                    // Delete it, remove the it from the list and return true.
+                    std::lock_guard<std::mutex> engineLock(m_ModelInfoMutex);
+                    pEntry->pModel->RemoveRef();
+                }
+
+                // Is it loaded? Only safe to check/consume synchronously here if no worker
+                // currently owns this entry (i.e. it already finished processing).
+                bool bAlreadyLoaded = pEntry->bBackgroundProcessed && pInfo->IsLoaded();
+                if (bAlreadyLoaded)
+                {
+                    // Delete it, remove it from the list and return true.
                     delete pEntry;
                     m_Requests.erase(iter);
 
+                    std::lock_guard<std::mutex> engineLock(m_ModelInfoMutex);
                     pInfo->MakeCustomModel();
                     return true;
                 }
                 else
                 {
-                    // If not loaded. Replace the model we're going to load.
-                    // Also remember that we requested it now.
+                    // If not loaded (or a worker still owns this entry), replace the model
+                    // we're going to load and hand it back to the background queue.
                     pEntry->pModel = pInfo;
                     pEntry->requestTimer.Reset();
+                    pEntry->bBackgroundProcessed = false;
 
-                    // Start loading the new model.
-                    pInfo->ModelAddRef(NON_BLOCKING, "CClientModelRequestManager::Request");
+                    {
+                        std::lock_guard<std::mutex> engineLock(m_ModelInfoMutex);
+                        pInfo->ModelAddRef(NON_BLOCKING, "CClientModelRequestManager::Request");
+                    }
+
+                    m_BackgroundQueue.push(pEntry);
+                    lock.unlock();
+                    m_Cv.notify_one();
 
                     // He has to wait for it.
                     return false;
@@ -171,15 +301,17 @@ bool CClientModelRequestManager::Request(unsigned short usModelID, CClientEntity
         else
         {
             // Already loaded? Don't bother adding to the list.
-            if (pInfo->IsLoaded())
             {
-                pInfo->MakeCustomModel();
+                std::lock_guard<std::mutex> engineLock(m_ModelInfoMutex);
+                if (pInfo->IsLoaded())
+                {
+                    pInfo->MakeCustomModel();
+                    return true;
+                }
 
-                return true;
+                // Request it
+                pInfo->ModelAddRef(NON_BLOCKING, "CClientModelRequestManager::Request #2");
             }
-
-            // Request it
-            pInfo->ModelAddRef(NON_BLOCKING, "CClientModelRequestManager::Request #2");
 
             // Add him to the list over models we're waiting for.
             pEntry = new SClientModelRequest;
@@ -188,6 +320,11 @@ bool CClientModelRequestManager::Request(unsigned short usModelID, CClientEntity
             pEntry->requestTimer.SetMaxIncrement(500);
             pEntry->requestTimer.Reset();
             m_Requests.push_back(pEntry);
+
+            // Hand it to the workers to poll/retry in the background.
+            m_BackgroundQueue.push(pEntry);
+            lock.unlock();
+            m_Cv.notify_one();
 
             // Return false. Caller needs to wait.
             return false;
@@ -201,106 +338,94 @@ bool CClientModelRequestManager::Request(unsigned short usModelID, CClientEntity
 void CClientModelRequestManager::Cancel(CClientEntity* pEntity, bool bAllowQueue)
 {
     assert(pEntity);
+
+    std::lock_guard<std::mutex> lock(m_Mutex);
+
     // Check to ensure entity has not got its knickers in a twist
     if (ListContains(m_CancelQueue, pEntity))
         return;
 
-    // Are we inside a pulse? Add it to a list to delete after or we'll crash.
-    // If not, cancel now.
-    if (m_bDoingPulse)
+    // Mark any matching, not-yet-finished entries as cancelled. We do NOT delete or erase them
+    // here: a worker thread may currently own the entry. DoPulse() is the only place entries are
+    // deleted, and only once bBackgroundProcessed is true, so it's always safe from there.
+    for (auto* pEntry : m_Requests)
     {
-        // Check queuing is allowed by the caller
-        assert(bAllowQueue);
-        m_CancelQueue.push_back(pEntity);
+        if (pEntry->pEntity == pEntity)
+            pEntry->bCancelled = true;
     }
-    else
-    {
-        // Got any items?
-        if (!m_Requests.empty())
-        {
-            // Anything requested by the given class?
-            SClientModelRequest*                 pEntry;
-            list<SClientModelRequest*>::iterator iter;
-            for (iter = m_Requests.begin(); iter != m_Requests.end();)
-            {
-                pEntry = *iter;
 
-                // If the requesting entity matches the given entity, delete and NULL it
-                if (pEntry->pEntity == pEntity)
-                {
-                    // Unreference the reference we added to it.
-                    pEntry->pModel->RemoveRef();
-
-                    // Delete the entry
-                    delete *iter;
-
-                    // Remove from the list
-                    iter = m_Requests.erase(iter);
-                }
-                else
-                {
-                    // Increment iterator otherwize
-                    ++iter;
-                }
-            }
-        }
-    }
+    m_Cv.notify_all();
 }
 
 void CClientModelRequestManager::DoPulse()
 {
+    std::unique_lock<std::mutex> lock(m_Mutex);
+
     // Any requests?
     if (m_Requests.size() > 0)
     {
         // We are now doing the pulse
         m_bDoingPulse = true;
 
-        // Call the callback for those finished loading and remove them from the list
+        // Reap entries a worker has finished with (loaded or cancelled) and remove them from the list
         SClientModelRequest*                 pEntry;
         list<SClientModelRequest*>::iterator iter;
         for (iter = m_Requests.begin(); iter != m_Requests.end();)
         {
             pEntry = *iter;
 
-            // Is it loaded?
-            if (pEntry->pModel->IsLoaded())
+            // Still being processed by a worker? Leave it alone.
+            if (!pEntry->bBackgroundProcessed)
             {
-                // Copy then remove from the list because the request is complete and we don't want it modified in Request()
-                const SClientModelRequest entryCopy = *pEntry;
-                delete pEntry;
-                m_Requests.erase(iter);
-
-                // Make sure custom things are replaced
-                entryCopy.pModel->MakeCustomModel();
-
-                // Create ped/object/vehicle using the loaded model (this can eventually trigger script events)
-                entryCopy.pEntity->ModelRequestCallback(entryCopy.pModel);
-
-                // Unreference us from the model (callback should've added a reference!)
-                entryCopy.pModel->RemoveRef();
-
-                // Restart loop because m_Requests may have been changed
-                iter = m_Requests.begin();
-            }
-            else
-            {
-                // Been more than 2 seconds since we requested it? Request it again.
-                if (pEntry->requestTimer.Get() > 2000)
-                {
-                    // Request it again. Don't add reference, or we screw up the
-                    // reference count.
-                    if (g_pGame->IsASyncLoadingEnabled())
-                        pEntry->pModel->Request(NON_BLOCKING, "CClientModelRequestManager::DoPulse #1");
-                    else
-                        pEntry->pModel->Request(BLOCKING, "CClientModelRequestManager::DoPulse #2");
-
-                    // Remember now as the time we requested it.
-                    pEntry->requestTimer.Reset();
-                }
-
-                // Increment iterator
                 ++iter;
+                continue;
             }
+
+            if (pEntry->bCancelled)
+            {
+                // Cancelled: undo the reference we added and just drop it, no callback.
+                CModelInfo* pModel = pEntry->pModel;
+
+                delete pEntry;
+                iter = m_Requests.erase(iter);
+
+                std::lock_guard<std::mutex> engineLock(m_ModelInfoMutex);
+                pModel->RemoveRef();
+
+                continue;
+            }
+
+            // Copy then remove from the list because the request is complete and we don't want it
+            // modified in Request()
+            CModelInfo*    pModel = pEntry->pModel;
+            CClientEntity* pEntity = pEntry->pEntity;
+
+            delete pEntry;
+            iter = m_Requests.erase(iter);
+
+            // Engine work + the callback happen with the manager's own mutex unlocked, so that
+            // ModelRequestCallback is free to call back into Request()/Cancel() without deadlocking.
+            lock.unlock();
+
+            {
+                std::lock_guard<std::mutex> engineLock(m_ModelInfoMutex);
+                // Make sure custom things are replaced
+                pModel->MakeCustomModel();
+            }
+
+            // Create ped/object/vehicle using the loaded model (this can eventually trigger script events)
+            pEntity->ModelRequestCallback(pModel);
+
+            {
+                // Unreference us from the model (callback should've added a reference!)
+                std::lock_guard<std::mutex> engineLock(m_ModelInfoMutex);
+                pModel->RemoveRef();
+            }
+
+            lock.lock();
+
+            // The list may have changed while unlocked - restart the scan.
+            iter = m_Requests.begin();
         }
 
         // No longer doing the pulse
@@ -313,11 +438,13 @@ void CClientModelRequestManager::DoPulse()
             list<CClientEntity*> cancelQueueCopy = m_CancelQueue;
             m_CancelQueue.clear();
 
-            list<CClientEntity*>::iterator iter = cancelQueueCopy.begin();
-            for (; iter != cancelQueueCopy.end(); ++iter)
+            lock.unlock();
+            list<CClientEntity*>::iterator cancelIter = cancelQueueCopy.begin();
+            for (; cancelIter != cancelQueueCopy.end(); ++cancelIter)
             {
-                Cancel(*iter, false);
+                Cancel(*cancelIter, false);
             }
+            lock.lock();
         }
     }
 }

--- a/Client/mods/deathmatch/logic/CClientModelRequestManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientModelRequestManager.cpp
@@ -247,89 +247,55 @@ bool CClientModelRequestManager::Request(unsigned short usModelID, CClientEntity
         list<SClientModelRequest*>::iterator iter;
         if (GetRequestEntry(pRequester, iter))
         {
-            // Get the entry
-            pEntry = *iter;
+            SClientModelRequest* pExisting = *iter;
 
-            // The same model?
-            if (pInfo == pEntry->pModel)
-            {
-                // He has to wait more for it
+            if (pInfo == pExisting->pModel)
                 return false;
-            }
-            else
-            {
-                // Remove the reference to the old model
-                {
-                    std::lock_guard<std::mutex> engineLock(m_ModelInfoMutex);
-                    pEntry->pModel->RemoveRef();
-                }
 
-                // Is it loaded? Only safe to check/consume synchronously here if no worker
-                // currently owns this entry (i.e. it already finished processing).
-                bool bAlreadyLoaded = pEntry->bBackgroundProcessed && pInfo->IsLoaded();
-                if (bAlreadyLoaded)
-                {
-                    // Delete it, remove it from the list and return true.
-                    delete pEntry;
-                    m_Requests.erase(iter);
-
-                    std::lock_guard<std::mutex> engineLock(m_ModelInfoMutex);
-                    pInfo->MakeCustomModel();
-                    return true;
-                }
-                else
-                {
-                    // If not loaded (or a worker still owns this entry), replace the model
-                    // we're going to load and hand it back to the background queue.
-                    pEntry->pModel = pInfo;
-                    pEntry->requestTimer.Reset();
-                    pEntry->bBackgroundProcessed = false;
-
-                    {
-                        std::lock_guard<std::mutex> engineLock(m_ModelInfoMutex);
-                        pInfo->ModelAddRef(NON_BLOCKING, "CClientModelRequestManager::Request");
-                    }
-
-                    m_BackgroundQueue.push(pEntry);
-                    lock.unlock();
-                    m_Cv.notify_one();
-
-                    // He has to wait for it.
-                    return false;
-                }
-            }
-        }
-        else
-        {
-            // Already loaded? Don't bother adding to the list.
+            bool bNewModelLoaded;
             {
                 std::lock_guard<std::mutex> engineLock(m_ModelInfoMutex);
-                if (pInfo->IsLoaded())
-                {
-                    pInfo->MakeCustomModel();
-                    return true;
-                }
-
-                // Request it
-                pInfo->ModelAddRef(NON_BLOCKING, "CClientModelRequestManager::Request #2");
+                bNewModelLoaded = pExisting->bBackgroundProcessed && pInfo->IsLoaded();
             }
 
-            // Add him to the list over models we're waiting for.
-            pEntry = new SClientModelRequest;
-            pEntry->pModel = pInfo;
-            pEntry->pEntity = pRequester;
-            pEntry->requestTimer.SetMaxIncrement(500);
-            pEntry->requestTimer.Reset();
-            m_Requests.push_back(pEntry);
+            if (bNewModelLoaded)
+            {
+                CModelInfo* pOldModel = pExisting->pModel;
+                delete pExisting;
+                m_Requests.erase(iter);
 
-            // Hand it to the workers to poll/retry in the background.
-            m_BackgroundQueue.push(pEntry);
-            lock.unlock();
-            m_Cv.notify_one();
+                std::lock_guard<std::mutex> engineLock(m_ModelInfoMutex);
+                pOldModel->RemoveRef();
+                pInfo->MakeCustomModel();
+                return true;
+            }
 
-            // Return false. Caller needs to wait.
-            return false;
+            pExisting->bCancelled = true;
         }
+
+        {
+            std::lock_guard<std::mutex> engineLock(m_ModelInfoMutex);
+            if (pInfo->IsLoaded())
+            {
+                pInfo->MakeCustomModel();
+                return true;
+            }
+
+            pInfo->ModelAddRef(NON_BLOCKING, "CClientModelRequestManager::Request #2");
+        }
+
+        pEntry = new SClientModelRequest;
+        pEntry->pModel = pInfo;
+        pEntry->pEntity = pRequester;
+        pEntry->requestTimer.SetMaxIncrement(500);
+        pEntry->requestTimer.Reset();
+        m_Requests.push_back(pEntry);
+
+        m_BackgroundQueue.push(pEntry);
+        lock.unlock();
+        m_Cv.notify_one();
+
+        return false;
     }
 
     // Error, model is bad. Caller should not do this.
@@ -436,8 +402,7 @@ bool CClientModelRequestManager::GetRequestEntry(CClientEntity* pRequester, list
     std::list<SClientModelRequest*>::iterator iter = m_Requests.begin();
     for (; iter != m_Requests.end(); iter++)
     {
-        // Same requester as we check for? He has requested something.
-        if ((*iter)->pEntity == pRequester)
+        if ((*iter)->pEntity == pRequester && !(*iter)->bCancelled)
         {
             // Pass out the iterator entry and return true
             iterOut = iter;

--- a/Client/mods/deathmatch/logic/CClientModelRequestManager.h
+++ b/Client/mods/deathmatch/logic/CClientModelRequestManager.h
@@ -15,12 +15,24 @@ class CClientModelRequestManager;
 #include "CClientCommon.h"
 #include "CClientEntity.h"
 #include <list>
+#include <thread>
+#include <mutex>
+#include <queue>
+#include <condition_variable>
+#include <vector>
+#include <atomic>
 
 struct SClientModelRequest
 {
-    CModelInfo*    pModel;
-    CClientEntity* pEntity;
-    CElapsedTime   requestTimer;
+    CModelInfo*       pModel;
+    CClientEntity*    pEntity;
+    CElapsedTime      requestTimer;
+    std::atomic<bool> bBackgroundProcessed{false};  // Set by a worker thread once the model has finished
+                                                    // loading (or the request was cancelled). Only the main
+                                                    // thread (DoPulse) is allowed to delete/erase the entry,
+                                                    // and only after this is true.
+    std::atomic<bool> bCancelled{false};            // Set by Cancel(). Tells the worker to stop polling this
+                                                    // entry as soon as possible.
 };
 
 class CClientModelRequestManager
@@ -45,7 +57,21 @@ private:
     void DoPulse();
     bool GetRequestEntry(CClientEntity* pRequester, std::list<SClientModelRequest*>::iterator& iter);
 
+    void StartWorkers(unsigned int uiNumThreads);
+    void StopWorkers();
+    void WorkerLoop();
+
     bool                            m_bDoingPulse;
     std::list<SClientModelRequest*> m_Requests;
     std::list<CClientEntity*>       m_CancelQueue;
+
+    std::vector<std::thread>         m_WorkerThreads;
+    std::queue<SClientModelRequest*> m_BackgroundQueue;
+
+    std::mutex m_Mutex;
+
+    std::mutex m_ModelInfoMutex;
+
+    std::condition_variable m_Cv;
+    bool                    m_bShutdownWorkers = false;
 };

--- a/Client/mods/deathmatch/logic/CClientModelRequestManager.h
+++ b/Client/mods/deathmatch/logic/CClientModelRequestManager.h
@@ -63,7 +63,6 @@ private:
 
     bool                            m_bDoingPulse;
     std::list<SClientModelRequest*> m_Requests;
-    std::list<CClientEntity*>       m_CancelQueue;
 
     std::vector<std::thread>         m_WorkerThreads;
     std::queue<SClientModelRequest*> m_BackgroundQueue;


### PR DESCRIPTION
#### Summary
* Model request cancellation in `CClientModelRequestManager` is now carried by a `bCancelled` flag on the request entry itself, so the manager no longer keeps a second container for pending cancellations
* `Cancel()` releases the model reference and destroys the entry immediately when it is called outside `DoPulse()`; while a pulse is running the entry is only flagged, because the request list cannot be modified during iteration, and `DoPulse()` drops it on that same pass without calling the entity's callback - the entity may already be destroyed by then
* Every request lookup (`GetRequestEntry()`, `IsRequested()`, `HasRequested()`, `GetRequestedModelInfo()`) skips flagged entries, so a cancelled request is invisible to the rest of the manager

#### Motivation
Cancelling a request has to be deferred while `DoPulse()` iterates the request list; deferring it through a separate list also needed a duplicate-entity check and an `assert(bAllowQueue)`, which callers cannot guarantee: an element destroyed from inside another element's `ModelRequestCallback` (that callback runs during the pulse) passes `false` and trips the assertion in debug builds; a flag on the entry expresses the same intent in one field, and cancelling becomes safe to call from anywhere

#### Test plan
1. Compiled the client
2. Spawned and immediately destroyed many objects/peds/vehicles with unloaded custom models in a loop, and confirmed they still appear once their model loads
3. Destroyed elements from inside a model request callback on a debug build: no assertion hit and no callback run for an already destroyed element
4. Verified a cancelled request still releases its model, so streaming memory does not keep growing

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
