### PR TITLE
Fix #1771: Mouse steering a vehicle in mid air while its controls are disabled

### DIFF
--- a/Client/game_sa/CControllerConfigManagerSA.cpp
+++ b/Client/game_sa/CControllerConfigManagerSA.cpp
@@ -19,6 +19,9 @@
 #define VAR_VerticalAimSensitivity     ((float*)(0xB6EC18))
 #define VAR_HorizontalMouseSensitivity 0xB6EC1C
 
+#define VAR_InAirMouseSteeringCar  0x6B4EC0
+#define VAR_InAirMouseSteeringQuad 0x6CE827
+
 static const float VERTICAL_AIM_SENSITIVITY_MIN = 0.000312f;
 static const float VERTICAL_AIM_SENSITIVITY_DEFAULT = 0.0015f;
 static const float VERTICAL_AIM_SENSITIVITY_MAX = VERTICAL_AIM_SENSITIVITY_DEFAULT * 2 - VERTICAL_AIM_SENSITIVITY_MIN;
@@ -30,6 +33,11 @@ CControllerConfigManagerSA::CControllerConfigManagerSA()
     m_bSteerWithMouse = *VAR_FlyWithMouse != 0;
     m_bFlyWithMouse = *VAR_SteerWithMouse != 0;
     MemSet((void*)0x5BC7B4, 0x90, 10);  // Stop vertical aim sensitivity value reset
+
+    MemPut<DWORD>(VAR_InAirMouseSteeringCar, (DWORD)&m_ucInAirMouseSteering);
+    MemPut<DWORD>(VAR_InAirMouseSteeringQuad, (DWORD)&m_ucInAirMouseSteering);
+
+    UpdateInAirMouseSteering();
 }
 
 void CControllerConfigManagerSA::SetControllerKeyAssociatedWithAction(eControllerAction action, int iKey, eControllerType controllerType)
@@ -97,6 +105,7 @@ void CControllerConfigManagerSA::ClearSettingsAssociatedWithAction(eControllerAc
 void CControllerConfigManagerSA::SetClassicControls(bool bClassicControls)
 {
     MemPutFast<unsigned char>(VAR_InputType, bClassicControls ? 0 : 1);
+    UpdateInAirMouseSteering();
 }
 
 void CControllerConfigManagerSA::SetMouseInverted(bool bInverted)
@@ -134,6 +143,13 @@ void CControllerConfigManagerSA::ApplySteerAndFlyWithMouseSettings()
         *VAR_FlyWithMouse = m_bFlyWithMouse;
         *VAR_SteerWithMouse = m_bSteerWithMouse;
     }
+
+    UpdateInAirMouseSteering();
+}
+
+void CControllerConfigManagerSA::UpdateInAirMouseSteering()
+{
+    m_ucInAirMouseSteering = (!m_bSuspendSteerAndFlyWithMouse && *VAR_InputType != 0) ? 1 : 0;
 }
 
 float CControllerConfigManagerSA::GetVerticalAimSensitivity()

--- a/Client/game_sa/CControllerConfigManagerSA.h
+++ b/Client/game_sa/CControllerConfigManagerSA.h
@@ -43,7 +43,11 @@ public:
     void ApplySteerAndFlyWithMouseSettings();
 
 protected:
+    void UpdateInAirMouseSteering();
+
     bool m_bSteerWithMouse;
     bool m_bFlyWithMouse;
     bool m_bSuspendSteerAndFlyWithMouse;
+
+    BYTE m_ucInAirMouseSteering;
 };


### PR DESCRIPTION
#### Summary

The engine lets the mouse steer a vehicle in mid air by testing the control method only, ignoring `CVehicle::m_bEnableMouseSteering`, so disabling `vehicle_left`, `vehicle_right`, `steer_forward` or `steer_back` with `toggleControl` could still be bypassed in the air; those checks now read a flag that is also dropped while the vehicle controls are suspended; nothing else changes

Closes #1771.

The code used in the video is from #1771
https://github.com/multitheftauto/mtasa-blue/files/5460109/steerbug.zip

Before ->

https://github.com/user-attachments/assets/2202656c-76bb-4556-89d2-94def2ce1743

After ->

https://github.com/user-attachments/assets/0c572c40-e9e2-43d1-8da9-e96899be31a0


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
