### PR TITLE
Drop the stored default when a timed object model is freed

### DIFF
--- a/Client/game_sa/CModelInfoSA.cpp
+++ b/Client/game_sa/CModelInfoSA.cpp
@@ -934,6 +934,7 @@ void CModelInfoSA::StaticResetModelTimes()
     {
         x.first->m_nTimeOn = x.second->m_nTimeOn;
         x.first->m_nTimeOff = x.second->m_nTimeOff;
+        delete x.second;
     }
     ms_ModelDefaultModelTimeInfo.clear();
 }
@@ -1986,8 +1987,16 @@ void CModelInfoSA::DeallocateModel(void)
             delete reinterpret_cast<CClumpModelInfoSAInterface*>(ppModelInfo[m_dwModelID]);
             break;
         case eModelInfoType::TIME:
-            delete reinterpret_cast<CTimeModelInfoSAInterface*>(ppModelInfo[m_dwModelID]);
+        {
+            auto* pTimeModelInfo = reinterpret_cast<CTimeModelInfoSAInterface*>(ppModelInfo[m_dwModelID]);
+            if (auto iter = ms_ModelDefaultModelTimeInfo.find(&pTimeModelInfo->timeInfo); iter != ms_ModelDefaultModelTimeInfo.end())
+            {
+                delete iter->second;
+                ms_ModelDefaultModelTimeInfo.erase(iter);
+            }
+            delete pTimeModelInfo;
             break;
+        }
         default:
             break;
     }


### PR DESCRIPTION
#### Summary
`SetTime` stores the model's original times in `ms_ModelDefaultModelTimeInfo`, keyed by `&pTimeModelInfo->timeInfo` (`CModelInfoSA.cpp:906-908`), which points inside the model info. `DeallocateModel` clears seven other default maps but not this one, then deletes the model info, so the key is left dangling.

`StaticResetModelTimes` writes through every key on the next server join. The stored values were also never deleted.

#### Motivation
`engineFreeModel` on a custom timed object model is enough to leave the entry behind; `CClientGame.cpp` calls `StaticResetModelTimes` once per join, and the loop writes two bytes through the freed pointer.

#### Test plan
Two custom timed object models allocated with `engineRequestModel`, `setObjectTime` called on both so `SetTime` inserts their defaults, then `engineFreeModel` on each. The map size is logged on each `DeallocateModel`.

```
before   dealloc id=12624 type=3 iface=2B9F3D80 timeDefaults=1
         dealloc id=12625 type=3 iface=2B9F3F00 timeDefaults=1
after    dealloc id=12624 type=3 iface=2CED8D90 timeDefaults=1
         dealloc id=12625 type=3 iface=2CED8BE0 timeDefaults=0
```

The two interfaces are at different addresses in both runs, so the entry is not being hidden by heap reuse. Before, the map still holds the entry after the interface it keys on has been deleted.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
