### PR TITLE
Fix #2762: Allow sprinting while standing on a static object

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA.cpp
@@ -1246,6 +1246,10 @@ void CMultiplayerSA::InitHooks()
     MemPut<DWORD>(0x55E870, 0xC2C03366);
     MemPut<WORD>(0x55E874, 0x0004);
 
+    // Let us also sprint while standing on a static entity (e.g. attached object); the game skips the whole sprint decision while standing on a static,
+    // non-contacted entity (0x6885B0: je 0x688667)
+    MemSet((void*)0x6885B0, 0x90, 6);
+
     // Create pickup objects in interior 0 instead of 13
     MemPut<BYTE>(0x59FAA3, 0x00);
 


### PR DESCRIPTION
#### Summary

Fix the game skips its whole sprint decision while standing on an entity flagged static that hasn't processed contact forces, so attached objects could never be sprinted on

Closes #2762.

Before ->

https://github.com/user-attachments/assets/12ec3156-1921-419c-8d35-22dfbf62f403

After ->

https://github.com/user-attachments/assets/f1da9f21-6a68-4580-a1bc-1a574738cae9


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
