### PR TITLE
Fix fromJSON crash with large data

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
@@ -190,6 +190,40 @@ void CLuaArguments::PushAsTable(lua_State* luaVM, CFastHashMap<CLuaArguments*, i
     }
 }
 
+void CLuaArguments::PushArgumentsAsTable(lua_State* luaVM) const
+{
+    LUA_CHECKSTACK(luaVM, 4);
+
+    CFastHashMap<CLuaArguments*, int> knownTables;
+
+    lua_newtable(luaVM);
+    lua_setfield(luaVM, LUA_REGISTRYINDEX, "cache");
+
+    lua_newtable(luaVM);
+
+    const int tableId = static_cast<int>(knownTables.size()) + 1;
+
+    lua_getfield(luaVM, LUA_REGISTRYINDEX, "cache");
+    lua_pushnumber(luaVM, tableId);
+    lua_pushvalue(luaVM, -3);
+    lua_settable(luaVM, -3);
+    lua_pop(luaVM, 1);
+
+    knownTables.insert(std::make_pair(const_cast<CLuaArguments*>(this), tableId));
+
+    int index = 1;
+
+    for (auto iter = m_Arguments.begin(); iter != m_Arguments.end(); ++iter)
+    {
+        (*iter)->Push(luaVM, &knownTables);
+        lua_rawseti(luaVM, -2, index++);
+    }
+
+    // Clear temporary registry cache
+    lua_pushnil(luaVM);
+    lua_setfield(luaVM, LUA_REGISTRYINDEX, "cache");
+}
+
 void CLuaArguments::PushArguments(const CLuaArguments& Arguments)
 {
     for (CLuaArgument* arg : Arguments)

--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.cpp
@@ -144,16 +144,18 @@ void CLuaArguments::PushArguments(lua_State* luaVM) const
     }
 }
 
