### PR TITLE
Fix #2210: Bone functions bringing back the removed head of a headless ped

### DIFF
--- a/Client/game_sa/CPedSA.cpp
+++ b/Client/game_sa/CPedSA.cpp
@@ -29,6 +29,8 @@ static bool g_onlyUpdateRotations = false;
 
 namespace
 {
+    constexpr std::uint8_t PED_NODE_HEAD = 2;
+
     constexpr std::uintptr_t FUNC_CRealTimeShadowManager_ReturnRealTimeShadow = 0x705B30;
     constexpr std::uintptr_t CLASS_CRealTimeShadowManager = 0xC40350;
     constexpr std::uintptr_t FUNC_CShadows_StoreShadowForPedObject = 0x707B40;
@@ -351,6 +353,32 @@ CVector* CPedSA::GetTransformedBonePosition(eBone bone, CVector* position)
         *position = *GetPosition();
 
     return position;
+}
+
+void CPedSA::UpdateRpHAnim()
+{
+    CEntitySA::UpdateRpHAnim();
+
+    const auto* pedInterface = GetPedInterface();
+    if (!pedInterface->pedFlags.bRemoveHead || pedInterface->bodyPartToRemove != PED_NODE_HEAD)
+        return;
+
+    RpClump*          clump = GetRpClump();
+    RpHAnimHierarchy* animHierarchy = clump ? GetAnimHierarchyFromSkinClump(clump) : nullptr;
+    if (!animHierarchy)
+        return;
+
+    constexpr eBone removedBones[] = {BONE_NECK, BONE_HEAD2, BONE_HEAD1, BONE_HEAD};
+    constexpr RwV3d hiddenScale{0.0f, 0.0f, 0.0f};
+
+    RwMatrix* boneMatrices = RpHAnimHierarchyGetMatrixArray(animHierarchy);
+
+    for (const auto boneId : removedBones)
+    {
+        const int matrixIndex = RpHAnimIDGetIndex(animHierarchy, boneId);
+        if (matrixIndex != -1)
+            RwMatrixScale(&boneMatrices[matrixIndex], &hiddenScale, TRANSFORM_BEFORE);
+    }
 }
 
 //

--- a/Client/game_sa/CPedSA.h
+++ b/Client/game_sa/CPedSA.h
@@ -414,6 +414,7 @@ public:
 
     CVector* GetBonePosition(eBone bone, CVector* position) override;
     CVector* GetTransformedBonePosition(eBone bone, CVector* position) override;
+    void     UpdateRpHAnim() override;
 
     bool IsDucking() const override { return GetPedInterface()->pedFlags.bIsDucking; }
     void SetDucking(bool duck) override { GetPedInterface()->pedFlags.bIsDucking = duck; }


### PR DESCRIPTION
#### Summary

The game hides a removed body part (`setPedHeadless`) by zero scaling its bone matrices in `CPed::PreRenderAfterTest`, so rebuilding the animation hierarchy (`updateElementRpHAnim`) brought the head back; re-apply that scaling after the rebuild

Closes #2210.

Before ->

https://github.com/user-attachments/assets/5c5c453f-3144-4b77-a0ce-2f12648ea9d1

After ->

https://github.com/user-attachments/assets/772bbeea-746a-41d9-b4dd-576f7a0ec8d2


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
