### PR TITLE
Fix audio loss when switching devices and support live audio device changes

### DIFF
--- a/Client/core/CMessageLoopHook.cpp
+++ b/Client/core/CMessageLoopHook.cpp
@@ -288,14 +288,32 @@ LRESULT CALLBACK CMessageLoopHook::ProcessMessage(HWND hwnd, UINT uMsg, WPARAM w
         }
     }
 
-    // A HID device (e.g. joystick) was plugged in or removed
-    if (uMsg == WM_DEVICECHANGE && (wParam == DBT_DEVICEARRIVAL || wParam == DBT_DEVICEREMOVECOMPLETE))
+    if (uMsg == WM_DEVICECHANGE)
     {
-        GetJoystickManager()->OnPossibleDeviceChange();
+        // Audio endpoints do not always raise arrival/removal, e.g. replugging into an existing
+        // jack, so the broader node change message refreshes the device pickers too
+        if (wParam == DBT_DEVICEARRIVAL || wParam == DBT_DEVICEREMOVECOMPLETE || wParam == DBT_DEVNODES_CHANGED)
+            CSettings::NotifyAudioDeviceChange();
 
-        CModManager* pModManager = CModManager::GetSingletonPtr();
-        if (pModManager && pModManager->IsLoaded())
-            pModManager->GetClient()->OnPossibleAudioDeviceChange();
+        if (wParam == DBT_DEVICEARRIVAL || wParam == DBT_DEVICEREMOVECOMPLETE)
+        {
+            // All three classes we registered for share this window, so only the broadcast's own
+            // class GUID says which one actually fired; without checking it, a joystick or
+            // microphone hotplug also restarts the native output audio hardware
+            const auto* pHeader = reinterpret_cast<const DEV_BROADCAST_HDR*>(lParam);
+            if (pHeader && pHeader->dbch_devicetype == DBT_DEVTYP_DEVICEINTERFACE)
+            {
+                const auto& classGuid = reinterpret_cast<const DEV_BROADCAST_DEVICEINTERFACE*>(pHeader)->dbcc_classguid;
+                if (IsEqualGUID(classGuid, GUID_DevInterfaceHID))
+                    GetJoystickManager()->OnPossibleDeviceChange();
+                else if (IsEqualGUID(classGuid, GUID_DevInterfaceAudioRender) || IsEqualGUID(classGuid, GUID_DevInterfaceAudioCapture))
+                {
+                    CModManager* pModManager = CModManager::GetSingletonPtr();
+                    if (pModManager && pModManager->IsLoaded())
+                        pModManager->GetClient()->OnPossibleAudioDeviceChange();
+                }
+            }
+        }
     }
 
     // Make sure our pointers are valid.

--- a/Client/core/CMessageLoopHook.cpp
+++ b/Client/core/CMessageLoopHook.cpp
@@ -18,6 +18,10 @@ extern CCore* g_pCore;
 // GUID_DEVINTERFACE_HID, used to get notified when a HID device (e.g. a joystick) is plugged in or removed
 DEFINE_GUID(GUID_DevInterfaceHID, 0x4D1E55B2, 0xF16F, 0x11CF, 0x88, 0xCB, 0x00, 0x11, 0x11, 0x00, 0x00, 0x30);
 
+// DEVINTERFACE_AUDIO_RENDER/CAPTURE, for output and microphone devices being plugged in or removed
+DEFINE_GUID(GUID_DevInterfaceAudioRender, 0xE6327CAD, 0xDCEC, 0x4949, 0xAE, 0x8A, 0x99, 0x1E, 0x97, 0x6A, 0x79, 0xD2);
+DEFINE_GUID(GUID_DevInterfaceAudioCapture, 0x2EEF81BE, 0x33FA, 0x4800, 0x96, 0x70, 0x1C, 0xD4, 0x74, 0x97, 0x2C, 0x3F);
+
 template <>
 CMessageLoopHook* CSingleton<CMessageLoopHook>::m_pSingleton = NULL;
 
@@ -36,6 +40,8 @@ CMessageLoopHook::CMessageLoopHook()
     m_bRefreshMsgQueueEnabled = true;
     m_MovementDummyWindow = NULL;
     m_hDeviceNotify = nullptr;
+    m_hAudioRenderDeviceNotify = nullptr;
+    m_hAudioCaptureDeviceNotify = nullptr;
 }
 
 CMessageLoopHook::~CMessageLoopHook()
@@ -81,6 +87,12 @@ void CMessageLoopHook::ApplyHook(HWND hFocusWindow)
         notificationFilter.dbcc_devicetype = DBT_DEVTYP_DEVICEINTERFACE;
         notificationFilter.dbcc_classguid = GUID_DevInterfaceHID;
         m_hDeviceNotify = RegisterDeviceNotification(hFocusWindow, &notificationFilter, DEVICE_NOTIFY_WINDOW_HANDLE);
+
+        // Same idea for sound output and microphone devices
+        notificationFilter.dbcc_classguid = GUID_DevInterfaceAudioRender;
+        m_hAudioRenderDeviceNotify = RegisterDeviceNotification(hFocusWindow, &notificationFilter, DEVICE_NOTIFY_WINDOW_HANDLE);
+        notificationFilter.dbcc_classguid = GUID_DevInterfaceAudioCapture;
+        m_hAudioCaptureDeviceNotify = RegisterDeviceNotification(hFocusWindow, &notificationFilter, DEVICE_NOTIFY_WINDOW_HANDLE);
     }
 }
 
@@ -99,6 +111,18 @@ void CMessageLoopHook::RemoveHook()
         {
             UnregisterDeviceNotification(m_hDeviceNotify);
             m_hDeviceNotify = nullptr;
+        }
+
+        if (m_hAudioRenderDeviceNotify)
+        {
+            UnregisterDeviceNotification(m_hAudioRenderDeviceNotify);
+            m_hAudioRenderDeviceNotify = nullptr;
+        }
+
+        if (m_hAudioCaptureDeviceNotify)
+        {
+            UnregisterDeviceNotification(m_hAudioCaptureDeviceNotify);
+            m_hAudioCaptureDeviceNotify = nullptr;
         }
     }
 }
@@ -182,7 +206,7 @@ LRESULT CALLBACK CMessageLoopHook::ProcessMessage(HWND hwnd, UINT uMsg, WPARAM w
             }
         }
 
-        // When updating m_bFocused in CClientGame from CPacketHandler (to fix another bug — see the note there),
+        // When updating m_bFocused in CClientGame from CPacketHandler (to fix another bug ï¿½ see the note there),
         // the window might not actually have focus at that moment (even though Windows reports it as focused).
         // In this case, isMTAWindowFocused returns false even though the window has focus.
         // Therefore, we need to intercept the window return operation and manually set the focus in CClientGame.
@@ -266,7 +290,13 @@ LRESULT CALLBACK CMessageLoopHook::ProcessMessage(HWND hwnd, UINT uMsg, WPARAM w
 
     // A HID device (e.g. joystick) was plugged in or removed
     if (uMsg == WM_DEVICECHANGE && (wParam == DBT_DEVICEARRIVAL || wParam == DBT_DEVICEREMOVECOMPLETE))
+    {
         GetJoystickManager()->OnPossibleDeviceChange();
+
+        CModManager* pModManager = CModManager::GetSingletonPtr();
+        if (pModManager && pModManager->IsLoaded())
+            pModManager->GetClient()->OnPossibleAudioDeviceChange();
+    }
 
     // Make sure our pointers are valid.
     if (pThis != NULL && hwnd == pThis->GetHookedWindowHandle() && g_pCore->AreModulesLoaded())

--- a/Client/core/CMessageLoopHook.cpp
+++ b/Client/core/CMessageLoopHook.cpp
@@ -206,7 +206,7 @@ LRESULT CALLBACK CMessageLoopHook::ProcessMessage(HWND hwnd, UINT uMsg, WPARAM w
             }
         }
 
-        // When updating m_bFocused in CClientGame from CPacketHandler (to fix another bug � see the note there),
+        // When updating m_bFocused in CClientGame from CPacketHandler (to fix another bug, see the note there),
         // the window might not actually have focus at that moment (even though Windows reports it as focused).
         // In this case, isMTAWindowFocused returns false even though the window has focus.
         // Therefore, we need to intercept the window return operation and manually set the focus in CClientGame.

--- a/Client/core/CMessageLoopHook.h
+++ b/Client/core/CMessageLoopHook.h
@@ -42,6 +42,8 @@ private:
     POINT        m_MoveOffset;
     HWND         m_MovementDummyWindow;
     HDEVNOTIFY   m_hDeviceNotify;
+    HDEVNOTIFY   m_hAudioRenderDeviceNotify;
+    HDEVNOTIFY   m_hAudioCaptureDeviceNotify;
 
     static WPARAM m_LastVirtualKeyCode;
     static UCHAR  m_LastScanCode;

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -340,6 +340,11 @@ void CSettings::ResetGuiPointers()
     m_pComboUsertrackMode = NULL;
     m_pAudioDefButton = NULL;
 
+    m_pAudioOutputDeviceLabel = NULL;
+    m_pSoundOutputDeviceCombo = NULL;
+    m_uiSoundOutputDeviceListRevision = 0;
+    m_bUpdatingSoundOutputDeviceCombo = false;
+
     m_pBindsList = NULL;
     m_pBindsDefButton = NULL;
 
@@ -1144,6 +1149,18 @@ void CSettings::CreateGUI()
     m_pCheckBoxUserAutoscan->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 52.0f));
     m_pCheckBoxUserAutoscan->AutoSize(NULL, 20.0f);
     m_pCheckBoxUserAutoscan->GetPosition(vecTemp, false);
+
+    m_pAudioOutputDeviceLabel = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabAudio, _("Output device")));
+    m_pAudioOutputDeviceLabel->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 30.0f), false);
+    m_pAudioOutputDeviceLabel->GetPosition(vecTemp, false);
+    m_pAudioOutputDeviceLabel->AutoSize(NULL, 20.0f);
+    m_pAudioOutputDeviceLabel->SetFont("default-bold-small");
+
+    m_pSoundOutputDeviceCombo = reinterpret_cast<CGUIComboBox*>(pManager->CreateComboBox(pTabAudio, ""));
+    m_pSoundOutputDeviceCombo->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 30.0f));
+    m_pSoundOutputDeviceCombo->SetSize(CVector2D(320.0f, 120.0f));
+    m_pSoundOutputDeviceCombo->SetReadOnly(true);
+    m_pSoundOutputDeviceCombo->SetSelectionHandler(GUI_CALLBACK(&CSettings::OnSoundOutputDeviceChanged, this));
 
     m_pAudioRadioLabel->GetPosition(vecTemp, false);
     vecTemp.fX = fIndentX + 173;
@@ -2162,6 +2179,7 @@ void CSettings::Update()
     if (m_dwFrameCount >= CORE_SETTINGS_UPDATE_INTERVAL)
     {
         UpdateJoypadTab();
+        UpdateSoundOutputDeviceCombo();
 
         m_dwFrameCount = 0;
     }
@@ -2209,6 +2227,52 @@ void CSettings::UpdateAudioTab()
     m_pCheckBoxMuteVoice->SetEnabled(!m_bMuteMaster);
 
     m_pComboUsertrackMode->SetSelectedItemByIndex(gameSettings->GetUsertrackMode());
+}
+
+void CSettings::UpdateSoundOutputDeviceCombo()
+{
+    if (!CModManager::GetSingleton().IsLoaded() || !m_pWindow->IsVisible() || !m_pSoundOutputDeviceCombo || m_pSoundOutputDeviceCombo->IsOpen())
+        return;
+
+    CClientBase* pClient = CModManager::GetSingleton().GetClient();
+
+    unsigned int uiRevision = pClient->GetSoundOutputDeviceListRevision();
+    if (uiRevision == m_uiSoundOutputDeviceListRevision)
+        return;
+
+    m_bUpdatingSoundOutputDeviceCombo = true;
+
+    std::vector<SSoundDeviceInfo> devices = pClient->GetSoundOutputDevices();
+    std::string                   strSelected = pClient->GetSoundOutputDeviceDriver();
+
+    m_pSoundOutputDeviceCombo->Clear();
+    int iSelect = 0;
+    for (size_t i = 0; i < devices.size(); i++)
+    {
+        CGUIListItem* pItem = m_pSoundOutputDeviceCombo->AddItem(devices[i].strName.c_str());
+        if (pItem)
+            pItem->SetData(devices[i].strDriver.c_str());
+        if (devices[i].strDriver == strSelected)
+            iSelect = static_cast<int>(i);
+    }
+    if (!devices.empty())
+        m_pSoundOutputDeviceCombo->SetSelectedItemByIndex(iSelect);
+
+    m_bUpdatingSoundOutputDeviceCombo = false;
+    m_uiSoundOutputDeviceListRevision = uiRevision;
+}
+
+bool CSettings::OnSoundOutputDeviceChanged(CGUIElement* pElement)
+{
+    if (m_bUpdatingSoundOutputDeviceCombo || !m_pSoundOutputDeviceCombo)
+        return true;
+
+    CGUIListItem* pItem = m_pSoundOutputDeviceCombo->GetSelectedItem();
+    if (!pItem || !pItem->GetData())
+        return true;
+
+    CModManager::GetSingleton().GetClient()->SetSoundOutputDevice(static_cast<const char*>(pItem->GetData()));
+    return true;
 }
 
 void CSettings::UpdateVideoTab()

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -345,6 +345,11 @@ void CSettings::ResetGuiPointers()
     m_uiSoundOutputDeviceListRevision = 0;
     m_bUpdatingSoundOutputDeviceCombo = false;
 
+    m_pAudioInputDeviceLabel = NULL;
+    m_pSoundInputDeviceCombo = NULL;
+    m_uiSoundInputDeviceListRevision = 0;
+    m_bUpdatingSoundInputDeviceCombo = false;
+
     m_pBindsList = NULL;
     m_pBindsDefButton = NULL;
 
@@ -1161,6 +1166,19 @@ void CSettings::CreateGUI()
     m_pSoundOutputDeviceCombo->SetSize(CVector2D(320.0f, 120.0f));
     m_pSoundOutputDeviceCombo->SetReadOnly(true);
     m_pSoundOutputDeviceCombo->SetSelectionHandler(GUI_CALLBACK(&CSettings::OnSoundOutputDeviceChanged, this));
+    m_pSoundOutputDeviceCombo->GetPosition(vecTemp, false);
+
+    m_pAudioInputDeviceLabel = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabAudio, _("Microphone")));
+    m_pAudioInputDeviceLabel->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 30.0f), false);
+    m_pAudioInputDeviceLabel->GetPosition(vecTemp, false);
+    m_pAudioInputDeviceLabel->AutoSize(NULL, 20.0f);
+    m_pAudioInputDeviceLabel->SetFont("default-bold-small");
+
+    m_pSoundInputDeviceCombo = reinterpret_cast<CGUIComboBox*>(pManager->CreateComboBox(pTabAudio, ""));
+    m_pSoundInputDeviceCombo->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 30.0f));
+    m_pSoundInputDeviceCombo->SetSize(CVector2D(320.0f, 120.0f));
+    m_pSoundInputDeviceCombo->SetReadOnly(true);
+    m_pSoundInputDeviceCombo->SetSelectionHandler(GUI_CALLBACK(&CSettings::OnSoundInputDeviceChanged, this));
 
     m_pAudioRadioLabel->GetPosition(vecTemp, false);
     vecTemp.fX = fIndentX + 173;
@@ -2180,6 +2198,7 @@ void CSettings::Update()
     {
         UpdateJoypadTab();
         UpdateSoundOutputDeviceCombo();
+        UpdateSoundInputDeviceCombo();
 
         m_dwFrameCount = 0;
     }
@@ -2272,6 +2291,58 @@ bool CSettings::OnSoundOutputDeviceChanged(CGUIElement* pElement)
         return true;
 
     CModManager::GetSingleton().GetClient()->SetSoundOutputDevice(static_cast<const char*>(pItem->GetData()));
