### PR TITLE
Fix alpha render ordering for glass

### DIFF
--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -676,6 +676,9 @@ void CModelInfoSA::SetIdeFlag(eModelIdeFlag eIdeFlag, bool bState)
         case eModelIdeFlag::DISABLE_BACKFACE_CULLING:
             m_pInterface->bIsBackfaceCulled = !bState;
             break;
+        case eModelIdeFlag::REALLY_DRAW_LAST:
+            SetRenderingAfterScene(bState);
+            break;
         default:
             break;
     }

--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -726,6 +726,8 @@ bool CModelInfoSA::GetIdeFlag(eModelIdeFlag eIdeFlag)
             return m_pInterface->bDontCollideWithFlyer;
         case eModelIdeFlag::DISABLE_BACKFACE_CULLING:
             return !m_pInterface->bIsBackfaceCulled;
+        case eModelIdeFlag::REALLY_DRAW_LAST:
+            return ShouldRenderAfterScene();
         default:
             return false;
     }

--- a/Client/game_sa/CModelInfoSA.h
+++ b/Client/game_sa/CModelInfoSA.h
@@ -356,6 +356,8 @@ protected:
     static std::map<unsigned short, int>                                              ms_DefaultTxdIDMap;
     SVehicleSupportedUpgrades                                                         m_ModelSupportedUpgrades;
 
+    bool m_renderAfterScene{false};
+
 public:
     CModelInfoSA();
 
@@ -494,6 +496,9 @@ public:
 
     bool IsDynamic() { return m_pInterface ? m_pInterface->usDynamicIndex != MODEL_PROPERTIES_GROUP_STATIC : false; };
     bool IsDamageableAtomic() override;
+
+    bool ShouldRenderAfterScene() const noexcept override { return m_renderAfterScene; }
+    void SetRenderingAfterScene(bool shouldRenderAfterScene) noexcept override { m_renderAfterScene = shouldRenderAfterScene; }
 
     static bool IsVehicleModel(std::uint32_t model) noexcept;
 

--- a/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaFunctionParseHelpers.cpp
@@ -799,6 +799,7 @@ ADD_ENUM(eModelIdeFlag::IS_TAG, "is_tag")
 ADD_ENUM(eModelIdeFlag::DISABLE_BACKFACE_CULLING, "disable_backface_culling")
 ADD_ENUM(eModelIdeFlag::IS_BREAKABLE_STATUE, "is_breakable_statue")
 ADD_ENUM(eModelIdeFlag::IS_CRANE, "is_crane")
+ADD_ENUM(eModelIdeFlag::REALLY_DRAW_LAST, "draw_after_scene")
 IMPLEMENT_ENUM_CLASS_END("model-ide-flag")
 
 // https://learn.microsoft.com/en-us/windows/win32/direct3d9/d3dformat

--- a/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_Rendering.cpp
@@ -927,6 +927,84 @@ static void __declspec(naked) HOOK_CRenderer_EverythingBarRoads()
     // clang-format on
 }
 
