### PR TITLE
Fix frame drops caused by objects in another dimension

### DIFF
--- a/Client/mods/deathmatch/logic/CClientStreamElement.cpp
+++ b/Client/mods/deathmatch/logic/CClientStreamElement.cpp
@@ -217,8 +217,8 @@ float CClientStreamElement::GetDistanceToBoundingBoxSquared(const CVector& vecPo
         m_iCachedRadiusCounter = 20 + rand() % 50;
     }
 
-    // Do a simple calculation if the element has a small radius
-    if (m_fCachedRadius < 20)
+    // Do a simple calculation if the element has a small radius, or is streamed out in another dimension and cannot stream in
+    if (m_fCachedRadius < 20 || (!IsStreamedIn() && !IsVisibleInAllDimensions() && GetDimension() != m_pStreamer->GetDimension()))
     {
         return (GetStreamPosition() - vecPosition).LengthSquared();
     }


### PR DESCRIPTION
#### Summary

Objects sitting in another dimension still cost frame time, and the cost scales with the model's bounding radius. `CClientStreamer::DoPulse` recomputes every active element's distance each frame before `Restream` looks at the dimension, and for a radius of 20 or more that means an entity matrix fetch plus an oriented box distance - work whose result is thrown away a few lines later.

Use the plain squared distance for elements that are streamed out and in another dimension. It is never smaller than the box distance, so nothing sorts closer than before, and those elements can't stream in anyway.

The condition is the negation of the stream-in gate in `Restream` (`CClientStreamer.cpp:489`), and the same expression already appears in `CClientObject.cpp:238`, `CClientPed.cpp:4197` and `CClientVehicle.cpp:3210`.

#### Motivation

Fixes #5261. Same setup as reported: 5000 x model 4449 (radius 330) in dimension 1, nothing rendered.

#### Test plan

Empty sky view so nothing renders and the streamer is the only cost; 15 s frame count per phase, each load phase bracketed by empty phases; server `fpslimit` 0, vsync off.

| | before | after |
|---|---|---|
| 5000 x model 4449 (radius 330), dimension 1 | **+3.2 ms/frame** (1205 -> 248 fps) | **+0.5-0.7 ms/frame** (1235 -> 663-781 fps, two sessions) |
| 5000 x model 1337 (radius 0.8), dimension 1 | +0.4 ms/frame | +0.4 ms/frame |

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
