### PR TITLE
Fix building pool resize corrupting the world

### DIFF
--- a/Client/game_sa/CBuildingsPoolSA.cpp
+++ b/Client/game_sa/CBuildingsPoolSA.cpp
@@ -28,6 +28,10 @@ extern CGameSA* pGame;
 
 class CClientEntity;
 
+// GTA SA object pool slot stride (412) differs from sizeof(CObjectSAInterface) (380)
+// because pool slots include alignment padding beyond the struct size.
+static constexpr std::uint32_t kObjectPoolStride = 412;
+
 CBuildingsPoolSA::CBuildingsPoolSA() : m_pOriginalBuildingsBackup(nullptr)
 {
     m_ppBuildingPoolInterface = (CPoolSAInterface<CBuildingSAInterface>**)0xB74498;
@@ -211,7 +215,7 @@ void CBuildingsPoolSA::RemoveAllWithBackup()
             if (building->HasMatrix())
             {
                 // Keep original matrix
-                m_buildingMatrix[building] = *building->matrix;
+                m_buildingMatrix[i] = *building->matrix;
 
                 building->RemoveMatrix();
             }
@@ -246,15 +250,13 @@ void CBuildingsPoolSA::RestoreBackup()
             auto* pBuilding = pBuildsingsPool->AllocateAtNoInit(i);
             std::memcpy(pBuilding, &originalData[i].second, sizeof(CBuildingSAInterface));
 
-            // Restore matrix if it was removed
-            auto it = m_buildingMatrix.find(pBuilding);
+            // Restore the matrix into the static list, where LoadObjectInstance put it originally;
+            // list1 links get stripped from their owner by GetOldestLink once the free list runs dry
+            auto it = m_buildingMatrix.find(i);
             if (it != m_buildingMatrix.end())
             {
-                if (!pBuilding->HasMatrix())
-                    pBuilding->AllocateMatrix();
-
+                pBuilding->AllocateStaticMatrix();
                 *pBuilding->matrix = it->second;
-                m_buildingMatrix.erase(it);
             }
 
             worldSA->Add(pBuilding, CBuildingPool_Constructor);
@@ -262,6 +264,7 @@ void CBuildingsPoolSA::RestoreBackup()
         }
     }
 
+    m_buildingMatrix.clear();
     m_pOriginalBuildingsBackup = nullptr;
 }
 
@@ -280,20 +283,14 @@ void CBuildingsPoolSA::PurgeStaleSectorEntries(void* oldPool, int poolSize)
     const auto poolStart = reinterpret_cast<std::uintptr_t>(oldPool);
     const auto poolEnd = poolStart + static_cast<std::uintptr_t>(poolSize) * sizeof(CBuildingSAInterface);
 
