### PR TITLE
Add player camera pitch synchronization

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPlayer.h
+++ b/Client/mods/deathmatch/logic/CClientPlayer.h
@@ -92,6 +92,9 @@ public:
     CClientPlayerVoice* GetVoice() { return m_voice; }
     void                SetPlayerVoice(CClientPlayerVoice* voice) { m_voice = voice; }
 
+    float GetCameraPitch() const { return m_fCameraPitch; }
+    void  SetCameraPitch(float fPitch) { m_fCameraPitch = fPitch; }
+
     float GetNametagDistance() { return m_fNametagDistance; }
     void  SetNametagDistance(float fDistance) { m_fNametagDistance = fDistance; }
 
@@ -161,6 +164,7 @@ private:
     unsigned int m_uiKeySyncCount;
     unsigned int m_uiVehicleSyncCount;
 
+    float m_fCameraPitch{};
     float m_fNametagDistance;
 
     bool m_bNetworkDead;

--- a/Client/mods/deathmatch/logic/CNetAPI.cpp
+++ b/Client/mods/deathmatch/logic/CNetAPI.cpp
@@ -978,6 +978,12 @@ void CNetAPI::ReadPlayerPuresync(CClientPlayer* pPlayer, NetBitStreamInterface& 
         pPlayer->SetCurrentWeaponSlot(WEAPONSLOT_TYPE_UNARMED);
     }
 
+    SCameraPitchSync cameraPitch;
+    if (BitStream.Read(&cameraPitch))
+    {
+        pPlayer->SetCameraPitch(cameraPitch.data.fValue);
+    }
+
     // null out the crouch bit or it'll conflict with the crouched syncing
     ControllerState.ShockButtonL = 0;
 

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPedDefs.cpp
@@ -1615,25 +1615,50 @@ bool CLuaPedDefs::IsPedBleeding(CClientPed* pPed)
 
 int CLuaPedDefs::GetPedCameraRotation(lua_State* luaVM)
 {
-    // Verify the argument
-    CClientPed*      pPed = NULL;
+    CClientPed* pPed = nullptr;
+    bool        bIncludePitch = false;
+
     CScriptArgReader argStream(luaVM);
     argStream.ReadUserData(pPed);
-
-    if (!argStream.HasErrors())
+    argStream.ReadBool(bIncludePitch, false);
+    if (argStream.HasErrors())
     {
-        float fRotation = 0.0f;
-        if (CStaticFunctionDefinitions::GetPedCameraRotation(*pPed, fRotation))
-        {
-            lua_pushnumber(luaVM, fRotation);
-            return 1;
-        }
-    }
-    else
         m_pScriptDebugging->LogCustom(luaVM, argStream.GetFullErrorMessage());
+        lua_pushboolean(luaVM, false);
+        return 1;
+    }
 
-    lua_pushboolean(luaVM, false);
-    return 1;
+    float fYaw = 0.0f;
+    if (!CStaticFunctionDefinitions::GetPedCameraRotation(*pPed, fYaw))
+    {
+        lua_pushboolean(luaVM, false);
+        return 1;
+    }
+
+    if (!bIncludePitch)
+    {
+        lua_pushnumber(luaVM, fYaw);
+        return 1;
+    }
+
+    float fPitch = 0.0f;
+    if (pPed->IsLocalPlayer())
+    {
+        CMatrix cameraMatrix;
+        g_pGame->GetCamera()->GetMatrix(&cameraMatrix);
+
+        const CVector& vecCamFwd = cameraMatrix.vFront;
+        fPitch = atan2(vecCamFwd.fZ, DistanceBetweenPoints2D(CVector(), vecCamFwd)) * (180.0f / PI);
+    }
+    else if (pPed->GetType() == CCLIENTPLAYER)
+    {
+        CClientPlayer* pPlayer = static_cast<CClientPlayer*>(pPed);
+        fPitch = pPlayer->GetCameraPitch();
+    }
+
+    lua_pushnumber(luaVM, fYaw);
+    lua_pushnumber(luaVM, fPitch);
+    return 2;
 }
 
 int CLuaPedDefs::IsPedOnFire(lua_State* luaVM)

--- a/Server/mods/deathmatch/logic/net/CSimPlayerPuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/net/CSimPlayerPuresyncPacket.cpp
@@ -257,6 +257,10 @@ bool CSimPlayerPuresyncPacket::Write(NetBitStreamInterface& BitStream) const
         }
     }
 
+    SCameraPitchSync cameraPitch;
+    cameraPitch.data.fValue = atan2(m_Cache.vecCamFwd.fZ, DistanceBetweenPoints2D(CVector(), m_Cache.vecCamFwd)) * (180.0f / PI);
+    BitStream.Write(&cameraPitch);
+
     // Success
     return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CPlayerPuresyncPacket.cpp
@@ -460,6 +460,12 @@ bool CPlayerPuresyncPacket::Write(NetBitStreamInterface& BitStream) const
             }
         }
 
