### PR TITLE
Follow-up for #5246: fix CGUI exception handling catching unrelated crashes

### DIFF
--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -1423,7 +1423,12 @@ void CCore::DoPostFramePulse()
     if (!IsFocused() && m_bLastFocused)
     {
         // Fix for #4948
-        m_pKeyBinds->CallAllGTAControlBinds(CONTROL_BOTH, false);
+        // A fatal fault dialog takes focus while pumping messages; releasing the
+        // control binds runs Lua handlers that touch the half-destroyed GUI.
+        // Skipping the release is safe because both fault paths terminate the
+        // process when the dialog closes.
+        if (!CLocalGUI::IsFaultDialogOpen())
+            m_pKeyBinds->CallAllGTAControlBinds(CONTROL_BOTH, false);
         m_bLastFocused = false;
     }
     else if (IsFocused() && !m_bLastFocused)

--- a/Client/core/CGUI.cpp
+++ b/Client/core/CGUI.cpp
@@ -58,11 +58,8 @@ CLocalGUI::~CLocalGUI()
 
 void CLocalGUI::SetSkin(const char* szName)
 {
-    // Guard against re-entrant calls. MessageBoxW pumps the message loop, so the
-    // fatal CC51 dialog below would otherwise trigger pulse calls that touch
-    // m_pConsole while windows are half-destroyed (DestroyWindows called but
-    // CreateWindows not yet reached). The guard also clears the flag if a
-    // window rebuild throws, so a failed skin change cannot disable later ones.
+    // CC51's pump runs pulse code on half-destroyed windows, so re-entrant
+    // calls are skipped. The guard clears on throw.
     static bool s_bInSetSkin = false;
     if (s_bInSetSkin)
         return;
@@ -73,8 +70,7 @@ void CLocalGUI::SetSkin(const char* szName)
         ~SetSkinGuard() { flag = false; }
     } guard(s_bInSetSkin);
 
-    // A fatal fault dialog may be pumping the message loop; do not rebuild the
-    // windows inside that pump.
+    // A fatal fault dialog is pumping messages; dont rebuild windows from inside it.
     if (CLocalGUI::IsFaultDialogOpen())
         return;
 
