### PR TITLE
Fix ped animation speed reset on skin change

### DIFF
--- a/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Client/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -2378,10 +2378,10 @@ bool CStaticFunctionDefinitions::SetPedAnimationProgress(CClientEntity& Entity, 
             if (pAnimAssociation)
             {
                 pAnimAssociation->SetCurrentProgress(fProgress);
-                return true;
             }
 
             Ped.m_AnimationCache.progress = fProgress;
+            return true;
         }
         else
         {
@@ -2407,10 +2407,10 @@ bool CStaticFunctionDefinitions::SetPedAnimationSpeed(CClientEntity& Entity, con
             if (pAnimAssociation)
             {
                 pAnimAssociation->SetCurrentSpeed(fSpeed);
-                return true;
             }
 
             Ped.m_AnimationCache.speed = fSpeed;
+            return true;
         }
     }
 

--- a/Client/mods/deathmatch/logic/rpc/CPedRPCs.cpp
+++ b/Client/mods/deathmatch/logic/rpc/CPedRPCs.cpp
@@ -310,8 +310,8 @@ void CPedRPCs::SetPedAnimationProgress(CClientEntity* pSource, NetBitStreamInter
                     if (pAnimAssociation)
                     {
                         pAnimAssociation->SetCurrentProgress(fProgress);
-                        pPed->m_AnimationCache.progress = fProgress;
                     }
+                    pPed->m_AnimationCache.progress = fProgress;
                 }
             }
             else
@@ -338,8 +338,8 @@ void CPedRPCs::SetPedAnimationSpeed(CClientEntity* pSource, NetBitStreamInterfac
                 if (pAnimAssociation)
                 {
                     pAnimAssociation->SetCurrentSpeed(fSpeed);
-                    pPed->m_AnimationCache.speed = fSpeed;
                 }
+                pPed->m_AnimationCache.speed = fSpeed;
             }
         }
     }


### PR DESCRIPTION
Fixes #882

Keep custom animation speed and progress cached when modified while playing
Fixes animation speed resetting back to 1.0 when changing ped skins or streaming in

#### Before
https://github.com/user-attachments/assets/4b4b6a3f-d5c8-48b1-865f-669865021f48


#### After
https://github.com/user-attachments/assets/dbc9c3f5-4bac-48e8-bfdb-4c427b68074f

