### PR TITLE
Synchronize water wave phase between clients

### DIFF
--- a/Client/game_sa/CWaterManagerSA.cpp
+++ b/Client/game_sa/CWaterManagerSA.cpp
@@ -818,6 +818,12 @@ float CWaterManagerSA::GetWaveLevel()
     return *(float*)VAR_WaveLevel;
 }
 
+void CWaterManagerSA::SetWavePhase(DWORD milliseconds)
+{
+    const DWORD gameTime = *reinterpret_cast<const DWORD*>(0xB7CB84);
+    *reinterpret_cast<DWORD*>(0xC228A4) = gameTime - milliseconds;
+}
+
 void CWaterManagerSA::SetWaveLevel(float fWaveLevel)
 {
     if (fWaveLevel >= 0.0f)

--- a/Client/game_sa/CWaterManagerSA.h
+++ b/Client/game_sa/CWaterManagerSA.h
@@ -166,6 +166,7 @@ public:
 
     float GetWaveLevel();
     void  SetWaveLevel(float fWaveLevel);
+    void  SetWavePhase(DWORD milliseconds) override;
     void  SetWaterDrawnLast(bool bEnable);
     bool  IsWaterDrawnLast();
 

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -3923,6 +3923,10 @@ void CClientGame::PreRenderSkyHandler()
 
 void CClientGame::PreWeatherUpdateHandler()
 {
+    // CTimer has advanced, but water physics and rendering have not run yet.
+    // Refresh even after a long frame or pause, using the shared real-time phase.
+    m_pManager->GetWaterManager()->UpdateWavePhase();
+
     // Fix #4803: Set MTA's weather types and zero InterpolationValue BEFORE
     // CWeather::Update runs. Zeroing InterpolationValue prevents the wrap branch
     // from ever firing (engine_interp >= 0 is always true), so the engine computes

--- a/Client/mods/deathmatch/logic/CClientGame.cpp
+++ b/Client/mods/deathmatch/logic/CClientGame.cpp
@@ -3923,7 +3923,6 @@ void CClientGame::PreRenderSkyHandler()
 
 void CClientGame::PreWeatherUpdateHandler()
 {
-    // CTimer has advanced, but water physics and rendering have not run yet.
     // Refresh even after a long frame or pause, using the shared real-time phase.
     m_pManager->GetWaterManager()->UpdateWavePhase();
 

--- a/Client/mods/deathmatch/logic/CClientWaterManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientWaterManager.cpp
@@ -24,7 +24,6 @@ void CClientWaterManager::ReceiveWaveSync(NetBitStreamInterface& stream)
     if (serverTime <= m_lastWaveServerTime)
         return;
 
-    // Use the existing transport ping; no separate clock request is needed.
     const auto now = GetTickCount64_();
     m_waveTargetTimeOffset = static_cast<double>(serverTime) + std::max(0, g_pNet->GetPing()) * 0.5 - static_cast<double>(now);
     if (!m_lastWaveServerTime)
@@ -41,14 +40,10 @@ void CClientWaterManager::UpdateWavePhase()
         return;
 
     const auto now = GetTickCount64_();
-
-    // Correct at at most 2% so packet jitter cannot snap water or buoyancy.
-    // Real elapsed time keeps different FPS/game speeds on the same wave clock.
     const double correction = std::max(0LL, now - m_lastWaveUpdate) * 0.02;
     m_waveTimeOffset += std::clamp(m_waveTargetTimeOffset - m_waveTimeOffset, -correction, correction);
     m_lastWaveUpdate = now;
 
-    // 105000 ms is the common period of GTA's 5000/3500/3000 ms waves.
     const auto phase = static_cast<DWORD>(std::fmod(static_cast<double>(now) + m_waveTimeOffset, 105000.0));
     g_pGame->GetWaterManager()->SetWavePhase(phase);
 }

--- a/Client/mods/deathmatch/logic/CClientWaterManager.cpp
+++ b/Client/mods/deathmatch/logic/CClientWaterManager.cpp
@@ -9,8 +9,49 @@
  *****************************************************************************/
 
 #include "StdInc.h"
+#include <algorithm>
+#include <cmath>
 
 using std::list;
+
+void CClientWaterManager::ReceiveWaveSync(NetBitStreamInterface& stream)
+{
+    unsigned int timeLow{}, timeHigh{};
+    if (!stream.Read(timeLow) || !stream.Read(timeHigh))
+        return;
+
+    const auto serverTime = (static_cast<std::uint64_t>(timeHigh) << 32) | timeLow;
+    if (serverTime <= m_lastWaveServerTime)
+        return;
+
+    // Use the existing transport ping; no separate clock request is needed.
+    const auto now = GetTickCount64_();
+    m_waveTargetTimeOffset = static_cast<double>(serverTime) + std::max(0, g_pNet->GetPing()) * 0.5 - static_cast<double>(now);
+    if (!m_lastWaveServerTime)
+    {
+        m_waveTimeOffset = m_waveTargetTimeOffset;
+        m_lastWaveUpdate = now;
+    }
+    m_lastWaveServerTime = serverTime;
+}
+
+void CClientWaterManager::UpdateWavePhase()
+{
+    if (!m_lastWaveServerTime)
+        return;
+
+    const auto now = GetTickCount64_();
+
+    // Correct at at most 2% so packet jitter cannot snap water or buoyancy.
+    // Real elapsed time keeps different FPS/game speeds on the same wave clock.
+    const double correction = std::max(0LL, now - m_lastWaveUpdate) * 0.02;
+    m_waveTimeOffset += std::clamp(m_waveTargetTimeOffset - m_waveTimeOffset, -correction, correction);
+    m_lastWaveUpdate = now;
+
+    // 105000 ms is the common period of GTA's 5000/3500/3000 ms waves.
+    const auto phase = static_cast<DWORD>(std::fmod(static_cast<double>(now) + m_waveTimeOffset, 105000.0));
+    g_pGame->GetWaterManager()->SetWavePhase(phase);
+}
 
 CClientWaterManager::CClientWaterManager(CClientManager* pManager)
 {

--- a/Client/mods/deathmatch/logic/CClientWaterManager.h
+++ b/Client/mods/deathmatch/logic/CClientWaterManager.h
@@ -14,6 +14,7 @@ class CClientWaterManager;
 
 #include "CClientManager.h"
 #include "CClientWater.h"
+#include <cstdint>
 
 class CClientWaterManager
 {
@@ -35,6 +36,8 @@ public:
 
     float GetWaveLevel();
     void  SetWaveLevel(float fWaveLevel);
+    void  UpdateWavePhase();
+    void  ReceiveWaveSync(NetBitStreamInterface& stream);
 
     unsigned short GetDimension() { return m_usDimension; };
     void           SetDimension(unsigned short usDimension);
@@ -54,4 +57,8 @@ private:
     std::list<CClientWater*> m_List;
     bool                     m_bDontRemoveFromList;
     unsigned short           m_usDimension;
+    std::uint64_t            m_lastWaveServerTime = 0;
+    long long                m_lastWaveUpdate = 0;
+    double                   m_waveTimeOffset = 0;
+    double                   m_waveTargetTimeOffset = 0;
 };

--- a/Client/mods/deathmatch/logic/CNetAPI.cpp
+++ b/Client/mods/deathmatch/logic/CNetAPI.cpp
@@ -214,6 +214,11 @@ bool CNetAPI::ProcessPacket(unsigned char bytePacketID, NetBitStreamInterface& B
                 m_bVehicleLastReturn = false;
             }
 
+            // The server clock travels with the existing acknowledgement, so
+            // waves need neither a separate packet nor a client sync authority.
+            if (BitStream.Can(eBitStreamVersion::WaterWaveSync))
+                m_pManager->GetWaterManager()->ReceiveWaveSync(BitStream);
+
             // Remember the last return sync time
             m_ulLastSyncReturnTime = CClientTime::GetTime();
             m_bStoredReturnSync = true;

--- a/Client/mods/deathmatch/logic/CNetAPI.cpp
+++ b/Client/mods/deathmatch/logic/CNetAPI.cpp
@@ -214,8 +214,6 @@ bool CNetAPI::ProcessPacket(unsigned char bytePacketID, NetBitStreamInterface& B
                 m_bVehicleLastReturn = false;
             }
 
-            // The server clock travels with the existing acknowledgement, so
-            // waves need neither a separate packet nor a client sync authority.
             if (BitStream.Can(eBitStreamVersion::WaterWaveSync))
                 m_pManager->GetWaterManager()->ReceiveWaveSync(BitStream);
 

--- a/Client/mods/deathmatch/logic/CPacketHandler.cpp
+++ b/Client/mods/deathmatch/logic/CPacketHandler.cpp
@@ -2690,6 +2690,9 @@ void CPacketHandler::Packet_MapInfo(NetBitStreamInterface& bitStream)
     bitStream.ReadBit(bOcclusionsEnabled);
 
     g_pGame->GetWorld()->SetOcclusionsEnabled(bOcclusionsEnabled);
+
+    if (bitStream.Can(eBitStreamVersion::WaterWaveSync))
+        g_pClientGame->GetManager()->GetWaterManager()->ReceiveWaveSync(bitStream);
 }
 
 void CPacketHandler::Packet_PartialPacketInfo(NetBitStreamInterface& bitStream)

--- a/Client/sdk/game/CWaterManager.h
+++ b/Client/sdk/game/CWaterManager.h
@@ -37,4 +37,5 @@ public:
     virtual void UndoChanges(void* pChangeSource = NULL) = 0;
     virtual void RebuildIndex() = 0;  // Call this after moving a polygon's vertices
     virtual void Reset() = 0;         // Reset all water to SA default
+    virtual void SetWavePhase(DWORD milliseconds) = 0;
 };

--- a/Server/mods/deathmatch/logic/packets/CMapInfoPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CMapInfoPacket.cpp
@@ -357,5 +357,12 @@ bool CMapInfoPacket::Write(NetBitStreamInterface& BitStream) const
     bool bOcclusionsEnabled = g_pGame->GetOcclusionsEnabled();
     BitStream.WriteBit(bOcclusionsEnabled);
 
+    if (BitStream.Can(eBitStreamVersion::WaterWaveSync))
+    {
+        const auto now = static_cast<std::uint64_t>(GetTickCount64_());
+        BitStream.Write(static_cast<unsigned int>(now));
+        BitStream.Write(static_cast<unsigned int>(now >> 32));
+    }
+
     return true;
 }