-    // ARRAY_StreamSectors is a flat array of CSector[120][120].
-    // Each CSector is { CPtrListSingleLink m_buildings; CPtrListDoubleLink m_dummies } = 2 DWORDs.
-    // We only scan m_buildings (even-indexed DWORDs).
-    auto*         sectorDwords = reinterpret_cast<DWORD*>(ARRAY_StreamSectors);
-    constexpr int kSectorCount = NUM_StreamSectorRows * NUM_StreamSectorCols;
-
-    for (int i = 0; i < kSectorCount; ++i)
+    const auto purgeList = [poolStart, poolEnd](DWORD* pHead)
     {
-        // A stale entry can only exist in a sector that has nodes; null head means empty list.
-        if (sectorDwords[i * 2] == 0)
-            continue;
+        // A stale entry can only exist in a list that has nodes; null head means empty list.
+        if (*pHead == 0)
+            return;
 
-        auto* pList = reinterpret_cast<CPtrNodeSingleListSAInterface<CEntitySAInterface>*>(&sectorDwords[i * 2]);
-        auto* pNode = reinterpret_cast<CPtrNodeSingleLink<CEntitySAInterface>*>(sectorDwords[i * 2]);
+        auto* pList = reinterpret_cast<CPtrNodeSingleListSAInterface<CEntitySAInterface>*>(pHead);
+        auto* pNode = reinterpret_cast<CPtrNodeSingleLink<CEntitySAInterface>*>(*pHead);
 
         while (pNode)
         {
@@ -306,7 +303,20 @@ void CBuildingsPoolSA::PurgeStaleSectorEntries(void* oldPool, int poolSize)
 
             pNode = pNext;
         }
-    }
+    };
+
+    // ARRAY_StreamSectors is a flat array of CSector[120][120].
+    // Each CSector is { CPtrListSingleLink m_buildings; CPtrListDoubleLink m_dummies } = 2 DWORDs.
+    // We only scan m_buildings (even-indexed DWORDs).
+    auto* sectorDwords = reinterpret_cast<DWORD*>(ARRAY_StreamSectors);
+    for (int i = 0; i < NUM_StreamSectorRows * NUM_StreamSectorCols; ++i)
+        purgeList(&sectorDwords[i * 2]);
+
+    // Big buildings (the LODs) never enter the sectors above; CEntity::Add puts them in
+    // CWorld::ms_aLodPtrLists instead, a flat CPtrListSingleLink[30][30] with the same node type.
+    auto* lodDwords = reinterpret_cast<DWORD*>(ARRAY_LodPtrLists);
+    for (int i = 0; i < NUM_LodPtrListRows * NUM_LodPtrListCols; ++i)
+        purgeList(&lodDwords[i]);
 }
 
 bool CBuildingsPoolSA::Resize(int size)
@@ -314,49 +324,50 @@ bool CBuildingsPoolSA::Resize(int size)
     auto*     pool = (*m_ppBuildingPoolInterface);
     const int currentSize = pool->m_nSize;
 
-    // Clear before the malloc calls so the rollback Resize(currentSize), called on
-    // allocation failure below, always runs the link sweeps regardless of whether
-    // RemoveAllWithBackup had set this flag before the outer call.
     const bool skipLinkSweeps = m_bLinkSweepsDone;
     m_bLinkSweepsDone = false;
 
-    m_buildingPool.entities.resize(size);
+    // Nothing below may throw or overflow: RemoveGameWorld already ran, and only a plain false
+    // return lets SetBuildingPoolSize put the untouched world back
+    if (size <= 0 || static_cast<size_t>(size) > MAX_CAPACITY)
+        return false;
 
-    void* oldPool = pool->m_pObjects;
-
-    // Safety scan: remove any sector building list nodes still referencing the
-    // old pool.. RemoveAllWithBackup should have removed them all via CWorld::Remove,
-    // but that call relies on GetBoundRect that can miss entities whose collision
-    // model is unloaded. Leaving stale nodes causes a crash in DeleteAllRwObjects.
-    if (oldPool != nullptr)
-        PurgeStaleSectorEntries(oldPool, currentSize);
-
-    if (oldPool != nullptr)
+    try
     {
-        MemSA::free(pool->m_pObjects);
-        pool->m_pObjects = nullptr;
+        m_buildingPool.entities.resize(size);
     }
-
-    if (pool->m_byteMap != nullptr)
+    catch (const std::bad_alloc&)
     {
-        MemSA::free(pool->m_byteMap);
-        pool->m_byteMap = nullptr;
-    }
-
-    CBuildingSAInterface* newObjects = MemSA::malloc_struct<CBuildingSAInterface>(size);
-    if (newObjects == nullptr)
-    {
-        Resize(currentSize);
         return false;
     }
+
+    // Allocate before touching the old pool: on failure it stays intact and RestoreBackup puts
+    // every building back at its old address, so nothing that points into it needs fixing
+    CBuildingSAInterface* newObjects = MemSA::malloc_struct<CBuildingSAInterface>(size);
+    if (newObjects == nullptr)
+        return false;
 
     tPoolObjectFlags* newBytemap = MemSA::malloc_struct<tPoolObjectFlags>(size);
     if (newBytemap == nullptr)
     {
         MemSA::free(newObjects);
-        Resize(currentSize);
         return false;
     }
