### PR TITLE
Search the whole pool in GetModelIdFromClump

### DIFF
--- a/Client/game_sa/CPoolsSA.cpp
+++ b/Client/game_sa/CPoolsSA.cpp
@@ -774,9 +774,9 @@ DWORD CPoolsSA::GetObjectPoolIndex(std::uint8_t* pInterface)
 uint CPoolsSA::GetModelIdFromClump(RpClump* pRpClump)
 {
     // Search our pools for a match
-    for (uint i = 0; i < m_pedPool.ulCount; i++)
+    for (const auto& slot : m_pedPool.arrayOfClientEntities)
     {
-        CEntitySA* pEntitySA = m_pedPool.arrayOfClientEntities[i].pEntity;
+        CEntitySA* pEntitySA = slot.pEntity;
         if (pEntitySA)
         {
             if (pEntitySA->GetRpClump() == pRpClump)
@@ -786,9 +786,9 @@ uint CPoolsSA::GetModelIdFromClump(RpClump* pRpClump)
         }
     }
 
-    for (uint i = 0; i < m_vehiclePool.ulCount; i++)
+    for (const auto& slot : m_vehiclePool.arrayOfClientEntities)
     {
-        CEntitySA* pEntitySA = m_vehiclePool.arrayOfClientEntities[i].pEntity;
+        CEntitySA* pEntitySA = slot.pEntity;
         if (pEntitySA)
         {
             if (pEntitySA->GetRpClump() == pRpClump)
@@ -798,9 +798,9 @@ uint CPoolsSA::GetModelIdFromClump(RpClump* pRpClump)
         }
     }
 
-    for (uint i = 0; i < m_objectPool.ulCount; i++)
+    for (const auto& slot : m_objectPool.arrayOfClientEntities)
     {
-        CEntitySA* pEntitySA = m_objectPool.arrayOfClientEntities[i].pEntity;
+        CEntitySA* pEntitySA = slot.pEntity;
         if (pEntitySA)
         {
             if (pEntitySA->GetRpClump() == pRpClump)


### PR DESCRIPTION
#### Summary
`GetModelIdFromClump` bounds its three pool scans by `ulCount`, but `arrayOfClientEntities` is indexed by the GTA pool slot (`CPoolsSA.cpp:72`, `:266`, `:428`) and removal leaves a hole (`:200`, `:324`, `:505`). An entity in a slot above the live count is never looked at.

The loops now walk the array, which is a fixed size `std::array`, so the bound cannot drift again. The existing null checks already handle empty slots.

#### Motivation
The only caller is the bad anim hierarchy diagnostic (`CMultiplayerSA_FixBadAnimId.cpp:86`). A miss falls through to the model info scan, which compares against each model's master `pRwObject` and so cannot match a per entity clump, and the function returns 0. `Utils.cpp:1944` only shows CL34 "GTA:SA had trouble loading a model" when the id is non zero, so the report is suppressed and the telemetry records `Corrupt model:0`.

#### Test plan
Create peds and objects, then destroy them one per tick so live entities are left in slots above the live count, and call `GetModelIdFromClump` on each live entity found there.

```
before   ped del OUT slot=6 ulCount=4 clump=1534CCF0 id=0
         ped del OUT slot=7 ulCount=4 clump=1534CD70 id=0
         ped del OUT slot=8 ulCount=4 clump=1534CDF0 id=0
```

A live ped with a valid clump at slot 6 while the loop bound is 4, and the lookup returns 0. With the array bound instead of the count the same entity is found by index.

#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
