### PR TITLE
Fix #2410: setElementBonePosition only working on the CJ skin

### DIFF
--- a/Client/game_sa/CEntitySA.cpp
+++ b/Client/game_sa/CEntitySA.cpp
@@ -696,12 +696,22 @@ bool CEntitySA::GetBonePosition(eBone boneId, CVector& position)
     return true;
 }
 
-// NOTE: The position will be reset if UpdateElementRpHAnim is called after this.
+// NOTE: CEntity::UpdateRpHAnim rebuilds the bone matrices from the animation hierarchy and
+// discards the position, so it's skipped for this frame (like the game does for the player)
 bool CEntitySA::SetBonePosition(eBone boneId, const CVector& position)
 {
     RwMatrix* rwBoneMatrix = GetBoneRwMatrix(boneId);
     if (!rwBoneMatrix)
         return false;
+
+    CEntitySAInterface* theInterface = GetInterface();
+    if (theInterface)
+    {
+        if (!theInterface->bDontUpdateHierarchy)
+            UpdateRpHAnim();
+
+        theInterface->bDontUpdateHierarchy = true;
+    }
 
     CMatrixSAInterface boneMatrix(rwBoneMatrix, false);
     boneMatrix.SetTranslateOnly(position);


### PR DESCRIPTION
#### Summary

The game rebuilds the ped bone matrices from the animation hierarchy on every `CEntity::UpdateRpHAnim`, which discarded the new position again; it only skips that rebuild for the player ped (CJ); `setElementBonePosition` now skips it for every ped, so the position survives the rest of the frame like it already did on CJ

Closes #2410.

The code used in the video:
```lua
addEventHandler("onClientPedsProcessed", root,
	function()
		local x, y, z = getElementBonePosition(localPlayer, 5)
		setElementBonePosition(localPlayer, 5, x, y, z + 5)
		updateElementRpHAnim(localPlayer)
	end
)
```

Before ->

https://github.com/user-attachments/assets/d7f5380a-08cd-407f-b1a8-f3da9a401124

After ->

https://github.com/user-attachments/assets/3440ae0b-4aa4-412a-ad66-81966687b888


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
