### PR TITLE
Fix onClientVehicleDamage firing twice for cancelled tyre damage

### DIFF
--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -4840,19 +4840,12 @@ bool CClientGame::VehicleDamageHandler(CEntitySAInterface* pVehicleInterface, fl
             return bAllowDamage;
         }
 
-        // Workaround: When a tyre-damage event is cancelled, the game's native code has
-        // already applied the physical "burst" state to the tyre before this hook even ran.
-        // On its next internal check (within the same game frame) it finds that state out
-        // of sync with the (unreduced) vehicle health and immediately re-invokes this same
-        // hook for the same tyre hit, which would otherwise fire onClientVehicleDamage a
-        // second time for one real hit. This does not happen for non-tyre damage, and does
-        // not happen when the event is left uncancelled (the health reduction that occurs
-        // then keeps the native state in sync, so there's nothing to "correct" and no retry).
-        // We can't reach into the native retry logic itself, so we detect and swallow the
-        // immediate duplicate here instead: same vehicle, same tyre, same loss amount,
-        // within the same frame as the previous call. Using the frame counter rather than a
-        // wall-clock time window makes this deterministic - the retry is a same-frame
-        // re-entry, not merely a "soon after" call.
+        // Cancelling tyre damage doesn't undo GTA's own "burst" state change on the tyre,
+        // which happens before this hook is even called. GTA then notices the health/tyre
+        // mismatch and calls us again for the same hit in the same frame, so we'd fire
+        // onClientVehicleDamage twice for one shot. Only affects tyres; only happens when
+        // cancelled. Filter out the same-frame repeat here since we can't touch the retry
+        // in GTA's code.
         if (ucTyre != UCHAR_INVALID_INDEX)
         {
             const bool bIsRetryOfSameHit = pVehicleInterface == m_pLastTyreDamageVehicleInterface && ucTyre == m_ucLastTyreDamageIndex &&

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -4842,20 +4842,21 @@ bool CClientGame::VehicleDamageHandler(CEntitySAInterface* pVehicleInterface, fl
 
         // Workaround: When a tyre-damage event is cancelled, the game's native code has
         // already applied the physical "burst" state to the tyre before this hook even ran.
-        // On its next internal check it finds that state out of sync with the (unreduced)
-        // vehicle health and immediately re-invokes this same hook for the same tyre hit,
-        // which would otherwise fire onClientVehicleDamage a second time for one real hit.
-        // This does not happen for non-tyre damage, and does not happen when the event is
-        // left uncancelled (the health reduction that occurs then keeps the native state in
-        // sync, so there's nothing to "correct" and no retry).
+        // On its next internal check (within the same game frame) it finds that state out
+        // of sync with the (unreduced) vehicle health and immediately re-invokes this same
+        // hook for the same tyre hit, which would otherwise fire onClientVehicleDamage a
+        // second time for one real hit. This does not happen for non-tyre damage, and does
+        // not happen when the event is left uncancelled (the health reduction that occurs
+        // then keeps the native state in sync, so there's nothing to "correct" and no retry).
         // We can't reach into the native retry logic itself, so we detect and swallow the
         // immediate duplicate here instead: same vehicle, same tyre, same loss amount,
-        // within a few milliseconds of the previous call.
+        // within the same frame as the previous call. Using the frame counter rather than a
+        // wall-clock time window makes this deterministic - the retry is a same-frame
+        // re-entry, not merely a "soon after" call.
         if (ucTyre != UCHAR_INVALID_INDEX)
         {
-            const unsigned long ulNowMs = CClientTime::GetTime();
-            const bool          bIsRetryOfSameHit = pVehicleInterface == m_pLastTyreDamageVehicleInterface && ucTyre == m_ucLastTyreDamageIndex &&
-                                           fLoss == m_fLastTyreDamageLoss && (ulNowMs - m_ulLastTyreDamageTickMs) <= 15;
+            const bool bIsRetryOfSameHit = pVehicleInterface == m_pLastTyreDamageVehicleInterface && ucTyre == m_ucLastTyreDamageIndex &&
+                                           fLoss == m_fLastTyreDamageLoss && m_uiFrameCount == m_uiLastTyreDamageFrame;
 
             if (bIsRetryOfSameHit)
             {
@@ -4867,7 +4868,7 @@ bool CClientGame::VehicleDamageHandler(CEntitySAInterface* pVehicleInterface, fl
             m_pLastTyreDamageVehicleInterface = pVehicleInterface;
             m_ucLastTyreDamageIndex = ucTyre;
             m_fLastTyreDamageLoss = fLoss;
-            m_ulLastTyreDamageTickMs = ulNowMs;
+            m_uiLastTyreDamageFrame = m_uiFrameCount;
         }
 
         CClientEntity* pClientAttacker = pPools->GetClientEntity((DWORD*)pAttackerInterface);

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -4840,6 +4840,36 @@ bool CClientGame::VehicleDamageHandler(CEntitySAInterface* pVehicleInterface, fl
             return bAllowDamage;
         }
 
+        // Workaround: When a tyre-damage event is cancelled, the game's native code has
+        // already applied the physical "burst" state to the tyre before this hook even ran.
+        // On its next internal check it finds that state out of sync with the (unreduced)
+        // vehicle health and immediately re-invokes this same hook for the same tyre hit,
+        // which would otherwise fire onClientVehicleDamage a second time for one real hit.
+        // This does not happen for non-tyre damage, and does not happen when the event is
+        // left uncancelled (the health reduction that occurs then keeps the native state in
+        // sync, so there's nothing to "correct" and no retry).
+        // We can't reach into the native retry logic itself, so we detect and swallow the
+        // immediate duplicate here instead: same vehicle, same tyre, same loss amount,
+        // within a few milliseconds of the previous call.
+        if (ucTyre != UCHAR_INVALID_INDEX)
+        {
+            const unsigned long ulNowMs = CClientTime::GetTime();
+            const bool          bIsRetryOfSameHit = pVehicleInterface == m_pLastTyreDamageVehicleInterface && ucTyre == m_ucLastTyreDamageIndex &&
+                                           fLoss == m_fLastTyreDamageLoss && (ulNowMs - m_ulLastTyreDamageTickMs) <= 15;
+
+            if (bIsRetryOfSameHit)
+            {
+                // This is the engine's own retry for the hit we just processed, not a new
+                // hit - don't fire the Lua event again, just repeat our previous decision.
+                return m_bLastTyreDamageAllowed;
+            }
+
+            m_pLastTyreDamageVehicleInterface = pVehicleInterface;
+            m_ucLastTyreDamageIndex = ucTyre;
+            m_fLastTyreDamageLoss = fLoss;
+            m_ulLastTyreDamageTickMs = ulNowMs;
+        }
+
         CClientEntity* pClientAttacker = pPools->GetClientEntity((DWORD*)pAttackerInterface);
 
         // GTA passes a zeroed position for explosion and fire damage, so report the vehicle position instead
@@ -4871,6 +4901,9 @@ bool CClientGame::VehicleDamageHandler(CEntitySAInterface* pVehicleInterface, fl
         {
             bAllowDamage = false;
         }
+
+        if (ucTyre != UCHAR_INVALID_INDEX)
+            m_bLastTyreDamageAllowed = bAllowDamage;
     }
 
     return bAllowDamage;

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -4840,21 +4840,20 @@ bool CClientGame::VehicleDamageHandler(CEntitySAInterface* pVehicleInterface, fl
             return bAllowDamage;
         }
 
-        // Cancelling tyre damage doesn't undo GTA's own "burst" state change on the tyre,
-        // which happens before this hook is even called. GTA then notices the health/tyre
-        // mismatch and calls us again for the same hit in the same frame, so we'd fire
-        // onClientVehicleDamage twice for one shot. Only affects tyres; only happens when
-        // cancelled. Filter out the same-frame repeat here since we can't touch the retry
-        // in GTA's code.
-        if (ucTyre != UCHAR_INVALID_INDEX)
+        // Tyre damage can be processed through different paths in GTA's damage handling.
+        // For weapons with skills, GTA processes tyre damage in the weapon-skill path
+        // before the general entity damage handling. When tyre damage is cancelled,
+        // this can cause the same hit to reach this handler again in the same frame.
+        // Filter out the repeated callback so onClientVehicleDamage is not fired twice.
+        if (ucTyre != UCHAR_INVALID_INDEX && weaponType >= WEAPONTYPE_PISTOL && weaponType <= WEAPONTYPE_TEC9)
         {
             const bool bIsRetryOfSameHit = pVehicleInterface == m_pLastTyreDamageVehicleInterface && ucTyre == m_ucLastTyreDamageIndex &&
                                            fLoss == m_fLastTyreDamageLoss && m_uiFrameCount == m_uiLastTyreDamageFrame;
 
             if (bIsRetryOfSameHit)
             {
-                // This is the engine's own retry for the hit we just processed, not a new
-                // hit - don't fire the Lua event again, just repeat our previous decision.
+                // Repeated callback for the same tyre hit in the same frame.
+                // Keep the decision from the original callback and don't fire the event again.
                 return m_bLastTyreDamageAllowed;
             }
 

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -827,7 +827,7 @@ private:
     CEntitySAInterface* m_pLastTyreDamageVehicleInterface = nullptr;
     uchar               m_ucLastTyreDamageIndex = UCHAR_INVALID_INDEX;
     float               m_fLastTyreDamageLoss = 0.0f;
-    unsigned long       m_ulLastTyreDamageTickMs = 0;
+    uint                m_uiLastTyreDamageFrame = 0;
     bool                m_bLastTyreDamageAllowed = true;
 
     eWeaponSlot                            m_lastWeaponSlot;

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -824,11 +824,11 @@ private:
     // Used by VehicleDamageHandler to detect and swallow the game engine's immediate
     // internal retry of a tyre-damage hit when that hit's event was cancelled (see comment
     // at the top of VehicleDamageHandler for the full explanation).
-    CEntitySAInterface* m_pLastTyreDamageVehicleInterface = nullptr;
-    uchar               m_ucLastTyreDamageIndex = UCHAR_INVALID_INDEX;
-    float               m_fLastTyreDamageLoss = 0.0f;
-    uint                m_uiLastTyreDamageFrame = 0;
-    bool                m_bLastTyreDamageAllowed = true;
+    CEntitySAInterface* m_pLastTyreDamageVehicleInterface{nullptr};
+    uchar               m_ucLastTyreDamageIndex{UCHAR_INVALID_INDEX};
+    float               m_fLastTyreDamageLoss{0.0f};
+    uint                m_uiLastTyreDamageFrame{0};
+    bool                m_bLastTyreDamageAllowed{true};
 
     eWeaponSlot                            m_lastWeaponSlot;
     SFixedArray<DWORD, WEAPONSLOT_MAX + 1> m_wasWeaponAmmoInClip;

--- a/Client/mods/deathmatch/logic/CClientGame.h
+++ b/Client/mods/deathmatch/logic/CClientGame.h
@@ -821,6 +821,15 @@ private:
     bool           m_bDamageSent;
     bool           m_serverProcessedDeath{false};  // Flag to track server-processed deaths
 
+    // Used by VehicleDamageHandler to detect and swallow the game engine's immediate
+    // internal retry of a tyre-damage hit when that hit's event was cancelled (see comment
+    // at the top of VehicleDamageHandler for the full explanation).
+    CEntitySAInterface* m_pLastTyreDamageVehicleInterface = nullptr;
+    uchar               m_ucLastTyreDamageIndex = UCHAR_INVALID_INDEX;
+    float               m_fLastTyreDamageLoss = 0.0f;
+    unsigned long       m_ulLastTyreDamageTickMs = 0;
+    bool                m_bLastTyreDamageAllowed = true;
+
     eWeaponSlot                            m_lastWeaponSlot;
     SFixedArray<DWORD, WEAPONSLOT_MAX + 1> m_wasWeaponAmmoInClip;
 


### PR DESCRIPTION
#### Summary

Fixes a bug where `onClientVehicleDamage` fires twice for a single tyre hit when the event is cancelled with `cancelEvent()`. This only affects tyre/wheel damage; damage to other vehicle parts is unaffected regardless of whether the event is cancelled.

The fix adds a same-frame deduplication check in `VehicleDamageHandler` (`CClientGame.cpp`): when a tyre-damage call matches the previous call (same vehicle, same tyre index, same loss amount, same frame), it is treated as a duplicate native damage call rather than a new hit, and the Lua event is not re-fired for it.

Before: <video src="https://github.com/user-attachments/assets/553b0067-dfda-407e-bcde-eee2c52d7959"></video>

After: <video src="https://github.com/user-attachments/assets/57caf757-f67f-417a-9d53-85937afa4e0a"></video>


#### Motivation

GTA handles tyre damage in two places inside `CWeapon::DoBulletImpact`.

First, when the weapon has weapon skills (for example, pistols through the Tec-9), damaging a tyre also goes through the weapon-skill handling, where the weapon stats are increased.

Second, GTA performs the general damage handling based on the type of entity that was hit. For vehicles, this is where the tyre is actually damaged. This path also handles cases that are not covered by the weapon-skill handling, such as weapons like the sniper rifle, which do not have weapon skills.

When `onClientVehicleDamage` is cancelled, the vehicle's health reduction is prevented, while the physical tyre damage remains applied. As a result, the same tyre hit can cause the vehicle damage handling to reach `VehicleDamageHandler` more than once within the same frame, resulting in `onClientVehicleDamage` being fired twice for a single hit.

This does not affect normal non-tyre vehicle damage, and it does not affect legitimate multiple hits registered within the same frame, such as multiple pellets from a weapon hitting the tyre. The deduplication therefore only filters calls that have the same vehicle, tyre index, loss amount, and frame.

Since these duplicate calls originate from GTA's original damage handling, rather than from MTA's own event dispatch logic, the duplicate is filtered at the point where MTA handles the vehicle damage callback.

Fixes the duplicate-event behaviour described in
https://github.com/multitheftauto/mtasa-blue/issues/5273#issuecomment-5502247457


#### Test plan

Tested in a local server with the following script:

```lua
addEventHandler("onClientVehicleDamage", root, function(...)
    cancelEvent()
    outputChatBox(inspect({...}))
end)
```

* Shot a vehicle's tyre repeatedly with a single-fire weapon (Colt 45/etc) -
  event now fires once per hit (previously fired twice).
* Shot a vehicle's tyre with a multi-pellet weapon (Minigun/etc) at close/long range -
  each pellet that hits the tyre still fires its own event; no legitimate hits were swallowed.
* Shot the vehicle body/doors/bonnet (non-tyre) with `cancelEvent()` active -
  still fires once, as before (unaffected by this change).
* Shot a tyre without `cancelEvent()` -
  still fires once, as before.
* Shot a vehicle's tyre with a fully automatic multi-pellet weapon and all shots/hits were registered correctly without any issues or missed events.


#### Checklist
* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
