### PR TITLE
Fix #668: Chainsaw weapon not damaging light vehicles (e.g. Sultan)

### DIFF
--- a/Client/multiplayer_sa/CMultiplayerSA_VehicleDamage.cpp
+++ b/Client/multiplayer_sa/CMultiplayerSA_VehicleDamage.cpp
@@ -301,6 +301,34 @@ static void __declspec(naked) HOOK_CAutomobile_VehicleDamage2()
     // clang-format on
 }
 
+#define HOOKPOS_CAutomobile_VehicleDamage_MeleeMinIntensity   0x06A7682
+#define HOOKSIZE_CAutomobile_VehicleDamage_MeleeMinIntensity  6
+#define HOOKCHECK_CAutomobile_VehicleDamage_MeleeMinIntensity 0x0F
+DWORD                         RETURN_CAutomobile_VehicleDamage_MeleeMinIntensity_A = 0x06A7688;
+DWORD                         RETURN_CAutomobile_VehicleDamage_MeleeMinIntensity_B = 0x06A84A3;
+static void __declspec(naked) HOOK_CAutomobile_VehicleDamage_MeleeMinIntensity()
+{
+    MTA_VERIFY_HOOK_LOCAL_SIZE;
+
+    // clang-format off
+    __asm
+    {
+        je      vehicleNotDamageable
+
+        cmp     dword ptr [esp+7Ch], 10h        // >= WEAPONTYPE_GRENADE, so a melee weapon
+        jae     cont
+
+        mov     dword ptr [esp+8], 0            // Melee: no minimum damage intensity
+
+cont:
+        jmp     RETURN_CAutomobile_VehicleDamage_MeleeMinIntensity_A
+
+vehicleNotDamageable:
+        jmp     RETURN_CAutomobile_VehicleDamage_MeleeMinIntensity_B
+    }
+    // clang-format on
+}
+
 //////////////////////////////////////////////////////////////////////////////////////////
 //
 // CPlane::VehicleDamage hook 1
@@ -523,6 +551,7 @@ void CMultiplayerSA::InitHooks_VehicleDamage()
     EZHookInstallChecked(CBike_BurstTyre);
     EZHookInstallChecked(CAutomobile_VehicleDamage1);
     EZHookInstallChecked(CAutomobile_VehicleDamage2);
+    EZHookInstallChecked(CAutomobile_VehicleDamage_MeleeMinIntensity);
     EZHookInstallChecked(CPlane_VehicleDamage1);
     EZHookInstallChecked(CPlane_VehicleDamage2);
     EZHookInstallChecked(CBike_VehicleDamage1);


### PR DESCRIPTION
#### Summary

`CAutomobile::VehicleDamage` drops an explicitly passed damage intensity that doesn't exceed its minimum of `25.0` - a minimum which is only scaled by the vehicle's mass for collisions; `CTaskSimpleFight::FightHitCar` passes melee damage scaled by the vehicle's mass (chainsaw: mass * weapon damage * 0.00075), so vehicles lighter than about `1622` kg, such as the Sultan with its `1400` kg, were never damaged by a chainsaw/melee weapon; neither the panels nor the health

Minimum is now dropped for chainsaw/melee weapons, so their damage is always applied; collision damage is untouched (it computes its own, mass scaled minimum) and so is every other weapon (guns and explosions pass a weapon of 49/51)

Closes #668.

Before ->

https://github.com/user-attachments/assets/2f93cfd1-83d7-4de8-830b-fc2888d24097

After ->

https://github.com/user-attachments/assets/7011d62e-48e9-4bdf-a38d-6f3a45800c48


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
