### PR TITLE
Fix elements staying streamed in after leaving an activated sector

### DIFF
--- a/Client/mods/deathmatch/logic/CClientStreamer.cpp
+++ b/Client/mods/deathmatch/logic/CClientStreamer.cpp
@@ -701,10 +701,20 @@ void CClientStreamer::OnElementEnterSector(CClientStreamElement* pElement, CClie
                 pSector->AddElements(&m_ActiveElements, &m_ActiveElementSet);
                 pSector->SetActivated(true);
             }
-            // If we're in a deactivated sector and streamed in, stream us out
-            else if (pElement->IsStreamedIn())
+            else
             {
-                m_ToStreamOut.push_back(pElement);
+                // We left an activated sector, so we are no longer an active element
+                if (pPreviousSector && pPreviousSector->IsActivated())
+                {
+                    m_ActiveElements.remove(pElement);
+                    m_ActiveElementSet.erase(pElement);
+                }
+
+                // If we're in a deactivated sector and streamed in, stream us out
+                if (pElement->IsStreamedIn())
+                {
+                    m_ToStreamOut.push_back(pElement);
+                }
             }
         }
     }


### PR DESCRIPTION
#### Summary
`OnElementEnterSector` adds an element to the active list when it enters an activated sector, but nothing removes it when the element moves out of one into a sector that is not activated. It is queued for stream out and still left in `m_ActiveElements` and `m_ActiveElementSet`, so `Restream` pulls it back in on the next pulse.

It is now removed there, the same way `RemoveElement` does it (`CClientStreamer.cpp:332-333`).

#### Motivation
The element stays streamed in even though its sector is not active, and it stays in the list that `DoPulse` walks and sorts every frame for the rest of the session.

#### Test plan
Objects use 300 unit sectors, a 3x3 activated block and a 500 unit stream distance, so the window only exists when the player stands near a sector edge. With the player at x=2095 the block ends at 2400: 60 objects created next to the player, then moved to x=2495, which is outside the block and 400 units away.

```
before   streamed in after the move   60 / 60
after    streamed in after the move    0 / 60
```

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
