### PR TITLE
Add radar and crosshair support to set/get/reset player hud component property

### DIFF
--- a/Client/game_sa/CHudSA.cpp
+++ b/Client/game_sa/CHudSA.cpp
@@ -1026,7 +1026,7 @@ void CHudSA::BeginRadarTransform() noexcept
     ms_RadarTransform.bActive = false;
     ms_bRadarCustomColor = false;
 
-    const SHudComponentData& radar = componentProperties.radar;
+    const SHudComponentData&   radar = componentProperties.radar;
     const SComponentPlacement& placement = radar.placement;
 
     HudPlacement::SRect customRect;
@@ -1059,7 +1059,7 @@ void CHudSA::EndRadarTransform() noexcept
 //
 HudPlacement::SVertexPlacement CHudSA::GetCrosshairPlacement() noexcept
 {
-    const SHudComponentData& crosshair = componentProperties.crosshair;
+    const SHudComponentData&   crosshair = componentProperties.crosshair;
     const SComponentPlacement& placement = crosshair.placement;
 
     HudPlacement::SRect customRect;
@@ -1155,8 +1155,8 @@ void CHudSA::RenderCrosshairSprite(CVector vecPos, CVector2D vecHalfSize, std::u
             usIntensity = ucAlpha;
     }
 
-    using RenderOneXLUSpriteFunc = void(__cdecl*)(CVector, CVector2D, std::uint8_t, std::uint8_t, std::uint8_t, std::uint16_t, float, std::uint8_t,
-                                                  std::uint8_t, std::uint8_t);
+    using RenderOneXLUSpriteFunc =
+        void(__cdecl*)(CVector, CVector2D, std::uint8_t, std::uint8_t, std::uint8_t, std::uint16_t, float, std::uint8_t, std::uint8_t, std::uint8_t);
     ((RenderOneXLUSpriteFunc)FUNC_CSprite_RenderOneXLUSprite)(vecPos, vecHalfSize, ucRed, ucGreen, ucBlue, usIntensity, fRhw, ucAlpha, ucUDir, ucVDir);
 }
 

--- a/Client/game_sa/CHudSA.cpp
+++ b/Client/game_sa/CHudSA.cpp
@@ -31,6 +31,14 @@ float CHudSA::calcStreetchX = 0.0f;
 float CHudSA::calcStreetchY = 0.0f;
 float CHudSA::blinkingBarHPValue = 10.0f;
 
+HudPlacement::SVertexTransform CHudSA::ms_RadarTransform{};
+bool                           CHudSA::ms_bRadarCustomColor = false;
+HudPlacement::SRgba            CHudSA::ms_RadarTint{};
+
+HudPlacement::SVertexTransform CHudSA::ms_CrosshairTransform{};
+bool                           CHudSA::ms_bCrosshairCustomColor = false;
+HudPlacement::SRgba            CHudSA::ms_CrosshairTint{};
+
 constexpr RwColor COLOR_BLACK = RwColor{0, 0, 0, 255};
 
 // CSprite2d::DrawBarChart
@@ -58,7 +66,9 @@ std::unordered_map<eHudComponent, SHudComponentData> defaultComponentProperties 
     {HUD_WEAPON, {RwColor{255, 255, 255, 255}, RwColor{255, 255, 255, 255}}},
     {HUD_WANTED,
      {CHudSA::GetHUDColour(eHudColour::GOLD), RwColor{0, 0, 0, 170}, false, false, COLOR_BLACK, eFontAlignment::ALIGN_RIGHT, eFontStyle::FONT_GOTHIC, 1, 0,
-      true}}};
+      true}},
+    {HUD_RADAR, {RwColor{255, 255, 255, 255}}},
+    {HUD_CROSSHAIR, {RwColor{255, 255, 255, 255}}}};
 
 CHudSA::CHudSA()
 {
@@ -94,6 +104,8 @@ CHudSA::CHudSA()
     componentProperties.radioName = MapGet(defaultComponentProperties, HUD_RADIO);
     componentProperties.weaponIcon = MapGet(defaultComponentProperties, HUD_WEAPON);
     componentProperties.wanted = MapGet(defaultComponentProperties, HUD_WANTED);
+    componentProperties.radar = MapGet(defaultComponentProperties, HUD_RADAR);
+    componentProperties.crosshair = MapGet(defaultComponentProperties, HUD_CROSSHAIR);
 }
 
 void CHudSA::Disable(bool bDisabled)
@@ -266,6 +278,43 @@ void CHudSA::UpdateStreetchCalculations()
     wantedPlacement.height = calcStreetchY * 1.21f;
     wantedPlacement.width = calcStreetchX * 0.6f;
     wantedPlacement.setDefaultXY = false;