@@ -110,11 +106,9 @@ void CLocalGUI::SetSkin(const char* szName)
         }
         catch (...)
         {
-            // Both the selected and the default skin failed. MessageBoxW pumps the
-            // message loop (re-entrant), but the guard above prevents further damage
-            // before TerminateProcess takes effect. Mark the dialog as open so a
-            // nested fault during the pump terminates instead of stacking another.
+            // Mark both layers' dialog flags first, so a nested fault exits instead of stacking.
             CLocalGUI::SetFaultDialogOpen(true);
+            pGUI->SetFatalFaultDialogOpen(true);
             MessageBoxUTF8(0, _("The skin you selected could not be loaded, and the default skin also could not be loaded, please reinstall MTA."),
                            _("Error") + _E("CC51"), MB_OK | MB_ICONERROR | MB_TOPMOST);
             TerminateProcess(GetCurrentProcess(), 9);
@@ -139,13 +133,10 @@ void CLocalGUI::SetSkin(const char* szName)
 
 void CLocalGUI::ChangeLocale(const char* szName)
 {
-    // Guard against re-entrant calls while the windows are half-destroyed during
-    // a skin change (the fatal skin dialog pumps the message loop).
+    // Windows are gone mid-rebuild, or a fatal dialog is pumping messages.
     if (!m_pConsole) [[unlikely]]
         return;
 
-    // A fatal fault dialog may be pumping the message loop; do not rebuild the
-    // windows inside that pump.
     if (CLocalGUI::IsFaultDialogOpen())
         return;
 
@@ -344,6 +335,10 @@ void CLocalGUI::ApplyQueuedLocale()
     if (!m_bHasQueuedLocaleChange)
         return;
 
+    // Console is gone mid-rebuild; keep the request queued for a later pulse.
+    if (!m_pConsole)
+        return;
+
     CClientVariables* cvars = CCore::GetSingleton().GetCVars();
 
     if (m_QueuedLocaleChange.empty())
@@ -390,6 +385,10 @@ void CLocalGUI::ApplyQueuedLocale()
 
 void CLocalGUI::DoPulse()
 {
+    // A fatal dialog is pumping messages; pulse work touches CEGUI and would throw.
+    if (CLocalGUI::IsFaultDialogOpen())
+        return;
+
     m_pVersionUpdater->DoPulse();
 
     CClientVariables* cvars = CCore::GetSingleton().GetCVars();
@@ -445,78 +444,39 @@ void CLocalGUI::DoPulse()
     // Show after any deferred locale/skin work so a prior prompt is not lost
     TryShowRestartPrompt();
 }
-// Set while a fatal GUI fault dialog is open, so a nested fault during the
-// dialog's message-loop pump terminates without stacking more dialogs.
+// True while the fatal CC51 dialog is open: nested faults exit instead of stacking.
 static bool s_bFaultDialogOpen = false;
 bool        CLocalGUI::IsFaultDialogOpen() noexcept
 {
-    return s_bFaultDialogOpen;
+    if (s_bFaultDialogOpen)
+        return true;
+
+    // CC54 does the same from the CEGUI layer.
+    if (CGUI* pGUI = CCore::GetSingleton().GetGUI())
+        return pGUI->IsFatalFaultDialogOpen();
+
+    return false;
 }
 void CLocalGUI::SetFaultDialogOpen(bool bOpen) noexcept
 {
     s_bFaultDialogOpen = bOpen;
 }
 
-// Error reporting for SEH faults in GUI rendering
-static void ReportGUISEHFault(DWORD dwExceptionCode, const char* szContext)
-{
-    // A nested fault can fire while this dialog pumps the message loop (the
-    // game frame keeps running). Show one dialog, then terminate immediately.
-    if (CLocalGUI::IsFaultDialogOpen())
-    {
-        TerminateProcess(GetCurrentProcess(), 9);
-        return;
-    }
-    CLocalGUI::SetFaultDialogOpen(true);
-
-    SString strMsg(
-        "Rendering fault in %s (code 0x%08X).\n\n"
-        "Usually caused by missing GUI/loading-screen assets.\n\n"
-        "Please verify game files or reinstall.",
-        szContext, dwExceptionCode);
-    WriteDebugEvent(SString("CLocalGUI::Draw SEH fault in %s code=0x%08X", szContext, dwExceptionCode));
-    MessageBoxUTF8(0, strMsg, _("Error") + _E("CC54"), MB_OK | MB_ICONERROR | MB_TOPMOST);
-    TerminateProcess(GetCurrentProcess(), 9);
-}
-
-// SEH filter for GUI rendering faults. Access violations and C++ exceptions
-// (CEGUI errors) are the common failures with missing or corrupt GUI assets;
-// other faults are left for the wider OnPresent guard.
-static int FilterGUISehFault(unsigned int uiExceptionCode)
-{
-    if (uiExceptionCode == EXCEPTION_ACCESS_VIOLATION || uiExceptionCode == CPP_EXCEPTION_CODE)
-        return EXCEPTION_EXECUTE_HANDLER;
-    return EXCEPTION_CONTINUE_SEARCH;
-}
-
-// SEH wrapper for the entire Draw body.
-static void DrawSEHGuard(CLocalGUI* pLocalGUI)
-{
-    __try
-    {
-        pLocalGUI->DrawInternal();
-    }
-    __except (FilterGUISehFault(GetExceptionCode()))
-    {
-        ReportGUISEHFault(GetExceptionCode(), "CLocalGUI::Draw");
-    }
-}
-
+// CEGUI faults are caught in CGUI_Impl::Draw; anything else goes to the crash handler.
 void CLocalGUI::Draw()
-{
-    DrawSEHGuard(this);
-}
-
-void CLocalGUI::DrawInternal()
 {
     // Get the game interface
     CGame*      pGame = CCore::GetSingleton().GetGame();
     SystemState systemState = pGame->GetSystemState();
     CGUI*       pGUI = CCore::GetSingleton().GetGUI();
 
-    // The windows may be half-destroyed while a fatal dialog pumps the message
-    // loop during a skin or locale change, so skip drawing until they are back.
+    // Windows are gone mid-rebuild; skip drawing until they are back.
     if (!m_pMainMenu) [[unlikely]]
+        return;
+
+    // A fatal dialog is pumping messages; dont redraw CEGUI or the same fault
+    // would rethrow each frame and terminate before the dialog can be read.
+    if (CLocalGUI::IsFaultDialogOpen())
         return;
 
     // Update mainmenu stuff
@@ -582,9 +542,14 @@ void CLocalGUI::Restore()
 
 void CLocalGUI::DrawMouseCursor()
 {
+    // Same reason as Draw: the fault dialog's pump must not re-enter CEGUI.
+    if (CLocalGUI::IsFaultDialogOpen())
+        return;
+
     CGUI* pGUI = CCore::GetSingleton().GetGUI();
 
-    pGUI->DrawMouseCursor();
+    if (pGUI)
+        pGUI->DrawMouseCursor();
 }
 
 CConsole* CLocalGUI::GetConsole()
@@ -933,6 +898,10 @@ bool CLocalGUI::ProcessMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPara
 
 bool CLocalGUI::InputGoesToGUI()
 {
+    // A fatal fault dialog is pumping messages; dont route input into CEGUI.
+    if (CLocalGUI::IsFaultDialogOpen())
+        return false;
+
     CGUI* pGUI = CCore::GetSingleton().GetGUI();
     if (!pGUI)
         return false;
@@ -948,6 +917,8 @@ void CLocalGUI::ForceCursorVisible(bool bVisible)
 
 void CLocalGUI::UpdateCursor()
 {
+    // Only called from Draw, which already returns while a fatal fault dialog
+    // is open, so the CEGUI calls below never run against a broken GUI state.
     CGUI* pGUI = CCore::GetSingleton().GetGUI();
 
     static DWORD dwWidth = CDirect3DData::GetSingleton().GetViewportWidth();

--- a/Client/core/CGUI.h
+++ b/Client/core/CGUI.h
@@ -52,13 +52,10 @@ public:
     void DoPulse();
 
     void Draw();
-    void DrawInternal();
     void Invalidate();
     void Restore();
 
-    // True while a fatal GUI fault dialog is open, so a nested fault during the
-    // dialog's message-loop pump terminates without stacking more dialogs, and
-    // window-rebuild paths (skin and locale changes) do not run inside the pump.
+    // True while a fatal fault dialog (CC51 or CC54) is open; rebuilds wait and nested faults exit.
     static bool IsFaultDialogOpen() noexcept;
     static void SetFaultDialogOpen(bool bOpen) noexcept;
 

--- a/Client/core/CKeyBinds.cpp
+++ b/Client/core/CKeyBinds.cpp
@@ -347,6 +347,11 @@ bool RemoveBindTypeBinds(Container& binds, bool isContainerMutable, KeyBindType 
 
 bool CKeyBinds::ProcessMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
+    // A fatal fault dialog is pumping messages; dont drive key or web input
+    // into the half-destroyed GUI state behind it.
+    if (CLocalGUI::IsFaultDialogOpen())
+        return false;
+
     if (g_pCore->IsWebCoreLoaded() && !m_pCore->IsMenuVisible() && !m_pCore->GetConsole()->IsVisible() && !m_pCore->IsChatInputEnabled())
         g_pCore->GetWebCore()->ProcessInputMessage(uMsg, wParam, lParam);
 
@@ -383,6 +388,11 @@ bool CKeyBinds::ProcessCharacter(WPARAM wChar)
 
 bool CKeyBinds::ProcessKeyStroke(const SBindableKey* pKey, bool bState)
 {
+    // Same reason as ProcessMessage: OnLoseFocus also lands here when the
+    // fault dialog takes focus, and the menu reads below touch destroyed windows.
+    if (CLocalGUI::IsFaultDialogOpen())
+        return false;
+
     m_bProcessingKeyStroke = true;
     // If the console, chat input or menu is up, ignore any messages and unset
     // any already pressed */
@@ -1803,6 +1813,11 @@ void CKeyBinds::DoPreFramePulse()
     m_pCore->GetGame()->GetPad()->GetCurrentControllerState(&cs);
     m_pCore->GetGame()->GetPad()->SetLastControllerState(&cs);
 
+    // A fatal fault dialog is pumping messages; bind handlers reach CEGUI, so
+    // leave queued binds alone until the dialog ends the process.
+    if (CLocalGUI::IsFaultDialogOpen())
+        return;
+
     // HACK: chatbox binds
     if (m_pChatBoxBind)
     {
@@ -1921,6 +1936,11 @@ bool CKeyBinds::ControlLeftAndRight(CControllerState& cs)
 
 void CKeyBinds::DoPostFramePulse()
 {
+    // Same reason as DoPreFramePulse: control binds can invoke Lua handlers that
+    // reach CEGUI while a fatal fault dialog is pumping messages.
+    if (CLocalGUI::IsFaultDialogOpen())
+        return;
+
     SystemState systemState = CCore::GetSingleton().GetGame()->GetSystemState();
 
     if (m_bWaitingToLoadDefaults &&

--- a/Client/core/CNewsBrowser.cpp
+++ b/Client/core/CNewsBrowser.cpp
@@ -239,16 +239,25 @@ void CNewsBrowser::AddNewsTab(const SNewsItem& newsItem)
     // Switch cwd
     pManager->PushGuiWorkingDirectory(newsItem.strContentFullDir);
 
-    // Load files
-    CGUIWindow* pWindow = LoadLayoutAndImages(m_pScrollPane, newsItem);
-    m_TabContentList.push_back(pWindow);
-
-    // Set tab name from content window title
-    if (pWindow)
+    try
     {
-        SString strTitle = pWindow->GetText();
-        if (!strTitle.empty())
-            pTab->SetText(strTitle);
+        // Load files
+        CGUIWindow* pWindow = LoadLayoutAndImages(m_pScrollPane, newsItem);
+        m_TabContentList.push_back(pWindow);
+
+        // Set tab name from content window title
+        if (pWindow)
+        {
+            SString strTitle = pWindow->GetText();
+            if (!strTitle.empty())
+                pTab->SetText(strTitle);
+        }
+    }
+    catch (...)
+    {
+        // Pop before rethrowing, or later asset loads resolve inside the failed dir and healthy installs look broken.
+        pManager->PopGuiWorkingDirectory(newsItem.strContentFullDir);
+        throw;
     }
 
     // Restore cwd

--- a/Client/core/DXHook/CDirect3DEvents9.cpp
+++ b/Client/core/DXHook/CDirect3DEvents9.cpp
@@ -577,43 +577,9 @@ void CDirect3DEvents9::OnRestore(IDirect3DDevice9* pDevice)
     CCore::GetSingleton().OnDeviceRestore();
 }
 
-int FilterException(uint exceptionCode);
-
-static void ReportOnPresentSEHFault(DWORD dwExceptionCode)
-{
-    // A nested fault can fire while this dialog pumps the message loop (the
-    // game frame keeps running). Show one dialog, then terminate immediately.
-    if (CLocalGUI::IsFaultDialogOpen())
-    {
-        TerminateProcess(GetCurrentProcess(), 9);
-        return;
-    }
-    CLocalGUI::SetFaultDialogOpen(true);
-
-    SString strMsg(
-        "Rendering fault during frame rendering (code 0x%08X).\n\n"
-        "Usually caused by missing GUI/loading-screen assets.\n\n"
-        "Please verify game files or reinstall.",
-        dwExceptionCode);
-    WriteDebugEvent(SString("OnPresent SEH fault code=0x%08X", dwExceptionCode));
-    MessageBoxUTF8(0, strMsg, _("Error") + _E("CC54"), MB_OK | MB_ICONERROR | MB_TOPMOST);
-    TerminateProcess(GetCurrentProcess(), 9);
-}
-
 void CDirect3DEvents9::OnPresent(IDirect3DDevice9* pDevice, IDirect3DDevice9* pStateDevice)
 {
-    __try
-    {
-        OnPresentInternal(pDevice, pStateDevice);
-    }
-    __except (FilterException(GetExceptionCode()))
-    {
-        ReportOnPresentSEHFault(GetExceptionCode());
-    }
-}
-
-void CDirect3DEvents9::OnPresentInternal(IDirect3DDevice9* pDevice, IDirect3DDevice9* pStateDevice)
-{
+    // CEGUI faults are caught in CGUI_Impl::Draw; anything else goes to the crash handler.
     TIMING_CHECKPOINT("+OnPresent1");
     CGraphics::GetSingleton().SetSkipMTARenderThisFrame(false);
     // Start a new scene. This isn't ideal and is not really recommended by MSDN.

--- a/Client/core/DXHook/CDirect3DEvents9.h
+++ b/Client/core/DXHook/CDirect3DEvents9.h
@@ -19,7 +19,6 @@ public:
     static void    OnDirect3DDeviceCreate(IDirect3DDevice9* pDevice);
     static void    OnDirect3DDeviceDestroy(IDirect3DDevice9* pDevice);
     static void    OnPresent(IDirect3DDevice9* pDevice, IDirect3DDevice9* pStateDevice);
-    static void    OnPresentInternal(IDirect3DDevice9* pDevice, IDirect3DDevice9* pStateDevice);
     static void    OnBeginScene(IDirect3DDevice9* pDevice);
     static bool    OnEndScene(IDirect3DDevice9* pDevice);
     static void    OnInvalidate(IDirect3DDevice9* pDevice);

--- a/Client/gui/CGUIElement_Impl.cpp
+++ b/Client/gui/CGUIElement_Impl.cpp
@@ -409,7 +409,7 @@ bool CGUIElement_Impl::SetFont(const char* szFontName)
         m_pWindow->setFont(CEGUI::String(szFontName));
         return true;
     }
-    catch (CEGUI::Exception e)
+    catch (const CEGUI::Exception&)
     {
         return false;
     }
@@ -427,7 +427,7 @@ std::string CGUIElement_Impl::GetFont()
             return strFontName.c_str();
         }
     }
-    catch (CEGUI::Exception e)
+    catch (const CEGUI::Exception&)
     {
     }
 
@@ -440,7 +440,7 @@ void CGUIElement_Impl::SetProperty(const char* szProperty, const char* szValue)
     {
         m_pWindow->setProperty(CGUI_Impl::GetUTFString(szProperty), CGUI_Impl::GetUTFString(szValue));
     }
-    catch (CEGUI::Exception e)
+    catch (const CEGUI::Exception&)
     {
     }
 }
@@ -453,7 +453,7 @@ std::string CGUIElement_Impl::GetProperty(const char* szProperty)
         // Return the string. std::string will copy it
         strValue = CGUI_Impl::GetUTFString(m_pWindow->getProperty(CGUI_Impl::GetUTFString(szProperty)).c_str());
     }
-    catch (CEGUI::Exception e)
+    catch (const CEGUI::Exception&)
     {
     }
 
@@ -468,11 +468,13 @@ void CGUIElement_Impl::FillProperties()
         CEGUI::String strKey = itPropertySet.getCurrentKey();
         CEGUI::String strValue = m_pWindow->getProperty(strKey);
 
-        CGUIProperty* pProperty = new CGUIProperty;
+        std::unique_ptr<CGUIProperty> pProperty = std::make_unique<CGUIProperty>();
         pProperty->strKey = strKey.c_str();
         pProperty->strValue = strValue.c_str();
 
-        m_Properties.push_back(pProperty);
+        // Hand over ownership only after push_back succeeds, so a throw still frees it.
+        m_Properties.push_back(pProperty.get());
+        pProperty.release();
         itPropertySet++;
     }
 }
@@ -490,6 +492,8 @@ void CGUIElement_Impl::EmptyProperties()
                 delete (*iter);
             }
         }
+        // Clear the nodes too, so callers see an empty list and can retry.
+        m_Properties.clear();
     }
 }
 
