### PR TITLE
Allow unlisted local files in CEF

### DIFF
--- a/Client/mods/deathmatch/logic/CClientWebBrowser.cpp
+++ b/Client/mods/deathmatch/logic/CClientWebBrowser.cpp
@@ -338,8 +338,8 @@ bool CClientWebBrowser::Events_OnResourceFileCheck(const SString& strPath, CBuff
     // Allow unlisted or non-downloaded files if they belong to the owning resource
     if (pFile == nullptr)
     {
-        const std::filesystem::path resourceDir = std::filesystem::path(m_pResource->GetResourceDirectoryPath(ACCESS_PUBLIC, "")).lexically_normal();
-        const std::filesystem::path targetFilePath = std::filesystem::path(strPath).lexically_normal();
+        const std::filesystem::path resourceDir = std::filesystem::path(m_pResource->GetResourceDirectoryPath(ACCESS_PUBLIC, "").c_str()).lexically_normal();
+        const std::filesystem::path targetFilePath = std::filesystem::path(strPath.c_str()).lexically_normal();
 
         SString localResourceDir = PathConform(resourceDir.string()).Replace("\\", "/");
         if (!localResourceDir.EndsWith("/"))

--- a/Client/mods/deathmatch/logic/CClientWebBrowser.cpp
+++ b/Client/mods/deathmatch/logic/CClientWebBrowser.cpp
@@ -338,11 +338,14 @@ bool CClientWebBrowser::Events_OnResourceFileCheck(const SString& strPath, CBuff
     // Allow unlisted or non-downloaded files if they belong to the owning resource
     if (pFile == nullptr)
     {
-        SString localResourceDir = PathConform(m_pResource->GetResourceDirectoryPath(ACCESS_PUBLIC, "")).Replace("\\", "/");
+        const std::filesystem::path resourceDir = std::filesystem::path(m_pResource->GetResourceDirectoryPath(ACCESS_PUBLIC, "")).lexically_normal();
+        const std::filesystem::path targetFilePath = std::filesystem::path(strPath).lexically_normal();
+
+        SString localResourceDir = PathConform(resourceDir.string()).Replace("\\", "/");
         if (!localResourceDir.EndsWith("/"))
             localResourceDir += "/";
 
-        const SString normalizedPath = PathConform(strPath).Replace("\\", "/");
+        const SString normalizedPath = PathConform(targetFilePath.string()).Replace("\\", "/");
         if (!normalizedPath.BeginsWithI(localResourceDir))
             return false;
 

--- a/Client/mods/deathmatch/logic/CClientWebBrowser.cpp
+++ b/Client/mods/deathmatch/logic/CClientWebBrowser.cpp
@@ -334,20 +334,12 @@ bool CClientWebBrowser::Events_OnResourcePathCheck(SString& strURL)
 
 bool CClientWebBrowser::Events_OnResourceFileCheck(const SString& strPath, CBuffer& outFileData)
 {
-    if (m_bBeingDestroyed)
+    if (m_bBeingDestroyed || !m_pResource)
         return false;
-
-    if (!m_pResource)
-    {
-        if (!FileExists(strPath))
-            return false;
-
-        return outFileData.LoadFromFile(strPath);
-    }
 
     auto pFile = g_pClientGame->GetResourceManager()->GetDownloadableResourceFile(strPath.ToLower());
 
-    // Script or user generated file not in meta.xml
+    // Allow unlisted or non-downloaded files if they belong to the owning resource
     if (pFile == nullptr)
     {
         SString localResourceDir = PathConform(m_pResource->GetResourceDirectoryPath(ACCESS_PUBLIC, "")).Replace("\\", "/");

--- a/Client/mods/deathmatch/logic/CClientWebBrowser.cpp
+++ b/Client/mods/deathmatch/logic/CClientWebBrowser.cpp
@@ -337,15 +337,32 @@ bool CClientWebBrowser::Events_OnResourceFileCheck(const SString& strPath, CBuff
     if (m_bBeingDestroyed)
         return false;
 
-    // If no resource is set, we do not require to verify the file
     if (!m_pResource)
-        return true;
+    {
+        if (!FileExists(strPath))
+            return false;
+
+        return outFileData.LoadFromFile(strPath);
+    }
 
     auto pFile = g_pClientGame->GetResourceManager()->GetDownloadableResourceFile(strPath.ToLower());
 
-    // If we did not download this file, it has been script or user generated, nothing to verify for us
+    // Script or user generated file not in meta.xml
     if (pFile == nullptr)
-        return true;
+    {
+        SString localResourceDir = PathConform(m_pResource->GetResourceDirectoryPath(ACCESS_PUBLIC, "")).Replace("\\", "/");
+        if (!localResourceDir.EndsWith("/"))
+            localResourceDir += "/";
+
+        const SString normalizedPath = PathConform(strPath).Replace("\\", "/");
+        if (!normalizedPath.BeginsWithI(localResourceDir))
+            return false;
+
+        if (!FileExists(strPath))
+            return false;
+
+        return outFileData.LoadFromFile(strPath);
+    }
 
     pFile->GenerateClientChecksum(outFileData);
     return pFile->DoesClientAndServerChecksumMatch();

--- a/Client/mods/deathmatch/logic/CClientWebBrowser.cpp
+++ b/Client/mods/deathmatch/logic/CClientWebBrowser.cpp
@@ -317,12 +317,8 @@ void CClientWebBrowser::Events_OnInputFocusChanged(bool bGainedFocus)
 
 bool CClientWebBrowser::Events_OnResourcePathCheck(SString& strURL)
 {
-    if (m_bBeingDestroyed)
+    if (m_bBeingDestroyed || !m_pResource)
         return false;
-
-    // If no resource is set, we are allowed to use the requested file
-    if (!m_pResource)
-        return true;
 
     CResource* pTempResource = m_pResource;  // Make a copy to ignore a changed resource
 


### PR DESCRIPTION
Relates to #5286

#### Before & After
<img width="300" height="220" alt="image" src="https://github.com/user-attachments/assets/cb585a1b-e8a0-4bbd-be5a-21879282c82a" />||||<img width="300" height="220" alt="image" src="https://github.com/user-attachments/assets/f79c3c64-2c8d-413e-96d8-4672ae1c7bb6" />

As discussed on [Discord](https://discord.com/channels/801330706252038164/801411628600000522/1544010407314989096), this allows CEF browsers to load local files from their owning resource without listing them in `meta.xml`, such as dynamic images, downloads, or other local assets.

Access is limited to the owning resource folder. Files from other resources must still be declared in `meta.xml`.

### Testing

[test_cef_local_files.zip](https://github.com/user-attachments/files/31752141/test_cef_local_files.zip)