+    return true;
+}
+
+void CSettings::UpdateSoundInputDeviceCombo()
+{
+    if (!CModManager::GetSingleton().IsLoaded() || !m_pWindow->IsVisible() || !m_pSoundInputDeviceCombo || m_pSoundInputDeviceCombo->IsOpen())
+        return;
+
+    CClientBase* pClient = CModManager::GetSingleton().GetClient();
+
+    unsigned int uiRevision = pClient->GetSoundInputDeviceListRevision();
+    if (uiRevision == m_uiSoundInputDeviceListRevision)
+        return;
+
+    m_bUpdatingSoundInputDeviceCombo = true;
+
+    std::vector<SSoundDeviceInfo> devices = pClient->GetSoundInputDevices();
+    std::string                   strSelected = pClient->GetSoundInputDeviceName();
+
+    m_pSoundInputDeviceCombo->Clear();
+    if (devices.empty())
+    {
+        m_pSoundInputDeviceCombo->AddItem(_("No microphone detected"));
+    }
+    else
+    {
+        int iSelect = 0;
+        for (size_t i = 0; i < devices.size(); i++)
+        {
+            CGUIListItem* pItem = m_pSoundInputDeviceCombo->AddItem(devices[i].strName.c_str());
+            if (pItem)
+                pItem->SetData(devices[i].strDriver.c_str());
+            if (devices[i].strDriver == strSelected)
+                iSelect = static_cast<int>(i);
+        }
+        m_pSoundInputDeviceCombo->SetSelectedItemByIndex(iSelect);
+    }
+
+    m_bUpdatingSoundInputDeviceCombo = false;
+    m_uiSoundInputDeviceListRevision = uiRevision;
+}
+
+bool CSettings::OnSoundInputDeviceChanged(CGUIElement* pElement)
+{
+    if (m_bUpdatingSoundInputDeviceCombo || !m_pSoundInputDeviceCombo)
+        return true;
+
+    CGUIListItem* pItem = m_pSoundInputDeviceCombo->GetSelectedItem();
+    if (!pItem || !pItem->GetData())
+        return true;
+
+    CModManager::GetSingleton().GetClient()->SetSoundInputDevice(static_cast<const char*>(pItem->GetData()));
     return true;
 }
 

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -17,6 +17,9 @@
 #include <game/CSettings.h>
 #include "CSteamClient.h"
 #include "DXHook/CProxyDirect3DDevice9.h"
+#include <dsound.h>
+
+#pragma comment(lib, "dsound.lib")
 
 using namespace std;
 
@@ -1155,27 +1158,28 @@ void CSettings::CreateGUI()
     m_pCheckBoxUserAutoscan->AutoSize(NULL, 20.0f);
     m_pCheckBoxUserAutoscan->GetPosition(vecTemp, false);
 
+    // Right column, clear of the volume slider rows below
     m_pAudioOutputDeviceLabel = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabAudio, _("Output device")));
-    m_pAudioOutputDeviceLabel->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 30.0f), false);
+    m_pAudioOutputDeviceLabel->SetPosition(CVector2D(tabPanelSize.fX - 330.0f, 13), false);
     m_pAudioOutputDeviceLabel->GetPosition(vecTemp, false);
     m_pAudioOutputDeviceLabel->AutoSize(NULL, 20.0f);
     m_pAudioOutputDeviceLabel->SetFont("default-bold-small");
 
     m_pSoundOutputDeviceCombo = reinterpret_cast<CGUIComboBox*>(pManager->CreateComboBox(pTabAudio, ""));
-    m_pSoundOutputDeviceCombo->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 30.0f));
+    m_pSoundOutputDeviceCombo->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 22.0f));
     m_pSoundOutputDeviceCombo->SetSize(CVector2D(320.0f, 120.0f));
     m_pSoundOutputDeviceCombo->SetReadOnly(true);
     m_pSoundOutputDeviceCombo->SetSelectionHandler(GUI_CALLBACK(&CSettings::OnSoundOutputDeviceChanged, this));
     m_pSoundOutputDeviceCombo->GetPosition(vecTemp, false);
 
     m_pAudioInputDeviceLabel = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabAudio, _("Microphone")));
-    m_pAudioInputDeviceLabel->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 30.0f), false);
+    m_pAudioInputDeviceLabel->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 38.0f), false);
     m_pAudioInputDeviceLabel->GetPosition(vecTemp, false);
     m_pAudioInputDeviceLabel->AutoSize(NULL, 20.0f);
     m_pAudioInputDeviceLabel->SetFont("default-bold-small");
 
     m_pSoundInputDeviceCombo = reinterpret_cast<CGUIComboBox*>(pManager->CreateComboBox(pTabAudio, ""));
-    m_pSoundInputDeviceCombo->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 30.0f));
+    m_pSoundInputDeviceCombo->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY + 22.0f));
     m_pSoundInputDeviceCombo->SetSize(CVector2D(320.0f, 120.0f));
     m_pSoundInputDeviceCombo->SetReadOnly(true);
     m_pSoundInputDeviceCombo->SetSelectionHandler(GUI_CALLBACK(&CSettings::OnSoundInputDeviceChanged, this));
@@ -2248,37 +2252,61 @@ void CSettings::UpdateAudioTab()
     m_pComboUsertrackMode->SetSelectedItemByIndex(gameSettings->GetUsertrackMode());
 }
 
+namespace
+{
+    BOOL CALLBACK AppendAudioDeviceNameCallback(GUID* pGuid, LPCSTR szDescription, LPCSTR szModule, LPVOID pContext)
+    {
+        // The first enumeration entry is the primary alias with a null GUID; only real devices matter here
+        if (pGuid && szDescription)
+            static_cast<std::vector<std::string>*>(pContext)->push_back(szDescription);
+        return TRUE;
+    }
+
+    std::vector<std::string> EnumerateAudioDeviceNames(bool bCapture)
+    {
+        std::vector<std::string> deviceNames;
+        if (bCapture)
+            DirectSoundCaptureEnumerateA(AppendAudioDeviceNameCallback, &deviceNames);
+        else
+            DirectSoundEnumerateA(AppendAudioDeviceNameCallback, &deviceNames);
+        return deviceNames;
+    }
+}  // namespace
+
+unsigned int CSettings::ms_uiAudioDeviceChangeRevision = 1;
+
+// The lists always come straight from DirectSound, so they work in the main menu and stay
+// identical once a mod loads. Selections are stored and applied by device name everywhere
 void CSettings::UpdateSoundOutputDeviceCombo()
 {
-    if (!CModManager::GetSingleton().IsLoaded() || !m_pWindow->IsVisible() || !m_pSoundOutputDeviceCombo || m_pSoundOutputDeviceCombo->IsOpen())
+    if (!m_pWindow->IsVisible() || !m_pSoundOutputDeviceCombo || m_pSoundOutputDeviceCombo->IsOpen())
         return;
 
-    CClientBase* pClient = CModManager::GetSingleton().GetClient();
-
-    unsigned int uiRevision = pClient->GetSoundOutputDeviceListRevision();
-    if (uiRevision == m_uiSoundOutputDeviceListRevision)
+    if (ms_uiAudioDeviceChangeRevision == m_uiSoundOutputDeviceListRevision)
         return;
 
     m_bUpdatingSoundOutputDeviceCombo = true;
-
-    std::vector<SSoundDeviceInfo> devices = pClient->GetSoundOutputDevices();
-    std::string                   strSelected = pClient->GetSoundOutputDeviceDriver();
-
     m_pSoundOutputDeviceCombo->Clear();
+
+    std::string strSelected;
+    CVARS_GET("audio_output_device", strSelected);
+
+    const std::vector<std::string> deviceNames = EnumerateAudioDeviceNames(false);
+
     int iSelect = 0;
-    for (size_t i = 0; i < devices.size(); i++)
+    for (size_t i = 0; i < deviceNames.size(); i++)
     {
-        CGUIListItem* pItem = m_pSoundOutputDeviceCombo->AddItem(devices[i].strName.c_str());
+        CGUIListItem* pItem = m_pSoundOutputDeviceCombo->AddItem(deviceNames[i].c_str());
         if (pItem)
-            pItem->SetData(devices[i].strDriver.c_str());
-        if (devices[i].strDriver == strSelected)
+            pItem->SetData(deviceNames[i].c_str());
+        if (deviceNames[i] == strSelected)
             iSelect = static_cast<int>(i);
     }
-    if (!devices.empty())
+    if (!deviceNames.empty())
         m_pSoundOutputDeviceCombo->SetSelectedItemByIndex(iSelect);
 
     m_bUpdatingSoundOutputDeviceCombo = false;
-    m_uiSoundOutputDeviceListRevision = uiRevision;
+    m_uiSoundOutputDeviceListRevision = ms_uiAudioDeviceChangeRevision;
 }
 
 bool CSettings::OnSoundOutputDeviceChanged(CGUIElement* pElement)
@@ -2290,47 +2318,54 @@ bool CSettings::OnSoundOutputDeviceChanged(CGUIElement* pElement)
     if (!pItem || !pItem->GetData())
         return true;
 
-    CModManager::GetSingleton().GetClient()->SetSoundOutputDevice(static_cast<const char*>(pItem->GetData()));
+    CVARS_SET("audio_output_device", pItem->GetText());
+
+    if (CModManager::GetSingleton().IsLoaded())
+        CModManager::GetSingleton().GetClient()->SetSoundOutputDevice(pItem->GetText());
+    else if (CMultiplayer* pMultiplayer = CCore::GetSingleton().GetMultiplayer())
+    {
+        // No mod running; retarget the native audio directly so the menu moves over live
+        pMultiplayer->SetPreferredAudioDeviceName(pItem->GetText());
+    }
     return true;
 }
 
 void CSettings::UpdateSoundInputDeviceCombo()
 {
-    if (!CModManager::GetSingleton().IsLoaded() || !m_pWindow->IsVisible() || !m_pSoundInputDeviceCombo || m_pSoundInputDeviceCombo->IsOpen())
+    if (!m_pWindow->IsVisible() || !m_pSoundInputDeviceCombo || m_pSoundInputDeviceCombo->IsOpen())
         return;
 
-    CClientBase* pClient = CModManager::GetSingleton().GetClient();
-
-    unsigned int uiRevision = pClient->GetSoundInputDeviceListRevision();
-    if (uiRevision == m_uiSoundInputDeviceListRevision)
+    if (ms_uiAudioDeviceChangeRevision == m_uiSoundInputDeviceListRevision)
         return;
 
     m_bUpdatingSoundInputDeviceCombo = true;
-
-    std::vector<SSoundDeviceInfo> devices = pClient->GetSoundInputDevices();
-    std::string                   strSelected = pClient->GetSoundInputDeviceName();
-
     m_pSoundInputDeviceCombo->Clear();
-    if (devices.empty())
+
+    std::string strSelected;
+    CVARS_GET("audio_input_device", strSelected);
+
+    const std::vector<std::string> deviceNames = EnumerateAudioDeviceNames(true);
+
+    if (deviceNames.empty())
     {
         m_pSoundInputDeviceCombo->AddItem(_("No microphone detected"));
     }
     else
     {
         int iSelect = 0;
-        for (size_t i = 0; i < devices.size(); i++)
+        for (size_t i = 0; i < deviceNames.size(); i++)
         {
-            CGUIListItem* pItem = m_pSoundInputDeviceCombo->AddItem(devices[i].strName.c_str());
+            CGUIListItem* pItem = m_pSoundInputDeviceCombo->AddItem(deviceNames[i].c_str());
             if (pItem)
-                pItem->SetData(devices[i].strDriver.c_str());
-            if (devices[i].strDriver == strSelected)
+                pItem->SetData(deviceNames[i].c_str());
+            if (deviceNames[i] == strSelected)
                 iSelect = static_cast<int>(i);
         }
         m_pSoundInputDeviceCombo->SetSelectedItemByIndex(iSelect);
     }
 
     m_bUpdatingSoundInputDeviceCombo = false;
-    m_uiSoundInputDeviceListRevision = uiRevision;
+    m_uiSoundInputDeviceListRevision = ms_uiAudioDeviceChangeRevision;
 }
 
 bool CSettings::OnSoundInputDeviceChanged(CGUIElement* pElement)
@@ -2342,7 +2377,11 @@ bool CSettings::OnSoundInputDeviceChanged(CGUIElement* pElement)
     if (!pItem || !pItem->GetData())
         return true;
 
-    CModManager::GetSingleton().GetClient()->SetSoundInputDevice(static_cast<const char*>(pItem->GetData()));
+    // Remember by name; the voice recorder resolves it when it starts
+    CVARS_SET("audio_input_device", pItem->GetText());
+
+    if (CModManager::GetSingleton().IsLoaded())
+        CModManager::GetSingleton().GetClient()->SetSoundInputDevice(pItem->GetText());
     return true;
 }
 

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -2294,7 +2294,7 @@ void CSettings::UpdateSoundOutputDeviceCombo()
     const std::vector<std::string> deviceNames = EnumerateAudioDeviceNames(false);
 
     int iSelect = 0;