@@ -504,9 +508,17 @@ CGUIPropertyIter CGUIElement_Impl::GetPropertiesBegin()
         // Return the list begin iterator
         return m_Properties.begin();
     }
-    catch (CEGUI::Exception e)
+    catch (const CEGUI::Exception&)
     {
-        return *(CGUIPropertyIter*)NULL;
+        // Empty range instead of a null iterator; drop half-read entries for a clean retry.
+        EmptyProperties();
+        return m_Properties.end();
+    }
+    catch (const std::bad_alloc&)
+    {
+        // Rethrow, but drop partial entries first so a retry starts clean.
+        EmptyProperties();
+        throw;
     }
 }
 
@@ -518,12 +530,20 @@ CGUIPropertyIter CGUIElement_Impl::GetPropertiesEnd()
         if (m_Properties.empty())
             FillProperties();
 
-        // Return the list begin iterator
+        // Return the list end iterator
         return m_Properties.end();
     }
-    catch (CEGUI::Exception e)
+    catch (const CEGUI::Exception&)
     {
-        return *(CGUIPropertyIter*)NULL;
+        // Same as GetPropertiesBegin: empty range, partial entries dropped.
+        EmptyProperties();
+        return m_Properties.end();
+    }
+    catch (const std::bad_alloc&)
+    {
+        // Rethrow, but drop partial entries first so a retry starts clean.
+        EmptyProperties();
+        throw;
     }
 }
 

