### PR TITLE
Fixing getElementRotation and getElementModel returning false on building types

### DIFF
--- a/Client/mods/deathmatch/logic/rpc/CObjectRPCs.cpp
+++ b/Client/mods/deathmatch/logic/rpc/CObjectRPCs.cpp
@@ -33,12 +33,21 @@ void CObjectRPCs::DestroyAllObjects(NetBitStreamInterface& bitStream)
 
 void CObjectRPCs::SetObjectRotation(CClientEntity* pSource, NetBitStreamInterface& bitStream)
 {
+    // Read out the new rotation
+    CVector vecRotation;
+
+    if (pSource->GetType() == CCLIENTBUILDING)
+    {
+        if (bitStream.Read(vecRotation.fX) && bitStream.Read(vecRotation.fY) && bitStream.Read(vecRotation.fZ))
+            static_cast<CClientBuilding*>(pSource)->SetRotationRadians(vecRotation);
+
+        return;
+    }
+
     // Grab the object
     CDeathmatchObject* pObject = static_cast<CDeathmatchObject*>(m_pObjectManager->Get(pSource->GetID()));
     if (pObject)
     {
-        // Read out the new rotation
-        CVector vecRotation;
         if (bitStream.Read(vecRotation.fX) && bitStream.Read(vecRotation.fY) && bitStream.Read(vecRotation.fZ))
         {
             // Set the new rotation

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -22,6 +22,7 @@
 #include "CBlip.h"
 #include "CWater.h"
 #include "CBuilding.h"
+#include "CBuildingManager.h"
 #include "CPlayerCamera.h"
 #include <cmath>
 #include "CElementDeleter.h"
@@ -714,6 +715,12 @@ bool CStaticFunctionDefinitions::GetElementModel(CElement* pElement, unsigned sh
             usModel = pObject->GetModel();
             break;
         }
+        case CElement::BUILDING:
+        {
+            CBuilding* pBuilding = static_cast<CBuilding*>(pElement);
+            usModel = pBuilding->GetModel();
+            break;
+        }
         case CElement::PICKUP:
         {
             CPickup* pPickup = static_cast<CPickup*>(pElement);
@@ -1227,6 +1234,18 @@ bool CStaticFunctionDefinitions::GetElementRotation(CElement* pElement, CVector&
 
             break;
         }
+        case CElement::BUILDING:
+        {
+            CBuilding* pBuilding = static_cast<CBuilding*>(pElement);
+            pBuilding->GetRotation(vecRotation);
+            ConvertRadiansToDegrees(vecRotation);
+            if (desiredRotOrder != EULER_DEFAULT && desiredRotOrder != EULER_ZXY)
+            {
+                vecRotation = ConvertEulerRotationOrder(vecRotation, EULER_ZXY, desiredRotOrder);
+            }
+
+            break;
+        }
         default:
             return false;
     }
@@ -1399,6 +1418,28 @@ bool CStaticFunctionDefinitions::SetElementRotation(CElement* pElement, const CV
                 CVector vZXY = ConvertEulerRotationOrder(vecRotation, argumentRotOrder, EULER_ZXY);
                 SetObjectRotation(pObject, vZXY);
             }
+
+            break;
+        }
+        case CElement::BUILDING:
+        {
+            CBuilding* pBuilding = static_cast<CBuilding*>(pElement);
+            CVector    vecRadians = vecRotation;
+
+            if (argumentRotOrder != EULER_DEFAULT && argumentRotOrder != EULER_ZXY)
+            {
+                vecRadians = ConvertEulerRotationOrder(vecRotation, argumentRotOrder, EULER_ZXY);
+            }
+
+            ConvertDegreesToRadians(vecRadians);
+            pBuilding->SetRotation(vecRadians);
+
+            CBitStream BitStream;
+            BitStream.pBitStream->Write(vecRadians.fX);
+            BitStream.pBitStream->Write(vecRadians.fY);
+            BitStream.pBitStream->Write(vecRadians.fZ);
+            m_pPlayerManager->BroadcastOnlyJoined(CElementRPCPacket(pBuilding, SET_OBJECT_ROTATION, *BitStream.pBitStream));
+
             break;
         }
         default:
@@ -1973,6 +2014,31 @@ bool CStaticFunctionDefinitions::SetElementModel(CElement* pElement, unsigned sh
             {
                 // Change canceled
                 pObject->SetModel(usOldModel);
+                return false;
+            }
+            break;
+        }
+        case CElement::BUILDING:
+        {
+            CBuilding* pBuilding = static_cast<CBuilding*>(pElement);
+            if (pBuilding->GetModel() == usModel)
+                return false;
+            if (!CBuildingManager::IsValidModel(usModel))
+                return false;
+            unsigned short usOldModel = pBuilding->GetModel();  // Get the old model
+            CLuaArguments  Arguments;
+            Arguments.PushNumber(usOldModel);
+            pBuilding->SetModel(usModel);   // Set the new model
+            Arguments.PushNumber(usModel);  // Get the new model
+            bool bContinue = pBuilding->CallEvent("onElementModelChange", Arguments);
+            // Check for another call to setElementModel
+            if (usModel != pBuilding->GetModel())
+                return false;
+
+            if (!bContinue)
+            {
+                // Change canceled
+                pBuilding->SetModel(usOldModel);
                 return false;
             }
             break;


### PR DESCRIPTION
Closes #5348.

```lua
local b = createBuilding(3095, 0, 0, 2)
outputChatBox(inspect({getElementModel(b)}))
outputChatBox(inspect({getElementRotation(b)}))
setElementModel(b, 980)
setElementRotation(b, 0, 0, 44)
outputChatBox(inspect({getElementModel(b)}))
outputChatBox(inspect({getElementRotation(b)}))
```

<img width="1920" height="1080" alt="Screenshot 2026-09-10 045524" src="https://github.com/user-attachments/assets/030e85da-bb2b-40b5-9819-9cc1109a40e8" />
