### PR TITLE
Improve streamer performance: Don't unload cached models the game is still using

### DIFF
--- a/Client/core/CModelCacheManager.cpp
+++ b/Client/core/CModelCacheManager.cpp
@@ -572,9 +572,7 @@ bool CModelCacheManagerImpl::TryReleaseCachedModel(ushort usModelId, SModelCache
 
     // The game marks models that it must keep loaded for missions or its own systems.
     // Dropping our ref on those would only cause the game to stream them right back in.
-    if (pStreamingInfo->flg & STREAMING_FLAG_MISSION_REQUIRED)
-        return false;
-    if (pStreamingInfo->flg & STREAMING_FLAG_GAME_REQUIRED)
+    if (pStreamingInfo->flg & (STREAMING_FLAG_MISSION_REQUIRED | STREAMING_FLAG_GAME_REQUIRED))
         return false;
 
     // Someone else still holds a ref, so our release would not free the model anyway.

--- a/Client/core/CModelCacheManager.cpp
+++ b/Client/core/CModelCacheManager.cpp
@@ -12,6 +12,7 @@
 #include <game/CStreaming.h>
 #include <game/CModelInfo.h>
 #include <game/CSettings.h>
+#include <game/CWorld.h>
 #include "CModelCacheManager.h"
 
 namespace
@@ -25,6 +26,13 @@ namespace
         bool       bIsModelCachedHere;
         bool       bIsModelLoadedByGame;
     };
+
+    // When the game itself tracks the model in its loaded ped/vehicle groups, keep our cache ref
+    // until the game has more than this many entries left. These floors mirror what the game's
+    // own cleanup uses when it decides which group models it can unload.
+    constexpr uint PED_STREAMING_FLOOR = 4u;
+    constexpr uint VEHICLE_STREAMING_FLOOR_EXTERIOR = 7u;
+    constexpr uint VEHICLE_STREAMING_FLOOR_INTERIOR = 4u;
 }  // namespace
 
 ///////////////////////////////////////////////////////////////
@@ -59,6 +67,7 @@ public:
     int  GetModelRefCount(ushort usModelId);
     void AddModelRefCount(ushort usModelId);
     void SubModelRefCount(ushort usModelId);
+    bool TryReleaseCachedModel(ushort usModelId, SModelCacheInfo& info, const char* contextTag, uint& uiNumModelsCachedHereOnly);
 
 protected:
     CGame*     m_pGame{};
@@ -358,9 +367,12 @@ void CModelCacheManagerImpl::UpdateModelCaching(const std::map<ushort, float>& n
 
     uint uiNumModelsCachedHereOnly = 0;
 
-    std::map<uint, ushort> maybeUncacheUnneededList;
-    std::map<uint, ushort> maybeUncacheNeededList;
-    std::map<uint, ushort> maybeCacheList;
+    // Multimaps so that models sharing a priority key all stay selectable: with a plain map,
+    // insertion would silently overwrite earlier entries with an equal key, hiding valid
+    // eviction or cache candidates from the loops below.
+    std::multimap<uint, ushort> maybeUncacheUnneededList;
+    std::multimap<uint, ushort> maybeUncacheNeededList;
+    std::multimap<uint, ushort> maybeCacheList;
 
     // Update active
     for (std::map<ushort, SModelCacheInfo>::iterator iter = currentCacheInfoMap.begin(); iter != currentCacheInfoMap.end(); ++iter)
@@ -387,9 +399,9 @@ void CModelCacheManagerImpl::UpdateModelCaching(const std::map<ushort, float>& n
                 // Update cached models that could be uncached
                 uint uiTicksSinceLastNeeded = (m_TickCountNow - info.lastNeeded).ToInt();
                 if (uiTicksSinceLastNeeded > 0)
-                    MapSet(maybeUncacheUnneededList, uiTicksSinceLastNeeded, usModelId);
+                    maybeUncacheUnneededList.emplace(uiTicksSinceLastNeeded, usModelId);
                 else
-                    MapSet(maybeUncacheNeededList, (int)info.fClosestDistSq, usModelId);
+                    maybeUncacheNeededList.emplace((int)info.fClosestDistSq, usModelId);
             }
             else
             {
@@ -397,38 +409,40 @@ void CModelCacheManagerImpl::UpdateModelCaching(const std::map<ushort, float>& n
                 {
                     // Update uncached models that could be cached
                     uint uiTicksSinceFirstNeeded = (m_TickCountNow - info.firstNeeded).ToInt();
-                    MapSet(maybeCacheList, uiTicksSinceFirstNeeded, usModelId);
+                    maybeCacheList.emplace(uiTicksSinceFirstNeeded, usModelId);
                 }
             }
         }
     }
 