-void CLuaArguments::PushAsTable(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKnownTables) const
+void CLuaArguments::PushAsTable(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKnownTables, bool isArray) const
 {
     // Ensure there is enough space on the Lua stack
     LUA_CHECKSTACK(luaVM, 4);
 
-    bool bKnownTablesCreated = false;
+    bool                              usedLocalKnownTables = false;
+    CFastHashMap<CLuaArguments*, int> localKnownTables;
+
     if (!pKnownTables)
     {
-        pKnownTables = new CFastHashMap<CLuaArguments*, int>();
-        bKnownTablesCreated = true;
+        pKnownTables = &localKnownTables;
+        usedLocalKnownTables = true;
 
         lua_newtable(luaVM);
         // using registry to make it fail safe, else we'd have to carry
@@ -172,56 +174,34 @@ void CLuaArguments::PushAsTable(lua_State* luaVM, CFastHashMap<CLuaArguments*, i
     lua_pop(luaVM, 1);
     pKnownTables->insert(std::make_pair((CLuaArguments*)this, size));
 
-    vector<CLuaArgument*>::const_iterator iter = m_Arguments.begin();
-    for (; iter != m_Arguments.end() && (iter + 1) != m_Arguments.end(); iter++)
+    // map
+    if (!isArray)
     {
-        (*iter)->Push(luaVM, pKnownTables);  // index
-        iter++;
-        (*iter)->Push(luaVM, pKnownTables);  // value
-        lua_settable(luaVM, -3);
+        vector<CLuaArgument*>::const_iterator iter = m_Arguments.begin();
+        for (; iter != m_Arguments.end() && (iter + 1) != m_Arguments.end(); iter++)
+        {
+            (*iter)->Push(luaVM, pKnownTables);  // index
+            iter++;
+            (*iter)->Push(luaVM, pKnownTables);  // value
+            lua_settable(luaVM, -3);
+        }
+    }
+    else  // array
+    {
+        int index = 1;
+        for (auto iter = m_Arguments.begin(); iter != m_Arguments.end(); ++iter)
+        {
+            (*iter)->Push(luaVM, pKnownTables);
+            lua_rawseti(luaVM, -2, index++);
+        }
     }
 
-    if (bKnownTablesCreated)
+    if (usedLocalKnownTables)
     {
         // clear the cache
         lua_pushnil(luaVM);
         lua_setfield(luaVM, LUA_REGISTRYINDEX, "cache");
-        delete pKnownTables;
     }
-}
-
-void CLuaArguments::PushArgumentsAsTable(lua_State* luaVM) const
-{
-    LUA_CHECKSTACK(luaVM, 4);
-
-    CFastHashMap<CLuaArguments*, int> knownTables;
-
-    lua_newtable(luaVM);
-    lua_setfield(luaVM, LUA_REGISTRYINDEX, "cache");
-
-    lua_newtable(luaVM);
-
-    const int tableId = static_cast<int>(knownTables.size()) + 1;
-
-    lua_getfield(luaVM, LUA_REGISTRYINDEX, "cache");
-    lua_pushnumber(luaVM, tableId);
-    lua_pushvalue(luaVM, -3);
-    lua_settable(luaVM, -3);
-    lua_pop(luaVM, 1);
-
-    knownTables.insert(std::make_pair(const_cast<CLuaArguments*>(this), tableId));
-
-    int index = 1;
-
-    for (auto iter = m_Arguments.begin(); iter != m_Arguments.end(); ++iter)
-    {
-        (*iter)->Push(luaVM, &knownTables);
-        lua_rawseti(luaVM, -2, index++);
-    }
-
-    // Clear temporary registry cache
-    lua_pushnil(luaVM);
-    lua_setfield(luaVM, LUA_REGISTRYINDEX, "cache");
 }
 
 void CLuaArguments::PushArguments(const CLuaArguments& Arguments)

--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -52,8 +52,7 @@ public:
     bool CallGlobal(class CLuaMain* pLuaMain, const char* szFunction, CLuaArguments* returnValues = NULL) const;
 
     void ReadTable(lua_State* luaVM, int iIndexBegin, CFastHashMap<const void*, CLuaArguments*>* pKnownTables = NULL);
-    void PushAsTable(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKnownTables = nullptr) const;
-    void PushArgumentsAsTable(lua_State* luaVM) const;
+    void PushAsTable(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKnownTables = nullptr, bool isArray = false) const;
 
     CLuaArgument* PushNil();
     CLuaArgument* PushBoolean(bool bBool);

--- a/Client/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -53,6 +53,7 @@ public:
 
     void ReadTable(lua_State* luaVM, int iIndexBegin, CFastHashMap<const void*, CLuaArguments*>* pKnownTables = NULL);
     void PushAsTable(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKnownTables = nullptr) const;
+    void PushArgumentsAsTable(lua_State* luaVM) const;
 
     CLuaArgument* PushNil();
     CLuaArgument* PushBoolean(bool bBool);

--- a/Server/mods/deathmatch/logic/lua/CLuaArguments.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaArguments.cpp
@@ -195,6 +195,40 @@ void CLuaArguments::PushAsTable(lua_State* luaVM, CFastHashMap<CLuaArguments*, i
     }
 }
 
+void CLuaArguments::PushArgumentsAsTable(lua_State* luaVM) const
+{
+    LUA_CHECKSTACK(luaVM, 4);
+
+    CFastHashMap<CLuaArguments*, int> knownTables;
+
+    lua_newtable(luaVM);
+    lua_setfield(luaVM, LUA_REGISTRYINDEX, "cache");
+
+    lua_newtable(luaVM);
+
+    const int tableId = static_cast<int>(knownTables.size()) + 1;
+
+    lua_getfield(luaVM, LUA_REGISTRYINDEX, "cache");
+    lua_pushnumber(luaVM, tableId);
+    lua_pushvalue(luaVM, -3);
+    lua_settable(luaVM, -3);
+    lua_pop(luaVM, 1);
+
+    knownTables.insert(std::make_pair(const_cast<CLuaArguments*>(this), tableId));
+
+    int index = 1;
+
+    for (auto iter = m_Arguments.begin(); iter != m_Arguments.end(); ++iter)
+    {
+        (*iter)->Push(luaVM, &knownTables);
+        lua_rawseti(luaVM, -2, index++);
+    }
+
+    // Clear temporary registry cache
+    lua_pushnil(luaVM);
+    lua_setfield(luaVM, LUA_REGISTRYINDEX, "cache");
+}
+
 void CLuaArguments::PushArguments(const CLuaArguments& Arguments)
 {
     for (CLuaArgument* argument : Arguments)

--- a/Server/mods/deathmatch/logic/lua/CLuaArguments.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaArguments.cpp
@@ -149,16 +149,18 @@ void CLuaArguments::PushArguments(lua_State* luaVM) const
     }
 }
 