-    for (size_t i = 0; i < deviceNames.size(); i++)
+    for (std::size_t i = 0; i < deviceNames.size(); i++)
     {
         CGUIListItem* pItem = m_pSoundOutputDeviceCombo->AddItem(deviceNames[i].c_str());
         if (pItem)
@@ -2353,7 +2353,7 @@ void CSettings::UpdateSoundInputDeviceCombo()
     else
     {
         int iSelect = 0;
-        for (size_t i = 0; i < deviceNames.size(); i++)
+        for (std::size_t i = 0; i < deviceNames.size(); i++)
         {
             CGUIListItem* pItem = m_pSoundInputDeviceCombo->AddItem(deviceNames[i].c_str());
             if (pItem)

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -101,6 +101,7 @@ public:
     void UpdateJoypadTab();
 
     void UpdateAudioTab();
+    void UpdateSoundOutputDeviceCombo();
 
     void UpdateVideoTab();
     void UpdatePostFxTab();
@@ -280,6 +281,11 @@ protected:
     CGUIComboBox*  m_pComboUsertrackMode;
     CGUIButton*    m_pAudioDefButton;
 
+    CGUILabel*    m_pAudioOutputDeviceLabel;
+    CGUIComboBox* m_pSoundOutputDeviceCombo;
+    unsigned int  m_uiSoundOutputDeviceListRevision;
+    bool          m_bUpdatingSoundOutputDeviceCombo;
+
     CGUIGridList* m_pBindsList;
     CGUIButton*   m_pBindsDefButton;
     CGUIHandle    m_hBind, m_hPriKey, m_hSecKeys[SecKeyNum];
@@ -379,6 +385,7 @@ protected:
 
     bool OnJoypadTextChanged(CGUIElement* pElement);
     bool OnJoypadDeviceChanged(CGUIElement* pElement);
+    bool OnSoundOutputDeviceChanged(CGUIElement* pElement);
     bool OnJoypadVibrationClick(CGUIElement* pElement);
     bool OnAxisSelectClick(CGUIElement* pElement);
     bool OnAudioDefaultClick(CGUIElement* pElement);

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -102,6 +102,7 @@ public:
 
     void UpdateAudioTab();
     void UpdateSoundOutputDeviceCombo();
+    void UpdateSoundInputDeviceCombo();
 
     void UpdateVideoTab();
     void UpdatePostFxTab();
@@ -286,6 +287,11 @@ protected:
     unsigned int  m_uiSoundOutputDeviceListRevision;
     bool          m_bUpdatingSoundOutputDeviceCombo;
 
+    CGUILabel*    m_pAudioInputDeviceLabel;
+    CGUIComboBox* m_pSoundInputDeviceCombo;
+    unsigned int  m_uiSoundInputDeviceListRevision;
+    bool          m_bUpdatingSoundInputDeviceCombo;
+
     CGUIGridList* m_pBindsList;
     CGUIButton*   m_pBindsDefButton;
     CGUIHandle    m_hBind, m_hPriKey, m_hSecKeys[SecKeyNum];
@@ -386,6 +392,7 @@ protected:
     bool OnJoypadTextChanged(CGUIElement* pElement);
     bool OnJoypadDeviceChanged(CGUIElement* pElement);
     bool OnSoundOutputDeviceChanged(CGUIElement* pElement);
+    bool OnSoundInputDeviceChanged(CGUIElement* pElement);
     bool OnJoypadVibrationClick(CGUIElement* pElement);
     bool OnAxisSelectClick(CGUIElement* pElement);
     bool OnAudioDefaultClick(CGUIElement* pElement);

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -104,6 +104,13 @@ public:
     void UpdateSoundOutputDeviceCombo();
     void UpdateSoundInputDeviceCombo();
 
+    // Bumped on WM_DEVICECHANGE so the combos refresh even while no mod is loaded
+    static void NotifyAudioDeviceChange() { ms_uiAudioDeviceChangeRevision++; }
+
+private:
+    static unsigned int ms_uiAudioDeviceChangeRevision;
+
+public:
     void UpdateVideoTab();
     void UpdatePostFxTab();
     void PopulateResolutionComboBox();

--- a/Client/game_sa/CAEAudioHardwareSA.cpp
+++ b/Client/game_sa/CAEAudioHardwareSA.cpp
@@ -53,3 +53,32 @@ void CAEAudioHardwareSA::LoadSoundBank(short wSoundBankID, short wSoundBankSlotI
     }
     // clang-format on
 }
+
+void CAEAudioHardwareSA::Terminate()
+{
+    DWORD dwThis = (DWORD)m_pInterface;
+    DWORD dwFunc = FUNC_CAEAudioHardware__Terminate;
+    // clang-format off
+    __asm
+    {
+        mov     ecx, dwThis
+        call    dwFunc
+    }
+    // clang-format on
+}
+
+bool CAEAudioHardwareSA::Initialise()
+{
+    DWORD dwThis = (DWORD)m_pInterface;
+    DWORD dwFunc = FUNC_CAEAudioHardware__Initialise;
+    bool  bReturn = false;
+    // clang-format off
+    __asm
+    {
+        mov     ecx, dwThis
+        call    dwFunc
+        mov     bReturn, al
+    }
+    // clang-format on
+    return bReturn;
+}

--- a/Client/game_sa/CAEAudioHardwareSA.cpp
+++ b/Client/game_sa/CAEAudioHardwareSA.cpp
@@ -56,29 +56,10 @@ void CAEAudioHardwareSA::LoadSoundBank(short wSoundBankID, short wSoundBankSlotI
 
 void CAEAudioHardwareSA::Terminate()
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAEAudioHardware__Terminate;
-    // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-    }
-    // clang-format on
+    m_pInterface->Terminate();
 }
 
 bool CAEAudioHardwareSA::Initialise()
 {
-    DWORD dwThis = (DWORD)m_pInterface;
-    DWORD dwFunc = FUNC_CAEAudioHardware__Initialise;
-    bool  bReturn = false;
-    // clang-format off
-    __asm
-    {
-        mov     ecx, dwThis
-        call    dwFunc
-        mov     bReturn, al
-    }
-    // clang-format on
-    return bReturn;
+    return m_pInterface->Initialise();
 }

--- a/Client/game_sa/CAEAudioHardwareSA.h
+++ b/Client/game_sa/CAEAudioHardwareSA.h
@@ -15,6 +15,8 @@
 
 #define FUNC_CAEAudioHardware__IsSoundBankLoaded 0x4D88C0
 #define FUNC_CAEAudioHardware__LoadSoundBank     0x4D88A0
+#define FUNC_CAEAudioHardware__Terminate         0x4D97A0
+#define FUNC_CAEAudioHardware__Initialise        0x4D9930
 
 #define CLASS_CAEAudioHardware 0xB5F8B8
 
@@ -28,6 +30,8 @@ public:
     CAEAudioHardwareSA(CAEAudioHardwareSAInterface* pInterface);
     bool IsSoundBankLoaded(short wSoundBankID, short wSoundBankSlotID);
     void LoadSoundBank(short wSoundBankID, short wSoundBankSlotID);
+    void Terminate();
+    bool Initialise();
 
 private:
     CAEAudioHardwareSAInterface* m_pInterface;

--- a/Client/game_sa/CAEAudioHardwareSA.h
+++ b/Client/game_sa/CAEAudioHardwareSA.h
@@ -22,6 +22,9 @@
 
 class CAEAudioHardwareSAInterface
 {
+public:
+    void Terminate() { reinterpret_cast<void(__thiscall*)(CAEAudioHardwareSAInterface*)>(FUNC_CAEAudioHardware__Terminate)(this); }
+    bool Initialise() { return reinterpret_cast<bool(__thiscall*)(CAEAudioHardwareSAInterface*)>(FUNC_CAEAudioHardware__Initialise)(this); }
 };
 
 class CAEAudioHardwareSA : public CAEAudioHardware

--- a/Client/mods/deathmatch/CClient.cpp
+++ b/Client/mods/deathmatch/CClient.cpp
@@ -301,6 +301,11 @@ void CClient::OnWindowFocusChange(bool state)
     g_pClientGame->OnWindowFocusChange(state);
 }
 
+void CClient::OnPossibleAudioDeviceChange()
+{
+    g_pClientGame->OnPossibleAudioDeviceChange();
+}
+
 CClient::InitializeArguments CClient::ExtractInitializeArguments(const char* arguments)
 {
     // Format: "nickname [password]"

--- a/Client/mods/deathmatch/CClient.cpp
+++ b/Client/mods/deathmatch/CClient.cpp
@@ -326,6 +326,26 @@ bool CClient::SetSoundOutputDevice(const std::string& strDriver)
     return g_pClientGame->SetSoundOutputDevice(strDriver);
 }
 
+unsigned int CClient::GetSoundInputDeviceListRevision()
+{
+    return g_pClientGame->GetSoundInputDeviceListRevision();
+}
+
+std::vector<SSoundDeviceInfo> CClient::GetSoundInputDevices()
+{
+    return g_pClientGame->GetSoundInputDevices();
+}
+
+std::string CClient::GetSoundInputDeviceName()
+{
+    return g_pClientGame->GetSoundInputDeviceName();
+}
+
+bool CClient::SetSoundInputDevice(const std::string& strName)
+{
+    return g_pClientGame->SetSoundInputDevice(strName);
+}
+
 CClient::InitializeArguments CClient::ExtractInitializeArguments(const char* arguments)
 {
     // Format: "nickname [password]"

--- a/Client/mods/deathmatch/CClient.cpp
+++ b/Client/mods/deathmatch/CClient.cpp
@@ -306,6 +306,26 @@ void CClient::OnPossibleAudioDeviceChange()
     g_pClientGame->OnPossibleAudioDeviceChange();
 }
 
+unsigned int CClient::GetSoundOutputDeviceListRevision()
+{
+    return g_pClientGame->GetSoundOutputDeviceListRevision();
+}
+
+std::vector<SSoundDeviceInfo> CClient::GetSoundOutputDevices()
+{
+    return g_pClientGame->GetSoundOutputDevices();
+}
+
+std::string CClient::GetSoundOutputDeviceDriver()
+{
+    return g_pClientGame->GetSoundOutputDeviceDriver();
+}
+
+bool CClient::SetSoundOutputDevice(const std::string& strDriver)
+{
+    return g_pClientGame->SetSoundOutputDevice(strDriver);
+}
+
 CClient::InitializeArguments CClient::ExtractInitializeArguments(const char* arguments)
 {
     // Format: "nickname [password]"

--- a/Client/mods/deathmatch/CClient.h
+++ b/Client/mods/deathmatch/CClient.h
@@ -37,6 +37,11 @@ public:
     void OnWindowFocusChange(bool state) override;
     void OnPossibleAudioDeviceChange() override;
 
+    unsigned int                  GetSoundOutputDeviceListRevision() override;
+    std::vector<SSoundDeviceInfo> GetSoundOutputDevices() override;
+    std::string                   GetSoundOutputDeviceDriver() override;
+    bool                          SetSoundOutputDevice(const std::string& strDriver) override;
+
 private:
     struct InitializeArguments
     {

--- a/Client/mods/deathmatch/CClient.h
+++ b/Client/mods/deathmatch/CClient.h
@@ -35,6 +35,7 @@ public:
     void GetPlayerNames(std::vector<SString>& vPlayerNames);
 
     void OnWindowFocusChange(bool state) override;
+    void OnPossibleAudioDeviceChange() override;
 
 private:
     struct InitializeArguments

--- a/Client/mods/deathmatch/CClient.h
+++ b/Client/mods/deathmatch/CClient.h
@@ -42,6 +42,11 @@ public:
     std::string                   GetSoundOutputDeviceDriver() override;
     bool                          SetSoundOutputDevice(const std::string& strDriver) override;
 
+    unsigned int                  GetSoundInputDeviceListRevision() override;
+    std::vector<SSoundDeviceInfo> GetSoundInputDevices() override;
+    std::string                   GetSoundInputDeviceName() override;
+    bool                          SetSoundInputDevice(const std::string& strName) override;
+
 private:
     struct InitializeArguments
     {

--- a/Client/mods/deathmatch/CVoiceRecorder.cpp
+++ b/Client/mods/deathmatch/CVoiceRecorder.cpp
@@ -16,6 +16,9 @@ CVoiceRecorder::CVoiceRecorder()
 {
     m_bEnabled = false;
 
+    // Starts on the microphone already chosen in the settings, even before any mod loads
+    g_pCore->GetCVars()->Get("audio_input_device", m_strSelectedDeviceName);
+
     m_VoiceState = VOICESTATE_AWAITING_INPUT;
     m_SampleRate = SAMPLERATE_WIDEBAND;
     m_ucQuality = 0;
@@ -105,7 +108,13 @@ void CVoiceRecorder::Init(bool bEnabled, unsigned int uiServerSampleRate, unsign
         for (PaDeviceIndex i = 0; i < Pa_GetDeviceCount(); i++)
         {
             const PaDeviceInfo* pInfo = Pa_GetDeviceInfo(i);
-            if (pInfo && pInfo->maxInputChannels > 0 && m_strSelectedDeviceName == pInfo->name)
+            if (!pInfo || pInfo->maxInputChannels <= 0 || !pInfo->name)
+                continue;
+
+            // This project only builds the DirectSound host API (pa_win_ds.c), whose names come
+            // straight from DirectSoundEnumerateA with no length cap. A prefix match could pick
+            // the wrong device just for sharing a long prefix
+            if (m_strSelectedDeviceName == pInfo->name)
             {
                 deviceIndex = i;
                 break;

--- a/Client/mods/deathmatch/CVoiceRecorder.cpp
+++ b/Client/mods/deathmatch/CVoiceRecorder.cpp
@@ -34,11 +34,19 @@ CVoiceRecorder::CVoiceRecorder()
     m_ulTimeOfLastSend = 0;
 
     m_uiBufferSizeBytes = 0;
+
+    m_uiLastServerSampleRate = 0;
+    m_uiLastBitrate = 0;
+
+    OnPossibleDeviceChange();
 }
 
 CVoiceRecorder::~CVoiceRecorder()
 {
     DeInit();
+
+    if (m_InputDeviceScanThread.joinable())
+        m_InputDeviceScanThread.join();
 }
 
 // TODO: Replace this with BASS
@@ -66,6 +74,9 @@ void CVoiceRecorder::Init(bool bEnabled, unsigned int uiServerSampleRate, unsign
     if (!bEnabled)  // If we aren't enabled, don't bother continuing
         return;
 
+    m_uiLastServerSampleRate = uiServerSampleRate;
+    m_uiLastBitrate = uiBitrate;
+
     std::unique_lock<std::mutex> lock(m_Mutex);
 
     // Convert the sample rate we received from the server (0-2) into an actual sample rate
@@ -88,9 +99,23 @@ void CVoiceRecorder::Init(bool bEnabled, unsigned int uiServerSampleRate, unsign
 
     PaError error = Pa_Initialize();
 
+    PaDeviceIndex deviceIndex = Pa_GetDefaultInputDevice();
+    if (!m_strSelectedDeviceName.empty())
+    {
+        for (PaDeviceIndex i = 0; i < Pa_GetDeviceCount(); i++)
+        {
+            const PaDeviceInfo* pInfo = Pa_GetDeviceInfo(i);
+            if (pInfo && pInfo->maxInputChannels > 0 && m_strSelectedDeviceName == pInfo->name)
+            {
+                deviceIndex = i;
+                break;
+            }
+        }
+    }
+
     PaStreamParameters inputDevice;
     inputDevice.channelCount = 1;
-    inputDevice.device = Pa_GetDefaultInputDevice();
+    inputDevice.device = deviceIndex;
     inputDevice.sampleFormat = paInt16;
     inputDevice.hostApiSpecificStreamInfo = nullptr;
     inputDevice.suggestedLatency = 0;
@@ -236,6 +261,78 @@ void CVoiceRecorder::DeInit()
     m_uiBufferSizeBytes = 0;
 }
 
+std::vector<SSoundDeviceInfo> CVoiceRecorder::GetAvailableInputDevices()
+{
+    std::vector<SSoundDeviceInfo> devices;
+
+    bool bTerminateAfter = Pa_Initialize() == paNoError;
+    if (!bTerminateAfter && !m_pAudioStream)
+        return devices;
+
+    PaDeviceIndex defaultDevice = Pa_GetDefaultInputDevice();
+    for (PaDeviceIndex i = 0; i < Pa_GetDeviceCount(); i++)
+    {
+        const PaDeviceInfo* pInfo = Pa_GetDeviceInfo(i);
+        if (!pInfo || pInfo->maxInputChannels <= 0)
+            continue;
+
+        devices.push_back({pInfo->name ? pInfo->name : "", pInfo->name ? pInfo->name : "", i == defaultDevice});
+    }
+
+    // Only tear PortAudio back down if it wasn't already running for an active recording
+    if (bTerminateAfter && !m_pAudioStream)
+        Pa_Terminate();
+
+    return devices;
+}
+
+std::string CVoiceRecorder::GetInputDeviceName()
+{
+    return m_strSelectedDeviceName;
+}
+
+bool CVoiceRecorder::SetInputDevice(const std::string& strName)
+{
+    m_strSelectedDeviceName = strName;
+
+    if (m_bEnabled)
+        Init(true, m_uiLastServerSampleRate, m_ucQuality, m_uiLastBitrate);
+
+    return true;
+}
+
+void CVoiceRecorder::OnPossibleDeviceChange()
+{
+    if (m_bInputDeviceScanRunning)
+        return;
+
+    if (m_InputDeviceScanThread.joinable())
+        m_InputDeviceScanThread.join();
+
+    m_bInputDeviceScanRunning = true;
+    m_bInputDeviceScanReady = false;
+
+    m_InputDeviceScanThread = std::thread(
+        [this]()
+        {
+            m_InputDeviceScanResult = GetAvailableInputDevices();
+            m_bInputDeviceScanReady.store(true, std::memory_order_release);
+        });
+}
+
+void CVoiceRecorder::CollectInputDeviceScanResult()
+{
+    if (!m_bInputDeviceScanReady.load(std::memory_order_acquire))
+        return;
+
+    m_InputDeviceScanThread.join();
+    m_InputDevices = std::move(m_InputDeviceScanResult);
+    m_InputDeviceScanResult.clear();
+    m_bInputDeviceScanReady = false;
+    m_bInputDeviceScanRunning = false;
+    m_uiInputDeviceListRevision++;
+}
+
 const SpeexMode* CVoiceRecorder::getSpeexModeFromSampleRate()
 {
     switch (m_SampleRate)
@@ -322,6 +419,8 @@ bool CVoiceRecorder::GetPTTState()
 
 void CVoiceRecorder::DoPulse()
 {
+    CollectInputDeviceScanResult();
+
     std::lock_guard<std::mutex> lock(m_Mutex);
 
     // A missing buffer still needs the flush below to run, so it can reset the

--- a/Client/mods/deathmatch/CVoiceRecorder.h
+++ b/Client/mods/deathmatch/CVoiceRecorder.h
@@ -20,9 +20,11 @@
 
 #include <mutex>
 #include <atomic>
+#include <thread>
 #include <speex/speex.h>
 #include <speex/speex_preprocess.h>
 #include <portaudio/portaudio.h>
+#include <core/CClientBase.h>
 
 enum eVoiceState
 {
@@ -65,6 +67,14 @@ public:
 
     const SpeexMode* getSpeexModeFromSampleRate();
 
+    std::vector<SSoundDeviceInfo> GetAvailableInputDevices();
+    std::string                   GetInputDeviceName();
+    bool                          SetInputDevice(const std::string& strName);
+
+    void                                 OnPossibleDeviceChange();
+    const std::vector<SSoundDeviceInfo>& GetInputDevices() const { return m_InputDevices; }
+    unsigned int                         GetInputDeviceListRevision() const { return m_uiInputDeviceListRevision; }
+
 private:
     void DeInit();
     void SendFrame(const void* inputBuffer);
@@ -93,6 +103,20 @@ private:
 
     eSampleRate   m_SampleRate;
     unsigned char m_ucQuality;
+
+    // Cached so a device switch can re-run Init with the same session parameters
+    unsigned int m_uiLastServerSampleRate;
+    unsigned int m_uiLastBitrate;
+    std::string  m_strSelectedDeviceName;
+
+    void CollectInputDeviceScanResult();
+
+    std::thread                   m_InputDeviceScanThread;
+    std::atomic<bool>             m_bInputDeviceScanRunning{false};
+    std::atomic<bool>             m_bInputDeviceScanReady{false};
+    std::vector<SSoundDeviceInfo> m_InputDeviceScanResult;
+    std::vector<SSoundDeviceInfo> m_InputDevices;
+    unsigned int                  m_uiInputDeviceListRevision{0};
 
     std::list<SString> m_EventQueue;
     std::mutex         m_Mutex;

--- a/Client/mods/deathmatch/CVoiceRecorder.h
+++ b/Client/mods/deathmatch/CVoiceRecorder.h
@@ -72,8 +72,8 @@ public:
     bool                          SetInputDevice(const std::string& strName);
 
     void                                 OnPossibleDeviceChange();
-    const std::vector<SSoundDeviceInfo>& GetInputDevices() const { return m_InputDevices; }
-    unsigned int                         GetInputDeviceListRevision() const { return m_uiInputDeviceListRevision; }
+    const std::vector<SSoundDeviceInfo>& GetInputDevices() const noexcept { return m_InputDevices; }
+    unsigned int                         GetInputDeviceListRevision() const noexcept { return m_uiInputDeviceListRevision; }
 
 private:
     void DeInit();

--- a/Client/mods/deathmatch/logic/CBassAudio.cpp
+++ b/Client/mods/deathmatch/logic/CBassAudio.cpp
@@ -182,6 +182,9 @@ bool CBassAudio::BeginLoadingMedia()
         m_pVars = new SSoundThreadVariables();
         m_pVars->strURL = m_strPath;
         m_pVars->lFlags = lFlags;
+        // BASS_SetDevice is per-thread; carry the selected device over so the new thread doesn't
+        // default to the lowest initialised one
+        m_pVars->dwDevice = BASS_GetDevice();
         HANDLE hThread = CreateThread(NULL, 0, reinterpret_cast<LPTHREAD_START_ROUTINE>(&CBassAudio::PlayStreamIntern), m_uiCallbackId, 0, NULL);
         if (!hThread)
         {
@@ -640,8 +643,12 @@ DWORD CBassAudio::PlayStreamIntern(LPVOID argument)
         pBassAudio->m_pVars->criticalSection.Lock();
         SString strURL = pBassAudio->m_pVars->strURL;
         long    lFlags = pBassAudio->m_pVars->lFlags;
+        DWORD   dwDevice = pBassAudio->m_pVars->dwDevice;
         pBassAudio->m_pVars->criticalSection.Unlock();
         UnlockCallbackId();
+
+        // Same per-thread requirement as above; must run before BASS_StreamCreateURL
+        BASS_SetDevice(dwDevice);
 
         // This can take a long time (30+ seconds on slow/failing connections).
         // The main thread will wait for it with WaitForAllStreamingThreads().
@@ -692,6 +699,11 @@ void CBassAudio::CompleteStreamConnect(HSTREAM pSound)
     if (pSound)
     {
         m_pSound = pSound;
+
+        // The connect can outlast a device switch; SetOutputDevice's migration loop only sees
+        // channels that already exist, so it would have skipped this one. Reapply against the
+        // device this thread has selected now, which is always the current one
+        BASS_ChannelSetDevice(pSound, BASS_GetDevice());
 
         BASS_ChannelGetAttribute(pSound, BASS_ATTRIB_FREQ, &m_fDefaultFrequency);
         BASS_ChannelSetAttribute(pSound, BASS_ATTRIB_FREQ, m_fPlaybackSpeed * m_fDefaultFrequency);

--- a/Client/mods/deathmatch/logic/CBassAudio.h
+++ b/Client/mods/deathmatch/logic/CBassAudio.h
@@ -32,6 +32,7 @@ struct SSoundThreadVariables
     ZERO_ON_NEW
     SString            strURL;
     long               lFlags;
+    DWORD              dwDevice;
     DWORD              pSound;
     bool               bStreamCreateResult;
     std::list<double>  onClientSoundFinishedDownloadQueue;

--- a/Client/mods/deathmatch/logic/CBassAudio.h
+++ b/Client/mods/deathmatch/logic/CBassAudio.h
@@ -84,6 +84,7 @@ public:
     float   GetPan();
     void    SetPan(float fPan);
     bool    SetLooped(bool bLoop);
+    DWORD   GetChannelHandle() const { return m_pSound; }
 
     void   DoPulse(const CVector& vecPlayerPosition, const CVector& vecCameraPosition, const CVector& vecLookAt);
     void   AddQueuedEvent(eSoundEventType type, const SString& strString, double dNumber = 0.0, bool bBool = false, const SString& strError = "");

--- a/Client/mods/deathmatch/logic/CBassAudio.h
+++ b/Client/mods/deathmatch/logic/CBassAudio.h
@@ -85,7 +85,7 @@ public:
     float   GetPan();
     void    SetPan(float fPan);
     bool    SetLooped(bool bLoop);
-    DWORD   GetChannelHandle() const { return m_pSound; }
+    DWORD   GetChannelHandle() const noexcept { return m_pSound; }
 
     void   DoPulse(const CVector& vecPlayerPosition, const CVector& vecCameraPosition, const CVector& vecLookAt);
     void   AddQueuedEvent(eSoundEventType type, const SString& strString, double dNumber = 0.0, bool bBool = false, const SString& strError = "");

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -7164,6 +7164,7 @@ void CClientGame::OnWindowFocusChange(bool state)
 void CClientGame::OnPossibleAudioDeviceChange()
 {
     m_pManager->GetSoundManager()->OnPossibleDeviceChange();
+    m_pVoiceRecorder->OnPossibleDeviceChange();
 }
 
 unsigned int CClientGame::GetSoundOutputDeviceListRevision()
@@ -7184,6 +7185,26 @@ std::string CClientGame::GetSoundOutputDeviceDriver()
 bool CClientGame::SetSoundOutputDevice(const std::string& strDriver)
 {
     return m_pManager->GetSoundManager()->SetOutputDevice(strDriver);
+}
+
+unsigned int CClientGame::GetSoundInputDeviceListRevision()
+{
+    return m_pVoiceRecorder->GetInputDeviceListRevision();
+}
+
+std::vector<SSoundDeviceInfo> CClientGame::GetSoundInputDevices()
+{
+    return m_pVoiceRecorder->GetInputDevices();
+}
+
+std::string CClientGame::GetSoundInputDeviceName()
+{
+    return m_pVoiceRecorder->GetInputDeviceName();
+}
+
+bool CClientGame::SetSoundInputDevice(const std::string& strName)
+{
+    return m_pVoiceRecorder->SetInputDevice(strName);
 }
 
 void CClientGame::InsertIFPPointerToMap(const unsigned int u32BlockNameHash, const std::shared_ptr<CClientIFP>& pIFP)

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -7166,6 +7166,26 @@ void CClientGame::OnPossibleAudioDeviceChange()
     m_pManager->GetSoundManager()->OnPossibleDeviceChange();
 }
 
+unsigned int CClientGame::GetSoundOutputDeviceListRevision()
+{
+    return m_pManager->GetSoundManager()->GetOutputDeviceListRevision();
+}
+
+std::vector<SSoundDeviceInfo> CClientGame::GetSoundOutputDevices()
+{
+    return m_pManager->GetSoundManager()->GetOutputDevices();
+}
+
+std::string CClientGame::GetSoundOutputDeviceDriver()
+{
+    return m_pManager->GetSoundManager()->GetOutputDeviceDriver();
+}
+
+bool CClientGame::SetSoundOutputDevice(const std::string& strDriver)
+{
+    return m_pManager->GetSoundManager()->SetOutputDevice(strDriver);
+}
+
 void CClientGame::InsertIFPPointerToMap(const unsigned int u32BlockNameHash, const std::shared_ptr<CClientIFP>& pIFP)
 {
     m_mapOfIfpPointers[u32BlockNameHash] = pIFP;

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -7164,6 +7164,7 @@ void CClientGame::OnWindowFocusChange(bool state)
 void CClientGame::OnPossibleAudioDeviceChange()
 {
     m_pManager->GetSoundManager()->OnPossibleDeviceChange();
+    m_pManager->GetSoundManager()->RestartNativeAudioOnNextPulse();
     m_pVoiceRecorder->OnPossibleDeviceChange();
 }
 

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -7161,6 +7161,11 @@ void CClientGame::OnWindowFocusChange(bool state)
     m_pRootEntity->CallEvent("onClientMTAFocusChange", Arguments, false);
 }
 
+void CClientGame::OnPossibleAudioDeviceChange()
+{
+    m_pManager->GetSoundManager()->OnPossibleDeviceChange();
+}
+
 void CClientGame::InsertIFPPointerToMap(const unsigned int u32BlockNameHash, const std::shared_ptr<CClientIFP>& pIFP)
 {
     m_mapOfIfpPointers[u32BlockNameHash] = pIFP;

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -514,6 +514,11 @@ public:
     void OnWindowFocusChange(bool state);
     void OnPossibleAudioDeviceChange();
 
+    unsigned int                  GetSoundOutputDeviceListRevision();
+    std::vector<SSoundDeviceInfo> GetSoundOutputDevices();
+    std::string                   GetSoundOutputDeviceDriver();
+    bool                          SetSoundOutputDevice(const std::string& strDriver);
+
     void                      SetAllowMultiCommandHandlers(MultiCommandHandlerPolicy policy) noexcept { m_allowMultiCommandHandlers = policy; }
     MultiCommandHandlerPolicy GetAllowMultiCommandHandlers() const noexcept { return m_allowMultiCommandHandlers; }
 

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -519,6 +519,11 @@ public:
     std::string                   GetSoundOutputDeviceDriver();
     bool                          SetSoundOutputDevice(const std::string& strDriver);
 
+    unsigned int                  GetSoundInputDeviceListRevision();
+    std::vector<SSoundDeviceInfo> GetSoundInputDevices();
+    std::string                   GetSoundInputDeviceName();
+    bool                          SetSoundInputDevice(const std::string& strName);
+
     void                      SetAllowMultiCommandHandlers(MultiCommandHandlerPolicy policy) noexcept { m_allowMultiCommandHandlers = policy; }
     MultiCommandHandlerPolicy GetAllowMultiCommandHandlers() const noexcept { return m_allowMultiCommandHandlers; }
 

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -512,6 +512,7 @@ public:
     void ReinitMarkers();
 
     void OnWindowFocusChange(bool state);
+    void OnPossibleAudioDeviceChange();
 
     void                      SetAllowMultiCommandHandlers(MultiCommandHandlerPolicy policy) noexcept { m_allowMultiCommandHandlers = policy; }
     MultiCommandHandlerPolicy GetAllowMultiCommandHandlers() const noexcept { return m_allowMultiCommandHandlers; }

--- a/Client/mods/deathmatch/logic/CClientPlayerVoice.h
+++ b/Client/mods/deathmatch/logic/CClientPlayerVoice.h
@@ -88,6 +88,12 @@ public:
 
     bool IsActive() { return m_bVoiceActive; }
 
+    void MoveToDevice(DWORD dwDevice)
+    {
+        if (m_pBassPlaybackStream)
+            BASS_ChannelSetDevice(m_pBassPlaybackStream, dwDevice);
+    }
+
 private:
     enum class EVoiceFrameResult
     {

--- a/Client/mods/deathmatch/logic/CClientSound.cpp
+++ b/Client/mods/deathmatch/logic/CClientSound.cpp
@@ -860,6 +860,11 @@ bool CClientSound::IsFinished()
     return false;
 }
 
+DWORD CClientSound::GetChannelHandle()
+{
+    return m_pAudio ? m_pAudio->GetChannelHandle() : 0;
+}
+
 bool CClientSound::GetPan(float& fPan)
 {
     if (m_pAudio && !m_b3D)

--- a/Client/mods/deathmatch/logic/CClientSound.h
+++ b/Client/mods/deathmatch/logic/CClientSound.h
@@ -93,7 +93,7 @@ public:
 
     bool  IsSoundStopped() { return m_pAudio == NULL; }
     DWORD GetChannelHandle();
-    bool IsFinished();
+    bool  IsFinished();
 
     bool IsSound3D() { return m_b3D; }
     bool IsSoundStream() { return m_bStream; }

--- a/Client/mods/deathmatch/logic/CClientSound.h
+++ b/Client/mods/deathmatch/logic/CClientSound.h
@@ -91,7 +91,8 @@ public:
 
     void Unlink() {};
 
-    bool IsSoundStopped() { return m_pAudio == NULL; }
+    bool  IsSoundStopped() { return m_pAudio == NULL; }
+    DWORD GetChannelHandle();
     bool IsFinished();
 
     bool IsSound3D() { return m_b3D; }

--- a/Client/mods/deathmatch/logic/CClientSoundManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientSoundManager.cpp
@@ -27,8 +27,29 @@ CClientSoundManager::CClientSoundManager(CClientManager* pClientManager)
     // whatever device was default at Init time
     BASS_SetConfig(BASS_CONFIG_DEV_DEFAULT, TRUE);
 
+    // Opens BASS straight on the device remembered in the settings, so nothing needs moving
+    // afterward; -1 falls back to the system default if there is no preference or it's gone.
+    // Native audio is not restarted here, that would deadlock the mod load; it already opened on
+    // the same device via the GUID resolved earlier
+    DWORD       dwInitDevice = static_cast<DWORD>(-1);
+    std::string strPreferredDevice;
+    g_pCore->GetCVars()->Get("audio_output_device", strPreferredDevice);
+    if (!strPreferredDevice.empty())
+    {
+        BASS_DEVICEINFO info;
+        for (DWORD i = 0; BASS_GetDeviceInfo(i, &info); i++)
+        {
+            if ((info.flags & BASS_DEVICE_ENABLED) && info.name && strPreferredDevice == info.name)
+            {
+                dwInitDevice = i;
+                m_strPreferredOutputDeviceName = strPreferredDevice;
+                break;
+            }
+        }
+    }
+
     // Initialize BASS audio library
-    if (!BASS_Init(-1, 44100, NULL, NULL, NULL))
+    if (!BASS_Init(dwInitDevice, 44100, NULL, NULL, NULL))
         g_pCore->GetConsole()->Printf("BASS ERROR %d in Init", BASS_ErrorGetCode());
 
     // Load the Plugins
@@ -395,10 +416,28 @@ void CClientSoundManager::CollectOutputDeviceScanResult()
 
 bool CClientSoundManager::SetOutputDevice(const std::string& strDriver)
 {
+    const DWORD dwPreviousDevice = BASS_GetDevice();
+
+    // Already the active device; nothing to move, but still remember the preference so hotplug
+    // re-resolution keeps targeting it
+    BASS_DEVICEINFO current;
+    if (BASS_GetDeviceInfo(BASS_GetDevice(), &current) && current.name && (strDriver == current.name || (current.driver && strDriver == current.driver)))
+    {
+        m_strPreferredOutputDeviceName = current.name;
+        if (g_pMultiplayer)
+            g_pMultiplayer->SetPreferredAudioDeviceName(m_strPreferredOutputDeviceName);
+        return true;
+    }
+
     BASS_DEVICEINFO info;
     for (DWORD i = 0; BASS_GetDeviceInfo(i, &info); i++)
     {
-        if (!(info.flags & BASS_DEVICE_ENABLED) || !info.driver || strDriver != info.driver)
+        if (!(info.flags & BASS_DEVICE_ENABLED) || !info.driver)
+            continue;
+
+        // The settings identify devices by display name; a BASS driver string still matches for
+        // callers that pass one
+        if (strDriver != info.driver && (!info.name || strDriver != info.name))
             continue;
 
         if (!(info.flags & BASS_DEVICE_INIT) && !BASS_Init(i, 44100, NULL, NULL, NULL))
@@ -422,6 +461,15 @@ bool CClientSoundManager::SetOutputDevice(const std::string& strDriver)
             CClientPlayerVoice* pVoice = (*iter)->GetVoice();
             if (pVoice)
                 pVoice->MoveToDevice(i);
+        }
+
+        // Free the device we left; otherwise it stays initialised and BASS keeps offering it as
+        // the fallback "lowest initialised device" to any thread that hasn't picked one itself
+        if (dwPreviousDevice != static_cast<DWORD>(-1) && dwPreviousDevice != i)
+        {
+            BASS_SetDevice(dwPreviousDevice);
+            BASS_Free();
+            BASS_SetDevice(i);
         }
 
         // Restarts the native audio engine on this same device right away; also remembered so a

--- a/Client/mods/deathmatch/logic/CClientSoundManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientSoundManager.cpp
@@ -374,6 +374,14 @@ void CClientSoundManager::OnPossibleDeviceChange()
 
 void CClientSoundManager::CollectOutputDeviceScanResult()
 {
+    if (m_bNativeAudioRestartPending.exchange(false) && g_pMultiplayer)
+    {
+        // Re-resolve the preferred device by name rather than just restarting outright: if that
+        // device is the one that just disappeared, this correctly falls back to the system
+        // default instead of retrying a dead GUID and failing to open at all
+        g_pMultiplayer->SetPreferredAudioDeviceName(m_strPreferredOutputDeviceName);
+    }
+
     if (!m_bOutputDeviceScanReady.load(std::memory_order_acquire))
         return;
 
@@ -416,9 +424,11 @@ bool CClientSoundManager::SetOutputDevice(const std::string& strDriver)
                 pVoice->MoveToDevice(i);
         }
 
-        // The native audio engine only picks this up on its own next (re)init, not immediately
+        // Restarts the native audio engine on this same device right away; also remembered so a
+        // hotplug event can re-resolve it later instead of blindly reusing a dead device's GUID
+        m_strPreferredOutputDeviceName = info.name ? info.name : "";
         if (g_pMultiplayer)
-            g_pMultiplayer->SetPreferredAudioDeviceName(info.name ? info.name : "");
+            g_pMultiplayer->SetPreferredAudioDeviceName(m_strPreferredOutputDeviceName);
 
         return true;
     }

--- a/Client/mods/deathmatch/logic/CClientSoundManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientSoundManager.cpp
@@ -21,6 +21,10 @@ CClientSoundManager::CClientSoundManager(CClientManager* pClientManager)
 {
     m_pClientManager = pClientManager;
 
+    // Keep following the system default device across output changes, instead of getting stuck on
+    // whatever device was default at Init time
+    BASS_SetConfig(BASS_CONFIG_DEV_DEFAULT, TRUE);
+
     // Initialize BASS audio library
     if (!BASS_Init(-1, 44100, NULL, NULL, NULL))
         g_pCore->GetConsole()->Printf("BASS ERROR %d in Init", BASS_ErrorGetCode());

--- a/Client/mods/deathmatch/logic/CClientSoundManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientSoundManager.cpp
@@ -70,10 +70,15 @@ CClientSoundManager::CClientSoundManager(CClientManager* pClientManager)
     {
         m_aValidatedSFX[i] = g_pGame->GetAudioContainer()->ValidateContainer(static_cast<eAudioLookupIndex>(i));
     }
+
+    OnPossibleDeviceChange();
 }
 
 CClientSoundManager::~CClientSoundManager()
 {
+    if (m_OutputDeviceScanThread.joinable())
+        m_OutputDeviceScanThread.join();
+
     ProcessStopQueues(true);
 
     // Signal stream threads to exit as soon as their blocking call returns
@@ -92,6 +97,7 @@ CClientSoundManager::~CClientSoundManager()
 void CClientSoundManager::DoPulse()
 {
     UpdateVolume();
+    CollectOutputDeviceScanResult();
 
     CClientCamera* pCamera = m_pClientManager->GetCamera();
 
@@ -344,6 +350,38 @@ std::string CClientSoundManager::GetOutputDeviceDriver()
     if (BASS_GetDeviceInfo(BASS_GetDevice(), &info) && info.driver)
         return info.driver;
     return "";
+}
+
+void CClientSoundManager::OnPossibleDeviceChange()
+{
+    if (m_bOutputDeviceScanRunning)
+        return;
+
+    if (m_OutputDeviceScanThread.joinable())
+        m_OutputDeviceScanThread.join();
+
+    m_bOutputDeviceScanRunning = true;
+    m_bOutputDeviceScanReady = false;
+
+    m_OutputDeviceScanThread = std::thread(
+        [this]()
+        {
+            m_OutputDeviceScanResult = GetAvailableOutputDevices();
+            m_bOutputDeviceScanReady.store(true, std::memory_order_release);
+        });
+}
+
+void CClientSoundManager::CollectOutputDeviceScanResult()
+{
+    if (!m_bOutputDeviceScanReady.load(std::memory_order_acquire))
+        return;
+
+    m_OutputDeviceScanThread.join();
+    m_OutputDevices = std::move(m_OutputDeviceScanResult);
+    m_OutputDeviceScanResult.clear();
+    m_bOutputDeviceScanReady = false;
+    m_bOutputDeviceScanRunning = false;
+    m_uiOutputDeviceListRevision++;
 }
 
 bool CClientSoundManager::SetOutputDevice(const std::string& strDriver)

--- a/Client/mods/deathmatch/logic/CClientSoundManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientSoundManager.cpp
@@ -17,6 +17,7 @@ using SharedUtil::CalcMTASAPath;
 using std::list;
 
 extern CCoreInterface* g_pCore;
+extern CMultiplayer*   g_pMultiplayer;
 
 CClientSoundManager::CClientSoundManager(CClientManager* pClientManager)
 {
@@ -414,6 +415,10 @@ bool CClientSoundManager::SetOutputDevice(const std::string& strDriver)
             if (pVoice)
                 pVoice->MoveToDevice(i);
         }
+
+        // The native audio engine only picks this up on its own next (re)init, not immediately
+        if (g_pMultiplayer)
+            g_pMultiplayer->SetPreferredAudioDeviceName(info.name ? info.name : "");
 
         return true;
     }

--- a/Client/mods/deathmatch/logic/CClientSoundManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientSoundManager.cpp
@@ -11,6 +11,7 @@
 #include "StdInc.h"
 #include <game/CSettings.h>
 #include "CBassAudio.h"
+#include "CClientPlayerManager.h"
 
 using SharedUtil::CalcMTASAPath;
 using std::list;
@@ -321,6 +322,64 @@ void CClientSoundManager::UpdateVolume()
 
     BASS_SetConfig(BASS_CONFIG_GVOL_STREAM, static_cast<DWORD>(fValue * 10000));
     BASS_SetConfig(BASS_CONFIG_GVOL_MUSIC, static_cast<DWORD>(fValue * 10000));
+}
+
+std::vector<SSoundDeviceInfo> CClientSoundManager::GetAvailableOutputDevices()
+{
+    std::vector<SSoundDeviceInfo> devices;
+    BASS_DEVICEINFO               info;
+    for (DWORD i = 0; BASS_GetDeviceInfo(i, &info); i++)
+    {
+        if (!(info.flags & BASS_DEVICE_ENABLED) || !info.driver)
+            continue;
+
+        devices.push_back({info.name ? info.name : "", info.driver, (info.flags & BASS_DEVICE_DEFAULT) != 0});
+    }
+    return devices;
+}
+
+std::string CClientSoundManager::GetOutputDeviceDriver()
+{
+    BASS_DEVICEINFO info;
+    if (BASS_GetDeviceInfo(BASS_GetDevice(), &info) && info.driver)
+        return info.driver;
+    return "";
+}
+
+bool CClientSoundManager::SetOutputDevice(const std::string& strDriver)
+{
+    BASS_DEVICEINFO info;
+    for (DWORD i = 0; BASS_GetDeviceInfo(i, &info); i++)
+    {
+        if (!(info.flags & BASS_DEVICE_ENABLED) || !info.driver || strDriver != info.driver)
+            continue;
+
+        if (!(info.flags & BASS_DEVICE_INIT) && !BASS_Init(i, 44100, NULL, NULL, NULL))
+            return false;
+
+        BASS_SetDevice(i);
+
+        // Move already-playing sounds over immediately instead of waiting for them to restart
+        for (CClientSound* pSound : m_Sounds)
+        {
+            DWORD dwChannel = pSound->GetChannelHandle();
+            if (dwChannel)
+                BASS_ChannelSetDevice(dwChannel, i);
+        }
+
+        // Voice playback streams live for the whole connection rather than per transmission, so
+        // anyone already talking needs to be moved over the same way
+        CClientPlayerManager* pPlayerManager = m_pClientManager->GetPlayerManager();
+        for (auto iter = pPlayerManager->IterBegin(); iter != pPlayerManager->IterEnd(); ++iter)
+        {
+            CClientPlayerVoice* pVoice = (*iter)->GetVoice();
+            if (pVoice)
+                pVoice->MoveToDevice(i);
+        }
+
+        return true;
+    }
+    return false;
 }
 
 //

--- a/Client/mods/deathmatch/logic/CClientSoundManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientSoundManager.cpp
@@ -17,7 +17,6 @@ using SharedUtil::CalcMTASAPath;
 using std::list;
 
 extern CCoreInterface* g_pCore;
-extern CMultiplayer*   g_pMultiplayer;
 
 CClientSoundManager::CClientSoundManager(CClientManager* pClientManager)
 {

--- a/Client/mods/deathmatch/logic/CClientSoundManager.h
+++ b/Client/mods/deathmatch/logic/CClientSoundManager.h
@@ -53,6 +53,7 @@ public:
     bool                          SetOutputDevice(const std::string& strDriver);
 
     void                                 OnPossibleDeviceChange();
+    void                                 RestartNativeAudioOnNextPulse() { m_bNativeAudioRestartPending = true; }
     const std::vector<SSoundDeviceInfo>& GetOutputDevices() const { return m_OutputDevices; }
     unsigned int                         GetOutputDeviceListRevision() const { return m_uiOutputDeviceListRevision; }
 
@@ -97,4 +98,6 @@ private:
     std::vector<SSoundDeviceInfo> m_OutputDeviceScanResult;
     std::vector<SSoundDeviceInfo> m_OutputDevices;
     unsigned int                  m_uiOutputDeviceListRevision{0};
+    std::atomic<bool>             m_bNativeAudioRestartPending{false};
+    std::string                   m_strPreferredOutputDeviceName;
 };

--- a/Client/mods/deathmatch/logic/CClientSoundManager.h
+++ b/Client/mods/deathmatch/logic/CClientSoundManager.h
@@ -14,15 +14,9 @@
 #include <thread>
 #include <atomic>
 #include <bass.h>
+#include <core/CClientBase.h>
 #include <game/CAudioContainer.h>
 #include "CClientSound.h"
-
-struct SSoundDeviceInfo
-{
-    std::string strName;
-    std::string strDriver;
-    bool        bIsDefault;
-};
 
 class CClientSoundManager
 {

--- a/Client/mods/deathmatch/logic/CClientSoundManager.h
+++ b/Client/mods/deathmatch/logic/CClientSoundManager.h
@@ -15,6 +15,13 @@
 #include <game/CAudioContainer.h>
 #include "CClientSound.h"
 
+struct SSoundDeviceInfo
+{
+    std::string strName;
+    std::string strDriver;
+    bool        bIsDefault;
+};
+
 class CClientSoundManager
 {
 public:
@@ -44,6 +51,10 @@ public:
     std::map<std::string, int> GetFxEffects() { return m_FxEffectNames; }
 
     void UpdateVolume();
+
+    std::vector<SSoundDeviceInfo> GetAvailableOutputDevices();
+    std::string                   GetOutputDeviceDriver();
+    bool                          SetOutputDevice(const std::string& strDriver);
 
     void UpdateDistanceStreaming(const CVector& vecListenerPosition);
 

--- a/Client/mods/deathmatch/logic/CClientSoundManager.h
+++ b/Client/mods/deathmatch/logic/CClientSoundManager.h
@@ -11,6 +11,8 @@
 #pragma once
 
 #include <list>
+#include <thread>
+#include <atomic>
 #include <bass.h>
 #include <game/CAudioContainer.h>
 #include "CClientSound.h"
@@ -56,6 +58,10 @@ public:
     std::string                   GetOutputDeviceDriver();
     bool                          SetOutputDevice(const std::string& strDriver);
 
+    void                                 OnPossibleDeviceChange();
+    const std::vector<SSoundDeviceInfo>& GetOutputDevices() const { return m_OutputDevices; }
+    unsigned int                         GetOutputDeviceListRevision() const { return m_uiOutputDeviceListRevision; }
+
     void UpdateDistanceStreaming(const CVector& vecListenerPosition);
 
     void OnDistanceStreamIn(CClientSound* pSound);
@@ -88,4 +94,13 @@ private:
     std::vector<DWORD>                  m_ChannelStopQueue;
     std::map<CBassAudio*, CElapsedTime> m_AudioStopQueue;
     CCriticalSection                    m_CS;
+
+    void CollectOutputDeviceScanResult();
+
+    std::thread                   m_OutputDeviceScanThread;
+    std::atomic<bool>             m_bOutputDeviceScanRunning{false};
+    std::atomic<bool>             m_bOutputDeviceScanReady{false};
+    std::vector<SSoundDeviceInfo> m_OutputDeviceScanResult;
+    std::vector<SSoundDeviceInfo> m_OutputDevices;
+    unsigned int                  m_uiOutputDeviceListRevision{0};
 };

--- a/Client/mods/deathmatch/logic/CClientSoundManager.h
+++ b/Client/mods/deathmatch/logic/CClientSoundManager.h
@@ -54,8 +54,8 @@ public:
 
     void                                 OnPossibleDeviceChange();
     void                                 RestartNativeAudioOnNextPulse() { m_bNativeAudioRestartPending = true; }
-    const std::vector<SSoundDeviceInfo>& GetOutputDevices() const { return m_OutputDevices; }
-    unsigned int                         GetOutputDeviceListRevision() const { return m_uiOutputDeviceListRevision; }
+    const std::vector<SSoundDeviceInfo>& GetOutputDevices() const noexcept { return m_OutputDevices; }
+    unsigned int                         GetOutputDeviceListRevision() const noexcept { return m_uiOutputDeviceListRevision; }
 
     void UpdateDistanceStreaming(const CVector& vecListenerPosition);
 

--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1595,6 +1595,7 @@ void CMultiplayerSA::InitHooks()
     InitHooks_Postprocess();
     InitHooks_Explosions();
     InitHooks_Tasks();
+    InitHooks_Audio();
 }
 
 // Used to store copied pointers for explosions in the FxSystem

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -88,6 +88,7 @@ public:
     void                InitHooks_DeviceSelection();
     void                InitHooks_Explosions();
     void                InitHooks_Tasks();
+    void                InitHooks_Audio();
     CRemoteDataStorage* CreateRemoteDataStorage();
     void                DestroyRemoteDataStorage(CRemoteDataStorage* pData);
     void                AddRemoteDataStorage(CPlayerPed* pPed, CRemoteDataStorage* pData);
@@ -356,6 +357,8 @@ public:
 
     void SetBoatWaterSplashEnabled(bool bEnabled);
     void SetTyreSmokeEnabled(bool bEnabled);
+
+    void SetPreferredAudioDeviceName(const std::string& strName) override;
 
     void SetLastStaticAnimationPlayed(eAnimGroup dwGroupID, eAnimID dwAnimID, DWORD dwAnimArrayAddress)
     {

--- a/Client/multiplayer_sa/CMultiplayerSA.h
+++ b/Client/multiplayer_sa/CMultiplayerSA.h
@@ -358,6 +358,7 @@ public:
     void SetBoatWaterSplashEnabled(bool bEnabled);
     void SetTyreSmokeEnabled(bool bEnabled);
 
+    void RestartAudioHardware() override;
     void SetPreferredAudioDeviceName(const std::string& strName) override;
 
     void SetLastStaticAnimationPlayed(eAnimGroup dwGroupID, eAnimID dwAnimID, DWORD dwAnimArrayAddress)

--- a/Client/multiplayer_sa/CMultiplayerSA_Audio.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Audio.cpp
@@ -22,13 +22,16 @@
 // device's GUID here lets it open on a specific one instead, matching the BASS output
 // picker (GH #1146). Confirmed via decompile that the call at 0x4D99F0 is the real
 // EAXDirectSoundCreate8 (the earlier one at 0x4D99E1 is CoInitialize); the hook replaces the
-// "push 0 ; call [import]" pair immediately before it with "push <guid> ; call [import]".
+// "push ebx ; call [import]" pair, where ebx holds the null default GUID, with a push of the
+// chosen GUID before the same import call.
 //
 //////////////////////////////////////////////////////////////////////////////////////////
 static GUID g_PreferredAudioDeviceGuid;
 static bool g_bHasPreferredAudioDeviceGuid = false;
 
-static constexpr std::uintptr_t FUNC_EAXDirectSoundCreate8 = 0x85801C;
+// Must stay a #define: a constexpr symbol here would make the asm below call the variable's own
+// storage as code instead of going through the import slot
+#define FUNC_EAXDirectSoundCreate8 0x85801C
 
 #define HOOKPOS_CAEAudioHardware_CreateDirectSound  0x4D99EF
 #define HOOKSIZE_CAEAudioHardware_CreateDirectSound 7
@@ -47,7 +50,7 @@ static void __declspec(naked)   HOOK_CAEAudioHardware_CreateDirectSound()
         useDefault:
         push 0
         doCall:
-        call dword ptr [FUNC_EAXDirectSoundCreate8]
+        call dword ptr ds:[FUNC_EAXDirectSoundCreate8]
         jmp  CONTINUE_CAEAudioHardware_CreateDirectSound
     }
     // clang-format on
@@ -66,8 +69,8 @@ namespace
     struct SFindDeviceContext
     {
         const std::string* pstrName;
-        bool                bFound;
-        GUID                guid;
+        bool               bFound;
+        GUID               guid;
     };
 
     BOOL CALLBACK FindDeviceByNameCallback(GUID* pGuid, LPCSTR strDescription, LPCSTR strModule, LPVOID pContext)
@@ -81,25 +84,317 @@ namespace
         }
         return TRUE;
     }
-}            // namespace
+}  // namespace
 
-extern CGame* pGameInterface;
+extern CGame*          pGameInterface;
+extern CCoreInterface* g_pCore;
+
+// Terminate() already stops and joins both threads (0x4D97A0 calls both Stop and both
+// WaitForExit), so there is no race to fix here. It just never closes their handles, since the
+// game normally only runs this once at process exit; closing them ourselves stops a repeated
+// switch from leaking a handle pair every time
+static constexpr std::uintptr_t VAR_AudioStreamThreadHandle = 0xB606CC;
+static constexpr std::uintptr_t VAR_AudioSmoothFadeThreadHandle = 0xB608D0;
+
+static void CloseLeakedAudioThreadHandle(std::uintptr_t slotAddress)
+{
+    HANDLE& handle = *reinterpret_cast<HANDLE*>(slotAddress);
+    if (handle)
+    {
+        CloseHandle(handle);
+        handle = nullptr;
+    }
+}
+
+// Terminate() deletes the CAEMP3BankLoader (m_pMP3BankLoader, this+0xD98) without closing the
+// CdStream handles it opened for every AUDIO\SFX pak; Initialise() then reopens them all in a
+// fresh loader. That never mattered for a one-shot Terminate at process exit, but on repeated
+// switches it fills the shared 32-slot gStreamFileHandles table, which PAKFILES.DAT is already
+// close to using up on its own; once full, sound banks fail to load silently, with no crash
+// (vehicle radio is unaffected, it reads through plain fopen()). Each pak's CdStreamHandle is
+// (index << 24) into that same table (m_StreamHandles at +0x20, m_PakLkupCount at +0x10), so this
+// closes exactly those handles
+static constexpr std::uintptr_t OBJ_AEAudioHardware = 0xB5F8B8;
+static constexpr std::uintptr_t OFFSET_AEAudioHardware_MP3BankLoader = 0xD98;
+static constexpr std::uintptr_t OFFSET_CAEBankLoader_PakLkupCount = 0x10;
+static constexpr std::uintptr_t OFFSET_CAEBankLoader_StreamHandles = 0x20;
+static constexpr std::uintptr_t VAR_GStreamFileHandles = 0x8E4010;
+static constexpr std::uint32_t  CD_STREAM_HANDLE_BITS = 24;
+static constexpr std::uint32_t  MAX_CD_STREAM_HANDLES = 32;
+
+static void ReleaseLeakedSfxPakStreamHandles()
+{
+    const std::uintptr_t pBankLoader = *reinterpret_cast<std::uintptr_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_MP3BankLoader);
+    if (!pBankLoader)
+        return;
+
+    const std::uint16_t usPakCount = *reinterpret_cast<std::uint16_t*>(pBankLoader + OFFSET_CAEBankLoader_PakLkupCount);
+    std::int32_t* const pStreamHandles = *reinterpret_cast<std::int32_t**>(pBankLoader + OFFSET_CAEBankLoader_StreamHandles);
+    if (!pStreamHandles)
+        return;
+
+    HANDLE* const pGlobalStreamHandles = reinterpret_cast<HANDLE*>(VAR_GStreamFileHandles);
+    for (std::uint16_t i = 0; i < usPakCount; i++)
+    {
+        // CdStreamOpen returns 0 both on a failed open and on a legitimate slot-0 open; slot 0 in
+        // practice always belongs to the game's own boot-time streaming archives, opened before
+        // any SFX pak, so skipping 0 here is the safe reading either way
+        if (pStreamHandles[i] == 0)
+            continue;
+
+        const std::uint32_t uiIndex = static_cast<std::uint32_t>(pStreamHandles[i]) >> CD_STREAM_HANDLE_BITS;
+        if (uiIndex >= MAX_CD_STREAM_HANDLES)
+            continue;
+
+        HANDLE& hFile = pGlobalStreamHandles[uiIndex];
+        if (hFile && hFile != INVALID_HANDLE_VALUE)
+        {
+            CloseHandle(hFile);
+            hFile = nullptr;
+        }
+    }
+}
+
+// Logs the hardware's real post-restart state; useful evidence if a future regression brings the
+// silent-SFX symptom back
+static constexpr std::uintptr_t OFFSET_AEAudioHardware_Initialised = 0x0;
+static constexpr std::uintptr_t OFFSET_AEAudioHardware_HardwareMixAvailable = 0x4;
+static constexpr std::uintptr_t OFFSET_AEAudioHardware_NumAvailableChannels = 0x8C;
+static constexpr std::uintptr_t OFFSET_AEAudioHardware_NumChannels = 0x8E;
+static constexpr std::uintptr_t OFFSET_AEAudioHardware_DSCapsFreeHw3DAllBuffers = 0xDE4;
+
+static void LogAudioHardwareState()
+{
+    const bool          bInitialised = *reinterpret_cast<bool*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_Initialised);
+    const bool          bHwMixAvailable = *reinterpret_cast<bool*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_HardwareMixAvailable);
+    const std::uint16_t usNumAvailableChannels = *reinterpret_cast<std::uint16_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_NumAvailableChannels);
+    const std::uint16_t usNumChannels = *reinterpret_cast<std::uint16_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_NumChannels);
+    const std::uint32_t uiFreeHw3DAllBuffers = *reinterpret_cast<std::uint32_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_DSCapsFreeHw3DAllBuffers);
+
+    OutputDebugLine(SString("[Audio] post-Initialise state: initialised=%d hwMix=%d numChannels=%d numAvailable=%d freeHw3DBuffers=%u", bInitialised,
+                            bHwMixAvailable, usNumChannels, usNumAvailableChannels, uiFreeHw3DAllBuffers));
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// Device-only restart
+//
+// Three investigation passes never pinned down what accumulates across repeated
+// Terminate()/Initialise() cycles to silence SFX after a couple of switches (the hardware's own
+// post-Initialise state came back identical every time, ruling out everything inside it). Rather
+// than keep chasing that, this sidesteps the problem: switching output device never needs to
+// touch the SFX pak/bank loader, the MP3 track loader, or the radio track manager, none of which
+// read or write the output device, even though Terminate()/Initialise() rebuild all of it anyway.
+// This rebuilds only what is genuinely device-dependent instead: the DirectSound device, the 3D
+// listener, every channel, and the two threads that service them, calling the same native
+// functions Initialise() itself calls for that part, verified address for address against
+// 0x4D9930/0x4D97A0. Everything left untouched keeps whatever valid state it already had.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+static constexpr std::uintptr_t OFFSET_AEAudioHardware_DSDevice = 0xDA0;
+static constexpr std::uintptr_t OFFSET_AEAudioHardware_DSCaps = 0xDAC;
+static constexpr std::uintptr_t OFFSET_AEAudioHardware_SpeakerConfig = 0xDA4;
+static constexpr std::uintptr_t OFFSET_AEAudioHardware_DirectSound3DListener = 0xE0C;
+static constexpr std::uintptr_t OFFSET_AEAudioHardware_StreamingChannel = 0xE10;
+static constexpr std::uintptr_t OFFSET_AEAudioHardware_StreamThread = 0xE14;
+static constexpr std::uintptr_t OFFSET_AEAudioHardware_Channels = 0xE64;     // CAEAudioChannel*[64]
+static constexpr std::uintptr_t OFFSET_AEAudioHardware_ChannelFlags0 = 0x6;  // int16, only slot 0 (the streaming channel) is set here
+static constexpr std::uint32_t  MAX_NUM_AUDIO_CHANNELS = 64;
+
+// Same double dereference the native SetCooperativeLevel call itself uses (PSGLOBAL(window) in
+// the reversed source); verified against the raw disassembly rather than an MTA-level window accessor
+static constexpr std::uintptr_t VAR_GameWindowHandlePtr = 0xC17054;
+
+static constexpr std::uintptr_t FUNC_OperatorNew = 0x82119A;
+static constexpr std::uintptr_t FUNC_InitDirectSoundListener = 0x4D9640;
+static constexpr std::uintptr_t FUNC_CAEStreamingChannel_Constructor = 0x4F1800;
+static constexpr std::uintptr_t FUNC_CAEStreamingChannel_Initialise = 0x4F22F0;
+static constexpr std::uintptr_t FUNC_CAEStaticChannel_Constructor = 0x4F0B10;
+static constexpr std::uintptr_t FUNC_CAEAudioChannel_SetVolume = 0x4D7C60;
+static constexpr std::uintptr_t FUNC_CAEStreamThread_Stop = 0x4F1590;
+static constexpr std::uintptr_t FUNC_CAEStreamThread_WaitForExit = 0x4F1220;
+static constexpr std::uintptr_t FUNC_CAEStreamThread_Initialise = 0x4F1680;
+static constexpr std::uintptr_t FUNC_CAEStreamThread_Start = 0x4F11F0;
+static constexpr std::uintptr_t FUNC_CAESmoothFadeThread_Stop = 0x4EEA30;
+static constexpr std::uintptr_t FUNC_CAESmoothFadeThread_WaitForExit = 0x4EEA40;
+static constexpr std::uintptr_t FUNC_CAESmoothFadeThread_Initialise = 0x4EEEC0;
+static constexpr std::uintptr_t FUNC_CAESmoothFadeThread_Start = 0x4EEA10;
+
+static void PartialTerminateAudioDevice()
+{
+    reinterpret_cast<void(__thiscall*)(void*)>(FUNC_CAEStreamThread_Stop)(reinterpret_cast<void*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_StreamThread));
+    reinterpret_cast<void(__thiscall*)(void*)>(FUNC_CAESmoothFadeThread_Stop)(reinterpret_cast<void*>(VAR_AudioSmoothFadeThreadHandle));
+    reinterpret_cast<void(__thiscall*)(void*)>(FUNC_CAEStreamThread_WaitForExit)(
+        reinterpret_cast<void*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_StreamThread));
+    reinterpret_cast<void(__thiscall*)(void*)>(FUNC_CAESmoothFadeThread_WaitForExit)(reinterpret_cast<void*>(VAR_AudioSmoothFadeThreadHandle));
+
+    // Each channel deleted through its own vtable's scalar deleting destructor (arg 1 also frees
+    // the memory), the same call the real Terminate() makes for this array
+    void** const ppChannels = reinterpret_cast<void**>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_Channels);
+    for (std::uint32_t i = 0; i < MAX_NUM_AUDIO_CHANNELS; i++)
+    {
+        if (void* pChannel = ppChannels[i])
+        {
+            void** const pVtable = *reinterpret_cast<void***>(pChannel);
+            reinterpret_cast<void(__thiscall*)(void*, int)>(pVtable[0])(pChannel, 1);
+            ppChannels[i] = nullptr;
+        }
+    }
+    *reinterpret_cast<void**>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_StreamingChannel) = nullptr;
+
+    IDirectSound3DListener*& pListener = *reinterpret_cast<IDirectSound3DListener**>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_DirectSound3DListener);
+    if (pListener)
+    {
+        pListener->Release();
+        pListener = nullptr;
+    }
+
+    IDirectSound8*& pDevice = *reinterpret_cast<IDirectSound8**>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_DSDevice);
+    if (pDevice)
+    {
+        pDevice->Release();
+        pDevice = nullptr;
+    }
+
+    *reinterpret_cast<bool*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_Initialised) = false;
+}
+
+static bool PartialInitialiseAudioDevice()
+{
+    IDirectSound8*& pDevice = *reinterpret_cast<IDirectSound8**>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_DSDevice);
+
+    CoInitialize(nullptr);
+
+    typedef HRESULT(WINAPI * EAXDirectSoundCreate8Func)(const GUID*, IDirectSound8**, IUnknown*);
+    const auto  pfnCreate = *reinterpret_cast<EAXDirectSoundCreate8Func*>(FUNC_EAXDirectSoundCreate8);
+    const GUID* pGuid = g_bHasPreferredAudioDeviceGuid ? &g_PreferredAudioDeviceGuid : nullptr;
+    if (FAILED(pfnCreate(pGuid, &pDevice, nullptr)))
+        return false;
+
+    DSCAPS& dsCaps = *reinterpret_cast<DSCAPS*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_DSCaps);
+    dsCaps.dwSize = sizeof(DSCAPS);
+    pDevice->GetCaps(&dsCaps);
+
+    const HWND hWindow = *reinterpret_cast<HWND*>(*reinterpret_cast<std::uintptr_t*>(VAR_GameWindowHandlePtr));
+    if (FAILED(pDevice->SetCooperativeLevel(hWindow, DSSCL_PRIORITY)))
+        return false;
+
+    const bool bListenerOk = reinterpret_cast<bool(__thiscall*)(void*, std::uint32_t, std::uint32_t, std::uint32_t)>(FUNC_InitDirectSoundListener)(
+        reinterpret_cast<void*>(OBJ_AEAudioHardware), 2, 48000, 16);
+    if (!bListenerOk)
+        return false;
+
+    DWORD& dwSpeakerConfig = *reinterpret_cast<DWORD*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_SpeakerConfig);
+    pDevice->GetSpeakerConfig(&dwSpeakerConfig);
+
+    void*&      pStreamingChannelSlot = *reinterpret_cast<void**>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_StreamingChannel);
+    void* const pStreamingChannel = reinterpret_cast<void*(__cdecl*)(std::size_t)>(FUNC_OperatorNew)(0x60098);
+    if (!pStreamingChannel)
+        return false;
+    reinterpret_cast<void(__thiscall*)(void*, IDirectSound8*, std::uint16_t)>(FUNC_CAEStreamingChannel_Constructor)(pStreamingChannel, pDevice, 0);
+    pStreamingChannelSlot = pStreamingChannel;
+    reinterpret_cast<void(__thiscall*)(void*)>(FUNC_CAEStreamingChannel_Initialise)(pStreamingChannel);
+
+    const std::uint32_t uiFreeHw3DAllBuffers = *reinterpret_cast<std::uint32_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_DSCapsFreeHw3DAllBuffers);
+    std::uint16_t&      usNumChannels = *reinterpret_cast<std::uint16_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_NumChannels);
+    bool&               bHwMixAvailable = *reinterpret_cast<bool*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_HardwareMixAvailable);
+    if (uiFreeHw3DAllBuffers < 0x18)
+    {
+        usNumChannels = 0x30;
+        bHwMixAvailable = false;
+    }
+    else
+    {
+        usNumChannels = static_cast<std::uint16_t>(std::min<std::uint32_t>(uiFreeHw3DAllBuffers, 0x40) - 7);
+        bHwMixAvailable = true;
+    }
+
+    void** const ppChannels = reinterpret_cast<void**>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_Channels);
+    for (std::uint16_t i = 1; i < usNumChannels; i++)
+    {
+        void* const pChannel = reinterpret_cast<void*(__cdecl*)(std::size_t)>(FUNC_OperatorNew)(0x90);
+        if (pChannel)
+            reinterpret_cast<void(__thiscall*)(void*, IDirectSound8*, std::uint16_t, bool, std::uint32_t, std::uint16_t)>(FUNC_CAEStaticChannel_Constructor)(
+                pChannel, pDevice, i, bHwMixAvailable, 44100, 16);
+        ppChannels[i] = pChannel;
+    }
+    ppChannels[0] = pStreamingChannel;
+
+    reinterpret_cast<void(__thiscall*)(void*, float)>(FUNC_CAEAudioChannel_SetVolume)(pStreamingChannel, -100.0f);
+    *reinterpret_cast<std::int16_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_ChannelFlags0) = 0x37;
+
+    reinterpret_cast<void(__thiscall*)(void*)>(FUNC_CAESmoothFadeThread_Initialise)(reinterpret_cast<void*>(VAR_AudioSmoothFadeThreadHandle));
+    reinterpret_cast<void(__thiscall*)(void*)>(FUNC_CAESmoothFadeThread_Start)(reinterpret_cast<void*>(VAR_AudioSmoothFadeThreadHandle));
+
+    void* const pStreamThread = reinterpret_cast<void*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_StreamThread);
+    reinterpret_cast<void(__thiscall*)(void*, void*)>(FUNC_CAEStreamThread_Initialise)(pStreamThread, pStreamingChannel);
+    reinterpret_cast<void(__thiscall*)(void*)>(FUNC_CAEStreamThread_Start)(pStreamThread);
+
+    *reinterpret_cast<std::uint16_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_NumAvailableChannels) = usNumChannels;
+    *reinterpret_cast<bool*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_Initialised) = true;
+    return true;
+}
 
 void CMultiplayerSA::RestartAudioHardware()
 {
-    // Same teardown/rebuild the game already does once at normal startup, just run again on
-    // demand; causes the same brief hitch, but never needs a full game restart to take effect
     CAEAudioHardware* pAEAudioHardware = pGameInterface->GetAEAudioHardware();
     if (!pAEAudioHardware)
         return;
 
-    pAEAudioHardware->Terminate();
-    if (!pAEAudioHardware->Initialise())
-        OutputDebugLine("[Audio] Native audio hardware failed to (re)initialise; no SFX/radio/vehicle sounds until it recovers");
+    // Try the device-only path first: lighter, faster, and it never touches the SFX pak/bank
+    // loader that three investigation passes never found the fault in. Two attempts, since the
+    // driver can briefly report the old device as still allocated while it finishes releasing it
+    for (int iAttempt = 0; iAttempt < 2; iAttempt++)
+    {
+        PartialTerminateAudioDevice();
+        CloseLeakedAudioThreadHandle(VAR_AudioStreamThreadHandle);
+        CloseLeakedAudioThreadHandle(VAR_AudioSmoothFadeThreadHandle);
+
+        if (PartialInitialiseAudioDevice())
+        {
+            LogAudioHardwareState();
+            return;
+        }
+
+        Sleep(50);
+    }
+
+    OutputDebugLine("[Audio] Device-only restart failed twice; falling back to a full native audio reinitialise");
+
+    // Same teardown/rebuild the game already does once at normal startup, just run again on
+    // demand; causes the same brief hitch, but never needs a full game restart to take effect
+    for (int iAttempt = 0; iAttempt < 4; iAttempt++)
+    {
+        // Must run before Terminate deletes the bank loader. Safe to call again on a retry too:
+        // Initialise() unconditionally allocates and repopulates a fresh loader, reopening every
+        // pak's CD stream, before any of its own failure paths can return
+        ReleaseLeakedSfxPakStreamHandles();
+
+        pAEAudioHardware->Terminate();
+        CloseLeakedAudioThreadHandle(VAR_AudioStreamThreadHandle);
+        CloseLeakedAudioThreadHandle(VAR_AudioSmoothFadeThreadHandle);
+
+        if (pAEAudioHardware->Initialise())
+        {
+            LogAudioHardwareState();
+            return;
+        }
+
+        Sleep(50);
+    }
+
+    // The last attempt's Initialise() still reopened every pak's CD stream before failing; the
+    // loop exits here instead of looping back, so nothing above catches that one
+    ReleaseLeakedSfxPakStreamHandles();
+
+    OutputDebugLine("[Audio] Native audio hardware failed to reinitialise; no SFX/radio/vehicle sounds until the next device switch");
 }
 
 void CMultiplayerSA::SetPreferredAudioDeviceName(const std::string& strName)
 {
+    const bool bHadGuid = g_bHasPreferredAudioDeviceGuid;
+    const GUID oldGuid = g_PreferredAudioDeviceGuid;
+
     if (strName.empty())
         g_bHasPreferredAudioDeviceGuid = false;
     else
@@ -111,6 +406,11 @@ void CMultiplayerSA::SetPreferredAudioDeviceName(const std::string& strName)
         if (findContext.bFound)
             g_PreferredAudioDeviceGuid = findContext.guid;
     }