--- a/Client/gui/CGUILabel_Impl.cpp
+++ b/Client/gui/CGUILabel_Impl.cpp
@@ -157,7 +157,7 @@ float CGUILabel_Impl::GetTextExtent()
             }
             return fMax;
         }
-        catch (CEGUI::Exception e)
+        catch (const CEGUI::Exception&)
         {
         }
     }

--- a/Client/gui/CGUI_Impl.cpp
+++ b/Client/gui/CGUI_Impl.cpp
@@ -200,9 +200,20 @@ void CGUI_Impl::SetSkin(const char* szName)
 
     PushGuiWorkingDirectory(CalcMTASAPath(PathJoin("skins", szName)));
 
-    CEGUI::Scheme* scheme = CEGUI::SchemeManager::getSingleton().loadScheme("CGUI.xml");
-    m_CurrentSchemeName = scheme->getName().c_str();
-    m_HasSchemeLoaded = true;
+    // Pop the working directory before the exception reaches the fallback skin,
+    // or later asset loads resolve inside the failed skin and healthy installs look broken.
+    CEGUI::Scheme* scheme;
+    try
+    {
+        scheme = CEGUI::SchemeManager::getSingleton().loadScheme("CGUI.xml");
+        m_CurrentSchemeName = scheme->getName().c_str();
+        m_HasSchemeLoaded = true;
+    }
+    catch (...)
+    {
+        PopGuiWorkingDirectory();
+        throw;
+    }
 
     PopGuiWorkingDirectory();
 