-    // If at or above cache limit, try to uncache unneeded first
-    if (uiNumModelsCachedHereOnly >= uiMaxCachedAllowed && !maybeUncacheUnneededList.empty())
+    // If at or above cache limit, try to uncache unneeded first.
+    // A model is only released when TryReleaseCachedModel decides the game no longer depends on it,
+    // and its map entry is kept so its history survives for the next demand.
+    bool bReleasedModel = false;
+    auto AttemptReleaseFromList = [&](const std::multimap<uint, ushort>& candidateList, const char* contextTag) -> bool
     {
-        const ushort     usModelId = maybeUncacheUnneededList.rbegin()->second;
-        SModelCacheInfo* pInfo = MapFind(currentCacheInfoMap, usModelId);
-        assert(pInfo);
-        assert(pInfo->bIsModelCachedHere);
-        SubModelRefCount(usModelId);
-        pInfo->bIsModelCachedHere = false;
-        MapRemove(currentCacheInfoMap, usModelId);
-        OutputDebugLine(SString("[Cache] End caching model %d  (UncacheUnneeded)", usModelId));
-    }
-    else if (uiNumModelsCachedHereOnly > uiMaxCachedAllowed && !maybeUncacheNeededList.empty())
-    {
-        // Only uncache from the needed list if above limit
+        for (auto it = candidateList.rbegin(); it != candidateList.rend(); ++it)
+        {
+            const ushort modelId = it->second;
+            auto         cacheIt = currentCacheInfoMap.find(modelId);
+            if (cacheIt == currentCacheInfoMap.end())
+                continue;
 
-        // Uncache furthest away model
-        const ushort     usModelId = maybeUncacheNeededList.rbegin()->second;
-        SModelCacheInfo* pInfo = MapFind(currentCacheInfoMap, usModelId);
-        assert(pInfo);
-        assert(pInfo->bIsModelCachedHere);
-        SubModelRefCount(usModelId);
-        pInfo->bIsModelCachedHere = false;
-        MapRemove(currentCacheInfoMap, usModelId);
-        OutputDebugLine(SString("[Cache] End caching model %d  (UncacheNeeded)", usModelId));
-    }
+            SModelCacheInfo& candidateInfo = cacheIt->second;
+            assert(candidateInfo.bIsModelCachedHere);
+
+            if (TryReleaseCachedModel(modelId, candidateInfo, contextTag, uiNumModelsCachedHereOnly))
+                return true;
+        }
+        return false;
+    };
+
+    if (uiNumModelsCachedHereOnly >= uiMaxCachedAllowed && !maybeUncacheUnneededList.empty())
+        bReleasedModel = AttemptReleaseFromList(maybeUncacheUnneededList, "UncacheUnneeded");
+
+    // Only uncache from the needed list if above limit, furthest away first
+    if (!bReleasedModel && uiNumModelsCachedHereOnly > uiMaxCachedAllowed && !maybeUncacheNeededList.empty())
+        bReleasedModel = AttemptReleaseFromList(maybeUncacheNeededList, "UncacheNeeded");
 
     // Cache if room
     if (!maybeCacheList.empty() && uiNumModelsCachedHereOnly < uiMaxCachedAllowed)
