### PR TITLE
Optimize CLuaTimerManager timer processing queue

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaTimerManager.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaTimerManager.cpp
@@ -17,13 +17,17 @@ void CLuaTimerManager::DoPulse(CLuaMain* pLuaMain)
     assert(!m_pPendingDelete);
     assert(!m_pProcessingTimer);
 
+    if (m_TimerList.empty())
+        return;
+
     CTickCount llCurrentTime = CTickCount::Now();
 
     // Use a separate queue to avoid trouble
     for (CFastList<CLuaTimer*>::const_iterator iter = m_TimerList.begin(); iter != m_TimerList.end(); iter++)
     {
-        if (!(*iter)->IsPaused())
-            m_ProcessQueue.push_back(*iter);
+        CLuaTimer* pTimer = *iter;
+        if (!pTimer->IsPaused() && llCurrentTime >= (pTimer->GetStartTime() + pTimer->GetDelay()))
+            m_ProcessQueue.push_back(pTimer);
     }
 
     while (!m_ProcessQueue.empty())


### PR DESCRIPTION
This PR reduces unnecessary CPU memory operations every frame, Skip processing when no timers exist,
Improves FPS stability in servers with many Lua timers.