+
+    void* oldPool = pool->m_pObjects;
+
+    // Safety scan: remove any sector or LOD list nodes still referencing the
+    // old pool.. RemoveAllWithBackup should have removed them all via CWorld::Remove,
+    // but that call relies on GetBoundRect that can miss entities whose collision
+    // model is unloaded. Leaving stale nodes causes a crash in DeleteAllRwObjects.
+    if (oldPool != nullptr)
+    {
+        PurgeStaleSectorEntries(oldPool, currentSize);
+        MemSA::free(oldPool);
+    }
+
+    if (pool->m_byteMap != nullptr)
+        MemSA::free(pool->m_byteMap);
 
     pool->m_pObjects = newObjects;
     pool->m_byteMap = newBytemap;
@@ -369,17 +380,23 @@ bool CBuildingsPoolSA::Resize(int size)
     }
 
     const std::uint32_t offset = (std::uint32_t)newObjects - (std::uint32_t)oldPool;
+
+    // Only pointers that actually fall inside the old buildings array were invalidated by the
+    // move above; a building or dummy whose LOD is the other pool type never moved and must be
+    // left untouched, otherwise it drifts a bit further off into unrelated memory on every resize.
+    const auto oldPoolStart = reinterpret_cast<std::uintptr_t>(oldPool);
+    const auto oldPoolEnd = oldPoolStart + static_cast<std::uintptr_t>(currentSize) * sizeof(CBuildingSAInterface);
+
     if (oldPool != nullptr)
     {
-        UpdateIplEntrysPointers(offset);
-    }
+        UpdateIplEntityArrayPointers(offset, oldPoolStart, oldPoolEnd);
+        UpdateObjectLods(offset, oldPoolStart, oldPoolEnd);
 
-    if (m_pOriginalBuildingsBackup)
-    {
-        UpdateBackupLodPointers(offset);
-    }
+        if (m_pOriginalBuildingsBackup)
+            UpdateBackupLodPointers(offset, oldPoolStart, oldPoolEnd);
 
-    pGame->GetPools()->GetDummyPool().UpdateBuildingLods(offset);
+        pGame->GetPools()->GetDummyPool().UpdateBuildingLods(offset, oldPoolStart, oldPoolEnd);
+    }
 
     // RemoveAllWithBackup already ran these in the same remove/resize cycle; skip them.
     // Run when Resize is called directly without a prior backup (e.g. pool size change).
@@ -393,7 +410,9 @@ bool CBuildingsPoolSA::Resize(int size)
     return true;
 }
 
-void CBuildingsPoolSA::UpdateIplEntrysPointers(uint32_t offset)
+// CIplStore::IplEntityIndexArrays: one array per text IPL with every entity LoadScene created for
+// it, dummies included, kept until shutdown and read again whenever a streamed IPL links its LODs
+void CBuildingsPoolSA::UpdateIplEntityArrayPointers(uint32_t offset, std::uintptr_t oldPoolStart, std::uintptr_t oldPoolEnd)
 {
     using buildings_array_t = CBuildingSAInterface* [1000];
     using ipl_entry_array_t = buildings_array_t* [40];
@@ -410,16 +429,14 @@ void CBuildingsPoolSA::UpdateIplEntrysPointers(uint32_t offset)
         size_t arraySize = MemSA::msize(*ppArray) / sizeof(CBuildingSAInterface*);
         for (size_t j = 0; j < arraySize; j++)
         {
-            CBuildingSAInterface* object = (*ppArray)[j];
-            if (object == nullptr)
-                continue;
-
-            (*ppArray)[j] = (CBuildingSAInterface*)((uint32_t)object + offset);
+            auto entityAddress = reinterpret_cast<std::uintptr_t>((*ppArray)[j]);
+            if (entityAddress >= oldPoolStart && entityAddress < oldPoolEnd)
+                (*ppArray)[j] = reinterpret_cast<CBuildingSAInterface*>(entityAddress + offset);
         }
     }
 }
 
