### PR TITLE
Fix getHeatHaze reading three settings from the wrong variables

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1697,7 +1697,7 @@ void CMultiplayerSA::GetHeatHaze(SHeatHazeSettings& settings)
 {
     int*  CPostEffects__m_HeatHazeFXIntensity = reinterpret_cast<decltype(CPostEffects__m_HeatHazeFXIntensity)>(0x8D50E8);
     int*  CPostEffects__m_HeatHazeFXRandomShift = reinterpret_cast<decltype(CPostEffects__m_HeatHazeFXRandomShift)>(0xC402C0);
-    int*  CPostEffects__m_HeatHazeFXSpeedMin = reinterpret_cast<decltype(CPostEffects__m_HeatHazeFXSpeedMin)>(0xC402C0);
+    int*  CPostEffects__m_HeatHazeFXSpeedMin = reinterpret_cast<decltype(CPostEffects__m_HeatHazeFXSpeedMin)>(0x8D50EC);
     int*  CPostEffects__m_HeatHazeFXSpeedMax = reinterpret_cast<decltype(CPostEffects__m_HeatHazeFXSpeedMax)>(0x8D50F0);
     int*  CPostEffects__m_HeatHazeFXScanSizeX = reinterpret_cast<decltype(CPostEffects__m_HeatHazeFXScanSizeX)>(0xC40304);
     int*  CPostEffects__m_HeatHazeFXScanSizeY = reinterpret_cast<decltype(CPostEffects__m_HeatHazeFXScanSizeY)>(0xC40308);
@@ -1709,8 +1709,8 @@ void CMultiplayerSA::GetHeatHaze(SHeatHazeSettings& settings)
     settings.ucRandomShift = static_cast<uchar>(*CPostEffects__m_HeatHazeFXRandomShift);
     settings.usSpeedMin = static_cast<ushort>(*CPostEffects__m_HeatHazeFXSpeedMin);
     settings.usSpeedMax = static_cast<ushort>(*CPostEffects__m_HeatHazeFXSpeedMax);
-    settings.sScanSizeX = static_cast<short>(*CPostEffects__m_HeatHazeFXScanSizeY);
-    settings.sScanSizeY = static_cast<short>(*CPostEffects__m_HeatHazeFXSpeedMax);
+    settings.sScanSizeX = static_cast<short>(*CPostEffects__m_HeatHazeFXScanSizeX);
+    settings.sScanSizeY = static_cast<short>(*CPostEffects__m_HeatHazeFXScanSizeY);
     settings.usRenderSizeX = static_cast<ushort>(*CPostEffects__m_HeatHazeFXRenderSizeX);
     settings.usRenderSizeY = static_cast<ushort>(*CPostEffects__m_HeatHazeFXRenderSizeY);
     settings.bInsideBuilding = *CPostEffects__m_bHeatHazeFX;


### PR DESCRIPTION
#### Summary
`CMultiplayerSA::GetHeatHaze` declares `m_HeatHazeFXSpeedMin` at `0xC402C0`, which is the random shift address, and then reads `sScanSizeX` from the scan size Y variable and `sScanSizeY` from the speed max variable. `DoSetHeatHazePokes` in the same file writes those three to `0x8D50EC`, `0xC40304` and `0xC40308`.

#### Motivation
`setHeatHaze` followed by `getHeatHaze` does not round trip, so a script cannot read back what it set.

#### Test plan
`setHeatHaze` with nine distinct values, then `getHeatHaze`:

```
                 set   before   after
speedMin          33      22      33      (22 is the random shift)
scanSizeX         55      66      55      (66 is scan size Y)
scanSizeY         66      44      66      (44 is speed max)
```

The other six fields were already correct. Each wrong value is exactly the value of the variable the code reads by mistake.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