+struct AlphaObjectInfo
+{
+    void* atomic;
+    void* callback;
+    float distance;
+};
+
+static bool InsertEntityIntoSortedList(CEntitySAInterface* entity, float distance)
+{
+    if (auto* modelInfo = pGameInterface->GetModelInfo(entity->m_nModelIndex); modelInfo && modelInfo->ShouldRenderAfterScene())
+    {
+        CBaseModelInfoSAInterface* baseModelInfo = modelInfo->GetInterface();
+        CColModelSAInterface*      col = baseModelInfo ? baseModelInfo->pColModel : nullptr;
+
+        if (col)
+        {
+            auto           boundBox = col->m_bounds;
+            const CVector& camPos = *(CVector*)0xB76870;
+            CVector        closestPoint;
+
+            closestPoint.fX = std::max(boundBox.m_vecMin.fX, std::min(camPos.fX, boundBox.m_vecMax.fX));
+            closestPoint.fY = std::max(boundBox.m_vecMin.fY, std::min(camPos.fY, boundBox.m_vecMax.fY));
+            closestPoint.fZ = std::max(boundBox.m_vecMin.fZ, std::min(camPos.fZ, boundBox.m_vecMax.fZ));
+
+            distance = (camPos - closestPoint).Length();
+        }
+
+        // CVisibilityPlugins::RenderEntity as callback
+        AlphaObjectInfo inf = {entity, (void*)0x732B40, distance};
+
+        // Call CLinkList::InsertSorted for m_alphaReallyDrawLastList
+        return ((bool(__thiscall*)(void*, AlphaObjectInfo*))0x733910)((void*)0xC881D0, &inf);
+    }
+
+    // Call CVisibilityPlugins::InsertEntityIntoSortedList
+    // Insert into m_alphaList
+    return ((bool(__cdecl*)(CEntitySAInterface*, float))0x00734570)(entity, distance);
+}
+
+static void RenderEntityAfterScene(CEntitySAInterface* entity, CBaseModelInfoSAInterface* modelInfoInterface)
+{
+    if (!modelInfoInterface) [[unlikely]]
+        return;
+
+    // RwEngineInstance->dOpenDevice.fpRenderStateGet/fpRenderStateSet
+    DWORD engine = *(DWORD*)0xC97B24;
+    auto  fpSet = reinterpret_cast<BOOL(__cdecl*)(DWORD, void*)>(*(DWORD*)(engine + 0x20));
+
+    entity->bImBeingRendered = true;
+
+    if (!entity->bBackfaceCulled)
+        fpSet(0x14 /*rwRENDERSTATECULLMODE*/, (void*)1 /*rwCULLMODECULLNONE*/);
+
+    bool resetColours = entity->SetupLighting();
+    entity->Render();
+    entity->RemoveLighting(resetColours);
+
+    if (!entity->bBackfaceCulled)
+        fpSet(0x14 /*rwRENDERSTATECULLMODE*/, (void*)2 /*rwCULLMODECULLBACK*/);
+
+    entity->bImBeingRendered = false;
+}
+
+static void TryRenderOneNonRoad(CEntitySAInterface* entity)
+{
+    if (entity && (entity->nType == ENTITY_TYPE_OBJECT || entity->nType == ENTITY_TYPE_BUILDING) && entity->m_pRwObject)
+    {
+        if (auto* modelInfo = pGameInterface->GetModelInfo(entity->m_nModelIndex); modelInfo && modelInfo->ShouldRenderAfterScene())
+        {
+            RenderEntityAfterScene(entity, modelInfo->GetInterface());
+            return;
+        }
+    }
+
+    // Call CRenderer::RenderOneNonRoad
+    ((void(__cdecl*)(CEntitySAInterface*))0x553260)(entity);
+}
+
 //////////////////////////////////////////////////////////////////////////////////////////
 //
 // CMultiplayerSA::InitHooks_Rendering
@@ -944,6 +1022,16 @@ void CMultiplayerSA::InitHooks_Rendering()
     MemPut<BYTE>(0x5D9A88, VEHICLE_SPECULAR_LIGHT_SLOT);  // RwD3D9SetLight
     MemPut<BYTE>(0x5D9A91, VEHICLE_SPECULAR_LIGHT_SLOT);  // RwD3D9EnableLight(TRUE)
     MemPut<BYTE>(0x5D9F1F, VEHICLE_SPECULAR_LIGHT_SLOT);  // RwD3D9EnableLight(FALSE)
+
+    HookInstallCall(0x5534D1, (DWORD)InsertEntityIntoSortedList);  // CRenderer::AddEntityToRenderList
+    HookInstallCall(0x55350C, (DWORD)InsertEntityIntoSortedList);  // CRenderer::AddEntityToRenderList
+    HookInstallCall(0x553C45, (DWORD)InsertEntityIntoSortedList);  // CRenderer::RenderEverythingBarRoads
+    HookInstallCall(0x55455A, (DWORD)InsertEntityIntoSortedList);  // CRenderer::SetupEntityVisibility
+    HookInstallCall(0x732C48, (DWORD)TryRenderOneNonRoad);         // CVisibilityPlugins::RenderEntity
+
+    // TODO fix entity brightness flickering when entering fade out phase
+    // HookInstallCall(0x732BD7, (DWORD)RenderFadingAtomic); // CVisibilityPlugins::RenderEntity
+    // HookInstallCall(0x732BDE, (DWORD)RenderFadingClump);  // CVisibilityPlugins::RenderEntity
 
     EZHookInstall(CallIdle);
     EZHookInstall(CEntity_Render);

--- a/Client/multiplayer_sa/StdInc.h
+++ b/Client/multiplayer_sa/StdInc.h
@@ -25,5 +25,6 @@
 #include "..\game_sa\CPedSA.h"
 #include "..\game_sa\CProjectileSA.h"
 #include "..\game_sa\TaskAttackSA.h"
+#include "../game_sa/CColModelSA.h"
 
 extern CMultiplayerSA* pMultiplayer;