-void CBuildingsPoolSA::UpdateBackupLodPointers(uint32_t offset)
+void CBuildingsPoolSA::UpdateBackupLodPointers(uint32_t offset, std::uintptr_t oldPoolStart, std::uintptr_t oldPoolEnd)
 {
     auto& arr = *m_pOriginalBuildingsBackup;
     for (size_t i = 0; i < arr.size(); ++i)
@@ -428,9 +445,10 @@ void CBuildingsPoolSA::UpdateBackupLodPointers(uint32_t offset)
         if (data.first)
         {
             CBuildingSAInterface* building = reinterpret_cast<CBuildingSAInterface*>(&data.second);
-            if (building->m_pLod != nullptr)
+            auto                  lodAddress = reinterpret_cast<std::uintptr_t>(building->m_pLod);
+            if (lodAddress >= oldPoolStart && lodAddress < oldPoolEnd)
             {
-                building->m_pLod = (CBuildingSAInterface*)((uint32_t)building->m_pLod + offset);
+                building->m_pLod = reinterpret_cast<CBuildingSAInterface*>(lodAddress + offset);
             }
         }
     }
@@ -500,23 +518,42 @@ void CBuildingsPoolSA::RemoveObjectEntityLinks()
     if (!pObjectPool)
         return;
 
-    // GTA SA object pool slot stride (412) differs from sizeof(CObjectSAInterface) (380)
-    // because pool slots include alignment padding beyond the struct size.
-    constexpr std::uint32_t objectStride = 412;
-    auto*                   pPoolBase = reinterpret_cast<std::uint8_t*>(pObjectPool->m_pObjects);
+    auto* pPoolBase = reinterpret_cast<std::uint8_t*>(pObjectPool->m_pObjects);
 
     for (int i = 0; i < pObjectPool->m_nSize; i++)
     {
         if (pObjectPool->IsEmpty(i))
             continue;
 
-        auto* object = reinterpret_cast<CObjectSAInterface*>(pPoolBase + i * objectStride);
+        auto* object = reinterpret_cast<CObjectSAInterface*>(pPoolBase + i * kObjectPoolStride);
         object->m_pCollidedEntity = nullptr;
         object->pLastContactedEntity[0] = nullptr;
         object->pLastContactedEntity[1] = nullptr;
         object->pLastContactedEntity[2] = nullptr;
         object->pLastContactedEntity[3] = nullptr;
         object->m_ucCollisionState = 0;
+    }
+}
+
+// A dummy hands its building LOD over to the CObject it streams in as and takes it back when the
+// object streams out again, so while the object lives it holds the only copy of that pointer
+void CBuildingsPoolSA::UpdateObjectLods(uint32_t offset, std::uintptr_t oldPoolStart, std::uintptr_t oldPoolEnd)
+{
+    auto* pObjectPool = *reinterpret_cast<CPoolSAInterface<CObjectSAInterface>**>(CLASS_CObjectPool);
+    if (!pObjectPool)
+        return;
+
+    auto* pPoolBase = reinterpret_cast<std::uint8_t*>(pObjectPool->m_pObjects);
+
+    for (int i = 0; i < pObjectPool->m_nSize; i++)
+    {
+        if (pObjectPool->IsEmpty(i))
+            continue;
+
+        auto* object = reinterpret_cast<CObjectSAInterface*>(pPoolBase + i * kObjectPoolStride);
+        auto  lodAddress = reinterpret_cast<std::uintptr_t>(object->GetLod());
+        if (lodAddress >= oldPoolStart && lodAddress < oldPoolEnd)
+            object->SetLod(reinterpret_cast<CEntitySAInterface*>(lodAddress + offset));
     }
 }
 

--- a/Client/game_sa/CBuildingsPoolSA.h
+++ b/Client/game_sa/CBuildingsPoolSA.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <algorithm>
+#include <limits>
 #include <game/CBuildingsPool.h>
 #include <CVector.h>
 #include "CPoolSAInterface.h"