@@ -261,36 +272,89 @@ CVector2D CGUI_Impl::GetResolution()
     return CVector2D(m_pRenderer->getWidth(), m_pRenderer->getHeight());
 }
 
+namespace
+{
+    // True while the CC54 dialog is open: nested faults exit instead of stacking.
+    bool s_bCEGUIFaultDialogOpen = false;
+
+    void ShowFatalCEGUIException(const CEGUI::Exception& exception, const char* szContext)
+    {
+        if (s_bCEGUIFaultDialogOpen)
+        {
+            // Nested fault in the first dialog's pump: exit instead of stacking another.
+            TerminateProcess(GetCurrentProcess(), 9);
+            return;
+        }
+        s_bCEGUIFaultDialogOpen = true;
+
+        WriteDebugEvent(SString("CGUI_Impl::%s - CEGUI exception: %s", szContext, exception.getMessage().c_str()));
+        SString strMsg(
+            "%s\n\n"
+            "Usually caused by missing GUI/loading-screen assets.\n\n"
+            "Please verify game files or reinstall MTA.",
+            exception.getMessage().c_str());
+        MessageBoxUTF8(0, strMsg, _("Error") + _E("CC54"), MB_OK | MB_ICONERROR | MB_TOPMOST);
+        TerminateProcess(GetCurrentProcess(), 9);
+    }
+}
+
+void CGUI_Impl::SetFatalFaultDialogOpen(bool bOpen)
+{
+    // Core sets this for CC51 too, so a CEGUI fault in its pump exits instead of stacking CC54.
+    s_bCEGUIFaultDialogOpen = bOpen;
+}
+
+bool CGUI_Impl::IsFatalFaultDialogOpen() const
+{
+    return s_bCEGUIFaultDialogOpen;
+}
+
 void CGUI_Impl::SetResolution(float fWidth, float fHeight)
 {
-    reinterpret_cast<CEGUI::DirectX9Renderer*>(m_pRenderer)->setDisplaySize(CEGUI::Size(fWidth, fHeight));
+    try
+    {
+        reinterpret_cast<CEGUI::DirectX9Renderer*>(m_pRenderer)->setDisplaySize(CEGUI::Size(fWidth, fHeight));
+    }
+    catch (const CEGUI::Exception& exception)
+    {
+        // Reachable from the vid command when the video mode changes.
+        ShowFatalCEGUIException(exception, "SetResolution");
+    }
 }
 
 void CGUI_Impl::Draw()
 {
-    // Redraw the changed elements
-    if (!m_RedrawQueue.empty())
+    try
     {
-        for (const auto handle : m_RedrawQueue)
+        // Redraw the changed elements
+        if (!m_RedrawQueue.empty())
         {
-            if (CGUIElement* pElement = ResolveRedrawHandle(handle))
+            for (const auto handle : m_RedrawQueue)
             {
-                pElement->ForceRedraw();
+                if (CGUIElement* pElement = ResolveRedrawHandle(handle))
+                {
+                    pElement->ForceRedraw();
+                }
+            }
+            m_RedrawQueue.clear();
+        }
+
+        if (!m_pSystem->renderGUI())
+        {
+            if (m_RenderOkTimer.Get() > 4000)
+            {
+                // 4 seconds and over 40 failed calls means we have a problem
+                BrowseToSolution("gui-render", EXIT_GAME_FIRST, "Some sort of DirectX problem has occurred");
             }
         }
-        m_RedrawQueue.clear();
+        else
+            m_RenderOkTimer.Reset();
     }
-
-    if (!m_pSystem->renderGUI())
+    catch (const CEGUI::Exception& exception)
     {
-        if (m_RenderOkTimer.Get() > 4000)
-        {
-            // 4 seconds and over 40 failed calls means we have a problem
-            BrowseToSolution("gui-render", EXIT_GAME_FIRST, "Some sort of DirectX problem has occurred");
-        }
+        // Missing or corrupt GUI assets throw here; show one clear error and exit.
+        ShowFatalCEGUIException(exception, "Draw");
     }
-    else
-        m_RenderOkTimer.Reset();
 }
 
 void CGUI_Impl::Invalidate()
