### PR TITLE
Fix #4121: No weapon switching when next and previous weapon are bound to the same key

### DIFF
--- a/Client/core/CKeyBinds.cpp
+++ b/Client/core/CKeyBinds.cpp
@@ -2004,8 +2004,14 @@ void CKeyBinds::DoPostFramePulse()
             }
             else
             {
-                cs.RightShoulder2 = g_bcControls[1].bState ? 255 : 0;  // Next Weapon
-                cs.LeftShoulder2 = g_bcControls[2].bState ? 255 : 0;   // Previous Weapon
+                bool bNextWeapon = g_bcControls[1].bState;
+                bool bPreviousWeapon = g_bcControls[2].bState;
+
+                if (bNextWeapon && bPreviousWeapon)
+                    bNextWeapon = bPreviousWeapon = false;
+
+                cs.RightShoulder2 = bNextWeapon ? 255 : 0;     // Next Weapon
+                cs.LeftShoulder2 = bPreviousWeapon ? 255 : 0;  // Previous Weapon
             }
 
             if (!ControlForwardsBackWards(cs))


### PR DESCRIPTION
#### Summary

Binding the same key to both `next weapon` & `previous weapon` no longer switches the weapon

#### Motivation

Both controls were sent to the game in the same frame, so it cycled a weapon forwards and backwards at once and glitched the switch. they r now cancelled out: when both are down, neither is reported, so the current weapon stays

Closes #4121. 

#### Test plan

Bind `Q` to both Next weapon and Previous weapon, then press `Q` in game; the weapon should not change; unbind Previous weapon: `Q` should cycle to the next weapon again

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