--- a/Server/mods/deathmatch/logic/packets/CReturnSyncPacket.cpp
+++ b/Server/mods/deathmatch/logic/packets/CReturnSyncPacket.cpp
@@ -53,6 +53,13 @@ bool CReturnSyncPacket::Write(NetBitStreamInterface& BitStream) const
             BitStream.Write(&position);
         }
 
+        if (BitStream.Can(eBitStreamVersion::WaterWaveSync))
+        {
+            const auto now = static_cast<std::uint64_t>(GetTickCount64_());
+            BitStream.Write(static_cast<unsigned int>(now));
+            BitStream.Write(static_cast<unsigned int>(now >> 32));
+        }
+
         return true;
     }
 

--- a/Shared/sdk/net/bitstream.h
+++ b/Shared/sdk/net/bitstream.h
@@ -40,6 +40,10 @@ enum class eBitStreamVersion : unsigned short
     // YYYY-MM-DD
     // Name,
 
+    // Server time in map info and return sync for water wave phase.
+    // 2026-09-12
+    WaterWaveSync,
+
     // This allows us to automatically increment the BitStreamVersion when things are added to this enum.
     // Make sure you only add things above this comment.
     Next,


### PR DESCRIPTION
#### Summary
Synchronize water wave phase using server timestamps appended to existing map-info and return-sync packets.
Clients advance the phase using elapsed real time and smooth timing corrections.
Closes #2536

#### Motivation
`setWaveHeight` synchronizes wave amplitude, but GTA calculates wave phase using each client’s local game timer. Players can therefore see different waves.

#### Test plan
- Connect two clients and set server-side setWaveHeight(2).
- Compare waves at identical coordinates with one client at 30 FPS and another at 90 FPS.
- Repeat after reconnecting, minimizing a client and introducing network latency.
- Check swimming, boat buoyancy and custom water polygons.

#### Checklist
* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
