### PR TITLE
Fix #629: setElementVisibleTo not hiding an element on the first call (e.g. Element/Marker)

### DIFF
--- a/Server/mods/deathmatch/logic/CElement.cpp
+++ b/Server/mods/deathmatch/logic/CElement.cpp
@@ -88,7 +88,7 @@ CElement::~CElement()
     std::list<CPerPlayerEntity*>::const_iterator iter = m_ElementReferenced.begin();
     for (; iter != m_ElementReferenced.end(); iter++)
     {
-        (*iter)->m_ElementReferences.remove(this);
+        (*iter)->m_ElementVisibility.erase(this);
     }
 
     RemoveAllCollisions();

--- a/Server/mods/deathmatch/logic/CPerPlayerEntity.cpp
+++ b/Server/mods/deathmatch/logic/CPerPlayerEntity.cpp
@@ -26,14 +26,10 @@ CPerPlayerEntity::CPerPlayerEntity(CElement* pParent) : CElement(pParent)
 
 CPerPlayerEntity::~CPerPlayerEntity()
 {
-    // Unsync us from everyone
-    // Sync ( false );
-
     // Unreference us from what we're referencing
-    list<CElement*>::const_iterator iter = m_ElementReferences.begin();
-    for (; iter != m_ElementReferences.end(); iter++)
+    for (std::map<CElement*, bool>::const_iterator iter = m_ElementVisibility.begin(); iter != m_ElementVisibility.end(); iter++)
     {
-        (*iter)->m_ElementReferenced.remove(this);
+        iter->first->m_ElementReferenced.remove(this);
     }
     MapRemove(ms_AllPerPlayerEntityMap, this);
 }
@@ -64,7 +60,7 @@ void CPerPlayerEntity::OnReferencedSubtreeAdd(CElement* pElement)
     assert(pElement);
 
     // Add all players below that item to our list
-    AddPlayersBelow(pElement, m_PlayersAdded);
+    UpdatePlayersBelow(pElement);
 }
 
 void CPerPlayerEntity::OnReferencedSubtreeRemove(CElement* pElement)
@@ -72,7 +68,7 @@ void CPerPlayerEntity::OnReferencedSubtreeRemove(CElement* pElement)
     assert(pElement);
 
     // Remove all players below that item from our list
-    RemovePlayersBelow(pElement, m_PlayersRemoved);
+    HidePlayersBelow(pElement);
 }
 
 void CPerPlayerEntity::UpdatePerPlayer()
