### PR TITLE
Fix #4921: Inability to move or attack while fastfire glitch is enabled

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -3163,7 +3163,10 @@ void CClientPed::ApplyControllerStateFixes(CControllerState& Current)
     {
         if (m_ulLastTimeBeganCrouch >= ulNow - 600.0f * fSpeedRatio)
         {
-            if (!g_pClientGame->IsGlitchEnabled(CClientGame::GLITCH_FASTFIRE))
+            // Zero jump/sprint unless fastfire is enabled. Even then, keep them zeroed while the crouch key is held,
+            // otherwise a key bound to both sprint and crouch (e.g. space) wedges the duck animation,
+            // leaving the player crouched and unable to move or fire until performing a melee attack
+            if (!g_pClientGame->IsGlitchEnabled(CClientGame::GLITCH_FASTFIRE) || Current.ShockButtonL != 0)
             {
                 Current.ButtonSquare = 0;
                 Current.ButtonCross = 0;


### PR DESCRIPTION
Steps to reproduce:

1- Apply this MTA Binds settings

<img width="645" height="17" alt="597056920-552e9c1e-ad37-4548-8da3-a0d9d62047ea" src="https://github.com/user-attachments/assets/a910e3da-b01d-4673-8ede-7a798a4e970f" />

2- setGlitchEnabled("fastfire", true)
3- Hit with your hand and press Space quickly


Closes #4921.


Before ->

https://github.com/user-attachments/assets/b34fe668-9050-4338-9bdf-1968245ba05e

After ->

https://github.com/user-attachments/assets/1a1d98ad-913d-41c3-ae32-e8da1ae73637