+        const CVector& vecCamFwd = pSourcePlayer->GetCamFwd();
+
+        SCameraPitchSync cameraPitch;
+        cameraPitch.data.fValue = atan2(vecCamFwd.fZ, DistanceBetweenPoints2D(CVector(), vecCamFwd)) * (180.0f / PI);
+        BitStream.Write(&cameraPitch);
+
         // Success
         return true;
     }

--- a/Shared/sdk/net/SyncStructures.h
+++ b/Shared/sdk/net/SyncStructures.h
@@ -629,6 +629,11 @@ struct SCameraRotationSync : public ISyncStructure
     } data;
 };
 
+struct SCameraPitchSync : public SFloatAsBitsSync<8>
+{
+    SCameraPitchSync() : SFloatAsBitsSync<8>(-90.0f, 90.0f, false) {}
+};
+
 struct SKeysyncRotation : public ISyncStructure
 {
     bool Read(NetBitStreamInterface& bitStream)

--- a/Shared/sdk/version.h
+++ b/Shared/sdk/version.h
@@ -112,7 +112,7 @@
 #define _NETCODE_VERSION_BRANCH_ID 0x4    // Use 0x1 - 0xF to indicate an incompatible branch is being used (0x0 is reserved, 0x4 is trunk)
 #define _CLIENT_NET_MODULE_VERSION 0x0B5  // (0x000 - 0xfff) Lvl9 wizards only
 #define _SERVER_NET_MODULE_VERSION 0x0AD  // (0x000 - 0xfff) Lvl9 wizards only
-#define _NETCODE_VERSION           0x1DF  // (0x000 - 0xfff) Increment when net messages change (pre-release)
+#define _NETCODE_VERSION           0x1E0  // (0x000 - 0xfff) Increment when net messages change (pre-release)
 
 // (0x000 - 0xfff) Update bitstream.h when net messages change (post-release). (Changing will also require additional backward compatibility code).
 #define MTA_DM_BITSTREAM_VERSION eBitStreamVersion::Latest


### PR DESCRIPTION
### Summary

This PR adds camera pitch synchronization for remote players through player pure sync and exposes it through `getPedCameraRotation`.

Previously, `getPedCameraRotation` only exposed the horizontal camera rotation (yaw). The client already sends its camera orientation to the server as part of player pure sync, including the vertical camera angle, but that information was not forwarded to other clients.

This change reuses the existing camera forward vector on the server, derives the pitch from it, and sends it as an 8-bit synchronized value.

The existing behavior of `getPedCameraRotation` is preserved:

```lua
local yaw = getPedCameraRotation(player)
```

The synchronized pitch can be requested explicitly:

```lua
local yaw, pitch = getPedCameraRotation(player, true)
```

This keeps existing resources backward compatible while allowing scripts to use the remote player's vertical camera direction.

### Motivation

On roleplay servers, head-tracking scripts commonly need each player's camera direction to make nearby players' heads follow where they are looking, especially when looking up or down.

Since remote camera pitch is not currently exposed to scripts, resources usually have to implement their own synchronization by sending camera data to the server with `triggerServerEvent` and then relaying it back to nearby clients.

This requires custom Lua events and additional network traffic for camera information that is already available in the engine's synchronization path.

By synchronizing and exposing the pitch natively, these resources can rely on the existing player sync instead of maintaining a separate client-to-server-to-client synchronization layer.

### Implementation

- Adds `SCameraPitchSync` using `SFloatAsBitsSync<8>`.
- Synchronizes camera pitch through player pure sync.
- Stores the latest synchronized pitch on `CClientPlayer`.
- Extends `getPedCameraRotation` with an optional pitch return value.
- Increments `_NETCODE_VERSION` because the network message layout changes.
- Reuses the camera orientation already sent by the client; no additional client-to-server data is introduced.

The pitch is represented in degrees in the `[-90, 90]` range.

### Testing

Tested with multiple clients while:

- standing still;
- walking and running;
- rotating the camera horizontally;
- looking up and down;
- rapidly changing camera direction.

Remote players correctly receive both yaw and pitch, while the original single-return-value behavior remains unchanged.

<img width="1920" height="822" alt="1F0B3B4E-EC11-466A-AC60-6E3E3A40710F" src="https://github.com/user-attachments/assets/da52ddd7-fc8d-4022-8e5a-c425daa52c8c" />
<img width="1920" height="822" alt="0C9EE57A-032F-46FE-80FA-B81D4291F280" src="https://github.com/user-attachments/assets/f5b736f1-172d-425b-967f-e475335ce661" />

This [test resource](https://github.com/user-attachments/files/31820186/test-resource-move-head.zip) was used to verify the synchronization by making nearby remote players look in the same direction as their camera.

### Network impact

This does not introduce a new packet or an additional client-to-server message.

The pitch is appended to the existing player pure sync data using 8 bits, resulting in one additional byte per synchronized player pure sync packet.