+
+    const HudPlacement::SRect radarRect = GetRadarDefaultRect();
+
+    SComponentPlacement& radarPlacement = componentProperties.radar.placement;
+    radarPlacement.x = radarRect.x;
+    radarPlacement.y = radarRect.y;
+    radarPlacement.width = radarRect.width;
+    radarPlacement.height = radarRect.height;
+    radarPlacement.setDefaultXY = false;
+
+    const HudPlacement::SRect crosshairRect = GetCrosshairDefaultRect();
+
+    SComponentPlacement& crosshairPlacement = componentProperties.crosshair.placement;
+    crosshairPlacement.x = crosshairRect.x;
+    crosshairPlacement.y = crosshairRect.y;
+    crosshairPlacement.width = crosshairRect.width;
+    crosshairPlacement.height = crosshairRect.height;
+    crosshairPlacement.setDefaultXY = false;
+}
+
+//
+// CHudSA::GetRadarDefaultRect
+//
+HudPlacement::SRect CHudSA::GetRadarDefaultRect() noexcept
+{
+    const float fStretchX = static_cast<float>(rsGlobal->maximumWidth) * (*reinterpret_cast<float*>(VAR_AspectRatioMultX));
+    const float fStretchY = static_cast<float>(rsGlobal->maximumHeight) * (*reinterpret_cast<float*>(VAR_AspectRatioMult));
+
+    return HudPlacement::GetDefaultRect(fStretchX, fStretchY, static_cast<float>(rsGlobal->maximumHeight));
+}
+
+//
+// CHudSA::GetCrosshairDefaultRect
+//
+HudPlacement::SRect CHudSA::GetCrosshairDefaultRect() noexcept
+{
+    return HudPlacement::GetCrosshairDefaultRect(static_cast<float>(rsGlobal->maximumWidth), static_cast<float>(rsGlobal->maximumHeight));
 }
 
 //
@@ -505,7 +554,7 @@ void CHudSA::ResetComponentFontData(const eHudComponent& component, const eHudCo
     }
 }
 
-SHudComponentData& CHudSA::GetHudComponentRef(const eHudComponent& component) const noexcept
+SHudComponentData& CHudSA::GetHudComponentRef(const eHudComponent& component) noexcept
 {
     switch (component)
     {
@@ -531,6 +580,10 @@ SHudComponentData& CHudSA::GetHudComponentRef(const eHudComponent& component) co
             return componentProperties.weaponIcon;
         case HUD_WANTED:
             return componentProperties.wanted;
+        case HUD_RADAR:
+            return componentProperties.radar;
+        case HUD_CROSSHAIR:
+            return componentProperties.crosshair;
         default:
             break;
     }
@@ -965,8 +1018,226 @@ static void HOOK_RenderHudBar(int playerId, int x, int y)
         CHudSA::RenderArmorBar(x, y);
 }
 
