### PR TITLE
Add optional Windows file caching for GTA IMG archives

### DIFF
--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -398,7 +398,7 @@ void CClientVariables::LoadDefaults()
     DEFAULT("browser_enable_gpu", true);                 // Enable GPU in CEF? (allows stuff like WebGL to function)
     DEFAULT("browser_enable_video_acceleration", true);  // Enable hardware video decoding in CEF?
     DEFAULT("process_cpu_affinity", true);               // Set CPU 0 affinity to improve game performance and fix the known issue in single-threaded games
-    DEFAULT("img_file_caching", true);                   // Let Windows cache IMG archive reads to reduce disk I/O
+    DEFAULT("img_file_caching", false);                  // Preserve GTA's original IMG read behavior unless caching is explicitly enabled
     DEFAULT("ask_before_disconnect", true);              // Ask before disconnecting from a server
     DEFAULT("allow_steam_client", false);                // Allow connecting with the local Steam client (to set GTA:SA ingame status)
     DEFAULT("use_mouse_sensitivity_for_aiming",

--- a/Client/core/CClientVariables.cpp
+++ b/Client/core/CClientVariables.cpp
@@ -398,6 +398,7 @@ void CClientVariables::LoadDefaults()
     DEFAULT("browser_enable_gpu", true);                 // Enable GPU in CEF? (allows stuff like WebGL to function)
     DEFAULT("browser_enable_video_acceleration", true);  // Enable hardware video decoding in CEF?
     DEFAULT("process_cpu_affinity", true);               // Set CPU 0 affinity to improve game performance and fix the known issue in single-threaded games
+    DEFAULT("img_file_caching", true);                   // Let Windows cache IMG archive reads to reduce disk I/O
     DEFAULT("ask_before_disconnect", true);              // Ask before disconnecting from a server
     DEFAULT("allow_steam_client", false);                // Allow connecting with the local Steam client (to set GTA:SA ingame status)
     DEFAULT("use_mouse_sensitivity_for_aiming",

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -1720,7 +1720,7 @@ void CSettings::CreateGUI()
     vecTemp = CVector2D(12.f, 12.f);
     float fComboWidth = 170.f;
     float fHeaderHeight = 20;
-    float fLineHeight = 27;
+    float fLineHeight = 25;
 
     // Misc section label
     m_pAdvancedMiscLabel = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabAdvanced, _("Misc")));
@@ -1906,9 +1906,9 @@ void CSettings::CreateGUI()
     m_pProcessAffinityCheckbox->AutoSize(nullptr, 20.0f);
     vecTemp.fY += fLineHeight;
 
-    // Allow disabling cached IMG reads for users experiencing streaming issues.
+    // Let users opt into Windows caching while preserving GTA's original IMG reads by default.
     m_pIMGFileCachingCheckbox =
-        reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabAdvanced, _("Cache game files in memory (requires restart)"), true));
+        reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabAdvanced, _("Enable Windows file caching for IMG archives"), false));
     m_pIMGFileCachingCheckbox->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY));
     m_pIMGFileCachingCheckbox->AutoSize(nullptr, 20.0f);
     m_pIMGFileCachingCheckbox->SetMouseEnterHandler(GUI_CALLBACK(&CSettings::OnShowAdvancedSettingDescription, this));
@@ -1966,11 +1966,11 @@ void CSettings::CreateGUI()
     vecTemp.fX -= fComboWidth + 15;
 
     // Description label
-    vecTemp.fY += 15.0f;
+    vecTemp.fY += 2.0f;
     m_pAdvancedSettingDescriptionLabel = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabAdvanced, ""));
-    m_pAdvancedSettingDescriptionLabel->SetPosition(CVector2D(vecTemp.fX + 10.f, vecTemp.fY));
-    m_pAdvancedSettingDescriptionLabel->SetFont("default-bold-small");
-    m_pAdvancedSettingDescriptionLabel->SetSize(CVector2D(500.0f, 95.0f));
+    m_pAdvancedSettingDescriptionLabel->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY));
+    m_pAdvancedSettingDescriptionLabel->SetFont("default");
+    m_pAdvancedSettingDescriptionLabel->SetSize(CVector2D(std::max(1.0f, tabPanelSize.fX - 2.0f * vecTemp.fX), 95.0f));
     m_pAdvancedSettingDescriptionLabel->SetHorizontalAlign(CGUI_ALIGN_HORIZONTALCENTER_WORDWRAP);
 
     // Set up the events
@@ -6141,9 +6141,8 @@ bool CSettings::OnShowAdvancedSettingDescription(CGUIElement* pElement)
         strText = std::string(_("CPU affinity:")) + " " + std::string(_("Only change if you're having stability issues."));
     else if (pCheckBox && pCheckBox == m_pIMGFileCachingCheckbox)
         strText =
