### PR TITLE
Fix server crash when parsing large JSON strings in fromJSON

### DIFF
--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
@@ -493,6 +493,13 @@ int CLuaUtilDefs::fromJSON(lua_State* luaVM)
 
     if (!argStream.HasErrors())
     {
+        if (strJson.length() > 512 * 1024)
+        {
+            m_pScriptDebugging->LogError(luaVM, "JSON string is too large and may cause server crash (>512KB).");
+            lua_pushnil(luaVM);
+            return 1;
+        }
+
         // Read it into lua arguments
         CLuaArguments Converted;
         if (Converted.ReadFromJSONString(strJson))


### PR DESCRIPTION
#### Summary
Added a safety size check (max 512KB) inside `CLuaUtilDefs::fromJSON` to prevent server freezes and crashes caused by excessively large JSON strings.
Resolves issue #5287.


#### Motivation
Parsing extremely large JSON strings (e.g., 600KB+) all at once synchronously blocks the main thread and creates a massive amount of `CLuaArgument` objects dynamically, leading to out-of-memory or watchdog timeouts (server crash).


#### Test plan
1. Compiled the MTA client source code locally.
2. Test `fromJSON` with standard small/medium JSON strings to ensure normal functionality remains unaffected.
3. Test `fromJSON` with a JSON payload exceeding 512KB and verify that it safely catches the limit, and logs a error message instead of crashing the server.


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