+
+    // Already open on this device; restarting again is wasteful at best and can deadlock if this
+    // lands mid join while the game is streaming audio banks
+    if (bHadGuid == g_bHasPreferredAudioDeviceGuid && (!bHadGuid || IsEqualGUID(oldGuid, g_PreferredAudioDeviceGuid)))
+        return;
 
     RestartAudioHardware();
 }
@@ -125,4 +425,19 @@ void CMultiplayerSA::SetPreferredAudioDeviceName(const std::string& strName)
 void CMultiplayerSA::InitHooks_Audio()
 {
     EZHookInstall(CAEAudioHardware_CreateDirectSound);
+
+    // Resolve the device remembered in the settings before the game opens its audio for the
+    // first time, so even the menu starts on it directly with no restart
+    std::string strPreferredDevice;
+    g_pCore->GetCVars()->Get("audio_output_device", strPreferredDevice);
+    if (!strPreferredDevice.empty())
+    {
+        SFindDeviceContext findContext{&strPreferredDevice, false, {}};
+        DirectSoundEnumerateA(FindDeviceByNameCallback, &findContext);
+        if (findContext.bFound)
+        {
+            g_PreferredAudioDeviceGuid = findContext.guid;
+            g_bHasPreferredAudioDeviceGuid = true;
+        }
+    }
 }