@@ -19,6 +21,14 @@
 class CBuildingsPoolSA : public CBuildingsPool
 {
 public:
+    // The largest size every allocation in Resize can still express: m_nSize is an int, and both
+    // MemSA::malloc_struct and the wrapper vector multiply it by their element size in 32 bits
+    static constexpr std::size_t MAX_CAPACITY = std::min<std::size_t>({
+        static_cast<std::size_t>(std::numeric_limits<int>::max()),
+        std::numeric_limits<std::size_t>::max() / sizeof(CBuildingSAInterface),
+        std::numeric_limits<std::size_t>::max() / sizeof(SClientEntity<CBuildingSA>),
+    });
+
     CBuildingsPoolSA();
     ~CBuildingsPoolSA() = default;
 
@@ -36,8 +46,9 @@ public:
 private:
     void RemoveBuildingFromWorld(CBuildingSAInterface* pBuilding);
     bool AddBuildingToPool(CClientBuilding* pClientBuilding, CBuildingSA* pBuilding);
-    void UpdateIplEntrysPointers(uint32_t offset);
-    void UpdateBackupLodPointers(uint32_t offset);
+    void UpdateIplEntityArrayPointers(uint32_t offset, std::uintptr_t oldPoolStart, std::uintptr_t oldPoolEnd);
+    void UpdateBackupLodPointers(uint32_t offset, std::uintptr_t oldPoolStart, std::uintptr_t oldPoolEnd);
+    void UpdateObjectLods(uint32_t offset, std::uintptr_t oldPoolStart, std::uintptr_t oldPoolEnd);
     void RemoveVehicleDamageLinks();
     void RemovePedsContactEnityLinks();
     void RemoveObjectEntityLinks();
@@ -53,7 +64,7 @@ private:
 
     std::unique_ptr<backup_container_t> m_pOriginalBuildingsBackup;
 
-    std::unordered_map<CBuildingSAInterface*, CMatrix_Padded> m_buildingMatrix{};
+    std::unordered_map<size_t, CMatrix_Padded> m_buildingMatrix{};
 
     // Set by RemoveAllWithBackup after sweeping stale entity links (vehicle damage,
     // ped contact, object entity refs). Cleared by Resize to skip a redundant pass

--- a/Client/game_sa/CDummyPoolSA.cpp
+++ b/Client/game_sa/CDummyPoolSA.cpp
@@ -74,15 +74,18 @@ void CDummyPoolSA::RestoreBackup()
     m_pOriginalElementsBackup = nullptr;
 }
 
-void CDummyPoolSA::UpdateBuildingLods(const std::uint32_t offset)
+void CDummyPoolSA::UpdateBuildingLods(const std::uint32_t offset, const std::uintptr_t oldPoolStart, const std::uintptr_t oldPoolEnd)
 {
     if (m_pOriginalElementsBackup)
-        UpdateBackupLodOffset(offset);
+        UpdateBackupLodOffset(offset, oldPoolStart, oldPoolEnd);
     else
-        UpdateLodsOffestInPool(offset);
+        UpdateLodsOffestInPool(offset, oldPoolStart, oldPoolEnd);
 }
 
-void CDummyPoolSA::UpdateBackupLodOffset(const std::uint32_t offset)
+// A dummy's LOD can point at another dummy just as easily as at a building, so only shift it
+// when it actually falls inside the buildings pool range that just moved; otherwise the pointer
+// is left as is, since it was never invalidated by this resize.
+void CDummyPoolSA::UpdateBackupLodOffset(const std::uint32_t offset, const std::uintptr_t oldPoolStart, const std::uintptr_t oldPoolEnd)
 {
     for (auto& it : *m_pOriginalElementsBackup)
     {
@@ -90,19 +93,21 @@ void CDummyPoolSA::UpdateBackupLodOffset(const std::uint32_t offset)
         {
             CEntitySAInterface* object = reinterpret_cast<CEntitySAInterface*>(&it.second);
             CEntitySAInterface* lod = object->GetLod();
-            if (lod)
-                object->SetLod((CEntitySAInterface*)((std::uint32_t)lod + offset));
+            auto                lodAddress = reinterpret_cast<std::uintptr_t>(lod);
+            if (lodAddress >= oldPoolStart && lodAddress < oldPoolEnd)
+                object->SetLod(reinterpret_cast<CEntitySAInterface*>(lodAddress + offset));
         }
     }
 }
 