-            _("Lets Windows cache IMG game archives in RAM by removing FILE_FLAG_NO_BUFFERING. Enabled by default to reduce disk reads and potentially "
-              "reduce loading stutter on SSDs and HDDs. Older HDDs do not automatically benefit from disabling it. Try turning it off if performance worsens. "
-              "Requires restarting MTA.");
+            _("Off by default to preserve GTA's original behavior. When enabled, removes FILE_FLAG_NO_BUFFERING so Windows can cache IMG game archives in RAM. "
+              "This may reduce disk reads and loading stutter on SSDs and HDDs. Try turning it off if performance worsens. Requires restarting MTA.");
 
     if (strText != "")
         m_pAdvancedSettingDescriptionLabel->SetText(strText.c_str());

--- a/Client/core/CSettings.cpp
+++ b/Client/core/CSettings.cpp
@@ -1906,6 +1906,15 @@ void CSettings::CreateGUI()
     m_pProcessAffinityCheckbox->AutoSize(nullptr, 20.0f);
     vecTemp.fY += fLineHeight;
 
+    // Allow disabling cached IMG reads for users experiencing streaming issues.
+    m_pIMGFileCachingCheckbox =
+        reinterpret_cast<CGUICheckBox*>(pManager->CreateCheckBox(pTabAdvanced, _("Cache game files in memory (requires restart)"), true));
+    m_pIMGFileCachingCheckbox->SetPosition(CVector2D(vecTemp.fX, vecTemp.fY));
+    m_pIMGFileCachingCheckbox->AutoSize(nullptr, 20.0f);
+    m_pIMGFileCachingCheckbox->SetMouseEnterHandler(GUI_CALLBACK(&CSettings::OnShowAdvancedSettingDescription, this));
+    m_pIMGFileCachingCheckbox->SetMouseLeaveHandler(GUI_CALLBACK(&CSettings::OnHideAdvancedSettingDescription, this));
+    vecTemp.fY += fLineHeight;
+
     // Auto updater section label
     m_pAdvancedUpdaterLabel = reinterpret_cast<CGUILabel*>(pManager->CreateLabel(pTabAdvanced, _("Auto updater")));
     m_pAdvancedUpdaterLabel->SetPosition(CVector2D(vecTemp.fX - 10.0f, vecTemp.fY));
@@ -4162,6 +4171,9 @@ void CSettings::LoadData()
     CVARS_GET("photosaving", bVar);
     m_pPhotoSavingCheckbox->SetSelected(bVar);
 
+    CVARS_GET("img_file_caching", bVar);
+    m_pIMGFileCachingCheckbox->SetSelected(bVar);
+
     // Process CPU Affinity
     CVARS_GET("process_cpu_affinity", bVar);
     m_pProcessAffinityCheckbox->SetSelected(bVar);
@@ -4606,6 +4618,11 @@ void CSettings::SaveData()
     CVARS_SET("photosaving", photoSaving);
     CScreenShot::SetPhotoSavingInsideDocuments(photoSaving);
 
+    // Archive handles retain their opening flags, so save the preference and request a restart.
+    const bool bIMGFileCaching = m_pIMGFileCachingCheckbox->GetSelected();
+    const bool bIMGFileCachingChanged = bIMGFileCaching != CVARS_GET_VALUE<bool>("img_file_caching");
+    CVARS_SET("img_file_caching", bIMGFileCaching);
+
     // Process CPU Affinity
     bool affinity = m_pProcessAffinityCheckbox->GetSelected();
     CVARS_SET("process_cpu_affinity", affinity);
@@ -4794,7 +4811,7 @@ void CSettings::SaveData()
 
     // Ask to restart?
     if (bIsVideoModeChanged || bIsAntiAliasingChanged || bIsCustomizedSAFilesChanged || processsDPIAwareChanged || bBrowserGPUSettingChanged ||
-        bBrowserVideoAccelSettingChanged)
+        bBrowserVideoAccelSettingChanged || bIMGFileCachingChanged)
         ShowRestartQuestion();
     else if (CModManager::GetSingleton().IsLoaded() && bBrowserSettingChanged)
         ShowDisconnectQuestion();
@@ -6122,6 +6139,11 @@ bool CSettings::OnShowAdvancedSettingDescription(CGUIElement* pElement)
         strText = std::string(_("Auto updater:")) + " " + std::string(_("Select default to automatically install important updates."));
     else if (pCheckBox && pCheckBox == m_pProcessAffinityCheckbox)
         strText = std::string(_("CPU affinity:")) + " " + std::string(_("Only change if you're having stability issues."));
+    else if (pCheckBox && pCheckBox == m_pIMGFileCachingCheckbox)
+        strText =
+            _("Lets Windows cache IMG game archives in RAM by removing FILE_FLAG_NO_BUFFERING. Enabled by default to reduce disk reads and potentially "
+              "reduce loading stutter on SSDs and HDDs. Older HDDs do not automatically benefit from disabling it. Try turning it off if performance worsens. "
+              "Requires restarting MTA.");
 
     if (strText != "")
         m_pAdvancedSettingDescriptionLabel->SetText(strText.c_str());