--- a/Client/sdk/game/CModelInfo.h
+++ b/Client/sdk/game/CModelInfo.h
@@ -53,6 +53,9 @@ enum class eModelIdeFlag
     DISABLE_BACKFACE_CULLING,
     IS_BREAKABLE_STATUE,
     IS_CRANE,
+
+    // Our custom flag
+    REALLY_DRAW_LAST,
 };
 
 enum class eModelInfoType : unsigned char
@@ -256,4 +259,7 @@ public:
     virtual unsigned int GetParentID() = 0;
     virtual bool         IsDynamic() = 0;
     virtual bool         IsDamageableAtomic() = 0;
+
+    virtual bool ShouldRenderAfterScene() const noexcept = 0;
+    virtual void SetRenderingAfterScene(bool shouldRenderAfterScene) noexcept = 0;
 };


### PR DESCRIPTION
This has been an annoying bug for years, making it impossible to create large glass windows in models. Instead, developers have been forced to use small windows (as tut explained in his [guide](www.youtube.com/watch?v=Nn9-zkONkWU)) or render the glass as material line 3D through scripts.

Flags such as `draw_last` and `no_zbuffer_write` have not properly fixed this issue over the years, and the underlying bug has remained.

## My investigation
<details>
<summary>More info</summary>
The bug is caused by the way GTA handles its `m_alphaList`, which is the list that models with the `draw_last` flag are added to.

The list also contains vehicles and many other objects, such as vegetation and fences. It is sorted by distance, with the closest entities being rendered first. The problem is that the distance is calculated from the center of the entity (pivot point) to the camera. This causes issues with large glass windows.

For example, a vehicle may be visible behind a large glass window, but because the distance from the center of the glass window to the camera is greater than the distance from the vehicle to the camera, the vehicle is rendered before the glass. This results in the vehicle disappearing behind the glass.
<img width="693" height="705" alt="image" src="https://github.com/user-attachments/assets/8da352fa-4c6b-43ad-9c27-dcd0760698a3" />

The `no_zbuffer_write` flag can appear to help in this situation because the glass no longer occludes the vehicle. However, this causes the vehicle to be rendered completely in front of the glass, which looks bad
<img width="711" height="628" alt="image" src="https://github.com/user-attachments/assets/97ba80a1-25a7-43ea-b427-6d1807d2c288" />.
</details>

## Initial approach
Initially, I tried to fix the rendering order by changing how the distance is calculated. Instead of calculating the distance from the center of the entity, I calculated it from the closest point of its bounding box to the camera. This did actually work for vehicles, bushes... However, it caused a chain reaction of other rendering issues. It introduced problems with the map, buildings could disappear at the wrong time, lod models started flickering, and some models with broken bounding boxes were still rendered incorrectly.

Overall, this approach was unsuccessful.

## Final approach
R* was apparently aware of these issues and introduced a separate rendering list specifically for the grasshouse object (3261): `m_alphaReallyDrawLastList`.

This list is rendered literally after the entire scene has been rendered. This allows things such as shadows/lights on the ground, and rendered grass to remain visible through the glass. Unfortunately, this functionality was hardcoded specifically for model ID 3261 instead of being exposed through a dedicated model flag.

This PR adds a custom `draw_after_scene` flag to `engineSetModelFlag` that allows models to be rendered through `m_alphaReallyDrawLastList`.

Additionally, to prevent similar ordering issues, the distance is calculated using the closest point of the entity's bounding box rather than its center.

This allows large glass windows to be rendered correctly without relying on `no_zbuffer_write` or script-based glass rendering.
Fixed #3124 

## Comparisons
<details>
<summary>More info</summary>
BEFORE
<img width="1564" height="773" alt="image" src="https://github.com/user-attachments/assets/d94585c8-7bea-4f55-be71-655c6b0f064c" />
<img width="1587" height="775" alt="image" src="https://github.com/user-attachments/assets/e53d81f7-4b0f-4900-af22-5a383f4b7dcc" />

AFTER
<img width="1573" height="666" alt="image" src="https://github.com/user-attachments/assets/fe7daeb1-b32e-42d8-9abd-f43c2e321992" />
<img width="1582" height="832" alt="image" src="https://github.com/user-attachments/assets/7dcb1f69-e80f-4e7b-b240-293de9438fd2" />
</details>

## Additional issue
While working on this PR, I also found another bug where the glass becomes brighter/flickers when entering the fade-out phase. I will address this separately in another PR once this one has been merged.

Additionally, `m_alphaReallyDrawLastList` list has a capacity of 50 elements. PR #4786 will allow it to be expanded.

**Tests**
[glass.zip](https://github.com/user-attachments/files/32093342/glass.zip)
