### PR TITLE
Fix vehicle shadows remaining visible at zero alpha

### DIFF
--- a/Client/game_sa/CSettingsSA.cpp
+++ b/Client/game_sa/CSettingsSA.cpp
@@ -18,6 +18,7 @@
 #include "CSettingsSA.h"
 #include "CCameraSA.h"
 #include "CCamSA.h"
+#include "CVehicleSA.h"
 
 extern CCoreInterface* g_pCore;
 extern CGameSA*        pGame;
@@ -37,6 +38,46 @@ void HOOK_GetFxQuality();
 DWORD RETURN_StoreShadowForVehicle = 0x70BDA9;
 void  HOOK_StoreShadowForVehicle();
 
+namespace
+{
+    constexpr std::uintptr_t FUNC_CStencilShadows_RenderForVehicle = 0x70FAE0;
+    constexpr std::uintptr_t CALL_CStencilShadows_Process_RenderForVehicle = 0x711E26;
+    struct VehicleStencilShadow
+    {
+        CVehicleSAInterface*  owner;
+        short                 faceCount;
+        BYTE                  type;
+        BYTE                  padding;
+        DWORD                 capacity;
+        DWORD                 vertexCount;
+        CVector*              vertices;
+        VehicleStencilShadow* next;
+        VehicleStencilShadow* previous;
+    };
+    static_assert(sizeof(VehicleStencilShadow) == 0x1C);
+    static_assert(offsetof(VehicleStencilShadow, vertexCount) == 0xC);
+
+    bool __cdecl IsVehicleShadowHidden(CVehicleSAInterface* vehicle)
+    {
+        // Native vehicles without an MTA wrapper must retain GTA's normal shadows.
+        auto* const entry = pGame->GetPools()->GetVehicle(reinterpret_cast<DWORD*>(vehicle));
+        return entry && entry->pEntity && entry->pEntity->GetAlpha() == 0;
+    }
+
+    void __cdecl RenderVehicleStencilShadow(VehicleStencilShadow* shadow, CVector* cameraPosition)
+    {
+        if (IsVehicleShadowHidden(shadow->owner))
+        {
+            // Clear cached triangles too; GTA rebuilds them when alpha is restored.
+            shadow->vertexCount = 0;
+            return;
+        }
+
+        using RenderForVehicle = void(__cdecl*)(VehicleStencilShadow*, CVector*);
+        reinterpret_cast<RenderForVehicle>(FUNC_CStencilShadows_RenderForVehicle)(shadow, cameraPosition);
+    }
+}
+
 float ms_fVehicleLODDistance, ms_fTrainPlaneLODDistance, ms_fPedsLODDistance;
 
 CSettingsSA::CSettingsSA()
@@ -51,6 +92,7 @@ CSettingsSA::CSettingsSA()
     SetAspectRatio(ASPECT_RATIO_4_3);
     HookInstall(HOOKPOS_GetFxQuality, (DWORD)HOOK_GetFxQuality, 5);
     HookInstall(HOOKPOS_StoreShadowForVehicle, (DWORD)HOOK_StoreShadowForVehicle, 9);
+    HookInstallCall(CALL_CStencilShadows_Process_RenderForVehicle, reinterpret_cast<DWORD>(RenderVehicleStencilShadow));
     m_iDesktopWidth = 0;
     m_iDesktopHeight = 0;
     MemPut<BYTE>(0x6FF420, 0xC3);  // Truncate CalculateAspectRatio
@@ -396,7 +438,8 @@ static void __declspec(naked) HOOK_GetFxQuality()
     // clang-format on
 }
 
-// Hook to discover what vehicle will be calling GetFxQuality
+// Filter invisible vehicles before GTA selects static/dynamic blob shadows.
+// Unrefreshed static shadows expire normally. Also track the model for GetFxQuality.
 static void __declspec(naked) HOOK_StoreShadowForVehicle()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;
