### PR TITLE
Reduce per-frame client overhead: gate ped clump alpha, skip idle streamer pass, fix nametag viewport cache

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -5360,7 +5360,14 @@ void CClientPed::UpdateAlphaAndVisibility()
         effectiveAlpha = 0;
 
     if (RpClump* clump = m_pPlayerPed->GetRpClump())
-        g_pGame->GetVisibilityPlugins()->SetClumpAlpha(clump, effectiveAlpha);
+    {
+        if (clump != m_pLastAlphaClump || effectiveAlpha != m_ucAppliedClumpAlpha)
+        {
+            m_pLastAlphaClump = clump;
+            m_ucAppliedClumpAlpha = effectiveAlpha;
+            g_pGame->GetVisibilityPlugins()->SetClumpAlpha(clump, effectiveAlpha);
+        }
+    }
 
     // GTA decides whether to create ped shadows from its visibility flag, not
     // the RenderWare clump alpha. Keep both states aligned at zero alpha.

--- a/Client/mods/deathmatch/logic/CClientPed.h
+++ b/Client/mods/deathmatch/logic/CClientPed.h
@@ -723,6 +723,8 @@ public:
     eMoveAnim                                m_MoveAnim;
     std::list<CClientProjectile*>            m_Projectiles;
     unsigned char                            m_ucAlpha;
+    unsigned char                            m_ucAppliedClumpAlpha{0};
+    const void*                              m_pLastAlphaClump{nullptr};
     float                                    m_fTargetRotation;
     int                                      m_iVehicleInOutState;
     bool                                     m_bRecreatingModel;

--- a/Client/mods/deathmatch/logic/CClientStreamer.cpp
+++ b/Client/mods/deathmatch/logic/CClientStreamer.cpp
@@ -186,6 +186,9 @@ void                CClientStreamer::DoPulse(CVector& vecPosition)
         }
     }
 
+    if (m_ActiveElements.empty() && m_ToStreamOut.empty())
+        return;
+
     // Update distances every frame
     SetExpDistances(&m_ActiveElements);
     m_ActiveElements.sort(CompareExpDistance);

--- a/Client/mods/deathmatch/logic/CNametags.cpp
+++ b/Client/mods/deathmatch/logic/CNametags.cpp
@@ -50,10 +50,6 @@ void CNametags::DoPulse()
     if (!m_bVisible)
         return;
 
-    // Grab the resolution width and height
-    static float fResWidth = static_cast<float>(g_pCore->GetGraphics()->GetViewportWidth());
-    static float fResHeight = static_cast<float>(g_pCore->GetGraphics()->GetViewportHeight());
-
     // Got any players that are not local?
     if (m_pPlayerManager->Count() <= 1 && !bRenderOwn)
         return;
@@ -234,10 +230,12 @@ void CNametags::DrawTagForPlayer(CClientPlayer* pPlayer, unsigned char ucAlpha)
     if (pPlayer->GetInterior() != m_ucInterior)
         return;
 
-    // Grab the resolution width and height
+    // Grab the resolution width and height. Read fresh each frame: the viewport can change
+    // on alt-tab/display switch, and a value cached on the first call misplaces every tag
+    // (and its health bar) until the client restarts.
     CGraphicsInterface* pGraphics = g_pCore->GetGraphics();
-    static float        fResWidth = static_cast<float>(pGraphics->GetViewportWidth());
-    static float        fResHeight = static_cast<float>(pGraphics->GetViewportHeight());
+    const float         fResWidth = static_cast<float>(pGraphics->GetViewportWidth());
+    const float         fResHeight = static_cast<float>(pGraphics->GetViewportHeight());
 
     // Get the position
     CVector vecPosition;


### PR DESCRIPTION
#### Summary
Three small, safe reductions of per-frame CPU work in the client:

- **`CClientPed`** (`SetClumpAlpha`) was pushed to RenderWare on every pulse for every streamed-in ped, even when neither the requested alpha nor the clump had changed (each call re-walks the clump's atomics/materials). `SetAlpha` only stores the value and the game's own per-frame alpha calls are disabled, so this loop is the sole writer of the clump alpha. Added a small `{clump, alpha}` cache: RenderWare is now only touched when the effective alpha (including the interior-visibility case) or the clump pointer (model rebuild) actually changes. Visual behavior is unchanged.

- **`CClientStreamer`** (`DoPulse`) always ran the per-frame distance update, sort and restream pass even for streamers with no active elements and an empty stream-out queue. Added an early-out so quiet streamers (e.g. LOD objects / pickups / lights) cost a few pointer compares per frame instead of an empty list walk and sort.

- **`CNametags`** the viewport size was cached in a function-local `static` on first call. After an Alt-Tab or display change, every nametag and health bar stayed laid out for the old resolution until restart. The size is now read fresh each frame (negligible cost), and two dead `static` declarations in `DoPulse` were removed.


#### Motivation
The client periodically wastes CPU every frame for no visible benefit:

- On a busy server the per-ped `SetClumpAlpha` calls add up to real per-frame cost (N native calls/frame with identical values).
- Empty streamers still paid for an O(n) distance update + list sort + restream walk each frame.
- The nametag viewport `static` was both a stale-state bug after resolution changes and dead code in `DoPulse`.

These are behavior-preserving changes aimed at removing predictable per-frame overhead without touching streaming/visibility semantics.


#### Test plan
1. Build the client (Release). The project compiled cleanly with these changes in place.
2. Join a server and play normally:
   - Nametags and health bars render and occlude exactly as before.
   - `setPedAlpha`, ped visibility (different-interior hide), and model changes (`setPedModel` / clothes rebuild) all still apply immediately.
   - Vehicles/peds/objects stream in and out at the same distances as before.
3. Change the display resolution (or Alt-Tab to a screen of different size) and confirm nametags/health bars re-layout correctly instead of staying on the old resolution.
4. Regression check for future changes: ped alpha/visibility must keep working when a ped's clump is rebuilt, and streamers must still restream when elements are added/removed or the camera crosses a sector boundary.


#### Checklist
* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