@@ -301,8 +365,8 @@ void CGUI_Impl::Invalidate()
     }
     catch (const CEGUI::Exception& exception)
     {
-        MessageBox(0, exception.getMessage().c_str(), "CEGUI Exception", MB_OK | MB_ICONERROR | MB_TOPMOST);
-        TerminateProcess(GetCurrentProcess(), 1);
+        // A CEGUI fault here unwinds through the D3D reset path and crashes harder in COM.
+        ShowFatalCEGUIException(exception, "Invalidate");
     }
 }
 
@@ -314,14 +378,20 @@ void CGUI_Impl::Restore()
     }
     catch (const CEGUI::Exception& exception)
     {
-        MessageBox(0, exception.getMessage().c_str(), "CEGUI Exception", MB_OK | MB_ICONERROR | MB_TOPMOST);
-        TerminateProcess(GetCurrentProcess(), 1);
+        ShowFatalCEGUIException(exception, "Restore");
     }
 }
 
 void CGUI_Impl::DrawMouseCursor()
 {
-    CEGUI::MouseCursor::getSingleton().draw();
+    try
+    {
+        CEGUI::MouseCursor::getSingleton().draw();
+    }
+    catch (const CEGUI::Exception& exception)
+    {
+        ShowFatalCEGUIException(exception, "DrawMouseCursor");
+    }
 }
 
 void CGUI_Impl::ProcessMouseInput(CGUIMouseInput eMouseInput, unsigned long ulX, unsigned long ulY, CGUIMouseButton eMouseButton)