@@ -404,6 +447,17 @@ static void __declspec(naked) HOOK_StoreShadowForVehicle()
     // clang-format off
     __asm
     {
+        pushad
+        mov     eax, [esp+36]
+        push    eax
+        call    IsVehicleShadowHidden
+        add     esp, 4
+        test    al, al
+        popad
+        jz      visible
+        retn
+
+    visible:
         // Hooked from 0x70BDA0  5 bytes
         mov     eax, [esp+4]            // Get vehicle
         mov     ax, [eax+34]            // pEntity->m_nModelIndex

--- a/Client/game_sa/CSettingsSA.cpp
+++ b/Client/game_sa/CSettingsSA.cpp
@@ -447,13 +447,11 @@ static void __declspec(naked) HOOK_StoreShadowForVehicle()
     // clang-format off
     __asm
     {
-        pushad
-        mov     eax, [esp+36]
+        mov     eax, [esp+4]
         push    eax
         call    IsVehicleShadowHidden
         add     esp, 4
         test    al, al
-        popad
         jz      visible
         retn
 

--- a/Client/game_sa/CSettingsSA.cpp
+++ b/Client/game_sa/CSettingsSA.cpp
@@ -40,6 +40,8 @@ void  HOOK_StoreShadowForVehicle();
 
 namespace
 {
+    constexpr std::uintptr_t FUNC_FindPlayerVehicle = 0x56E0D0;
+    constexpr std::uintptr_t CALL_CShadows_RenderExtraPlayerShadows_FindPlayerVehicle = 0x707FB6;
     constexpr std::uintptr_t FUNC_CStencilShadows_RenderForVehicle = 0x70FAE0;
     constexpr std::uintptr_t CALL_CStencilShadows_Process_RenderForVehicle = 0x711E26;
     struct VehicleStencilShadow
@@ -62,6 +64,15 @@ namespace
         // Native vehicles without an MTA wrapper must retain GTA's normal shadows.
         auto* const entry = pGame->GetPools()->GetVehicle(reinterpret_cast<DWORD*>(vehicle));
         return entry && entry->pEntity && entry->pEntity->GetAlpha() == 0;
+    }
+
+    CVehicleSAInterface* __cdecl FindPlayerVehicleForExtraShadows(int playerId, bool includeRemote)
+    {
+        using FindPlayerVehicle = CVehicleSAInterface*(__cdecl*)(int, bool);
+        auto* const vehicle = reinterpret_cast<FindPlayerVehicle>(FUNC_FindPlayerVehicle)(playerId, includeRemote);
+
+        // Returning no vehicle skips GTA's separate point-light shadows through its normal early exit.
+        return vehicle && IsVehicleShadowHidden(vehicle) ? nullptr : vehicle;
     }
 
     void __cdecl RenderVehicleStencilShadow(VehicleStencilShadow* shadow, CVector* cameraPosition)
@@ -92,6 +103,7 @@ CSettingsSA::CSettingsSA()
     SetAspectRatio(ASPECT_RATIO_4_3);
     HookInstall(HOOKPOS_GetFxQuality, (DWORD)HOOK_GetFxQuality, 5);
     HookInstall(HOOKPOS_StoreShadowForVehicle, (DWORD)HOOK_StoreShadowForVehicle, 9);
+    HookInstallCall(CALL_CShadows_RenderExtraPlayerShadows_FindPlayerVehicle, reinterpret_cast<DWORD>(FindPlayerVehicleForExtraShadows));
     HookInstallCall(CALL_CStencilShadows_Process_RenderForVehicle, reinterpret_cast<DWORD>(RenderVehicleStencilShadow));
     m_iDesktopWidth = 0;
     m_iDesktopHeight = 0;


### PR DESCRIPTION
#### Summary
Fix vehicle shadows remaining visible when the vehicle's alpha is 0.

**Before/After**

<img width="960" height="1080" alt="mta-screen_2026-09-05_10-34-41" src="https://github.com/user-attachments/assets/e47542bf-bc6a-4923-aba9-9535252c2c89" />

<img width="960" height="1080" alt="mta-screen_2026-09-05_10-41-09" src="https://github.com/user-attachments/assets/5c6e77c3-fe1c-4bee-993f-596aeaafb0c5" />


#### Motivation
An invisible vehicle could still be located by its shadow when using:
`setElementAlpha(vehicle, 0)`

The shadow should disappear together with the vehicle and return when its alpha is restored.
Follow-up to #5270.

#### Test plan
`setElementAlpha(vehicle, 0)` on a occupied/unoccupied vehicle.


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