+//
+// CHudSA::BeginRadarTransform
+//
+void CHudSA::BeginRadarTransform() noexcept
+{
+    ms_RadarTransform.bActive = false;
+    ms_bRadarCustomColor = false;
+
+    const SHudComponentData& radar = componentProperties.radar;
+    const SComponentPlacement& placement = radar.placement;
+
+    HudPlacement::SRect customRect;
+    customRect.x = placement.customX;
+    customRect.y = placement.customY;
+    customRect.width = placement.customWidth;
+    customRect.height = placement.customHeight;
+
+    ms_RadarTransform = HudPlacement::BuildTransform(GetRadarDefaultRect(), placement.useCustomPosition, placement.useCustomSize, customRect);
+
+    const std::uint8_t ucAlpha = radar.useCustomAlpha ? radar.fillColor.a : 255;
+    if (radar.fillColor.r != 255 || radar.fillColor.g != 255 || radar.fillColor.b != 255 || ucAlpha != 255)
+    {
+        ms_RadarTint = HudPlacement::SRgba{radar.fillColor.r, radar.fillColor.g, radar.fillColor.b, ucAlpha};
+        ms_bRadarCustomColor = true;
+    }
+}
+
+//
+// CHudSA::EndRadarTransform
+//
+void CHudSA::EndRadarTransform() noexcept
+{
+    ms_RadarTransform.bActive = false;
+    ms_bRadarCustomColor = false;
+}
+
+//
+// CHudSA::GetCrosshairPlacement
+//
+HudPlacement::SVertexPlacement CHudSA::GetCrosshairPlacement() noexcept
+{
+    const SHudComponentData& crosshair = componentProperties.crosshair;
+    const SComponentPlacement& placement = crosshair.placement;
+
+    HudPlacement::SRect customRect;
+    customRect.x = placement.customX;
+    customRect.y = placement.customY;
+    customRect.width = placement.customWidth;
+    customRect.height = placement.customHeight;
+
+    HudPlacement::SVertexPlacement result;
+    result.transform = HudPlacement::BuildTransform(GetCrosshairDefaultRect(), placement.useCustomPosition, placement.useCustomSize, customRect);
+
+    const std::uint8_t ucAlpha = crosshair.useCustomAlpha ? crosshair.fillColor.a : 255;
+    if (crosshair.fillColor.r != 255 || crosshair.fillColor.g != 255 || crosshair.fillColor.b != 255 || ucAlpha != 255)
+    {
+        result.color = HudPlacement::SRgba{crosshair.fillColor.r, crosshair.fillColor.g, crosshair.fillColor.b, ucAlpha};
+        result.bUseColor = true;
+    }
+
+    return result;
+}
+
+//
+// CHudSA::BeginCrosshairTransform
+//
+void CHudSA::BeginCrosshairTransform() noexcept
+{
+    const HudPlacement::SVertexPlacement placement = GetCrosshairPlacement();
+
+    ms_CrosshairTransform = placement.transform;
+    ms_CrosshairTint = placement.color;
+    ms_bCrosshairCustomColor = placement.bUseColor;
+}
+
+//
+// CHudSA::EndCrosshairTransform
+//
+void CHudSA::EndCrosshairTransform() noexcept
+{
+    ms_CrosshairTransform.bActive = false;
+    ms_bCrosshairCustomColor = false;
+}
+
+//
+// CHudSA::RenderCrosshair_Sprite
+//
+void __fastcall CHudSA::RenderCrosshair_Sprite(void* pSprite, void*, CRect* pRect, RwColor* pColor)
+{
+    BeginCrosshairTransform();
+
+    ((void(__thiscall*)(void*, CRect*, RwColor*))FUNC_CSprite2d_Draw)(pSprite, pRect, pColor);
+
+    EndCrosshairTransform();
+}
+
+//
+// CHudSA::RenderCrosshair_Rect
+//
+void CHudSA::RenderCrosshair_Rect(CRect* pRect, RwColor* pColor)
+{
+    BeginCrosshairTransform();
+
+    ((void(__cdecl*)(CRect*, RwColor*))FUNC_CSprite2d_DrawRect)(pRect, pColor);
+
+    EndCrosshairTransform();
+}
+
+//
+// CHudSA::RenderCrosshairSprite
+//
+void CHudSA::RenderCrosshairSprite(CVector vecPos, CVector2D vecHalfSize, std::uint8_t ucRed, std::uint8_t ucGreen, std::uint8_t ucBlue,
+                                   std::uint16_t usIntensity, float fRhw, std::uint8_t ucAlpha, std::uint8_t ucUDir, std::uint8_t ucVDir)
+{
+    const HudPlacement::SVertexPlacement placement = GetCrosshairPlacement();
+
+    if (placement.transform.bActive)
+    {
+        vecPos.fX = placement.transform.fScaleX * vecPos.fX + placement.transform.fOffsetX;
+        vecPos.fY = placement.transform.fScaleY * vecPos.fY + placement.transform.fOffsetY;
+        vecHalfSize.fX *= placement.transform.fScaleX;
+        vecHalfSize.fY *= placement.transform.fScaleY;
+    }
+
+    if (placement.bUseColor)
+    {
+        const auto ucModulate = [](std::uint8_t ucValue, std::uint8_t ucTint) { return static_cast<std::uint8_t>((ucValue * ucTint + 127) / 255); };
+
+        ucRed = ucModulate(ucRed, placement.color.r);
+        ucGreen = ucModulate(ucGreen, placement.color.g);
+        ucBlue = ucModulate(ucBlue, placement.color.b);
+        ucAlpha = ucModulate(ucAlpha, placement.color.a);
+
+        if (placement.color.a != 255)
+            usIntensity = ucAlpha;
+    }
+
+    using RenderOneXLUSpriteFunc = void(__cdecl*)(CVector, CVector2D, std::uint8_t, std::uint8_t, std::uint8_t, std::uint16_t, float, std::uint8_t,
+                                                  std::uint8_t, std::uint8_t);
+    ((RenderOneXLUSpriteFunc)FUNC_CSprite_RenderOneXLUSprite)(vecPos, vecHalfSize, ucRed, ucGreen, ucBlue, usIntensity, fRhw, ucAlpha, ucUDir, ucVDir);
+}
+
+//
+// CHudSA::ApplyHudVertexTransform
+//
+void CHudSA::ApplyHudVertexTransform(void* pVertices, int iNumVertices) noexcept
+{
+    if (!pVertices || iNumVertices <= 0)
+        return;
+
+    HudPlacement::SVertexPlacement placement;
+
+    if (ms_RadarTransform.bActive || ms_bRadarCustomColor)
+    {
+        placement.transform = ms_RadarTransform;
+        placement.color = ms_RadarTint;
+        placement.bUseColor = ms_bRadarCustomColor;
+    }
+    else if (ms_CrosshairTransform.bActive || ms_bCrosshairCustomColor)
+    {
+        placement.transform = ms_CrosshairTransform;
+        placement.color = ms_CrosshairTint;
+        placement.bUseColor = ms_bCrosshairCustomColor;
+    }
+    else
+    {
+        return;
+    }
+
+    constexpr int VERTEX_FLOATS = 7;
+    constexpr int VERTEX_COLOR = 4;
+
+    float* pFloats = static_cast<float*>(pVertices);
+    for (int i = 0; i < iNumVertices; i++, pFloats += VERTEX_FLOATS)
+    {
+        if (placement.transform.bActive)
+            HudPlacement::ApplyToVertex(placement.transform, pFloats[0], pFloats[1]);
+
+        if (placement.bUseColor)
+        {
+            std::uint32_t* pColor = reinterpret_cast<std::uint32_t*>(pFloats + VERTEX_COLOR);
+            *pColor = HudPlacement::ModulateArgb(*pColor, placement.color);
+        }
+    }
+}
+
+static void HookCallsToTarget(DWORD dwStart, DWORD dwEnd, DWORD dwTarget, DWORD dwHookHandler)
+{
+    for (DWORD dwAddr = dwStart; dwAddr + 5 <= dwEnd; dwAddr++)
+    {
+        if (*(BYTE*)dwAddr != 0xE8 || dwAddr + 5 + *(DWORD*)(dwAddr + 1) != dwTarget)
+            continue;
+
+        HookInstallCall(dwAddr, dwHookHandler);
+    }
+}
+
+//
+// CHudSA::RenderRadar
+//
+void CHudSA::RenderRadar()
+{
+    BeginRadarTransform();
+
+    ((void(__cdecl*)())FUNC_DrawRadar)();
+
+    EndRadarTransform();
+}
+
+//
+// CHudSA::StaticSetHooks
+//
 void CHudSA::StaticSetHooks()
 {
+    HookInstallCall(CALLER_DrawRadar, (DWORD)&RenderRadar);
+
+    HookCallsToTarget(FUNC_DrawCrossHairs, DRAW_CROSSHAIRS_END, FUNC_CSprite2d_Draw, (DWORD)&RenderCrosshair_Sprite);
+    HookCallsToTarget(FUNC_DrawCrossHairs, DRAW_CROSSHAIRS_END, FUNC_CSprite2d_DrawRect, (DWORD)&RenderCrosshair_Rect);
+    HookCallsToTarget(FUNC_DrawCrossHairs, DRAW_CROSSHAIRS_END, FUNC_CSprite_RenderOneXLUSprite, (DWORD)&RenderCrosshairSprite);
+
     HookInstall(FUNC_RenderHealthBar, &HOOK_RenderHudBar, 11);
     HookInstall(FUNC_RenderBreathBar, &HOOK_RenderHudBar, 11);
     HookInstall(FUNC_RenderArmorBar, &HOOK_RenderHudBar, 11);

--- a/Client/game_sa/CHudSA.h
+++ b/Client/game_sa/CHudSA.h
@@ -315,7 +315,7 @@ private:
                                      std::uint8_t a, std::uint8_t uDir, std::uint8_t vDir);
 
     static void __fastcall RenderCrosshair_Sprite(void* sprite, void*, CRect* rect, RwColor* color);