@@ -493,8 +563,9 @@ CGUIFont* CGUI_Impl::CreateFntFromWinFont(const char* szFontName, const char* sz
             {
                 pResult = (CGUIFont_Impl*)CreateFnt(szFontName, lookList[i], uSize, uFlags, bAutoScale);
             }
-            catch (CEGUI::Exception e)
+            catch (const CEGUI::Exception&)
             {
+                // Try the next location; failure is reported after the loop.
             }
         }
 
@@ -657,7 +728,7 @@ bool CGUI_Impl::LoadImageset(const SString& strFilename)
     {
         return GetImageSetManager()->createImageset(strFilename, "", true) != NULL;
     }
-    catch (CEGUI::AlreadyExistsException exc)
+    catch (const CEGUI::AlreadyExistsException&)
     {
         return true;
     }
@@ -1088,7 +1159,16 @@ void CGUI_Impl::SetDefaultGuiWorkingDirectory(const SString& strDir)
 void CGUI_Impl::PushGuiWorkingDirectory(const SString& strDir)
 {
     m_GuiWorkingDirectoryStack.push_back(PathConform(strDir + "\\"));
-    ApplyGuiWorkingDirectory();
+    try
+    {
+        ApplyGuiWorkingDirectory();
+    }
+    catch (...)
+    {
+        // Applying failed: drop the pushed entry, or a later Pop restores the wrong directory.
+        m_GuiWorkingDirectoryStack.pop_back();
+        throw;
+    }
 }
 
 void CGUI_Impl::PopGuiWorkingDirectory(const SString& strDirCheck)