--- a/Client/multiplayer_sa/CMultiplayerSA_Audio.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Audio.cpp
@@ -1,0 +1,111 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        multiplayer_sa/CMultiplayerSA_Audio.cpp
+ *
+ *  Multi Theft Auto is available from https://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+#include "StdInc.h"
+#include <dsound.h>
+
+#pragma comment(lib, "dsound.lib")
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CAEAudioHardware::Initialise
+//
+// The native audio engine always passes a null device GUID to EAXDirectSoundCreate8, so it
+// only ever opens on whatever Windows considers the default device; substituting a chosen
+// device's GUID here lets it open on a specific one instead, matching the BASS output
+// picker (GH #1146). Confirmed via decompile that the call at 0x4D99F0 is the real
+// EAXDirectSoundCreate8 (the earlier one at 0x4D99E1 is CoInitialize); the hook replaces the
+// "push 0 ; call [import]" pair immediately before it with "push <guid> ; call [import]".
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+static GUID g_PreferredAudioDeviceGuid;
+static bool g_bHasPreferredAudioDeviceGuid = false;
+
+static constexpr std::uintptr_t FUNC_EAXDirectSoundCreate8 = 0x85801C;
+
+#define HOOKPOS_CAEAudioHardware_CreateDirectSound  0x4D99EF
+#define HOOKSIZE_CAEAudioHardware_CreateDirectSound 7
+static constexpr std::uintptr_t CONTINUE_CAEAudioHardware_CreateDirectSound = 0x4D99F6;
+static void __declspec(naked)   HOOK_CAEAudioHardware_CreateDirectSound()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        cmp  g_bHasPreferredAudioDeviceGuid, 0
+        jz   useDefault
+        push offset g_PreferredAudioDeviceGuid
+        jmp  doCall
+        useDefault:
+        push 0
+        doCall:
+        call dword ptr [FUNC_EAXDirectSoundCreate8]
+        jmp  CONTINUE_CAEAudioHardware_CreateDirectSound
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CMultiplayerSA::SetPreferredAudioDeviceName
+//
+// Resolves the given device name to a DirectSound GUID, to be substituted next time
+// CAEAudioHardware::Initialise runs (game restart, not immediately - see the hook above)
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+namespace
+{
+    struct SFindDeviceContext
+    {
+        const std::string* pstrName;
+        bool                bFound;
+        GUID                guid;
+    };
+
+    BOOL CALLBACK FindDeviceByNameCallback(GUID* pGuid, LPCSTR strDescription, LPCSTR strModule, LPVOID pContext)
+    {
+        auto* pFindContext = static_cast<SFindDeviceContext*>(pContext);
+        if (pGuid && strDescription && *pFindContext->pstrName == strDescription)
+        {
+            pFindContext->guid = *pGuid;
+            pFindContext->bFound = true;
+            return FALSE;
+        }
+        return TRUE;
+    }
+}            // namespace
+
+void CMultiplayerSA::SetPreferredAudioDeviceName(const std::string& strName)
+{
+    if (strName.empty())
+    {
+        g_bHasPreferredAudioDeviceGuid = false;
+        return;
+    }
+
+    SFindDeviceContext findContext{&strName, false, {}};
+    DirectSoundEnumerateA(FindDeviceByNameCallback, &findContext);
+
+    g_bHasPreferredAudioDeviceGuid = findContext.bFound;
+    if (findContext.bFound)
+        g_PreferredAudioDeviceGuid = findContext.guid;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
+// CMultiplayerSA::InitHooks_Audio
+//
+// Setup hooks
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+void CMultiplayerSA::InitHooks_Audio()
+{
+    EZHookInstall(CAEAudioHardware_CreateDirectSound);
+}

--- a/Client/multiplayer_sa/CMultiplayerSA_Audio.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Audio.cpp
@@ -9,6 +9,7 @@
  *****************************************************************************/
 #include "StdInc.h"
 #include <dsound.h>
+#include <game/CAEAudioHardware.h>
 
 #pragma comment(lib, "dsound.lib")
 
@@ -56,8 +57,8 @@ static void __declspec(naked)   HOOK_CAEAudioHardware_CreateDirectSound()
 //
 // CMultiplayerSA::SetPreferredAudioDeviceName
 //
-// Resolves the given device name to a DirectSound GUID, to be substituted next time
-// CAEAudioHardware::Initialise runs (game restart, not immediately - see the hook above)
+// Resolves the given device name to a DirectSound GUID, to be substituted by the hook above,
+// then restarts the audio hardware right away so it takes effect immediately
 //
 //////////////////////////////////////////////////////////////////////////////////////////
 namespace
@@ -82,20 +83,36 @@ namespace
     }
 }            // namespace
 