-    static void          RenderCrosshair_Rect(CRect* rect, RwColor* color);
+    static void            RenderCrosshair_Rect(CRect* rect, RwColor* color);
 
     static void RenderWanted(bool empty, float x, float y, const char* strLevel);
 

--- a/Client/game_sa/CHudSA.h
+++ b/Client/game_sa/CHudSA.h
@@ -16,6 +16,7 @@
 #include <game/RenderWare.h>
 #include "CFontSA.h"
 #include "CRect.h"
+#include "CHudSAPlacement.h"
 
 #define FUNC_Draw 0x58FAE0
 
@@ -47,10 +48,16 @@
 #define FUNC_CStats_GetFatAndMuscleModifier 0x559AF0
 #define FUNC_CSprite2d_DrawBarChart         0x728640
 #define FUNC_CSprite2d_Draw                 0x728350
+#define FUNC_CSprite2d_DrawRect             0x727B60
 #define FUNC_CSprite_RenderOneXLUSprite     0x70D000
 
 #define FUNC_CRadar_DrawRadarMap 0x586880
 #define FUNC_CRadar_DrawBlips    0x588050
+
+#define CALLER_DrawRadar 0x58FC53
+
+#define FUNC_DrawCrossHairs 0x58E020
+#define DRAW_CROSSHAIRS_END 0x58EAF0
 
 #define CODE_ShowMoney          0x58F47D
 #define CODE_ShowRadarAltimeter 0x58A5A6