--- a/Client/core/CSettings.h
+++ b/Client/core/CSettings.h
@@ -240,6 +240,7 @@ protected:
     CGUICheckBox*  m_pPhotoSavingCheckbox;
     CGUICheckBox*  m_pCheckBoxAskBeforeDisconnect;
     CGUICheckBox*  m_pProcessAffinityCheckbox;
+    CGUICheckBox*  m_pIMGFileCachingCheckbox;
     CGUILabel*     m_pUpdateBuildTypeLabel;
     CGUIComboBox*  m_pUpdateBuildTypeCombo;
     CGUILabel*     m_pUpdateAutoInstallLabel;

--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -228,10 +228,6 @@ CGameSA::CGameSA()
         MemPut<WORD>(0x05B8E55, MAX_RWOBJECT_INSTANCES * 12);  // Default is 1000 * 12
         MemPut<WORD>(0x05B8EB0, MAX_RWOBJECT_INSTANCES * 12);  // Default is 1000 * 12
 
-        // Remove FILE_FLAG_NO_BUFFERING from GTA SA's IMG archive reads, following SilentPatch's approach.
-        // This allows Windows to cache file data, potentially reducing disk I/O and improving streaming performance.
-        MemPut<uint8_t>(0x406BC6, 0xEB);
-
         // Increase matrix array size
         MemPut<int>(0x054F3A1, MAX_OBJECTS * 3);  // Default is 900
 

--- a/Client/game_sa/CGameSA.cpp
+++ b/Client/game_sa/CGameSA.cpp
@@ -228,6 +228,10 @@ CGameSA::CGameSA()
         MemPut<WORD>(0x05B8E55, MAX_RWOBJECT_INSTANCES * 12);  // Default is 1000 * 12
         MemPut<WORD>(0x05B8EB0, MAX_RWOBJECT_INSTANCES * 12);  // Default is 1000 * 12
 
+        // Remove FILE_FLAG_NO_BUFFERING from GTA SA's IMG archive reads, following SilentPatch's approach.
+        // This allows Windows to cache file data, potentially reducing disk I/O and improving streaming performance.
+        MemPut<uint8_t>(0x406BC6, 0xEB);
+
         // Increase matrix array size
         MemPut<int>(0x054F3A1, MAX_OBJECTS * 3);  // Default is 900
 

--- a/Client/game_sa/gamesa_init.cpp
+++ b/Client/game_sa/gamesa_init.cpp
@@ -38,7 +38,7 @@ MTAEXPORT CGame* GetGameInterface(CCoreInterface* pCore)
 
     // Remove FILE_FLAG_NO_BUFFERING to let Windows cache IMG reads and reduce disk I/O.
     // Apply this before CdStreamInit opens archives; existing handles require a restart to change their flags.
-    bool bIMGFileCaching = true;
+    bool bIMGFileCaching = false;
     pCore->GetCVars()->Get("img_file_caching", bIMGFileCaching);
     MemPut<uint8_t>(0x406BC6, bIMGFileCaching ? 0xEB : 0x77);
 

--- a/Client/game_sa/gamesa_init.cpp
+++ b/Client/game_sa/gamesa_init.cpp
@@ -36,6 +36,12 @@ MTAEXPORT CGame* GetGameInterface(CCoreInterface* pCore)
     pGame = new CGameSA;
     g_pCore = pCore;
 
+    // Remove FILE_FLAG_NO_BUFFERING to let Windows cache IMG reads and reduce disk I/O.
+    // Apply this before CdStreamInit opens archives; existing handles require a restart to change their flags.
+    bool bIMGFileCaching = true;
+    pCore->GetCVars()->Get("img_file_caching", bIMGFileCaching);
+    MemPut<uint8_t>(0x406BC6, bIMGFileCaching ? 0xEB : 0x77);
+
     return (CGame*)pGame;
 }
 


### PR DESCRIPTION
#### Summary
Adds an `Enable Windows file caching for IMG archives` checkbox in Advanced settings, disabled by default. The preference is saved and changes require restarting MTA.

Following SilentPatch's approach, the patch changes the opcode at `0x406BC6`:
- **Enabled:** `0xEB` (`JMP`) skips `FILE_FLAG_NO_BUFFERING`, allowing Windows to cache IMG reads.
- **Disabled:** `0x77` (`JA`) restores GTA's original behavior: unbuffered reads for reported sector sizes ≤2048 bytes; caching permitted for larger sectors.

Unchecked means **original GTA behavior**, not `always disable caching.`

#### Motivation
Inspired by SilentPatch's approach to GTA SA's unbuffered archive reads. Allowing Windows to cache frequently accessed game data may reduce disk I/O and improve streaming performance in certain situations on modern hardware, including SSD-based systems.

#### Test plan
Start MTA and travel around the map with the option disabled, then enable it and restart. Compare loading stutter and streaming performance. Confirm the setting persists after restarting.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