-void CDummyPoolSA::UpdateLodsOffestInPool(const std::uint32_t offset)
+void CDummyPoolSA::UpdateLodsOffestInPool(const std::uint32_t offset, const std::uintptr_t oldPoolStart, const std::uintptr_t oldPoolEnd)
 {
     for (auto i = 0; i < (*m_ppDummyPoolInterface)->Size(); i++)
     {
         CEntitySAInterface* object = (*m_ppDummyPoolInterface)->GetObject(i);
         CEntitySAInterface* lod = object->GetLod();
-        if (lod)
-            object->SetLod((CEntitySAInterface*)((std::uint32_t)lod + offset));
+        auto                lodAddress = reinterpret_cast<std::uintptr_t>(lod);
+        if (lodAddress >= oldPoolStart && lodAddress < oldPoolEnd)
+            object->SetLod(reinterpret_cast<CEntitySAInterface*>(lodAddress + offset));
     }
 }

--- a/Client/game_sa/CDummyPoolSA.h
+++ b/Client/game_sa/CDummyPoolSA.h
@@ -26,11 +26,11 @@ public:
 
     void RemoveAllWithBackup() override;
     void RestoreBackup() override;
-    void UpdateBuildingLods(const std::uint32_t offset);
+    void UpdateBuildingLods(const std::uint32_t offset, const std::uintptr_t oldPoolStart, const std::uintptr_t oldPoolEnd) override;
 
 private:
-    void UpdateBackupLodOffset(const std::uint32_t offest);
-    void UpdateLodsOffestInPool(const std::uint32_t offset);
+    void UpdateBackupLodOffset(const std::uint32_t offset, const std::uintptr_t oldPoolStart, const std::uintptr_t oldPoolEnd);
+    void UpdateLodsOffestInPool(const std::uint32_t offset, const std::uintptr_t oldPoolStart, const std::uintptr_t oldPoolEnd);
 
 private:
     CPoolSAInterface<CEntitySAInterface>** m_ppDummyPoolInterface;

--- a/Client/game_sa/CPlaceableSA.h
+++ b/Client/game_sa/CPlaceableSA.h
@@ -30,6 +30,7 @@ public:
 
     bool HasMatrix() const noexcept { return matrix != nullptr; }
     void AllocateMatrix() { ((void(__thiscall*)(void*))0x54F560)(this); }
+    void AllocateStaticMatrix() { ((void(__thiscall*)(void*))0x54F4C0)(this); }
     void RemoveMatrix() { ((void(__thiscall*)(void*))0x54F3B0)(this); }
 
     void SetOrientation(float x, float y, float z) { ((void(__thiscall*)(CPlaceableSAInterface * pEntity, float, float, float))0x439A80)(this, x, y, z); }

--- a/Client/game_sa/CPoolsSA.cpp
+++ b/Client/game_sa/CPoolsSA.cpp
@@ -874,6 +874,17 @@ int CPoolsSA::GetPoolDefaultCapacity(ePools pool)
     return 0;
 }
 
+int CPoolsSA::GetPoolMaxCapacity(ePools pool)
+{
+    switch (pool)
+    {
+        case BUILDING_POOL:
+            return static_cast<int>(CBuildingsPoolSA::MAX_CAPACITY);
+        default:
+            return std::numeric_limits<int>::max();
+    }
+}
+
 int CPoolsSA::GetPoolDefaultModdedCapacity(ePools pool)
 {
     switch (pool)

--- a/Client/game_sa/CPoolsSA.cpp
+++ b/Client/game_sa/CPoolsSA.cpp
@@ -874,15 +874,9 @@ int CPoolsSA::GetPoolDefaultCapacity(ePools pool)
     return 0;
 }
 