@@ -104,74 +100,69 @@ void CPerPlayerEntity::UpdatePerPlayer()
 
 bool CPerPlayerEntity::AddVisibleToReference(CElement* pElement)
 {
-    // If he isn't already referencing this element
-    if (!IsVisibleToReferenced(pElement))
-    {
-        // Add him to our list and add us to his list
-        m_ElementReferences.push_back(pElement);
-        pElement->m_ElementReferenced.push_back(this);
-
-        // Add the reference to it and update the players
-        OnReferencedSubtreeAdd(pElement);
-        UpdatePerPlayerEntities();
-
-        return true;
-    }
-
-    return false;
+    return SetElementVisibility(pElement, true);
 }
 
 bool CPerPlayerEntity::RemoveVisibleToReference(CElement* pElement)
 {
-    // We reference this element?
-    if (IsVisibleToReferenced(pElement))
+    return SetElementVisibility(pElement, false);
+}
+
+bool CPerPlayerEntity::SetElementVisibility(CElement* pElement, bool bVisible)
+{
+    assert(pElement);
+
+    std::map<CElement*, bool>::iterator iter = m_ElementVisibility.find(pElement);
+    if (iter != m_ElementVisibility.end())
     {
-        // Remove him from our list and unreference us from his list
-        m_ElementReferences.remove(pElement);
-        pElement->m_ElementReferenced.remove(this);
+        // Nothing to do if the value is already what we were asked to set
+        if (iter->second == bVisible)
+            return false;
 
-        // Update the players
-        OnReferencedSubtreeRemove(pElement);
-        UpdatePerPlayerEntities();
+        iter->second = bVisible;
+    }
+    else
+    {
+        m_ElementVisibility[pElement] = bVisible;
 
-        return true;
+        pElement->m_ElementReferenced.push_back(this);
     }
 
-    return false;
+    UpdatePlayersBelow(pElement);
+    UpdatePerPlayerEntities();
+
+    return true;
 }
 
 void CPerPlayerEntity::ClearVisibleToReferences()
 {
-    // For each reference in our list
-    bool                            bCleared = false;
-    list<CElement*>::const_iterator iter = m_ElementReferences.begin();
-    for (; iter != m_ElementReferences.end(); iter++)
-    {
-        // Unreference us from it
-        (*iter)->m_ElementReferenced.remove(this);
+    CElement* pRoot = g_pGame->GetMapManager()->GetRootElement();
+    assert(pRoot);
 
-        // Notify our inherits that he was removed
-        OnReferencedSubtreeRemove(*iter);
-        bCleared = true;
+    for (std::map<CElement*, bool>::iterator iter = m_ElementVisibility.begin(); iter != m_ElementVisibility.end(); iter++)
+    {
+        iter->first->m_ElementReferenced.remove(this);
     }
+    m_ElementVisibility.clear();
 
-    // Clear the list and update the players
-    if (bCleared)
+    // Restore the default visibility, which is being visible to everyone
+    if (pRoot)
     {
-        m_ElementReferences.clear();
+        m_ElementVisibility[pRoot] = true;
+        pRoot->m_ElementReferenced.push_back(this);
+
+        UpdatePlayersBelow(pRoot);
         UpdatePerPlayerEntities();
     }
 }
 
-bool CPerPlayerEntity::IsVisibleToReferenced(CElement* pElement)
+bool CPerPlayerEntity::IsVisibleToElement(CElement* pElement)
 {
-    list<CElement*>::const_iterator iter = m_ElementReferences.begin();
-    for (; iter != m_ElementReferences.end(); iter++)
+    for (CElement* pCurrent = pElement; pCurrent; pCurrent = pCurrent->GetParentEntity())
     {
-        if (*iter == pElement)
-        {
-            return true;
-        }
+        std::map<CElement*, bool>::const_iterator iter = m_ElementVisibility.find(pCurrent);
+        if (iter != m_ElementVisibility.end())
+            return iter->second;
     }
 
     return false;
@@ -287,49 +278,38 @@ void CPerPlayerEntity::RemoveIdenticalEntries(std::set<CPlayer*>& List1, std::se
     }
 }
 
-void CPerPlayerEntity::AddPlayersBelow(CElement* pElement, std::set<CPlayer*>& Added)
+void CPerPlayerEntity::UpdatePlayersBelow(CElement* pElement)
 {
     assert(pElement);
 
     // Is this a player?
     if (IS_PLAYER(pElement))
     {
-        // Are we not already visible to that player? Add it to the list
-        CPlayer* pPlayer = static_cast<CPlayer*>(pElement);
-        if (!IsVisibleToPlayer(*pPlayer))
-        {
-            MapInsert(Added, pPlayer);
-        }
-
-        // Add it to our reference list
-        AddPlayerReference(pPlayer);
+        SyncPlayerVisibility(static_cast<CPlayer*>(pElement));
     }
 
     // Call ourself on all its children elements
     CChildListType ::const_iterator iterChildren = pElement->IterBegin();
     for (; iterChildren != pElement->IterEnd(); iterChildren++)
     {
-        CElement* pElement = *iterChildren;
-        if (pElement->CountChildren() || IS_PLAYER(pElement))  // This check reduces cpu usage when loading large maps (due to recursion)
-            AddPlayersBelow(pElement, Added);
+        CElement* pChild = *iterChildren;
+        if (pChild->CountChildren() || IS_PLAYER(pChild))  // This check reduces cpu usage when loading large maps (due to recursion)
+            UpdatePlayersBelow(pChild);
     }
 }
 
-void CPerPlayerEntity::RemovePlayersBelow(CElement* pElement, std::set<CPlayer*>& Removed)
+void CPerPlayerEntity::HidePlayersBelow(CElement* pElement)
 {
     assert(pElement);
 
     // Is this a player?
     if (IS_PLAYER(pElement))
     {
-        // Remove the reference
         CPlayer* pPlayer = static_cast<CPlayer*>(pElement);
-        RemovePlayerReference(pPlayer);
-
-        // Did we just loose the last reference to that player? Add him to the list over removed players.
-        if (!IsVisibleToPlayer(*pPlayer))
+        if (IsVisibleToPlayer(*pPlayer))
         {
-            MapInsert(Removed, pPlayer);
+            RemovePlayerReference(pPlayer);
+            MapInsert(m_PlayersRemoved, pPlayer);
         }
     }
 
@@ -337,9 +317,28 @@ void CPerPlayerEntity::RemovePlayersBelow(CElement* pElement, std::set<CPlayer*>
     CChildListType ::const_iterator iterChildren = pElement->IterBegin();
     for (; iterChildren != pElement->IterEnd(); iterChildren++)
     {
-        CElement* pElement = *iterChildren;
-        if (pElement->CountChildren() || IS_PLAYER(pElement))  // This check reduces cpu usage when unloading large maps (due to recursion)
-            RemovePlayersBelow(pElement, Removed);
+        CElement* pChild = *iterChildren;
+        if (pChild->CountChildren() || IS_PLAYER(pChild))  // This check reduces cpu usage when loading large maps (due to recursion)
+            HidePlayersBelow(pChild);
+    }
+}
+
+void CPerPlayerEntity::SyncPlayerVisibility(CPlayer* pPlayer)
+{
+    const bool bVisible = IsVisibleToElement(pPlayer);
+
+    if (bVisible == IsVisibleToPlayer(*pPlayer))
+        return;
+
+    if (bVisible)
+    {
+        AddPlayerReference(pPlayer);
+        MapInsert(m_PlayersAdded, pPlayer);
+    }
+    else
+    {
+        RemovePlayerReference(pPlayer);
+        MapInsert(m_PlayersRemoved, pPlayer);
     }
 }
 

--- a/Server/mods/deathmatch/logic/CPerPlayerEntity.h
+++ b/Server/mods/deathmatch/logic/CPerPlayerEntity.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include <map>
+
 #include "CElement.h"
 #include "packets/CPacket.h"
 
@@ -36,7 +38,7 @@ public:
     bool AddVisibleToReference(CElement* pElement);
     bool RemoveVisibleToReference(CElement* pElement);
     void ClearVisibleToReferences();
-    bool IsVisibleToReferenced(CElement* pElement);
+    bool IsVisibleToElement(CElement* pElement);
 
     bool IsVisibleToPlayer(CPlayer& Player);
 
@@ -52,16 +54,19 @@ protected:
     void BroadcastOnlyVisible(const CPacket& Packet);
     bool m_bIsSynced;
 
-    std::list<CElement*> m_ElementReferences;
-
 private:
     void RemoveIdenticalEntries(std::set<class CPlayer*>& List1, std::set<class CPlayer*>& List2);
 
-    void AddPlayersBelow(CElement* pElement, std::set<class CPlayer*>& Added);
-    void RemovePlayersBelow(CElement* pElement, std::set<class CPlayer*>& Removed);
+    bool SetElementVisibility(CElement* pElement, bool bVisible);
+
+    void UpdatePlayersBelow(CElement* pElement);
+    void HidePlayersBelow(CElement* pElement);
+    void SyncPlayerVisibility(class CPlayer* pPlayer);
 
     void AddPlayerReference(class CPlayer* pPlayer);
     void RemovePlayerReference(class CPlayer* pPlayer);
+
+    std::map<CElement*, bool> m_ElementVisibility;
 
     std::set<CPlayer*> m_PlayersAdded;
     std::set<CPlayer*> m_PlayersRemoved;

--- a/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
+++ b/Server/mods/deathmatch/logic/luadefs/CLuaElementDefs.cpp
@@ -1467,7 +1467,7 @@ int CLuaElementDefs::isElementVisibleTo(lua_State* luaVM)
         if (IS_PERPLAYER_ENTITY(pElement))
         {
             // Return true if we're visible for the given element
-            if (static_cast<CPerPlayerEntity*>(pElement)->IsVisibleToReferenced(pVisibleTo))
+            if (static_cast<CPerPlayerEntity*>(pElement)->IsVisibleToElement(pVisibleTo))
             {
                 lua_pushboolean(luaVM, true);
                 return 1;


### PR DESCRIPTION
#### Summary

`setElementVisibleTo` stored the elements an entity is visible to in a plain list and only checked for direct membership, so hiding an element from a player was ignored unless that player had been added first with `setElementVisibleTo(marker, player, true)`; the default reference is the root element, so `setElementVisibleTo(marker, player, false)` did nothing and returned false

Visibility is now stored per element with its value, and the setting on the deepest ancestor of a player (or on the player itself) wins; a player not covered by any setting is not visible; hiding therefore works on the first call, the order of the calls is irrelevant

Closes #629.


#### Test plan

1. Created a marker and called `setElementVisibleTo(marker, player, false)`; verified it hides the marker on the first call without needing a prior true setup
2. Tested `setElementVisibleTo` with different call orders and verified that order no longer affects the visibility outcome
3. Verified player visibility correctly respects the deepest ancestor setting in the hierarchy


#### Checklist

* [x] Your code should follow the [coding guidelines](https://wiki.multitheftauto.com/index.php?title=Coding_guidelines).
* [x] Smaller pull requests are easier to review. If your pull request is beefy, your pull request should be reviewable commit-by-commit.
