### PR TITLE
Fix #4070: Prevent vehicle tuning models from spinning when created via createBuilding

### DIFF
--- a/Client/game_sa/CBuildingsPoolSA.cpp
+++ b/Client/game_sa/CBuildingsPoolSA.cpp
@@ -85,6 +85,15 @@ CBuilding* CBuildingsPoolSA::AddBuilding(CClientBuilding* pClientBuilding, uint1
     if (prevGroup != MODEL_PROPERTIES_GROUP_STATIC)
         modelInfo->SetObjectPropertiesGroup(MODEL_PROPERTIES_GROUP_STATIC);
 
+    // Fix vehicle tuning models (e.g. exh_*) spinning endlessly. Their model info flags get misread as special types (like CRANE) in LoadObjectInstance,
+    // causing PreRender to rewrite their matrix each frame.
+    auto*      pModelInterface = modelInfo->GetInterface();
+    const bool bVehicleTuningPart = pModelInterface && modelInfo->GetModelType() == eModelInfoType::ATOMIC && pModelInterface->bWetRoadReflection;
+    const auto prevSpecialType = bVehicleTuningPart ? pModelInterface->eSpecialModelType : eModelSpecialType::NONE;
+
+    if (prevSpecialType != eModelSpecialType::NONE)
+        pModelInterface->eSpecialModelType = eModelSpecialType::NONE;
+
     // Load building
     SFileObjectInstance instance{};
     instance.modelID = modelId;
@@ -99,9 +108,11 @@ CBuilding* CBuildingsPoolSA::AddBuilding(CClientBuilding* pClientBuilding, uint1
     pBuilding->m_pLod = nullptr;
     pBuilding->m_iplIndex = 0;
 
-    // Restore changed properties group
+    // Restore changed properties group and special model type
     if (prevGroup != MODEL_PROPERTIES_GROUP_STATIC)
         modelInfo->SetObjectPropertiesGroup(prevGroup);
+    if (prevSpecialType != eModelSpecialType::NONE)
+        pModelInterface->eSpecialModelType = prevSpecialType;
 
     // Always stream model collosion
     // TODO We can setup collison bounding box and use GTA streamer for it


### PR DESCRIPTION
This PR fixes vehicle tuning models (e.g. `exh_*`) spinning endlessly when created with `createBuilding`; these models share one flag byte: the bits read as the special model type (`nSpecialType`, bits 11–14) are actually the vehicle part flags (`CarMod`), so a tuning model's special type is garbage (e.g. `CRANE`). `CEntity::SetModelIndexNoCreate`, called from `LoadObjectInstance`, latches this into the created entity, and `CEntity::PreRender` then calls `ModifyMatrixForCrane()` every frame, rotating the building by the current time

The fix clears the special type only around the load call (same pattern as the existing properties-group save/restore) and restores it right after

Closes #4070.

Before ->

https://github.com/user-attachments/assets/abe5ba91-8249-411a-8d01-1bafbde7ac86

After ->

https://github.com/user-attachments/assets/3c28ce00-0a08-4598-a5c6-b360e32a27e0

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
