### PR TITLE
Fix throwable weapon throw distance on high FPS

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_FrameRateFixes.cpp
@@ -9,11 +9,29 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include <game/CWeaponInfo.h>
+#include <algorithm>
 
 static bool         bWouldBeNewFrame = false;
 static unsigned int nLastFrameTime = 0;
 
 constexpr float kOriginalTimeStep = 50.0f / 30.0f;
+
+// GTA:SA 16-frame counter ceiling at 30 FPS (0x215)
+constexpr unsigned int ThrowableGrenadeTargetMaxMs = 533u;
+
+// 5 frames at 30 FPS: button debounce duration
+constexpr unsigned int ThrowableQuickTapFloorMs = 160u;
+
+// Animation sequence duration to fire keyframe: START_THROW (200ms) + animLoopFire (241ms)
+constexpr unsigned int ThrowableGrenadeHighFpsMaxMs = 441u;
+
+// Satchel sequence duration to fire keyframe: START_THROW (200ms) + animLoop2Fire (155ms)
+constexpr unsigned int ThrowableSatchelHighFpsMaxMs = 355u;
+
+// Compensates for Euler integration and ground slide truncation to equalize throw distance across all frame rates
+constexpr unsigned int ThrowableSatchelNativeMaxMs = 433u;
+constexpr unsigned int ThrowableSatchelMaxFpsCompensationMs = 28u;
 
 // Fixes player movement issue while aiming and walking on high FPS.
 // Only rescales the compare threshold; m_MoveCmd's reset is NOPed separately in InitHooks_FrameRateFixes.
@@ -849,6 +867,84 @@ static void __declspec(naked) HOOK_CPhysical__ApplyAirResistance()
     // clang-format on
 }
 
+// Normalizes throwable attack button counter across all frame rates so quick-taps, partial holds, and full charges
+// produce identical launch speed and trajectory at 240 FPS as native 30 FPS.
+static void FixThrowableThrowCounter(unsigned int* buttonCounter, bool isButtonReleased, unsigned int weaponType)
+{
+    if (!buttonCounter)
+        return;
+
+    const bool isSatchel = (weaponType == WEAPONTYPE_REMOTE_SATCHEL_CHARGE);
+
+    unsigned int targetMax = ThrowableGrenadeTargetMaxMs;
+    if (isSatchel)
+    {
+        const float timeStep = *reinterpret_cast<const float*>(0xB7CB5C);
+        const float timeStepFactor = std::clamp(timeStep / kOriginalTimeStep, 0.0f, 1.0f);
+        const float fpsCompensation = static_cast<float>(ThrowableSatchelMaxFpsCompensationMs) * (1.0f - timeStepFactor);
+        targetMax = ThrowableSatchelNativeMaxMs + static_cast<unsigned int>(fpsCompensation);
+    }
+
+    const unsigned int highFpsMax = isSatchel ? ThrowableSatchelHighFpsMaxMs : ThrowableGrenadeHighFpsMaxMs;
+
+    // Full charge: player held the button all the way until the throw release keyframe, or counter reached high-FPS ceiling
+    if (!isButtonReleased || *buttonCounter >= highFpsMax)
+    {
+        *buttonCounter = targetMax;
+        return;
+    }
+
+    // Quick-tap: enforce native 30 FPS floor
+    if (*buttonCounter <= ThrowableQuickTapFloorMs)
+    {
+        *buttonCounter = ThrowableQuickTapFloorMs;
+        return;
+    }
+
+    // Partial charge: scale linearly between [floor, highFpsMax] -> [floor, targetMax]
+    if (highFpsMax > ThrowableQuickTapFloorMs)
+    {
+        const float progress = static_cast<float>(*buttonCounter - ThrowableQuickTapFloorMs) / static_cast<float>(highFpsMax - ThrowableQuickTapFloorMs);
+        *buttonCounter = ThrowableQuickTapFloorMs + static_cast<unsigned int>(progress * static_cast<float>(targetMax - ThrowableQuickTapFloorMs));
+    }
+
+    if (*buttonCounter > targetMax)
+        *buttonCounter = targetMax;
+}
+
+#define HOOKPOS_CTaskSimpleThrowProjectile__ProcessPed_Force  0x62B01E
+#define HOOKSIZE_CTaskSimpleThrowProjectile__ProcessPed_Force 0xF
+static const unsigned int     RETURN_CTaskSimpleThrowProjectile__ProcessPed_Force = 0x62B02D;
+static void __declspec(naked) HOOK_CTaskSimpleThrowProjectile__ProcessPed_Force()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        pushad
+        // Retrieve active weapon type from ped (edi)
+        movsx eax, byte ptr [edi+0x718]
+        imul eax, 0x1C
+        mov eax, [edi+eax+0x5A0]
+        push eax
+
+        // Retrieve isButtonReleased from CTaskSimpleThrowProjectile (ebx+0x0A)
+        movzx edx, byte ptr [ebx+0x0A]
+        push edx
+
+        // Pass pointer to buttonCounter (ebx+0x20)
+        lea ecx, [ebx+0x20]
+        push ecx
+
+        call FixThrowableThrowCounter
+        add esp, 12
+        popad
+        jmp RETURN_CTaskSimpleThrowProjectile__ProcessPed_Force
+    }
+    // clang-format on
+}
+
 template <unsigned int returnAddress>
 static void __declspec(naked) HOOK_VehicleRapidStopFix()
 {
@@ -954,4 +1050,5 @@ void CMultiplayerSA::InitHooks_FrameRateFixes()
     EZHookInstall(CTaskSimpleSwim__ProcessSwimmingResistance);
 
     EZHookInstall(CWeapon_Update);
+    EZHookInstall(CTaskSimpleThrowProjectile__ProcessPed_Force);
 }


### PR DESCRIPTION
### Problem
1. **Throw Force**: On high FPS, throwing animations reach the release keyframe faster in real time (355ms for satchels, 441ms for grenades) before `m_ButtonCounter` reaches its native ceiling (433ms/533ms), resulting in lower launch velocity.
2. **Landing Distance**: Discrete 30 FPS Euler integration moves the projectile ~26cm forward in its final landing frame before collision is registered. High FPS samples contact continuously, eliminating this step overshoot.

### Solution
Instead of hooking `CObject::ProcessControl` (which affects all world objects and only accounts for ~4cm of slide), we hook `CTaskSimpleThrowProjectile::ProcessPed` at `0x62B01E`:
- Normalizes full-charge throws to the native ceiling when held until release.
- Enforces 160ms floor for quick-taps and rescales partial holds linearly.
- Applies timeStep-based compensation for satchels to ensure identical landing distance (~6.33m) across 30, 60, and 240+ FPS.

### Testing
**Before/After:** https://streamable.com/mh6eue