+extern CGame* pGameInterface;
+
+void CMultiplayerSA::RestartAudioHardware()
+{
+    // Same teardown/rebuild the game already does once at normal startup, just run again on
+    // demand; causes the same brief hitch, but never needs a full game restart to take effect
+    CAEAudioHardware* pAEAudioHardware = pGameInterface->GetAEAudioHardware();
+    if (!pAEAudioHardware)
+        return;
+
+    pAEAudioHardware->Terminate();
+    if (!pAEAudioHardware->Initialise())
+        OutputDebugLine("[Audio] Native audio hardware failed to (re)initialise; no SFX/radio/vehicle sounds until it recovers");
+}
+
 void CMultiplayerSA::SetPreferredAudioDeviceName(const std::string& strName)
 {
     if (strName.empty())
-    {
         g_bHasPreferredAudioDeviceGuid = false;
-        return;
+    else
+    {
+        SFindDeviceContext findContext{&strName, false, {}};
+        DirectSoundEnumerateA(FindDeviceByNameCallback, &findContext);
+
+        g_bHasPreferredAudioDeviceGuid = findContext.bFound;
+        if (findContext.bFound)
+            g_PreferredAudioDeviceGuid = findContext.guid;
     }
 
-    SFindDeviceContext findContext{&strName, false, {}};
-    DirectSoundEnumerateA(FindDeviceByNameCallback, &findContext);
-
-    g_bHasPreferredAudioDeviceGuid = findContext.bFound;
-    if (findContext.bFound)
-        g_PreferredAudioDeviceGuid = findContext.guid;
+    RestartAudioHardware();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/Client/multiplayer_sa/CMultiplayerSA_Audio.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Audio.cpp
@@ -68,18 +68,18 @@ namespace
 {
     struct SFindDeviceContext
     {
-        const std::string* pstrName;
-        bool               bFound;
+        const std::string* name;
+        bool               found;
         GUID               guid;
     };
 
-    BOOL CALLBACK FindDeviceByNameCallback(GUID* pGuid, LPCSTR strDescription, LPCSTR strModule, LPVOID pContext)
+    BOOL CALLBACK FindDeviceByNameCallback(GUID* guid, LPCSTR strDescription, LPCSTR strModule, LPVOID context)
     {
-        auto* pFindContext = static_cast<SFindDeviceContext*>(pContext);
-        if (pGuid && strDescription && *pFindContext->pstrName == strDescription)
+        auto* findContext = static_cast<SFindDeviceContext*>(context);
+        if (guid && strDescription && *findContext->name == strDescription)
         {
-            pFindContext->guid = *pGuid;
-            pFindContext->bFound = true;
+            findContext->guid = *guid;
+            findContext->found = true;
             return FALSE;
         }
         return TRUE;
@@ -124,33 +124,33 @@ static constexpr std::uint32_t  MAX_CD_STREAM_HANDLES = 32;
 
 static void ReleaseLeakedSfxPakStreamHandles()
 {
-    const std::uintptr_t pBankLoader = *reinterpret_cast<std::uintptr_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_MP3BankLoader);
-    if (!pBankLoader)
+    const std::uintptr_t bankLoader = *reinterpret_cast<std::uintptr_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_MP3BankLoader);
+    if (!bankLoader)
         return;
 
-    const std::uint16_t usPakCount = *reinterpret_cast<std::uint16_t*>(pBankLoader + OFFSET_CAEBankLoader_PakLkupCount);
-    std::int32_t* const pStreamHandles = *reinterpret_cast<std::int32_t**>(pBankLoader + OFFSET_CAEBankLoader_StreamHandles);
-    if (!pStreamHandles)
+    const std::uint16_t pakCount = *reinterpret_cast<std::uint16_t*>(bankLoader + OFFSET_CAEBankLoader_PakLkupCount);
+    std::int32_t* const streamHandles = *reinterpret_cast<std::int32_t**>(bankLoader + OFFSET_CAEBankLoader_StreamHandles);
+    if (!streamHandles)
         return;
 
-    HANDLE* const pGlobalStreamHandles = reinterpret_cast<HANDLE*>(VAR_GStreamFileHandles);
-    for (std::uint16_t i = 0; i < usPakCount; i++)
+    HANDLE* const globalStreamHandles = reinterpret_cast<HANDLE*>(VAR_GStreamFileHandles);
+    for (std::uint16_t i = 0; i < pakCount; i++)
     {
         // CdStreamOpen returns 0 both on a failed open and on a legitimate slot-0 open; slot 0 in
         // practice always belongs to the game's own boot-time streaming archives, opened before
         // any SFX pak, so skipping 0 here is the safe reading either way
-        if (pStreamHandles[i] == 0)
+        if (streamHandles[i] == 0)
             continue;
 
-        const std::uint32_t uiIndex = static_cast<std::uint32_t>(pStreamHandles[i]) >> CD_STREAM_HANDLE_BITS;
-        if (uiIndex >= MAX_CD_STREAM_HANDLES)
+        const std::uint32_t index = static_cast<std::uint32_t>(streamHandles[i]) >> CD_STREAM_HANDLE_BITS;
+        if (index >= MAX_CD_STREAM_HANDLES)
             continue;
 
-        HANDLE& hFile = pGlobalStreamHandles[uiIndex];
-        if (hFile && hFile != INVALID_HANDLE_VALUE)
+        HANDLE& file = globalStreamHandles[index];
+        if (file && file != INVALID_HANDLE_VALUE)
         {
-            CloseHandle(hFile);
-            hFile = nullptr;
+            CloseHandle(file);
+            file = nullptr;
         }
     }
 }
@@ -165,14 +165,14 @@ static constexpr std::uintptr_t OFFSET_AEAudioHardware_DSCapsFreeHw3DAllBuffers 
 
 static void LogAudioHardwareState()
 {
-    const bool          bInitialised = *reinterpret_cast<bool*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_Initialised);
-    const bool          bHwMixAvailable = *reinterpret_cast<bool*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_HardwareMixAvailable);
-    const std::uint16_t usNumAvailableChannels = *reinterpret_cast<std::uint16_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_NumAvailableChannels);
-    const std::uint16_t usNumChannels = *reinterpret_cast<std::uint16_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_NumChannels);
-    const std::uint32_t uiFreeHw3DAllBuffers = *reinterpret_cast<std::uint32_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_DSCapsFreeHw3DAllBuffers);
+    const bool          initialised = *reinterpret_cast<bool*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_Initialised);
+    const bool          hwMixAvailable = *reinterpret_cast<bool*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_HardwareMixAvailable);
+    const std::uint16_t numAvailableChannels = *reinterpret_cast<std::uint16_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_NumAvailableChannels);
+    const std::uint16_t numChannels = *reinterpret_cast<std::uint16_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_NumChannels);
+    const std::uint32_t freeHw3DAllBuffers = *reinterpret_cast<std::uint32_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_DSCapsFreeHw3DAllBuffers);
 
