### PR TITLE
Fix diving too deep and rising too slowly at high FPS

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
@@ -772,6 +772,77 @@ static void __declspec(naked) HOOK_CTaskSimpleSwim__ProcessSwimmingResistance()
     // clang-format on
 }
 
+// Fixes diving too deep on high FPS (#3344). HOOK_CTaskSimpleSwim__ProcessSwimmingResistance above scales every
+// component of the target velocity by kOriginalTimeStep / timestep, which is right for x and y (per-frame animation
+// shifts) but not for the dive velocity in z, an absolute speed. Scale it the other way here so the two cancel out.
+#define HOOKPOS_CTaskSimpleSwim__ProcessSwimmingResistance_DiveSpeed  0x68A42B
+#define HOOKSIZE_CTaskSimpleSwim__ProcessSwimmingResistance_DiveSpeed 6
+static constexpr std::uintptr_t RETURN_CTaskSimpleSwim__ProcessSwimmingResistance_DiveSpeed = 0x68A431;
+static void __declspec(naked)   HOOK_CTaskSimpleSwim__ProcessSwimmingResistance_DiveSpeed()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        fmul    ds:[0x858EF4]           // Original: the dive speed, -0.1f
+        fmul    ds:[0xB7CB5C]           // CTimer::ms_fTimeStep
+        fdiv    kOriginalTimeStep       // 1.666f
+        jmp     RETURN_CTaskSimpleSwim__ProcessSwimmingResistance_DiveSpeed
+    }
+    // clang-format on
+}
+
+// Same for the constant buoyancy of the underwater swim state, which every dive ends in, against the same
+// HOOK_CTaskSimpleSwim__ProcessSwimmingResistance scaling
+#define HOOKPOS_CTaskSimpleSwim__ProcessSwimmingResistance_Buoyancy  0x68A4CA
+#define HOOKSIZE_CTaskSimpleSwim__ProcessSwimmingResistance_Buoyancy 6
+static constexpr std::uintptr_t RETURN_CTaskSimpleSwim__ProcessSwimmingResistance_Buoyancy = 0x68A4D0;
+static void __declspec(naked)   HOOK_CTaskSimpleSwim__ProcessSwimmingResistance_Buoyancy()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        fld     ds:[0x8708CC]           // Original: the buoyancy of the underwater state, 0.01f
+        fmul    ds:[0xB7CB5C]           // CTimer::ms_fTimeStep
+        fdiv    kOriginalTimeStep       // 1.666f
+        faddp   st(1), st               // Original: add it to the target velocity
+        jmp     RETURN_CTaskSimpleSwim__ProcessSwimmingResistance_Buoyancy
+    }
+    // clang-format on
+}
+
+// cBuoyancy::CalcBuoyancyForce takes the whole vertical momentum off the upward impulse once the entity rises faster
+// than four times what the impulse gives it. The impulse scales with the timestep, the momentum does not, so on high
+// FPS the damping sets in at a fraction of the 30 FPS rise speed and holds a surfacing ped down. Scale the momentum
+// by the same ratio for peds, which covers every ped in water, not only the swimming local player.
+#define HOOKPOS_cBuoyancy__CalcBuoyancyForce_Damping  0x6C27B7
+#define HOOKSIZE_cBuoyancy__CalcBuoyancyForce_Damping 6
+static constexpr std::uintptr_t RETURN_cBuoyancy__CalcBuoyancyForce_Damping = 0x6C27BD;
+static void __declspec(naked)   HOOK_cBuoyancy__CalcBuoyancyForce_Damping()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        fld     dword ptr [eax+8Ch]     // Original: CPhysical::m_fMass, multiplied with the vertical speed next
+        push    edx
+        mov     dl, byte ptr [eax+36h]  // CEntitySAInterface::nType, a 3 bit field
+        and     dl, 7
+        cmp     dl, ENTITY_TYPE_PED
+        pop     edx
+        jne     done
+        fmul    ds:[0xB7CB5C]           // CTimer::ms_fTimeStep
+        fdiv    kOriginalTimeStep       // 1.666f
+    done:
+        jmp     RETURN_cBuoyancy__CalcBuoyancyForce_Damping
+    }
+    // clang-format on
+}
+
 // Fixes invisible weapon particles (extinguisher, spraycan, flamethrower) at high FPS
 #define HOOKPOS_CWeapon_Update  0x73DC3D
 #define HOOKSIZE_CWeapon_Update 5
@@ -947,6 +1018,9 @@ void CMultiplayerSA::InitHooks_FrameRateFixes()
     EZHookInstall(CTaskSimpleSwim__ProcessEffects);
     EZHookInstall(CTaskSimpleSwim__ProcessEffectsBubbleFix);
     EZHookInstall(CTaskSimpleSwim__ProcessSwimmingResistance);
+    EZHookInstall(CTaskSimpleSwim__ProcessSwimmingResistance_DiveSpeed);
+    EZHookInstall(CTaskSimpleSwim__ProcessSwimmingResistance_Buoyancy);
+    EZHookInstall(cBuoyancy__CalcBuoyancyForce_Damping);
 
     EZHookInstall(CWeapon_Update);
 }


### PR DESCRIPTION
#### Summary

`HOOK_CTaskSimpleSwim__ProcessSwimmingResistance` (added in #379) scales the whole target velocity by `kOriginalTimeStep / timestep`. That is correct for x and y, which come from the per-frame animation shift, but the dive velocity in z and the buoyancy of the underwater swim state are absolute speeds, so both ended up scaled by fps / 30 as well. This PR scales those two constants back at the instruction that loads them.

The depth is only half of it. `cBuoyancy::CalcBuoyancyForce` subtracts the entity's vertical momentum from the buoyancy impulse, but the impulse is scaled by the timestep and the momentum is not, so at high frame rates the damping starts well below the 30 FPS rise speed and a surfacing ped is held under. The momentum is now scaled the same way, for peds only, so vehicles and objects are untouched.

#### Motivation

Fixes #3344. With an uncapped frame rate a dive goes far deeper than the game allows: twice as deep at 60 FPS as at 30, roughly eight times as deep at 240. Once the depth is corrected the ascent turns out to be wrong in the other direction.

#### Test plan

Tested in game on open water, with the client frame limit and vsync off:

1. Press the dive control once from the surface and note the lowest z reached, and how long it takes to get back to the surface.
2. Repeat at 30, 60, 120, 240 and uncapped.
3. The depth is now the same at every frame rate, and the time back to the surface matches the 30 FPS run.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