@@ -1102,7 +1182,8 @@ void CGUI_Impl::PopGuiWorkingDirectory(const SString& strDirCheck)
         if (!strDirCheck.empty())
         {
             const SString& strWas = m_GuiWorkingDirectoryStack.back();
-            if (strDirCheck != strWas)
+            // Push conforms paths, so compare conformed.
+            if (PathConform(strDirCheck + "\\") != strWas)
             {
                 OutputDebugLine(SString("CGUI_Impl::PopWorkingDirectory - Mismatch. Got '%s', expected '%s'", *strWas, *strDirCheck));
             }

--- a/Client/gui/CGUI_Impl.h
+++ b/Client/gui/CGUI_Impl.h
@@ -75,6 +75,9 @@ public:
     void Invalidate();
     void Restore();
 
+    void SetFatalFaultDialogOpen(bool bOpen) override;
+    bool IsFatalFaultDialogOpen() const override;
+
     void DrawMouseCursor();
 
     void ProcessMouseInput(CGUIMouseInput eMouseInput, unsigned long ulX = 0, unsigned long ulY = 0, CGUIMouseButton eMouseButton = NoButton);

--- a/Client/sdk/gui/CGUI.h
+++ b/Client/sdk/gui/CGUI.h
@@ -173,4 +173,9 @@ public:
 
     virtual void         Cleanup() = 0;
     virtual CGUIElement* GetScriptRoot() = 0;
+
+    // Lets core know CC54 is open, and lets core report CC51 back to CEGUI. Both
+    // dialogs pump messages, so the other layer skips rebuilds and wont stack its own.
+    virtual void SetFatalFaultDialogOpen(bool bOpen) = 0;
+    virtual bool IsFatalFaultDialogOpen() const = 0;
 };


### PR DESCRIPTION
PR #5246 made the client show a friendly "reinstall MTA" dialog when GUI rendering
fails. But the protection was too wide: it wrapped the entire render and frame-update
code, so any crash during a frame - even one completely unrelated to the GUI - was
mislabeled as a rendering fault with no crash info. This PR narrows the protection
back down to the GUI itself, so only real GUI errors get the friendly dialog and
everything else goes back to the normal crash handler. It also fixes a few leftover
bugs in the same area.

What the PR does:

- Only real GUI errors now show the dialog, and it includes the actual error message.
- Other crashes reach the normal crash handler with full crash info again.
- Both error dialogs share a "fatal dialog is open" flag, so a second fault while a
  dialog is open just exits instead of stacking dialogs.
- While a fatal dialog is open, the game pauses all GUI work (drawing, input
  routing, key binds, window rebuilds) instead of touching broken windows.
- Skin and news-tab loading now clean up after a failure, so a healthy install
  can't be misreported as missing assets.
- The GUI property cache is cleaned up and safe on failure.
- A queued language change is postponed instead of dropped while the console is
  being rebuilt.