-    OutputDebugLine(SString("[Audio] post-Initialise state: initialised=%d hwMix=%d numChannels=%d numAvailable=%d freeHw3DBuffers=%u", bInitialised,
-                            bHwMixAvailable, usNumChannels, usNumAvailableChannels, uiFreeHw3DAllBuffers));
+    OutputDebugLine(SString("[Audio] post-Initialise state: initialised=%d hwMix=%d numChannels=%d numAvailable=%d freeHw3DBuffers=%u", initialised,
+                            hwMixAvailable, numChannels, numAvailableChannels, freeHw3DAllBuffers));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -230,30 +230,30 @@ static void PartialTerminateAudioDevice()
 
     // Each channel deleted through its own vtable's scalar deleting destructor (arg 1 also frees
     // the memory), the same call the real Terminate() makes for this array
-    void** const ppChannels = reinterpret_cast<void**>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_Channels);
+    void** const channels = reinterpret_cast<void**>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_Channels);
     for (std::uint32_t i = 0; i < MAX_NUM_AUDIO_CHANNELS; i++)
     {
-        if (void* pChannel = ppChannels[i])
+        if (void* channel = channels[i])
         {
-            void** const pVtable = *reinterpret_cast<void***>(pChannel);
-            reinterpret_cast<void(__thiscall*)(void*, int)>(pVtable[0])(pChannel, 1);
-            ppChannels[i] = nullptr;
+            void** const vtable = *reinterpret_cast<void***>(channel);
+            reinterpret_cast<void(__thiscall*)(void*, int)>(vtable[0])(channel, 1);
+            channels[i] = nullptr;
         }
     }
     *reinterpret_cast<void**>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_StreamingChannel) = nullptr;
 
-    IDirectSound3DListener*& pListener = *reinterpret_cast<IDirectSound3DListener**>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_DirectSound3DListener);
-    if (pListener)
+    IDirectSound3DListener*& listener = *reinterpret_cast<IDirectSound3DListener**>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_DirectSound3DListener);
+    if (listener)
     {
-        pListener->Release();
-        pListener = nullptr;
+        listener->Release();
+        listener = nullptr;
     }
 
-    IDirectSound8*& pDevice = *reinterpret_cast<IDirectSound8**>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_DSDevice);
-    if (pDevice)
+    IDirectSound8*& device = *reinterpret_cast<IDirectSound8**>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_DSDevice);
+    if (device)
     {
-        pDevice->Release();
-        pDevice = nullptr;
+        device->Release();
+        device = nullptr;
     }
 
     *reinterpret_cast<bool*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_Initialised) = false;
@@ -261,90 +261,90 @@ static void PartialTerminateAudioDevice()
 
 static bool PartialInitialiseAudioDevice()
 {
-    IDirectSound8*& pDevice = *reinterpret_cast<IDirectSound8**>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_DSDevice);
+    IDirectSound8*& device = *reinterpret_cast<IDirectSound8**>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_DSDevice);
 
     CoInitialize(nullptr);
 
     typedef HRESULT(WINAPI * EAXDirectSoundCreate8Func)(const GUID*, IDirectSound8**, IUnknown*);
-    const auto  pfnCreate = *reinterpret_cast<EAXDirectSoundCreate8Func*>(FUNC_EAXDirectSoundCreate8);
-    const GUID* pGuid = g_bHasPreferredAudioDeviceGuid ? &g_PreferredAudioDeviceGuid : nullptr;
-    if (FAILED(pfnCreate(pGuid, &pDevice, nullptr)))
+    const auto  create = *reinterpret_cast<EAXDirectSoundCreate8Func*>(FUNC_EAXDirectSoundCreate8);
+    const GUID* guid = g_bHasPreferredAudioDeviceGuid ? &g_PreferredAudioDeviceGuid : nullptr;
+    if (FAILED(create(guid, &device, nullptr)))
         return false;
 
     DSCAPS& dsCaps = *reinterpret_cast<DSCAPS*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_DSCaps);
     dsCaps.dwSize = sizeof(DSCAPS);
