### PR TITLE
Fix hitching every 300 units when many objects are around

### DIFF
--- a/Client/mods/deathmatch/logic/CClientStreamSector.cpp
+++ b/Client/mods/deathmatch/logic/CClientStreamSector.cpp
@@ -158,11 +158,15 @@ void CClientStreamSector::AddElements(list<CClientStreamElement*>* pList, std::u
 
 void CClientStreamSector::RemoveElements(list<CClientStreamElement*>* pList, std::unordered_set<CClientStreamElement*>* pSet)
 {
-    list<CClientStreamElement*>::iterator iter = m_Elements.begin();
-    for (; iter != m_Elements.end(); iter++)
+    if (m_Elements.empty())
+        return;
+
+    if (pSet)
     {
-        pList->remove(*iter);
-        if (pSet)
-            pSet->erase(*iter);
+        for (CClientStreamElement* pElement : m_Elements)
+            pSet->erase(pElement);
     }
+
+    // list::remove per element walks the whole active list each time, so strip our elements in a single pass
+    pList->remove_if([this](CClientStreamElement* pElement) { return pElement->GetStreamSector() == this; });
 }


### PR DESCRIPTION
#### Summary

Crossing a sector boundary (every 300 units) hitches when there are many objects around, and the hitch grows with their count - even for objects in another dimension. When `OnEnterSector` deactivates a sector, `RemoveElements` called `list::remove` once per element, each walking the whole active list: k x n steps per crossing.

Each element already records the sector it is in, so the active list can be stripped in a single `remove_if` pass instead: k + n. `CClientStreamer::OnElementEnterSector` is the only writer of both the sector's element list and that back pointer, and it sets them together, so they cannot disagree. The active-element set is maintained as before.

#### Motivation

Fixes #5262. This is the half #4695 left behind - it added the active-element set and made `AddElements` O(1), but `RemoveElements` kept calling `list::remove` per element.

Same setup as reported: 8000 x model 1337 along a line, then moving through them.

#### Test plan

Flying along the reported line (8000 x 1337, x 1000-2600, z 200) at 120 units/s, frame time at each sector boundary (x = 1500, 1800, 2100, 2400) against the same run's empty pass. Server `fpslimit` 0, vsync off, three sessions per build.

| objects in dimension 88 | before | after |
|---|---|---|
| spike at each boundary, over the empty pass | **+5 to +14 ms** | **0 to +2 ms** |
| average frame time away from boundaries | +0.4 ms | +0.4 ms (unchanged, that is #5261) |

In the player's own dimension the boundary frames went from 9-13 ms to 5-6 ms; the odd 40-50 ms frame there is GTA loading the models that actually stream in, present before and after.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
