### PR TITLE
Move the initialization of `g_pCore` before `CGameSA`

### DIFF
--- a/Client/game_sa/gamesa_init.cpp
+++ b/Client/game_sa/gamesa_init.cpp
@@ -33,8 +33,8 @@ MTAEXPORT CGame* GetGameInterface(CCoreInterface* pCore)
 
     SetMemoryAllocationFailureHandler();
 
-    pGame = new CGameSA;
     g_pCore = pCore;
+    pGame = new CGameSA;
 
     return (CGame*)pGame;
 }


### PR DESCRIPTION
Save other developers the headache.

I think it would be better to write the code directly in the `CGameSA` constructor rather than in an exported function.

Example #5338