### PR TITLE
Fix crash when a custom IMG model is restored while still in use

### DIFF
--- a/Client/mods/deathmatch/logic/CClientIMG.cpp
+++ b/Client/mods/deathmatch/logic/CClientIMG.cpp
@@ -17,6 +17,17 @@ struct tImgHeader
     unsigned int uiFilesCount;
 };
 
+// SetStreamingInfo force-removes the model's RwObject, and the streamer no longer tracks it
+// after the archive change, so entities still using it have to be streamed out first
+static void StreamOutModelUsers(unsigned int uiModelID)
+{
+    if (CClientVehicleManager::IsValidModel(uiModelID))
+        g_pClientGame->GetVehicleManager()->RestreamVehicles(static_cast<unsigned short>(uiModelID));
+
+    if (CClientPedManager::IsValidWeaponModel(uiModelID))
+        g_pClientGame->GetPedManager()->RestreamWeapon(static_cast<unsigned short>(uiModelID));
+}
+
 CClientIMG::CClientIMG(class CClientManager* pManager, ElementID ID)
     : ClassInit(this), CClientEntity(ID), m_pImgManager(pManager->GetIMGManager()), m_ucArchiveID(INVALID_ARCHIVE_ID), m_LargestFileSizeBlocks(0)
 {
@@ -180,6 +191,7 @@ bool CClientIMG::StreamDisable()
     // Unlink all models
     for (const auto& v : m_restoreInfo)
     {
+        StreamOutModelUsers(v.uiModelID);
         g_pGame->GetStreaming()->SetStreamingInfo(v.uiModelID, v.ucStreamID, v.uiOffset, v.usSize);
     }
     m_restoreInfo.clear();
@@ -219,15 +231,7 @@ bool CClientIMG::LinkModel(unsigned int uiModelID, size_t uiFileID)
 
     m_restoreInfo.emplace_back(uiModelID, pCurrInfo->offsetInBlocks, pCurrInfo->sizeInBlocks, pCurrInfo->archiveId);
 
-    // Internally stream out the vehicle before calling CStreamingSA::RemoveModel
-    // otherwise a crash will occur if the player is inside a vehicle that gets unloaded by the streamer
-    if (CClientVehicleManager::IsValidModel(uiModelID))
-        g_pClientGame->GetVehicleManager()->RestreamVehicles(static_cast<unsigned short>(uiModelID));
-
-    // Weapon models already in a ped's hand keep their old RW clump until the weapon slot is
-    // re-requested, same as vehicles above (see CClientDFF::ReplaceWeaponModel for the equivalent case)
-    if (CClientPedManager::IsValidWeaponModel(uiModelID))
-        g_pClientGame->GetPedManager()->RestreamWeapon(static_cast<unsigned short>(uiModelID));
+    StreamOutModelUsers(uiModelID);
 
     g_pGame->GetStreaming()->SetStreamingInfo(uiModelID, m_ucArchiveID, pFileInfo->uiOffset, pFileInfo->usSize);
 
@@ -242,6 +246,7 @@ bool CClientIMG::UnlinkModel(unsigned int uiModelID)
     if (it == m_restoreInfo.end())
         return false;
 
+    StreamOutModelUsers(uiModelID);
     g_pGame->GetStreaming()->SetStreamingInfo(uiModelID, it->ucStreamID, it->uiOffset, it->usSize);
 
     m_restoreInfo.erase(it);


### PR DESCRIPTION
#### Summary
`SetStreamingInfo` force-removes the model's RwObject, and the streamer stops tracking entities that still use it. `LinkModel` streams those entities out first; `UnlinkModel` and `StreamDisable` make the same call without it, so `engineRestoreDFFImage` - or destroying the IMG element - frees the RW object under live entities.

`StreamDisable` does call `RestreamWorld()`, but only after every `SetStreamingInfo` in the loop has already run, and not at all during session shutdown.

The guard moves into a file-local helper used by all three.

#### Motivation
The vehicle guard came from #4544 and the weapon one from #5146; neither covered the restore paths. `CStreaming::RemoveModel` at `0x4089A0` has no reference count - for a vehicle it calls `CVehicleModelInfo::DeleteRwObject`, which destroys the CVehicleStructure and the master clump regardless of who is using them.

#### Test plan
Custom IMG holding a `banshee.dff`, `engineImageLinkDFF` onto model 429, spawn a Banshee and get in, then `engineRestoreDFFImage(429)`.

**Before:** `0xC0000005` at `gta_sa.exe+0x124765`, `EAX=0` - `CEntity::GetColModel` returned null and the render path dereferenced it.

https://streamable.com/kc6ud6

**After:** the call returns true and the game keeps running.

https://streamable.com/fujmyi

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
