### PR TITLE
Fix Ctrl getting stuck in the GUI after Ctrl+Alt

### DIFF
--- a/Client/core/CGUI.cpp
+++ b/Client/core/CGUI.cpp
@@ -814,6 +814,22 @@ bool CLocalGUI::ProcessMessage(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPara
                 return false;
             }
 
+            case WM_SYSKEYDOWN:
+            case WM_SYSKEYUP:
+            {
+                // While Alt is held every key arrives as a system key message. Keep the modifier state of the GUI in
+                // step anyway, otherwise a Control or Shift released with Alt down stays pressed for it and the next
+                // letter acts as a shortcut. Nothing is consumed, so Alt+F4 and Alt+Enter still reach the window.
+                if (wParam == VK_CONTROL || wParam == VK_SHIFT)
+                {
+                    DWORD dwTemp = TranslateScanCodeToGUIKey(wParam);
+                    if (dwTemp > 0)
+                        pGUI->ProcessKeyboardInput(dwTemp, uMsg == WM_SYSKEYDOWN);
+                }
+
+                return false;
+            }
+
             case WM_IME_COMPOSITION:
             {
                 if (lParam & GCS_RESULTSTR)


### PR DESCRIPTION
Fixes #2609.

`CLocalGUI::ProcessMessage` handles WM_KEYDOWN/WM_KEYUP but not the WM_SYSKEY* pair. Windows uses those while Alt is held, so releasing Ctrl before Alt means CEGUI never gets the keyup and keeps Ctrl flagged as down. Next letter typed into the console or a gui edit box is treated as Ctrl+letter.

Added Ctrl and Shift to that switch. Both return false, so Alt+F4, Alt+Enter etc. still go through to the window.

Repro: edit box focused, hold Ctrl, tap Alt, release Ctrl, release Alt, type "ax" -> box ends up empty (Ctrl+A then Ctrl+X). With the fix you get "ax".
