### PR TITLE
Fix server crash when listing a long ACL right or group object

### DIFF
--- a/Server/mods/deathmatch/logic/luadefs/CLuaACLDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaACLDefs.cpp
@@ -418,7 +418,6 @@ int CLuaACLDefs::aclListRights(lua_State* luaVM)
         lua_newtable(luaVM);
 
         // Loop through ACL
-        char                                           szRightName[128];
         CAccessControlListRight::ERightType            eType;
         unsigned int                                   uiIndex = 0;
         list<CAccessControlListRight*>::const_iterator iter = pACL->IterBegin();
@@ -429,35 +428,36 @@ int CLuaACLDefs::aclListRights(lua_State* luaVM)
             if (!bAll && eType != eAllowed)
                 continue;
 
+            const char* szPrefix = "unknown.";
             switch (eType)
             {
                 case CAccessControlListRight::RIGHT_TYPE_COMMAND:
-                    strcpy(szRightName, "command.");
+                    szPrefix = "command.";
                     break;
 
                 case CAccessControlListRight::RIGHT_TYPE_FUNCTION:
-                    strcpy(szRightName, "function.");
+                    szPrefix = "function.";
                     break;
 
                 case CAccessControlListRight::RIGHT_TYPE_RESOURCE:
-                    strcpy(szRightName, "resource.");
+                    szPrefix = "resource.";
                     break;
 
                 case CAccessControlListRight::RIGHT_TYPE_GENERAL:
-                    strcpy(szRightName, "general.");
+                    szPrefix = "general.";
                     break;
 
                 default:
-                    strcpy(szRightName, "unknown.");
                     break;
             }
 
             // Append right name
-            strncat(szRightName, (*iter)->GetRightName(), NUMELMS(szRightName) - 1);
+            SString strRightName = szPrefix;
+            strRightName += (*iter)->GetRightName();
 
             // Push its name onto the table
             lua_pushnumber(luaVM, ++uiIndex);
-            lua_pushstring(luaVM, szRightName);
+            lua_pushstring(luaVM, strRightName);
             lua_settable(luaVM, -3);
         }
 
@@ -803,29 +803,30 @@ int CLuaACLDefs::aclGroupListObjects(lua_State* luaVM)
         lua_newtable(luaVM);
 
         // Loop through ACL stuff
-        char                                                 szBuffer[255];
         unsigned int                                         uiIndex = 0;
         list<CAccessControlListGroupObject*>::const_iterator iter = pGroup->IterBeginObjects();
         for (; iter != pGroup->IterEndObjects(); ++iter)
         {
             // Put the base type depending on the type
+            const char* szPrefix = "";
             switch ((*iter)->GetObjectType())
             {
                 case CAccessControlListGroupObject::OBJECT_TYPE_RESOURCE:
-                    strcpy(szBuffer, "resource.");
+                    szPrefix = "resource.";
                     break;
 
                 case CAccessControlListGroupObject::OBJECT_TYPE_USER:
-                    strcpy(szBuffer, "user.");
+                    szPrefix = "user.";
                     break;
             };
 
             // Append the object name
-            strncat(szBuffer, (*iter)->GetObjectName(), 254);
+            SString strObjectName = szPrefix;
+            strObjectName += (*iter)->GetObjectName();
 
             // Push its name onto the table
             lua_pushnumber(luaVM, ++uiIndex);
-            lua_pushstring(luaVM, szBuffer);
+            lua_pushstring(luaVM, strObjectName);
             lua_settable(luaVM, -3);
         }
         // Return the table


### PR DESCRIPTION
#### Summary

`aclListRights` builds the string it returns in a `char[128]` with `strncat`, and
`aclGroupListObjects` does the same in a `char[255]`:

```cpp
char szRightName[128];
strcpy(szRightName, "function.");
strncat(szRightName, (*iter)->GetRightName(), NUMELMS(szRightName) - 1);
```

`strncat`'s third argument caps how many bytes are taken from the source, not how many the
destination can hold, and it always appends a terminator. So the worst case is `9 + 127 + 1 = 137`
bytes into 128. Nothing bounds the name on the way in: `aclSetRight` validates only the prefix, and
`acl.xml` is loaded with no cap at all, so a right name of 119 characters is already over the edge.

Both are now built with `SString`. While there, `szBuffer` in `aclGroupListObjects` was appended to
without being written first if a group object was of neither known type; the prefix is now a
separate variable that always has a value.

#### Test plan

A server resource that adds a 300-character right and then calls `aclListRights`, and the same for a
group object, on a debug build:

```lua
local acl = aclCreate("bufftest")
aclSetRight(acl, "function." .. string.rep("A", 300), true)
local rights = aclListRights(acl)
outputServerLog(("returned %d entries, longest %d chars"):format(#rights, #(rights[1] or "")))
```

Before: the server dies inside `aclListRights`. The log ends on the line before the call, there is
no shutdown line, and the process is gone.

```
[acltest] aclSetRight with a 309 character name -> true
[acltest] calling aclListRights ...
```

After: it returns the name whole, and the group object listing with a 255-character name behaves the
same way.

```
[acltest] aclListRights returned 1 entries, longest 309 chars
[acltest] aclGroupListObjects returned 1 entries, longest 255 chars
[acltest] ---- survived, no stack corruption ----
```

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
