### PR TITLE
Fix streaming memory never scaling up for a large gta3.img

### DIFF
--- a/Client/core/CCore.cpp
+++ b/Client/core/CCore.cpp
@@ -2100,7 +2100,7 @@ void CCore::CalculateStreamingMemoryRange()
     float fMaxAmount = EvalSamplePosition<float>(maxPoints, NUMELMS(maxPoints), iSystemRamMB);
 
     // Scale max if gta3.img is over 1GB
-    SString strGta3imgFilename = PathJoin(GetLaunchPath(), "models", "gta3.img");
+    SString strGta3imgFilename = PathJoin(UTF8FilePath(g_gtaDirectory), "models", "gta3.img");
     uint    uiFileSizeMB = FileSize(strGta3imgFilename) / 0x100000LL;
     float   fSizeScale = UnlerpClamped(1024, uiFileSizeMB, 2048);
     fMaxAmount += fMaxAmount * fSizeScale;


### PR DESCRIPTION
#### Summary
`CalculateStreamingMemoryRange` looks for `gta3.img` under `GetLaunchPath()`, which is the mirrored game directory in ProgramData and has no `models`. The size always reads as 0, so the scaling step for a `gta3.img` over 1GB never runs.

#### Motivation
Broken since a8f255b4ab, when MTA started launching the mirrored executable.

#### Test plan
Logging both paths on a stock install:

- old: `...\ProgramData\MTA San Andreas All\1.7\GTA San Andreas\models\gta3.img` -> 0 bytes
- new: `...\Rockstar Games\Grand Theft Auto San Andreas\models\gta3.img` -> 937,680,896 bytes

`Client/multiplayer_sa/CMultiplayerSA.cpp:752` reads `TrakLkup.dat` the same way; left unchanged, as it would alter behaviour for existing installs.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