@@ -515,6 +529,7 @@ bool CModelCacheManagerImpl::UnloadModel(ushort usModelId)
 ///////////////////////////////////////////////////////////////
 void CModelCacheManagerImpl::OnRestreamModel(ushort usModelId)
 {
+    // Keep forced restream untouched: callers expect full removal when restreaming.
     std::map<ushort, SModelCacheInfo>* mapList[] = {&m_PedModelCacheInfoMap, &m_VehicleModelCacheInfoMap};
 
     for (uint i = 0; i < NUMELMS(mapList); i++)
@@ -533,4 +548,74 @@ void CModelCacheManagerImpl::OnRestreamModel(ushort usModelId)
             }
         }
     }
+}
+
+///////////////////////////////////////////////////////////////
+//
+// CModelCacheManagerImpl::TryReleaseCachedModel
+//
+// Drop our cache ref on a model, unless the game still depends on it.
+// Only called when the cache is at or above its limit.
+//
+///////////////////////////////////////////////////////////////
+bool CModelCacheManagerImpl::TryReleaseCachedModel(ushort usModelId, SModelCacheInfo& info, const char* contextTag, uint& uiNumModelsCachedHereOnly)
+{
+    assert(info.bIsModelCachedHere);
+
+    CStreaming* pStreaming = m_pGame->GetStreaming();
+    if (!pStreaming)
+        return false;
+
+    CStreamingInfo* pStreamingInfo = pStreaming->GetStreamingInfo(usModelId);
+    if (!pStreamingInfo)
+        return false;
+
+    // The game marks models that it must keep loaded for missions or its own systems.
+    // Dropping our ref on those would only cause the game to stream them right back in.
+    if (pStreamingInfo->flg & STREAMING_FLAG_MISSION_REQUIRED)
+        return false;
+    if (pStreamingInfo->flg & STREAMING_FLAG_GAME_REQUIRED)
+        return false;
+
+    // Someone else still holds a ref, so our release would not free the model anyway.
+    if (GetModelRefCount(usModelId) > 1)
+        return false;
+
+    CModelInfo*          pModelInfo = m_pGame->GetModelInfo(usModelId, true);
+    const eModelInfoType modelType = pModelInfo ? pModelInfo->GetModelType() : eModelInfoType::UNKNOWN;
+
+    // If the game still tracks this model in its loaded ped group, keep it cached while
+    // the group is near empty, so we don't fight the game over which models stay loaded.
+    if (modelType == eModelInfoType::PED && pStreaming->IsModelInLoadedPedGroup(usModelId))
+    {
+        if (pStreaming->GetNumPedsLoaded() <= PED_STREAMING_FLOOR)
+            return false;
+    }
+
+    // Same for the loaded vehicle group, with a smaller floor inside interiors.
+    // CWorld::GetCurrentArea reads the same CGame::currArea that the game's own
+    // vehicle floor logic checks, so one lookup covers both cases.
+    if (modelType == eModelInfoType::VEHICLE && pStreaming->IsModelInLoadedVehicleGroup(usModelId))
+    {
+        const uint vehicleCount = pStreaming->GetNumLoadedVehicles();
+        const bool bIsInterior = m_pGame->GetWorld() && m_pGame->GetWorld()->GetCurrentArea() != 0;
+        const uint minVehicleBudget = bIsInterior ? VEHICLE_STREAMING_FLOOR_INTERIOR : VEHICLE_STREAMING_FLOOR_EXTERIOR;
+        if (vehicleCount <= minVehicleBudget)
+            return false;
+    }
+
+    SubModelRefCount(usModelId);
+    info.bIsModelCachedHere = false;
+    info.lastNeeded = m_TickCountNow;
+    // Also reset the first-needed time. Otherwise a still-needed model would keep its old
+    // firstNeeded and win the recache list on the next pulse, causing a release/cache cycle.
+    info.firstNeeded = m_TickCountNow;
+    info.bIsModelLoadedByGame = false;
+
+    if (uiNumModelsCachedHereOnly > 0)
+        uiNumModelsCachedHereOnly--;
+
+    OutputDebugLine(SString("[Cache] End caching model %d  (%s)", usModelId, contextTag));
+
+    return true;
 }