-    pDevice->GetCaps(&dsCaps);
+    device->GetCaps(&dsCaps);
 
-    const HWND hWindow = *reinterpret_cast<HWND*>(*reinterpret_cast<std::uintptr_t*>(VAR_GameWindowHandlePtr));
-    if (FAILED(pDevice->SetCooperativeLevel(hWindow, DSSCL_PRIORITY)))
+    const HWND window = *reinterpret_cast<HWND*>(*reinterpret_cast<std::uintptr_t*>(VAR_GameWindowHandlePtr));
+    if (FAILED(device->SetCooperativeLevel(window, DSSCL_PRIORITY)))
         return false;
 
-    const bool bListenerOk = reinterpret_cast<bool(__thiscall*)(void*, std::uint32_t, std::uint32_t, std::uint32_t)>(FUNC_InitDirectSoundListener)(
+    const bool listenerOk = reinterpret_cast<bool(__thiscall*)(void*, std::uint32_t, std::uint32_t, std::uint32_t)>(FUNC_InitDirectSoundListener)(
         reinterpret_cast<void*>(OBJ_AEAudioHardware), 2, 48000, 16);
-    if (!bListenerOk)
+    if (!listenerOk)
         return false;
 
-    DWORD& dwSpeakerConfig = *reinterpret_cast<DWORD*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_SpeakerConfig);
-    pDevice->GetSpeakerConfig(&dwSpeakerConfig);
+    DWORD& speakerConfig = *reinterpret_cast<DWORD*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_SpeakerConfig);
+    device->GetSpeakerConfig(&speakerConfig);
 
-    void*&      pStreamingChannelSlot = *reinterpret_cast<void**>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_StreamingChannel);
-    void* const pStreamingChannel = reinterpret_cast<void*(__cdecl*)(std::size_t)>(FUNC_OperatorNew)(0x60098);
-    if (!pStreamingChannel)
+    void*&      streamingChannelSlot = *reinterpret_cast<void**>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_StreamingChannel);
+    void* const streamingChannel = reinterpret_cast<void*(__cdecl*)(std::size_t)>(FUNC_OperatorNew)(0x60098);
+    if (!streamingChannel)
         return false;
-    reinterpret_cast<void(__thiscall*)(void*, IDirectSound8*, std::uint16_t)>(FUNC_CAEStreamingChannel_Constructor)(pStreamingChannel, pDevice, 0);
-    pStreamingChannelSlot = pStreamingChannel;
-    reinterpret_cast<void(__thiscall*)(void*)>(FUNC_CAEStreamingChannel_Initialise)(pStreamingChannel);
+    reinterpret_cast<void(__thiscall*)(void*, IDirectSound8*, std::uint16_t)>(FUNC_CAEStreamingChannel_Constructor)(streamingChannel, device, 0);
+    streamingChannelSlot = streamingChannel;
+    reinterpret_cast<void(__thiscall*)(void*)>(FUNC_CAEStreamingChannel_Initialise)(streamingChannel);
 
-    const std::uint32_t uiFreeHw3DAllBuffers = *reinterpret_cast<std::uint32_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_DSCapsFreeHw3DAllBuffers);
-    std::uint16_t&      usNumChannels = *reinterpret_cast<std::uint16_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_NumChannels);
-    bool&               bHwMixAvailable = *reinterpret_cast<bool*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_HardwareMixAvailable);
-    if (uiFreeHw3DAllBuffers < 0x18)
+    const std::uint32_t freeHw3DAllBuffers = *reinterpret_cast<std::uint32_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_DSCapsFreeHw3DAllBuffers);
+    std::uint16_t&      numChannels = *reinterpret_cast<std::uint16_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_NumChannels);
+    bool&               hwMixAvailable = *reinterpret_cast<bool*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_HardwareMixAvailable);
+    if (freeHw3DAllBuffers < 0x18)
     {
-        usNumChannels = 0x30;
-        bHwMixAvailable = false;
+        numChannels = 0x30;
+        hwMixAvailable = false;
     }
     else
     {
-        usNumChannels = static_cast<std::uint16_t>(std::min<std::uint32_t>(uiFreeHw3DAllBuffers, 0x40) - 7);
-        bHwMixAvailable = true;
+        numChannels = static_cast<std::uint16_t>(std::min<std::uint32_t>(freeHw3DAllBuffers, 0x40) - 7);
+        hwMixAvailable = true;
     }
 
-    void** const ppChannels = reinterpret_cast<void**>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_Channels);
-    for (std::uint16_t i = 1; i < usNumChannels; i++)
+    void** const channels = reinterpret_cast<void**>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_Channels);
+    for (std::uint16_t i = 1; i < numChannels; i++)
     {
-        void* const pChannel = reinterpret_cast<void*(__cdecl*)(std::size_t)>(FUNC_OperatorNew)(0x90);
-        if (pChannel)
+        void* const channel = reinterpret_cast<void*(__cdecl*)(std::size_t)>(FUNC_OperatorNew)(0x90);
+        if (channel)
             reinterpret_cast<void(__thiscall*)(void*, IDirectSound8*, std::uint16_t, bool, std::uint32_t, std::uint16_t)>(FUNC_CAEStaticChannel_Constructor)(
-                pChannel, pDevice, i, bHwMixAvailable, 44100, 16);
-        ppChannels[i] = pChannel;
+                channel, device, i, hwMixAvailable, 44100, 16);
+        channels[i] = channel;
     }
-    ppChannels[0] = pStreamingChannel;
+    channels[0] = streamingChannel;
 
-    reinterpret_cast<void(__thiscall*)(void*, float)>(FUNC_CAEAudioChannel_SetVolume)(pStreamingChannel, -100.0f);
+    reinterpret_cast<void(__thiscall*)(void*, float)>(FUNC_CAEAudioChannel_SetVolume)(streamingChannel, -100.0f);
     *reinterpret_cast<std::int16_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_ChannelFlags0) = 0x37;
 
     reinterpret_cast<void(__thiscall*)(void*)>(FUNC_CAESmoothFadeThread_Initialise)(reinterpret_cast<void*>(VAR_AudioSmoothFadeThreadHandle));
     reinterpret_cast<void(__thiscall*)(void*)>(FUNC_CAESmoothFadeThread_Start)(reinterpret_cast<void*>(VAR_AudioSmoothFadeThreadHandle));
 
-    void* const pStreamThread = reinterpret_cast<void*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_StreamThread);
-    reinterpret_cast<void(__thiscall*)(void*, void*)>(FUNC_CAEStreamThread_Initialise)(pStreamThread, pStreamingChannel);
-    reinterpret_cast<void(__thiscall*)(void*)>(FUNC_CAEStreamThread_Start)(pStreamThread);
+    void* const streamThread = reinterpret_cast<void*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_StreamThread);
+    reinterpret_cast<void(__thiscall*)(void*, void*)>(FUNC_CAEStreamThread_Initialise)(streamThread, streamingChannel);
+    reinterpret_cast<void(__thiscall*)(void*)>(FUNC_CAEStreamThread_Start)(streamThread);
 
-    *reinterpret_cast<std::uint16_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_NumAvailableChannels) = usNumChannels;
+    *reinterpret_cast<std::uint16_t*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_NumAvailableChannels) = numChannels;
     *reinterpret_cast<bool*>(OBJ_AEAudioHardware + OFFSET_AEAudioHardware_Initialised) = true;
     return true;
 }
 
 void CMultiplayerSA::RestartAudioHardware()
 {
-    CAEAudioHardware* pAEAudioHardware = pGameInterface->GetAEAudioHardware();
-    if (!pAEAudioHardware)
+    CAEAudioHardware* audioHardware = pGameInterface->GetAEAudioHardware();
+    if (!audioHardware)
         return;
 
     // Try the device-only path first: lighter, faster, and it never touches the SFX pak/bank
     // loader that three investigation passes never found the fault in. Two attempts, since the
     // driver can briefly report the old device as still allocated while it finishes releasing it
-    for (int iAttempt = 0; iAttempt < 2; iAttempt++)
+    for (int attempt = 0; attempt < 2; attempt++)
     {
         PartialTerminateAudioDevice();
         CloseLeakedAudioThreadHandle(VAR_AudioStreamThreadHandle);
@@ -363,18 +363,18 @@ void CMultiplayerSA::RestartAudioHardware()
 
     // Same teardown/rebuild the game already does once at normal startup, just run again on
     // demand; causes the same brief hitch, but never needs a full game restart to take effect
-    for (int iAttempt = 0; iAttempt < 4; iAttempt++)
+    for (int attempt = 0; attempt < 4; attempt++)
     {
         // Must run before Terminate deletes the bank loader. Safe to call again on a retry too:
         // Initialise() unconditionally allocates and repopulates a fresh loader, reopening every
         // pak's CD stream, before any of its own failure paths can return
         ReleaseLeakedSfxPakStreamHandles();
 
-        pAEAudioHardware->Terminate();
+        audioHardware->Terminate();
         CloseLeakedAudioThreadHandle(VAR_AudioStreamThreadHandle);
         CloseLeakedAudioThreadHandle(VAR_AudioSmoothFadeThreadHandle);
 
-        if (pAEAudioHardware->Initialise())
+        if (audioHardware->Initialise())
         {
             LogAudioHardwareState();
             return;
@@ -392,7 +392,7 @@ void CMultiplayerSA::RestartAudioHardware()
 
 void CMultiplayerSA::SetPreferredAudioDeviceName(const std::string& strName)
 {
-    const bool bHadGuid = g_bHasPreferredAudioDeviceGuid;
+    const bool hadGuid = g_bHasPreferredAudioDeviceGuid;
     const GUID oldGuid = g_PreferredAudioDeviceGuid;
 
     if (strName.empty())
@@ -402,14 +402,14 @@ void CMultiplayerSA::SetPreferredAudioDeviceName(const std::string& strName)
         SFindDeviceContext findContext{&strName, false, {}};
         DirectSoundEnumerateA(FindDeviceByNameCallback, &findContext);
 
-        g_bHasPreferredAudioDeviceGuid = findContext.bFound;
-        if (findContext.bFound)
+        g_bHasPreferredAudioDeviceGuid = findContext.found;
+        if (findContext.found)
             g_PreferredAudioDeviceGuid = findContext.guid;
     }
 
     // Already open on this device; restarting again is wasteful at best and can deadlock if this
     // lands mid join while the game is streaming audio banks
-    if (bHadGuid == g_bHasPreferredAudioDeviceGuid && (!bHadGuid || IsEqualGUID(oldGuid, g_PreferredAudioDeviceGuid)))
+    if (hadGuid == g_bHasPreferredAudioDeviceGuid && (!hadGuid || IsEqualGUID(oldGuid, g_PreferredAudioDeviceGuid)))
         return;
 
     RestartAudioHardware();
@@ -434,7 +434,7 @@ void CMultiplayerSA::InitHooks_Audio()
     {
         SFindDeviceContext findContext{&strPreferredDevice, false, {}};
         DirectSoundEnumerateA(FindDeviceByNameCallback, &findContext);
-        if (findContext.bFound)
+        if (findContext.found)
         {
             g_PreferredAudioDeviceGuid = findContext.guid;
             g_bHasPreferredAudioDeviceGuid = true;

--- a/Client/sdk/core/CClientBase.h
+++ b/Client/sdk/core/CClientBase.h
@@ -34,4 +34,5 @@ public:
     virtual void GetPlayerNames(std::vector<SString>& vPlayerNames) = 0;
 
     virtual void OnWindowFocusChange(bool state) = 0;
+    virtual void OnPossibleAudioDeviceChange() = 0;
 };

--- a/Client/sdk/core/CClientBase.h
+++ b/Client/sdk/core/CClientBase.h
@@ -14,6 +14,13 @@
 #include "CCoreInterface.h"
 #include "CExceptionInformation.h"
 
+struct SSoundDeviceInfo
+{
+    std::string strName;
+    std::string strDriver;
+    bool        bIsDefault;
+};
+
 class CClientBase
 {
 public:
@@ -35,4 +42,9 @@ public:
 
     virtual void OnWindowFocusChange(bool state) = 0;
     virtual void OnPossibleAudioDeviceChange() = 0;
+
+    virtual unsigned int                  GetSoundOutputDeviceListRevision() = 0;
+    virtual std::vector<SSoundDeviceInfo> GetSoundOutputDevices() = 0;
+    virtual std::string                   GetSoundOutputDeviceDriver() = 0;
+    virtual bool                          SetSoundOutputDevice(const std::string& strDriver) = 0;
 };

--- a/Client/sdk/core/CClientBase.h
+++ b/Client/sdk/core/CClientBase.h
@@ -47,4 +47,9 @@ public:
     virtual std::vector<SSoundDeviceInfo> GetSoundOutputDevices() = 0;
     virtual std::string                   GetSoundOutputDeviceDriver() = 0;
     virtual bool                          SetSoundOutputDevice(const std::string& strDriver) = 0;
+
+    virtual unsigned int                  GetSoundInputDeviceListRevision() = 0;
+    virtual std::vector<SSoundDeviceInfo> GetSoundInputDevices() = 0;
+    virtual std::string                   GetSoundInputDeviceName() = 0;
+    virtual bool                          SetSoundInputDevice(const std::string& strName) = 0;
 };

--- a/Client/sdk/game/CAEAudioHardware.h
+++ b/Client/sdk/game/CAEAudioHardware.h
@@ -65,4 +65,11 @@ class CAEAudioHardware
 public:
     virtual bool IsSoundBankLoaded(short wSoundBankID, short wSoundBankSlotID) = 0;
     virtual void LoadSoundBank(short wSoundBankID, short wSoundBankSlotID) = 0;
+
+    // Full teardown/rebuild of the native audio device (DirectSound object, all channels, the
+    // streaming and fade threads); used to make it pick up a different output device without
+    // restarting the game. Causes a brief, unavoidable audio hitch while it runs, the same as
+    // the one already happening once at normal game startup.
+    virtual void Terminate() = 0;
+    virtual bool Initialise() = 0;
 };

--- a/Client/sdk/multiplayer/CMultiplayer.h
+++ b/Client/sdk/multiplayer/CMultiplayer.h
@@ -470,6 +470,9 @@ public:
     virtual unsigned int EntryInfoNodePool_NoOfUsedSpaces() const noexcept = 0;
     virtual unsigned int PtrNodeDoubleLinkPool_NoOfUsedSpaces() const noexcept = 0;
 
-    // Takes effect the next time the game's own audio hardware (re)initialises, not immediately
+    // Restarts the game's own audio hardware immediately, so it re-opens on whatever device is
+    // currently preferred (or the system default, if none is); causes a brief hitch, the same
+    // one that already happens once at normal game startup
+    virtual void RestartAudioHardware() = 0;
     virtual void SetPreferredAudioDeviceName(const std::string& strName) = 0;
 };

--- a/Client/sdk/multiplayer/CMultiplayer.h
+++ b/Client/sdk/multiplayer/CMultiplayer.h
@@ -469,4 +469,7 @@ public:
 
     virtual unsigned int EntryInfoNodePool_NoOfUsedSpaces() const noexcept = 0;
     virtual unsigned int PtrNodeDoubleLinkPool_NoOfUsedSpaces() const noexcept = 0;
+
+    // Takes effect the next time the game's own audio hardware (re)initialises, not immediately
+    virtual void SetPreferredAudioDeviceName(const std::string& strName) = 0;
 };


### PR DESCRIPTION
#### Summary

This is both a **bugfix** and an **enhancement** at the same time. For as long as I can remember, if you unplug an audio device or connect a new one, MTA would become completely silent because it only detected the audio output device once, when the game started.

Now the game detects when the current audio output or input device changes (unplugged, replugged, plugged for first time, or the OS default changes) and reacts live, no restart needed. Also adds explicit output and input device pickers to Settings > Audio, so you can pick a specific device directly instead of only following the OS default; picking one there applies immediately across all three audio paths: MTA's own BASS-based sounds (playSound, internet radio), the native GTA:SA engine (weapons, footsteps, engines, ambience, ped chatter, vehicle radio), and voice chat.

<img width="1920" height="1080" alt="Grand Theft Auto San Andreas Screenshot 2026 09 03 - 22 16 11 36" src="https://github.com/user-attachments/assets/80aad6d8-2e3c-40bf-9f2f-2cec81c79c99" />
<img width="1920" height="1080" alt="Grand Theft Auto San Andreas Screenshot 2026 09 03 - 22 16 14 70" src="https://github.com/user-attachments/assets/947c5782-f6a9-42a4-b0bb-ab4c77a9f95b" />

#### Motivation
Fixes #1146 

I also wanted to add **per-device audio settings**, but I feel like that would’ve made the PR way too complicated.

#### Test plan
Tested manually in-game over many sessions:
- Switched the output device repeatedly (10+ times in a row, including forcing switches under 1 second apart) and confirmed native SFX, vehicle radio, and MTA sounds all kept working indefinitely, with no silent/muted state.
- Unplugged and replugged both output and input devices and confirmed the pickers refresh and the active device follows without a restart.
- Confirmed an unrelated joystick or microphone hotplug no longer triggers a native audio restart (only an actual output/input device change does).

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.