### PR TITLE
Fix #5299: Add debugscript warnings for playSound/playSound3D failures

### DIFF
--- a/Client/mods/deathmatch/logic/CClientSound.cpp
+++ b/Client/mods/deathmatch/logic/CClientSound.cpp
@@ -28,6 +28,7 @@ CClientSound::CClientSound(CClientManager* pManager, ElementID ID) : ClassInit(t
     m_bPan = true;
     m_fPan = 0.0f;
     m_bThrottle = false;
+    m_bStreamFailureWarned = false;
 
     m_uiBufferLength = 0;
     m_uiFrameNumberCreated = g_pClientGame->GetFrameCount();
@@ -805,6 +806,12 @@ void CClientSound::Process3D(const CVector& vecPlayerPosition, const CVector& ve
         }
         else if (eventInfo.type == SOUND_EVENT_STREAM_RESULT)
         {
+            if (!eventInfo.bBool && !m_bStreamFailureWarned)
+            {
+                m_bStreamFailureWarned = true;
+                g_pClientGame->GetScriptDebugging()->LogWarning(m_LuaDebugInfo, SString("Unable to stream sound '%s'", *m_strPath));
+            }
+
             // Call onClientSoundStream Lua event
             CLuaArguments Arguments;
             Arguments.PushBoolean(eventInfo.bBool);

--- a/Client/mods/deathmatch/logic/CClientSound.h
+++ b/Client/mods/deathmatch/logic/CClientSound.h
@@ -19,6 +19,7 @@ class CBassAudio;
 #include "CClientSoundManager.h"
 #include "CClientEntity.h"
 #include "CSimulatedPlayPosition.h"
+#include "lua/LuaCommon.h"
 
 class CClientSound final : public CClientEntity
 {
@@ -82,6 +83,9 @@ public:
 
     bool SetPan(float fPan);
     bool GetPan(float& fPan);
+
+    void                 SetLuaDebugInfo(const SLuaDebugInfo& luaDebugInfo) { m_LuaDebugInfo = luaDebugInfo; }
+    const SLuaDebugInfo& GetLuaDebugInfo() const { return m_LuaDebugInfo; }
 
     bool SetFxEffect(uint uiFxEffect, bool bEnable);
     bool IsFxEffectEnabled(uint uiFxEffect);
@@ -155,6 +159,8 @@ private:
     bool                       m_bDoneCreate;
     double                     m_dLength;
     std::map<SString, SString> m_SavedTags;
+    bool                       m_bStreamFailureWarned;
+    SLuaDebugInfo              m_LuaDebugInfo;
 
     // Playback altering stuff
     float m_fPitch;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
@@ -13,13 +13,11 @@
 #include <lua/CLuaFunctionParser.h>
 #include "CBassAudio.h"
 
-#include <algorithm>
 #include <array>
 #include <cctype>
 #include <cmath>
 #include <memory>
 #include <ranges>
-#include <stdexcept>
 
 static bool IsValidFFTBandCount(int length, int bands) noexcept
 {

--- a/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
@@ -70,6 +70,25 @@ static bool IsSoundURL(const std::string& soundPath) noexcept
            (soundPath.length() <= 2048 || soundPath.find('\n') == std::string::npos);
 }
 
+static SString SanitizeSoundPath(const std::string& path)
+{
+    constexpr size_t MAX_LOGGED_LENGTH = 256;
+
+    SString      result;
+    const size_t length = (path.size() < MAX_LOGGED_LENGTH) ? path.size() : MAX_LOGGED_LENGTH;
+
+    for (size_t i = 0; i < length; i++)
+    {
+        const unsigned char c = static_cast<unsigned char>(path[i]);
+        result += (std::isprint(c) && c != '\n' && c != '\r' && c != '\t') ? static_cast<char>(c) : '?';
+    }
+
+    if (path.size() > MAX_LOGGED_LENGTH)
+        result += "...";
+
+    return result;
+}
+
 std::variant<CClientSound*, bool> CLuaAudioDefs::PlaySound(lua_State* luaVM, const std::string path, std::optional<bool> loop, std::optional<bool> throttle)
 {
     CResource* resource = &lua_getownerresource(luaVM);
@@ -80,7 +99,14 @@ std::variant<CClientSound*, bool> CLuaAudioDefs::PlaySound(lua_State* luaVM, con
     bool        isRawData = false;
 
     if (CResourceManager::ParseResourcePathInput(soundPath, resource, &filename, nullptr, true))
+    {
+        if (!FileExists(filename.c_str()))
+        {
+            m_pScriptDebugging->LogWarning(luaVM, SString("Bad usage @ 'playSound' [Unable to load sound '%s']", *SanitizeSoundPath(path)));
+        }
+
         soundPath = filename;
+    }
     else
     {
         if (IsSoundURL(soundPath))
@@ -121,7 +147,14 @@ std::variant<CClientSound*, bool> CLuaAudioDefs::PlaySound3D(lua_State* luaVM, c
     bool        isRawData = false;
 
     if (CResourceManager::ParseResourcePathInput(soundPath, resource, &filename, nullptr, true))
+    {
+        if (!FileExists(filename.c_str()))
+        {
+            m_pScriptDebugging->LogWarning(luaVM, SString("Bad usage @ 'playSound3D' [Unable to load sound '%s']", *SanitizeSoundPath(path)));
+        }
+
         soundPath = filename;
+    }
     else
     {
         if (IsSoundURL(soundPath))

--- a/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
@@ -124,6 +124,8 @@ std::variant<CClientSound*, bool> CLuaAudioDefs::PlaySound(lua_State* luaVM, con
         {
             sound->SetParent(resource->GetResourceDynamicEntity());
 
+            sound->SetLuaDebugInfo(m_pScriptDebugging->GetLuaDebugInfo(luaVM));
+
             // call onClientSoundStarted
             CLuaArguments Arguments;
             Arguments.PushString("play");  // Reason
@@ -171,6 +173,8 @@ std::variant<CClientSound*, bool> CLuaAudioDefs::PlaySound3D(lua_State* luaVM, c
         if (sound)
         {
             sound->SetParent(resource->GetResourceDynamicEntity());
+
+            sound->SetLuaDebugInfo(m_pScriptDebugging->GetLuaDebugInfo(luaVM));
 
             // call onClientSoundStarted
             CLuaArguments Arguments;

--- a/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaAudioDefs.cpp
@@ -13,11 +13,13 @@
 #include <lua/CLuaFunctionParser.h>
 #include "CBassAudio.h"
 
+#include <algorithm>
 #include <array>
 #include <cctype>
 #include <cmath>
 #include <memory>
 #include <ranges>
+#include <stdexcept>
 
 static bool IsValidFFTBandCount(int length, int bands) noexcept
 {
@@ -70,14 +72,15 @@ static bool IsSoundURL(const std::string& soundPath) noexcept
            (soundPath.length() <= 2048 || soundPath.find('\n') == std::string::npos);
 }
 
-static SString SanitizeSoundPath(const std::string& path)
+static std::string SanitizeSoundPath(std::string_view path)
 {
-    constexpr size_t MAX_LOGGED_LENGTH = 256;
+    constexpr std::size_t MAX_LOGGED_LENGTH = 256;
 
-    SString      result;
-    const size_t length = (path.size() < MAX_LOGGED_LENGTH) ? path.size() : MAX_LOGGED_LENGTH;
+    std::string       result;
+    const std::size_t length = std::min(path.size(), MAX_LOGGED_LENGTH);
+    result.reserve(length + (path.size() > MAX_LOGGED_LENGTH ? 3 : 0));
 
-    for (size_t i = 0; i < length; i++)
+    for (std::size_t i = 0; i < length; i++)
     {
         const unsigned char c = static_cast<unsigned char>(path[i]);
         result += (std::isprint(c) && c != '\n' && c != '\r' && c != '\t') ? static_cast<char>(c) : '?';
@@ -102,7 +105,7 @@ std::variant<CClientSound*, bool> CLuaAudioDefs::PlaySound(lua_State* luaVM, con
     {
         if (!FileExists(filename.c_str()))
         {
-            m_pScriptDebugging->LogWarning(luaVM, SString("Bad usage @ 'playSound' [Unable to load sound '%s']", *SanitizeSoundPath(path)));
+            throw LuaFunctionError(SString("Unable to load sound '%s'.", SanitizeSoundPath(path).c_str()), true);
         }
 
         soundPath = filename;
@@ -152,7 +155,7 @@ std::variant<CClientSound*, bool> CLuaAudioDefs::PlaySound3D(lua_State* luaVM, c
     {
         if (!FileExists(filename.c_str()))
         {
-            m_pScriptDebugging->LogWarning(luaVM, SString("Bad usage @ 'playSound3D' [Unable to load sound '%s']", *SanitizeSoundPath(path)));
+            throw LuaFunctionError(SString("Unable to load sound '%s'.", SanitizeSoundPath(path).c_str()), true);
         }
 
         soundPath = filename;


### PR DESCRIPTION
Now logs a debugscript warning `Unable to load sound '...'` or `Unable to stream sound '...'`

Closes #5299.