--- a/Client/game_sa/CStreamingSA.cpp
+++ b/Client/game_sa/CStreamingSA.cpp
@@ -55,6 +55,13 @@ namespace
     constexpr size_t MAX_STREAMS_NUM = 255;
     constexpr size_t MAX_IMAGES_NUM = MAX_STREAMS_NUM - RESERVED_STREAMS_NUM;
     constexpr size_t MIN_IMAGES_NUM = 6;  // GTA3(yes, it is presented twice), GTA_INT, CARREC, SCRIPT, CUTSCENE, PLAYER
+
+    // The game keeps fixed lists of the ped and vehicle models it tracks for population streaming.
+    // Vehicle slots are kept compact: valid entries come first, the rest are marked unused.
+    constexpr std::size_t  NUM_LOADED_PED_SLOTS = 8;
+    constexpr std::size_t  NUM_LOADED_VEHICLE_SLOTS = 23;
+    constexpr std::int32_t NUM_PED_SLOT_MAX_VALUE = 0xFFFF;
+    constexpr std::int16_t VEHICLE_SLOT_UNUSED = -1;
 }  // namespace
 
 bool IsUpgradeModelId(DWORD dwModelID)
@@ -538,4 +545,56 @@ void CStreamingSA::LoadSceneCollision(const CVector* position)
 {
     auto CStreaming_LoadSceneCollision = (void(__cdecl*)(const CVector*))FUNC_CStreaming_LoadSceneCollision;
     CStreaming_LoadSceneCollision(position);
+}
+
+std::uint32_t CStreamingSA::GetNumPedsLoaded() const noexcept
+{
+    return *reinterpret_cast<const std::uint32_t*>(VAR_CStreaming_msNumPedsLoaded);
+}
+
+bool CStreamingSA::IsModelInLoadedPedGroup(std::uint16_t modelId) const noexcept
+{
+    const auto* pPedSlots = reinterpret_cast<const std::int32_t*>(ARRAY_CStreaming_msPedsLoaded);
+    for (std::size_t i = 0; i < NUM_LOADED_PED_SLOTS; ++i)
+    {
+        const std::int32_t pedSlot = pPedSlots[i];
+        if (pedSlot < 0 || pedSlot > NUM_PED_SLOT_MAX_VALUE)
+            continue;
+
+        if (static_cast<std::uint16_t>(pedSlot) == modelId)
+            return true;
+    }
+    return false;
+}
+
+std::uint32_t CStreamingSA::GetNumLoadedVehicles() const noexcept
+{
+    const auto*   pVehicleSlots = reinterpret_cast<const std::int16_t*>(ARRAY_CStreaming_msVehiclesLoaded);
+    std::uint32_t count = 0;
+    for (std::size_t i = 0; i < NUM_LOADED_VEHICLE_SLOTS; ++i)
+    {
+        if (pVehicleSlots[i] == VEHICLE_SLOT_UNUSED)
+            break;
+
+        ++count;
+    }
+    return count;
+}
+
+bool CStreamingSA::IsModelInLoadedVehicleGroup(std::uint16_t modelId) const noexcept
+{
+    const auto* pVehicleSlots = reinterpret_cast<const std::int16_t*>(ARRAY_CStreaming_msVehiclesLoaded);
+    for (std::size_t i = 0; i < NUM_LOADED_VEHICLE_SLOTS; ++i)
+    {
+        const std::int16_t vehicleSlot = pVehicleSlots[i];
+        if (vehicleSlot == VEHICLE_SLOT_UNUSED)
+            break;
+
+        if (vehicleSlot < 0)
+            continue;
+
+        if (static_cast<std::uint16_t>(vehicleSlot) == modelId)
+            return true;
+    }
+    return false;
 }