-int CPoolsSA::GetPoolMaxCapacity(ePools pool)
+int CPoolsSA::GetPoolMaxCapacity(ePools pool) const noexcept
 {
-    switch (pool)
-    {
-        case BUILDING_POOL:
-            return static_cast<int>(CBuildingsPoolSA::MAX_CAPACITY);
-        default:
-            return std::numeric_limits<int>::max();
-    }
+    return pool == BUILDING_POOL ? static_cast<int>(CBuildingsPoolSA::MAX_CAPACITY) : std::numeric_limits<int>::max();
 }
 
 int CPoolsSA::GetPoolDefaultModdedCapacity(ePools pool)

--- a/Client/game_sa/CPoolsSA.h
+++ b/Client/game_sa/CPoolsSA.h
@@ -91,7 +91,7 @@ public:
     int  GetNumberOfUsedSpaces(ePools pools);
     int  GetPoolDefaultCapacity(ePools pool);
     int  GetPoolDefaultModdedCapacity(ePools pool);
-    int  GetPoolMaxCapacity(ePools pool) override;
+    int  GetPoolMaxCapacity(ePools pool) const noexcept override;
     int  GetPoolCapacity(ePools pool);
     void SetPoolCapacity(ePools pool, int iValue);
 

--- a/Client/game_sa/CPoolsSA.h
+++ b/Client/game_sa/CPoolsSA.h
@@ -91,6 +91,7 @@ public:
     int  GetNumberOfUsedSpaces(ePools pools);
     int  GetPoolDefaultCapacity(ePools pool);
     int  GetPoolDefaultModdedCapacity(ePools pool);
+    int  GetPoolMaxCapacity(ePools pool) override;
     int  GetPoolCapacity(ePools pool);
     void SetPoolCapacity(ePools pool, int iValue);
 

--- a/Client/game_sa/CWorldSA.h
+++ b/Client/game_sa/CWorldSA.h
@@ -32,6 +32,9 @@
 #define ARRAY_StreamSectors         0xB7D0B8
 #define NUM_StreamSectorRows        120
 #define NUM_StreamSectorCols        120
+#define ARRAY_LodPtrLists           0xB99EB8
+#define NUM_LodPtrListRows          30
+#define NUM_LodPtrListCols          30
 #define ARRAY_StreamRepeatSectors   0xB992B8
 #define NUM_StreamRepeatSectorRows  16
 #define NUM_StreamRepeatSectorCols  16

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -2578,6 +2578,13 @@ bool CLuaEngineDefs::EngineSetPoolCapacity(lua_State* luaVM, ePools pool, size_t
         return false;
     }
 
+    const size_t maxSize = g_pGame->GetPools()->GetPoolMaxCapacity(pool);
+    if (newSize > maxSize)
+    {
+        m_pScriptDebugging->LogWarning(luaVM, "Cannot set the pool capacity to more than the maximum capacity.");
+        return false;
+    }
+
     switch (pool)
     {
         case ePools::BUILDING_POOL:

--- a/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaEngineDefs.cpp
@@ -2578,10 +2578,10 @@ bool CLuaEngineDefs::EngineSetPoolCapacity(lua_State* luaVM, ePools pool, size_t
         return false;
     }
 
-    const size_t maxSize = g_pGame->GetPools()->GetPoolMaxCapacity(pool);
+    const std::size_t maxSize = g_pGame->GetPools()->GetPoolMaxCapacity(pool);
     if (newSize > maxSize)
     {
-        m_pScriptDebugging->LogWarning(luaVM, "Cannot set the pool capacity to more than the maximum capacity.");
+        m_pScriptDebugging->LogWarning(luaVM, SString("Cannot set the pool capacity to more than the maximum capacity (%d).", maxSize));
         return false;
     }
 

--- a/Client/sdk/game/CDummyPool.h
+++ b/Client/sdk/game/CDummyPool.h
@@ -18,5 +18,5 @@ class CDummyPool
 public:
     virtual void RemoveAllWithBackup() = 0;
     virtual void RestoreBackup() = 0;
-    virtual void UpdateBuildingLods(const std::uint32_t offset) = 0;
+    virtual void UpdateBuildingLods(const std::uint32_t offset, const std::uintptr_t oldPoolStart, const std::uintptr_t oldPoolEnd) = 0;
 };