@@ -170,6 +177,9 @@ struct ComponentProperties
 
     SHudComponentData weaponIcon;
     SHudComponentData wanted;
+
+    SHudComponentData radar;
+    SHudComponentData crosshair;
 };
 
 class CHudSA : public CHud
@@ -270,6 +280,15 @@ public:
 
     static void StaticSetHooks();
 
+    static void BeginRadarTransform() noexcept;
+    static void EndRadarTransform() noexcept;
+    static void RenderRadar();
+
+    static void BeginCrosshairTransform() noexcept;
+    static void EndCrosshairTransform() noexcept;
+
+    static void ApplyHudVertexTransform(void* pVertices, int iNumVertices) noexcept;
+
     static void RenderHealthBar(int x, int y);
     static void RenderBreathBar(int x, int y);
     static void RenderArmorBar(int x, int y);
@@ -280,7 +299,7 @@ private:
     void ResetComponent(SComponentPlacement& placement, bool resetSize) noexcept;
     void ResetComponentFontData(const eHudComponent& component, const eHudComponentProperty& property) noexcept;
 
-    SHudComponentData& GetHudComponentRef(const eHudComponent& component) const noexcept;
+    static SHudComponentData& GetHudComponentRef(const eHudComponent& component) noexcept;
 
     static void RenderText(float x, float y, const char* text, SHudComponentData& properties, bool useSecondColor = false, bool drawFromBottom = false,
                            bool scaleForLanguage = false);
@@ -295,7 +314,18 @@ private:
     static void RenderWeaponIcon_XLU(CVector pos, CVector2D halfSize, std::uint8_t r, std::uint8_t g, std::uint8_t b, std::uint16_t intensity, float rhw,
                                      std::uint8_t a, std::uint8_t uDir, std::uint8_t vDir);
 
+    static void __fastcall RenderCrosshair_Sprite(void* sprite, void*, CRect* rect, RwColor* color);
+    static void          RenderCrosshair_Rect(CRect* rect, RwColor* color);
+
     static void RenderWanted(bool empty, float x, float y, const char* strLevel);
+
+    static HudPlacement::SRect GetRadarDefaultRect() noexcept;
+    static HudPlacement::SRect GetCrosshairDefaultRect() noexcept;
+
+    static HudPlacement::SVertexPlacement GetCrosshairPlacement() noexcept;
+
+    static void RenderCrosshairSprite(CVector vecPos, CVector2D vecHalfSize, std::uint8_t ucRed, std::uint8_t ucGreen, std::uint8_t ucBlue,
+                                      std::uint16_t usIntensity, float fRhw, std::uint8_t ucAlpha, std::uint8_t ucUDir, std::uint8_t ucVDir);
 
 private:
     std::map<eHudComponent, SHudComponent> m_HudComponentMap;
@@ -310,4 +340,13 @@ private:
     static float calcStreetchX;
     static float calcStreetchY;
     static float blinkingBarHPValue;
+
+    static HudPlacement::SVertexTransform ms_RadarTransform;
+
+    static bool                ms_bRadarCustomColor;
+    static HudPlacement::SRgba ms_RadarTint;
+
+    static HudPlacement::SVertexTransform ms_CrosshairTransform;
+    static bool                           ms_bCrosshairCustomColor;
+    static HudPlacement::SRgba            ms_CrosshairTint;
 };