-void CLuaArguments::PushAsTable(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKnownTables) const
+void CLuaArguments::PushAsTable(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKnownTables, bool isArray) const
 {
     // Ensure there is enough space on the Lua stack
     LUA_CHECKSTACK(luaVM, 4);
 
-    bool bKnownTablesCreated = false;
+    bool                              usedLocalKnownTables = false;
+    CFastHashMap<CLuaArguments*, int> localKnownTables;
+
     if (!pKnownTables)
     {
-        pKnownTables = new CFastHashMap<CLuaArguments*, int>();
-        bKnownTablesCreated = true;
+        pKnownTables = &localKnownTables;
+        usedLocalKnownTables = true;
 
         lua_newtable(luaVM);
         // using registry to make it fail safe, else we'd have to carry
@@ -177,56 +179,34 @@ void CLuaArguments::PushAsTable(lua_State* luaVM, CFastHashMap<CLuaArguments*, i
     lua_pop(luaVM, 1);
     pKnownTables->insert(std::make_pair((CLuaArguments*)this, size));
 
-    std::vector<CLuaArgument*>::const_iterator iter = m_Arguments.begin();
-    for (; iter != m_Arguments.end() && (iter + 1) != m_Arguments.end(); ++iter)
+    // map
+    if (!isArray)
     {
-        (*iter)->Push(luaVM, pKnownTables);  // index
-        ++iter;
-        (*iter)->Push(luaVM, pKnownTables);  // value
-        lua_settable(luaVM, -3);
+        vector<CLuaArgument*>::const_iterator iter = m_Arguments.begin();
+        for (; iter != m_Arguments.end() && (iter + 1) != m_Arguments.end(); iter++)
+        {
+            (*iter)->Push(luaVM, pKnownTables);  // index
+            iter++;
+            (*iter)->Push(luaVM, pKnownTables);  // value
+            lua_settable(luaVM, -3);
+        }
+    }
+    else  // array
+    {
+        int index = 1;
+        for (auto iter = m_Arguments.begin(); iter != m_Arguments.end(); ++iter)
+        {
+            (*iter)->Push(luaVM, pKnownTables);
+            lua_rawseti(luaVM, -2, index++);
+        }
     }
 
-    if (bKnownTablesCreated)
+    if (usedLocalKnownTables)
     {
         // clear the cache
         lua_pushnil(luaVM);
         lua_setfield(luaVM, LUA_REGISTRYINDEX, "cache");
-        delete pKnownTables;
     }
-}
-
-void CLuaArguments::PushArgumentsAsTable(lua_State* luaVM) const
-{
-    LUA_CHECKSTACK(luaVM, 4);
-
-    CFastHashMap<CLuaArguments*, int> knownTables;
-
-    lua_newtable(luaVM);
-    lua_setfield(luaVM, LUA_REGISTRYINDEX, "cache");
-
-    lua_newtable(luaVM);
-
-    const int tableId = static_cast<int>(knownTables.size()) + 1;
-
-    lua_getfield(luaVM, LUA_REGISTRYINDEX, "cache");
-    lua_pushnumber(luaVM, tableId);
-    lua_pushvalue(luaVM, -3);
-    lua_settable(luaVM, -3);
-    lua_pop(luaVM, 1);
-
-    knownTables.insert(std::make_pair(const_cast<CLuaArguments*>(this), tableId));
-
-    int index = 1;
-
-    for (auto iter = m_Arguments.begin(); iter != m_Arguments.end(); ++iter)
-    {
-        (*iter)->Push(luaVM, &knownTables);
-        lua_rawseti(luaVM, -2, index++);
-    }
-
-    // Clear temporary registry cache
-    lua_pushnil(luaVM);
-    lua_setfield(luaVM, LUA_REGISTRYINDEX, "cache");
 }
 
 void CLuaArguments::PushArguments(const CLuaArguments& Arguments)

--- a/Server/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -65,6 +65,7 @@ public:
 
     void ReadTable(lua_State* luaVM, int iIndexBegin, CFastHashMap<const void*, CLuaArguments*>* pKnownTables = NULL);
     void PushAsTable(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKnownTables = nullptr) const;
+    void PushArgumentsAsTable(lua_State* luaVM) const;
 
     CLuaArgument* PushNil();
     CLuaArgument* PushBoolean(bool bBool);

--- a/Server/mods/deathmatch/logic/lua/CLuaArguments.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaArguments.h
@@ -64,8 +64,7 @@ public:
     bool CallGlobal(class CLuaMain* pLuaMain, const char* szFunction, CLuaArguments* returnValues = NULL) const;
 
     void ReadTable(lua_State* luaVM, int iIndexBegin, CFastHashMap<const void*, CLuaArguments*>* pKnownTables = NULL);
-    void PushAsTable(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKnownTables = nullptr) const;
-    void PushArgumentsAsTable(lua_State* luaVM) const;
+    void PushAsTable(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKnownTables = nullptr, bool isArray = false) const;
 
     CLuaArgument* PushNil();
     CLuaArgument* PushBoolean(bool bBool);

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
@@ -507,7 +507,7 @@ int CLuaUtilDefs::fromJSON(lua_State* luaVM)
             // GitHub Issue: #5287
             if (!lua_checkstack(luaVM, count))
             {
-                Converted.PushArgumentsAsTable(luaVM);
+                Converted.PushAsTable(luaVM, nullptr, true);
                 return 1;
             }
 

--- a/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
+++ b/Shared/mods/deathmatch/logic/luadefs/CLuaUtilDefs.cpp
@@ -497,9 +497,23 @@ int CLuaUtilDefs::fromJSON(lua_State* luaVM)
         CLuaArguments Converted;
         if (Converted.ReadFromJSONString(strJson))
         {
+            const int count = static_cast<int>(Converted.Count());
+
+            // Keep the original fromJSON behavior as long as all
+            // return values can fit on the Lua stack.
+            //
+            // If the root JSON is a large array and the values cannot
+            // be returned unpacked, return them as a single Lua table.
+            // GitHub Issue: #5287
+            if (!lua_checkstack(luaVM, count))
+            {
+                Converted.PushArgumentsAsTable(luaVM);
+                return 1;
+            }
+
             // Return it as data
             Converted.PushArguments(luaVM);
-            return static_cast<int>(Converted.Count());
+            return count;
         }
     }
     else


### PR DESCRIPTION
#### Summary
`fromJSON` could cause a **Lua stack overflow** and crash when parsing a large JSON array.

When the root JSON element is an array, fromJSON returns its elements as multiple Lua return values. For sufficiently large arrays, the number of return values can exceed the Lua C stack limit (`LUAI_MAXCSTACK`).

In this case, `lua_checkstack` fails, but the values were still pushed onto the Lua stack. This eventually exhausted the stack and caused a crash inside `api_incr_top`.

Before pushing the parsed values, `fromJSON` now checks whether all return values can fit on the Lua stack. If there is not enough space, the parsed values are packed into a **single** Lua table and returned as one value instead.

This preserves the existing behavior for normal sized arrays while preventing Lua stack overflow crashes for large JSON arrays.

#### Motivation
Fixed #5287 


#### Test plan
```lua
local file = fileOpen('modelNames.json')
local data = fileRead(file, fileGetSize(file))

local tbl = fromJSON(data)
print(#tbl)

local json = [[
[
    {
        "id": 9557,
        "name": "lake_sfw"
    },
    {
        "id": 8487,
        "name": "ballyswtr01_lvs"
    }
]

]]

local a, b = fromJSON(json);
print(a, b);
```

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