--- a/Client/sdk/game/CPools.h
+++ b/Client/sdk/game/CPools.h
@@ -103,7 +103,7 @@ public:
     virtual int  GetNumberOfUsedSpaces(ePools pool) = 0;
     virtual int  GetPoolDefaultCapacity(ePools pool) = 0;
     virtual int  GetPoolDefaultModdedCapacity(ePools pool) = 0;
-    virtual int  GetPoolMaxCapacity(ePools pool) = 0;
+    virtual int  GetPoolMaxCapacity(ePools pool) const noexcept = 0;
     virtual int  GetPoolCapacity(ePools pool) = 0;
     virtual void SetPoolCapacity(ePools pool, int iValue) = 0;
 

--- a/Client/sdk/game/CPools.h
+++ b/Client/sdk/game/CPools.h
@@ -103,6 +103,7 @@ public:
     virtual int  GetNumberOfUsedSpaces(ePools pool) = 0;
     virtual int  GetPoolDefaultCapacity(ePools pool) = 0;
     virtual int  GetPoolDefaultModdedCapacity(ePools pool) = 0;
+    virtual int  GetPoolMaxCapacity(ePools pool) = 0;
     virtual int  GetPoolCapacity(ePools pool) = 0;
     virtual void SetPoolCapacity(ePools pool, int iValue) = 0;
 


### PR DESCRIPTION
#### Summary

`engineSetPoolCapacity("building")` reallocates the building pool, which means all buildings move to new addresses. There were still several places keeping pointers or state from the old pool:

* LOD pointers were being shifted even when the target was a dummy, causing them to point to unrelated memory after resizing.
* `CIplStore::IplEntityIndexArrays` was shifted without checking the range. These arrays can also contain dummies and are used again when streamed IPLs link their LODs.
* Streamed in `CObject`s kept the building LOD they got from their dummy. This was never updated, and the stale value was copied back to the dummy when the object streamed out.
* Big buildings (LODs) are stored in `CWorld::ms_aLodPtrLists` rather than the sectors, so the existing stale node cleanup didn't cover them.
* Tilted buildings lost their tilt after resizing. Their saved matrix was associated with the old pool address, so it couldn't be restored. It was also being recreated in the dynamic matrix list, which gets cleared by `GetOldestLink`.

`Resize` now allocates the new pool before freeing the old one and cannot throw. If the allocation fails or the requested capacity is too large, it returns false without leaving the world in a broken state.

The maximum capacity is also limited to what the allocation code can safely handle (`CBuildingsPoolSA::MAX_CAPACITY`). This limit is exposed through `CPools::GetPoolMaxCapacity` and reported by the Lua function along with the existing limits.

https://streamable.com/z6owli

#### Motivation

Fixes #5252.

Calling the function could rotate some native LODs, such as the Vinewood sign, and eventually corrupt the world while moving around. Passing a very large value could also throw `vector too long` during the resize and leave the map unloaded for the rest of the session.

Also fixes the same type of issue reported in #3912 on an older build.

#### Test plan

Run `engineSetPoolCapacity("building", 180000)` and check the Vinewood sign from a distance to make sure it keeps its tilt.

Move around the map for a while so IPLs and objects stream in and out, then call the function several times. There should be no corruption or crashes.

Also test with an absurd value (`1299000900`). The function should warn and return false, while the map remains intact.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.