--- a/Client/game_sa/CHudSAPlacement.h
+++ b/Client/game_sa/CHudSAPlacement.h
@@ -1,0 +1,116 @@
+/*****************************************************************************
+ *
+ *  PROJECT:     Multi Theft Auto v1.0
+ *  LICENSE:     See LICENSE in the top level directory
+ *  FILE:        game_sa/CHudSAPlacement.h
+ *  PURPOSE:     Geometry and colour helpers for the placement of the HUD
+ *               components the game draws itself (the radar and the crosshair)
+ *
+ *  Multi Theft Auto is available from https://www.multitheftauto.com/
+ *
+ *****************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+namespace HudPlacement
+{
+    constexpr float RADAR_LEFT = 36.0f;
+    constexpr float RADAR_RIGHT = 138.0f;
+    constexpr float RADAR_BOTTOM = 24.0f;
+    constexpr float RADAR_TOP = 108.0f;
+
+    struct SRect
+    {
+        float x{0.0f};
+        float y{0.0f};
+        float width{0.0f};
+        float height{0.0f};
+    };
+
+    struct SVertexTransform
+    {
+        bool  bActive{false};
+        float fScaleX{1.0f};
+        float fScaleY{1.0f};
+        float fOffsetX{0.0f};
+        float fOffsetY{0.0f};
+    };
+
+    inline SRect GetDefaultRect(float fStretchX, float fStretchY, float fScreenHeight) noexcept
+    {
+        SRect rect;
+        rect.x = RADAR_LEFT * fStretchX;
+        rect.y = fScreenHeight - RADAR_TOP * fStretchY;
+        rect.width = (RADAR_RIGHT - RADAR_LEFT) * fStretchX;
+        rect.height = (RADAR_TOP - RADAR_BOTTOM) * fStretchY;
+        return rect;
+    }
+
+    inline SRect GetCrosshairDefaultRect(float fScreenWidth, float fScreenHeight) noexcept
+    {
+        SRect rect;
+        rect.x = fScreenWidth * 0.5f;
+        rect.y = fScreenHeight * 0.5f;
+        rect.width = fScreenWidth;
+        rect.height = fScreenHeight;
+        return rect;
+    }
+
+    inline SVertexTransform BuildTransform(const SRect& defaultRect, bool bUseCustomPosition, bool bUseCustomSize, const SRect& customRect) noexcept
+    {
+        SVertexTransform transform;
+
+        if ((!bUseCustomPosition && !bUseCustomSize) || defaultRect.width <= 0.0f || defaultRect.height <= 0.0f)
+            return transform;
+
+        const float fWidth = bUseCustomSize ? customRect.width : defaultRect.width;
+        const float fHeight = bUseCustomSize ? customRect.height : defaultRect.height;
+        if (fWidth <= 0.0f || fHeight <= 0.0f)
+            return transform;
+
+        const float fX = bUseCustomPosition ? customRect.x : defaultRect.x;
+        const float fY = bUseCustomPosition ? customRect.y : defaultRect.y;
+
+        transform.bActive = true;
+        transform.fScaleX = fWidth / defaultRect.width;
+        transform.fScaleY = fHeight / defaultRect.height;
+        transform.fOffsetX = fX - defaultRect.x * transform.fScaleX;
+        transform.fOffsetY = fY - defaultRect.y * transform.fScaleY;
+        return transform;
+    }
+
+    inline void ApplyToVertex(const SVertexTransform& transform, float& fX, float& fY) noexcept
+    {
+        fX = fX * transform.fScaleX + transform.fOffsetX;
+        fY = fY * transform.fScaleY + transform.fOffsetY;
+    }
+
+    struct SRgba
+    {
+        std::uint8_t r{255};
+        std::uint8_t g{255};
+        std::uint8_t b{255};
+        std::uint8_t a{255};
+    };
+
+    struct SVertexPlacement
+    {
+        SVertexTransform transform;
+        SRgba            color;
+        bool             bUseColor{false};
+    };
+
+    inline std::uint32_t ModulateArgb(std::uint32_t uiArgb, const SRgba& tint) noexcept
+    {
+        const auto ucMultiply = [](std::uint32_t uiChannel, std::uint8_t ucTint) { return (uiChannel * ucTint + 127) / 255; };
+
+        const std::uint32_t uiAlpha = ucMultiply((uiArgb >> 24) & 0xFF, tint.a);
+        const std::uint32_t uiRed = ucMultiply((uiArgb >> 16) & 0xFF, tint.r);
+        const std::uint32_t uiGreen = ucMultiply((uiArgb >> 8) & 0xFF, tint.g);
+        const std::uint32_t uiBlue = ucMultiply(uiArgb & 0xFF, tint.b);
+
+        return (uiAlpha << 24) | (uiRed << 16) | (uiGreen << 8) | uiBlue;
+    }
+}

--- a/Client/game_sa/CRenderWareSA.ShaderSupport.cpp
+++ b/Client/game_sa/CRenderWareSA.ShaderSupport.cpp
@@ -13,6 +13,7 @@
 #include "StdInc.h"
 #include <core/CCoreInterface.h>
 #include "CGameSA.h"
+#include "CHudSA.h"
 #include "CRenderWareSA.ShaderMatching.h"
 #include "CRenderWareSA.ShaderSupport.h"
 
@@ -933,9 +934,11 @@ static void __declspec(naked) HOOK_RwIm2DRenderIndexedPrimitive()
 // Note that RwIm2DRenderPrimitive is being called to render something
 //
 //////////////////////////////////////////////////////////////////////////////////////////
-__declspec(noinline) void OnMY_RwIm2DRenderPrimitive_Pre(DWORD dwAddrCalledFrom)
+__declspec(noinline) void OnMY_RwIm2DRenderPrimitive_Pre(DWORD dwAddrCalledFrom, void* pVertices, int iNumVertices)
 {
     CRenderWareSA::ms_iRenderingType = RT_2DNI;
+
+    CHudSA::ApplyHudVertexTransform(pVertices, iNumVertices);
 }
 
 __declspec(noinline) void OnMY_RwIm2DRenderPrimitive_Post(DWORD dwAddrCalledFrom)
@@ -955,9 +958,11 @@ static void __declspec(naked) HOOK_RwIm2DRenderPrimitive()
     __asm
     {
         pushad
-        push    [esp+32+4*0]
+        push    [esp+32+4*3]    // numVertices
+        push    [esp+32+4*3]    // vertices
+        push    [esp+32+4*2]    // address called from
         call    OnMY_RwIm2DRenderPrimitive_Pre
-        add     esp, 4*1
+        add     esp, 4*3
         popad
 
         push    [esp+4*3]

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
@@ -852,8 +852,8 @@ bool CLuaPlayerDefs::ResetPlayerHudComponentProperty(eHudComponent component, eH
     if (component == HUD_ALL)
     {
         static constexpr eHudComponent resettableComponents[] = {
-            HUD_AMMO,      HUD_WEAPON, HUD_HEALTH,  HUD_BREATH, HUD_ARMOUR,     HUD_MONEY, HUD_VEHICLE_NAME, HUD_AREA_NAME,
-            HUD_RADAR,     HUD_CLOCK,  HUD_RADIO,   HUD_WANTED, HUD_CROSSHAIR,  HUD_VITAL_STATS, HUD_HELP_TEXT,
+            HUD_AMMO,  HUD_WEAPON, HUD_HEALTH, HUD_BREATH, HUD_ARMOUR,    HUD_MONEY,       HUD_VEHICLE_NAME, HUD_AREA_NAME,
+            HUD_RADAR, HUD_CLOCK,  HUD_RADIO,  HUD_WANTED, HUD_CROSSHAIR, HUD_VITAL_STATS, HUD_HELP_TEXT,
         };
 
         for (eHudComponent comp : resettableComponents)

--- a/Client/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
+++ b/Client/mods/deathmatch/logic/luadefs/CLuaPlayerDefs.cpp
@@ -652,11 +652,32 @@ bool CLuaPlayerDefs::IsPlayerCrosshairVisible()
     return g_pGame->GetHud()->IsCrosshairVisible();
 }
 
+static bool IsGameDrawnComponent(eHudComponent component) noexcept
+{
+    return component == HUD_RADAR || component == HUD_CROSSHAIR;
+}
+
+static bool IsRadarPart(eHudComponent component) noexcept
+{
+    return component == HUD_RADAR_MAP || component == HUD_RADAR_BLIPS || component == HUD_RADAR_ALTIMETER;
+}
+
+static bool IsSupportedGameDrawnProperty(eHudComponent component, eHudComponentProperty property) noexcept
+{
+    if (property == eHudComponentProperty::POSITION || property == eHudComponentProperty::SIZE)
+        return true;
+
+    return (component == HUD_RADAR || component == HUD_CROSSHAIR) &&
+           (property == eHudComponentProperty::FILL_COLOR || property == eHudComponentProperty::CUSTOM_ALPHA);
+}
+
 bool CLuaPlayerDefs::SetPlayerHudComponentProperty(eHudComponent component, eHudComponentProperty property,
                                                    std::variant<CVector2D, float, bool, std::string> value)
 {
-    if (component == HUD_ALL || component == HUD_CROSSHAIR || component == HUD_VITAL_STATS || component == HUD_HELP_TEXT || component == HUD_RADAR ||
-        component == HUD_RADAR_MAP || component == HUD_RADAR_BLIPS || component == HUD_RADAR_ALTIMETER)
+    if (component == HUD_ALL || component == HUD_VITAL_STATS || component == HUD_HELP_TEXT || IsRadarPart(component))
+        return false;
+
+    if (IsGameDrawnComponent(component) && !IsSupportedGameDrawnProperty(component, property))
         return false;
 
     CHud* hud = g_pGame->GetHud();
@@ -676,13 +697,18 @@ bool CLuaPlayerDefs::SetPlayerHudComponentProperty(eHudComponent component, eHud
             if (!std::holds_alternative<CVector2D>(value))
                 return false;
 
-            hud->SetComponentSize(component, std::get<CVector2D>(value));
+            const CVector2D& size = std::get<CVector2D>(value);
+            if (IsGameDrawnComponent(component) && (size.fX <= 0.0f || size.fY <= 0.0f))
+                return false;
+
+            hud->SetComponentSize(component, size);
             return true;
         }
         case eHudComponentProperty::FILL_COLOR:
         case eHudComponentProperty::FILL_COLOR_SECONDARY:
         {
-            if (!hud->IsComponentBar(component) && !hud->IsComponentText(component) && component != HUD_WEAPON)
+            if (!hud->IsComponentBar(component) && !hud->IsComponentText(component) && component != HUD_WEAPON && component != HUD_RADAR &&
+                component != HUD_CROSSHAIR)
                 return false;
 
             if (!std::holds_alternative<float>(value))
@@ -815,21 +841,23 @@ bool CLuaPlayerDefs::SetPlayerHudComponentProperty(eHudComponent component, eHud
 
 bool CLuaPlayerDefs::ResetPlayerHudComponentProperty(eHudComponent component, eHudComponentProperty property) noexcept
 {
-    if (component == HUD_CROSSHAIR || component == HUD_VITAL_STATS || component == HUD_HELP_TEXT || component == HUD_RADAR)
+    if (component == HUD_VITAL_STATS || component == HUD_HELP_TEXT || IsRadarPart(component))
+        return false;
+
+    if (IsGameDrawnComponent(component) && property != eHudComponentProperty::ALL_PROPERTIES && !IsSupportedGameDrawnProperty(component, property))
         return false;
 
     CHud* hud = g_pGame->GetHud();
 
     if (component == HUD_ALL)
     {
-        for (std::size_t iComp = 0; iComp < static_cast<std::size_t>(HUD_HELP_TEXT); iComp++)
-        {
-            eHudComponent comp = static_cast<eHudComponent>(iComp);
-            if (comp == HUD_ALL)
-                continue;
+        static constexpr eHudComponent resettableComponents[] = {
+            HUD_AMMO,      HUD_WEAPON, HUD_HEALTH,  HUD_BREATH, HUD_ARMOUR,     HUD_MONEY, HUD_VEHICLE_NAME, HUD_AREA_NAME,
+            HUD_RADAR,     HUD_CLOCK,  HUD_RADIO,   HUD_WANTED, HUD_CROSSHAIR,  HUD_VITAL_STATS, HUD_HELP_TEXT,
+        };
 
+        for (eHudComponent comp : resettableComponents)
             ResetPlayerHudComponentProperty(comp, property);
-        }
 
         return true;
     }
@@ -852,7 +880,8 @@ bool CLuaPlayerDefs::ResetPlayerHudComponentProperty(eHudComponent component, eH
         case eHudComponentProperty::FILL_COLOR:
         case eHudComponentProperty::FILL_COLOR_SECONDARY:
         {
-            if (!hud->IsComponentBar(component) && !hud->IsComponentText(component) && component != HUD_WEAPON)
+            if (!hud->IsComponentBar(component) && !hud->IsComponentText(component) && component != HUD_WEAPON && component != HUD_RADAR &&
+                component != HUD_CROSSHAIR)
                 return false;
 
             bool second = property == eHudComponentProperty::FILL_COLOR_SECONDARY;
@@ -945,7 +974,10 @@ bool CLuaPlayerDefs::ResetPlayerHudComponentProperty(eHudComponent component, eH
 std::variant<float, bool, std::string, CLuaMultiReturn<float, float>, CLuaMultiReturn<std::uint8_t, std::uint8_t, std::uint8_t, std::uint8_t>>
 CLuaPlayerDefs::GetPlayerHudComponentProperty(eHudComponent component, eHudComponentProperty property)
 {
-    if (component == HUD_ALL || component == HUD_CROSSHAIR || component == HUD_VITAL_STATS || component == HUD_HELP_TEXT || component == HUD_RADAR)
+    if (component == HUD_ALL || component == HUD_VITAL_STATS || component == HUD_HELP_TEXT || IsRadarPart(component))
+        return false;
+
+    if (IsGameDrawnComponent(component) && !IsSupportedGameDrawnProperty(component, property))
         return false;
 
     CHud* hud = g_pGame->GetHud();
@@ -964,7 +996,8 @@ CLuaPlayerDefs::GetPlayerHudComponentProperty(eHudComponent component, eHudCompo
         }
         case eHudComponentProperty::FILL_COLOR:
         {
-            if (!hud->IsComponentBar(component) && !hud->IsComponentText(component) && component != HUD_WEAPON)
+            if (!hud->IsComponentBar(component) && !hud->IsComponentText(component) && component != HUD_WEAPON && component != HUD_RADAR &&
+                component != HUD_CROSSHAIR)
                 return false;
 
             SColor color = hud->GetComponentColor(component);


### PR DESCRIPTION
#### Summary
`setPlayerHudComponentProperty`, `getPlayerHudComponentProperty` and `resetPlayerHudComponentProperty` now support the radar and crosshair components (position, size, fillColor and useCustomAlpha)

- Closes #4563.
- Closes #4009.
- Closes #4553.

#### Example
```lua
setPlayerHudComponentProperty("radar", "position", 1200, 800)
setPlayerHudComponentProperty("radar", "size", 128, 128)
setPlayerHudComponentProperty("radar", "fillColor", tocolor(55, 255, 255, 255))
setPlayerHudComponentProperty("radar", "useCustomAlpha", true)

setPlayerHudComponentProperty("crosshair", "fillColor", tocolor(255, 0, 255, 255))
```
<img width="1920" height="1080" alt="Screenshot 2026-09-12 134258" src="https://github.com/user-attachments/assets/df264463-b9f8-4338-8292-7f0766509cfd" />


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
