### PR TITLE
Fix #4122: Remember vehicle/seat when ped/player dies

### DIFF
--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -2151,10 +2151,14 @@ void CGame::Packet_PedWasted(CPedWastedPacket& Packet)
             pPed->SetVehicleAction(CPed::VEHICLEACTION_NONE);
 
         // Remove him from any occupied vehicle
+        // The client keeps the player paired with the vehicle until he respawns,
+        // so remember it and let the occupied-vehicle getters report it while dead
         if (pVehicle)
         {
-            pVehicle->SetOccupant(NULL, pPed->GetOccupiedVehicleSeat());
+            const unsigned int uiOccupiedSeat = pPed->GetOccupiedVehicleSeat();
+            pVehicle->SetOccupant(NULL, uiOccupiedSeat);
             pPed->SetOccupiedVehicle(NULL, 0);
+            pPed->SetVehicleOccupiedOnDeath(pVehicle, uiOccupiedSeat);
         }
 
         CElement* pKiller = (Packet.m_Killer != INVALID_ELEMENT_ID) ? CElementIDs::GetElement(Packet.m_Killer) : NULL;
@@ -2210,11 +2214,15 @@ void CGame::Packet_PlayerWasted(CPlayerWastedPacket& Packet)
             pPlayer->SetVehicleAction(CPed::VEHICLEACTION_NONE);
 
         // Remove him from any occupied vehicle
+        // The client keeps the player paired with the vehicle until he respawns,
+        // so remember it and let the occupied-vehicle getters report it while dead
         CVehicle* pVehicle = pPlayer->GetOccupiedVehicle();
         if (pVehicle)
         {
-            pVehicle->SetOccupant(NULL, pPlayer->GetOccupiedVehicleSeat());
+            const unsigned int uiOccupiedSeat = pPlayer->GetOccupiedVehicleSeat();
+            pVehicle->SetOccupant(NULL, uiOccupiedSeat);
             pPlayer->SetOccupiedVehicle(NULL, 0);
+            pPlayer->SetVehicleOccupiedOnDeath(pVehicle, uiOccupiedSeat);
         }
 
         CElement* pKiller = (Packet.m_Killer != INVALID_ELEMENT_ID) ? CElementIDs::GetElement(Packet.m_Killer) : NULL;

--- a/Server/mods/deathmatch/logic/CPed.cpp
+++ b/Server/mods/deathmatch/logic/CPed.cpp
@@ -12,6 +12,7 @@
 #include "StdInc.h"
 #include "CPed.h"
 #include "CPedManager.h"
+#include "CElementRefManager.h"
 #include "CLogger.h"
 #include "Utils.h"
 #include "CStaticFunctionDefinitions.h"
@@ -73,6 +74,11 @@ CPed::CPed(CPedManager* pPedManager, CElement* pParent, unsigned short usModel) 
     m_uiVehicleSeat = INVALID_VEHICLE_SEAT;
     m_uiVehicleAction = CPed::VEHICLEACTION_NONE;
 
+    m_pVehicleOnDeath = NULL;
+    m_uiVehicleSeatOnDeath = INVALID_VEHICLE_SEAT;
+
+    CElementRefManager::AddElementRefs(ELEMENT_REF_DEBUG(this, "CPed"), &m_pVehicleOnDeath, NULL);
+
     m_vecVelocity.fX = m_vecVelocity.fY = m_vecVelocity.fZ = 0.0f;
 
     m_pSyncer = NULL;
@@ -113,6 +119,8 @@ CPed::~CPed()
     {
         m_pVehicle->SetOccupant(NULL, m_uiVehicleSeat);
     }
+
+    CElementRefManager::RemoveElementRefs(ELEMENT_REF_DEBUG(this, "CPed"), &m_pVehicleOnDeath, NULL);
 
     SetSyncer(NULL);
 
@@ -409,6 +417,9 @@ void CPed::SetContactElement(CElement* pElement)
 void CPed::SetIsDead(bool bDead)
 {
     m_bIsDead = bDead;
+
+    if (!bDead)
+        SetVehicleOccupiedOnDeath(NULL, INVALID_VEHICLE_SEAT);
 }
 
 CVehicle* CPed::SetOccupiedVehicle(CVehicle* pVehicle, unsigned int uiSeat)
@@ -420,6 +431,9 @@ CVehicle* CPed::SetOccupiedVehicle(CVehicle* pVehicle, unsigned int uiSeat)
         m_pVehicle = pVehicle;
         m_uiVehicleSeat = uiSeat;
 
