### PR TITLE
Fix camera jitter while aiming and walking at high FPS

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
@@ -16,6 +16,7 @@ static unsigned int nLastFrameTime = 0;
 constexpr float kOriginalTimeStep = 50.0f / 30.0f;
 
 // Fixes player movement issue while aiming and walking on high FPS.
+// Only rescales the compare threshold; m_MoveCmd's reset is NOPed separately in InitHooks_FrameRateFixes.
 #define HOOKPOS_CTaskSimpleUseGun__SetMoveAnim  0x61E4F2
 #define HOOKSIZE_CTaskSimpleUseGun__SetMoveAnim 0x6
 const unsigned int            RETURN_CTaskSimpleUseGun__SetMoveAnim = 0x61E4F8;
@@ -907,6 +908,10 @@ void CMultiplayerSA::InitHooks_FrameRateFixes()
     EZHookInstall(CFallingGlassPane__Update_A);
     EZHookInstall(CFallingGlassPane__Update_B);
     EZHookInstall(CFallingGlassPane__Update_C);
+
+    // Fixes camera jitter while aiming and walking at high FPS.
+    // CTaskSimpleUseGun::SetMoveAnim
+    MemSet((void*)0x61E5E4, 0x90, 0x6);
 
     // Fixes slow camera movement towards the back of the vehicle on high FPS.
     // CCam::Process_FollowCar_SA


### PR DESCRIPTION
#### Summary
Stops the third person aim camera from looking shaky while walking and aiming with a weapon, at high frame rates.

https://github.com/user-attachments/assets/83bbcb5a-a516-4fbd-b628-3eda71b5e39b



#### Motivation

Fixes #5335 

SetMoveAnim resets m_MoveCmd to zero every frame the ped counts as barely moving. At high FPS that reset fires before the command can accumulate past the blend threshold, so the moving-while-aiming animation never kicks in and the camera looks shaky instead. This NOPs out the reset itself instead of only rescaling the threshold like the existing hook did; gta-reversed's own decompilation already documents it as a known bug.

#### Test plan
Tested in game with an uncapped frame rate: equipped a weapon, aimed while walking, and confirmed the camera no longer shakes. Switched to 144 FPS and lower, where the issue never reproduced, to confirm behavior there is unchanged.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