--- a/Client/game_sa/CStreamingSA.h
+++ b/Client/game_sa/CStreamingSA.h
@@ -23,6 +23,10 @@
 #define FUNC_CStreaming_LoadScene                0x40EB70
 #define FUNC_CStreaming_LoadSceneCollision       0x40ED80
 
+#define ARRAY_CStreaming_msPedsLoaded     0x8E4C00
+#define VAR_CStreaming_msNumPedsLoaded    0x8E4BB0
+#define ARRAY_CStreaming_msVehiclesLoaded 0x8E4C24
+
 struct CArchiveInfo
 {
     char  szName[40];
@@ -81,6 +85,11 @@ public:
 
     void LoadScene(const CVector* position);
     void LoadSceneCollision(const CVector* position);
+
+    std::uint32_t GetNumPedsLoaded() const noexcept override;
+    bool          IsModelInLoadedPedGroup(std::uint16_t modelId) const noexcept override;
+    std::uint32_t GetNumLoadedVehicles() const noexcept override;
+    bool          IsModelInLoadedVehicleGroup(std::uint16_t modelId) const noexcept override;
 
 private:
     void AllocateArchive();

--- a/Client/sdk/game/CStreaming.h
+++ b/Client/sdk/game/CStreaming.h
@@ -66,6 +66,11 @@ struct CStreamingInfo
 };
 static_assert(sizeof(CStreamingInfo) == 0x14, "Invalid size for CStreamingInfo");
 
+// Values of CStreamingInfo::flg. These mark models that the game must keep loaded,
+// so higher layers can avoid dropping their own refs on such models.
+constexpr std::uint8_t STREAMING_FLAG_GAME_REQUIRED = 0x2u;
+constexpr std::uint8_t STREAMING_FLAG_MISSION_REQUIRED = 0x4u;
+
 class CStreaming
 {
 public:
@@ -86,4 +91,10 @@ public:
     virtual void          RemoveBigBuildings() = 0;
     virtual void          LoadScene(const CVector* position) = 0;
     virtual void          LoadSceneCollision(const CVector* position) = 0;
+    // State of the game's loaded ped/vehicle model groups. Used by the model cache
+    // manager to avoid unloading models that the game itself is still tracking.
+    virtual std::uint32_t GetNumPedsLoaded() const noexcept = 0;
+    virtual bool          IsModelInLoadedPedGroup(std::uint16_t modelId) const noexcept = 0;
+    virtual std::uint32_t GetNumLoadedVehicles() const noexcept = 0;
+    virtual bool          IsModelInLoadedVehicleGroup(std::uint16_t modelId) const noexcept = 0;
 };


### PR DESCRIPTION
Streaming performance tweaks

**Description**
The client keeps a small cache of ped and vehicle models so they don't have to stream from disk all the time. GTA also keeps its own short lists of loaded ped and vehicle models. Whenever the cache was full, it freed one model per frame tick without checking GTA's lists. If GTA was still using that model, GTA loaded it again right away. The cache and the game ended up fighting: free the model, load it back, free it again, wasting disk reads and streaming time.

**What changed**
Before freeing a cached model, the cache now asks the game whether the model is still needed. A model is kept when the game has marked it as required, when something besides the cache still holds a reference to it, or when the game still tracks it in its own loaded ped or vehicle lists while those lists are small enough that the game itself would not unload anything (4 entries or fewer for peds, 7 or fewer for vehicles outdoors, and 4 indoors). Those numbers are the same ones the game uses when deciding whether it may unload models from its lists, so the cache and the game now agree. When a model is guarded this way, the cache moves on to the next candidate, so it still frees something whenever one is available; when every candidate is guarded, nothing is freed that tick and the cache simply tries again next tick.

The "Mission" flag handling is preserved to avoid unexpected behavior with not yet fully-understood SA internals.

Two smaller fixes are included; The candidate lists changed from a map to a multimap, so models sharing the same priority are no longer silently dropped. And a just-freed model no longer wins the re-cache on the very next tick, which stops a free-and-re-cache loop.