### PR TITLE
Fix out of bounds write when replacing a model with a DFF that has _dam parts

### DIFF
--- a/Client/game_sa/CFileLoaderSA.cpp
+++ b/Client/game_sa/CFileLoaderSA.cpp
@@ -54,12 +54,16 @@ CEntitySAInterface* CFileLoaderSA::LoadObjectInstance(const char* szLine)
     return CFileLoader_LoadObjectInstance(szLine);
 }
 
+class CDamagableModelInfo;
+
 class CAtomicModelInfo
 {
 public:
     void DeleteRwObject() { ((void(__thiscall*)(CAtomicModelInfo*))(*(void***)this)[8])(this); }
 
     void SetAtomic(RpAtomic* atomic) { ((void(__thiscall*)(CAtomicModelInfo*, RpAtomic*))(*(void***)this)[15])(this, atomic); }
+
+    CDamagableModelInfo* AsDamageAtomicModelInfoPtr() { return ((CDamagableModelInfo * (__thiscall*)(CAtomicModelInfo*))(*(void***)this)[2])(this); }
 };
 
 class CDamagableModelInfo
@@ -210,12 +214,19 @@ RpAtomic* CFileLoader_SetRelatedModelInfoCB(RpAtomic* atomic, SRelatedModelInfo*
         GetNameAndDamage(frameNodeName, name, bDamage);
     }
 
+    CDamagableModelInfo* pDamagableModelInfo = bDamage ? pAtomicModelInfo->AsDamageAtomicModelInfoPtr() : nullptr;
+    if (bDamage && !pDamagableModelInfo)
+    {
+        // Returning null would stop RpClumpForAllAtomics, so leave the atomic with the clump
+        pRelatedModelInfo->bAtomicNotConsumed = true;
+        return atomic;
+    }
+
     CVisibilityPlugins_SetAtomicRenderCallback(atomic, 0);
 
     RpAtomic* pOldAtomic = reinterpret_cast<RpAtomic*>(pBaseModelInfo->pRwObject);
     if (bDamage)
     {
-        auto pDamagableModelInfo = reinterpret_cast<CDamagableModelInfo*>(pAtomicModelInfo);
         pDamagableModelInfo->SetDamagedAtomic(atomic);
     }
     else

--- a/Client/game_sa/CFileLoaderSA.h
+++ b/Client/game_sa/CFileLoaderSA.h
@@ -13,6 +13,7 @@ struct SRelatedModelInfo
 {
     RpClump* pClump;
     bool     bDeleteOldRwObject;
+    bool     bAtomicNotConsumed;
 };
 
 struct SFileObjectInstance

--- a/Client/game_sa/CRenderWareSA.cpp
+++ b/Client/game_sa/CRenderWareSA.cpp
@@ -527,9 +527,11 @@ bool AtomicsReplacer(RpAtomic* pAtomic, void* data)
     relatedModelInfo.bDeleteOldRwObject = true;
     CFileLoader_SetRelatedModelInfoCB(pAtomic, &relatedModelInfo);
 
-    // The above function adds a reference to the model's TXD by either
-    // calling CAtomicModelInfo::SetAtomic or CDamagableModelInfo::SetDamagedAtomic. Remove it again.
-    CTxdStore_RemoveRef(pData->usTxdID);
+    // The above function adds a reference to the model's TXD when it calls
+    // CAtomicModelInfo::SetAtomic or CDamagableModelInfo::SetDamagedAtomic. It calls neither if the
+    // atomic was left with the clump, so only remove the reference when one was taken.
+    if (!relatedModelInfo.bAtomicNotConsumed)
+        CTxdStore_RemoveRef(pData->usTxdID);
     return true;
 }
 


### PR DESCRIPTION
#### Summary
The `_dam` branch of `CFileLoader_SetRelatedModelInfoCB` casts the model info to `CDamagableModelInfo` without checking. `SetDamagedAtomic` writes to `[this+0x20]`, which only exists on the damageable subclass, and `CBaseModelInfoSAInterface` is `0x20` bytes - so on a plain atomic model the write lands past the end of the allocation, on the next model info's vtable pointer.

The game dispatches through `AsDamageAtomicModelInfoPtr` (vtable slot 2) first. That call is restored, the atomic is left with the clump the caller destroys, and `AtomicsReplacer` skips its TXD release since nothing took a reference.

#### Motivation
Reachable from `engineReplaceModel` with any DFF whose frame name ends in `_dam` when the target model is not damageable. Slot 2 returns null for a plain atomic (`0x4C4A90`) and `this` for a damageable one (`0x4C55C0`).

#### Test plan
A vehicle DFF onto model 2232 (plain atomic) and onto 996 (damageable, as a control), logging the dword at `modelinfo+0x20`:

```
        model  slot2     pre       post
before  2232   00000000  0085BBF0  2B289380   overwritten, once per _dam atomic
        996    00B1C07C  00000000  2B11CD54   correct
after   2232   00000000  0085BBF0  0085BBF0   untouched
        996    00B1C07C  00000000  2C562158   correct
```

`0085BBF0` is the next model info's vtable pointer. The unfixed client died on it: `0xC0000005`, `EIP=00000000`, `ECX=00B154D4` (the address written to), `EDX=2B288E08` (the value written).

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.