### PR TITLE
Fix onClientVehicleDamage not firing for boat collisions

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA_1.3.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_1.3.cpp
@@ -46,9 +46,6 @@ DWORD RETURN_CWorld_RemoveFallenCars_Cancel = 0x56609B;
 #define HOOKPOS_CVehicleModelInterface_SetClump 0x4C9606
 DWORD RETURN_CVehicleModelInterface_SetClump = 0x4C9611;
 
-#define HOOKPOS_CBoat_ApplyDamage 0x6F1C32
-DWORD RETURN_CBoat_ApplyDamage = 0x6F1C3E;
-
 #define HOOKPOS_CProjectile_FixTearGasCrash 0x4C0403
 DWORD RETURN_CProjectile_FixTearGasCrash_Fix = 0x4C05B9;
 DWORD RETURN_CProjectile_FixTearGasCrash_Cont = 0x4C0409;
@@ -67,7 +64,6 @@ void          HOOK_CTaskSimpleJetpack_ProcessInputFixFPS2();
 void          HOOK_CWorld_RemoveFallenPeds();
 void          HOOK_CWorld_RemoveFallenCars();
 void          HOOK_CVehicleModelInterface_SetClump();
-void          HOOK_CBoat_ApplyDamage();
 void          HOOK_CProjectile_FixTearGasCrash();
 void          HOOK_CProjectile_FixExplosionLocation();
 void* __cdecl HOOK_CMemoryMgr_MallocAlign(int size, int alignment, int nHint);
@@ -94,8 +90,6 @@ void CMultiplayerSA::InitHooks_13()
     HookInstall(HOOKPOS_CWorld_RemoveFallenCars, (DWORD)HOOK_CWorld_RemoveFallenCars, 5);
 
     HookInstall(HOOKPOS_CVehicleModelInterface_SetClump, (DWORD)HOOK_CVehicleModelInterface_SetClump, 7);
-
-    HookInstall(HOOKPOS_CBoat_ApplyDamage, (DWORD)HOOK_CBoat_ApplyDamage, 12);
 
     HookInstall(HOOKPOS_CProjectile_FixTearGasCrash, (DWORD)HOOK_CProjectile_FixTearGasCrash, 6);
 
@@ -492,32 +486,6 @@ static void __declspec(naked) HOOK_CVehicleModelInterface_SetClump()
         mov ecx, esi
         mov dword ptr [esp+14h], 0FFFFFFFFh
         jmp RETURN_CVehicleModelInterface_SetClump
-    }
-    // clang-format on
-}
-
-static void __declspec(naked) HOOK_CBoat_ApplyDamage()
-{
-    MTA_VERIFY_HOOK_LOCAL_SIZE;
-
-    // clang-format off
-    __asm
-    {
-        push eax
-        // Check if vehicleFlags->bCanBeDamaged is set
-        mov  eax, [esi+42Ah]
-        test eax, 20h
-        jz   boatCanBeDamaged
-        fst  dword ptr [esi+4C0h]
-    }
-    // clang-format on
-
-    boatCanBeDamaged :
-        // clang-format off
-    __asm
-    {
-        pop eax
-        jmp RETURN_CBoat_ApplyDamage
     }
     // clang-format on
 }

--- a/Client/multiplayer_sa/CMultiplayerSA_VehicleDamage.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_VehicleDamage.cpp
@@ -245,7 +245,7 @@ static void __declspec(naked) HOOK_CAutomobile_VehicleDamage1()
 //////////////////////////////////////////////////////////////////////////////////////////
 //
 // CVehicle::VehicleDamage hook 2
-//      (Used for CAutomobile, CBike and CPlane hooks)
+//      (Used for CAutomobile, CBike, CPlane and CBoat hooks)
 //
 // Trigger event
 //
@@ -451,6 +451,54 @@ static void __declspec(naked) HOOK_CBike_VehicleDamage2()
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //
+// CBoat::ProcessControl hook
+//
+// Trigger event
+//
+// CBoat has no VehicleDamage override, its collision damage is applied inline in
+// ProcessControl. The health store that follows the subtraction is part of the same hook,
+// because a damage proof boat has to keep the value out of its health, which is what the
+// separate CBoat_ApplyDamage hook did before.
+//
+//////////////////////////////////////////////////////////////////////////////////////////
+// Hook info
+#define HOOKPOS_CBoat_VehicleDamage2   0x06F1C2C
+#define HOOKSIZE_CBoat_VehicleDamage2  18
+#define HOOKCHECK_CBoat_VehicleDamage2 0xD8
+DWORD                         RETURN_CBoat_VehicleDamage2 = 0x06F1C3E;
+static void __declspec(naked) HOOK_CBoat_VehicleDamage2()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        // vehicleFlags->bCanBeDamaged, damage proof boats stay silent like cars
+        test    byte ptr [esi+42Ah], 20h
+        jz      damageProof
+
+        sub     esp, 4
+        fstp    dword ptr [esp] // Pop loss into the second argument
+        push    esi
+        call    OnMY_CVehicle_VehicleDamage2
+        add     esp, 4*2
+        // Loss is on fp stack (from function return)
+
+        // Continue replaced code
+        fsubr   dword ptr [esi+4C0h]
+        fst     dword ptr [esi+4C0h]
+        jmp     RETURN_CBoat_VehicleDamage2
+
+damageProof:
+        // The same without the health store
+        fsubr   dword ptr [esi+4C0h]
+        jmp     RETURN_CBoat_VehicleDamage2
+    }
+    // clang-format on
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+//
 // CMultiplayerSA::SetVehicleDamageHandler
 //
 // Set handler for functions in this file
@@ -479,4 +527,5 @@ void CMultiplayerSA::InitHooks_VehicleDamage()
     EZHookInstallChecked(CPlane_VehicleDamage2);
     EZHookInstallChecked(CBike_VehicleDamage1);
     EZHookInstallChecked(CBike_VehicleDamage2);
+    EZHookInstallChecked(CBoat_VehicleDamage2);
 }


### PR DESCRIPTION
#### Summary

`CBoat` does not override `CVehicle::VehicleDamage`, its vtable slot points at the empty stub, so the hooks that raise `onClientVehicleDamage` for cars, bikes and planes never ran for boats. Boat collision damage is applied inline in `CBoat::ProcessControl` instead. This PR hooks that health subtraction the same way the existing `VehicleDamage2` hooks do, with the collided vehicle as the attacker and no weapon. Damage proof boats are skipped first, as they are for cars.

#### Motivation

Fixes #2212. Scripts received `onClientVehicleCollision` and could watch a boat lose health, but never got the damage event, so the damage could not be cancelled:

```lua
addEventHandler("onClientVehicleDamage", root, function()
    cancelEvent()
end)
```

Weapon damage on a boat already fired the event because it goes through `CVehicle::InflictDamage`, which is the "not always" in the report.

Note for scripts: a boat collision now raises several damage events, one per damage tick the game applies, and `cancelEvent()` in the handler blocks the damage.

#### Test plan

Tested in game with a client resource logging the collision, the damage events and the vehicle health:

1. Ram a Speeder into a moored boat at speed.
2. The damage events fire with the loss the game applies and add up to the health drop, with the boat that was hit as the attacker.
3. With `cancelEvent()` in the handler the boat stays at full health.
4. Shooting a boat still fires the event as before.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
