### PR TITLE
Fix hook size on CPtrNodeDoubleLinkPool::New overwriting the pool-full path

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA_ObjectStreamerOptimization.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_ObjectStreamerOptimization.cpp
@@ -70,7 +70,7 @@ static void __declspec(naked) HOOK_CEntryInfoList__Flush()
 }
 
 #define HOOKPOS_CPtrNodeDoubleLinkPool__New  0x55233E
-#define HOOKSIZE_CPtrNodeDoubleLinkPool__New 0x6
+#define HOOKSIZE_CPtrNodeDoubleLinkPool__New 0x5
 static void __declspec(naked) HOOK_CPtrNodeDoubleLinkPool__New()
 {
     MTA_VERIFY_HOOK_LOCAL_SIZE;


### PR DESCRIPTION
#### Summary
The hook at `0x55233E` replaces `lea eax,[ecx+eax*4]` / `pop esi` / `ret`, which is 5 bytes, but is installed with a size of 6. `HookInstall` pads the extra byte with `0x90`, and that byte is `pop edi` at `0x552343`: the first instruction of the path `CPool<CPtrNodeDoubleLink>::New` takes when the pool is full. That path then runs `xor eax,eax` / `pop esi` / `ret` one stack entry off and returns to the caller's saved `esi`.

`CEntryInfoNodePool::New` at `0x536D6E` is byte-identical and is already declared as 5.

#### Motivation
Pool exhaustion is fatal either way, since GTA's callers write through the returned pointer without checking it, but with the correct size the fault stays inside a named GTA function instead of returning to a data address where no module owns it.

#### Test plan
Byte at `0x552343` read in a running client right after the hook is installed:

```
HOOKSIZE 0x6   before=0x5F  after=0x90
HOOKSIZE 0x5   before=0x5F  after=0x5F
```

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