+        if (pVehicle)
+            SetVehicleOccupiedOnDeath(NULL, INVALID_VEHICLE_SEAT);
+
         // Make sure the vehicle knows
         if (m_pVehicle)
         {
@@ -430,6 +444,12 @@ CVehicle* CPed::SetOccupiedVehicle(CVehicle* pVehicle, unsigned int uiSeat)
     }
 
     return m_pVehicle;
+}
+
+void CPed::SetVehicleOccupiedOnDeath(CVehicle* pVehicle, unsigned int uiSeat)
+{
+    m_pVehicleOnDeath = pVehicle;
+    m_uiVehicleSeatOnDeath = pVehicle ? uiSeat : INVALID_VEHICLE_SEAT;
 }
 
 void CPed::SetVehicleAction(unsigned int uiAction)

--- a/Server/mods/deathmatch/logic/CPed.h
+++ b/Server/mods/deathmatch/logic/CPed.h
@@ -259,6 +259,10 @@ public:
     unsigned int GetOccupiedVehicleSeat() { return m_uiVehicleSeat; };
     CVehicle*    SetOccupiedVehicle(CVehicle* pVehicle, unsigned int uiSeat);
 
+    CVehicle*    GetVehicleOccupiedOnDeath() { return m_pVehicleOnDeath; };
+    unsigned int GetVehicleOccupiedSeatOnDeath() { return m_uiVehicleSeatOnDeath; };
+    void         SetVehicleOccupiedOnDeath(CVehicle* pVehicle, unsigned int uiSeat);
+
     unsigned int GetVehicleAction() { return m_uiVehicleAction; };
     void         SetVehicleAction(unsigned int uiAction);
 
@@ -358,6 +362,9 @@ protected:
     CVehicle*    m_pVehicle;
     unsigned int m_uiVehicleSeat;
     unsigned int m_uiVehicleAction;
+
+    CVehicle*    m_pVehicleOnDeath;
+    unsigned int m_uiVehicleSeatOnDeath;
 
     bool m_bSyncable;
     bool m_bCollisionsEnabled;

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -2461,7 +2461,10 @@ CVehicle* CStaticFunctionDefinitions::GetPedOccupiedVehicle(CPed* pPed)
 {
     assert(pPed);
 
-    return pPed->GetOccupiedVehicle();
+    if (CVehicle* pVehicle = pPed->GetOccupiedVehicle())
+        return pVehicle;
+
+    return pPed->IsDead() ? pPed->GetVehicleOccupiedOnDeath() : NULL;
 }
 
 bool CStaticFunctionDefinitions::GetPedOccupiedVehicleSeat(CPed* pPed, unsigned int& uiSeat)
@@ -2473,6 +2476,13 @@ bool CStaticFunctionDefinitions::GetPedOccupiedVehicleSeat(CPed* pPed, unsigned 
         uiSeat = pPed->GetOccupiedVehicleSeat();
         return true;
     }
+
+    if (pPed->IsDead() && pPed->GetVehicleOccupiedOnDeath())
+    {
+        uiSeat = pPed->GetVehicleOccupiedSeatOnDeath();
+        return true;
+    }
+
     return false;
 }
 
@@ -3961,11 +3971,15 @@ bool CStaticFunctionDefinitions::KillPed(CElement* pElement, CElement* pKiller, 
                 pPed->SetVehicleAction(CPed::VEHICLEACTION_NONE);
 
             // Remove him from any occupied vehicle
+            // The client keeps the ped paired with the vehicle until it respawns,
+            // so remember it and let the occupied-vehicle getters report it while dead
             CVehicle* pVehicle = pPed->GetOccupiedVehicle();
             if (pVehicle)
             {
-                pVehicle->SetOccupant(NULL, pPed->GetOccupiedVehicleSeat());
+                const unsigned int uiOccupiedSeat = pPed->GetOccupiedVehicleSeat();
+                pVehicle->SetOccupant(NULL, uiOccupiedSeat);
                 pPed->SetOccupiedVehicle(NULL, 0);
+                pPed->SetVehicleOccupiedOnDeath(pVehicle, uiOccupiedSeat);
             }
 
             // Update the ped


### PR DESCRIPTION
#### Summary

`getPedOccupiedVehicle` and `getPedOccupiedVehicleSeat` now work on dead players/peds server-side (like the client-side)


#### Motivation

Dying inside a vehicle clears the occupant link server-side, but the client keeps the ped paired with the vehicle until it respawns, so `getPedOccupiedVehicle` returned `false` server-side while returning the vehicle client-side

Closes #4122.


#### Test plan

Enter a vehicle, die inside it and call `getPedOccupiedVehicle`; should return the vehicle


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
